### PR TITLE
po: Use C.UTF-8 locale for Zanata cli

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -112,7 +112,7 @@ update-po: po/cockpit.pot
 		$(MSGMERGE) --output-file=$(srcdir)/po/$$lang.po $(srcdir)/po/$$lang.po $<; \
 	done
 
-ZANATA_CLI = LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 zanata-cli -B
+ZANATA_CLI = LANG=C.UTF-8 LC_ALL=C.UTF-8 zanata-cli -B
 
 upload-pot: po/cockpit.pot
 	$(ZANATA_CLI) push --includes cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \

--- a/po/cs.po
+++ b/po/cs.po
@@ -10,34 +10,41 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"POT-Creation-Date: 2019-09-23 08:08+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-15 04:43+0000\n"
+"PO-Revision-Date: 2019-09-21 12:00+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech\n"
 "Language: cs\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
 
-#: pkg/docker/storage.jsx:259
+#: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
 msgstr "(sdíleno s operačním systémem)"
+
+#: pkg/networkmanager/interfaces.js:2353
+msgid "$0 Active Rule"
+msgid_plural "$0 Active Rules"
+msgstr[0] "$0 aktivní pravidlo"
+msgstr[1] "$0 aktivní pravidla"
+msgstr[2] "$0 aktivních pravidel"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 Blokové zařízení"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/mdraid-details.jsx:187
 msgid "$0 Chunk Size"
 msgstr "$0 Velikost bloku dat"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "$0 Disks"
 msgstr "$0 Disky"
 
-#: pkg/storaged/content-views.jsx:334
+#: pkg/storaged/content-views.jsx:339
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "$0 Souborový systém"
@@ -46,34 +53,34 @@ msgstr "$0 Souborový systém"
 msgid "$0 Network"
 msgstr "Síť $0"
 
-#: pkg/packagekit/history.jsx:101
+#: pkg/packagekit/history.jsx:100
 msgid "$0 Package"
 msgid_plural "$0 Packages"
 msgstr[0] "$0 balíček"
 msgstr[1] "$0 balíčky"
 msgstr[2] "$0 balíčků"
 
-#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:478 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 Šablona"
 
-#: src/base1/test-locale.js:80 src/base1/test-locale.js:81
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:83 src/base1/test-locale.js:84
+#: src/base1/test-locale.js:85 src/base1/test-locale.js:86
 msgid "$0 bit"
 msgid_plural "$0 bits"
 msgstr[0] "$0 bit"
 msgstr[1] "$0 bity"
 msgstr[2] "$0 bitů"
 
-#: src/base1/test-locale.js:71 src/base1/test-locale.js:72
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+#: src/base1/test-locale.js:74 src/base1/test-locale.js:75
+#: src/base1/test-locale.js:87 src/base1/test-locale.js:88
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtů"
 
-#: src/base1/test-locale.js:73 src/base1/test-locale.js:74
+#: src/base1/test-locale.js:76 src/base1/test-locale.js:77
 msgctxt "memory"
 msgid "$0 byte"
 msgid_plural "$0 bytes"
@@ -81,21 +88,28 @@ msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtů"
 
-#: pkg/storaged/vdo-details.jsx:280
+#: pkg/storaged/vdo-details.jsx:286
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 data + $1 režie využito z $2 ($3)"
 
-#: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
+#: pkg/lib/plot.js:971
+msgid "$0 day"
+msgid_plural "$0 days"
+msgstr[0] "$0 den"
+msgstr[1] "$0 dny"
+msgstr[2] "$0 dnů"
+
+#: src/base1/test-locale.js:65 src/base1/test-locale.js:66
+#: src/base1/test-locale.js:67 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:207
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 disk chybí"
 msgstr[1] "$0 disky chybí"
 msgstr[2] "$0 disků chybí"
 
-#: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: src/base1/test-locale.js:68 src/base1/test-locale.js:70
+#: src/base1/test-locale.js:72 pkg/playground/translate.js:32
 #: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
@@ -116,17 +130,24 @@ msgstr "$0 skončilo s kódem $1"
 msgid "$0 failed"
 msgstr "$0 se nezdařilo"
 
-#: pkg/storaged/lvol-tabs.jsx:159
+#: pkg/storaged/lvol-tabs.jsx:160
 msgid "$0 filesystems can not be made larger."
 msgstr "$0 souborových systémů nelze zvětšit."
 
-#: pkg/storaged/lvol-tabs.jsx:156
+#: pkg/storaged/lvol-tabs.jsx:157
 msgid "$0 filesystems can not be made smaller."
 msgstr "$0 souborových systémů nelze zmenšit."
 
-#: pkg/storaged/lvol-tabs.jsx:152
+#: pkg/storaged/lvol-tabs.jsx:153
 msgid "$0 filesystems can not be resized here."
 msgstr "$0 souborovým systémům nelze změnit velikost zde."
+
+#: pkg/lib/plot.js:974
+msgid "$0 hour"
+msgid_plural "$0 hours"
+msgstr[0] "$0 hodina"
+msgstr[1] "$0 hodiny"
+msgstr[2] "$0 hodin"
 
 #: pkg/machines/components/desktopConsole.jsx:44
 msgid ""
@@ -136,21 +157,35 @@ msgstr ""
 "$0 je k dispozici pro většinu operačních systémů. Pro instalaci vyhledejte v "
 "GNOME Software nebo spusťte následující:"
 
-#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:511
+#: pkg/storaged/format-dialog.jsx:265 pkg/storaged/lvol-tabs.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:264 pkg/storaged/mdraid-details.jsx:232
+#: pkg/storaged/mdraid-details.jsx:284 pkg/storaged/vdo-details.jsx:147
+#: pkg/storaged/vdo-details.jsx:178 pkg/storaged/vgroup-details.jsx:199
 msgid "$0 is in active use"
 msgstr "$0 je právě používáno"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:150
+#: pkg/lib/cockpit-components-install-dialog.jsx:151
 msgid "$0 is not available from any repository."
 msgstr "$0 není k dispozici z žádného z repozitářů."
 
 #: src/base1/cockpit.js:2755
 msgid "$0 killed with signal $1"
 msgstr "$0 vynuceně ukončeno signálem $1"
+
+#: pkg/lib/plot.js:977
+msgid "$0 minute"
+msgid_plural "$0 minutes"
+msgstr[0] "$0 minuta"
+msgstr[1] "$0 minuty"
+msgstr[2] "$0 minut"
+
+#: pkg/lib/plot.js:965
+msgid "$0 month"
+msgid_plural "$0 months"
+msgstr[0] "$0 měsíc"
+msgstr[1] "$0 měsíce"
+msgstr[2] "$0 měsíců"
 
 #: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
@@ -163,11 +198,18 @@ msgstr[2] "$0 výskytů"
 msgid "$0 of $1"
 msgstr "$0 z $1"
 
+#: pkg/systemd/init.js:418
+msgid "$0 service has failed"
+msgid_plural "$0 services have failed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: pkg/docker/util.js:125
 msgid "$0 shares"
 msgstr "$0 sdílení"
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "$0 slots remain"
 msgstr "$0 slotů zbývá"
 
@@ -178,15 +220,29 @@ msgstr[0] "$0 aktualizace"
 msgstr[1] "$0 aktualizace"
 msgstr[2] "$0 aktualizací"
 
-#: pkg/storaged/vdo-details.jsx:292
+#: pkg/storaged/vdo-details.jsx:298
 msgid "$0 used of $1 ($2 saved)"
 msgstr "použito $0 z $1 ($2 ušetřeno)"
+
+#: pkg/lib/plot.js:968
+msgid "$0 week"
+msgid_plural "$0 weeks"
+msgstr[0] "$0 týden"
+msgstr[1] "$0 týdny"
+msgstr[2] "$0 týdnů"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 bude nainstalováno."
 
-#: pkg/storaged/vgroup-details.jsx:117
+#: pkg/lib/plot.js:962
+msgid "$0 year"
+msgid_plural "$0 years"
+msgstr[0] "$0 rok"
+msgstr[1] "$0 roky"
+msgstr[2] "$0 let"
+
+#: pkg/storaged/vgroup-details.jsx:111
 msgid "$0, $1 free"
 msgstr "$0, $1 volné"
 
@@ -197,7 +253,7 @@ msgstr[0] "$1 oprava zabezpečení"
 msgstr[1] "$1 opravy zabezpečení"
 msgstr[2] "$1 oprav zabezpečení"
 
-#: pkg/networkmanager/interfaces.js:2769
+#: pkg/networkmanager/interfaces.js:2777
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -213,16 +269,16 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:574
+#: pkg/networkmanager/firewall.jsx:576
 msgid "(Optional)"
 msgstr "(Volitelné)"
 
-#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
-#: pkg/storaged/fsys-tab.jsx:160
+#: pkg/networkmanager/firewall.jsx:501 pkg/networkmanager/firewall.jsx:650
+#: pkg/storaged/fsys-tab.jsx:163
 msgid "(default)"
 msgstr "(výchozí)"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:138
 msgid "(none)"
 msgstr "(žádné)"
 
@@ -233,36 +289,43 @@ msgstr[0] ", včetně $1 opravy zabezpečení"
 msgstr[1] ", včetně $1 oprav zabezpečení"
 msgstr[2] ", včetně $1 oprav zabezpečení"
 
-#: pkg/storaged/nfs-details.jsx:325
+#: pkg/storaged/nfs-details.jsx:333
 msgid "--"
 msgstr "–"
 
-#: pkg/storaged/mdraids-panel.jsx:70
+#: pkg/storaged/mdraids-panel.jsx:86
 msgid "1 MiB"
 msgstr "1 MiB"
 
-#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
+#: pkg/systemd/index.html:455 pkg/systemd/index.html:459
 msgid "1 Minute"
 msgstr "1 minuta"
 
+#: pkg/docker/containers-view.jsx:614
+msgid "1 Vulnerability"
+msgid_plural "$0 Vulnerabilities"
+msgstr[0] "1 zranitelnost"
+msgstr[1] "$0 zranitelnosti"
+msgstr[2] "$0 zranitelností"
+
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:194
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 den"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:190
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 hodina"
 
-#: pkg/systemd/host.js:1686
+#: pkg/systemd/host.js:1729
 msgid "1 min"
 msgstr "1 minuta"
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:196
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 týden"
@@ -275,7 +338,7 @@ msgstr "10."
 msgid "11th"
 msgstr "11. "
 
-#: pkg/storaged/mdraids-panel.jsx:68
+#: pkg/storaged/mdraids-panel.jsx:84
 msgid "128 KiB"
 msgstr "128 KiB"
 
@@ -295,7 +358,7 @@ msgstr "14."
 msgid "15th"
 msgstr "15."
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/mdraids-panel.jsx:81
 msgid "16 KiB"
 msgstr "16 KiB"
 
@@ -319,15 +382,15 @@ msgstr "19."
 msgid "1st"
 msgstr "1."
 
-#: pkg/storaged/mdraids-panel.jsx:71
+#: pkg/storaged/mdraids-panel.jsx:87
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1685
+#: pkg/systemd/host.js:1728
 msgid "2 min"
 msgstr "2 min"
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:461
 msgid "20 Minutes"
 msgstr "20 minut"
 
@@ -375,7 +438,7 @@ msgstr "29."
 msgid "2nd"
 msgstr "2."
 
-#: pkg/systemd/host.js:1684
+#: pkg/systemd/host.js:1727
 msgid "3 min"
 msgstr "3 min"
 
@@ -387,7 +450,7 @@ msgstr "30."
 msgid "31st"
 msgstr "31."
 
-#: pkg/storaged/mdraids-panel.jsx:66
+#: pkg/storaged/mdraids-panel.jsx:82
 msgid "32 KiB"
 msgstr "32 KiB"
 
@@ -395,15 +458,15 @@ msgstr "32 KiB"
 msgid "3rd"
 msgstr "3."
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:79
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1683
+#: pkg/systemd/host.js:1726
 msgid "4 min"
 msgstr "4 min"
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:462
 msgid "40 Minutes"
 msgstr "40 minut"
 
@@ -411,21 +474,21 @@ msgstr "40 minut"
 msgid "4th"
 msgstr "4."
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:460
 msgid "5 Minutes"
 msgstr "5 minut"
 
-#: pkg/systemd/host.js:1682
+#: pkg/systemd/host.js:1725
 msgid "5 min"
 msgstr "5 min"
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:188
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 minut"
 
-#: pkg/storaged/mdraids-panel.jsx:69
+#: pkg/storaged/mdraids-panel.jsx:85
 msgid "512 KiB"
 msgstr "512 KiB"
 
@@ -434,16 +497,16 @@ msgid "5th"
 msgstr "5."
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:192
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 hodin"
 
-#: pkg/systemd/index.html:452
+#: pkg/systemd/index.html:463
 msgid "60 Minutes"
 msgstr "60 minut"
 
-#: pkg/storaged/mdraids-panel.jsx:67
+#: pkg/storaged/mdraids-panel.jsx:83
 msgid "64 KiB"
 msgstr "64 KiB"
 
@@ -455,15 +518,15 @@ msgstr "6."
 msgid "7th"
 msgstr "7."
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/mdraids-panel.jsx:80
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1999
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:2016
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -483,7 +546,7 @@ msgstr ""
 "Na {{#strong}}{{host}}{{/strong}} není nainstalovaná kompatibilní verze "
 "Cockpit."
 
-#: pkg/storaged/vdos-panel.jsx:59
+#: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "Je zapotřebí disk."
 
@@ -494,19 +557,19 @@ msgstr ""
 "Z důvodu zabezpečení, spolehlivosti a rychlosti je zapotřebí moderního "
 "prohlížeče."
 
-#: pkg/storaged/mdraid-details.jsx:119
+#: pkg/storaged/mdraid-details.jsx:113
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Před odebráním tohoto disku je třeba přidat náhradní."
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2806
 msgid "ARP Monitoring"
 msgstr "ARP monitorování"
 
-#: pkg/networkmanager/interfaces.js:2016
+#: pkg/networkmanager/interfaces.js:2028
 msgid "ARP Ping"
 msgstr "ARP ping"
 
@@ -523,10 +586,6 @@ msgstr "Chybí"
 msgid "Access"
 msgstr "Přístup"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:12
-msgid "Access Policy"
-msgstr "Politika přístupu"
-
 #: pkg/users/index.html:249
 msgid "Account Expiration"
 msgstr "Skončení platnosti účtu"
@@ -539,7 +598,8 @@ msgstr "Nastavení účtu"
 msgid "Account not available or cannot be edited."
 msgstr "Účet není k dispozici nebo ho není možné měnit."
 
-#: pkg/users/index.html:71 pkg/users/manifest.json.in
+#: pkg/playground/translate.html:95 pkg/users/index.html:71
+#: pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Účty"
 
@@ -550,7 +610,7 @@ msgstr "Účty"
 
 #: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
-#: pkg/storaged/content-views.jsx:256
+#: pkg/storaged/content-views.jsx:261
 msgid "Activate"
 msgstr "Aktivovat"
 
@@ -559,11 +619,11 @@ msgid "Activating $target"
 msgstr "Aktivuje se $target"
 
 # auto translated by TM merge from project: ibus-libpinyin, version: master, DocId: ibus-libpinyin
-#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
+#: pkg/networkmanager/interfaces.js:852 pkg/networkmanager/interfaces.js:2022
 msgid "Active"
 msgstr "Aktivní"
 
-#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:1996 pkg/networkmanager/interfaces.js:2013
 msgid "Active Backup"
 msgstr "Aktivní záloha"
 
@@ -571,40 +631,41 @@ msgstr "Aktivní záloha"
 msgid "Active Pages"
 msgstr "Aktivní stránky"
 
-#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1044 pkg/storaged/dialog.jsx:1048
 msgid "Active since"
 msgstr "Aktivní od"
 
-#: pkg/systemd/service-details.jsx:352
+#: pkg/systemd/service-details.jsx:354
 msgid "Active since "
 msgstr "Aktivní od"
 
-#: pkg/networkmanager/firewall.jsx:954
+#: pkg/networkmanager/firewall.jsx:956
 msgid "Active zones"
 msgstr "Aktivní zóny"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:2001
 msgid "Adaptive load balancing"
 msgstr "Přizpůsobující se rozkládání zátěže"
 
-#: pkg/networkmanager/interfaces.js:1988
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Adaptive transmit load balancing"
 msgstr "Přizpůsobující se rozkládání přenosové zátěže odesílání"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
-#: pkg/storaged/vgroup-details.jsx:63
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
+#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
+#: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
+#: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:198
+#: pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Přidat"
 
-#: pkg/networkmanager/interfaces.js:3115
+#: pkg/networkmanager/interfaces.js:3126
 msgid "Add $0"
 msgstr "Přidat $0"
 
-#: pkg/docker/storage.jsx:378
+#: pkg/docker/storage.jsx:383
 msgid "Add Additional Storage"
 msgstr "Přidat další úložiště"
 
@@ -616,15 +677,15 @@ msgstr "Přidat sloučení linek"
 msgid "Add Bridge"
 msgstr "Přidat síťový most"
 
-#: pkg/machines/components/diskAdd.jsx:368
+#: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Přidat disk"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:51
+#: pkg/storaged/mdraid-details.jsx:45 pkg/storaged/vgroup-details.jsx:52
 msgid "Add Disks"
 msgstr "Přidat disky"
 
-#: pkg/storaged/crypto-keyslots.jsx:200
+#: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Add Key"
 msgstr "Přidat klíč"
 
@@ -632,16 +693,20 @@ msgstr "Přidat klíč"
 msgid "Add Machine to Dashboard"
 msgstr "Přidat stroj na přehled"
 
-#: pkg/networkmanager/firewall.jsx:482
+#: pkg/machines/components/nicAdd.jsx:218
+msgid "Add Network Interface"
+msgstr "Přidat síťové rozhraní"
+
+#: pkg/networkmanager/firewall.jsx:484
 msgid "Add Ports"
 msgstr "Přidat porty"
 
-#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
-#: pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:484 pkg/networkmanager/firewall.jsx:906
+#: pkg/networkmanager/firewall.jsx:918
 msgid "Add Services"
 msgstr "Přidat služby"
 
-#: pkg/docker/storage.jsx:217
+#: pkg/docker/storage.jsx:219
 msgid "Add Storage"
 msgstr "Přidat úložiště"
 
@@ -653,12 +718,12 @@ msgstr "Přidat tým"
 msgid "Add VLAN"
 msgstr "Přidat VLAN"
 
-#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
-#: pkg/networkmanager/firewall.jsx:921
+#: pkg/networkmanager/firewall.jsx:732 pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:923
 msgid "Add Zone"
 msgstr "Přidat zónu"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/iscsi-panel.jsx:42
 msgid "Add iSCSI Portal"
 msgstr "Přidat iSCSI portál"
 
@@ -666,7 +731,7 @@ msgstr "Přidat iSCSI portál"
 msgid "Add key"
 msgstr "Přidat klíč"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add ports to the following zones:"
 msgstr "Přidat porty do následujících zón:"
 
@@ -674,15 +739,15 @@ msgstr "Přidat porty do následujících zón:"
 msgid "Add public key"
 msgstr "Přidat veřejnou část klíče"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add services to following zones:"
 msgstr "Přidat služby do následujících zón:"
 
-#: pkg/networkmanager/firewall.jsx:806
+#: pkg/networkmanager/firewall.jsx:808
 msgid "Add zone"
 msgstr "Přidat zónu"
 
-#: pkg/networkmanager/interfaces.js:3114
+#: pkg/networkmanager/interfaces.js:3125
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -690,7 +755,7 @@ msgstr ""
 "Přidání <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/firewall.jsx:586
+#: pkg/networkmanager/firewall.jsx:588
 msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
@@ -706,15 +771,15 @@ msgstr "Přidání klíče"
 msgid "Adding physical volume to $target"
 msgstr "Přidává se fyzický svazek do $target"
 
-#: pkg/machines/components/vmDisksTab.jsx:78
+#: pkg/machines/components/vmDisksTab.jsx:116
 msgid "Additional"
 msgstr "Další"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "Additional DNS $val"
 msgstr "Další DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "Additional DNS Search Domains $val"
 msgstr "Další DNS domény k prohledávání $val"
 
@@ -726,7 +791,7 @@ msgstr "Další úložiště"
 msgid "Additional actions"
 msgstr "Další akce"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional address $val"
 msgstr "Další adresa $val"
 
@@ -738,20 +803,20 @@ msgstr "Další balíčky:"
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:107
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Address"
 msgstr "Adresa"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Address $val"
 msgstr "Adresa $val"
 
-#: pkg/storaged/crypto-keyslots.jsx:192
+#: pkg/storaged/crypto-keyslots.jsx:193
 msgid "Address cannot be empty"
 msgstr "Adresu je třeba vyplnit"
 
-#: pkg/storaged/crypto-keyslots.jsx:194
+#: pkg/storaged/crypto-keyslots.jsx:195
 msgid "Address is not a valid URL"
 msgstr "Do adresy nebyla vyplněná platná URL"
 
@@ -768,7 +833,7 @@ msgid "Address:"
 msgstr "Adresa:"
 
 # auto translated by TM merge from project: Spacewalk Web UI, version: master, DocId: java/code/src/com/redhat/rhn/frontend/strings/java/StringResource
-#: pkg/networkmanager/interfaces.js:3321
+#: pkg/networkmanager/interfaces.js:3332
 msgid "Addresses"
 msgstr "Adresy"
 
@@ -784,7 +849,7 @@ msgstr "Heslo správce"
 msgid "Advanced TCA"
 msgstr "Pokročilé TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:430
 msgid "After"
 msgstr "Později"
 
@@ -800,7 +865,7 @@ msgstr ""
 "cert. autorit."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:902
+#: pkg/systemd/init.js:964
 msgid "After system boot"
 msgstr "Po startu systému"
 
@@ -808,7 +873,7 @@ msgstr "Po startu systému"
 msgid "Alert and above"
 msgstr "Výstraha a závažnější"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Vše"
 
@@ -816,7 +881,7 @@ msgstr "Vše"
 msgid "All In One"
 msgstr "Vše v jednom"
 
-#: pkg/docker/storage.jsx:381
+#: pkg/docker/storage.jsx:386
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -828,11 +893,11 @@ msgstr ""
 msgid "Allow running (unmask)"
 msgstr "Umožnit spouštění (odmaskovat)"
 
-#: pkg/networkmanager/firewall.jsx:781
+#: pkg/networkmanager/firewall.jsx:783
 msgid "Allowed Addresses"
 msgstr "Adresy, které umožněny"
 
-#: pkg/networkmanager/firewall.jsx:967
+#: pkg/networkmanager/firewall.jsx:969
 msgid "Allowed Services"
 msgstr "Dovolené služby"
 
@@ -841,13 +906,10 @@ msgstr "Dovolené služby"
 msgid "Always"
 msgstr "Vždy"
 
-#: pkg/machines/components/diskAdd.jsx:116
+#: pkg/machines/components/diskAdd.jsx:117
+#: pkg/machines/components/nicAdd.jsx:86
 msgid "Always attach"
 msgstr "Vždy připojit"
-
-#: node_modules/registry-image-widgets/views/annotations.html:1
-msgid "Annotations"
-msgstr "Anotace"
 
 #: pkg/lib/cockpit-components-modifications.jsx:82
 msgid "Ansible Playbook"
@@ -867,10 +929,10 @@ msgstr "Aplikace"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:354
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:108 pkg/storaged/fsys-tab.jsx:80
+#: pkg/storaged/fsys-tab.jsx:129 pkg/storaged/nfs-details.jsx:198
 msgid "Apply"
 msgstr "Použít"
 
@@ -898,21 +960,16 @@ msgstr "Aplikují se aktualizace"
 msgid "Applying updates failed"
 msgstr "Aplikace aktualizací se nezdařila"
 
-# auto translated by TM merge from project: retrace-server, version: master, DocId: retrace-server
-#: node_modules/registry-image-widgets/views/image-config.html:16
-msgid "Architecture"
-msgstr "Architektura"
-
 #: pkg/systemd/index.html:92
 msgid "Asset Tag"
 msgstr "Inventární štítek"
 
-#: pkg/storaged/mdraids-panel.jsx:79
+#: pkg/storaged/mdraids-panel.jsx:96
 msgid "At least $0 disks are needed."
 msgstr "Je vyžadováno alespoň $0 disků."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraid-details.jsx:52 pkg/storaged/vgroup-details.jsx:59
+#: pkg/storaged/vgroups-panel.jsx:66
 msgid "At least one disk is needed."
 msgstr "Je vyžadován alespoň 1 disk."
 
@@ -924,7 +981,7 @@ msgstr "V uvedený čas"
 msgid "Audit log"
 msgstr "Záznam auditu"
 
-#: pkg/networkmanager/interfaces.js:839
+#: pkg/networkmanager/interfaces.js:844
 msgid "Authenticating"
 msgstr "Ověřování"
 
@@ -954,14 +1011,12 @@ msgstr ""
 "ověření totožnosti"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/storaged/iscsi-panel.jsx:147
+#: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Nutné ověření"
 
 # auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
-#: pkg/docker/index.html:702
-#: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:413
+#: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Autor"
 
@@ -971,22 +1026,22 @@ msgstr "Pověřené veřejné SSH klíče"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
 #: pkg/networkmanager/index.html:176
-#: pkg/machines/components/networks/createNetworkDialog.jsx:176
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
-#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
-#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
+#: pkg/machines/components/networks/createNetworkDialog.jsx:162
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:3340 pkg/networkmanager/interfaces.js:3344
+#: pkg/networkmanager/interfaces.js:3350 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automaticky"
 
-#: pkg/networkmanager/interfaces.js:1975
+#: pkg/networkmanager/interfaces.js:1987
 msgid "Automatic (DHCP only)"
 msgstr "Automaticky (pouze DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1965
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Automatic (DHCP)"
 msgstr "Automaticky (DHCP)"
 
-#: pkg/systemd/init.js:295
+#: pkg/systemd/init.js:307
 msgid "Automatic Startup"
 msgstr "Automatické spouštění"
 
@@ -998,15 +1053,15 @@ msgstr "Automatické aktualizace"
 msgid "Automatically start libvirt on boot"
 msgstr "Spouštět libvirt automaticky při startu"
 
-#: pkg/systemd/service-details.jsx:396
+#: pkg/systemd/service-details.jsx:398
 msgid "Automatically starts"
 msgstr "Spouští se automaticky"
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/index.html:400
 msgid "Automatically using NTP"
 msgstr "Automatické použití NTP"
 
-#: pkg/systemd/index.html:390
+#: pkg/systemd/index.html:401
 msgid "Automatically using specific NTP servers"
 msgstr "Automatické použití uvedených NTP serverů"
 
@@ -1027,11 +1082,11 @@ msgstr "Automatické spouštění"
 msgid "Available"
 msgstr "Dostupný"
 
-#: pkg/packagekit/updates.jsx:824
+#: pkg/packagekit/updates.jsx:825
 msgid "Available Updates"
 msgstr "Dostupné aktualizace"
 
-#: pkg/storaged/iscsi-panel.jsx:124
+#: pkg/storaged/iscsi-panel.jsx:125
 msgid "Available targets on $0"
 msgstr "Cíle dostupné na $0"
 
@@ -1039,15 +1094,15 @@ msgstr "Cíle dostupné na $0"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: pkg/systemd/hwinfo.jsx:92
+#: pkg/systemd/hwinfo.jsx:96
 msgid "BIOS"
 msgstr "BIOS"
 
-#: pkg/systemd/hwinfo.jsx:100
+#: pkg/systemd/hwinfo.jsx:104
 msgid "BIOS date"
 msgstr "Datum vydání BIOS"
 
-#: pkg/systemd/hwinfo.jsx:96
+#: pkg/systemd/hwinfo.jsx:100
 msgid "BIOS version"
 msgstr "Verze BIOS"
 
@@ -1055,7 +1110,7 @@ msgstr "Verze BIOS"
 msgid "Back to Accounts"
 msgstr "Zpět k účtům"
 
-#: pkg/storaged/vdo-details.jsx:270
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Backing Device"
 msgstr "Podkladové zařízení"
 
@@ -1067,11 +1122,11 @@ msgstr "Data předaná mechanizmu passwd1 jsou chybná"
 msgid "Balancer"
 msgstr "Rozkládání zátěže"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/systemd/service-details.jsx:429
 msgid "Before"
 msgstr "Před"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:420
 msgid "Binds To"
 msgstr "Spojuje k"
 
@@ -1091,17 +1146,17 @@ msgstr "Skříň se šachtami pro blade servery"
 msgid "Block"
 msgstr "Blok"
 
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:666
 msgid "Block device for filesystems"
 msgstr "Blokové zařízení pro souborové systémy"
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/mdraid-details.jsx:97
 msgid "Blocked"
 msgstr "Blokované"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2803
+#: pkg/networkmanager/interfaces.js:2529 pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2811
 msgid "Bond"
 msgstr "Vazba"
 
@@ -1118,13 +1173,13 @@ msgstr "Pořadí zavádění"
 msgid "Boot order settings could not be saved"
 msgstr "Nastavení pořadí zavádění se nepodařilo uložit"
 
-#: pkg/systemd/service-details.jsx:423
+#: pkg/systemd/service-details.jsx:425
 msgid "Bound By"
 msgstr "Spojeno"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
-#: pkg/networkmanager/interfaces.js:2880
+#: pkg/networkmanager/interfaces.js:2535 pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2888
 msgid "Bridge"
 msgstr "Most"
 
@@ -1136,34 +1191,30 @@ msgstr "Nastavení portu mostu"
 msgid "Bridge Settings"
 msgstr "Nastavení mostu"
 
-#: pkg/networkmanager/interfaces.js:2901
+#: pkg/networkmanager/interfaces.js:2909
 msgid "Bridge port"
 msgstr "Port mostu"
 
 # auto translated by TM merge from project: tvtime, version: 1.0.7, DocId: tvtime
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1998 pkg/networkmanager/interfaces.js:2015
 msgid "Broadcast"
 msgstr "Vysílání"
 
-#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
+#: pkg/networkmanager/interfaces.js:2824 pkg/networkmanager/interfaces.js:2858
 msgid "Broken configuration"
 msgstr "Chybné nastavení"
 
-#: pkg/systemd/host.js:508
+#: pkg/systemd/host.js:511
 msgid "Bug Fix Updates Available"
 msgstr "Jsou k dispozici aktualizace opravující zabezpečení"
 
-#: pkg/packagekit/updates.jsx:314
+#: pkg/packagekit/updates.jsx:315
 msgid "Bugs:"
 msgstr "Chyby:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:18
-msgid "Built"
-msgstr "Sestaveno"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:109
 #: pkg/machines/components/vm/bootOrderModal.jsx:132
-#: pkg/machines/components/vmDisksTab.jsx:72
+#: pkg/machines/components/vmDisksTab.jsx:110
 msgid "Bus"
 msgstr "Sběrnice"
 
@@ -1172,19 +1223,19 @@ msgid "Bus Expansion Chassis"
 msgstr "Skříň rozšíření sběrnice"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:272
-#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:112
 msgid "CPU"
 msgstr "Procesor"
 
-#: pkg/systemd/hwinfo.jsx:113
+#: pkg/systemd/hwinfo.jsx:117
 msgid "CPU Security"
 msgstr "Zabezpečení procesoru"
 
-#: pkg/systemd/hwinfo.jsx:205
+#: pkg/systemd/hwinfo.jsx:209
 msgid "CPU Security Toggles"
 msgstr "Přepínače zabezpečení procesoru"
 
-#: pkg/systemd/host.js:1565
+#: pkg/systemd/host.js:1603
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Stav procesoru"
@@ -1201,12 +1252,12 @@ msgstr "Priorita procesoru"
 msgid "CPU usage:"
 msgstr "Využití procesoru:"
 
-#: pkg/machines/components/diskAdd.jsx:251
+#: pkg/machines/components/diskAdd.jsx:174
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "Mezipaměť"
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1739
 msgid "Cached"
 msgstr "Uloženo v mezipaměti"
 
@@ -1214,11 +1265,11 @@ msgstr "Uloženo v mezipaměti"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Nedaří se spojit s Docker"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:318
 msgid "Can't delete while unlocked"
 msgstr "Nelze smazat neuzamčený"
 
-#: pkg/dashboard/list.js:212
+#: pkg/dashboard/list.js:220
 msgid "Can't load image"
 msgstr "Obraz se nedaří smazat"
 
@@ -1233,37 +1284,39 @@ msgstr "Obraz se nedaří smazat"
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
+#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
+#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
 #: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:597
-#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/nicAdd.jsx:232
+#: pkg/machines/components/nicEdit.jsx:181
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:93
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
-#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
-#: pkg/systemd/hwinfo.jsx:216
+#: pkg/networkmanager/firewall.jsx:592 pkg/networkmanager/firewall.jsx:660
+#: pkg/networkmanager/firewall.jsx:803 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:394
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:220
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Storno"
 
-#: pkg/shell/indexes.js:421
+#: pkg/shell/indexes.js:472
 msgid "Cannot connect to an unknown machine"
 msgstr "Nelze se připojit k neznámému stroji"
 
-#: src/base1/cockpit.js:4031
+#: src/base1/cockpit.js:4035
 msgid "Cannot forward login credentials"
 msgstr "Nedaří přeposlat přístupové údaje"
 
@@ -1272,25 +1325,25 @@ msgid "Cannot schedule event in the past"
 msgstr "Nelze naplánovat událost v minulosti"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/machines/components/vmDisksTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:108
 msgid "Capacity"
 msgstr "Kapacita"
 
-#: pkg/networkmanager/interfaces.js:2602
+#: pkg/networkmanager/interfaces.js:2610
 msgid "Carrier"
 msgstr "Nosný signál"
 
-#: pkg/docker/index.html:664 pkg/systemd/index.html:333
-#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:181
+#: pkg/docker/index.html:664 pkg/systemd/index.html:344
+#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Změnit"
 
-#: pkg/systemd/index.html:289
+#: pkg/systemd/index.html:300
 msgid "Change Host Name"
 msgstr "Změnit název počítače"
 
-#: pkg/shell/index.html:312
+#: pkg/shell/index.html:313
 msgid "Change Password"
 msgstr "Změnit heslo"
 
@@ -1298,19 +1351,19 @@ msgstr "Změnit heslo"
 msgid "Change Performance Profile"
 msgstr "Změnit profil výkonu"
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:199
 msgid "Change Profile"
 msgstr "Změnit profil"
 
-#: pkg/systemd/index.html:358
+#: pkg/systemd/index.html:369
 msgid "Change System Time"
 msgstr "Změnit systémový čas"
 
-#: pkg/storaged/iscsi-panel.jsx:176
+#: pkg/storaged/iscsi-panel.jsx:183
 msgid "Change iSCSI Initiator Name"
 msgstr "Změnit název iSCSI iniciátoru"
 
-#: pkg/storaged/crypto-keyslots.jsx:247
+#: pkg/storaged/crypto-keyslots.jsx:255
 msgid "Change passphrase"
 msgstr "Změnit heslovou frázi"
 
@@ -1322,18 +1375,18 @@ msgstr "Změnit limity prostředku"
 msgid "Change resources limits"
 msgstr "Změnit limity prostředků"
 
-#: pkg/networkmanager/interfaces.js:3165
+#: pkg/networkmanager/interfaces.js:3176
 msgid "Change the settings"
 msgstr "Změnit nastavení"
 
-#: pkg/machines/components/nicEdit.jsx:287
+#: pkg/machines/components/nicEdit.jsx:157
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Změny se projeví až po vypnutí virt. stroje"
 
-#: pkg/networkmanager/interfaces.js:3164
+#: pkg/networkmanager/interfaces.js:3175
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1349,7 +1402,7 @@ msgstr "Zkontrolovat aktualizace"
 msgid "Checking $target"
 msgstr "Ověřuje se $target"
 
-#: pkg/networkmanager/interfaces.js:843
+#: pkg/networkmanager/interfaces.js:848
 msgid "Checking IP"
 msgstr "Ověřuje se IP adresa"
 
@@ -1369,11 +1422,11 @@ msgstr "Hledají se nové aplikace"
 msgid "Checking for public keys"
 msgstr "Hledají se veřejné klíče"
 
-#: pkg/systemd/host.js:537
+#: pkg/systemd/host.js:540
 msgid "Checking for updates…"
 msgstr "Zjišťování případných aktualizací…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:142
+#: pkg/lib/cockpit-components-install-dialog.jsx:143
 msgid "Checking installed software"
 msgstr "Zjišťuje se nainstalovaný sofware"
 
@@ -1385,12 +1438,12 @@ msgstr "Zvolte operační systém"
 msgid "Choose the language to be used in the application"
 msgstr "Vyberte jazyk aplikace"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/mdraids-panel.jsx:72
 msgid "Chunk Size"
 msgstr "Velikost bloku"
 
 # auto translated by TM merge from project: libosinfo, version: master, DocId: libosinfo
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Class"
 msgstr "Třída"
 
@@ -1400,13 +1453,13 @@ msgstr "Čištění pro $target"
 
 #: pkg/systemd/service-details.jsx:188
 msgid "Clear 'Failed to start'"
-msgstr ""
+msgstr "Vyčistit „Nepodařilo se spustit“"
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr "Vyčistit všechny filtry"
 
-#: pkg/systemd/host.js:750
+#: pkg/systemd/host.js:776
 msgid "Click to see system hardware information"
 msgstr "Kliknutím zobrazíte informace o hardware"
 
@@ -1426,14 +1479,14 @@ msgstr "Klientský software"
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
 #: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
 #: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
 #: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:394
 msgid "Close"
 msgstr "Zavřít"
 
-#: pkg/shell/active-pages.js:103
+#: pkg/shell/active-pages.js:104
 msgid "Close Selected Pages"
 msgstr "Zavřít vybrané stránky"
 
@@ -1441,7 +1494,7 @@ msgstr "Zavřít vybrané stránky"
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Cockpit ověřování není nastaveno správně."
 
-#: pkg/lib/machine-dialogs.js:427
+#: pkg/lib/machine-dialogs.js:429
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
@@ -1449,11 +1502,11 @@ msgstr ""
 "Cockpit se nepodařilo kontaktovat uvedený stroj $0. Ověřte, že je ssh "
 "spuštěno na portu $1 nebo v jeho adrese zadejte jiný port."
 
-#: src/base1/cockpit.js:4037
+#: src/base1/cockpit.js:4041
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit se nepodařilo daný stroj kontaktovat."
 
-#: pkg/shell/base_index.js:752
+#: pkg/shell/base_index.js:759
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1482,7 +1535,7 @@ msgstr ""
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit je interaktivní rozhraní pro správu linuxového serveru."
 
-#: src/base1/cockpit.js:4035
+#: src/base1/cockpit.js:4039
 msgid "Cockpit is not compatible with the software on the system."
 msgstr "Cockpit není kompatibilní se softwarem v systému."
 
@@ -1490,7 +1543,7 @@ msgstr "Cockpit není kompatibilní se softwarem v systému."
 msgid "Cockpit is not installed"
 msgstr "Cockpit není nainstalován"
 
-#: src/base1/cockpit.js:4029
+#: src/base1/cockpit.js:4033
 msgid "Cockpit is not installed on the system."
 msgstr "Cockpit není v systému nainstalován."
 
@@ -1557,21 +1610,20 @@ msgstr "Barva"
 msgid "Combined memory usage"
 msgstr "Kombinované využití paměti"
 
-#: pkg/docker/overview.js:86
+#: pkg/docker/overview.js:88
 msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Kombinované využití $0 jádra procesoru"
 msgstr[1] "Kombinované využití $0 jader procesoru"
 msgstr[2] "Kombinované využití $0 jader procesoru"
 
-#: pkg/networkmanager/firewall.jsx:554
+#: pkg/networkmanager/firewall.jsx:556
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Jsou přijímány čárkou oddělované porty, rozsahy a alternativní názvy"
 
 # auto translated by TM merge from project: SETroubleShoot, version: master, DocId: framework/po/setroubleshoot
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
 #: pkg/docker/index.html:708 pkg/systemd/services.html:282
-#: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
 msgid "Command"
@@ -1586,7 +1638,7 @@ msgid "Command:"
 msgstr "Příkaz:"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/shell/index.html:261
+#: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Komentář"
 
@@ -1607,11 +1659,11 @@ msgstr "Komunikace s procesem služby tuned se nezdařila"
 msgid "Compact PCI"
 msgstr "Compact PCI"
 
-#: pkg/storaged/content-views.jsx:522
+#: pkg/storaged/content-views.jsx:532
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Kompatibilní se všemi systémy a zařízeními (MBR)"
 
-#: pkg/storaged/content-views.jsx:524
+#: pkg/storaged/content-views.jsx:535
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "Kompatibilní s moderním systémem a pevnými disky > 2TB (GPT)"
 
@@ -1619,8 +1671,8 @@ msgstr "Kompatibilní s moderním systémem a pevnými disky > 2TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Komprimovat výpisy paměti z havárií pro úsporu místa"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:310
+#: pkg/storaged/vdos-panel.jsx:87
 msgid "Compression"
 msgstr "Komprese"
 
@@ -1628,34 +1680,34 @@ msgstr "Komprese"
 msgid "Computer OU"
 msgstr "Organizační jednotka počítače"
 
-#: pkg/systemd/service-details.jsx:442
+#: pkg/systemd/service-details.jsx:444
 msgid "Condition $0=$1 was not met"
 msgstr "Podmínka $0=$1 nebyla splněna"
 
-#: pkg/systemd/service-details.jsx:492
+#: pkg/systemd/service-details.jsx:494
 msgid "Condition failed"
 msgstr "Podmínka nebyla úspěšná"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/networkmanager/interfaces.js:2737
+#: pkg/networkmanager/interfaces.js:2745
 msgid "Configure"
 msgstr "Nastavit"
 
-#: pkg/docker/storage.jsx:331
+#: pkg/docker/storage.jsx:335
 msgid "Configure storage..."
 msgstr "Nastavit úložiště…"
 
-#: pkg/networkmanager/interfaces.js:837
+#: pkg/networkmanager/interfaces.js:842
 msgid "Configuring"
 msgstr "Nastavuje se"
 
-#: pkg/networkmanager/interfaces.js:841
+#: pkg/networkmanager/interfaces.js:846
 msgid "Configuring IP"
 msgstr "Nastavuje se IP adresa"
 
 # auto translated by TM merge from project: ibus-input-pad, version: head, DocId: ibus-input-pad
-#: pkg/shell/index.html:297 pkg/users/index.html:176
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/shell/index.html:298 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:315
 msgid "Confirm"
 msgstr "Potvrdit"
 
@@ -1667,15 +1719,15 @@ msgstr "Potvrdit nové heslo"
 msgid "Confirm deletion of the Virtual Network"
 msgstr "Potvrďte smazání virtuální sítě"
 
-#: pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:372
 msgid "Confirm removal with passphrase"
 msgstr "Potvrdit odebrání pomocí heslové fráze"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
 msgstr "V konfliktu s"
 
-#: pkg/systemd/service-details.jsx:425
+#: pkg/systemd/service-details.jsx:427
 msgid "Conflicts"
 msgstr "Konflikty"
 
@@ -1684,7 +1736,7 @@ msgstr "Konflikty"
 msgid "Connect"
 msgstr "Připojit"
 
-#: pkg/networkmanager/interfaces.js:2724
+#: pkg/networkmanager/interfaces.js:2732
 msgid "Connect automatically"
 msgstr "Připojit se automaticky"
 
@@ -1721,24 +1773,27 @@ msgstr "Připojování k procesu služby SETroubleshoot…"
 msgid "Connecting to Virtualization Service"
 msgstr "Připojuje se ke službě virtualizace"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:467
 msgid "Connecting to the machine"
 msgstr "Připojování ke stroji"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
 #: pkg/machines/components/machinesConnectionSelector.jsx:34
-#: pkg/machines/components/networks/createNetworkDialog.jsx:106
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Spojení"
 
-#: pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:414
 msgid "Connection Error"
 msgstr "Chyba připojení"
 
-#: src/base1/cockpit.js:4027
+#: pkg/shell/index.html:396
+msgid "Connection failed"
+msgstr "Připojení se nezdařilo"
+
+#: src/base1/cockpit.js:4031
 msgid "Connection has timed out."
 msgstr "Překročen časový limit připojení."
 
@@ -1746,7 +1801,7 @@ msgstr "Překročen časový limit připojení."
 msgid "Connection will be lost"
 msgstr "Spojení bude ztraceno"
 
-#: pkg/systemd/service-details.jsx:424
+#: pkg/systemd/service-details.jsx:426
 msgid "Consists Of"
 msgstr "Sestává se z"
 
@@ -1754,7 +1809,7 @@ msgstr "Sestává se z"
 msgid "Console Type"
 msgstr "Typ konzole"
 
-#: pkg/machines/components/vm/vm.jsx:51
+#: pkg/machines/components/vm/vm.jsx:53
 msgid "Consoles"
 msgstr "Konzole"
 
@@ -1763,7 +1818,6 @@ msgid "Contacted domain"
 msgstr "Připojená doména"
 
 #: pkg/docker/console.html:4
-#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Kontejner"
 
@@ -1803,16 +1857,16 @@ msgid "Containers"
 msgstr "Kontejnery"
 
 # auto translated by TM merge from project: comps, version: master, DocId: po/comps
-#: pkg/storaged/content-views.jsx:557
+#: pkg/storaged/content-views.jsx:570
 msgid "Content"
 msgstr "Obsah"
 
-#: src/base1/test-locale.js:42 src/base1/test-locale.js:53
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:56
 #: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Ovládání"
 
-#: src/base1/test-locale.js:43 src/base1/test-locale.js:55
+#: src/base1/test-locale.js:46 src/base1/test-locale.js:58
 #: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
@@ -1834,7 +1888,7 @@ msgstr "Zkopírovat do schránky"
 msgid "Cores per socket"
 msgstr "Jader na patici"
 
-#: pkg/docker/storage.jsx:428
+#: pkg/docker/storage.jsx:438
 msgid "Could not add all disks"
 msgstr "Nedaří se přidat všechny disky"
 
@@ -1842,7 +1896,7 @@ msgstr "Nedaří se přidat všechny disky"
 msgid "Could not contact {{host}}"
 msgstr "Nedaří se kontaktovat {{host}}"
 
-#: pkg/docker/storage.jsx:468
+#: pkg/docker/storage.jsx:484
 msgid "Could not reset the storage pool"
 msgstr "Nedaří se resetovat fond úložiště"
 
@@ -1854,7 +1908,7 @@ msgstr "Nedaří se změnit skupiny uživatele"
 msgid "Couldn't change user password"
 msgstr "Nedaří se změnit heslo uživatele"
 
-#: pkg/shell/indexes.js:419
+#: pkg/shell/indexes.js:470
 msgid "Couldn't connect to the machine"
 msgstr "Nedaří se připojit ke stroji"
 
@@ -1874,29 +1928,30 @@ msgstr "Nedaří se vypsat uživatele"
 msgid "Couldn't load user data"
 msgstr "Nedaří se načíst data uživatele"
 
-#: pkg/kdump/kdump-view.jsx:336 pkg/kdump/kdump-view.jsx:504
+#: pkg/kdump/kdump-view.jsx:337 pkg/kdump/kdump-view.jsx:506
 msgid "Crash dump location"
 msgstr "Umístění výpisu paměti pádu"
 
-#: pkg/kdump/kdump-view.jsx:304
+#: pkg/kdump/kdump-view.jsx:305
 msgid "Crash system"
 msgstr "Zhavarovat systém"
 
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
-#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/networks/createNetworkDialog.jsx:482
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:96
+#: pkg/storaged/content-views.jsx:127 pkg/storaged/content-views.jsx:709
+#: pkg/storaged/lvol-tabs.jsx:360 pkg/storaged/mdraids-panel.jsx:103
+#: pkg/storaged/vdos-panel.jsx:113 pkg/storaged/vgroups-panel.jsx:72
 msgid "Create"
 msgstr "Vytvořit"
 
-#: pkg/storaged/content-views.jsx:639
+#: pkg/storaged/content-views.jsx:653
 msgid "Create Logical Volume"
 msgstr "Vytvořit logický svazek"
 
-#: pkg/machines/components/diskAdd.jsx:552
+#: pkg/machines/components/diskAdd.jsx:423
 msgid "Create New"
 msgstr "Vytvořit nový"
 
@@ -1904,20 +1959,24 @@ msgstr "Vytvořit nový"
 msgid "Create New Account"
 msgstr "Vytvořit nový účet"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+msgid "Create New Volume"
+msgstr "Vytvořit nový svazek"
+
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
+#: pkg/storaged/content-views.jsx:439 pkg/storaged/format-dialog.jsx:336
 msgid "Create Partition"
 msgstr "Vytvořit oddíl"
 
-#: pkg/storaged/content-views.jsx:552
+#: pkg/storaged/content-views.jsx:565
 msgid "Create Partition Table"
 msgstr "Vytvořit tabulku rozdělení na oddíly"
 
-#: pkg/storaged/format-dialog.jsx:184
+#: pkg/storaged/format-dialog.jsx:189
 msgid "Create Partition on $0"
 msgstr "Vytvořit oddíl na $0"
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/mdraids-panel.jsx:39
 msgid "Create RAID Device"
 msgstr "Vytvořit RAID zařízení"
 
@@ -1925,7 +1984,7 @@ msgstr "Vytvořit RAID zařízení"
 msgid "Create Report"
 msgstr "Vytvořit výkaz"
 
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
+#: pkg/storaged/lvol-tabs.jsx:354 pkg/storaged/lvol-tabs.jsx:395
 msgid "Create Snapshot"
 msgstr "Pořídit zachycený stav"
 
@@ -1933,7 +1992,7 @@ msgstr "Pořídit zachycený stav"
 msgid "Create Storage Pool"
 msgstr "Vytvořit fond úložiště"
 
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:138
 msgid "Create Thin Volume"
 msgstr "Vytvořit tenký svazek"
 
@@ -1945,7 +2004,7 @@ msgstr "Vytvořit časovač"
 msgid "Create Timers"
 msgstr "Vytvořit časovače"
 
-#: pkg/storaged/vdos-panel.jsx:46
+#: pkg/storaged/vdos-panel.jsx:47
 msgid "Create VDO Device"
 msgstr "Vytvořit VDO zařízení"
 
@@ -1953,12 +2012,17 @@ msgstr "Vytvořit VDO zařízení"
 msgid "Create VM"
 msgstr "Vytvořit virt. stroj"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:477
-#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+#: pkg/machines/components/networks/createNetworkDialog.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:516
 msgid "Create Virtual Network"
 msgstr "Vytvořit virtuální síť"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:135
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:148
+msgid "Create Volume"
+msgstr "Vytvořit svazek"
+
+#: pkg/storaged/vgroups-panel.jsx:54
 msgid "Create Volume Group"
 msgstr "Vytvořit skupinu svazků"
 
@@ -1966,12 +2030,12 @@ msgstr "Vytvořit skupinu svazků"
 msgid "Create diagnostic report"
 msgstr "Vytvořit diagnostické hlášení"
 
-#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
-#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
+#: pkg/networkmanager/interfaces.js:3850 pkg/networkmanager/interfaces.js:4050
+#: pkg/networkmanager/interfaces.js:4305 pkg/networkmanager/interfaces.js:4510
 msgid "Create it"
 msgstr "Vytvořit to"
 
-#: pkg/storaged/content-views.jsx:708
+#: pkg/storaged/content-views.jsx:728
 msgid "Create new Logical Volume"
 msgstr "Vytvořit nový logický svazek"
 
@@ -2004,7 +2068,7 @@ msgstr "Vytváří se oddíl $target"
 msgid "Creating snapshot of $target"
 msgstr "Pořizování zachyceného stavu $target"
 
-#: pkg/networkmanager/interfaces.js:4491
+#: pkg/networkmanager/interfaces.js:4509
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2012,7 +2076,7 @@ msgstr ""
 "Vytvoření této VLAN přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:3833
+#: pkg/networkmanager/interfaces.js:3849
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2020,7 +2084,7 @@ msgstr ""
 "Vytvoření tohoto sdružení linek přeruší spojení se serverem a znepřístupní "
 "tak rozhraní pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:4286
+#: pkg/networkmanager/interfaces.js:4304
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2028,7 +2092,7 @@ msgstr ""
 "Vytvoření tohoto mostu přeruší spojení se serverem a znepřístupní tak "
 "rozhraní pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:4032
+#: pkg/networkmanager/interfaces.js:4049
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2065,23 +2129,23 @@ msgid "Current boot"
 msgstr "Od tohoto spuštění systému"
 
 # auto translated by TM merge from project: libreport, version: rhel6, DocId: libreport
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Uživatelsky určené"
 
-#: pkg/networkmanager/firewall.jsx:548
+#: pkg/networkmanager/firewall.jsx:550
 msgid "Custom Ports"
 msgstr "Uživatelsky určené porty"
 
-#: pkg/storaged/format-dialog.jsx:118
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Custom encryption options"
 msgstr "Uživatelsky určené předvolby šifrování"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/format-dialog.jsx:95 pkg/storaged/nfs-details.jsx:183
 msgid "Custom mount options"
 msgstr "Uživatelsky určené předvolby připojení"
 
-#: pkg/networkmanager/firewall.jsx:748
+#: pkg/networkmanager/firewall.jsx:750
 msgid "Custom zones"
 msgstr "Uživatelsky určené zóny"
 
@@ -2095,19 +2159,19 @@ msgid "DISK IS FAILING"
 msgstr "DISK SELHÁVÁ"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:3328
+#: pkg/networkmanager/interfaces.js:3339
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3332
+#: pkg/networkmanager/interfaces.js:3343
 msgid "DNS Search Domains"
 msgstr "DNS prohledávané domény"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "DNS Search Domains $val"
 msgstr "Prohledávat DNS domény $val"
 
@@ -2119,17 +2183,17 @@ msgstr "Tmavý"
 msgid "Dashboard"
 msgstr "Přehled"
 
-#: pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/lvol-tabs.jsx:463
 msgid "Data Used"
 msgstr "Využito dat"
 
 #: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
-#: pkg/storaged/content-views.jsx:254
+#: pkg/storaged/content-views.jsx:259
 msgid "Deactivate"
 msgstr "Deaktivovat"
 
-#: pkg/networkmanager/interfaces.js:849
+#: pkg/networkmanager/interfaces.js:854
 msgid "Deactivating"
 msgstr "Deaktivuje se"
 
@@ -2141,18 +2205,17 @@ msgstr "Deaktivuje se $target"
 msgid "Debug and above"
 msgstr "Ladící a závažnější"
 
-#: pkg/storaged/vdo-details.jsx:310 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdo-details.jsx:316 pkg/storaged/vdos-panel.jsx:91
 msgid "Deduplication"
 msgstr "Deduplikace"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
-#: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
 msgstr "Výchozí"
 
-#: pkg/systemd/index.html:438
+#: pkg/systemd/index.html:449
 msgid "Delay"
 msgstr "Prodleva"
 
@@ -2160,7 +2223,7 @@ msgstr "Prodleva"
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/details.js:293 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
@@ -2168,16 +2231,23 @@ msgstr "Prodleva"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
+#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:319
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
+#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
+#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Smazat"
 
-#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2454 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Smazat $0"
+
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:67
+msgid "Delete $0 volume"
+msgid_plural "Delete $0 volumes"
+msgstr[0] "Smazat $0 svazek"
+msgstr[1] "Smazat $0 svazky"
+msgstr[2] "Smazat $0 svazků"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
@@ -2207,7 +2277,7 @@ msgstr "Smazat svazek v tomto fondu"
 msgid "Deleting $target"
 msgstr "Maže se $target"
 
-#: pkg/networkmanager/interfaces.js:2446
+#: pkg/networkmanager/interfaces.js:2453
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2215,27 +2285,27 @@ msgstr ""
 "Smazání <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/storaged/mdraid-details.jsx:300
+#: pkg/storaged/mdraid-details.jsx:296
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Smazání RAID zařízení vymaže veškerá data, která se na něm nacházejí."
 
-#: pkg/storaged/vdo-details.jsx:200
+#: pkg/storaged/vdo-details.jsx:204
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Smazání VDO zařízení vymaže veškerá data na něm."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:292
 msgid "Deleting a container will erase all data in it."
 msgstr "Smazání kontejneru vymaže veškerá data v něm."
 
-#: pkg/storaged/content-views.jsx:273
+#: pkg/storaged/content-views.jsx:278
 msgid "Deleting a logical volume will delete all data in it."
 msgstr "Smazání logického svazku vymaže veškerá data na něm."
 
-#: pkg/storaged/content-views.jsx:276
+#: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr "Smazání oddílu vymaže veškerá data v něm."
 
-#: pkg/storaged/vgroup-details.jsx:212
+#: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Smazání skupiny svazků vymaže veškerá data v ní."
 
@@ -2252,15 +2322,14 @@ msgid "Deleting volume group $target"
 msgstr "Maže se skupina svazků $target"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/systemd/services.html:268
-#: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:759
+#: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Popis"
 
 #: pkg/playground/manifest.json.in
 msgid "Design Patterns"
-msgstr ""
+msgstr "Návrhové vzory"
 
 # auto translated by TM merge from project: Fedora Websites, version: arm.fedoraproject.org, DocId: po/arm.fedoraproject.org
 #: pkg/lib/machine-info.js:66
@@ -2280,44 +2349,39 @@ msgid "Detachable"
 msgstr "Odpojitelné"
 
 # auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
-#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
-#: pkg/systemd/host.js:762
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:384
+#: pkg/systemd/host.js:786 pkg/systemd/host.js:797
 msgid "Details"
 msgstr "Podrobnosti"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/machines/components/networks/createNetworkDialog.jsx:169
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:155
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
-#: pkg/machines/components/vmDisksTab.jsx:58
+#: pkg/machines/components/vmDisksTab.jsx:96
 msgid "Device"
 msgstr "Zařízení"
 
-#: pkg/storaged/vdo-details.jsx:267
+#: pkg/storaged/vdo-details.jsx:273
 msgid "Device File"
 msgstr "Soubor představující zařízení"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:564
 msgid "Device is read-only"
 msgstr "Zařízení je pouze pro čtení"
 
 #: pkg/sosreport/manifest.json.in
 msgid "Diagnostic Reports"
-msgstr ""
+msgstr "Diagnostická hlášení"
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Diagnostická hlášení"
 
-#: node_modules/registry-image-widgets/views/image-body.html:22
-msgid "Digest"
-msgstr "Otisk"
-
 # auto translated by TM merge from project: usermode, version: default, DocId: usermode
-#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Složka"
@@ -2326,16 +2390,16 @@ msgstr "Složka"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Složka $0 není zapisovatelná nebo neexistuje."
 
-#: pkg/systemd/hwinfo.jsx:191
+#: pkg/systemd/hwinfo.jsx:195
 msgid "Disable simultaneous multithreading"
 msgstr "Vypnout souběžné vícevláknové zpracovávání"
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:233
 msgid "Disable tuned"
 msgstr "Vypnout proces služby tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1981
+#: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Vypnuto"
 
@@ -2348,7 +2412,7 @@ msgid "Disconnect"
 msgstr "Odpojit"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
+#: pkg/shell/indexes.js:180 pkg/shell/indexes.js:660
 msgid "Disconnected"
 msgstr "Odpojeno"
 
@@ -2357,7 +2421,7 @@ msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Odpojeno od sériové konzole. Klikněte na tlačítko Znovu připojit"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/storaged/vdos-panel.jsx:55
+#: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Disk"
 
@@ -2366,15 +2430,15 @@ msgid "Disk $0 fail to get detached from VM $1"
 msgstr "Disk $0 se nepodařilo odpojit od virt. stroje $1"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:588
 msgid "Disk I/O"
 msgstr "Diskový vst/výst."
 
-#: pkg/machines/components/diskAdd.jsx:525
+#: pkg/machines/components/diskAdd.jsx:396
 msgid "Disk failed to be attached"
 msgstr "Disk se nepodařilo připojit"
 
-#: pkg/machines/components/diskAdd.jsx:504
+#: pkg/machines/components/diskAdd.jsx:373
 msgid "Disk failed to be created"
 msgstr "Disk se nepodařilo vytvořit"
 
@@ -2387,9 +2451,9 @@ msgid "Disk passphrase"
 msgstr "Heslová fráze k disku"
 
 # auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
+#: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
 msgid "Disks"
 msgstr "Disky"
 
@@ -2404,11 +2468,7 @@ msgstr "Jazyk zobrazení"
 
 #: pkg/docker/manifest.json.in
 msgid "Docker Containers"
-msgstr ""
-
-#: node_modules/registry-image-widgets/views/image-meta.html:10
-msgid "Docker Version"
-msgstr "Verze Docker"
+msgstr "Docker kontejnery"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
@@ -2418,7 +2478,7 @@ msgstr "Docker na tomto systému není nainstalovaný nebo aktivovaný"
 msgid "Docking Station"
 msgstr "Dokovací stanice"
 
-#: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
+#: pkg/realmd/operation.html:11 pkg/systemd/index.html:125
 #: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Doména"
@@ -2444,11 +2504,11 @@ msgid "Domain Administrator Password"
 msgstr "Heslo správce domény"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1085
+#: pkg/systemd/init.js:1147
 msgid "Don't Repeat"
 msgstr "Neopakovat"
 
-#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
+#: pkg/storaged/content-views.jsx:524 pkg/storaged/format-dialog.jsx:289
 msgid "Don't overwrite existing data"
 msgstr "Nepřepisovat existující data"
 
@@ -2483,22 +2543,16 @@ msgstr "Staženo"
 msgid "Downloading"
 msgstr "Stahuje se"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:179
+#: pkg/lib/cockpit-components-install-dialog.jsx:180
 msgid "Downloading $0"
 msgstr "Stahuje se $0"
 
 # auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/docker/storage.jsx:167 pkg/storaged/drive-details.jsx:68
+#: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Jednotka"
 
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
-msgctxt "storage"
-msgid "Drive"
-msgstr "Jednotka"
-
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:102
 msgid "Drives"
 msgstr "Jednotky"
 
@@ -2515,8 +2569,8 @@ msgid "Duplicate port"
 msgstr "Duplikovat port"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
-#: pkg/storaged/nfs-details.jsx:306
+#: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/nfs-details.jsx:314
 msgid "Edit"
 msgstr "Upravit"
 
@@ -2524,15 +2578,11 @@ msgstr "Upravit"
 msgid "Edit Server"
 msgstr "Upravit server"
 
-#: pkg/storaged/crypto-keyslots.jsx:270
+#: pkg/storaged/crypto-keyslots.jsx:276
 msgid "Edit Tang keyserver"
 msgstr "Upravit Tang server s klíči"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:7
-msgid "Edit image stream"
-msgstr "Upravit proud obrazů"
-
-#: pkg/storaged/crypto-keyslots.jsx:535
+#: pkg/storaged/crypto-keyslots.jsx:548
 msgid "Editing a key requires a free slot"
 msgstr "K upravení klíče je zapotřebí volného slotu"
 
@@ -2545,14 +2595,14 @@ msgid "Embedded PC"
 msgstr "Jednodeskový počítač"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
+#: pkg/playground/translate.html:57 src/base1/test-locale.js:47
+#: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Prázdný"
 
 # auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
+#: pkg/playground/translate.html:62 src/base1/test-locale.js:48
+#: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Prázdný"
@@ -2569,53 +2619,53 @@ msgstr "Emulovaný stroj"
 msgid "Enable Service"
 msgstr "Zapnout službu"
 
-#: pkg/systemd/index.html:161
+#: pkg/systemd/index.html:168
 msgid "Enable stored metrics…"
 msgstr "Zapnout uchovávání metrik…"
 
-#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:216
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: pkg/storaged/format-dialog.jsx:292
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Encrypt data"
 msgstr "Šifrovat data"
 
-#: pkg/storaged/utils.js:273
+#: pkg/storaged/utils.js:274
 msgid "Encrypted $0"
 msgstr "Šifrované $0"
 
-#: pkg/storaged/utils.js:265
+#: pkg/storaged/utils.js:266
 msgid "Encrypted Logical Volume of $0"
 msgstr "Šifrovaný logický svazek na $0"
 
-#: pkg/storaged/utils.js:267
+#: pkg/storaged/utils.js:268
 msgid "Encrypted Partition of $0"
 msgstr "Šifrovaný oddíl na $0"
 
-#: pkg/storaged/content-views.jsx:348
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Šifrovaná data"
 
-#: pkg/storaged/lvol-tabs.jsx:140
+#: pkg/storaged/lvol-tabs.jsx:141
 msgid "Encrypted volumes can not be resized here."
 msgstr "Zde není možné upravovat velikost šifrovaných svazků."
 
-#: pkg/storaged/lvol-tabs.jsx:143
+#: pkg/storaged/lvol-tabs.jsx:144
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr "Šifrované svazky je třeba před změnou velikosti odemknout."
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Šifrování"
 
-#: pkg/storaged/crypto-tab.jsx:102
+#: pkg/storaged/crypto-tab.jsx:105
 msgid "Encryption Options"
 msgstr "Volby šifrování"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+#: pkg/machines/components/networks/createNetworkDialog.jsx:238
 msgid "End"
 msgstr "Konec"
 
@@ -2628,11 +2678,11 @@ msgstr "Konec je třeba vyplnit"
 msgid "Enforcing"
 msgstr "Vynucující"
 
-#: pkg/systemd/host.js:510
+#: pkg/systemd/host.js:513
 msgid "Enhancement Updates Available"
 msgstr "Jsou k dispozici vylepšující aktualizace"
 
-#: pkg/lib/machine-dialogs.js:445
+#: pkg/lib/machine-dialogs.js:447
 msgid "Enter IP address or host name"
 msgstr "Zadejte IP adresu nebo název stroje"
 
@@ -2644,7 +2694,7 @@ msgstr ""
 "Zadání jiného hesla zde znamená, že ho bude třeba zadávat pokaždé znovu při "
 "připojování k tomuto stroji"
 
-#: pkg/networkmanager/firewall.jsx:784
+#: pkg/networkmanager/firewall.jsx:786
 msgid "Entire subnet"
 msgstr "Celá podsíť"
 
@@ -2658,16 +2708,15 @@ msgid "Entrypoint"
 msgstr "Koncový bod"
 
 #: pkg/docker/index.html:528
-#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Prostředí"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
-#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:286
 msgid "Erase"
 msgstr "Smazat"
 
-#: pkg/docker/storage.jsx:447
+#: pkg/docker/storage.jsx:460
 msgid "Erase containers and reset storage pool"
 msgstr "Vymazat kontejnery a resetovat fond úložiště"
 
@@ -2675,14 +2724,14 @@ msgstr "Vymazat kontejnery a resetovat fond úložiště"
 msgid "Erasing $target"
 msgstr "Vymazává se $target"
 
-#: pkg/packagekit/updates.jsx:312
+#: pkg/packagekit/updates.jsx:313
 msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
-#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
+#: pkg/storaged/storage-controls.jsx:100 pkg/storaged/storage-controls.jsx:194
+#: pkg/systemd/service-details.jsx:450 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Chyba"
 
@@ -2722,7 +2771,7 @@ msgstr "Ethernet MAC adresa"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2015
+#: pkg/networkmanager/interfaces.js:2027
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2731,11 +2780,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Vše"
 
-#: pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:563
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Příklad: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:569
+#: pkg/networkmanager/firewall.jsx:571
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Příkaz: 88,2019,nfs,rsync"
 
@@ -2745,7 +2794,7 @@ msgstr "Skvělé heslo"
 
 #: pkg/playground/manifest.json.in
 msgid "Exceptions"
-msgstr ""
+msgstr "Výjimky"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
@@ -2763,21 +2812,21 @@ msgstr "Rozšiřující šasi"
 msgid "Expose container ports"
 msgstr "Odhalit porty kontejneru"
 
-#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:459 pkg/storaged/format-dialog.jsx:259
 msgid "Extended Partition"
 msgstr "Rozšířený oddíl"
 
 # auto translated by TM merge from project: appstream-glib, version: master, DocId: appstream-glib
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "NEZDAŘILO SE"
 
 # auto translated by TM merge from project: retrace-server, version: master, DocId: retrace-server
-#: pkg/networkmanager/interfaces.js:851
+#: pkg/networkmanager/interfaces.js:856
 msgid "Failed"
 msgstr "Neúspěšné"
 
-#: pkg/lib/machine-dialogs.js:410
+#: pkg/lib/machine-dialogs.js:412
 msgid "Failed to add machine: $0"
 msgstr "Nepodařilo se přidat stroj: $0"
 
@@ -2789,7 +2838,7 @@ msgstr "Přidání portu se nezdařilo"
 msgid "Failed to add service"
 msgstr "Službu se nepodařilo přidat"
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:711
 msgid "Failed to add zone"
 msgstr "Zónu se nepodařilo přidat"
 
@@ -2809,7 +2858,7 @@ msgstr "Nepodařilo se zakázat proces služby tuned"
 msgid "Failed to disable tuned profile"
 msgstr "Nepodařilo se vypnout profil tuned"
 
-#: pkg/lib/machine-dialogs.js:492
+#: pkg/lib/machine-dialogs.js:494
 msgid "Failed to edit machine: $0"
 msgstr "Nepodařilo se  upravit stroj: $0"
 
@@ -2817,7 +2866,7 @@ msgstr "Nepodařilo se  upravit stroj: $0"
 msgid "Failed to enable tuned"
 msgstr "Nepodařilo se zapnout tuned"
 
-#: pkg/machines/components/vmnetworktab.jsx:55
+#: pkg/machines/components/vmnetworktab.jsx:60
 msgid "Failed to fetch the IP addresses of the interfaces present in $0"
 msgstr "Nepodařilo se zjistit IP adresy rozhraní nacházející se v $0"
 
@@ -2825,11 +2874,11 @@ msgstr "Nepodařilo se zjistit IP adresy rozhraní nacházející se v $0"
 msgid "Failed to load authorized keys."
 msgstr "Nepodařilo se nahrát ověřovací klíče."
 
-#: pkg/networkmanager/firewall.jsx:621
+#: pkg/networkmanager/firewall.jsx:623
 msgid "Failed to remove service"
 msgstr "Službu se nepodařilo odbrat"
 
-#: pkg/systemd/service-details.jsx:340
+#: pkg/systemd/service-details.jsx:342
 msgid "Failed to start"
 msgstr "Nepodařilo se spustit"
 
@@ -2856,7 +2905,7 @@ msgid "File"
 msgstr "Soubor"
 
 # auto translated by TM merge from project: usermode, version: default, DocId: usermode
-#: pkg/storaged/content-views.jsx:145
+#: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "Souborový systém"
 
@@ -2864,11 +2913,11 @@ msgstr "Souborový systém"
 msgid "Filesystem Directory"
 msgstr "Složka v souborovém systému"
 
-#: pkg/storaged/fsys-tab.jsx:123
+#: pkg/storaged/fsys-tab.jsx:126
 msgid "Filesystem Mounting"
 msgstr "Připojování souborového systému"
 
-#: pkg/storaged/fsys-tab.jsx:70
+#: pkg/storaged/fsys-tab.jsx:71
 msgid "Filesystem Name"
 msgstr "Název souborového systému"
 
@@ -2877,7 +2926,7 @@ msgstr "Název souborového systému"
 msgid "Filesystems"
 msgstr "Souborové systémy"
 
-#: pkg/networkmanager/firewall.jsx:516
+#: pkg/networkmanager/firewall.jsx:518
 msgid "Filter Services"
 msgstr "Filtrovat služby"
 
@@ -2886,28 +2935,24 @@ msgid "Filter by name or description..."
 msgstr "Filtrovat podle názvu nebo popisu…"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Otisk"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
+#: pkg/networkmanager/firewall.jsx:947 pkg/networkmanager/firewall.jsx:950
 msgid "Firewall"
 msgstr "Brána firewall"
 
-#: pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:895
 msgid "Firewall is not available"
 msgstr "Brána firewall není k dispozici"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:35
-msgid "Follows docker repo"
-msgstr "Následuje docker repozitář"
-
-#: pkg/storaged/vdos-panel.jsx:88
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "For legacy applications only. Reduces performance."
 msgstr "Pouze pro staré aplikace. Snižuje výkon."
 
-#: pkg/systemd/service-details.jsx:322
+#: pkg/systemd/service-details.jsx:324
 msgid "Forbidden from running"
 msgstr "Spuštění zakázáno"
 
@@ -2931,59 +2976,59 @@ msgstr "Vynutit vypnutí"
 msgid "Force password change"
 msgstr "Vynutit změnu hesla"
 
-#: pkg/storaged/crypto-keyslots.jsx:373
+#: pkg/storaged/crypto-keyslots.jsx:381
 msgid "Force remove passphrase in $0"
 msgstr "Vynutit odebrání heslové fráze v $0"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/machines/components/diskAdd.jsx:157
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
+#: pkg/storaged/content-views.jsx:323 pkg/storaged/content-views.jsx:542
+#: pkg/storaged/format-dialog.jsx:336
 msgid "Format"
 msgstr "Formát"
 
-#: pkg/storaged/format-dialog.jsx:186
+#: pkg/storaged/format-dialog.jsx:191
 msgid "Format $0"
 msgstr "Naformátovat $0"
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/storaged/content-views.jsx:518
 msgid "Format Disk $0"
 msgstr "Naformátovat disk $0"
 
-#: pkg/storaged/content-views.jsx:531
+#: pkg/storaged/content-views.jsx:543
 msgid "Formatting a disk will erase all data on it."
 msgstr "Formátování disku vymaže všechna data, která na něm nyní jsou."
 
-#: pkg/storaged/format-dialog.jsx:325
+#: pkg/storaged/format-dialog.jsx:338
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "Formátování úložného zařízení vymaže všechna data, která na něm nyní jsou."
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+#: pkg/machines/components/networks/createNetworkDialog.jsx:133
 msgid "Forward Mode"
 msgstr "Režim přeposílání"
 
-#: pkg/networkmanager/interfaces.js:2873
+#: pkg/networkmanager/interfaces.js:2881
 msgid "Forward delay $forward_delay"
 msgstr "Prodleva přeposlání $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:55
 msgid "Forwarding mode"
 msgstr "Režim přeposílání"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
+#: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Volno"
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/content-views.jsx:440
+#: pkg/storaged/content-views.jsx:445
 msgid "Free Space"
 msgstr "Volné místo"
 
-#: pkg/storaged/lvol-tabs.jsx:371
+#: pkg/storaged/lvol-tabs.jsx:379
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -3000,10 +3045,6 @@ msgstr "pátek"
 msgid "Fridays"
 msgstr "Pátky"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:6
-msgid "From"
-msgstr "Z"
-
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
@@ -3016,9 +3057,13 @@ msgstr "Brána:"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2723 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Obecné"
+
+#: pkg/machines/components/nicAdd.jsx:49
+msgid "Generate automatically"
+msgstr "Vytvořit automaticky"
 
 #: pkg/sosreport/index.html:55
 msgid "Generating report"
@@ -3029,15 +3074,15 @@ msgid "Get new image"
 msgstr "Získat nový obraz"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
-#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/vmDisksTab.jsx:51
 msgid "GiB"
 msgstr "GiB"
 
-#: pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:200
 msgid "Go to"
 msgstr "Jít na"
 
@@ -3046,7 +3091,7 @@ msgid "Go to Application"
 msgstr "Přejít na aplikaci"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Přejít na nyní"
@@ -3059,21 +3104,21 @@ msgstr "Grafická konzole (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Grafická konzole v desktopovém prohlížeči"
 
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
-#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
-#: pkg/storaged/vdo-details.jsx:298
+#: pkg/storaged/lvol-tabs.jsx:239 pkg/storaged/lvol-tabs.jsx:407
+#: pkg/storaged/lvol-tabs.jsx:459 pkg/storaged/vdo-details.jsx:235
+#: pkg/storaged/vdo-details.jsx:304
 msgid "Grow"
 msgstr "Zvětšit"
 
-#: pkg/storaged/lvol-tabs.jsx:417
+#: pkg/storaged/lvol-tabs.jsx:425
 msgid "Grow Content"
 msgstr "Zvětšit obsah"
 
-#: pkg/storaged/lvol-tabs.jsx:231
+#: pkg/storaged/lvol-tabs.jsx:235
 msgid "Grow Logical Volume"
 msgstr "Zvětšit logický svazek"
 
-#: pkg/storaged/vdo-details.jsx:218
+#: pkg/storaged/vdo-details.jsx:223
 msgid "Grow logical size of $0"
 msgstr "Zvětšit logickou velikost $0"
 
@@ -3085,7 +3130,7 @@ msgstr "Zvětšit a využít veškerý dostupný prostor"
 msgid "Hair Pin mode"
 msgstr "Hair Pin režim"
 
-#: pkg/networkmanager/interfaces.js:2899
+#: pkg/networkmanager/interfaces.js:2907
 msgid "Hairpin mode"
 msgstr "Hair Pin režim"
 
@@ -3094,13 +3139,7 @@ msgid "Hand Held"
 msgstr "Pro držení v rukou"
 
 # auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/docker/storage.jsx:166
-msgid "Hard Disk"
-msgstr "Pevný disk"
-
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/storaged/drives-panel.jsx:85
-msgctxt "storage"
+#: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Pevný disk"
 
@@ -3109,15 +3148,15 @@ msgstr "Pevný disk"
 msgid "Hardware"
 msgstr "Hardware"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:274
 msgid "Hardware Information"
 msgstr "Informace o hardware"
 
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2883
 msgid "Hello time $hello_time"
 msgstr "Oznamovací čas $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Hide Performance Options"
 msgstr "Předvolby pro výkonnost"
 
@@ -3125,7 +3164,7 @@ msgstr "Předvolby pro výkonnost"
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:389
 msgid "Host"
 msgstr "Počítač"
 
@@ -3134,16 +3173,16 @@ msgid "Host Device"
 msgstr "Zařízení hostitele"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Název počítače"
 
-#: src/base1/cockpit.js:4023
+#: src/base1/cockpit.js:4027
 msgid "Host key is incorrect"
 msgstr "Klíč stroje není správný"
 
-#: pkg/realmd/operation.js:601
+#: pkg/realmd/operation.js:603
 msgid "Host name should not be changed in a domain"
 msgstr "Název stroje není v doméně možné měnit"
 
@@ -3155,7 +3194,7 @@ msgstr "Hostitele je třeba vyplnit"
 msgid "Hour : Minute"
 msgstr "Hodina:minuta"
 
-#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
+#: pkg/systemd/init.js:1223 pkg/systemd/init.js:1252
 msgid "Hour needs to be a number between 0-23"
 msgstr "Je třeba, aby hodina bylo číslo z rozmezí 0 až 23"
 
@@ -3164,17 +3203,17 @@ msgstr "Je třeba, aby hodina bylo číslo z rozmezí 0 až 23"
 msgid "Hours"
 msgstr "Hodin"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
+#: pkg/systemd/index.html:249 pkg/systemd/host.js:1642
 msgid "I/O Wait"
 msgstr "Čekání na vst./výst."
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "ID"
 msgstr "Identif."
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
-#: pkg/machines/components/vmnetworktab.jsx:133
+#: pkg/machines/components/vmnetworktab.jsx:143
 msgid "IP Address"
 msgstr "IP adresa"
 
@@ -3183,7 +3222,7 @@ msgstr "IP adresa"
 msgid "IP Address:"
 msgstr "IP adresa:"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+#: pkg/machines/components/networks/createNetworkDialog.jsx:183
 msgid "IP Configuration"
 msgstr "Nastavení IP"
 
@@ -3191,7 +3230,7 @@ msgstr "Nastavení IP"
 msgid "IP Prefix Length:"
 msgstr "Délka předpony IP adresy:"
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "IP Range"
 msgstr "Rozsah IP adres"
 
@@ -3200,7 +3239,7 @@ msgid "IP Settings"
 msgstr "Nastavení IP"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:2924
+#: pkg/networkmanager/interfaces.js:2932
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3208,7 +3247,7 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "IPv4 adresa"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+#: pkg/machines/components/networks/createNetworkDialog.jsx:265
 msgid "IPv4 Network"
 msgstr "IPv4 síť"
 
@@ -3216,20 +3255,20 @@ msgstr "IPv4 síť"
 msgid "IPv4 Network should not be empty"
 msgstr "IPv4 síť je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv4 Settings"
 msgstr "Nastavení IPv4"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+#: pkg/machines/components/networks/createNetworkDialog.jsx:199
 msgid "IPv4 and IPv6"
 msgstr "IPv4 a IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+#: pkg/machines/components/networks/createNetworkDialog.jsx:193
 msgid "IPv4 only"
 msgstr "Pouze IPv4"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:2925
+#: pkg/networkmanager/interfaces.js:2933
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3237,7 +3276,7 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "IPv6 adresa"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+#: pkg/machines/components/networks/createNetworkDialog.jsx:309
 msgid "IPv6 Network"
 msgstr "IPv6 síť"
 
@@ -3245,11 +3284,11 @@ msgstr "IPv6 síť"
 msgid "IPv6 Network should not be empty"
 msgstr "IPv6 síť je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv6 Settings"
 msgstr "Nastavení IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+#: pkg/machines/components/networks/createNetworkDialog.jsx:196
 msgid "IPv6 only"
 msgstr "Pouze IPv6"
 
@@ -3258,7 +3297,7 @@ msgstr "Pouze IPv6"
 msgid "Id"
 msgstr "Identif."
 
-#: pkg/networkmanager/interfaces.js:2916
+#: pkg/networkmanager/interfaces.js:2924
 msgid "Id $id"
 msgstr "Identif. $id"
 
@@ -3267,23 +3306,16 @@ msgstr "Identif. $id"
 msgid "Id:"
 msgstr "Identif.:"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: node_modules/registry-image-widgets/views/image-body.html:24
-#: node_modules/registry-image-widgets/views/image-listing.html:7
-msgid "Identifier"
-msgstr "Identifikátor"
-
-#: pkg/storaged/crypto-keyslots.jsx:325
+#: pkg/storaged/crypto-keyslots.jsx:333
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Pokud tang-show-keys není k dispozici, spusťte následující:"
 
 # auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
-#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1990 pkg/packagekit/updates.jsx:498
 msgid "Ignore"
 msgstr "Ignorovat"
 
 #: pkg/docker/index.html:270 pkg/docker/index.html:433
-#: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
 msgstr "Obraz"
@@ -3299,14 +3331,6 @@ msgstr "Tvorba obrazů"
 #: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Hledání obrazu"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
-msgid "Image count"
-msgstr "Počet obrazů"
-
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
-msgid "Image stream"
-msgstr "Proud obrazu"
 
 #: pkg/docker/index.html:157
 msgid "Image:"
@@ -3325,31 +3349,15 @@ msgstr "Obrazy"
 msgid "Images and running containers"
 msgstr "Obrazy a spuštěné kontejnery"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:15
-#: node_modules/registry-image-widgets/views/imagestream-body.html:16
-msgid "Images may be pulled by anonymous users"
-msgstr "Obrazy mohou být stahovány anonymními uživateli"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:20
-#: node_modules/registry-image-widgets/views/imagestream-body.html:21
-msgid "Images may be pulled by any authenticated user or group"
-msgstr ""
-"Obrazy mohou být stahovány jakýmkoli přihlášeným uživatelem nebo skupinou"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:25
-#: node_modules/registry-image-widgets/views/imagestream-body.html:26
-msgid "Images may only be pulled by specific users or groups"
-msgstr "Obrazy mohou být stahovány pouze konkrétními uživateli či skupinami"
-
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Okamžitě spustit virt. stroj"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Import VM"
-msgstr ""
+msgstr "Importovat virt. stroj"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/storaged/mdraid-details.jsx:94
 msgid "In Sync"
 msgstr "Synchronní"
 
@@ -3369,16 +3377,16 @@ msgstr ""
 "strong}}."
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
-#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:1431
+#: pkg/networkmanager/interfaces.js:1438 pkg/networkmanager/interfaces.js:2626
 msgid "Inactive"
 msgstr "Neaktivní"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Inactive volume"
 msgstr "Neaktivní svazek"
 
-#: pkg/networkmanager/firewall.jsx:762
+#: pkg/networkmanager/firewall.jsx:764
 msgid "Included services"
 msgstr "Obsažené služby"
 
@@ -3386,7 +3394,7 @@ msgstr "Obsažené služby"
 msgid "Incorrect Host Key"
 msgstr "Nesprávný klíč stroje"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:69
+#: pkg/storaged/vdo-details.jsx:307 pkg/storaged/vdos-panel.jsx:73
 msgid "Index Memory"
 msgstr "Paměť indexu"
 
@@ -3394,11 +3402,11 @@ msgstr "Paměť indexu"
 msgid "Info and above"
 msgstr "Informace a závažnější"
 
-#: pkg/docker/storage.jsx:309
+#: pkg/docker/storage.jsx:313
 msgid "Information about the Docker storage pool is not available."
 msgstr "Informace o Docker fondu úložiště nejsou k dispozici."
 
-#: pkg/packagekit/updates.jsx:453
+#: pkg/packagekit/updates.jsx:455
 msgid "Initializing..."
 msgstr "Inicializace…"
 
@@ -3412,12 +3420,12 @@ msgstr "IQN iniciátoru by mělo být vyplněné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/lib/cockpit-components-install-dialog.jsx:116
 #: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Nainstalovat"
 
-#: pkg/packagekit/updates.jsx:808
+#: pkg/packagekit/updates.jsx:809
 msgid "Install All Updates"
 msgstr "Nainstalovat všechny aktualizace"
 
@@ -3425,7 +3433,7 @@ msgstr "Nainstalovat všechny aktualizace"
 msgid "Install NFS Support"
 msgstr "Nainstalovat podporu pro NFS"
 
-#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
+#: pkg/packagekit/updates.jsx:809 pkg/packagekit/updates.jsx:815
 msgid "Install Security Updates"
 msgstr "Nainstalovat aktualizace zabezpečení"
 
@@ -3433,7 +3441,7 @@ msgstr "Nainstalovat aktualizace zabezpečení"
 msgid "Install Software"
 msgstr "Nainstalovat software"
 
-#: pkg/storaged/vdos-panel.jsx:171
+#: pkg/storaged/vdos-panel.jsx:181
 msgid "Install VDO support"
 msgstr "Nainstalovat podporu pro VDO"
 
@@ -3465,11 +3473,11 @@ msgstr "Nainstalováno"
 msgid "Installing"
 msgstr "Instaluje se"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:183
+#: pkg/lib/cockpit-components-install-dialog.jsx:184
 msgid "Installing $0"
 msgstr "Instaluje se $0"
 
-#: pkg/systemd/service-details.jsx:487
+#: pkg/systemd/service-details.jsx:489
 msgid "Instance of template: "
 msgstr "Instance šablony:"
 
@@ -3477,14 +3485,14 @@ msgstr "Instance šablony:"
 msgid "Instantiate"
 msgstr "Vytvořit instanci a spustit"
 
-#: pkg/machines/components/nicEdit.jsx:132
+#: pkg/machines/components/nicBody.jsx:131
 msgid "Interface Type"
 msgstr "Typ rozhraní"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
-#: pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/firewall.jsx:769 pkg/networkmanager/firewall.jsx:957
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Interfaces"
 msgstr "Rozhraní"
 
@@ -3493,7 +3501,7 @@ msgid "Internal Error: Invalid challenge header"
 msgstr "Vnitřní chyba: neplatná hlavička výzvy"
 
 # auto translated by TM merge from project: Pulseaudio, version: 6.0, DocId: pulseaudio.pot
-#: src/base1/cockpit.js:4025
+#: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Vnitřní chyba"
 
@@ -3521,15 +3529,15 @@ msgstr "Neplatná IPv6 předpona"
 msgid "Invalid address $0"
 msgstr "Neplatná adresa $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
+#: pkg/systemd/host.js:1506 pkg/systemd/shutdown.js:143
 msgid "Invalid date format"
 msgstr "Neplatný formát data"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
+#: pkg/systemd/host.js:1502 pkg/systemd/shutdown.js:139
 msgid "Invalid date format and invalid time format"
 msgstr "Neplatný formát data a času"
 
-#: pkg/systemd/init.js:1196
+#: pkg/systemd/init.js:1258
 msgid "Invalid date format."
 msgstr "Neplatný formát data."
 
@@ -3557,7 +3565,7 @@ msgstr "Neplatná metrika $0"
 msgid "Invalid number of days"
 msgstr "Neplatný počet dnů"
 
-#: pkg/systemd/init.js:1143
+#: pkg/systemd/init.js:1205
 msgid "Invalid number."
 msgstr "Neplatné číslo."
 
@@ -3581,15 +3589,15 @@ msgstr "Neplatná předpona nebo maska sítě $0"
 msgid "Invalid range"
 msgstr "Neplatný rozsah"
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
+#: pkg/systemd/host.js:1504 pkg/systemd/shutdown.js:141
 msgid "Invalid time format"
 msgstr "Neplatný formát času"
 
-#: pkg/systemd/index.html:374
+#: pkg/systemd/index.html:385
 msgid "Invalid time zone"
 msgstr "Neplatná časová zóna"
 
-#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:169
 msgid "Invalid username or password"
 msgstr "Neplatné uživatelské jméno a heslo"
 
@@ -3615,7 +3623,7 @@ msgid "Join"
 msgstr "Spojit"
 
 # auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
-#: pkg/realmd/operation.js:596
+#: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Připojit se k doméně"
 
@@ -3624,11 +3632,11 @@ msgstr "Připojit se k doméně"
 msgid "Join a Domain"
 msgstr "Připojit se k doméně"
 
-#: pkg/realmd/operation.js:505
+#: pkg/realmd/operation.js:507
 msgid "Joining this domain is not supported"
 msgstr "Připojení se do této domény není podporováno"
 
-#: pkg/systemd/service-details.jsx:434
+#: pkg/systemd/service-details.jsx:436
 msgid "Joins Namespace Of"
 msgstr "Připojuje jmenný prostor od"
 
@@ -3637,15 +3645,15 @@ msgstr "Připojuje jmenný prostor od"
 msgid "Journal"
 msgstr "Žurnál"
 
-#: pkg/systemd/logs.js:407
+#: pkg/systemd/logs.js:409
 msgid "Journal entry"
 msgstr "Položka žurnálu"
 
-#: pkg/systemd/logs.js:438
+#: pkg/systemd/logs.js:440
 msgid "Journal entry not found"
 msgstr "Položka žurnálu nenalezena"
 
-#: pkg/kdump/kdump-view.jsx:459
+#: pkg/kdump/kdump-view.jsx:461
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
@@ -3665,7 +3673,7 @@ msgid "Kerberos Ticket"
 msgstr "Kerberos tiket"
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Kernel
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
+#: pkg/systemd/index.html:245 pkg/systemd/host.js:1643
 msgid "Kernel"
 msgstr "Jádro"
 
@@ -3673,27 +3681,27 @@ msgstr "Jádro"
 msgid "Kernel Dump"
 msgstr "Výpis paměti jádra"
 
-#: pkg/storaged/crypto-keyslots.jsx:563
+#: pkg/storaged/crypto-keyslots.jsx:576
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Sloty klíčů s neznámým typem zde není možné upravovat"
 
-#: pkg/storaged/crypto-keyslots.jsx:202
+#: pkg/storaged/crypto-keyslots.jsx:204
 msgid "Key source"
 msgstr "Zdroj klíče"
 
-#: pkg/storaged/crypto-keyslots.jsx:586
+#: pkg/storaged/crypto-keyslots.jsx:599
 msgid "Keys"
 msgstr "Klíče"
 
-#: pkg/storaged/crypto-keyslots.jsx:557
+#: pkg/storaged/crypto-keyslots.jsx:570
 msgid "Keyserver"
 msgstr "Server s klíči"
 
-#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:272
+#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Keyserver address"
 msgstr "Adresa serveru s klíči"
 
-#: pkg/storaged/crypto-keyslots.jsx:415
+#: pkg/storaged/crypto-keyslots.jsx:424
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Odebrání serveru s klíči může zabránit odemčení $0."
 
@@ -3704,11 +3712,6 @@ msgstr "LACP klíč"
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "LVM skupina svazků"
-
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: node_modules/registry-image-widgets/views/image-meta.html:3
-msgid "Labels"
-msgstr "Štítky"
 
 #: pkg/lib/machine-info.js:72
 msgid "Laptop"
@@ -3726,13 +3729,9 @@ msgstr "Uplynulých 7 dnů"
 msgid "Last Login"
 msgstr "Poslední přihlášení"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:305
 msgid "Last Trigger"
 msgstr "Naposledy spuštěno"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:8
-msgid "Last Updated"
-msgstr "Naposledy aktualizováno"
 
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
@@ -3788,7 +3787,7 @@ msgstr "Hlídání linky"
 msgid "Link down delay"
 msgstr "Prodleva neaktivní linky"
 
-#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1978 pkg/networkmanager/interfaces.js:1988
 msgid "Link local"
 msgstr "Lokální propoj"
 
@@ -3808,11 +3807,11 @@ msgstr "Linky"
 msgid "Links:"
 msgstr "Linky:"
 
-#: pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:2014
 msgid "Load Balancing"
 msgstr "Rozkládání zátěže"
 
-#: pkg/systemd/logs.js:138
+#: pkg/systemd/logs.js:139
 msgid "Load earlier entries"
 msgstr "Načíst dřívější položky"
 
@@ -3832,9 +3831,9 @@ msgstr "Načítání dostupných aktualizací, čekejte…"
 msgid "Loading system modifications..."
 msgstr "Načítání modifikací systému…"
 
-#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:369
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:145 pkg/systemd/logs.js:160
+#: pkg/systemd/logs.js:207 pkg/systemd/logs.js:256 pkg/systemd/logs.js:318
 msgid "Loading..."
 msgstr "Načítání…"
 
@@ -3842,7 +3841,7 @@ msgstr "Načítání…"
 msgid "Local Accounts"
 msgstr "Místní účty"
 
-#: pkg/docker/storage.jsx:198
+#: pkg/docker/storage.jsx:200
 msgid "Local Disks"
 msgstr "Místní disky"
 
@@ -3854,7 +3853,7 @@ msgstr "Místní souborový systém"
 msgid "Local Install Media"
 msgstr "Místní instalační médium"
 
-#: pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:167
 msgid "Local Mount Point"
 msgstr "Místní přípojný bod"
 
@@ -3864,7 +3863,7 @@ msgid "Location"
 msgstr "Umístění"
 
 # auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
-#: pkg/storaged/content-views.jsx:238
+#: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Uzamknout"
 
@@ -3911,23 +3910,23 @@ msgid "Logged In"
 msgstr "Přihlášeni"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/storaged/vdo-details.jsx:289
+#: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "Logický"
 
-#: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
+#: pkg/storaged/vdo-details.jsx:225 pkg/storaged/vdos-panel.jsx:66
 msgid "Logical Size"
 msgstr "Logická velikost"
 
-#: pkg/storaged/utils.js:197
+#: pkg/storaged/utils.js:198
 msgid "Logical Volume"
 msgstr "Logický svazek"
 
-#: pkg/storaged/utils.js:195
+#: pkg/storaged/utils.js:196
 msgid "Logical Volume (Snapshot)"
 msgstr "Logický svazek (zachycený stav)"
 
-#: pkg/storaged/utils.js:269
+#: pkg/storaged/utils.js:270
 msgid "Logical Volume of $0"
 msgstr "Logický svazek na $0"
 
@@ -3943,7 +3942,7 @@ msgstr "Formát přihlašování"
 msgid "Login Password"
 msgstr "Přihlašovací heslo"
 
-#: src/base1/cockpit.js:4015
+#: src/base1/cockpit.js:4019
 msgid "Login failed"
 msgstr "Přihlášení se nezdařilo"
 
@@ -3972,11 +3971,13 @@ msgid "Lunch Box"
 msgstr "Kufříkový počítač"
 
 #: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
 # auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
-#: pkg/machines/components/vmnetworktab.jsx:132
+#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/vmnetworktab.jsx:141
 msgid "MAC Address"
 msgstr "MAC adresa"
 
@@ -3984,35 +3985,27 @@ msgstr "MAC adresa"
 msgid "MAC Address:"
 msgstr "MAC adresa"
 
-#: pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:2006
 msgid "MII (Recommended)"
 msgstr "MII (doporučeno)"
 
-#: pkg/networkmanager/interfaces.js:2773
+#: pkg/networkmanager/interfaces.js:2781
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4557
+#: pkg/networkmanager/interfaces.js:4575
 msgid "MTU must be a positive number"
 msgstr "Je třeba, aby MTU bylo kladné číslo"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:103
-msgid "Mac"
-msgstr "Mac"
-
-#: pkg/machines/components/nicEdit.jsx:169
-msgid "Mac Address"
-msgstr "MAC adresa"
 
 #: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Identif. stroje"
 
-#: pkg/systemd/index.html:267
+#: pkg/systemd/index.html:278
 msgid "Machine SSH Key Fingerprints"
 msgstr "Otisky SSH klíče stroje"
 
-#: pkg/shell/indexes.js:302
+#: pkg/shell/indexes.js:353
 msgid "Machines"
 msgstr "Stroje"
 
@@ -4020,12 +4013,12 @@ msgstr "Stroje"
 msgid "Main Server Chassis"
 msgstr "Hlavní skříň serveru"
 
-#: pkg/storaged/crypto-keyslots.jsx:319
+#: pkg/storaged/crypto-keyslots.jsx:327
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Ověřte, že otisk klíče z Tang serveru odpovídá:"
 
 # auto translated by TM merge from project: Entangle, version: master, DocId: entangle
-#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1979 pkg/networkmanager/interfaces.js:1989
 msgid "Manual"
 msgstr "Ruční"
 
@@ -4033,11 +4026,11 @@ msgstr "Ruční"
 msgid "Manual Connection"
 msgstr "Ruční připojení"
 
-#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
+#: pkg/systemd/index.html:395 pkg/systemd/index.html:399
 msgid "Manually"
 msgstr "Ručně"
 
-#: pkg/storaged/crypto-keyslots.jsx:322
+#: pkg/storaged/crypto-keyslots.jsx:330
 msgid "Manually check with SSH: "
 msgstr "Zkontrolovat ručně s SSH:"
 
@@ -4049,7 +4042,7 @@ msgstr "Označování $target jako vadný"
 msgid "Mask Service"
 msgstr "Maskovat službu"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
 msgid "Mask or Prefix Length"
 msgstr "Maska nebo délka předpony"
 
@@ -4057,7 +4050,7 @@ msgstr "Maska nebo délka předpony"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Masku nebo délku předpony je třeba vyplnit"
 
-#: pkg/systemd/service-details.jsx:321
+#: pkg/systemd/service-details.jsx:323
 msgid "Masked"
 msgstr "Maskováno"
 
@@ -4070,7 +4063,7 @@ msgstr ""
 "Maskování služby zabrání všem závislým jednotkám ve spouštění. To může mít "
 "větší dopad, než zamýšleno. Potvrďte, že chcete tuto jednotku maskovat."
 
-#: pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Master"
 msgstr "Hlavní"
 
@@ -4086,7 +4079,7 @@ msgstr "Přenosová jednotka nejvýše"
 msgid "Maximum memory could not be saved"
 msgstr "Paměťové maximum se nepodařilo uložit"
 
-#: pkg/networkmanager/interfaces.js:2877
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Maximum message age $max_age"
 msgstr "Maximální stáří zpráv $max_age"
 
@@ -4098,34 +4091,34 @@ msgstr ""
 "Maximální počet virtuálních procesorů, přiřazených operačnímu systému hosta. "
 "Je třeba, aby bylo z rozmezí 1 až $0"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:350
 msgid "Member of RAID Device"
 msgstr "Člen RAID zařízení"
 
-#: pkg/storaged/content-views.jsx:341
+#: pkg/storaged/content-views.jsx:346
 msgid "Member of RAID Device $0"
 msgstr "Člen RAID zařízení $0"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
-#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:263
 msgid "Memory"
 msgstr "Paměť"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/systemd/host.js:1658
+#: pkg/systemd/host.js:1701
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Paměť"
 
-#: pkg/systemd/index.html:205
+#: pkg/systemd/index.html:216
 msgid "Memory & Swap"
 msgstr "Operační paměť a odkládací prostor stránek"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Memory Technology"
 msgstr "Technologie paměti"
 
@@ -4154,19 +4147,18 @@ msgstr "Využití paměti:"
 msgid "Message to logged in users"
 msgstr "Zpráva přihlášeným uživatelům"
 
-#: node_modules/registry-image-widgets/views/image-panel.html:15
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
-msgid "Metadata"
-msgstr "Metadata"
+#: pkg/shell/index.html:399
+msgid "Messages related to the failure might be found in the journal:"
+msgstr "Zprávy týkající se nezdaru se mohou nacházet v žurnálu:"
 
-#: pkg/storaged/lvol-tabs.jsx:458
+#: pkg/storaged/lvol-tabs.jsx:466
 msgid "Metadata Used"
 msgstr "Využito metadat"
 
 # auto translated by TM merge from project: libbytesize, version: master, DocId: libbytesize
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
 msgid "MiB"
@@ -4180,7 +4172,7 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini věž"
 
-#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1229 pkg/systemd/init.js:1238 pkg/systemd/init.js:1247
 msgid "Minute needs to be a number between 0-59"
 msgstr "Je třeba, aby minuta bylo číslo z rozmezí 0-59"
 
@@ -4189,7 +4181,7 @@ msgstr "Je třeba, aby minuta bylo číslo z rozmezí 0-59"
 msgid "Minutes"
 msgstr "Minut"
 
-#: pkg/systemd/hwinfo.jsx:62 pkg/systemd/hwinfo.jsx:67
+#: pkg/systemd/hwinfo.jsx:66 pkg/systemd/hwinfo.jsx:71
 msgid "Mitigations"
 msgstr "Zmírnění dopadu"
 
@@ -4198,11 +4190,11 @@ msgid "Mode"
 msgstr "Režim"
 
 # auto translated by TM merge from project: Cockpit, version: master, DocId: cockpit
-#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:254
 msgid "Model"
 msgstr "Model"
 
-#: pkg/machines/components/vmnetworktab.jsx:123
+#: pkg/machines/components/vmnetworktab.jsx:131
 msgid "Model type"
 msgstr "Typ modelu"
 
@@ -4229,7 +4221,7 @@ msgid "Monitoring Targets"
 msgstr "Cíle monitorování"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/realmd/operation.js:529
+#: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Další"
 
@@ -4239,28 +4231,28 @@ msgid "More Information"
 msgstr "Více informací"
 
 # auto translated by TM merge from project: Fedora Websites, version: getfedora.org, DocId: po/getfedora
-#: pkg/kdump/kdump-view.jsx:448
+#: pkg/kdump/kdump-view.jsx:450
 msgid "More details"
 msgstr "Další podrobnosti"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:309
 msgid "Mount"
 msgstr "Připojit (mount)"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:84 pkg/storaged/fsys-tab.jsx:174
+#: pkg/storaged/nfs-details.jsx:178
 msgid "Mount Options"
 msgstr "Předvolby připojení"
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
+#: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:160 pkg/storaged/nfs-details.jsx:326
 #: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Přípojný bod"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/format-dialog.jsx:93 pkg/storaged/nfs-details.jsx:181
 msgid "Mount at boot"
 msgstr "Připojit při startu"
 
@@ -4268,23 +4260,23 @@ msgstr "Připojit při startu"
 msgid "Mount container volumes"
 msgstr "Připojit svazky kontejneru"
 
-#: pkg/storaged/format-dialog.jsx:78
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount point can not be empty"
 msgstr "Přípojný bod je třeba vyplnit"
 
-#: pkg/storaged/nfs-details.jsx:166
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount point cannot be empty."
 msgstr "Přípojný bod je třeba vyplnit."
 
-#: pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:174
 msgid "Mount point must start with \"/\"."
 msgstr "Je třeba, aby popis přípojného bodu začínal na „/“."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:94 pkg/storaged/nfs-details.jsx:182
 msgid "Mount read only"
 msgstr "Připojit pouze pro čtení"
 
-#: pkg/storaged/fsys-tab.jsx:180
+#: pkg/storaged/fsys-tab.jsx:183
 msgid "Mounted At"
 msgstr "Připojeno v"
 
@@ -4304,7 +4296,7 @@ msgstr "Skříň pro více systémů"
 msgid "NAT to $0"
 msgstr "NAT na $0"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "NFS Mount"
 msgstr "NFS připojení"
 
@@ -4316,15 +4308,15 @@ msgstr "NFS připojení"
 msgid "NFS Support not installed"
 msgstr "Podpora pro NFS není nainstalovaná"
 
-#: pkg/machines/components/vmnetworktab.jsx:97
+#: pkg/machines/components/vmnetworktab.jsx:102
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "Nepodařilo se změnit stav síť. rozhraní $0 virt. stroje $1 "
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:2029
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
-#: pkg/systemd/host.js:1531
+#: pkg/systemd/host.js:1569
 msgid "NTP Server"
 msgstr "NTP server"
 
@@ -4332,32 +4324,30 @@ msgstr "NTP server"
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
-#: pkg/networkmanager/index.html:319
-#: node_modules/registry-image-widgets/views/image-body.html:2
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
+#: pkg/networkmanager/index.html:319 pkg/docker/containers-view.jsx:359
+#: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/createNetworkDialog.jsx:122
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:108
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
-#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
-#: pkg/systemd/hwinfo.jsx:79
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:33
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/storaged/content-views.jsx:113 pkg/storaged/content-views.jsx:655
+#: pkg/storaged/format-dialog.jsx:295 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:73 pkg/storaged/fsys-tab.jsx:153
+#: pkg/storaged/iscsi-panel.jsx:128 pkg/storaged/iscsi-panel.jsx:185
+#: pkg/storaged/lvol-tabs.jsx:34 pkg/storaged/lvol-tabs.jsx:356
+#: pkg/storaged/lvol-tabs.jsx:398 pkg/storaged/lvol-tabs.jsx:452
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:49 pkg/storaged/vgroup-details.jsx:175
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/init.js:302
 msgid "Name"
 msgstr "Název"
 
-#: pkg/storaged/vdos-panel.jsx:52
+#: pkg/storaged/vdos-panel.jsx:54
 msgid "Name can not be empty."
 msgstr "Název je třeba vyplnit."
 
@@ -4395,7 +4385,7 @@ msgstr "Název je třeba vyplnit"
 msgid "Name: "
 msgstr "Název:"
 
-#: pkg/systemd/host.js:1365
+#: pkg/systemd/host.js:1402
 msgid "Need at least one NTP server"
 msgstr "Je třeba alespoň jeden NTP server"
 
@@ -4404,7 +4394,15 @@ msgid "Netmask"
 msgstr "Maska sítě"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/machines/components/aggregateStatusCards.jsx:72
+msgid "Network"
+msgid_plural "Networks"
+msgstr[0] "Síť"
+msgstr[1] "Sítě"
+msgstr[2] "Sítí"
+
+#: pkg/dashboard/index.html:72
+msgctxt "label"
 msgid "Network"
 msgstr "Síť"
 
@@ -4429,7 +4427,7 @@ msgstr ""
 msgid "Network File System"
 msgstr "Síťový souborový systém"
 
-#: pkg/machines/components/vm/vm.jsx:50
+#: pkg/machines/components/vm/vm.jsx:52
 msgid "Network Interfaces"
 msgstr "Síťová rozhraní"
 
@@ -4437,7 +4435,7 @@ msgstr "Síťová rozhraní"
 msgid "Network Selection does not support PXE."
 msgstr "Síťový výběr nepodporuje PXE."
 
-#: pkg/systemd/host.js:570
+#: pkg/systemd/host.js:589
 msgid "Network Traffic"
 msgstr "Síťový provoz"
 
@@ -4445,7 +4443,8 @@ msgstr "Síťový provoz"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Síťová zařízení a grafy vyžadují NetworkManager"
 
-#: pkg/machines/components/nicEdit.jsx:245
+#: pkg/machines/components/nicAdd.jsx:176
+#: pkg/machines/components/nicEdit.jsx:119
 msgid "Network interface settings could not be saved"
 msgstr "Nastavení síťového rozhraní se nepodařilo uložit"
 
@@ -4455,12 +4454,12 @@ msgstr "NetworkManager není spuštěný."
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Networking
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:946 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Síť"
 
 # auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Networking
-#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
+#: pkg/networkmanager/interfaces.js:1645 pkg/networkmanager/interfaces.js:2228
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Síť"
@@ -4469,8 +4468,8 @@ msgstr "Síť"
 msgid "Networking Logs"
 msgstr "Záznamy událostí sítě"
 
-#: pkg/machines/components/networks/networkList.jsx:45
-#: pkg/machines/components/networks/networkList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:54
 msgid "Networks"
 msgstr "Sítě"
 
@@ -4486,19 +4485,19 @@ msgstr "Heslo platí napořád"
 msgid "Never lock account"
 msgstr "Účet nikdy nezamykat"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "New NFS Mount"
 msgstr "Nové NFS připojení"
 
-#: pkg/shell/index.html:289 pkg/users/index.html:218
+#: pkg/shell/index.html:290 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Nové heslo"
 
-#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:39
 msgid "New Volume Name"
 msgstr "Název pro nový svazek"
 
-#: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
+#: pkg/storaged/crypto-keyslots.jsx:214 pkg/storaged/crypto-keyslots.jsx:260
 msgid "New passphrase"
 msgstr "Nová heslová fráze"
 
@@ -4511,28 +4510,28 @@ msgstr "Nové heslo nebylo přijato"
 msgid "Next"
 msgstr "Další"
 
-#: pkg/systemd/init.js:292
+#: pkg/systemd/init.js:304
 msgid "Next Run"
 msgstr "Příští spuštění"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
+#: pkg/systemd/index.html:237 pkg/systemd/host.js:1645
 msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2614
 msgid "No"
 msgstr "Ne"
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:465
 msgid "No Delay"
 msgstr "Bez prodlevy"
 
-#: pkg/storaged/format-dialog.jsx:252
+#: pkg/storaged/format-dialog.jsx:257
 msgid "No Filesystem"
 msgstr "Žádný souborový systém"
 
-#: pkg/storaged/content-views.jsx:715
+#: pkg/storaged/content-views.jsx:735
 msgid "No Logical Volumes"
 msgstr "Žádné logické svazky"
 
@@ -4544,7 +4543,7 @@ msgstr "Žádné shodující se výsledky"
 msgid "No NFS mounts set up"
 msgstr "Nejsou nastavená žádná NFS připojení"
 
-#: pkg/machines/components/nicEdit.jsx:118
+#: pkg/machines/components/nicBody.jsx:117
 msgid "No Network Devices"
 msgstr "Žádná síťová zařízení"
 
@@ -4552,12 +4551,16 @@ msgstr "Žádná síťová zařízení"
 msgid "No SELinux alerts."
 msgstr "Žádné výstrahy SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:209
-#: pkg/machines/components/diskAdd.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:444
+msgid "No Storage"
+msgstr "Žádné úložiště"
+
+#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/diskAdd.jsx:144
 msgid "No Storage Pools available"
 msgstr "Nejsou k dispozici žádné fondy úložiště"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:113
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Pro tento fond úložiště nejsou definované žádné úložné svazky"
 
@@ -4569,15 +4572,15 @@ msgstr "Žádné modifikace systému"
 msgid "No VM is running or defined on this host"
 msgstr "Na tomto stroji nejsou spuštěné nebo definované žádné virt. stroje"
 
-#: pkg/machines/components/nicEdit.jsx:116
+#: pkg/machines/components/nicBody.jsx:115
 msgid "No Virtual Networks"
 msgstr "Žádné virtuální sítě"
 
-#: pkg/networkmanager/firewall.jsx:956
+#: pkg/networkmanager/firewall.jsx:958
 msgid "No active zones"
 msgstr "Žádné aktivní zóny"
 
-#: pkg/docker/storage.jsx:206
+#: pkg/docker/storage.jsx:208
 msgid "No additional local storage found."
 msgstr "Nenalezeno žádné další místní úložiště."
 
@@ -4593,7 +4596,7 @@ msgstr "Nejsou nainstalované ani dostupné žádné aplikace"
 msgid "No archive has been created."
 msgstr "Nebyl vytvořen žádný archiv."
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "No available slots"
 msgstr "Nejsou k dispozici žádné sloty"
 
@@ -4601,11 +4604,11 @@ msgstr "Nejsou k dispozici žádné sloty"
 msgid "No boot device found"
 msgstr "Nenalezeno žádné zařízení pro zavádění"
 
-#: pkg/networkmanager/interfaces.js:1428
+#: pkg/networkmanager/interfaces.js:1433
 msgid "No carrier"
 msgstr "Bez signálu"
 
-#: pkg/kdump/kdump-view.jsx:396
+#: pkg/kdump/kdump-view.jsx:398
 msgid "No configuration found"
 msgstr "Nenalezeno žádné nastavení"
 
@@ -4625,7 +4628,7 @@ msgstr "Žádné kontejnery"
 msgid "No containers that match the current filter"
 msgstr "Žádné kontejnery, které by odpovídaly stávajícímu filtru"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:761
 msgid "No description available"
 msgstr "Není k dispozici žádný popis"
 
@@ -4633,26 +4636,26 @@ msgstr "Není k dispozici žádný popis"
 msgid "No description provided."
 msgstr "Není poskytnut žádný popis."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/mdraid-details.jsx:49 pkg/storaged/mdraids-panel.jsx:92
+#: pkg/storaged/vdos-panel.jsx:59 pkg/storaged/vgroup-details.jsx:56
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "No disks are available."
 msgstr "Nejsou k dispozici žádné disky."
 
-#: pkg/machines/components/vmDisksTab.jsx:85
+#: pkg/machines/components/vmDisksTab.jsx:121
 msgid "No disks defined for this VM"
 msgstr "Pro tento virt. stroj nejsou definované žádné disky"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:103
 msgid "No drives attached"
 msgstr "Nejsou připojené žádné jednotky"
 
-#: pkg/storaged/crypto-keyslots.jsx:581
+#: pkg/storaged/crypto-keyslots.jsx:594
 msgid "No free key slots"
 msgstr "Žádné volné sloty klíčů"
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/content-views.jsx:700
+#: pkg/storaged/content-views.jsx:720
 msgid "No free space"
 msgstr "Žádné volné místo"
 
@@ -4660,13 +4663,9 @@ msgstr "Žádné volné místo"
 msgid "No host keys found."
 msgstr "Nenalezeny žádné klíče stroje."
 
-#: pkg/storaged/iscsi-panel.jsx:262
+#: pkg/storaged/iscsi-panel.jsx:269
 msgid "No iSCSI targets set up"
 msgstr "Nejsou nastavené žádné iSCSI cíle"
-
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
-msgid "No image streams are present."
-msgstr "Nejsou přítomné žádné proudy obrazů."
 
 #: pkg/docker/containers-view.jsx:705
 msgid "No images"
@@ -4680,19 +4679,15 @@ msgstr "Stávajícímu filtru neodpovídají žádné obrazy"
 msgid "No installation package found for this application."
 msgstr "Pro tuto aplikaci nebyl nalezen žádný instalační balíček."
 
-#: pkg/storaged/crypto-keyslots.jsx:520
+#: pkg/storaged/crypto-keyslots.jsx:533
 msgid "No keys added"
 msgstr "Nepřidány žádné klíče"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
-msgid "No matching files found"
-msgstr "Nenalezeny žádné odpovídající soubory"
 
 #: pkg/storaged/drive-details.jsx:75
 msgid "No media inserted"
 msgstr "Není vloženo žádné médium"
 
-#: pkg/kdump/kdump-view.jsx:450
+#: pkg/kdump/kdump-view.jsx:452
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -4702,11 +4697,11 @@ msgstr ""
 "crashkernel (např. v /etc/default/grub) pro vyhrazení paměti při startu. "
 "Příklad: crashkernel=512M"
 
-#: pkg/machines/components/vmnetworktab.jsx:70
+#: pkg/machines/components/vmnetworktab.jsx:75
 msgid "No network interfaces defined for this VM"
 msgstr "Pro tento virt. stroj nebyla určena žádná síťová rozhraní"
 
-#: pkg/machines/components/networks/networkList.jsx:51
+#: pkg/machines/components/networks/networkList.jsx:56
 msgid "No network is defined on this host"
 msgstr "Na tomto hostiteli není definována žádná síť"
 
@@ -4714,11 +4709,11 @@ msgstr "Na tomto hostiteli není definována žádná síť"
 msgid "No networks available"
 msgstr "Žádné sítě k dispozici"
 
-#: pkg/networkmanager/firewall.jsx:969
+#: pkg/networkmanager/firewall.jsx:971
 msgid "No open ports"
 msgstr "Žádné otevřené porty"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:537
 msgid "No partitioning"
 msgstr "Žádný oddíl"
 
@@ -4738,25 +4733,21 @@ msgstr "Žádné spuštěné kontejnery"
 msgid "No running containers that match the current filter"
 msgstr "Žádné spuštěné kontejnery, které by odpovídaly stávajícímu filtru"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:50
+#: pkg/machines/components/storagePools/storagePoolList.jsx:55
 msgid "No storage pool is defined on this host"
 msgstr "Na tomto stroji není definován žádný fond úložiště"
 
-#: pkg/storaged/mdraids-panel.jsx:130
+#: pkg/storaged/mdraids-panel.jsx:147
 msgid "No storage set up as RAID"
 msgstr "Žádné úložiště nastavené jako RAID"
 
-#: pkg/storaged/vdos-panel.jsx:167
+#: pkg/storaged/vdos-panel.jsx:177
 msgid "No storage set up as VDO"
 msgstr "Žádné úložiště nastavené jako VDO"
 
 #: pkg/lib/credentials.js:186
 msgid "No such file or directory"
 msgstr "Žádný takový soubor nebo složka"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:73
-msgid "No tags are present."
-msgstr "Nejsou přítomné žádné štítky"
 
 #: pkg/packagekit/updates.jsx:42
 msgid "No updates pending"
@@ -4766,14 +4757,13 @@ msgstr "Žádné čekající aktualizace"
 msgid "No user name specified"
 msgstr "Nebylo zadáno uživatelské jméno"
 
-#: pkg/storaged/vgroups-panel.jsx:114
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr "Nejsou vytvořené žádné skupiny svazků"
 
-#: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419
-#: pkg/machines/components/networks/createNetworkDialog.jsx:204
-#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:421
+#: pkg/machines/components/networks/createNetworkDialog.jsx:190
+#: pkg/networkmanager/firewall.jsx:766 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Žádný"
 
@@ -4793,11 +4783,11 @@ msgstr "Není platná soukromá část klíče"
 msgid "Not authorized to access Docker on this system"
 msgstr "Neoprávněni k přístupu k Dockeru na tomto systému"
 
-#: pkg/systemd/logs.js:527
+#: pkg/systemd/logs.js:529
 msgid "Not authorized to upload-report"
 msgstr "Neoprávněni k nahrání výkazu"
 
-#: pkg/networkmanager/interfaces.js:831
+#: pkg/networkmanager/interfaces.js:836
 msgid "Not available"
 msgstr "Není k dispozici"
 
@@ -4805,12 +4795,16 @@ msgstr "Není k dispozici"
 msgid "Not connected"
 msgstr "Nepřipojeno"
 
-#: pkg/storaged/lvol-tabs.jsx:369
+#: pkg/systemd/host.js:577
+msgid "Not connected to Insights"
+msgstr "Nepřipojeno k Insights"
+
+#: pkg/storaged/lvol-tabs.jsx:377
 msgid "Not enough space to grow."
 msgstr "Pro zvětšení není k dispozici dostatek prostoru."
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/docker/details.js:185 pkg/storaged/details.jsx:121
+#: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Nenalezeno"
 
@@ -4818,11 +4812,11 @@ msgstr "Nenalezeno"
 msgid "Not mounted"
 msgstr "Nepřipojeno"
 
-#: src/base1/cockpit.js:4013
+#: src/base1/cockpit.js:4017
 msgid "Not permitted to perform this action."
 msgstr "Neoprávněni k provedení této akce."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:361
 msgid "Not running"
 msgstr "Není spuštěné"
 
@@ -4830,12 +4824,8 @@ msgstr "Není spuštěné"
 msgid "Not synchronized"
 msgstr "Nesynchronizováno"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:44
-msgid "Not yet synced"
-msgstr "Doposud nesynchronizováno"
-
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/systemd/service-details.jsx:448
+#: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Poznámka"
 
@@ -4846,6 +4836,14 @@ msgstr "Notebook"
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "Oznámení a závažnější"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications"
+msgstr "Oznamování"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications Receiver"
+msgstr "Přijímač oznámení"
 
 #: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
@@ -4859,11 +4857,11 @@ msgstr "Vyskytlo se mezi $0 a $1"
 msgid "Ok"
 msgstr "Ok"
 
-#: pkg/shell/index.html:281 pkg/users/index.html:215
+#: pkg/shell/index.html:282 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Původní heslo"
 
-#: pkg/storaged/crypto-keyslots.jsx:249
+#: pkg/storaged/crypto-keyslots.jsx:257
 msgid "Old passphrase"
 msgstr "Původní heslová fráze"
 
@@ -4871,15 +4869,11 @@ msgstr "Původní heslová fráze"
 msgid "Old password not accepted"
 msgstr "Původní heslo nebylo přijato"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:7
-msgid "On Build"
-msgstr "Při sestavování"
-
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:431
 msgid "On Failure"
 msgstr "Při nezdaru"
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr "Na připojeném zařízení"
 
@@ -4902,7 +4896,7 @@ msgstr ""
 msgid "One Time Password"
 msgstr "Jednorázové heslo"
 
-#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:77
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:76
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
@@ -4918,7 +4912,7 @@ msgstr "Je použito pouze $0 z $1."
 msgid "Only Emergency"
 msgstr "Pouze nouzové"
 
-#: pkg/systemd/init.js:1117
+#: pkg/systemd/init.js:1179
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr ""
 "Dovolena jsou pouze písmena a číslice, dále ještě znaky  : , _ , . , @ , -"
@@ -4949,13 +4943,13 @@ msgstr "Operace „$operation“ na $target"
 msgid "Operation is in progress"
 msgstr "Operace probíhá"
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/drives-panel.jsx:76
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Mechanika optických disků"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:137 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Přepínače"
 
@@ -4967,7 +4961,7 @@ msgstr "Nebo použijte přibalený prohlížeč"
 msgid "Other"
 msgstr "Ostatní"
 
-#: pkg/storaged/content-views.jsx:353
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Ostatní data"
@@ -4983,19 +4977,19 @@ msgstr "Ostatní volby"
 # auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Overview
 #: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/vm/vm.jsx:49
 msgid "Overview"
 msgstr "Přehled"
 
-#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:525 pkg/storaged/format-dialog.jsx:290
 msgid "Overwrite existing data with zeros"
 msgstr "Přepsat existující data nulami"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "PCI"
 msgstr "PCI"
 
-#: pkg/packagekit/updates.jsx:501
+#: pkg/packagekit/updates.jsx:503
 msgid "Package information"
 msgstr "Informace o balíčku"
 
@@ -5003,11 +4997,11 @@ msgstr "Informace o balíčku"
 msgid "PackageKit crashed"
 msgstr "PackageKit zhavaroval"
 
-#: pkg/packagekit/updates.jsx:564
+#: pkg/packagekit/updates.jsx:565
 msgid "PackageKit is not installed"
 msgstr "PackageKit není nainstalovaný"
 
-#: pkg/packagekit/updates.jsx:718
+#: pkg/packagekit/updates.jsx:719
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit ohlásilo chybový kód $0"
 
@@ -5021,63 +5015,63 @@ msgstr "Balíčky"
 msgid "Parent"
 msgstr "Nadřazené"
 
-#: pkg/networkmanager/interfaces.js:2915
+#: pkg/networkmanager/interfaces.js:2923
 msgid "Parent $parent"
 msgstr "Nadřazené $parent"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:421
 msgid "Part Of"
 msgstr "Součástí"
 
-#: pkg/networkmanager/interfaces.js:1474
+#: pkg/networkmanager/interfaces.js:1479
 msgid "Part of "
 msgstr "Součástí"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "Oddíl"
 
-#: pkg/storaged/utils.js:271
+#: pkg/storaged/utils.js:272
 msgid "Partition of $0"
 msgstr "Oddíl na $0"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/storaged/content-views.jsx:519
+#: pkg/storaged/content-views.jsx:528
 msgid "Partitioning"
 msgstr "Vytváření oddílů"
 
-#: pkg/networkmanager/interfaces.js:2009
+#: pkg/networkmanager/interfaces.js:2021
 msgid "Passive"
 msgstr "Pasivní"
 
 # auto translated by TM merge from project: anaconda, version: f22-branch, DocId: anaconda
-#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
+#: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
+#: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:307
 msgid "Passphrase"
 msgstr "Heslo"
 
-#: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
-#: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:299
+#: pkg/storaged/crypto-keyslots.jsx:158 pkg/storaged/crypto-keyslots.jsx:217
+#: pkg/storaged/crypto-keyslots.jsx:258 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/format-dialog.jsx:311
 msgid "Passphrase cannot be empty"
 msgstr "Heslovou frázi je třeba vyplnit"
 
-#: pkg/storaged/crypto-keyslots.jsx:356
+#: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Passphrase removal may prevent unlocking $0."
 msgstr "Odebrání heslové fráze může bránit odemknutí $0."
 
-#: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/crypto-keyslots.jsx:225 pkg/storaged/crypto-keyslots.jsx:263
+#: pkg/storaged/format-dialog.jsx:319
 msgid "Passphrases do not match"
 msgstr "Zadání heslové fráze se neshodují"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
+#: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
 #: pkg/users/index.html:173 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
+#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Heslo"
 
@@ -5118,7 +5112,7 @@ msgstr "Sem vložte obsah veřejné části svého ssh klíče"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:481
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Popis umístění"
 
@@ -5126,11 +5120,11 @@ msgstr "Popis umístění"
 msgid "Path cost"
 msgstr "Náklady trasy"
 
-#: pkg/networkmanager/interfaces.js:2897
+#: pkg/networkmanager/interfaces.js:2905
 msgid "Path cost $path_cost"
 msgstr "Náklady trasy $path_cost"
 
-#: pkg/storaged/nfs-details.jsx:151
+#: pkg/storaged/nfs-details.jsx:155
 msgid "Path on Server"
 msgstr "Popis umístění na serveru"
 
@@ -5138,11 +5132,11 @@ msgstr "Popis umístění na serveru"
 msgid "Path on host's filesystem"
 msgstr "Umístění v souborovém systému hostitele"
 
-#: pkg/storaged/nfs-details.jsx:155
+#: pkg/storaged/nfs-details.jsx:160
 msgid "Path on server cannot be empty."
 msgstr "Popis umístění na serveru je třeba vyplnit."
 
-#: pkg/storaged/nfs-details.jsx:157
+#: pkg/storaged/nfs-details.jsx:162
 msgid "Path on server must start with \"/\"."
 msgstr "Je třeba, aby popis umístění na serveru začínal na „/“."
 
@@ -5150,12 +5144,12 @@ msgstr "Je třeba, aby popis umístění na serveru začínal na „/“."
 msgid "Path to ISO file on host's file system"
 msgstr "Popis umístění ISO souboru na souborovém systému hostitele"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:141
 msgid "Path to file"
 msgstr "Popis umístění serveru"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/systemd/services.jsx:42
+#: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Popisy umístění"
 
@@ -5163,7 +5157,7 @@ msgstr "Popisy umístění"
 msgid "Pause"
 msgstr "Pozastavit"
 
-#: pkg/systemd/index.html:152
+#: pkg/systemd/index.html:159
 msgid "Performance Profile"
 msgstr "Výkonnostní profil"
 
@@ -5172,7 +5166,7 @@ msgid "Peripheral Chassis"
 msgstr "Skříň periferií"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:3642
+#: pkg/networkmanager/interfaces.js:3657
 msgid "Permanent"
 msgstr "Trvalá"
 
@@ -5185,7 +5179,8 @@ msgstr "Přístup zamítnut"
 msgid "Permissive"
 msgstr "Permisivní"
 
-#: pkg/machines/components/diskAdd.jsx:110
+#: pkg/machines/components/diskAdd.jsx:111
+#: pkg/machines/components/nicAdd.jsx:80
 msgid "Persistence"
 msgstr "Trvalost"
 
@@ -5194,7 +5189,7 @@ msgstr "Trvalost"
 msgid "Persistent"
 msgstr "Trvalé"
 
-#: pkg/storaged/vdo-details.jsx:277
+#: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "Fyzické"
 
@@ -5202,11 +5197,11 @@ msgstr "Fyzické"
 msgid "Physical Disk Device"
 msgstr "Fyzické diskové zařízení"
 
-#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
+#: pkg/storaged/content-views.jsx:154 pkg/storaged/content-views.jsx:348
 msgid "Physical Volume"
 msgstr "Fyzický svazek"
 
-#: pkg/storaged/vgroup-details.jsx:133
+#: pkg/storaged/vgroup-details.jsx:127
 msgid "Physical Volumes"
 msgstr "Fyzické svazky"
 
@@ -5214,11 +5209,11 @@ msgstr "Fyzické svazky"
 msgid "Physical disk device on host"
 msgstr "Fyzické diskové zařízení na hostiteli"
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:343
 msgid "Physical volume of $0"
 msgstr "Fyzický svazek od $0"
 
-#: pkg/storaged/lvol-tabs.jsx:164
+#: pkg/storaged/lvol-tabs.jsx:165
 msgid "Physical volumes can not be resized here."
 msgstr "Zde není možné měnit velikost fyzických svazků."
 
@@ -5234,10 +5229,10 @@ msgstr "Cíl pro ping"
 msgid "Pizza Box"
 msgstr "Velikost „krabice od pizzy“"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:291
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:296
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:199
+#: pkg/storaged/vgroup-details.jsx:207
 msgid "Please confirm deletion of $0"
 msgstr "Potvrďte smazání $0"
 
@@ -5245,19 +5240,19 @@ msgstr "Potvrďte smazání $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Potvrďte vynucené smazání $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/mdraid-details.jsx:240 pkg/storaged/vdo-details.jsx:155
 msgid "Please confirm stopping of $0"
 msgstr "Potvrďte zastavení $0"
 
-#: pkg/machines/components/diskAdd.jsx:483
+#: pkg/machines/components/diskAdd.jsx:350
 msgid "Please enter new volume name"
 msgstr "Zadejte název pro nový svazek"
 
-#: pkg/machines/components/diskAdd.jsx:486
+#: pkg/machines/components/diskAdd.jsx:353
 msgid "Please enter new volume size"
 msgstr "Zadejte velikost nového svazku"
 
-#: pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:896
 msgid "Please install the $0 package"
 msgstr "Nainstalujte balíček $0"
 
@@ -5277,30 +5272,34 @@ msgstr "Pro přístup k jeho konzoli je třeba virtuální stroj napřed zapnout
 msgid "Please try another term"
 msgstr "Zkuste jiný pojem"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Plug"
 msgstr "Připojit"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:127
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Úložiště"
 
-#: pkg/storaged/utils.js:191
+#: pkg/storaged/utils.js:192
 msgid "Pool for Thin Logical Volumes"
 msgstr "Fond pro thin logické svazky"
 
-#: pkg/storaged/content-views.jsx:594
+#: pkg/storaged/content-views.jsx:607
 msgid "Pool for Thin Volumes"
 msgstr "Fond pro thin svazky"
 
-#: pkg/storaged/content-views.jsx:651
+#: pkg/storaged/content-views.jsx:668
 msgid "Pool for thinly provisioned volumes"
 msgstr "Fond pro tence poskytované svazky"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:142
+msgid "Pool type doesn't support volume creation"
+msgstr "Typ fondu nepodporuje vytvoření svazku"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
@@ -5312,8 +5311,8 @@ msgstr "Svazky fondu jsou využívány virt. stroji"
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:108
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:113
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Port"
 msgstr "Port"
 
@@ -5328,9 +5327,8 @@ msgstr "Přenosný"
 
 # auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
-#: pkg/networkmanager/index.html:323
-#: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/index.html:323 pkg/docker/containers-view.jsx:414
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Ports"
 msgstr "Porty"
 
@@ -5338,7 +5336,7 @@ msgstr "Porty"
 msgid "Ports:"
 msgstr "Porty:"
 
-#: pkg/systemd/index.html:132
+#: pkg/systemd/index.html:139
 msgid "Power Options"
 msgstr "Možnosti napájení"
 
@@ -5350,7 +5348,7 @@ msgstr "Upřednostňovaný počet patic který odhalit hostovi."
 msgid "Prefix"
 msgstr "Předpona"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
 msgid "Prefix Length"
 msgstr "Délka předpony"
 
@@ -5358,20 +5356,20 @@ msgstr "Délka předpony"
 msgid "Prefix Length should not be empty"
 msgstr "Délku předpony je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length"
 msgstr "Délka předpony"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length or Netmask"
 msgstr "Délka předpony nebo maska sítě"
 
 #: pkg/playground/manifest.json.in
 msgid "Preloaded"
-msgstr ""
+msgstr "Přednahráno"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/networkmanager/interfaces.js:835
+#: pkg/networkmanager/interfaces.js:840
 msgid "Preparing"
 msgstr "Příprava"
 
@@ -5380,11 +5378,11 @@ msgid "Present"
 msgstr "Přítomno"
 
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
-#: pkg/networkmanager/interfaces.js:3643
+#: pkg/networkmanager/interfaces.js:3658
 msgid "Preserve"
 msgstr "Zachovat"
 
-#: pkg/systemd/index.html:295
+#: pkg/systemd/index.html:306
 msgid "Pretty Host Name"
 msgstr "Hezký název stroje"
 
@@ -5403,7 +5401,7 @@ msgstr "Primární"
 msgid "Priority"
 msgstr "Priorita"
 
-#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
+#: pkg/networkmanager/interfaces.js:2879 pkg/networkmanager/interfaces.js:2903
 msgid "Priority $priority"
 msgstr "Priorita $priority"
 
@@ -5416,11 +5414,11 @@ msgid "Privileged"
 msgstr "Privilegované"
 
 # auto translated by TM merge from project: libreport, version: master, DocId: libreport
-#: pkg/systemd/logs.js:488
+#: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Podrobnosti o problému"
 
-#: pkg/systemd/logs.js:487
+#: pkg/systemd/logs.js:489
 msgid "Problem info"
 msgstr "Informace o problému"
 
@@ -5428,7 +5426,7 @@ msgstr "Informace o problému"
 msgid "Problems"
 msgstr "Problémy"
 
-#: pkg/storaged/dialog.jsx:1043
+#: pkg/storaged/dialog.jsx:1044
 msgid "Process"
 msgstr "Proces"
 
@@ -5453,7 +5451,7 @@ msgstr "Časový limit výzvy prostřednictvím ssh-add překročen"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Časový limit výzvy prostřednictvím ssh-keygen překročen"
 
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:434
 msgid "Propagates Reload To"
 msgstr "Propaguje načíst znovu k"
 
@@ -5464,67 +5462,63 @@ msgstr "Propaguje načíst znovu k"
 msgid "Protocol"
 msgstr "Protokol"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:231
 msgid "Public Key"
 msgstr "Veřejná část klíče"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr "Veřejný repozitář pro stahování"
-
-#: pkg/storaged/content-views.jsx:645
+#: pkg/storaged/content-views.jsx:660
 msgid "Purpose"
 msgstr "Účel"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/mdraid-details.jsx:174
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:45
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (proužkování)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:175
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/mdraids-panel.jsx:52
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (zrcadlení)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/mdraids-panel.jsx:68
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (proužkování zrcadel)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:176
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/mdraids-panel.jsx:56
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (vyhrazená parita)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:177
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (distribuovaná parita)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:178
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:53
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (dvojitá distribuovaná parita)"
 
@@ -5537,20 +5531,20 @@ msgstr "RAID skříň"
 msgid "RAID Device"
 msgstr "RAID zařízení"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/mdraid-details.jsx:311 pkg/storaged/utils.js:242
 msgid "RAID Device $0"
 msgstr "RAID zařízení $0"
 
 # auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
-#: pkg/storaged/mdraids-panel.jsx:129
+#: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "RAID zařízení"
 
-#: pkg/storaged/mdraids-panel.jsx:41
+#: pkg/storaged/mdraids-panel.jsx:42
 msgid "RAID Level"
 msgstr "RAID úroveň"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:157
 msgid "RAID Member"
 msgstr "Člen RAID"
 
@@ -5558,11 +5552,11 @@ msgstr "Člen RAID"
 msgid "Rack Mount Chassis"
 msgstr "Skříň do stojanu"
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3659
 msgid "Random"
 msgstr "Náhodné"
 
-#: pkg/networkmanager/firewall.jsx:789
+#: pkg/networkmanager/firewall.jsx:791
 msgid "Range"
 msgstr "Rozsah"
 
@@ -5570,23 +5564,23 @@ msgstr "Rozsah"
 msgid "Range must be strictly ordered"
 msgstr "Je třeba, aby rozsah byl striktně řazený"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Rank"
 msgstr "Rank"
 
-#: pkg/kdump/kdump-view.jsx:388
+#: pkg/kdump/kdump-view.jsx:390
 msgid "Raw to a device"
 msgstr "Neupravované na zařízení"
 
 #: pkg/playground/manifest.json.in
 msgid "React Patterns"
-msgstr ""
+msgstr "React vzory"
 
-#: pkg/systemd/hwinfo.jsx:193
+#: pkg/systemd/hwinfo.jsx:197
 msgid "Read more..."
 msgstr "Zjistit více…"
 
-#: pkg/systemd/service-details.jsx:386
+#: pkg/systemd/service-details.jsx:388
 msgid "Read-only"
 msgstr "Pouze pro čtení"
 
@@ -5598,15 +5592,15 @@ msgstr "Pouze pro čtení"
 msgid "ReadWrite"
 msgstr "Čtení i zápis"
 
-#: pkg/storaged/plot.jsx:310
+#: pkg/storaged/plot.jsx:312
 msgid "Reading"
 msgstr "Čtení"
 
-#: pkg/kdump/kdump-view.jsx:413
+#: pkg/kdump/kdump-view.jsx:415
 msgid "Reading..."
 msgstr "Načítání…"
 
-#: pkg/machines/components/vmDisksTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:112
 msgid "Readonly"
 msgstr "Pouze pro čtení"
 
@@ -5619,11 +5613,11 @@ msgctxt "verb"
 msgid "Ready"
 msgstr "Připraveno"
 
-#: pkg/systemd/index.html:304
+#: pkg/systemd/index.html:315
 msgid "Real Host Name"
 msgstr "Skutečný název stroje"
 
-#: pkg/systemd/host.js:1037
+#: pkg/systemd/host.js:1074
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5631,12 +5625,12 @@ msgstr ""
 "Skutečný název stroje může obsahovat pouze malá písmena (bez diakritiky), "
 "číslice, spojovníky a tečky (u použitých subdomén)"
 
-#: pkg/systemd/host.js:1038
+#: pkg/systemd/host.js:1075
 msgid "Real host name must be 64 characters or less"
 msgstr "Je třeba, aby skutečný název stroje byl nanejvýš 64 znaků dlouhý"
 
 # auto translated by TM merge from project: system-config-kdump, version: master, DocId: system-config-kdump
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
+#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Restartovat"
 
@@ -5650,16 +5644,16 @@ msgstr "Příchozí"
 msgid "Recent"
 msgstr "Nedávné"
 
-#: pkg/storaged/format-dialog.jsx:248
+#: pkg/storaged/format-dialog.jsx:253
 msgid "Recommended default"
 msgstr "Doporučené výchozí"
 
-#: pkg/shell/index.html:381 pkg/shell/simple.html:138
+#: pkg/shell/index.html:382 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Znovu připojit"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Recovering"
 msgstr "Zotavování"
 
@@ -5667,7 +5661,7 @@ msgstr "Zotavování"
 msgid "Recovering RAID Device $target"
 msgstr "Zotavování RAID zařízení $target"
 
-#: pkg/docker/storage.jsx:389
+#: pkg/docker/storage.jsx:396
 msgid "Reformat and add disks"
 msgstr "Znovu naformátovat a přidat disky"
 
@@ -5687,7 +5681,7 @@ msgstr "Odmítá se připojit. Klíč stroje neodpovídá"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Odmítá se připojit. Klíč stroje není znám"
 
-#: pkg/packagekit/updates.jsx:779
+#: pkg/packagekit/updates.jsx:780
 msgid "Register…"
 msgstr "Zaregistrovat…"
 
@@ -5695,7 +5689,7 @@ msgstr "Zaregistrovat…"
 msgid "Reload"
 msgstr "Načíst znovu"
 
-#: pkg/systemd/service-details.jsx:433
+#: pkg/systemd/service-details.jsx:435
 msgid "Reload Propagated From"
 msgstr "Znovu načíst propagováno z"
 
@@ -5703,15 +5697,15 @@ msgstr "Znovu načíst propagováno z"
 msgid "Remote URL"
 msgstr "Vzdálená URL adresa"
 
-#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:386
+#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:388
 msgid "Remote over NFS"
 msgstr "Vzdálené přes NFS"
 
-#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:384
+#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:386
 msgid "Remote over SSH"
 msgstr "Vzdálené přes SSH"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/drives-panel.jsx:72 pkg/storaged/drives-panel.jsx:74
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "Vyjímatelná jednotka"
@@ -5722,20 +5716,20 @@ msgstr "Odebrání:"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
 #: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
+#: pkg/storaged/nfs-details.jsx:316
 msgid "Remove"
 msgstr "Odebrat"
 
-#: pkg/networkmanager/interfaces.js:3067
+#: pkg/networkmanager/interfaces.js:3076
 msgid "Remove $0"
 msgstr "Odebrat $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:414
+#: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
 msgstr "Odebrat $0?"
 
-#: pkg/storaged/crypto-keyslots.jsx:423
+#: pkg/storaged/crypto-keyslots.jsx:433
 msgid "Remove Tang keyserver"
 msgstr "Odebrat Tang server s klíči"
 
@@ -5743,19 +5737,19 @@ msgstr "Odebrat Tang server s klíči"
 msgid "Remove device"
 msgstr "Odebrat zařízení"
 
-#: pkg/storaged/crypto-keyslots.jsx:387
+#: pkg/storaged/crypto-keyslots.jsx:396
 msgid "Remove passphrase"
 msgstr "Odebrat heslovou frázi"
 
-#: pkg/storaged/crypto-keyslots.jsx:354
+#: pkg/storaged/crypto-keyslots.jsx:362
 msgid "Remove passphrase in $0?"
 msgstr "Odebrat heslovou frázi v $0?"
 
-#: pkg/networkmanager/firewall.jsx:661
+#: pkg/networkmanager/firewall.jsx:663
 msgid "Remove service"
 msgstr "Odebrat službu"
 
-#: pkg/networkmanager/firewall.jsx:640
+#: pkg/networkmanager/firewall.jsx:642
 msgid "Remove service from zones"
 msgstr "Odebrat službu ze zón"
 
@@ -5764,7 +5758,7 @@ msgstr "Odebrat službu ze zón"
 msgid "Removing"
 msgstr "Odebírá se"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:181
+#: pkg/lib/cockpit-components-install-dialog.jsx:182
 msgid "Removing $0"
 msgstr "Odebírá se $0"
 
@@ -5772,7 +5766,7 @@ msgstr "Odebírá se $0"
 msgid "Removing $target from RAID Device"
 msgstr "Odebírání $target z RAID zařízení"
 
-#: pkg/networkmanager/interfaces.js:3066
+#: pkg/networkmanager/interfaces.js:3075
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5784,16 +5778,16 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Odebírání fyzického svazku z $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:234
+#: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
+#: pkg/storaged/vgroup-details.jsx:231
 msgid "Rename"
 msgstr "Přejmenovat"
 
-#: pkg/storaged/lvol-tabs.jsx:31
+#: pkg/storaged/lvol-tabs.jsx:32
 msgid "Rename Logical Volume"
 msgstr "Přejmenovat logický svazek"
 
-#: pkg/storaged/vgroup-details.jsx:178
+#: pkg/storaged/vgroup-details.jsx:173
 msgid "Rename Volume Group"
 msgstr "Přejmenovat skupinu svazků"
 
@@ -5825,32 +5819,31 @@ msgstr "Opakovat každý týden"
 msgid "Repeat Yearly"
 msgstr "Opakovat každý rok"
 
-#: pkg/storaged/crypto-keyslots.jsx:204 pkg/storaged/crypto-keyslots.jsx:214
-#: pkg/storaged/crypto-keyslots.jsx:256
+#: pkg/storaged/crypto-keyslots.jsx:207 pkg/storaged/crypto-keyslots.jsx:219
+#: pkg/storaged/crypto-keyslots.jsx:262
 msgid "Repeat passphrase"
 msgstr "Zopakovat heslovou frázi"
 
 # auto translated by TM merge from project: abrt, version: rhel7, DocId: abrt
-#: pkg/systemd/logs.js:512
+#: pkg/systemd/logs.js:514
 msgid "Report"
 msgstr "Nahlásit"
 
 # auto translated by TM merge from project: gnome-abrt, version: master, DocId: gnome-abrt
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:509
 msgid "Reported"
 msgstr "Nahlášeno"
 
-#: pkg/systemd/logs.js:529
+#: pkg/systemd/logs.js:531
 msgid "Reporter 'reporter-ureport' not found."
 msgstr "Hlásič „reporter-ureport“ nenalezen."
 
-#: pkg/systemd/logs.js:531
+#: pkg/systemd/logs.js:533
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Hlášení nebylo úspěšné. Zkuste spustit `reporter-ureport -d "
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
 #: pkg/docker/index.html:690
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Repozitář"
 
@@ -5862,31 +5855,31 @@ msgstr "Vyžadovat změnu hesla každých $0 dnů"
 msgid "Require password change on $0"
 msgstr "Vyžadovat změnu hesla na $0"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:422
 msgid "Required By"
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:372
+#: pkg/systemd/service-details.jsx:374
 msgid "Required by "
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "Vyžaduje"
 
-#: pkg/systemd/service-details.jsx:387
+#: pkg/systemd/service-details.jsx:389
 msgid "Requires administration access to edit"
 msgstr "Pro úpravu jsou vyžadována oprávnění správce systému"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:418
 msgid "Requisite"
 msgstr "Závislost"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:423
 msgid "Requisite Of"
 msgstr "Závislost pro"
 
-#: pkg/kdump/kdump-view.jsx:501
+#: pkg/kdump/kdump-view.jsx:503
 msgid "Reserved memory"
 msgstr "Vyhrazená paměť"
 
@@ -5896,11 +5889,11 @@ msgstr "Vyhrazená paměť"
 msgid "Reset"
 msgstr "Reset"
 
-#: pkg/docker/storage.jsx:441
+#: pkg/docker/storage.jsx:452
 msgid "Reset Storage Pool"
 msgstr "Resetovat fond úložišť"
 
-#: pkg/docker/storage.jsx:444
+#: pkg/docker/storage.jsx:455
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
@@ -5912,7 +5905,7 @@ msgstr ""
 msgid "Resizing $target"
 msgstr "Mění se velikost $target"
 
-#: pkg/storaged/lvol-tabs.jsx:225 pkg/storaged/lvol-tabs.jsx:307
+#: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
@@ -5920,15 +5913,15 @@ msgstr ""
 "Změna velikost šifrovaného souborového systému vyžaduje jeho odemčení. "
 "Zadejte heslovou frázi."
 
-#: pkg/docker/index.html:138 pkg/systemd/index.html:134
-#: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
+#: pkg/docker/index.html:138 pkg/systemd/index.html:141
+#: pkg/systemd/index.html:151 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
 #: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Restartovat"
 
-#: pkg/packagekit/updates.jsx:498
+#: pkg/packagekit/updates.jsx:500
 msgid "Restart Now"
 msgstr "Restartovat nyní"
 
@@ -5940,11 +5933,11 @@ msgstr "Zásada restartu"
 msgid "Restart Policy:"
 msgstr "Zásada restartu:"
 
-#: pkg/packagekit/updates.jsx:493
+#: pkg/packagekit/updates.jsx:495
 msgid "Restart Recommended"
 msgstr "Doporučen restart"
 
-#: pkg/packagekit/updates.jsx:866
+#: pkg/packagekit/updates.jsx:867
 msgid "Restarting"
 msgstr "Restartuje se"
 
@@ -5974,7 +5967,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Role"
 
-#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:1995 pkg/networkmanager/interfaces.js:2012
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5986,7 +5979,7 @@ msgstr "Trasa na $0"
 msgid "Routed Network"
 msgstr "Směrovaná síť"
 
-#: pkg/networkmanager/interfaces.js:3337
+#: pkg/networkmanager/interfaces.js:3348
 msgid "Routes"
 msgstr "Trasy"
 
@@ -6000,10 +5993,6 @@ msgstr "Spustit"
 msgid "Run Image"
 msgstr "Spustit obraz"
 
-#: node_modules/registry-image-widgets/views/image-config.html:8
-msgid "Run as"
-msgstr "Spustit jako"
-
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
@@ -6014,13 +6003,13 @@ msgid "Runner"
 msgstr "Spouštěč"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Spuštěné"
 
 #: pkg/selinux/manifest.json.in
 msgid "SELinux"
-msgstr ""
+msgstr "SELinux"
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -6082,6 +6071,14 @@ msgstr "STP maximální stáří zprávy"
 msgid "STP Priority"
 msgstr "STP priorita"
 
+#: pkg/shell/index.html:403
+msgid ""
+"Safari users need to import and trust the certificate of the self-signing CA:"
+""
+msgstr ""
+"Uživatelé prohlížeče Safari budou potřebovat naimportovat si certifikát samu "
+"sebe podepisující certifikační autority a nastavit ji jako důvěryhodnou:"
+
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
 #: pkg/systemd/services.html:132
 msgid "Saturday"
@@ -6092,26 +6089,26 @@ msgid "Saturdays"
 msgstr "Soboty"
 
 # auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:266 pkg/storaged/crypto-keyslots.jsx:285
 msgid "Save"
 msgstr "Uložit"
 
-#: pkg/systemd/hwinfo.jsx:219
+#: pkg/systemd/hwinfo.jsx:223
 msgid "Save and reboot"
 msgstr "Uložit a restartovat"
 
-#: pkg/storaged/vdos-panel.jsx:82
+#: pkg/storaged/vdos-panel.jsx:88
 msgid "Save space by compressing individual blocks with LZ4"
 msgstr "Šetřit prostorem komprimováním jednotlivých bloků pomocí LZ4"
 
-#: pkg/storaged/vdos-panel.jsx:85
+#: pkg/storaged/vdos-panel.jsx:92
 msgid "Save space by storing identical data blocks just once"
 msgstr "Šetřit prostorem tím, že stejné bloky dat budou ukládány pouze jednou"
 
-#: pkg/storaged/crypto-keyslots.jsx:226 pkg/storaged/crypto-keyslots.jsx:276
+#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:283
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
@@ -6124,11 +6121,11 @@ msgid "Sealed-case PC"
 msgstr "Počítač se zapečetěnou skříní"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:905
+#: pkg/systemd/init.js:967
 msgid "Seconds"
 msgstr "Sekund"
 
-#: pkg/systemd/index.html:106
+#: pkg/systemd/index.html:113
 msgid "Secure Shell Keys"
 msgstr "Klíče zabezpečeného shellu"
 
@@ -6141,7 +6138,7 @@ msgstr "Jisté vymazávání $target"
 msgid "Security"
 msgstr "Zabezpečení"
 
-#: pkg/systemd/host.js:506
+#: pkg/systemd/host.js:509
 msgid "Security Updates Available"
 msgstr "Jsou k dispozici aktualizace zabezpečení"
 
@@ -6177,11 +6174,11 @@ msgstr "Sériová konzole"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:323 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Server"
 
-#: pkg/storaged/iscsi-panel.jsx:43 pkg/storaged/nfs-details.jsx:143
+#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:146
 msgid "Server Address"
 msgstr "Adresa serveru"
 
@@ -6193,15 +6190,15 @@ msgstr "Správce serveru"
 msgid "Server Software"
 msgstr "Serverový software"
 
-#: pkg/storaged/iscsi-panel.jsx:44
+#: pkg/storaged/iscsi-panel.jsx:45
 msgid "Server address cannot be empty."
 msgstr "Adresu serveru je třeba vyplnit."
 
-#: pkg/storaged/nfs-details.jsx:147
+#: pkg/storaged/nfs-details.jsx:151
 msgid "Server cannot be empty."
 msgstr "Server je třeba vyplnit."
 
-#: src/base1/cockpit.js:4033
+#: src/base1/cockpit.js:4037
 msgid "Server has closed the connection."
 msgstr "Server zavřel spojení."
 
@@ -6211,8 +6208,8 @@ msgid "Servers"
 msgstr "Servery"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:970
+#: pkg/storaged/dialog.jsx:1048
 msgid "Service"
 msgstr "Služba"
 
@@ -6220,23 +6217,23 @@ msgstr "Služba"
 msgid "Service Logs"
 msgstr "Záznamy událostí služby"
 
-#: pkg/kdump/kdump-view.jsx:442
+#: pkg/kdump/kdump-view.jsx:444
 msgid "Service has an error"
 msgstr "Služba má chybu"
 
-#: pkg/kdump/kdump-view.jsx:438
+#: pkg/kdump/kdump-view.jsx:440
 msgid "Service is running"
 msgstr "Služba je spuštěná"
 
-#: pkg/kdump/kdump-view.jsx:444
+#: pkg/kdump/kdump-view.jsx:446
 msgid "Service is starting"
 msgstr "Služba se spouští"
 
-#: pkg/kdump/kdump-view.jsx:440
+#: pkg/kdump/kdump-view.jsx:442
 msgid "Service is stopped"
 msgstr "Služba je zastavená"
 
-#: pkg/kdump/kdump-view.jsx:446
+#: pkg/kdump/kdump-view.jsx:448
 msgid "Service is stopping"
 msgstr "Služba se zastavuje"
 
@@ -6246,12 +6243,12 @@ msgstr "Název služby"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:510 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Služby"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:50
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1044
 msgid "Session"
 msgstr "Sezení"
 
@@ -6260,11 +6257,11 @@ msgstr "Sezení"
 msgid "Set"
 msgstr "Nastavit"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+#: pkg/machines/components/networks/createNetworkDialog.jsx:217
 msgid "Set DHCP Range"
 msgstr "Nastavit DHCP rozsah"
 
-#: pkg/systemd/host.js:781
+#: pkg/systemd/host.js:816
 msgid "Set Host name"
 msgstr "Nastavit název stroje"
 
@@ -6272,13 +6269,17 @@ msgstr "Nastavit název stroje"
 msgid "Set Password"
 msgstr "Nastavit heslo"
 
-#: pkg/systemd/index.html:378
+#: pkg/systemd/index.html:389
 msgid "Set Time"
 msgstr "Nastavit čas"
 
 #: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Nastavit proměnné prostředí pro kontejner"
+
+#: pkg/machines/components/nicAdd.jsx:60
+msgid "Set manually"
+msgstr "Nastavit ručně"
 
 #: pkg/networkmanager/index.html:183
 msgid "Set to"
@@ -6304,16 +6305,16 @@ msgid "Setting up loop device $target"
 msgstr "Nastavování zařízení zpětné smyčky $target"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:383
 msgid "Severity"
 msgstr "Závažnost"
 
-#: pkg/packagekit/updates.jsx:310
+#: pkg/packagekit/updates.jsx:311
 msgid "Severity:"
 msgstr "Závažnost:"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Shared"
 msgstr "Sdílené"
 
@@ -6325,15 +6326,15 @@ msgstr "Shellový skript"
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Show Performance Options"
 msgstr "Zobrazit předvolby pro výkonnost"
 
-#: pkg/storaged/overview.jsx:56
+#: pkg/storaged/overview.jsx:54
 msgid "Show all"
 msgstr "Zobrazit vše"
 
-#: pkg/storaged/drives-panel.jsx:122
+#: pkg/storaged/drives-panel.jsx:104
 msgid "Show all $0 drives"
 msgstr "Zobrazit všech $0 jednotek"
 
@@ -6345,25 +6346,25 @@ msgstr "Zobrazit všechny kontejnery"
 msgid "Show all images"
 msgstr "Zobrazit všechny obrazy"
 
-#: pkg/systemd/index.html:107
+#: pkg/systemd/index.html:114
 msgid "Show fingerprints"
 msgstr "Zobrazit otisky"
 
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
+#: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Zmenšit"
 
-#: pkg/storaged/lvol-tabs.jsx:313
+#: pkg/storaged/lvol-tabs.jsx:320
 msgid "Shrink Logical Volume"
 msgstr "Zmenšit logický svazek"
 
-#: pkg/storaged/lvol-tabs.jsx:415
+#: pkg/storaged/lvol-tabs.jsx:423
 msgid "Shrink Volume"
 msgstr "Zmenšit oddíl"
 
 # auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
-#: pkg/systemd/index.html:147 pkg/machines/components/vm/vmActions.jsx:56
+#: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
 msgstr "Vypnout"
@@ -6375,47 +6376,47 @@ msgstr "Single Rank"
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
-#: pkg/machines/components/diskAdd.jsx:172
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:79
+#: pkg/storaged/content-views.jsx:118 pkg/storaged/content-views.jsx:702
+#: pkg/storaged/format-dialog.jsx:278 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:212 pkg/storaged/lvol-tabs.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:402 pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/nfs-details.jsx:329 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:263
 msgid "Size"
 msgstr "Velikost"
 
-#: pkg/storaged/dialog.jsx:911
+#: pkg/storaged/dialog.jsx:912
 msgid "Size cannot be negative"
 msgstr "Velikost nemůže být záporná"
 
-#: pkg/storaged/dialog.jsx:909
+#: pkg/storaged/dialog.jsx:910
 msgid "Size cannot be zero"
 msgstr "Velikost nemůže být nula"
 
-#: pkg/storaged/dialog.jsx:913
+#: pkg/storaged/dialog.jsx:914
 msgid "Size is too large"
 msgstr "Příliš velké"
 
-#: pkg/storaged/dialog.jsx:907
+#: pkg/storaged/dialog.jsx:908
 msgid "Size must be a number"
 msgstr "Je třeba, aby velikost byla číslo"
 
-#: pkg/storaged/dialog.jsx:915
+#: pkg/storaged/dialog.jsx:916
 msgid "Size must be at least $0"
 msgstr "Je třeba, aby velikost byla alespoň $0"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Slot"
 msgstr "Slot"
 
-#: pkg/storaged/crypto-keyslots.jsx:531
+#: pkg/storaged/crypto-keyslots.jsx:544
 msgid "Slot $0"
 msgstr "Slot $0"
 
-#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "Sokety"
 
@@ -6423,7 +6424,7 @@ msgstr "Sokety"
 msgid "Software Updates"
 msgstr "Aktualizace software"
 
-#: pkg/systemd/hwinfo.jsx:208
+#: pkg/systemd/hwinfo.jsx:212
 msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
@@ -6433,12 +6434,7 @@ msgstr ""
 "zneužití. Mají negativní dopad na výkonnost. Nastavení měníte na vlastní "
 "nebezpeční."
 
-#: pkg/docker/storage.jsx:165
-msgid "Solid-State Disk"
-msgstr "Jednotka bez pohyblivých částí"
-
-#: pkg/storaged/drives-panel.jsx:87
-msgctxt "storage"
+#: pkg/docker/storage.jsx:167
 msgid "Solid-State Disk"
 msgstr "Jednotka bez pohyblivých částí"
 
@@ -6460,16 +6456,16 @@ msgid ""
 msgstr ""
 "Správa balíčků je v tuto chvíli používána nějakým jiným programem, vyčkejte…"
 
-#: pkg/networkmanager/firewall.jsx:739
+#: pkg/networkmanager/firewall.jsx:741
 msgid "Sorted from least trusted to most trusted"
 msgstr "Seřazeno od nejméně po nejvíce důvěryhodné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/machines/components/diskAdd.jsx:541
-#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/diskAdd.jsx:412
+#: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
-#: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/vmDisksTab.jsx:114
+#: pkg/machines/components/vmnetworktab.jsx:160
 msgid "Source"
 msgstr "Zdroj"
 
@@ -6483,10 +6479,6 @@ msgstr "Zdrojový formát"
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
 msgstr "Popis umístění zdroje"
-
-#: node_modules/registry-image-widgets/views/image-body.html:8
-msgid "Source URL"
-msgstr "Zdrojová URL adresa"
 
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
@@ -6505,7 +6497,7 @@ msgstr "Zdroj by měl začínat na http, ftp nebo nfs protokol"
 msgid "Space-saving Computer"
 msgstr "Prostorově úsporný počítač"
 
-#: pkg/networkmanager/interfaces.js:2869
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
@@ -6513,26 +6505,26 @@ msgstr "Spanning Tree Protocol"
 msgid "Spanning Tree Protocol (STP)"
 msgstr "Spanning Tree Protocol (STP)"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Spare"
 msgstr "Náhradní"
 
-#: pkg/systemd/index.html:455
+#: pkg/systemd/index.html:466
 msgid "Specific Time"
 msgstr "Konkrétní čas"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Speed"
 msgstr "Rychlost"
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3660
 msgid "Stable"
 msgstr "Stabilní"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/machines/components/networks/createNetworkDialog.jsx:237
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:223
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:265 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Spustit"
 
@@ -6544,11 +6536,11 @@ msgstr "Spustit Docker"
 msgid "Start Multipath"
 msgstr "Spustit multipath"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:343
 msgid "Start Service"
 msgstr "Spustit službu"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Start and Enable"
 msgstr "Spustit a zapnout"
 
@@ -6579,10 +6571,10 @@ msgstr "Při spuštění"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/vmnetworktab.jsx:186 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/hwinfo.jsx:263 pkg/systemd/init.js:306
 msgid "State"
 msgstr "Stav"
 
@@ -6591,13 +6583,13 @@ msgstr "Stav"
 msgid "State:"
 msgstr "Stav:"
 
-#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:369
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:213
+#: pkg/systemd/service-details.jsx:371
 msgid "Static"
 msgstr "Statické"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
+#: pkg/networkmanager/interfaces.js:2633 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Stav"
 
@@ -6611,21 +6603,21 @@ msgstr "Lepkavé"
 
 # auto translated by TM merge from project: Fedora Media Writer, version: master, DocId: mediawriter
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
 #: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Zastavit"
 
-#: pkg/storaged/mdraid-details.jsx:247
+#: pkg/storaged/mdraid-details.jsx:244
 msgid "Stop Device"
 msgstr "Zastavit zařízení"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Stop and Disable"
 msgstr "Zastavit a vypnout"
 
-#: pkg/storaged/nfs-details.jsx:259
+#: pkg/storaged/nfs-details.jsx:267
 msgid "Stop and Unmount"
 msgstr "Zastavit a odpojit"
 
@@ -6633,13 +6625,9 @@ msgstr "Zastavit a odpojit"
 msgid "Stop and delete"
 msgstr "Zastavit a smazat"
 
-#: pkg/storaged/nfs-details.jsx:284
+#: pkg/storaged/nfs-details.jsx:292
 msgid "Stop and remove"
 msgstr "Zastavit a odebrat"
-
-#: node_modules/registry-image-widgets/views/image-config.html:14
-msgid "Stop with"
-msgstr "Zastavit pomocí"
 
 # auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
 #: pkg/docker/util.js:231
@@ -6665,6 +6653,13 @@ msgstr "Úložiště"
 msgid "Storage Logs"
 msgstr "Záznamy událostí úložiště"
 
+#: pkg/machines/components/aggregateStatusCards.jsx:47
+msgid "Storage Pool"
+msgid_plural "Storage Pools"
+msgstr[0] "Fond úložiště"
+msgstr[1] "Fondy úložiště"
+msgstr[2] "Fondů úložiště"
+
 #: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "Fond úložiště $0 se nepodařilo aktivovat"
@@ -6681,8 +6676,8 @@ msgstr "Název fondu úložiště"
 msgid "Storage Pool failed to be created"
 msgstr "Fond úložiště se nepodařilo uložit"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:44
-#: pkg/machines/components/storagePools/storagePoolList.jsx:48
+#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/storagePoolList.jsx:53
 msgid "Storage Pools"
 msgstr "Fondy úložiště"
 
@@ -6706,19 +6701,19 @@ msgstr "Fond úložiště"
 msgid "Storage size must not be 0"
 msgstr "Velikost úložiště nemůže být nula"
 
-#: pkg/systemd/index.html:155
+#: pkg/systemd/index.html:162
 msgid "Store Metrics"
 msgstr "Ukládat metriky"
 
-#: pkg/storaged/format-dialog.jsx:122
+#: pkg/storaged/format-dialog.jsx:126
 msgid "Store passphrase"
 msgstr "Uložit heslovou frázi"
 
-#: pkg/storaged/crypto-tab.jsx:67 pkg/storaged/crypto-tab.jsx:69
+#: pkg/storaged/crypto-tab.jsx:68 pkg/storaged/crypto-tab.jsx:70
 msgid "Stored Passphrase"
 msgstr "Uložená heslová fráze"
 
-#: pkg/storaged/crypto-tab.jsx:126
+#: pkg/storaged/crypto-tab.jsx:129
 msgid "Stored passphrase"
 msgstr "Uložená heslová fráze"
 
@@ -6730,11 +6725,6 @@ msgstr "Dílčí skříň"
 msgid "Sub Notebook"
 msgstr "Zmenšený notebook"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: node_modules/registry-image-widgets/views/image-body.html:4
-msgid "Summary"
-msgstr "Souhrn"
-
 # auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
 #: pkg/systemd/services.html:133
 msgid "Sunday"
@@ -6744,33 +6734,33 @@ msgstr "neděle"
 msgid "Sundays"
 msgstr "Neděle"
 
-#: pkg/storaged/optional-panel.jsx:95
+#: pkg/storaged/optional-panel.jsx:98
 msgid "Support is installed."
 msgstr "Podpora je nainstalovaná."
 
 # auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
-#: pkg/storaged/content-views.jsx:157
+#: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Odkládací oddíl"
 
-#: pkg/storaged/content-views.jsx:351
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Odkládací prostor"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
+#: pkg/systemd/index.html:259 pkg/systemd/host.js:1756
 msgid "Swap Used"
 msgstr "Využití odkládacího prostoru"
 
-#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:3060
 msgid "Switch off $0"
 msgstr "Vypnout $0"
 
-#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2486 pkg/networkmanager/interfaces.js:3048
 msgid "Switch on $0"
 msgstr "Zapnout $0"
 
-#: pkg/networkmanager/interfaces.js:2503
+#: pkg/networkmanager/interfaces.js:2510
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6778,7 +6768,7 @@ msgstr ""
 "Vypnutí <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:3050
+#: pkg/networkmanager/interfaces.js:3059
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6786,7 +6776,7 @@ msgstr ""
 "Vypnutí <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3047
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6817,12 +6807,16 @@ msgstr "Synchronizuje se RAID zařízení $target"
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
 #: pkg/systemd/index.html:4
 #: pkg/machines/components/machinesConnectionSelector.jsx:43
-#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:273
 #: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Systém"
 
-#: pkg/systemd/hwinfo.jsx:273
+#: pkg/systemd/index.html:171
+msgid "System Health"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:277
 msgid "System Information"
 msgstr "Informace o systému"
 
@@ -6830,28 +6824,28 @@ msgstr "Informace o systému"
 msgid "System Modifications"
 msgstr "Modifikace systému"
 
-#: pkg/systemd/host.js:490
+#: pkg/systemd/host.js:493
 msgid "System Not Registered"
 msgstr "Systém není zaregistrován"
 
-#: pkg/systemd/services.jsx:38
+#: pkg/systemd/services.jsx:47
 msgid "System Services"
 msgstr "Systémové služby"
 
-#: pkg/systemd/index.html:121
+#: pkg/systemd/index.html:128
 msgid "System Time"
 msgstr "Systémový čas"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:499
 msgid "System Up To Date"
 msgstr "Systém je aktuální"
 
-#: pkg/packagekit/updates.jsx:878
+#: pkg/packagekit/updates.jsx:879
 msgid "System is up to date"
 msgstr "Systém je aktuální"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "TCP"
 msgstr "TCP"
 
@@ -6861,19 +6855,15 @@ msgid "Tablet"
 msgstr "Tablet"
 
 #: pkg/docker/index.html:696
-#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Štítek"
 
 # auto translated by TM merge from project: ibus, version: head, DocId: ibus10
-#: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
 #: pkg/docker/containers-view.jsx:409
 msgid "Tags"
 msgstr "Šítky"
 
-#: pkg/storaged/crypto-keyslots.jsx:207
+#: pkg/storaged/crypto-keyslots.jsx:210
 msgid "Tang keyserver"
 msgstr "Tang server s klíči"
 
@@ -6891,17 +6881,17 @@ msgstr "Popis umístění cíle"
 msgid "Target path should not be empty"
 msgstr "Popis umístění cíle je třeba vyplnit"
 
-#: pkg/systemd/services.jsx:39
+#: pkg/systemd/services.jsx:48
 msgid "Targets"
 msgstr "Cíle"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
-#: pkg/networkmanager/interfaces.js:2826
+#: pkg/networkmanager/interfaces.js:2531 pkg/networkmanager/interfaces.js:2543
+#: pkg/networkmanager/interfaces.js:2834
 msgid "Team"
 msgstr "Tým"
 
-#: pkg/networkmanager/interfaces.js:2854
+#: pkg/networkmanager/interfaces.js:2862
 msgid "Team Port"
 msgstr "Port týmu"
 
@@ -6921,11 +6911,11 @@ msgstr "Terminál"
 msgid "Terminate Session"
 msgstr "Ukončit sezení"
 
-#: pkg/kdump/kdump-view.jsx:476 pkg/kdump/kdump-view.jsx:484
+#: pkg/kdump/kdump-view.jsx:478 pkg/kdump/kdump-view.jsx:486
 msgid "Test Configuration"
 msgstr "Vyzkoušet nastavení"
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr "Test je k dispozici pouze pokud je spuštěná služba kdump."
 
@@ -6937,25 +6927,25 @@ msgstr "Vyzkoušet nastavení kdump"
 msgid "Testing connection"
 msgstr "Zkouška spojení"
 
-#: pkg/docker/storage.jsx:507
+#: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr "Docker fond úložiště není na tomto systému možné spravovat."
 
-#: pkg/lib/machine-dialogs.js:384
+#: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP adresa nebo název stroje nemůže obsahovat prázdný znak."
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/mdraid-details.jsx:213
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID pole je v degradovaném stavu"
 
-#: pkg/storaged/mdraid-details.jsx:148
+#: pkg/storaged/mdraid-details.jsx:142
 msgid "The RAID device must be running in order to add spare disks."
 msgstr ""
 "Aby bylo možné přidávat náhradní disky je třeba, aby RAID zařízení bylo "
 "spuštěné."
 
-#: pkg/storaged/mdraid-details.jsx:115
+#: pkg/storaged/mdraid-details.jsx:109
 msgid "The RAID device must be running in order to remove disks."
 msgstr ""
 "Aby bylo možné odebírat disky je třeba, aby RAID zařízení bylo spuštěné."
@@ -7026,7 +7016,7 @@ msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr "Vytváření tohoto VDO zařízení není dokončeno a proto ho nelze použít."
 
-#: pkg/storaged/crypto-keyslots.jsx:516
+#: pkg/storaged/crypto-keyslots.jsx:529
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr "Stávající uživatel není oprávněn zobrazovat informace o klíčích."
@@ -7035,7 +7025,7 @@ msgstr "Stávající uživatel není oprávněn zobrazovat informace o klíčíc
 msgid "The directory on the server being exported"
 msgstr "Složka na serveru, kterou exportovat"
 
-#: pkg/storaged/dialog.jsx:1012
+#: pkg/storaged/dialog.jsx:1013
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -7043,14 +7033,14 @@ msgstr ""
 "Souborový systém je používán přihlašovacími sezeními a systémovými službami. "
 "Pokračování je zastaví."
 
-#: pkg/storaged/dialog.jsx:1014
+#: pkg/storaged/dialog.jsx:1015
 msgid ""
 "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Souborový systém je používán přihlašovacími sezeními. Pokračování je zastaví."
 ""
 
-#: pkg/storaged/dialog.jsx:1016
+#: pkg/storaged/dialog.jsx:1017
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
@@ -7086,15 +7076,15 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr "Zadaný klíč není platný."
 
-#: pkg/storaged/mdraid-details.jsx:121
+#: pkg/storaged/mdraid-details.jsx:115
 msgid "The last disk of a RAID device cannot be removed."
 msgstr "Poslední zbývající disk RAID zařízení není možné odebrat."
 
-#: pkg/storaged/crypto-keyslots.jsx:541
+#: pkg/storaged/crypto-keyslots.jsx:554
 msgid "The last key slot can not be removed"
 msgstr "Poslední zbývající slot klíče není možné odebrat"
 
-#: pkg/storaged/vgroup-details.jsx:96
+#: pkg/storaged/vgroup-details.jsx:90
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Poslední zbývající fyzický svazek skupiny svazků není možné odebrat."
 
@@ -7102,7 +7092,7 @@ msgstr "Poslední zbývající fyzický svazek skupiny svazků není možné ode
 msgid "The logged in user is not permitted to view system modifications"
 msgstr "Přihlášený uživatel není oprávněn zobrazovat modifikace systému"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:464
 msgid "The machine is restarting"
 msgstr "Stroj se restartuje"
 
@@ -7118,13 +7108,20 @@ msgstr "Zadání hesla se neshodují"
 msgid "The passwords do not match."
 msgstr "Zadání hesla se neshodují."
 
-#: pkg/machines/components/diskAdd.jsx:80
+#: pkg/machines/components/diskAdd.jsx:81
 msgid "The pool is empty"
 msgstr "Fond je prázdný"
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Sken z $time ($type) nenalezl žádné zranitelnosti."
+
+#: pkg/docker/containers-view.jsx:436
+msgid "The scan from $time ($type) found one vulnerability:"
+msgid_plural "The scan from $time ($type) found $count vulnerabilities:"
+msgstr[0] "Při skenu z $time ($type) nalezena jedna zranitelnost:"
+msgstr[1] "Při skenu z $time ($type) nalezeny $count zranitelnosti:"
+msgstr[2] "Při skenu z $time ($type) nalezeny $count zranitelností:"
 
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
@@ -7139,6 +7136,16 @@ msgid ""
 "The selected Operating System has minimum storage size requirement of $0 $1"
 msgstr "Vybraný operační systém vyžaduje velikost úložiště přinejmenším $0 $1"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:382
+msgid "The selected Operating System has recommended memory $0 $1"
+msgstr ""
+"Pro zvolený operační systém je doporučená velikost operační paměti $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:417
+msgid "The selected Operating System has recommended storage size of $0 $1"
+msgstr ""
+"Pro zvolený operační systém je doporučená velikost datového úložiště $0 $1"
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -7147,16 +7154,16 @@ msgstr ""
 "Server odmítl ověřit „$0“ pomocí ověření heslem a nejsou k dispozici žádné "
 "další metody ověření."
 
-#: src/base1/cockpit.js:4017
+#: src/base1/cockpit.js:4021
 msgid "The server refused to authenticate using any supported methods."
 msgstr "Server odmítl ověřit u všech podporovaných metod."
 
-#: pkg/systemd/hwinfo.jsx:65
+#: pkg/systemd/hwinfo.jsx:69
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 "Uživatel $0 není oprávněn měnit zmírňování dopadu chyb zabezpečení procesoru"
 
-#: pkg/systemd/init.js:751
+#: pkg/systemd/init.js:813
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Uživatel <b>$0</b> není oprávněn pro vytváření časovačů"
 
@@ -7164,11 +7171,11 @@ msgstr "Uživatel <b>$0</b> není oprávněn pro vytváření časovačů"
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "Uživatel <b>$0</b> není oprávněn měnit profily"
 
-#: pkg/systemd/host.js:70
+#: pkg/systemd/host.js:72
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Uživatel <b>$0</b> není oprávněn měnit systémový čas"
 
-#: pkg/dashboard/list.js:223
+#: pkg/dashboard/list.js:231
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "Uživatel <b>$0</b> není oprávněn spravovat servery"
 
@@ -7180,19 +7187,19 @@ msgstr "Uživatel <b>$0</b> není oprávněn spravovat úložiště"
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat účty"
 
-#: pkg/systemd/host.js:54
+#: pkg/systemd/host.js:56
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat názvy strojů"
 
-#: pkg/networkmanager/interfaces.js:1525
+#: pkg/networkmanager/interfaces.js:1530
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat nastavení sítě"
 
-#: pkg/realmd/operation.js:642
+#: pkg/realmd/operation.js:644
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat oblasti"
 
-#: pkg/systemd/host.js:62
+#: pkg/systemd/host.js:64
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr "Uživatel <b>$0</b> není oprávněn vypínat či restartovat tento server"
 
@@ -7227,7 +7234,7 @@ msgstr ""
 msgid "There are no authorized public keys for this account."
 msgstr "Pro tento účet nejsou žádné pověřené klíče."
 
-#: pkg/storaged/vgroup-details.jsx:102
+#: pkg/storaged/vgroup-details.jsx:96
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
@@ -7235,11 +7242,15 @@ msgstr ""
 "Pro odebrání tohoto fyzického svazku není k dispozici dostatek volného místa."
 " Je třeba alespoň $0 dalšího volného prostoru."
 
-#: pkg/storaged/utils.js:193
+#: pkg/shell/index.html:398
+msgid "There was an unexpected error while connecting to the machine."
+msgstr "Při připojování ke stroji došlo k neočekávané chybě."
+
+#: pkg/storaged/utils.js:194
 msgid "Thin Logical Volume"
 msgstr "Tenký logický svazek"
 
-#: pkg/storaged/nfs-details.jsx:118
+#: pkg/storaged/nfs-details.jsx:120
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr "Toto NFS připojení je používáno a měnit je možné jen jeho volby."
 
@@ -7247,7 +7258,7 @@ msgstr "Toto NFS připojení je používáno a měnit je možné jen jeho volby.
 msgid "This VDO device does not use all of its backing device."
 msgstr "Toto VDO zařízení nepoužívá ze svého podkladového zařízení vše."
 
-#: pkg/systemd/init.js:1200
+#: pkg/systemd/init.js:1262
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -7255,11 +7266,11 @@ msgstr ""
 "Tento den neexistuje ve všech měsících.<br> Časovač bude vykonán pouze v "
 "měsících, které mají 31. den"
 
-#: pkg/networkmanager/interfaces.js:2636
+#: pkg/networkmanager/interfaces.js:2644
 msgid "This device cannot be managed here."
 msgstr "Toto zařízení zde nelze spravovat."
 
-#: pkg/storaged/dialog.jsx:997
+#: pkg/storaged/dialog.jsx:998
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -7267,11 +7278,11 @@ msgstr ""
 "Na tomto zařízení se nacházejí souborové systémy, které jsou v tuto chvíli "
 "používány. Pokračování je odpojí."
 
-#: pkg/storaged/dialog.jsx:976
+#: pkg/storaged/dialog.jsx:977
 msgid "This device is currently used for RAID devices."
 msgstr "Toto zařízení je v tuto chvíli používáno pro RAID zařízení."
 
-#: pkg/storaged/dialog.jsx:1005
+#: pkg/storaged/dialog.jsx:1006
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -7279,15 +7290,15 @@ msgstr ""
 "Toto zařízení je v tuto chvíli používáno pro RAID zařízení. Pokračování ho z "
 "nich odebere."
 
-#: pkg/storaged/dialog.jsx:980
+#: pkg/storaged/dialog.jsx:981
 msgid "This device is currently used for VDO devices."
 msgstr "Toto zařízení je v tuto chvíli používáno pro VDO zařízení."
 
-#: pkg/storaged/dialog.jsx:972
+#: pkg/storaged/dialog.jsx:973
 msgid "This device is currently used for volume groups."
 msgstr "Toto zařízení je v tuto chvíli používáno ve skupinách svazků."
 
-#: pkg/storaged/dialog.jsx:1001
+#: pkg/storaged/dialog.jsx:1002
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7295,11 +7306,11 @@ msgstr ""
 "Toto zařízení je v tuto chvíli používáno ve skupinách svazků. Pokračování ho "
 "odebere z jeho skupin svazků."
 
-#: pkg/storaged/mdraid-details.jsx:117
+#: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "Disk není možné vyjmout v průběhu zotavování zařízení."
 
-#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
+#: pkg/systemd/init.js:1174 pkg/systemd/init.js:1188 pkg/systemd/init.js:1197
 msgid "This field cannot be empty."
 msgstr "Tuto kolonku je třeba vyplnit."
 
@@ -7307,12 +7318,12 @@ msgstr "Tuto kolonku je třeba vyplnit."
 msgid "This image does not exist."
 msgstr "Tento obraz neexistuje."
 
-#: pkg/storaged/lvol-tabs.jsx:408
+#: pkg/storaged/lvol-tabs.jsx:416
 msgid "This logical volume is not completely used by its content."
 msgstr ""
 "Tento logický svazek není zcela využíván obsahem, který se na něm nachází."
 
-#: pkg/lib/machine-dialogs.js:362
+#: pkg/lib/machine-dialogs.js:364
 msgid "This machine has already been added."
 msgstr "Tento stroj už byl přidán."
 
@@ -7329,11 +7340,11 @@ msgstr "Tento balíček není kompatibilní s touto verzí Cockpit"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Tento balíček vyžaduje Cockpit verze $s a novější"
 
-#: pkg/machines/components/diskAdd.jsx:215
+#: pkg/machines/components/diskAdd.jsx:138
 msgid "This pool type does not support Storage Volume creation"
 msgstr "Tento typ fondu nepodporuje vytvoření svazku úložiště"
 
-#: pkg/packagekit/updates.jsx:774
+#: pkg/packagekit/updates.jsx:775
 msgid "This system is not registered"
 msgstr "Tento systém není zaregistrován"
 
@@ -7361,7 +7372,7 @@ msgstr "Tato jednotka není navržena k tomu, aby byla výslovně zapnuta."
 msgid "This user name already exists"
 msgstr "Toto uživatelské jméno už existuje"
 
-#: pkg/lib/machine-dialogs.js:378
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
@@ -7373,7 +7384,7 @@ msgstr ""
 msgid "This volume is already used by another VM."
 msgstr "Tento svazek už je využíván jiným virt. strojem"
 
-#: pkg/storaged/lvol-tabs.jsx:186
+#: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
 msgstr ""
 "Než bude možné změnit jeho velikost je třeba, aby tento svazek byl aktivován."
@@ -7384,7 +7395,7 @@ msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
 "Tento webový prohlížeč je příliš starý pro spuštění Cockpit (chybí $0)"
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:835
 msgid "This web console will be updated."
 msgstr "Tato webová konzole bude aktualizována"
 
@@ -7398,7 +7409,7 @@ msgstr ""
 "závislosti na nastavení se systém nemusí automaticky zrestartovat a proces "
 "může chvíli trvat."
 
-#: pkg/kdump/kdump-view.jsx:489
+#: pkg/kdump/kdump-view.jsx:491
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Toto vyzkouší nastavení kdump vyvoláním havárie jádra."
 
@@ -7415,15 +7426,15 @@ msgstr "čtvrtek"
 msgid "Thursdays"
 msgstr "Čtvrtky"
 
-#: pkg/systemd/index.html:364
+#: pkg/systemd/index.html:375
 msgid "Time Zone"
 msgstr "Časová zóna"
 
-#: pkg/systemd/services.jsx:41
+#: pkg/systemd/services.jsx:50
 msgid "Timers"
 msgstr "Časovače"
 
-#: pkg/shell/index.html:305
+#: pkg/shell/index.html:306
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -7431,21 +7442,13 @@ msgstr ""
 "Tip: Nastavte si heslo ke klíči stejné jako pro přihlašování a budete se "
 "vůči ostatním systémům ověřovat automaticky."
 
-#: pkg/packagekit/updates.jsx:775
+#: pkg/packagekit/updates.jsx:776
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
 msgstr ""
 "Pro získávání aktualizací software je třeba systém zaregistrovat u Red Hat, "
 "buď pomocí Red Hat portálu pro zákazníky nebo místního serveru předplatného."
-
-#: node_modules/registry-image-widgets/views/image-pull.html:4
-msgid "To pull this image:"
-msgstr "Pro stažení tohoto obrazu:"
-
-#: node_modules/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push an image to this image stream:"
-msgstr "Pro nahrání obrazu do tohoto proudu obrazů:"
 
 #: pkg/lib/machine-change-port.html:11
 msgid ""
@@ -7454,16 +7457,12 @@ msgid ""
 msgstr ""
 "Pro vyzkoušení jiného portu bude třeba přejít na novější verzi cockpit-ws."
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
-msgid "Too many files found"
-msgstr "Nalezeno příliš mnoho souborů"
-
-#: src/base1/cockpit.js:4039
+#: src/base1/cockpit.js:4043
 msgid "Too much data"
 msgstr "Příliš mnoho dat"
 
 # auto translated by TM merge from project: retrace-server, version: master, DocId: retrace-server
-#: pkg/docker/storage.jsx:341
+#: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Celkem"
 
@@ -7477,27 +7476,27 @@ msgstr "Věž"
 
 #: pkg/playground/manifest.json.in
 msgid "Translating"
-msgstr ""
+msgstr "Překládání"
 
-#: pkg/systemd/service-details.jsx:431
+#: pkg/systemd/service-details.jsx:433
 msgid "Triggered By"
 msgstr "Spuštěno na základě"
 
-#: pkg/systemd/service-details.jsx:430
+#: pkg/systemd/service-details.jsx:432
 msgid "Triggers"
 msgstr "Spouštěče"
 
 # auto translated by TM merge from project: SETroubleShoot, version: master, DocId: framework/po/setroubleshoot
-#: pkg/shell/index.html:382 pkg/shell/simple.html:139
+#: pkg/shell/index.html:383 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Řešit potíže"
 
-#: pkg/storaged/crypto-keyslots.jsx:331
+#: pkg/storaged/crypto-keyslots.jsx:339
 msgid "Trust key"
 msgstr "Důvěryhodný klíč"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:737
 msgid "Trust level"
 msgstr "Stupeň důvěryhodnosti"
 
@@ -7526,7 +7525,7 @@ msgstr "úterý"
 msgid "Tuesdays"
 msgstr "Úterky"
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:261
 msgid "Tuned has failed to start"
 msgstr "Spuštění procesu služby tuned se nezdařilo"
 
@@ -7543,7 +7542,7 @@ msgid "Tuned is off"
 msgstr "Tuned je vypnuté"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/shell/index.html:265
+#: pkg/shell/index.html:266
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
@@ -7552,10 +7551,10 @@ msgstr "Tuned je vypnuté"
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmnetworktab.jsx:120
+#: pkg/storaged/format-dialog.jsx:293 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Type"
 msgstr "Typ"
 
@@ -7571,7 +7570,7 @@ msgstr "Zadejte heslo"
 msgid "Type to filter…"
 msgstr "Filtrujte psaním…"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:970
 msgid "UDP"
 msgstr "UDP"
 
@@ -7614,17 +7613,13 @@ msgstr "Nedaří se získat výstrahu: $0"
 msgid "Unable to reach server"
 msgstr "Server se nedaří dosáhnout"
 
-#: pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:290
 msgid "Unable to remove mount"
 msgstr "Účet se nedaří odebrat"
 
 #: pkg/users/local.js:60
 msgid "Unable to rename root account"
 msgstr "Účet správce (root) není možné přejmenovat"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:41
-msgid "Unable to resolve"
-msgstr "Nedaří se vyřešit"
 
 #: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
@@ -7634,7 +7629,7 @@ msgstr "Nedaří se spustit opravu: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "Nedaří se spustit setroubleshootd"
 
-#: pkg/storaged/nfs-details.jsx:257
+#: pkg/storaged/nfs-details.jsx:265
 msgid "Unable to unmount filesystem"
 msgstr "Nedaří se odpojit souborový systém"
 
@@ -7644,11 +7639,11 @@ msgid "Unavailable"
 msgstr "Nedostupné"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:758 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Neočekávaná chyba"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+#: pkg/machines/components/networks/createNetworkDialog.jsx:114
 msgid "Unique Network Name"
 msgstr "Doposud nepoužívaný název sítě"
 
@@ -7657,27 +7652,24 @@ msgid "Unique name"
 msgstr "Neopakující se název"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1048
 msgid "Unit"
 msgstr "Jednotka"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: node_modules/registry-image-widgets/views/image-body.html:16
-#: node_modules/registry-image-widgets/views/imagestream-body.html:30
-#: node_modules/registry-image-widgets/views/imagestream-body.html:31
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
-#: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
-#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
+#: pkg/machines/components/vmnetworktab.jsx:149
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1081
+#: pkg/networkmanager/interfaces.js:2551 pkg/networkmanager/interfaces.js:2553
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Neznámé"
 
-#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
+#: pkg/networkmanager/interfaces.js:2537 pkg/networkmanager/interfaces.js:2549
 msgid "Unknown \"$0\""
 msgstr "Neznámé „$0“"
 
-#: pkg/storaged/mdraid-details.jsx:104
+#: pkg/storaged/mdraid-details.jsx:98
 msgid "Unknown ($0)"
 msgstr "Neznámé ($0)"
 
@@ -7689,7 +7681,7 @@ msgstr "Neznámá aplikace"
 msgid "Unknown Host Key"
 msgstr "Neznámý klíč stroje"
 
-#: pkg/networkmanager/interfaces.js:2652
+#: pkg/networkmanager/interfaces.js:2660
 msgid "Unknown configuration"
 msgstr "Neznámé nastavení"
 
@@ -7701,7 +7693,7 @@ msgstr "Neznámý název stroje"
 msgid "Unknown service name"
 msgstr "Neznámý název služby"
 
-#: pkg/storaged/crypto-keyslots.jsx:562
+#: pkg/storaged/crypto-keyslots.jsx:575
 msgid "Unknown type"
 msgstr "Neznámý typ"
 
@@ -7709,20 +7701,20 @@ msgstr "Neznámý typ"
 msgid "Unless Stopped"
 msgstr "Pokud nezastaveno"
 
-#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
-#: pkg/storaged/content-views.jsx:240
+#: pkg/storaged/content-views.jsx:227 pkg/storaged/content-views.jsx:232
+#: pkg/storaged/content-views.jsx:245
 msgid "Unlock"
 msgstr "Odemknout"
 
-#: pkg/shell/index.html:212 pkg/shell/index.html:253
+#: pkg/shell/index.html:213 pkg/shell/index.html:254
 msgid "Unlock Key"
 msgstr "Odemknout klíč"
 
-#: pkg/storaged/format-dialog.jsx:116
+#: pkg/storaged/format-dialog.jsx:120
 msgid "Unlock at boot"
 msgstr "Odemknout při startu systému"
 
-#: pkg/storaged/format-dialog.jsx:117
+#: pkg/storaged/format-dialog.jsx:121
 msgid "Unlock read only"
 msgstr "Odemknout pouze pro čtení"
 
@@ -7730,7 +7722,7 @@ msgstr "Odemknout pouze pro čtení"
 msgid "Unlocking $target"
 msgstr "Odemyká se $target"
 
-#: pkg/storaged/crypto-keyslots.jsx:173
+#: pkg/storaged/crypto-keyslots.jsx:174
 msgid "Unlocking disk..."
 msgstr "Odemykání disku…"
 
@@ -7739,7 +7731,7 @@ msgid "Unmanaged Interfaces"
 msgstr "Nespravovaná rozhraní"
 
 # auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
-#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:308
 msgid "Unmount"
 msgstr "Odpojit"
 
@@ -7751,37 +7743,33 @@ msgstr "Odpojování $target"
 msgid "Unnamed"
 msgstr "Bez názvu"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Unplug"
 msgstr "Odpojit"
 
-#: pkg/storaged/content-views.jsx:159
+#: pkg/storaged/content-views.jsx:163
 msgid "Unrecognized Data"
 msgstr "Nerozpoznaná data"
 
-#: pkg/storaged/content-views.jsx:358
+#: pkg/storaged/content-views.jsx:363
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Nerozpoznaná data"
 
-#: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
+#: pkg/storaged/lvol-tabs.jsx:90 pkg/storaged/lvol-tabs.jsx:179
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Nerozpoznaná data zde nelze zmenšit."
-
-#: node_modules/registry-image-widgets/views/image-listing.html:46
-msgid "Unresolved"
-msgstr "Nevyřešené"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "Nepodporovaný mechanizmus nastavení"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Unsupported volume"
 msgstr "Nepodporovaný svazek"
 
-#: src/base1/cockpit.js:4019 src/base1/cockpit.js:4021
+#: src/base1/cockpit.js:4023 src/base1/cockpit.js:4025
 msgid "Untrusted host"
 msgstr "Nedůvěryhodný stroj"
 
@@ -7802,11 +7790,11 @@ msgstr "Až $0 $1 k dispozici na tomto stroji"
 msgid "Update"
 msgstr "Aktualizovat"
 
-#: pkg/packagekit/history.jsx:126
+#: pkg/packagekit/history.jsx:125
 msgid "Update History"
 msgstr "Historie aktualizací"
 
-#: pkg/packagekit/updates.jsx:471
+#: pkg/packagekit/updates.jsx:473
 msgid "Update Log"
 msgstr "Záznam událostí aktualizací"
 
@@ -7815,11 +7803,11 @@ msgstr "Záznam událostí aktualizací"
 msgid "Updated"
 msgstr "Aktualizováno"
 
-#: pkg/packagekit/updates.jsx:494
+#: pkg/packagekit/updates.jsx:496
 msgid "Updated packages may require a restart to take effect."
 msgstr "Aby se uplatnily, aktualizované balíčky mohou vyžadovat restart."
 
-#: pkg/systemd/host.js:512
+#: pkg/systemd/host.js:515
 msgid "Updates Available"
 msgstr "Jsou k dispozici aktualizace"
 
@@ -7827,27 +7815,27 @@ msgstr "Jsou k dispozici aktualizace"
 msgid "Updating"
 msgstr "Aktualizuje se"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:408
 msgid "Updating status..."
 msgstr "Aktualizace stavu…"
 
 # auto translated by TM merge from project: audit-viewer, version: default, DocId: audit-viewer
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
+#: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Použití"
 
-#: pkg/systemd/host.js:1630
+#: pkg/systemd/host.js:1673
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Využití $0 jádra procesoru"
 msgstr[1] "Využití $0 jader procesoru"
 msgstr[2] "Využití $0 jader procesoru"
 
-#: pkg/storaged/vdos-panel.jsx:87
+#: pkg/storaged/vdos-panel.jsx:95
 msgid "Use 512 Byte emulation"
 msgstr "Použít emulaci 512 bajtů"
 
-#: pkg/machines/components/diskAdd.jsx:561
+#: pkg/machines/components/diskAdd.jsx:432
 msgid "Use Existing"
 msgstr "Použít existující"
 
@@ -7855,15 +7843,15 @@ msgstr "Použít existující"
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Pro ověřování vůči ostatním systémům použít následující klíče"
 
-#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
+#: pkg/systemd/index.html:267 pkg/docker/storage.jsx:344
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
+#: pkg/machines/components/vmDisksTab.jsx:106 pkg/storaged/fsys-tab.jsx:196
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1738
 msgid "Used"
 msgstr "Využito"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
 msgid "Used by"
 msgstr "Používá"
 
@@ -7873,8 +7861,8 @@ msgstr "Využito kontejnery"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1601
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:241
+#: pkg/systemd/host.js:1644
 msgid "User"
 msgstr "Uživatel"
 
@@ -7899,7 +7887,7 @@ msgid "User name cannot be empty"
 msgstr "Uživatelské jméno je třeba vyplnit"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Uživatelské jméno"
 
@@ -7911,11 +7899,11 @@ msgstr "Pomocí přihlašovacích údajů, které jsou k dispozici"
 msgid "VCPU settings could not be saved"
 msgstr "Nastavení virt. procesoru se nepodařilo uložit"
 
-#: pkg/storaged/content-views.jsx:155
+#: pkg/storaged/content-views.jsx:159
 msgid "VDO Backing"
 msgstr "Podklad pro VDO"
 
-#: pkg/storaged/content-views.jsx:356
+#: pkg/storaged/content-views.jsx:361
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "Podklad pro VDO"
@@ -7924,25 +7912,25 @@ msgstr "Podklad pro VDO"
 msgid "VDO Device"
 msgstr "VDO zařízení"
 
-#: pkg/storaged/utils.js:252 pkg/storaged/vdo-details.jsx:255
+#: pkg/storaged/utils.js:253 pkg/storaged/vdo-details.jsx:261
 msgid "VDO Device $0"
 msgstr "VDO zařízení $0"
 
-#: pkg/storaged/vdos-panel.jsx:166
+#: pkg/storaged/vdos-panel.jsx:176
 msgid "VDO Devices"
 msgstr "VDO zařízení"
 
-#: pkg/storaged/lvol-tabs.jsx:84 pkg/storaged/lvol-tabs.jsx:171
+#: pkg/storaged/lvol-tabs.jsx:85 pkg/storaged/lvol-tabs.jsx:172
 msgid "VDO backing devices can not be made smaller"
 msgstr "Zařízení, která jsou podkladem pro VDO, není možné zmenšovat"
 
-#: pkg/storaged/vdos-panel.jsx:172
+#: pkg/storaged/vdos-panel.jsx:182
 msgid "VDO support not installed"
 msgstr "Podpora pro VDO není nainstalovaná"
 
 # auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
-#: pkg/networkmanager/interfaces.js:2918
+#: pkg/networkmanager/interfaces.js:2533 pkg/networkmanager/interfaces.js:2545
+#: pkg/networkmanager/interfaces.js:2926
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7970,7 +7958,7 @@ msgstr "Nepodařilo se vynutit vypnutí virt. stroje $0"
 msgid "VM $0 failed to get deleted"
 msgstr "Virt. stroj $0 se nezdařilo smazat"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
 msgid "VM $0 failed to get installed"
 msgstr "Virt. stroj $0 se nezdařilo nainstalovat"
 
@@ -8025,7 +8013,7 @@ msgstr "Ověřuje se klíč"
 
 # auto translated by TM merge from project: libosinfo, version: master, DocId: libosinfo
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:254
 msgid "Vendor"
 msgstr "Výrobce"
 
@@ -8033,7 +8021,7 @@ msgstr "Výrobce"
 msgid "Verified"
 msgstr "Ověřeno"
 
-#: pkg/storaged/crypto-keyslots.jsx:316
+#: pkg/storaged/crypto-keyslots.jsx:324
 msgid "Verify key"
 msgstr "Ověřit klíč"
 
@@ -8043,8 +8031,8 @@ msgid "Verifying"
 msgstr "Ověřuje se"
 
 # auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
+#: pkg/packagekit/updates.jsx:382 pkg/systemd/hwinfo.jsx:87
 msgid "Version"
 msgstr "Verze"
 
@@ -8056,8 +8044,8 @@ msgstr "Velmi jisté vymazávání $target"
 msgid "View automation script"
 msgstr "Zobrazit automatizační skript"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/storagePools/storagePoolList.jsx:46
 #: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Virtuální stroje"
@@ -8066,7 +8054,7 @@ msgstr "Virtuální stroje"
 msgid "Virtual Network"
 msgstr "Virtuální síť"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+#: pkg/machines/components/networks/createNetworkDialog.jsx:412
 msgid "Virtual Network failed to be created"
 msgstr "Vytvoření virtuální sítě se nezdařilo"
 
@@ -8081,10 +8069,10 @@ msgstr "Virtualizační služba je k dispozici"
 # auto translated by TM merge from project: anaconda, version: master, DocId: main
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/diskAdd.jsx:90
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Svazek"
 
@@ -8093,7 +8081,7 @@ msgstr "Svazek"
 msgid "Volume Group"
 msgstr "Skupina oddílů"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/utils.js:248 pkg/storaged/vgroup-details.jsx:229
 msgid "Volume Group $0"
 msgstr "Skupina svazků $0"
 
@@ -8105,16 +8093,19 @@ msgstr "Název skupiny svazků"
 msgid "Volume Group name should not be empty"
 msgstr "Název skupiny svazků je třeba vyplnit"
 
-#: pkg/storaged/vgroups-panel.jsx:113
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr "Skupiny svazků"
 
-#: pkg/storaged/lvol-tabs.jsx:410
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:65
+msgid "Volume failed to be created"
+msgstr "Svazek se nepodařilo vytvořit"
+
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Volume size is $0. Content size is $1."
 msgstr "Velikost svazku je $0. Velikost obsahu na něm je $1."
 
 #: pkg/docker/index.html:517
-#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Svazky"
 
@@ -8126,7 +8117,7 @@ msgstr "Svazky:"
 msgid "WWPN"
 msgstr "Neopakující se číslo portu"
 
-#: pkg/networkmanager/interfaces.js:845
+#: pkg/networkmanager/interfaces.js:850
 msgid "Waiting"
 msgstr "Čeká se"
 
@@ -8139,16 +8130,16 @@ msgstr "Čeká se na podrobnosti…"
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr "Čeká se až ostatní programy dokončí použití správy balíčků…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:140
-#: pkg/lib/cockpit-components-install-dialog.jsx:175
+#: pkg/lib/cockpit-components-install-dialog.jsx:141
+#: pkg/lib/cockpit-components-install-dialog.jsx:176
 msgid "Waiting for other software management operations to finish"
 msgstr "Čeká se na dokončení ostatních operací správy balíčků"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:424
 msgid "Wanted By"
 msgstr "Vyžadováno"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:419
 msgid "Wants"
 msgstr "Vyžaduje"
 
@@ -8173,7 +8164,7 @@ msgstr "Středy"
 msgid "Weeks"
 msgstr "Týdny"
 
-#: pkg/storaged/crypto-keyslots.jsx:324
+#: pkg/storaged/crypto-keyslots.jsx:332
 msgid "What if tang-show-keys is not available?"
 msgstr "Co když příkaz tang-show-keys není k dispozici?"
 
@@ -8185,12 +8176,12 @@ msgstr "Bílá"
 msgid "With terminal"
 msgstr "S terminálem"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/mdraid-details.jsx:96
 msgid "Write-mostly"
 msgstr "Převážně zápis"
 
 # auto translated by TM merge from project: asknot-ng, version: 0.1, DocId: locale/asknot-ng
-#: pkg/storaged/plot.jsx:313
+#: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Zapisování"
 
@@ -8198,12 +8189,12 @@ msgstr "Zapisování"
 msgid "Wrong user name or password"
 msgstr "Chybné uživatelské jméno nebo heslo"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1997
 msgid "XOR"
 msgstr "XOR"
 
 # auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
-#: pkg/networkmanager/interfaces.js:2605
+#: pkg/networkmanager/interfaces.js:2613
 msgid "Yes"
 msgstr "Ano"
 
@@ -8216,7 +8207,7 @@ msgstr ""
 "synchronizaci uživatelských účtů je zapotřebí uživatele s oprávněním pro "
 "správu systému."
 
-#: pkg/dashboard/list.js:440
+#: pkg/dashboard/list.js:448
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
@@ -8224,7 +8215,7 @@ msgstr ""
 ""
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
-#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
+#: pkg/networkmanager/firewall.jsx:905 pkg/networkmanager/firewall.jsx:911
 msgid "You are not authorized to modify the firewall."
 msgstr "Nemáte oprávnění upravovat bránu firewall"
 
@@ -8234,7 +8225,7 @@ msgid ""
 "account."
 msgstr "Nemáte oprávnění zobrazovat pověřené klíče pro tento účet."
 
-#: pkg/docker/storage.jsx:504
+#: pkg/docker/storage.jsx:520
 msgid "You don't have permission to manage the Docker storage pool."
 msgstr "Nemáte oprávnění spravovat fond úložiště pro Docker."
 
@@ -8246,7 +8237,7 @@ msgstr "Pro změnu hesla je třeba vyčkat déle"
 msgid "You need to select the most closely matching Operating System"
 msgstr "Je třeba vybrat co nejvíce odpovídající operační systém"
 
-#: pkg/packagekit/updates.jsx:836
+#: pkg/packagekit/updates.jsx:837
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -8254,7 +8245,7 @@ msgstr ""
 "Váš prohlížeč se odpojí, ale to neovlivní proces aktualizace. Můžete se "
 "kdykoli znovu připojit a podívat se na postup."
 
-#: pkg/packagekit/updates.jsx:867
+#: pkg/packagekit/updates.jsx:868
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -8262,31 +8253,31 @@ msgstr ""
 "Server brzy zavře spojení. Po dokončení jeho restartu se budete moci opět "
 "připojit."
 
-#: src/base1/cockpit.js:4009
+#: src/base1/cockpit.js:4013
 msgid "Your session has been terminated."
 msgstr "Vaše sezení bylo ukončeno."
 
-#: src/base1/cockpit.js:4011
+#: src/base1/cockpit.js:4015
 msgid "Your session has expired. Please log in again."
 msgstr "Platnost vašeho sezení skončila. Přihlaste se znovu."
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "Zone"
 msgstr "Zóna"
 
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "Zones"
 msgstr "Zóny"
 
-#: pkg/lib/journal.js:215
+#: pkg/lib/journal.js:217
 msgid "[$0 bytes of binary data]"
 msgstr "[$0 bajtů binárních dat]"
 
-#: pkg/lib/journal.js:217
+#: pkg/lib/journal.js:219
 msgid "[binary data]"
 msgstr "[binarní data]"
 
-#: pkg/lib/journal.js:211
+#: pkg/lib/journal.js:213
 msgid "[no data]"
 msgstr "[žádná data]"
 
@@ -8314,7 +8305,7 @@ msgstr "v"
 msgid "bridge"
 msgstr "most"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "bug fix"
 msgstr "oprava chyby"
 
@@ -8376,7 +8367,7 @@ msgstr "např. „$0“"
 msgid "enabled"
 msgstr "povoleno"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "enhancement"
 msgstr "vylepšení"
 
@@ -8388,7 +8379,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "každý den"
 
-#: pkg/systemd/host.js:903
+#: pkg/systemd/host.js:940
 msgid "failed to list ssh host keys: $0"
 msgstr "nepodařilo se vypsat ssh klíče stroje: $0"
 
@@ -8412,7 +8403,7 @@ msgstr "IQN iSCSI iniciátoru"
 msgid "iSCSI Target"
 msgstr "iSCSI cíl"
 
-#: pkg/storaged/iscsi-panel.jsx:261
+#: pkg/storaged/iscsi-panel.jsx:268
 msgid "iSCSI Targets"
 msgstr "iSCSI cíle"
 
@@ -8434,11 +8425,11 @@ msgstr "nečinný"
 msgid "inactive"
 msgstr "neaktivní"
 
-#: pkg/kdump/kdump-view.jsx:376
+#: pkg/kdump/kdump-view.jsx:378
 msgid "invalid: multiple targets defined"
 msgstr "neplatné: definováno vícero cílů"
 
-#: pkg/kdump/kdump-view.jsx:493
+#: pkg/kdump/kdump-view.jsx:495
 msgid "kdump status"
 msgstr "stav kdump"
 
@@ -8446,11 +8437,11 @@ msgstr "stav kdump"
 msgid "key"
 msgstr "klíč"
 
-#: pkg/storaged/crypto-keyslots.jsx:350
+#: pkg/storaged/crypto-keyslots.jsx:358
 msgid "key slot $0"
 msgstr "slot pro klíč $0"
 
-#: pkg/kdump/kdump-view.jsx:380 pkg/kdump/kdump-view.jsx:382
+#: pkg/kdump/kdump-view.jsx:382 pkg/kdump/kdump-view.jsx:384
 msgid "locally in $0"
 msgstr "místně v $0"
 
@@ -8469,18 +8460,17 @@ msgstr "cíl výpisu nfs nemá podobu server:umisteni"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ne"
 
 # auto translated by TM merge from project: anaconda, version: rhel8-alpha-branch, DocId: anaconda
-#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "nic"
 
-#: pkg/systemd/host.js:712
+#: pkg/systemd/host.js:738
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "z $0 jádra procesoru"
@@ -8508,7 +8498,7 @@ msgstr "spuštěné"
 msgid "search by name, namespace or description"
 msgstr "hledat podle názvu, jmenného prostoru nebo popisu"
 
-#: pkg/packagekit/updates.jsx:261
+#: pkg/packagekit/updates.jsx:262
 msgid "security"
 msgstr "zabezpečení"
 
@@ -8583,8 +8573,7 @@ msgid "undefined"
 msgstr "nedefinované"
 
 # auto translated by TM merge from project: Spacewalk Backend, version: master, DocId: client/rhel/rhn-client-tools/po/rhn-client-tools
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
+#: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "neznámý"
 
@@ -8592,7 +8581,7 @@ msgstr "neznámý"
 msgid "unknown target"
 msgstr "neznámý cíl"
 
-#: pkg/storaged/utils.js:427
+#: pkg/storaged/utils.js:431
 msgid "unpartitioned space on $0"
 msgstr "nerozdělené místo na $0"
 
@@ -8637,14 +8626,6 @@ msgstr ""
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "ano"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:6
-msgid ""
-"{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
-"count: {{ condition.generation }}"
-msgstr ""
-"{{ condition.message }}. Časové razítko: {{ condition.lastTransitionTime }} "
-"Počet chyb: {{ condition.generation }}"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,11 +12,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"POT-Creation-Date: 2019-09-23 08:08+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-15 01:44+0000\n"
+"PO-Revision-Date: 2019-09-20 05:25+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: pl\n"
@@ -24,23 +24,30 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Zanata 4.6.2\n"
 
-#: pkg/docker/storage.jsx:259
+#: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
 msgstr " (współdzielone z systemem operacyjnym)"
+
+#: pkg/networkmanager/interfaces.js:2353
+msgid "$0 Active Rule"
+msgid_plural "$0 Active Rules"
+msgstr[0] "$0 aktywna reguła"
+msgstr[1] "$0 aktywne reguły"
+msgstr[2] "$0 aktywnych reguł"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "Urządzenie blokowe $0"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/mdraid-details.jsx:187
 msgid "$0 Chunk Size"
 msgstr "Rozmiar bloku: $0"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "$0 Disks"
 msgstr "Dyski: $0"
 
-#: pkg/storaged/content-views.jsx:334
+#: pkg/storaged/content-views.jsx:339
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "System plików $0"
@@ -49,34 +56,34 @@ msgstr "System plików $0"
 msgid "$0 Network"
 msgstr "Sieć $0"
 
-#: pkg/packagekit/history.jsx:101
+#: pkg/packagekit/history.jsx:100
 msgid "$0 Package"
 msgid_plural "$0 Packages"
 msgstr[0] "$0 pakiet"
 msgstr[1] "$0 pakiety"
 msgstr[2] "$0 pakietów"
 
-#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:478 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "Szablon $0"
 
-#: src/base1/test-locale.js:80 src/base1/test-locale.js:81
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:83 src/base1/test-locale.js:84
+#: src/base1/test-locale.js:85 src/base1/test-locale.js:86
 msgid "$0 bit"
 msgid_plural "$0 bits"
 msgstr[0] "$0 bit"
 msgstr[1] "$0 bity"
 msgstr[2] "$0 bitów"
 
-#: src/base1/test-locale.js:71 src/base1/test-locale.js:72
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+#: src/base1/test-locale.js:74 src/base1/test-locale.js:75
+#: src/base1/test-locale.js:87 src/base1/test-locale.js:88
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtów"
 
-#: src/base1/test-locale.js:73 src/base1/test-locale.js:74
+#: src/base1/test-locale.js:76 src/base1/test-locale.js:77
 msgctxt "memory"
 msgid "$0 byte"
 msgid_plural "$0 bytes"
@@ -84,21 +91,28 @@ msgstr[0] "$0 bajt"
 msgstr[1] "$0 bajty"
 msgstr[2] "$0 bajtów"
 
-#: pkg/storaged/vdo-details.jsx:280
+#: pkg/storaged/vdo-details.jsx:286
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 danych + $1 nadwyżki użyto z $2 ($3)"
 
-#: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
+#: pkg/lib/plot.js:971
+msgid "$0 day"
+msgid_plural "$0 days"
+msgstr[0] "$0 dzień"
+msgstr[1] "$0 dni"
+msgstr[2] "$0 dni"
+
+#: src/base1/test-locale.js:65 src/base1/test-locale.js:66
+#: src/base1/test-locale.js:67 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:207
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "Brak $0 dysku"
 msgstr[1] "Brak $0 dysków"
 msgstr[2] "Brak $0 dysków"
 
-#: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: src/base1/test-locale.js:68 src/base1/test-locale.js:70
+#: src/base1/test-locale.js:72 pkg/playground/translate.js:32
 #: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
@@ -119,17 +133,24 @@ msgstr "$0 zakończyło działanie z kodem $1"
 msgid "$0 failed"
 msgstr "$0 się nie powiodło"
 
-#: pkg/storaged/lvol-tabs.jsx:159
+#: pkg/storaged/lvol-tabs.jsx:160
 msgid "$0 filesystems can not be made larger."
 msgstr "Systemy plików $0 nie mogą być powiększane."
 
-#: pkg/storaged/lvol-tabs.jsx:156
+#: pkg/storaged/lvol-tabs.jsx:157
 msgid "$0 filesystems can not be made smaller."
 msgstr "Systemy plików $0 nie mogą być zmniejszane."
 
-#: pkg/storaged/lvol-tabs.jsx:152
+#: pkg/storaged/lvol-tabs.jsx:153
 msgid "$0 filesystems can not be resized here."
 msgstr "Nie można tutaj zmieniać rozmiaru systemów plików $0."
+
+#: pkg/lib/plot.js:974
+msgid "$0 hour"
+msgid_plural "$0 hours"
+msgstr[0] "$0 godzina"
+msgstr[1] "$0 godziny"
+msgstr[2] "$0 godzin"
 
 #: pkg/machines/components/desktopConsole.jsx:44
 msgid ""
@@ -139,21 +160,35 @@ msgstr ""
 "$0 jest dostępne dla większości systemów operacyjnych. Aby zainstalować, "
 "należy wyszukać w Menedżerze oprogramowania GNOME lub wykonać polecenie:"
 
-#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:511
+#: pkg/storaged/format-dialog.jsx:265 pkg/storaged/lvol-tabs.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:264 pkg/storaged/mdraid-details.jsx:232
+#: pkg/storaged/mdraid-details.jsx:284 pkg/storaged/vdo-details.jsx:147
+#: pkg/storaged/vdo-details.jsx:178 pkg/storaged/vgroup-details.jsx:199
 msgid "$0 is in active use"
 msgstr "$0 jest obecnie używane"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:150
+#: pkg/lib/cockpit-components-install-dialog.jsx:151
 msgid "$0 is not available from any repository."
 msgstr "$0 nie jest dostępne w żadnym repozytorium."
 
 #: src/base1/cockpit.js:2755
 msgid "$0 killed with signal $1"
 msgstr "$0 zostało zakończone z sygnałem $1"
+
+#: pkg/lib/plot.js:977
+msgid "$0 minute"
+msgid_plural "$0 minutes"
+msgstr[0] "$0 minuta"
+msgstr[1] "$0 minuty"
+msgstr[2] "$0 minut"
+
+#: pkg/lib/plot.js:965
+msgid "$0 month"
+msgid_plural "$0 months"
+msgstr[0] "$0 miesiąc"
+msgstr[1] "$0 miesiące"
+msgstr[2] "$0 miesięcy"
 
 #: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
@@ -166,11 +201,18 @@ msgstr[2] "$0 wystąpień"
 msgid "$0 of $1"
 msgstr "$0 z $1"
 
+#: pkg/systemd/init.js:418
+msgid "$0 service has failed"
+msgid_plural "$0 services have failed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: pkg/docker/util.js:125
 msgid "$0 shares"
 msgstr "Udziały: $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "$0 slots remain"
 msgstr "Pozostało gniazd: $0"
 
@@ -181,15 +223,29 @@ msgstr[0] "$0 aktualizacja"
 msgstr[1] "$0 aktualizacje"
 msgstr[2] "$0 aktualizacji"
 
-#: pkg/storaged/vdo-details.jsx:292
+#: pkg/storaged/vdo-details.jsx:298
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 używanych z $1 ($2 zapisano)"
+
+#: pkg/lib/plot.js:968
+msgid "$0 week"
+msgid_plural "$0 weeks"
+msgstr[0] "$0 tydzień"
+msgstr[1] "$0 tygodnie"
+msgstr[2] "$0 tygodni"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 zostanie zainstalowane."
 
-#: pkg/storaged/vgroup-details.jsx:117
+#: pkg/lib/plot.js:962
+msgid "$0 year"
+msgid_plural "$0 years"
+msgstr[0] "$0 rok"
+msgstr[1] "$0 lata"
+msgstr[2] "$0 lat"
+
+#: pkg/storaged/vgroup-details.jsx:111
 msgid "$0, $1 free"
 msgstr "$0, wolne: $1"
 
@@ -200,7 +256,7 @@ msgstr[0] "$1 poprawka zabezpieczeń"
 msgstr[1] "$1 poprawki zabezpieczeń"
 msgstr[2] "$1 poprawek zabezpieczeń"
 
-#: pkg/networkmanager/interfaces.js:2769
+#: pkg/networkmanager/interfaces.js:2777
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -216,16 +272,16 @@ msgstr "${hip}:${hport} → $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:574
+#: pkg/networkmanager/firewall.jsx:576
 msgid "(Optional)"
 msgstr "(Opcjonalne)"
 
-#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
-#: pkg/storaged/fsys-tab.jsx:160
+#: pkg/networkmanager/firewall.jsx:501 pkg/networkmanager/firewall.jsx:650
+#: pkg/storaged/fsys-tab.jsx:163
 msgid "(default)"
 msgstr "(domyślnie)"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:138
 msgid "(none)"
 msgstr "(brak)"
 
@@ -236,36 +292,43 @@ msgstr[0] ", w tym $1 poprawka zabezpieczeń"
 msgstr[1] ", w tym $1 poprawki zabezpieczeń"
 msgstr[2] ", w tym $1 poprawek zabezpieczeń"
 
-#: pkg/storaged/nfs-details.jsx:325
+#: pkg/storaged/nfs-details.jsx:333
 msgid "--"
 msgstr "—"
 
-#: pkg/storaged/mdraids-panel.jsx:70
+#: pkg/storaged/mdraids-panel.jsx:86
 msgid "1 MiB"
 msgstr "1 MiB"
 
-#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
+#: pkg/systemd/index.html:455 pkg/systemd/index.html:459
 msgid "1 Minute"
 msgstr "1 minuta"
 
+#: pkg/docker/containers-view.jsx:614
+msgid "1 Vulnerability"
+msgid_plural "$0 Vulnerabilities"
+msgstr[0] "1 zagrożenie"
+msgstr[1] "$0 zagrożenia"
+msgstr[2] "$0 zagrożeń"
+
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:194
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 dzień"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:190
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 godzina"
 
-#: pkg/systemd/host.js:1686
+#: pkg/systemd/host.js:1729
 msgid "1 min"
 msgstr "1 minuta"
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:196
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 tydzień"
@@ -278,7 +341,7 @@ msgstr "10."
 msgid "11th"
 msgstr "11."
 
-#: pkg/storaged/mdraids-panel.jsx:68
+#: pkg/storaged/mdraids-panel.jsx:84
 msgid "128 KiB"
 msgstr "128 KiB"
 
@@ -298,7 +361,7 @@ msgstr "14."
 msgid "15th"
 msgstr "15."
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/mdraids-panel.jsx:81
 msgid "16 KiB"
 msgstr "16 KiB"
 
@@ -322,15 +385,15 @@ msgstr "19."
 msgid "1st"
 msgstr "1."
 
-#: pkg/storaged/mdraids-panel.jsx:71
+#: pkg/storaged/mdraids-panel.jsx:87
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1685
+#: pkg/systemd/host.js:1728
 msgid "2 min"
 msgstr "2 minuty"
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:461
 msgid "20 Minutes"
 msgstr "20 minut"
 
@@ -378,7 +441,7 @@ msgstr "29."
 msgid "2nd"
 msgstr "2."
 
-#: pkg/systemd/host.js:1684
+#: pkg/systemd/host.js:1727
 msgid "3 min"
 msgstr "3 minuty"
 
@@ -390,7 +453,7 @@ msgstr "30."
 msgid "31st"
 msgstr "31."
 
-#: pkg/storaged/mdraids-panel.jsx:66
+#: pkg/storaged/mdraids-panel.jsx:82
 msgid "32 KiB"
 msgstr "32 KiB"
 
@@ -398,15 +461,15 @@ msgstr "32 KiB"
 msgid "3rd"
 msgstr "3."
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:79
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1683
+#: pkg/systemd/host.js:1726
 msgid "4 min"
 msgstr "4 minuty"
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:462
 msgid "40 Minutes"
 msgstr "40 minut"
 
@@ -414,21 +477,21 @@ msgstr "40 minut"
 msgid "4th"
 msgstr "4."
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:460
 msgid "5 Minutes"
 msgstr "5 minut"
 
-#: pkg/systemd/host.js:1682
+#: pkg/systemd/host.js:1725
 msgid "5 min"
 msgstr "5 minut"
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:188
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 minut"
 
-#: pkg/storaged/mdraids-panel.jsx:69
+#: pkg/storaged/mdraids-panel.jsx:85
 msgid "512 KiB"
 msgstr "512 KiB"
 
@@ -437,16 +500,16 @@ msgid "5th"
 msgstr "5."
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:192
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 godzin"
 
-#: pkg/systemd/index.html:452
+#: pkg/systemd/index.html:463
 msgid "60 Minutes"
 msgstr "Godzina"
 
-#: pkg/storaged/mdraids-panel.jsx:67
+#: pkg/storaged/mdraids-panel.jsx:83
 msgid "64 KiB"
 msgstr "64 KiB"
 
@@ -458,15 +521,15 @@ msgstr "6."
 msgid "7th"
 msgstr "7."
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/mdraids-panel.jsx:80
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1999
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:2016
 msgid "802.3ad LACP"
 msgstr "LACP 802.3ad"
 
@@ -485,7 +548,7 @@ msgid ""
 msgstr ""
 "Na {{#strong}}{{host}}{{/strong}} nie zainstalowano zgodnej wersji Cockpit."
 
-#: pkg/storaged/vdos-panel.jsx:59
+#: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "Wymagany jest dysk."
 
@@ -496,19 +559,19 @@ msgstr ""
 "Z powodów bezpieczeństwa, niezawodności i wydajności wymagana jest "
 "nowoczesna przeglądarka."
 
-#: pkg/storaged/mdraid-details.jsx:119
+#: pkg/storaged/mdraid-details.jsx:113
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Przed usunięciem tego dysku należy najpierw dodać dysk zapasowy."
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2806
 msgid "ARP Monitoring"
 msgstr "Monitorowanie ARP"
 
-#: pkg/networkmanager/interfaces.js:2016
+#: pkg/networkmanager/interfaces.js:2028
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
@@ -525,10 +588,6 @@ msgstr "Nieobecne"
 msgid "Access"
 msgstr "Dostęp"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:12
-msgid "Access Policy"
-msgstr "Zasady dostępu"
-
 #: pkg/users/index.html:249
 msgid "Account Expiration"
 msgstr "Wygasanie konta"
@@ -541,7 +600,8 @@ msgstr "Ustawienia konta"
 msgid "Account not available or cannot be edited."
 msgstr "Konto jest niedostępne lub nie może być modyfikowane."
 
-#: pkg/users/index.html:71 pkg/users/manifest.json.in
+#: pkg/playground/translate.html:95 pkg/users/index.html:71
+#: pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Konta"
 
@@ -552,7 +612,7 @@ msgstr "Konta"
 
 #: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
-#: pkg/storaged/content-views.jsx:256
+#: pkg/storaged/content-views.jsx:261
 msgid "Activate"
 msgstr "Aktywuj"
 
@@ -560,11 +620,11 @@ msgstr "Aktywuj"
 msgid "Activating $target"
 msgstr "Aktywowanie $target"
 
-#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
+#: pkg/networkmanager/interfaces.js:852 pkg/networkmanager/interfaces.js:2022
 msgid "Active"
 msgstr "Aktywne"
 
-#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:1996 pkg/networkmanager/interfaces.js:2013
 msgid "Active Backup"
 msgstr "Aktywna kopia zapasowa"
 
@@ -572,39 +632,40 @@ msgstr "Aktywna kopia zapasowa"
 msgid "Active Pages"
 msgstr "Aktywne strony"
 
-#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1044 pkg/storaged/dialog.jsx:1048
 msgid "Active since"
 msgstr "Aktywne od"
 
-#: pkg/systemd/service-details.jsx:352
+#: pkg/systemd/service-details.jsx:354
 msgid "Active since "
 msgstr "Aktywna od "
 
-#: pkg/networkmanager/firewall.jsx:954
+#: pkg/networkmanager/firewall.jsx:956
 msgid "Active zones"
 msgstr "Aktywne strefy"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:2001
 msgid "Adaptive load balancing"
 msgstr "Adaptacyjne równoważenie obciążenia"
 
-#: pkg/networkmanager/interfaces.js:1988
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
-#: pkg/storaged/vgroup-details.jsx:63
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
+#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
+#: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
+#: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:198
+#: pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Dodaj"
 
-#: pkg/networkmanager/interfaces.js:3115
+#: pkg/networkmanager/interfaces.js:3126
 msgid "Add $0"
 msgstr "Dodaj $0"
 
-#: pkg/docker/storage.jsx:378
+#: pkg/docker/storage.jsx:383
 msgid "Add Additional Storage"
 msgstr "Dodaj dodatkowe urządzenia do przechowywania danych"
 
@@ -616,15 +677,15 @@ msgstr "Dodaj węzeł"
 msgid "Add Bridge"
 msgstr "Dodaj mostek"
 
-#: pkg/machines/components/diskAdd.jsx:368
+#: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Dodaj dysk"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:51
+#: pkg/storaged/mdraid-details.jsx:45 pkg/storaged/vgroup-details.jsx:52
 msgid "Add Disks"
 msgstr "Dodaj dyski"
 
-#: pkg/storaged/crypto-keyslots.jsx:200
+#: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Add Key"
 msgstr "Dodaj klucz"
 
@@ -632,16 +693,20 @@ msgstr "Dodaj klucz"
 msgid "Add Machine to Dashboard"
 msgstr "Dodaj komputer do panelu kontrolnego"
 
-#: pkg/networkmanager/firewall.jsx:482
+#: pkg/machines/components/nicAdd.jsx:218
+msgid "Add Network Interface"
+msgstr "Dodaj interfejs sieciowy"
+
+#: pkg/networkmanager/firewall.jsx:484
 msgid "Add Ports"
 msgstr "Dodaj porty"
 
-#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
-#: pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:484 pkg/networkmanager/firewall.jsx:906
+#: pkg/networkmanager/firewall.jsx:918
 msgid "Add Services"
 msgstr "Dodaj usługi"
 
-#: pkg/docker/storage.jsx:217
+#: pkg/docker/storage.jsx:219
 msgid "Add Storage"
 msgstr "Dodaj urządzenia do przechowywania danych"
 
@@ -653,12 +718,12 @@ msgstr "Dodaj zespół"
 msgid "Add VLAN"
 msgstr "Dodaj VLAN"
 
-#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
-#: pkg/networkmanager/firewall.jsx:921
+#: pkg/networkmanager/firewall.jsx:732 pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:923
 msgid "Add Zone"
 msgstr "Dodaj strefę"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/iscsi-panel.jsx:42
 msgid "Add iSCSI Portal"
 msgstr "Dodaj portal iSCSI"
 
@@ -666,7 +731,7 @@ msgstr "Dodaj portal iSCSI"
 msgid "Add key"
 msgstr "Dodaj klucz"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add ports to the following zones:"
 msgstr "Dodanie portów do tych stref:"
 
@@ -674,15 +739,15 @@ msgstr "Dodanie portów do tych stref:"
 msgid "Add public key"
 msgstr "Dodaj klucz publiczny"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add services to following zones:"
 msgstr "Dodanie usług do tych stref:"
 
-#: pkg/networkmanager/firewall.jsx:806
+#: pkg/networkmanager/firewall.jsx:808
 msgid "Add zone"
 msgstr "Dodaj strefę"
 
-#: pkg/networkmanager/interfaces.js:3114
+#: pkg/networkmanager/interfaces.js:3125
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -690,7 +755,7 @@ msgstr ""
 "Dodanie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/networkmanager/firewall.jsx:586
+#: pkg/networkmanager/firewall.jsx:588
 msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
@@ -707,15 +772,15 @@ msgstr "Dodawanie klucza"
 msgid "Adding physical volume to $target"
 msgstr "Dodawanie woluminu fizycznego do $target"
 
-#: pkg/machines/components/vmDisksTab.jsx:78
+#: pkg/machines/components/vmDisksTab.jsx:116
 msgid "Additional"
 msgstr "Dodatkowe"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "Additional DNS $val"
 msgstr "Dodatkowy DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "Additional DNS Search Domains $val"
 msgstr "Dodatkowe domeny wyszukiwania DNS $val"
 
@@ -727,7 +792,7 @@ msgstr "Dodatkowe urządzenia do przechowywania danych"
 msgid "Additional actions"
 msgstr "Dodatkowe działania"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional address $val"
 msgstr "Dodatkowy adres $val"
 
@@ -738,20 +803,20 @@ msgstr "Dodatkowe pakiety:"
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:107
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Address"
 msgstr "Adres"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Address $val"
 msgstr "Adres $val"
 
-#: pkg/storaged/crypto-keyslots.jsx:192
+#: pkg/storaged/crypto-keyslots.jsx:193
 msgid "Address cannot be empty"
 msgstr "Adres nie może być pusty"
 
-#: pkg/storaged/crypto-keyslots.jsx:194
+#: pkg/storaged/crypto-keyslots.jsx:195
 msgid "Address is not a valid URL"
 msgstr "Adres nie jest prawidłowym adresem URL"
 
@@ -766,7 +831,7 @@ msgstr "Adres nie jest w podsieci"
 msgid "Address:"
 msgstr "Adres:"
 
-#: pkg/networkmanager/interfaces.js:3321
+#: pkg/networkmanager/interfaces.js:3332
 msgid "Addresses"
 msgstr "Adresy"
 
@@ -782,7 +847,7 @@ msgstr "Hasło administratora"
 msgid "Advanced TCA"
 msgstr "Zaawansowane TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:430
 msgid "After"
 msgstr "Po"
 
@@ -798,7 +863,7 @@ msgstr ""
 "zmianie."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:902
+#: pkg/systemd/init.js:964
 msgid "After system boot"
 msgstr "Po uruchomieniu systemu"
 
@@ -806,7 +871,7 @@ msgstr "Po uruchomieniu systemu"
 msgid "Alert and above"
 msgstr "Alarmy i powyżej"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Wszystkie"
 
@@ -814,7 +879,7 @@ msgstr "Wszystkie"
 msgid "All In One"
 msgstr "Zintegrowane"
 
-#: pkg/docker/storage.jsx:381
+#: pkg/docker/storage.jsx:386
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -826,11 +891,11 @@ msgstr ""
 msgid "Allow running (unmask)"
 msgstr "Zezwolenie na uruchamianie (odmaskowanie)"
 
-#: pkg/networkmanager/firewall.jsx:781
+#: pkg/networkmanager/firewall.jsx:783
 msgid "Allowed Addresses"
 msgstr "Dozwolone adresy"
 
-#: pkg/networkmanager/firewall.jsx:967
+#: pkg/networkmanager/firewall.jsx:969
 msgid "Allowed Services"
 msgstr "Dozwolone usługi"
 
@@ -838,13 +903,10 @@ msgstr "Dozwolone usługi"
 msgid "Always"
 msgstr "Zawsze"
 
-#: pkg/machines/components/diskAdd.jsx:116
+#: pkg/machines/components/diskAdd.jsx:117
+#: pkg/machines/components/nicAdd.jsx:86
 msgid "Always attach"
 msgstr "Podłączanie za każdym razem"
-
-#: node_modules/registry-image-widgets/views/annotations.html:1
-msgid "Annotations"
-msgstr "Adnotacje"
 
 #: pkg/lib/cockpit-components-modifications.jsx:82
 msgid "Ansible Playbook"
@@ -863,10 +925,10 @@ msgstr "Aplikacje"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:354
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:108 pkg/storaged/fsys-tab.jsx:80
+#: pkg/storaged/fsys-tab.jsx:129 pkg/storaged/nfs-details.jsx:198
 msgid "Apply"
 msgstr "Zastosuj"
 
@@ -894,20 +956,16 @@ msgstr "Zastosowywanie aktualizacji"
 msgid "Applying updates failed"
 msgstr "Zastosowanie aktualizacji się nie powiodło"
 
-#: node_modules/registry-image-widgets/views/image-config.html:16
-msgid "Architecture"
-msgstr "Architektura"
-
 #: pkg/systemd/index.html:92
 msgid "Asset Tag"
 msgstr "Etykieta zasobu"
 
-#: pkg/storaged/mdraids-panel.jsx:79
+#: pkg/storaged/mdraids-panel.jsx:96
 msgid "At least $0 disks are needed."
 msgstr "Wymagane są co najmniej $0 dyski."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraid-details.jsx:52 pkg/storaged/vgroup-details.jsx:59
+#: pkg/storaged/vgroups-panel.jsx:66
 msgid "At least one disk is needed."
 msgstr "Wymagany jest co najmniej jeden dysk."
 
@@ -919,7 +977,7 @@ msgstr "O podanym czasie"
 msgid "Audit log"
 msgstr "Dziennik audytu"
 
-#: pkg/networkmanager/interfaces.js:839
+#: pkg/networkmanager/interfaces.js:844
 msgid "Authenticating"
 msgstr "Uwierzytelnianie"
 
@@ -948,13 +1006,11 @@ msgstr ""
 "Wymagane jest uwierzytelnienie, aby wykonać zadania wymagające uprawnień za "
 "pomocą konsoli internetowej Cockpit"
 
-#: pkg/storaged/iscsi-panel.jsx:147
+#: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Wymagane jest uwierzytelnienie"
 
-#: pkg/docker/index.html:702
-#: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:413
+#: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Autor"
 
@@ -963,22 +1019,22 @@ msgid "Authorized Public SSH Keys"
 msgstr "Upoważnione publiczne klucze SSH"
 
 #: pkg/networkmanager/index.html:176
-#: pkg/machines/components/networks/createNetworkDialog.jsx:176
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
-#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
-#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
+#: pkg/machines/components/networks/createNetworkDialog.jsx:162
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:3340 pkg/networkmanager/interfaces.js:3344
+#: pkg/networkmanager/interfaces.js:3350 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatyczne"
 
-#: pkg/networkmanager/interfaces.js:1975
+#: pkg/networkmanager/interfaces.js:1987
 msgid "Automatic (DHCP only)"
 msgstr "Automatyczne (tylko DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1965
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Automatic (DHCP)"
 msgstr "Automatyczne (DHCP)"
 
-#: pkg/systemd/init.js:295
+#: pkg/systemd/init.js:307
 msgid "Automatic Startup"
 msgstr "Automatyczne uruchamianie"
 
@@ -990,15 +1046,15 @@ msgstr "Automatyczne aktualizacje"
 msgid "Automatically start libvirt on boot"
 msgstr "Automatyczne włączanie usługi libvirt podczas uruchamiania"
 
-#: pkg/systemd/service-details.jsx:396
+#: pkg/systemd/service-details.jsx:398
 msgid "Automatically starts"
 msgstr "Automatycznie się uruchamia"
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/index.html:400
 msgid "Automatically using NTP"
 msgstr "Automatycznie za pomocą NTP"
 
-#: pkg/systemd/index.html:390
+#: pkg/systemd/index.html:401
 msgid "Automatically using specific NTP servers"
 msgstr "Automatycznie za pomocą podanych serwerów NTP"
 
@@ -1018,11 +1074,11 @@ msgstr "Automatyczne uruchamianie"
 msgid "Available"
 msgstr "Dostępne"
 
-#: pkg/packagekit/updates.jsx:824
+#: pkg/packagekit/updates.jsx:825
 msgid "Available Updates"
 msgstr "Dostępne aktualizacje"
 
-#: pkg/storaged/iscsi-panel.jsx:124
+#: pkg/storaged/iscsi-panel.jsx:125
 msgid "Available targets on $0"
 msgstr "Dostępne cele w $0"
 
@@ -1030,15 +1086,15 @@ msgstr "Dostępne cele w $0"
 msgid "Avatar"
 msgstr "Awatar"
 
-#: pkg/systemd/hwinfo.jsx:92
+#: pkg/systemd/hwinfo.jsx:96
 msgid "BIOS"
 msgstr "BIOS"
 
-#: pkg/systemd/hwinfo.jsx:100
+#: pkg/systemd/hwinfo.jsx:104
 msgid "BIOS date"
 msgstr "Data BIOS-u"
 
-#: pkg/systemd/hwinfo.jsx:96
+#: pkg/systemd/hwinfo.jsx:100
 msgid "BIOS version"
 msgstr "Wersja BIOS-u"
 
@@ -1046,7 +1102,7 @@ msgstr "Wersja BIOS-u"
 msgid "Back to Accounts"
 msgstr "Wróć do kont"
 
-#: pkg/storaged/vdo-details.jsx:270
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Backing Device"
 msgstr "Urządzenie podstawowe"
 
@@ -1058,11 +1114,11 @@ msgstr "Przekazano błędne dane dla mechanizmu passwd1"
 msgid "Balancer"
 msgstr "Równoważenie"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/systemd/service-details.jsx:429
 msgid "Before"
 msgstr "Przed"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:420
 msgid "Binds To"
 msgstr "Dowiązuje do"
 
@@ -1082,16 +1138,16 @@ msgstr "Obudowa kasetowa"
 msgid "Block"
 msgstr "Zablokuj"
 
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:666
 msgid "Block device for filesystems"
 msgstr "Urządzenie blokowe dla systemów plików"
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/mdraid-details.jsx:97
 msgid "Blocked"
 msgstr "Zablokowane"
 
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2803
+#: pkg/networkmanager/interfaces.js:2529 pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2811
 msgid "Bond"
 msgstr "Wiązanie"
 
@@ -1108,12 +1164,12 @@ msgstr "Kolejność uruchamiania"
 msgid "Boot order settings could not be saved"
 msgstr "Nie można zapisać ustawień kolejności uruchamiania"
 
-#: pkg/systemd/service-details.jsx:423
+#: pkg/systemd/service-details.jsx:425
 msgid "Bound By"
 msgstr "Dowiązane przez"
 
-#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
-#: pkg/networkmanager/interfaces.js:2880
+#: pkg/networkmanager/interfaces.js:2535 pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2888
 msgid "Bridge"
 msgstr "Mostek"
 
@@ -1125,33 +1181,29 @@ msgstr "Ustawienia portu mostku"
 msgid "Bridge Settings"
 msgstr "Ustawienia mostka"
 
-#: pkg/networkmanager/interfaces.js:2901
+#: pkg/networkmanager/interfaces.js:2909
 msgid "Bridge port"
 msgstr "Port mostku"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1998 pkg/networkmanager/interfaces.js:2015
 msgid "Broadcast"
 msgstr "Broadcast"
 
-#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
+#: pkg/networkmanager/interfaces.js:2824 pkg/networkmanager/interfaces.js:2858
 msgid "Broken configuration"
 msgstr "Uszkodzona konfiguracja"
 
-#: pkg/systemd/host.js:508
+#: pkg/systemd/host.js:511
 msgid "Bug Fix Updates Available"
 msgstr "Dostępne są aktualizacje naprawiające błędy"
 
-#: pkg/packagekit/updates.jsx:314
+#: pkg/packagekit/updates.jsx:315
 msgid "Bugs:"
 msgstr "Błędy:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:18
-msgid "Built"
-msgstr "Zbudowane"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:109
 #: pkg/machines/components/vm/bootOrderModal.jsx:132
-#: pkg/machines/components/vmDisksTab.jsx:72
+#: pkg/machines/components/vmDisksTab.jsx:110
 msgid "Bus"
 msgstr "Magistrala"
 
@@ -1160,19 +1212,19 @@ msgid "Bus Expansion Chassis"
 msgstr "Obudowa rozszerzenia magistrali"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:272
-#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:112
 msgid "CPU"
 msgstr "Procesor"
 
-#: pkg/systemd/hwinfo.jsx:113
+#: pkg/systemd/hwinfo.jsx:117
 msgid "CPU Security"
 msgstr "Zabezpieczenia procesora"
 
-#: pkg/systemd/hwinfo.jsx:205
+#: pkg/systemd/hwinfo.jsx:209
 msgid "CPU Security Toggles"
 msgstr "Przełączniki zabezpieczeń procesora"
 
-#: pkg/systemd/host.js:1565
+#: pkg/systemd/host.js:1603
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Stan procesora"
@@ -1189,12 +1241,12 @@ msgstr "Priorytet procesora"
 msgid "CPU usage:"
 msgstr "Użycie procesora:"
 
-#: pkg/machines/components/diskAdd.jsx:251
+#: pkg/machines/components/diskAdd.jsx:174
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "Pamięć podręczna"
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1739
 msgid "Cached"
 msgstr "W pamięci podręcznej"
 
@@ -1202,11 +1254,11 @@ msgstr "W pamięci podręcznej"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Nie można połączyć z Dockerem"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:318
 msgid "Can't delete while unlocked"
 msgstr "Nie można usunąć, kiedy jest odblokowane"
 
-#: pkg/dashboard/list.js:212
+#: pkg/dashboard/list.js:220
 msgid "Can't load image"
 msgstr "Nie można wczytać obrazu"
 
@@ -1221,37 +1273,39 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
+#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
+#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
 #: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:597
-#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/nicAdd.jsx:232
+#: pkg/machines/components/nicEdit.jsx:181
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:93
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
-#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
-#: pkg/systemd/hwinfo.jsx:216
+#: pkg/networkmanager/firewall.jsx:592 pkg/networkmanager/firewall.jsx:660
+#: pkg/networkmanager/firewall.jsx:803 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:394
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:220
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Anuluj"
 
-#: pkg/shell/indexes.js:421
+#: pkg/shell/indexes.js:472
 msgid "Cannot connect to an unknown machine"
 msgstr "Nie można połączyć z nieznanym komputerem"
 
-#: src/base1/cockpit.js:4031
+#: src/base1/cockpit.js:4035
 msgid "Cannot forward login credentials"
 msgstr "Nie można przekazać danych uwierzytelniania logowania"
 
@@ -1259,25 +1313,25 @@ msgstr "Nie można przekazać danych uwierzytelniania logowania"
 msgid "Cannot schedule event in the past"
 msgstr "Nie można planować zdarzeń w przeszłości"
 
-#: pkg/machines/components/vmDisksTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:108
 msgid "Capacity"
 msgstr "Pojemność"
 
-#: pkg/networkmanager/interfaces.js:2602
+#: pkg/networkmanager/interfaces.js:2610
 msgid "Carrier"
 msgstr "Operator"
 
-#: pkg/docker/index.html:664 pkg/systemd/index.html:333
-#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:181
+#: pkg/docker/index.html:664 pkg/systemd/index.html:344
+#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Zmień"
 
-#: pkg/systemd/index.html:289
+#: pkg/systemd/index.html:300
 msgid "Change Host Name"
 msgstr "Zmień nazwę komputera"
 
-#: pkg/shell/index.html:312
+#: pkg/shell/index.html:313
 msgid "Change Password"
 msgstr "Zmień hasło"
 
@@ -1285,19 +1339,19 @@ msgstr "Zmień hasło"
 msgid "Change Performance Profile"
 msgstr "Zmień profil wydajności"
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:199
 msgid "Change Profile"
 msgstr "Zmień profil"
 
-#: pkg/systemd/index.html:358
+#: pkg/systemd/index.html:369
 msgid "Change System Time"
 msgstr "Zmień czas systemu"
 
-#: pkg/storaged/iscsi-panel.jsx:176
+#: pkg/storaged/iscsi-panel.jsx:183
 msgid "Change iSCSI Initiator Name"
 msgstr "Zmień nazwę inicjatora iSCSI"
 
-#: pkg/storaged/crypto-keyslots.jsx:247
+#: pkg/storaged/crypto-keyslots.jsx:255
 msgid "Change passphrase"
 msgstr "Zmień hasło"
 
@@ -1309,18 +1363,18 @@ msgstr "Zmień ograniczenia zasobów"
 msgid "Change resources limits"
 msgstr "Zmień ograniczenia zasobów"
 
-#: pkg/networkmanager/interfaces.js:3165
+#: pkg/networkmanager/interfaces.js:3176
 msgid "Change the settings"
 msgstr "Zmień ustawienia"
 
-#: pkg/machines/components/nicEdit.jsx:287
+#: pkg/machines/components/nicEdit.jsx:157
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Zmiany zostaną uwzględnione po wyłączeniu maszyny wirtualnej"
 
-#: pkg/networkmanager/interfaces.js:3164
+#: pkg/networkmanager/interfaces.js:3175
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1336,7 +1390,7 @@ msgstr "Wyszukaj aktualizacje"
 msgid "Checking $target"
 msgstr "Sprawdzanie $target"
 
-#: pkg/networkmanager/interfaces.js:843
+#: pkg/networkmanager/interfaces.js:848
 msgid "Checking IP"
 msgstr "Sprawdzanie IP"
 
@@ -1356,11 +1410,11 @@ msgstr "Wyszukiwanie nowych aplikacji"
 msgid "Checking for public keys"
 msgstr "Wyszukiwanie kluczy publicznych"
 
-#: pkg/systemd/host.js:537
+#: pkg/systemd/host.js:540
 msgid "Checking for updates…"
 msgstr "Wyszukiwanie aktualizacji…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:142
+#: pkg/lib/cockpit-components-install-dialog.jsx:143
 msgid "Checking installed software"
 msgstr "Sprawdzanie zainstalowanego oprogramowania"
 
@@ -1372,11 +1426,11 @@ msgstr "Wybierz system operacyjny"
 msgid "Choose the language to be used in the application"
 msgstr "Proszę wybrać język używany w aplikacji"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/mdraids-panel.jsx:72
 msgid "Chunk Size"
 msgstr "Rozmiar bloku"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Class"
 msgstr "Klasa"
 
@@ -1386,13 +1440,13 @@ msgstr "Czyszczenie dla $target"
 
 #: pkg/systemd/service-details.jsx:188
 msgid "Clear 'Failed to start'"
-msgstr ""
+msgstr "Wyczyść „Uruchomienie się nie powiodło”"
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr "Wyczyść wszystkie filtry"
 
-#: pkg/systemd/host.js:750
+#: pkg/systemd/host.js:776
 msgid "Click to see system hardware information"
 msgstr "Kliknięcie wyświetli informacje o sprzęcie komputera"
 
@@ -1410,14 +1464,14 @@ msgstr "Oprogramowanie klienta"
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
 #: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
 #: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
 #: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:394
 msgid "Close"
 msgstr "Zamknij"
 
-#: pkg/shell/active-pages.js:103
+#: pkg/shell/active-pages.js:104
 msgid "Close Selected Pages"
 msgstr "Zamknij zaznaczone strony"
 
@@ -1425,7 +1479,7 @@ msgstr "Zamknij zaznaczone strony"
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Uwierzytelnianie Cockpit jest niepoprawnie skonfigurowane."
 
-#: pkg/lib/machine-dialogs.js:427
+#: pkg/lib/machine-dialogs.js:429
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
@@ -1434,11 +1488,11 @@ msgstr ""
 "upewnić, że ma on uruchomioną usługę ssh na porcie $1 lub podać inny port "
 "w adresie."
 
-#: src/base1/cockpit.js:4037
+#: src/base1/cockpit.js:4041
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit nie może skontaktować się z podanym komputerem."
 
-#: pkg/shell/base_index.js:752
+#: pkg/shell/base_index.js:759
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1467,7 +1521,7 @@ msgstr ""
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit to interaktywny interfejs do administrowania serwerami Linux."
 
-#: src/base1/cockpit.js:4035
+#: src/base1/cockpit.js:4039
 msgid "Cockpit is not compatible with the software on the system."
 msgstr "Cockpit nie jest zgodny z oprogramowaniem w systemie."
 
@@ -1475,7 +1529,7 @@ msgstr "Cockpit nie jest zgodny z oprogramowaniem w systemie."
 msgid "Cockpit is not installed"
 msgstr "Cockpit nie jest zainstalowany"
 
-#: src/base1/cockpit.js:4029
+#: src/base1/cockpit.js:4033
 msgid "Cockpit is not installed on the system."
 msgstr "Cockpit nie jest zainstalowany w systemie."
 
@@ -1542,20 +1596,19 @@ msgstr "Kolor"
 msgid "Combined memory usage"
 msgstr "Łączne użycie pamięci"
 
-#: pkg/docker/overview.js:86
+#: pkg/docker/overview.js:88
 msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Łączne użycie $0 rdzenia procesora"
 msgstr[1] "Łączne użycie $0 rdzeni procesora"
 msgstr[2] "Łączne użycie $0 rdzeni procesora"
 
-#: pkg/networkmanager/firewall.jsx:554
+#: pkg/networkmanager/firewall.jsx:556
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Przyjmowane są porty, zakresy i aliasy oddzielone przecinkami"
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
 #: pkg/docker/index.html:708 pkg/systemd/services.html:282
-#: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
 msgid "Command"
@@ -1569,7 +1622,7 @@ msgstr "Polecenie nie może być puste"
 msgid "Command:"
 msgstr "Polecenie:"
 
-#: pkg/shell/index.html:261
+#: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Komentarz"
 
@@ -1590,11 +1643,11 @@ msgstr "Komunikacja z tuned się nie powiodła"
 msgid "Compact PCI"
 msgstr "Kompaktowe PCI"
 
-#: pkg/storaged/content-views.jsx:522
+#: pkg/storaged/content-views.jsx:532
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Zgodne ze wszystkimi systemami i urządzeniami (MBR)"
 
-#: pkg/storaged/content-views.jsx:524
+#: pkg/storaged/content-views.jsx:535
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
 
@@ -1602,8 +1655,8 @@ msgstr "Zgodne z nowoczesnymi systemami i dyskami twardymi > 2 TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Kompresowanie zrzutów awarii, aby oszczędzać miejsce"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:310
+#: pkg/storaged/vdos-panel.jsx:87
 msgid "Compression"
 msgstr "Kompresja"
 
@@ -1611,32 +1664,32 @@ msgstr "Kompresja"
 msgid "Computer OU"
 msgstr "OU komputera"
 
-#: pkg/systemd/service-details.jsx:442
+#: pkg/systemd/service-details.jsx:444
 msgid "Condition $0=$1 was not met"
 msgstr "Warunek $0=$1 nie został spełniony"
 
-#: pkg/systemd/service-details.jsx:492
+#: pkg/systemd/service-details.jsx:494
 msgid "Condition failed"
 msgstr "Warunek się nie powiódł"
 
-#: pkg/networkmanager/interfaces.js:2737
+#: pkg/networkmanager/interfaces.js:2745
 msgid "Configure"
 msgstr "Skonfiguruj"
 
-#: pkg/docker/storage.jsx:331
+#: pkg/docker/storage.jsx:335
 msgid "Configure storage..."
 msgstr "Skonfiguruj urządzenia do przechowywania danych…"
 
-#: pkg/networkmanager/interfaces.js:837
+#: pkg/networkmanager/interfaces.js:842
 msgid "Configuring"
 msgstr "Konfigurowanie"
 
-#: pkg/networkmanager/interfaces.js:841
+#: pkg/networkmanager/interfaces.js:846
 msgid "Configuring IP"
 msgstr "Konfigurowanie IP"
 
-#: pkg/shell/index.html:297 pkg/users/index.html:176
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/shell/index.html:298 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:315
 msgid "Confirm"
 msgstr "Potwierdź"
 
@@ -1648,15 +1701,15 @@ msgstr "Potwierdź nowe hasło"
 msgid "Confirm deletion of the Virtual Network"
 msgstr "Potwierdź usunięcie sieci wirtualnej"
 
-#: pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:372
 msgid "Confirm removal with passphrase"
 msgstr "Potwierdź usunięcie hasłem"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
 msgstr "W konflikcie z"
 
-#: pkg/systemd/service-details.jsx:425
+#: pkg/systemd/service-details.jsx:427
 msgid "Conflicts"
 msgstr "Powoduje konflikt z"
 
@@ -1664,7 +1717,7 @@ msgstr "Powoduje konflikt z"
 msgid "Connect"
 msgstr "Połącz"
 
-#: pkg/networkmanager/interfaces.js:2724
+#: pkg/networkmanager/interfaces.js:2732
 msgid "Connect automatically"
 msgstr "Łączenie automatyczne"
 
@@ -1703,23 +1756,26 @@ msgstr "Łączenie z usługą SETroubleshoot…"
 msgid "Connecting to Virtualization Service"
 msgstr "Łączenie z usługą wirtualizacji"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:467
 msgid "Connecting to the machine"
 msgstr "Łączenie z komputerem"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:34
-#: pkg/machines/components/networks/createNetworkDialog.jsx:106
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Połączenie"
 
-#: pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:414
 msgid "Connection Error"
 msgstr "Błąd połączenia"
 
-#: src/base1/cockpit.js:4027
+#: pkg/shell/index.html:396
+msgid "Connection failed"
+msgstr "Połączenie się nie powiodło"
+
+#: src/base1/cockpit.js:4031
 msgid "Connection has timed out."
 msgstr "Połączenie przekroczyło czas oczekiwania."
 
@@ -1727,7 +1783,7 @@ msgstr "Połączenie przekroczyło czas oczekiwania."
 msgid "Connection will be lost"
 msgstr "Połączenie zostanie utracone"
 
-#: pkg/systemd/service-details.jsx:424
+#: pkg/systemd/service-details.jsx:426
 msgid "Consists Of"
 msgstr "Składa się z"
 
@@ -1735,7 +1791,7 @@ msgstr "Składa się z"
 msgid "Console Type"
 msgstr "Typ konsoli"
 
-#: pkg/machines/components/vm/vm.jsx:51
+#: pkg/machines/components/vm/vm.jsx:53
 msgid "Consoles"
 msgstr "Konsole"
 
@@ -1744,7 +1800,6 @@ msgid "Contacted domain"
 msgstr "Skontaktowana domena"
 
 #: pkg/docker/console.html:4
-#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Kontener"
 
@@ -1782,16 +1837,16 @@ msgctxt "page-title"
 msgid "Containers"
 msgstr "Kontenery"
 
-#: pkg/storaged/content-views.jsx:557
+#: pkg/storaged/content-views.jsx:570
 msgid "Content"
 msgstr "Zawartość"
 
-#: src/base1/test-locale.js:42 src/base1/test-locale.js:53
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:56
 #: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Sterowanie"
 
-#: src/base1/test-locale.js:43 src/base1/test-locale.js:55
+#: src/base1/test-locale.js:46 src/base1/test-locale.js:58
 #: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
@@ -1813,7 +1868,7 @@ msgstr "Skopiuj do schowka"
 msgid "Cores per socket"
 msgstr "Rdzenie na gniazdo"
 
-#: pkg/docker/storage.jsx:428
+#: pkg/docker/storage.jsx:438
 msgid "Could not add all disks"
 msgstr "Nie można dodać wszystkich dysków"
 
@@ -1821,7 +1876,7 @@ msgstr "Nie można dodać wszystkich dysków"
 msgid "Could not contact {{host}}"
 msgstr "Nie można skontaktować się z {{host}}"
 
-#: pkg/docker/storage.jsx:468
+#: pkg/docker/storage.jsx:484
 msgid "Could not reset the storage pool"
 msgstr "Nie można przywrócić puli urządzeń do przechowywania danych"
 
@@ -1833,7 +1888,7 @@ msgstr "Nie można zmienić grup użytkownika"
 msgid "Couldn't change user password"
 msgstr "Nie można zmienić hasła użytkownika"
 
-#: pkg/shell/indexes.js:419
+#: pkg/shell/indexes.js:470
 msgid "Couldn't connect to the machine"
 msgstr "Nie można połączyć z komputerem"
 
@@ -1853,29 +1908,30 @@ msgstr "Nie można wyświetlić listy użytkowników"
 msgid "Couldn't load user data"
 msgstr "Nie można wczytać danych użytkownika"
 
-#: pkg/kdump/kdump-view.jsx:336 pkg/kdump/kdump-view.jsx:504
+#: pkg/kdump/kdump-view.jsx:337 pkg/kdump/kdump-view.jsx:506
 msgid "Crash dump location"
 msgstr "Położenie zrzutu awarii"
 
-#: pkg/kdump/kdump-view.jsx:304
+#: pkg/kdump/kdump-view.jsx:305
 msgid "Crash system"
 msgstr "System awarii"
 
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
-#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/networks/createNetworkDialog.jsx:482
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:96
+#: pkg/storaged/content-views.jsx:127 pkg/storaged/content-views.jsx:709
+#: pkg/storaged/lvol-tabs.jsx:360 pkg/storaged/mdraids-panel.jsx:103
+#: pkg/storaged/vdos-panel.jsx:113 pkg/storaged/vgroups-panel.jsx:72
 msgid "Create"
 msgstr "Utwórz"
 
-#: pkg/storaged/content-views.jsx:639
+#: pkg/storaged/content-views.jsx:653
 msgid "Create Logical Volume"
 msgstr "Utwórz wolumin logiczny"
 
-#: pkg/machines/components/diskAdd.jsx:552
+#: pkg/machines/components/diskAdd.jsx:423
 msgid "Create New"
 msgstr "Utwórz nowy"
 
@@ -1883,19 +1939,23 @@ msgstr "Utwórz nowy"
 msgid "Create New Account"
 msgstr "Utwórz nowe konto"
 
-#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+msgid "Create New Volume"
+msgstr "Utwórz nowy wolumin"
+
+#: pkg/storaged/content-views.jsx:439 pkg/storaged/format-dialog.jsx:336
 msgid "Create Partition"
 msgstr "Utwórz partycję"
 
-#: pkg/storaged/content-views.jsx:552
+#: pkg/storaged/content-views.jsx:565
 msgid "Create Partition Table"
 msgstr "Utwórz tablicę partycji"
 
-#: pkg/storaged/format-dialog.jsx:184
+#: pkg/storaged/format-dialog.jsx:189
 msgid "Create Partition on $0"
 msgstr "Utwórz partycję na $0"
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/mdraids-panel.jsx:39
 msgid "Create RAID Device"
 msgstr "Utwórz urządzenie RAID"
 
@@ -1903,7 +1963,7 @@ msgstr "Utwórz urządzenie RAID"
 msgid "Create Report"
 msgstr "Utwórz raport"
 
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
+#: pkg/storaged/lvol-tabs.jsx:354 pkg/storaged/lvol-tabs.jsx:395
 msgid "Create Snapshot"
 msgstr "Utwórz migawkę"
 
@@ -1911,7 +1971,7 @@ msgstr "Utwórz migawkę"
 msgid "Create Storage Pool"
 msgstr "Utwórz pulę urządzeń do przechowywania danych"
 
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:138
 msgid "Create Thin Volume"
 msgstr "Utwórz cienki wolumin"
 
@@ -1923,7 +1983,7 @@ msgstr "Utwórz licznik"
 msgid "Create Timers"
 msgstr "Utwórz liczniki"
 
-#: pkg/storaged/vdos-panel.jsx:46
+#: pkg/storaged/vdos-panel.jsx:47
 msgid "Create VDO Device"
 msgstr "Utwórz urządzenie VDO"
 
@@ -1931,12 +1991,17 @@ msgstr "Utwórz urządzenie VDO"
 msgid "Create VM"
 msgstr "Utwórz maszynę wirtualną"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:477
-#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+#: pkg/machines/components/networks/createNetworkDialog.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:516
 msgid "Create Virtual Network"
 msgstr "Utwórz sieć wirtualną"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:135
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:148
+msgid "Create Volume"
+msgstr "Utwórz wolumin"
+
+#: pkg/storaged/vgroups-panel.jsx:54
 msgid "Create Volume Group"
 msgstr "Utwórz grupę woluminów"
 
@@ -1944,12 +2009,12 @@ msgstr "Utwórz grupę woluminów"
 msgid "Create diagnostic report"
 msgstr "Utwórz raport diagnostyczny"
 
-#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
-#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
+#: pkg/networkmanager/interfaces.js:3850 pkg/networkmanager/interfaces.js:4050
+#: pkg/networkmanager/interfaces.js:4305 pkg/networkmanager/interfaces.js:4510
 msgid "Create it"
 msgstr "Utwórz"
 
-#: pkg/storaged/content-views.jsx:708
+#: pkg/storaged/content-views.jsx:728
 msgid "Create new Logical Volume"
 msgstr "Utworzono:"
 
@@ -1982,7 +2047,7 @@ msgstr "Tworzenie partycji $target"
 msgid "Creating snapshot of $target"
 msgstr "Tworzenie migawki $target"
 
-#: pkg/networkmanager/interfaces.js:4491
+#: pkg/networkmanager/interfaces.js:4509
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1990,7 +2055,7 @@ msgstr ""
 "Utworzenie tej sieci VLAN zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:3833
+#: pkg/networkmanager/interfaces.js:3849
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1998,7 +2063,7 @@ msgstr ""
 "Utworzenie tego wiązania zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:4286
+#: pkg/networkmanager/interfaces.js:4304
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2006,7 +2071,7 @@ msgstr ""
 "Utworzenie tego mostka zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:4032
+#: pkg/networkmanager/interfaces.js:4049
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2042,23 +2107,23 @@ msgstr "Obecny przydział"
 msgid "Current boot"
 msgstr "Obecne uruchomienie"
 
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Niestandardowe"
 
-#: pkg/networkmanager/firewall.jsx:548
+#: pkg/networkmanager/firewall.jsx:550
 msgid "Custom Ports"
 msgstr "Niestandardowe porty"
 
-#: pkg/storaged/format-dialog.jsx:118
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Custom encryption options"
 msgstr "Niestandardowe opcje szyfrowania"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/format-dialog.jsx:95 pkg/storaged/nfs-details.jsx:183
 msgid "Custom mount options"
 msgstr "Niestandardowe opcje montowania"
 
-#: pkg/networkmanager/firewall.jsx:748
+#: pkg/networkmanager/firewall.jsx:750
 msgid "Custom zones"
 msgstr "Niestandardowe strefy"
 
@@ -2071,19 +2136,19 @@ msgstr "Zakres DHCP"
 msgid "DISK IS FAILING"
 msgstr "NA DYSKU WYSTĘPUJĄ BŁĘDY"
 
-#: pkg/networkmanager/interfaces.js:3328
+#: pkg/networkmanager/interfaces.js:3339
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3332
+#: pkg/networkmanager/interfaces.js:3343
 msgid "DNS Search Domains"
 msgstr "Domeny wyszukiwania DNS"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "DNS Search Domains $val"
 msgstr "Domeny wyszukiwania DNS $val"
 
@@ -2095,17 +2160,17 @@ msgstr "Ciemny"
 msgid "Dashboard"
 msgstr "Panel kontrolny"
 
-#: pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/lvol-tabs.jsx:463
 msgid "Data Used"
 msgstr "Użyte dane"
 
 #: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
-#: pkg/storaged/content-views.jsx:254
+#: pkg/storaged/content-views.jsx:259
 msgid "Deactivate"
 msgstr "Dezaktywuj"
 
-#: pkg/networkmanager/interfaces.js:849
+#: pkg/networkmanager/interfaces.js:854
 msgid "Deactivating"
 msgstr "Dezaktywowanie"
 
@@ -2117,24 +2182,23 @@ msgstr "Dezaktywowanie $target"
 msgid "Debug and above"
 msgstr "Debugowania i powyżej"
 
-#: pkg/storaged/vdo-details.jsx:310 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdo-details.jsx:316 pkg/storaged/vdos-panel.jsx:91
 msgid "Deduplication"
 msgstr "Deduplikacja"
 
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
-#: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
 msgstr "Domyślne"
 
-#: pkg/systemd/index.html:438
+#: pkg/systemd/index.html:449
 msgid "Delay"
 msgstr "Opóźnienie"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/details.js:293 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
@@ -2142,16 +2206,23 @@ msgstr "Opóźnienie"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
+#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:319
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
+#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
+#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Usuń"
 
-#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2454 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Usuń $0"
+
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:67
+msgid "Delete $0 volume"
+msgid_plural "Delete $0 volumes"
+msgstr[0] "Usuń $0 wolumin"
+msgstr[1] "Usuń $0 woluminy"
+msgstr[2] "Usuń $0 woluminów"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
@@ -2181,7 +2252,7 @@ msgstr "Usuń woluminy wewnątrz tej puli"
 msgid "Deleting $target"
 msgstr "Usuwanie $target"
 
-#: pkg/networkmanager/interfaces.js:2446
+#: pkg/networkmanager/interfaces.js:2453
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2189,29 +2260,29 @@ msgstr ""
 "Usunięcie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/storaged/mdraid-details.jsx:300
+#: pkg/storaged/mdraid-details.jsx:296
 msgid "Deleting a RAID device will erase all data on it."
 msgstr ""
 "Usunięcie urządzenia RAID usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/storaged/vdo-details.jsx:200
+#: pkg/storaged/vdo-details.jsx:204
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Usunięcie urządzenia VDO usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:292
 msgid "Deleting a container will erase all data in it."
 msgstr "Usunięcie kontenera usunie wszystkie znajdujące się w nim dane."
 
-#: pkg/storaged/content-views.jsx:273
+#: pkg/storaged/content-views.jsx:278
 msgid "Deleting a logical volume will delete all data in it."
 msgstr ""
 "Usunięcie woluminu logicznego usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/storaged/content-views.jsx:276
+#: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr "Usunięcie partycji usunie wszystkie znajdujące się na niej dane."
 
-#: pkg/storaged/vgroup-details.jsx:212
+#: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 "Usunięcie grupy woluminów usunie wszystkie znajdujące się w niej dane."
@@ -2228,15 +2299,14 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Usuwanie grupy woluminów $target"
 
-#: pkg/systemd/services.html:268
-#: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:759
+#: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Opis"
 
 #: pkg/playground/manifest.json.in
 msgid "Design Patterns"
-msgstr ""
+msgstr "Wzory projektowania"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2254,42 +2324,37 @@ msgstr ""
 msgid "Detachable"
 msgstr "Odłączalny"
 
-#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
-#: pkg/systemd/host.js:762
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:384
+#: pkg/systemd/host.js:786 pkg/systemd/host.js:797
 msgid "Details"
 msgstr "Szczegóły"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:169
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:155
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
-#: pkg/machines/components/vmDisksTab.jsx:58
+#: pkg/machines/components/vmDisksTab.jsx:96
 msgid "Device"
 msgstr "Urządzenie"
 
-#: pkg/storaged/vdo-details.jsx:267
+#: pkg/storaged/vdo-details.jsx:273
 msgid "Device File"
 msgstr "Plik urządzenia"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:564
 msgid "Device is read-only"
 msgstr "Urządzenie jest tylko do odczytu"
 
 #: pkg/sosreport/manifest.json.in
 msgid "Diagnostic Reports"
-msgstr ""
+msgstr "Raporty diagnostyczne"
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Raporty diagnostyczne"
 
-#: node_modules/registry-image-widgets/views/image-body.html:22
-msgid "Digest"
-msgstr "Przegląd"
-
-#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Katalog"
@@ -2298,16 +2363,16 @@ msgstr "Katalog"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Katalog $0 nie jest zapisywalny lub nie istnieje."
 
-#: pkg/systemd/hwinfo.jsx:191
+#: pkg/systemd/hwinfo.jsx:195
 msgid "Disable simultaneous multithreading"
 msgstr "Wyłącz wielowątkowość współbieżną"
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:233
 msgid "Disable tuned"
 msgstr "Wyłącz tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1981
+#: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Wyłączone"
 
@@ -2320,7 +2385,7 @@ msgid "Disconnect"
 msgstr "Rozłącz"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
+#: pkg/shell/indexes.js:180 pkg/shell/indexes.js:660
 msgid "Disconnected"
 msgstr "Rozłączono"
 
@@ -2329,7 +2394,7 @@ msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr ""
 "Rozłączono z konsoli szeregowej. Proszę kliknąć przycisk „Połącz ponownie”."
 
-#: pkg/storaged/vdos-panel.jsx:55
+#: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Dysk"
 
@@ -2337,15 +2402,15 @@ msgstr "Dysk"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr "Odłączenie dysku $0 z maszyny wirtualnej $1 się nie powiodło"
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:588
 msgid "Disk I/O"
 msgstr "Wejście/wyjście dysku"
 
-#: pkg/machines/components/diskAdd.jsx:525
+#: pkg/machines/components/diskAdd.jsx:396
 msgid "Disk failed to be attached"
 msgstr "Podłączenie dysku się nie powiodło"
 
-#: pkg/machines/components/diskAdd.jsx:504
+#: pkg/machines/components/diskAdd.jsx:373
 msgid "Disk failed to be created"
 msgstr "Utworzenie dysku się nie powiodło"
 
@@ -2357,9 +2422,9 @@ msgstr "Dysk jest OK"
 msgid "Disk passphrase"
 msgstr "Hasło dysku"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
+#: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
 msgid "Disks"
 msgstr "Dyski"
 
@@ -2374,11 +2439,7 @@ msgstr "Język"
 
 #: pkg/docker/manifest.json.in
 msgid "Docker Containers"
-msgstr ""
-
-#: node_modules/registry-image-widgets/views/image-meta.html:10
-msgid "Docker Version"
-msgstr "Wersja Dockera"
+msgstr "Kontenery Docker"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
@@ -2388,7 +2449,7 @@ msgstr "Docker nie jest zainstalowany lub aktywowany w tym systemie"
 msgid "Docking Station"
 msgstr "Stacja dokująca"
 
-#: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
+#: pkg/realmd/operation.html:11 pkg/systemd/index.html:125
 #: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domena"
@@ -2414,11 +2475,11 @@ msgid "Domain Administrator Password"
 msgstr "Hasło administratora domeny"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1085
+#: pkg/systemd/init.js:1147
 msgid "Don't Repeat"
 msgstr "Bez powtarzania"
 
-#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
+#: pkg/storaged/content-views.jsx:524 pkg/storaged/format-dialog.jsx:289
 msgid "Don't overwrite existing data"
 msgstr "Nie zastępuj istniejących danych"
 
@@ -2450,20 +2511,15 @@ msgstr "Pobrano"
 msgid "Downloading"
 msgstr "Pobieranie"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:179
+#: pkg/lib/cockpit-components-install-dialog.jsx:180
 msgid "Downloading $0"
 msgstr "Pobieranie $0"
 
-#: pkg/docker/storage.jsx:167 pkg/storaged/drive-details.jsx:68
+#: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Napęd"
 
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
-msgctxt "storage"
-msgid "Drive"
-msgstr "Napęd"
-
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:102
 msgid "Drives"
 msgstr "Napędy"
 
@@ -2479,8 +2535,8 @@ msgstr "Podwójny alias"
 msgid "Duplicate port"
 msgstr "Podwójny port"
 
-#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
-#: pkg/storaged/nfs-details.jsx:306
+#: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/nfs-details.jsx:314
 msgid "Edit"
 msgstr "Modyfikuj"
 
@@ -2488,15 +2544,11 @@ msgstr "Modyfikuj"
 msgid "Edit Server"
 msgstr "Modyfikuj serwer"
 
-#: pkg/storaged/crypto-keyslots.jsx:270
+#: pkg/storaged/crypto-keyslots.jsx:276
 msgid "Edit Tang keyserver"
 msgstr "Modyfikuj serwer kluczy Tang"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:7
-msgid "Edit image stream"
-msgstr "Modyfikuj strumień obrazu"
-
-#: pkg/storaged/crypto-keyslots.jsx:535
+#: pkg/storaged/crypto-keyslots.jsx:548
 msgid "Editing a key requires a free slot"
 msgstr "Modyfikacja klucza wymaga wolnego gniazda"
 
@@ -2508,13 +2560,13 @@ msgstr "Wysuwanie $target"
 msgid "Embedded PC"
 msgstr "Komputer osadzony"
 
-#: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
+#: pkg/playground/translate.html:57 src/base1/test-locale.js:47
+#: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Puste"
 
-#: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
+#: pkg/playground/translate.html:62 src/base1/test-locale.js:48
+#: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Puste"
@@ -2531,52 +2583,52 @@ msgstr "Emulowany komputer"
 msgid "Enable Service"
 msgstr "Włącz usługę"
 
-#: pkg/systemd/index.html:161
+#: pkg/systemd/index.html:168
 msgid "Enable stored metrics…"
 msgstr "Włącz przechowywane statystyki…"
 
-#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:216
 msgid "Enabled"
 msgstr "Włączone"
 
-#: pkg/storaged/format-dialog.jsx:292
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Encrypt data"
 msgstr "Zaszyfruj dane"
 
-#: pkg/storaged/utils.js:273
+#: pkg/storaged/utils.js:274
 msgid "Encrypted $0"
 msgstr "Zaszyfrowane $0"
 
-#: pkg/storaged/utils.js:265
+#: pkg/storaged/utils.js:266
 msgid "Encrypted Logical Volume of $0"
 msgstr "Zaszyfrowany wolumin logiczny $0"
 
-#: pkg/storaged/utils.js:267
+#: pkg/storaged/utils.js:268
 msgid "Encrypted Partition of $0"
 msgstr "Zaszyfrowana partycja $0"
 
-#: pkg/storaged/content-views.jsx:348
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Zaszyfrowane dane"
 
-#: pkg/storaged/lvol-tabs.jsx:140
+#: pkg/storaged/lvol-tabs.jsx:141
 msgid "Encrypted volumes can not be resized here."
 msgstr "Nie można tutaj zmieniać rozmiaru zaszyfrowanych woluminów."
 
-#: pkg/storaged/lvol-tabs.jsx:143
+#: pkg/storaged/lvol-tabs.jsx:144
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr "Zaszyfrowane woluminy muszą zostać odblokowane przed zmianą rozmiaru."
 
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Szyfrowanie"
 
-#: pkg/storaged/crypto-tab.jsx:102
+#: pkg/storaged/crypto-tab.jsx:105
 msgid "Encryption Options"
 msgstr "Opcje szyfrowania"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+#: pkg/machines/components/networks/createNetworkDialog.jsx:238
 msgid "End"
 msgstr "Koniec"
 
@@ -2589,11 +2641,11 @@ msgstr "Koniec nie może być pusty"
 msgid "Enforcing"
 msgstr "Wymuszanie"
 
-#: pkg/systemd/host.js:510
+#: pkg/systemd/host.js:513
 msgid "Enhancement Updates Available"
 msgstr "Dostępne są aktualizacje z ulepszeniami"
 
-#: pkg/lib/machine-dialogs.js:445
+#: pkg/lib/machine-dialogs.js:447
 msgid "Enter IP address or host name"
 msgstr "Adres IP lub nazwa komputera"
 
@@ -2605,7 +2657,7 @@ msgstr ""
 "Wpisanie tutaj innego hasła oznacza, że będzie wymagane jego wpisanie za "
 "każdym połączeniem do tej maszyny"
 
-#: pkg/networkmanager/firewall.jsx:784
+#: pkg/networkmanager/firewall.jsx:786
 msgid "Entire subnet"
 msgstr "Cała podsieć"
 
@@ -2618,15 +2670,14 @@ msgid "Entrypoint"
 msgstr "Punkt wejścia"
 
 #: pkg/docker/index.html:528
-#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Środowisko"
 
-#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:286
 msgid "Erase"
 msgstr "Wymaż"
 
-#: pkg/docker/storage.jsx:447
+#: pkg/docker/storage.jsx:460
 msgid "Erase containers and reset storage pool"
 msgstr "Usuń kontenery i przywróć pulę urządzeń do przechowywania danych"
 
@@ -2634,14 +2685,14 @@ msgstr "Usuń kontenery i przywróć pulę urządzeń do przechowywania danych"
 msgid "Erasing $target"
 msgstr "Czyszczenie $target"
 
-#: pkg/packagekit/updates.jsx:312
+#: pkg/packagekit/updates.jsx:313
 msgid "Errata:"
 msgstr "Poprawka:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
-#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
+#: pkg/storaged/storage-controls.jsx:100 pkg/storaged/storage-controls.jsx:194
+#: pkg/systemd/service-details.jsx:450 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Błąd"
 
@@ -2682,7 +2733,7 @@ msgstr "MAC ethernetu"
 msgid "Ethernet MTU"
 msgstr "MTU ethernetu"
 
-#: pkg/networkmanager/interfaces.js:2015
+#: pkg/networkmanager/interfaces.js:2027
 msgid "Ethtool"
 msgstr "ethtool"
 
@@ -2690,11 +2741,11 @@ msgstr "ethtool"
 msgid "Everything"
 msgstr "Wszystko"
 
-#: pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:563
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Przykład: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:569
+#: pkg/networkmanager/firewall.jsx:571
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Przykład: 88,2019,nfs,rsync"
 
@@ -2704,7 +2755,7 @@ msgstr "Doskonałe hasło"
 
 #: pkg/playground/manifest.json.in
 msgid "Exceptions"
-msgstr ""
+msgstr "Wyjątki"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
@@ -2722,19 +2773,19 @@ msgstr "Obudowa rozszerzenia"
 msgid "Expose container ports"
 msgstr "Eksponuj porty kontenera"
 
-#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:459 pkg/storaged/format-dialog.jsx:259
 msgid "Extended Partition"
 msgstr "Rozszerzona partycja"
 
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "NIEPOWODZENIE"
 
-#: pkg/networkmanager/interfaces.js:851
+#: pkg/networkmanager/interfaces.js:856
 msgid "Failed"
 msgstr "Niepowodzenie"
 
-#: pkg/lib/machine-dialogs.js:410
+#: pkg/lib/machine-dialogs.js:412
 msgid "Failed to add machine: $0"
 msgstr "Dodanie komputera się nie powiodło: $0"
 
@@ -2746,7 +2797,7 @@ msgstr "Dodanie portu się nie powiodło"
 msgid "Failed to add service"
 msgstr "Dodanie usługi się nie powiodło"
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:711
 msgid "Failed to add zone"
 msgstr "Dodanie strefy się nie powiodło"
 
@@ -2766,7 +2817,7 @@ msgstr "Wyłączenie tuned się nie powiodło"
 msgid "Failed to disable tuned profile"
 msgstr "Wyłączenie profilu tuned się nie powiodło"
 
-#: pkg/lib/machine-dialogs.js:492
+#: pkg/lib/machine-dialogs.js:494
 msgid "Failed to edit machine: $0"
 msgstr "Modyfikacja komputera się nie powiodła: $0"
 
@@ -2774,7 +2825,7 @@ msgstr "Modyfikacja komputera się nie powiodła: $0"
 msgid "Failed to enable tuned"
 msgstr "Włączenie tuned się nie powiodło"
 
-#: pkg/machines/components/vmnetworktab.jsx:55
+#: pkg/machines/components/vmnetworktab.jsx:60
 msgid "Failed to fetch the IP addresses of the interfaces present in $0"
 msgstr "Pobranie adresów IP interfejsów obecnych w $0 się nie powiodło"
 
@@ -2782,11 +2833,11 @@ msgstr "Pobranie adresów IP interfejsów obecnych w $0 się nie powiodło"
 msgid "Failed to load authorized keys."
 msgstr "Wczytanie upoważnionych kluczy się nie powiodło."
 
-#: pkg/networkmanager/firewall.jsx:621
+#: pkg/networkmanager/firewall.jsx:623
 msgid "Failed to remove service"
 msgstr "Usunięcie usługi się nie powiodło"
 
-#: pkg/systemd/service-details.jsx:340
+#: pkg/systemd/service-details.jsx:342
 msgid "Failed to start"
 msgstr "Uruchomienie się nie powiodło"
 
@@ -2812,7 +2863,7 @@ msgstr ""
 msgid "File"
 msgstr "Plik"
 
-#: pkg/storaged/content-views.jsx:145
+#: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "System plików"
 
@@ -2820,11 +2871,11 @@ msgstr "System plików"
 msgid "Filesystem Directory"
 msgstr "Katalog systemu plików"
 
-#: pkg/storaged/fsys-tab.jsx:123
+#: pkg/storaged/fsys-tab.jsx:126
 msgid "Filesystem Mounting"
 msgstr "Montowanie systemu plików"
 
-#: pkg/storaged/fsys-tab.jsx:70
+#: pkg/storaged/fsys-tab.jsx:71
 msgid "Filesystem Name"
 msgstr "Nazwa systemu plików"
 
@@ -2832,36 +2883,32 @@ msgstr "Nazwa systemu plików"
 msgid "Filesystems"
 msgstr "Systemy plików"
 
-#: pkg/networkmanager/firewall.jsx:516
+#: pkg/networkmanager/firewall.jsx:518
 msgid "Filter Services"
 msgstr "Filtrowanie usług"
 
 #: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
-msgstr "Wyszukiwanie według nazwy lub opisu…"
+msgstr "Filtrowanie według nazwy lub opisu…"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Odcisk"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
+#: pkg/networkmanager/firewall.jsx:947 pkg/networkmanager/firewall.jsx:950
 msgid "Firewall"
 msgstr "Zapora sieciowa"
 
-#: pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:895
 msgid "Firewall is not available"
 msgstr "Zapora sieciowa jest niedostępna"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:35
-msgid "Follows docker repo"
-msgstr "Obserwuje repozytorium Dockera"
-
-#: pkg/storaged/vdos-panel.jsx:88
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "For legacy applications only. Reduces performance."
 msgstr "Tylko dla przestarzałych programów. Zmniejsza wydajność."
 
-#: pkg/systemd/service-details.jsx:322
+#: pkg/systemd/service-details.jsx:324
 msgid "Forbidden from running"
 msgstr "Zabronione uruchamianie"
 
@@ -2885,57 +2932,57 @@ msgstr "Wymuś wyłączenie"
 msgid "Force password change"
 msgstr "Wymuszenie zmiany hasła"
 
-#: pkg/storaged/crypto-keyslots.jsx:373
+#: pkg/storaged/crypto-keyslots.jsx:381
 msgid "Force remove passphrase in $0"
 msgstr "Wymuś usunięcie hasła w $0"
 
-#: pkg/machines/components/diskAdd.jsx:157
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
+#: pkg/storaged/content-views.jsx:323 pkg/storaged/content-views.jsx:542
+#: pkg/storaged/format-dialog.jsx:336
 msgid "Format"
 msgstr "Sformatuj"
 
-#: pkg/storaged/format-dialog.jsx:186
+#: pkg/storaged/format-dialog.jsx:191
 msgid "Format $0"
 msgstr "Sformatuj $0"
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/storaged/content-views.jsx:518
 msgid "Format Disk $0"
 msgstr "Sformatuj dysk $0"
 
-#: pkg/storaged/content-views.jsx:531
+#: pkg/storaged/content-views.jsx:543
 msgid "Formatting a disk will erase all data on it."
 msgstr "Sformatowanie dysku usunie wszystkie znajdujące się na nim dane."
 
-#: pkg/storaged/format-dialog.jsx:325
+#: pkg/storaged/format-dialog.jsx:338
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "Sformatowanie urządzenia do przechowywania danych usunie wszystkie "
 "znajdujące się na nim dane."
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+#: pkg/machines/components/networks/createNetworkDialog.jsx:133
 msgid "Forward Mode"
 msgstr "Tryb przekierowania"
 
-#: pkg/networkmanager/interfaces.js:2873
+#: pkg/networkmanager/interfaces.js:2881
 msgid "Forward delay $forward_delay"
 msgstr "Opóźnienie w przód $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:55
 msgid "Forwarding mode"
 msgstr "Tryb przekierowania"
 
-#: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
+#: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Wolne"
 
-#: pkg/storaged/content-views.jsx:440
+#: pkg/storaged/content-views.jsx:445
 msgid "Free Space"
 msgstr "Wolne miejsce"
 
-#: pkg/storaged/lvol-tabs.jsx:371
+#: pkg/storaged/lvol-tabs.jsx:379
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -2951,10 +2998,6 @@ msgstr "piątek"
 msgid "Fridays"
 msgstr "piątki"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:6
-msgid "From"
-msgstr "Z"
-
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
 msgstr "Imię i nazwisko"
@@ -2964,9 +3007,13 @@ msgid "Gateway:"
 msgstr "Brama:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2723 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Ogólne"
+
+#: pkg/machines/components/nicAdd.jsx:49
+msgid "Generate automatically"
+msgstr "Utwórz automatycznie"
 
 #: pkg/sosreport/index.html:55
 msgid "Generating report"
@@ -2976,15 +3023,15 @@ msgstr "Tworzenie raportu"
 msgid "Get new image"
 msgstr "Pobierz nowy obraz"
 
-#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/vmDisksTab.jsx:51
 msgid "GiB"
 msgstr "GiB"
 
-#: pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:200
 msgid "Go to"
 msgstr "Przejdź do"
 
@@ -2993,7 +3040,7 @@ msgid "Go to Application"
 msgstr "Przejdź do aplikacji"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Przejdź teraz"
@@ -3006,21 +3053,21 @@ msgstr "Konsola graficzna (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Konsola graficzna w przeglądarce pulpitu"
 
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
-#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
-#: pkg/storaged/vdo-details.jsx:298
+#: pkg/storaged/lvol-tabs.jsx:239 pkg/storaged/lvol-tabs.jsx:407
+#: pkg/storaged/lvol-tabs.jsx:459 pkg/storaged/vdo-details.jsx:235
+#: pkg/storaged/vdo-details.jsx:304
 msgid "Grow"
 msgstr "Powiększ"
 
-#: pkg/storaged/lvol-tabs.jsx:417
+#: pkg/storaged/lvol-tabs.jsx:425
 msgid "Grow Content"
 msgstr "Powiększ zawartość"
 
-#: pkg/storaged/lvol-tabs.jsx:231
+#: pkg/storaged/lvol-tabs.jsx:235
 msgid "Grow Logical Volume"
 msgstr "Powiększ wolumin logiczny"
 
-#: pkg/storaged/vdo-details.jsx:218
+#: pkg/storaged/vdo-details.jsx:223
 msgid "Grow logical size of $0"
 msgstr "Powiększ rozmiar logiczny $0"
 
@@ -3032,7 +3079,7 @@ msgstr "Powiększ do użycia całego miejsca"
 msgid "Hair Pin mode"
 msgstr "Tryb Hairpin"
 
-#: pkg/networkmanager/interfaces.js:2899
+#: pkg/networkmanager/interfaces.js:2907
 msgid "Hairpin mode"
 msgstr "Tryb Hairpin"
 
@@ -3040,12 +3087,7 @@ msgstr "Tryb Hairpin"
 msgid "Hand Held"
 msgstr "Przenośny"
 
-#: pkg/docker/storage.jsx:166
-msgid "Hard Disk"
-msgstr "Dysk twardy"
-
-#: pkg/storaged/drives-panel.jsx:85
-msgctxt "storage"
+#: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Dysk twardy"
 
@@ -3053,22 +3095,22 @@ msgstr "Dysk twardy"
 msgid "Hardware"
 msgstr "Sprzęt"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:274
 msgid "Hardware Information"
 msgstr "Informacje o sprzęcie"
 
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2883
 msgid "Hello time $hello_time"
 msgstr "Czas powitania $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Hide Performance Options"
 msgstr "Ukryj opcje wydajności"
 
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:389
 msgid "Host"
 msgstr "Gospodarz"
 
@@ -3076,16 +3118,16 @@ msgstr "Gospodarz"
 msgid "Host Device"
 msgstr "Urządzenie gospodarza"
 
-#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Nazwa komputera"
 
-#: src/base1/cockpit.js:4023
+#: src/base1/cockpit.js:4027
 msgid "Host key is incorrect"
 msgstr "Klucz komputera jest niepoprawny"
 
-#: pkg/realmd/operation.js:601
+#: pkg/realmd/operation.js:603
 msgid "Host name should not be changed in a domain"
 msgstr "Nie należy zmieniać nazwy komputera w domenie"
 
@@ -3097,7 +3139,7 @@ msgstr "Gospodarz nie może być pusty"
 msgid "Hour : Minute"
 msgstr "Godzina : Minuta"
 
-#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
+#: pkg/systemd/init.js:1223 pkg/systemd/init.js:1252
 msgid "Hour needs to be a number between 0-23"
 msgstr "Godzina musi być liczbą między 0 a 23"
 
@@ -3105,16 +3147,16 @@ msgstr "Godzina musi być liczbą między 0 a 23"
 msgid "Hours"
 msgstr "Godziny"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
+#: pkg/systemd/index.html:249 pkg/systemd/host.js:1642
 msgid "I/O Wait"
 msgstr "Oczekiwanie wejścia/wyjścia"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "ID"
 msgstr "Identyfikator"
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
-#: pkg/machines/components/vmnetworktab.jsx:133
+#: pkg/machines/components/vmnetworktab.jsx:143
 msgid "IP Address"
 msgstr "Adres IP"
 
@@ -3122,7 +3164,7 @@ msgstr "Adres IP"
 msgid "IP Address:"
 msgstr "Adres IP:"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+#: pkg/machines/components/networks/createNetworkDialog.jsx:183
 msgid "IP Configuration"
 msgstr "Konfiguracja IP"
 
@@ -3130,7 +3172,7 @@ msgstr "Konfiguracja IP"
 msgid "IP Prefix Length:"
 msgstr "Długość przedrostka IP:"
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "IP Range"
 msgstr "Zakres IP"
 
@@ -3138,7 +3180,7 @@ msgstr "Zakres IP"
 msgid "IP Settings"
 msgstr "Ustawienia IP"
 
-#: pkg/networkmanager/interfaces.js:2924
+#: pkg/networkmanager/interfaces.js:2932
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3146,7 +3188,7 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "Adres IPv4"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+#: pkg/machines/components/networks/createNetworkDialog.jsx:265
 msgid "IPv4 Network"
 msgstr "Sieć IPv4"
 
@@ -3154,19 +3196,19 @@ msgstr "Sieć IPv4"
 msgid "IPv4 Network should not be empty"
 msgstr "Sieć IPv4 nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv4 Settings"
 msgstr "Ustawienia IPv4"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+#: pkg/machines/components/networks/createNetworkDialog.jsx:199
 msgid "IPv4 and IPv6"
 msgstr "IPv4 i IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+#: pkg/machines/components/networks/createNetworkDialog.jsx:193
 msgid "IPv4 only"
 msgstr "Tylko IPv4"
 
-#: pkg/networkmanager/interfaces.js:2925
+#: pkg/networkmanager/interfaces.js:2933
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3174,7 +3216,7 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "Adres IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+#: pkg/machines/components/networks/createNetworkDialog.jsx:309
 msgid "IPv6 Network"
 msgstr "Sieć IPv6"
 
@@ -3182,11 +3224,11 @@ msgstr "Sieć IPv6"
 msgid "IPv6 Network should not be empty"
 msgstr "Sieć IPv6 nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv6 Settings"
 msgstr "Ustawienia IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+#: pkg/machines/components/networks/createNetworkDialog.jsx:196
 msgid "IPv6 only"
 msgstr "Tylko IPv6"
 
@@ -3194,7 +3236,7 @@ msgstr "Tylko IPv6"
 msgid "Id"
 msgstr "Identyfikator"
 
-#: pkg/networkmanager/interfaces.js:2916
+#: pkg/networkmanager/interfaces.js:2924
 msgid "Id $id"
 msgstr "Identyfikator $id"
 
@@ -3202,21 +3244,15 @@ msgstr "Identyfikator $id"
 msgid "Id:"
 msgstr "Identyfikator:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:24
-#: node_modules/registry-image-widgets/views/image-listing.html:7
-msgid "Identifier"
-msgstr "Identyfikator"
-
-#: pkg/storaged/crypto-keyslots.jsx:325
+#: pkg/storaged/crypto-keyslots.jsx:333
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Jeśli tang-show-keys jest niedostępne, należy wykonać:"
 
-#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1990 pkg/packagekit/updates.jsx:498
 msgid "Ignore"
 msgstr "Ignorowanie"
 
 #: pkg/docker/index.html:270 pkg/docker/index.html:433
-#: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
 msgstr "Obraz"
@@ -3232,14 +3268,6 @@ msgstr "Budowanie obrazu"
 #: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Wyszukiwanie obrazów"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
-msgid "Image count"
-msgstr "Liczba obrazów"
-
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
-msgid "Image stream"
-msgstr "Strumień obrazu"
 
 #: pkg/docker/index.html:157
 msgid "Image:"
@@ -3258,32 +3286,15 @@ msgstr "Obrazy"
 msgid "Images and running containers"
 msgstr "Obrazy i uruchomione kontenery"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:15
-#: node_modules/registry-image-widgets/views/imagestream-body.html:16
-msgid "Images may be pulled by anonymous users"
-msgstr "Obrazy mogą być pobierane przez anonimowych użytkowników"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:20
-#: node_modules/registry-image-widgets/views/imagestream-body.html:21
-msgid "Images may be pulled by any authenticated user or group"
-msgstr ""
-"Obrazy mogą być pobierane przez wszystkich uwierzytelnionych użytkowników "
-"i grupy"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:25
-#: node_modules/registry-image-widgets/views/imagestream-body.html:26
-msgid "Images may only be pulled by specific users or groups"
-msgstr "Obrazy mogą być pobierane tylko przez podanych użytkowników i grupy"
-
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Od razu uruchom maszynę wirtualną"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Import VM"
-msgstr ""
+msgstr "Zaimportuj maszynę wirtualną"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/storaged/mdraid-details.jsx:94
 msgid "In Sync"
 msgstr "Zsynchronizowane"
 
@@ -3303,16 +3314,16 @@ msgstr ""
 "Aby synchronizować użytkowników, należy się zalogować "
 "w {{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
-#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:1431
+#: pkg/networkmanager/interfaces.js:1438 pkg/networkmanager/interfaces.js:2626
 msgid "Inactive"
 msgstr "Nieaktywne"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Inactive volume"
 msgstr "Nieaktywny wolumin"
 
-#: pkg/networkmanager/firewall.jsx:762
+#: pkg/networkmanager/firewall.jsx:764
 msgid "Included services"
 msgstr "Dołączone usługi"
 
@@ -3320,7 +3331,7 @@ msgstr "Dołączone usługi"
 msgid "Incorrect Host Key"
 msgstr "Niepoprawny klucz komputera"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:69
+#: pkg/storaged/vdo-details.jsx:307 pkg/storaged/vdos-panel.jsx:73
 msgid "Index Memory"
 msgstr "Pamięć indeksu"
 
@@ -3328,12 +3339,12 @@ msgstr "Pamięć indeksu"
 msgid "Info and above"
 msgstr "Informacje i powyżej"
 
-#: pkg/docker/storage.jsx:309
+#: pkg/docker/storage.jsx:313
 msgid "Information about the Docker storage pool is not available."
 msgstr ""
 "Informacje o puli urządzeń do przechowywania danych Docker są niedostępne."
 
-#: pkg/packagekit/updates.jsx:453
+#: pkg/packagekit/updates.jsx:455
 msgid "Initializing..."
 msgstr "Inicjowanie…"
 
@@ -3346,12 +3357,12 @@ msgid "Initiator IQN should not be empty"
 msgstr "Inicjator IQN nie może być pusty"
 
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/lib/cockpit-components-install-dialog.jsx:116
 #: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Zainstaluj"
 
-#: pkg/packagekit/updates.jsx:808
+#: pkg/packagekit/updates.jsx:809
 msgid "Install All Updates"
 msgstr "Zainstaluj wszystkie aktualizacje"
 
@@ -3359,7 +3370,7 @@ msgstr "Zainstaluj wszystkie aktualizacje"
 msgid "Install NFS Support"
 msgstr "Zainstaluj obsługę NFS"
 
-#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
+#: pkg/packagekit/updates.jsx:809 pkg/packagekit/updates.jsx:815
 msgid "Install Security Updates"
 msgstr "Zainstaluj aktualizacje zabezpieczeń"
 
@@ -3367,7 +3378,7 @@ msgstr "Zainstaluj aktualizacje zabezpieczeń"
 msgid "Install Software"
 msgstr "Zainstaluj oprogramowanie"
 
-#: pkg/storaged/vdos-panel.jsx:171
+#: pkg/storaged/vdos-panel.jsx:181
 msgid "Install VDO support"
 msgstr "Zainstaluj obsługę VDO"
 
@@ -3398,11 +3409,11 @@ msgstr "Zainstalowano"
 msgid "Installing"
 msgstr "Instalowanie"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:183
+#: pkg/lib/cockpit-components-install-dialog.jsx:184
 msgid "Installing $0"
 msgstr "Instalowanie $0"
 
-#: pkg/systemd/service-details.jsx:487
+#: pkg/systemd/service-details.jsx:489
 msgid "Instance of template: "
 msgstr "Wystąpienie szablonu: "
 
@@ -3410,13 +3421,13 @@ msgstr "Wystąpienie szablonu: "
 msgid "Instantiate"
 msgstr "Wystąpienie"
 
-#: pkg/machines/components/nicEdit.jsx:132
+#: pkg/machines/components/nicBody.jsx:131
 msgid "Interface Type"
 msgstr "Typ interfejsu"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
-#: pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/firewall.jsx:769 pkg/networkmanager/firewall.jsx:957
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Interfaces"
 msgstr "Interfejsy"
 
@@ -3424,7 +3435,7 @@ msgstr "Interfejsy"
 msgid "Internal Error: Invalid challenge header"
 msgstr "Wewnętrzny błąd: nieprawidłowy nagłówek wyzwania"
 
-#: src/base1/cockpit.js:4025
+#: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Wewnętrzny błąd"
 
@@ -3452,15 +3463,15 @@ msgstr "Nieprawidłowy przedrostek IPv6"
 msgid "Invalid address $0"
 msgstr "Nieprawidłowy adres $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
+#: pkg/systemd/host.js:1506 pkg/systemd/shutdown.js:143
 msgid "Invalid date format"
 msgstr "Nieprawidłowy format daty"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
+#: pkg/systemd/host.js:1502 pkg/systemd/shutdown.js:139
 msgid "Invalid date format and invalid time format"
 msgstr "Nieprawidłowy format daty i nieprawidłowy format czasu"
 
-#: pkg/systemd/init.js:1196
+#: pkg/systemd/init.js:1258
 msgid "Invalid date format."
 msgstr "Nieprawidłowy format daty."
 
@@ -3488,7 +3499,7 @@ msgstr "Nieprawidłowe parametry $0"
 msgid "Invalid number of days"
 msgstr "Nieprawidłowa liczba dni"
 
-#: pkg/systemd/init.js:1143
+#: pkg/systemd/init.js:1205
 msgid "Invalid number."
 msgstr "Nieprawidłowy numer."
 
@@ -3512,15 +3523,15 @@ msgstr "Nieprawidłowy przedrostek lub maska sieci $0"
 msgid "Invalid range"
 msgstr "Nieprawidłowy zakres"
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
+#: pkg/systemd/host.js:1504 pkg/systemd/shutdown.js:141
 msgid "Invalid time format"
 msgstr "Nieprawidłowy format czasu"
 
-#: pkg/systemd/index.html:374
+#: pkg/systemd/index.html:385
 msgid "Invalid time zone"
 msgstr "Nieprawidłowa strefa czasowa"
 
-#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:169
 msgid "Invalid username or password"
 msgstr "Nieprawidłowa nazwa użytkownika lub hasło"
 
@@ -3544,7 +3555,7 @@ msgstr "Zadania"
 msgid "Join"
 msgstr "Dołącz"
 
-#: pkg/realmd/operation.js:596
+#: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Dołącz do domeny"
 
@@ -3552,11 +3563,11 @@ msgstr "Dołącz do domeny"
 msgid "Join a Domain"
 msgstr "Dołącz do domeny"
 
-#: pkg/realmd/operation.js:505
+#: pkg/realmd/operation.js:507
 msgid "Joining this domain is not supported"
 msgstr "Dołączenie do tej domeny jest nieobsługiwane"
 
-#: pkg/systemd/service-details.jsx:434
+#: pkg/systemd/service-details.jsx:436
 msgid "Joins Namespace Of"
 msgstr "Dołącza do przestrzeni nazw"
 
@@ -3564,15 +3575,15 @@ msgstr "Dołącza do przestrzeni nazw"
 msgid "Journal"
 msgstr "Dziennik"
 
-#: pkg/systemd/logs.js:407
+#: pkg/systemd/logs.js:409
 msgid "Journal entry"
 msgstr "Wpis dziennika"
 
-#: pkg/systemd/logs.js:438
+#: pkg/systemd/logs.js:440
 msgid "Journal entry not found"
 msgstr "Nie odnaleziono wpisu dziennika"
 
-#: pkg/kdump/kdump-view.jsx:459
+#: pkg/kdump/kdump-view.jsx:461
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
@@ -3591,7 +3602,7 @@ msgstr "SSO oparte na Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Zgłoszenie Kerberos"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
+#: pkg/systemd/index.html:245 pkg/systemd/host.js:1643
 msgid "Kernel"
 msgstr "Jądro"
 
@@ -3599,28 +3610,28 @@ msgstr "Jądro"
 msgid "Kernel Dump"
 msgstr "Zrzut jądra"
 
-#: pkg/storaged/crypto-keyslots.jsx:563
+#: pkg/storaged/crypto-keyslots.jsx:576
 msgid "Key slots with unknown types can not be edited here"
 msgstr ""
 "Nie można modyfikować gniazd na klucze o nieznanym typie w tym miejscu"
 
-#: pkg/storaged/crypto-keyslots.jsx:202
+#: pkg/storaged/crypto-keyslots.jsx:204
 msgid "Key source"
 msgstr "Źródło kluczy"
 
-#: pkg/storaged/crypto-keyslots.jsx:586
+#: pkg/storaged/crypto-keyslots.jsx:599
 msgid "Keys"
 msgstr "Klucze"
 
-#: pkg/storaged/crypto-keyslots.jsx:557
+#: pkg/storaged/crypto-keyslots.jsx:570
 msgid "Keyserver"
 msgstr "Serwer kluczy"
 
-#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:272
+#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Keyserver address"
 msgstr "Adres serwera kluczy"
 
-#: pkg/storaged/crypto-keyslots.jsx:415
+#: pkg/storaged/crypto-keyslots.jsx:424
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Usunięcie serwera kluczy może uniemożliwić odblokowanie $0."
 
@@ -3631,10 +3642,6 @@ msgstr "Klucz LACP"
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "Grupa woluminów LVM"
-
-#: node_modules/registry-image-widgets/views/image-meta.html:3
-msgid "Labels"
-msgstr "Etykiety"
 
 #: pkg/lib/machine-info.js:72
 msgid "Laptop"
@@ -3652,13 +3659,9 @@ msgstr "Ostatni tydzień"
 msgid "Last Login"
 msgstr "Ostatnie logowanie"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:305
 msgid "Last Trigger"
 msgstr "Ostatnio wyzwolono"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:8
-msgid "Last Updated"
-msgstr "Ostatnio zaktualizowano"
 
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
@@ -3714,7 +3717,7 @@ msgstr "Obserwacja łącza"
 msgid "Link down delay"
 msgstr "Opóźnienie łącza w dół"
 
-#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1978 pkg/networkmanager/interfaces.js:1988
 msgid "Link local"
 msgstr "Link-local"
 
@@ -3734,11 +3737,11 @@ msgstr "Łącza"
 msgid "Links:"
 msgstr "Odnośniki:"
 
-#: pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:2014
 msgid "Load Balancing"
 msgstr "Równoważenie obciążenia"
 
-#: pkg/systemd/logs.js:138
+#: pkg/systemd/logs.js:139
 msgid "Load earlier entries"
 msgstr "Wczytaj wcześniejsze wpisy"
 
@@ -3758,9 +3761,9 @@ msgstr "Wczytywanie dostępnych aktualizacji, proszę czekać…"
 msgid "Loading system modifications..."
 msgstr "Wczytywanie modyfikacji systemu…"
 
-#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:369
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:145 pkg/systemd/logs.js:160
+#: pkg/systemd/logs.js:207 pkg/systemd/logs.js:256 pkg/systemd/logs.js:318
 msgid "Loading..."
 msgstr "Wczytywanie…"
 
@@ -3768,7 +3771,7 @@ msgstr "Wczytywanie…"
 msgid "Local Accounts"
 msgstr "Lokalne konta"
 
-#: pkg/docker/storage.jsx:198
+#: pkg/docker/storage.jsx:200
 msgid "Local Disks"
 msgstr "Lokalne dyski"
 
@@ -3780,7 +3783,7 @@ msgstr "Lokalny system plików"
 msgid "Local Install Media"
 msgstr "Lokalny nośnik instalacji"
 
-#: pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:167
 msgid "Local Mount Point"
 msgstr "Lokalny punkt montowania"
 
@@ -3788,7 +3791,7 @@ msgstr "Lokalny punkt montowania"
 msgid "Location"
 msgstr "Położenie"
 
-#: pkg/storaged/content-views.jsx:238
+#: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Zablokuj"
 
@@ -3832,23 +3835,23 @@ msgstr "Komunikaty dziennika"
 msgid "Logged In"
 msgstr "Zalogowano"
 
-#: pkg/storaged/vdo-details.jsx:289
+#: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "Logiczny"
 
-#: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
+#: pkg/storaged/vdo-details.jsx:225 pkg/storaged/vdos-panel.jsx:66
 msgid "Logical Size"
 msgstr "Rozmiar logiczny"
 
-#: pkg/storaged/utils.js:197
+#: pkg/storaged/utils.js:198
 msgid "Logical Volume"
 msgstr "Wolumin logiczny"
 
-#: pkg/storaged/utils.js:195
+#: pkg/storaged/utils.js:196
 msgid "Logical Volume (Snapshot)"
 msgstr "Wolumin logiczny (migawka)"
 
-#: pkg/storaged/utils.js:269
+#: pkg/storaged/utils.js:270
 msgid "Logical Volume of $0"
 msgstr "Wolumin logiczny $0"
 
@@ -3864,7 +3867,7 @@ msgstr "Format logowania"
 msgid "Login Password"
 msgstr "Hasło logowania"
 
-#: src/base1/cockpit.js:4015
+#: src/base1/cockpit.js:4019
 msgid "Login failed"
 msgstr "Logowanie się nie powiodło"
 
@@ -3893,10 +3896,12 @@ msgid "Lunch Box"
 msgstr "Lunch Box"
 
 #: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:132
+#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/vmnetworktab.jsx:141
 msgid "MAC Address"
 msgstr "Adres MAC"
 
@@ -3904,35 +3909,27 @@ msgstr "Adres MAC"
 msgid "MAC Address:"
 msgstr "Adres MAC:"
 
-#: pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:2006
 msgid "MII (Recommended)"
 msgstr "MII (zalecane)"
 
-#: pkg/networkmanager/interfaces.js:2773
+#: pkg/networkmanager/interfaces.js:2781
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4557
+#: pkg/networkmanager/interfaces.js:4575
 msgid "MTU must be a positive number"
 msgstr "MTU musi być liczbą dodatnią"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:103
-msgid "Mac"
-msgstr "Mac"
-
-#: pkg/machines/components/nicEdit.jsx:169
-msgid "Mac Address"
-msgstr "Adres MAC"
 
 #: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Identyfikator komputera"
 
-#: pkg/systemd/index.html:267
+#: pkg/systemd/index.html:278
 msgid "Machine SSH Key Fingerprints"
 msgstr "Odciski kluczy SSH komputera"
 
-#: pkg/shell/indexes.js:302
+#: pkg/shell/indexes.js:353
 msgid "Machines"
 msgstr "Komputery"
 
@@ -3940,12 +3937,12 @@ msgstr "Komputery"
 msgid "Main Server Chassis"
 msgstr "Główna obudowa serwera"
 
-#: pkg/storaged/crypto-keyslots.jsx:319
+#: pkg/storaged/crypto-keyslots.jsx:327
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
 "Proszę się upewnić, że suma kontrolna klucza z serwera Tang się zgadza:"
 
-#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1979 pkg/networkmanager/interfaces.js:1989
 msgid "Manual"
 msgstr "Ręczne"
 
@@ -3953,11 +3950,11 @@ msgstr "Ręczne"
 msgid "Manual Connection"
 msgstr "Ręczne połączenie"
 
-#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
+#: pkg/systemd/index.html:395 pkg/systemd/index.html:399
 msgid "Manually"
 msgstr "Ręcznie"
 
-#: pkg/storaged/crypto-keyslots.jsx:322
+#: pkg/storaged/crypto-keyslots.jsx:330
 msgid "Manually check with SSH: "
 msgstr "Ręczne sprawdzenie za pomocą SSH:"
 
@@ -3969,7 +3966,7 @@ msgstr "Oznaczanie $target jako wadliwe"
 msgid "Mask Service"
 msgstr "Zamaskuj usługę"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
 msgid "Mask or Prefix Length"
 msgstr "Długość maski lub przedrostka"
 
@@ -3977,7 +3974,7 @@ msgstr "Długość maski lub przedrostka"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Długość maski lub przedrostka nie może być pusta"
 
-#: pkg/systemd/service-details.jsx:321
+#: pkg/systemd/service-details.jsx:323
 msgid "Masked"
 msgstr "Zamaskowana"
 
@@ -3991,7 +3988,7 @@ msgstr ""
 "Może to mieć większy efekt, niż się wydaje. Proszę potwierdzić, że ta "
 "jednostka ma zostać zamaskowana."
 
-#: pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Master"
 msgstr "Główne"
 
@@ -4007,7 +4004,7 @@ msgstr "MTU"
 msgid "Maximum memory could not be saved"
 msgstr "Nie można zapisać maksymalnej ilości pamięci"
 
-#: pkg/networkmanager/interfaces.js:2877
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Maximum message age $max_age"
 msgstr "Maksymalny wiek komunikatu $max_age"
 
@@ -4019,32 +4016,32 @@ msgstr ""
 "Maksymalna liczba wirtualnych procesorów przydzielonych do systemu "
 "operacyjnego gościa, musi wynosić między 1 a $0"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:350
 msgid "Member of RAID Device"
 msgstr "Element urządzenia RAID"
 
-#: pkg/storaged/content-views.jsx:341
+#: pkg/storaged/content-views.jsx:346
 msgid "Member of RAID Device $0"
 msgstr "Element urządzenia RAID $0"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
-#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:263
 msgid "Memory"
 msgstr "Pamięć"
 
-#: pkg/systemd/host.js:1658
+#: pkg/systemd/host.js:1701
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Pamięć"
 
-#: pkg/systemd/index.html:205
+#: pkg/systemd/index.html:216
 msgid "Memory & Swap"
 msgstr "Pamięć i przestrzeń wymiany"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Memory Technology"
 msgstr "Technologia pamięci"
 
@@ -4073,18 +4070,18 @@ msgstr "Użycie pamięci:"
 msgid "Message to logged in users"
 msgstr "Wiadomość do zalogowanych użytkowników"
 
-#: node_modules/registry-image-widgets/views/image-panel.html:15
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
-msgid "Metadata"
-msgstr "Metadane"
+#: pkg/shell/index.html:399
+msgid "Messages related to the failure might be found in the journal:"
+msgstr ""
+"Być może w dzienniku znajdują się komunikaty związane z niepowodzeniem:"
 
-#: pkg/storaged/lvol-tabs.jsx:458
+#: pkg/storaged/lvol-tabs.jsx:466
 msgid "Metadata Used"
 msgstr "Użyte metadane"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
 msgid "MiB"
@@ -4098,7 +4095,7 @@ msgstr "Mini PC"
 msgid "Mini Tower"
 msgstr "Mini Tower"
 
-#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1229 pkg/systemd/init.js:1238 pkg/systemd/init.js:1247
 msgid "Minute needs to be a number between 0-59"
 msgstr "Minuta musi być liczbą między 0 a 59"
 
@@ -4106,7 +4103,7 @@ msgstr "Minuta musi być liczbą między 0 a 59"
 msgid "Minutes"
 msgstr "Minuty"
 
-#: pkg/systemd/hwinfo.jsx:62 pkg/systemd/hwinfo.jsx:67
+#: pkg/systemd/hwinfo.jsx:66 pkg/systemd/hwinfo.jsx:71
 msgid "Mitigations"
 msgstr "Poprawki zmniejszające ryzyko"
 
@@ -4114,11 +4111,11 @@ msgstr "Poprawki zmniejszające ryzyko"
 msgid "Mode"
 msgstr "Tryb"
 
-#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:254
 msgid "Model"
 msgstr "Model"
 
-#: pkg/machines/components/vmnetworktab.jsx:123
+#: pkg/machines/components/vmnetworktab.jsx:131
 msgid "Model type"
 msgstr "Typ modelu"
 
@@ -4143,7 +4140,7 @@ msgstr "Odstęp monitorowania"
 msgid "Monitoring Targets"
 msgstr "Cele monitorowania"
 
-#: pkg/realmd/operation.js:529
+#: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Więcej"
 
@@ -4152,27 +4149,27 @@ msgstr "Więcej"
 msgid "More Information"
 msgstr "Więcej informacji"
 
-#: pkg/kdump/kdump-view.jsx:448
+#: pkg/kdump/kdump-view.jsx:450
 msgid "More details"
 msgstr "Więcej informacji"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:309
 msgid "Mount"
 msgstr "Zamontuj"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:84 pkg/storaged/fsys-tab.jsx:174
+#: pkg/storaged/nfs-details.jsx:178
 msgid "Mount Options"
 msgstr "Opcje montowania"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
+#: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:160 pkg/storaged/nfs-details.jsx:326
 #: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Punkt montowania"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/format-dialog.jsx:93 pkg/storaged/nfs-details.jsx:181
 msgid "Mount at boot"
 msgstr "Montowanie podczas uruchamiania"
 
@@ -4180,23 +4177,23 @@ msgstr "Montowanie podczas uruchamiania"
 msgid "Mount container volumes"
 msgstr "Zamontuj woluminy kontenera"
 
-#: pkg/storaged/format-dialog.jsx:78
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount point can not be empty"
 msgstr "Punkt montowania nie może być pusty"
 
-#: pkg/storaged/nfs-details.jsx:166
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount point cannot be empty."
 msgstr "Punkt montowania nie może być pusty."
 
-#: pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:174
 msgid "Mount point must start with \"/\"."
 msgstr "Punkt montowania musi zaczynać się od „/”."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:94 pkg/storaged/nfs-details.jsx:182
 msgid "Mount read only"
 msgstr "Montowanie tylko do odczytu"
 
-#: pkg/storaged/fsys-tab.jsx:180
+#: pkg/storaged/fsys-tab.jsx:183
 msgid "Mounted At"
 msgstr "Zamontowano w"
 
@@ -4216,7 +4213,7 @@ msgstr "Obudowa dla wielu komputerów"
 msgid "NAT to $0"
 msgstr "NAT do $0"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "NFS Mount"
 msgstr "Punkt montowania NFS"
 
@@ -4228,47 +4225,45 @@ msgstr "Punkty montowania NFS"
 msgid "NFS Support not installed"
 msgstr "Obsługa NFS nie jest zainstalowana"
 
-#: pkg/machines/components/vmnetworktab.jsx:97
+#: pkg/machines/components/vmnetworktab.jsx:102
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "Zmiana stanu NIC $0 maszyny wirtualnej $1 się nie powiodła"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:2029
 msgid "NSNA Ping"
 msgstr "Ping NSNA"
 
-#: pkg/systemd/host.js:1531
+#: pkg/systemd/host.js:1569
 msgid "NTP Server"
 msgstr "Serwer NTP"
 
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
-#: pkg/networkmanager/index.html:319
-#: node_modules/registry-image-widgets/views/image-body.html:2
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
+#: pkg/networkmanager/index.html:319 pkg/docker/containers-view.jsx:359
+#: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/createNetworkDialog.jsx:122
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:108
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
-#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
-#: pkg/systemd/hwinfo.jsx:79
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:33
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/storaged/content-views.jsx:113 pkg/storaged/content-views.jsx:655
+#: pkg/storaged/format-dialog.jsx:295 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:73 pkg/storaged/fsys-tab.jsx:153
+#: pkg/storaged/iscsi-panel.jsx:128 pkg/storaged/iscsi-panel.jsx:185
+#: pkg/storaged/lvol-tabs.jsx:34 pkg/storaged/lvol-tabs.jsx:356
+#: pkg/storaged/lvol-tabs.jsx:398 pkg/storaged/lvol-tabs.jsx:452
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:49 pkg/storaged/vgroup-details.jsx:175
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/init.js:302
 msgid "Name"
 msgstr "Nazwa"
 
-#: pkg/storaged/vdos-panel.jsx:52
+#: pkg/storaged/vdos-panel.jsx:54
 msgid "Name can not be empty."
 msgstr "Nazwa nie może być pusta."
 
@@ -4306,7 +4301,7 @@ msgstr "Nazwa nie może być pusta"
 msgid "Name: "
 msgstr "Nazwa: "
 
-#: pkg/systemd/host.js:1365
+#: pkg/systemd/host.js:1402
 msgid "Need at least one NTP server"
 msgstr "Wymagany jest co najmniej jeden serwer NTP"
 
@@ -4314,7 +4309,15 @@ msgstr "Wymagany jest co najmniej jeden serwer NTP"
 msgid "Netmask"
 msgstr "Maska sieci"
 
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/machines/components/aggregateStatusCards.jsx:72
+msgid "Network"
+msgid_plural "Networks"
+msgstr[0] "Sieć"
+msgstr[1] "Sieci"
+msgstr[2] "Sieci"
+
+#: pkg/dashboard/index.html:72
+msgctxt "label"
 msgid "Network"
 msgstr "Sieć"
 
@@ -4340,7 +4343,7 @@ msgstr ""
 msgid "Network File System"
 msgstr "NFS"
 
-#: pkg/machines/components/vm/vm.jsx:50
+#: pkg/machines/components/vm/vm.jsx:52
 msgid "Network Interfaces"
 msgstr "Interfejsy sieciowe"
 
@@ -4348,7 +4351,7 @@ msgstr "Interfejsy sieciowe"
 msgid "Network Selection does not support PXE."
 msgstr "Wybór sieci nie obsługuje PXE."
 
-#: pkg/systemd/host.js:570
+#: pkg/systemd/host.js:589
 msgid "Network Traffic"
 msgstr "Ruch sieciowy"
 
@@ -4356,7 +4359,8 @@ msgstr "Ruch sieciowy"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Urządzenia i wykresy sieciowe wymagają usługi NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:245
+#: pkg/machines/components/nicAdd.jsx:176
+#: pkg/machines/components/nicEdit.jsx:119
 msgid "Network interface settings could not be saved"
 msgstr "Nie można zapisać ustawień interfejsu sieciowego"
 
@@ -4365,11 +4369,11 @@ msgid "NetworkManager is not running."
 msgstr "Usługa NetworkManager nie jest uruchomiona."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:946 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Sieć"
 
-#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
+#: pkg/networkmanager/interfaces.js:1645 pkg/networkmanager/interfaces.js:2228
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Sieć"
@@ -4378,8 +4382,8 @@ msgstr "Sieć"
 msgid "Networking Logs"
 msgstr "Dzienniki sieci"
 
-#: pkg/machines/components/networks/networkList.jsx:45
-#: pkg/machines/components/networks/networkList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:54
 msgid "Networks"
 msgstr "Sieci"
 
@@ -4395,19 +4399,19 @@ msgstr "Bez wygasania hasła"
 msgid "Never lock account"
 msgstr "Bez blokowania konta"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "New NFS Mount"
 msgstr "Nowy punkt montowania NFS"
 
-#: pkg/shell/index.html:289 pkg/users/index.html:218
+#: pkg/shell/index.html:290 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Nowe hasło"
 
-#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:39
 msgid "New Volume Name"
 msgstr "Nazwa nowego woluminu"
 
-#: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
+#: pkg/storaged/crypto-keyslots.jsx:214 pkg/storaged/crypto-keyslots.jsx:260
 msgid "New passphrase"
 msgstr "Nowe hasło"
 
@@ -4419,28 +4423,28 @@ msgstr "Nie przyjęto nowego hasła"
 msgid "Next"
 msgstr "Dalej"
 
-#: pkg/systemd/init.js:292
+#: pkg/systemd/init.js:304
 msgid "Next Run"
 msgstr "Następne uruchomienie"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
+#: pkg/systemd/index.html:237 pkg/systemd/host.js:1645
 msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2614
 msgid "No"
 msgstr "Nie"
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:465
 msgid "No Delay"
 msgstr "Brak opóźnienia"
 
-#: pkg/storaged/format-dialog.jsx:252
+#: pkg/storaged/format-dialog.jsx:257
 msgid "No Filesystem"
 msgstr "Brak systemu plików"
 
-#: pkg/storaged/content-views.jsx:715
+#: pkg/storaged/content-views.jsx:735
 msgid "No Logical Volumes"
 msgstr "Brak woluminów logicznych"
 
@@ -4452,7 +4456,7 @@ msgstr "Brak wyników"
 msgid "No NFS mounts set up"
 msgstr "Nie ustawiono żadnych punktów montowania NFS"
 
-#: pkg/machines/components/nicEdit.jsx:118
+#: pkg/machines/components/nicBody.jsx:117
 msgid "No Network Devices"
 msgstr "Brak urządzeń sieciowych"
 
@@ -4460,12 +4464,16 @@ msgstr "Brak urządzeń sieciowych"
 msgid "No SELinux alerts."
 msgstr "Brak alarmów SELinuksa."
 
-#: pkg/machines/components/diskAdd.jsx:209
-#: pkg/machines/components/diskAdd.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:444
+msgid "No Storage"
+msgstr "Brak urządzeń do przechowywania danych"
+
+#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/diskAdd.jsx:144
 msgid "No Storage Pools available"
 msgstr "Brak dostępnych pul urządzeń do przechowywania danych"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:113
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr ""
 "Dla tej puli urządzeń do przechowywania danych nie określono żadnych "
@@ -4480,15 +4488,15 @@ msgid "No VM is running or defined on this host"
 msgstr ""
 "Brak uruchomionych lub określonych maszyn wirtualnych na tym gospodarzu"
 
-#: pkg/machines/components/nicEdit.jsx:116
+#: pkg/machines/components/nicBody.jsx:115
 msgid "No Virtual Networks"
 msgstr "Brak sieci wirtualnych"
 
-#: pkg/networkmanager/firewall.jsx:956
+#: pkg/networkmanager/firewall.jsx:958
 msgid "No active zones"
 msgstr "Brak aktywnych stref"
 
-#: pkg/docker/storage.jsx:206
+#: pkg/docker/storage.jsx:208
 msgid "No additional local storage found."
 msgstr ""
 "Nie odnaleziono dodatkowych lokalnych urządzeń do przechowywania danych."
@@ -4505,7 +4513,7 @@ msgstr "Brak zainstalowanych lub dostępnych aplikacji"
 msgid "No archive has been created."
 msgstr "Nie utworzono archiwum."
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "No available slots"
 msgstr "Brak dostępnych gniazd"
 
@@ -4513,11 +4521,11 @@ msgstr "Brak dostępnych gniazd"
 msgid "No boot device found"
 msgstr "Nie odnaleziono żadnego urządzenia startowego"
 
-#: pkg/networkmanager/interfaces.js:1428
+#: pkg/networkmanager/interfaces.js:1433
 msgid "No carrier"
 msgstr "Brak operatora"
 
-#: pkg/kdump/kdump-view.jsx:396
+#: pkg/kdump/kdump-view.jsx:398
 msgid "No configuration found"
 msgstr "Nie odnaleziono konfiguracji"
 
@@ -4537,7 +4545,7 @@ msgstr "Brak kontenerów"
 msgid "No containers that match the current filter"
 msgstr "Brak kontenerów pasujących do obecnego filtru"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:761
 msgid "No description available"
 msgstr "Brak dostępnego opisu"
 
@@ -4545,25 +4553,25 @@ msgstr "Brak dostępnego opisu"
 msgid "No description provided."
 msgstr "Nie podano opisu."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/mdraid-details.jsx:49 pkg/storaged/mdraids-panel.jsx:92
+#: pkg/storaged/vdos-panel.jsx:59 pkg/storaged/vgroup-details.jsx:56
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "No disks are available."
 msgstr "Brak dostępnych dysków."
 
-#: pkg/machines/components/vmDisksTab.jsx:85
+#: pkg/machines/components/vmDisksTab.jsx:121
 msgid "No disks defined for this VM"
 msgstr "Nie określono dysków dla tej maszyny wirtualnej"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:103
 msgid "No drives attached"
 msgstr "Nie podłączono dysków"
 
-#: pkg/storaged/crypto-keyslots.jsx:581
+#: pkg/storaged/crypto-keyslots.jsx:594
 msgid "No free key slots"
 msgstr "Brak wolnych gniazd na klucze"
 
-#: pkg/storaged/content-views.jsx:700
+#: pkg/storaged/content-views.jsx:720
 msgid "No free space"
 msgstr "Brak wolnego miejsca"
 
@@ -4571,13 +4579,9 @@ msgstr "Brak wolnego miejsca"
 msgid "No host keys found."
 msgstr "Nie odnaleziono kluczy komputera."
 
-#: pkg/storaged/iscsi-panel.jsx:262
+#: pkg/storaged/iscsi-panel.jsx:269
 msgid "No iSCSI targets set up"
 msgstr "Nie ustawiono żadnych celów iSCSI"
-
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
-msgid "No image streams are present."
-msgstr "Żadne strumienie obrazów nie są obecne."
 
 #: pkg/docker/containers-view.jsx:705
 msgid "No images"
@@ -4591,19 +4595,15 @@ msgstr "Brak obrazów pasujących do obecnego filtru"
 msgid "No installation package found for this application."
 msgstr "Nie odnaleziono pakietu instalacji dla tego programu."
 
-#: pkg/storaged/crypto-keyslots.jsx:520
+#: pkg/storaged/crypto-keyslots.jsx:533
 msgid "No keys added"
 msgstr "Nie dodano kluczy"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
-msgid "No matching files found"
-msgstr "Nie odnaleziono pasujących plików"
 
 #: pkg/storaged/drive-details.jsx:75
 msgid "No media inserted"
 msgstr "Nie włożono żadnego nośnika"
 
-#: pkg/kdump/kdump-view.jsx:450
+#: pkg/kdump/kdump-view.jsx:452
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -4613,11 +4613,11 @@ msgstr ""
 "jądra (tzn. w /etc/default/grub), aby zastrzec pamięć w czasie uruchamiania. "
 "Przykład: crashkernel=512M"
 
-#: pkg/machines/components/vmnetworktab.jsx:70
+#: pkg/machines/components/vmnetworktab.jsx:75
 msgid "No network interfaces defined for this VM"
 msgstr "Nie określono interfejsów sieciowych dla tej maszyny wirtualnej"
 
-#: pkg/machines/components/networks/networkList.jsx:51
+#: pkg/machines/components/networks/networkList.jsx:56
 msgid "No network is defined on this host"
 msgstr "Na tym gospodarzu nie określono żadnej sieci"
 
@@ -4625,11 +4625,11 @@ msgstr "Na tym gospodarzu nie określono żadnej sieci"
 msgid "No networks available"
 msgstr "Brak dostępnych sieci"
 
-#: pkg/networkmanager/firewall.jsx:969
+#: pkg/networkmanager/firewall.jsx:971
 msgid "No open ports"
 msgstr "Brak otwartych portów"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:537
 msgid "No partitioning"
 msgstr "Brak partycjonowania"
 
@@ -4649,27 +4649,23 @@ msgstr "Brak uruchomionych kontenerów"
 msgid "No running containers that match the current filter"
 msgstr "Brak uruchomionych kontenerów pasujących do obecnego filtru"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:50
+#: pkg/machines/components/storagePools/storagePoolList.jsx:55
 msgid "No storage pool is defined on this host"
 msgstr ""
 "Na tym gospodarzu nie określono żadnej puli urządzeń do przechowywania "
 "danych"
 
-#: pkg/storaged/mdraids-panel.jsx:130
+#: pkg/storaged/mdraids-panel.jsx:147
 msgid "No storage set up as RAID"
 msgstr "Nie ustawiono żadnego urządzenia do przechowywania danych jako RAID"
 
-#: pkg/storaged/vdos-panel.jsx:167
+#: pkg/storaged/vdos-panel.jsx:177
 msgid "No storage set up as VDO"
 msgstr "Nie ustawiono żadnego urządzenia do przechowywania danych jako VDO"
 
 #: pkg/lib/credentials.js:186
 msgid "No such file or directory"
 msgstr "Nie ma takiego pliku lub katalogu"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:73
-msgid "No tags are present."
-msgstr "Brak etykiet."
 
 #: pkg/packagekit/updates.jsx:42
 msgid "No updates pending"
@@ -4679,14 +4675,13 @@ msgstr "Brak oczekujących aktualizacji"
 msgid "No user name specified"
 msgstr "Nie podano nazwy użytkownika"
 
-#: pkg/storaged/vgroups-panel.jsx:114
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr "Nie utworzono grup woluminów"
 
-#: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419
-#: pkg/machines/components/networks/createNetworkDialog.jsx:204
-#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:421
+#: pkg/machines/components/networks/createNetworkDialog.jsx:190
+#: pkg/networkmanager/firewall.jsx:766 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Brak"
 
@@ -4706,11 +4701,11 @@ msgstr "Nieprawidłowy klucz prywatny"
 msgid "Not authorized to access Docker on this system"
 msgstr "Brak upoważnienia do łączenia z Dockerem w tym systemie"
 
-#: pkg/systemd/logs.js:527
+#: pkg/systemd/logs.js:529
 msgid "Not authorized to upload-report"
 msgstr "Brak upoważnienia do „upload-report”"
 
-#: pkg/networkmanager/interfaces.js:831
+#: pkg/networkmanager/interfaces.js:836
 msgid "Not available"
 msgstr "Niedostępne"
 
@@ -4718,11 +4713,15 @@ msgstr "Niedostępne"
 msgid "Not connected"
 msgstr "Nie połączono"
 
-#: pkg/storaged/lvol-tabs.jsx:369
+#: pkg/systemd/host.js:577
+msgid "Not connected to Insights"
+msgstr "Nie połączono z Insights"
+
+#: pkg/storaged/lvol-tabs.jsx:377
 msgid "Not enough space to grow."
 msgstr "Za mało miejsca do powiększenia."
 
-#: pkg/docker/details.js:185 pkg/storaged/details.jsx:121
+#: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Nie odnaleziono"
 
@@ -4730,11 +4729,11 @@ msgstr "Nie odnaleziono"
 msgid "Not mounted"
 msgstr "Niezamontowane"
 
-#: src/base1/cockpit.js:4013
+#: src/base1/cockpit.js:4017
 msgid "Not permitted to perform this action."
 msgstr "Brak uprawnień do wykonania tego działania."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:361
 msgid "Not running"
 msgstr "Niedziałające"
 
@@ -4742,11 +4741,7 @@ msgstr "Niedziałające"
 msgid "Not synchronized"
 msgstr "Niesynchronizowane"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:44
-msgid "Not yet synced"
-msgstr "Jeszcze nie zsynchronizowano"
-
-#: pkg/systemd/service-details.jsx:448
+#: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Uwaga"
 
@@ -4757,6 +4752,14 @@ msgstr "Notebook"
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "Uwagi i powyżej"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications"
+msgstr "Powiadomienia"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications Receiver"
+msgstr "Odbiornik powiadomień"
 
 #: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
@@ -4770,11 +4773,11 @@ msgstr "Wystąpiło między $0 a $1"
 msgid "Ok"
 msgstr "OK"
 
-#: pkg/shell/index.html:281 pkg/users/index.html:215
+#: pkg/shell/index.html:282 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Poprzednie hasło"
 
-#: pkg/storaged/crypto-keyslots.jsx:249
+#: pkg/storaged/crypto-keyslots.jsx:257
 msgid "Old passphrase"
 msgstr "Poprzednie hasło"
 
@@ -4782,15 +4785,11 @@ msgstr "Poprzednie hasło"
 msgid "Old password not accepted"
 msgstr "Nie przyjęto poprzedniego hasła"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:7
-msgid "On Build"
-msgstr "Podczas budowania"
-
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:431
 msgid "On Failure"
 msgstr "Podczas niepowodzenia"
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr "Na zamontowanym urządzeniu"
 
@@ -4813,7 +4812,7 @@ msgstr ""
 msgid "One Time Password"
 msgstr "Hasło jednorazowe"
 
-#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:77
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:76
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
@@ -4829,7 +4828,7 @@ msgstr "Tylko $0 z $1 jest używane."
 msgid "Only Emergency"
 msgstr "Tylko awaryjne"
 
-#: pkg/systemd/init.js:1117
+#: pkg/systemd/init.js:1179
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Dozwolone są tylko litery, liczby i znaki „:”, „_”, „.”, „@”, „-”."
 
@@ -4859,12 +4858,12 @@ msgstr "Działanie „$operation” na $target"
 msgid "Operation is in progress"
 msgstr "Działanie jest wykonywane"
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/drives-panel.jsx:76
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Napęd optyczny"
 
-#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:137 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Opcje"
 
@@ -4876,7 +4875,7 @@ msgstr "Lub użyj dołączonej przeglądarki"
 msgid "Other"
 msgstr "Inne"
 
-#: pkg/storaged/content-views.jsx:353
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Inne dane"
@@ -4891,19 +4890,19 @@ msgstr "Inne opcje"
 
 #: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/vm/vm.jsx:49
 msgid "Overview"
 msgstr "Przegląd"
 
-#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:525 pkg/storaged/format-dialog.jsx:290
 msgid "Overwrite existing data with zeros"
 msgstr "Zastąp istniejące dane zerami"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "PCI"
 msgstr "PCI"
 
-#: pkg/packagekit/updates.jsx:501
+#: pkg/packagekit/updates.jsx:503
 msgid "Package information"
 msgstr "Informacje o pakiecie"
 
@@ -4911,11 +4910,11 @@ msgstr "Informacje o pakiecie"
 msgid "PackageKit crashed"
 msgstr "Usługa PackageKit uległa awarii"
 
-#: pkg/packagekit/updates.jsx:564
+#: pkg/packagekit/updates.jsx:565
 msgid "PackageKit is not installed"
 msgstr "Usługa PackageKit nie jest zainstalowana"
 
-#: pkg/packagekit/updates.jsx:718
+#: pkg/packagekit/updates.jsx:719
 msgid "PackageKit reported error code $0"
 msgstr "Usługa PackageKit zgłosiła kod błędu $0"
 
@@ -4927,59 +4926,59 @@ msgstr "Pakiety"
 msgid "Parent"
 msgstr "Nadrzędne"
 
-#: pkg/networkmanager/interfaces.js:2915
+#: pkg/networkmanager/interfaces.js:2923
 msgid "Parent $parent"
 msgstr "Nadrzędne $parent"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:421
 msgid "Part Of"
 msgstr "Część"
 
-#: pkg/networkmanager/interfaces.js:1474
+#: pkg/networkmanager/interfaces.js:1479
 msgid "Part of "
 msgstr "Część "
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "Partycja"
 
-#: pkg/storaged/utils.js:271
+#: pkg/storaged/utils.js:272
 msgid "Partition of $0"
 msgstr "Partycja $0"
 
-#: pkg/storaged/content-views.jsx:519
+#: pkg/storaged/content-views.jsx:528
 msgid "Partitioning"
 msgstr "Partycjonowanie"
 
-#: pkg/networkmanager/interfaces.js:2009
+#: pkg/networkmanager/interfaces.js:2021
 msgid "Passive"
 msgstr "Pasywnie"
 
-#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
+#: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
+#: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:307
 msgid "Passphrase"
 msgstr "Hasło"
 
-#: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
-#: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:299
+#: pkg/storaged/crypto-keyslots.jsx:158 pkg/storaged/crypto-keyslots.jsx:217
+#: pkg/storaged/crypto-keyslots.jsx:258 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/format-dialog.jsx:311
 msgid "Passphrase cannot be empty"
 msgstr "Hasło nie może być puste"
 
-#: pkg/storaged/crypto-keyslots.jsx:356
+#: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Passphrase removal may prevent unlocking $0."
 msgstr "Usunięcie hasła może uniemożliwić odblokowanie $0."
 
-#: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/crypto-keyslots.jsx:225 pkg/storaged/crypto-keyslots.jsx:263
+#: pkg/storaged/format-dialog.jsx:319
 msgid "Passphrases do not match"
 msgstr "Hasła się nie zgadzają"
 
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
+#: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
 #: pkg/users/index.html:173 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
+#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Hasło"
 
@@ -5019,7 +5018,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "Proszę tutaj wkleić zawartość pliku publicznego klucza SSH"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:481
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Ścieżka"
 
@@ -5027,11 +5026,11 @@ msgstr "Ścieżka"
 msgid "Path cost"
 msgstr "Koszt ścieżki"
 
-#: pkg/networkmanager/interfaces.js:2897
+#: pkg/networkmanager/interfaces.js:2905
 msgid "Path cost $path_cost"
 msgstr "Koszt ścieżki $path_cost"
 
-#: pkg/storaged/nfs-details.jsx:151
+#: pkg/storaged/nfs-details.jsx:155
 msgid "Path on Server"
 msgstr "Ścieżka na serwerze"
 
@@ -5039,11 +5038,11 @@ msgstr "Ścieżka na serwerze"
 msgid "Path on host's filesystem"
 msgstr "Ścieżka w systemie plików gospodarza"
 
-#: pkg/storaged/nfs-details.jsx:155
+#: pkg/storaged/nfs-details.jsx:160
 msgid "Path on server cannot be empty."
 msgstr "Ścieżka na serwerze nie może być pusta."
 
-#: pkg/storaged/nfs-details.jsx:157
+#: pkg/storaged/nfs-details.jsx:162
 msgid "Path on server must start with \"/\"."
 msgstr "Ścieżka na serwerze musi zaczynać się od „/”."
 
@@ -5051,11 +5050,11 @@ msgstr "Ścieżka na serwerze musi zaczynać się od „/”."
 msgid "Path to ISO file on host's file system"
 msgstr "Ścieżka do pliku ISO w systemie plików gospodarza"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:141
 msgid "Path to file"
 msgstr "Ścieżka do pliku"
 
-#: pkg/systemd/services.jsx:42
+#: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Ścieżki"
 
@@ -5063,7 +5062,7 @@ msgstr "Ścieżki"
 msgid "Pause"
 msgstr "Wstrzymaj"
 
-#: pkg/systemd/index.html:152
+#: pkg/systemd/index.html:159
 msgid "Performance Profile"
 msgstr "Profil wydajności"
 
@@ -5071,7 +5070,7 @@ msgstr "Profil wydajności"
 msgid "Peripheral Chassis"
 msgstr "Obudowa peryferyjna"
 
-#: pkg/networkmanager/interfaces.js:3642
+#: pkg/networkmanager/interfaces.js:3657
 msgid "Permanent"
 msgstr "Trwałe"
 
@@ -5083,7 +5082,8 @@ msgstr "Odmowa dostępu"
 msgid "Permissive"
 msgstr "Zezwalanie"
 
-#: pkg/machines/components/diskAdd.jsx:110
+#: pkg/machines/components/diskAdd.jsx:111
+#: pkg/machines/components/nicAdd.jsx:80
 msgid "Persistence"
 msgstr "Trwałość"
 
@@ -5092,7 +5092,7 @@ msgstr "Trwałość"
 msgid "Persistent"
 msgstr "Trwałe"
 
-#: pkg/storaged/vdo-details.jsx:277
+#: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "Fizyczny"
 
@@ -5100,11 +5100,11 @@ msgstr "Fizyczny"
 msgid "Physical Disk Device"
 msgstr "Fizyczne urządzenie dyskowe"
 
-#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
+#: pkg/storaged/content-views.jsx:154 pkg/storaged/content-views.jsx:348
 msgid "Physical Volume"
 msgstr "Wolumin fizyczny"
 
-#: pkg/storaged/vgroup-details.jsx:133
+#: pkg/storaged/vgroup-details.jsx:127
 msgid "Physical Volumes"
 msgstr "Woluminy fizyczne"
 
@@ -5112,11 +5112,11 @@ msgstr "Woluminy fizyczne"
 msgid "Physical disk device on host"
 msgstr "Fizyczne urządzenie dyskowe na gospodarzu"
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:343
 msgid "Physical volume of $0"
 msgstr "Wolumin fizyczny $0"
 
-#: pkg/storaged/lvol-tabs.jsx:164
+#: pkg/storaged/lvol-tabs.jsx:165
 msgid "Physical volumes can not be resized here."
 msgstr "Nie można tutaj zmieniać rozmiaru woluminów fizycznych."
 
@@ -5132,10 +5132,10 @@ msgstr "Cel pingu"
 msgid "Pizza Box"
 msgstr "Pizza Box"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:291
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:296
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:199
+#: pkg/storaged/vgroup-details.jsx:207
 msgid "Please confirm deletion of $0"
 msgstr "Proszę potwierdzić usunięcie $0"
 
@@ -5143,19 +5143,19 @@ msgstr "Proszę potwierdzić usunięcie $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Proszę potwierdzić wymuszenie usunięcia $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/mdraid-details.jsx:240 pkg/storaged/vdo-details.jsx:155
 msgid "Please confirm stopping of $0"
 msgstr "Proszę potwierdzić zatrzymanie $0"
 
-#: pkg/machines/components/diskAdd.jsx:483
+#: pkg/machines/components/diskAdd.jsx:350
 msgid "Please enter new volume name"
 msgstr "Proszę podać nazwę nowego woluminu"
 
-#: pkg/machines/components/diskAdd.jsx:486
+#: pkg/machines/components/diskAdd.jsx:353
 msgid "Please enter new volume size"
 msgstr "Proszę podać rozmiar nowego woluminu"
 
-#: pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:896
 msgid "Please install the $0 package"
 msgstr "Proszę zainstalować pakiet $0"
 
@@ -5176,29 +5176,33 @@ msgstr ""
 msgid "Please try another term"
 msgstr "Proszę spróbować innego terminu"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Plug"
 msgstr "Podłącz"
 
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:127
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Pula"
 
-#: pkg/storaged/utils.js:191
+#: pkg/storaged/utils.js:192
 msgid "Pool for Thin Logical Volumes"
 msgstr "Pula dla cienkich woluminów logicznych"
 
-#: pkg/storaged/content-views.jsx:594
+#: pkg/storaged/content-views.jsx:607
 msgid "Pool for Thin Volumes"
 msgstr "Pula dla cienkich woluminów"
 
-#: pkg/storaged/content-views.jsx:651
+#: pkg/storaged/content-views.jsx:668
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pula dla cienko nadzorowanych woluminów"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:142
+msgid "Pool type doesn't support volume creation"
+msgstr "Typ puli nie obsługuje tworzenia woluminów"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
@@ -5209,8 +5213,8 @@ msgstr "Woluminy puli są używane przez maszyny wirtualne "
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:108
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:113
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Port"
 msgstr "Port"
 
@@ -5223,9 +5227,8 @@ msgid "Portable"
 msgstr "Przenośne"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
-#: pkg/networkmanager/index.html:323
-#: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/index.html:323 pkg/docker/containers-view.jsx:414
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Ports"
 msgstr "Porty"
 
@@ -5233,7 +5236,7 @@ msgstr "Porty"
 msgid "Ports:"
 msgstr "Porty:"
 
-#: pkg/systemd/index.html:132
+#: pkg/systemd/index.html:139
 msgid "Power Options"
 msgstr "Opcje zasilania"
 
@@ -5245,7 +5248,7 @@ msgstr "Preferowana liczba gniazd eksponowanych gościowi."
 msgid "Prefix"
 msgstr "Przedrostek"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
 msgid "Prefix Length"
 msgstr "Długość przedrostka"
 
@@ -5253,19 +5256,19 @@ msgstr "Długość przedrostka"
 msgid "Prefix Length should not be empty"
 msgstr "Długość przedrostka nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length"
 msgstr "Długość przedrostka"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length or Netmask"
 msgstr "Długość przedrostka lub maska sieci"
 
 #: pkg/playground/manifest.json.in
 msgid "Preloaded"
-msgstr ""
+msgstr "Uprzednio wczytane"
 
-#: pkg/networkmanager/interfaces.js:835
+#: pkg/networkmanager/interfaces.js:840
 msgid "Preparing"
 msgstr "Przygotowywanie"
 
@@ -5273,11 +5276,11 @@ msgstr "Przygotowywanie"
 msgid "Present"
 msgstr "Obecne"
 
-#: pkg/networkmanager/interfaces.js:3643
+#: pkg/networkmanager/interfaces.js:3658
 msgid "Preserve"
 msgstr "Zachowaj"
 
-#: pkg/systemd/index.html:295
+#: pkg/systemd/index.html:306
 msgid "Pretty Host Name"
 msgstr "Czytelna nazwa komputera"
 
@@ -5294,7 +5297,7 @@ msgstr "Główne"
 msgid "Priority"
 msgstr "Priorytet"
 
-#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
+#: pkg/networkmanager/interfaces.js:2879 pkg/networkmanager/interfaces.js:2903
 msgid "Priority $priority"
 msgstr "Priorytet $priority"
 
@@ -5306,11 +5309,11 @@ msgstr "Prywatne"
 msgid "Privileged"
 msgstr "Uprawnione"
 
-#: pkg/systemd/logs.js:488
+#: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Informacje o problemie"
 
-#: pkg/systemd/logs.js:487
+#: pkg/systemd/logs.js:489
 msgid "Problem info"
 msgstr "Informacje o problemie"
 
@@ -5318,7 +5321,7 @@ msgstr "Informacje o problemie"
 msgid "Problems"
 msgstr "Problemy"
 
-#: pkg/storaged/dialog.jsx:1043
+#: pkg/storaged/dialog.jsx:1044
 msgid "Process"
 msgstr "Proces"
 
@@ -5343,7 +5346,7 @@ msgstr "Pytanie przez ssh-add przekroczyło czas oczekiwania"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Pytanie przez ssh-keygen przekroczyło czas oczekiwania"
 
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:434
 msgid "Propagates Reload To"
 msgstr "Wysyła ponowne wczytanie do"
 
@@ -5353,67 +5356,63 @@ msgstr "Wysyła ponowne wczytanie do"
 msgid "Protocol"
 msgstr "Protokół"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:231
 msgid "Public Key"
 msgstr "Klucz publiczny"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr "Publiczne repozytorium do pobierania"
-
-#: pkg/storaged/content-views.jsx:645
+#: pkg/storaged/content-views.jsx:660
 msgid "Purpose"
 msgstr "Zastosowanie"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/mdraid-details.jsx:174
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:45
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Striping)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:175
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/mdraids-panel.jsx:52
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Lustrzany)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/mdraids-panel.jsx:68
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RID 10 (Striping lustrzany)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:176
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/mdraids-panel.jsx:56
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Dedykowana parzystość)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:177
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Rozproszona parzystość)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:178
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:53
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (Podwójna rozproszona parzystość)"
 
@@ -5425,19 +5424,19 @@ msgstr "Obudowa RAID"
 msgid "RAID Device"
 msgstr "Urządzenie RAID"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/mdraid-details.jsx:311 pkg/storaged/utils.js:242
 msgid "RAID Device $0"
 msgstr "Urządzenie RAID $0"
 
-#: pkg/storaged/mdraids-panel.jsx:129
+#: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "Urządzenia RAID"
 
-#: pkg/storaged/mdraids-panel.jsx:41
+#: pkg/storaged/mdraids-panel.jsx:42
 msgid "RAID Level"
 msgstr "Poziom macierzy RAID"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:157
 msgid "RAID Member"
 msgstr "Element macierzy RAID"
 
@@ -5445,11 +5444,11 @@ msgstr "Element macierzy RAID"
 msgid "Rack Mount Chassis"
 msgstr "Obudowa do montowania w szafie"
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3659
 msgid "Random"
 msgstr "Losowo"
 
-#: pkg/networkmanager/firewall.jsx:789
+#: pkg/networkmanager/firewall.jsx:791
 msgid "Range"
 msgstr "Zakres"
 
@@ -5457,23 +5456,23 @@ msgstr "Zakres"
 msgid "Range must be strictly ordered"
 msgstr "Zakres musi być w ścisłej kolejności"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Rank"
 msgstr "Stopień"
 
-#: pkg/kdump/kdump-view.jsx:388
+#: pkg/kdump/kdump-view.jsx:390
 msgid "Raw to a device"
 msgstr "Surowe do urządzenia"
 
 #: pkg/playground/manifest.json.in
 msgid "React Patterns"
-msgstr ""
+msgstr "Wzory React"
 
-#: pkg/systemd/hwinfo.jsx:193
+#: pkg/systemd/hwinfo.jsx:197
 msgid "Read more..."
 msgstr "Więcej informacji…"
 
-#: pkg/systemd/service-details.jsx:386
+#: pkg/systemd/service-details.jsx:388
 msgid "Read-only"
 msgstr "Tylko do odczytu"
 
@@ -5485,15 +5484,15 @@ msgstr "Tylko do odczytu"
 msgid "ReadWrite"
 msgstr "Odczyt i zapis"
 
-#: pkg/storaged/plot.jsx:310
+#: pkg/storaged/plot.jsx:312
 msgid "Reading"
 msgstr "Odczytywanie"
 
-#: pkg/kdump/kdump-view.jsx:413
+#: pkg/kdump/kdump-view.jsx:415
 msgid "Reading..."
 msgstr "Odczytywanie…"
 
-#: pkg/machines/components/vmDisksTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:112
 msgid "Readonly"
 msgstr "Tylko do odczytu"
 
@@ -5506,11 +5505,11 @@ msgctxt "verb"
 msgid "Ready"
 msgstr "Gotowe"
 
-#: pkg/systemd/index.html:304
+#: pkg/systemd/index.html:315
 msgid "Real Host Name"
 msgstr "Prawdziwa nazwa komputera"
 
-#: pkg/systemd/host.js:1037
+#: pkg/systemd/host.js:1074
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5518,11 +5517,11 @@ msgstr ""
 "Prawdziwa nazwa komputera może zawierać tylko małe litery, cyfry, myślniki "
 "i kropki (z zaludnionymi poddomenami)"
 
-#: pkg/systemd/host.js:1038
+#: pkg/systemd/host.js:1075
 msgid "Real host name must be 64 characters or less"
 msgstr "Prawdziwa nazwa komputera może mieć co najwyżej 64 znaki"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
+#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Uruchom ponownie"
 
@@ -5536,16 +5535,16 @@ msgstr "Odbieranie"
 msgid "Recent"
 msgstr "Ostatnie"
 
-#: pkg/storaged/format-dialog.jsx:248
+#: pkg/storaged/format-dialog.jsx:253
 msgid "Recommended default"
 msgstr "Zalecana wartość domyślna"
 
-#: pkg/shell/index.html:381 pkg/shell/simple.html:138
+#: pkg/shell/index.html:382 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Połącz ponownie"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Recovering"
 msgstr "Odzyskiwanie"
 
@@ -5553,7 +5552,7 @@ msgstr "Odzyskiwanie"
 msgid "Recovering RAID Device $target"
 msgstr "Przywracanie urządzenia RAID $target"
 
-#: pkg/docker/storage.jsx:389
+#: pkg/docker/storage.jsx:396
 msgid "Reformat and add disks"
 msgstr "Sformatuj ponownie i dodaj dyski"
 
@@ -5573,7 +5572,7 @@ msgstr "Odmowa połączenia. Klucze komputera się nie zgadzają"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Odmowa połączenia. Klucz komputera jest nieznany"
 
-#: pkg/packagekit/updates.jsx:779
+#: pkg/packagekit/updates.jsx:780
 msgid "Register…"
 msgstr "Zarejestruj…"
 
@@ -5581,7 +5580,7 @@ msgstr "Zarejestruj…"
 msgid "Reload"
 msgstr "Wczytaj ponownie"
 
-#: pkg/systemd/service-details.jsx:433
+#: pkg/systemd/service-details.jsx:435
 msgid "Reload Propagated From"
 msgstr "Odebrano ponowne wczytanie z"
 
@@ -5589,15 +5588,15 @@ msgstr "Odebrano ponowne wczytanie z"
 msgid "Remote URL"
 msgstr "Zdalny adres URL"
 
-#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:386
+#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:388
 msgid "Remote over NFS"
 msgstr "Zdalnie przez NFS"
 
-#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:384
+#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:386
 msgid "Remote over SSH"
 msgstr "Zdalnie przez SSH"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/drives-panel.jsx:72 pkg/storaged/drives-panel.jsx:74
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "Dysk wymienny"
@@ -5607,20 +5606,20 @@ msgid "Removals:"
 msgstr "Usuwane:"
 
 #: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
+#: pkg/storaged/nfs-details.jsx:316
 msgid "Remove"
 msgstr "Usuń"
 
-#: pkg/networkmanager/interfaces.js:3067
+#: pkg/networkmanager/interfaces.js:3076
 msgid "Remove $0"
 msgstr "Usuń $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:414
+#: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
 msgstr "Usunąć $0?"
 
-#: pkg/storaged/crypto-keyslots.jsx:423
+#: pkg/storaged/crypto-keyslots.jsx:433
 msgid "Remove Tang keyserver"
 msgstr "Usuń serwer kluczy Tang"
 
@@ -5628,19 +5627,19 @@ msgstr "Usuń serwer kluczy Tang"
 msgid "Remove device"
 msgstr "Usuń urządzenie"
 
-#: pkg/storaged/crypto-keyslots.jsx:387
+#: pkg/storaged/crypto-keyslots.jsx:396
 msgid "Remove passphrase"
 msgstr "Usuń hasło"
 
-#: pkg/storaged/crypto-keyslots.jsx:354
+#: pkg/storaged/crypto-keyslots.jsx:362
 msgid "Remove passphrase in $0?"
 msgstr "Usunąć hasło w $0?"
 
-#: pkg/networkmanager/firewall.jsx:661
+#: pkg/networkmanager/firewall.jsx:663
 msgid "Remove service"
 msgstr "Usuń usługę"
 
-#: pkg/networkmanager/firewall.jsx:640
+#: pkg/networkmanager/firewall.jsx:642
 msgid "Remove service from zones"
 msgstr "Usuń usługę ze stref"
 
@@ -5648,7 +5647,7 @@ msgstr "Usuń usługę ze stref"
 msgid "Removing"
 msgstr "Usuwanie"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:181
+#: pkg/lib/cockpit-components-install-dialog.jsx:182
 msgid "Removing $0"
 msgstr "Usuwanie $0"
 
@@ -5656,7 +5655,7 @@ msgstr "Usuwanie $0"
 msgid "Removing $target from RAID Device"
 msgstr "Usuwanie $target z urządzenia RAID"
 
-#: pkg/networkmanager/interfaces.js:3066
+#: pkg/networkmanager/interfaces.js:3075
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5668,16 +5667,16 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Usuwanie woluminu fizycznego z $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:234
+#: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
+#: pkg/storaged/vgroup-details.jsx:231
 msgid "Rename"
 msgstr "Zmień nazwę"
 
-#: pkg/storaged/lvol-tabs.jsx:31
+#: pkg/storaged/lvol-tabs.jsx:32
 msgid "Rename Logical Volume"
 msgstr "Zmiana nazwy woluminu logicznego"
 
-#: pkg/storaged/vgroup-details.jsx:178
+#: pkg/storaged/vgroup-details.jsx:173
 msgid "Rename Volume Group"
 msgstr "Zmień nazwę grupy woluminów"
 
@@ -5709,29 +5708,28 @@ msgstr "Powtarzanie co tydzień"
 msgid "Repeat Yearly"
 msgstr "Powtarzanie co roku"
 
-#: pkg/storaged/crypto-keyslots.jsx:204 pkg/storaged/crypto-keyslots.jsx:214
-#: pkg/storaged/crypto-keyslots.jsx:256
+#: pkg/storaged/crypto-keyslots.jsx:207 pkg/storaged/crypto-keyslots.jsx:219
+#: pkg/storaged/crypto-keyslots.jsx:262
 msgid "Repeat passphrase"
 msgstr "Powtórzenie hasła"
 
-#: pkg/systemd/logs.js:512
+#: pkg/systemd/logs.js:514
 msgid "Report"
 msgstr "Zgłoś"
 
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:509
 msgid "Reported"
 msgstr "Zgłoszono"
 
-#: pkg/systemd/logs.js:529
+#: pkg/systemd/logs.js:531
 msgid "Reporter 'reporter-ureport' not found."
 msgstr "Nie odnaleziono modułu zgłaszania „reporter-ureport”."
 
-#: pkg/systemd/logs.js:531
+#: pkg/systemd/logs.js:533
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Zgłoszenie się nie powiodło. Proszę wykonać „reporter-ureport -d "
 
 #: pkg/docker/index.html:690
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Repozytorium"
 
@@ -5743,31 +5741,31 @@ msgstr "Wymaganie zmiany hasła co $0 dni"
 msgid "Require password change on $0"
 msgstr "Wymaganie zmiany hasła w dniu $0"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:422
 msgid "Required By"
 msgstr "Wymagane przez"
 
-#: pkg/systemd/service-details.jsx:372
+#: pkg/systemd/service-details.jsx:374
 msgid "Required by "
 msgstr "Wymagana przez "
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "Wymaga"
 
-#: pkg/systemd/service-details.jsx:387
+#: pkg/systemd/service-details.jsx:389
 msgid "Requires administration access to edit"
 msgstr "Modyfikacja wymaga dostępu administratora"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:418
 msgid "Requisite"
 msgstr "Potrzebne"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:423
 msgid "Requisite Of"
 msgstr "Potrzebne dla"
 
-#: pkg/kdump/kdump-view.jsx:501
+#: pkg/kdump/kdump-view.jsx:503
 msgid "Reserved memory"
 msgstr "Zastrzeżona pamięć"
 
@@ -5776,11 +5774,11 @@ msgstr "Zastrzeżona pamięć"
 msgid "Reset"
 msgstr "Przywróć"
 
-#: pkg/docker/storage.jsx:441
+#: pkg/docker/storage.jsx:452
 msgid "Reset Storage Pool"
 msgstr "Przywróć pulę urządzeń do przechowywania danych"
 
-#: pkg/docker/storage.jsx:444
+#: pkg/docker/storage.jsx:455
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
@@ -5793,7 +5791,7 @@ msgstr ""
 msgid "Resizing $target"
 msgstr "Zmienianie rozmiaru $target"
 
-#: pkg/storaged/lvol-tabs.jsx:225 pkg/storaged/lvol-tabs.jsx:307
+#: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
@@ -5801,15 +5799,15 @@ msgstr ""
 "Zmiana rozmiaru zaszyfrowanego systemu plików wymaga odblokowania dysku. "
 "Proszę podać obecne hasło dysku."
 
-#: pkg/docker/index.html:138 pkg/systemd/index.html:134
-#: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
+#: pkg/docker/index.html:138 pkg/systemd/index.html:141
+#: pkg/systemd/index.html:151 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
 #: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Uruchom ponownie"
 
-#: pkg/packagekit/updates.jsx:498
+#: pkg/packagekit/updates.jsx:500
 msgid "Restart Now"
 msgstr "Uruchom ponownie teraz"
 
@@ -5821,11 +5819,11 @@ msgstr "Zasady ponownego uruchamiania"
 msgid "Restart Policy:"
 msgstr "Zasady ponownego uruchamiania:"
 
-#: pkg/packagekit/updates.jsx:493
+#: pkg/packagekit/updates.jsx:495
 msgid "Restart Recommended"
 msgstr "Ponowne uruchomienie jest zalecane"
 
-#: pkg/packagekit/updates.jsx:866
+#: pkg/packagekit/updates.jsx:867
 msgid "Restarting"
 msgstr "Ponowne uruchamianie"
 
@@ -5856,7 +5854,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Role"
 
-#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:1995 pkg/networkmanager/interfaces.js:2012
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5868,7 +5866,7 @@ msgstr "Trasa do $0"
 msgid "Routed Network"
 msgstr "Trasowana sieć"
 
-#: pkg/networkmanager/interfaces.js:3337
+#: pkg/networkmanager/interfaces.js:3348
 msgid "Routes"
 msgstr "Trasy"
 
@@ -5881,10 +5879,6 @@ msgstr "Uruchom"
 msgid "Run Image"
 msgstr "Uruchom obraz"
 
-#: node_modules/registry-image-widgets/views/image-config.html:8
-msgid "Run as"
-msgstr "Działanie jako"
-
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
@@ -5894,13 +5888,13 @@ msgstr "Uruchamianie po włączeniu gospodarza"
 msgid "Runner"
 msgstr "Uruchamianie"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Działające"
 
 #: pkg/selinux/manifest.json.in
 msgid "SELinux"
-msgstr ""
+msgstr "SELinux"
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5962,6 +5956,14 @@ msgstr "Maksymalny wiek komunikatu STP"
 msgid "STP Priority"
 msgstr "Priorytet STP"
 
+#: pkg/shell/index.html:403
+msgid ""
+"Safari users need to import and trust the certificate of the self-signing CA:"
+""
+msgstr ""
+"Użytkownicy przeglądarki Safari muszą zaimportować certyfikat "
+"samopodpisującego CA i oznaczyć go jako zaufany:"
+
 #: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "sobota"
@@ -5970,27 +5972,27 @@ msgstr "sobota"
 msgid "Saturdays"
 msgstr "soboty"
 
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:266 pkg/storaged/crypto-keyslots.jsx:285
 msgid "Save"
 msgstr "Zapisz"
 
-#: pkg/systemd/hwinfo.jsx:219
+#: pkg/systemd/hwinfo.jsx:223
 msgid "Save and reboot"
 msgstr "Zapisz i uruchom ponownie"
 
-#: pkg/storaged/vdos-panel.jsx:82
+#: pkg/storaged/vdos-panel.jsx:88
 msgid "Save space by compressing individual blocks with LZ4"
 msgstr "Oszczędź miejsce kompresując poszczególne bloki za pomocą L4"
 
-#: pkg/storaged/vdos-panel.jsx:85
+#: pkg/storaged/vdos-panel.jsx:92
 msgid "Save space by storing identical data blocks just once"
 msgstr ""
 "Oszczędź miejsce przez przechowywanie identycznych bloków danych tylko raz"
 
-#: pkg/storaged/crypto-keyslots.jsx:226 pkg/storaged/crypto-keyslots.jsx:276
+#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:283
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
@@ -6003,11 +6005,11 @@ msgid "Sealed-case PC"
 msgstr "Sealed-case PC"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:905
+#: pkg/systemd/init.js:967
 msgid "Seconds"
 msgstr "Sekundy"
 
-#: pkg/systemd/index.html:106
+#: pkg/systemd/index.html:113
 msgid "Secure Shell Keys"
 msgstr "Klucze SSH"
 
@@ -6019,7 +6021,7 @@ msgstr "Bezpieczne usuwanie zawartości $target"
 msgid "Security"
 msgstr "Zabezpieczenia"
 
-#: pkg/systemd/host.js:506
+#: pkg/systemd/host.js:509
 msgid "Security Updates Available"
 msgstr "Dostępne są aktualizacje bezpieczeństwa"
 
@@ -6054,11 +6056,11 @@ msgid "Serial Console"
 msgstr "Konsola szeregowa"
 
 #: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:323 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Serwer"
 
-#: pkg/storaged/iscsi-panel.jsx:43 pkg/storaged/nfs-details.jsx:143
+#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:146
 msgid "Server Address"
 msgstr "Adres serwera"
 
@@ -6070,15 +6072,15 @@ msgstr "Administrator serwera"
 msgid "Server Software"
 msgstr "Oprogramowanie serwera"
 
-#: pkg/storaged/iscsi-panel.jsx:44
+#: pkg/storaged/iscsi-panel.jsx:45
 msgid "Server address cannot be empty."
 msgstr "Adres serwera nie może być pusty."
 
-#: pkg/storaged/nfs-details.jsx:147
+#: pkg/storaged/nfs-details.jsx:151
 msgid "Server cannot be empty."
 msgstr "Serwer nie może być pusty."
 
-#: src/base1/cockpit.js:4033
+#: src/base1/cockpit.js:4037
 msgid "Server has closed the connection."
 msgstr "Serwer zamknął połączenie."
 
@@ -6086,8 +6088,8 @@ msgstr "Serwer zamknął połączenie."
 msgid "Servers"
 msgstr "Serwery"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:970
+#: pkg/storaged/dialog.jsx:1048
 msgid "Service"
 msgstr "Usługa"
 
@@ -6095,23 +6097,23 @@ msgstr "Usługa"
 msgid "Service Logs"
 msgstr "Dzienniki serwera"
 
-#: pkg/kdump/kdump-view.jsx:442
+#: pkg/kdump/kdump-view.jsx:444
 msgid "Service has an error"
 msgstr "Usługa ma błąd"
 
-#: pkg/kdump/kdump-view.jsx:438
+#: pkg/kdump/kdump-view.jsx:440
 msgid "Service is running"
 msgstr "Usługa jest uruchomiona"
 
-#: pkg/kdump/kdump-view.jsx:444
+#: pkg/kdump/kdump-view.jsx:446
 msgid "Service is starting"
 msgstr "Usługa jest uruchamiana"
 
-#: pkg/kdump/kdump-view.jsx:440
+#: pkg/kdump/kdump-view.jsx:442
 msgid "Service is stopped"
 msgstr "Usługa jest zatrzymana"
 
-#: pkg/kdump/kdump-view.jsx:446
+#: pkg/kdump/kdump-view.jsx:448
 msgid "Service is stopping"
 msgstr "Usługa jest zatrzymywana"
 
@@ -6120,12 +6122,12 @@ msgid "Service name"
 msgstr "Nazwa usługi"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:510 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Usługi"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:50
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1044
 msgid "Session"
 msgstr "Sesja"
 
@@ -6133,11 +6135,11 @@ msgstr "Sesja"
 msgid "Set"
 msgstr "Ustaw"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+#: pkg/machines/components/networks/createNetworkDialog.jsx:217
 msgid "Set DHCP Range"
 msgstr "Ustaw zakres DHCP"
 
-#: pkg/systemd/host.js:781
+#: pkg/systemd/host.js:816
 msgid "Set Host name"
 msgstr "Ustaw nazwę komputera"
 
@@ -6145,13 +6147,17 @@ msgstr "Ustaw nazwę komputera"
 msgid "Set Password"
 msgstr "Ustaw hasło"
 
-#: pkg/systemd/index.html:378
+#: pkg/systemd/index.html:389
 msgid "Set Time"
 msgstr "Ustaw czas"
 
 #: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Ustaw zmienne środowiskowe kontenera"
+
+#: pkg/machines/components/nicAdd.jsx:60
+msgid "Set manually"
+msgstr "Ustaw ręcznie"
 
 #: pkg/networkmanager/index.html:183
 msgid "Set to"
@@ -6176,15 +6182,15 @@ msgstr "Ustawianie"
 msgid "Setting up loop device $target"
 msgstr "Ustawianie urządzenia zwrotnego $target"
 
-#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:383
 msgid "Severity"
 msgstr "Ważność"
 
-#: pkg/packagekit/updates.jsx:310
+#: pkg/packagekit/updates.jsx:311
 msgid "Severity:"
 msgstr "Ważność:"
 
-#: pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Shared"
 msgstr "Współdzielone"
 
@@ -6196,15 +6202,15 @@ msgstr "Skrypt powłoki"
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Show Performance Options"
 msgstr "Wyświetl opcje wydajności"
 
-#: pkg/storaged/overview.jsx:56
+#: pkg/storaged/overview.jsx:54
 msgid "Show all"
 msgstr "Wyświetl wszystkie"
 
-#: pkg/storaged/drives-panel.jsx:122
+#: pkg/storaged/drives-panel.jsx:104
 msgid "Show all $0 drives"
 msgstr "Wyświetl wszystkie urządzenia $0"
 
@@ -6216,23 +6222,23 @@ msgstr "Wyświetl wszystkie kontenery"
 msgid "Show all images"
 msgstr "Wyświetl wszystkie obrazy"
 
-#: pkg/systemd/index.html:107
+#: pkg/systemd/index.html:114
 msgid "Show fingerprints"
 msgstr "Wyświetl odciski"
 
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
+#: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Zmniejsz"
 
-#: pkg/storaged/lvol-tabs.jsx:313
+#: pkg/storaged/lvol-tabs.jsx:320
 msgid "Shrink Logical Volume"
 msgstr "Zmniejsz wolumin logiczny"
 
-#: pkg/storaged/lvol-tabs.jsx:415
+#: pkg/storaged/lvol-tabs.jsx:423
 msgid "Shrink Volume"
 msgstr "Zmniejsz wolumin"
 
-#: pkg/systemd/index.html:147 pkg/machines/components/vm/vmActions.jsx:56
+#: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
 msgstr "Wyłącz"
@@ -6243,47 +6249,47 @@ msgstr "Pojedynczy stopień"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
-#: pkg/machines/components/diskAdd.jsx:172
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:79
+#: pkg/storaged/content-views.jsx:118 pkg/storaged/content-views.jsx:702
+#: pkg/storaged/format-dialog.jsx:278 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:212 pkg/storaged/lvol-tabs.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:402 pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/nfs-details.jsx:329 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:263
 msgid "Size"
 msgstr "Rozmiar"
 
-#: pkg/storaged/dialog.jsx:911
+#: pkg/storaged/dialog.jsx:912
 msgid "Size cannot be negative"
 msgstr "Rozmiar nie może być ujemny"
 
-#: pkg/storaged/dialog.jsx:909
+#: pkg/storaged/dialog.jsx:910
 msgid "Size cannot be zero"
 msgstr "Rozmiar nie może wynosić zero"
 
-#: pkg/storaged/dialog.jsx:913
+#: pkg/storaged/dialog.jsx:914
 msgid "Size is too large"
 msgstr "Rozmiar jest za duży"
 
-#: pkg/storaged/dialog.jsx:907
+#: pkg/storaged/dialog.jsx:908
 msgid "Size must be a number"
 msgstr "Rozmiar musi być liczbą"
 
-#: pkg/storaged/dialog.jsx:915
+#: pkg/storaged/dialog.jsx:916
 msgid "Size must be at least $0"
 msgstr "Rozmiar musi wynosić co najmniej $0"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Slot"
 msgstr "Gniazdo"
 
-#: pkg/storaged/crypto-keyslots.jsx:531
+#: pkg/storaged/crypto-keyslots.jsx:544
 msgid "Slot $0"
 msgstr "Gniazdo $0"
 
-#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "Gniazda"
 
@@ -6291,7 +6297,7 @@ msgstr "Gniazda"
 msgid "Software Updates"
 msgstr "Aktualizacje oprogramowania"
 
-#: pkg/systemd/hwinfo.jsx:208
+#: pkg/systemd/hwinfo.jsx:212
 msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
@@ -6301,12 +6307,7 @@ msgstr ""
 "procesora. Ich efektem ubocznym jest zmniejszenie wydajności. Należy "
 "zmieniać te ustawienia na własne ryzyko."
 
-#: pkg/docker/storage.jsx:165
-msgid "Solid-State Disk"
-msgstr "Dysk SSD"
-
-#: pkg/storaged/drives-panel.jsx:87
-msgctxt "storage"
+#: pkg/docker/storage.jsx:167
 msgid "Solid-State Disk"
 msgstr "Dysk SSD"
 
@@ -6327,15 +6328,15 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "Inny program obecnie używa menedżera pakietów, proszę czekać…"
 
-#: pkg/networkmanager/firewall.jsx:739
+#: pkg/networkmanager/firewall.jsx:741
 msgid "Sorted from least trusted to most trusted"
 msgstr "Uporządkowane od najmniej do najbardziej zaufanych"
 
-#: pkg/machines/components/diskAdd.jsx:541
-#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/diskAdd.jsx:412
+#: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
-#: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/vmDisksTab.jsx:114
+#: pkg/machines/components/vmnetworktab.jsx:160
 msgid "Source"
 msgstr "Źródło"
 
@@ -6349,10 +6350,6 @@ msgstr "Format źródłowy"
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
 msgstr "Ścieżka źródłowa"
-
-#: node_modules/registry-image-widgets/views/image-body.html:8
-msgid "Source URL"
-msgstr "Źródłowy adres URL"
 
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
@@ -6371,7 +6368,7 @@ msgstr "Źródło musi zaczynać się od protokołu http, ftp lub nfs"
 msgid "Space-saving Computer"
 msgstr "Komputer oszczędzający miejsce"
 
-#: pkg/networkmanager/interfaces.js:2869
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Spanning Tree Protocol"
 msgstr "Protokół STP"
 
@@ -6379,26 +6376,26 @@ msgstr "Protokół STP"
 msgid "Spanning Tree Protocol (STP)"
 msgstr "Protokół STP"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Spare"
 msgstr "Zapasowe"
 
-#: pkg/systemd/index.html:455
+#: pkg/systemd/index.html:466
 msgid "Specific Time"
 msgstr "Podany czas"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Speed"
 msgstr "Prędkość"
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3660
 msgid "Stable"
 msgstr "Stabilna"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/machines/components/networks/createNetworkDialog.jsx:237
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:223
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:265 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Rozpocznij"
 
@@ -6410,11 +6407,11 @@ msgstr "Uruchom Dockera"
 msgid "Start Multipath"
 msgstr "Uruchom urządzenie wielościeżkowe"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:343
 msgid "Start Service"
 msgstr "Uruchom usługę"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Start and Enable"
 msgstr "Uruchom i włącz"
 
@@ -6444,10 +6441,10 @@ msgid "Startup"
 msgstr "Uruchamianie"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/vmnetworktab.jsx:186 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/hwinfo.jsx:263 pkg/systemd/init.js:306
 msgid "State"
 msgstr "Stan"
 
@@ -6455,12 +6452,12 @@ msgstr "Stan"
 msgid "State:"
 msgstr "Stan:"
 
-#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:369
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:213
+#: pkg/systemd/service-details.jsx:371
 msgid "Static"
 msgstr "Statyczne"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
+#: pkg/networkmanager/interfaces.js:2633 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Stan"
 
@@ -6473,21 +6470,21 @@ msgid "Sticky"
 msgstr "Lepkie"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
 #: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Zatrzymaj"
 
-#: pkg/storaged/mdraid-details.jsx:247
+#: pkg/storaged/mdraid-details.jsx:244
 msgid "Stop Device"
 msgstr "Zatrzymaj urządzenie"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Stop and Disable"
 msgstr "Zatrzymaj i wyłącz"
 
-#: pkg/storaged/nfs-details.jsx:259
+#: pkg/storaged/nfs-details.jsx:267
 msgid "Stop and Unmount"
 msgstr "Zatrzymaj i odmontuj"
 
@@ -6495,13 +6492,9 @@ msgstr "Zatrzymaj i odmontuj"
 msgid "Stop and delete"
 msgstr "Zatrzymaj i usuń"
 
-#: pkg/storaged/nfs-details.jsx:284
+#: pkg/storaged/nfs-details.jsx:292
 msgid "Stop and remove"
 msgstr "Zatrzymaj i usuń"
-
-#: node_modules/registry-image-widgets/views/image-config.html:14
-msgid "Stop with"
-msgstr "Zatrzymanie za pomocą"
 
 #: pkg/docker/util.js:231
 msgid "Stopped"
@@ -6525,6 +6518,13 @@ msgstr "Przechowywanie danych"
 msgid "Storage Logs"
 msgstr "Dzienniki urządzeń do przechowywania danych"
 
+#: pkg/machines/components/aggregateStatusCards.jsx:47
+msgid "Storage Pool"
+msgid_plural "Storage Pools"
+msgstr[0] "Pula urządzeń do przechowywania danych"
+msgstr[1] "Pule urządzeń do przechowywania danych"
+msgstr[2] "Pule urządzeń do przechowywania danych"
+
 #: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "Aktywacja puli urządzeń do przechowywania danych $0 się nie powiodła"
@@ -6542,8 +6542,8 @@ msgstr "Nazwa puli urządzeń do przechowywania danych"
 msgid "Storage Pool failed to be created"
 msgstr "Utworzenie puli urządzeń do przechowywania danych się nie powiodło"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:44
-#: pkg/machines/components/storagePools/storagePoolList.jsx:48
+#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/storagePoolList.jsx:53
 msgid "Storage Pools"
 msgstr "Pule urządzeń do przechowywania danych"
 
@@ -6568,19 +6568,19 @@ msgstr "Pula urządzeń do przechowywania danych"
 msgid "Storage size must not be 0"
 msgstr "Rozmiar urządzenia do przechowywania danych nie może wynosić 0"
 
-#: pkg/systemd/index.html:155
+#: pkg/systemd/index.html:162
 msgid "Store Metrics"
 msgstr "Przechowuj statystyki"
 
-#: pkg/storaged/format-dialog.jsx:122
+#: pkg/storaged/format-dialog.jsx:126
 msgid "Store passphrase"
 msgstr "Przechowaj hasło"
 
-#: pkg/storaged/crypto-tab.jsx:67 pkg/storaged/crypto-tab.jsx:69
+#: pkg/storaged/crypto-tab.jsx:68 pkg/storaged/crypto-tab.jsx:70
 msgid "Stored Passphrase"
 msgstr "Zachowane hasło"
 
-#: pkg/storaged/crypto-tab.jsx:126
+#: pkg/storaged/crypto-tab.jsx:129
 msgid "Stored passphrase"
 msgstr "Zachowane hasło"
 
@@ -6592,10 +6592,6 @@ msgstr "Obudowa podrzędna"
 msgid "Sub Notebook"
 msgstr "Sub Notebook"
 
-#: node_modules/registry-image-widgets/views/image-body.html:4
-msgid "Summary"
-msgstr "Podsumowanie"
-
 #: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "niedziela"
@@ -6604,32 +6600,32 @@ msgstr "niedziela"
 msgid "Sundays"
 msgstr "niedziele"
 
-#: pkg/storaged/optional-panel.jsx:95
+#: pkg/storaged/optional-panel.jsx:98
 msgid "Support is installed."
 msgstr "Obsługa jest zainstalowana."
 
-#: pkg/storaged/content-views.jsx:157
+#: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Partycja wymiany"
 
-#: pkg/storaged/content-views.jsx:351
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Przestrzeń wymiany"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
+#: pkg/systemd/index.html:259 pkg/systemd/host.js:1756
 msgid "Swap Used"
 msgstr "Używana przestrzeń wymiany"
 
-#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:3060
 msgid "Switch off $0"
 msgstr "Wyłącz $0"
 
-#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2486 pkg/networkmanager/interfaces.js:3048
 msgid "Switch on $0"
 msgstr "Włącz $0"
 
-#: pkg/networkmanager/interfaces.js:2503
+#: pkg/networkmanager/interfaces.js:2510
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6637,7 +6633,7 @@ msgstr ""
 "Wyłączenie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:3050
+#: pkg/networkmanager/interfaces.js:3059
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6645,7 +6641,7 @@ msgstr ""
 "Wyłączenie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3047
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6675,12 +6671,16 @@ msgstr "Synchronizowanie urządzenia RAID $target"
 
 #: pkg/systemd/index.html:4
 #: pkg/machines/components/machinesConnectionSelector.jsx:43
-#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:273
 #: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "System"
 
-#: pkg/systemd/hwinfo.jsx:273
+#: pkg/systemd/index.html:171
+msgid "System Health"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:277
 msgid "System Information"
 msgstr "Informacje o systemie"
 
@@ -6688,28 +6688,28 @@ msgstr "Informacje o systemie"
 msgid "System Modifications"
 msgstr "Modyfikacje systemu"
 
-#: pkg/systemd/host.js:490
+#: pkg/systemd/host.js:493
 msgid "System Not Registered"
 msgstr "System nie jest zarejestrowany"
 
-#: pkg/systemd/services.jsx:38
+#: pkg/systemd/services.jsx:47
 msgid "System Services"
 msgstr "Usługi systemowe"
 
-#: pkg/systemd/index.html:121
+#: pkg/systemd/index.html:128
 msgid "System Time"
 msgstr "Czas systemowy"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:499
 msgid "System Up To Date"
 msgstr "System jest aktualny"
 
-#: pkg/packagekit/updates.jsx:878
+#: pkg/packagekit/updates.jsx:879
 msgid "System is up to date"
 msgstr "System jest aktualny"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "TCP"
 msgstr "TCP"
 
@@ -6718,18 +6718,14 @@ msgid "Tablet"
 msgstr "Tablet"
 
 #: pkg/docker/index.html:696
-#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Etykieta"
 
-#: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
 #: pkg/docker/containers-view.jsx:409
 msgid "Tags"
 msgstr "Etykiety"
 
-#: pkg/storaged/crypto-keyslots.jsx:207
+#: pkg/storaged/crypto-keyslots.jsx:210
 msgid "Tang keyserver"
 msgstr "Serwer kluczy Tang"
 
@@ -6746,16 +6742,16 @@ msgstr "Ścieżka docelowa"
 msgid "Target path should not be empty"
 msgstr "Ścieżka docelowa nie może być pusta"
 
-#: pkg/systemd/services.jsx:39
+#: pkg/systemd/services.jsx:48
 msgid "Targets"
 msgstr "Cele"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
-#: pkg/networkmanager/interfaces.js:2826
+#: pkg/networkmanager/interfaces.js:2531 pkg/networkmanager/interfaces.js:2543
+#: pkg/networkmanager/interfaces.js:2834
 msgid "Team"
 msgstr "Zespół"
 
-#: pkg/networkmanager/interfaces.js:2854
+#: pkg/networkmanager/interfaces.js:2862
 msgid "Team Port"
 msgstr "Port zespołu"
 
@@ -6775,11 +6771,11 @@ msgstr "Terminal"
 msgid "Terminate Session"
 msgstr "Zakończ sesję"
 
-#: pkg/kdump/kdump-view.jsx:476 pkg/kdump/kdump-view.jsx:484
+#: pkg/kdump/kdump-view.jsx:478 pkg/kdump/kdump-view.jsx:486
 msgid "Test Configuration"
 msgstr "Przetestuj konfigurację"
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr "Test jest dostępny tylko, jeśli usługa kdump jest uruchomiona."
 
@@ -6791,25 +6787,25 @@ msgstr "Przetestuj ustawienia kdump"
 msgid "Testing connection"
 msgstr "Testowanie połączenia"
 
-#: pkg/docker/storage.jsx:507
+#: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr ""
 "Pula urządzeń do przechowywania danych Docker nie może być zarządzana na tym "
 "systemie."
 
-#: pkg/lib/machine-dialogs.js:384
+#: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "Adres IP lub nazwa komputera nie może zawierać spacji."
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/mdraid-details.jsx:213
 msgid "The RAID Array is in a degraded state"
 msgstr "Macierz RAID jest w stanie zdegradowanym"
 
-#: pkg/storaged/mdraid-details.jsx:148
+#: pkg/storaged/mdraid-details.jsx:142
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "Urządzenie RAID musi być uruchomione, aby dodać zapasowe dyski."
 
-#: pkg/storaged/mdraid-details.jsx:115
+#: pkg/storaged/mdraid-details.jsx:109
 msgid "The RAID device must be running in order to remove disks."
 msgstr "Urządzenie RAID musi być uruchomione, aby usunąć dyski."
 
@@ -6888,7 +6884,7 @@ msgstr ""
 "Utworzenie tego urządzenia VDO nie zostało ukończone, więc nie można go "
 "używać."
 
-#: pkg/storaged/crypto-keyslots.jsx:516
+#: pkg/storaged/crypto-keyslots.jsx:529
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
@@ -6899,7 +6895,7 @@ msgstr ""
 msgid "The directory on the server being exported"
 msgstr "Eksportowany katalog na serwerze"
 
-#: pkg/storaged/dialog.jsx:1012
+#: pkg/storaged/dialog.jsx:1013
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -6907,13 +6903,13 @@ msgstr ""
 "System plików jest używany przez sesje logowania i usługi systemowe. "
 "Kontynuacja je zatrzyma."
 
-#: pkg/storaged/dialog.jsx:1014
+#: pkg/storaged/dialog.jsx:1015
 msgid ""
 "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "System plików jest używany przez sesje logowania. Kontynuacja je zatrzyma."
 
-#: pkg/storaged/dialog.jsx:1016
+#: pkg/storaged/dialog.jsx:1017
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
@@ -6949,15 +6945,15 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr "Podany klucz jest nieprawidłowy."
 
-#: pkg/storaged/mdraid-details.jsx:121
+#: pkg/storaged/mdraid-details.jsx:115
 msgid "The last disk of a RAID device cannot be removed."
 msgstr "Nie można usuwać ostatniego dysku urządzenia RAID."
 
-#: pkg/storaged/crypto-keyslots.jsx:541
+#: pkg/storaged/crypto-keyslots.jsx:554
 msgid "The last key slot can not be removed"
 msgstr "Nie można usunąć ostatniego gniazda na klucz"
 
-#: pkg/storaged/vgroup-details.jsx:96
+#: pkg/storaged/vgroup-details.jsx:90
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Nie można usunąć ostatniego woluminu fizycznego grupy woluminów."
 
@@ -6966,7 +6962,7 @@ msgid "The logged in user is not permitted to view system modifications"
 msgstr ""
 "Zalogowany użytkownik nie ma zezwolenia na wyświetlanie modyfikacji systemu"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:464
 msgid "The machine is restarting"
 msgstr "Komputer jest ponownie uruchamiany"
 
@@ -6982,13 +6978,20 @@ msgstr "Hasła się nie zgadzają"
 msgid "The passwords do not match."
 msgstr "Hasła się nie zgadzają."
 
-#: pkg/machines/components/diskAdd.jsx:80
+#: pkg/machines/components/diskAdd.jsx:81
 msgid "The pool is empty"
 msgstr "Pula jest pusta"
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Wyszukiwanie z $time ($type) nie zwróciło żadnych zagrożeń."
+
+#: pkg/docker/containers-view.jsx:436
+msgid "The scan from $time ($type) found one vulnerability:"
+msgid_plural "The scan from $time ($type) found $count vulnerabilities:"
+msgstr[0] "Wyszukiwanie z $time ($type) znalazło jedno zagrożenie:"
+msgstr[1] "Wyszukiwanie z $time ($type) znalazło $count zagrożenia:"
+msgstr[2] "Wyszukiwanie z $time ($type) znalazło $count zagrożeń:"
 
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
@@ -7005,6 +7008,17 @@ msgstr ""
 "Wybrany system operacyjny wymaga urządzenia do przechowywania danych "
 "o rozmiarze co najmniej $0 $1"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:382
+msgid "The selected Operating System has recommended memory $0 $1"
+msgstr ""
+"Dla wybranego systemu operacyjnego zaleca się co najmniej $0 $1 pamięci"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:417
+msgid "The selected Operating System has recommended storage size of $0 $1"
+msgstr ""
+"Dla wybranego systemu operacyjnego zaleca się urządzenia do przechowywania "
+"danych o rozmiarze co najmniej $0 $1"
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -7013,18 +7027,18 @@ msgstr ""
 "Serwer odmówił uwierzytelnienia „$0” za pomocą hasła, a żadne inne "
 "obsługiwane metody uwierzytelniania nie są dostępne."
 
-#: src/base1/cockpit.js:4017
+#: src/base1/cockpit.js:4021
 msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 "Serwer odmówił uwierzytelnienia za pomocą wszystkich obsługiwanych metod."
 
-#: pkg/systemd/hwinfo.jsx:65
+#: pkg/systemd/hwinfo.jsx:69
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 "Użytkownik $0 nie ma zezwolenia na zmianę poprawek zabezpieczeń procesora "
 "zmniejszających ryzyko"
 
-#: pkg/systemd/init.js:751
+#: pkg/systemd/init.js:813
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Użytkownik <b>$0</b> nie ma uprawnień do tworzenia liczników"
 
@@ -7032,11 +7046,11 @@ msgstr "Użytkownik <b>$0</b> nie ma uprawnień do tworzenia liczników"
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na zmianę profili"
 
-#: pkg/systemd/host.js:70
+#: pkg/systemd/host.js:72
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na zmianę czasu systemu"
 
-#: pkg/dashboard/list.js:223
+#: pkg/dashboard/list.js:231
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na zarządzanie serwerami"
 
@@ -7050,21 +7064,21 @@ msgstr ""
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie kont"
 
-#: pkg/systemd/host.js:54
+#: pkg/systemd/host.js:56
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr ""
 "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie nazw komputerów"
 
-#: pkg/networkmanager/interfaces.js:1525
+#: pkg/networkmanager/interfaces.js:1530
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
 
-#: pkg/realmd/operation.js:642
+#: pkg/realmd/operation.js:644
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie obszarów"
 
-#: pkg/systemd/host.js:62
+#: pkg/systemd/host.js:64
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
 "Użytkownik <b>$0</b> nie może wyłączać ani ponownie uruchamiać tego serwera"
@@ -7101,7 +7115,7 @@ msgstr ""
 msgid "There are no authorized public keys for this account."
 msgstr "Brak upoważnionych publicznych kluczy dla tego konta."
 
-#: pkg/storaged/vgroup-details.jsx:102
+#: pkg/storaged/vgroup-details.jsx:96
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
@@ -7109,11 +7123,15 @@ msgstr ""
 "Za mało wolnego miejsca, aby usunąć ten wolumin fizyczny. Wymagane jest co "
 "najmniej $0 wolnego miejsca więcej."
 
-#: pkg/storaged/utils.js:193
+#: pkg/shell/index.html:398
+msgid "There was an unexpected error while connecting to the machine."
+msgstr "Wystąpił nieoczekiwany błąd podczas łączenia z maszyną."
+
+#: pkg/storaged/utils.js:194
 msgid "Thin Logical Volume"
 msgstr "Cienki wolumin logiczny"
 
-#: pkg/storaged/nfs-details.jsx:118
+#: pkg/storaged/nfs-details.jsx:120
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr ""
 "Ten punkt montowania NFS jest używany. Można zmieniać tylko jego opcje."
@@ -7122,7 +7140,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr "To urządzenie VDO nie używa całości swojego urządzenia podstawowego."
 
-#: pkg/systemd/init.js:1200
+#: pkg/systemd/init.js:1262
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -7130,11 +7148,11 @@ msgstr ""
 "Ten dzień nie istnieje we wszystkich miesiącach.<br> Licznik będzie "
 "wykonywany tylko w miesiącach z 31. dniem."
 
-#: pkg/networkmanager/interfaces.js:2636
+#: pkg/networkmanager/interfaces.js:2644
 msgid "This device cannot be managed here."
 msgstr "Tutaj nie można zarządzać tym urządzeniem."
 
-#: pkg/storaged/dialog.jsx:997
+#: pkg/storaged/dialog.jsx:998
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -7142,11 +7160,11 @@ msgstr ""
 "To urządzenie ma obecnie używane systemy plików. Kontynuacja odmontuje "
 "wszystkie jego systemy plików."
 
-#: pkg/storaged/dialog.jsx:976
+#: pkg/storaged/dialog.jsx:977
 msgid "This device is currently used for RAID devices."
 msgstr "To urządzenie jest obecnie używane dla urządzeń RAID."
 
-#: pkg/storaged/dialog.jsx:1005
+#: pkg/storaged/dialog.jsx:1006
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -7154,15 +7172,15 @@ msgstr ""
 "To urządzenie jest obecnie używane dla urządzeń RAID. Kontynuacja usunie je "
 "z jego urządzeń RAID."
 
-#: pkg/storaged/dialog.jsx:980
+#: pkg/storaged/dialog.jsx:981
 msgid "This device is currently used for VDO devices."
 msgstr "To urządzenie jest obecnie używane dla urządzeń VDO."
 
-#: pkg/storaged/dialog.jsx:972
+#: pkg/storaged/dialog.jsx:973
 msgid "This device is currently used for volume groups."
 msgstr "To urządzenie jest obecnie używane dla grup woluminów."
 
-#: pkg/storaged/dialog.jsx:1001
+#: pkg/storaged/dialog.jsx:1002
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7170,11 +7188,11 @@ msgstr ""
 "To urządzenie jest obecnie używane dla grup woluminów. Kontynuacja usunie je "
 "z jego grup woluminów."
 
-#: pkg/storaged/mdraid-details.jsx:117
+#: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "Ten dysk nie może zostać usunięty podczas przywracania urządzenia."
 
-#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
+#: pkg/systemd/init.js:1174 pkg/systemd/init.js:1188 pkg/systemd/init.js:1197
 msgid "This field cannot be empty."
 msgstr "To pole nie może być puste."
 
@@ -7182,12 +7200,12 @@ msgstr "To pole nie może być puste."
 msgid "This image does not exist."
 msgstr "Ten obraz nie istnieje."
 
-#: pkg/storaged/lvol-tabs.jsx:408
+#: pkg/storaged/lvol-tabs.jsx:416
 msgid "This logical volume is not completely used by its content."
 msgstr ""
 "Ten wolumin logiczny nie jest całkowicie używany przez swoją zawartość."
 
-#: pkg/lib/machine-dialogs.js:362
+#: pkg/lib/machine-dialogs.js:364
 msgid "This machine has already been added."
 msgstr "Ten komputer został już dodany."
 
@@ -7204,12 +7222,12 @@ msgstr "Ten pakiet nie jest zgodny z tą wersją Cockpit"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Ten pakiet wymaga Cockpit w wersji %s lub nowszej"
 
-#: pkg/machines/components/diskAdd.jsx:215
+#: pkg/machines/components/diskAdd.jsx:138
 msgid "This pool type does not support Storage Volume creation"
 msgstr ""
 "Ten typ puli nie obsługuje tworzenia woluminów do przechowywania danych"
 
-#: pkg/packagekit/updates.jsx:774
+#: pkg/packagekit/updates.jsx:775
 msgid "This system is not registered"
 msgstr "Ten system nie jest zarejestrowany"
 
@@ -7237,7 +7255,7 @@ msgstr "Ta jednostka nie została zaprojektowana do bezpośredniego włączania.
 msgid "This user name already exists"
 msgstr "Ta nazwa użytkownika już istnieje"
 
-#: pkg/lib/machine-dialogs.js:378
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
@@ -7249,7 +7267,7 @@ msgstr ""
 msgid "This volume is already used by another VM."
 msgstr "Ten wolumin jest już używany przez inną maszynę wirtualną."
 
-#: pkg/storaged/lvol-tabs.jsx:186
+#: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
 msgstr "Ten wolumin musi zostać aktywowany przed zmianą rozmiaru."
 
@@ -7257,7 +7275,7 @@ msgstr "Ten wolumin musi zostać aktywowany przed zmianą rozmiaru."
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "Ta przeglądarka jest za stara, aby uruchomić Cockpit (brak $0)"
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:835
 msgid "This web console will be updated."
 msgstr "Ta konsola internetowa zostanie zaktualizowana."
 
@@ -7271,7 +7289,7 @@ msgstr ""
 "komputera. W zależności od ustawień, komputer może nie zostać automatycznie "
 "włączony ponownie, a cały proces może chwilę zająć."
 
-#: pkg/kdump/kdump-view.jsx:489
+#: pkg/kdump/kdump-view.jsx:491
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Przetestuje to konfigurację kdump przez zawieszenie jądra."
 
@@ -7287,15 +7305,15 @@ msgstr "czwartek"
 msgid "Thursdays"
 msgstr "czwartki"
 
-#: pkg/systemd/index.html:364
+#: pkg/systemd/index.html:375
 msgid "Time Zone"
 msgstr "Strefa czasowa"
 
-#: pkg/systemd/services.jsx:41
+#: pkg/systemd/services.jsx:50
 msgid "Timers"
 msgstr "Liczniki"
 
-#: pkg/shell/index.html:305
+#: pkg/shell/index.html:306
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -7303,7 +7321,7 @@ msgstr ""
 "Wskazówka: ustawienie hasła klucza na takie samo, jak hasło logowania "
 "automatycznie uwierzytelni w innych systemach."
 
-#: pkg/packagekit/updates.jsx:775
+#: pkg/packagekit/updates.jsx:776
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -7311,14 +7329,6 @@ msgstr ""
 "Aby otrzymywać aktualizacje oprogramowania, ten system musi zostać "
 "zarejestrowany w firmie Red Hat za pomocą serwisu Red Hat Customer Portal "
 "lub lokalnego serwera subskrypcji."
-
-#: node_modules/registry-image-widgets/views/image-pull.html:4
-msgid "To pull this image:"
-msgstr "Aby pobrać ten obraz:"
-
-#: node_modules/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push an image to this image stream:"
-msgstr "Aby wysłać obraz do tego potoku obrazów:"
 
 #: pkg/lib/machine-change-port.html:11
 msgid ""
@@ -7328,15 +7338,11 @@ msgstr ""
 "Należy zaktualizować cockpit-ws do nowszej wersji, aby spróbować innego "
 "portu."
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
-msgid "Too many files found"
-msgstr "Odnaleziono za dużo plików"
-
-#: src/base1/cockpit.js:4039
+#: src/base1/cockpit.js:4043
 msgid "Too much data"
 msgstr "Za dużo danych"
 
-#: pkg/docker/storage.jsx:341
+#: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Razem"
 
@@ -7350,26 +7356,26 @@ msgstr "Tower"
 
 #: pkg/playground/manifest.json.in
 msgid "Translating"
-msgstr ""
+msgstr "Tłumaczenie"
 
-#: pkg/systemd/service-details.jsx:431
+#: pkg/systemd/service-details.jsx:433
 msgid "Triggered By"
 msgstr "Wyzwalane przez"
 
-#: pkg/systemd/service-details.jsx:430
+#: pkg/systemd/service-details.jsx:432
 msgid "Triggers"
 msgstr "Wyzwalacze"
 
-#: pkg/shell/index.html:382 pkg/shell/simple.html:139
+#: pkg/shell/index.html:383 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Rozwiązywanie problemów"
 
-#: pkg/storaged/crypto-keyslots.jsx:331
+#: pkg/storaged/crypto-keyslots.jsx:339
 msgid "Trust key"
 msgstr "Zaufaj kluczowi"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:737
 msgid "Trust level"
 msgstr "Poziom zaufania"
 
@@ -7397,7 +7403,7 @@ msgstr "wtorek"
 msgid "Tuesdays"
 msgstr "wtorki"
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:261
 msgid "Tuned has failed to start"
 msgstr "Uruchomienie tuned się nie powiodło"
 
@@ -7413,7 +7419,7 @@ msgstr "tuned nie jest uruchomione"
 msgid "Tuned is off"
 msgstr "tuned jest wyłączone"
 
-#: pkg/shell/index.html:265
+#: pkg/shell/index.html:266
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
@@ -7422,10 +7428,10 @@ msgstr "tuned jest wyłączone"
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmnetworktab.jsx:120
+#: pkg/storaged/format-dialog.jsx:293 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Type"
 msgstr "Typ"
 
@@ -7441,7 +7447,7 @@ msgstr "Proszę wpisać hasło"
 msgid "Type to filter…"
 msgstr "Filtrowanie…"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:970
 msgid "UDP"
 msgstr "UDP"
 
@@ -7482,17 +7488,13 @@ msgstr "Nie można pobrać alarmu: $0"
 msgid "Unable to reach server"
 msgstr "Nie można połączyć się z serwerem"
 
-#: pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:290
 msgid "Unable to remove mount"
 msgstr "Nie można usunąć punktu montowania"
 
 #: pkg/users/local.js:60
 msgid "Unable to rename root account"
 msgstr "Nie można zmienić nazwy konta roota"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:41
-msgid "Unable to resolve"
-msgstr "Nie można rozwiązać"
 
 #: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
@@ -7502,7 +7504,7 @@ msgstr "Nie można wykonać poprawki: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "Nie można uruchomić usługi setroubleshootd"
 
-#: pkg/storaged/nfs-details.jsx:257
+#: pkg/storaged/nfs-details.jsx:265
 msgid "Unable to unmount filesystem"
 msgstr "Nie można odmontować systemu plików"
 
@@ -7511,11 +7513,11 @@ msgid "Unavailable"
 msgstr "Niedostępne"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:758 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Nieoczekiwany błąd"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+#: pkg/machines/components/networks/createNetworkDialog.jsx:114
 msgid "Unique Network Name"
 msgstr "Unikalna nazwa sieci"
 
@@ -7524,26 +7526,23 @@ msgid "Unique name"
 msgstr "Unikalna nazwa"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1048
 msgid "Unit"
 msgstr "Jednostka"
 
-#: node_modules/registry-image-widgets/views/image-body.html:16
-#: node_modules/registry-image-widgets/views/imagestream-body.html:30
-#: node_modules/registry-image-widgets/views/imagestream-body.html:31
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
-#: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
-#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
+#: pkg/machines/components/vmnetworktab.jsx:149
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1081
+#: pkg/networkmanager/interfaces.js:2551 pkg/networkmanager/interfaces.js:2553
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Nieznane"
 
-#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
+#: pkg/networkmanager/interfaces.js:2537 pkg/networkmanager/interfaces.js:2549
 msgid "Unknown \"$0\""
 msgstr "Nieznane „$0”"
 
-#: pkg/storaged/mdraid-details.jsx:104
+#: pkg/storaged/mdraid-details.jsx:98
 msgid "Unknown ($0)"
 msgstr "Nieznane ($0)"
 
@@ -7555,7 +7554,7 @@ msgstr "Nieznana aplikacja"
 msgid "Unknown Host Key"
 msgstr "Nieznany klucz komputera"
 
-#: pkg/networkmanager/interfaces.js:2652
+#: pkg/networkmanager/interfaces.js:2660
 msgid "Unknown configuration"
 msgstr "Nieznana konfiguracja"
 
@@ -7567,7 +7566,7 @@ msgstr "Nieznana nazwa komputera"
 msgid "Unknown service name"
 msgstr "Nieznana nazwa usługi"
 
-#: pkg/storaged/crypto-keyslots.jsx:562
+#: pkg/storaged/crypto-keyslots.jsx:575
 msgid "Unknown type"
 msgstr "Nieznany typ"
 
@@ -7575,20 +7574,20 @@ msgstr "Nieznany typ"
 msgid "Unless Stopped"
 msgstr "Do zatrzymania"
 
-#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
-#: pkg/storaged/content-views.jsx:240
+#: pkg/storaged/content-views.jsx:227 pkg/storaged/content-views.jsx:232
+#: pkg/storaged/content-views.jsx:245
 msgid "Unlock"
 msgstr "Odblokuj"
 
-#: pkg/shell/index.html:212 pkg/shell/index.html:253
+#: pkg/shell/index.html:213 pkg/shell/index.html:254
 msgid "Unlock Key"
 msgstr "Odblokuj klucz"
 
-#: pkg/storaged/format-dialog.jsx:116
+#: pkg/storaged/format-dialog.jsx:120
 msgid "Unlock at boot"
 msgstr "Odblokowywanie podczas uruchamiania"
 
-#: pkg/storaged/format-dialog.jsx:117
+#: pkg/storaged/format-dialog.jsx:121
 msgid "Unlock read only"
 msgstr "Odblokowywanie tylko do odczytu"
 
@@ -7596,7 +7595,7 @@ msgstr "Odblokowywanie tylko do odczytu"
 msgid "Unlocking $target"
 msgstr "Odblokowywanie $target"
 
-#: pkg/storaged/crypto-keyslots.jsx:173
+#: pkg/storaged/crypto-keyslots.jsx:174
 msgid "Unlocking disk..."
 msgstr "Odblokowywanie dysku…"
 
@@ -7604,7 +7603,7 @@ msgstr "Odblokowywanie dysku…"
 msgid "Unmanaged Interfaces"
 msgstr "Niezarządzane interfejsy"
 
-#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:308
 msgid "Unmount"
 msgstr "Odmontuj"
 
@@ -7616,37 +7615,33 @@ msgstr "Odmontowywanie $target"
 msgid "Unnamed"
 msgstr "Bez nazwy"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Unplug"
 msgstr "Odłącz"
 
-#: pkg/storaged/content-views.jsx:159
+#: pkg/storaged/content-views.jsx:163
 msgid "Unrecognized Data"
 msgstr "Nierozpoznane dane"
 
-#: pkg/storaged/content-views.jsx:358
+#: pkg/storaged/content-views.jsx:363
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Nierozpoznane dane"
 
-#: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
+#: pkg/storaged/lvol-tabs.jsx:90 pkg/storaged/lvol-tabs.jsx:179
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Nie można tutaj zmniejszać nieznanych danych."
-
-#: node_modules/registry-image-widgets/views/image-listing.html:46
-msgid "Unresolved"
-msgstr "Nierozwiązane"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "Nieobsługiwany mechanizm ustawiania"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Unsupported volume"
 msgstr "Nieobsługiwany wolumin"
 
-#: src/base1/cockpit.js:4019 src/base1/cockpit.js:4021
+#: src/base1/cockpit.js:4023 src/base1/cockpit.js:4025
 msgid "Untrusted host"
 msgstr "Niezaufany komputer"
 
@@ -7666,11 +7661,11 @@ msgstr "Do $0 $1 dostępnej na gospodarzu"
 msgid "Update"
 msgstr "Zaktualizuj"
 
-#: pkg/packagekit/history.jsx:126
+#: pkg/packagekit/history.jsx:125
 msgid "Update History"
 msgstr "Historia aktualizacji"
 
-#: pkg/packagekit/updates.jsx:471
+#: pkg/packagekit/updates.jsx:473
 msgid "Update Log"
 msgstr "Dziennik aktualizacji"
 
@@ -7678,11 +7673,11 @@ msgstr "Dziennik aktualizacji"
 msgid "Updated"
 msgstr "Zaktualizowano"
 
-#: pkg/packagekit/updates.jsx:494
+#: pkg/packagekit/updates.jsx:496
 msgid "Updated packages may require a restart to take effect."
 msgstr "Zaktualizowane pakiety mogą wymagać ponownego uruchomienia."
 
-#: pkg/systemd/host.js:512
+#: pkg/systemd/host.js:515
 msgid "Updates Available"
 msgstr "Dostępne są aktualizacje"
 
@@ -7690,26 +7685,26 @@ msgstr "Dostępne są aktualizacje"
 msgid "Updating"
 msgstr "Aktualizowanie"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:408
 msgid "Updating status..."
 msgstr "Aktualizowanie stanu…"
 
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
+#: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Użycie"
 
-#: pkg/systemd/host.js:1630
+#: pkg/systemd/host.js:1673
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Użycie $0 rdzenia procesora"
 msgstr[1] "Użycie $0 rdzeni procesora"
 msgstr[2] "Użycie $0 rdzeni procesora"
 
-#: pkg/storaged/vdos-panel.jsx:87
+#: pkg/storaged/vdos-panel.jsx:95
 msgid "Use 512 Byte emulation"
 msgstr "Użycie emulacji 512 bajtów"
 
-#: pkg/machines/components/diskAdd.jsx:561
+#: pkg/machines/components/diskAdd.jsx:432
 msgid "Use Existing"
 msgstr "Użyj istniejącej"
 
@@ -7717,15 +7712,15 @@ msgstr "Użyj istniejącej"
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Użycie poniższych kluczy do uwierzytelniania w innych systemach"
 
-#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
+#: pkg/systemd/index.html:267 pkg/docker/storage.jsx:344
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
+#: pkg/machines/components/vmDisksTab.jsx:106 pkg/storaged/fsys-tab.jsx:196
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1738
 msgid "Used"
 msgstr "Używane"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
 msgid "Used by"
 msgstr "Używane przez"
 
@@ -7734,8 +7729,8 @@ msgid "Used by Containers"
 msgstr "Używane przez kontenery"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1601
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:241
+#: pkg/systemd/host.js:1644
 msgid "User"
 msgstr "Użytkownik"
 
@@ -7757,7 +7752,7 @@ msgstr "Nazwa użytkownika"
 msgid "User name cannot be empty"
 msgstr "Nazwa użytkownika nie może być pusta"
 
-#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
@@ -7769,11 +7764,11 @@ msgstr "Używanie dostępnych danych uwierzytelniania"
 msgid "VCPU settings could not be saved"
 msgstr "Nie można zapisać ustawień wirtualnego procesora"
 
-#: pkg/storaged/content-views.jsx:155
+#: pkg/storaged/content-views.jsx:159
 msgid "VDO Backing"
 msgstr "Podstawa VDO"
 
-#: pkg/storaged/content-views.jsx:356
+#: pkg/storaged/content-views.jsx:361
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "Podstawa VDO"
@@ -7782,24 +7777,24 @@ msgstr "Podstawa VDO"
 msgid "VDO Device"
 msgstr "Urządzenie VDO"
 
-#: pkg/storaged/utils.js:252 pkg/storaged/vdo-details.jsx:255
+#: pkg/storaged/utils.js:253 pkg/storaged/vdo-details.jsx:261
 msgid "VDO Device $0"
 msgstr "Urządzenie VDO $0"
 
-#: pkg/storaged/vdos-panel.jsx:166
+#: pkg/storaged/vdos-panel.jsx:176
 msgid "VDO Devices"
 msgstr "Urządzenia VDO"
 
-#: pkg/storaged/lvol-tabs.jsx:84 pkg/storaged/lvol-tabs.jsx:171
+#: pkg/storaged/lvol-tabs.jsx:85 pkg/storaged/lvol-tabs.jsx:172
 msgid "VDO backing devices can not be made smaller"
 msgstr "Urządzenia mechanizmu VDO nie mogą być zmniejszane"
 
-#: pkg/storaged/vdos-panel.jsx:172
+#: pkg/storaged/vdos-panel.jsx:182
 msgid "VDO support not installed"
 msgstr "Obsługa VDO nie jest zainstalowana"
 
-#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
-#: pkg/networkmanager/interfaces.js:2918
+#: pkg/networkmanager/interfaces.js:2533 pkg/networkmanager/interfaces.js:2545
+#: pkg/networkmanager/interfaces.js:2926
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7828,7 +7823,7 @@ msgstr "Wymuszenie wyłączenia maszyny wirtualnej $0 się nie powiodło"
 msgid "VM $0 failed to get deleted"
 msgstr "Usunięcie maszyny wirtualnej $0 się nie powiodło"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
 msgid "VM $0 failed to get installed"
 msgstr "Zainstalowanie maszyny wirtualnej $0 się nie powiodło"
 
@@ -7881,7 +7876,7 @@ msgid "Validating key"
 msgstr "Sprawdzanie poprawności klucza"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:254
 msgid "Vendor"
 msgstr "Producent"
 
@@ -7889,7 +7884,7 @@ msgstr "Producent"
 msgid "Verified"
 msgstr "Sprawdzono poprawność"
 
-#: pkg/storaged/crypto-keyslots.jsx:316
+#: pkg/storaged/crypto-keyslots.jsx:324
 msgid "Verify key"
 msgstr "Sprawdź poprawność klucza"
 
@@ -7897,8 +7892,8 @@ msgstr "Sprawdź poprawność klucza"
 msgid "Verifying"
 msgstr "Sprawdzanie poprawności"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
+#: pkg/packagekit/updates.jsx:382 pkg/systemd/hwinfo.jsx:87
 msgid "Version"
 msgstr "Wersja"
 
@@ -7910,8 +7905,8 @@ msgstr "Bardzo bezpieczne usuwanie zawartości $target"
 msgid "View automation script"
 msgstr "Wyświetl skrypt automatyzacji"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/storagePools/storagePoolList.jsx:46
 #: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Maszyny wirtualne"
@@ -7920,7 +7915,7 @@ msgstr "Maszyny wirtualne"
 msgid "Virtual Network"
 msgstr "Sieć wirtualna"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+#: pkg/machines/components/networks/createNetworkDialog.jsx:412
 msgid "Virtual Network failed to be created"
 msgstr "Utworzenie sieci wirtualnej się nie powiodło"
 
@@ -7934,10 +7929,10 @@ msgstr "Usługa wirtualizacji jest dostępna"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/diskAdd.jsx:90
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Wolumin"
 
@@ -7945,7 +7940,7 @@ msgstr "Wolumin"
 msgid "Volume Group"
 msgstr "Grupa woluminów"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/utils.js:248 pkg/storaged/vgroup-details.jsx:229
 msgid "Volume Group $0"
 msgstr "Grupa woluminów $0"
 
@@ -7957,16 +7952,19 @@ msgstr "Nazwa grupy woluminów"
 msgid "Volume Group name should not be empty"
 msgstr "Nazwa grupy woluminów nie może być pusta"
 
-#: pkg/storaged/vgroups-panel.jsx:113
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr "Grupy woluminów"
 
-#: pkg/storaged/lvol-tabs.jsx:410
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:65
+msgid "Volume failed to be created"
+msgstr "Utworzenie woluminu się nie powiodło"
+
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Volume size is $0. Content size is $1."
 msgstr "Rozmiar woluminu to $0. Rozmiar zawartości to $1."
 
 #: pkg/docker/index.html:517
-#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Woluminy"
 
@@ -7978,7 +7976,7 @@ msgstr "Woluminy:"
 msgid "WWPN"
 msgstr "WWPN"
 
-#: pkg/networkmanager/interfaces.js:845
+#: pkg/networkmanager/interfaces.js:850
 msgid "Waiting"
 msgstr "Oczekiwanie"
 
@@ -7991,17 +7989,17 @@ msgstr "Oczekiwanie na informacje…"
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr "Oczekiwanie, aż inne programy skończą korzystać z menedżera pakietów…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:140
-#: pkg/lib/cockpit-components-install-dialog.jsx:175
+#: pkg/lib/cockpit-components-install-dialog.jsx:141
+#: pkg/lib/cockpit-components-install-dialog.jsx:176
 msgid "Waiting for other software management operations to finish"
 msgstr ""
 "Oczekiwanie na ukończenie pozostałych działań zarządzania oprogramowaniem"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:424
 msgid "Wanted By"
 msgstr "Chciane przez"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:419
 msgid "Wants"
 msgstr "Chce"
 
@@ -8025,7 +8023,7 @@ msgstr "środy"
 msgid "Weeks"
 msgstr "Tygodnie"
 
-#: pkg/storaged/crypto-keyslots.jsx:324
+#: pkg/storaged/crypto-keyslots.jsx:332
 msgid "What if tang-show-keys is not available?"
 msgstr "Co, jeśli tang-show-keys jest niedostępne?"
 
@@ -8037,11 +8035,11 @@ msgstr "Biały"
 msgid "With terminal"
 msgstr "Z terminalem"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/mdraid-details.jsx:96
 msgid "Write-mostly"
 msgstr "Głównie zapisywane"
 
-#: pkg/storaged/plot.jsx:313
+#: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Zapisywanie"
 
@@ -8049,11 +8047,11 @@ msgstr "Zapisywanie"
 msgid "Wrong user name or password"
 msgstr "Błędna nazwa użytkownika lub hasło"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1997
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2605
+#: pkg/networkmanager/interfaces.js:2613
 msgid "Yes"
 msgstr "Tak"
 
@@ -8065,13 +8063,13 @@ msgstr ""
 "Połączono z {{#strong}}{{host}}{{/strong}}, jednakże do synchronizacji "
 "użytkowników wymagane są uprawnienia superużytkownika."
 
-#: pkg/dashboard/list.js:440
+#: pkg/dashboard/list.js:448
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr "Obecnie połączono bezpośrednio z tym serwerem. Nie można go usunąć."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
-#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
+#: pkg/networkmanager/firewall.jsx:905 pkg/networkmanager/firewall.jsx:911
 msgid "You are not authorized to modify the firewall."
 msgstr "Brak upoważnienia do modyfikacji zapory sieciowej."
 
@@ -8083,7 +8081,7 @@ msgstr ""
 "Brak uprawnienia do wyświetlania upoważnionych publicznych kluczy dla tego "
 "konta."
 
-#: pkg/docker/storage.jsx:504
+#: pkg/docker/storage.jsx:520
 msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 "Brak uprawnień do zrządzania pulą urządzeń do przechowywania danych Docker."
@@ -8096,7 +8094,7 @@ msgstr "Należy poczekać dłużej na zmianę hasła"
 msgid "You need to select the most closely matching Operating System"
 msgstr "Należy wybrać najlepiej pasujący system operacyjny"
 
-#: pkg/packagekit/updates.jsx:836
+#: pkg/packagekit/updates.jsx:837
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -8104,7 +8102,7 @@ msgstr ""
 "Przeglądarka się rozłączy, ale nie wpłynie to na proces aktualizacji. Można "
 "połączyć się ponownie za kilka chwil, aby kontynuować obserwację procesu."
 
-#: pkg/packagekit/updates.jsx:867
+#: pkg/packagekit/updates.jsx:868
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -8112,31 +8110,31 @@ msgstr ""
 "Serwer niedługo zamknie połączenie. Można połączyć jeszcze raz po jego "
 "ponownym uruchomieniu."
 
-#: src/base1/cockpit.js:4009
+#: src/base1/cockpit.js:4013
 msgid "Your session has been terminated."
 msgstr "Sesja została zakończona."
 
-#: src/base1/cockpit.js:4011
+#: src/base1/cockpit.js:4015
 msgid "Your session has expired. Please log in again."
 msgstr "Sesja wygasła. Proszę zalogować się ponownie."
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "Zone"
 msgstr "Strefa"
 
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "Zones"
 msgstr "Strefy"
 
-#: pkg/lib/journal.js:215
+#: pkg/lib/journal.js:217
 msgid "[$0 bytes of binary data]"
 msgstr "[$0 B danych binarnych]"
 
-#: pkg/lib/journal.js:217
+#: pkg/lib/journal.js:219
 msgid "[binary data]"
 msgstr "[dane binarne]"
 
-#: pkg/lib/journal.js:211
+#: pkg/lib/journal.js:213
 msgid "[no data]"
 msgstr "[brak danych]"
 
@@ -8162,7 +8160,7 @@ msgstr "w"
 msgid "bridge"
 msgstr "mostek"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "bug fix"
 msgstr "poprawka błędu"
 
@@ -8219,7 +8217,7 @@ msgstr "np. „$0”"
 msgid "enabled"
 msgstr "włączone"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "enhancement"
 msgstr "ulepszenie"
 
@@ -8231,7 +8229,7 @@ msgstr "Ethernet"
 msgid "every day"
 msgstr "codziennie"
 
-#: pkg/systemd/host.js:903
+#: pkg/systemd/host.js:940
 msgid "failed to list ssh host keys: $0"
 msgstr "wyświetlenie listy kluczy SSH komputera się nie powiodło: $0"
 
@@ -8255,7 +8253,7 @@ msgstr "Inicjator IQN iSCSI"
 msgid "iSCSI Target"
 msgstr "Cel iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:261
+#: pkg/storaged/iscsi-panel.jsx:268
 msgid "iSCSI Targets"
 msgstr "Cele iSCSI"
 
@@ -8276,11 +8274,11 @@ msgstr "bezczynne"
 msgid "inactive"
 msgstr "nieaktywne"
 
-#: pkg/kdump/kdump-view.jsx:376
+#: pkg/kdump/kdump-view.jsx:378
 msgid "invalid: multiple targets defined"
 msgstr "nieprawidłowe: podano wiele celów"
 
-#: pkg/kdump/kdump-view.jsx:493
+#: pkg/kdump/kdump-view.jsx:495
 msgid "kdump status"
 msgstr "stan kdump"
 
@@ -8288,11 +8286,11 @@ msgstr "stan kdump"
 msgid "key"
 msgstr "klucz"
 
-#: pkg/storaged/crypto-keyslots.jsx:350
+#: pkg/storaged/crypto-keyslots.jsx:358
 msgid "key slot $0"
 msgstr "gniazdo na klucz $0"
 
-#: pkg/kdump/kdump-view.jsx:380 pkg/kdump/kdump-view.jsx:382
+#: pkg/kdump/kdump-view.jsx:382 pkg/kdump/kdump-view.jsx:384
 msgid "locally in $0"
 msgstr "lokalnie w $0"
 
@@ -8311,17 +8309,16 @@ msgstr "cel zrzutu NFS nie jest sformatowany jako serwer:ścieżka"
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "nie"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "brak"
 
-#: pkg/systemd/host.js:712
+#: pkg/systemd/host.js:738
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "$0 rdzenia procesora"
@@ -8348,7 +8345,7 @@ msgstr "działanie"
 msgid "search by name, namespace or description"
 msgstr "wyszukiwanie według nazwy, przestrzeni nazw lub opisu"
 
-#: pkg/packagekit/updates.jsx:261
+#: pkg/packagekit/updates.jsx:262
 msgid "security"
 msgstr "bezpieczeństwo"
 
@@ -8420,8 +8417,7 @@ msgstr "UDP"
 msgid "undefined"
 msgstr "nieokreślone"
 
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
+#: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "nieznane"
 
@@ -8429,7 +8425,7 @@ msgstr "nieznane"
 msgid "unknown target"
 msgstr "nieznany cel"
 
-#: pkg/storaged/utils.js:427
+#: pkg/storaged/utils.js:431
 msgid "unpartitioned space on $0"
 msgstr "nieprzydzielone miejsce na $0"
 
@@ -8472,14 +8468,6 @@ msgstr ""
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "tak"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:6
-msgid ""
-"{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
-"count: {{ condition.generation }}"
-msgstr ""
-"{{ condition.message }}. Czas: {{ condition.lastTransitionTime }} Liczba "
-"błędów: {{ condition.generation }}"

--- a/po/ru.po
+++ b/po/ru.po
@@ -6,79 +6,81 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 08:58+0200\n"
-"PO-Revision-Date: 2019-06-25 08:32+0000\n"
-"Last-Translator: Dmitry Astankov <mornie@basealt.ru>\n"
-"Language-Team: Russian\n"
-"Language: ru\n"
+"POT-Creation-Date: 2019-09-23 08:08+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2019-09-23 07:42+0000\n"
+"Last-Translator: Dmitry Astankov <mornie@basealt.ru>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: pkg/docker/storage.jsx:259
-#, fuzzy
+#: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
 msgstr " (в общем доступе с ОС)"
+
+#: pkg/networkmanager/interfaces.js:2353
+msgid "$0 Active Rule"
+msgid_plural "$0 Active Rules"
+msgstr[0] "$0 активное правило"
+msgstr[1] "$0 активных правила"
+msgstr[2] "$0 активных правил"
 
 #: pkg/storaged/others-panel.jsx:57
 #, fuzzy
 msgid "$0 Block Device"
 msgstr "$0 Блочное устройство"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/mdraid-details.jsx:187
 msgid "$0 Chunk Size"
 msgstr "размер блока: $0"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "$0 Disks"
 msgstr "дисков: $0"
 
-#: pkg/storaged/content-views.jsx:334
+#: pkg/storaged/content-views.jsx:339
 #, fuzzy
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "$0 Файловая система"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:105
-#, fuzzy
 msgid "$0 Network"
-msgstr "$0 Сеть"
+msgstr "$0 сеть"
 
-#: pkg/packagekit/history.jsx:101
+#: pkg/packagekit/history.jsx:100
 msgid "$0 Package"
 msgid_plural "$0 Packages"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "$0 пакет"
+msgstr[1] "$0 пакета"
+msgstr[2] "$0 пакетов"
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:478 pkg/systemd/service-details.jsx:58
 #, fuzzy
 msgid "$0 Template"
 msgstr "$0 Шаблон"
 
-#: src/base1/test-locale.js:80 src/base1/test-locale.js:81
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
-#, fuzzy
+#: src/base1/test-locale.js:83 src/base1/test-locale.js:84
+#: src/base1/test-locale.js:85 src/base1/test-locale.js:86
 msgid "$0 bit"
 msgid_plural "$0 bits"
 msgstr[0] "$0 бит"
 msgstr[1] "$0 бита"
 msgstr[2] "$0 битов"
 
-#: src/base1/test-locale.js:71 src/base1/test-locale.js:72
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
-#, fuzzy
+#: src/base1/test-locale.js:74 src/base1/test-locale.js:75
+#: src/base1/test-locale.js:87 src/base1/test-locale.js:88
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 байт"
 msgstr[1] "$0 байта"
 msgstr[2] "$0 байтов"
 
-#: src/base1/test-locale.js:73 src/base1/test-locale.js:74
-#, fuzzy
+#: src/base1/test-locale.js:76 src/base1/test-locale.js:77
 msgctxt "memory"
 msgid "$0 byte"
 msgid_plural "$0 bytes"
@@ -86,85 +88,111 @@ msgstr[0] "$0 байт"
 msgstr[1] "$0 байта"
 msgstr[2] "$0 байтов"
 
-#: pkg/storaged/vdo-details.jsx:280
+#: pkg/storaged/vdo-details.jsx:286
 #, fuzzy
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 данных + $1 служебной информации использовано из $2 ($3)"
 
-#: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
-#, fuzzy
+#: pkg/lib/plot.js:971
+msgid "$0 day"
+msgid_plural "$0 days"
+msgstr[0] "$0 день"
+msgstr[1] "$0 дня"
+msgstr[2] "$0 дней"
+
+#: src/base1/test-locale.js:65 src/base1/test-locale.js:66
+#: src/base1/test-locale.js:67 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:207
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 диск отсутствует"
-msgstr[1] "$0 диска отсутствует"
-msgstr[2] "$0 дисков отсутствует"
+msgstr[1] "$0 диска отсутствуют"
+msgstr[2] "$0 дисков отсутствуют"
 
-#: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: src/base1/test-locale.js:68 src/base1/test-locale.js:70
+#: src/base1/test-locale.js:72 pkg/playground/translate.js:32
 #: pkg/playground/translate.js:35
-#, fuzzy
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 диск отсутствует"
-msgstr[1] "$0 диска отсутствует"
-msgstr[2] "$0 дисков отсутствует"
+msgstr[1] "$0 диска отсутствуют"
+msgstr[2] "$0 дисков отсутствуют"
 
 #: src/ws/login.js:326 src/ws/login.js:667
-#, fuzzy
 msgid "$0 error"
-msgstr "$0 ошибка"
+msgstr "Ошибка $0"
 
 #: src/base1/cockpit.js:2757
-#, fuzzy
 msgid "$0 exited with code $1"
-msgstr "Работа $0 завершена с кодом $1"
+msgstr "Процесс $0 завершил работу с кодом $1"
 
 #: src/base1/cockpit.js:2759
-#, fuzzy
 msgid "$0 failed"
-msgstr "$0 не удалось"
+msgstr "Сбой процесса $0"
 
-#: pkg/storaged/lvol-tabs.jsx:159
+#: pkg/storaged/lvol-tabs.jsx:160
 msgid "$0 filesystems can not be made larger."
-msgstr "$0 файловые системы не могут быть увеличены."
+msgstr "Файловые системы $0 не могут быть увеличены."
 
-#: pkg/storaged/lvol-tabs.jsx:156
+#: pkg/storaged/lvol-tabs.jsx:157
 msgid "$0 filesystems can not be made smaller."
-msgstr "$0 файловые системы не могут быть уменьшены."
+msgstr "Файловые системы $0 не могут быть уменьшены."
 
-#: pkg/storaged/lvol-tabs.jsx:152
+#: pkg/storaged/lvol-tabs.jsx:153
 msgid "$0 filesystems can not be resized here."
-msgstr "$0 файловые системы здесь не могут быть изменены."
+msgstr "Размер файловых систем $0 невозможно изменить здесь."
+
+#: pkg/lib/plot.js:974
+msgid "$0 hour"
+msgid_plural "$0 hours"
+msgstr[0] "$0 час"
+msgstr[1] "$0 часа"
+msgstr[2] "$0 часов"
 
 #: pkg/machines/components/desktopConsole.jsx:44
 msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
 msgstr ""
-"$0 доступен для большинства операционных систем. Чтобы установить его, "
-"выполните поиск в программном обеспечении GNOME или выполните следующие "
-"действия:"
+"Средство $0 доступно для большинства операционных систем. Чтобы установить "
+"его, выполните поиск среди программного обеспечения GNOME или запустите "
+"следующую команду:"
 
-#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:511
+#: pkg/storaged/format-dialog.jsx:265 pkg/storaged/lvol-tabs.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:264 pkg/storaged/mdraid-details.jsx:232
+#: pkg/storaged/mdraid-details.jsx:284 pkg/storaged/vdo-details.jsx:147
+#: pkg/storaged/vdo-details.jsx:178 pkg/storaged/vgroup-details.jsx:199
+#, fuzzy
 msgid "$0 is in active use"
 msgstr "$0 активно используется"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:150
+#: pkg/lib/cockpit-components-install-dialog.jsx:151
+#, fuzzy
 msgid "$0 is not available from any repository."
 msgstr "$0 недоступен из какого-либо репозитория."
 
 #: src/base1/cockpit.js:2755
 msgid "$0 killed with signal $1"
-msgstr "$0 убит сигналом $1"
+msgstr "Процесс $0 прерван с сигналом $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:429
+#: pkg/lib/plot.js:977
+msgid "$0 minute"
+msgid_plural "$0 minutes"
+msgstr[0] "$0 минута"
+msgstr[1] "$0 минуты"
+msgstr[2] "$0 минут"
+
+#: pkg/lib/plot.js:965
+msgid "$0 month"
+msgid_plural "$0 months"
+msgstr[0] "$0 месяц"
+msgstr[1] "$0 месяца"
+msgstr[2] "$0 месяцев"
+
+#: pkg/selinux/setroubleshoot-view.jsx:439
+#, fuzzy
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$0 вхождение"
@@ -175,30 +203,57 @@ msgstr[2] "$1 вхождений"
 msgid "$0 of $1"
 msgstr "$0 из $1"
 
+#: pkg/systemd/init.js:418
+msgid "$0 service has failed"
+msgid_plural "$0 services have failed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: pkg/docker/util.js:125
+#, fuzzy
 msgid "$0 shares"
 msgstr "$0 акции"
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
+#, fuzzy
 msgid "$0 slots remain"
 msgstr "$0 слоты остаются"
 
 #: pkg/packagekit/updates.jsx:159
+#, fuzzy
 msgid "$0 update"
 msgid_plural "$0 updates"
 msgstr[0] "$0 Обновить"
 msgstr[1] "$0 обновления"
 msgstr[2] "$0 обновления"
 
-#: pkg/storaged/vdo-details.jsx:292
+#: pkg/storaged/vdo-details.jsx:298
+#, fuzzy
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 используется $1 ($2 Сохраненный)"
 
+#: pkg/lib/plot.js:968
+msgid "$0 week"
+msgid_plural "$0 weeks"
+msgstr[0] "$0 неделя"
+msgstr[1] "$0 недели"
+msgstr[2] "$0 недель"
+
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
+#, fuzzy
 msgid "$0 will be installed."
 msgstr "$0 будет установлен."
 
-#: pkg/storaged/vgroup-details.jsx:117
+#: pkg/lib/plot.js:962
+msgid "$0 year"
+msgid_plural "$0 years"
+msgstr[0] "$0 год"
+msgstr[1] "$0 года"
+msgstr[2] "$0 лет"
+
+#: pkg/storaged/vgroup-details.jsx:111
+#, fuzzy
 msgid "$0, $1 free"
 msgstr "$0, $1 свободно"
 
@@ -207,9 +262,9 @@ msgid "$1 security fix"
 msgid_plural "$1 security fixes"
 msgstr[0] "$1 исправление безопасности"
 msgstr[1] "$1 исправления безопасности"
-msgstr[2] "$1 исправления безопасности"
+msgstr[2] "$1 исправлений безопасности"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2777
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -225,16 +280,16 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:576
 msgid "(Optional)"
 msgstr "(необязательно)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
-#: pkg/storaged/fsys-tab.jsx:160
+#: pkg/networkmanager/firewall.jsx:501 pkg/networkmanager/firewall.jsx:650
+#: pkg/storaged/fsys-tab.jsx:163
 msgid "(default)"
 msgstr "(по умолчанию)"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:138
 msgid "(none)"
 msgstr "(нет)"
 
@@ -245,245 +300,252 @@ msgstr[0] ", в том числе $1 исправление безопаснос
 msgstr[1] ", в том числе $1 исправления безопасности"
 msgstr[2] ", в том числе $1 исправлений безопасности"
 
-#: pkg/storaged/nfs-details.jsx:325
+#: pkg/storaged/nfs-details.jsx:333
 msgid "--"
 msgstr "--"
 
-#: pkg/storaged/mdraids-panel.jsx:70
+#: pkg/storaged/mdraids-panel.jsx:86
 msgid "1 MiB"
 msgstr "1 МиБ"
 
-#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
+#: pkg/systemd/index.html:455 pkg/systemd/index.html:459
 msgid "1 Minute"
 msgstr "1 минута"
 
+#: pkg/docker/containers-view.jsx:614
+msgid "1 Vulnerability"
+msgid_plural "$0 Vulnerabilities"
+msgstr[0] "$0 уязвимость"
+msgstr[1] "$0 уязвимости"
+msgstr[2] "$0 уязвимостей"
+
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:194
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 день"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:190
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 час"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1729
 msgid "1 min"
 msgstr "1 мин"
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:196
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 неделя"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10-го числа"
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:68
+#: pkg/storaged/mdraids-panel.jsx:84
 msgid "128 KiB"
 msgstr "128 КиБ"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12-го числа"
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13-го числа"
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14-го числа"
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/mdraids-panel.jsx:81
 msgid "16 KiB"
 msgstr "16 КиБ"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16-го числа"
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17-го числа"
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18-го числа"
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19-го числа"
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:71
+#: pkg/storaged/mdraids-panel.jsx:87
 msgid "2 MiB"
 msgstr "2 МиБ"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1728
 msgid "2 min"
 msgstr "2 мин"
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:461
 msgid "20 Minutes"
 msgstr "20 минут"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20-го числа"
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21-го числа"
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22-го числа"
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23-го числа"
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24-го числа"
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25-го числа"
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26-го числа"
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27-го числа"
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28-го числа"
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29-го числа"
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2-го числа"
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1727
 msgid "3 min"
 msgstr "3 мин"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30-го числа"
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:66
+#: pkg/storaged/mdraids-panel.jsx:82
 msgid "32 KiB"
 msgstr "32 КиБ"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:79
 msgid "4 KiB"
 msgstr "4 КиБ"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1726
 msgid "4 min"
 msgstr "4 мин"
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:462
 msgid "40 Minutes"
 msgstr "40 минут"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4-го числа"
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:460
 msgid "5 Minutes"
 msgstr "5 минут"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1725
 msgid "5 min"
 msgstr "5 мин"
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:188
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 минут"
 
-#: pkg/storaged/mdraids-panel.jsx:69
+#: pkg/storaged/mdraids-panel.jsx:85
 msgid "512 KiB"
 msgstr "512 КиБ"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5-го числа"
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:192
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 часов"
 
-#: pkg/systemd/index.html:452
+#: pkg/systemd/index.html:463
 msgid "60 Minutes"
 msgstr "60 минут"
 
-#: pkg/storaged/mdraids-panel.jsx:67
+#: pkg/storaged/mdraids-panel.jsx:83
 msgid "64 KiB"
 msgstr "64 КиБ"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6-го числа"
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7-го числа"
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/mdraids-panel.jsx:80
 msgid "8 KiB"
 msgstr "8 КиБ"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1999
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2016
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8-го числа"
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9-го числа"
 
@@ -492,9 +554,10 @@ msgid ""
 "A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
 "strong}}."
 msgstr ""
-"Совместимая версия Cockpit не установлена ​​на {{#strong}}{{host}}{{/strong}}."
+"Совместимая версия Cockpit не установлена ​​на {{#strong}}{{host}}{{/"
+"strong}}."
 
-#: pkg/storaged/vdos-panel.jsx:59
+#: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "Требуется диск."
 
@@ -505,21 +568,23 @@ msgstr ""
 "Для обеспечения безопасности, надёжности и производительности необходим "
 "современный браузер."
 
-#: pkg/storaged/mdraid-details.jsx:119
+#: pkg/storaged/mdraid-details.jsx:113
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr ""
 "Перед тем, как этот диск можно будет удалить, необходимо добавить запасной "
 "диск."
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2806
+#, fuzzy
 msgid "ARP Monitoring"
 msgstr "Мониторинг ARP"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2028
+#, fuzzy
 msgid "ARP Ping"
 msgstr "Проверка связи ARP"
 
@@ -528,13 +593,13 @@ msgstr "Проверка связи ARP"
 msgid "About Cockpit"
 msgstr "О Cockpit"
 
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr "Отсутствует"
+
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
 msgstr "Доступ"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:12
-msgid "Access Policy"
-msgstr "Политика доступа"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -548,7 +613,8 @@ msgstr "Параметры учётной записи"
 msgid "Account not available or cannot be edited."
 msgstr "Учётная запись недоступна или не может быть изменена."
 
-#: pkg/users/index.html:71
+#: pkg/playground/translate.html:95 pkg/users/index.html:71
+#: pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Учётные записи"
 
@@ -557,9 +623,9 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Учётные записи"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/machines/components/networks/network.jsx:148
-#: pkg/storaged/content-views.jsx:256
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/storaged/content-views.jsx:261
 msgid "Activate"
 msgstr "Включить"
 
@@ -568,11 +634,11 @@ msgid "Activating $target"
 msgstr "Включение $target"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:852 pkg/networkmanager/interfaces.js:2022
 msgid "Active"
 msgstr "Активно"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1996 pkg/networkmanager/interfaces.js:2013
 msgid "Active Backup"
 msgstr "Активное резервирование"
 
@@ -580,56 +646,60 @@ msgstr "Активное резервирование"
 msgid "Active Pages"
 msgstr "Активные страницы"
 
-#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1044 pkg/storaged/dialog.jsx:1048
 msgid "Active since"
 msgstr "Активно с"
 
-#: pkg/networkmanager/firewall.jsx:924
+#: pkg/systemd/service-details.jsx:354
+msgid "Active since "
+msgstr "Активно с"
+
+#: pkg/networkmanager/firewall.jsx:956
 msgid "Active zones"
 msgstr "Активные зоны"
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/interfaces.js:2001
 msgid "Adaptive load balancing"
 msgstr "Адаптивная балансировка нагрузки"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Adaptive transmit load balancing"
 msgstr "Адаптивная балансировка нагрузки передачи"
 
-#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/vgroup-details.jsx:63
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
+#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
+#: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
+#: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:198
+#: pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Добавить"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3126
 msgid "Add $0"
 msgstr "Добавить $0"
 
-#: pkg/docker/storage.jsx:378
+#: pkg/docker/storage.jsx:383
 msgid "Add Additional Storage"
 msgstr "Добавление дополнительного хранилища"
 
 #: pkg/networkmanager/index.html:110
-#, fuzzy
 msgid "Add Bond"
-msgstr "Добавить связь"
+msgstr "Добавить объединение"
 
 #: pkg/networkmanager/index.html:112
 msgid "Add Bridge"
 msgstr "Добавить мост"
 
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Добавить диск"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:51
+#: pkg/storaged/mdraid-details.jsx:45 pkg/storaged/vgroup-details.jsx:52
 msgid "Add Disks"
 msgstr "Добавление дисков"
 
-#: pkg/storaged/crypto-keyslots.jsx:200
+#: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Add Key"
 msgstr "Добавление ключа"
 
@@ -637,16 +707,20 @@ msgstr "Добавление ключа"
 msgid "Add Machine to Dashboard"
 msgstr "Добавление компьютера на информационную панель"
 
-#: pkg/networkmanager/firewall.jsx:457
+#: pkg/machines/components/nicAdd.jsx:218
+msgid "Add Network Interface"
+msgstr "Добавить сетевой интерфейс"
+
+#: pkg/networkmanager/firewall.jsx:484
 msgid "Add Ports"
 msgstr "Добавить порты"
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:484 pkg/networkmanager/firewall.jsx:906
+#: pkg/networkmanager/firewall.jsx:918
 msgid "Add Services"
 msgstr "Добавить службы"
 
-#: pkg/docker/storage.jsx:217
+#: pkg/docker/storage.jsx:219
 msgid "Add Storage"
 msgstr "Добавить хранилище"
 
@@ -658,20 +732,20 @@ msgstr "Добавить сопряжение"
 msgid "Add VLAN"
 msgstr "Добавить VLAN"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:732 pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:923
 msgid "Add Zone"
 msgstr "Добавить зону"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/iscsi-panel.jsx:42
 msgid "Add iSCSI Portal"
-msgstr "Добавить iSCSI Portal"
+msgstr "Добавить портал iSCSI"
 
 #: pkg/shell/index.html:172 pkg/users/index.html:414
 msgid "Add key"
 msgstr "Добавить ключ"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add ports to the following zones:"
 msgstr "Добавить порты в следующие зоны:"
 
@@ -679,21 +753,29 @@ msgstr "Добавить порты в следующие зоны:"
 msgid "Add public key"
 msgstr "Добавить открытый ключ"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add services to following zones:"
 msgstr "Добавить службы в следующие зоны:"
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:808
 msgid "Add zone"
 msgstr "Добавить зону"
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3125
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
 msgstr ""
 "Добавление <b>$0</b> приведёт к разрыву соединения с сервером и "
 "недоступности интерфейса администратора."
+
+#: pkg/networkmanager/firewall.jsx:588
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
+msgstr ""
+"Добавление пользовательских портов приведёт к перезагрузке firewalld. При "
+"этом будет утеряна любая конфигурация среды выполнения."
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -703,15 +785,15 @@ msgstr "Добавление ключа"
 msgid "Adding physical volume to $target"
 msgstr "Добавление физического тома в $target"
 
-#: pkg/machines/components/vmDisksTab.jsx:78
+#: pkg/machines/components/vmDisksTab.jsx:116
 msgid "Additional"
 msgstr "Дополнительно"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2676
 msgid "Additional DNS $val"
 msgstr "Дополнительный DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2679
 msgid "Additional DNS Search Domains $val"
 msgstr "Дополнительные домены поиска DNS $val"
 
@@ -719,7 +801,11 @@ msgstr "Дополнительные домены поиска DNS $val"
 msgid "Additional Storage"
 msgstr "Дополнительное хранилище"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr "Дополнительные действия"
+
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional address $val"
 msgstr "Дополнительный адрес $val"
 
@@ -730,28 +816,35 @@ msgstr "Дополнительные пакеты:"
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:107
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Address"
 msgstr "Адрес"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Address $val"
 msgstr "Адрес $val"
 
-#: pkg/storaged/crypto-keyslots.jsx:192
+#: pkg/storaged/crypto-keyslots.jsx:193
 msgid "Address cannot be empty"
 msgstr "Адрес не может быть пустым"
 
-#: pkg/storaged/crypto-keyslots.jsx:194
+#: pkg/storaged/crypto-keyslots.jsx:195
 msgid "Address is not a valid URL"
 msgstr "Недопустимое значение URL-адреса"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr "Адрес должен находиться в диапазоне адресов подсети"
 
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Адрес:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3332
 msgid "Addresses"
 msgstr "Адреса"
 
@@ -767,7 +860,7 @@ msgstr "Пароль администратора"
 msgid "Advanced TCA"
 msgstr "Расширенный TCA"
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:430
 #, fuzzy
 msgid "After"
 msgstr "Через/After="
@@ -783,25 +876,24 @@ msgstr ""
 "службы, поскольку параметры разрешения DNS и список доверенных центров "
 "сертификации могут измениться."
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:964
 msgid "After system boot"
 msgstr "После загрузки системы"
 
 #: pkg/systemd/logs.html:57
-#, fuzzy
 msgid "Alert and above"
-msgstr "Оповещение и выше"
+msgstr "Оповещения и выше"
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Все"
 
 #: pkg/lib/machine-info.js:76
 msgid "All In One"
-msgstr "Всё в одном"
+msgstr "Моноблок"
 
-#: pkg/docker/storage.jsx:381
+#: pkg/docker/storage.jsx:386
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -809,11 +901,15 @@ msgstr ""
 "Все данные на выбранных дисках будут удалены, а диски будут добавлены в пул "
 "носителей."
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr "Разрешить выполнение (снять маску)"
+
+#: pkg/networkmanager/firewall.jsx:783
 msgid "Allowed Addresses"
 msgstr "Разрешённые адреса"
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:969
 msgid "Allowed Services"
 msgstr "Разрешённые службы"
 
@@ -821,20 +917,21 @@ msgstr "Разрешённые службы"
 msgid "Always"
 msgstr "Всегда"
 
-#: pkg/machines/components/diskAdd.jsx:116
+#: pkg/machines/components/diskAdd.jsx:117
+#: pkg/machines/components/nicAdd.jsx:86
 msgid "Always attach"
 msgstr "Всегда подключать"
 
-#: node_modules/registry-image-widgets/views/annotations.html:1
-msgid "Annotations"
-msgstr "Примечания"
+#: pkg/lib/cockpit-components-modifications.jsx:82
+msgid "Ansible Playbook"
+msgstr "Плейбук Ansible"
 
 #: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr "Стиль отображения:"
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Приложения"
 
@@ -842,10 +939,10 @@ msgstr "Приложения"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
-#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
-#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
-#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:354
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:108 pkg/storaged/fsys-tab.jsx:80
+#: pkg/storaged/fsys-tab.jsx:129 pkg/storaged/nfs-details.jsx:198
 msgid "Apply"
 msgstr "Применить"
 
@@ -857,11 +954,11 @@ msgstr "Применить все обновления"
 msgid "Apply security updates"
 msgstr "Применить обновления безопасности"
 
-#: pkg/selinux/setroubleshoot-view.jsx:112
+#: pkg/selinux/setroubleshoot-view.jsx:113
 msgid "Apply this solution"
 msgstr "Применить это решение"
 
-#: pkg/selinux/setroubleshoot-view.jsx:87
+#: pkg/selinux/setroubleshoot-view.jsx:88
 msgid "Applying solution..."
 msgstr "Применение решения..."
 
@@ -873,39 +970,34 @@ msgstr "Применение обновлений"
 msgid "Applying updates failed"
 msgstr "Не удалось применить обновления"
 
-#: node_modules/registry-image-widgets/views/image-config.html:16
-msgid "Architecture"
-msgstr "Архитектура"
-
 # ctx::sourcefile::/systems/Search
 #: pkg/systemd/index.html:92
-#, fuzzy
 msgid "Asset Tag"
-msgstr "Ярлык/Тег актива"
+msgstr "Инвентарный номер"
 
-#: pkg/storaged/mdraids-panel.jsx:79
+#: pkg/storaged/mdraids-panel.jsx:96
 msgid "At least $0 disks are needed."
 msgstr "Минимально необходимое количество дисков: $0."
 
-#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
-#: pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/mdraid-details.jsx:52 pkg/storaged/vgroup-details.jsx:59
+#: pkg/storaged/vgroups-panel.jsx:66
 msgid "At least one disk is needed."
 msgstr "Необходим хотя бы один диск."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "В определённое время"
 
-#: pkg/selinux/setroubleshoot-view.jsx:414
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Журнал аудита"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:844
 msgid "Authenticating"
 msgstr "Проверка подлинности"
 
-#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
+#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 msgid "Authentication"
 msgstr "Проверка подлинности"
 
@@ -929,13 +1021,11 @@ msgstr ""
 "Для выполнения привилегированных задач с помощью веб-консоли Cockpit "
 "необходима проверка подлинности"
 
-#: pkg/storaged/iscsi-panel.jsx:147
+#: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Необходима проверка подлинности"
 
-#: pkg/docker/index.html:702
-#: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:413
+#: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Автор"
 
@@ -943,22 +1033,23 @@ msgstr "Автор"
 msgid "Authorized Public SSH Keys"
 msgstr "Авторизованные открытые SSH-ключи"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:162
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:3340 pkg/networkmanager/interfaces.js:3344
+#: pkg/networkmanager/interfaces.js:3350 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1987
 msgid "Automatic (DHCP only)"
 msgstr "Автоматически (только DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Automatic (DHCP)"
 msgstr "Автоматически (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:307
 msgid "Automatic Startup"
 msgstr "Автоматический запуск"
 
@@ -970,16 +1061,24 @@ msgstr "Автоматическое обновление"
 msgid "Automatically start libvirt on boot"
 msgstr "Автоматически запускать libvirt при загрузке"
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/service-details.jsx:398
+msgid "Automatically starts"
+msgstr "Запускается автоматически"
+
+#: pkg/systemd/index.html:400
 msgid "Automatically using NTP"
-msgstr "Автоматическое использование NTP"
+msgstr "Автоматически с использованием серверов NTP"
 
-#: pkg/systemd/index.html:390
+#: pkg/systemd/index.html:401
 msgid "Automatically using specific NTP servers"
-msgstr "Автоматическое использование определённых NTP-серверов"
+msgstr "Автоматически с использованием определённых серверов NTP"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/lib/cockpit-components-modifications.jsx:71
+msgid "Automation Script"
+msgstr "Сценарий автоматизации"
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr "Автозапуск"
@@ -990,11 +1089,11 @@ msgstr "Автозапуск"
 msgid "Available"
 msgstr "Доступно"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:825
 msgid "Available Updates"
 msgstr "Доступные обновления"
 
-#: pkg/storaged/iscsi-panel.jsx:124
+#: pkg/storaged/iscsi-panel.jsx:125
 msgid "Available targets on $0"
 msgstr "Доступные цели на $0"
 
@@ -1002,15 +1101,15 @@ msgstr "Доступные цели на $0"
 msgid "Avatar"
 msgstr "Аватар"
 
-#: pkg/systemd/hwinfo.jsx:92
+#: pkg/systemd/hwinfo.jsx:96
 msgid "BIOS"
 msgstr "BIOS"
 
-#: pkg/systemd/hwinfo.jsx:100
+#: pkg/systemd/hwinfo.jsx:104
 msgid "BIOS date"
 msgstr "Дата BIOS"
 
-#: pkg/systemd/hwinfo.jsx:96
+#: pkg/systemd/hwinfo.jsx:100
 msgid "BIOS version"
 msgstr "Версия BIOS"
 
@@ -1018,7 +1117,7 @@ msgstr "Версия BIOS"
 msgid "Back to Accounts"
 msgstr "Вернуться к учётным записям"
 
-#: pkg/storaged/vdo-details.jsx:270
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Backing Device"
 msgstr "Резервное устройство"
 
@@ -1027,15 +1126,14 @@ msgid "Bad data passed for passwd1 mechanism"
 msgstr "Механизму passwd1 переданы неверные данные"
 
 #: pkg/networkmanager/index.html:333
-#, fuzzy
 msgid "Balancer"
 msgstr "Подсистема балансировки"
 
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:429
 msgid "Before"
 msgstr "Before="
 
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:420
 msgid "Binds To"
 msgstr "BindsTo="
 
@@ -1045,7 +1143,7 @@ msgstr "Чёрный"
 
 #: pkg/lib/machine-info.js:91
 msgid "Blade"
-msgstr "Блейд-сервер"
+msgstr "Ультракомпактный сервер"
 
 #: pkg/lib/machine-info.js:92
 msgid "Blade enclosure"
@@ -1055,16 +1153,16 @@ msgstr "Корзина"
 msgid "Block"
 msgstr "Блок"
 
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:666
 msgid "Block device for filesystems"
 msgstr "Устройство блочного ввода-вывода для файловых систем"
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/mdraid-details.jsx:97
 msgid "Blocked"
 msgstr "Заблокировано"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2529 pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2811
 msgid "Bond"
 msgstr "Объединение"
 
@@ -1081,13 +1179,13 @@ msgstr "Порядок загрузки"
 msgid "Boot order settings could not be saved"
 msgstr "Не удалось сохранить параметры порядка загрузки"
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:425
 msgid "Bound By"
 msgstr "BoundBy="
 
 # translation auto-copied from project Anaconda, version master, document anaconda, author Igor Gorbounov
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2535 pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2888
 msgid "Bridge"
 msgstr "Мост"
 
@@ -1099,34 +1197,30 @@ msgstr "Параметры порта моста"
 msgid "Bridge Settings"
 msgstr "Параметры моста"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2909
 msgid "Bridge port"
 msgstr "Порт моста"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1998 pkg/networkmanager/interfaces.js:2015
 msgid "Broadcast"
 msgstr "Трансляция"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2824 pkg/networkmanager/interfaces.js:2858
 msgid "Broken configuration"
 msgstr "Неверная конфигурация"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:511
 msgid "Bug Fix Updates Available"
 msgstr "Доступны исправления ошибок"
 
 # ctx::sourcefile::/rhn/errata/manage/Create.do
-#: pkg/packagekit/updates.jsx:314
+#: pkg/packagekit/updates.jsx:315
 msgid "Bugs:"
 msgstr "Ошибки:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:18
-msgid "Built"
-msgstr "Создано"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:109
 #: pkg/machines/components/vm/bootOrderModal.jsx:132
-#: pkg/machines/components/vmDisksTab.jsx:72
+#: pkg/machines/components/vmDisksTab.jsx:110
 msgid "Bus"
 msgstr "Шина"
 
@@ -1135,19 +1229,19 @@ msgid "Bus Expansion Chassis"
 msgstr "Корпус расширения шины"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:272
-#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:112
 msgid "CPU"
 msgstr "ЦП"
 
-#: pkg/systemd/hwinfo.jsx:113
+#: pkg/systemd/hwinfo.jsx:117
 msgid "CPU Security"
 msgstr "Безопасность процессора"
 
-#: pkg/systemd/hwinfo.jsx:205
+#: pkg/systemd/hwinfo.jsx:209
 msgid "CPU Security Toggles"
-msgstr ""
+msgstr "Переключатели безопасности ЦП"
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1603
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Состояние процессора"
@@ -1164,12 +1258,12 @@ msgstr "Приоритет ЦП"
 msgid "CPU usage:"
 msgstr "Использование ЦП:"
 
+#: pkg/machines/components/diskAdd.jsx:174
 #: pkg/machines/components/vmDiskColumns.jsx:75
-#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr "Кэш"
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1739
 msgid "Cached"
 msgstr "Кэшировано"
 
@@ -1177,54 +1271,58 @@ msgstr "Кэшировано"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Не удаётся подключиться к Docker"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:318
 msgid "Can't delete while unlocked"
 msgstr "Невозможно удалить в разблокированном состоянии"
 
-#: pkg/dashboard/list.js:212
+#: pkg/dashboard/list.js:220
 msgid "Can't load image"
 msgstr "Не удаётся загрузить образ"
 
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90
-#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
-#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
-#: pkg/users/index.html:356 pkg/users/index.html:413
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
+#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
+#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
+#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
+#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
+#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
+#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/nicAdd.jsx:232
+#: pkg/machines/components/nicEdit.jsx:181
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:93
+#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/vcpuModal.jsx:232
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
-#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
-#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
-#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
-#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
-#: pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:592 pkg/networkmanager/firewall.jsx:660
+#: pkg/networkmanager/firewall.jsx:803 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:394
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:220
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Отмена"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:472
 msgid "Cannot connect to an unknown machine"
 msgstr "Не удаётся подключиться к неизвестному компьютеру"
 
-#: src/base1/cockpit.js:4031
+#: src/base1/cockpit.js:4035
 msgid "Cannot forward login credentials"
 msgstr "Не удаётся передать учётные данные для входа"
 
@@ -1232,25 +1330,26 @@ msgstr "Не удаётся передать учётные данные для 
 msgid "Cannot schedule event in the past"
 msgstr "Невозможно запланировать событие в прошлом"
 
-#: pkg/machines/components/vmDisksTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:108
 msgid "Capacity"
 msgstr "Ёмкость"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2610
+#, fuzzy
 msgid "Carrier"
 msgstr "Несущая частота"
 
-#: pkg/docker/index.html:664 pkg/systemd/index.html:333
-#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:181
+#: pkg/docker/index.html:664 pkg/systemd/index.html:344
+#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Изменить"
 
-#: pkg/systemd/index.html:289
+#: pkg/systemd/index.html:300
 msgid "Change Host Name"
 msgstr "Изменить имя узла"
 
-#: pkg/shell/index.html:312
+#: pkg/shell/index.html:313
 msgid "Change Password"
 msgstr "Изменить пароль"
 
@@ -1258,19 +1357,19 @@ msgstr "Изменить пароль"
 msgid "Change Performance Profile"
 msgstr "Изменить профиль производительности"
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:199
 msgid "Change Profile"
 msgstr "Изменить профиль"
 
-#: pkg/systemd/index.html:358
+#: pkg/systemd/index.html:369
 msgid "Change System Time"
 msgstr "Изменить системное время"
 
-#: pkg/storaged/iscsi-panel.jsx:176
+#: pkg/storaged/iscsi-panel.jsx:183
 msgid "Change iSCSI Initiator Name"
 msgstr "Изменить имя инициатора iSCSI"
 
-#: pkg/storaged/crypto-keyslots.jsx:247
+#: pkg/storaged/crypto-keyslots.jsx:255
 msgid "Change passphrase"
 msgstr "Изменить парольную фразу"
 
@@ -1282,24 +1381,24 @@ msgstr "Изменить ограничения ресурсов"
 msgid "Change resources limits"
 msgstr "Изменение ограничений ресурсов"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3176
 msgid "Change the settings"
-msgstr "Изменение настроек"
+msgstr "Изменить параметры"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/nicEdit.jsx:157
 #: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Изменения вступят в силу после выключения виртуальной машины"
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3175
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr ""
-"Изменение настроек приведёт к разрыву соединения с сервером и недоступности "
-"интерфейса администратора."
+"Изменение параметров приведёт к разрыву соединения с сервером и "
+"недоступности интерфейса администратора."
 
 #: pkg/packagekit/updates.jsx:175
 msgid "Check for Updates"
@@ -1309,7 +1408,7 @@ msgstr "Проверить наличие обновлений"
 msgid "Checking $target"
 msgstr "Проверка $target"
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:848
 msgid "Checking IP"
 msgstr "Проверка IP-адреса"
 
@@ -1329,23 +1428,27 @@ msgstr "Проверка наличия новых приложений"
 msgid "Checking for public keys"
 msgstr "Проверка открытых ключей"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:540
 msgid "Checking for updates…"
 msgstr "Проверка наличия обновлений…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:142
+#: pkg/lib/cockpit-components-install-dialog.jsx:143
 msgid "Checking installed software"
 msgstr "Проверка установленного программного обеспечения"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr "Выберите операционную систему"
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Выберите язык, который будет использоваться в приложении"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/mdraids-panel.jsx:72
 msgid "Chunk Size"
 msgstr "Размер блока"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Class"
 msgstr "Класс"
 
@@ -1353,40 +1456,41 @@ msgstr "Класс"
 msgid "Cleaning up for $target"
 msgstr "Очистка данных $target"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr "Очистить «Сбой запуска»"
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr "Сбросить все фильтры"
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:776
 msgid "Click to see system hardware information"
 msgstr "Щёлкните для просмотра информации об оборудовании"
 
 #: pkg/machines/components/desktopConsole.jsx:41
-#, fuzzy
 msgid ""
 "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
-"После нажатия «Launch Remote Viewer» будет загружен файл .vv и выполнен "
-"запуск $0"
+"После нажатия кнопки «Запустить средство удалённого просмотра» будет "
+"загружен файл .vv и выполнен запуск $0."
 
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
 msgstr "Клиентское программное обеспечение"
 
-#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
-#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
-#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
-#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
-#: pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
-#: pkg/apps/utils.jsx:108
+#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
+#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
+#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:394
 msgid "Close"
 msgstr "Закрыть"
 
-#: pkg/shell/active-pages.js:103
+#: pkg/shell/active-pages.js:104
 msgid "Close Selected Pages"
 msgstr "Закрыть выделенные страницы"
 
@@ -1394,7 +1498,7 @@ msgstr "Закрыть выделенные страницы"
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Проверка подлинности Cockpit настроена неправильно."
 
-#: pkg/lib/machine-dialogs.js:427
+#: pkg/lib/machine-dialogs.js:429
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
@@ -1402,11 +1506,11 @@ msgstr ""
 "Не удалось установить связь между Cockpit и заданным узлом $0. Убедитесь, "
 "что на порте $1 работает SSH, или укажите другой порт в адресе."
 
-#: src/base1/cockpit.js:4037
+#: src/base1/cockpit.js:4041
 msgid "Cockpit could not contact the given host."
 msgstr "Не удалось установить связь между Cockpit и заданным узлом."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:759
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1428,14 +1532,14 @@ msgstr ""
 "Cockpit представляет собой диспетчер серверов, упрощающий администрирование "
 "серверов Linux через веб-браузер. Переключение между терминалом и веб-"
 "инструментом не представляет сложности. Служба, запущенная с помощью "
-"Cockpit, может быть остановлена ​​через терминал. Аналогично, если в терминале "
-"возникает ошибка, её можно увидеть в интерфейсе журнала Cockpit."
+"Cockpit, может быть остановлена ​​через терминал. Аналогично, если в "
+"терминале возникает ошибка, её можно увидеть в интерфейсе журнала Cockpit."
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit — это интерактивный интерфейс администратора серверов Linux."
 
-#: src/base1/cockpit.js:4035
+#: src/base1/cockpit.js:4039
 msgid "Cockpit is not compatible with the software on the system."
 msgstr "Cockpit не совместим с программным обеспечением в системе."
 
@@ -1443,7 +1547,7 @@ msgstr "Cockpit не совместим с программным обеспеч
 msgid "Cockpit is not installed"
 msgstr "Cockpit не установлен"
 
-#: src/base1/cockpit.js:4029
+#: src/base1/cockpit.js:4033
 msgid "Cockpit is not installed on the system."
 msgstr "Cockpit не установлен в системе."
 
@@ -1469,13 +1573,13 @@ msgstr ""
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
+"sync_link}}.{{/can_sync}} For more authentication options and "
+"troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
-"Cockpit. {{#can_sync}}Вы можете попытаться {{#sync_link}}синхронизировать "
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
+" {{#can_sync}}Вы можете попытаться {{#sync_link}}синхронизировать "
 "пользователей{{/sync_link}}.{{/can_sync}} Для получения дополнительных "
 "параметров проверки подлинности и устранения неполадок обновите cockpit-ws "
 "до новой версии."
@@ -1484,6 +1588,7 @@ msgstr ""
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
+""
 
 #: pkg/lib/machine-auth-failed.html:6
 msgid ""
@@ -1491,10 +1596,10 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
-"Cockpit. Для использования Cockpit на этом компьютере вам необходимо "
-"включить один из следующих методов проверки подлинности в конфигурации SSHD "
-"на {{#strong}}{{host}}{{/strong}}:"
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
+" Для использования Cockpit на этом компьютере вам необходимо включить один "
+"из следующих методов проверки подлинности в конфигурации SSHD на "
+"{{#strong}}{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
@@ -1502,8 +1607,8 @@ msgid ""
 "change your authentication credentials below. {{#can_sync}}You may prefer to "
 "{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью "
-"Cockpit. Вы можете изменить учётные данные для проверки подлинности ниже. "
+"Не удалось выполнить вход в {{#strong}}{{host}}{{/strong}} с помощью Cockpit."
+" Вы можете изменить учётные данные для проверки подлинности ниже. "
 "{{#can_sync}}Возможно, вы предпочтёте {{#sync_link}}синхронизировать учётные "
 "записи и пароли{{/sync_link}}.{{/can_sync}}"
 
@@ -1512,25 +1617,22 @@ msgid "Color"
 msgstr "Цвет"
 
 #: pkg/docker/index.html:102
-#, fuzzy
 msgid "Combined memory usage"
-msgstr "Использование комбинированной памяти"
+msgstr "Объединённое использование памяти"
 
-#: pkg/docker/overview.js:86
-#, fuzzy
+#: pkg/docker/overview.js:88
 msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
-msgstr[0] "Комбинированное использование $0 ядра процессора"
-msgstr[1] "Комбинированное использование $0 ядер процессора"
-msgstr[2] "Комбинированное использование $0 ядер процессора"
+msgstr[0] "Объединённое использование $0 ядра процессора"
+msgstr[1] "Объединённое использование $0 ядер процессора"
+msgstr[2] "Объединённое использование $0 ядер процессора"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:556
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Допустимы порты, диапазоны и псевдонимы с разделителями-запятыми"
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
-#: node_modules/registry-image-widgets/views/image-config.html:2
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
 msgid "Command"
@@ -1544,14 +1646,14 @@ msgstr "Команда не может быть пустой"
 msgid "Command:"
 msgstr "Команда:"
 
-#: pkg/shell/index.html:261
+#: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Комментарий"
 
 #: pkg/docker/index.html:140 pkg/docker/index.html:718
 #: pkg/docker/containers-view.jsx:328
 msgid "Commit"
-msgstr "Сохранить"
+msgstr "Подтвердить"
 
 #: pkg/docker/index.html:678
 msgid "Commit Image"
@@ -1563,13 +1665,13 @@ msgstr "Сбой связи с демоном tuned"
 
 #: pkg/lib/machine-info.js:89
 msgid "Compact PCI"
-msgstr "CompactPCI"
+msgstr "Компактный PCI"
 
-#: pkg/storaged/content-views.jsx:522
+#: pkg/storaged/content-views.jsx:532
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Совместимость со всеми системами и устройствами (MBR)"
 
-#: pkg/storaged/content-views.jsx:524
+#: pkg/storaged/content-views.jsx:535
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr ""
 "Совместимость с современными системами и жёсткими дисками объёмом более 2 ТБ "
@@ -1579,42 +1681,41 @@ msgstr ""
 msgid "Compress crash dumps to save space"
 msgstr "Сжимать аварийные дампы для экономии места"
 
-#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
-#: pkg/kdump/kdump-view.jsx:156
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:310
+#: pkg/storaged/vdos-panel.jsx:87
 msgid "Compression"
 msgstr "Сжатие"
 
 #: pkg/realmd/operation.html:44
-#, fuzzy
 msgid "Computer OU"
-msgstr "Компьютерное подразделение"
+msgstr "Подразделение"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:444
 msgid "Condition $0=$1 was not met"
 msgstr "Не выполнено условие $0=$1"
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:494
 msgid "Condition failed"
 msgstr "Условие не выполнено"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2745
 msgid "Configure"
 msgstr "Настроить"
 
-#: pkg/docker/storage.jsx:331
+#: pkg/docker/storage.jsx:335
 msgid "Configure storage..."
 msgstr "Настроить хранилище..."
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:842
 msgid "Configuring"
 msgstr "Настройка"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:846
 msgid "Configuring IP"
 msgstr "Настройка IP-адреса"
 
-#: pkg/shell/index.html:297 pkg/users/index.html:176
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/shell/index.html:298 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:315
 msgid "Confirm"
 msgstr "Подтверждение"
 
@@ -1624,17 +1725,17 @@ msgstr "Подтвердите новый пароль"
 
 #: pkg/machines/components/networks/networkDelete.jsx:95
 msgid "Confirm deletion of the Virtual Network"
-msgstr ""
+msgstr "Подтвердите удаление виртуальной сети"
 
-#: pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:372
 msgid "Confirm removal with passphrase"
 msgstr "Подтвердить удаление с помощью парольной фразы"
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
 msgstr "ConflictedBy="
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:427
 msgid "Conflicts"
 msgstr "Conflicts="
 
@@ -1642,7 +1743,7 @@ msgstr "Conflicts="
 msgid "Connect"
 msgstr "Подключиться"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2732
 msgid "Connect automatically"
 msgstr "Подключаться автоматически"
 
@@ -1666,14 +1767,14 @@ msgstr "Подключение"
 msgid ""
 "Connecting simultaneously to more than {{ limit }} machines is unsupported."
 msgstr ""
-"Одновременное подключение к количеству компьютеров, превышающему "
-"{{ limit }}, не поддерживается."
+"Одновременное подключение к количеству компьютеров, превышающему {{ limit "
+"}}, не поддерживается."
 
 #: pkg/docker/index.html:54
 msgid "Connecting to Docker"
 msgstr "Подключение к Docker"
 
-#: pkg/selinux/setroubleshoot-view.jsx:371
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "Подключение к демону SETroubleshoot..."
 
@@ -1681,24 +1782,27 @@ msgstr "Подключение к демону SETroubleshoot..."
 msgid "Connecting to Virtualization Service"
 msgstr "Подключение к службе виртуализации"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:467
 msgid "Connecting to the machine"
 msgstr "Подключение к компьютеру"
 
 # ctx::sourcefile::Navigation Menu
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Подключение"
 
-#: pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:414
 msgid "Connection Error"
 msgstr "Ошибка подключения"
 
-#: src/base1/cockpit.js:4027
+#: pkg/shell/index.html:396
+msgid "Connection failed"
+msgstr "Ошибка подключения"
+
+#: src/base1/cockpit.js:4031
 msgid "Connection has timed out."
 msgstr "Превышено время ожидания подключения."
 
@@ -1706,7 +1810,7 @@ msgstr "Превышено время ожидания подключения."
 msgid "Connection will be lost"
 msgstr "Подключение будет прервано"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:426
 msgid "Consists Of"
 msgstr "ConsistsOf="
 
@@ -1714,7 +1818,7 @@ msgstr "ConsistsOf="
 msgid "Console Type"
 msgstr "Тип консоли"
 
-#: pkg/machines/components/vm/vm.jsx:51
+#: pkg/machines/components/vm/vm.jsx:53
 msgid "Consoles"
 msgstr "Консоли"
 
@@ -1723,7 +1827,6 @@ msgid "Contacted domain"
 msgstr "Связь с доменом установлена"
 
 #: pkg/docker/console.html:4
-#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Контейнер"
 
@@ -1762,16 +1865,16 @@ msgid "Containers"
 msgstr "Контейнеры"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/storaged/content-views.jsx:557
+#: pkg/storaged/content-views.jsx:570
 msgid "Content"
 msgstr "Содержимое"
 
-#: src/base1/test-locale.js:42 src/base1/test-locale.js:53
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:56
 #: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Управление"
 
-#: src/base1/test-locale.js:43 src/base1/test-locale.js:55
+#: src/base1/test-locale.js:46 src/base1/test-locale.js:58
 #: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
@@ -1785,11 +1888,15 @@ msgstr "Компьютер-трансформер"
 msgid "Copy"
 msgstr "Копировать"
 
+#: pkg/lib/cockpit-components-modifications.jsx:106
+msgid "Copy to clipboard"
+msgstr "Копировать в буфер обмена"
+
 #: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
 msgstr "Количество ядер на сокет"
 
-#: pkg/docker/storage.jsx:428
+#: pkg/docker/storage.jsx:438
 msgid "Could not add all disks"
 msgstr "Не удалось добавить все диски"
 
@@ -1797,7 +1904,7 @@ msgstr "Не удалось добавить все диски"
 msgid "Could not contact {{host}}"
 msgstr "Не удалось связаться с {{host}}"
 
-#: pkg/docker/storage.jsx:468
+#: pkg/docker/storage.jsx:484
 msgid "Could not reset the storage pool"
 msgstr "Не удалось сбросить пул носителей"
 
@@ -1809,7 +1916,7 @@ msgstr "Не удалось изменить группы пользовател
 msgid "Couldn't change user password"
 msgstr "Не удалось изменить пароль пользователя"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:470
 msgid "Couldn't connect to the machine"
 msgstr "Не удалось подключиться к компьютеру"
 
@@ -1829,29 +1936,30 @@ msgstr "Не удалось получить список пользовател
 msgid "Couldn't load user data"
 msgstr "Не удалось загрузить данные пользователя"
 
-#: pkg/kdump/kdump-view.jsx:336 pkg/kdump/kdump-view.jsx:504
+#: pkg/kdump/kdump-view.jsx:337 pkg/kdump/kdump-view.jsx:506
 msgid "Crash dump location"
 msgstr "Расположение аварийного дампа"
 
-#: pkg/kdump/kdump-view.jsx:304
-#, fuzzy
+#: pkg/kdump/kdump-view.jsx:305
 msgid "Crash system"
-msgstr "Аварийная система"
+msgstr "Сбой системы"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
-#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
-#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:482
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:96
+#: pkg/storaged/content-views.jsx:127 pkg/storaged/content-views.jsx:709
+#: pkg/storaged/lvol-tabs.jsx:360 pkg/storaged/mdraids-panel.jsx:103
+#: pkg/storaged/vdos-panel.jsx:113 pkg/storaged/vgroups-panel.jsx:72
 msgid "Create"
 msgstr "Создать"
 
-#: pkg/storaged/content-views.jsx:639
+#: pkg/storaged/content-views.jsx:653
 msgid "Create Logical Volume"
 msgstr "Создание логического тома"
 
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:423
 msgid "Create New"
 msgstr "Создать новый"
 
@@ -1859,19 +1967,23 @@ msgstr "Создать новый"
 msgid "Create New Account"
 msgstr "Создать учётную запись"
 
-#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+msgid "Create New Volume"
+msgstr "Создать новый том"
+
+#: pkg/storaged/content-views.jsx:439 pkg/storaged/format-dialog.jsx:336
 msgid "Create Partition"
 msgstr "Создать раздел"
 
-#: pkg/storaged/content-views.jsx:552
+#: pkg/storaged/content-views.jsx:565
 msgid "Create Partition Table"
 msgstr "Создать таблицу разделов"
 
-#: pkg/storaged/format-dialog.jsx:184
+#: pkg/storaged/format-dialog.jsx:189
 msgid "Create Partition on $0"
 msgstr "Создание раздела на $0"
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/mdraids-panel.jsx:39
 msgid "Create RAID Device"
 msgstr "Создание RAID-устройства"
 
@@ -1879,35 +1991,45 @@ msgstr "Создание RAID-устройства"
 msgid "Create Report"
 msgstr "Создать отчёт"
 
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
+#: pkg/storaged/lvol-tabs.jsx:354 pkg/storaged/lvol-tabs.jsx:395
 msgid "Create Snapshot"
 msgstr "Создание моментального снимка"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Создать пул носителей"
 
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:138
 msgid "Create Thin Volume"
-msgstr "Создание тонкого тома"
+msgstr "Создать тонкий том"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Создать таймер"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Создание таймера"
 
-#: pkg/storaged/vdos-panel.jsx:46
+#: pkg/storaged/vdos-panel.jsx:47
 msgid "Create VDO Device"
 msgstr "Создание устройства VDO"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
-msgstr "Создать виртуальную машину"
+msgstr "Создать ВМ"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/machines/components/networks/createNetworkDialog.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:516
+msgid "Create Virtual Network"
+msgstr "Создать виртуальную сеть"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:135
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:148
+msgid "Create Volume"
+msgstr "Создать том"
+
+#: pkg/storaged/vgroups-panel.jsx:54
 msgid "Create Volume Group"
 msgstr "Создать группу томов"
 
@@ -1915,12 +2037,12 @@ msgstr "Создать группу томов"
 msgid "Create diagnostic report"
 msgstr "Создание диагностического отчёта"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3850 pkg/networkmanager/interfaces.js:4050
+#: pkg/networkmanager/interfaces.js:4305 pkg/networkmanager/interfaces.js:4510
 msgid "Create it"
 msgstr "Создать"
 
-#: pkg/storaged/content-views.jsx:708
+#: pkg/storaged/content-views.jsx:728
 msgid "Create new Logical Volume"
 msgstr "Создать новый логический том"
 
@@ -1955,7 +2077,7 @@ msgstr "Создание раздела $target"
 msgid "Creating snapshot of $target"
 msgstr "Создание моментального снимка $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4509
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1963,7 +2085,7 @@ msgstr ""
 "Создание этой VLAN приведёт к разрыву соединения с сервером и недоступности "
 "интерфейса администратора."
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3849
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1971,7 +2093,7 @@ msgstr ""
 "Создание этого объединения приведёт к разрыву соединения с сервером и "
 "недоступности интерфейса администратора."
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4304
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1979,7 +2101,7 @@ msgstr ""
 "Создание этого моста приведёт к разрыву соединения с сервером и "
 "недоступности интерфейса администратора."
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4049
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1991,14 +2113,13 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Создание группы томов $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr "Ошибка создания виртуальной машины $0"
 
 #: pkg/systemd/logs.html:58
-#, fuzzy
 msgid "Critical and above"
-msgstr "Критический и выше"
+msgstr "Критические оповещения и выше"
 
 #: pkg/machines/components/vnc.jsx:109
 msgid "Ctrl+Alt+Del"
@@ -2016,23 +2137,23 @@ msgstr "Текущее распределение"
 msgid "Current boot"
 msgstr "Текущая сессия"
 
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Настраиваемое"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:550
 msgid "Custom Ports"
 msgstr "Настраиваемые порты"
 
-#: pkg/storaged/format-dialog.jsx:118
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Custom encryption options"
 msgstr "Пользовательские параметры шифрования"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
+#: pkg/storaged/format-dialog.jsx:95 pkg/storaged/nfs-details.jsx:183
 msgid "Custom mount options"
 msgstr "Пользовательские параметры подключения"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:750
 msgid "Custom zones"
 msgstr "Настраиваемые зоны"
 
@@ -2045,19 +2166,19 @@ msgstr "Диапазон адресов DHCP"
 msgid "DISK IS FAILING"
 msgstr "СБОЙ В РАБОТЕ ДИСКА"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3339
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2676
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3343
 msgid "DNS Search Domains"
 msgstr "Домены поиска DNS"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2679
 msgid "DNS Search Domains $val"
 msgstr "Домены поиска DNS $val"
 
@@ -2069,17 +2190,17 @@ msgstr "Тёмный"
 msgid "Dashboard"
 msgstr "Панель мониторинга"
 
-#: pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/lvol-tabs.jsx:463
 msgid "Data Used"
 msgstr "Использованные данные"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/machines/components/networks/network.jsx:144
-#: pkg/storaged/content-views.jsx:254
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/storaged/content-views.jsx:259
 msgid "Deactivate"
 msgstr "Отключить"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:854
 msgid "Deactivating"
 msgstr "Отключение"
 
@@ -2088,46 +2209,52 @@ msgid "Deactivating $target"
 msgstr "Отключение $target"
 
 #: pkg/systemd/logs.html:63
-#, fuzzy
 msgid "Debug and above"
-msgstr "Отладка и выше"
+msgstr "Отладочные сообщения и выше"
 
-#: pkg/storaged/vdo-details.jsx:310 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdo-details.jsx:316 pkg/storaged/vdos-panel.jsx:91
 msgid "Deduplication"
 msgstr "Дедупликация"
 
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
-#: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
 msgstr "По умолчанию"
 
-#: pkg/systemd/index.html:438
+#: pkg/systemd/index.html:449
 msgid "Delay"
 msgstr "Задержка"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/docker/containers-view.jsx:202
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
+#: pkg/docker/details.js:293 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
-#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
+#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:319
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
+#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
+#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Удалить"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2454 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Удалить $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:67
+msgid "Delete $0 volume"
+msgid_plural "Delete $0 volumes"
+msgstr[0] "Удалить $0 том"
+msgstr[1] "Удалить $0 тома"
+msgstr[2] "Удалить $0 томов"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr "Удалить содержимое"
 
@@ -2136,11 +2263,10 @@ msgid "Delete Files"
 msgstr "Удалить файлы"
 
 #: pkg/machines/components/networks/networkDelete.jsx:92
-#, fuzzy
 msgid "Delete Network $0"
-msgstr "Удалить $0"
+msgstr "Удаление сети $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr "Удаление пула носителей $0"
 
@@ -2148,7 +2274,7 @@ msgstr "Удаление пула носителей $0"
 msgid "Delete associated storage files:"
 msgstr "Удаление связанных файлов хранилища:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr "Удалить тома в этом пуле"
 
@@ -2156,7 +2282,7 @@ msgstr "Удалить тома в этом пуле"
 msgid "Deleting $target"
 msgstr "Удаление $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2453
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2164,31 +2290,31 @@ msgstr ""
 "Удаление <b>$0</b> приведёт к разрыву соединения с сервером и недоступности "
 "интерфейса администратора."
 
-#: pkg/storaged/mdraid-details.jsx:300
+#: pkg/storaged/mdraid-details.jsx:296
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Удаление RAID-устройства приведёт к удалению всех данных на нём."
 
-#: pkg/storaged/vdo-details.jsx:200
+#: pkg/storaged/vdo-details.jsx:204
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Удаление устройства VDO приведёт к удалению всех данных на нём."
 
-#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:292
 msgid "Deleting a container will erase all data in it."
 msgstr "Удаление контейнера приведёт к удалению всех данных в нем."
 
-#: pkg/storaged/content-views.jsx:273
+#: pkg/storaged/content-views.jsx:278
 msgid "Deleting a logical volume will delete all data in it."
 msgstr "Удаление логического тома приведёт к удалению всех данных в нём."
 
-#: pkg/storaged/content-views.jsx:276
+#: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr "Удаление раздела приведёт к удалению всех данных в нём."
 
-#: pkg/storaged/vgroup-details.jsx:212
+#: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Удаление группы томов приведёт к удалению всех данных в них."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2200,52 +2326,63 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Удаление группы томов $target"
 
-#: pkg/systemd/services.html:413
-#: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:759
+#: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Описание"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr "Шаблоны проектирования"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Настольный компьютер"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
+"Перед попыткой удаления отсоедините диски, использующие этот пул, от всех "
+"виртуальных машин."
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
 msgstr "Съёмный компьютер"
 
 # translation auto-copied from project libreport, version master, document libreport
-#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:384
+#: pkg/systemd/host.js:786 pkg/systemd/host.js:797
 msgid "Details"
 msgstr "Подробности"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:155
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
-#: pkg/machines/components/vmDisksTab.jsx:58
+#: pkg/machines/components/vmDisksTab.jsx:96
 msgid "Device"
 msgstr "Устройство"
 
-#: pkg/storaged/vdo-details.jsx:267
+#: pkg/storaged/vdo-details.jsx:273
 msgid "Device File"
 msgstr "Файл устройства"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:564
 msgid "Device is read-only"
 msgstr "Устройство доступно только для чтения"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr "Диагностические отчёты"
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Диагностические отчёты"
 
-#: node_modules/registry-image-widgets/views/image-body.html:22
-msgid "Digest"
-msgstr "Дайджест"
-
-#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Каталог"
@@ -2254,29 +2391,29 @@ msgstr "Каталог"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Каталог $0 недоступен для записи или не существует."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Отключить"
-
-#: pkg/systemd/hwinfo.jsx:191
+#: pkg/systemd/hwinfo.jsx:195
 msgid "Disable simultaneous multithreading"
 msgstr "Отключить одновременную многопотоковость"
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:233
 msgid "Disable tuned"
 msgstr "Отключить демон tuned"
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1981
+#: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Отключено"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr "Запретить выполнение (добавить маску)"
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Отключиться"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:180 pkg/shell/indexes.js:660
 msgid "Disconnected"
 msgstr "Отключено"
 
@@ -2286,7 +2423,7 @@ msgstr ""
 "Подключение к последовательной консоли прервано. Нажмите кнопку «Повторить "
 "подключение»."
 
-#: pkg/storaged/vdos-panel.jsx:55
+#: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Диск"
 
@@ -2295,15 +2432,15 @@ msgid "Disk $0 fail to get detached from VM $1"
 msgstr "Не удалось отключить диск $0 от виртуальной машины $1"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager, author ypoyarko
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:588
 msgid "Disk I/O"
 msgstr "Дисковый ввод-вывод"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:396
 msgid "Disk failed to be attached"
 msgstr "Не удалось подключить диск"
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:373
 msgid "Disk failed to be created"
 msgstr "Не удалось создать диск"
 
@@ -2315,9 +2452,9 @@ msgstr "Диск в порядке"
 msgid "Disk passphrase"
 msgstr "Парольная фраза диска"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
-#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
+#: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
+#: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
 msgid "Disks"
 msgstr "Диски"
 
@@ -2330,9 +2467,9 @@ msgstr "Невозможно удалить диски из виртуальны
 msgid "Display Language"
 msgstr "Язык интерфейса"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:10
-msgid "Docker Version"
-msgstr "Версия Docker"
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr "Контейнеры Docker"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
@@ -2340,9 +2477,9 @@ msgstr "Docker не установлен или не активирован в �
 
 #: pkg/lib/machine-info.js:75
 msgid "Docking Station"
-msgstr "Док-станция"
+msgstr "Стыковочный узел"
 
-#: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
+#: pkg/realmd/operation.html:11 pkg/systemd/index.html:125
 #: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Домен"
@@ -2367,12 +2504,12 @@ msgstr "Имя администратора домена"
 msgid "Domain Administrator Password"
 msgstr "Пароль администратора домена"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1147
 msgid "Don't Repeat"
 msgstr "Без повтора"
 
-#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
+#: pkg/storaged/content-views.jsx:524 pkg/storaged/format-dialog.jsx:289
 msgid "Don't overwrite existing data"
 msgstr "Не заменять существующие данные"
 
@@ -2404,22 +2541,21 @@ msgstr "Загружено"
 msgid "Downloading"
 msgstr "Загрузка"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:179
+#: pkg/lib/cockpit-components-install-dialog.jsx:180
 msgid "Downloading $0"
 msgstr "Загрузка $0"
 
-#: pkg/docker/storage.jsx:167 pkg/storaged/drive-details.jsx:68
+#: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Устройство"
 
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
-msgctxt "storage"
-msgid "Drive"
-msgstr "Накопитель"
-
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:102
 msgid "Drives"
 msgstr "Устройства"
+
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr "Двухранговая"
 
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
@@ -2429,8 +2565,8 @@ msgstr "Повторяющийся псевдоним"
 msgid "Duplicate port"
 msgstr "Повторяющийся порт"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
-#: pkg/storaged/nfs-details.jsx:306
+#: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/nfs-details.jsx:314
 msgid "Edit"
 msgstr "Изменить"
 
@@ -2438,15 +2574,11 @@ msgstr "Изменить"
 msgid "Edit Server"
 msgstr "Изменение сервера"
 
-#: pkg/storaged/crypto-keyslots.jsx:270
+#: pkg/storaged/crypto-keyslots.jsx:276
 msgid "Edit Tang keyserver"
 msgstr "Изменение сервера криптографических ключей Tang"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:7
-msgid "Edit image stream"
-msgstr "Изменение потока образа"
-
-#: pkg/storaged/crypto-keyslots.jsx:535
+#: pkg/storaged/crypto-keyslots.jsx:548
 msgid "Editing a key requires a free slot"
 msgstr "Для редактирования ключа необходим свободный слот"
 
@@ -2458,13 +2590,13 @@ msgstr "Извлечение $target"
 msgid "Embedded PC"
 msgstr "Встраиваемый компьютер"
 
-#: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
+#: pkg/playground/translate.html:57 src/base1/test-locale.js:47
+#: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Пусто"
 
-#: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
+#: pkg/playground/translate.html:62 src/base1/test-locale.js:48
+#: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Очистить"
@@ -2477,74 +2609,75 @@ msgstr "Очистка $target"
 msgid "Emulated Machine"
 msgstr "Эмулированный компьютер"
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Включить"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Включить принудительно"
-
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
 msgstr "Включить службу"
 
-#: pkg/systemd/index.html:161
+#: pkg/systemd/index.html:168
 msgid "Enable stored metrics…"
 msgstr "Включить сохранённые показатели..."
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:216
 msgid "Enabled"
 msgstr "Включено"
 
-#: pkg/storaged/format-dialog.jsx:292
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Encrypt data"
 msgstr "Шифровать данные"
 
-#: pkg/storaged/utils.js:273
+#: pkg/storaged/utils.js:274
 msgid "Encrypted $0"
 msgstr "Зашифрованный $0"
 
-#: pkg/storaged/utils.js:265
+#: pkg/storaged/utils.js:266
 msgid "Encrypted Logical Volume of $0"
 msgstr "Зашифрованный логический том $0"
 
-#: pkg/storaged/utils.js:267
+#: pkg/storaged/utils.js:268
 msgid "Encrypted Partition of $0"
 msgstr "Зашифрованный раздел $0"
 
-#: pkg/storaged/content-views.jsx:348
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Зашифрованные данные"
 
-#: pkg/storaged/lvol-tabs.jsx:140
+#: pkg/storaged/lvol-tabs.jsx:141
 msgid "Encrypted volumes can not be resized here."
 msgstr "Невозможно изменить размер зашифрованных томов."
 
-#: pkg/storaged/lvol-tabs.jsx:143
+#: pkg/storaged/lvol-tabs.jsx:144
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr ""
 "Зашифрованные тома необходимо разблокировать, прежде чем станет возможным "
 "изменение их размера."
 
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Шифрование"
 
-#: pkg/storaged/crypto-tab.jsx:102
+#: pkg/storaged/crypto-tab.jsx:105
 msgid "Encryption Options"
 msgstr "Параметры шифрования"
 
-#: pkg/selinux/setroubleshoot-view.jsx:299
-msgid "Enforce policy:"
-msgstr "Применить политику:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:238
+msgid "End"
+msgstr "Конец"
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr "Конец не должен быть пустым"
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr "Принудительная"
+
+#: pkg/systemd/host.js:513
 msgid "Enhancement Updates Available"
 msgstr "Доступны улучшения"
 
-#: pkg/lib/machine-dialogs.js:445
+#: pkg/lib/machine-dialogs.js:447
 msgid "Enter IP address or host name"
 msgstr "Введите IP-адрес или имя узла"
 
@@ -2556,7 +2689,7 @@ msgstr ""
 "Ввод другого пароля здесь приведёт к тому, что вам придётся вводить его "
 "заново при каждом подключении к этому компьютеру"
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:786
 msgid "Entire subnet"
 msgstr "Адрес всей подсети"
 
@@ -2570,15 +2703,14 @@ msgstr "Точка входа"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/docker/index.html:528
-#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Среда"
 
-#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:286
 msgid "Erase"
 msgstr "Удаление"
 
-#: pkg/docker/storage.jsx:447
+#: pkg/docker/storage.jsx:460
 msgid "Erase containers and reset storage pool"
 msgstr "Удалить контейнеры и сбросить пул носителей"
 
@@ -2586,21 +2718,20 @@ msgstr "Удалить контейнеры и сбросить пул носи�
 msgid "Erasing $target"
 msgstr "Стирание $target"
 
-#: pkg/packagekit/updates.jsx:312
+#: pkg/packagekit/updates.jsx:313
 msgid "Errata:"
 msgstr "Опечатки:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
-#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:100 pkg/storaged/storage-controls.jsx:194
+#: pkg/systemd/service-details.jsx:450 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Ошибка"
 
 #: pkg/systemd/logs.html:59
-#, fuzzy
 msgid "Error and above"
-msgstr "Ошибка и выше"
+msgstr "Сообщения об ошибках и выше"
 
 #: pkg/lib/machine-sync-users.html:13
 msgid "Error loading users: {{perm_failed}}"
@@ -2609,6 +2740,10 @@ msgstr "Произошла ошибка при загрузке пользова
 #: pkg/docker/util.js:507
 msgid "Error message from Docker:"
 msgstr "Сообщение об ошибке от Docker:"
+
+#: pkg/lib/cockpit-components-modifications.jsx:145
+msgid "Error running semanage to discover system modifications"
+msgstr "Ошибка выполнения команды semanage для обнаружения изменений системы"
 
 #: pkg/users/authorized-keys.js:121
 msgid "Error saving authorized keys: "
@@ -2630,7 +2765,7 @@ msgstr "Ethernet MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2027
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2638,11 +2773,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Все"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:563
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Пример: 22, ssh, 8080, 5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:571
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Пример: 88, 2019, nfs, rsync"
 
@@ -2650,11 +2785,11 @@ msgstr "Пример: 88, 2019, nfs, rsync"
 msgid "Excellent password"
 msgstr "Отличный пароль"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
-msgstr "Существующий образ диска"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
+msgstr "Исключения"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr "Существующий образ диска в файловой системе узла"
 
@@ -2664,41 +2799,41 @@ msgstr "Выход с кодом $ExitCode"
 
 #: pkg/lib/machine-info.js:81
 msgid "Expansion Chassis"
-msgstr "Шасси расширения"
+msgstr "Корпус расширения"
 
 #: pkg/docker/index.html:510
 msgid "Expose container ports"
 msgstr "Показывать порты контейнера"
 
-#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:459 pkg/storaged/format-dialog.jsx:259
 msgid "Extended Partition"
 msgstr "Дополнительный раздел"
 
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "СБОЙ"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:856
 msgid "Failed"
 msgstr "Сбой"
 
-#: pkg/lib/machine-dialogs.js:410
+#: pkg/lib/machine-dialogs.js:412
 msgid "Failed to add machine: $0"
 msgstr "Не удалось добавить компьютер: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
-msgstr ""
+msgstr "Не удалось добавить порт"
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr "Не удалось добавить службу"
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:711
 msgid "Failed to add zone"
 msgstr "Не удалось добавить зону"
 
-#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
+#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
 msgid "Failed to change password"
 msgstr "Не удалось изменить пароль"
 
@@ -2714,7 +2849,7 @@ msgstr "Не удалось отключить демон tuned"
 msgid "Failed to disable tuned profile"
 msgstr "Не удалось отключить профиль демона tuned"
 
-#: pkg/lib/machine-dialogs.js:492
+#: pkg/lib/machine-dialogs.js:494
 msgid "Failed to edit machine: $0"
 msgstr "Не удалось изменить компьютер: $0"
 
@@ -2722,7 +2857,7 @@ msgstr "Не удалось изменить компьютер: $0"
 msgid "Failed to enable tuned"
 msgstr "Не удалось включить демон tuned"
 
-#: pkg/machines/components/vmnetworktab.jsx:55
+#: pkg/machines/components/vmnetworktab.jsx:60
 msgid "Failed to fetch the IP addresses of the interfaces present in $0"
 msgstr "Не удалось получить IP-адреса интерфейсов, присутствующих в $0"
 
@@ -2730,16 +2865,19 @@ msgstr "Не удалось получить IP-адреса интерфейс�
 msgid "Failed to load authorized keys."
 msgstr "Не удалось загрузить авторизованные ключи."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:623
 msgid "Failed to remove service"
 msgstr "Не удалось удалить службу"
+
+#: pkg/systemd/service-details.jsx:342
+msgid "Failed to start"
+msgstr "Сбой запуска"
 
 #: pkg/docker/containers.js:60
 msgid "Failed to start Docker: $0"
 msgstr "Не удалось запустить Docker: $0"
 
 #: pkg/docker/util.js:559
-#, fuzzy
 msgid "Failed to stop Docker scope: $0"
 msgstr "Не удалось остановить область Docker: $0"
 
@@ -2758,19 +2896,19 @@ msgstr ""
 msgid "File"
 msgstr "Файл"
 
-#: pkg/storaged/content-views.jsx:145
+#: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "Файловая система"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Каталог файловой системы"
 
-#: pkg/storaged/fsys-tab.jsx:123
+#: pkg/storaged/fsys-tab.jsx:126
 msgid "Filesystem Mounting"
 msgstr "Подключение файловой системы"
 
-#: pkg/storaged/fsys-tab.jsx:70
+#: pkg/storaged/fsys-tab.jsx:71
 msgid "Filesystem Name"
 msgstr "Имя файловой системы"
 
@@ -2778,37 +2916,34 @@ msgstr "Имя файловой системы"
 msgid "Filesystems"
 msgstr "Файловые системы"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:518
 msgid "Filter Services"
 msgstr "Фильтровать службы"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr "Фильтровать по имени или описанию..."
 
-#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Отпечаток"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:947 pkg/networkmanager/firewall.jsx:950
 msgid "Firewall"
 msgstr "Межсетевой экран"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:895
 msgid "Firewall is not available"
 msgstr "Межсетевой экран недоступен"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:35
-#, fuzzy
-msgid "Follows docker repo"
-msgstr "Следит за докером-репо"
-
-#: pkg/storaged/vdos-panel.jsx:88
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "For legacy applications only. Reduces performance."
-msgstr ""
-"Только для устаревших приложений. Установка данного флажка снижает "
-"производительность."
+msgstr "Только для устаревших приложений. Снижает производительность."
+
+#: pkg/systemd/service-details.jsx:324
+msgid "Forbidden from running"
+msgstr "Выполнение запрещено"
 
 #: pkg/users/index.html:122
 msgid "Force Change"
@@ -2830,51 +2965,56 @@ msgstr "Принудительное завершение работы"
 msgid "Force password change"
 msgstr "Принудительно изменить пароль"
 
-#: pkg/storaged/crypto-keyslots.jsx:373
+#: pkg/storaged/crypto-keyslots.jsx:381
 msgid "Force remove passphrase in $0"
 msgstr "Принудительно удалить парольную фразу в $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
-#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
+#: pkg/storaged/content-views.jsx:323 pkg/storaged/content-views.jsx:542
+#: pkg/storaged/format-dialog.jsx:336
 msgid "Format"
 msgstr "Форматировать"
 
-#: pkg/storaged/format-dialog.jsx:186
+#: pkg/storaged/format-dialog.jsx:191
 msgid "Format $0"
 msgstr "Форматирование $0"
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/storaged/content-views.jsx:518
 msgid "Format Disk $0"
 msgstr "Форматирование диска $0"
 
-#: pkg/storaged/content-views.jsx:531
+#: pkg/storaged/content-views.jsx:543
 msgid "Formatting a disk will erase all data on it."
 msgstr "При форматировании диска все данные на нём будут удалены."
 
-#: pkg/storaged/format-dialog.jsx:325
+#: pkg/storaged/format-dialog.jsx:338
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "При форматировании запоминающего устройства все данные на нём будут удалены."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:133
+msgid "Forward Mode"
+msgstr "Режим пересылки"
+
+#: pkg/networkmanager/interfaces.js:2881
 msgid "Forward delay $forward_delay"
 msgstr "Задержка смены состояний $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:55
 msgid "Forwarding mode"
 msgstr "Режим переадресации"
 
-#: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
+#: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Свободно"
 
-#: pkg/storaged/content-views.jsx:440
+#: pkg/storaged/content-views.jsx:445
 msgid "Free Space"
 msgstr "свободного места"
 
-#: pkg/storaged/lvol-tabs.jsx:371
+#: pkg/storaged/lvol-tabs.jsx:379
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -2882,17 +3022,13 @@ msgstr ""
 "Освободите место в этой группе: сожмите или удалите другие логические тома "
 "или добавьте новый физический том."
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Пятница"
 
 #: pkg/packagekit/autoupdates.jsx:321
 msgid "Fridays"
 msgstr "По пятницам"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:6
-msgid "From"
-msgstr "От"
 
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
@@ -2904,9 +3040,13 @@ msgid "Gateway:"
 msgstr "Шлюз:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2723 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Общее"
+
+#: pkg/machines/components/nicAdd.jsx:49
+msgid "Generate automatically"
+msgstr "Создать автоматически"
 
 #: pkg/sosreport/index.html:55
 msgid "Generating report"
@@ -2916,15 +3056,15 @@ msgstr "Создание отчёта"
 msgid "Get new image"
 msgstr "Получить новый образ"
 
+#: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/memorySelectRow.jsx:46
-#: pkg/machines/components/vmDisksTab.jsx:44
-#: pkg/machines/components/diskAdd.jsx:186
+#: pkg/machines/components/vmDisksTab.jsx:51
 msgid "GiB"
 msgstr "ГиБ"
 
-#: pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:200
 msgid "Go to"
 msgstr "Переход..."
 
@@ -2933,7 +3073,7 @@ msgid "Go to Application"
 msgstr "Перейти к приложению"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Текущий момент"
@@ -2946,21 +3086,21 @@ msgstr "Графическая консоль (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Графическая консоль в средстве просмотра для рабочего стола"
 
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
-#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
-#: pkg/storaged/vdo-details.jsx:298
+#: pkg/storaged/lvol-tabs.jsx:239 pkg/storaged/lvol-tabs.jsx:407
+#: pkg/storaged/lvol-tabs.jsx:459 pkg/storaged/vdo-details.jsx:235
+#: pkg/storaged/vdo-details.jsx:304
 msgid "Grow"
 msgstr "Расширить"
 
-#: pkg/storaged/lvol-tabs.jsx:417
+#: pkg/storaged/lvol-tabs.jsx:425
 msgid "Grow Content"
 msgstr "Расширить содержимое"
 
-#: pkg/storaged/lvol-tabs.jsx:231
+#: pkg/storaged/lvol-tabs.jsx:235
 msgid "Grow Logical Volume"
 msgstr "Расширение логического тома"
 
-#: pkg/storaged/vdo-details.jsx:218
+#: pkg/storaged/vdo-details.jsx:223
 msgid "Grow logical size of $0"
 msgstr "Расширение логического размера $0"
 
@@ -2970,9 +3110,9 @@ msgstr "Расширить на всё пространство"
 
 #: pkg/networkmanager/index.html:252
 msgid "Hair Pin mode"
-msgstr "Режим Hairpin"
+msgstr "Режим NAT loopback"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2907
 msgid "Hairpin mode"
 msgstr "Режим Hairpin"
 
@@ -2980,12 +3120,7 @@ msgstr "Режим Hairpin"
 msgid "Hand Held"
 msgstr "Карманный компьютер"
 
-#: pkg/docker/storage.jsx:166
-msgid "Hard Disk"
-msgstr "Жёсткий диск"
-
-#: pkg/storaged/drives-panel.jsx:85
-msgctxt "storage"
+#: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Жёсткий диск"
 
@@ -2993,22 +3128,22 @@ msgstr "Жёсткий диск"
 msgid "Hardware"
 msgstr "Оборудование"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:274
 msgid "Hardware Information"
 msgstr "Сведения об оборудовании"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2883
 msgid "Hello time $hello_time"
 msgstr "Время приветствия $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Hide Performance Options"
 msgstr "Скрыть параметры быстродействия"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:389
 msgid "Host"
 msgstr "Узел"
 
@@ -3016,41 +3151,45 @@ msgstr "Узел"
 msgid "Host Device"
 msgstr "Главное устройство"
 
-#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Имя узла"
 
-#: src/base1/cockpit.js:4023
+#: src/base1/cockpit.js:4027
 msgid "Host key is incorrect"
 msgstr "Неверный ключ узла"
 
-#: pkg/realmd/operation.js:601
+#: pkg/realmd/operation.js:603
 msgid "Host name should not be changed in a domain"
 msgstr "Имя узла не должно изменяться в домене"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Имя узла не должно быть пустым"
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "Часы : Минуты"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1223 pkg/systemd/init.js:1252
 msgid "Hour needs to be a number between 0-23"
 msgstr "Количество часов должно лежать в интервале от 0 до 23"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "ч"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:249 pkg/systemd/host.js:1642
 msgid "I/O Wait"
 msgstr "Ожидание ввода-вывода"
 
+#: pkg/systemd/hwinfo.jsx:263
+msgid "ID"
+msgstr "Идентификатор"
+
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
-#: pkg/machines/components/vmnetworktab.jsx:133
+#: pkg/machines/components/vmnetworktab.jsx:143
 msgid "IP Address"
 msgstr "IP-адрес"
 
@@ -3058,11 +3197,15 @@ msgstr "IP-адрес"
 msgid "IP Address:"
 msgstr "IP-адрес:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:183
+msgid "IP Configuration"
+msgstr "Настройка IP"
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "Длина префикса сети:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:957
 msgid "IP Range"
 msgstr "Диапазон IP-адресов"
 
@@ -3070,7 +3213,7 @@ msgstr "Диапазон IP-адресов"
 msgid "IP Settings"
 msgstr "Параметры IP"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2932
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3078,11 +3221,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "IPv4-адрес"
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:265
+msgid "IPv4 Network"
+msgstr "Сеть IPv4"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr "Сеть IPv4 не должна быть пустой"
+
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv4 Settings"
 msgstr "Параметры IPv4"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:199
+msgid "IPv4 and IPv6"
+msgstr "IPv4 и IPv6"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:193
+msgid "IPv4 only"
+msgstr "Только IPv4"
+
+#: pkg/networkmanager/interfaces.js:2933
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3090,16 +3249,28 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "IPv6-адрес"
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:309
+msgid "IPv6 Network"
+msgstr "Сеть IPv6"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr "Сеть IPv6 не должна быть пустой"
+
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv6 Settings"
 msgstr "Параметры IPv6"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:196
+msgid "IPv6 only"
+msgstr "Только IPv6"
 
 # translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Идентификатор"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2924
 msgid "Id $id"
 msgstr "Идентификатор $id"
 
@@ -3107,22 +3278,15 @@ msgstr "Идентификатор $id"
 msgid "Id:"
 msgstr "Идентификатор:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:24
-#: node_modules/registry-image-widgets/views/image-listing.html:7
-msgid "Identifier"
-msgstr "Идентификатор"
-
-#: pkg/storaged/crypto-keyslots.jsx:325
-#, fuzzy
+#: pkg/storaged/crypto-keyslots.jsx:333
 msgid "If tang-show-keys is not available, run the following:"
-msgstr "Если клавиши танга-шоу недоступны, выполните следующие действия:"
+msgstr "Если команда tang-show-keys недоступна, выполните следующую команду:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1990 pkg/packagekit/updates.jsx:498
 msgid "Ignore"
 msgstr "Игнорировать"
 
 #: pkg/docker/index.html:270 pkg/docker/index.html:433
-#: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
 msgstr "Образ"
@@ -3138,14 +3302,6 @@ msgstr "Image Builder"
 #: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Поиск образов"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
-msgid "Image count"
-msgstr "Количество образов"
-
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
-msgid "Image stream"
-msgstr "Поток образа"
 
 #: pkg/docker/index.html:157
 msgid "Image:"
@@ -3164,37 +3320,25 @@ msgstr "Образы"
 msgid "Images and running containers"
 msgstr "Образы и работающие контейнеры"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:15
-#: node_modules/registry-image-widgets/views/imagestream-body.html:16
-msgid "Images may be pulled by anonymous users"
-msgstr "Образы могут быть загружены анонимными пользователями"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:20
-#: node_modules/registry-image-widgets/views/imagestream-body.html:21
-msgid "Images may be pulled by any authenticated user or group"
-msgstr ""
-"Образы могут быть загружены любым прошедшим проверку подлинности "
-"пользователем или группой"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:25
-#: node_modules/registry-image-widgets/views/imagestream-body.html:26
-msgid "Images may only be pulled by specific users or groups"
-msgstr ""
-"Образы могут быть загружены только определёнными пользователями или группами"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
-msgstr "Немедленно запустите VM"
+msgstr "Запустить ВМ сразу после создания"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr "Импортировать ВМ"
+
+#: pkg/storaged/mdraid-details.jsx:94
 msgid "In Sync"
 msgstr "В синхронизации"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
+"В большинстве конфигураций macvtap не работает при взаимодействии узла и "
+"гостевой сети"
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
@@ -3204,54 +3348,54 @@ msgstr ""
 "Чтобы синхронизировать пользователей, вам необходимо войти в систему "
 "{{#strong}}{{host}}{{/strong}}"
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:1431
+#: pkg/networkmanager/interfaces.js:1438 pkg/networkmanager/interfaces.js:2626
 msgid "Inactive"
 msgstr "Неактивно"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Inactive volume"
 msgstr "Неактивный том"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:764
 msgid "Included services"
-msgstr ""
+msgstr "Включённые службы"
 
 #: pkg/lib/machine-invalid-hostkey.html:2
 msgid "Incorrect Host Key"
 msgstr "Неверный ключ хоста"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:69
+#: pkg/storaged/vdo-details.jsx:307 pkg/storaged/vdos-panel.jsx:73
 msgid "Index Memory"
 msgstr "Индексная память"
 
 #: pkg/systemd/logs.html:62
 msgid "Info and above"
-msgstr "Информация и выше"
+msgstr "Информационные сообщения и выше"
 
-#: pkg/docker/storage.jsx:309
+#: pkg/docker/storage.jsx:313
 msgid "Information about the Docker storage pool is not available."
-msgstr "Информация о пуле хранения Docker недоступна."
+msgstr "Информация о пуле носителей Docker недоступна."
 
-#: pkg/packagekit/updates.jsx:453
+#: pkg/packagekit/updates.jsx:455
 msgid "Initializing..."
 msgstr "Инициализация ..."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
-msgstr ""
+msgstr "Инициатор"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
-msgstr ""
+msgstr "IQN инициатора не должно быть пустым"
 
-#: pkg/machines/components/vm/vmActions.jsx:98
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/lib/cockpit-components-install-dialog.jsx:116
+#: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Установка"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:809
 msgid "Install All Updates"
 msgstr "Установить все обновления"
 
@@ -3259,7 +3403,7 @@ msgstr "Установить все обновления"
 msgid "Install NFS Support"
 msgstr "Установка поддержки NFS"
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:809 pkg/packagekit/updates.jsx:815
 msgid "Install Security Updates"
 msgstr "Установка обновлений безопасности"
 
@@ -3267,23 +3411,23 @@ msgstr "Установка обновлений безопасности"
 msgid "Install Software"
 msgstr "Установить программное обеспечение"
 
-#: pkg/storaged/vdos-panel.jsx:171
+#: pkg/storaged/vdos-panel.jsx:181
 msgid "Install VDO support"
 msgstr "Установить поддержку VDO"
 
-#: pkg/selinux/setroubleshoot-view.jsx:379
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Установите setroubleshoot-server для устранения неполадок в SELinux."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Источник установки"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Тип источника установки"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Источник установки не должен быть пустым"
 
@@ -3297,21 +3441,25 @@ msgstr "Установлен"
 msgid "Installing"
 msgstr "Установка"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:183
+#: pkg/lib/cockpit-components-install-dialog.jsx:184
 msgid "Installing $0"
 msgstr "Установка $0"
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:489
+msgid "Instance of template: "
+msgstr "Экземпляр шаблона: "
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "иллюстрировать примерами"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicBody.jsx:131
 msgid "Interface Type"
-msgstr ""
+msgstr "Тип интерфейса"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:769 pkg/networkmanager/firewall.jsx:957
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Interfaces"
 msgstr "Интерфейсы"
 
@@ -3319,23 +3467,43 @@ msgstr "Интерфейсы"
 msgid "Internal Error: Invalid challenge header"
 msgstr "Внутренняя ошибка: неверный заголовок запроса"
 
-#: src/base1/cockpit.js:4025
+#: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Внутренняя ошибка"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr "Недопустимый IPv4-адрес"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr "Недопустимая маска или длина префикса адреса IPv4"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr "Недопустимый IPv6-адрес"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr "Недопустимый префикс адреса IPv6"
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "Недействительный адрес $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
+#: pkg/systemd/host.js:1506 pkg/systemd/shutdown.js:143
 msgid "Invalid date format"
 msgstr "Неверный формат даты"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
+#: pkg/systemd/host.js:1502 pkg/systemd/shutdown.js:139
 msgid "Invalid date format and invalid time format"
 msgstr "Недопустимый формат даты и неверный формат времени"
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1258
 msgid "Invalid date format."
 msgstr "Неверный формат даты."
 
@@ -3347,7 +3515,7 @@ msgstr "Недопустимая дата истечения срока дейс
 msgid "Invalid file permissions"
 msgstr "Недопустимые разрешения файлов"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Неверное имя файла"
 
@@ -3363,7 +3531,7 @@ msgstr "Недопустимый показатель $0"
 msgid "Invalid number of days"
 msgstr "Недопустимое количество дней"
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1205
 msgid "Invalid number."
 msgstr "Неправильный номер."
 
@@ -3371,37 +3539,37 @@ msgstr "Неправильный номер."
 msgid "Invalid port"
 msgstr "Недопустимый порт"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
-msgstr ""
+msgstr "Недопустимый номер порта"
 
 #: pkg/networkmanager/utils.js:41
 msgid "Invalid prefix $0"
 msgstr "Недопустимый префикс $0"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 msgid "Invalid prefix or netmask $0"
 msgstr "Недопустимый префикс или сетевая маска $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
-msgstr ""
+msgstr "Недопустимый диапазон"
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
+#: pkg/systemd/host.js:1504 pkg/systemd/shutdown.js:141
 msgid "Invalid time format"
 msgstr "Недопустимый формат времени"
 
-#: pkg/systemd/index.html:374
+#: pkg/systemd/index.html:385
 msgid "Invalid time zone"
 msgstr "Недействительный часовой пояс"
 
-#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:169
 msgid "Invalid username or password"
 msgstr "Неверное имя пользователя или пароль"
 
 #: pkg/lib/machine-info.js:96
 msgid "IoT Gateway"
-msgstr "IoT Gateway"
+msgstr "Шлюз Интернета вещей"
 
 #: pkg/lib/machine-change-port.html:15
 msgid "Is sshd running on a different port?"
@@ -3409,7 +3577,7 @@ msgstr "Работает ли sshd на другом порту?"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:108
 msgid "Isolated Network"
-msgstr ""
+msgstr "Изолированная сеть"
 
 #: pkg/storaged/jobs-panel.jsx:186
 msgid "Jobs"
@@ -3420,7 +3588,7 @@ msgstr "Задания"
 msgid "Join"
 msgstr "Присоединиться"
 
-#: pkg/realmd/operation.js:596
+#: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Войти в домен"
 
@@ -3428,11 +3596,11 @@ msgstr "Войти в домен"
 msgid "Join a Domain"
 msgstr "Присоединиться к домену"
 
-#: pkg/realmd/operation.js:505
+#: pkg/realmd/operation.js:507
 msgid "Joining this domain is not supported"
 msgstr "Присоединение к этому домену не поддерживается"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:436
 msgid "Joins Namespace Of"
 msgstr "Присоединяется к пространству имен"
 
@@ -3440,15 +3608,15 @@ msgstr "Присоединяется к пространству имен"
 msgid "Journal"
 msgstr "журнал"
 
-#: pkg/systemd/logs.js:407
+#: pkg/systemd/logs.js:409
 msgid "Journal entry"
 msgstr "запись в журнале"
 
-#: pkg/systemd/logs.js:438
+#: pkg/systemd/logs.js:440
 msgid "Journal entry not found"
 msgstr "Запись в журнале не найдена"
 
-#: pkg/kdump/kdump-view.jsx:459
+#: pkg/kdump/kdump-view.jsx:461
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
@@ -3466,35 +3634,35 @@ msgstr "SSO на основе Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Билеты на Kerberos"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:245 pkg/systemd/host.js:1643
 msgid "Kernel"
 msgstr "Ядро"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Дамп ядра"
 
-#: pkg/storaged/crypto-keyslots.jsx:563
+#: pkg/storaged/crypto-keyslots.jsx:576
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Ключевые слоты с неизвестными типами нельзя редактировать здесь"
 
-#: pkg/storaged/crypto-keyslots.jsx:202
+#: pkg/storaged/crypto-keyslots.jsx:204
 msgid "Key source"
 msgstr "Основной источник"
 
-#: pkg/storaged/crypto-keyslots.jsx:586
+#: pkg/storaged/crypto-keyslots.jsx:599
 msgid "Keys"
 msgstr "Ключи"
 
-#: pkg/storaged/crypto-keyslots.jsx:557
+#: pkg/storaged/crypto-keyslots.jsx:570
 msgid "Keyserver"
 msgstr "сервера ключей"
 
-#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:272
+#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Keyserver address"
 msgstr "Адрес сервера"
 
-#: pkg/storaged/crypto-keyslots.jsx:415
+#: pkg/storaged/crypto-keyslots.jsx:424
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Удаление Keyserver может предотвратить разблокировку $0"
 
@@ -3502,13 +3670,13 @@ msgstr "Удаление Keyserver может предотвратить раз�
 msgid "LACP Key"
 msgstr "Ключ LACP"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:3
-msgid "Labels"
-msgstr "Метки"
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr "Группа томов LVM"
 
 #: pkg/lib/machine-info.js:72
 msgid "Laptop"
-msgstr "портативный компьютер"
+msgstr "Полноразмерный ноутбук"
 
 #: pkg/systemd/logs.html:44
 msgid "Last 24 hours"
@@ -3522,14 +3690,9 @@ msgstr "Последние 7 дней"
 msgid "Last Login"
 msgstr "Последний вход"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:305
 msgid "Last Trigger"
 msgstr "Последнее срабатывание"
-
-# translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author ypoyarko
-#: node_modules/registry-image-widgets/views/image-listing.html:8
-msgid "Last Updated"
-msgstr "Обновлено"
 
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
@@ -3537,7 +3700,7 @@ msgstr "Последний раз проверено: $0 тому назад"
 
 #: pkg/machines/components/desktopConsole.jsx:128
 msgid "Launch Remote Viewer"
-msgstr "Запустить средство удаленного просмотра"
+msgstr "Запустить средство удалённого просмотра"
 
 #: pkg/realmd/operation.html:24 pkg/realmd/operation.html:28
 msgid "Leave Domain"
@@ -3558,6 +3721,7 @@ msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
+""
 msgstr ""
 "Оставьте пустым, чтобы подключиться к этому аппарату в качестве текущего "
 "пользователя{{#default_user}} ({{default_user}}){{/default_user}}Если вы "
@@ -3584,7 +3748,7 @@ msgstr "Просмотр ссылок"
 msgid "Link down delay"
 msgstr "Задержка разрыва соединения"
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1978 pkg/networkmanager/interfaces.js:1988
 msgid "Link local"
 msgstr "Ссылка локальная"
 
@@ -3604,11 +3768,11 @@ msgstr "связи"
 msgid "Links:"
 msgstr "Ссылки:"
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2014
 msgid "Load Balancing"
 msgstr "Балансировки нагрузки"
 
-#: pkg/systemd/logs.js:138
+#: pkg/systemd/logs.js:139
 msgid "Load earlier entries"
 msgstr "Загрузка ранних записей"
 
@@ -3624,10 +3788,14 @@ msgstr "Загрузка доступных обновлений не удала
 msgid "Loading available updates, please wait..."
 msgstr "Загружайте доступные обновления, подождите ..."
 
+#: pkg/lib/cockpit-components-modifications.jsx:151
+msgid "Loading system modifications..."
+msgstr "Загрузка изменений системы..."
+
 # translation auto-copied from project webkitgtk3, version 2.0.3, document webkitgtk3, author ypoyarko
-#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
-#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:369
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:145 pkg/systemd/logs.js:160
+#: pkg/systemd/logs.js:207 pkg/systemd/logs.js:256 pkg/systemd/logs.js:318
 msgid "Loading..."
 msgstr "Загрузка..."
 
@@ -3635,7 +3803,7 @@ msgstr "Загрузка..."
 msgid "Local Accounts"
 msgstr "Локальные учётные записи"
 
-#: pkg/docker/storage.jsx:198
+#: pkg/docker/storage.jsx:200
 msgid "Local Disks"
 msgstr "Локальные диски"
 
@@ -3643,11 +3811,11 @@ msgstr "Локальные диски"
 msgid "Local Filesystem"
 msgstr "Локальная файловая система"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
-msgstr ""
+msgstr "Локальный установочный носитель"
 
-#: pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:167
 msgid "Local Mount Point"
 msgstr "Местная точка монтирования"
 
@@ -3655,7 +3823,7 @@ msgstr "Местная точка монтирования"
 msgid "Location"
 msgstr "Адрес"
 
-#: pkg/storaged/content-views.jsx:238
+#: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Заблокировать"
 
@@ -3699,23 +3867,23 @@ msgstr "Журнальные сообщения"
 msgid "Logged In"
 msgstr "Записан"
 
-#: pkg/storaged/vdo-details.jsx:289
+#: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "логический"
 
-#: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
+#: pkg/storaged/vdo-details.jsx:225 pkg/storaged/vdos-panel.jsx:66
 msgid "Logical Size"
 msgstr "Логический размер"
 
-#: pkg/storaged/utils.js:197
+#: pkg/storaged/utils.js:198
 msgid "Logical Volume"
 msgstr "Логический том"
 
-#: pkg/storaged/utils.js:195
+#: pkg/storaged/utils.js:196
 msgid "Logical Volume (Snapshot)"
 msgstr "Логический том (моментальный снимок)"
 
-#: pkg/storaged/utils.js:269
+#: pkg/storaged/utils.js:270
 msgid "Logical Volume of $0"
 msgstr "Логический том $0"
 
@@ -3725,13 +3893,13 @@ msgstr "Войти снова"
 
 #: pkg/realmd/operation.html:14
 msgid "Login Format"
-msgstr ""
+msgstr "Формат учётной записи"
 
 #: pkg/lib/machine-change-auth.html:68
 msgid "Login Password"
 msgstr "Пароль для входа"
 
-#: src/base1/cockpit.js:4015
+#: src/base1/cockpit.js:4019
 msgid "Login failed"
 msgstr "Ошибка входа"
 
@@ -3743,7 +3911,7 @@ msgstr "Вход имеет повышенные привилегии админ
 msgid "Logout Successful"
 msgstr "Выйти успешно"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Журналы"
 
@@ -3753,18 +3921,20 @@ msgstr "Потерянное соединение. Попытка повторн
 
 #: pkg/lib/machine-info.js:67
 msgid "Low Profile Desktop"
-msgstr "Низкий профиль рабочего стола"
+msgstr "Низкопрофильный настольный компьютер"
 
 #: pkg/lib/machine-info.js:79
 msgid "Lunch Box"
-msgstr "Коробка для ланча"
+msgstr "Портативный компьютер в ударопрочном корпусе"
 
 # translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
 #: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:132
+#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/vmnetworktab.jsx:141
 msgid "MAC Address"
 msgstr "MAC-адрес"
 
@@ -3772,47 +3942,39 @@ msgstr "MAC-адрес"
 msgid "MAC Address:"
 msgstr "MAC-адрес:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:2006
 msgid "MII (Recommended)"
 msgstr "MII (рекомендуется)"
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2781
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4575
 msgid "MTU must be a positive number"
 msgstr "MTU должно быть положительным числом"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:103
-msgid "Mac"
-msgstr ""
-
-#: pkg/machines/components/nicEdit.jsx:160
-msgid "Mac Address"
-msgstr "MAC-адрес"
 
 #: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Идентификатор системы"
 
-#: pkg/systemd/index.html:267
+#: pkg/systemd/index.html:278
 msgid "Machine SSH Key Fingerprints"
 msgstr "Отпечатки пальцев машины SSH"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:353
 msgid "Machines"
 msgstr "Машины"
 
 #: pkg/lib/machine-info.js:80
 msgid "Main Server Chassis"
-msgstr "Основной серверный корпус"
+msgstr "Главный серверный корпус"
 
-#: pkg/storaged/crypto-keyslots.jsx:319
+#: pkg/storaged/crypto-keyslots.jsx:327
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Убедитесь, что хэш ключа с сервера Tang соответствует:"
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1979 pkg/networkmanager/interfaces.js:1989
 msgid "Manual"
 msgstr "Вручную"
 
@@ -3820,11 +3982,11 @@ msgstr "Вручную"
 msgid "Manual Connection"
 msgstr "Ручное подключение"
 
-#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
+#: pkg/systemd/index.html:395 pkg/systemd/index.html:399
 msgid "Manually"
 msgstr "Вручную"
 
-#: pkg/storaged/crypto-keyslots.jsx:322
+#: pkg/storaged/crypto-keyslots.jsx:330
 msgid "Manually check with SSH: "
 msgstr "Вручную проверять с помощью SSH: "
 
@@ -3832,31 +3994,49 @@ msgstr "Вручную проверять с помощью SSH: "
 msgid "Marking $target as faulty"
 msgstr "маркировка $target как неисправный"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Применить маску"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr "Скрыть службу"
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Принудительное применение маски"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "Mask or Prefix Length"
+msgstr "Маска или длина префикса"
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr "Маска или длина префикса не должна быть пустой"
+
+#: pkg/systemd/service-details.jsx:323
+msgid "Masked"
+msgstr "Скрыто"
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+"Маскирование службы делает невозможным выполнение всех связанных с ней служб."
+" Эффект может оказаться серьёзнее, чем кажется. Подтвердите маскирование "
+"данной службы."
+
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Master"
 msgstr "Мастер"
 
 #: pkg/machines/components/vm/memoryModal.jsx:165
 msgid "Maximum Allocation"
-msgstr ""
+msgstr "Максимальный размер участка памяти"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:96
 msgid "Maximum Transmission Unit"
-msgstr ""
+msgstr "Максимальный передаваемый блок данных"
 
 #: pkg/machines/components/vm/memoryModal.jsx:99
 msgid "Maximum memory could not be saved"
-msgstr ""
+msgstr "Не удалось сохранить максимальное значение для памяти"
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Maximum message age $max_age"
 msgstr "Максимальное время жизни сообщения $max_age"
 
@@ -3868,48 +4048,51 @@ msgstr ""
 "Максимальное количество виртуальных процессоров, выделенных для гостевой ОС, "
 "которое должно быть от 1 до $0"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:350
 msgid "Member of RAID Device"
 msgstr "Член RAID-устройства"
 
-#: pkg/storaged/content-views.jsx:341
+#: pkg/storaged/content-views.jsx:346
 msgid "Member of RAID Device $0"
 msgstr "Член RAID-устройства $0"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:263
 msgid "Memory"
 msgstr "Память"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1701
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Память"
 
-#: pkg/systemd/index.html:205
+#: pkg/systemd/index.html:216
 msgid "Memory & Swap"
 msgstr "Память и обмен"
+
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Memory Technology"
+msgstr "Технология памяти"
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
 msgid "Memory could not be saved"
-msgstr ""
+msgstr "Не удалось сохранить значение для памяти"
 
 #: pkg/docker/index.html:454 pkg/docker/index.html:626
 msgid "Memory limit"
 msgstr "Предел памяти"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
-#, fuzzy
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
-msgstr "Использование памяти:"
+msgstr "Значение для памяти должно отличаться от нуля"
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
-msgstr ""
+msgstr "Объём памяти от 128 МиБ до максимального размера участка памяти"
 
 #: pkg/docker/index.html:211
 msgid "Memory usage:"
@@ -3919,20 +4102,19 @@ msgstr "Использование памяти:"
 msgid "Message to logged in users"
 msgstr "Сообщение для зарегистрированных пользователей"
 
-#: node_modules/registry-image-widgets/views/image-panel.html:15
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
-msgid "Metadata"
-msgstr "Метаданные"
+#: pkg/shell/index.html:399
+msgid "Messages related to the failure might be found in the journal:"
+msgstr "Сообщения, связанные с ошибкой, могут быть найдены в журнале:"
 
-#: pkg/storaged/lvol-tabs.jsx:458
+#: pkg/storaged/lvol-tabs.jsx:466
 msgid "Metadata Used"
 msgstr "Используемые метаданные"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
-#: pkg/machines/components/memorySelectRow.jsx:43
-#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "МиБ"
 
@@ -3942,29 +4124,29 @@ msgstr "Мини-ПК"
 
 #: pkg/lib/machine-info.js:69
 msgid "Mini Tower"
-msgstr "Мини-башня"
+msgstr "Компьютер в корпусе «мини-башня»"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1229 pkg/systemd/init.js:1238 pkg/systemd/init.js:1247
 msgid "Minute needs to be a number between 0-59"
 msgstr "Минута должна быть числом от 0 до 59"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "мин"
 
-#: pkg/systemd/hwinfo.jsx:62 pkg/systemd/hwinfo.jsx:67
+#: pkg/systemd/hwinfo.jsx:66 pkg/systemd/hwinfo.jsx:71
 msgid "Mitigations"
-msgstr ""
+msgstr "Меры по защите"
 
 #: pkg/networkmanager/index.html:284
 msgid "Mode"
 msgstr "Режим"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:254
 msgid "Model"
 msgstr "Модель"
 
-#: pkg/machines/components/vmnetworktab.jsx:123
+#: pkg/machines/components/vmnetworktab.jsx:131
 msgid "Model type"
 msgstr "Тип модели"
 
@@ -3973,7 +4155,7 @@ msgstr "Тип модели"
 msgid "Modifying $target"
 msgstr "Изменение $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Понедельник"
 
@@ -3989,7 +4171,7 @@ msgstr "Интервал мониторинга"
 msgid "Monitoring Targets"
 msgstr "Цели мониторинга"
 
-#: pkg/realmd/operation.js:529
+#: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Больше"
 
@@ -3998,27 +4180,27 @@ msgstr "Больше"
 msgid "More Information"
 msgstr "Дополнительная информация"
 
-#: pkg/kdump/kdump-view.jsx:448
+#: pkg/kdump/kdump-view.jsx:450
 msgid "More details"
 msgstr "Подробности"
 
-#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
-#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:309
 msgid "Mount"
 msgstr "гора"
 
-#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:81
+#: pkg/storaged/format-dialog.jsx:84 pkg/storaged/fsys-tab.jsx:174
+#: pkg/storaged/nfs-details.jsx:178
 msgid "Mount Options"
 msgstr "Параметры крепления"
 
-#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/format-dialog.jsx:71
+#: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:160 pkg/storaged/nfs-details.jsx:326
+#: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Точка подключения"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
+#: pkg/storaged/format-dialog.jsx:93 pkg/storaged/nfs-details.jsx:181
 msgid "Mount at boot"
 msgstr "Гора при загрузке"
 
@@ -4026,23 +4208,23 @@ msgstr "Гора при загрузке"
 msgid "Mount container volumes"
 msgstr "Объемы контейнеров"
 
-#: pkg/storaged/format-dialog.jsx:78
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount point can not be empty"
 msgstr "Точка монтирования не может быть пуста"
 
-#: pkg/storaged/nfs-details.jsx:166
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount point cannot be empty."
 msgstr "Точка монтирования не может быть пуста."
 
-#: pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:174
 msgid "Mount point must start with \"/\"."
 msgstr "Точка монтирования должна начинаться с \"/\"."
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
+#: pkg/storaged/format-dialog.jsx:94 pkg/storaged/nfs-details.jsx:182
 msgid "Mount read only"
 msgstr "Только для чтения"
 
-#: pkg/storaged/fsys-tab.jsx:180
+#: pkg/storaged/fsys-tab.jsx:183
 msgid "Mounted At"
 msgstr "Установлено на"
 
@@ -4056,13 +4238,13 @@ msgstr "монтаж $target"
 
 #: pkg/lib/machine-info.js:88
 msgid "Multi-system Chassis"
-msgstr "Многосистемное шасси"
+msgstr "Корпус для нескольких систем"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:93
 msgid "NAT to $0"
-msgstr ""
+msgstr "NAT к $0"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "NFS Mount"
 msgstr "Подключение по NFS"
 
@@ -4074,45 +4256,46 @@ msgstr "Подключения по NFS"
 msgid "NFS Support not installed"
 msgstr "Поддержка NFS не установлена"
 
-#: pkg/machines/components/vmnetworktab.jsx:97
+#: pkg/machines/components/vmnetworktab.jsx:102
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
+"Не удалось изменить состояние сетевого адаптера $0 виртуальной машины $1"
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2029
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1569
 msgid "NTP Server"
 msgstr "Сервер NTP"
 
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
-#: pkg/networkmanager/index.html:319
-#: node_modules/registry-image-widgets/views/image-body.html:2
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
-#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
-#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
-#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
-#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
+#: pkg/networkmanager/index.html:319 pkg/docker/containers-view.jsx:359
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
+#: pkg/machines/components/networks/createNetworkDialog.jsx:108
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:33
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/storaged/content-views.jsx:113 pkg/storaged/content-views.jsx:655
+#: pkg/storaged/format-dialog.jsx:295 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:73 pkg/storaged/fsys-tab.jsx:153
+#: pkg/storaged/iscsi-panel.jsx:128 pkg/storaged/iscsi-panel.jsx:185
+#: pkg/storaged/lvol-tabs.jsx:34 pkg/storaged/lvol-tabs.jsx:356
+#: pkg/storaged/lvol-tabs.jsx:398 pkg/storaged/lvol-tabs.jsx:452
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:49 pkg/storaged/vgroup-details.jsx:175
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/init.js:302
 msgid "Name"
 msgstr "Имя"
 
-#: pkg/storaged/vdos-panel.jsx:52
+#: pkg/storaged/vdos-panel.jsx:54
 msgid "Name can not be empty."
 msgstr "Имя не может быть пустым."
 
@@ -4122,15 +4305,15 @@ msgstr "Имя не может быть пустым."
 
 #: pkg/storaged/utils.js:159
 msgid "Name cannot be longer than $0 bytes"
-msgstr ""
+msgstr "Длина имени в байтах не должна превышать $0"
 
 #: pkg/storaged/utils.js:157
 msgid "Name cannot be longer than $0 characters"
-msgstr ""
+msgstr "Длина имени в символах не должна превышать $0"
 
 #: pkg/storaged/utils.js:133
 msgid "Name cannot be longer than 127 characters."
-msgstr "Имя не может быть длиннее 127 символов."
+msgstr "Длина имени должна составлять не более 127 символов"
 
 #: pkg/storaged/utils.js:137
 msgid "Name cannot contain the character '$0'."
@@ -4141,15 +4324,16 @@ msgid "Name cannot contain whitespace."
 msgstr "Имя не может содержать пробелы."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Имя не должно быть пустым"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:36
 msgid "Name: "
-msgstr ""
+msgstr "Имя: "
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1402
 msgid "Need at least one NTP server"
 msgstr "Нужна, по крайней мере, один сервер NTP"
 
@@ -4157,35 +4341,48 @@ msgstr "Нужна, по крайней мере, один сервер NTP"
 msgid "Netmask"
 msgstr "Маска сети"
 
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/machines/components/aggregateStatusCards.jsx:72
+msgid "Network"
+msgid_plural "Networks"
+msgstr[0] "сеть"
+msgstr[1] "сети"
+msgstr[2] "сетей"
+
+#: pkg/dashboard/index.html:72
+msgctxt "label"
 msgid "Network"
 msgstr "Сеть"
 
 #: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
-msgstr ""
+msgstr "Не удалось включить сеть $0"
 
 #: pkg/machines/components/networks/network.jsx:130
 msgid "Network $0 failed to get deactivated"
-msgstr ""
+msgstr "Не удалось отключить сеть $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
-msgstr ""
+msgstr "Сетевая загрузка (PXE)"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+"Сетевая загрузка доступна только при использовании подключения «System»"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Сетевая файловая система"
 
-#: pkg/machines/components/vm/vm.jsx:50
+#: pkg/machines/components/vm/vm.jsx:52
 msgid "Network Interfaces"
-msgstr ""
+msgstr "Сетевые интерфейсы"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
-msgstr ""
+msgstr "Выбор сети не поддерживает PXE."
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:589
 msgid "Network Traffic"
 msgstr "Сетевой трафик"
 
@@ -4193,20 +4390,21 @@ msgstr "Сетевой трафик"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Для сетевых устройств и графиков требуется NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicAdd.jsx:176
+#: pkg/machines/components/nicEdit.jsx:119
 msgid "Network interface settings could not be saved"
-msgstr ""
+msgstr "Не удалось сохранить параметры сетевого интерфейса"
 
 #: pkg/networkmanager/index.html:46
 msgid "NetworkManager is not running."
 msgstr "NetworkManager не работает."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:946 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Сеть"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1645 pkg/networkmanager/interfaces.js:2228
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Сеть"
@@ -4215,8 +4413,8 @@ msgstr "Сеть"
 msgid "Networking Logs"
 msgstr "Сетевые журналы"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:54
 msgid "Networks"
 msgstr "Сети"
 
@@ -4225,32 +4423,30 @@ msgid "Never"
 msgstr "Никогда"
 
 #: pkg/users/index.html:297 pkg/users/local.js:872
-#, fuzzy
 msgid "Never expire password"
-msgstr "Никогда не истекает пароль"
+msgstr "Пароль с неограниченным сроком действия"
 
 #: pkg/users/index.html:258 pkg/users/local.js:880
 msgid "Never lock account"
 msgstr "Никогда не блокировать аккаунт"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "New NFS Mount"
 msgstr "Новое подключение по NFS"
 
-#: pkg/shell/index.html:289 pkg/users/index.html:218
+#: pkg/shell/index.html:290 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Новый пароль"
 
-#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:39
 msgid "New Volume Name"
 msgstr "Новое имя тома"
 
-#: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
+#: pkg/storaged/crypto-keyslots.jsx:214 pkg/storaged/crypto-keyslots.jsx:260
 msgid "New passphrase"
 msgstr "Новая кодовая фраза"
 
-#: pkg/users/local.js:139 pkg/lib/credentials.js:237
-#, fuzzy
+#: pkg/lib/credentials.js:237 pkg/users/local.js:139
 msgid "New password was not accepted"
 msgstr "Новый пароль не был принят"
 
@@ -4258,65 +4454,78 @@ msgstr "Новый пароль не был принят"
 msgid "Next"
 msgstr "Далее"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:304
 msgid "Next Run"
 msgstr "Следующий запуск"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:237 pkg/systemd/host.js:1645
 msgid "Nice"
 msgstr "Приоритет"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2614
 msgid "No"
 msgstr "Нет"
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:465
 msgid "No Delay"
 msgstr "Без задержки"
 
-#: pkg/storaged/format-dialog.jsx:252
+#: pkg/storaged/format-dialog.jsx:257
 msgid "No Filesystem"
 msgstr "Нет файловой системы"
 
-#: pkg/storaged/content-views.jsx:715
+#: pkg/storaged/content-views.jsx:735
 msgid "No Logical Volumes"
 msgstr "Нет логических томов"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
-msgstr ""
+msgstr "Соответствующие результаты не найдены."
 
 #: pkg/storaged/nfs-panel.jsx:111
 msgid "No NFS mounts set up"
 msgstr "Подключения по NFS отсутствуют"
 
-#: pkg/selinux/setroubleshoot-view.jsx:365
+#: pkg/machines/components/nicBody.jsx:117
+msgid "No Network Devices"
+msgstr "Сетевые устройства отсутствуют"
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Оповещения SELinux отсутствуют."
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
-msgid "No Storage Pools available"
-msgstr ""
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:444
+msgid "No Storage"
+msgstr "Нет хранилища"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
+#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/diskAdd.jsx:144
+msgid "No Storage Pools available"
+msgstr "Нет доступных пулов носителей"
+
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:113
 msgid "No Storage Volumes defined for this Storage Pool"
-msgstr "Для этого пула хранения не определены тома хранения"
+msgstr "Для этого пула носителей не определены тома хранения"
+
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "No System Modifications"
+msgstr "Изменения системы отсутствуют"
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
-msgstr "Никакая виртуальная машина не запущена или не определена на этом хосте"
+msgstr ""
+"Никакая виртуальная машина не запущена или не определена на этом хосте"
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicBody.jsx:115
 msgid "No Virtual Networks"
-msgstr ""
+msgstr "Нет виртуальных сетей"
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:958
 msgid "No active zones"
-msgstr ""
+msgstr "Нет активных зон"
 
-#: pkg/docker/storage.jsx:206
+#: pkg/docker/storage.jsx:208
 msgid "No additional local storage found."
 msgstr "Никакого дополнительного локального хранилища не найдено."
 
@@ -4332,7 +4541,7 @@ msgstr "Нет приложений, установленных или дост�
 msgid "No archive has been created."
 msgstr "Архив не создан."
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "No available slots"
 msgstr "Нет доступных слотов"
 
@@ -4340,11 +4549,11 @@ msgstr "Нет доступных слотов"
 msgid "No boot device found"
 msgstr "Не найдено загрузочного устройства"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1433
 msgid "No carrier"
 msgstr "Нет перевозчика"
 
-#: pkg/kdump/kdump-view.jsx:396
+#: pkg/kdump/kdump-view.jsx:398
 msgid "No configuration found"
 msgstr "Конфигурация не найдена"
 
@@ -4364,33 +4573,33 @@ msgstr "Контейнеры отсутствуют"
 msgid "No containers that match the current filter"
 msgstr "Отсутствуют контейнеры, соответствующие текущему фильтру"
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:761
 msgid "No description available"
-msgstr ""
+msgstr "Описание отсутствует"
 
 #: pkg/apps/application.jsx:79
 msgid "No description provided."
 msgstr "Нет описания."
 
-#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
-#: pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/mdraid-details.jsx:49 pkg/storaged/mdraids-panel.jsx:92
+#: pkg/storaged/vdos-panel.jsx:59 pkg/storaged/vgroup-details.jsx:56
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "No disks are available."
 msgstr "Нет доступных дисков."
 
-#: pkg/machines/components/vmDisksTab.jsx:85
+#: pkg/machines/components/vmDisksTab.jsx:121
 msgid "No disks defined for this VM"
 msgstr "Диски, определенные для этой виртуальной машины"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:103
 msgid "No drives attached"
 msgstr "Приводы не подключены"
 
-#: pkg/storaged/crypto-keyslots.jsx:581
+#: pkg/storaged/crypto-keyslots.jsx:594
 msgid "No free key slots"
 msgstr "Нет свободных слотов для ключей"
 
-#: pkg/storaged/content-views.jsx:700
+#: pkg/storaged/content-views.jsx:720
 msgid "No free space"
 msgstr "Нет свободного места"
 
@@ -4398,13 +4607,9 @@ msgstr "Нет свободного места"
 msgid "No host keys found."
 msgstr "Не найдено ключей хоста."
 
-#: pkg/storaged/iscsi-panel.jsx:262
+#: pkg/storaged/iscsi-panel.jsx:269
 msgid "No iSCSI targets set up"
 msgstr "Нет установленных целей iSCSI"
-
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
-msgid "No image streams are present."
-msgstr "Нет потоков изображений."
 
 #: pkg/docker/containers-view.jsx:705
 msgid "No images"
@@ -4418,19 +4623,15 @@ msgstr "Отсутствуют образы, соответствующие те
 msgid "No installation package found for this application."
 msgstr "Пакет установки для этого приложения не установлен."
 
-#: pkg/storaged/crypto-keyslots.jsx:520
+#: pkg/storaged/crypto-keyslots.jsx:533
 msgid "No keys added"
 msgstr "Не добавлены ключи"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
-msgid "No matching files found"
-msgstr "Не найдено совпадающих файлов"
 
 #: pkg/storaged/drive-details.jsx:75
 msgid "No media inserted"
 msgstr "Не вставлен носитель"
 
-#: pkg/kdump/kdump-view.jsx:450
+#: pkg/kdump/kdump-view.jsx:452
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -4440,23 +4641,23 @@ msgstr ""
 "(например, в файле / etc / default / grub), чтобы зарезервировать память во "
 "время загрузки. Пример: crashkernel = 512M"
 
-#: pkg/machines/components/vmnetworktab.jsx:70
+#: pkg/machines/components/vmnetworktab.jsx:75
 msgid "No network interfaces defined for this VM"
 msgstr "Сетевые интерфейсы, определенные для этой виртуальной машины"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:56
 msgid "No network is defined on this host"
-msgstr ""
+msgstr "На этом узле не определено ни одной сети"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:180
 msgid "No networks available"
-msgstr ""
+msgstr "Нет доступных сетей"
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:971
 msgid "No open ports"
 msgstr "Нет открытых портов"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:537
 msgid "No partitioning"
 msgstr "Без разбиения"
 
@@ -4476,26 +4677,21 @@ msgstr "Нет работающих контейнеров"
 msgid "No running containers that match the current filter"
 msgstr "Нет работающих контейнеров, соответствующих текущему фильтру"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:50
+#: pkg/machines/components/storagePools/storagePoolList.jsx:55
 msgid "No storage pool is defined on this host"
-msgstr "На этом хосте не определен пул хранения"
+msgstr "На этом узле не определён пул носителей"
 
-#: pkg/storaged/mdraids-panel.jsx:130
+#: pkg/storaged/mdraids-panel.jsx:147
 msgid "No storage set up as RAID"
 msgstr "Нет хранилища, настроенного как RAID"
 
-#: pkg/storaged/vdos-panel.jsx:167
+#: pkg/storaged/vdos-panel.jsx:177
 msgid "No storage set up as VDO"
 msgstr "Нет хранилища, настроенного как VDO"
 
 #: pkg/lib/credentials.js:186
 msgid "No such file or directory"
 msgstr "Данный файл или каталог отсутствует"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:73
-#, fuzzy
-msgid "No tags are present."
-msgstr "Метки/теги отсутствуют."
 
 #: pkg/packagekit/updates.jsx:42
 msgid "No updates pending"
@@ -4505,19 +4701,19 @@ msgstr "Нет ожидающих обновления"
 msgid "No user name specified"
 msgstr "Не указано имя пользователя"
 
-#: pkg/storaged/vgroups-panel.jsx:114
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr "Нет групп томов"
 
-#: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
-#: pkg/kdump/kdump-view.jsx:419
+#: pkg/kdump/kdump-view.jsx:421
+#: pkg/machines/components/networks/createNetworkDialog.jsx:190
+#: pkg/networkmanager/firewall.jsx:766 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Нет"
 
 #: pkg/machines/helpers.js:224
 msgid "None (Isolated Network)"
-msgstr ""
+msgstr "Нет (изолированная сеть)"
 
 #: pkg/playground/translate.html:29
 msgid "Not Ready"
@@ -4531,11 +4727,11 @@ msgstr "Недействительный закрытый ключ"
 msgid "Not authorized to access Docker on this system"
 msgstr "Не разрешено доступ к Докеру в этой системе"
 
-#: pkg/systemd/logs.js:527
+#: pkg/systemd/logs.js:529
 msgid "Not authorized to upload-report"
-msgstr "Не разрешено выгрузка-отчет"
+msgstr "Для отправки отчёта недостаточно прав"
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:836
 msgid "Not available"
 msgstr "Недоступно"
 
@@ -4543,11 +4739,15 @@ msgstr "Недоступно"
 msgid "Not connected"
 msgstr "Не подключен"
 
-#: pkg/storaged/lvol-tabs.jsx:369
-msgid "Not enough space to grow."
-msgstr ""
+#: pkg/systemd/host.js:577
+msgid "Not connected to Insights"
+msgstr "Нет подключения к Insights"
 
-#: pkg/docker/details.js:185 pkg/storaged/details.jsx:121
+#: pkg/storaged/lvol-tabs.jsx:377
+msgid "Not enough space to grow."
+msgstr "Недостаточно места для увеличения."
+
+#: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Не найдено"
 
@@ -4555,23 +4755,19 @@ msgstr "Не найдено"
 msgid "Not mounted"
 msgstr "Не установлен"
 
-#: src/base1/cockpit.js:4013
+#: src/base1/cockpit.js:4017
 msgid "Not permitted to perform this action."
 msgstr "Не разрешено выполнять это действие."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:361
 msgid "Not running"
-msgstr "Не бегать"
+msgstr "Не работает"
 
 #: pkg/systemd/index.html:63
 msgid "Not synchronized"
 msgstr "Не синхронизирован"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:44
-msgid "Not yet synced"
-msgstr "Еще не синхронизирован"
-
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Примечание"
 
@@ -4581,54 +4777,45 @@ msgstr "Ноутбук"
 
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
-msgstr "Извещение и выше"
+msgstr "Уведомления и выше"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr "Поставщик ОС"
+#: pkg/playground/manifest.json.in
+msgid "Notifications"
+msgstr "Уведомления"
 
-#: pkg/selinux/setroubleshoot-view.jsx:394
+#: pkg/playground/manifest.json.in
+msgid "Notifications Receiver"
+msgstr "Приёмник уведомлений"
+
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr "Происходило $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:389
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr "Произошло между $0 а также $1"
-
-#: pkg/lib/patterns.js:246
-msgid "Off"
-msgstr "Выкл"
 
 #: pkg/lib/cockpit-components-dialog.jsx:194
 msgid "Ok"
 msgstr "OK"
 
-#: pkg/shell/index.html:281 pkg/users/index.html:215
+#: pkg/shell/index.html:282 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Старый пароль"
 
-#: pkg/storaged/crypto-keyslots.jsx:249
+#: pkg/storaged/crypto-keyslots.jsx:257
 msgid "Old passphrase"
 msgstr "Старая кодовая фраза"
 
-#: pkg/users/local.js:86 pkg/lib/credentials.js:218
-#, fuzzy
+#: pkg/lib/credentials.js:218 pkg/users/local.js:86
 msgid "Old password not accepted"
-msgstr "Старый пароль не принимается"
+msgstr "Старый пароль не был принят"
 
-#: pkg/lib/patterns.js:246
-msgid "On"
-msgstr "Вкл"
-
-#: node_modules/registry-image-widgets/views/image-meta.html:7
-msgid "On Build"
-msgstr "Построить"
-
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:431
 msgid "On Failure"
 msgstr "О неисправности"
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr "На установленном устройстве"
 
@@ -4651,27 +4838,30 @@ msgstr ""
 msgid "One Time Password"
 msgstr "Одноразовый пароль"
 
-#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:77
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:76
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
 msgstr ""
+"Один или несколько выбранных томов используются доменами. Сначала отключите "
+"диски, чтобы разрешить удаление тома."
 
 #: pkg/storaged/vdo-details.jsx:134
+#, fuzzy
 msgid "Only $0 of $1 are used."
 msgstr "Только $0 из $1 используются."
 
 #: pkg/systemd/logs.html:56
 msgid "Only Emergency"
-msgstr "Только чрезвычайная ситуация"
+msgstr "Только экстренные оповещения"
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1179
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Только алфавиты, числа,:, _,. , @ , - разрешены."
 
 #: pkg/machines/components/vm/memoryModal.jsx:196
 msgid "Only editable when the guest is shut off"
-msgstr ""
+msgstr "Может редактироваться, только когда гостевая система выключена"
 
 #: pkg/shell/index.html:43 pkg/shell/simple.html:29
 msgid "Ooops!"
@@ -4679,10 +4869,10 @@ msgstr "По электронной почте Ой!"
 
 #: pkg/machines/helpers.js:222
 msgid "Open"
-msgstr ""
+msgstr "Открытая"
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Операционная система"
 
@@ -4693,15 +4883,15 @@ msgstr "Операция '$operation'on $target"
 #: pkg/machines/components/storagePools/storagePool.jsx:175
 #: pkg/machines/components/storagePools/storagePool.jsx:180
 msgid "Operation is in progress"
-msgstr ""
+msgstr "Операция выполняется"
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/drives-panel.jsx:76
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Оптический привод"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:137 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Параметры"
 
@@ -4712,9 +4902,9 @@ msgstr "Или используйте связанный браузер"
 # translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author ypoyarko
 #: pkg/lib/machine-info.js:64
 msgid "Other"
-msgstr "Другие"
+msgstr "Прочее"
 
-#: pkg/storaged/content-views.jsx:353
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Другие данные"
@@ -4728,94 +4918,98 @@ msgid "Other Options"
 msgstr "Другие опции"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
+#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/networks/network.jsx:72
+#: pkg/machines/components/vm/vm.jsx:49
 msgid "Overview"
 msgstr "Обзор"
 
-#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:525 pkg/storaged/format-dialog.jsx:290
 msgid "Overwrite existing data with zeros"
 msgstr "Заменять существующие данные нулями"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "PCI"
 msgstr "PCI"
 
-#: pkg/packagekit/updates.jsx:501
+#: pkg/packagekit/updates.jsx:503
 msgid "Package information"
 msgstr "Информация о пакете"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
-msgstr "Пакет PackageKit разбился"
+msgstr "Сбой PackageKit"
 
-#: pkg/packagekit/updates.jsx:564
+#: pkg/packagekit/updates.jsx:565
 msgid "PackageKit is not installed"
 msgstr "PackageKit не установлен"
 
-#: pkg/packagekit/updates.jsx:718
+#: pkg/packagekit/updates.jsx:719
 msgid "PackageKit reported error code $0"
-msgstr "PackageKit сообщил код ошибки $0"
+msgstr "PackageKit передал код ошибки $0"
+
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr "Пакеты"
 
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Родитель"
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2923
 msgid "Parent $parent"
-msgstr "родитель $parent"
+msgstr "Родительский элемент $parent"
 
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:421
 msgid "Part Of"
 msgstr "Часть"
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1479
 msgid "Part of "
 msgstr "Часть "
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "раздел"
 
-#: pkg/storaged/utils.js:271
+#: pkg/storaged/utils.js:272
 msgid "Partition of $0"
 msgstr "Раздел $0"
 
-#: pkg/storaged/content-views.jsx:519
+#: pkg/storaged/content-views.jsx:528
 msgid "Partitioning"
 msgstr "Разбиение"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2021
 msgid "Passive"
 msgstr "пассивный"
 
 # translation auto-copied from project Anaconda, version master, document anaconda, author Igor Gorbounov
-#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
+#: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
+#: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:307
 msgid "Passphrase"
 msgstr "Парольная фраза"
 
-#: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
-#: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:299
+#: pkg/storaged/crypto-keyslots.jsx:158 pkg/storaged/crypto-keyslots.jsx:217
+#: pkg/storaged/crypto-keyslots.jsx:258 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/format-dialog.jsx:311
 msgid "Passphrase cannot be empty"
 msgstr "Парольная фраза не может быть пустой"
 
-#: pkg/storaged/crypto-keyslots.jsx:356
+#: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Passphrase removal may prevent unlocking $0."
 msgstr "Удаление парольной фразы может предотвратить разблокировку $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/crypto-keyslots.jsx:225 pkg/storaged/crypto-keyslots.jsx:263
+#: pkg/storaged/format-dialog.jsx:319
 msgid "Passphrases do not match"
 msgstr "Парольные фразы не совпадают"
 
-#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
+#: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
+#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Пароль"
 
@@ -4824,9 +5018,8 @@ msgid "Password Expiration"
 msgstr "Истечение срока действия пароля"
 
 #: pkg/users/local.js:277
-#, fuzzy
 msgid "Password is not acceptable"
-msgstr "Пароль не приемлем"
+msgstr "Недопустимый пароль"
 
 #: pkg/users/local.js:265
 msgid "Password is too weak"
@@ -4849,13 +5042,14 @@ msgstr ""
 
 #: pkg/lib/cockpit-components-context-menu.jsx:104
 msgid "Paste"
-msgstr ""
+msgstr "Вставить"
 
 #: pkg/users/index.html:409
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Вставьте сюда содержимое вашего файла открытого SSH-ключа."
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Путь"
 
@@ -4863,51 +5057,51 @@ msgstr "Путь"
 msgid "Path cost"
 msgstr "Стоимость пути"
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2905
 msgid "Path cost $path_cost"
-msgstr "Стоимость пути $path_Стоимость"
+msgstr "Стоимость пути $path_cost"
 
-#: pkg/storaged/nfs-details.jsx:151
+#: pkg/storaged/nfs-details.jsx:155
 msgid "Path on Server"
 msgstr "Путь на сервере"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Путь в файловой системе хоста"
 
-#: pkg/storaged/nfs-details.jsx:155
+#: pkg/storaged/nfs-details.jsx:160
 msgid "Path on server cannot be empty."
 msgstr "Путь на сервере не может быть пустым."
 
-#: pkg/storaged/nfs-details.jsx:157
+#: pkg/storaged/nfs-details.jsx:162
 msgid "Path on server must start with \"/\"."
 msgstr "Путь на сервере должен начинаться с «/»."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Путь к файлу ISO в файловой системе хоста"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:141
 msgid "Path to file"
 msgstr "Путь к файлу"
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Пути"
 
 #: pkg/machines/components/vm/vmActions.jsx:77
 msgid "Pause"
-msgstr ""
+msgstr "Приостановить"
 
-#: pkg/systemd/index.html:152
+#: pkg/systemd/index.html:159
 msgid "Performance Profile"
 msgstr "Профиль производительности"
 
 #: pkg/lib/machine-info.js:84
 msgid "Peripheral Chassis"
-msgstr "Периферийное шасси"
+msgstr "Корпус для периферийных устройств"
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3657
 msgid "Permanent"
 msgstr "Постоянная"
 
@@ -4915,60 +5109,66 @@ msgstr "Постоянная"
 msgid "Permission denied"
 msgstr "Отказано в разрешении"
 
-#: pkg/machines/components/diskAdd.jsx:110
-msgid "Persistence"
-msgstr ""
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr "Нестрогая"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
+#: pkg/machines/components/diskAdd.jsx:111
+#: pkg/machines/components/nicAdd.jsx:80
+msgid "Persistence"
+msgstr "Сохраняемость"
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
-msgstr ""
+msgstr "Постоянно"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/storaged/vdo-details.jsx:277
+#: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "Физическая"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
-msgstr ""
+msgstr "Физические дисковое устройство"
 
-#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
+#: pkg/storaged/content-views.jsx:154 pkg/storaged/content-views.jsx:348
 msgid "Physical Volume"
 msgstr "Физический объем"
 
-#: pkg/storaged/vgroup-details.jsx:133
+#: pkg/storaged/vgroup-details.jsx:127
 msgid "Physical Volumes"
 msgstr "Физические тома"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
-msgstr ""
+msgstr "Физическое дисковое устройство на узле"
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:343
 msgid "Physical volume of $0"
 msgstr "Физический объем $0"
 
-#: pkg/storaged/lvol-tabs.jsx:164
+#: pkg/storaged/lvol-tabs.jsx:165
 msgid "Physical volumes can not be resized here."
 msgstr "Здесь физические размеры не могут быть изменены."
 
 #: pkg/networkmanager/index.html:343
+#, fuzzy
 msgid "Ping Interval"
 msgstr "Интервал Ping"
 
 #: pkg/networkmanager/index.html:347
 msgid "Ping Target"
-msgstr "Ping Target"
+msgstr ""
 
 #: pkg/lib/machine-info.js:68
 msgid "Pizza Box"
-msgstr "Коробка для пиццы"
+msgstr "Ультратонкий корпус"
 
-#: pkg/docker/details.js:290 pkg/docker/util.js:612
-#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
-#: pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:291
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:296
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:199
+#: pkg/storaged/vgroup-details.jsx:207
 msgid "Please confirm deletion of $0"
 msgstr "Пожалуйста, подтвердите удаление $0"
 
@@ -4976,19 +5176,19 @@ msgstr "Пожалуйста, подтвердите удаление $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Пожалуйста, подтвердите принудительное удаление $0"
 
-#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
+#: pkg/storaged/mdraid-details.jsx:240 pkg/storaged/vdo-details.jsx:155
 msgid "Please confirm stopping of $0"
 msgstr "Пожалуйста, подтвердите прекращение $0"
 
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:350
 msgid "Please enter new volume name"
 msgstr "Введите новое имя тома"
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:353
 msgid "Please enter new volume size"
 msgstr "Введите новый размер тома"
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:896
 msgid "Please install the $0 package"
 msgstr "Пожалуйста, установите $0 пакет"
 
@@ -5004,56 +5204,65 @@ msgstr "Укажите хост для подключения к"
 msgid "Please start the virtual machine to access its console."
 msgstr ""
 "Пожалуйста, запустите виртуальную машину, чтобы получить доступ к ее консоли."
+""
 
 #: pkg/docker/search.js:148
 msgid "Please try another term"
 msgstr "Попробуйте другой термин"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Plug"
 msgstr "штепсель"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
+#: pkg/machines/components/diskAdd.jsx:127
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Пул"
 
-#: pkg/storaged/utils.js:191
+#: pkg/storaged/utils.js:192
 msgid "Pool for Thin Logical Volumes"
 msgstr "Пул для тонких логических томов"
 
-#: pkg/storaged/content-views.jsx:594
+#: pkg/storaged/content-views.jsx:607
 msgid "Pool for Thin Volumes"
-msgstr "Бассейн для тонких томов"
+msgstr "Пул для тонких томов"
 
-#: pkg/storaged/content-views.jsx:651
+#: pkg/storaged/content-views.jsx:668
 msgid "Pool for thinly provisioned volumes"
-msgstr "Бассейн для тонко заготовленных объемов"
+msgstr "Пул для «тонко» резервируемых томов"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:142
+msgid "Pool type doesn't support volume creation"
+msgstr "Тип пула не поддерживает создание томов"
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr "Тома пула используются виртуальными машинами "
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:108
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:113
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Port"
 msgstr "Порт"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr "Номер и тип порта не совпадают"
 
 #: pkg/lib/machine-info.js:71
-#, fuzzy
 msgid "Portable"
-msgstr "Портативный"
+msgstr "Портативный компьютер"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
-#: pkg/networkmanager/index.html:323
-#: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/index.html:323 pkg/docker/containers-view.jsx:414
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Ports"
 msgstr "Порты"
 
@@ -5061,49 +5270,57 @@ msgstr "Порты"
 msgid "Ports:"
 msgstr "Порты:"
 
-#: pkg/systemd/index.html:132
+#: pkg/systemd/index.html:139
 msgid "Power Options"
 msgstr "Электропитание"
 
 #: pkg/machines/components/vcpuModal.jsx:206
 msgid "Preferred number of sockets to expose to the guest."
-msgstr "Предпочтительное количество сокетов, которые выставляют гостю."
+msgstr "Предпочтительное количество сокетов для выставления гостевой системе."
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:135
 msgid "Prefix"
-msgstr ""
+msgstr "Префикс"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "Prefix Length"
+msgstr "Длина префикса"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr "Длина префикса не должна быть пустой"
+
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length"
 msgstr "Длина префикса"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length or Netmask"
 msgstr "Длина префикса или маска сети"
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr "Предварительно загружено"
+
+#: pkg/networkmanager/interfaces.js:840
 msgid "Preparing"
 msgstr "Идёт подготовка"
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr "Присутствует"
+
+#: pkg/networkmanager/interfaces.js:3658
 msgid "Preserve"
 msgstr "Не изменять"
 
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr "Предустановка"
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
-msgstr "Принудительная предустановка"
-
-#: pkg/systemd/index.html:295
+#: pkg/systemd/index.html:306
 msgid "Pretty Host Name"
 msgstr "Довольно имя хоста"
 
 #: pkg/systemd/logs.html:43
 msgid "Previous boot"
-msgstr ""
+msgstr "Предыдущая загрузка"
 
 #: pkg/networkmanager/index.html:289
 msgid "Primary"
@@ -5114,23 +5331,23 @@ msgstr "Основной"
 msgid "Priority"
 msgstr "Приоритет"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2879 pkg/networkmanager/interfaces.js:2903
 msgid "Priority $priority"
-msgstr "приоритет $priority"
+msgstr "Приоритет $priority"
 
 #: pkg/machines/helpers.js:227
 msgid "Private"
-msgstr ""
+msgstr "Частная"
 
 #: pkg/shell/index.html:39
 msgid "Privileged"
 msgstr "привилегированный"
 
-#: pkg/systemd/logs.js:488
+#: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Информация о проблемах"
 
-#: pkg/systemd/logs.js:487
+#: pkg/systemd/logs.js:489
 msgid "Problem info"
 msgstr "Информация о проблеме"
 
@@ -5138,14 +5355,14 @@ msgstr "Информация о проблеме"
 msgid "Problems"
 msgstr "Проблемы"
 
-#: pkg/storaged/dialog.jsx:1043
+#: pkg/storaged/dialog.jsx:1044
 msgid "Process"
 msgstr "Процесс"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:121
 #: pkg/machines/components/vm/bootOrderModal.jsx:127
 msgid "Product"
-msgstr ""
+msgstr "Продукт"
 
 #: pkg/shell/index.html:86 pkg/shell/simple.html:62
 msgid "Project website"
@@ -5163,7 +5380,7 @@ msgstr "Вызов через ssh-add"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Вызов с помощью ssh-keygen"
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:434
 msgid "Propagates Reload To"
 msgstr "Продвигает"
 
@@ -5173,126 +5390,126 @@ msgstr "Продвигает"
 msgid "Protocol"
 msgstr "Протокол"
 
-#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:231
 msgid "Public Key"
 msgstr "Открытый ключ"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr "Общественное вытягивание репо"
-
-#: pkg/storaged/content-views.jsx:645
+#: pkg/storaged/content-views.jsx:660
 msgid "Purpose"
 msgstr "Назначение"
 
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "QEMU / KVM Системное соединение"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "QEMU / KVM Подключение пользователя"
-
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/mdraid-details.jsx:174
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:45
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (полоса)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:175
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/mdraids-panel.jsx:52
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (зеркало)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/mdraids-panel.jsx:68
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (полоса зеркал)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:176
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/mdraids-panel.jsx:56
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (выделенная четность)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:177
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (распределенная четность)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:178
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:53
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (Double Distributed Parity)"
 
 #: pkg/lib/machine-info.js:85
 msgid "RAID Chassis"
-msgstr "Шасси RAID"
+msgstr "Корпус для RAID-массива"
 
 # translation auto-copied from project Blivet, version master, document blivet
 #: pkg/storaged/pvol-tabs.jsx:59
 msgid "RAID Device"
 msgstr "Устройство RAID"
 
-#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
+#: pkg/storaged/mdraid-details.jsx:311 pkg/storaged/utils.js:242
 msgid "RAID Device $0"
 msgstr "Устройство RAID $0"
 
-#: pkg/storaged/mdraids-panel.jsx:129
+#: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "Устройства RAID"
 
-#: pkg/storaged/mdraids-panel.jsx:41
+#: pkg/storaged/mdraids-panel.jsx:42
 msgid "RAID Level"
 msgstr "Уровень RAID"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:157
 msgid "RAID Member"
 msgstr "Пользователи"
 
 #: pkg/lib/machine-info.js:86
 msgid "Rack Mount Chassis"
-msgstr "Корпус для монтажа в стойку"
+msgstr "Монтируемый в стойку корпус"
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3659
 msgid "Random"
 msgstr "Случайный"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:791
 msgid "Range"
-msgstr ""
+msgstr "Диапазон"
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
-msgstr ""
+msgstr "Диапазон должен быть строго упорядочен"
 
-#: pkg/kdump/kdump-view.jsx:388
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Rank"
+msgstr "Ранг"
+
+#: pkg/kdump/kdump-view.jsx:390
 msgid "Raw to a device"
 msgstr "Необработанные устройства"
 
-#: pkg/systemd/hwinfo.jsx:193
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr "Шаблоны реагирования"
+
+#: pkg/systemd/hwinfo.jsx:197
 msgid "Read more..."
-msgstr ""
+msgstr "Подробнее..."
+
+#: pkg/systemd/service-details.jsx:388
+msgid "Read-only"
+msgstr "Только для чтения"
 
 #: pkg/docker/index.html:365
 msgid "ReadOnly"
@@ -5302,15 +5519,15 @@ msgstr "ReadOnly"
 msgid "ReadWrite"
 msgstr "Читай пиши"
 
-#: pkg/storaged/plot.jsx:310
+#: pkg/storaged/plot.jsx:312
 msgid "Reading"
 msgstr "Чтение"
 
-#: pkg/kdump/kdump-view.jsx:413
+#: pkg/kdump/kdump-view.jsx:415
 msgid "Reading..."
 msgstr "Чтение..."
 
-#: pkg/machines/components/vmDisksTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:112
 msgid "Readonly"
 msgstr "Только для чтения"
 
@@ -5323,11 +5540,11 @@ msgctxt "verb"
 msgid "Ready"
 msgstr "Готов"
 
-#: pkg/systemd/index.html:304
+#: pkg/systemd/index.html:315
 msgid "Real Host Name"
 msgstr "Реальное имя хоста"
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1074
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5335,11 +5552,11 @@ msgstr ""
 "Реальное имя хоста может содержать только строчные символы, цифры, тире и "
 "периоды (с заполненными субдоменами)"
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1075
 msgid "Real host name must be 64 characters or less"
 msgstr "Реальное имя хоста должно быть не менее 64 символов"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
+#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Перезагрузка"
 
@@ -5353,16 +5570,16 @@ msgstr "Приём"
 msgid "Recent"
 msgstr "Недавние"
 
-#: pkg/storaged/format-dialog.jsx:248
+#: pkg/storaged/format-dialog.jsx:253
 msgid "Recommended default"
-msgstr ""
+msgstr "Рекомендуется по умолчанию"
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:382 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Заново"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Recovering"
 msgstr "Восстановление"
 
@@ -5370,7 +5587,7 @@ msgstr "Восстановление"
 msgid "Recovering RAID Device $target"
 msgstr "Восстановление RAID-устройства $target"
 
-#: pkg/docker/storage.jsx:389
+#: pkg/docker/storage.jsx:396
 msgid "Reformat and add disks"
 msgstr "Переформатировать и добавить диски"
 
@@ -5390,31 +5607,31 @@ msgstr "Отказ от подключения. Хост-ключ не соот�
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Отказ от подключения. Хост-ключ неизвестен"
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:780
 msgid "Register…"
 msgstr "Регистр…"
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:435
 msgid "Reload Propagated From"
 msgstr "Перезагрузить Пропагандированный"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Удаленный URL"
 
-#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:386
+#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:388
 msgid "Remote over NFS"
 msgstr "Удаленный доступ к NFS"
 
-#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:384
+#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:386
 msgid "Remote over SSH"
 msgstr "Удаленный доступ к SSH"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/drives-panel.jsx:72 pkg/storaged/drives-panel.jsx:74
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "Съемный диск"
@@ -5423,21 +5640,21 @@ msgstr "Съемный диск"
 msgid "Removals:"
 msgstr "Удаления:"
 
-#: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
-#: pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
+#: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
+#: pkg/storaged/nfs-details.jsx:316
 msgid "Remove"
 msgstr "Удалить зону"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3076
 msgid "Remove $0"
 msgstr "Удалить $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:414
+#: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
 msgstr "Удалить $0?"
 
-#: pkg/storaged/crypto-keyslots.jsx:423
+#: pkg/storaged/crypto-keyslots.jsx:433
 msgid "Remove Tang keyserver"
 msgstr "Удалить сервер ключей Tang"
 
@@ -5445,28 +5662,28 @@ msgstr "Удалить сервер ключей Tang"
 msgid "Remove device"
 msgstr "Удалить устройство"
 
-#: pkg/storaged/crypto-keyslots.jsx:387
+#: pkg/storaged/crypto-keyslots.jsx:396
 msgid "Remove passphrase"
 msgstr "Удалить кодовую фразу"
 
-#: pkg/storaged/crypto-keyslots.jsx:354
+#: pkg/storaged/crypto-keyslots.jsx:362
 msgid "Remove passphrase in $0?"
 msgstr "Удалить кодовую фразу в $0?"
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:663
 msgid "Remove service"
-msgstr ""
+msgstr "Удалить службу"
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:642
 msgid "Remove service from zones"
-msgstr ""
+msgstr "Удаление службы из зон"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
 msgstr "Удаление"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:181
+#: pkg/lib/cockpit-components-install-dialog.jsx:182
 msgid "Removing $0"
 msgstr "Удаление $0"
 
@@ -5474,7 +5691,7 @@ msgstr "Удаление $0"
 msgid "Removing $target from RAID Device"
 msgstr "Удаление $target с устройства RAID"
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3075
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5486,16 +5703,16 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Удаление физического объема из $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:234
+#: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
+#: pkg/storaged/vgroup-details.jsx:231
 msgid "Rename"
 msgstr "Переименовать"
 
-#: pkg/storaged/lvol-tabs.jsx:31
+#: pkg/storaged/lvol-tabs.jsx:32
 msgid "Rename Logical Volume"
 msgstr "Переименовать логический том"
 
-#: pkg/storaged/vgroup-details.jsx:178
+#: pkg/storaged/vgroup-details.jsx:173
 msgid "Rename Volume Group"
 msgstr "Переименовать группу томов"
 
@@ -5507,53 +5724,51 @@ msgstr "Переименование $target"
 msgid "Repairing $target"
 msgstr "ремонт $target"
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Повторять ежедневно"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Повторять ежечасно"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Повторять ежемесячно"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Повторять еженедельно"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Повторять ежегодно"
 
-#: pkg/storaged/crypto-keyslots.jsx:204 pkg/storaged/crypto-keyslots.jsx:214
-#: pkg/storaged/crypto-keyslots.jsx:256
+#: pkg/storaged/crypto-keyslots.jsx:207 pkg/storaged/crypto-keyslots.jsx:219
+#: pkg/storaged/crypto-keyslots.jsx:262
 msgid "Repeat passphrase"
 msgstr "Повторить кодовую фразу"
 
-#: pkg/systemd/logs.js:512
+#: pkg/systemd/logs.js:514
 msgid "Report"
 msgstr "Сообщить"
 
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:509
 msgid "Reported"
-msgstr ""
-
-#: pkg/systemd/logs.js:529
-#, fuzzy
-msgid "Reporter 'reporter-ureport' not found."
-msgstr "Репортер «репортер-урепорт» не найден."
+msgstr "Отчёт отправлен"
 
 #: pkg/systemd/logs.js:531
-#, fuzzy
+msgid "Reporter 'reporter-ureport' not found."
+msgstr "Создатель отчётов «reporter-ureport» не найден."
+
+#: pkg/systemd/logs.js:533
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr ""
-"Отчетность была неприемлемой. Попробуйте запустить `reporter-ureport -d "
+"Отправка отчёта не удалась. Попробуйте выполнить команду `reporter-ureport -"
+"d "
 
 # translation auto-copied from project Red Hat Satellite User Guide, version 6.0, document appe-Glossary_of_Terms
 #: pkg/docker/index.html:690
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Репозиторий"
 
@@ -5565,24 +5780,32 @@ msgstr "Требовать изменение пароля каждый $0 дн�
 msgid "Require password change on $0"
 msgstr "Требовать изменения пароля $0"
 
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:422
 msgid "Required By"
 msgstr "Требуется для"
 
+#: pkg/systemd/service-details.jsx:374
+msgid "Required by "
+msgstr "Требуется для "
+
 # translation auto-copied from project RHN Satellite UI, version 5.7, document java/code/src/com/redhat/rhn/frontend/strings/jsp/StringResource, author ypoyarko
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "Требуются"
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:389
+msgid "Requires administration access to edit"
+msgstr "Для изменения необходимы права администратора"
+
+#: pkg/systemd/service-details.jsx:418
 msgid "Requisite"
 msgstr "Реквизит"
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:423
 msgid "Requisite Of"
 msgstr "Реквизиты"
 
-#: pkg/kdump/kdump-view.jsx:501
+#: pkg/kdump/kdump-view.jsx:503
 msgid "Reserved memory"
 msgstr "Зарезервированная память"
 
@@ -5591,11 +5814,11 @@ msgstr "Зарезервированная память"
 msgid "Reset"
 msgstr "Сброс"
 
-#: pkg/docker/storage.jsx:441
+#: pkg/docker/storage.jsx:452
 msgid "Reset Storage Pool"
 msgstr "Сброс пула носителей"
 
-#: pkg/docker/storage.jsx:444
+#: pkg/docker/storage.jsx:455
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
@@ -5608,21 +5831,24 @@ msgstr ""
 msgid "Resizing $target"
 msgstr "Изменение размера $target"
 
-#: pkg/storaged/lvol-tabs.jsx:225 pkg/storaged/lvol-tabs.jsx:307
+#: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
 msgstr ""
+"Для изменения размера зашифрованной файловой системы необходимо "
+"разблокировать диск. Введите парольную фразу текущего диска."
 
 # ctx::sourcefile::/rhn/admin/config/Restart.do
-#: pkg/docker/index.html:138 pkg/systemd/index.html:134
-#: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
-#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
+#: pkg/docker/index.html:138 pkg/systemd/index.html:141
+#: pkg/systemd/index.html:151 pkg/docker/containers-view.jsx:315
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Перезапустить"
 
-#: pkg/packagekit/updates.jsx:498
+#: pkg/packagekit/updates.jsx:500
 msgid "Restart Now"
 msgstr "Перезагрузить сейчас"
 
@@ -5634,21 +5860,21 @@ msgstr "Политика перезагрузки"
 msgid "Restart Policy:"
 msgstr "Политика перезагрузки:"
 
-#: pkg/packagekit/updates.jsx:493
+#: pkg/packagekit/updates.jsx:495
 msgid "Restart Recommended"
 msgstr "Рекомендуется перезапустить"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:867
 msgid "Restarting"
 msgstr "Перезапуск"
 
 #: pkg/networkmanager/index.html:39
 msgid "Restoring connection"
-msgstr "Восстановление соединения"
+msgstr "Восстановление подключения"
 
 #: pkg/machines/components/vm/vmActions.jsx:84
 msgid "Resume"
-msgstr ""
+msgstr "Возобновить"
 
 #: pkg/docker/index.html:555
 msgid "Retries:"
@@ -5659,7 +5885,8 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Повторное использование моего пароля для привилегированных задач"
 
 #: pkg/shell/index.html:159
-msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgid ""
+"Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Повторное использование моего пароля для привилегированных задач и "
 "подключение к другим машинам"
@@ -5668,58 +5895,53 @@ msgstr ""
 msgid "Roles"
 msgstr "Роли"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1995 pkg/networkmanager/interfaces.js:2012
 msgid "Round Robin"
 msgstr "Циклический перебор"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:98
 msgid "Route to $0"
-msgstr ""
+msgstr "Маршрутизация к $0"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:100
 msgid "Routed Network"
-msgstr ""
+msgstr "Сеть с маршрутизацией"
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3348
 msgid "Routes"
 msgstr "Маршруты"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Запуск"
 
 #: pkg/docker/index.html:427
-#, fuzzy
 msgid "Run Image"
-msgstr "Запустить изображение"
-
-#: node_modules/registry-image-widgets/views/image-config.html:8
-msgid "Run as"
-msgstr "Беги как"
+msgstr "Запуск образа"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
-msgstr ""
+msgstr "Выполнять при загрузке узла"
 
 #: pkg/networkmanager/index.html:328
 msgid "Runner"
-msgstr "полоз"
+msgstr "Средство запуска"
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Работает"
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
-msgstr "Время запуска"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
+msgstr "SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:364
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr "Ошибки контроля доступа SELinux"
 
-#: pkg/selinux/setroubleshoot-view.jsx:297
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "Политика SELinux"
 
@@ -5727,15 +5949,15 @@ msgstr "Политика SELinux"
 msgid "SELinux Troubleshoot"
 msgstr "SELinux Устранение неполадок"
 
-#: pkg/selinux/setroubleshoot-view.jsx:356
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "SELinux отключён в системе"
 
-#: pkg/selinux/setroubleshoot-view.jsx:284
+#: pkg/selinux/setroubleshoot-view.jsx:285
 msgid "SELinux is disabled on the system."
 msgstr "SELinux отключён в системе."
 
-#: pkg/selinux/setroubleshoot-view.jsx:276
+#: pkg/selinux/setroubleshoot-view.jsx:277
 msgid "SELinux system status is unknown."
 msgstr "Состояние системы SELinux неизвестно."
 
@@ -5775,7 +5997,15 @@ msgstr "Максимальное время жизни сообщения"
 msgid "STP Priority"
 msgstr "Приоритет"
 
-#: pkg/systemd/services.html:240
+#: pkg/shell/index.html:403
+msgid ""
+"Safari users need to import and trust the certificate of the self-signing CA:"
+""
+msgstr ""
+"Пользователям Safari необходимо импортировать и установить доверие к "
+"самозаверенному сертификату центра сертификации:"
+
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Суббота"
 
@@ -5783,27 +6013,26 @@ msgstr "Суббота"
 msgid "Saturdays"
 msgstr "По субботам"
 
-#: pkg/systemd/services.html:523
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:266 pkg/storaged/crypto-keyslots.jsx:285
 msgid "Save"
 msgstr "Сохранить"
 
-#: pkg/systemd/hwinfo.jsx:219
+#: pkg/systemd/hwinfo.jsx:223
 msgid "Save and reboot"
-msgstr ""
+msgstr "Сохранить и перезагрузить"
 
-#: pkg/storaged/vdos-panel.jsx:82
+#: pkg/storaged/vdos-panel.jsx:88
 msgid "Save space by compressing individual blocks with LZ4"
-msgstr ""
+msgstr "Экономьте место, сжимая отдельные блоки по алгоритму LZ4"
 
-#: pkg/storaged/vdos-panel.jsx:85
+#: pkg/storaged/vdos-panel.jsx:92
 msgid "Save space by storing identical data blocks just once"
-msgstr ""
+msgstr "Экономьте место, сохраняя блоки идентичных данных лишь один раз"
 
-#: pkg/storaged/crypto-keyslots.jsx:226 pkg/storaged/crypto-keyslots.jsx:276
+#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:283
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
@@ -5813,14 +6042,14 @@ msgstr ""
 
 #: pkg/lib/machine-info.js:87
 msgid "Sealed-case PC"
-msgstr "Компьютер с герметичным корпусом"
+msgstr "Компьютер с невскрываемым корпусом"
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:967
 msgid "Seconds"
 msgstr "с"
 
-#: pkg/systemd/index.html:106
+#: pkg/systemd/index.html:113
 msgid "Secure Shell Keys"
 msgstr "Ключи SSH"
 
@@ -5832,7 +6061,7 @@ msgstr "Безопасное стирание $target"
 msgid "Security"
 msgstr "Безопасность"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:509
 msgid "Security Updates Available"
 msgstr "Доступные обновления для системы безопасности"
 
@@ -5842,16 +6071,15 @@ msgstr "Выбрать"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with "
+"{{#strong}}{{host}}{{/strong}}"
 msgstr ""
-"Выберите пользователей, с которыми вы хотите синхронизировать {{#strong}}"
-"{{host}}{{/strong}}"
+"Выберите пользователей, с которыми вы хотите синхронизировать "
+"{{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
-#, fuzzy
 msgid "Send Non-Maskable Interrupt"
-msgstr "Отправить не-маскируемое прерывание"
+msgstr "Отправить немаскируемое прерывание"
 
 #: pkg/machines/components/vnc.jsx:108
 msgid "Send key"
@@ -5868,12 +6096,12 @@ msgid "Serial Console"
 msgstr "Серийная консоль"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
-#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: pkg/storaged/nfs-details.jsx:323 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Сервер"
 
-#: pkg/storaged/iscsi-panel.jsx:43 pkg/storaged/nfs-details.jsx:143
+#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:146
 msgid "Server Address"
 msgstr "Адрес сервера"
 
@@ -5883,17 +6111,17 @@ msgstr "Администратор сервера"
 
 #: pkg/realmd/operation.html:17
 msgid "Server Software"
-msgstr ""
+msgstr "Серверное программное обеспечение"
 
-#: pkg/storaged/iscsi-panel.jsx:44
+#: pkg/storaged/iscsi-panel.jsx:45
 msgid "Server address cannot be empty."
 msgstr "Адрес сервера не может быть пустым."
 
-#: pkg/storaged/nfs-details.jsx:147
+#: pkg/storaged/nfs-details.jsx:151
 msgid "Server cannot be empty."
 msgstr "Сервер не может быть пустым."
 
-#: src/base1/cockpit.js:4033
+#: src/base1/cockpit.js:4037
 msgid "Server has closed the connection."
 msgstr "Сервер закрыл соединение."
 
@@ -5901,45 +6129,46 @@ msgstr "Сервер закрыл соединение."
 msgid "Servers"
 msgstr "Серверы"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:970
+#: pkg/storaged/dialog.jsx:1048
 msgid "Service"
 msgstr "Служба"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Журналы службы"
 
-#: pkg/kdump/kdump-view.jsx:442
+#: pkg/kdump/kdump-view.jsx:444
 msgid "Service has an error"
 msgstr "У службы есть ошибка"
 
-#: pkg/kdump/kdump-view.jsx:438
+#: pkg/kdump/kdump-view.jsx:440
 msgid "Service is running"
-msgstr "Служба работает"
+msgstr "Служба запущена"
 
-#: pkg/kdump/kdump-view.jsx:444
+#: pkg/kdump/kdump-view.jsx:446
 msgid "Service is starting"
 msgstr "Служба запускается"
 
-#: pkg/kdump/kdump-view.jsx:440
+#: pkg/kdump/kdump-view.jsx:442
 msgid "Service is stopped"
 msgstr "Служба остановлена"
 
-#: pkg/kdump/kdump-view.jsx:446
+#: pkg/kdump/kdump-view.jsx:448
 msgid "Service is stopping"
 msgstr "Служба останавливается"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Название службы"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:510 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Службы"
 
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1044
 msgid "Session"
 msgstr "Сеанс"
 
@@ -5947,7 +6176,11 @@ msgstr "Сеанс"
 msgid "Set"
 msgstr "Настроить"
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:217
+msgid "Set DHCP Range"
+msgstr "Задать диапазон DHCP"
+
+#: pkg/systemd/host.js:816
 msgid "Set Host name"
 msgstr "Установить имя хоста"
 
@@ -5955,13 +6188,17 @@ msgstr "Установить имя хоста"
 msgid "Set Password"
 msgstr "Задать пароль"
 
-#: pkg/systemd/index.html:378
+#: pkg/systemd/index.html:389
 msgid "Set Time"
 msgstr "Установленное время"
 
 #: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Установка переменных среды контейнера"
+
+#: pkg/machines/components/nicAdd.jsx:60
+msgid "Set manually"
+msgstr "Задать вручную"
 
 #: pkg/networkmanager/index.html:183
 msgid "Set to"
@@ -5971,7 +6208,7 @@ msgstr "Установлен в"
 msgid "Set up"
 msgstr "Настроить"
 
-#: pkg/selinux/setroubleshoot-view.jsx:293
+#: pkg/selinux/setroubleshoot-view.jsx:294
 msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
@@ -5987,33 +6224,37 @@ msgid "Setting up loop device $target"
 msgstr "Настройка петлевого устройства $target"
 
 # translation auto-copied from project Customer Portal Translations, version PCM_template, document template, author ypoyarko
-#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:383
 msgid "Severity"
 msgstr "Приоритет"
 
-#: pkg/packagekit/updates.jsx:310
+#: pkg/packagekit/updates.jsx:311
 msgid "Severity:"
 msgstr "Строгость:"
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Shared"
 msgstr "Общее"
 
+#: pkg/lib/cockpit-components-modifications.jsx:78
+msgid "Shell Script"
+msgstr "Сценарий оболочки"
+
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
-msgstr ""
+msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Show Performance Options"
 msgstr "Показать параметры быстродействия"
 
-#: pkg/storaged/overview.jsx:56
+#: pkg/storaged/overview.jsx:54
 msgid "Show all"
-msgstr ""
+msgstr "Показать все"
 
-#: pkg/storaged/drives-panel.jsx:122
+#: pkg/storaged/drives-panel.jsx:104
 msgid "Show all $0 drives"
-msgstr ""
+msgstr "Показать все ($0) диски"
 
 #: pkg/docker/index.html:128
 msgid "Show all containers"
@@ -6023,103 +6264,106 @@ msgstr "Показать все контейнеры"
 msgid "Show all images"
 msgstr "Показать все изображения"
 
-#: pkg/systemd/index.html:107
+#: pkg/systemd/index.html:114
 msgid "Show fingerprints"
 msgstr "Показать отпечатки пальцев"
 
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
+#: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Уменьшить"
 
-#: pkg/storaged/lvol-tabs.jsx:313
+#: pkg/storaged/lvol-tabs.jsx:320
 msgid "Shrink Logical Volume"
 msgstr "Термоусадочный логический том"
 
-#: pkg/storaged/lvol-tabs.jsx:415
+#: pkg/storaged/lvol-tabs.jsx:423
 msgid "Shrink Volume"
 msgstr "Сжать том"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
-#: pkg/systemd/index.html:147 pkg/machines/components/vm/vmActions.jsx:56
+#: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
 msgstr "Выключение"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr "Одноранговая"
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
-#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:79
+#: pkg/storaged/content-views.jsx:118 pkg/storaged/content-views.jsx:702
+#: pkg/storaged/format-dialog.jsx:278 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:212 pkg/storaged/lvol-tabs.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:402 pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/nfs-details.jsx:329 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:263
 msgid "Size"
 msgstr "Размер"
 
-#: pkg/storaged/dialog.jsx:911
+#: pkg/storaged/dialog.jsx:912
 msgid "Size cannot be negative"
 msgstr "Размер не может быть отрицательным"
 
-#: pkg/storaged/dialog.jsx:909
+#: pkg/storaged/dialog.jsx:910
 msgid "Size cannot be zero"
 msgstr "Размер не может быть равен нулю"
 
-#: pkg/storaged/dialog.jsx:913
+#: pkg/storaged/dialog.jsx:914
 msgid "Size is too large"
 msgstr "Слишком большой размер"
 
-#: pkg/storaged/dialog.jsx:907
+#: pkg/storaged/dialog.jsx:908
 msgid "Size must be a number"
 msgstr "Размер должен быть числом"
 
-#: pkg/storaged/dialog.jsx:915
+#: pkg/storaged/dialog.jsx:916
 msgid "Size must be at least $0"
 msgstr "Размер должен быть не менее $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Slot"
 msgstr "слот"
 
-#: pkg/storaged/crypto-keyslots.jsx:531
+#: pkg/storaged/crypto-keyslots.jsx:544
 msgid "Slot $0"
 msgstr "слот $0"
 
 # translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author ypoyarko
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "Сокеты"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Программные обновления"
 
-#: pkg/systemd/hwinfo.jsx:208
+#: pkg/systemd/hwinfo.jsx:212
 msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
 "settings at your own risk."
 msgstr ""
+"Программные обходные решения помогают предотвратить проблемы безопасности ЦП."
+" Побочным эффектом этих мер является снижение производительности. Вы "
+"изменяете эти параметры на свой страх и риск."
 
-#: pkg/docker/storage.jsx:165
+#: pkg/docker/storage.jsx:167
 msgid "Solid-State Disk"
 msgstr "Твердотельный диск"
 
-#: pkg/storaged/drives-panel.jsx:87
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "Твердотельный диск"
-
-#: pkg/selinux/setroubleshoot-view.jsx:95
+#: pkg/selinux/setroubleshoot-view.jsx:96
 msgid "Solution applied successfully"
 msgstr "Решение успешно применено"
 
-#: pkg/selinux/setroubleshoot-view.jsx:102
+#: pkg/selinux/setroubleshoot-view.jsx:103
 msgid "Solution failed"
 msgstr "Не удалось решить проблему"
 
-#: pkg/selinux/setroubleshoot-view.jsx:409
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr "Решения"
 
@@ -6130,68 +6374,74 @@ msgstr ""
 "Некоторые другие программы в настоящее время используют диспетчер пакетов, "
 "пожалуйста, подождите ..."
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:741
 msgid "Sorted from least trusted to most trusted"
-msgstr ""
+msgstr "Сортировка от наименее доверенных к наиболее доверенным"
 
-#: pkg/machines/components/nicEdit.jsx:141
-#: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:148
-#: pkg/machines/components/diskAdd.jsx:504
+#: pkg/machines/components/diskAdd.jsx:412
+#: pkg/machines/components/nicBody.jsx:149
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/vmDisksTab.jsx:114
+#: pkg/machines/components/vmnetworktab.jsx:160
 msgid "Source"
 msgstr "Источник"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
-msgstr ""
+msgstr "Формат источника"
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Путь к источнику"
 
-#: node_modules/registry-image-widgets/views/image-body.html:8
-msgid "Source URL"
-msgstr "Исходный URL"
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr "Исходная группа томов"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Исходный путь не должен быть пустым"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
-msgstr ""
+msgstr "Путь должен начинаться с указания протокола HTTP, FTP или NFS"
 
 #: pkg/lib/machine-info.js:78
 msgid "Space-saving Computer"
 msgstr "Компактный компьютер"
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Spanning Tree Protocol"
 msgstr "Протокол связующего дерева"
 
 #: pkg/networkmanager/index.html:218
 msgid "Spanning Tree Protocol (STP)"
-msgstr "Протокол покрывающего дерева (STP)"
+msgstr "Протокол связующего дерева (STP)"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Spare"
 msgstr "Запасной"
 
-#: pkg/systemd/index.html:455
+#: pkg/systemd/index.html:466
 msgid "Specific Time"
 msgstr "Конкретное время"
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Speed"
+msgstr "Скорость"
+
+#: pkg/networkmanager/interfaces.js:3660
 msgid "Stable"
 msgstr "Стабильный"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
-#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
+#: pkg/machines/components/networks/createNetworkDialog.jsx:223
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:265 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Запустить"
 
@@ -6203,17 +6453,26 @@ msgstr "Запустить Docker"
 msgid "Start Multipath"
 msgstr "Запустить Multipath"
 
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:343
 msgid "Start Service"
 msgstr "Начало службы"
+
+#: pkg/systemd/service-details.jsx:413
+msgid "Start and Enable"
+msgstr "Включить и запустить"
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Начать libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
-msgstr "Запуск пула при загрузке хоста"
+msgstr "Запускать пул при загрузке узла"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr "Начало не должно быть пустым"
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6223,15 +6482,15 @@ msgstr "Запуск устройства RAID $target"
 msgid "Starting swapspace $target"
 msgstr "Запуск swapspace $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Запускать"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/vmnetworktab.jsx:186 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/hwinfo.jsx:263 pkg/systemd/init.js:306
 msgid "State"
 msgstr "Состояние"
 
@@ -6240,11 +6499,12 @@ msgstr "Состояние"
 msgid "State:"
 msgstr "Состояние:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:213
+#: pkg/systemd/service-details.jsx:371
 msgid "Static"
 msgstr "Статически"
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2633 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Состояние"
 
@@ -6253,21 +6513,26 @@ msgid "Stick PC"
 msgstr "Stick PC"
 
 #: pkg/networkmanager/index.html:367
+#, fuzzy
 msgid "Sticky"
 msgstr "липкий"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
-#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
-#: pkg/systemd/init.js:542
+#: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Остановить"
 
-#: pkg/storaged/mdraid-details.jsx:247
+#: pkg/storaged/mdraid-details.jsx:244
 msgid "Stop Device"
 msgstr "Остановить устройство"
 
-#: pkg/storaged/nfs-details.jsx:259
+#: pkg/systemd/service-details.jsx:413
+msgid "Stop and Disable"
+msgstr "Остановить и отключить"
+
+#: pkg/storaged/nfs-details.jsx:267
 msgid "Stop and Unmount"
 msgstr "Стоп и отключение"
 
@@ -6275,13 +6540,9 @@ msgstr "Стоп и отключение"
 msgid "Stop and delete"
 msgstr "Остановить и удалить"
 
-#: pkg/storaged/nfs-details.jsx:284
+#: pkg/storaged/nfs-details.jsx:292
 msgid "Stop and remove"
 msgstr "Остановить и удалить"
-
-#: node_modules/registry-image-widgets/views/image-config.html:14
-msgid "Stop with"
-msgstr "Остановитесь"
 
 #: pkg/docker/util.js:231
 msgid "Stopped"
@@ -6297,8 +6558,8 @@ msgstr "Остановка обмена $target"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Хранилище"
 
@@ -6306,26 +6567,33 @@ msgstr "Хранилище"
 msgid "Storage Logs"
 msgstr "Журналы хранения"
 
+#: pkg/machines/components/aggregateStatusCards.jsx:47
+msgid "Storage Pool"
+msgid_plural "Storage Pools"
+msgstr[0] "пул носителей"
+msgstr[1] "пула носителей"
+msgstr[2] "пулов носителей"
+
 #: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
-msgstr ""
+msgstr "Не удалось включить пул носителей $0"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:153
 msgid "Storage Pool $0 failed to get deactivated"
-msgstr ""
+msgstr "Не удалось отключить пул носителей $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
-msgstr "Имя пула хранения"
+msgstr "Имя пула носителей"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
-msgstr "Не удалось создать пул хранения"
+msgstr "Не удалось создать пул носителей"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:44
-#: pkg/machines/components/storagePools/storagePoolList.jsx:48
+#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/storagePoolList.jsx:53
 msgid "Storage Pools"
-msgstr "Бассейны"
+msgstr "Пулы носителей"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:88
 msgid "Storage Volumes"
@@ -6333,46 +6601,45 @@ msgstr "Объемы хранения"
 
 #: pkg/machines/components/storagePools/storageVolumeDelete.jsx:48
 msgid "Storage Volumes could not be deleted"
-msgstr ""
+msgstr "Не удалось удалить тома хранилища"
 
 #: pkg/storaged/devices.jsx:76
 msgid "Storage can not be managed on this system."
-msgstr ""
+msgstr "Управление хранилищем недоступно в данной системе."
 
 #: pkg/docker/index.html:304
 msgid "Storage pool"
-msgstr "Пул"
+msgstr "Пул носителей"
 
-#: pkg/systemd/index.html:155
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr "Размер хранилища не может быть равен нулю"
+
+#: pkg/systemd/index.html:162
 msgid "Store Metrics"
 msgstr "Сохранять показатели"
 
-#: pkg/storaged/format-dialog.jsx:122
+#: pkg/storaged/format-dialog.jsx:126
 msgid "Store passphrase"
 msgstr "Хранить парольную фразу"
 
-#: pkg/storaged/crypto-tab.jsx:67 pkg/storaged/crypto-tab.jsx:69
+#: pkg/storaged/crypto-tab.jsx:68 pkg/storaged/crypto-tab.jsx:70
 msgid "Stored Passphrase"
 msgstr "Сохраненная парольная фраза"
 
-#: pkg/storaged/crypto-tab.jsx:126
+#: pkg/storaged/crypto-tab.jsx:129
 msgid "Stored passphrase"
 msgstr "Сохраненная кодовая фраза"
 
 #: pkg/lib/machine-info.js:82
 msgid "Sub Chassis"
-msgstr "Sub Chassis"
+msgstr "Дополнительный корпус"
 
 #: pkg/lib/machine-info.js:77
 msgid "Sub Notebook"
-msgstr "Sub Notebook"
+msgstr "Субноутбук"
 
-#: node_modules/registry-image-widgets/views/image-body.html:4
-#, fuzzy
-msgid "Summary"
-msgstr "Краткое описание:"
-
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Воскресенье"
 
@@ -6380,32 +6647,32 @@ msgstr "Воскресенье"
 msgid "Sundays"
 msgstr "По воскресеньям"
 
-#: pkg/storaged/optional-panel.jsx:95
+#: pkg/storaged/optional-panel.jsx:98
 msgid "Support is installed."
 msgstr "Установлена ​​поддержка."
 
-#: pkg/storaged/content-views.jsx:157
+#: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Подкачка"
 
-#: pkg/storaged/content-views.jsx:351
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Swap Space"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:259 pkg/systemd/host.js:1756
 msgid "Swap Used"
 msgstr "Обмен Swap"
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:3060
 msgid "Switch off $0"
 msgstr "Выключить $0"
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2486 pkg/networkmanager/interfaces.js:3048
 msgid "Switch on $0"
 msgstr "Включить $0"
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2510
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6413,7 +6680,7 @@ msgstr ""
 "Отключение <b>$0</b> приведёт к разрыву соединения с сервером и "
 "недоступности интерфейса администратора."
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3059
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6421,7 +6688,7 @@ msgstr ""
 "Отключение <b>$0</b> приведёт к разрыву соединения с сервером и "
 "недоступности интерфейса администратора."
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3047
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6450,60 +6717,66 @@ msgid "Synchronizing RAID Device $target"
 msgstr "Синхронизация RAID-устройства $target"
 
 # translation auto-copied from project virt-manager, version 0.10.0, document virt-manager, author ypoyarko
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:273
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Система"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/index.html:171
+msgid "System Health"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:277
 msgid "System Information"
 msgstr "Сведения о системе"
 
-#: pkg/systemd/host.js:480
+#: pkg/selinux/setroubleshoot-view.jsx:467
+msgid "System Modifications"
+msgstr "Изменения системы"
+
+#: pkg/systemd/host.js:493
 msgid "System Not Registered"
 msgstr "Система не зарегистрирована"
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:47
 msgid "System Services"
 msgstr "Системные службы"
 
-#: pkg/systemd/index.html:121
+#: pkg/systemd/index.html:128
 msgid "System Time"
 msgstr "Системное время"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:499
 msgid "System Up To Date"
 msgstr "Система до даты"
 
 # ctx::sourcefile::/systems/SystemEntitlements
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:879
 msgid "System is up to date"
 msgstr "Система не нуждается в обновлении"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:970
 msgid "TCP"
 msgstr "TCP"
 
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
-msgstr "Планшет"
+msgstr "Планшетный ПК"
 
 # translation auto-copied from project shotwell-core, version 0.14.1, document shotwell-core
 #: pkg/docker/index.html:696
-#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Метка"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
 #: pkg/docker/containers-view.jsx:409
 msgid "Tags"
 msgstr "Теги"
 
-#: pkg/storaged/crypto-keyslots.jsx:207
+#: pkg/storaged/crypto-keyslots.jsx:210
 msgid "Tang keyserver"
 msgstr "Tang keyserver"
 
@@ -6512,25 +6785,25 @@ msgstr "Tang keyserver"
 msgid "Target"
 msgstr "Целевой"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Целевой путь"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Целевой путь не должен быть пустым"
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:48
 msgid "Targets"
 msgstr "Цели"
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2531 pkg/networkmanager/interfaces.js:2543
+#: pkg/networkmanager/interfaces.js:2834
 msgid "Team"
 msgstr "Группа"
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2862
 msgid "Team Port"
 msgstr "Порт агрегации (team)"
 
@@ -6542,7 +6815,7 @@ msgstr "Настройки командного порта"
 msgid "Team Settings"
 msgstr "Настройки команды"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Терминал"
 
@@ -6550,11 +6823,11 @@ msgstr "Терминал"
 msgid "Terminate Session"
 msgstr "Завершить сеанс"
 
-#: pkg/kdump/kdump-view.jsx:476 pkg/kdump/kdump-view.jsx:484
+#: pkg/kdump/kdump-view.jsx:478 pkg/kdump/kdump-view.jsx:486
 msgid "Test Configuration"
 msgstr "Проверить конфигурацию"
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr "Проверка доступна только при запущенной службе kdump."
 
@@ -6564,68 +6837,72 @@ msgstr "Проверить настройки kdump"
 
 #: pkg/networkmanager/index.html:38
 msgid "Testing connection"
-msgstr "Тестирование соединения"
+msgstr "Проверка подключения"
 
-#: pkg/docker/storage.jsx:507
+#: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
-msgstr "Пул хранения Docker нельзя управлять в этой системе."
+msgstr "Пулом носителей Docker невозможно управлять в этой системе."
 
-#: pkg/lib/machine-dialogs.js:384
+#: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP-адрес или имя хоста не могут содержать пробелы."
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/mdraid-details.jsx:213
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID-массив находится в деградированном состоянии"
 
-#: pkg/storaged/mdraid-details.jsx:148
+#: pkg/storaged/mdraid-details.jsx:142
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "Устройство RAID должно работать, чтобы добавить запасные диски."
 
-#: pkg/storaged/mdraid-details.jsx:115
+#: pkg/storaged/mdraid-details.jsx:109
 msgid "The RAID device must be running in order to remove disks."
 msgstr "Устройство RAID должно быть запущено для удаления дисков."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
-msgstr ""
+msgstr "Не удалось удалить пул носителей"
 
 #: pkg/machines/components/vm/stateIcon.jsx:40
 msgid "The VM crashed."
-msgstr "VM потерпела крах."
+msgstr "Виртуальная машина аварийно завершила работу."
 
 #: pkg/machines/components/vm/stateIcon.jsx:39
 msgid "The VM is down."
-msgstr "VM отключена."
+msgstr "Виртуальная машина не работает."
 
 #: pkg/machines/components/vm/stateIcon.jsx:38
 msgid "The VM is going down."
-msgstr "ВМ идет вниз."
+msgstr "Виртуальная машина завершает работу."
 
 #: pkg/machines/components/vm/stateIcon.jsx:36
 msgid "The VM is idle."
-msgstr "VM бездействует."
+msgstr "Виртуальная машина бездействует."
 
 #: pkg/machines/components/vm/stateIcon.jsx:43
 msgid "The VM is in process of dying (shut down or crash is not completed)."
-msgstr "VM находится в процессе умирания (закрытие или сбой не завершены)."
+msgstr ""
+"Виртуальная машина находится в процессе завершения работы или аварийного "
+"выключения."
 
 #: pkg/machines/components/vm/stateIcon.jsx:37
 msgid "The VM is paused."
-msgstr "VM приостановлена."
+msgstr "Виртуальная машина приостановлена."
 
 #: pkg/machines/components/deleteDialog.jsx:64
 msgid "The VM is running and will be forced off before deletion."
-msgstr "VM запускается и будет отключена перед удалением."
+msgstr ""
+"Виртуальная машина работает и будет принудительно отключена перед удалением."
 
 #: pkg/machines/components/vm/stateIcon.jsx:35
 msgid "The VM is running."
-msgstr "VM запущена."
+msgstr "Виртуальная машина работает."
 
 #: pkg/machines/components/vm/stateIcon.jsx:47
 msgid "The VM is suspended by guest power management."
-msgstr "VM приостанавливается управлением гостевой системой."
+msgstr ""
+"Виртуальная машина приостановлена управлением питанием гостевой системы."
 
 #: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
@@ -6634,8 +6911,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
+" Are you sure you want to continue connecting?"
 msgstr ""
 "Подлинность хоста {{#strong}}{{host}}{{/strong}} не может быть установлена. "
 "Вы действительно хотите продолжить соединение?"
@@ -6644,45 +6921,47 @@ msgstr ""
 msgid "The collected information will be stored locally on the system."
 msgstr "Собранная информация будет храниться локально в системе."
 
-#: pkg/selinux/setroubleshoot-view.jsx:291
+#: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Конфигурированное состояние неизвестно, оно может измениться при следующей "
 "загрузке."
 
 #: pkg/storaged/vdo-details.jsx:119
+#, fuzzy
 msgid ""
 "The creation of this VDO device did not finish and the device can't be used."
 msgstr ""
 "Создание этого устройства VDO не завершилось, и устройство не может быть "
 "использовано."
 
-#: pkg/storaged/crypto-keyslots.jsx:516
+#: pkg/storaged/crypto-keyslots.jsx:529
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
 "Пользователю в настоящий момент не разрешено просматривать информацию о "
 "ключах."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Каталог на экспортируемом сервере"
 
-#: pkg/storaged/dialog.jsx:1012
+#: pkg/storaged/dialog.jsx:1013
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
 msgstr ""
-"Файловая система используется сеансами входа в систему и системными "
-"службами. Продолжающие действия остановят их."
+"Файловая система используется сеансами входа в систему и системными службами."
+" Продолжающие действия остановят их."
 
-#: pkg/storaged/dialog.jsx:1014
-msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialog.jsx:1015
+msgid ""
+"The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Файловая система используется сеансами входа в систему. Продолжающие "
 "действия остановят их."
 
-#: pkg/storaged/dialog.jsx:1016
+#: pkg/storaged/dialog.jsx:1017
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
@@ -6690,7 +6969,8 @@ msgstr ""
 "остановлены."
 
 #: pkg/docker/util.js:631
-msgid "The following containers depend on this image and will become unusable."
+msgid ""
+"The following containers depend on this image and will become unusable."
 msgstr ""
 "Следующие контейнеры зависят от этого изображения и станут непригодными для "
 "использования."
@@ -6719,27 +6999,30 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr "Указанный ключ недействителен."
 
-#: pkg/storaged/mdraid-details.jsx:121
+#: pkg/storaged/mdraid-details.jsx:115
 msgid "The last disk of a RAID device cannot be removed."
 msgstr "Последний диск RAID-устройства не может быть удален."
 
-#: pkg/storaged/crypto-keyslots.jsx:541
+#: pkg/storaged/crypto-keyslots.jsx:554
 msgid "The last key slot can not be removed"
 msgstr "Последний ключевой слот нельзя удалить"
 
-#: pkg/storaged/vgroup-details.jsx:96
+#: pkg/storaged/vgroup-details.jsx:90
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Последний физический том группы томов не может быть удален."
 
-#: pkg/shell/indexes.js:407
-#, fuzzy
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "The logged in user is not permitted to view system modifications"
+msgstr ""
+"Выполнившему вход пользователю запрещено просматривать изменения системы"
+
+#: pkg/shell/indexes.js:464
 msgid "The machine is restarting"
-msgstr "Аппарат перезапускается"
+msgstr "Компьютер перезагружается"
 
 #: pkg/machines/components/networks/networkDelete.jsx:76
-#, fuzzy
 msgid "The network could not be deleted"
-msgstr "Целевой путь не должен быть пустым"
+msgstr "Не удалось удалить сеть"
 
 #: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
@@ -6749,17 +7032,45 @@ msgstr "пароли не совпадают"
 msgid "The passwords do not match."
 msgstr "Пароли не совпадают."
 
-#: pkg/machines/components/diskAdd.jsx:80
+#: pkg/machines/components/diskAdd.jsx:81
 msgid "The pool is empty"
 msgstr "Пул пуст"
 
 #: pkg/docker/containers-view.jsx:434
+#, fuzzy
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Сканирование с $time ($type) не обнаружено уязвимостей."
 
+#: pkg/docker/containers-view.jsx:436
+msgid "The scan from $time ($type) found one vulnerability:"
+msgid_plural "The scan from $time ($type) found $count vulnerabilities:"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: pkg/docker/containers-view.jsx:432
+#, fuzzy
 msgid "The scan from $time ($type) was not successful."
 msgstr "Сканирование с $time ($type) не удалось."
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr "Минимальный объём памяти для выбранной операционной системы — $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+"Минимальный размер хранилища для выбранной операционной системы — $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:382
+msgid "The selected Operating System has recommended memory $0 $1"
+msgstr "Рекомендуемый объём памяти для выбранной операционной системы — $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:417
+msgid "The selected Operating System has recommended storage size of $0 $1"
+msgstr ""
+"Рекомендуемый размер хранилища для выбранной операционной системы — $0 $1"
 
 #: src/ws/login.js:645
 msgid ""
@@ -6769,17 +7080,18 @@ msgstr ""
 "Сервер отказался аутентифицировать '$0', используя аутентификацию по паролю, "
 "а также другие поддерживаемые методы проверки подлинности."
 
-#: src/base1/cockpit.js:4017
+#: src/base1/cockpit.js:4021
 msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 "Сервер отказался аутентифицироваться с использованием любых поддерживаемых "
 "методов."
 
-#: pkg/systemd/hwinfo.jsx:65
+#: pkg/systemd/hwinfo.jsx:69
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
+"Пользователю $0 не разрешено изменять параметры, влияющие на безопасность ЦП"
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:813
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Пользователь <b>$0</b> не имеет разрешений для создания таймеров"
 
@@ -6787,15 +7099,11 @@ msgstr "Пользователь <b>$0</b> не имеет разрешений 
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "Пользователь <b>$0</b> не разрешается изменять профили"
 
-#: pkg/systemd/host.js:70
+#: pkg/systemd/host.js:72
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Пользователь <b>$0</b> не разрешено изменять системное время"
 
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr "Пользователь <b>$0</b> не разрешено включать или отключать услуги"
-
-#: pkg/dashboard/list.js:223
+#: pkg/dashboard/list.js:231
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "Пользователь <b>$0</b> не разрешено управлять серверами"
 
@@ -6807,26 +7115,23 @@ msgstr "Пользователь <b>$0</b> не разрешено управл�
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "Пользователь <b>$0</b> не разрешено изменять учетные записи"
 
-#: pkg/systemd/host.js:54
+#: pkg/systemd/host.js:56
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Пользователь <b>$0</b> не разрешается изменять имена хостов"
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1530
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Пользователь <b>$0</b> не разрешено изменять настройки сети"
 
-#: pkg/realmd/operation.js:642
+#: pkg/realmd/operation.js:644
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Пользователь <b>$0</b> не разрешено изменять сферы"
 
-#: pkg/systemd/host.js:62
+#: pkg/systemd/host.js:64
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
-"Пользователь <b>$0</b> не разрешено выключение или перезагрузка этого сервера"
-
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr "Пользователь <b>$0</b> не разрешено запускать или останавливать услуги"
+"Пользователь <b>$0</b> не разрешено выключение или перезагрузка этого "
+"сервера"
 
 #: pkg/users/local.js:553
 msgid ""
@@ -6838,7 +7143,8 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible "
+"$0)"
 msgstr ""
 "Конфигурация веб-браузера предотвращает запуск Cockpit (недоступный $0)"
 
@@ -6858,7 +7164,7 @@ msgstr ""
 msgid "There are no authorized public keys for this account."
 msgstr "Для этой учетной записи нет официальных ключей."
 
-#: pkg/storaged/vgroup-details.jsx:102
+#: pkg/storaged/vgroup-details.jsx:96
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
@@ -6866,21 +7172,26 @@ msgstr ""
 "Недостаточно свободного места в другом месте для удаления этого физического "
 "тома. По крайней мере $0 требуется больше свободного места."
 
-#: pkg/storaged/utils.js:193
+#: pkg/shell/index.html:398
+msgid "There was an unexpected error while connecting to the machine."
+msgstr "Произошла непредвиденная ошибка при подключении к компьютеру."
+
+#: pkg/storaged/utils.js:194
 msgid "Thin Logical Volume"
 msgstr "Тонкий логический том"
 
-#: pkg/storaged/nfs-details.jsx:118
+#: pkg/storaged/nfs-details.jsx:120
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr ""
 "Данное подключение по NFS используется. Возможно только изменение его "
 "параметров."
 
 #: pkg/storaged/vdo-details.jsx:133
+#, fuzzy
 msgid "This VDO device does not use all of its backing device."
 msgstr "Это устройство VDO не использует все его поддерживающее устройство."
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1262
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6888,11 +7199,11 @@ msgstr ""
 "Этот день не существует в течение всех месяцев.<br> Таймер будет выполняться "
 "только в месяцах с 31-м."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2644
 msgid "This device cannot be managed here."
 msgstr "Здесь невозможно управлять этим устройством."
 
-#: pkg/storaged/dialog.jsx:997
+#: pkg/storaged/dialog.jsx:998
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -6900,11 +7211,11 @@ msgstr ""
 "Это устройство имеет файловые системы, которые в настоящее время "
 "используются. В процессе работы будет отключено все файловые системы."
 
-#: pkg/storaged/dialog.jsx:976
+#: pkg/storaged/dialog.jsx:977
 msgid "This device is currently used for RAID devices."
 msgstr "В настоящее время это устройство используется для устройств RAID."
 
-#: pkg/storaged/dialog.jsx:1005
+#: pkg/storaged/dialog.jsx:1006
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -6912,15 +7223,15 @@ msgstr ""
 "В настоящее время это устройство используется для устройств RAID. "
 "Продолжающийся будет удалять его с его RAID-устройств."
 
-#: pkg/storaged/dialog.jsx:980
+#: pkg/storaged/dialog.jsx:981
 msgid "This device is currently used for VDO devices."
 msgstr "В настоящее время это устройство используется для устройств VDO."
 
-#: pkg/storaged/dialog.jsx:972
+#: pkg/storaged/dialog.jsx:973
 msgid "This device is currently used for volume groups."
 msgstr "В настоящее время это устройство используется для групп томов."
 
-#: pkg/storaged/dialog.jsx:1001
+#: pkg/storaged/dialog.jsx:1002
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -6928,11 +7239,11 @@ msgstr ""
 "В настоящее время это устройство используется для групп томов. Продолжение "
 "будет удалено из групп томов."
 
-#: pkg/storaged/mdraid-details.jsx:117
+#: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "Этот диск не может быть удален во время восстановления устройства."
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1174 pkg/systemd/init.js:1188 pkg/systemd/init.js:1197
 msgid "This field cannot be empty."
 msgstr "Это поле не может быть пустым."
 
@@ -6940,11 +7251,11 @@ msgstr "Это поле не может быть пустым."
 msgid "This image does not exist."
 msgstr "Это изображение не существует."
 
-#: pkg/storaged/lvol-tabs.jsx:408
+#: pkg/storaged/lvol-tabs.jsx:416
 msgid "This logical volume is not completely used by its content."
-msgstr ""
+msgstr "Логический том используется содержимым не до конца."
 
-#: pkg/lib/machine-dialogs.js:362
+#: pkg/lib/machine-dialogs.js:364
 msgid "This machine has already been added."
 msgstr "Эта машина уже добавлена."
 
@@ -6954,14 +7265,18 @@ msgstr "Это может занять некоторое время"
 
 #: src/bridge/cockpitpackages.c:506
 msgid "This package is not compatible with this version of Cockpit"
-msgstr "Этот пакет несовместим с этой версией Cockpit"
+msgstr "Этот пакет несовместим с текущей версией Cockpit"
 
 #: src/bridge/cockpitpackages.c:495
 #, c-format
 msgid "This package requires Cockpit version %s or later"
 msgstr "Этот пакет требует версии Cockpit %s или позже"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:138
+msgid "This pool type does not support Storage Volume creation"
+msgstr "Тип данного пула не поддерживает создание томов хранения"
+
+#: pkg/packagekit/updates.jsx:775
 msgid "This system is not registered"
 msgstr "Эта система не зарегистрирована"
 
@@ -6981,20 +7296,15 @@ msgstr ""
 "Этот инструмент соберёт информацию о конфигурации системы и диагностическую "
 "информацию для использования при диагностике проблем с системой."
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr "Это устройство является экземпляром $0 шаблон."
-
-#: pkg/systemd/services.html:360
-#, fuzzy
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
-msgstr "Этот элемент не предназначено для включения явно."
+msgstr "Эта служба не предназначена для явного включения."
 
 #: pkg/users/local.js:561
 msgid "This user name already exists"
 msgstr "Такое имя пользователя уже существует"
 
-#: pkg/lib/machine-dialogs.js:378
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
@@ -7002,20 +7312,21 @@ msgstr ""
 "Эта версия cockpit-ws не поддерживает подключение к хосту с другим "
 "пользователем или портом"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
-msgstr ""
+msgstr "Этот том уже используется другой виртуальной машиной."
 
-#: pkg/storaged/lvol-tabs.jsx:186
+#: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
-msgstr "Этот том необходимо активировать, прежде чем его можно будет изменить."
+msgstr ""
+"Этот том необходимо активировать, прежде чем его можно будет изменить."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr ""
 "Этот веб-браузер слишком стар, чтобы запустить Cockpit (отсутствует $0)"
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:835
 msgid "This web console will be updated."
 msgstr "Эта веб-консоль будет обновлена."
 
@@ -7025,11 +7336,11 @@ msgid ""
 "Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
-"Это проверит настройки kdump, разбив ядро ​​и тем самым систему. В зависимости "
-"от настроек система может не перезагружаться автоматически, и процесс может "
-"занять некоторое время."
+"Это проверит настройки kdump, разбив ядро ​​и тем самым систему. В "
+"зависимости от настроек система может не перезагружаться автоматически, и "
+"процесс может занять некоторое время."
 
-#: pkg/kdump/kdump-view.jsx:489
+#: pkg/kdump/kdump-view.jsx:491
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr ""
 "Конфигурация kdump будет проверена путём осуществления умышленного сбоя в "
@@ -7039,7 +7350,7 @@ msgstr ""
 msgid "Threads per core"
 msgstr "Потоков на ядро"
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Четверг"
 
@@ -7048,15 +7359,15 @@ msgid "Thursdays"
 msgstr "По четвергам"
 
 # ctx::sourcefile::/rhn/account/LocalePreferences
-#: pkg/systemd/index.html:364
+#: pkg/systemd/index.html:375
 msgid "Time Zone"
 msgstr "Часовой пояс"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:50
 msgid "Timers"
 msgstr "Таймеры"
 
-#: pkg/shell/index.html:305
+#: pkg/shell/index.html:306
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -7064,7 +7375,7 @@ msgstr ""
 "Совет. Сделайте свой ключевой пароль в соответствии с вашим паролем для "
 "входа в систему для автоматической аутентификации с другими системами."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:776
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -7072,14 +7383,6 @@ msgstr ""
 "Чтобы получать обновления программного обеспечения, эту систему необходимо "
 "зарегистрировать в Red Hat, используя либо клиентский портал Red Hat, либо "
 "локальный сервер подписки."
-
-#: node_modules/registry-image-widgets/views/image-pull.html:4
-msgid "To pull this image:"
-msgstr "Чтобы вытащить это изображение:"
-
-#: node_modules/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push an image to this image stream:"
-msgstr "Чтобы поместить изображение в этот поток изображения:"
 
 #: pkg/lib/machine-change-port.html:11
 msgid ""
@@ -7089,15 +7392,11 @@ msgstr ""
 "Чтобы попробовать другой порт, вам нужно обновить кокпит-ws до более новой "
 "версии."
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
-msgid "Too many files found"
-msgstr "Слишком много файлов найдено"
-
-#: src/base1/cockpit.js:4039
+#: src/base1/cockpit.js:4043
 msgid "Too much data"
 msgstr "Слишком много данных"
 
-#: pkg/docker/storage.jsx:341
+#: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Всего"
 
@@ -7107,28 +7406,32 @@ msgstr "Общий размер: $0"
 
 #: pkg/lib/machine-info.js:70
 msgid "Tower"
-msgstr "башня"
+msgstr "Компьютер в корпусе «башня»"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr "Перевод"
+
+#: pkg/systemd/service-details.jsx:433
 msgid "Triggered By"
 msgstr "Вызваны"
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:432
 msgid "Triggers"
 msgstr "Триггеры"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:383 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Диагностика"
 
-#: pkg/storaged/crypto-keyslots.jsx:331
+#: pkg/storaged/crypto-keyslots.jsx:339
 msgid "Trust key"
 msgstr "Целевой ключ"
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:737
 msgid "Trust level"
-msgstr ""
+msgstr "Уровень доверия"
 
 #: src/ws/login.html:111
 msgid "Try Again"
@@ -7146,7 +7449,7 @@ msgstr "Попробуйте снова подключиться"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Попытка синхронизировать с {{Server}}"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Вторник"
 
@@ -7154,7 +7457,7 @@ msgstr "Вторник"
 msgid "Tuesdays"
 msgstr "По вторникам"
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:261
 msgid "Tuned has failed to start"
 msgstr "Сбой при запуске демона tuned"
 
@@ -7170,23 +7473,25 @@ msgstr "Демон tuned не запущен"
 msgid "Tuned is off"
 msgstr "Демон tuned отключен"
 
-#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:266
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
+#: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
-#: pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/vmnetworktab.jsx:120
+#: pkg/storaged/format-dialog.jsx:293 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Type"
 msgstr "Тип"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:145
 msgid "Type ID"
-msgstr ""
+msgstr "Идентификатор типа"
 
 #: pkg/lib/machine-change-auth.html:42
 msgid "Type a password"
@@ -7196,11 +7501,11 @@ msgstr "Введите пароль"
 msgid "Type to filter…"
 msgstr "Тип фильтра ..."
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:970
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "Ссылка (URL)"
 
@@ -7213,7 +7518,7 @@ msgstr "UUID"
 msgid "Unable to apply settings: $0"
 msgstr "Невозможно применить настройки: $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:119
+#: pkg/selinux/setroubleshoot-view.jsx:120
 msgid "Unable to apply this solution automatically"
 msgstr "Невозможно применить это решение автоматически"
 
@@ -7225,8 +7530,8 @@ msgstr "Не удалось подключиться к этому адресу"
 msgid "Unable to delete root account"
 msgstr "Невозможно удалить учётную запись суперпользователя"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Unable to get alert details."
 msgstr "Не удалось получить сведения об оповещении."
 
@@ -7238,17 +7543,13 @@ msgstr "Не удалось получить оповещение: $0"
 msgid "Unable to reach server"
 msgstr "Не удалось связаться с сервером"
 
-#: pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:290
 msgid "Unable to remove mount"
 msgstr "Не удалось удалить mount"
 
 #: pkg/users/local.js:60
 msgid "Unable to rename root account"
 msgstr "Невозможно переименовать учётную запись суперпользователя"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:41
-msgid "Unable to resolve"
-msgstr "Не удалось разрешить"
 
 #: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
@@ -7258,7 +7559,7 @@ msgstr "Не удалось запустить исправление: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "Не удалось запустить setroubleshootd"
 
-#: pkg/storaged/nfs-details.jsx:257
+#: pkg/storaged/nfs-details.jsx:265
 msgid "Unable to unmount filesystem"
 msgstr "Не удалось отключить файловую систему"
 
@@ -7267,35 +7568,36 @@ msgid "Unavailable"
 msgstr "Недоступно"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:758 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Непредвиденная ошибка"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/networks/createNetworkDialog.jsx:114
+msgid "Unique Network Name"
+msgstr "Уникальное сетевое имя"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Уникальное имя"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1048
 msgid "Unit"
 msgstr "Сервис"
 
-#: node_modules/registry-image-widgets/views/image-body.html:16
-#: node_modules/registry-image-widgets/views/imagestream-body.html:30
-#: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
+#: pkg/machines/components/vmnetworktab.jsx:149
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1081
+#: pkg/networkmanager/interfaces.js:2551 pkg/networkmanager/interfaces.js:2553
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
-#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2537 pkg/networkmanager/interfaces.js:2549
 msgid "Unknown \"$0\""
 msgstr "Неизвестный \"$0\""
 
-#: pkg/storaged/mdraid-details.jsx:104
+#: pkg/storaged/mdraid-details.jsx:98
 msgid "Unknown ($0)"
 msgstr "Неизвестный ($0)"
 
@@ -7307,7 +7609,7 @@ msgstr "Неизвестное приложение"
 msgid "Unknown Host Key"
 msgstr "Неизвестный ключ хоста"
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2660
 msgid "Unknown configuration"
 msgstr "Неизвестная конфигурация"
 
@@ -7315,11 +7617,11 @@ msgstr "Неизвестная конфигурация"
 msgid "Unknown host name"
 msgstr "Неизвестное имя хоста"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
-msgstr ""
+msgstr "Неизвестное название службы"
 
-#: pkg/storaged/crypto-keyslots.jsx:562
+#: pkg/storaged/crypto-keyslots.jsx:575
 msgid "Unknown type"
 msgstr "Неизвестный тип"
 
@@ -7327,20 +7629,20 @@ msgstr "Неизвестный тип"
 msgid "Unless Stopped"
 msgstr "Если не остановлено"
 
-#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
-#: pkg/storaged/content-views.jsx:240
+#: pkg/storaged/content-views.jsx:227 pkg/storaged/content-views.jsx:232
+#: pkg/storaged/content-views.jsx:245
 msgid "Unlock"
 msgstr "Разблокировать"
 
-#: pkg/shell/index.html:212 pkg/shell/index.html:253
+#: pkg/shell/index.html:213 pkg/shell/index.html:254
 msgid "Unlock Key"
 msgstr "Разблокировать ключ"
 
-#: pkg/storaged/format-dialog.jsx:116
+#: pkg/storaged/format-dialog.jsx:120
 msgid "Unlock at boot"
 msgstr "Разблокировка при загрузке"
 
-#: pkg/storaged/format-dialog.jsx:117
+#: pkg/storaged/format-dialog.jsx:121
 msgid "Unlock read only"
 msgstr "Разблокировать только чтение"
 
@@ -7348,7 +7650,7 @@ msgstr "Разблокировать только чтение"
 msgid "Unlocking $target"
 msgstr "размыкание $target"
 
-#: pkg/storaged/crypto-keyslots.jsx:173
+#: pkg/storaged/crypto-keyslots.jsx:174
 msgid "Unlocking disk..."
 msgstr "Разблокировка диска ..."
 
@@ -7356,11 +7658,7 @@ msgstr "Разблокировка диска ..."
 msgid "Unmanaged Interfaces"
 msgstr "Неуправляемые интерфейсы"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr "Снять маску"
-
-#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:308
 msgid "Unmount"
 msgstr "Отсоединить"
 
@@ -7372,37 +7670,33 @@ msgstr "Размонтирование $target"
 msgid "Unnamed"
 msgstr "Безымянный"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Unplug"
 msgstr "Отключайте"
 
-#: pkg/storaged/content-views.jsx:159
+#: pkg/storaged/content-views.jsx:163
 msgid "Unrecognized Data"
 msgstr "Непризнанные данные"
 
-#: pkg/storaged/content-views.jsx:358
+#: pkg/storaged/content-views.jsx:363
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Непризнанные данные"
 
-#: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
+#: pkg/storaged/lvol-tabs.jsx:90 pkg/storaged/lvol-tabs.jsx:179
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Здесь не могут быть уменьшены нераспознанные данные."
-
-#: node_modules/registry-image-widgets/views/image-listing.html:46
-msgid "Unresolved"
-msgstr "неразрешенный"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "Неподдерживаемый механизм установки"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Unsupported volume"
 msgstr "Неподдерживаемый объем"
 
-#: src/base1/cockpit.js:4019 src/base1/cockpit.js:4021
+#: src/base1/cockpit.js:4023 src/base1/cockpit.js:4025
 msgid "Untrusted host"
 msgstr "Неверный хозяин"
 
@@ -7410,24 +7704,24 @@ msgstr "Неверный хозяин"
 msgid "Up since $0"
 msgstr "С тех пор $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
-msgstr ""
+msgstr "В расположении по умолчанию доступно до $0 $1"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
-msgstr ""
+msgstr "На узле доступно до $0 $1"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/lib/machine-change-port.html:41
 msgid "Update"
 msgstr "Обновить"
 
-#: pkg/packagekit/history.jsx:126
+#: pkg/packagekit/history.jsx:125
 msgid "Update History"
 msgstr "История обновлений"
 
-#: pkg/packagekit/updates.jsx:471
+#: pkg/packagekit/updates.jsx:473
 msgid "Update Log"
 msgstr "Журнал обновлений"
 
@@ -7435,11 +7729,11 @@ msgstr "Журнал обновлений"
 msgid "Updated"
 msgstr "Обновлено"
 
-#: pkg/packagekit/updates.jsx:494
+#: pkg/packagekit/updates.jsx:496
 msgid "Updated packages may require a restart to take effect."
 msgstr "Обновленные пакеты могут потребовать перезагрузки."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:515
 msgid "Updates Available"
 msgstr "Доступные обновления"
 
@@ -7447,23 +7741,27 @@ msgstr "Доступные обновления"
 msgid "Updating"
 msgstr "обновление"
 
+#: pkg/systemd/service-details.jsx:408
+msgid "Updating status..."
+msgstr "Обновление состояния..."
+
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
+#: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Формат"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1673
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Использование $0 ядра процессора"
 msgstr[1] "Использование $0 ядер процессора"
 msgstr[2] "Использование $0 ядер процессора"
 
-#: pkg/storaged/vdos-panel.jsx:87
+#: pkg/storaged/vdos-panel.jsx:95
 msgid "Use 512 Byte emulation"
 msgstr "Использовать эмуляцию 512 байт"
 
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:432
 msgid "Use Existing"
 msgstr "Использовать существующие"
 
@@ -7471,25 +7769,25 @@ msgstr "Использовать существующие"
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Используйте следующие ключи для аутентификации с другими системами"
 
-#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
+#: pkg/systemd/index.html:267 pkg/docker/storage.jsx:344
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/machines/components/vmDisksTab.jsx:106 pkg/storaged/fsys-tab.jsx:196
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1738
 msgid "Used"
 msgstr "Использовано"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
 msgid "Used by"
-msgstr ""
+msgstr "Используется"
 
 #: pkg/docker/index.html:264
 msgid "Used by Containers"
 msgstr "Используется контейнерами"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:241
+#: pkg/systemd/host.js:1644
 msgid "User"
 msgstr "Пользователь"
 
@@ -7502,7 +7800,7 @@ msgstr "Имя пользователя"
 msgid "User Password"
 msgstr "Пользовательский пароль"
 
-#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
+#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Пользователь"
@@ -7511,7 +7809,7 @@ msgstr "Пользователь"
 msgid "User name cannot be empty"
 msgstr "Имя пользователя не может быть пустым"
 
-#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Имя пользователя"
 
@@ -7523,11 +7821,11 @@ msgstr "Использование доступных учетных данны�
 msgid "VCPU settings could not be saved"
 msgstr "Не удалось сохранить настройки VCPU"
 
-#: pkg/storaged/content-views.jsx:155
+#: pkg/storaged/content-views.jsx:159
 msgid "VDO Backing"
 msgstr "Поддержка VDO"
 
-#: pkg/storaged/content-views.jsx:356
+#: pkg/storaged/content-views.jsx:361
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "Поддержка VDO"
@@ -7536,25 +7834,25 @@ msgstr "Поддержка VDO"
 msgid "VDO Device"
 msgstr "Устройство VDO"
 
-#: pkg/storaged/utils.js:252 pkg/storaged/vdo-details.jsx:255
+#: pkg/storaged/utils.js:253 pkg/storaged/vdo-details.jsx:261
 msgid "VDO Device $0"
 msgstr "Устройство VDO $0"
 
-#: pkg/storaged/vdos-panel.jsx:166
+#: pkg/storaged/vdos-panel.jsx:176
 msgid "VDO Devices"
 msgstr "Устройства VDO"
 
-#: pkg/storaged/lvol-tabs.jsx:84 pkg/storaged/lvol-tabs.jsx:171
+#: pkg/storaged/lvol-tabs.jsx:85 pkg/storaged/lvol-tabs.jsx:172
 msgid "VDO backing devices can not be made smaller"
 msgstr "Устройства поддержки VDO не могут быть уменьшены"
 
-#: pkg/storaged/vdos-panel.jsx:172
+#: pkg/storaged/vdos-panel.jsx:182
 msgid "VDO support not installed"
 msgstr "Поддержка VDO не установлена"
 
 # translation auto-copied from project Anaconda, version master, document anaconda
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2533 pkg/networkmanager/interfaces.js:2545
+#: pkg/networkmanager/interfaces.js:2926
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7568,43 +7866,43 @@ msgstr "Настройка VLAN"
 
 #: pkg/machines/hostvmslist.jsx:116
 msgid "VM $0 failed to Reboot"
-msgstr ""
+msgstr "Не удалось перезапустить виртуальную машину $0"
 
 #: pkg/machines/hostvmslist.jsx:122
 msgid "VM $0 failed to force Reboot"
-msgstr ""
+msgstr "Не удалось принудительно перезапустить виртуальную машину $0"
 
 #: pkg/machines/hostvmslist.jsx:146
 msgid "VM $0 failed to force shutdown"
-msgstr ""
+msgstr "Не удалось принудительно завершить работу виртуальной машины $0"
 
 #: pkg/machines/components/deleteDialog.jsx:136
 msgid "VM $0 failed to get deleted"
-msgstr ""
+msgstr "Не удалось удалить виртуальную машину $0"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
 msgid "VM $0 failed to get installed"
-msgstr ""
+msgstr "Не удалось установить виртуальную машину $0"
 
 #: pkg/machines/hostvmslist.jsx:134
 msgid "VM $0 failed to pause"
-msgstr ""
+msgstr "Не удалось приостановить виртуальную машину $0"
 
 #: pkg/machines/hostvmslist.jsx:140
 msgid "VM $0 failed to resume"
-msgstr ""
+msgstr "Не удалось возобновить виртуальную машину $0"
 
 #: pkg/machines/hostvmslist.jsx:152
 msgid "VM $0 failed to send NMI"
-msgstr ""
+msgstr "Ошибка отправки немаскируемого прерывания виртуальной машиной $0"
 
 #: pkg/machines/hostvmslist.jsx:128
 msgid "VM $0 failed to shutdown"
-msgstr ""
+msgstr "Не удалось завершить работу виртуальной машины $0"
 
 #: pkg/machines/hostvmslist.jsx:104
 msgid "VM $0 failed to start"
-msgstr ""
+msgstr "Не удалось запустить виртуальную машину $0"
 
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
@@ -7624,7 +7922,7 @@ msgstr "Порт VNC TLS:"
 
 #: pkg/realmd/operation.js:164
 msgid "Validating address"
-msgstr ""
+msgstr "Проверка адреса"
 
 #: src/ws/login.html:101
 msgid "Validating authentication token"
@@ -7636,7 +7934,7 @@ msgstr "Контрольный ключ"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:254
 msgid "Vendor"
 msgstr "Производитель"
 
@@ -7644,18 +7942,17 @@ msgstr "Производитель"
 msgid "Verified"
 msgstr "проверенный"
 
-#: pkg/storaged/crypto-keyslots.jsx:316
-#, fuzzy
+#: pkg/storaged/crypto-keyslots.jsx:324
 msgid "Verify key"
-msgstr "Подтвердить ключ"
+msgstr "Проверка ключа"
 
 #: pkg/packagekit/updates.jsx:54
 msgid "Verifying"
 msgstr "Проверка"
 
 # translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
+#: pkg/packagekit/updates.jsx:382 pkg/systemd/hwinfo.jsx:87
 msgid "Version"
 msgstr "Версия"
 
@@ -7663,15 +7960,23 @@ msgstr "Версия"
 msgid "Very securely erasing $target"
 msgstr "Очень надежно стирает $target"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/components/networks/networkList.jsx:39
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/lib/cockpit-components-modifications.jsx:173
+msgid "View automation script"
+msgstr "Просмотреть сценарий автоматизации"
+
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/storagePools/storagePoolList.jsx:46
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Виртуальные машины"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
-msgstr ""
+msgstr "Виртуальная сеть"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:412
+msgid "Virtual Network failed to be created"
+msgstr "Не удалось создать виртуальную сеть"
 
 #: pkg/machines/components/libvirtSlate.jsx:80
 msgid "Virtualization Service (libvirt) is Not Active"
@@ -7681,11 +7986,12 @@ msgstr "Служба виртуализации (libvirt) не активна"
 msgid "Virtualization Service is Available"
 msgstr "Доступна служба виртуализации"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
+#: pkg/machines/components/diskAdd.jsx:90
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Том"
 
@@ -7693,20 +7999,31 @@ msgstr "Том"
 msgid "Volume Group"
 msgstr "Группа томов"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/utils.js:248 pkg/storaged/vgroup-details.jsx:229
 msgid "Volume Group $0"
 msgstr "Группа томов $0"
 
-#: pkg/storaged/vgroups-panel.jsx:113
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr "Имя группы томов"
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr "Имя группы томов не должно быть пустым"
+
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr "Группы томов"
 
-#: pkg/storaged/lvol-tabs.jsx:410
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:65
+msgid "Volume failed to be created"
+msgstr "Не удалось создать том"
+
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Volume size is $0. Content size is $1."
-msgstr ""
+msgstr "Размер тома составляет $0. Содержимое занимает $1."
 
 #: pkg/docker/index.html:517
-#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Список томов"
 
@@ -7716,15 +8033,15 @@ msgstr "Объемы:"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:140
 msgid "WWPN"
-msgstr ""
+msgstr "WWPN"
 
 # translation auto-copied from project evolution-data-server, version el6, document evolution-data-server-2.32
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:850
 msgid "Waiting"
 msgstr "Ожидание"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Waiting for details..."
 msgstr "В ожидании подробностей ..."
 
@@ -7732,29 +8049,29 @@ msgstr "В ожидании подробностей ..."
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr "Ожидание завершения других программ с помощью диспетчера пакетов ..."
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:140
-#: pkg/lib/cockpit-components-install-dialog.jsx:175
+#: pkg/lib/cockpit-components-install-dialog.jsx:141
+#: pkg/lib/cockpit-components-install-dialog.jsx:176
 msgid "Waiting for other software management operations to finish"
 msgstr ""
 "Ожидание выполнения других операций управления программным обеспечением"
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:424
 msgid "Wanted By"
 msgstr "Желателен для"
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:419
 msgid "Wants"
 msgstr "Желательны"
 
 #: pkg/systemd/logs.html:60
 msgid "Warning and above"
-msgstr "Предупреждение и выше"
+msgstr "Предупреждающие сообщения и выше"
 
 #: cockpit.appdata.xml.in.h:1
 msgid "Web Console for Linux servers"
 msgstr "Веб-консоль для серверов Linux"
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Среда"
 
@@ -7762,13 +8079,13 @@ msgstr "Среда"
 msgid "Wednesdays"
 msgstr "По средам"
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "нед"
 
-#: pkg/storaged/crypto-keyslots.jsx:324
+#: pkg/storaged/crypto-keyslots.jsx:332
 msgid "What if tang-show-keys is not available?"
-msgstr "Что делать, если танг-шоу-ключи недоступны?"
+msgstr "Что делать, если команда tang-show-keys недоступна?"
 
 #: pkg/systemd/terminal.jsx:101
 msgid "White"
@@ -7778,11 +8095,11 @@ msgstr "Белый"
 msgid "With terminal"
 msgstr "С терминалом"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/mdraid-details.jsx:96
 msgid "Write-mostly"
 msgstr "Списание в основном"
 
-#: pkg/storaged/plot.jsx:313
+#: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Запись"
 
@@ -7790,11 +8107,11 @@ msgstr "Запись"
 msgid "Wrong user name or password"
 msgstr "Неверное имя пользователя или пароль"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1997
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2613
 msgid "Yes"
 msgstr "Да"
 
@@ -7806,15 +8123,15 @@ msgstr ""
 "Вы подключены к {{#strong}}{{host}}{{/strong}}, однако для синхронизации "
 "пользователей требуется пользователь с привилегиями суперпользователя."
 
-#: pkg/dashboard/list.js:440
+#: pkg/dashboard/list.js:448
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
 "Вы в настоящий момент подключены непосредственно к этому серверу. Вы не "
 "можете удалить его."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:905 pkg/networkmanager/firewall.jsx:911
 msgid "You are not authorized to modify the firewall."
 msgstr "У вас нет прав на изменение брандмауэра."
 
@@ -7826,20 +8143,19 @@ msgstr ""
 "У вас нет разрешения на просмотр разрешенных открытых ключей для этой "
 "учетной записи."
 
-#: pkg/docker/storage.jsx:504
+#: pkg/docker/storage.jsx:520
 msgid "You don't have permission to manage the Docker storage pool."
-msgstr "У вас нет разрешения на управление пулом хранилища Docker."
+msgstr "У вас нет прав на управление пулом носителей Docker."
 
 #: pkg/users/local.js:120
 msgid "You must wait longer to change your password"
 msgstr "Вы должны подождать дольше, чтобы сменить пароль"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
-msgstr ""
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
+msgstr "Необходимо выбрать наиболее соответствующую операционную систему"
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:837
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -7848,7 +8164,7 @@ msgstr ""
 "повторно подключиться через несколько секунд, чтобы продолжить просмотр "
 "прогресса."
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:868
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7856,40 +8172,36 @@ msgstr ""
 "Скоро ваш сервер закроет соединение. После перезапуска вы можете снова "
 "подключиться."
 
-#: src/base1/cockpit.js:4009
+#: src/base1/cockpit.js:4013
 msgid "Your session has been terminated."
 msgstr "Ваша сессия завершена."
 
-#: src/base1/cockpit.js:4011
+#: src/base1/cockpit.js:4015
 msgid "Your session has expired. Please log in again."
 msgstr "Время сеанса истекло. Пожалуйста, войдите снова."
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:957
 msgid "Zone"
-msgstr ""
+msgstr "Зона"
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:970
 msgid "Zones"
-msgstr ""
+msgstr "Зоны"
 
-#: pkg/lib/journal.js:215
+#: pkg/lib/journal.js:217
 msgid "[$0 bytes of binary data]"
 msgstr "[$0 байты двоичных данных]"
 
-#: pkg/lib/journal.js:217
+#: pkg/lib/journal.js:219
 msgid "[binary data]"
 msgstr "[двоичные данные]"
 
-#: pkg/lib/journal.js:211
+#: pkg/lib/journal.js:213
 msgid "[no data]"
 msgstr "[нет данных]"
 
-#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
-msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
-msgstr ""
-
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "Активно"
@@ -7911,7 +8223,7 @@ msgstr "в"
 msgid "bridge"
 msgstr "мост"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "bug fix"
 msgstr "Исправлена ​​ошибка"
 
@@ -7930,7 +8242,7 @@ msgstr ""
 
 #: pkg/machines/helpers.js:193
 msgid "crashed"
-msgstr "разбившийся"
+msgstr "аварийно завершила работу"
 
 #: pkg/machines/helpers.js:206
 msgid "custom"
@@ -7957,6 +8269,7 @@ msgid "down"
 msgstr "вниз"
 
 #: pkg/machines/helpers.js:194
+#, fuzzy
 msgid "dying"
 msgstr "умирающий"
 
@@ -7968,7 +8281,7 @@ msgstr "например, \"$0\""
 msgid "enabled"
 msgstr "включено"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "enhancement"
 msgstr "улучшение"
 
@@ -7980,7 +8293,7 @@ msgstr "локальные сети"
 msgid "every day"
 msgstr "каждый день"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:940
 msgid "failed to list ssh host keys: $0"
 msgstr "не удалось перечислить ключи хоста ssh: $0"
 
@@ -7990,46 +8303,46 @@ msgstr "узел"
 
 #: pkg/machines/helpers.js:203
 msgid "host device"
-msgstr ""
+msgstr "главное устройство"
 
 #: pkg/machines/helpers.js:215
 msgid "hostdev"
 msgstr "hostdev"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
-msgstr ""
+msgstr "IQN инициатора iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
-msgstr ""
+msgstr "Цель iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:261
+#: pkg/storaged/iscsi-panel.jsx:268
 msgid "iSCSI Targets"
 msgstr "Цели iSCSI"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
-msgstr ""
+msgstr "Цель iSCSI direct"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
-msgstr ""
+msgstr "IQN цели iSCSI"
 
 #: pkg/machines/helpers.js:189
 msgid "idle"
-msgstr "вхолостую"
+msgstr "бездействует"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 msgid "inactive"
 msgstr "Неактивно"
 
-#: pkg/kdump/kdump-view.jsx:376
+#: pkg/kdump/kdump-view.jsx:378
 msgid "invalid: multiple targets defined"
 msgstr "недействителен: несколько заданных целей"
 
-#: pkg/kdump/kdump-view.jsx:493
+#: pkg/kdump/kdump-view.jsx:495
 msgid "kdump status"
 msgstr "Статус kdump"
 
@@ -8037,11 +8350,11 @@ msgstr "Статус kdump"
 msgid "key"
 msgstr "ключ"
 
-#: pkg/storaged/crypto-keyslots.jsx:350
+#: pkg/storaged/crypto-keyslots.jsx:358
 msgid "key slot $0"
 msgstr "ключевой слот $0"
 
-#: pkg/kdump/kdump-view.jsx:380 pkg/kdump/kdump-view.jsx:382
+#: pkg/kdump/kdump-view.jsx:382 pkg/kdump/kdump-view.jsx:384
 msgid "locally in $0"
 msgstr "локально в $0"
 
@@ -8057,20 +8370,19 @@ msgstr "сеть"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "Назначение дампа nfs не отформатировано как сервер: путь"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "нет"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "нет"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:738
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "из $0 ядра процессора"
@@ -8079,15 +8391,7 @@ msgstr[2] "из $0 ядер процессора"
 
 #: pkg/machines/helpers.js:190
 msgid "paused"
-msgstr "приостановлено"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "raw"
+msgstr "приостановлена"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -8095,17 +8399,17 @@ msgstr "рекомендуемые"
 
 #: pkg/machines/helpers.js:202
 msgid "redirected device"
-msgstr ""
+msgstr "перенаправленное устройство"
 
 #: pkg/machines/helpers.js:188
 msgid "running"
-msgstr "выполняется"
+msgstr "работает"
 
 #: pkg/docker/search.js:50
 msgid "search by name, namespace or description"
 msgstr "Поиск по имени, пространству имён или описанию"
 
-#: pkg/packagekit/updates.jsx:261
+#: pkg/packagekit/updates.jsx:262
 msgid "security"
 msgstr "безопасность"
 
@@ -8131,13 +8435,13 @@ msgstr "показать больше"
 
 #: pkg/machines/helpers.js:192
 msgid "shut off"
-msgstr "Заткнись"
+msgstr "отключена"
 
 #: pkg/machines/helpers.js:191
 msgid "shutdown"
-msgstr "неисправность"
+msgstr "не работает"
 
-#: pkg/selinux/setroubleshoot-view.jsx:123
+#: pkg/selinux/setroubleshoot-view.jsx:124
 msgid "solution details"
 msgstr "детали решения"
 
@@ -8158,9 +8462,8 @@ msgid "suspended (PM)"
 msgstr "приостановлено (PM)"
 
 #: pkg/docker/run.js:474
-#, fuzzy
 msgid "to host path"
-msgstr "путь хозяина"
+msgstr "к адресу узла"
 
 #: pkg/docker/run.js:418
 msgid "to host port"
@@ -8178,8 +8481,7 @@ msgstr "udp"
 msgid "undefined"
 msgstr "не определено"
 
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "неизвестно"
 
@@ -8187,7 +8489,7 @@ msgstr "неизвестно"
 msgid "unknown target"
 msgstr "неизвестная цель"
 
-#: pkg/storaged/utils.js:427
+#: pkg/storaged/utils.js:431
 msgid "unpartitioned space on $0"
 msgstr "нераспределенное пространство на $0"
 
@@ -8221,117 +8523,17 @@ msgstr "значение"
 msgid "vhostuser"
 msgstr "vhostuser"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
+"Для создания новых виртуальных машин в системе должен быть установлен пакет "
+"virt-install"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "да"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:6
-msgid ""
-"{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
-"count: {{ condition.generation }}"
-msgstr ""
-"{{ condition.message }}, Отметка: {{ condition.lastTransitionTime }} "
-"Количество ошибок: {{ condition.generation }}"
-
-#~ msgid "'Organization' required to register."
-#~ msgstr "Название организации, необходимое для регистрации."
-
-#~ msgid "'Organization' required when using activation keys."
-#~ msgstr ""
-#~ "Название организации, необходимое при использовании ключей активации."
-
-#~ msgid "Access denied"
-#~ msgstr "Доступ запрещён"
-
-#~ msgid "Activation Key"
-#~ msgstr "Ключ активации"
-
-#~ msgid ""
-#~ "Couldn't get system subscription status. Please ensure subscription-"
-#~ "manager is installed."
-#~ msgstr ""
-#~ "Не удалось получить статус системной подписки. Убедитесь, что диспетчер "
-#~ "подписок установлен."
-
-#~ msgid "Custom URL"
-#~ msgstr "Настраиваемый URL-адрес"
-
-#~ msgid "Ends"
-#~ msgstr "Дата окончания"
-
-#~ msgid "Installed products"
-#~ msgstr "Установленные продукты"
-
-#~ msgid "Invalid credentials"
-#~ msgstr "Недопустимые учетные данные"
-
-#~ msgid "Login"
-#~ msgstr "Вход"
-
-#~ msgid "Login/password or activation key required to register."
-#~ msgstr ""
-#~ "Имя/пароль пользователя или ключ активации, необходимые для регистрации."
-
-#~ msgid "No installed products on the system."
-#~ msgstr "Нет установленных продуктов в системе."
-
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#~ msgid "Organization"
-#~ msgstr "Организация"
-
-#~ msgid "Product ID"
-#~ msgstr "Идентификатор продукта"
-
-#~ msgid "Product name"
-#~ msgstr "Название продукта"
-
-#~ msgid "Proxy"
-#~ msgstr "Прокси"
-
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#~ msgid "Register"
-#~ msgstr "Регистрация"
-
-#~ msgid "Register system"
-#~ msgstr "Система регистрации"
-
-#~ msgid "Retrieving subscription status..."
-#~ msgstr "Получение статуса подписки ..."
-
-#~ msgid "Starts"
-#~ msgstr "Дата начала"
-
-#~ msgid "Status: $0"
-#~ msgstr "Статус: $0"
-
-#~ msgid "Status: System isn't registered"
-#~ msgstr "Статус: система не зарегистрирована"
-
-# translation auto-copied from project Customer Portal Translations, version management_page, document Management_Prototype.html, author ypoyarko
-#~ msgid "Subscriptions"
-#~ msgstr "Подписки"
-
-#~ msgid "The current user isn't allowed to access system subscription status."
-#~ msgstr ""
-#~ "Текущему пользователю не разрешен доступ к системному состоянию подписки."
-
-#~ msgid "Unable to connect"
-#~ msgstr "Не удалось подключиться"
-
-#~ msgid "Unregister"
-#~ msgstr "Удалить регистрацию"
-
-#~ msgid "Unregistering system..."
-#~ msgstr "Незарегистрированная система ..."
-
-#~ msgid "Use proxy server"
-#~ msgstr "Использовать прокси-сервер"

--- a/po/sv.po
+++ b/po/sv.po
@@ -1,90 +1,104 @@
 # Göran Uddeborg <goeran@uddeborg.se>, 2018. #zanata
+# Göran Uddeborg <goeran@uddeborg.se>, 2019. #zanata
 # Martin Pitt <mpitt@redhat.com>, 2019. #zanata
+# Peter von Weisz <daishan.swe@gmail.com>, 2019. #zanata
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-03 08:58+0200\n"
-"PO-Revision-Date: 2019-06-02 09:24+0000\n"
-"Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
-"Language-Team: Swedish\n"
-"Language: sv\n"
+"POT-Creation-Date: 2019-09-23 08:08+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2019-09-20 11:25+0000\n"
+"Last-Translator: Göran Uddeborg <goeran@uddeborg.se>\n"
+"Language-Team: Swedish\n"
+"Language: sv\n"
 "X-Generator: Zanata 4.6.2\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
 
-#: pkg/docker/storage.jsx:259
+#: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
 msgstr "(delat med OS:et)"
+
+#: pkg/networkmanager/interfaces.js:2353
+msgid "$0 Active Rule"
+msgid_plural "$0 Active Rules"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0 blockenhet"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/mdraid-details.jsx:187
 msgid "$0 Chunk Size"
 msgstr "$0 styckesstorlek"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "$0 Disks"
 msgstr "$0 diskar"
 
-#: pkg/storaged/content-views.jsx:334
+#: pkg/storaged/content-views.jsx:339
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "$0 filsystem"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:105
 msgid "$0 Network"
-msgstr ""
+msgstr "$0 Nätverk"
 
-#: pkg/packagekit/history.jsx:101
+#: pkg/packagekit/history.jsx:100
 msgid "$0 Package"
 msgid_plural "$0 Packages"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "$0 Paket"
+msgstr[1] "$0 Paket"
 
-#: pkg/systemd/init.js:395 pkg/systemd/init.js:749
+#: pkg/systemd/init.js:478 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "$0 mall"
 
-#: src/base1/test-locale.js:80 src/base1/test-locale.js:81
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:83 src/base1/test-locale.js:84
+#: src/base1/test-locale.js:85 src/base1/test-locale.js:86
 msgid "$0 bit"
 msgid_plural "$0 bits"
 msgstr[0] "$0 bit"
 msgstr[1] "$0 bitar"
 
-#: src/base1/test-locale.js:71 src/base1/test-locale.js:72
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+#: src/base1/test-locale.js:74 src/base1/test-locale.js:75
+#: src/base1/test-locale.js:87 src/base1/test-locale.js:88
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 byte"
 
-#: src/base1/test-locale.js:73 src/base1/test-locale.js:74
+#: src/base1/test-locale.js:76 src/base1/test-locale.js:77
 msgctxt "memory"
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 byte"
 msgstr[1] "$0 byte"
 
-#: pkg/storaged/vdo-details.jsx:280
+#: pkg/storaged/vdo-details.jsx:286
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 data + $1 överskjutande använt av $2 ($3)"
 
-#: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
+#: pkg/lib/plot.js:971
+msgid "$0 day"
+msgid_plural "$0 days"
+msgstr[0] "$0 dag"
+msgstr[1] "$0 dagar"
+
+#: src/base1/test-locale.js:65 src/base1/test-locale.js:66
+#: src/base1/test-locale.js:67 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:207
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "$0 disk saknas"
 msgstr[1] "$0 diskar saknas"
 
-#: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: src/base1/test-locale.js:68 src/base1/test-locale.js:70
+#: src/base1/test-locale.js:72 pkg/playground/translate.js:32
 #: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
@@ -104,17 +118,23 @@ msgstr "$0 avslutade med kod $1"
 msgid "$0 failed"
 msgstr "$0 misslyckades"
 
-#: pkg/storaged/lvol-tabs.jsx:159
+#: pkg/storaged/lvol-tabs.jsx:160
 msgid "$0 filesystems can not be made larger."
 msgstr "$0 filsystem kan inte göras större."
 
-#: pkg/storaged/lvol-tabs.jsx:156
+#: pkg/storaged/lvol-tabs.jsx:157
 msgid "$0 filesystems can not be made smaller."
 msgstr "$0 filsystem kan inte göras mindre."
 
-#: pkg/storaged/lvol-tabs.jsx:152
+#: pkg/storaged/lvol-tabs.jsx:153
 msgid "$0 filesystems can not be resized here."
 msgstr "$0 filsystem kan inte storleksändras här."
+
+#: pkg/lib/plot.js:974
+msgid "$0 hour"
+msgid_plural "$0 hours"
+msgstr[0] "$0 timme"
+msgstr[1] "$0 timmar"
 
 #: pkg/machines/components/desktopConsole.jsx:44
 msgid ""
@@ -124,15 +144,15 @@ msgstr ""
 "$0 är tillgängligt till de flesta operativsystem.  Sök efter det i GNOME-"
 "programvara för att installera det eller kör följande:"
 
-#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/lvol-tabs.jsx:200 pkg/storaged/lvol-tabs.jsx:259
-#: pkg/storaged/vdo-details.jsx:146 pkg/storaged/vdo-details.jsx:175
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:511
+#: pkg/storaged/format-dialog.jsx:265 pkg/storaged/lvol-tabs.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:264 pkg/storaged/mdraid-details.jsx:232
+#: pkg/storaged/mdraid-details.jsx:284 pkg/storaged/vdo-details.jsx:147
+#: pkg/storaged/vdo-details.jsx:178 pkg/storaged/vgroup-details.jsx:199
 msgid "$0 is in active use"
 msgstr "$0 används aktivt"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:150
+#: pkg/lib/cockpit-components-install-dialog.jsx:151
 msgid "$0 is not available from any repository."
 msgstr "$0 är inte tillgängligt från något förråd."
 
@@ -140,7 +160,19 @@ msgstr "$0 är inte tillgängligt från något förråd."
 msgid "$0 killed with signal $1"
 msgstr "$0 dödad med signal $1"
 
-#: pkg/selinux/setroubleshoot-view.jsx:429
+#: pkg/lib/plot.js:977
+msgid "$0 minute"
+msgid_plural "$0 minutes"
+msgstr[0] "$0 minut"
+msgstr[1] "$0 minuter"
+
+#: pkg/lib/plot.js:965
+msgid "$0 month"
+msgid_plural "$0 months"
+msgstr[0] "$0 månad"
+msgstr[1] "$0 månader"
+
+#: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
 msgid_plural "$1 occurrences"
 msgstr[0] "$0 förekomst"
@@ -150,11 +182,17 @@ msgstr[1] "$0 förekomster"
 msgid "$0 of $1"
 msgstr "$0 av $1"
 
+#: pkg/systemd/init.js:418
+msgid "$0 service has failed"
+msgid_plural "$0 services have failed"
+msgstr[0] ""
+msgstr[1] ""
+
 #: pkg/docker/util.js:125
 msgid "$0 shares"
 msgstr "$0 utdelningar"
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "$0 slots remain"
 msgstr "$0 fack återstår"
 
@@ -164,15 +202,27 @@ msgid_plural "$0 updates"
 msgstr[0] "$0 uppdatering"
 msgstr[1] "$0 uppdateringar"
 
-#: pkg/storaged/vdo-details.jsx:292
+#: pkg/storaged/vdo-details.jsx:298
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 använt av $1 ($2 sparat)"
+
+#: pkg/lib/plot.js:968
+msgid "$0 week"
+msgid_plural "$0 weeks"
+msgstr[0] "$0 vecka"
+msgstr[1] "$0 veckor"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "$0 kommer att installeras."
 
-#: pkg/storaged/vgroup-details.jsx:117
+#: pkg/lib/plot.js:962
+msgid "$0 year"
+msgid_plural "$0 years"
+msgstr[0] "$0 år"
+msgstr[1] "$0 år"
+
+#: pkg/storaged/vgroup-details.jsx:111
 msgid "$0, $1 free"
 msgstr "$0, $1 fritt"
 
@@ -182,7 +232,7 @@ msgid_plural "$1 security fixes"
 msgstr[0] "$1 säkerhetsfix"
 msgstr[1] "$1 säkerhetsfixar"
 
-#: pkg/networkmanager/interfaces.js:2757
+#: pkg/networkmanager/interfaces.js:2777
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -198,16 +248,16 @@ msgstr "${hip}:${hport} → $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:549
+#: pkg/networkmanager/firewall.jsx:576
 msgid "(Optional)"
-msgstr ""
+msgstr "(Valfritt)"
 
-#: pkg/networkmanager/firewall.jsx:474 pkg/networkmanager/firewall.jsx:618
-#: pkg/storaged/fsys-tab.jsx:160
+#: pkg/networkmanager/firewall.jsx:501 pkg/networkmanager/firewall.jsx:650
+#: pkg/storaged/fsys-tab.jsx:163
 msgid "(default)"
 msgstr "(standard)"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:138
 msgid "(none)"
 msgstr "(ingen)"
 
@@ -217,245 +267,251 @@ msgid_plural ", including $1 security fixes"
 msgstr[0] ", inklusive $1 säkerhetsfix"
 msgstr[1] ", inklusive $1 säkerhetsfixar"
 
-#: pkg/storaged/nfs-details.jsx:325
+#: pkg/storaged/nfs-details.jsx:333
 msgid "--"
 msgstr "—"
 
-#: pkg/storaged/mdraids-panel.jsx:70
+#: pkg/storaged/mdraids-panel.jsx:86
 msgid "1 MiB"
 msgstr "1 MiB"
 
-#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
+#: pkg/systemd/index.html:455 pkg/systemd/index.html:459
 msgid "1 Minute"
 msgstr "1 minut"
 
+#: pkg/docker/containers-view.jsx:614
+msgid "1 Vulnerability"
+msgid_plural "$0 Vulnerabilities"
+msgstr[0] ""
+msgstr[1] ""
+
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:194
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 dag"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:190
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 timma"
 
-#: pkg/systemd/host.js:1669
+#: pkg/systemd/host.js:1729
 msgid "1 min"
 msgstr "1 min"
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:196
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 vecka"
 
-#: pkg/systemd/services.html:273
+#: pkg/systemd/services.html:165
 msgid "10th"
 msgstr "10:e"
 
-#: pkg/systemd/services.html:274
+#: pkg/systemd/services.html:166
 msgid "11th"
 msgstr "11:e"
 
-#: pkg/storaged/mdraids-panel.jsx:68
+#: pkg/storaged/mdraids-panel.jsx:84
 msgid "128 KiB"
 msgstr "128 KiB"
 
-#: pkg/systemd/services.html:275
+#: pkg/systemd/services.html:167
 msgid "12th"
 msgstr "12:e"
 
-#: pkg/systemd/services.html:276
+#: pkg/systemd/services.html:168
 msgid "13th"
 msgstr "13:e"
 
-#: pkg/systemd/services.html:277
+#: pkg/systemd/services.html:169
 msgid "14th"
 msgstr "14:e"
 
-#: pkg/systemd/services.html:278
+#: pkg/systemd/services.html:170
 msgid "15th"
 msgstr "15:e"
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/mdraids-panel.jsx:81
 msgid "16 KiB"
 msgstr "16 KiB"
 
-#: pkg/systemd/services.html:279
+#: pkg/systemd/services.html:171
 msgid "16th"
 msgstr "16:e"
 
-#: pkg/systemd/services.html:280
+#: pkg/systemd/services.html:172
 msgid "17th"
 msgstr "17:e"
 
-#: pkg/systemd/services.html:281
+#: pkg/systemd/services.html:173
 msgid "18th"
 msgstr "18:e"
 
-#: pkg/systemd/services.html:282
+#: pkg/systemd/services.html:174
 msgid "19th"
 msgstr "19:e"
 
-#: pkg/systemd/services.html:264
+#: pkg/systemd/services.html:156
 msgid "1st"
 msgstr "1:a"
 
-#: pkg/storaged/mdraids-panel.jsx:71
+#: pkg/storaged/mdraids-panel.jsx:87
 msgid "2 MiB"
 msgstr "2 MiB"
 
-#: pkg/systemd/host.js:1668
+#: pkg/systemd/host.js:1728
 msgid "2 min"
 msgstr "2 min"
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:461
 msgid "20 Minutes"
 msgstr "20 minuter"
 
-#: pkg/systemd/services.html:283
+#: pkg/systemd/services.html:175
 msgid "20th"
 msgstr "20:e"
 
-#: pkg/systemd/services.html:284
+#: pkg/systemd/services.html:176
 msgid "21st"
 msgstr "21:a"
 
-#: pkg/systemd/services.html:285
+#: pkg/systemd/services.html:177
 msgid "22nd"
 msgstr "22:a"
 
-#: pkg/systemd/services.html:286
+#: pkg/systemd/services.html:178
 msgid "23rd"
 msgstr "23:e"
 
-#: pkg/systemd/services.html:287
+#: pkg/systemd/services.html:179
 msgid "24th"
 msgstr "24:e"
 
-#: pkg/systemd/services.html:288
+#: pkg/systemd/services.html:180
 msgid "25th"
 msgstr "25:e"
 
-#: pkg/systemd/services.html:289
+#: pkg/systemd/services.html:181
 msgid "26th"
 msgstr "26:e"
 
-#: pkg/systemd/services.html:290
+#: pkg/systemd/services.html:182
 msgid "27th"
 msgstr "27:e"
 
-#: pkg/systemd/services.html:291
+#: pkg/systemd/services.html:183
 msgid "28th"
 msgstr "28:e"
 
-#: pkg/systemd/services.html:292
+#: pkg/systemd/services.html:184
 msgid "29th"
 msgstr "29:e"
 
-#: pkg/systemd/services.html:265
+#: pkg/systemd/services.html:157
 msgid "2nd"
 msgstr "2:a"
 
-#: pkg/systemd/host.js:1667
+#: pkg/systemd/host.js:1727
 msgid "3 min"
 msgstr "3 min"
 
-#: pkg/systemd/services.html:293
+#: pkg/systemd/services.html:185
 msgid "30th"
 msgstr "30:e"
 
-#: pkg/systemd/services.html:294
+#: pkg/systemd/services.html:186
 msgid "31st"
 msgstr "31:a"
 
-#: pkg/storaged/mdraids-panel.jsx:66
+#: pkg/storaged/mdraids-panel.jsx:82
 msgid "32 KiB"
 msgstr "32 KiB"
 
-#: pkg/systemd/services.html:266
+#: pkg/systemd/services.html:158
 msgid "3rd"
 msgstr "3:e"
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:79
 msgid "4 KiB"
 msgstr "4 KiB"
 
-#: pkg/systemd/host.js:1666
+#: pkg/systemd/host.js:1726
 msgid "4 min"
 msgstr "4 min"
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:462
 msgid "40 Minutes"
 msgstr "40 minuter"
 
-#: pkg/systemd/services.html:267
+#: pkg/systemd/services.html:159
 msgid "4th"
 msgstr "4:e"
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:460
 msgid "5 Minutes"
 msgstr "5 minuter"
 
-#: pkg/systemd/host.js:1665
+#: pkg/systemd/host.js:1725
 msgid "5 min"
 msgstr "5 min"
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:188
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 minuter"
 
-#: pkg/storaged/mdraids-panel.jsx:69
+#: pkg/storaged/mdraids-panel.jsx:85
 msgid "512 KiB"
 msgstr "512 KiB"
 
-#: pkg/systemd/services.html:268
+#: pkg/systemd/services.html:160
 msgid "5th"
 msgstr "5:e"
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:192
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 timmar"
 
-#: pkg/systemd/index.html:452
+#: pkg/systemd/index.html:463
 msgid "60 Minutes"
 msgstr "60 minuter"
 
-#: pkg/storaged/mdraids-panel.jsx:67
+#: pkg/storaged/mdraids-panel.jsx:83
 msgid "64 KiB"
 msgstr "64 KiB"
 
-#: pkg/systemd/services.html:269
+#: pkg/systemd/services.html:161
 msgid "6th"
 msgstr "6:e"
 
-#: pkg/systemd/services.html:270
+#: pkg/systemd/services.html:162
 msgid "7th"
 msgstr "7:e"
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/mdraids-panel.jsx:80
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1999
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2016
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
-#: pkg/systemd/services.html:271
+#: pkg/systemd/services.html:163
 msgid "8th"
 msgstr "8:e"
 
-#: pkg/systemd/services.html:272
+#: pkg/systemd/services.html:164
 msgid "9th"
 msgstr "9:e"
 
@@ -467,7 +523,7 @@ msgstr ""
 "Ingen kompatibel version av Cockpit är installerad på {{#strong}}{{host}}{{/"
 "strong}}."
 
-#: pkg/storaged/vdos-panel.jsx:59
+#: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "En disk behövs."
 
@@ -476,19 +532,19 @@ msgid ""
 "A modern browser is required for security, reliability, and performance."
 msgstr "En modern webbläsare krävs för säkerhet, pålitlighet och prestanda."
 
-#: pkg/storaged/mdraid-details.jsx:119
+#: pkg/storaged/mdraid-details.jsx:113
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "En reservdisk behöver läggas till först före denna disk kan tas bort."
 
-#: pkg/networkmanager/interfaces.js:1986
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2786
+#: pkg/networkmanager/interfaces.js:2806
 msgid "ARP Monitoring"
 msgstr "ARP-övervakning"
 
-#: pkg/networkmanager/interfaces.js:2007
+#: pkg/networkmanager/interfaces.js:2028
 msgid "ARP Ping"
 msgstr "ARP-ping"
 
@@ -497,13 +553,13 @@ msgstr "ARP-ping"
 msgid "About Cockpit"
 msgstr "Om Cockpit"
 
+#: pkg/lib/machine-info.js:251
+msgid "Absent"
+msgstr "Frånvarande"
+
 #: pkg/users/index.html:104 pkg/users/index.html:190
 msgid "Access"
 msgstr "Åtkomst"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:12
-msgid "Access Policy"
-msgstr "Åtkomstpolicy"
 
 #: pkg/users/index.html:249
 msgid "Account Expiration"
@@ -517,7 +573,8 @@ msgstr "Kontoinställningar"
 msgid "Account not available or cannot be edited."
 msgstr "Kontot är inte tillgängligt eller kan inte redigeras."
 
-#: pkg/users/index.html:71
+#: pkg/playground/translate.html:95 pkg/users/index.html:71
+#: pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Konton"
 
@@ -526,9 +583,9 @@ msgctxt "page-title"
 msgid "Accounts"
 msgstr "Konton"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:170
 #: pkg/machines/components/networks/network.jsx:148
-#: pkg/storaged/content-views.jsx:256
+#: pkg/machines/components/storagePools/storagePool.jsx:170
+#: pkg/storaged/content-views.jsx:261
 msgid "Activate"
 msgstr "Aktivera"
 
@@ -536,11 +593,11 @@ msgstr "Aktivera"
 msgid "Activating $target"
 msgstr "Aktivera $target"
 
-#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:852 pkg/networkmanager/interfaces.js:2022
 msgid "Active"
 msgstr "Aktivt"
 
-#: pkg/networkmanager/interfaces.js:1975 pkg/networkmanager/interfaces.js:1992
+#: pkg/networkmanager/interfaces.js:1996 pkg/networkmanager/interfaces.js:2013
 msgid "Active Backup"
 msgstr "Aktiv reserv"
 
@@ -548,35 +605,40 @@ msgstr "Aktiv reserv"
 msgid "Active Pages"
 msgstr "Aktiva sidor"
 
-#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1044 pkg/storaged/dialog.jsx:1048
 msgid "Active since"
 msgstr "Aktivt sedan"
 
-#: pkg/networkmanager/firewall.jsx:924
-msgid "Active zones"
-msgstr ""
+#: pkg/systemd/service-details.jsx:354
+msgid "Active since "
+msgstr "Aktiv sedan"
 
-#: pkg/networkmanager/interfaces.js:1980
+#: pkg/networkmanager/firewall.jsx:956
+msgid "Active zones"
+msgstr "Aktiva zoner"
+
+#: pkg/networkmanager/interfaces.js:2001
 msgid "Adaptive load balancing"
 msgstr "Adaptiv lastbalansering"
 
-#: pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptiv lastbalansering av sändning"
 
-#: pkg/shell/index.html:181 pkg/lib/machine-add.html:43
-#: pkg/machines/components/diskAdd.jsx:563 pkg/storaged/iscsi-panel.jsx:132
-#: pkg/storaged/iscsi-panel.jsx:155 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/nfs-details.jsx:191 pkg/storaged/mdraid-details.jsx:57
-#: pkg/storaged/vgroup-details.jsx:63
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
+#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
+#: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
+#: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:198
+#: pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Lägg till"
 
-#: pkg/networkmanager/interfaces.js:3103
+#: pkg/networkmanager/interfaces.js:3126
 msgid "Add $0"
 msgstr "Lägg till $0"
 
-#: pkg/docker/storage.jsx:378
+#: pkg/docker/storage.jsx:383
 msgid "Add Additional Storage"
 msgstr "Lägg till ytterligare lagring"
 
@@ -588,15 +650,15 @@ msgstr "Lägg till bindning"
 msgid "Add Bridge"
 msgstr "Lägg till brygga"
 
-#: pkg/machines/components/diskAdd.jsx:360
+#: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Lägg till disk"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:51
+#: pkg/storaged/mdraid-details.jsx:45 pkg/storaged/vgroup-details.jsx:52
 msgid "Add Disks"
 msgstr "Lägg till diskar"
 
-#: pkg/storaged/crypto-keyslots.jsx:200
+#: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Add Key"
 msgstr "Lägg till nyckel"
 
@@ -604,16 +666,20 @@ msgstr "Lägg till nyckel"
 msgid "Add Machine to Dashboard"
 msgstr "Lägg till en maskin till panelen"
 
-#: pkg/networkmanager/firewall.jsx:457
-msgid "Add Ports"
+#: pkg/machines/components/nicAdd.jsx:218
+msgid "Add Network Interface"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:457 pkg/networkmanager/firewall.jsx:874
-#: pkg/networkmanager/firewall.jsx:886
+#: pkg/networkmanager/firewall.jsx:484
+msgid "Add Ports"
+msgstr "Lägg till portar"
+
+#: pkg/networkmanager/firewall.jsx:484 pkg/networkmanager/firewall.jsx:906
+#: pkg/networkmanager/firewall.jsx:918
 msgid "Add Services"
 msgstr "Lägg till tjänster"
 
-#: pkg/docker/storage.jsx:217
+#: pkg/docker/storage.jsx:219
 msgid "Add Storage"
 msgstr "Lägg till lagring"
 
@@ -625,12 +691,12 @@ msgstr "Lägg till team"
 msgid "Add VLAN"
 msgstr " Lägg till VLAN"
 
-#: pkg/networkmanager/firewall.jsx:700 pkg/networkmanager/firewall.jsx:880
-#: pkg/networkmanager/firewall.jsx:891
+#: pkg/networkmanager/firewall.jsx:732 pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:923
 msgid "Add Zone"
-msgstr ""
+msgstr "Lägg till zon"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/iscsi-panel.jsx:42
 msgid "Add iSCSI Portal"
 msgstr "Lägg till iSCSI-portal"
 
@@ -638,29 +704,35 @@ msgstr "Lägg till iSCSI-portal"
 msgid "Add key"
 msgstr "Lägg till nyckel"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add ports to the following zones:"
-msgstr ""
+msgstr "Lägg till portar i följande zoner:"
 
 #: pkg/users/index.html:406
 msgid "Add public key"
 msgstr "Lägg till publik nyckel"
 
-#: pkg/networkmanager/firewall.jsx:458
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add services to following zones:"
-msgstr ""
+msgstr "Lägg till tjänster i följande zoner:"
 
-#: pkg/networkmanager/firewall.jsx:776
+#: pkg/networkmanager/firewall.jsx:808
 msgid "Add zone"
-msgstr ""
+msgstr "Lägg till zon"
 
-#: pkg/networkmanager/interfaces.js:3102
+#: pkg/networkmanager/interfaces.js:3125
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
 msgstr ""
 "Att lägga till <b>$0</b> kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
+
+#: pkg/networkmanager/firewall.jsx:588
+msgid ""
+"Adding custom ports will reload firewalld. A reload will result in the loss "
+"of any runtime-only configuration!"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -670,15 +742,15 @@ msgstr "Lägger till nyckel"
 msgid "Adding physical volume to $target"
 msgstr "Lägger till fysisk volym till $target"
 
-#: pkg/machines/components/vmDisksTab.jsx:78
+#: pkg/machines/components/vmDisksTab.jsx:116
 msgid "Additional"
 msgstr "Ytterligare"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2676
 msgid "Additional DNS $val"
 msgstr "Ytterligare DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2679
 msgid "Additional DNS Search Domains $val"
 msgstr "Ytterligare DNS-sökdomäner $val"
 
@@ -686,7 +758,11 @@ msgstr "Ytterligare DNS-sökdomäner $val"
 msgid "Additional Storage"
 msgstr "Ytterligare lagring"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/systemd/service-details.jsx:209
+msgid "Additional actions"
+msgstr "Ytterligare åtgärder"
+
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional address $val"
 msgstr "Ytterligare adress $val"
 
@@ -697,28 +773,35 @@ msgstr "Ytterligare paket:"
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:107
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Address"
 msgstr "Adress"
 
-#: pkg/networkmanager/interfaces.js:2651
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Address $val"
 msgstr "Adress $val"
 
-#: pkg/storaged/crypto-keyslots.jsx:192
+#: pkg/storaged/crypto-keyslots.jsx:193
 msgid "Address cannot be empty"
 msgstr "Adressen kan inte vara tom"
 
-#: pkg/storaged/crypto-keyslots.jsx:194
+#: pkg/storaged/crypto-keyslots.jsx:195
 msgid "Address is not a valid URL"
 msgstr "Adressen är inte en giltig URL"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:60
+#: pkg/machines/components/networks/createNetworkDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:88
+#: pkg/machines/components/networks/createNetworkDialog.jsx:95
+msgid "Address not within subnet"
+msgstr "Adress inte inom subnät"
 
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Adress:"
 
-#: pkg/networkmanager/interfaces.js:3309
+#: pkg/networkmanager/interfaces.js:3332
 msgid "Addresses"
 msgstr "Adresser"
 
@@ -734,7 +817,7 @@ msgstr "Administratörslösenord"
 msgid "Advanced TCA"
 msgstr "Avanserad TCA"
 
-#: pkg/systemd/services.html:455 pkg/systemd/init.js:730
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:430
 msgid "After"
 msgstr "Efter"
 
@@ -745,8 +828,8 @@ msgid ""
 "settings and the list of trusted CAs may change."
 msgstr ""
 
-#: pkg/systemd/services.html:446 pkg/systemd/services.html:450
-#: pkg/systemd/init.js:1073
+#: pkg/systemd/services.html:301 pkg/systemd/services.html:305
+#: pkg/systemd/init.js:964
 msgid "After system boot"
 msgstr "Efter systemstart"
 
@@ -754,7 +837,7 @@ msgstr "Efter systemstart"
 msgid "Alert and above"
 msgstr "Larm och högre"
 
-#: pkg/systemd/services.html:71 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
 msgid "All"
 msgstr ""
 
@@ -762,7 +845,7 @@ msgstr ""
 msgid "All In One"
 msgstr "Allt-i-ett"
 
-#: pkg/docker/storage.jsx:381
+#: pkg/docker/storage.jsx:386
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -770,11 +853,15 @@ msgstr ""
 "Alla data på valda diskar kommer raderas och diskarna kommer läggas till i "
 "lagringspoolen."
 
-#: pkg/networkmanager/firewall.jsx:751
+#: pkg/systemd/service-details.jsx:159
+msgid "Allow running (unmask)"
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:783
 msgid "Allowed Addresses"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:937
+#: pkg/networkmanager/firewall.jsx:969
 msgid "Allowed Services"
 msgstr "Tillåtna tjänster"
 
@@ -782,20 +869,21 @@ msgstr "Tillåtna tjänster"
 msgid "Always"
 msgstr "Alltid"
 
-#: pkg/machines/components/diskAdd.jsx:116
+#: pkg/machines/components/diskAdd.jsx:117
+#: pkg/machines/components/nicAdd.jsx:86
 msgid "Always attach"
 msgstr "Anslut alltid"
 
-#: node_modules/registry-image-widgets/views/annotations.html:1
-msgid "Annotations"
-msgstr "Noteringar"
+#: pkg/lib/cockpit-components-modifications.jsx:82
+msgid "Ansible Playbook"
+msgstr ""
 
 #: pkg/systemd/terminal.jsx:93
 msgid "Appearance:"
 msgstr ""
 
 #: pkg/apps/index.html:23 pkg/apps/application-list.jsx:152
-#: pkg/apps/application.jsx:143
+#: pkg/apps/application.jsx:143 pkg/apps/manifest.json.in
 msgid "Applications"
 msgstr "Program"
 
@@ -803,10 +891,10 @@ msgstr "Program"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/machines/components/vcpuModal.jsx:235
-#: pkg/storaged/crypto-tab.jsx:76 pkg/storaged/crypto-tab.jsx:105
-#: pkg/storaged/fsys-tab.jsx:78 pkg/storaged/fsys-tab.jsx:126
-#: pkg/storaged/nfs-details.jsx:191 pkg/kdump/kdump-view.jsx:352
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:354
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:108 pkg/storaged/fsys-tab.jsx:80
+#: pkg/storaged/fsys-tab.jsx:129 pkg/storaged/nfs-details.jsx:198
 msgid "Apply"
 msgstr "Lägg på"
 
@@ -818,11 +906,11 @@ msgstr "Lägg på alla uppdateringar"
 msgid "Apply security updates"
 msgstr "Lägg på säkerhetsuppdateringar"
 
-#: pkg/selinux/setroubleshoot-view.jsx:112
+#: pkg/selinux/setroubleshoot-view.jsx:113
 msgid "Apply this solution"
 msgstr "Lägg på denna lösning"
 
-#: pkg/selinux/setroubleshoot-view.jsx:87
+#: pkg/selinux/setroubleshoot-view.jsx:88
 msgid "Applying solution..."
 msgstr "Lägger på lösning …"
 
@@ -834,37 +922,33 @@ msgstr "Lägger på uppdateringar"
 msgid "Applying updates failed"
 msgstr "Att lägga på uppdateringar misslyckades"
 
-#: node_modules/registry-image-widgets/views/image-config.html:16
-msgid "Architecture"
-msgstr "Arkitektur"
-
 #: pkg/systemd/index.html:92
 msgid "Asset Tag"
 msgstr "Inventariebeteckning"
 
-#: pkg/storaged/mdraids-panel.jsx:79
+#: pkg/storaged/mdraids-panel.jsx:96
 msgid "At least $0 disks are needed."
 msgstr "Åtminstone $0 diskar behövs."
 
-#: pkg/storaged/vgroups-panel.jsx:63 pkg/storaged/mdraid-details.jsx:51
-#: pkg/storaged/vgroup-details.jsx:57
+#: pkg/storaged/mdraid-details.jsx:52 pkg/storaged/vgroup-details.jsx:59
+#: pkg/storaged/vgroups-panel.jsx:66
 msgid "At least one disk is needed."
 msgstr "Åtminstone en disk behövs."
 
-#: pkg/systemd/services.html:451
+#: pkg/systemd/services.html:306
 msgid "At specific time"
 msgstr "Vid en specifik tidpunkt"
 
-#: pkg/selinux/setroubleshoot-view.jsx:414
+#: pkg/selinux/setroubleshoot-view.jsx:424
 msgid "Audit log"
 msgstr "Granskningslogg"
 
-#: pkg/networkmanager/interfaces.js:830
+#: pkg/networkmanager/interfaces.js:844
 msgid "Authenticating"
 msgstr "Autentiserar"
 
-#: pkg/realmd/operation.html:47 pkg/shell/index.html:66
-#: pkg/shell/index.html:149 pkg/lib/machine-change-auth.html:32
+#: pkg/lib/machine-change-auth.html:32 pkg/realmd/operation.html:47
+#: pkg/shell/index.html:66 pkg/shell/index.html:149
 msgid "Authentication"
 msgstr "Autentisering"
 
@@ -888,13 +972,11 @@ msgstr ""
 "Autentisering krävs för att utföra priviligierade uppgifter med Cockpits "
 "webbkonsol"
 
-#: pkg/storaged/iscsi-panel.jsx:147
+#: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Autentisering krävs"
 
-#: pkg/docker/index.html:702
-#: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:413
+#: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Upphovsman"
 
@@ -902,22 +984,23 @@ msgstr "Upphovsman"
 msgid "Authorized Public SSH Keys"
 msgstr "Auktoriserade publika SSH-nycklar"
 
-#: pkg/networkmanager/index.html:176 pkg/networkmanager/interfaces.js:1965
-#: pkg/networkmanager/interfaces.js:2759 pkg/networkmanager/interfaces.js:3317
-#: pkg/networkmanager/interfaces.js:3321 pkg/networkmanager/interfaces.js:3327
-#: pkg/realmd/operation.js:338
+#: pkg/networkmanager/index.html:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:162
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:3340 pkg/networkmanager/interfaces.js:3344
+#: pkg/networkmanager/interfaces.js:3350 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatisk"
 
-#: pkg/networkmanager/interfaces.js:1966
+#: pkg/networkmanager/interfaces.js:1987
 msgid "Automatic (DHCP only)"
 msgstr "Automatiskt (endast DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1956
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Automatic (DHCP)"
 msgstr "Automatiskt (DHCP)"
 
-#: pkg/systemd/services.html:125 pkg/systemd/init.js:286
+#: pkg/systemd/init.js:307
 msgid "Automatic Startup"
 msgstr ""
 
@@ -929,16 +1012,24 @@ msgstr "Automatiska uppdateringar"
 msgid "Automatically start libvirt on boot"
 msgstr "Starta automatiskt libvirt vid uppstart"
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/service-details.jsx:398
+msgid "Automatically starts"
+msgstr ""
+
+#: pkg/systemd/index.html:400
 msgid "Automatically using NTP"
 msgstr "Använder automatiskt NTP"
 
-#: pkg/systemd/index.html:390
+#: pkg/systemd/index.html:401
 msgid "Automatically using specific NTP servers"
 msgstr "Använder automatiskt specifika NTP-servrar"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:64
+#: pkg/lib/cockpit-components-modifications.jsx:71
+msgid "Automation Script"
+msgstr ""
+
 #: pkg/machines/components/networks/networkOverviewTab.jsx:86
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:69
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:166
 msgid "Autostart"
 msgstr ""
@@ -949,11 +1040,11 @@ msgstr ""
 msgid "Available"
 msgstr "Tillgängliga"
 
-#: pkg/packagekit/updates.jsx:822
+#: pkg/packagekit/updates.jsx:825
 msgid "Available Updates"
 msgstr "Tillgängliga uppdateringar"
 
-#: pkg/storaged/iscsi-panel.jsx:124
+#: pkg/storaged/iscsi-panel.jsx:125
 msgid "Available targets on $0"
 msgstr "Tillgängliga mål på $0"
 
@@ -961,15 +1052,15 @@ msgstr "Tillgängliga mål på $0"
 msgid "Avatar"
 msgstr "Avatar"
 
-#: pkg/systemd/hwinfo.jsx:92
+#: pkg/systemd/hwinfo.jsx:96
 msgid "BIOS"
 msgstr "BIOS"
 
-#: pkg/systemd/hwinfo.jsx:100
+#: pkg/systemd/hwinfo.jsx:104
 msgid "BIOS date"
 msgstr "BIOS-datum"
 
-#: pkg/systemd/hwinfo.jsx:96
+#: pkg/systemd/hwinfo.jsx:100
 msgid "BIOS version"
 msgstr "BIOS-version"
 
@@ -977,7 +1068,7 @@ msgstr "BIOS-version"
 msgid "Back to Accounts"
 msgstr "Tilllbaka till konton"
 
-#: pkg/storaged/vdo-details.jsx:270
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Backing Device"
 msgstr "Bakomliggande enhet"
 
@@ -989,11 +1080,11 @@ msgstr "Felaktiga data skickade för passwd1-mekanismen"
 msgid "Balancer"
 msgstr "Balanserare"
 
-#: pkg/systemd/init.js:729
+#: pkg/systemd/service-details.jsx:429
 msgid "Before"
 msgstr "Före"
 
-#: pkg/systemd/init.js:720
+#: pkg/systemd/service-details.jsx:420
 msgid "Binds To"
 msgstr "Binder till"
 
@@ -1013,16 +1104,16 @@ msgstr "Bladhölje"
 msgid "Block"
 msgstr "Block"
 
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:666
 msgid "Block device for filesystems"
 msgstr "Blockenhet för filsystem"
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/mdraid-details.jsx:97
 msgid "Blocked"
 msgstr "Blockerat"
 
-#: pkg/networkmanager/interfaces.js:2510 pkg/networkmanager/interfaces.js:2522
-#: pkg/networkmanager/interfaces.js:2791
+#: pkg/networkmanager/interfaces.js:2529 pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2811
 msgid "Bond"
 msgstr "Binda"
 
@@ -1039,12 +1130,12 @@ msgstr ""
 msgid "Boot order settings could not be saved"
 msgstr ""
 
-#: pkg/systemd/init.js:725
+#: pkg/systemd/service-details.jsx:425
 msgid "Bound By"
 msgstr "Bundet av"
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2535 pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2888
 msgid "Bridge"
 msgstr "Brygga"
 
@@ -1056,33 +1147,29 @@ msgstr "Bryggportinställningar"
 msgid "Bridge Settings"
 msgstr "Brygginställningar"
 
-#: pkg/networkmanager/interfaces.js:2889
+#: pkg/networkmanager/interfaces.js:2909
 msgid "Bridge port"
 msgstr "Bryggport"
 
-#: pkg/networkmanager/interfaces.js:1977 pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:1998 pkg/networkmanager/interfaces.js:2015
 msgid "Broadcast"
 msgstr "Utsändning"
 
-#: pkg/networkmanager/interfaces.js:2804 pkg/networkmanager/interfaces.js:2838
+#: pkg/networkmanager/interfaces.js:2824 pkg/networkmanager/interfaces.js:2858
 msgid "Broken configuration"
 msgstr "Trasig konfiguration"
 
-#: pkg/systemd/host.js:498
+#: pkg/systemd/host.js:511
 msgid "Bug Fix Updates Available"
 msgstr "Felrättningsuppdateringar tillgängliga"
 
-#: pkg/packagekit/updates.jsx:314
+#: pkg/packagekit/updates.jsx:315
 msgid "Bugs:"
 msgstr "Fel:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:18
-msgid "Built"
-msgstr "Byggd"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:109
 #: pkg/machines/components/vm/bootOrderModal.jsx:132
-#: pkg/machines/components/vmDisksTab.jsx:72
+#: pkg/machines/components/vmDisksTab.jsx:110
 msgid "Bus"
 msgstr "Buss"
 
@@ -1091,19 +1178,19 @@ msgid "Bus Expansion Chassis"
 msgstr "Bussexpansionschassi"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:272
-#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:112
 msgid "CPU"
 msgstr "CPU"
 
-#: pkg/systemd/hwinfo.jsx:113
+#: pkg/systemd/hwinfo.jsx:117
 msgid "CPU Security"
 msgstr ""
 
-#: pkg/systemd/hwinfo.jsx:205
+#: pkg/systemd/hwinfo.jsx:209
 msgid "CPU Security Toggles"
 msgstr ""
 
-#: pkg/systemd/host.js:1548
+#: pkg/systemd/host.js:1603
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "CPU-status"
@@ -1120,12 +1207,12 @@ msgstr "CPU-prioritet"
 msgid "CPU usage:"
 msgstr "CPU-användning:"
 
+#: pkg/machines/components/diskAdd.jsx:174
 #: pkg/machines/components/vmDiskColumns.jsx:75
-#: pkg/machines/components/diskAdd.jsx:246
 msgid "Cache"
 msgstr ""
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1679
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1739
 msgid "Cached"
 msgstr "Cachad"
 
@@ -1133,54 +1220,58 @@ msgstr "Cachad"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Kan inte ansluta till Docker"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:318
 msgid "Can't delete while unlocked"
 msgstr "Kan inte radera när olåst"
 
-#: pkg/dashboard/list.js:212
+#: pkg/dashboard/list.js:220
 msgid "Can't load image"
 msgstr "Kan inte ladda avbilden"
 
 #: pkg/dashboard/index.html:175 pkg/docker/index.html:565
 #: pkg/docker/index.html:599 pkg/docker/index.html:663
 #: pkg/docker/index.html:717 pkg/docker/index.html:757
-#: pkg/docker/index.html:786 pkg/networkmanager/index.html:477
+#: pkg/docker/index.html:786 pkg/lib/machine-add.html:42
+#: pkg/lib/machine-change-auth.html:80 pkg/lib/machine-change-port.html:40
+#: pkg/lib/machine-sync-users.html:74 pkg/networkmanager/index.html:477
 #: pkg/networkmanager/index.html:501 pkg/networkmanager/index.html:525
 #: pkg/networkmanager/index.html:549 pkg/networkmanager/index.html:573
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90
-#: pkg/systemd/services.html:522 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/users/index.html:198 pkg/users/index.html:237
-#: pkg/users/index.html:276 pkg/users/index.html:315 pkg/users/index.html:332
-#: pkg/users/index.html:356 pkg/users/index.html:413
-#: pkg/lib/machine-add.html:42 pkg/lib/machine-change-port.html:40
-#: pkg/lib/machine-sync-users.html:74 pkg/lib/machine-change-auth.html:80
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:731
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
+#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
+#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
+#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
+#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
+#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
+#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
+#: pkg/machines/components/networks/networkDelete.jsx:100
+#: pkg/machines/components/nicAdd.jsx:232
+#: pkg/machines/components/nicEdit.jsx:181
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:93
+#: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:128
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:487
-#: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/vcpuModal.jsx:232
-#: pkg/machines/components/nicEdit.jsx:296
-#: pkg/machines/components/diskAdd.jsx:560 pkg/networkmanager/firewall.jsx:560
-#: pkg/networkmanager/firewall.jsx:628 pkg/networkmanager/firewall.jsx:771
-#: pkg/sosreport/index.js:51 pkg/storaged/jobs-panel.jsx:123
-#: pkg/storaged/dialog.jsx:393 pkg/systemd/hwinfo.jsx:216
-#: pkg/lib/cockpit-components-dialog.jsx:159 pkg/apps/utils.jsx:86
-#: pkg/packagekit/updates.jsx:179
+#: pkg/networkmanager/firewall.jsx:592 pkg/networkmanager/firewall.jsx:660
+#: pkg/networkmanager/firewall.jsx:803 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:394
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:220
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: pkg/shell/indexes.js:415
+#: pkg/shell/indexes.js:472
 msgid "Cannot connect to an unknown machine"
 msgstr "Kan inte ansluta till en okänd maskin"
 
-#: src/base1/cockpit.js:4031
+#: src/base1/cockpit.js:4035
 msgid "Cannot forward login credentials"
 msgstr "Kan inte vidarebefordra inloggningskreditiven"
 
@@ -1188,25 +1279,25 @@ msgstr "Kan inte vidarebefordra inloggningskreditiven"
 msgid "Cannot schedule event in the past"
 msgstr "Kan inte schemalägga händelser i det förflutna"
 
-#: pkg/machines/components/vmDisksTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:108
 msgid "Capacity"
 msgstr "Kapacitet"
 
-#: pkg/networkmanager/interfaces.js:2590
+#: pkg/networkmanager/interfaces.js:2610
 msgid "Carrier"
 msgstr "Transportör"
 
-#: pkg/docker/index.html:664 pkg/systemd/index.html:333
-#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:181
+#: pkg/docker/index.html:664 pkg/systemd/index.html:344
+#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Ändra"
 
-#: pkg/systemd/index.html:289
+#: pkg/systemd/index.html:300
 msgid "Change Host Name"
 msgstr "Ändra värdnamn"
 
-#: pkg/shell/index.html:312
+#: pkg/shell/index.html:313
 msgid "Change Password"
 msgstr "Ändra lösenord"
 
@@ -1214,19 +1305,19 @@ msgstr "Ändra lösenord"
 msgid "Change Performance Profile"
 msgstr "Ändra prestandaprofil"
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:199
 msgid "Change Profile"
 msgstr "Ändra profil"
 
-#: pkg/systemd/index.html:358
+#: pkg/systemd/index.html:369
 msgid "Change System Time"
 msgstr "Ändra systemtid"
 
-#: pkg/storaged/iscsi-panel.jsx:176
+#: pkg/storaged/iscsi-panel.jsx:183
 msgid "Change iSCSI Initiator Name"
 msgstr "Ändra iSCSI-initierarnamn"
 
-#: pkg/storaged/crypto-keyslots.jsx:247
+#: pkg/storaged/crypto-keyslots.jsx:255
 msgid "Change passphrase"
 msgstr "Ändra lösenfras"
 
@@ -1238,18 +1329,18 @@ msgstr "Ändra resursgränser"
 msgid "Change resources limits"
 msgstr "Ändra resursgränser"
 
-#: pkg/networkmanager/interfaces.js:3153
+#: pkg/networkmanager/interfaces.js:3176
 msgid "Change the settings"
 msgstr "Ändra inställningarna"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:283
+#: pkg/machines/components/nicEdit.jsx:157
 #: pkg/machines/components/vcpuModal.jsx:183
+#: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
-#: pkg/machines/components/nicEdit.jsx:272
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Ändringar kommer verkställas efter att VM:en stängs av"
 
-#: pkg/networkmanager/interfaces.js:3152
+#: pkg/networkmanager/interfaces.js:3175
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1265,7 +1356,7 @@ msgstr "Kontrollera om det finns uppdateringar"
 msgid "Checking $target"
 msgstr "Kontrollerar $target"
 
-#: pkg/networkmanager/interfaces.js:834
+#: pkg/networkmanager/interfaces.js:848
 msgid "Checking IP"
 msgstr "Kontrollerar IP"
 
@@ -1285,23 +1376,27 @@ msgstr "Kontrollerar om det finns nya program"
 msgid "Checking for public keys"
 msgstr "Kontrollerar om det finns publika nycklar"
 
-#: pkg/systemd/host.js:517
+#: pkg/systemd/host.js:540
 msgid "Checking for updates…"
 msgstr "Kontrollerar om det finns uppdateringar …"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:142
+#: pkg/lib/cockpit-components-install-dialog.jsx:143
 msgid "Checking installed software"
 msgstr "Kontrollerar installerad programvara"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:351
+msgid "Choose an operating system"
+msgstr ""
 
 #: pkg/shell/index.html:117 pkg/shell/simple.html:85
 msgid "Choose the language to be used in the application"
 msgstr "Välj språk som skall användas i programmet"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/mdraids-panel.jsx:72
 msgid "Chunk Size"
 msgstr "Styckesstorlek"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Class"
 msgstr "Klass"
 
@@ -1309,11 +1404,15 @@ msgstr "Klass"
 msgid "Cleaning up for $target"
 msgstr "Rensar upp för $target"
 
-#: pkg/systemd/services.html:194
+#: pkg/systemd/service-details.jsx:188
+msgid "Clear 'Failed to start'"
+msgstr ""
+
+#: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr ""
 
-#: pkg/systemd/host.js:734
+#: pkg/systemd/host.js:776
 msgid "Click to see system hardware information"
 msgstr "Klicka för att se hårdvaruinformation för systemet"
 
@@ -1326,20 +1425,18 @@ msgstr "Att klicka ”Starta fjärrvisare” kommer hämta en .vv-fil och starta
 msgid "Client Software"
 msgstr ""
 
-#: pkg/docker/index.html:738 pkg/networkmanager/index.html:688
-#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:323
-#: pkg/shell/simple.html:72 pkg/systemd/services.html:363
-#: pkg/systemd/services.html:381 pkg/systemd/index.html:278
-#: pkg/users/index.html:45 pkg/lib/machine-auth-failed.html:20
-#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-not-supported.html:8
-#: pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/lib/machine-invalid-hostkey.html:12 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
-#: pkg/apps/utils.jsx:108
+#: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
+#: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
+#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
+#: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
+#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:394
 msgid "Close"
 msgstr "Stäng"
 
-#: pkg/shell/active-pages.js:103
+#: pkg/shell/active-pages.js:104
 msgid "Close Selected Pages"
 msgstr "Stäng valda sidor"
 
@@ -1347,7 +1444,7 @@ msgstr "Stäng valda sidor"
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Cockpit-autentisering är felaktigt konfigurerad."
 
-#: pkg/lib/machine-dialogs.js:427
+#: pkg/lib/machine-dialogs.js:429
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
@@ -1355,11 +1452,11 @@ msgstr ""
 "Cockpit kunde inte kontakta den angivna värden $0.  Se till att den har ssh "
 "körande på port $1, eller ange en annan port i adressen."
 
-#: src/base1/cockpit.js:4037
+#: src/base1/cockpit.js:4041
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit kunde inte kontakta den angivna värden."
 
-#: pkg/shell/base_index.js:738
+#: pkg/shell/base_index.js:759
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1388,7 +1485,7 @@ msgstr ""
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit är ett interaktivt administratörsgränssnitt för Linuxservrar."
 
-#: src/base1/cockpit.js:4035
+#: src/base1/cockpit.js:4039
 msgid "Cockpit is not compatible with the software on the system."
 msgstr "Cockpit är inte kompatibelt med programvaran på systemet."
 
@@ -1396,7 +1493,7 @@ msgstr "Cockpit är inte kompatibelt med programvaran på systemet."
 msgid "Cockpit is not installed"
 msgstr "Cockpit är inte installerat"
 
-#: src/base1/cockpit.js:4029
+#: src/base1/cockpit.js:4033
 msgid "Cockpit is not installed on the system."
 msgstr "Cockpit är inte installerat på systemet."
 
@@ -1420,15 +1517,15 @@ msgstr "Cockpit kunde inte kontakta {{#strong}}{{host}}{{/strong}}."
 
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
-"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"You may want to try to {{#sync_link}}synchronize users{{/sync_link}}.{{/"
-"can_sync}} For more authentication options and troubleshooting support "
-"please upgrade cockpit-ws to a newer version."
+"Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
+"sync_link}}.{{/can_sync}} For more authentication options and "
+"troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
-"Cockpit kunde inte logga in på {{#strong}}{{host}}{{/strong}}. {{#can_sync}}"
-"Du kan vilja försöka att {{#sync_link}}synkronisera användare{{/sync_link}}."
-"{{/can_sync}}  För fler autentiseringsalternativ och hjälp med felsökning, "
-"uppgradera cockpit-ws till en nyare version."
+"Cockpit kunde inte logga in på {{#strong}}{{host}}{{/strong}}. "
+"{{#can_sync}}Du kan vilja försöka att {{#sync_link}}synkronisera användare{{/"
+"sync_link}}.{{/can_sync}}  För fler autentiseringsalternativ och hjälp med "
+"felsökning, uppgradera cockpit-ws till en nyare version."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1463,19 +1560,18 @@ msgstr "Färg"
 msgid "Combined memory usage"
 msgstr "Kombinerad minnesanvändning"
 
-#: pkg/docker/overview.js:86
+#: pkg/docker/overview.js:88
 msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Kombinerad användning av $0 CPU-kärna"
 msgstr[1] "Kombinerad användning av $0 CPU-kärnor"
 
-#: pkg/networkmanager/firewall.jsx:529
+#: pkg/networkmanager/firewall.jsx:556
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr ""
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
-#: pkg/docker/index.html:708 pkg/systemd/services.html:427
-#: node_modules/registry-image-widgets/views/image-config.html:2
+#: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
 msgid "Command"
@@ -1489,7 +1585,7 @@ msgstr "Kommandot får inte vara tomt"
 msgid "Command:"
 msgstr "Kommando:"
 
-#: pkg/shell/index.html:261
+#: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Kommentar"
 
@@ -1510,11 +1606,11 @@ msgstr "Kommunikationen med tuned har misslyckats"
 msgid "Compact PCI"
 msgstr "Kompakt PCI"
 
-#: pkg/storaged/content-views.jsx:522
+#: pkg/storaged/content-views.jsx:532
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Kompatibel med alla system och enheter (MBR)"
 
-#: pkg/storaged/content-views.jsx:524
+#: pkg/storaged/content-views.jsx:535
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "Kompatibel med moderna system och hårddiskar > 2 TB (GPT)"
 
@@ -1522,8 +1618,8 @@ msgstr "Kompatibel med moderna system och hårddiskar > 2 TB (GPT)"
 msgid "Compress crash dumps to save space"
 msgstr "Komprimera kraschdumpar för att spara utrymme"
 
-#: pkg/storaged/vdo-details.jsx:304 pkg/storaged/vdos-panel.jsx:81
-#: pkg/kdump/kdump-view.jsx:156
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:310
+#: pkg/storaged/vdos-panel.jsx:87
 msgid "Compression"
 msgstr "Komprimering"
 
@@ -1531,32 +1627,32 @@ msgstr "Komprimering"
 msgid "Computer OU"
 msgstr "Dator-OU"
 
-#: pkg/systemd/init.js:692
+#: pkg/systemd/service-details.jsx:444
 msgid "Condition $0=$1 was not met"
 msgstr "Villkoret $0=$1 uppfylldes inte"
 
-#: pkg/systemd/services.html:143
+#: pkg/systemd/service-details.jsx:494
 msgid "Condition failed"
 msgstr "Villkoret misslyckades"
 
-#: pkg/networkmanager/interfaces.js:2725
+#: pkg/networkmanager/interfaces.js:2745
 msgid "Configure"
 msgstr "Konfigurera"
 
-#: pkg/docker/storage.jsx:331
+#: pkg/docker/storage.jsx:335
 msgid "Configure storage..."
 msgstr "Konfigurera lagring …"
 
-#: pkg/networkmanager/interfaces.js:828
+#: pkg/networkmanager/interfaces.js:842
 msgid "Configuring"
 msgstr "Konfigurerar"
 
-#: pkg/networkmanager/interfaces.js:832
+#: pkg/networkmanager/interfaces.js:846
 msgid "Configuring IP"
 msgstr "Konfigurerar IP"
 
-#: pkg/shell/index.html:297 pkg/users/index.html:176
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/shell/index.html:298 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:315
 msgid "Confirm"
 msgstr "Bekräfta"
 
@@ -1568,15 +1664,15 @@ msgstr "Bekräfta nytt lösenord"
 msgid "Confirm deletion of the Virtual Network"
 msgstr ""
 
-#: pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:372
 msgid "Confirm removal with passphrase"
 msgstr "Bekräfta borttagandet med en lösenfras"
 
-#: pkg/systemd/init.js:728
+#: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
 msgstr "Står i konflikt med"
 
-#: pkg/systemd/init.js:727
+#: pkg/systemd/service-details.jsx:427
 msgid "Conflicts"
 msgstr "Konflikter"
 
@@ -1584,7 +1680,7 @@ msgstr "Konflikter"
 msgid "Connect"
 msgstr "Anslut"
 
-#: pkg/networkmanager/interfaces.js:2712
+#: pkg/networkmanager/interfaces.js:2732
 msgid "Connect automatically"
 msgstr "Anslut automatiskt"
 
@@ -1613,7 +1709,7 @@ msgstr "Att ansluta till mer än {{ limit }} maskiner samtidigt stödjs inte."
 msgid "Connecting to Docker"
 msgstr "Ansluter till Docker"
 
-#: pkg/selinux/setroubleshoot-view.jsx:371
+#: pkg/selinux/setroubleshoot-view.jsx:381
 msgid "Connecting to SETroubleshoot daemon..."
 msgstr "Anslut till SETroubleshoot-demonen …"
 
@@ -1621,23 +1717,26 @@ msgstr "Anslut till SETroubleshoot-demonen …"
 msgid "Connecting to Virtualization Service"
 msgstr "Ansluter till virtualiseringstjänsten"
 
-#: pkg/shell/indexes.js:410
+#: pkg/shell/indexes.js:467
 msgid "Connecting to the machine"
 msgstr "Ansluter till maskinen"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:648
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:40
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/machinesConnectionSelector.jsx:34
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "Anslutning"
 
-#: pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:414
 msgid "Connection Error"
 msgstr "Anslutningsfel"
 
-#: src/base1/cockpit.js:4027
+#: pkg/shell/index.html:396
+msgid "Connection failed"
+msgstr ""
+
+#: src/base1/cockpit.js:4031
 msgid "Connection has timed out."
 msgstr "Anslutningens tidsgräns överskreds."
 
@@ -1645,7 +1744,7 @@ msgstr "Anslutningens tidsgräns överskreds."
 msgid "Connection will be lost"
 msgstr "Anslutningen kommer gå förlorad"
 
-#: pkg/systemd/init.js:726
+#: pkg/systemd/service-details.jsx:426
 msgid "Consists Of"
 msgstr "Består av"
 
@@ -1653,7 +1752,7 @@ msgstr "Består av"
 msgid "Console Type"
 msgstr "Konsoltyp"
 
-#: pkg/machines/components/vm/vm.jsx:51
+#: pkg/machines/components/vm/vm.jsx:53
 msgid "Consoles"
 msgstr "Konsoler"
 
@@ -1662,7 +1761,6 @@ msgid "Contacted domain"
 msgstr ""
 
 #: pkg/docker/console.html:4
-#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Behållare"
 
@@ -1700,16 +1798,16 @@ msgctxt "page-title"
 msgid "Containers"
 msgstr "Behållare"
 
-#: pkg/storaged/content-views.jsx:557
+#: pkg/storaged/content-views.jsx:570
 msgid "Content"
 msgstr "Innehåll"
 
-#: src/base1/test-locale.js:42 src/base1/test-locale.js:53
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:56
 #: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Styrning"
 
-#: src/base1/test-locale.js:43 src/base1/test-locale.js:55
+#: src/base1/test-locale.js:46 src/base1/test-locale.js:58
 #: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
@@ -1723,11 +1821,15 @@ msgstr "Konvertibel"
 msgid "Copy"
 msgstr ""
 
+#: pkg/lib/cockpit-components-modifications.jsx:106
+msgid "Copy to clipboard"
+msgstr ""
+
 #: pkg/machines/components/vcpuModal.jsx:209
 msgid "Cores per socket"
 msgstr "Kärnor per sockel"
 
-#: pkg/docker/storage.jsx:428
+#: pkg/docker/storage.jsx:438
 msgid "Could not add all disks"
 msgstr "Kunde inte lägga till alla diskar"
 
@@ -1735,7 +1837,7 @@ msgstr "Kunde inte lägga till alla diskar"
 msgid "Could not contact {{host}}"
 msgstr "Kunde inte kontakta {{host}}"
 
-#: pkg/docker/storage.jsx:468
+#: pkg/docker/storage.jsx:484
 msgid "Could not reset the storage pool"
 msgstr "Kunde inte återställa lagringspoolen"
 
@@ -1747,7 +1849,7 @@ msgstr "Kunde inte ändra användarens grupper"
 msgid "Couldn't change user password"
 msgstr "Kunde inte ändra användarens lösenord"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:470
 msgid "Couldn't connect to the machine"
 msgstr "Kunde inte ansluta till maskinen"
 
@@ -1767,28 +1869,30 @@ msgstr "Kunde inte lista användare"
 msgid "Couldn't load user data"
 msgstr "Kunde inte läsa in användardata"
 
-#: pkg/kdump/kdump-view.jsx:336 pkg/kdump/kdump-view.jsx:504
+#: pkg/kdump/kdump-view.jsx:337 pkg/kdump/kdump-view.jsx:506
 msgid "Crash dump location"
 msgstr "Kraschdumpplats"
 
-#: pkg/kdump/kdump-view.jsx:304
+#: pkg/kdump/kdump-view.jsx:305
 msgid "Crash system"
 msgstr "Krashsystem"
 
 #: pkg/users/index.html:199
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:736
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:490
-#: pkg/storaged/vgroups-panel.jsx:69 pkg/storaged/content-views.jsx:123
-#: pkg/storaged/content-views.jsx:689 pkg/storaged/lvol-tabs.jsx:352
-#: pkg/storaged/mdraids-panel.jsx:86 pkg/storaged/vdos-panel.jsx:105
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
+#: pkg/machines/components/networks/createNetworkDialog.jsx:482
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:96
+#: pkg/storaged/content-views.jsx:127 pkg/storaged/content-views.jsx:709
+#: pkg/storaged/lvol-tabs.jsx:360 pkg/storaged/mdraids-panel.jsx:103
+#: pkg/storaged/vdos-panel.jsx:113 pkg/storaged/vgroups-panel.jsx:72
 msgid "Create"
 msgstr "Skapa"
 
-#: pkg/storaged/content-views.jsx:639
+#: pkg/storaged/content-views.jsx:653
 msgid "Create Logical Volume"
 msgstr "Skapa en logisk volym"
 
-#: pkg/machines/components/diskAdd.jsx:515
+#: pkg/machines/components/diskAdd.jsx:423
 msgid "Create New"
 msgstr "Skapa ny"
 
@@ -1796,19 +1900,23 @@ msgstr "Skapa ny"
 msgid "Create New Account"
 msgstr "Skapa ett nytt konto"
 
-#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+msgid "Create New Volume"
+msgstr ""
+
+#: pkg/storaged/content-views.jsx:439 pkg/storaged/format-dialog.jsx:336
 msgid "Create Partition"
 msgstr "Skapa en partition"
 
-#: pkg/storaged/content-views.jsx:552
+#: pkg/storaged/content-views.jsx:565
 msgid "Create Partition Table"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:184
+#: pkg/storaged/format-dialog.jsx:189
 msgid "Create Partition on $0"
 msgstr ""
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/mdraids-panel.jsx:39
 msgid "Create RAID Device"
 msgstr "Skapa en RAID-enhet"
 
@@ -1816,35 +1924,45 @@ msgstr "Skapa en RAID-enhet"
 msgid "Create Report"
 msgstr "Skapa en rapport"
 
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
+#: pkg/storaged/lvol-tabs.jsx:354 pkg/storaged/lvol-tabs.jsx:395
 msgid "Create Snapshot"
 msgstr "Skapa en ögonblicksbild"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:524
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:548
 msgid "Create Storage Pool"
 msgstr "Skapa en lagringspool"
 
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:138
 msgid "Create Thin Volume"
 msgstr "Skapa en tunn volym"
 
-#: pkg/systemd/services.html:64
+#: pkg/systemd/services.html:58
 msgid "Create Timer"
 msgstr "Skapa en timer"
 
-#: pkg/systemd/services.html:393
+#: pkg/systemd/services.html:248
 msgid "Create Timers"
 msgstr "Skapa timrar"
 
-#: pkg/storaged/vdos-panel.jsx:46
+#: pkg/storaged/vdos-panel.jsx:47
 msgid "Create VDO Device"
 msgstr "Skapa en VDO-enhet"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:778
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Create VM"
 msgstr "Skapa en VM"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/machines/components/networks/createNetworkDialog.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:516
+msgid "Create Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:135
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:148
+msgid "Create Volume"
+msgstr ""
+
+#: pkg/storaged/vgroups-panel.jsx:54
 msgid "Create Volume Group"
 msgstr "Skapa en volymgrupp"
 
@@ -1852,12 +1970,12 @@ msgstr "Skapa en volymgrupp"
 msgid "Create diagnostic report"
 msgstr "Skapa en diagnostisk rapport"
 
-#: pkg/networkmanager/interfaces.js:3822 pkg/networkmanager/interfaces.js:4021
-#: pkg/networkmanager/interfaces.js:4275 pkg/networkmanager/interfaces.js:4480
+#: pkg/networkmanager/interfaces.js:3850 pkg/networkmanager/interfaces.js:4050
+#: pkg/networkmanager/interfaces.js:4305 pkg/networkmanager/interfaces.js:4510
 msgid "Create it"
 msgstr "Skapa den"
 
-#: pkg/storaged/content-views.jsx:708
+#: pkg/storaged/content-views.jsx:728
 msgid "Create new Logical Volume"
 msgstr "Skapa en ny logisk volym"
 
@@ -1890,7 +2008,7 @@ msgstr "Skapar en partition på $target"
 msgid "Creating snapshot of $target"
 msgstr "Skapar en ögonblicksbild av $target"
 
-#: pkg/networkmanager/interfaces.js:4479
+#: pkg/networkmanager/interfaces.js:4509
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1898,7 +2016,7 @@ msgstr ""
 "Att skapa detta VLAN kommer bryta anslutningen till servern, och kommer göra "
 "administrationsgränssnittet otillgängligt."
 
-#: pkg/networkmanager/interfaces.js:3821
+#: pkg/networkmanager/interfaces.js:3849
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1906,7 +2024,7 @@ msgstr ""
 "Att skapa denna bindning kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
 
-#: pkg/networkmanager/interfaces.js:4274
+#: pkg/networkmanager/interfaces.js:4304
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1914,7 +2032,7 @@ msgstr ""
 "Att skapa denna brygga kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
 
-#: pkg/networkmanager/interfaces.js:4020
+#: pkg/networkmanager/interfaces.js:4049
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1926,7 +2044,7 @@ msgstr ""
 msgid "Creating volume group $target"
 msgstr "Skapar en volymgrupp $target"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:634
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:683
 msgid "Creation of VM $0 failed"
 msgstr ""
 
@@ -1950,23 +2068,23 @@ msgstr ""
 msgid "Current boot"
 msgstr "Nuvarande uppstart"
 
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Anpassat"
 
-#: pkg/networkmanager/firewall.jsx:523
+#: pkg/networkmanager/firewall.jsx:550
 msgid "Custom Ports"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:118
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Custom encryption options"
 msgstr "Anpassade krypteringsalternativ"
 
-#: pkg/storaged/nfs-details.jsx:176 pkg/storaged/format-dialog.jsx:91
+#: pkg/storaged/format-dialog.jsx:95 pkg/storaged/nfs-details.jsx:183
 msgid "Custom mount options"
 msgstr "Anpassade monteringsalternativ"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:750
 msgid "Custom zones"
 msgstr ""
 
@@ -1979,19 +2097,19 @@ msgstr ""
 msgid "DISK IS FAILING"
 msgstr "DISKEN GÅR SÖNDER"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3339
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2656
+#: pkg/networkmanager/interfaces.js:2676
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3320
+#: pkg/networkmanager/interfaces.js:3343
 msgid "DNS Search Domains"
 msgstr "DNS-sökdomäner"
 
-#: pkg/networkmanager/interfaces.js:2659
+#: pkg/networkmanager/interfaces.js:2679
 msgid "DNS Search Domains $val"
 msgstr "DNS-sökdomäner $val"
 
@@ -2003,17 +2121,17 @@ msgstr ""
 msgid "Dashboard"
 msgstr "Panel"
 
-#: pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/lvol-tabs.jsx:463
 msgid "Data Used"
 msgstr "Data använt"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:165
 #: pkg/machines/components/networks/network.jsx:144
-#: pkg/storaged/content-views.jsx:254
+#: pkg/machines/components/storagePools/storagePool.jsx:165
+#: pkg/storaged/content-views.jsx:259
 msgid "Deactivate"
 msgstr "Avaktivera"
 
-#: pkg/networkmanager/interfaces.js:840
+#: pkg/networkmanager/interfaces.js:854
 msgid "Deactivating"
 msgstr "Avaktiverar"
 
@@ -2025,42 +2143,48 @@ msgstr "Avaktiverar $target"
 msgid "Debug and above"
 msgstr "Felsökning och högre"
 
-#: pkg/storaged/vdo-details.jsx:310 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdo-details.jsx:316 pkg/storaged/vdos-panel.jsx:91
 msgid "Deduplication"
 msgstr "Avduplicering"
 
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
-#: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
 msgstr "Standard"
 
-#: pkg/systemd/index.html:438
+#: pkg/systemd/index.html:449
 msgid "Delay"
 msgstr "Fördröjning"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
-#: pkg/users/index.html:357 pkg/docker/details.js:292 pkg/docker/util.js:641
-#: pkg/docker/containers-view.jsx:202
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:114
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:131
+#: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
+#: pkg/docker/details.js:293 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
 #: pkg/machines/components/networks/networkDelete.jsx:103
-#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
-#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
+#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:319
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
+#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
+#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Ta bort"
 
-#: pkg/networkmanager/interfaces.js:2435 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2454 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Ta bort $0"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:97
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:67
+msgid "Delete $0 volume"
+msgid_plural "Delete $0 volumes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
 msgstr ""
 
@@ -2069,11 +2193,10 @@ msgid "Delete Files"
 msgstr "Ta bort filer"
 
 #: pkg/machines/components/networks/networkDelete.jsx:92
-#, fuzzy
 msgid "Delete Network $0"
-msgstr "Ta bort $0"
+msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:120
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:217
 msgid "Delete Storage Pool $0"
 msgstr ""
 
@@ -2081,7 +2204,7 @@ msgstr ""
 msgid "Delete associated storage files:"
 msgstr "Ta bort assoicierade lagringsfiler:"
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:104
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:170
 msgid "Delete the Volumes inside this Pool"
 msgstr ""
 
@@ -2089,7 +2212,7 @@ msgstr ""
 msgid "Deleting $target"
 msgstr "Tar bort $target"
 
-#: pkg/networkmanager/interfaces.js:2434
+#: pkg/networkmanager/interfaces.js:2453
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2097,31 +2220,31 @@ msgstr ""
 "Att ta bort <b>$0</b> kommer bryta anslutningen till servern, och kommer "
 "göra administrationsgränssnittet otillgängligt."
 
-#: pkg/storaged/mdraid-details.jsx:300
+#: pkg/storaged/mdraid-details.jsx:296
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Att ta bort en RAID-enhet kommer att radera all data på den."
 
-#: pkg/storaged/vdo-details.jsx:200
+#: pkg/storaged/vdo-details.jsx:204
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Att ta bort en VDO-enhet kommer att ta bort all data på den."
 
-#: pkg/docker/details.js:291 pkg/docker/containers-view.jsx:201
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:292
 msgid "Deleting a container will erase all data in it."
 msgstr "Att ta bort en behållare kommer att radera all data i den."
 
-#: pkg/storaged/content-views.jsx:273
+#: pkg/storaged/content-views.jsx:278
 msgid "Deleting a logical volume will delete all data in it."
 msgstr "Att ta bort en logisk volym kommer att ta bort all data i den."
 
-#: pkg/storaged/content-views.jsx:276
+#: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr "Att ta bort en partition kommer att ta bort all data i den."
 
-#: pkg/storaged/vgroup-details.jsx:212
+#: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
 msgstr "Att ta bort en volymgrupp kommer att radera all data i den."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:107
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:174
 msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
@@ -2131,51 +2254,60 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Tar bort volymgruppen $target"
 
-#: pkg/systemd/services.html:413
-#: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:727 pkg/systemd/init.js:280
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:759
+#: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Beskrivning"
+
+#: pkg/playground/manifest.json.in
+msgid "Design Patterns"
+msgstr ""
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Skrivbord"
 
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:151
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:187
+msgid ""
+"Detach the disks using this pool from any VMs before attempting deletion."
+msgstr ""
+
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
 msgstr "Frånkopplingsbar"
 
-#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/networkmanager/firewall.jsx:94
-#: pkg/systemd/host.js:745 pkg/packagekit/updates.jsx:383
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:384
+#: pkg/systemd/host.js:786 pkg/systemd/host.js:797
 msgid "Details"
 msgstr "Detaljer"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:155
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
-#: pkg/machines/components/networks/networkList.jsx:47
 #: pkg/machines/components/vmDiskColumns.jsx:43
-#: pkg/machines/components/vmDisksTab.jsx:58
+#: pkg/machines/components/vmDisksTab.jsx:96
 msgid "Device"
 msgstr "Enhet"
 
-#: pkg/storaged/vdo-details.jsx:267
+#: pkg/storaged/vdo-details.jsx:273
 msgid "Device File"
 msgstr "Enhetsfil"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:564
 msgid "Device is read-only"
 msgstr "Enheten är skrivskyddad"
+
+#: pkg/sosreport/manifest.json.in
+msgid "Diagnostic Reports"
+msgstr ""
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Diagnostikrapporter"
 
-#: node_modules/registry-image-widgets/views/image-body.html:22
-msgid "Digest"
-msgstr "Kontrollsumma"
-
-#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Katalog"
@@ -2184,29 +2316,29 @@ msgstr "Katalog"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Katalogen $0 är inte skrivbar eller finns inte."
 
-#: pkg/systemd/init.js:571
-msgid "Disable"
-msgstr "Avaktivera"
-
-#: pkg/systemd/hwinfo.jsx:191
+#: pkg/systemd/hwinfo.jsx:195
 msgid "Disable simultaneous multithreading"
 msgstr ""
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:233
 msgid "Disable tuned"
 msgstr "Avaktivera tuned"
 
-#: pkg/systemd/services.html:73 pkg/networkmanager/interfaces.js:1960
-#: pkg/systemd/init.js:213
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1981
+#: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Avaktiverad"
+
+#: pkg/systemd/service-details.jsx:192
+msgid "Disallow running (mask)"
+msgstr ""
 
 #: pkg/machines/components/serialConsole.jsx:136
 msgid "Disconnect"
 msgstr "Koppla ifrån"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:149 pkg/shell/indexes.js:603
+#: pkg/shell/indexes.js:180 pkg/shell/indexes.js:660
 msgid "Disconnected"
 msgstr "Frånkopplad"
 
@@ -2214,7 +2346,7 @@ msgstr "Frånkopplad"
 msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr "Frånkopplad från seriekonsolen.  Klicka på återanslutknappen."
 
-#: pkg/storaged/vdos-panel.jsx:55
+#: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Disk"
 
@@ -2222,15 +2354,15 @@ msgstr "Disk"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr ""
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:549
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:588
 msgid "Disk I/O"
 msgstr "Disk-I/O"
 
-#: pkg/machines/components/diskAdd.jsx:489
+#: pkg/machines/components/diskAdd.jsx:396
 msgid "Disk failed to be attached"
 msgstr "Disken kunde inte anslutas"
 
-#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/diskAdd.jsx:373
 msgid "Disk failed to be created"
 msgstr "Disken kunde inte skapas"
 
@@ -2242,9 +2374,9 @@ msgstr "Disken är OK"
 msgid "Disk passphrase"
 msgstr "Disklösenfras"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/vgroups-panel.jsx:59
-#: pkg/storaged/mdraids-panel.jsx:73 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/vgroup-details.jsx:53
+#: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
+#: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
 msgid "Disks"
 msgstr "Diskar"
 
@@ -2257,9 +2389,9 @@ msgstr ""
 msgid "Display Language"
 msgstr "Visningsspråk"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:10
-msgid "Docker Version"
-msgstr "Docker-version"
+#: pkg/docker/manifest.json.in
+msgid "Docker Containers"
+msgstr ""
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
@@ -2269,7 +2401,7 @@ msgstr "Docker är inte installerat eller aktiverat på systemet"
 msgid "Docking Station"
 msgstr "Dockningsstation"
 
-#: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
+#: pkg/realmd/operation.html:11 pkg/systemd/index.html:125
 #: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Domän"
@@ -2294,12 +2426,12 @@ msgstr "Domänadministratörens namn"
 msgid "Domain Administrator Password"
 msgstr "Domänadministratörens lösenord"
 
-#: pkg/systemd/services.html:483 pkg/systemd/services.html:487
-#: pkg/systemd/init.js:1256
+#: pkg/systemd/services.html:338 pkg/systemd/services.html:342
+#: pkg/systemd/init.js:1147
 msgid "Don't Repeat"
 msgstr "Upprepa inte"
 
-#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
+#: pkg/storaged/content-views.jsx:524 pkg/storaged/format-dialog.jsx:289
 msgid "Don't overwrite existing data"
 msgstr "Skriv inte över befintliga data"
 
@@ -2331,22 +2463,21 @@ msgstr "Hämtat"
 msgid "Downloading"
 msgstr "Hämtar"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:179
+#: pkg/lib/cockpit-components-install-dialog.jsx:180
 msgid "Downloading $0"
 msgstr "Hämtar $0"
 
-#: pkg/docker/storage.jsx:167 pkg/storaged/drive-details.jsx:68
+#: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Enhet"
 
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
-msgctxt "storage"
-msgid "Drive"
-msgstr "Enhet"
-
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:102
 msgid "Drives"
 msgstr "Enheter"
+
+#: pkg/lib/machine-info.js:244
+msgid "Dual Rank"
+msgstr ""
 
 #: pkg/docker/run.js:348
 msgid "Duplicate alias"
@@ -2356,8 +2487,8 @@ msgstr "Dubblerat alias"
 msgid "Duplicate port"
 msgstr "Dubblerad port"
 
-#: pkg/machines/components/nicEdit.jsx:281 pkg/storaged/crypto-tab.jsx:128
-#: pkg/storaged/nfs-details.jsx:306
+#: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/nfs-details.jsx:314
 msgid "Edit"
 msgstr "Redigera"
 
@@ -2365,15 +2496,11 @@ msgstr "Redigera"
 msgid "Edit Server"
 msgstr "Redigera server"
 
-#: pkg/storaged/crypto-keyslots.jsx:270
+#: pkg/storaged/crypto-keyslots.jsx:276
 msgid "Edit Tang keyserver"
 msgstr "Redigera Tang-nyckelserver"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:7
-msgid "Edit image stream"
-msgstr "Redigera avbildsström"
-
-#: pkg/storaged/crypto-keyslots.jsx:535
+#: pkg/storaged/crypto-keyslots.jsx:548
 msgid "Editing a key requires a free slot"
 msgstr "Att redigera en nyckel kräver ett fritt fack"
 
@@ -2385,13 +2512,13 @@ msgstr "Matar ut $target"
 msgid "Embedded PC"
 msgstr "Inbäddad PC"
 
-#: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
+#: pkg/playground/translate.html:57 src/base1/test-locale.js:47
+#: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Tom"
 
-#: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
+#: pkg/playground/translate.html:62 src/base1/test-locale.js:48
+#: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Töm"
@@ -2404,72 +2531,73 @@ msgstr "Tömmer $target"
 msgid "Emulated Machine"
 msgstr ""
 
-#: pkg/systemd/init.js:569
-msgid "Enable"
-msgstr "Aktivera"
-
-#: pkg/systemd/init.js:570
-msgid "Enable Forcefully"
-msgstr "Aktivera tvingande"
-
 #: pkg/networkmanager/index.html:50
 msgid "Enable Service"
 msgstr "Aktivera tjänst"
 
-#: pkg/systemd/index.html:161
+#: pkg/systemd/index.html:168
 msgid "Enable stored metrics…"
 msgstr "Aktivera lagrade mätningar …"
 
-#: pkg/systemd/services.html:72 pkg/systemd/init.js:210
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:216
 msgid "Enabled"
 msgstr "Aktiverad"
 
-#: pkg/storaged/format-dialog.jsx:292
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Encrypt data"
 msgstr ""
 
-#: pkg/storaged/utils.js:273
+#: pkg/storaged/utils.js:274
 msgid "Encrypted $0"
 msgstr "Krypterad $0"
 
-#: pkg/storaged/utils.js:265
+#: pkg/storaged/utils.js:266
 msgid "Encrypted Logical Volume of $0"
 msgstr "Krypterad logisk volym av $0"
 
-#: pkg/storaged/utils.js:267
+#: pkg/storaged/utils.js:268
 msgid "Encrypted Partition of $0"
 msgstr "Krypterad partition av $0"
 
-#: pkg/storaged/content-views.jsx:348
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Krypterad data"
 
-#: pkg/storaged/lvol-tabs.jsx:140
+#: pkg/storaged/lvol-tabs.jsx:141
 msgid "Encrypted volumes can not be resized here."
 msgstr "Storleken på krypterade volymer kan inte ändras här."
 
-#: pkg/storaged/lvol-tabs.jsx:143
+#: pkg/storaged/lvol-tabs.jsx:144
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr "Krypterade volymer behöver låsas upp innan deras storlek kan ändras."
 
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Kryptering"
 
-#: pkg/storaged/crypto-tab.jsx:102
+#: pkg/storaged/crypto-tab.jsx:105
 msgid "Encryption Options"
 msgstr "Krypteringsalternativ"
 
-#: pkg/selinux/setroubleshoot-view.jsx:299
-msgid "Enforce policy:"
-msgstr "Tvingande policy:"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:238
+msgid "End"
+msgstr ""
 
-#: pkg/systemd/host.js:500
+#: pkg/machines/components/networks/createNetworkDialog.jsx:63
+#: pkg/machines/components/networks/createNetworkDialog.jsx:91
+msgid "End should not be empty"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Enforcing"
+msgstr ""
+
+#: pkg/systemd/host.js:513
 msgid "Enhancement Updates Available"
 msgstr "Förbättringsuppdateringar är tillgängliga"
 
-#: pkg/lib/machine-dialogs.js:445
+#: pkg/lib/machine-dialogs.js:447
 msgid "Enter IP address or host name"
 msgstr "Ange en IP-adress eller ett värdnamn"
 
@@ -2481,7 +2609,7 @@ msgstr ""
 "Att ange ett annat lösenord här innebär att du kommer behöva skriva in det "
 "igen varje gång du återansluter till denna maskin"
 
-#: pkg/networkmanager/firewall.jsx:754
+#: pkg/networkmanager/firewall.jsx:786
 msgid "Entire subnet"
 msgstr ""
 
@@ -2494,15 +2622,14 @@ msgid "Entrypoint"
 msgstr "Ingångspunkt"
 
 #: pkg/docker/index.html:528
-#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Miljö"
 
-#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:286
 msgid "Erase"
 msgstr "Radera"
 
-#: pkg/docker/storage.jsx:447
+#: pkg/docker/storage.jsx:460
 msgid "Erase containers and reset storage pool"
 msgstr "Radera behållare och återställ lagringspoolen"
 
@@ -2510,14 +2637,14 @@ msgstr "Radera behållare och återställ lagringspoolen"
 msgid "Erasing $target"
 msgstr "Raderar $target"
 
-#: pkg/packagekit/updates.jsx:312
+#: pkg/packagekit/updates.jsx:313
 msgid "Errata:"
 msgstr "Errata:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
-#: pkg/systemd/services.html:375 pkg/storaged/multipath.jsx:57
-#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/users/local.js:1476 pkg/apps/utils.jsx:100
+#: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
+#: pkg/storaged/storage-controls.jsx:100 pkg/storaged/storage-controls.jsx:194
+#: pkg/systemd/service-details.jsx:450 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Fel"
 
@@ -2532,6 +2659,10 @@ msgstr "Fel när användare lästes in: {{perm_failed}}"
 #: pkg/docker/util.js:507
 msgid "Error message from Docker:"
 msgstr "Felmeddelande från Docker:"
+
+#: pkg/lib/cockpit-components-modifications.jsx:145
+msgid "Error running semanage to discover system modifications"
+msgstr ""
 
 #: pkg/users/authorized-keys.js:121
 msgid "Error saving authorized keys: "
@@ -2553,7 +2684,7 @@ msgstr "Ethernet-MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet-MTU"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:2027
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2561,11 +2692,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Allting"
 
-#: pkg/networkmanager/firewall.jsx:536
+#: pkg/networkmanager/firewall.jsx:563
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:544
+#: pkg/networkmanager/firewall.jsx:571
 msgid "Example: 88,2019,nfs,rsync"
 msgstr ""
 
@@ -2573,11 +2704,11 @@ msgstr ""
 msgid "Excellent password"
 msgstr "Utmärkt lösenord"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:265
-msgid "Existing Disk Image"
+#: pkg/playground/manifest.json.in
+msgid "Exceptions"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:206
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
 msgstr ""
 
@@ -2593,36 +2724,35 @@ msgstr "Expansionschassin"
 msgid "Expose container ports"
 msgstr "Exponerade behållarportar"
 
-#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:459 pkg/storaged/format-dialog.jsx:259
 msgid "Extended Partition"
 msgstr "Utökad partition"
 
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "MISSLYCKADES"
 
-#: pkg/networkmanager/interfaces.js:842
+#: pkg/networkmanager/interfaces.js:856
 msgid "Failed"
 msgstr "Misslyckades"
 
-#: pkg/lib/machine-dialogs.js:410
+#: pkg/lib/machine-dialogs.js:412
 msgid "Failed to add machine: $0"
 msgstr "Misslyckades att lägga till en maskin: $0"
 
-#: pkg/networkmanager/firewall.jsx:237
-#, fuzzy
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add port"
-msgstr "Misslyckades att ändra lösenord"
+msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:237
+#: pkg/networkmanager/firewall.jsx:262
 msgid "Failed to add service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:679
+#: pkg/networkmanager/firewall.jsx:711
 msgid "Failed to add zone"
 msgstr ""
 
-#: pkg/users/local.js:130 pkg/users/local.js:162 pkg/lib/credentials.js:228
+#: pkg/lib/credentials.js:228 pkg/users/local.js:130 pkg/users/local.js:162
 msgid "Failed to change password"
 msgstr "Misslyckades att ändra lösenord"
 
@@ -2638,7 +2768,7 @@ msgstr "Misslyckades att avaktivera tuned"
 msgid "Failed to disable tuned profile"
 msgstr "Misslyckades avaktivera en tuned-profil"
 
-#: pkg/lib/machine-dialogs.js:492
+#: pkg/lib/machine-dialogs.js:494
 msgid "Failed to edit machine: $0"
 msgstr "Misslyckades att redigera en makin: $0"
 
@@ -2646,7 +2776,7 @@ msgstr "Misslyckades att redigera en makin: $0"
 msgid "Failed to enable tuned"
 msgstr "Misslyckades att aktivera tuned"
 
-#: pkg/machines/components/vmnetworktab.jsx:55
+#: pkg/machines/components/vmnetworktab.jsx:60
 msgid "Failed to fetch the IP addresses of the interfaces present in $0"
 msgstr ""
 
@@ -2654,8 +2784,12 @@ msgstr ""
 msgid "Failed to load authorized keys."
 msgstr "Misslyckades att läsa in auktoriserade nycklar."
 
-#: pkg/networkmanager/firewall.jsx:591
+#: pkg/networkmanager/firewall.jsx:623
 msgid "Failed to remove service"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:342
+msgid "Failed to start"
 msgstr ""
 
 #: pkg/docker/containers.js:60
@@ -2679,19 +2813,19 @@ msgstr "Färre än det maximala antalet virtuella CPU:er skall vara aktiverade."
 msgid "File"
 msgstr "Arkiv"
 
-#: pkg/storaged/content-views.jsx:145
+#: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "Filsystem"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:76
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:62
 msgid "Filesystem Directory"
 msgstr "Filsystemskatalog"
 
-#: pkg/storaged/fsys-tab.jsx:123
+#: pkg/storaged/fsys-tab.jsx:126
 msgid "Filesystem Mounting"
 msgstr "Filsystemmontering"
 
-#: pkg/storaged/fsys-tab.jsx:70
+#: pkg/storaged/fsys-tab.jsx:71
 msgid "Filesystem Name"
 msgstr "Filsystemsnamn"
 
@@ -2699,33 +2833,33 @@ msgstr "Filsystemsnamn"
 msgid "Filesystems"
 msgstr "Filsystem"
 
-#: pkg/networkmanager/firewall.jsx:491
+#: pkg/networkmanager/firewall.jsx:518
 msgid "Filter Services"
 msgstr "Filtrera tjänster"
 
-#: pkg/systemd/services.html:68
+#: pkg/systemd/services.html:62
 msgid "Filter by name or description..."
 msgstr ""
 
-#: pkg/shell/index.html:269 pkg/lib/machine-unknown-hostkey.html:10
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Fingeravtryck"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:915 pkg/networkmanager/firewall.jsx:918
+#: pkg/networkmanager/firewall.jsx:947 pkg/networkmanager/firewall.jsx:950
 msgid "Firewall"
 msgstr "Brandvägg"
 
-#: pkg/networkmanager/firewall.jsx:863
+#: pkg/networkmanager/firewall.jsx:895
 msgid "Firewall is not available"
 msgstr "Brandväggen är inte tillgänglig"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:35
-msgid "Follows docker repo"
-msgstr "Följer docker-förråd"
-
-#: pkg/storaged/vdos-panel.jsx:88
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "For legacy applications only. Reduces performance."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:324
+msgid "Forbidden from running"
 msgstr ""
 
 #: pkg/users/index.html:122
@@ -2748,50 +2882,55 @@ msgstr "Framtvinga avstängning"
 msgid "Force password change"
 msgstr "Framtvinga lösenordsändring"
 
-#: pkg/storaged/crypto-keyslots.jsx:373
+#: pkg/storaged/crypto-keyslots.jsx:381
 msgid "Force remove passphrase in $0"
 msgstr "Framtvinga borttagande av lösenfras i $0"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:260
-#: pkg/machines/components/diskAdd.jsx:147 pkg/storaged/content-views.jsx:318
-#: pkg/storaged/content-views.jsx:530 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
+#: pkg/storaged/content-views.jsx:323 pkg/storaged/content-views.jsx:542
+#: pkg/storaged/format-dialog.jsx:336
 msgid "Format"
 msgstr "Formater"
 
-#: pkg/storaged/format-dialog.jsx:186
+#: pkg/storaged/format-dialog.jsx:191
 msgid "Format $0"
 msgstr "Formatera $0"
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/storaged/content-views.jsx:518
 msgid "Format Disk $0"
 msgstr "Formatera disken $0"
 
-#: pkg/storaged/content-views.jsx:531
+#: pkg/storaged/content-views.jsx:543
 msgid "Formatting a disk will erase all data on it."
 msgstr "Att formatera en disk kommer att radera all data på den."
 
-#: pkg/storaged/format-dialog.jsx:325
+#: pkg/storaged/format-dialog.jsx:338
 msgid "Formatting a storage device will erase all data on it."
 msgstr "Att formatera en lagringsenhet kommer att radera all data på den."
 
-#: pkg/networkmanager/interfaces.js:2861
+#: pkg/machines/components/networks/createNetworkDialog.jsx:133
+msgid "Forward Mode"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2881
 msgid "Forward delay $forward_delay"
 msgstr "Fördröjning framåt $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/networks/networkList.jsx:55
 msgid "Forwarding mode"
 msgstr ""
 
-#: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
+#: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Ledigt"
 
-#: pkg/storaged/content-views.jsx:440
+#: pkg/storaged/content-views.jsx:445
 msgid "Free Space"
 msgstr "Ledigt utrymme"
 
-#: pkg/storaged/lvol-tabs.jsx:371
+#: pkg/storaged/lvol-tabs.jsx:379
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -2799,17 +2938,13 @@ msgstr ""
 "Frigör utrymme i denna grupp: krymp eller radera andra logiska volymer eller "
 "lägg till en ytterligare fysisk volym."
 
-#: pkg/systemd/services.html:239
+#: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "Fredag"
 
 #: pkg/packagekit/autoupdates.jsx:321
 msgid "Fridays"
 msgstr ""
-
-#: node_modules/registry-image-widgets/views/image-listing.html:6
-msgid "From"
-msgstr "Från"
 
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
@@ -2820,9 +2955,13 @@ msgid "Gateway:"
 msgstr "Gateway:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2703 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2723 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Allmänt"
+
+#: pkg/machines/components/nicAdd.jsx:49
+msgid "Generate automatically"
+msgstr ""
 
 #: pkg/sosreport/index.html:55
 msgid "Generating report"
@@ -2832,15 +2971,15 @@ msgstr "Genererar en rapport"
 msgid "Get new image"
 msgstr "Hämta ny avbild"
 
+#: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/memorySelectRow.jsx:46
-#: pkg/machines/components/vmDisksTab.jsx:44
-#: pkg/machines/components/diskAdd.jsx:186
+#: pkg/machines/components/vmDisksTab.jsx:51
 msgid "GiB"
 msgstr "GiB"
 
-#: pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:200
 msgid "Go to"
 msgstr "Gå till"
 
@@ -2849,7 +2988,7 @@ msgid "Go to Application"
 msgstr "Gå till programmet"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Gå till nu"
@@ -2862,21 +3001,21 @@ msgstr "Grafisk konsol (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Grafisk konsol i skrivbordsvisare"
 
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
-#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
-#: pkg/storaged/vdo-details.jsx:298
+#: pkg/storaged/lvol-tabs.jsx:239 pkg/storaged/lvol-tabs.jsx:407
+#: pkg/storaged/lvol-tabs.jsx:459 pkg/storaged/vdo-details.jsx:235
+#: pkg/storaged/vdo-details.jsx:304
 msgid "Grow"
 msgstr "Utöka"
 
-#: pkg/storaged/lvol-tabs.jsx:417
+#: pkg/storaged/lvol-tabs.jsx:425
 msgid "Grow Content"
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:231
+#: pkg/storaged/lvol-tabs.jsx:235
 msgid "Grow Logical Volume"
 msgstr "Utöka en logisk volym"
 
-#: pkg/storaged/vdo-details.jsx:218
+#: pkg/storaged/vdo-details.jsx:223
 msgid "Grow logical size of $0"
 msgstr "Utöka den logiska storleken av $0"
 
@@ -2888,7 +3027,7 @@ msgstr "Utöka till att ta allt utrymme"
 msgid "Hair Pin mode"
 msgstr "Hårnålsläge"
 
-#: pkg/networkmanager/interfaces.js:2887
+#: pkg/networkmanager/interfaces.js:2907
 msgid "Hairpin mode"
 msgstr "Hårnålsläge"
 
@@ -2896,12 +3035,7 @@ msgstr "Hårnålsläge"
 msgid "Hand Held"
 msgstr "Handhållen"
 
-#: pkg/docker/storage.jsx:166
-msgid "Hard Disk"
-msgstr "Hårddisk"
-
-#: pkg/storaged/drives-panel.jsx:85
-msgctxt "storage"
+#: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Hårddisk"
 
@@ -2909,22 +3043,22 @@ msgstr "Hårddisk"
 msgid "Hardware"
 msgstr "Hårdvara"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:261
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:274
 msgid "Hardware Information"
 msgstr "Hårdvaruinformation"
 
-#: pkg/networkmanager/interfaces.js:2863
+#: pkg/networkmanager/interfaces.js:2883
 msgid "Hello time $hello_time"
 msgstr "Hälsningstid $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Hide Performance Options"
 msgstr ""
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:151
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:332
+#: pkg/machines/components/vm/bootOrderModal.jsx:97
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:389
 msgid "Host"
 msgstr "Värd"
 
@@ -2932,41 +3066,45 @@ msgstr "Värd"
 msgid "Host Device"
 msgstr ""
 
-#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:156
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Värdnamn"
 
-#: src/base1/cockpit.js:4023
+#: src/base1/cockpit.js:4027
 msgid "Host key is incorrect"
 msgstr "Värdnyckeln är felaktig"
 
-#: pkg/realmd/operation.js:601
+#: pkg/realmd/operation.js:603
 msgid "Host name should not be changed in a domain"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:162
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:148
 msgid "Host should not be empty"
 msgstr "Värden får inte vara tom"
 
-#: pkg/systemd/services.html:499
+#: pkg/systemd/services.html:354
 msgid "Hour : Minute"
 msgstr "Timme : Minut"
 
-#: pkg/systemd/init.js:1332 pkg/systemd/init.js:1361
+#: pkg/systemd/init.js:1223 pkg/systemd/init.js:1252
 msgid "Hour needs to be a number between 0-23"
 msgstr "Timmen måste vara ett tal mellan 0-23"
 
-#: pkg/systemd/services.html:465
+#: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Timmar"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1582
+#: pkg/systemd/index.html:249 pkg/systemd/host.js:1642
 msgid "I/O Wait"
 msgstr "I/O-väntan"
 
+#: pkg/systemd/hwinfo.jsx:263
+msgid "ID"
+msgstr ""
+
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
-#: pkg/machines/components/vmnetworktab.jsx:133
+#: pkg/machines/components/vmnetworktab.jsx:143
 msgid "IP Address"
 msgstr "IP-adress"
 
@@ -2974,11 +3112,15 @@ msgstr "IP-adress"
 msgid "IP Address:"
 msgstr "IP-adress:"
 
+#: pkg/machines/components/networks/createNetworkDialog.jsx:183
+msgid "IP Configuration"
+msgstr ""
+
 #: pkg/docker/index.html:180
 msgid "IP Prefix Length:"
 msgstr "IP-prefixlängd:"
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:957
 msgid "IP Range"
 msgstr ""
 
@@ -2986,7 +3128,7 @@ msgstr ""
 msgid "IP Settings"
 msgstr "IP-inställningar"
 
-#: pkg/networkmanager/interfaces.js:2912
+#: pkg/networkmanager/interfaces.js:2932
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -2994,11 +3136,27 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:265
+msgid "IPv4 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:45
+msgid "IPv4 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv4 Settings"
 msgstr "IPv4-inställningar"
 
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/machines/components/networks/createNetworkDialog.jsx:199
+msgid "IPv4 and IPv6"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:193
+msgid "IPv4 only"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2933
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3006,15 +3164,27 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3359
+#: pkg/machines/components/networks/createNetworkDialog.jsx:309
+msgid "IPv6 Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:73
+msgid "IPv6 Network should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv6 Settings"
 msgstr "IPv6-inställningar"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:196
+msgid "IPv6 only"
+msgstr ""
 
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 msgid "Id"
 msgstr "Id"
 
-#: pkg/networkmanager/interfaces.js:2904
+#: pkg/networkmanager/interfaces.js:2924
 msgid "Id $id"
 msgstr "Id $id"
 
@@ -3022,21 +3192,15 @@ msgstr "Id $id"
 msgid "Id:"
 msgstr "Id:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:24
-#: node_modules/registry-image-widgets/views/image-listing.html:7
-msgid "Identifier"
-msgstr "Identifierare"
-
-#: pkg/storaged/crypto-keyslots.jsx:325
+#: pkg/storaged/crypto-keyslots.jsx:333
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Om tang-show-keys inte är tillgängligt, kör det följande:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1990 pkg/packagekit/updates.jsx:498
 msgid "Ignore"
 msgstr "Ignorera"
 
 #: pkg/docker/index.html:270 pkg/docker/index.html:433
-#: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
 msgstr "Avbild"
@@ -3052,14 +3216,6 @@ msgstr "Avbildsbyggare"
 #: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Avbildssökning"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
-msgid "Image count"
-msgstr "Avbildsantal"
-
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
-msgid "Image stream"
-msgstr "Avbildsström"
 
 #: pkg/docker/index.html:157
 msgid "Image:"
@@ -3078,31 +3234,19 @@ msgstr "Avbilder"
 msgid "Images and running containers"
 msgstr "Avbilder och körande behållare"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:15
-#: node_modules/registry-image-widgets/views/imagestream-body.html:16
-msgid "Images may be pulled by anonymous users"
-msgstr "Avbilder kan dras ner av anonyma användare"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:20
-#: node_modules/registry-image-widgets/views/imagestream-body.html:21
-msgid "Images may be pulled by any authenticated user or group"
-msgstr ""
-"Avbilder kandras ner av vilken autentiserad användare eller grupp som helst"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:25
-#: node_modules/registry-image-widgets/views/imagestream-body.html:26
-msgid "Images may only be pulled by specific users or groups"
-msgstr "Avbilder kan endast dras ner av specifika användare eller grupper"
-
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:714
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Starta VM:en omedelbart"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
+msgid "Import VM"
+msgstr ""
+
+#: pkg/storaged/mdraid-details.jsx:94
 msgid "In Sync"
 msgstr "I synk"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:214
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:237
 msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
@@ -3116,16 +3260,16 @@ msgstr ""
 "För att synkronisera användare behöver du logga in på {{#strong}}{{host}}{{/"
 "strong}}."
 
-#: pkg/networkmanager/interfaces.js:824 pkg/networkmanager/interfaces.js:1417
-#: pkg/networkmanager/interfaces.js:1424 pkg/networkmanager/interfaces.js:2606
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:1431
+#: pkg/networkmanager/interfaces.js:1438 pkg/networkmanager/interfaces.js:2626
 msgid "Inactive"
 msgstr "Inaktiv"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Inactive volume"
 msgstr "Inaktiv volym"
 
-#: pkg/networkmanager/firewall.jsx:732
+#: pkg/networkmanager/firewall.jsx:764
 msgid "Included services"
 msgstr ""
 
@@ -3133,7 +3277,7 @@ msgstr ""
 msgid "Incorrect Host Key"
 msgstr "Felaktig värdnyckel"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:69
+#: pkg/storaged/vdo-details.jsx:307 pkg/storaged/vdos-panel.jsx:73
 msgid "Index Memory"
 msgstr "Indexminne"
 
@@ -3141,29 +3285,29 @@ msgstr "Indexminne"
 msgid "Info and above"
 msgstr "Info och högre"
 
-#: pkg/docker/storage.jsx:309
+#: pkg/docker/storage.jsx:313
 msgid "Information about the Docker storage pool is not available."
 msgstr "Information om Dockers lagringspool är inte tillgängligt."
 
-#: pkg/packagekit/updates.jsx:453
+#: pkg/packagekit/updates.jsx:455
 msgid "Initializing..."
 msgstr "Initierar …"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:178
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:164
 msgid "Initiator"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:189
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:175
 msgid "Initiator IQN should not be empty"
 msgstr ""
 
-#: pkg/machines/components/vm/vmActions.jsx:98
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
+#: pkg/lib/cockpit-components-install-dialog.jsx:116
+#: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Installera"
 
-#: pkg/packagekit/updates.jsx:806
+#: pkg/packagekit/updates.jsx:809
 msgid "Install All Updates"
 msgstr "Installera alla uppdateringar"
 
@@ -3171,7 +3315,7 @@ msgstr "Installera alla uppdateringar"
 msgid "Install NFS Support"
 msgstr "Installera stöd för NFS"
 
-#: pkg/packagekit/updates.jsx:806 pkg/packagekit/updates.jsx:812
+#: pkg/packagekit/updates.jsx:809 pkg/packagekit/updates.jsx:815
 msgid "Install Security Updates"
 msgstr "Installera säkerhetsuppdateringar"
 
@@ -3179,23 +3323,23 @@ msgstr "Installera säkerhetsuppdateringar"
 msgid "Install Software"
 msgstr "Installera programvara"
 
-#: pkg/storaged/vdos-panel.jsx:171
+#: pkg/storaged/vdos-panel.jsx:181
 msgid "Install VDO support"
 msgstr "Installera VDO-stöd"
 
-#: pkg/selinux/setroubleshoot-view.jsx:379
+#: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Installera setroubleshoot-server för att felsöka SELinux-händelser."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:269
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:298
 msgid "Installation Source"
 msgstr "Installationskälla"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:255
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:280
 msgid "Installation Source Type"
 msgstr "Installatinskälltyp"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:152
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:149
 msgid "Installation Source should not be empty"
 msgstr "Installationskällan skall inte vara tom"
 
@@ -3208,21 +3352,25 @@ msgstr "Installerad"
 msgid "Installing"
 msgstr "Installerar"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:183
+#: pkg/lib/cockpit-components-install-dialog.jsx:184
 msgid "Installing $0"
 msgstr "Installerar $0"
 
-#: pkg/systemd/services.html:184
+#: pkg/systemd/service-details.jsx:489
+msgid "Instance of template: "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:62
 msgid "Instantiate"
 msgstr "Instatiera"
 
-#: pkg/machines/components/nicEdit.jsx:123
+#: pkg/machines/components/nicBody.jsx:131
 msgid "Interface Type"
 msgstr ""
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/interfaces.js:2986 pkg/networkmanager/firewall.jsx:737
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:769 pkg/networkmanager/firewall.jsx:957
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Interfaces"
 msgstr "Gränssnitt"
 
@@ -3230,23 +3378,43 @@ msgstr "Gränssnitt"
 msgid "Internal Error: Invalid challenge header"
 msgstr "Internt fel: felaktig utmaningshuvud"
 
-#: src/base1/cockpit.js:4025
+#: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Internt fel"
 
-#: pkg/networkmanager/utils.js:88 pkg/networkmanager/utils.js:171
+#: pkg/machines/components/networks/createNetworkDialog.jsx:47
+#: pkg/machines/components/networks/createNetworkDialog.jsx:58
+#: pkg/machines/components/networks/createNetworkDialog.jsx:65
+msgid "Invalid IPv4 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:52
+msgid "Invalid IPv4 mask or prefix length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:75
+#: pkg/machines/components/networks/createNetworkDialog.jsx:86
+#: pkg/machines/components/networks/createNetworkDialog.jsx:93
+msgid "Invalid IPv6 address"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:80
+msgid "Invalid IPv6 prefix"
+msgstr ""
+
+#: pkg/networkmanager/utils.js:90 pkg/networkmanager/utils.js:175
 msgid "Invalid address $0"
 msgstr "Felaktig adress $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1452
+#: pkg/systemd/host.js:1506 pkg/systemd/shutdown.js:143
 msgid "Invalid date format"
 msgstr "Felaktigt datumformat"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1448
+#: pkg/systemd/host.js:1502 pkg/systemd/shutdown.js:139
 msgid "Invalid date format and invalid time format"
 msgstr "Felaktigt datumformat och felaktigt tidsformat"
 
-#: pkg/systemd/init.js:1367
+#: pkg/systemd/init.js:1258
 msgid "Invalid date format."
 msgstr "Felaktigt datumformat."
 
@@ -3258,7 +3426,7 @@ msgstr "Felaktigt utgångsdatum"
 msgid "Invalid file permissions"
 msgstr "Felaktiga filrättigheter"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:139
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:136
 msgid "Invalid filename"
 msgstr "Felaktigt filnamn"
 
@@ -3274,7 +3442,7 @@ msgstr "Felaktigt mått $0"
 msgid "Invalid number of days"
 msgstr "Felaktigt antal dagar"
 
-#: pkg/systemd/init.js:1314
+#: pkg/systemd/init.js:1205
 msgid "Invalid number."
 msgstr "Felaktigt tal."
 
@@ -3282,7 +3450,7 @@ msgstr "Felaktigt tal."
 msgid "Invalid port"
 msgstr "Felaktig port"
 
-#: pkg/networkmanager/firewall.jsx:335
+#: pkg/networkmanager/firewall.jsx:360
 msgid "Invalid port number"
 msgstr ""
 
@@ -3290,23 +3458,23 @@ msgstr ""
 msgid "Invalid prefix $0"
 msgstr "Felaktigt prefix $0"
 
-#: pkg/networkmanager/utils.js:132
+#: pkg/networkmanager/utils.js:136
 msgid "Invalid prefix or netmask $0"
 msgstr "Felaktigt prefix eller nätmask $0"
 
-#: pkg/networkmanager/firewall.jsx:362
+#: pkg/networkmanager/firewall.jsx:387
 msgid "Invalid range"
 msgstr ""
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1450
+#: pkg/systemd/host.js:1504 pkg/systemd/shutdown.js:141
 msgid "Invalid time format"
 msgstr "Felaktigt tidsformat"
 
-#: pkg/systemd/index.html:374
+#: pkg/systemd/index.html:385
 msgid "Invalid time zone"
 msgstr "Felaktigt tidszon"
 
-#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:169
 msgid "Invalid username or password"
 msgstr "Felaktigt användarnamn eller lösenord"
 
@@ -3330,7 +3498,7 @@ msgstr "Jobb"
 msgid "Join"
 msgstr "Gå med"
 
-#: pkg/realmd/operation.js:596
+#: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Gå med i domän"
 
@@ -3338,11 +3506,11 @@ msgstr "Gå med i domän"
 msgid "Join a Domain"
 msgstr "Gå med i en domän"
 
-#: pkg/realmd/operation.js:505
+#: pkg/realmd/operation.js:507
 msgid "Joining this domain is not supported"
 msgstr "Att gå med i denna domän stödjs inte"
 
-#: pkg/systemd/init.js:736
+#: pkg/systemd/service-details.jsx:436
 msgid "Joins Namespace Of"
 msgstr "Går med i namnrymden för"
 
@@ -3350,15 +3518,15 @@ msgstr "Går med i namnrymden för"
 msgid "Journal"
 msgstr "Journal"
 
-#: pkg/systemd/logs.js:407
+#: pkg/systemd/logs.js:409
 msgid "Journal entry"
 msgstr "Journalpost"
 
-#: pkg/systemd/logs.js:438
+#: pkg/systemd/logs.js:440
 msgid "Journal entry not found"
 msgstr "Journalposten hittades inte"
 
-#: pkg/kdump/kdump-view.jsx:459
+#: pkg/kdump/kdump-view.jsx:461
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
@@ -3377,35 +3545,35 @@ msgstr "Kerberos-baserad SSO"
 msgid "Kerberos Ticket"
 msgstr "Kerberosbiljett"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1583
+#: pkg/systemd/index.html:245 pkg/systemd/host.js:1643
 msgid "Kernel"
 msgstr "Kärnan"
 
-#: pkg/kdump/index.html:23
+#: pkg/kdump/index.html:23 pkg/kdump/manifest.json.in
 msgid "Kernel Dump"
 msgstr "Kärndump"
 
-#: pkg/storaged/crypto-keyslots.jsx:563
+#: pkg/storaged/crypto-keyslots.jsx:576
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Nyckelfack med okända typer kan inte redigeras här"
 
-#: pkg/storaged/crypto-keyslots.jsx:202
+#: pkg/storaged/crypto-keyslots.jsx:204
 msgid "Key source"
 msgstr "Nyckelkälla"
 
-#: pkg/storaged/crypto-keyslots.jsx:586
+#: pkg/storaged/crypto-keyslots.jsx:599
 msgid "Keys"
 msgstr "Nycklar"
 
-#: pkg/storaged/crypto-keyslots.jsx:557
+#: pkg/storaged/crypto-keyslots.jsx:570
 msgid "Keyserver"
 msgstr "Nyckelserver"
 
-#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:272
+#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Keyserver address"
 msgstr "Nyckelserverns adress"
 
-#: pkg/storaged/crypto-keyslots.jsx:415
+#: pkg/storaged/crypto-keyslots.jsx:424
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Att ta bort nyckelservern kan förhindra upplåsning av $0."
 
@@ -3413,9 +3581,9 @@ msgstr "Att ta bort nyckelservern kan förhindra upplåsning av $0."
 msgid "LACP Key"
 msgstr "LACP-nyckel"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:3
-msgid "Labels"
-msgstr "Etiketter"
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
+msgid "LVM Volume Group"
+msgstr ""
 
 #: pkg/lib/machine-info.js:72
 msgid "Laptop"
@@ -3433,13 +3601,9 @@ msgstr "Senaste 7 datgarna"
 msgid "Last Login"
 msgstr "Senaste inloggning"
 
-#: pkg/systemd/init.js:284
+#: pkg/systemd/init.js:305
 msgid "Last Trigger"
 msgstr "Senaste trigger"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:8
-msgid "Last Updated"
-msgstr "Senast uppdaterad"
 
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
@@ -3459,15 +3623,16 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"Lämna tomt för att ansluta till denna maskin som den nu inloggade "
-"användaren.  Om du anger ett annat användarnamn kommer den användaren alltid "
-"användas när man ansluter till denna maskin."
+"Lämna tomt för att ansluta till denna maskin som den nu inloggade användaren."
+"  Om du anger ett annat användarnamn kommer den användaren alltid användas "
+"när man ansluter till denna maskin."
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
 "different username, that user will always be used connecting to this machine."
+""
 msgstr ""
 "Lämna tomt för att ansluta till denna maskin som den nu inloggade "
 "användaren{{#default_user}} ({{default_user}}){{/default_user}}.  Om du "
@@ -3494,7 +3659,7 @@ msgstr "Länkbetraktelse"
 msgid "Link down delay"
 msgstr "Länk nere fördröjning"
 
-#: pkg/networkmanager/interfaces.js:1957 pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1978 pkg/networkmanager/interfaces.js:1988
 msgid "Link local"
 msgstr "Länklokal"
 
@@ -3514,11 +3679,11 @@ msgstr "Länkar"
 msgid "Links:"
 msgstr "Länkar:"
 
-#: pkg/networkmanager/interfaces.js:1993
+#: pkg/networkmanager/interfaces.js:2014
 msgid "Load Balancing"
 msgstr "Lastbalansering"
 
-#: pkg/systemd/logs.js:138
+#: pkg/systemd/logs.js:139
 msgid "Load earlier entries"
 msgstr "Läs in tidigare poster"
 
@@ -3534,9 +3699,13 @@ msgstr "Inläsningen av tillgängliga uppdateringar misslyckades"
 msgid "Loading available updates, please wait..."
 msgstr "Läser in tillgängliga uppdateringar, var god dröj …"
 
-#: pkg/systemd/services.html:84 pkg/storaged/devices.jsx:65
-#: pkg/systemd/logs.js:144 pkg/systemd/logs.js:159 pkg/systemd/logs.js:206
-#: pkg/systemd/logs.js:255 pkg/systemd/logs.js:317 pkg/kdump/kdump-view.jsx:367
+#: pkg/lib/cockpit-components-modifications.jsx:151
+msgid "Loading system modifications..."
+msgstr ""
+
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:369
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:145 pkg/systemd/logs.js:160
+#: pkg/systemd/logs.js:207 pkg/systemd/logs.js:256 pkg/systemd/logs.js:318
 msgid "Loading..."
 msgstr "Läser in …"
 
@@ -3544,7 +3713,7 @@ msgstr "Läser in …"
 msgid "Local Accounts"
 msgstr "Lokala konton"
 
-#: pkg/docker/storage.jsx:198
+#: pkg/docker/storage.jsx:200
 msgid "Local Disks"
 msgstr "Lokala diskar"
 
@@ -3552,11 +3721,11 @@ msgstr "Lokala diskar"
 msgid "Local Filesystem"
 msgstr "Lokala filsystem"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:261
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:286
 msgid "Local Install Media"
 msgstr ""
 
-#: pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:167
 msgid "Local Mount Point"
 msgstr "Lokal monteringspunkt"
 
@@ -3564,7 +3733,7 @@ msgstr "Lokal monteringspunkt"
 msgid "Location"
 msgstr "Plats"
 
-#: pkg/storaged/content-views.jsx:238
+#: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Lås"
 
@@ -3608,23 +3777,23 @@ msgstr "Loggmeddelanden"
 msgid "Logged In"
 msgstr "Inloggad"
 
-#: pkg/storaged/vdo-details.jsx:289
+#: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "Logisk"
 
-#: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
+#: pkg/storaged/vdo-details.jsx:225 pkg/storaged/vdos-panel.jsx:66
 msgid "Logical Size"
 msgstr "Logisk storlek"
 
-#: pkg/storaged/utils.js:197
+#: pkg/storaged/utils.js:198
 msgid "Logical Volume"
 msgstr "Logisk volym"
 
-#: pkg/storaged/utils.js:195
+#: pkg/storaged/utils.js:196
 msgid "Logical Volume (Snapshot)"
 msgstr "Logisk volym (ögonblicksbild)"
 
-#: pkg/storaged/utils.js:269
+#: pkg/storaged/utils.js:270
 msgid "Logical Volume of $0"
 msgstr "Logisk voly av $0"
 
@@ -3640,7 +3809,7 @@ msgstr ""
 msgid "Login Password"
 msgstr "Inloggningslösenord"
 
-#: src/base1/cockpit.js:4015
+#: src/base1/cockpit.js:4019
 msgid "Login failed"
 msgstr "Inloggningen misslyckades"
 
@@ -3652,7 +3821,7 @@ msgstr "Inloggningen har upphöjda administratörsprivilegier"
 msgid "Logout Successful"
 msgstr "Utloggningen lyckades"
 
-#: pkg/systemd/logs.html:82
+#: pkg/systemd/logs.html:82 pkg/systemd/manifest.json.in
 msgid "Logs"
 msgstr "Loggar"
 
@@ -3669,10 +3838,12 @@ msgid "Lunch Box"
 msgstr "Lunchlåda"
 
 #: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:132
+#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/vmnetworktab.jsx:141
 msgid "MAC Address"
 msgstr "MAC-adress"
 
@@ -3680,35 +3851,27 @@ msgstr "MAC-adress"
 msgid "MAC Address:"
 msgstr "MAC-adress:"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:2006
 msgid "MII (Recommended)"
 msgstr "MII (Rekommenderas)"
 
-#: pkg/networkmanager/interfaces.js:2761
+#: pkg/networkmanager/interfaces.js:2781
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4545
+#: pkg/networkmanager/interfaces.js:4575
 msgid "MTU must be a positive number"
 msgstr "MTU måste vara ett positivt tal"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:103
-msgid "Mac"
-msgstr ""
-
-#: pkg/machines/components/nicEdit.jsx:160
-msgid "Mac Address"
-msgstr "Mac-adress"
 
 #: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Makin-ID"
 
-#: pkg/systemd/index.html:267
+#: pkg/systemd/index.html:278
 msgid "Machine SSH Key Fingerprints"
 msgstr "Makinens SSH-nyckels fingeravtryck"
 
-#: pkg/shell/indexes.js:296
+#: pkg/shell/indexes.js:353
 msgid "Machines"
 msgstr "Maskiner"
 
@@ -3716,11 +3879,11 @@ msgstr "Maskiner"
 msgid "Main Server Chassis"
 msgstr "Huvudserverchassi"
 
-#: pkg/storaged/crypto-keyslots.jsx:319
+#: pkg/storaged/crypto-keyslots.jsx:327
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Se till att kontrollsumman för nyckeln från Tang-servern stämmer:"
 
-#: pkg/networkmanager/interfaces.js:1958 pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1979 pkg/networkmanager/interfaces.js:1989
 msgid "Manual"
 msgstr "Manuell"
 
@@ -3728,11 +3891,11 @@ msgstr "Manuell"
 msgid "Manual Connection"
 msgstr "Manuell anslutning"
 
-#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
+#: pkg/systemd/index.html:395 pkg/systemd/index.html:399
 msgid "Manually"
 msgstr "Manuellt"
 
-#: pkg/storaged/crypto-keyslots.jsx:322
+#: pkg/storaged/crypto-keyslots.jsx:330
 msgid "Manually check with SSH: "
 msgstr "Kontrollera manuellt med SSH:"
 
@@ -3740,15 +3903,30 @@ msgstr "Kontrollera manuellt med SSH:"
 msgid "Marking $target as faulty"
 msgstr "Markerar $target som felaktig"
 
-#: pkg/systemd/init.js:574
-msgid "Mask"
-msgstr "Maskera"
+#: pkg/systemd/service-details.jsx:199 pkg/systemd/service-details.jsx:202
+msgid "Mask Service"
+msgstr ""
 
-#: pkg/systemd/init.js:575
-msgid "Mask Forcefully"
-msgstr "Maskera tvingande"
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+msgid "Mask or Prefix Length"
+msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2767
+#: pkg/machines/components/networks/createNetworkDialog.jsx:50
+msgid "Mask or Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:323
+msgid "Masked"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:200
+msgid ""
+"Masking service prevents all dependant units from running. This can have "
+"bigger impact than anticipated. Please confirm that you want to mask this "
+"unit."
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Master"
 msgstr "Huvudgränssnitt"
 
@@ -3764,7 +3942,7 @@ msgstr ""
 msgid "Maximum memory could not be saved"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2865
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Maximum message age $max_age"
 msgstr "Maximal meddelandeålder $max_age"
 
@@ -3776,30 +3954,34 @@ msgstr ""
 "Maximalt antal virtuella CPU:er allokerade till gäst-OS:et, vilket måste "
 "vara mellan 1 och $0"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:350
 msgid "Member of RAID Device"
 msgstr "Medlem i RAID-enhet"
 
-#: pkg/storaged/content-views.jsx:341
+#: pkg/storaged/content-views.jsx:346
 msgid "Member of RAID Device $0"
 msgstr "Medlem i RAID-enhet $0"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:349
-#: pkg/machines/components/vmOverviewTab.jsx:74
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:263
 msgid "Memory"
 msgstr "Minne"
 
-#: pkg/systemd/host.js:1641
+#: pkg/systemd/host.js:1701
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Minne"
 
-#: pkg/systemd/index.html:205
+#: pkg/systemd/index.html:216
 msgid "Memory & Swap"
 msgstr "Minne och växling"
+
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Memory Technology"
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:103
 #: pkg/machines/components/vm/memoryModal.jsx:113
@@ -3810,10 +3992,9 @@ msgstr ""
 msgid "Memory limit"
 msgstr "Minnesgräns"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:156
-#, fuzzy
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:153
 msgid "Memory must not be 0"
-msgstr "Minnesanvändning:"
+msgstr ""
 
 #: pkg/machines/components/vm/memoryModal.jsx:158
 msgid "Memory size between 128 MiB and the maximum allocation"
@@ -3827,20 +4008,19 @@ msgstr "Minnesanvändning:"
 msgid "Message to logged in users"
 msgstr "Meddelande till inloggade användare"
 
-#: node_modules/registry-image-widgets/views/image-panel.html:15
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
-msgid "Metadata"
-msgstr "Metadata"
+#: pkg/shell/index.html:399
+msgid "Messages related to the failure might be found in the journal:"
+msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:458
+#: pkg/storaged/lvol-tabs.jsx:466
 msgid "Metadata Used"
 msgstr "Metadata använt"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
+#: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
-#: pkg/machines/components/memorySelectRow.jsx:43
-#: pkg/machines/components/diskAdd.jsx:183
 msgid "MiB"
 msgstr "MiB"
 
@@ -3852,15 +4032,15 @@ msgstr "Mini-PC"
 msgid "Mini Tower"
 msgstr "Minitorn"
 
-#: pkg/systemd/init.js:1338 pkg/systemd/init.js:1347 pkg/systemd/init.js:1356
+#: pkg/systemd/init.js:1229 pkg/systemd/init.js:1238 pkg/systemd/init.js:1247
 msgid "Minute needs to be a number between 0-59"
 msgstr "Minuterna måste vara ett tal mellan 0-59"
 
-#: pkg/systemd/services.html:464
+#: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minuter"
 
-#: pkg/systemd/hwinfo.jsx:62 pkg/systemd/hwinfo.jsx:67
+#: pkg/systemd/hwinfo.jsx:66 pkg/systemd/hwinfo.jsx:71
 msgid "Mitigations"
 msgstr ""
 
@@ -3868,11 +4048,11 @@ msgstr ""
 msgid "Mode"
 msgstr "Läge"
 
-#: pkg/machines/components/nicEdit.jsx:54 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:254
 msgid "Model"
 msgstr "Modell"
 
-#: pkg/machines/components/vmnetworktab.jsx:123
+#: pkg/machines/components/vmnetworktab.jsx:131
 msgid "Model type"
 msgstr "Modelltyp"
 
@@ -3881,7 +4061,7 @@ msgstr "Modelltyp"
 msgid "Modifying $target"
 msgstr "Modifiera $target"
 
-#: pkg/systemd/services.html:235
+#: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "Måndag"
 
@@ -3897,7 +4077,7 @@ msgstr "Övervakningsintervall"
 msgid "Monitoring Targets"
 msgstr "Övervakningsmål"
 
-#: pkg/realmd/operation.js:529
+#: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Mera"
 
@@ -3906,27 +4086,27 @@ msgstr "Mera"
 msgid "More Information"
 msgstr "Mer information"
 
-#: pkg/kdump/kdump-view.jsx:448
+#: pkg/kdump/kdump-view.jsx:450
 msgid "More details"
 msgstr "Fler detaljer"
 
-#: pkg/storaged/fsys-tab.jsx:163 pkg/storaged/fsys-tab.jsx:186
-#: pkg/storaged/nfs-details.jsx:301 pkg/kdump/kdump-view.jsx:99
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:309
 msgid "Mount"
 msgstr "Montering"
 
-#: pkg/storaged/fsys-tab.jsx:171 pkg/storaged/nfs-details.jsx:172
-#: pkg/storaged/format-dialog.jsx:81
+#: pkg/storaged/format-dialog.jsx:84 pkg/storaged/fsys-tab.jsx:174
+#: pkg/storaged/nfs-details.jsx:178
 msgid "Mount Options"
 msgstr "Monteringsflaggor"
 
-#: pkg/storaged/nfs-panel.jsx:102 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
-#: pkg/storaged/format-dialog.jsx:71
+#: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:160 pkg/storaged/nfs-details.jsx:326
+#: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Monteringspunkt"
 
-#: pkg/storaged/nfs-details.jsx:174 pkg/storaged/format-dialog.jsx:89
+#: pkg/storaged/format-dialog.jsx:93 pkg/storaged/nfs-details.jsx:181
 msgid "Mount at boot"
 msgstr "Montera vid uppstart"
 
@@ -3934,23 +4114,23 @@ msgstr "Montera vid uppstart"
 msgid "Mount container volumes"
 msgstr "Montera behållarvolymer"
 
-#: pkg/storaged/format-dialog.jsx:78
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount point can not be empty"
 msgstr "Monteringspunkten får inte vara tom"
 
-#: pkg/storaged/nfs-details.jsx:166
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount point cannot be empty."
 msgstr "Monteringspunkten får inte vara tom."
 
-#: pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:174
 msgid "Mount point must start with \"/\"."
 msgstr "Monteringspunkten måste börja med ”/”."
 
-#: pkg/storaged/nfs-details.jsx:175 pkg/storaged/format-dialog.jsx:90
+#: pkg/storaged/format-dialog.jsx:94 pkg/storaged/nfs-details.jsx:182
 msgid "Mount read only"
 msgstr "Montera skrivskyddat"
 
-#: pkg/storaged/fsys-tab.jsx:180
+#: pkg/storaged/fsys-tab.jsx:183
 msgid "Mounted At"
 msgstr "Monterad på"
 
@@ -3970,7 +4150,7 @@ msgstr "Multisystemschassi"
 msgid "NAT to $0"
 msgstr ""
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "NFS Mount"
 msgstr "NFS-montering"
 
@@ -3982,45 +4162,45 @@ msgstr "NFS-monteringar"
 msgid "NFS Support not installed"
 msgstr "Stöd för NFS är inte installerat"
 
-#: pkg/machines/components/vmnetworktab.jsx:97
+#: pkg/machines/components/vmnetworktab.jsx:102
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2008
+#: pkg/networkmanager/interfaces.js:2029
 msgid "NSNA Ping"
 msgstr "NSNA-ping"
 
-#: pkg/systemd/host.js:1514
+#: pkg/systemd/host.js:1569
 msgid "NTP Server"
 msgstr "NTP-server"
 
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
-#: pkg/networkmanager/index.html:319
-#: node_modules/registry-image-widgets/views/image-body.html:2
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:168
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:56
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/diskAdd.jsx:126 pkg/machines/hostvmslist.jsx:83
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/storaged/content-views.jsx:111
-#: pkg/storaged/content-views.jsx:641 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
-#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
-#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/format-dialog.jsx:286
-#: pkg/storaged/vgroup-details.jsx:180 pkg/systemd/hwinfo.jsx:79
-#: pkg/systemd/init.js:281 pkg/packagekit/updates.jsx:380
+#: pkg/networkmanager/index.html:319 pkg/docker/containers-view.jsx:359
+#: pkg/docker/containers-view.jsx:683
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
+#: pkg/machines/components/networks/createNetworkDialog.jsx:108
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:33
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/storaged/content-views.jsx:113 pkg/storaged/content-views.jsx:655
+#: pkg/storaged/format-dialog.jsx:295 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:73 pkg/storaged/fsys-tab.jsx:153
+#: pkg/storaged/iscsi-panel.jsx:128 pkg/storaged/iscsi-panel.jsx:185
+#: pkg/storaged/lvol-tabs.jsx:34 pkg/storaged/lvol-tabs.jsx:356
+#: pkg/storaged/lvol-tabs.jsx:398 pkg/storaged/lvol-tabs.jsx:452
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:49 pkg/storaged/vgroup-details.jsx:175
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/init.js:302
 msgid "Name"
 msgstr "Namn"
 
-#: pkg/storaged/vdos-panel.jsx:52
+#: pkg/storaged/vdos-panel.jsx:54
 msgid "Name can not be empty."
 msgstr "Namnet får inte vara tomt."
 
@@ -4049,7 +4229,8 @@ msgid "Name cannot contain whitespace."
 msgstr "Namnet får inte innehålla blanktecken."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:121
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:67
+#: pkg/machines/components/networks/createNetworkDialog.jsx:41
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:53
 msgid "Name should not be empty"
 msgstr "Namnet får inte vara tomt"
 
@@ -4057,7 +4238,7 @@ msgstr "Namnet får inte vara tomt"
 msgid "Name: "
 msgstr ""
 
-#: pkg/systemd/host.js:1348
+#: pkg/systemd/host.js:1402
 msgid "Need at least one NTP server"
 msgstr "Behöver åtminstone en NTP-server"
 
@@ -4065,9 +4246,17 @@ msgstr "Behöver åtminstone en NTP-server"
 msgid "Netmask"
 msgstr ""
 
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/machines/components/aggregateStatusCards.jsx:72
+#, fuzzy
 msgid "Network"
-msgstr "Nätverk"
+msgid_plural "Networks"
+msgstr[0] "Nätverk"
+msgstr[1] ""
+
+#: pkg/dashboard/index.html:72
+msgctxt "label"
+msgid "Network"
+msgstr ""
 
 #: pkg/machines/components/networks/network.jsx:118
 msgid "Network $0 failed to get activated"
@@ -4077,23 +4266,27 @@ msgstr ""
 msgid "Network $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:264
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:292
 msgid "Network Boot (PXE)"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:77
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:289
+msgid "Network Boot is available only when using System connection"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:63
 msgid "Network File System"
 msgstr "Nätverksfilsystem"
 
-#: pkg/machines/components/vm/vm.jsx:50
+#: pkg/machines/components/vm/vm.jsx:52
 msgid "Network Interfaces"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:243
 msgid "Network Selection does not support PXE."
 msgstr ""
 
-#: pkg/systemd/host.js:550
+#: pkg/systemd/host.js:589
 msgid "Network Traffic"
 msgstr "Nätverkstrafik"
 
@@ -4101,7 +4294,8 @@ msgstr "Nätverkstrafik"
 msgid "Network devices and graphs require NetworkManager."
 msgstr "Nätverksenheter och -grafer behöver NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:232
+#: pkg/machines/components/nicAdd.jsx:176
+#: pkg/machines/components/nicEdit.jsx:119
 msgid "Network interface settings could not be saved"
 msgstr ""
 
@@ -4110,11 +4304,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager kör inte."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:914
+#: pkg/networkmanager/firewall.jsx:946 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Nätverk"
 
-#: pkg/networkmanager/interfaces.js:1625 pkg/networkmanager/interfaces.js:2207
+#: pkg/networkmanager/interfaces.js:1645 pkg/networkmanager/interfaces.js:2228
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Nätverk"
@@ -4123,8 +4317,8 @@ msgstr "Nätverk"
 msgid "Networking Logs"
 msgstr "Nätverksloggar"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/networks/networkList.jsx:46
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:54
 msgid "Networks"
 msgstr "Nätverk"
 
@@ -4140,23 +4334,23 @@ msgstr "Låt aldrig lösenord gå ut"
 msgid "Never lock account"
 msgstr "Lås aldrig konton"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "New NFS Mount"
 msgstr "Ny NFS-montering"
 
-#: pkg/shell/index.html:289 pkg/users/index.html:218
+#: pkg/shell/index.html:290 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Nytt lösenord"
 
-#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:39
 msgid "New Volume Name"
 msgstr "Nytt volymnamn"
 
-#: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
+#: pkg/storaged/crypto-keyslots.jsx:214 pkg/storaged/crypto-keyslots.jsx:260
 msgid "New passphrase"
 msgstr "Ny lösenfras"
 
-#: pkg/users/local.js:139 pkg/lib/credentials.js:237
+#: pkg/lib/credentials.js:237 pkg/users/local.js:139
 msgid "New password was not accepted"
 msgstr "Det nya lösenordet godtogs inte"
 
@@ -4164,32 +4358,32 @@ msgstr "Det nya lösenordet godtogs inte"
 msgid "Next"
 msgstr "Nästa"
 
-#: pkg/systemd/init.js:283
+#: pkg/systemd/init.js:304
 msgid "Next Run"
 msgstr "Nästa körning"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1585
+#: pkg/systemd/index.html:237 pkg/systemd/host.js:1645
 msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2594
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2614
 msgid "No"
 msgstr "Nej"
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:465
 msgid "No Delay"
 msgstr "Ingen fördröjning"
 
-#: pkg/storaged/format-dialog.jsx:252
+#: pkg/storaged/format-dialog.jsx:257
 msgid "No Filesystem"
 msgstr "Inget filsystem"
 
-#: pkg/storaged/content-views.jsx:715
+#: pkg/storaged/content-views.jsx:735
 msgid "No Logical Volumes"
 msgstr "Inga logiska volymer"
 
-#: pkg/systemd/services.html:192
+#: pkg/systemd/services.html:84
 msgid "No Matching Results"
 msgstr ""
 
@@ -4197,32 +4391,44 @@ msgstr ""
 msgid "No NFS mounts set up"
 msgstr "Inga NFS-monteringar uppsatta"
 
-#: pkg/selinux/setroubleshoot-view.jsx:365
+#: pkg/machines/components/nicBody.jsx:117
+msgid "No Network Devices"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:375
 msgid "No SELinux alerts."
 msgstr "Inga SELinux-larm."
 
-#: pkg/machines/components/diskAdd.jsx:204
-#: pkg/machines/components/diskAdd.jsx:216
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:444
+msgid "No Storage"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/diskAdd.jsx:144
 msgid "No Storage Pools available"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:113
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Inga lagringsvolymer är definierade för denna lagringspool"
+
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "No System Modifications"
+msgstr ""
 
 #: pkg/machines/hostvmslist.jsx:85
 msgid "No VM is running or defined on this host"
 msgstr "Ingen VM kör eller är definierad på denna värd."
 
-#: pkg/machines/components/nicEdit.jsx:110
+#: pkg/machines/components/nicBody.jsx:115
 msgid "No Virtual Networks"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:926
+#: pkg/networkmanager/firewall.jsx:958
 msgid "No active zones"
 msgstr ""
 
-#: pkg/docker/storage.jsx:206
+#: pkg/docker/storage.jsx:208
 msgid "No additional local storage found."
 msgstr "Ingen ytterligare lokal lagring hittad."
 
@@ -4238,7 +4444,7 @@ msgstr "Inga program installerade eller tillgängliga"
 msgid "No archive has been created."
 msgstr "Inget arkiv har skapats."
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "No available slots"
 msgstr "Inga tillgängliga platser"
 
@@ -4246,11 +4452,11 @@ msgstr "Inga tillgängliga platser"
 msgid "No boot device found"
 msgstr "Ingen startenhet hittades"
 
-#: pkg/networkmanager/interfaces.js:1419
+#: pkg/networkmanager/interfaces.js:1433
 msgid "No carrier"
 msgstr "Ingen bärvåg"
 
-#: pkg/kdump/kdump-view.jsx:396
+#: pkg/kdump/kdump-view.jsx:398
 msgid "No configuration found"
 msgstr "Ingen konfiguration hittad"
 
@@ -4270,7 +4476,7 @@ msgstr "Inga behållare"
 msgid "No containers that match the current filter"
 msgstr "Inga behållare som stämmer med det aktuella filtret"
 
-#: pkg/networkmanager/firewall.jsx:729
+#: pkg/networkmanager/firewall.jsx:761
 msgid "No description available"
 msgstr ""
 
@@ -4278,25 +4484,25 @@ msgstr ""
 msgid "No description provided."
 msgstr "Ingen besrkivning tillhandahållen."
 
-#: pkg/storaged/vgroups-panel.jsx:60 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/mdraid-details.jsx:48
-#: pkg/storaged/vgroup-details.jsx:54
+#: pkg/storaged/mdraid-details.jsx:49 pkg/storaged/mdraids-panel.jsx:92
+#: pkg/storaged/vdos-panel.jsx:59 pkg/storaged/vgroup-details.jsx:56
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "No disks are available."
 msgstr "Inga diskar är tillgängliga."
 
-#: pkg/machines/components/vmDisksTab.jsx:85
+#: pkg/machines/components/vmDisksTab.jsx:121
 msgid "No disks defined for this VM"
 msgstr "Inga diskar är definerade för denna VM"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:103
 msgid "No drives attached"
 msgstr "Inga diskar är anslutna"
 
-#: pkg/storaged/crypto-keyslots.jsx:581
+#: pkg/storaged/crypto-keyslots.jsx:594
 msgid "No free key slots"
 msgstr "Inga fria nyckelfack"
 
-#: pkg/storaged/content-views.jsx:700
+#: pkg/storaged/content-views.jsx:720
 msgid "No free space"
 msgstr "Inget ledigt utrymme"
 
@@ -4304,13 +4510,9 @@ msgstr "Inget ledigt utrymme"
 msgid "No host keys found."
 msgstr "Inga värdnycklar hittade."
 
-#: pkg/storaged/iscsi-panel.jsx:262
+#: pkg/storaged/iscsi-panel.jsx:269
 msgid "No iSCSI targets set up"
 msgstr "Inga iSCSI-mål är uppsatta"
-
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
-msgid "No image streams are present."
-msgstr "Ingen avbildsström finns."
 
 #: pkg/docker/containers-view.jsx:705
 msgid "No images"
@@ -4324,19 +4526,15 @@ msgstr "Inga avbilder som stämmer med det aktuella filtret"
 msgid "No installation package found for this application."
 msgstr "Inget installationspaket hittat för detta program."
 
-#: pkg/storaged/crypto-keyslots.jsx:520
+#: pkg/storaged/crypto-keyslots.jsx:533
 msgid "No keys added"
 msgstr "Inga nycklar tillagda"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
-msgid "No matching files found"
-msgstr "Inga matchande filer hittade"
 
 #: pkg/storaged/drive-details.jsx:75
 msgid "No media inserted"
 msgstr "Inget medium isatt"
 
-#: pkg/kdump/kdump-view.jsx:450
+#: pkg/kdump/kdump-view.jsx:452
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -4346,11 +4544,11 @@ msgstr ""
 "kommandorad (t.ex. i /etc/default/grub) för att reservera minne vid "
 "uppstartstillfället.  Exempel: crashkernel=512M"
 
-#: pkg/machines/components/vmnetworktab.jsx:70
+#: pkg/machines/components/vmnetworktab.jsx:75
 msgid "No network interfaces defined for this VM"
 msgstr "Inga nätverksgränssnitt är definierade för denna VM"
 
-#: pkg/machines/components/networks/networkList.jsx:48
+#: pkg/machines/components/networks/networkList.jsx:56
 msgid "No network is defined on this host"
 msgstr ""
 
@@ -4358,11 +4556,11 @@ msgstr ""
 msgid "No networks available"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:939
+#: pkg/networkmanager/firewall.jsx:971
 msgid "No open ports"
 msgstr "Inga öppna portar"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:537
 msgid "No partitioning"
 msgstr "Ingen partitionering"
 
@@ -4382,25 +4580,21 @@ msgstr "Inga körande behållare"
 msgid "No running containers that match the current filter"
 msgstr "Inga körande behållare som stämmer med det aktuella filtret"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:50
+#: pkg/machines/components/storagePools/storagePoolList.jsx:55
 msgid "No storage pool is defined on this host"
 msgstr "Ingen lagringspool är definierad på denna värd"
 
-#: pkg/storaged/mdraids-panel.jsx:130
+#: pkg/storaged/mdraids-panel.jsx:147
 msgid "No storage set up as RAID"
 msgstr "Ingen lagring uppsatt som RAID"
 
-#: pkg/storaged/vdos-panel.jsx:167
+#: pkg/storaged/vdos-panel.jsx:177
 msgid "No storage set up as VDO"
 msgstr "Ingen lagring uppsatt som VDO"
 
 #: pkg/lib/credentials.js:186
 msgid "No such file or directory"
 msgstr "Filen eller katalogen finns inte"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:73
-msgid "No tags are present."
-msgstr "Inga taggar finns."
 
 #: pkg/packagekit/updates.jsx:42
 msgid "No updates pending"
@@ -4410,13 +4604,13 @@ msgstr "Inga väntande uppdateringar"
 msgid "No user name specified"
 msgstr "Inget användarnamn angivet."
 
-#: pkg/storaged/vgroups-panel.jsx:114
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr "Inga volymgrupper skapade"
 
-#: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/networkmanager/firewall.jsx:734 pkg/tuned/dialog.js:231
-#: pkg/kdump/kdump-view.jsx:419
+#: pkg/kdump/kdump-view.jsx:421
+#: pkg/machines/components/networks/createNetworkDialog.jsx:190
+#: pkg/networkmanager/firewall.jsx:766 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Inga"
 
@@ -4436,11 +4630,11 @@ msgstr "Inte en giltig privat nyckel"
 msgid "Not authorized to access Docker on this system"
 msgstr "Har inte rättigheter att komma åt Docker på detta system"
 
-#: pkg/systemd/logs.js:527
+#: pkg/systemd/logs.js:529
 msgid "Not authorized to upload-report"
 msgstr "Har inte rättigheter att skicka rapport"
 
-#: pkg/networkmanager/interfaces.js:822
+#: pkg/networkmanager/interfaces.js:836
 msgid "Not available"
 msgstr "Inte tillgängligt"
 
@@ -4448,11 +4642,15 @@ msgstr "Inte tillgängligt"
 msgid "Not connected"
 msgstr "Inte ansluten"
 
-#: pkg/storaged/lvol-tabs.jsx:369
+#: pkg/systemd/host.js:577
+msgid "Not connected to Insights"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:377
 msgid "Not enough space to grow."
 msgstr "Inte tillräckligt med utrymme för att växa"
 
-#: pkg/docker/details.js:185 pkg/storaged/details.jsx:121
+#: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Finns inte"
 
@@ -4460,11 +4658,11 @@ msgstr "Finns inte"
 msgid "Not mounted"
 msgstr "Inte monterat"
 
-#: src/base1/cockpit.js:4013
+#: src/base1/cockpit.js:4017
 msgid "Not permitted to perform this action."
 msgstr "Inte tillåtet att utföra denna åtgärd."
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:361
 msgid "Not running"
 msgstr "Kör inte"
 
@@ -4472,11 +4670,7 @@ msgstr "Kör inte"
 msgid "Not synchronized"
 msgstr "Inte synkroniserad"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:44
-msgid "Not yet synced"
-msgstr "Inte synkade ännu"
-
-#: pkg/systemd/services.html:357
+#: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Observera"
 
@@ -4488,51 +4682,43 @@ msgstr "Bärbar (notebook)"
 msgid "Notice and above"
 msgstr "Notering och högre"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:317
-msgid "OS Vendor"
-msgstr "OS-leverantör"
+#: pkg/playground/manifest.json.in
+msgid "Notifications"
+msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:394
+#: pkg/playground/manifest.json.in
+msgid "Notifications Receiver"
+msgstr ""
+
+#: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
 msgstr "Hände $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:389
+#: pkg/selinux/setroubleshoot-view.jsx:399
 msgid "Occurred between $0 and $1"
 msgstr "Hände mellan $0 och $1"
-
-#: pkg/lib/patterns.js:246
-msgid "Off"
-msgstr "Av"
 
 #: pkg/lib/cockpit-components-dialog.jsx:194
 msgid "Ok"
 msgstr "Ok"
 
-#: pkg/shell/index.html:281 pkg/users/index.html:215
+#: pkg/shell/index.html:282 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Gammalt lösenord"
 
-#: pkg/storaged/crypto-keyslots.jsx:249
+#: pkg/storaged/crypto-keyslots.jsx:257
 msgid "Old passphrase"
 msgstr "Gammal lösenfras"
 
-#: pkg/users/local.js:86 pkg/lib/credentials.js:218
+#: pkg/lib/credentials.js:218 pkg/users/local.js:86
 msgid "Old password not accepted"
 msgstr "Det gamla lösenordet accepterades inte"
 
-#: pkg/lib/patterns.js:246
-msgid "On"
-msgstr "På"
-
-#: node_modules/registry-image-widgets/views/image-meta.html:7
-msgid "On Build"
-msgstr "Vid bygge"
-
-#: pkg/docker/index.html:549 pkg/systemd/init.js:731
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:431
 msgid "On Failure"
 msgstr "Vid misslyckande"
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr "På en monterad enhet"
 
@@ -4554,7 +4740,7 @@ msgstr ""
 msgid "One Time Password"
 msgstr "Engångslösenord"
 
-#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:77
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:76
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
@@ -4568,7 +4754,7 @@ msgstr "Endast $0 av $1 används."
 msgid "Only Emergency"
 msgstr "Endast nödläge"
 
-#: pkg/systemd/init.js:1288
+#: pkg/systemd/init.js:1179
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Endast alfabetet, nummer, :, _, ., @, - är tillåtna."
 
@@ -4585,7 +4771,7 @@ msgid "Open"
 msgstr ""
 
 #: pkg/systemd/index.html:98
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:332
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:342
 msgid "Operating System"
 msgstr "Operativsystem"
 
@@ -4595,16 +4781,15 @@ msgstr "Åtgärden ”$operation” på $target"
 
 #: pkg/machines/components/storagePools/storagePool.jsx:175
 #: pkg/machines/components/storagePools/storagePool.jsx:180
-#, fuzzy
 msgid "Operation is in progress"
-msgstr "oVirt-inloggning pågår"
+msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/drives-panel.jsx:76
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Optisk enhet"
 
-#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:137 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Alternativ"
 
@@ -4616,7 +4801,7 @@ msgstr "Eller använd en medpackad bläddrare"
 msgid "Other"
 msgstr "Annan"
 
-#: pkg/storaged/content-views.jsx:353
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Andra data"
@@ -4629,93 +4814,97 @@ msgstr "Andra enheter"
 msgid "Other Options"
 msgstr "Andra alternativ"
 
-#: pkg/docker/index.html:299 pkg/machines/components/vm/vm.jsx:47
+#: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/networks/network.jsx:72
+#: pkg/machines/components/vm/vm.jsx:49
 msgid "Overview"
 msgstr "Översikt"
 
-#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:525 pkg/storaged/format-dialog.jsx:290
 msgid "Overwrite existing data with zeros"
 msgstr "Skriv över befintliga data med nollor"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "PCI"
 msgstr "PCI"
 
-#: pkg/packagekit/updates.jsx:501
+#: pkg/packagekit/updates.jsx:503
 msgid "Package information"
 msgstr "Paketinformation"
 
-#: pkg/lib/packagekit.js:115
+#: pkg/lib/packagekit.js:126
 msgid "PackageKit crashed"
 msgstr "PackageKit kraschade"
 
-#: pkg/packagekit/updates.jsx:564
+#: pkg/packagekit/updates.jsx:565
 msgid "PackageKit is not installed"
 msgstr "PackageKit är inte installerat"
 
-#: pkg/packagekit/updates.jsx:718
+#: pkg/packagekit/updates.jsx:719
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit rapporterade felkod $0"
+
+#: pkg/playground/manifest.json.in
+msgid "Packages"
+msgstr ""
 
 #: pkg/networkmanager/index.html:156
 msgid "Parent"
 msgstr "Förälder"
 
-#: pkg/networkmanager/interfaces.js:2903
+#: pkg/networkmanager/interfaces.js:2923
 msgid "Parent $parent"
 msgstr "Förälder $parent"
 
-#: pkg/systemd/init.js:721
+#: pkg/systemd/service-details.jsx:421
 msgid "Part Of"
 msgstr "Del av"
 
-#: pkg/networkmanager/interfaces.js:1465
+#: pkg/networkmanager/interfaces.js:1479
 msgid "Part of "
 msgstr "Del av"
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "Partition"
 
-#: pkg/storaged/utils.js:271
+#: pkg/storaged/utils.js:272
 msgid "Partition of $0"
 msgstr "Partition av $0"
 
-#: pkg/storaged/content-views.jsx:519
+#: pkg/storaged/content-views.jsx:528
 msgid "Partitioning"
 msgstr "Partitionering"
 
-#: pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:2021
 msgid "Passive"
 msgstr "Passiv"
 
-#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
+#: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
+#: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:307
 msgid "Passphrase"
 msgstr "Lösenfras"
 
-#: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
-#: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:299
+#: pkg/storaged/crypto-keyslots.jsx:158 pkg/storaged/crypto-keyslots.jsx:217
+#: pkg/storaged/crypto-keyslots.jsx:258 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/format-dialog.jsx:311
 msgid "Passphrase cannot be empty"
 msgstr "Lösenfrasen får inte vara tom"
 
-#: pkg/storaged/crypto-keyslots.jsx:356
+#: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Passphrase removal may prevent unlocking $0."
 msgstr "Att ta bort lösenfrasen kan förhindra upplåsning av $0."
 
-#: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/crypto-keyslots.jsx:225 pkg/storaged/crypto-keyslots.jsx:263
+#: pkg/storaged/format-dialog.jsx:319
 msgid "Passphrases do not match"
 msgstr "Lösenfraserna stämmer inte överens"
 
-#: pkg/shell/index.html:203 pkg/shell/index.html:231 pkg/shell/index.html:244
-#: pkg/users/index.html:118 pkg/users/index.html:173
-#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-sync-users.html:61
-#: pkg/lib/machine-change-auth.html:52 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
+#: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
+#: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
+#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Lösenord"
 
@@ -4754,7 +4943,8 @@ msgstr ""
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Klistra in innehållet i din publika SSH-nyckelfil här"
 
-#: pkg/systemd/services.html:126 pkg/machines/components/deleteDialog.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:45
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Sökväg"
 
@@ -4762,35 +4952,35 @@ msgstr "Sökväg"
 msgid "Path cost"
 msgstr "Sökvägskostnad"
 
-#: pkg/networkmanager/interfaces.js:2885
+#: pkg/networkmanager/interfaces.js:2905
 msgid "Path cost $path_cost"
 msgstr "Sökvägskostnad $path_cost"
 
-#: pkg/storaged/nfs-details.jsx:151
+#: pkg/storaged/nfs-details.jsx:155
 msgid "Path on Server"
 msgstr "Sökväg på servern"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:130
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:116
 msgid "Path on host's filesystem"
 msgstr "Sökväg på värdens filsystem"
 
-#: pkg/storaged/nfs-details.jsx:155
+#: pkg/storaged/nfs-details.jsx:160
 msgid "Path on server cannot be empty."
 msgstr "Sökvägen på servern får inte vara tom."
 
-#: pkg/storaged/nfs-details.jsx:157
+#: pkg/storaged/nfs-details.jsx:162
 msgid "Path on server must start with \"/\"."
 msgstr "Sökvägen på servern måste börja med ”/”."
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:197
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:220
 msgid "Path to ISO file on host's file system"
 msgstr "Sökväg till ISO-fil på värdens filsystem"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:141
 msgid "Path to file"
 msgstr "Sökväg till filen"
 
-#: pkg/systemd/services.html:60
+#: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Sökvägar"
 
@@ -4798,7 +4988,7 @@ msgstr "Sökvägar"
 msgid "Pause"
 msgstr ""
 
-#: pkg/systemd/index.html:152
+#: pkg/systemd/index.html:159
 msgid "Performance Profile"
 msgstr "Prestandaprofil"
 
@@ -4806,7 +4996,7 @@ msgstr "Prestandaprofil"
 msgid "Peripheral Chassis"
 msgstr "Periferichassi"
 
-#: pkg/networkmanager/interfaces.js:3630
+#: pkg/networkmanager/interfaces.js:3657
 msgid "Permanent"
 msgstr "Permanent"
 
@@ -4814,40 +5004,45 @@ msgstr "Permanent"
 msgid "Permission denied"
 msgstr "Åtkomst nekas"
 
-#: pkg/machines/components/diskAdd.jsx:110
+#: pkg/selinux/setroubleshoot-view.jsx:296
+msgid "Permissive"
+msgstr ""
+
+#: pkg/machines/components/diskAdd.jsx:111
+#: pkg/machines/components/nicAdd.jsx:80
 msgid "Persistence"
 msgstr "Varaktighet"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:61
 #: pkg/machines/components/networks/networkOverviewTab.jsx:83
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:66
 msgid "Persistent"
 msgstr ""
 
-#: pkg/storaged/vdo-details.jsx:277
+#: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "Fysiskt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:79
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:65
 msgid "Physical Disk Device"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
+#: pkg/storaged/content-views.jsx:154 pkg/storaged/content-views.jsx:348
 msgid "Physical Volume"
 msgstr "Fysisk volym"
 
-#: pkg/storaged/vgroup-details.jsx:133
+#: pkg/storaged/vgroup-details.jsx:127
 msgid "Physical Volumes"
 msgstr "Fysiska volymer"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:211
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:197
 msgid "Physical disk device on host"
 msgstr ""
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:343
 msgid "Physical volume of $0"
 msgstr "Fysisk volym för $0"
 
-#: pkg/storaged/lvol-tabs.jsx:164
+#: pkg/storaged/lvol-tabs.jsx:165
 msgid "Physical volumes can not be resized here."
 msgstr "Storleken på fysiska volymer kan inte ändras här."
 
@@ -4863,10 +5058,10 @@ msgstr "Ping-mål"
 msgid "Pizza Box"
 msgstr "Pizzalåda"
 
-#: pkg/docker/details.js:290 pkg/docker/util.js:612
-#: pkg/docker/containers-view.jsx:200 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/vdo-details.jsx:195 pkg/storaged/mdraid-details.jsx:295
-#: pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:291
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:296
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:199
+#: pkg/storaged/vgroup-details.jsx:207
 msgid "Please confirm deletion of $0"
 msgstr "Bekräfta raderingen av $0"
 
@@ -4874,19 +5069,19 @@ msgstr "Bekräfta raderingen av $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Bekräfta den tvingande raderingen av $0"
 
-#: pkg/storaged/vdo-details.jsx:153 pkg/storaged/mdraid-details.jsx:243
+#: pkg/storaged/mdraid-details.jsx:240 pkg/storaged/vdo-details.jsx:155
 msgid "Please confirm stopping of $0"
 msgstr "Bekräfta stoppandet av $0"
 
-#: pkg/machines/components/diskAdd.jsx:447
+#: pkg/machines/components/diskAdd.jsx:350
 msgid "Please enter new volume name"
 msgstr "Ange ett nytt volymnamn"
 
-#: pkg/machines/components/diskAdd.jsx:450
+#: pkg/machines/components/diskAdd.jsx:353
 msgid "Please enter new volume size"
 msgstr "Ange en ny volymstorlek"
 
-#: pkg/networkmanager/firewall.jsx:864
+#: pkg/networkmanager/firewall.jsx:896
 msgid "Please install the $0 package"
 msgstr "Installera paketet $0"
 
@@ -4906,39 +5101,49 @@ msgstr "Starta den virtuella maskinen för att komma åt dess konsol."
 msgid "Please try another term"
 msgstr "Försök med en annan term"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Plug"
 msgstr "Plugg"
 
-#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/deleteDialog.jsx:53
+#: pkg/machines/components/diskAdd.jsx:127
+#: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/machines/components/diskAdd.jsx:199 pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Pool"
 
-#: pkg/storaged/utils.js:191
+#: pkg/storaged/utils.js:192
 msgid "Pool for Thin Logical Volumes"
 msgstr "Pool för tunna logiska volymer"
 
-#: pkg/storaged/content-views.jsx:594
+#: pkg/storaged/content-views.jsx:607
 msgid "Pool for Thin Volumes"
 msgstr "Pool för tunna volymer"
 
-#: pkg/storaged/content-views.jsx:651
+#: pkg/storaged/content-views.jsx:668
 msgid "Pool for thinly provisioned volumes"
 msgstr "Pool för tunt underhållna volymer"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:142
+msgid "Pool type doesn't support volume creation"
+msgstr ""
+
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
+msgid "Pool's volumes are used by VMs "
+msgstr ""
 
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:108
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:113
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Port"
 msgstr "Port"
 
-#: pkg/networkmanager/firewall.jsx:339
+#: pkg/networkmanager/firewall.jsx:364
 msgid "Port number and type do not match"
 msgstr ""
 
@@ -4947,9 +5152,8 @@ msgid "Portable"
 msgstr "Bärbar"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
-#: pkg/networkmanager/index.html:323
-#: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2986
+#: pkg/networkmanager/index.html:323 pkg/docker/containers-view.jsx:414
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Ports"
 msgstr "Portar"
 
@@ -4957,7 +5161,7 @@ msgstr "Portar"
 msgid "Ports:"
 msgstr "Portar:"
 
-#: pkg/systemd/index.html:132
+#: pkg/systemd/index.html:139
 msgid "Power Options"
 msgstr "Strömalternativ"
 
@@ -4969,31 +5173,39 @@ msgstr "Föredraget antal uttag att exponera för gästen."
 msgid "Prefix"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+msgid "Prefix Length"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:78
+msgid "Prefix Length should not be empty"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length"
 msgstr "Prefixlängd"
 
-#: pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length or Netmask"
 msgstr "Nätmaskens prefixlängd"
 
-#: pkg/networkmanager/interfaces.js:826
+#: pkg/playground/manifest.json.in
+msgid "Preloaded"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:840
 msgid "Preparing"
 msgstr "Förbereder"
 
-#: pkg/networkmanager/interfaces.js:3631
+#: pkg/lib/machine-info.js:251
+msgid "Present"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3658
 msgid "Preserve"
 msgstr "Bevara"
 
-#: pkg/systemd/init.js:572
-msgid "Preset"
-msgstr "Förinställ"
-
-#: pkg/systemd/init.js:573
-msgid "Preset Forcefully"
-msgstr "Förinställ tvingande"
-
-#: pkg/systemd/index.html:295
+#: pkg/systemd/index.html:306
 msgid "Pretty Host Name"
 msgstr "Snyggt värdnamn"
 
@@ -5010,7 +5222,7 @@ msgstr "Primär"
 msgid "Priority"
 msgstr "Prioritet"
 
-#: pkg/networkmanager/interfaces.js:2859 pkg/networkmanager/interfaces.js:2883
+#: pkg/networkmanager/interfaces.js:2879 pkg/networkmanager/interfaces.js:2903
 msgid "Priority $priority"
 msgstr "Prioritet $priority"
 
@@ -5022,11 +5234,11 @@ msgstr ""
 msgid "Privileged"
 msgstr "Priviligierad"
 
-#: pkg/systemd/logs.js:488
+#: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Problemdetaljer"
 
-#: pkg/systemd/logs.js:487
+#: pkg/systemd/logs.js:489
 msgid "Problem info"
 msgstr "Probleminformation"
 
@@ -5034,7 +5246,7 @@ msgstr "Probleminformation"
 msgid "Problems"
 msgstr "Problem"
 
-#: pkg/storaged/dialog.jsx:1043
+#: pkg/storaged/dialog.jsx:1044
 msgid "Process"
 msgstr "Process"
 
@@ -5059,7 +5271,7 @@ msgstr "Tidsgränsen överskreds vid fråga via ssh-add"
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Tidsgränsen överskreds vid fråga via ssh-keygen"
 
-#: pkg/systemd/init.js:734
+#: pkg/systemd/service-details.jsx:434
 msgid "Propagates Reload To"
 msgstr "Vidarebefordrar omladdning till"
 
@@ -5069,75 +5281,63 @@ msgstr "Vidarebefordrar omladdning till"
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: pkg/shell/index.html:230 pkg/lib/machine-auth-failed.html:9
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:231
 msgid "Public Key"
 msgstr "Publik nyckel"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr "Publikt hämtningsförråd"
-
-#: pkg/storaged/content-views.jsx:645
+#: pkg/storaged/content-views.jsx:660
 msgid "Purpose"
 msgstr "Syfte"
 
-#: pkg/machines/components/machinesConnectionSelector.jsx:31
-msgid "QEMU/KVM System connection"
-msgstr "QEMU/KVM-systemanslutning"
-
-#: pkg/machines/components/machinesConnectionSelector.jsx:39
-msgid "QEMU/KVM User connection"
-msgstr "QEMU/KVM-användaranslutning"
-
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/mdraid-details.jsx:174
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:45
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Strimlor)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:175
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/mdraids-panel.jsx:52
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Spegel)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/mdraids-panel.jsx:68
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Strimlor av speglar)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:176
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/mdraids-panel.jsx:56
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (dedikerad paritet)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:177
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (distribuerad paritet)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:178
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:53
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (dubbel distribuerad paritet)"
 
@@ -5149,19 +5349,19 @@ msgstr "RAID-chassi"
 msgid "RAID Device"
 msgstr "RAID-enhet"
 
-#: pkg/storaged/utils.js:241 pkg/storaged/mdraid-details.jsx:315
+#: pkg/storaged/mdraid-details.jsx:311 pkg/storaged/utils.js:242
 msgid "RAID Device $0"
 msgstr "RAID-enhet $0"
 
-#: pkg/storaged/mdraids-panel.jsx:129
+#: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "RAID-enheter"
 
-#: pkg/storaged/mdraids-panel.jsx:41
+#: pkg/storaged/mdraids-panel.jsx:42
 msgid "RAID Level"
 msgstr "RAID-nivå"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:157
 msgid "RAID Member"
 msgstr "RAID-medlem"
 
@@ -5169,24 +5369,36 @@ msgstr "RAID-medlem"
 msgid "Rack Mount Chassis"
 msgstr "Rackmonteringschassi"
 
-#: pkg/networkmanager/interfaces.js:3632
+#: pkg/networkmanager/interfaces.js:3659
 msgid "Random"
 msgstr "Slumpvis"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:791
 msgid "Range"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:370
+#: pkg/networkmanager/firewall.jsx:395
 msgid "Range must be strictly ordered"
 msgstr ""
 
-#: pkg/kdump/kdump-view.jsx:388
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Rank"
+msgstr ""
+
+#: pkg/kdump/kdump-view.jsx:390
 msgid "Raw to a device"
 msgstr "Rå till en enhet"
 
-#: pkg/systemd/hwinfo.jsx:193
+#: pkg/playground/manifest.json.in
+msgid "React Patterns"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:197
 msgid "Read more..."
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:388
+msgid "Read-only"
 msgstr ""
 
 #: pkg/docker/index.html:365
@@ -5197,15 +5409,15 @@ msgstr "LäsEndast"
 msgid "ReadWrite"
 msgstr "LäsSkriv"
 
-#: pkg/storaged/plot.jsx:310
+#: pkg/storaged/plot.jsx:312
 msgid "Reading"
 msgstr "Läser"
 
-#: pkg/kdump/kdump-view.jsx:413
+#: pkg/kdump/kdump-view.jsx:415
 msgid "Reading..."
 msgstr "Läser …"
 
-#: pkg/machines/components/vmDisksTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:112
 msgid "Readonly"
 msgstr "Skrivskyddat"
 
@@ -5218,11 +5430,11 @@ msgctxt "verb"
 msgid "Ready"
 msgstr "Klar"
 
-#: pkg/systemd/index.html:304
+#: pkg/systemd/index.html:315
 msgid "Real Host Name"
 msgstr "Verkligt värdnamn"
 
-#: pkg/systemd/host.js:1020
+#: pkg/systemd/host.js:1074
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5230,11 +5442,11 @@ msgstr ""
 "Det verkliga värdnamnet kan endast innehålla gemena bokstäver, siffror, "
 "bindestreck och punkter (med populerade underdomäner)"
 
-#: pkg/systemd/host.js:1021
+#: pkg/systemd/host.js:1075
 msgid "Real host name must be 64 characters or less"
 msgstr "Det verkliga värdnamnet får bara vara 64 tecken eller mindre"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
+#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Starta om"
 
@@ -5248,16 +5460,16 @@ msgstr "Tar emot"
 msgid "Recent"
 msgstr "Senaste"
 
-#: pkg/storaged/format-dialog.jsx:248
+#: pkg/storaged/format-dialog.jsx:253
 msgid "Recommended default"
 msgstr ""
 
-#: pkg/shell/index.html:386 pkg/shell/simple.html:138
+#: pkg/shell/index.html:382 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Återanslut"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Recovering"
 msgstr "Återställer"
 
@@ -5265,7 +5477,7 @@ msgstr "Återställer"
 msgid "Recovering RAID Device $target"
 msgstr "Återställer RAID-enhet $target"
 
-#: pkg/docker/storage.jsx:389
+#: pkg/docker/storage.jsx:396
 msgid "Reformat and add disks"
 msgstr "Omformatera och lägg till diskar"
 
@@ -5285,31 +5497,31 @@ msgstr "Vägrar att ansluta.  Värdnyckeln stämmer inte"
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Vägrar att ansluta.  Värdnyckeln är okänd"
 
-#: pkg/packagekit/updates.jsx:777
+#: pkg/packagekit/updates.jsx:780
 msgid "Register…"
 msgstr "Registrera …"
 
-#: pkg/systemd/init.js:546
+#: pkg/systemd/service-details.jsx:165
 msgid "Reload"
 msgstr "Läs om"
 
-#: pkg/systemd/init.js:735
+#: pkg/systemd/service-details.jsx:435
 msgid "Reload Propagated From"
 msgstr "Omläsning vidarebefordrad från"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:245
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:268
 msgid "Remote URL"
 msgstr "Fjärr-URL"
 
-#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:386
+#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:388
 msgid "Remote over NFS"
 msgstr "Fjärr över NFS"
 
-#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:384
+#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:386
 msgid "Remote over SSH"
 msgstr "Fjärr över SSH"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/drives-panel.jsx:72 pkg/storaged/drives-panel.jsx:74
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "Löstagbar disk"
@@ -5318,21 +5530,21 @@ msgstr "Löstagbar disk"
 msgid "Removals:"
 msgstr "Borttagningar:"
 
-#: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308 pkg/apps/application-list.jsx:85
-#: pkg/apps/application.jsx:109
+#: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
+#: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
+#: pkg/storaged/nfs-details.jsx:316
 msgid "Remove"
 msgstr "Ta bort"
 
-#: pkg/networkmanager/interfaces.js:3055
+#: pkg/networkmanager/interfaces.js:3076
 msgid "Remove $0"
 msgstr "Ta bort $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:414
+#: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
 msgstr "Ta bort $0?"
 
-#: pkg/storaged/crypto-keyslots.jsx:423
+#: pkg/storaged/crypto-keyslots.jsx:433
 msgid "Remove Tang keyserver"
 msgstr "Ta bort Tang-nyckelserver"
 
@@ -5340,19 +5552,19 @@ msgstr "Ta bort Tang-nyckelserver"
 msgid "Remove device"
 msgstr "Ta bort enhet"
 
-#: pkg/storaged/crypto-keyslots.jsx:387
+#: pkg/storaged/crypto-keyslots.jsx:396
 msgid "Remove passphrase"
 msgstr "Ta bort lösenfras"
 
-#: pkg/storaged/crypto-keyslots.jsx:354
+#: pkg/storaged/crypto-keyslots.jsx:362
 msgid "Remove passphrase in $0?"
 msgstr "Ta bort lösenfrasen i $0?"
 
-#: pkg/networkmanager/firewall.jsx:631
+#: pkg/networkmanager/firewall.jsx:663
 msgid "Remove service"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:610
+#: pkg/networkmanager/firewall.jsx:642
 msgid "Remove service from zones"
 msgstr ""
 
@@ -5360,7 +5572,7 @@ msgstr ""
 msgid "Removing"
 msgstr "Tar bort"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:181
+#: pkg/lib/cockpit-components-install-dialog.jsx:182
 msgid "Removing $0"
 msgstr "Tar bort $0"
 
@@ -5368,7 +5580,7 @@ msgstr "Tar bort $0"
 msgid "Removing $target from RAID Device"
 msgstr "Tar bort $target från RAID-enheten"
 
-#: pkg/networkmanager/interfaces.js:3054
+#: pkg/networkmanager/interfaces.js:3075
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5380,16 +5592,16 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Tar bort den fysiska volymen från $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:234
+#: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
+#: pkg/storaged/vgroup-details.jsx:231
 msgid "Rename"
 msgstr "Byt namn"
 
-#: pkg/storaged/lvol-tabs.jsx:31
+#: pkg/storaged/lvol-tabs.jsx:32
 msgid "Rename Logical Volume"
 msgstr "Byt namn på en logisk volym"
 
-#: pkg/storaged/vgroup-details.jsx:178
+#: pkg/storaged/vgroup-details.jsx:173
 msgid "Rename Volume Group"
 msgstr "Byt namn på en volymgrupp"
 
@@ -5401,49 +5613,48 @@ msgstr "Byter namn på $target"
 msgid "Repairing $target"
 msgstr "Reparerar $target"
 
-#: pkg/systemd/services.html:489
+#: pkg/systemd/services.html:344
 msgid "Repeat Daily"
 msgstr "Upprepa dagligen"
 
-#: pkg/systemd/services.html:488
+#: pkg/systemd/services.html:343
 msgid "Repeat Hourly"
 msgstr "Upprepa varje timma"
 
-#: pkg/systemd/services.html:491
+#: pkg/systemd/services.html:346
 msgid "Repeat Monthly"
 msgstr "Upprepa varje månad"
 
-#: pkg/systemd/services.html:490
+#: pkg/systemd/services.html:345
 msgid "Repeat Weekly"
 msgstr "Upprepa varje vecka"
 
-#: pkg/systemd/services.html:492
+#: pkg/systemd/services.html:347
 msgid "Repeat Yearly"
 msgstr "Upprepa årligen"
 
-#: pkg/storaged/crypto-keyslots.jsx:204 pkg/storaged/crypto-keyslots.jsx:214
-#: pkg/storaged/crypto-keyslots.jsx:256
+#: pkg/storaged/crypto-keyslots.jsx:207 pkg/storaged/crypto-keyslots.jsx:219
+#: pkg/storaged/crypto-keyslots.jsx:262
 msgid "Repeat passphrase"
 msgstr "Upprepa lösenfrasen"
 
-#: pkg/systemd/logs.js:512
+#: pkg/systemd/logs.js:514
 msgid "Report"
 msgstr "Rapport"
 
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:509
 msgid "Reported"
 msgstr "Rapporterad"
 
-#: pkg/systemd/logs.js:529
+#: pkg/systemd/logs.js:531
 msgid "Reporter 'reporter-ureport' not found."
 msgstr "Rapporteraren ”reporter-ureport” finns inte."
 
-#: pkg/systemd/logs.js:531
+#: pkg/systemd/logs.js:533
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Rapporterandet misslyckades.  Försök att köra ”reporter-ureport -d"
 
 #: pkg/docker/index.html:690
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Förråd"
 
@@ -5455,23 +5666,31 @@ msgstr "Begär en lösenordsändring var $0:e dag"
 msgid "Require password change on $0"
 msgstr "Begär lösenordsändring den $0"
 
-#: pkg/systemd/init.js:722
+#: pkg/systemd/service-details.jsx:422
 msgid "Required By"
 msgstr "Begärd av"
 
-#: pkg/systemd/init.js:717
+#: pkg/systemd/service-details.jsx:374
+msgid "Required by "
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "Begär"
 
-#: pkg/systemd/init.js:718
+#: pkg/systemd/service-details.jsx:389
+msgid "Requires administration access to edit"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:418
 msgid "Requisite"
 msgstr "Behov"
 
-#: pkg/systemd/init.js:723
+#: pkg/systemd/service-details.jsx:423
 msgid "Requisite Of"
 msgstr "Behov av"
 
-#: pkg/kdump/kdump-view.jsx:501
+#: pkg/kdump/kdump-view.jsx:503
 msgid "Reserved memory"
 msgstr "Reserverat minne"
 
@@ -5480,11 +5699,11 @@ msgstr "Reserverat minne"
 msgid "Reset"
 msgstr "Återställ"
 
-#: pkg/docker/storage.jsx:441
+#: pkg/docker/storage.jsx:452
 msgid "Reset Storage Pool"
 msgstr "Återställ lagringspoolen"
 
-#: pkg/docker/storage.jsx:444
+#: pkg/docker/storage.jsx:455
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
@@ -5497,20 +5716,21 @@ msgstr ""
 msgid "Resizing $target"
 msgstr "Ändrar storlek på $target"
 
-#: pkg/storaged/lvol-tabs.jsx:225 pkg/storaged/lvol-tabs.jsx:307
+#: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
 msgstr ""
 
-#: pkg/docker/index.html:138 pkg/systemd/index.html:134
-#: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
-#: pkg/machines/components/vm/vmActions.jsx:42 pkg/systemd/shutdown.js:95
-#: pkg/systemd/shutdown.js:96 pkg/systemd/init.js:545
+#: pkg/docker/index.html:138 pkg/systemd/index.html:141
+#: pkg/systemd/index.html:151 pkg/docker/containers-view.jsx:315
+#: pkg/machines/components/vm/vmActions.jsx:42
+#: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
+#: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Starta om"
 
-#: pkg/packagekit/updates.jsx:498
+#: pkg/packagekit/updates.jsx:500
 msgid "Restart Now"
 msgstr "Starta om nu"
 
@@ -5522,11 +5742,11 @@ msgstr "Omstartspolicy"
 msgid "Restart Policy:"
 msgstr "Omstartspolicy:"
 
-#: pkg/packagekit/updates.jsx:493
+#: pkg/packagekit/updates.jsx:495
 msgid "Restart Recommended"
 msgstr "Omstart rekommenderas"
 
-#: pkg/packagekit/updates.jsx:864
+#: pkg/packagekit/updates.jsx:867
 msgid "Restarting"
 msgstr "Startar om"
 
@@ -5547,7 +5767,8 @@ msgid "Reuse my password for privileged tasks"
 msgstr "Återanvänd mitt lösenord för priviligierade uppgifter"
 
 #: pkg/shell/index.html:159
-msgid "Reuse my password for privileged tasks and to connect to other machines"
+msgid ""
+"Reuse my password for privileged tasks and to connect to other machines"
 msgstr ""
 "Återanvänd mitt lösenord för priviligierade uppgifter och för att ansluta "
 "till andra maskiner"
@@ -5556,7 +5777,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Roller"
 
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1995 pkg/networkmanager/interfaces.js:2012
 msgid "Round Robin"
 msgstr "Turas om"
 
@@ -5568,22 +5789,18 @@ msgstr ""
 msgid "Routed Network"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3325
+#: pkg/networkmanager/interfaces.js:3348
 msgid "Routes"
 msgstr "Rutter"
 
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
-#: pkg/systemd/services.html:441 pkg/machines/components/vm/vmActions.jsx:91
+#: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
 msgstr "Kör"
 
 #: pkg/docker/index.html:427
 msgid "Run Image"
 msgstr "Kör avbild"
-
-#: node_modules/registry-image-widgets/views/image-config.html:8
-msgid "Run as"
-msgstr "Kör som"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
@@ -5594,19 +5811,19 @@ msgstr ""
 msgid "Runner"
 msgstr "Körare"
 
-#: pkg/storaged/mdraid-details.jsx:342
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Kör"
 
-#: pkg/systemd/services.html:123
-msgid "Running Since"
+#: pkg/selinux/manifest.json.in
+msgid "SELinux"
 msgstr ""
 
-#: pkg/selinux/setroubleshoot-view.jsx:364
+#: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
 msgstr "SELinux-fel vid åtkomstkontroller"
 
-#: pkg/selinux/setroubleshoot-view.jsx:297
+#: pkg/selinux/setroubleshoot-view.jsx:301
 msgid "SELinux Policy"
 msgstr "SELinux-policy"
 
@@ -5614,15 +5831,15 @@ msgstr "SELinux-policy"
 msgid "SELinux Troubleshoot"
 msgstr "SELinux-felsökning"
 
-#: pkg/selinux/setroubleshoot-view.jsx:356
+#: pkg/selinux/setroubleshoot-view.jsx:365
 msgid "SELinux is disabled on the system"
 msgstr "SELinux är avaktiverat på systemet"
 
-#: pkg/selinux/setroubleshoot-view.jsx:284
+#: pkg/selinux/setroubleshoot-view.jsx:285
 msgid "SELinux is disabled on the system."
 msgstr "SELinux är avaktiverat på systemet."
 
-#: pkg/selinux/setroubleshoot-view.jsx:276
+#: pkg/selinux/setroubleshoot-view.jsx:277
 msgid "SELinux system status is unknown."
 msgstr "SELinux systemstatus är okänd."
 
@@ -5662,7 +5879,13 @@ msgstr "STP maximal meddelandeålder"
 msgid "STP Priority"
 msgstr "STP-prioritet"
 
-#: pkg/systemd/services.html:240
+#: pkg/shell/index.html:403
+msgid ""
+"Safari users need to import and trust the certificate of the self-signing CA:"
+""
+msgstr ""
+
+#: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "Lördag"
 
@@ -5670,27 +5893,26 @@ msgstr "Lördag"
 msgid "Saturdays"
 msgstr ""
 
-#: pkg/systemd/services.html:523
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/machines/components/nicEdit.jsx:299 pkg/storaged/crypto-keyslots.jsx:261
-#: pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:266 pkg/storaged/crypto-keyslots.jsx:285
 msgid "Save"
 msgstr "Spara"
 
-#: pkg/systemd/hwinfo.jsx:219
+#: pkg/systemd/hwinfo.jsx:223
 msgid "Save and reboot"
 msgstr ""
 
-#: pkg/storaged/vdos-panel.jsx:82
+#: pkg/storaged/vdos-panel.jsx:88
 msgid "Save space by compressing individual blocks with LZ4"
 msgstr ""
 
-#: pkg/storaged/vdos-panel.jsx:85
+#: pkg/storaged/vdos-panel.jsx:92
 msgid "Save space by storing identical data blocks just once"
 msgstr ""
 
-#: pkg/storaged/crypto-keyslots.jsx:226 pkg/storaged/crypto-keyslots.jsx:276
+#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:283
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
@@ -5702,12 +5924,12 @@ msgstr ""
 msgid "Sealed-case PC"
 msgstr "PC med slutet hölje"
 
-#: pkg/systemd/services.html:459 pkg/systemd/services.html:463
-#: pkg/systemd/init.js:1076
+#: pkg/systemd/services.html:314 pkg/systemd/services.html:318
+#: pkg/systemd/init.js:967
 msgid "Seconds"
 msgstr "Sekunder"
 
-#: pkg/systemd/index.html:106
+#: pkg/systemd/index.html:113
 msgid "Secure Shell Keys"
 msgstr "Säkra skalnycklar"
 
@@ -5719,7 +5941,7 @@ msgstr "Raderar säkert $target"
 msgid "Security"
 msgstr "Säkerhet"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:509
 msgid "Security Updates Available"
 msgstr "Säkerhetsuppdateringar tillgängliga"
 
@@ -5729,8 +5951,8 @@ msgstr "Välj"
 
 #: pkg/lib/machine-sync-users.html:8
 msgid ""
-"Select the users that you would like to be synchronized with {{#strong}}"
-"{{host}}{{/strong}}"
+"Select the users that you would like to be synchronized with "
+"{{#strong}}{{host}}{{/strong}}"
 msgstr ""
 "Välj användaren som du vill skall synkorniseras med {{#strong}}{{host}}{{/"
 "strong}}"
@@ -5753,12 +5975,12 @@ msgstr "Skickar"
 msgid "Serial Console"
 msgstr "Seriekonsol"
 
-#: src/ws/login.html:94 pkg/storaged/nfs-panel.jsx:101
-#: pkg/storaged/nfs-details.jsx:315 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: pkg/storaged/nfs-details.jsx:323 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Server"
 
-#: pkg/storaged/iscsi-panel.jsx:43 pkg/storaged/nfs-details.jsx:143
+#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:146
 msgid "Server Address"
 msgstr "Serveradress"
 
@@ -5770,15 +5992,15 @@ msgstr "Serveradministratör"
 msgid "Server Software"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:44
+#: pkg/storaged/iscsi-panel.jsx:45
 msgid "Server address cannot be empty."
 msgstr "Serveradressen får inte vara tom."
 
-#: pkg/storaged/nfs-details.jsx:147
+#: pkg/storaged/nfs-details.jsx:151
 msgid "Server cannot be empty."
 msgstr "Servern får inte vara tom."
 
-#: src/base1/cockpit.js:4033
+#: src/base1/cockpit.js:4037
 msgid "Server has closed the connection."
 msgstr "Servern har stängt förbindelsen."
 
@@ -5786,45 +6008,46 @@ msgstr "Servern har stängt förbindelsen."
 msgid "Servers"
 msgstr "Servrar"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:938
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:970
+#: pkg/storaged/dialog.jsx:1048
 msgid "Service"
 msgstr "Tjänst"
 
-#: pkg/systemd/services.html:337
+#: pkg/systemd/services.html:229
 msgid "Service Logs"
 msgstr "Tjänsteloggar"
 
-#: pkg/kdump/kdump-view.jsx:442
+#: pkg/kdump/kdump-view.jsx:444
 msgid "Service has an error"
 msgstr "Tjänsten har ett fel"
 
-#: pkg/kdump/kdump-view.jsx:438
+#: pkg/kdump/kdump-view.jsx:440
 msgid "Service is running"
 msgstr "Tjänster kör"
 
-#: pkg/kdump/kdump-view.jsx:444
+#: pkg/kdump/kdump-view.jsx:446
 msgid "Service is starting"
 msgstr "Tjänsten startar"
 
-#: pkg/kdump/kdump-view.jsx:440
+#: pkg/kdump/kdump-view.jsx:442
 msgid "Service is stopped"
 msgstr "Tjänsten är stoppad"
 
-#: pkg/kdump/kdump-view.jsx:446
+#: pkg/kdump/kdump-view.jsx:448
 msgid "Service is stopping"
 msgstr "Tjänsten stoppas"
 
-#: pkg/systemd/services.html:399
+#: pkg/systemd/services.html:254
 msgid "Service name"
 msgstr "Tjänstenamn"
 
-#: pkg/systemd/services.html:4 pkg/systemd/services.html:330
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/systemd/services.html:4 pkg/systemd/services.html:222
+#: pkg/networkmanager/firewall.jsx:510 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Tjänster"
 
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
+#: pkg/machines/components/machinesConnectionSelector.jsx:50
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1044
 msgid "Session"
 msgstr "Session"
 
@@ -5832,7 +6055,11 @@ msgstr "Session"
 msgid "Set"
 msgstr "Sätt"
 
-#: pkg/systemd/host.js:764
+#: pkg/machines/components/networks/createNetworkDialog.jsx:217
+msgid "Set DHCP Range"
+msgstr ""
+
+#: pkg/systemd/host.js:816
 msgid "Set Host name"
 msgstr "Sätt värdnamn"
 
@@ -5840,13 +6067,17 @@ msgstr "Sätt värdnamn"
 msgid "Set Password"
 msgstr "Sätt lösenord"
 
-#: pkg/systemd/index.html:378
+#: pkg/systemd/index.html:389
 msgid "Set Time"
 msgstr "Ställ in tiden"
 
 #: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Sätt behållarens miljövariabler"
+
+#: pkg/machines/components/nicAdd.jsx:60
+msgid "Set manually"
+msgstr ""
 
 #: pkg/networkmanager/index.html:183
 msgid "Set to"
@@ -5856,7 +6087,7 @@ msgstr "Sätt till"
 msgid "Set up"
 msgstr "Sätt upp"
 
-#: pkg/selinux/setroubleshoot-view.jsx:293
+#: pkg/selinux/setroubleshoot-view.jsx:294
 msgid ""
 "Setting deviates from the configured state and will revert on the next boot."
 msgstr ""
@@ -5871,31 +6102,35 @@ msgstr "Sätter upp"
 msgid "Setting up loop device $target"
 msgstr "Sätter upp vändslingeenheten $target"
 
-#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:383
 msgid "Severity"
 msgstr "Allvarsgrad"
 
-#: pkg/packagekit/updates.jsx:310
+#: pkg/packagekit/updates.jsx:311
 msgid "Severity:"
 msgstr "Allvarsgrad:"
 
-#: pkg/networkmanager/interfaces.js:1959
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Shared"
 msgstr "Delad"
+
+#: pkg/lib/cockpit-components-modifications.jsx:78
+msgid "Shell Script"
+msgstr ""
 
 #: pkg/lib/cockpit-components-context-menu.jsx:105
 msgid "Shift+Insert"
 msgstr ""
 
-#: pkg/machines/components/diskAdd.jsx:238
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Show Performance Options"
 msgstr ""
 
-#: pkg/storaged/overview.jsx:56
+#: pkg/storaged/overview.jsx:54
 msgid "Show all"
 msgstr ""
 
-#: pkg/storaged/drives-panel.jsx:122
+#: pkg/storaged/drives-panel.jsx:104
 msgid "Show all $0 drives"
 msgstr ""
 
@@ -5907,101 +6142,101 @@ msgstr "Visa alla behållare"
 msgid "Show all images"
 msgstr "Visa alla avbilder"
 
-#: pkg/systemd/index.html:107
+#: pkg/systemd/index.html:114
 msgid "Show fingerprints"
 msgstr "Visa fingeravtryck"
 
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
+#: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Krymp"
 
-#: pkg/storaged/lvol-tabs.jsx:313
+#: pkg/storaged/lvol-tabs.jsx:320
 msgid "Shrink Logical Volume"
 msgstr "Krymp en logisk volym"
 
-#: pkg/storaged/lvol-tabs.jsx:415
+#: pkg/storaged/lvol-tabs.jsx:423
 msgid "Shrink Volume"
 msgstr ""
 
-#: pkg/systemd/index.html:147 pkg/machines/components/vm/vmActions.jsx:56
+#: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
 msgstr "Stäng av"
 
+#: pkg/lib/machine-info.js:242
+msgid "Single Rank"
+msgstr ""
+
 #: pkg/docker/containers-view.jsx:683
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:430
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/components/diskAdd.jsx:167 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/fsys-panel.jsx:110 pkg/storaged/lvol-tabs.jsx:210
-#: pkg/storaged/lvol-tabs.jsx:269 pkg/storaged/lvol-tabs.jsx:394
-#: pkg/storaged/lvol-tabs.jsx:447 pkg/storaged/nfs-details.jsx:321
-#: pkg/storaged/part-tab.jsx:36 pkg/storaged/format-dialog.jsx:271
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:79
+#: pkg/storaged/content-views.jsx:118 pkg/storaged/content-views.jsx:702
+#: pkg/storaged/format-dialog.jsx:278 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:212 pkg/storaged/lvol-tabs.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:402 pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/nfs-details.jsx:329 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:263
 msgid "Size"
 msgstr "Storlek"
 
-#: pkg/storaged/dialog.jsx:911
+#: pkg/storaged/dialog.jsx:912
 msgid "Size cannot be negative"
 msgstr "Storleken kan inte vara negativ"
 
-#: pkg/storaged/dialog.jsx:909
+#: pkg/storaged/dialog.jsx:910
 msgid "Size cannot be zero"
 msgstr "Storleken kan inte vara noll"
 
-#: pkg/storaged/dialog.jsx:913
+#: pkg/storaged/dialog.jsx:914
 msgid "Size is too large"
 msgstr "Storleken är för stor"
 
-#: pkg/storaged/dialog.jsx:907
+#: pkg/storaged/dialog.jsx:908
 msgid "Size must be a number"
 msgstr "Storleken måste vara ett tal"
 
-#: pkg/storaged/dialog.jsx:915
+#: pkg/storaged/dialog.jsx:916
 msgid "Size must be at least $0"
 msgstr "Storleken måste vara åtminstone $0"
 
-#: pkg/systemd/hwinfo.jsx:249
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Slot"
 msgstr "Plats"
 
-#: pkg/storaged/crypto-keyslots.jsx:531
+#: pkg/storaged/crypto-keyslots.jsx:544
 msgid "Slot $0"
 msgstr "Plats $0"
 
-#: pkg/systemd/services.html:58 pkg/machines/components/vcpuModal.jsx:206
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "Uttag"
 
-#: pkg/packagekit/index.html:23
+#: pkg/packagekit/index.html:23 pkg/packagekit/manifest.json.in
 msgid "Software Updates"
 msgstr "Programvaruuppdateringar"
 
-#: pkg/systemd/hwinfo.jsx:208
+#: pkg/systemd/hwinfo.jsx:212
 msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
 "settings at your own risk."
 msgstr ""
 
-#: pkg/docker/storage.jsx:165
+#: pkg/docker/storage.jsx:167
 msgid "Solid-State Disk"
 msgstr "SSD-minne"
 
-#: pkg/storaged/drives-panel.jsx:87
-msgctxt "storage"
-msgid "Solid-State Disk"
-msgstr "SSD-minne"
-
-#: pkg/selinux/setroubleshoot-view.jsx:95
+#: pkg/selinux/setroubleshoot-view.jsx:96
 msgid "Solution applied successfully"
 msgstr "Lösningen verkställd"
 
-#: pkg/selinux/setroubleshoot-view.jsx:102
+#: pkg/selinux/setroubleshoot-view.jsx:103
 msgid "Solution failed"
 msgstr "Lösningen misslyckades"
 
-#: pkg/selinux/setroubleshoot-view.jsx:409
+#: pkg/selinux/setroubleshoot-view.jsx:419
 msgid "Solutions"
 msgstr "Lösningar"
 
@@ -6010,38 +6245,39 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "Något annat program använder just nu pakethanteraren, var god dröj …"
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:741
 msgid "Sorted from least trusted to most trusted"
 msgstr ""
 
-#: pkg/machines/components/nicEdit.jsx:141
-#: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:148
-#: pkg/machines/components/diskAdd.jsx:504
+#: pkg/machines/components/diskAdd.jsx:412
+#: pkg/machines/components/nicBody.jsx:149
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/vmDisksTab.jsx:114
+#: pkg/machines/components/vmnetworktab.jsx:160
 msgid "Source"
 msgstr "Källa"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
 msgid "Source Format"
 msgstr ""
 
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:207
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:234
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:42
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:218
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source Path"
 msgstr "Källsökväg"
 
-#: node_modules/registry-image-widgets/views/image-body.html:8
-msgid "Source URL"
-msgstr "Käll-URL"
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
+msgid "Source Volume Group"
+msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:235
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:256
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:224
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:245
 msgid "Source path should not be empty"
 msgstr "Källsökvägen får inte vara tom"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:147
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:144
 msgid "Source should start with http, ftp or nfs protocol"
 msgstr "Källan skall börja med ett av protokollen http, ftp eller nfs"
 
@@ -6049,7 +6285,7 @@ msgstr "Källan skall börja med ett av protokollen http, ftp eller nfs"
 msgid "Space-saving Computer"
 msgstr "Utrymmessparande dator"
 
-#: pkg/networkmanager/interfaces.js:2857
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Spanning Tree Protocol"
 msgstr "Uppspännande-träd-protokollet"
 
@@ -6057,21 +6293,26 @@ msgstr "Uppspännande-träd-protokollet"
 msgid "Spanning Tree Protocol (STP)"
 msgstr "Uppspännande-träd-protokollet (STP)"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Spare"
 msgstr "Reserv"
 
-#: pkg/systemd/index.html:455
+#: pkg/systemd/index.html:466
 msgid "Specific Time"
 msgstr "Specifik tid"
 
-#: pkg/networkmanager/interfaces.js:3633
+#: pkg/systemd/hwinfo.jsx:263
+msgid "Speed"
+msgstr ""
+
+#: pkg/networkmanager/interfaces.js:3660
 msgid "Stable"
 msgstr "Stabilt"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/storaged/swap-tab.jsx:77 pkg/storaged/vdo-details.jsx:259
-#: pkg/storaged/mdraid-details.jsx:319 pkg/systemd/init.js:541
+#: pkg/machines/components/networks/createNetworkDialog.jsx:223
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:265 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Starta"
 
@@ -6083,17 +6324,26 @@ msgstr "Starta Docker"
 msgid "Start Multipath"
 msgstr "Starta multipath"
 
-#: pkg/networkmanager/index.html:44
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:343
 msgid "Start Service"
 msgstr "Starta tjänst"
+
+#: pkg/systemd/service-details.jsx:413
+msgid "Start and Enable"
+msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:105
 msgid "Start libvirt"
 msgstr "Starta libvirt"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:293
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:304
 msgid "Start pool when host boots"
 msgstr "Starta poolen när värden startar upp"
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:56
+#: pkg/machines/components/networks/createNetworkDialog.jsx:84
+msgid "Start should not be empty"
+msgstr ""
 
 #: pkg/storaged/jobs-panel.jsx:59
 msgid "Starting RAID Device $target"
@@ -6103,15 +6353,15 @@ msgstr "Starta RAID-enhet $target"
 msgid "Starting swapspace $target"
 msgstr "Starta växlingsutrymmet $target"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:286
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:297
 msgid "Startup"
 msgstr "Uppstart"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/networks/networkList.jsx:47
-#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:285
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/vmnetworktab.jsx:186 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/hwinfo.jsx:263 pkg/systemd/init.js:306
 msgid "State"
 msgstr "Tillstånd"
 
@@ -6119,11 +6369,12 @@ msgstr "Tillstånd"
 msgid "State:"
 msgstr "Tillstånd:"
 
-#: pkg/systemd/services.html:74 pkg/systemd/init.js:207
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:213
+#: pkg/systemd/service-details.jsx:371
 msgid "Static"
 msgstr "Statisk"
 
-#: pkg/systemd/services.html:121 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:2633 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Status"
 
@@ -6136,17 +6387,21 @@ msgid "Sticky"
 msgstr "Fast"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/swap-tab.jsx:76 pkg/storaged/vdo-details.jsx:157
-#: pkg/storaged/vdo-details.jsx:258 pkg/storaged/mdraid-details.jsx:318
-#: pkg/systemd/init.js:542
+#: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
+#: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Stoppa"
 
-#: pkg/storaged/mdraid-details.jsx:247
+#: pkg/storaged/mdraid-details.jsx:244
 msgid "Stop Device"
 msgstr "Stoppa enhet"
 
-#: pkg/storaged/nfs-details.jsx:259
+#: pkg/systemd/service-details.jsx:413
+msgid "Stop and Disable"
+msgstr ""
+
+#: pkg/storaged/nfs-details.jsx:267
 msgid "Stop and Unmount"
 msgstr "Stoppa och avmontera"
 
@@ -6154,13 +6409,9 @@ msgstr "Stoppa och avmontera"
 msgid "Stop and delete"
 msgstr "Stoppa och radera"
 
-#: pkg/storaged/nfs-details.jsx:284
+#: pkg/storaged/nfs-details.jsx:292
 msgid "Stop and remove"
 msgstr "Stoppa och ta bort"
-
-#: node_modules/registry-image-widgets/views/image-config.html:14
-msgid "Stop with"
-msgstr "Stoppa med"
 
 #: pkg/docker/util.js:231
 msgid "Stopped"
@@ -6175,14 +6426,20 @@ msgid "Stopping swapspace $target"
 msgstr "Stoppar växlingsutrymmet $target"
 
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:393
-#: pkg/storaged/details.jsx:127
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:438
+#: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
 msgid "Storage"
 msgstr "Lagring"
 
 #: pkg/storaged/logs-panel.jsx:37
 msgid "Storage Logs"
 msgstr "Lagringsloggar"
+
+#: pkg/machines/components/aggregateStatusCards.jsx:47
+msgid "Storage Pool"
+msgid_plural "Storage Pools"
+msgstr[0] ""
+msgstr[1] ""
 
 #: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
@@ -6192,16 +6449,16 @@ msgstr ""
 msgid "Storage Pool $0 failed to get deactivated"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:61
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:47
 msgid "Storage Pool Name"
 msgstr "Lagringspoolsnamn"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:439
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:461
 msgid "Storage Pool failed to be created"
 msgstr "Lagringspoolen kunde inte skapas"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:44
-#: pkg/machines/components/storagePools/storagePoolList.jsx:48
+#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/storagePoolList.jsx:53
 msgid "Storage Pools"
 msgstr "Lagringspooler"
 
@@ -6221,19 +6478,23 @@ msgstr ""
 msgid "Storage pool"
 msgstr "Lagringspool"
 
-#: pkg/systemd/index.html:155
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:169
+msgid "Storage size must not be 0"
+msgstr ""
+
+#: pkg/systemd/index.html:162
 msgid "Store Metrics"
 msgstr ""
 
-#: pkg/storaged/format-dialog.jsx:122
+#: pkg/storaged/format-dialog.jsx:126
 msgid "Store passphrase"
 msgstr "Lagra lösenfrasen"
 
-#: pkg/storaged/crypto-tab.jsx:67 pkg/storaged/crypto-tab.jsx:69
+#: pkg/storaged/crypto-tab.jsx:68 pkg/storaged/crypto-tab.jsx:70
 msgid "Stored Passphrase"
 msgstr "Lagrad lösenfras"
 
-#: pkg/storaged/crypto-tab.jsx:126
+#: pkg/storaged/crypto-tab.jsx:129
 msgid "Stored passphrase"
 msgstr "Lagrad lösenfras"
 
@@ -6245,11 +6506,7 @@ msgstr "Underchassi"
 msgid "Sub Notebook"
 msgstr "ULPC"
 
-#: node_modules/registry-image-widgets/views/image-body.html:4
-msgid "Summary"
-msgstr "Sammanfattning"
-
-#: pkg/systemd/services.html:241
+#: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "Söndag"
 
@@ -6257,32 +6514,32 @@ msgstr "Söndag"
 msgid "Sundays"
 msgstr ""
 
-#: pkg/storaged/optional-panel.jsx:95
+#: pkg/storaged/optional-panel.jsx:98
 msgid "Support is installed."
 msgstr "Stöd är installerat."
 
-#: pkg/storaged/content-views.jsx:157
+#: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Växlingsutrymme"
 
-#: pkg/storaged/content-views.jsx:351
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Växlingsutrymme"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1692
+#: pkg/systemd/index.html:259 pkg/systemd/host.js:1756
 msgid "Swap Used"
 msgstr "Använt växlingsutrymme"
 
-#: pkg/networkmanager/interfaces.js:2492 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:3060
 msgid "Switch off $0"
 msgstr "Stäng av $0"
 
-#: pkg/networkmanager/interfaces.js:2467 pkg/networkmanager/interfaces.js:3027
+#: pkg/networkmanager/interfaces.js:2486 pkg/networkmanager/interfaces.js:3048
 msgid "Switch on $0"
 msgstr "Sätt på $0"
 
-#: pkg/networkmanager/interfaces.js:2491
+#: pkg/networkmanager/interfaces.js:2510
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6290,7 +6547,7 @@ msgstr ""
 "Att slå av <b>$0</b> kommer bryta anslutningen till servern, och kommer göra "
 "administrationsgränssnittet otillgängligt."
 
-#: pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:3059
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6298,7 +6555,7 @@ msgstr ""
 "Att slå av <b>$0</b> kommer bryta anslutningen till servern, och kommer göra "
 "administrationsgränssnittet otillgängligt."
 
-#: pkg/networkmanager/interfaces.js:2466 pkg/networkmanager/interfaces.js:3026
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3047
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6326,37 +6583,47 @@ msgstr "Synkroniserad med {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Synkroniserar RAID-enheten $target"
 
-#: pkg/systemd/index.html:4 pkg/machines/helpers.js:184
-#: pkg/systemd/hwinfo.jsx:260
+#: pkg/systemd/index.html:4
+#: pkg/machines/components/machinesConnectionSelector.jsx:43
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:273
+#: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "System"
 
-#: pkg/systemd/hwinfo.jsx:264
+#: pkg/systemd/index.html:171
+msgid "System Health"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:277
 msgid "System Information"
 msgstr "Systeminformation"
 
-#: pkg/systemd/host.js:480
+#: pkg/selinux/setroubleshoot-view.jsx:467
+msgid "System Modifications"
+msgstr ""
+
+#: pkg/systemd/host.js:493
 msgid "System Not Registered"
 msgstr "Systemet är inte registrerat"
 
-#: pkg/systemd/services.html:57
+#: pkg/systemd/services.jsx:47
 msgid "System Services"
 msgstr "Systemtjänster"
 
-#: pkg/systemd/index.html:121
+#: pkg/systemd/index.html:128
 msgid "System Time"
 msgstr "Systemtid"
 
-#: pkg/systemd/host.js:486
+#: pkg/systemd/host.js:499
 msgid "System Up To Date"
 msgstr "Systemet är uppdaterat"
 
-#: pkg/packagekit/updates.jsx:876
+#: pkg/packagekit/updates.jsx:879
 msgid "System is up to date"
 msgstr "Systemet är uppdaterat"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:970
 msgid "TCP"
 msgstr "TCP"
 
@@ -6365,18 +6632,14 @@ msgid "Tablet"
 msgstr "Platta"
 
 #: pkg/docker/index.html:696
-#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Tagg"
 
-#: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
 #: pkg/docker/containers-view.jsx:409
 msgid "Tags"
 msgstr "Taggar"
 
-#: pkg/storaged/crypto-keyslots.jsx:207
+#: pkg/storaged/crypto-keyslots.jsx:210
 msgid "Tang keyserver"
 msgstr "Tang-nyckelserver"
 
@@ -6384,25 +6647,25 @@ msgstr "Tang-nyckelserver"
 msgid "Target"
 msgstr "Mål"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:57
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:125
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:111
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
 msgid "Target Path"
 msgstr "Målsökväg"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:134
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:120
 msgid "Target path should not be empty"
 msgstr "Målsökvägen får inte vara tom"
 
-#: pkg/systemd/services.html:56
+#: pkg/systemd/services.jsx:48
 msgid "Targets"
 msgstr "Mål"
 
-#: pkg/networkmanager/interfaces.js:2512 pkg/networkmanager/interfaces.js:2524
-#: pkg/networkmanager/interfaces.js:2814
+#: pkg/networkmanager/interfaces.js:2531 pkg/networkmanager/interfaces.js:2543
+#: pkg/networkmanager/interfaces.js:2834
 msgid "Team"
 msgstr "Team"
 
-#: pkg/networkmanager/interfaces.js:2842
+#: pkg/networkmanager/interfaces.js:2862
 msgid "Team Port"
 msgstr "Team-port"
 
@@ -6414,7 +6677,7 @@ msgstr "Team-portsinställningar"
 msgid "Team Settings"
 msgstr "Team-inställningar"
 
-#: pkg/systemd/terminal.html:4
+#: pkg/systemd/terminal.html:4 pkg/systemd/manifest.json.in
 msgid "Terminal"
 msgstr "Terminal"
 
@@ -6422,11 +6685,11 @@ msgstr "Terminal"
 msgid "Terminate Session"
 msgstr "Avsluta sessionen"
 
-#: pkg/kdump/kdump-view.jsx:476 pkg/kdump/kdump-view.jsx:484
+#: pkg/kdump/kdump-view.jsx:478 pkg/kdump/kdump-view.jsx:486
 msgid "Test Configuration"
 msgstr "Testa konfigurationen"
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr "Testet är endast tillgängligt medans tjänsten kdump kör."
 
@@ -6438,28 +6701,28 @@ msgstr "Testa kdump-inställningar"
 msgid "Testing connection"
 msgstr "Testar anslutningen"
 
-#: pkg/docker/storage.jsx:507
+#: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr "Dockers lagringspool kan inte hanteras på det här system."
 
-#: pkg/lib/machine-dialogs.js:384
+#: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "IP-adressen och värdnamnet får inte innehålla blanktecken."
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/mdraid-details.jsx:213
 msgid "The RAID Array is in a degraded state"
 msgstr "RAID-vektor är i ett nedsatt tillstånd"
 
-#: pkg/storaged/mdraid-details.jsx:148
+#: pkg/storaged/mdraid-details.jsx:142
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "RAID-enheten måste köra för att kunna lägga till reservdiskar."
 
-#: pkg/storaged/mdraid-details.jsx:115
+#: pkg/storaged/mdraid-details.jsx:109
 msgid "The RAID device must be running in order to remove disks."
 msgstr "RAID-enheten måste köra för att kunna ta bort diskar."
 
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:80
-#: pkg/machines/components/storagePools/storagePoolDelete.jsx:84
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:125
+#: pkg/machines/components/storagePools/storagePoolDelete.jsx:129
 msgid "The Storage Pool could not be deleted"
 msgstr ""
 
@@ -6507,8 +6770,8 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
-"established. Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
+" Are you sure you want to continue connecting?"
 msgstr ""
 "Autenticiteten hos värden {{#strong}}{{host}}{{/strong}} kan inte "
 "fastställas.  Är du säker på att du vill fortsätta ansluta?"
@@ -6517,10 +6780,11 @@ msgstr ""
 msgid "The collected information will be stored locally on the system."
 msgstr "Den insamlade informationen kommer lagras lokalt på systemet."
 
-#: pkg/selinux/setroubleshoot-view.jsx:291
+#: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
 "Det konfigurerade tillståndet är okänt, det kan ändra sig vid nästa uppstart."
+""
 
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
@@ -6528,18 +6792,18 @@ msgid ""
 msgstr ""
 "Skapandet av denna VDO-enhet avslutade inte och enheten kan inte användas."
 
-#: pkg/storaged/crypto-keyslots.jsx:516
+#: pkg/storaged/crypto-keyslots.jsx:529
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
 "Användaren som för närvarande är inloggad har inte tillstånd att se "
 "information om nycklar."
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:205
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:191
 msgid "The directory on the server being exported"
 msgstr "Katalogen på servern exporteras"
 
-#: pkg/storaged/dialog.jsx:1012
+#: pkg/storaged/dialog.jsx:1013
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -6547,20 +6811,22 @@ msgstr ""
 "Filsystemet används av inloggningssesioner och systemtjänster.  Att gå "
 "vidare kommer stoppa dessa."
 
-#: pkg/storaged/dialog.jsx:1014
-msgid "The filesystem is in use by login sessions. Proceeding will stop these."
+#: pkg/storaged/dialog.jsx:1015
+msgid ""
+"The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Filsystemet används av inloggningssessioner.  Att gå vidare kommer stoppa "
 "dessa."
 
-#: pkg/storaged/dialog.jsx:1016
+#: pkg/storaged/dialog.jsx:1017
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
 "Filsystemet används av systemtjänster.  Att gå vidare kommer stoppa dessa."
 
 #: pkg/docker/util.js:631
-msgid "The following containers depend on this image and will become unusable."
+msgid ""
+"The following containers depend on this image and will become unusable."
 msgstr "Följande behållare beror på denna avbild och kommer bli oanvändbara."
 
 #: pkg/sosreport/index.html:51
@@ -6587,26 +6853,29 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr "Nyckeln du angav var inte giltig."
 
-#: pkg/storaged/mdraid-details.jsx:121
+#: pkg/storaged/mdraid-details.jsx:115
 msgid "The last disk of a RAID device cannot be removed."
 msgstr "Den sista disken i en RAID-enhet kan inte tas bort."
 
-#: pkg/storaged/crypto-keyslots.jsx:541
+#: pkg/storaged/crypto-keyslots.jsx:554
 msgid "The last key slot can not be removed"
 msgstr "Det sista nyckelfacket kan inte tas bort"
 
-#: pkg/storaged/vgroup-details.jsx:96
+#: pkg/storaged/vgroup-details.jsx:90
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Den sista fysiska volymen i en volymgrupp kan inte tas bort."
 
-#: pkg/shell/indexes.js:407
+#: pkg/lib/cockpit-components-modifications.jsx:144
+msgid "The logged in user is not permitted to view system modifications"
+msgstr ""
+
+#: pkg/shell/indexes.js:464
 msgid "The machine is restarting"
 msgstr "Maskinen startar om"
 
 #: pkg/machines/components/networks/networkDelete.jsx:76
-#, fuzzy
 msgid "The network could not be deleted"
-msgstr "Målsökvägen får inte vara tom"
+msgstr ""
 
 #: pkg/users/local.js:443 pkg/users/local.js:1399
 msgid "The passwords do not match"
@@ -6616,7 +6885,7 @@ msgstr "Lösenorden stämmer inte överens"
 msgid "The passwords do not match."
 msgstr "Lösenorden stämmer inte överens."
 
-#: pkg/machines/components/diskAdd.jsx:80
+#: pkg/machines/components/diskAdd.jsx:81
 msgid "The pool is empty"
 msgstr "Poolen är tom"
 
@@ -6624,9 +6893,32 @@ msgstr "Poolen är tom"
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Skanningen från $time ($type) hittade inga sårbarheter."
 
+#: pkg/docker/containers-view.jsx:436
+msgid "The scan from $time ($type) found one vulnerability:"
+msgid_plural "The scan from $time ($type) found $count vulnerabilities:"
+msgstr[0] ""
+msgstr[1] ""
+
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
 msgstr "Skanningen från $time ($type) lyckades inte."
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:160
+msgid "The selected Operating System has minimum memory requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+msgid ""
+"The selected Operating System has minimum storage size requirement of $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:382
+msgid "The selected Operating System has recommended memory $0 $1"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:417
+msgid "The selected Operating System has recommended storage size of $0 $1"
+msgstr ""
 
 #: src/ws/login.js:645
 msgid ""
@@ -6636,15 +6928,15 @@ msgstr ""
 "Servern vägrade att autentisera ”$0” med lösenordsautentisering, och inga "
 "andra stödda autentiseringsmetoder är tillgängliga."
 
-#: src/base1/cockpit.js:4017
+#: src/base1/cockpit.js:4021
 msgid "The server refused to authenticate using any supported methods."
 msgstr "Servern vägrade att autentisera med några stödda metoder."
 
-#: pkg/systemd/hwinfo.jsx:65
+#: pkg/systemd/hwinfo.jsx:69
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr ""
 
-#: pkg/systemd/init.js:922
+#: pkg/systemd/init.js:813
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Användaren <b>$0</b> har inte rättighet att skapa timrar"
 
@@ -6652,17 +6944,11 @@ msgstr "Användaren <b>$0</b> har inte rättighet att skapa timrar"
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra profiler"
 
-#: pkg/systemd/host.js:70
+#: pkg/systemd/host.js:72
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra systemtiden"
 
-#: pkg/systemd/init.js:614
-msgid "The user <b>$0</b> is not permitted to enable or disable services"
-msgstr ""
-"Användaren <b>$0</b> har inte rättighet att aktivera eller avaktivera "
-"tjänster"
-
-#: pkg/dashboard/list.js:223
+#: pkg/dashboard/list.js:231
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "Användaren <b>$0</b> har inte rättighet att hantera servrar"
 
@@ -6674,27 +6960,22 @@ msgstr "Användaren <b>$0</b> har inte rättighet att hantera lagring"
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra konton"
 
-#: pkg/systemd/host.js:54
+#: pkg/systemd/host.js:56
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra värdnamn"
 
-#: pkg/networkmanager/interfaces.js:1516
+#: pkg/networkmanager/interfaces.js:1530
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "Användaren <b>$0</b> har inte rättighet att ändra nätverksinställningar"
 
-#: pkg/realmd/operation.js:642
+#: pkg/realmd/operation.js:644
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Användaren <b>$0</b> har inte rättighet att ändra riken"
 
-#: pkg/systemd/host.js:62
+#: pkg/systemd/host.js:64
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr "Användaren <b>$0</b> har inte rättighet att starta om denna server"
-
-#: pkg/systemd/init.js:606 pkg/systemd/init.js:610
-msgid "The user <b>$0</b> is not permitted to start or stop services"
-msgstr ""
-"Användaren <b>$0</b> har inte rättighet att starta eller stoppa tjänster"
 
 #: pkg/users/local.js:553
 msgid ""
@@ -6706,7 +6987,8 @@ msgstr ""
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
-"The web browser configuration prevents Cockpit from running (inaccessible $0)"
+"The web browser configuration prevents Cockpit from running (inaccessible "
+"$0)"
 msgstr ""
 "Webbläsarens konfiguration förhindrar Cockpit från att köra (oåtkomlig $0)"
 
@@ -6726,7 +7008,7 @@ msgstr ""
 msgid "There are no authorized public keys for this account."
 msgstr "Det finns inga auktoriserade publika nycklar för detta konto."
 
-#: pkg/storaged/vgroup-details.jsx:102
+#: pkg/storaged/vgroup-details.jsx:96
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
@@ -6734,11 +7016,15 @@ msgstr ""
 "Det finns inte tillräckligt med fritt utrymme någon annanstans för att ta "
 "bort dennay fysiska volym.  Åtminstone $0 mer ledigt utrymme behövs."
 
-#: pkg/storaged/utils.js:193
+#: pkg/shell/index.html:398
+msgid "There was an unexpected error while connecting to the machine."
+msgstr ""
+
+#: pkg/storaged/utils.js:194
 msgid "Thin Logical Volume"
 msgstr "Tunn logisk volym"
 
-#: pkg/storaged/nfs-details.jsx:118
+#: pkg/storaged/nfs-details.jsx:120
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr "Denna NFS-montering används och endast dess alternativ kan ändras."
 
@@ -6746,7 +7032,7 @@ msgstr "Denna NFS-montering används och endast dess alternativ kan ändras."
 msgid "This VDO device does not use all of its backing device."
 msgstr "Denna VDO-enhet använder inte alla sina underliggande enheter."
 
-#: pkg/systemd/init.js:1371
+#: pkg/systemd/init.js:1262
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -6754,11 +7040,11 @@ msgstr ""
 "Denna dag finns inte i alla månader.<br>Timern kommer bara köras i månader "
 "som har den 31:e."
 
-#: pkg/networkmanager/interfaces.js:2624
+#: pkg/networkmanager/interfaces.js:2644
 msgid "This device cannot be managed here."
 msgstr "Denna enhet kan inte hanteras här."
 
-#: pkg/storaged/dialog.jsx:997
+#: pkg/storaged/dialog.jsx:998
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -6766,11 +7052,11 @@ msgstr ""
 "Denna enhet har filsystem som används just nu.  Att gå vidare kommer "
 "avmontera alla filsystem på den."
 
-#: pkg/storaged/dialog.jsx:976
+#: pkg/storaged/dialog.jsx:977
 msgid "This device is currently used for RAID devices."
 msgstr "Denna enhet används just nu till RAID-enheter."
 
-#: pkg/storaged/dialog.jsx:1005
+#: pkg/storaged/dialog.jsx:1006
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -6778,15 +7064,15 @@ msgstr ""
 "Denna enhet används just nu till RAID-enheter.  Att gå vidare kommer ta bort "
 "den från sin RAID-enhet."
 
-#: pkg/storaged/dialog.jsx:980
+#: pkg/storaged/dialog.jsx:981
 msgid "This device is currently used for VDO devices."
 msgstr "Denna enhet används just nu till VDO-enheter."
 
-#: pkg/storaged/dialog.jsx:972
+#: pkg/storaged/dialog.jsx:973
 msgid "This device is currently used for volume groups."
 msgstr "Denna enhet används just nu till volymgrupper."
 
-#: pkg/storaged/dialog.jsx:1001
+#: pkg/storaged/dialog.jsx:1002
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -6794,11 +7080,11 @@ msgstr ""
 "Denna enhet används just nu till volymgrupper.  Att gå vidare kommer ta bort "
 "den från sin volymgrupper."
 
-#: pkg/storaged/mdraid-details.jsx:117
+#: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
 msgstr "Denna disk kan inte tas bort medans enheten återhämtar sig."
 
-#: pkg/systemd/init.js:1283 pkg/systemd/init.js:1297 pkg/systemd/init.js:1306
+#: pkg/systemd/init.js:1174 pkg/systemd/init.js:1188 pkg/systemd/init.js:1197
 msgid "This field cannot be empty."
 msgstr "Detta fält får inte vara tomt."
 
@@ -6806,11 +7092,11 @@ msgstr "Detta fält får inte vara tomt."
 msgid "This image does not exist."
 msgstr "Denna avbild finns inte."
 
-#: pkg/storaged/lvol-tabs.jsx:408
+#: pkg/storaged/lvol-tabs.jsx:416
 msgid "This logical volume is not completely used by its content."
 msgstr ""
 
-#: pkg/lib/machine-dialogs.js:362
+#: pkg/lib/machine-dialogs.js:364
 msgid "This machine has already been added."
 msgstr "Denna maskin har redan lagts till."
 
@@ -6827,7 +7113,11 @@ msgstr "Detta paket är inte kopatibelt med denna version av Cockpit"
 msgid "This package requires Cockpit version %s or later"
 msgstr "Detta paket behöver Cockpit version %s eller senare"
 
-#: pkg/packagekit/updates.jsx:772
+#: pkg/machines/components/diskAdd.jsx:138
+msgid "This pool type does not support Storage Volume creation"
+msgstr ""
+
+#: pkg/packagekit/updates.jsx:775
 msgid "This system is not registered"
 msgstr "Detta system är inte registrerat"
 
@@ -6848,11 +7138,7 @@ msgstr ""
 "information från systemet för att användas vid diagnostisering av problem "
 "med systemet."
 
-#: pkg/systemd/init.js:685
-msgid "This unit is an instance of the $0 template."
-msgstr "Denna enhet är en instans av mallen $0."
-
-#: pkg/systemd/services.html:360
+#: pkg/systemd/service-details.jsx:298
 msgid "This unit is not designed to be enabled explicitly."
 msgstr "Denna enhet är inte gjord för att aktiveras explicit."
 
@@ -6860,7 +7146,7 @@ msgstr "Denna enhet är inte gjord för att aktiveras explicit."
 msgid "This user name already exists"
 msgstr "Detta användarnamn finns redan"
 
-#: pkg/lib/machine-dialogs.js:378
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
@@ -6868,11 +7154,11 @@ msgstr ""
 "Denna version av cockpit-ws stödjer inte att ansluta till en värd med en "
 "alternativ användare eller port"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:423
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:468
 msgid "This volume is already used by another VM."
 msgstr ""
 
-#: pkg/storaged/lvol-tabs.jsx:186
+#: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
 msgstr "Denna volym behöver aktiveras före dess storlek kan ändras."
 
@@ -6880,7 +7166,7 @@ msgstr "Denna volym behöver aktiveras före dess storlek kan ändras."
 msgid "This web browser is too old to run Cockpit (missing $0)"
 msgstr "Denna webbläsare är för gammal för att köra Cockpit (saknar $0)"
 
-#: pkg/packagekit/updates.jsx:832
+#: pkg/packagekit/updates.jsx:835
 msgid "This web console will be updated."
 msgstr "Denna webbkonsol kommer uppdateras."
 
@@ -6894,7 +7180,7 @@ msgstr ""
 "systemet.  Beroende på inställningarna kanske inte systemet kommer starta om "
 "automatiskt och processen kan ta en stund."
 
-#: pkg/kdump/kdump-view.jsx:489
+#: pkg/kdump/kdump-view.jsx:491
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Detta kommer testa kdump-inställningarna genom att krascha kärnan."
 
@@ -6902,7 +7188,7 @@ msgstr "Detta kommer testa kdump-inställningarna genom att krascha kärnan."
 msgid "Threads per core"
 msgstr "Trådar per kärna"
 
-#: pkg/systemd/services.html:238
+#: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "Torsdag"
 
@@ -6910,15 +7196,15 @@ msgstr "Torsdag"
 msgid "Thursdays"
 msgstr ""
 
-#: pkg/systemd/index.html:364
+#: pkg/systemd/index.html:375
 msgid "Time Zone"
 msgstr "Tidszon"
 
-#: pkg/systemd/services.html:59
+#: pkg/systemd/services.jsx:50
 msgid "Timers"
 msgstr "Timrar"
 
-#: pkg/shell/index.html:305
+#: pkg/shell/index.html:306
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -6926,7 +7212,7 @@ msgstr ""
 "Tips: gör så att ditt nyckellösenord stämmer med ditt inloggningslösenord "
 "för att automatiskt autentisera mot andra system."
 
-#: pkg/packagekit/updates.jsx:773
+#: pkg/packagekit/updates.jsx:776
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -6934,14 +7220,6 @@ msgstr ""
 "För att få programvaruuppdateringar behöver detta system registreras hos Red "
 "Hat, antingen genom att använda Red Hats kundportal eller en lokal "
 "prenumerationsserver."
-
-#: node_modules/registry-image-widgets/views/image-pull.html:4
-msgid "To pull this image:"
-msgstr "För att hämta denna avbild:"
-
-#: node_modules/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push an image to this image stream:"
-msgstr "För att trycka ut denna avbild till denna avbildsström:"
 
 #: pkg/lib/machine-change-port.html:11
 msgid ""
@@ -6951,15 +7229,11 @@ msgstr ""
 "För att använda en annan port behöver du uppgradera cockpit-ws till en nyare "
 "version."
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
-msgid "Too many files found"
-msgstr "För många filer hittade"
-
-#: src/base1/cockpit.js:4039
+#: src/base1/cockpit.js:4043
 msgid "Too much data"
 msgstr "För mycket data"
 
-#: pkg/docker/storage.jsx:341
+#: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Totalt"
 
@@ -6971,24 +7245,28 @@ msgstr "Total storlek: $0"
 msgid "Tower"
 msgstr "Torn"
 
-#: pkg/systemd/init.js:733
+#: pkg/playground/manifest.json.in
+msgid "Translating"
+msgstr ""
+
+#: pkg/systemd/service-details.jsx:433
 msgid "Triggered By"
 msgstr "Utlöst av"
 
-#: pkg/systemd/init.js:732
+#: pkg/systemd/service-details.jsx:432
 msgid "Triggers"
 msgstr "Utlösare"
 
-#: pkg/shell/index.html:387 pkg/shell/simple.html:139
+#: pkg/shell/index.html:383 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Felsök"
 
-#: pkg/storaged/crypto-keyslots.jsx:331
+#: pkg/storaged/crypto-keyslots.jsx:339
 msgid "Trust key"
 msgstr "Förtroendenyckel"
 
-#: pkg/networkmanager/firewall.jsx:705
+#: pkg/networkmanager/firewall.jsx:737
 msgid "Trust level"
 msgstr ""
 
@@ -7008,7 +7286,7 @@ msgstr "Försök att återansluta"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Försök att synkronisera med {{Server}}"
 
-#: pkg/systemd/services.html:236
+#: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "Tisdag"
 
@@ -7016,7 +7294,7 @@ msgstr "Tisdag"
 msgid "Tuesdays"
 msgstr ""
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:261
 msgid "Tuned has failed to start"
 msgstr "Tuned har misslyckats med att starta"
 
@@ -7032,17 +7310,19 @@ msgstr "Tuned kör inte"
 msgid "Tuned is off"
 msgstr "Tuned är avslagen"
 
-#: pkg/shell/index.html:265 pkg/machines/components/vm/bootOrderModal.jsx:108
+#: pkg/shell/index.html:266
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
+#: pkg/machines/components/vm/bootOrderModal.jsx:108
 #: pkg/machines/components/vm/bootOrderModal.jsx:119
 #: pkg/machines/components/vm/bootOrderModal.jsx:125
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:99
-#: pkg/machines/components/vmnetworktab.jsx:114 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/storaged/format-dialog.jsx:283
-#: pkg/systemd/hwinfo.jsx:75
+#: pkg/machines/components/vmnetworktab.jsx:120
+#: pkg/storaged/format-dialog.jsx:293 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Type"
 msgstr "Typ"
 
@@ -7058,11 +7338,11 @@ msgstr "Skriv ett lösenord"
 msgid "Type to filter…"
 msgstr "Skriv för att filtrera …"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:938
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:970
 msgid "UDP"
 msgstr "UDP"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:262
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:287
 msgid "URL"
 msgstr "URL"
 
@@ -7074,7 +7354,7 @@ msgstr "UUID"
 msgid "Unable to apply settings: $0"
 msgstr "Kan inte verkställa inställningarna: $0"
 
-#: pkg/selinux/setroubleshoot-view.jsx:119
+#: pkg/selinux/setroubleshoot-view.jsx:120
 msgid "Unable to apply this solution automatically"
 msgstr "Kan inte verkställa denna lösning automatiskt"
 
@@ -7086,8 +7366,8 @@ msgstr "Kan inte ansluta till den adressen"
 msgid "Unable to delete root account"
 msgstr "Det går inte att ta bort root-kontot"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Unable to get alert details."
 msgstr "Kan inte ta bort larmdetaljer."
 
@@ -7099,17 +7379,13 @@ msgstr "Kan inte hämta larmet: $0"
 msgid "Unable to reach server"
 msgstr "Kan inte nå servern"
 
-#: pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:290
 msgid "Unable to remove mount"
 msgstr "Kan inte ta bort monteringen"
 
 #: pkg/users/local.js:60
 msgid "Unable to rename root account"
 msgstr "Kan inte byta namn på root-kontot"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:41
-msgid "Unable to resolve"
-msgstr "Kan inte lösa upp"
 
 #: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
@@ -7119,7 +7395,7 @@ msgstr "Kan inte köra fixen: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "Kan inte starta setroubleshootd"
 
-#: pkg/storaged/nfs-details.jsx:257
+#: pkg/storaged/nfs-details.jsx:265
 msgid "Unable to unmount filesystem"
 msgstr "Kan inte avmontera filsystem"
 
@@ -7128,35 +7404,36 @@ msgid "Unavailable"
 msgstr "Otillgänglig"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:737 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:758 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Oväntat fel"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:175
+#: pkg/machines/components/networks/createNetworkDialog.jsx:114
+msgid "Unique Network Name"
+msgstr ""
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:198
 msgid "Unique name"
 msgstr "Unikt namn"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1048
 msgid "Unit"
 msgstr "Enhet"
 
-#: node_modules/registry-image-widgets/views/image-body.html:16
-#: node_modules/registry-image-widgets/views/imagestream-body.html:30
-#: node_modules/registry-image-widgets/views/imagestream-body.html:31
-#: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:596 pkg/networkmanager/interfaces.js:1067
-#: pkg/networkmanager/interfaces.js:2532 pkg/networkmanager/interfaces.js:2534
+#: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
+#: pkg/machines/components/vmnetworktab.jsx:149
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1081
+#: pkg/networkmanager/interfaces.js:2551 pkg/networkmanager/interfaces.js:2553
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
-#: pkg/lib/machine-info.js:65
 msgid "Unknown"
 msgstr "Okänd"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
+#: pkg/networkmanager/interfaces.js:2537 pkg/networkmanager/interfaces.js:2549
 msgid "Unknown \"$0\""
 msgstr "Okänt ”$0”"
 
-#: pkg/storaged/mdraid-details.jsx:104
+#: pkg/storaged/mdraid-details.jsx:98
 msgid "Unknown ($0)"
 msgstr "Okänt ($0)"
 
@@ -7168,7 +7445,7 @@ msgstr "Okänt program"
 msgid "Unknown Host Key"
 msgstr "Okänd värdnyckel"
 
-#: pkg/networkmanager/interfaces.js:2640
+#: pkg/networkmanager/interfaces.js:2660
 msgid "Unknown configuration"
 msgstr "Okänd konfiguration"
 
@@ -7176,11 +7453,11 @@ msgstr "Okänd konfiguration"
 msgid "Unknown host name"
 msgstr "Okänt värdnamn"
 
-#: pkg/networkmanager/firewall.jsx:333
+#: pkg/networkmanager/firewall.jsx:358
 msgid "Unknown service name"
 msgstr ""
 
-#: pkg/storaged/crypto-keyslots.jsx:562
+#: pkg/storaged/crypto-keyslots.jsx:575
 msgid "Unknown type"
 msgstr "Okänd typ"
 
@@ -7188,20 +7465,20 @@ msgstr "Okänd typ"
 msgid "Unless Stopped"
 msgstr "Om inte stoppad"
 
-#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
-#: pkg/storaged/content-views.jsx:240
+#: pkg/storaged/content-views.jsx:227 pkg/storaged/content-views.jsx:232
+#: pkg/storaged/content-views.jsx:245
 msgid "Unlock"
 msgstr "Lås upp"
 
-#: pkg/shell/index.html:212 pkg/shell/index.html:253
+#: pkg/shell/index.html:213 pkg/shell/index.html:254
 msgid "Unlock Key"
 msgstr "Lås upp nyckeln"
 
-#: pkg/storaged/format-dialog.jsx:116
+#: pkg/storaged/format-dialog.jsx:120
 msgid "Unlock at boot"
 msgstr "Lås upp vid uppstart"
 
-#: pkg/storaged/format-dialog.jsx:117
+#: pkg/storaged/format-dialog.jsx:121
 msgid "Unlock read only"
 msgstr "Lås upp endast för läsning"
 
@@ -7209,7 +7486,7 @@ msgstr "Lås upp endast för läsning"
 msgid "Unlocking $target"
 msgstr "Lås upp $target"
 
-#: pkg/storaged/crypto-keyslots.jsx:173
+#: pkg/storaged/crypto-keyslots.jsx:174
 msgid "Unlocking disk..."
 msgstr "Låser upp disken …"
 
@@ -7217,11 +7494,7 @@ msgstr "Låser upp disken …"
 msgid "Unmanaged Interfaces"
 msgstr "Ej hanterade gränssnitt"
 
-#: pkg/systemd/init.js:576
-msgid "Unmask"
-msgstr "Avmaskera"
-
-#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:308
 msgid "Unmount"
 msgstr "Avmontera"
 
@@ -7233,37 +7506,33 @@ msgstr "Avmonterar $target"
 msgid "Unnamed"
 msgstr "Namnlös"
 
-#: pkg/machines/components/vmnetworktab.jsx:184
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Unplug"
 msgstr "Koppla ur"
 
-#: pkg/storaged/content-views.jsx:159
+#: pkg/storaged/content-views.jsx:163
 msgid "Unrecognized Data"
 msgstr "Okända data"
 
-#: pkg/storaged/content-views.jsx:358
+#: pkg/storaged/content-views.jsx:363
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Okända data"
 
-#: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
+#: pkg/storaged/lvol-tabs.jsx:90 pkg/storaged/lvol-tabs.jsx:179
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Okända data får inte göras mindre här."
-
-#: node_modules/registry-image-widgets/views/image-listing.html:46
-msgid "Unresolved"
-msgstr "Ej upplöst"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "Uppsättningsmekanism som ej stöds"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Unsupported volume"
 msgstr "Volym som ej stöds"
 
-#: src/base1/cockpit.js:4019 src/base1/cockpit.js:4021
+#: src/base1/cockpit.js:4023 src/base1/cockpit.js:4025
 msgid "Untrusted host"
 msgstr "Ej betrodd värd"
 
@@ -7271,11 +7540,11 @@ msgstr "Ej betrodd värd"
 msgid "Up since $0"
 msgstr "Uppe sedan $0"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:442
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:489
 msgid "Up to $0 $1 available in the default location"
 msgstr ""
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:365
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:402
 msgid "Up to $0 $1 available on the host"
 msgstr ""
 
@@ -7283,11 +7552,11 @@ msgstr ""
 msgid "Update"
 msgstr "Uppdatera"
 
-#: pkg/packagekit/history.jsx:126
+#: pkg/packagekit/history.jsx:125
 msgid "Update History"
 msgstr "Uppdatera historiken"
 
-#: pkg/packagekit/updates.jsx:471
+#: pkg/packagekit/updates.jsx:473
 msgid "Update Log"
 msgstr "Uppdatera loggen"
 
@@ -7295,11 +7564,11 @@ msgstr "Uppdatera loggen"
 msgid "Updated"
 msgstr "Uppdaterat"
 
-#: pkg/packagekit/updates.jsx:494
+#: pkg/packagekit/updates.jsx:496
 msgid "Updated packages may require a restart to take effect."
 msgstr "Uppdaterade paket kan behöva en omstart för att få effekt."
 
-#: pkg/systemd/host.js:502
+#: pkg/systemd/host.js:515
 msgid "Updates Available"
 msgstr "Uppdateringar tillgängliga"
 
@@ -7307,21 +7576,25 @@ msgstr "Uppdateringar tillgängliga"
 msgid "Updating"
 msgstr "Uppdaterar"
 
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
+#: pkg/systemd/service-details.jsx:408
+msgid "Updating status..."
+msgstr ""
+
+#: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Användning"
 
-#: pkg/systemd/host.js:1613
+#: pkg/systemd/host.js:1673
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Användning av $0 CPU-kärna"
 msgstr[1] "Användning av $0 CPU-kärnor"
 
-#: pkg/storaged/vdos-panel.jsx:87
+#: pkg/storaged/vdos-panel.jsx:95
 msgid "Use 512 Byte emulation"
 msgstr "Använd 512-byteemulering"
 
-#: pkg/machines/components/diskAdd.jsx:524
+#: pkg/machines/components/diskAdd.jsx:432
 msgid "Use Existing"
 msgstr "Använd befintlig"
 
@@ -7329,15 +7602,15 @@ msgstr "Använd befintlig"
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Använd följande nycklar för att autentisera mot andra system"
 
-#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
+#: pkg/systemd/index.html:267 pkg/docker/storage.jsx:344
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1678
+#: pkg/machines/components/vmDisksTab.jsx:106 pkg/storaged/fsys-tab.jsx:196
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1738
 msgid "Used"
 msgstr "Använt"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
 msgid "Used by"
 msgstr ""
 
@@ -7346,8 +7619,8 @@ msgid "Used by Containers"
 msgstr "Används av behållare"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1584
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:241
+#: pkg/systemd/host.js:1644
 msgid "User"
 msgstr "Användare"
 
@@ -7360,7 +7633,7 @@ msgstr "Användarnamn"
 msgid "User Password"
 msgstr "Användarens lösenord"
 
-#: pkg/lib/machine-sync-users.html:54 pkg/lib/machine-change-auth.html:18
+#: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
 #: src/ws/login.html:43
 msgid "User name"
 msgstr "Användarnamn"
@@ -7369,7 +7642,7 @@ msgstr "Användarnamn"
 msgid "User name cannot be empty"
 msgstr "Användarnamnet får inte vara tomt"
 
-#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Användarnamn"
 
@@ -7381,11 +7654,11 @@ msgstr "Använder tillgängliga kreditiv"
 msgid "VCPU settings could not be saved"
 msgstr "VCPU-inställningarna kunde inte sparas"
 
-#: pkg/storaged/content-views.jsx:155
+#: pkg/storaged/content-views.jsx:159
 msgid "VDO Backing"
 msgstr "VDO-underlag"
 
-#: pkg/storaged/content-views.jsx:356
+#: pkg/storaged/content-views.jsx:361
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "VDO-underlag"
@@ -7394,24 +7667,24 @@ msgstr "VDO-underlag"
 msgid "VDO Device"
 msgstr "VDO-enhet"
 
-#: pkg/storaged/utils.js:252 pkg/storaged/vdo-details.jsx:255
+#: pkg/storaged/utils.js:253 pkg/storaged/vdo-details.jsx:261
 msgid "VDO Device $0"
 msgstr "VDO-enhet $0"
 
-#: pkg/storaged/vdos-panel.jsx:166
+#: pkg/storaged/vdos-panel.jsx:176
 msgid "VDO Devices"
 msgstr "VDO-enheter"
 
-#: pkg/storaged/lvol-tabs.jsx:84 pkg/storaged/lvol-tabs.jsx:171
+#: pkg/storaged/lvol-tabs.jsx:85 pkg/storaged/lvol-tabs.jsx:172
 msgid "VDO backing devices can not be made smaller"
 msgstr "VDO-underlagsenheter kan inte göras mindre"
 
-#: pkg/storaged/vdos-panel.jsx:172
+#: pkg/storaged/vdos-panel.jsx:182
 msgid "VDO support not installed"
 msgstr "VDO-stöd är inte installerat"
 
-#: pkg/networkmanager/interfaces.js:2514 pkg/networkmanager/interfaces.js:2526
-#: pkg/networkmanager/interfaces.js:2906
+#: pkg/networkmanager/interfaces.js:2533 pkg/networkmanager/interfaces.js:2545
+#: pkg/networkmanager/interfaces.js:2926
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7439,7 +7712,7 @@ msgstr ""
 msgid "VM $0 failed to get deleted"
 msgstr ""
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1305
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
 msgid "VM $0 failed to get installed"
 msgstr ""
 
@@ -7492,7 +7765,7 @@ msgid "Validating key"
 msgstr "Validerar nyckeln"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:249
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:254
 msgid "Vendor"
 msgstr "Leverantör"
 
@@ -7500,7 +7773,7 @@ msgstr "Leverantör"
 msgid "Verified"
 msgstr "Verifierad"
 
-#: pkg/storaged/crypto-keyslots.jsx:316
+#: pkg/storaged/crypto-keyslots.jsx:324
 msgid "Verify key"
 msgstr "Verifiera nyckel"
 
@@ -7508,8 +7781,8 @@ msgstr "Verifiera nyckel"
 msgid "Verifying"
 msgstr "Verifierar"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/systemd/hwinfo.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
+#: pkg/packagekit/updates.jsx:382 pkg/systemd/hwinfo.jsx:87
 msgid "Version"
 msgstr "Version"
 
@@ -7517,14 +7790,22 @@ msgstr "Version"
 msgid "Very securely erasing $target"
 msgstr "Raderar mycket säkert $target"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:41
-#: pkg/machines/components/networks/networkList.jsx:39
-#: pkg/machines/hostvmslist.jsx:82
+#: pkg/lib/cockpit-components-modifications.jsx:173
+msgid "View automation script"
+msgstr ""
+
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/storagePools/storagePoolList.jsx:46
+#: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Virtuella maskiner"
 
 #: pkg/machines/components/create-vm-dialog/pxe-helpers.js:161
 msgid "Virtual Network"
+msgstr ""
+
+#: pkg/machines/components/networks/createNetworkDialog.jsx:412
+msgid "Virtual Network failed to be created"
 msgstr ""
 
 #: pkg/machines/components/libvirtSlate.jsx:80
@@ -7535,11 +7816,12 @@ msgstr "Virtualiseringstjänsten (libvirt) är inte aktiv"
 msgid "Virtualization Service is Available"
 msgstr "Virtualiseringstjänsten är tillgänglig"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:413
-#: pkg/machines/components/vm/bootOrderModal.jsx:96
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
+#: pkg/machines/components/diskAdd.jsx:90
+#: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/machines/components/diskAdd.jsx:89 pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Volym"
 
@@ -7547,20 +7829,31 @@ msgstr "Volym"
 msgid "Volume Group"
 msgstr "Volymgrupp"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/utils.js:248 pkg/storaged/vgroup-details.jsx:229
 msgid "Volume Group $0"
 msgstr "Volymgrupp $0"
 
-#: pkg/storaged/vgroups-panel.jsx:113
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:200
+msgid "Volume Group name"
+msgstr ""
+
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:284
+msgid "Volume Group name should not be empty"
+msgstr ""
+
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr "Volymgrupper"
 
-#: pkg/storaged/lvol-tabs.jsx:410
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:65
+msgid "Volume failed to be created"
+msgstr ""
+
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Volume size is $0. Content size is $1."
 msgstr ""
 
 #: pkg/docker/index.html:517
-#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Volymer"
 
@@ -7572,12 +7865,12 @@ msgstr "Volymer:"
 msgid "WWPN"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:836
+#: pkg/networkmanager/interfaces.js:850
 msgid "Waiting"
 msgstr "Väntar"
 
-#: pkg/selinux/setroubleshoot-view.jsx:72
-#: pkg/selinux/setroubleshoot-view.jsx:170
+#: pkg/selinux/setroubleshoot-view.jsx:73
+#: pkg/selinux/setroubleshoot-view.jsx:171
 msgid "Waiting for details..."
 msgstr "Väntar på detaljer …"
 
@@ -7585,16 +7878,16 @@ msgstr "Väntar på detaljer …"
 msgid "Waiting for other programs to finish using the package manager..."
 msgstr "Väntar på att andra program skall sluta använda pekethanteraren …"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:140
-#: pkg/lib/cockpit-components-install-dialog.jsx:175
+#: pkg/lib/cockpit-components-install-dialog.jsx:141
+#: pkg/lib/cockpit-components-install-dialog.jsx:176
 msgid "Waiting for other software management operations to finish"
 msgstr "Väntar på att andra programvaruhanteringsåtgärder skall bli klara"
 
-#: pkg/systemd/init.js:724
+#: pkg/systemd/service-details.jsx:424
 msgid "Wanted By"
 msgstr "Önskat av"
 
-#: pkg/systemd/init.js:719
+#: pkg/systemd/service-details.jsx:419
 msgid "Wants"
 msgstr "Önskar"
 
@@ -7606,7 +7899,7 @@ msgstr "Varning och högre"
 msgid "Web Console for Linux servers"
 msgstr "Webbkonsol för Linuxservrar"
 
-#: pkg/systemd/services.html:237
+#: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "Onsdag"
 
@@ -7614,11 +7907,11 @@ msgstr "Onsdag"
 msgid "Wednesdays"
 msgstr ""
 
-#: pkg/systemd/services.html:466
+#: pkg/systemd/services.html:321
 msgid "Weeks"
 msgstr "Veckor"
 
-#: pkg/storaged/crypto-keyslots.jsx:324
+#: pkg/storaged/crypto-keyslots.jsx:332
 msgid "What if tang-show-keys is not available?"
 msgstr "Vad gör man om tang-show-keys inte är tillgängligt?"
 
@@ -7630,11 +7923,11 @@ msgstr ""
 msgid "With terminal"
 msgstr "Med terminal"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/mdraid-details.jsx:96
 msgid "Write-mostly"
 msgstr "Skriv huvudsakligen"
 
-#: pkg/storaged/plot.jsx:313
+#: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Skriver"
 
@@ -7642,11 +7935,11 @@ msgstr "Skriver"
 msgid "Wrong user name or password"
 msgstr "Fel användarnamn eller lösenord"
 
-#: pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1997
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2593
+#: pkg/networkmanager/interfaces.js:2613
 msgid "Yes"
 msgstr "Ja"
 
@@ -7658,15 +7951,15 @@ msgstr ""
 "Du är ansluten till {{#strong}}{{host}}{{/strong}}, dock, för att "
 "synkronisera användare krävs en användare med superanvändarens rättigheter."
 
-#: pkg/dashboard/list.js:440
+#: pkg/dashboard/list.js:448
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
 "Du är för närvarande ansluten direkt till denna server.  Du kan inte ta bort "
 "den."
 
-#: pkg/networkmanager/firewall.jsx:69 pkg/networkmanager/firewall.jsx:115
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/firewall.jsx:879
+#: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
+#: pkg/networkmanager/firewall.jsx:905 pkg/networkmanager/firewall.jsx:911
 msgid "You are not authorized to modify the firewall."
 msgstr "Du har inte rättigheter att ändra brandväggen."
 
@@ -7678,7 +7971,7 @@ msgstr ""
 "Du har inte rättigheter att se de auktoriserade publika nycklarna för detta "
 "konto."
 
-#: pkg/docker/storage.jsx:504
+#: pkg/docker/storage.jsx:520
 msgid "You don't have permission to manage the Docker storage pool."
 msgstr "Du har inte rättigheter att hantera lagringspoolen för Docker."
 
@@ -7686,12 +7979,11 @@ msgstr "Du har inte rättigheter att hantera lagringspoolen för Docker."
 msgid "You must wait longer to change your password"
 msgstr "Du måste vänta längre på att ändra ditt lösenord"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:128
-msgid ""
-"You need to select the most closely matching OS vendor and Operating System"
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:125
+msgid "You need to select the most closely matching Operating System"
 msgstr ""
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:837
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -7700,7 +7992,7 @@ msgstr ""
 "uppdateringsprocessen.  Du kan återansluta om några ögonblick för att "
 "fortsätta följa förloppet."
 
-#: pkg/packagekit/updates.jsx:865
+#: pkg/packagekit/updates.jsx:868
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -7708,40 +8000,36 @@ msgstr ""
 "Din server kommer stänga förbindelsen snart.  Du kan återansluta efter att "
 "den har startat om."
 
-#: src/base1/cockpit.js:4009
+#: src/base1/cockpit.js:4013
 msgid "Your session has been terminated."
 msgstr "Din session har avslutats."
 
-#: src/base1/cockpit.js:4011
+#: src/base1/cockpit.js:4015
 msgid "Your session has expired. Please log in again."
 msgstr "Din session har gått ut.  Logga in igen."
 
-#: pkg/networkmanager/firewall.jsx:925
+#: pkg/networkmanager/firewall.jsx:957
 msgid "Zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:938
+#: pkg/networkmanager/firewall.jsx:970
 msgid "Zones"
 msgstr ""
 
-#: pkg/lib/journal.js:215
+#: pkg/lib/journal.js:217
 msgid "[$0 bytes of binary data]"
 msgstr "[$0 byte med binärdata]"
 
-#: pkg/lib/journal.js:217
+#: pkg/lib/journal.js:219
 msgid "[binary data]"
 msgstr "[binärdata]"
 
-#: pkg/lib/journal.js:211
+#: pkg/lib/journal.js:213
 msgid "[no data]"
 msgstr "[inga data]"
 
-#: build-results/cockpit-197.x-1.wip.fc30.src.rpm:2946
-msgid "]:ίp8RB%-Q2)g*)-ŉíÄ"
-msgstr ""
-
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
 msgid "active"
 msgstr "aktiv"
@@ -7762,7 +8050,7 @@ msgstr "klockan"
 msgid "bridge"
 msgstr "brygga"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "bug fix"
 msgstr "felrättning"
 
@@ -7819,7 +8107,7 @@ msgstr "t.ex. ”$0”"
 msgid "enabled"
 msgstr "aktiverat"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "enhancement"
 msgstr "förbättring"
 
@@ -7831,7 +8119,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "varje dag"
 
-#: pkg/systemd/host.js:886
+#: pkg/systemd/host.js:940
 msgid "failed to list ssh host keys: $0"
 msgstr "misslyckades att lista ssh-värdnycklar: $0"
 
@@ -7847,23 +8135,23 @@ msgstr ""
 msgid "hostdev"
 msgstr "värdenhet"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:183
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:169
 msgid "iSCSI Initiator IQN"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:78
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:64
 msgid "iSCSI Target"
 msgstr ""
 
-#: pkg/storaged/iscsi-panel.jsx:261
+#: pkg/storaged/iscsi-panel.jsx:268
 msgid "iSCSI Targets"
 msgstr "iSCSI-mål"
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:83
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:70
 msgid "iSCSI direct Target"
 msgstr ""
 
-#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:208
+#: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:194
 msgid "iSCSI target IQN"
 msgstr ""
 
@@ -7871,16 +8159,16 @@ msgstr ""
 msgid "idle"
 msgstr "overksam"
 
-#: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/machines/components/networks/network.jsx:59
+#: pkg/machines/components/storagePools/storagePool.jsx:70
 msgid "inactive"
 msgstr "inaktiv"
 
-#: pkg/kdump/kdump-view.jsx:376
+#: pkg/kdump/kdump-view.jsx:378
 msgid "invalid: multiple targets defined"
 msgstr "felaktigt: flera mål definierade"
 
-#: pkg/kdump/kdump-view.jsx:493
+#: pkg/kdump/kdump-view.jsx:495
 msgid "kdump status"
 msgstr "kdump-status"
 
@@ -7888,11 +8176,11 @@ msgstr "kdump-status"
 msgid "key"
 msgstr "nyckel"
 
-#: pkg/storaged/crypto-keyslots.jsx:350
+#: pkg/storaged/crypto-keyslots.jsx:358
 msgid "key slot $0"
 msgstr "nyckelfack $0"
 
-#: pkg/kdump/kdump-view.jsx:380 pkg/kdump/kdump-view.jsx:382
+#: pkg/kdump/kdump-view.jsx:382 pkg/kdump/kdump-view.jsx:384
 msgid "locally in $0"
 msgstr "lokalt i $0"
 
@@ -7908,20 +8196,19 @@ msgstr "nätverk"
 msgid "nfs dump target isn't formated as server:path"
 msgstr "nfs-dumpmålet är inte formaterat som server:sökväg"
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "nej"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "ingen"
 
-#: pkg/systemd/host.js:691
+#: pkg/systemd/host.js:738
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "av $0 CPU-kärna"
@@ -7930,14 +8217,6 @@ msgstr[1] "av $0 CPU-kärnor"
 #: pkg/machines/helpers.js:190
 msgid "paused"
 msgstr "stannad"
-
-#: pkg/machines/components/diskAdd.jsx:154
-msgid "qcow2"
-msgstr "qcow2"
-
-#: pkg/machines/components/diskAdd.jsx:157
-msgid "raw"
-msgstr "rå"
 
 #: pkg/tuned/change-profile.jsx:42
 msgid "recommended"
@@ -7955,7 +8234,7 @@ msgstr "kör"
 msgid "search by name, namespace or description"
 msgstr "leta efter namn, namnrymd eller beskrivning"
 
-#: pkg/packagekit/updates.jsx:261
+#: pkg/packagekit/updates.jsx:262
 msgid "security"
 msgstr "säkerhet"
 
@@ -7987,7 +8266,7 @@ msgstr "stäng av"
 msgid "shutdown"
 msgstr "avstängning"
 
-#: pkg/selinux/setroubleshoot-view.jsx:123
+#: pkg/selinux/setroubleshoot-view.jsx:124
 msgid "solution details"
 msgstr "lösningsdetaljer"
 
@@ -8027,8 +8306,7 @@ msgstr "udp"
 msgid "undefined"
 msgstr "odefinierad"
 
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:249 pkg/systemd/init.js:263
+#: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "okänd"
 
@@ -8036,7 +8314,7 @@ msgstr "okänd"
 msgid "unknown target"
 msgstr "okänt mål"
 
-#: pkg/storaged/utils.js:427
+#: pkg/storaged/utils.js:431
 msgid "unpartitioned space on $0"
 msgstr "opartitionerat utrymmer på $0"
 
@@ -8068,1423 +8346,15 @@ msgstr "värde"
 msgid "vhostuser"
 msgstr "vhost-användare"
 
-#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:783
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:836
 msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
 
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:62
-#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:65
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
+#: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "ja"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:6
-msgid ""
-"{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
-"count: {{ condition.generation }}"
-msgstr ""
-"{{ condition.message }}.  Tidsstämpel: {{ condition.lastTransitionTime }}  "
-"Felantal: {{ condition.generation }}"
-
-#~ msgid " 1\"Do you want to delete the following Nodes?"
-#~ msgstr " 1\"Vill du radera följande noder?"
-
-#~ msgid "$0 vCPU Details"
-#~ msgstr "$0 vCPU-detaljer"
-
-#~ msgid "$0% Free"
-#~ msgid_plural "$0% Free"
-#~ msgstr[0] "$0 % fritt"
-#~ msgstr[1] "$0 % fritt"
-
-#~ msgid "$0% Used"
-#~ msgid_plural "$0% Used"
-#~ msgstr[0] "$0 % använt"
-#~ msgstr[1] "$0 % använt"
-
-#~ msgid "'Organization' required to register."
-#~ msgstr "“Organisation” krävs för att registrera."
-
-#~ msgid "'Organization' required when using activation keys."
-#~ msgstr "“Organisation” krävs vid användning av aktiveringsnycklar."
-
-#~ msgid "AWS Elastic Block Store"
-#~ msgstr "AWS elastisk blocklagring"
-
-#~ msgid "Access Modes"
-#~ msgstr "Åtkomstlägen"
-
-#~ msgid "Access denied"
-#~ msgstr "Åtkomst nekas"
-
-#~ msgid "Action"
-#~ msgstr "Åtgärd"
-
-#~ msgid "Activation Key"
-#~ msgstr "Aktiveringsnyckel"
-
-#~ msgid "Actual"
-#~ msgstr "Aktuell"
-
-#~ msgid "Add Cluster Node"
-#~ msgstr "Lägg till klusternod"
-
-#~ msgid "Add Group"
-#~ msgstr "Lägg till grupp"
-
-#~ msgid "Add Kubernetes Node"
-#~ msgstr "Lägg till Kubernetesnod"
-
-#~ msgid "Add Member"
-#~ msgstr "Lägg till medlem"
-
-#~ msgid "Add Membership"
-#~ msgstr "Lägg till medlemskap"
-
-#~ msgid "Add New Cluster"
-#~ msgstr "Lägg till nytt kluster"
-
-#~ msgid "Add New User"
-#~ msgstr "Lägg till ny användare"
-
-#~ msgid "Add Role"
-#~ msgstr "Lägg till roll"
-
-#~ msgid "Add User"
-#~ msgstr "Lägg till användare"
-
-#~ msgid "Add membership"
-#~ msgstr "Lägg till medlemskap"
-
-#~ msgid "Adjust"
-#~ msgstr "Justera"
-
-#~ msgid "Adjust Persistent Volume '{{ item.metadata.name }}'"
-#~ msgstr "Justera beständig volym ”{{ item.metadata.name }}”"
-
-#~ msgid "Adjust Replication Controller {{ item.metadata.name }}"
-#~ msgstr "Justera replikeringskontroll {{ item.metadata.name }}"
-
-#~ msgid "Adjust Route"
-#~ msgstr "Justera rutt"
-
-#~ msgid "Adjust Service"
-#~ msgstr "Justera tjänst"
-
-#~ msgid "Admin"
-#~ msgstr "Admin"
-
-#~ msgid "All Projects"
-#~ msgstr "Alla projekt"
-
-#~ msgid "All Types"
-#~ msgstr "Alla typer"
-
-#~ msgid "All healthy"
-#~ msgstr "Alla friska"
-
-#~ msgid "All images"
-#~ msgstr "Alla bilder"
-
-#~ msgid "All in use"
-#~ msgstr "Alla används"
-
-#~ msgid "All running"
-#~ msgstr "Alla kör"
-
-#~ msgid "All running virtual machines will be turned off."
-#~ msgstr "Alla körande virtuella maskiner kommer stängas av."
-
-#~ msgid "Anonymous: Allow all unauthenticated users to pull images"
-#~ msgstr "Anonymt: tillåt alla oautentiserade användare att hämta avbilder"
-
-#~ msgid "Automatically selected host"
-#~ msgstr "Automatiskt vald värd"
-
-#~ msgid "Azure"
-#~ msgstr "Azure"
-
-#~ msgid "Base Template"
-#~ msgstr "Basmall"
-
-#~ msgid "Base template"
-#~ msgstr "Basmall"
-
-#~ msgid "Base template:"
-#~ msgstr "Basmall:"
-
-#~ msgid "Boot ID"
-#~ msgstr "Start-ID"
-
-#~ msgid "CPU Utilization: $0%"
-#~ msgstr "CPU-användning: $0 %"
-
-#~ msgid "CREATE VM action failed"
-#~ msgstr "Åtgärden SKAPA VM misslyckades"
-
-#~ msgid "Cannot decrypt PEM-encoded private key"
-#~ msgstr "Kan inte dektryptera en PEM-kodad privat nyckel"
-
-#~ msgid "Ceph Filesystem Mount"
-#~ msgstr "Ceph-filsystemsmontering"
-
-#~ msgid "Ceph Monitors"
-#~ msgstr "Ceph-övervakare"
-
-#~ msgid "Change User"
-#~ msgstr "Ändra användare"
-
-#~ msgid "Change image stream"
-#~ msgstr "Ändra avbildsström"
-
-#~ msgid "Change project"
-#~ msgstr "Ändra projekt"
-
-#~ msgid "Cinder"
-#~ msgstr "Cinder"
-
-#~ msgid "Claim"
-#~ msgstr "Anspråk"
-
-#~ msgid "Claim Name"
-#~ msgstr "Anspråksnamn"
-
-#~ msgid "Client Certificate"
-#~ msgstr "Klientcertifikat"
-
-#~ msgid "Cluster"
-#~ msgstr "Kluster"
-
-#~ msgid "Cluster Templates"
-#~ msgstr "Klustermallar"
-
-#~ msgid "Cluster Virtual Machines"
-#~ msgstr "Klustrets virtuella maskiner"
-
-#~ msgid "Configuration"
-#~ msgstr "Konfiguration"
-
-#~ msgid "Configure Flannel networking"
-#~ msgstr "Konfigurera Flannel-nätverk"
-
-#~ msgid "Configure Kubelet and Proxy"
-#~ msgstr "Konfigurerar Kubelet och Proxy"
-
-#~ msgid "Confirm migration"
-#~ msgstr "Bekräfta migrering"
-
-#~ msgid "Confirm reload:"
-#~ msgstr "Bekräfta omladdning:"
-
-#~ msgid "Confirm save:"
-#~ msgstr "Bekräfta sparandet:"
-
-#~ msgid "Connect to oVirt Engine"
-#~ msgstr "Anslut till oVirt Engine"
-
-#~ msgid "Connecting..."
-#~ msgstr "Ansluter …"
-
-#~ msgid "Connection Error: $0"
-#~ msgstr "Anslutningsfel: $0"
-
-#~ msgid "Connection Settings"
-#~ msgstr "Anslutningsinställningar"
-
-#~ msgid "Container ID"
-#~ msgstr "Behållar-ID"
-
-#~ msgid "Container Runtime Version"
-#~ msgstr "Behållarnas körtidsversion"
-
-#~ msgid "Could not list services"
-#~ msgstr "Kunde inte lista tjänster"
-
-#~ msgid "Could not parse PEM-encoded certificate"
-#~ msgstr "Kunde inte tolka PEM-kodat certifikat"
-
-#~ msgid "Could not parse PEM-encoded private key"
-#~ msgstr "Kunde inte tolka PEM-kodad privat nyckel"
-
-#~ msgid "Couldn't connect to server"
-#~ msgstr "Kunde inte ansluta till servern"
-
-#~ msgid "Couldn't find running API server"
-#~ msgstr "Kunde inte hitta en körande API-server"
-
-#~ msgid ""
-#~ "Couldn't get system subscription status. Please ensure subscription-"
-#~ "manager is installed."
-#~ msgstr ""
-#~ "Kunde inte få fram systemets prenumerationsstatus.  Se till att "
-#~ "subscription-manager är installerad."
-
-#~ msgid "Create New VM"
-#~ msgstr "Skapa en ny VM"
-
-#~ msgid "Create empty image stream"
-#~ msgstr "Skapa en tom avbildsström"
-
-#~ msgid "Create image stream"
-#~ msgstr "Skapa en avbildsström"
-
-#~ msgid "Custom URL"
-#~ msgstr "Anpassad URL"
-
-#~ msgid "DNS Policy"
-#~ msgstr "DNS-policy"
-
-#~ msgid "Delete '{{ name }}'"
-#~ msgstr "Ta bort”{{ name }}”"
-
-#~ msgid "Delete Node"
-#~ msgstr "Ta bort en nod"
-
-#~ msgid "Delete Persistent Volume"
-#~ msgstr "Ta bort en beständig volym"
-
-#~ msgid "Delete Persistent Volume Claim"
-#~ msgstr "Ta bort anspråk på en beständig volym"
-
-#~ msgid "Delete Project"
-#~ msgstr "Ta bort ett projekt"
-
-#~ msgid "Delete Selected"
-#~ msgstr "Ta bort det valda"
-
-#~ msgid "Delete image stream"
-#~ msgstr "Ta bort en avbildsström"
-
-#~ msgid "Delete {{ item.kind }}"
-#~ msgstr "Ta bort en {{ item.kind }}"
-
-#~ msgid ""
-#~ "Deleting a Pod will kill all associated containers. Pods may be "
-#~ "automatically created again in some cases."
-#~ msgstr ""
-#~ "Att ta bort en kapsel kommer döda tillhörande behållare.  Kapslar kan "
-#~ "automatiskt skapas igen i några fall."
-
-#~ msgid "Deploy"
-#~ msgstr "Placera ut"
-
-#~ msgid "Deploy Application"
-#~ msgstr "Placera ut ett program"
-
-#~ msgid "Deployment Causes"
-#~ msgstr "Utplaceringsorsaker"
-
-#~ msgid "Deployment Config"
-#~ msgstr "Utplaceringskonfiguration"
-
-#~ msgid "Deployment Configs"
-#~ msgstr "Utplaceringskonfigurationer"
-
-#~ msgid "Description:"
-#~ msgstr "Beskrivning:"
-
-#~ msgid "Disk Utilization: $0%"
-#~ msgstr "Diskanvändning: $0 %"
-
-#~ msgid "Display name"
-#~ msgstr "Visningsnamn"
-
-#~ msgid "Do you want to add the role '{{ fields.displayRole }}'?"
-#~ msgstr "Vill du lägga till rollen ”{{ fields.displayRole }}”?"
-
-#~ msgid ""
-#~ "Do you want to delete the '{{stream.metadata.namespace}}/{{stream."
-#~ "metadata.name}}' image stream?"
-#~ msgstr ""
-#~ "Vill du ta bort avbildsströmmen ”{{stream.metadata.namespace}}/{{stream."
-#~ "metadata.name}}”?"
-
-#~ msgid ""
-#~ "Do you want to delete the Persistent Volume '{{item.metadata.name}}'?"
-#~ msgstr "Vill du ta bort den beständiga volymen ”{{item.metadata.name}}”?"
-
-#~ msgid ""
-#~ "Do you want to delete the Persistent Volume Claim '{{item.metadata."
-#~ "name}}'?"
-#~ msgstr ""
-#~ "Vill du ta bort anspråket på den beständiga volymen ”{{item.metadata."
-#~ "name}}”?"
-
-#~ msgid "Do you want to delete the {{ item.kind }} '{{item.metadata.name}}'?"
-#~ msgstr "Vill du ta bort {{ item.kind }} ”{{item.metadata.name}}”?"
-
-#~ msgid "Do you want to delete this Node?"
-#~ msgstr "Vill du ta bort denna nod?"
-
-#~ msgid ""
-#~ "Do you want to remove the image tagged as '{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}'?"
-#~ msgstr ""
-#~ "Vill du ta bort avbilden med etiketten ”{{stream.metadata.namespace}}/"
-#~ "{{stream.metadata.name}}:{{tag.tag}}”?"
-
-#~ msgid ""
-#~ "Do you want to remove the role '{{ fields.displayRole }}' from member "
-#~ "{{ fields.member.metadata.name }}?"
-#~ msgstr ""
-#~ "Vill du ta bort rollen ”{{ fields.displayRole }}” från medlemmen "
-#~ "{{ fields.member.metadata.name }}?"
-
-#~ msgid "Don't pull images automatically"
-#~ msgstr "Hämta inte avbilder automatiskt"
-
-#~ msgid "Driver"
-#~ msgstr "Drivrutin"
-
-#~ msgid "Edit the vdsm.conf"
-#~ msgstr "Redigera vdsm.conf"
-
-#~ msgid "Empty Directory"
-#~ msgstr "Tom katalog"
-
-#~ msgid "Endpoint"
-#~ msgstr "Ändpunkt"
-
-#~ msgid "Endpoint Name"
-#~ msgstr "Ändpunktsnamn"
-
-#~ msgid "Endpoints"
-#~ msgstr "Ändpunkter"
-
-#~ msgid "Ends"
-#~ msgstr "Slutar"
-
-#~ msgid "Enter New VM name"
-#~ msgstr "Ange nytt VM-namn"
-
-#~ msgid "Error getting certificate details: $0"
-#~ msgstr "Fel när certifikatdetaljer hämtades: $0"
-
-#~ msgid "Error writing kubectl config"
-#~ msgstr "Fel när konfiguration av kubectl skrevs"
-
-#~ msgid "FQDN"
-#~ msgstr "FQDN"
-
-#~ msgid "Fibre Channel"
-#~ msgstr "Fiberkanal"
-
-#~ msgid "Filesystem Type"
-#~ msgstr "Filsystemstyp"
-
-#~ msgid "Flex"
-#~ msgstr "Flex"
-
-#~ msgid "Flocker"
-#~ msgstr "Flocker"
-
-#~ msgid "Flocker Dataset Name"
-#~ msgstr "Flockers datamängdsnamn"
-
-#~ msgid "GCE Persistent Disk"
-#~ msgstr "GCE beständig disk"
-
-#~ msgid "Git Repository"
-#~ msgstr "Git-förråd"
-
-#~ msgid "Gluster FS"
-#~ msgstr "Gluster-FS"
-
-#~ msgid "GlusterFS"
-#~ msgstr "GlusterFS"
-
-#~ msgid "Grant additional push or admin access to specific members below."
-#~ msgstr ""
-#~ "Ge ytterligare push- eller admin-åtkomst till de specifika medlemmarna "
-#~ "nedan."
-
-#~ msgid "Group Members"
-#~ msgstr "Gruppmedlemmar"
-
-#~ msgid "Group or Project"
-#~ msgstr "Grupp eller projekt"
-
-#~ msgid "Groups"
-#~ msgstr "Grupper"
-
-#~ msgid "HA"
-#~ msgstr "HA"
-
-#~ msgid "HA:"
-#~ msgstr "HA:"
-
-#~ msgid "Host Path"
-#~ msgstr "Värdsökväg"
-
-#~ msgid "Host to Maintenance"
-#~ msgstr "Värd till underhåll"
-
-#~ msgid "IP"
-#~ msgstr "IP"
-
-#~ msgid "ISCSI"
-#~ msgstr "ISCSI"
-
-#~ msgid "Identities"
-#~ msgstr "Identiteter"
-
-#~ msgid "Identity"
-#~ msgstr "Identitet"
-
-#~ msgid "Image ID"
-#~ msgstr "Avbilds-ID"
-
-#~ msgid "Image Name"
-#~ msgstr "Avbildsnamn"
-
-#~ msgid "Image Registry"
-#~ msgstr "Avbildsregister"
-
-#~ msgid "Image Stream"
-#~ msgstr "Avbildsström"
-
-#~ msgid "Image commands"
-#~ msgstr "Avbildskommandon"
-
-#~ msgid "Images by project"
-#~ msgstr "Avbilder per projekt"
-
-#~ msgid "Images pushed recently"
-#~ msgstr "Avbilder trycktes upp nyligen"
-
-#~ msgid ""
-#~ "In order to begin pushing images to the registry, use the commands below."
-#~ msgstr ""
-#~ "För att börja trycka avbilder till registret, använd kommandona nedan."
-
-#~ msgid ""
-#~ "In order to begin pushing images to the registry, you need to create a "
-#~ "project."
-#~ msgstr ""
-#~ "För att börja trycka avbilder till registret behöver du skapa ett projekt."
-
-#~ msgid "Installed products"
-#~ msgstr "Installerade produkter"
-
-#~ msgid "Interface"
-#~ msgstr "Gränssnitt"
-
-#~ msgid "Invalid credentials"
-#~ msgstr "Felaktiga kreditiv"
-
-#~ msgid "Kernel Version"
-#~ msgstr "Kärnversion"
-
-#~ msgid "Key Ring Path"
-#~ msgstr "Nyckelringssökväg"
-
-#~ msgid "Kubelet Version"
-#~ msgstr "Kubelet-version"
-
-#~ msgid "Kubernetes Cluster"
-#~ msgstr "Kubernetes-kluster"
-
-#~ msgid "Last Heartbeat"
-#~ msgstr "Senaste hjärtslag"
-
-#~ msgid "Last Status Change"
-#~ msgstr "Senaste statusändring"
-
-#~ msgid "Latest Version"
-#~ msgstr "Senaste version"
-
-#~ msgid "Loading data ..."
-#~ msgstr "Läser in data …"
-
-#~ msgid "Log into OpenShift command line tools:"
-#~ msgstr "Logga in till OpenShifts kommandoradsverktyg:"
-
-#~ msgid "Log into the registry:"
-#~ msgstr "Logga in i registret:"
-
-#~ msgid "Logical Unit Number"
-#~ msgstr "Logiskt enhetsnummer"
-
-#~ msgid "Login"
-#~ msgstr "Inloggning"
-
-#~ msgid "Login commands"
-#~ msgstr "Inloggningskommandon"
-
-#~ msgid "Login/password or activation key required to register."
-#~ msgstr ""
-#~ "Inloggning/lösenord eller aktiveringsnyckel krävs för att registrera."
-
-#~ msgid "MIGRATE action failed"
-#~ msgstr "Åtgärden MIGRATE misslyckades"
-
-#~ msgid "Manifest"
-#~ msgstr "Förteckning"
-
-#~ msgid "Medium"
-#~ msgstr "Medium"
-
-#~ msgid "Member of"
-#~ msgstr "Medlem i"
-
-#~ msgid "Members"
-#~ msgstr "Medlemmar"
-
-#~ msgid "Membership"
-#~ msgstr "Medlemskap"
-
-#~ msgid "Memory Utilization: $0%"
-#~ msgstr "Minnesanvändning: $0 %"
-
-#~ msgid "Message"
-#~ msgstr "Meddelande"
-
-#~ msgid "Migrate To:"
-#~ msgstr "Migrera till:"
-
-#~ msgid "Modify"
-#~ msgstr "Modifiera"
-
-#~ msgid "Monitors"
-#~ msgstr "Övervakare"
-
-#~ msgid "Mount Location"
-#~ msgstr "Monteringsplats"
-
-#~ msgid "NFS"
-#~ msgstr "NFS"
-
-#~ msgid "Namespace"
-#~ msgstr "Namnrymd"
-
-#~ msgid "Namespace cannot be empty."
-#~ msgstr "Namnrymden får inte vara tom."
-
-#~ msgid "New Group"
-#~ msgstr "Ny grupp"
-
-#~ msgid "New Project"
-#~ msgstr "Nytt projekt"
-
-#~ msgid "New image stream"
-#~ msgstr "Ny avbildsström"
-
-#~ msgid "New project"
-#~ msgstr "Nytt projekt"
-
-#~ msgid "No PEM-encoded certificate found"
-#~ msgstr "Inget PEM-kodat certifikat hittat"
-
-#~ msgid "No PEM-encoded private key found"
-#~ msgstr "Ingen PEM-kodad privat nyckel hittad"
-
-#~ msgid "No Pods are using this claim"
-#~ msgstr "Inga kapslar använder detta anspråk"
-
-#~ msgid "No VM found in oVirt."
-#~ msgstr "Ingen VM hittad i oVirt."
-
-#~ msgid "No Volume Bound"
-#~ msgstr "Ingen volymgräns"
-
-#~ msgid "No groups are present."
-#~ msgstr "Inga grupper finns."
-
-#~ msgid "No images pushed"
-#~ msgstr "Inga avbilder trycktes"
-
-#~ msgid "No installed products on the system."
-#~ msgstr "Inga installerade produkter på systemet."
-
-#~ msgid ""
-#~ "No metadata file was selected. Please select a Kubernetes metadata file."
-#~ msgstr "Ingen metadatafil valdes.  Välj en fil med Kubernetes metadata."
-
-#~ msgid "No nodes in cluster"
-#~ msgstr "Inga noder i klustret"
-
-#~ msgid "No oVirt connection"
-#~ msgstr "Ingen oVirt-förbindelse"
-
-#~ msgid "No pods deployed"
-#~ msgstr "Inga kapslar är utplacerade"
-
-#~ msgid "No pods replicated"
-#~ msgstr "Inga kapslar är replikerade"
-
-#~ msgid "No pods scheduled"
-#~ msgstr "Inga kapslar är schemalagda"
-
-#~ msgid "No pods selected"
-#~ msgstr "Inga kapslar är valda"
-
-#~ msgid "No projects are present."
-#~ msgstr "Inga projekt finns."
-
-#~ msgid "No users are present."
-#~ msgstr "Inga användare finns."
-
-#~ msgid "No volumes are present."
-#~ msgstr "Inga volymer finns."
-
-#~ msgid "No volumes in use"
-#~ msgstr "Inga volymer används"
-
-#~ msgid "Node"
-#~ msgstr "Nod"
-
-#~ msgid "Nodes"
-#~ msgstr "Noder"
-
-#~ msgid "Nodes are the machines that run your containers."
-#~ msgstr "Noder är maskinerna som kör dina behållare."
-
-#~ msgid "Not a valid number of replicas"
-#~ msgstr "Inte ett giltigt antal repliker"
-
-#~ msgid "Not a valid value for Host"
-#~ msgstr "Inte ett giltigt värde på värd"
-
-#~ msgid "Not deployed"
-#~ msgstr "Inte utplacerad"
-
-#~ msgid "Number of virtual CPUs that gonna be used."
-#~ msgstr "Antal virtuella CPU:er som kommer användas."
-
-#~ msgid "OK"
-#~ msgstr "OK"
-
-#~ msgid "OS"
-#~ msgstr "OS"
-
-#~ msgid "OS Type:"
-#~ msgstr "OS-typ:"
-
-#~ msgid "OS Versions"
-#~ msgstr "OS-versioner"
-
-#~ msgid "Optimized for:"
-#~ msgstr "Optimerad för:"
-
-#~ msgid "Organization"
-#~ msgstr "Organisation"
-
-#~ msgid "PD Name"
-#~ msgstr "PD-namn"
-
-#~ msgid "Pending Volume Claims"
-#~ msgstr "Väntande volymanspråk"
-
-#~ msgid "Persistent Volumes"
-#~ msgstr "Beständiga volymer"
-
-#~ msgid "Phase"
-#~ msgstr "Fas"
-
-#~ msgid "Please confirm, the host shall be switched to maintenance mode."
-#~ msgstr "Bekräfta att värden skall slås om till underhållsläge."
-
-#~ msgid "Please create another namespace for $0 \"$1\""
-#~ msgstr "Skapa en annan namnrymd för $0 ”$1”"
-
-#~ msgid "Please provide a GlusterFS volume name"
-#~ msgstr "Ge ett GlusterFS-volymnamn"
-
-#~ msgid "Please provide a username"
-#~ msgstr "Ange ett användarnamn"
-
-#~ msgid "Please provide a valid NFS server"
-#~ msgstr "Ange en giltig NFS-server"
-
-#~ msgid "Please provide a valid address"
-#~ msgstr "Ange en giltig adress"
-
-#~ msgid "Please provide a valid filesystem type"
-#~ msgstr "Ange en giltig filsystemtyp"
-
-#~ msgid "Please provide a valid interface"
-#~ msgstr "Ange ett giltigt gränssnitt"
-
-#~ msgid "Please provide a valid logical unit number"
-#~ msgstr "Ange ett giltigt nummer på en logisk enhet"
-
-#~ msgid "Please provide a valid name"
-#~ msgstr "Ange ett giltigt namn"
-
-#~ msgid "Please provide a valid namespace."
-#~ msgstr "Ange en giltig namnrymd."
-
-#~ msgid "Please provide a valid path"
-#~ msgstr "Ange en giltig sökväg"
-
-#~ msgid "Please provide a valid qualified name"
-#~ msgstr "Ange ett giltigt kvalificerat namn"
-
-#~ msgid "Please provide a valid storage capacity."
-#~ msgstr "Ange en giltig lagringskapacitet."
-
-#~ msgid "Please provide a valid target"
-#~ msgstr "Ange ett giltigt mål"
-
-#~ msgid ""
-#~ "Please provide fully qualified domain name and port of the oVirt engine."
-#~ msgstr "Ange ett full kvalificerat domännamn och en port till oVirt-motorn."
-
-#~ msgid ""
-#~ "Please provide valid oVirt engine fully qualified domain name (FQDN) and "
-#~ "port (443 by default)"
-#~ msgstr ""
-#~ "Ange ett giltigt fullständigt kvalificerat domännamn (FQDN) och en port "
-#~ "(443 som standard) till oVirt-motorn"
-
-#~ msgid ""
-#~ "Please refer to oVirt's $0 for more information about Remote Viewer setup."
-#~ msgstr ""
-#~ "Referera oVirts $0 för mer information om uppsättning av fjärrvisare."
-
-#~ msgid "Please select a valid access mode"
-#~ msgstr "Välj ett giltigt åtkomstläge"
-
-#~ msgid "Please select a valid endpoint"
-#~ msgstr "Välj en giltig slutpunkt"
-
-#~ msgid "Please select a valid policy option."
-#~ msgstr "Välj ett giltigt policyalternativ."
-
-#~ msgid "Please type an address"
-#~ msgstr "Skriv en adress"
-
-#~ msgid "Please wait till VMs list is loaded from the server."
-#~ msgstr "Vänta tills VM-listan är inläst från servern."
-
-#~ msgid "Please wait till list of templates is loaded from the server."
-#~ msgstr "Vänta till listan av mallar är inläst från servern."
-
-#~ msgid "Pod"
-#~ msgstr "Kapsel"
-
-#~ msgid "Pod Address"
-#~ msgstr "Kapseladress"
-
-#~ msgid "Pod Endpoints"
-#~ msgstr "Kapseländpunkter"
-
-#~ msgid "Pod Replicated"
-#~ msgstr "Kapsel replikerad"
-
-#~ msgid "Pod Selector"
-#~ msgstr "Kapselväljare"
-
-#~ msgid "Pods"
-#~ msgstr "Kapslar"
-
-#~ msgid ""
-#~ "Pods contain one or more containers that run together on a node, "
-#~ "containing your application code."
-#~ msgstr ""
-#~ "Kapslar innehåller en eller flera behållare som kör tillsamans på en nod, "
-#~ "och innehåller din programkod."
-
-#~ msgid "Pool Name"
-#~ msgstr "Poolnamn"
-
-#~ msgid "Populate"
-#~ msgstr "Populera"
-
-#~ msgid "Preparing for Maintenance"
-#~ msgstr "Förbereder för underhåll"
-
-#~ msgid "Private: Allow only specific users or groups to pull images"
-#~ msgstr ""
-#~ "Privat: tillåt endast specifika användare eller grupper att hämta avbilder"
-
-#~ msgid "Product ID"
-#~ msgstr "Produkt-ID"
-
-#~ msgid "Product name"
-#~ msgstr "Produktnamn"
-
-#~ msgid "Project"
-#~ msgstr "Projekt"
-
-#~ msgid "Project Members"
-#~ msgstr "Projektmedlemmar"
-
-#~ msgid "Project access policy allows anonymous users to pull images."
-#~ msgstr ""
-#~ "Projektåtkomstpolicyn tillåter anonyma användare att hämta avbilder."
-
-#~ msgid "Project access policy allows any authenticated user to pull images."
-#~ msgstr ""
-#~ "Projektåtkomstpolicyn tillåter alla autentiserade användare att hämta "
-#~ "avbilder."
-
-#~ msgid "Project access policy only allows specific members to access images."
-#~ msgstr ""
-#~ "Projektåtkomstpolicyn tillåter endast specifika medlemmar att komma åt "
-#~ "avbilder."
-
-#~ msgid "Project:"
-#~ msgstr "Projekt:"
-
-#~ msgid "Projects"
-#~ msgstr "Projekt"
-
-#~ msgid "Proxy"
-#~ msgstr "Proxy"
-
-#~ msgid "Proxy Version"
-#~ msgstr "Proxy-version"
-
-#~ msgid "Pull an image:"
-#~ msgstr "Hämta en avbild:"
-
-#~ msgid "Pull from"
-#~ msgstr "Hämta ifrån"
-
-#~ msgid "Pull specific tags from another image repository"
-#~ msgstr "Hämta specifika taggar från ett annat avbildsförråd"
-
-#~ msgid "Push an image:"
-#~ msgstr "Tryck ut en avbild:"
-
-#~ msgid "Qualified Name"
-#~ msgstr "Kvalificerat namn"
-
-#~ msgid "REBOOT action failed"
-#~ msgstr "Åtgärden REBOOT misslyckades"
-
-#~ msgid "Rados Block Device"
-#~ msgstr "Rados-blockenhet"
-
-#~ msgid "Read Only"
-#~ msgstr "Skrivskyddad"
-
-#~ msgid "Read and write from a single node"
-#~ msgstr "Läs och skriv från en enstaka nod"
-
-#~ msgid "Read and write from multiple nodes"
-#~ msgstr "Läs och skriv från flera noder"
-
-#~ msgid "Read only from multiple nodes"
-#~ msgstr "Läs endast från flera noder"
-
-#~ msgid "Reason"
-#~ msgstr "Orsak"
-
-#~ msgid "Reclaim Policy"
-#~ msgstr "Återvinningspolicy"
-
-#~ msgid "Recycle"
-#~ msgstr "Återvinn"
-
-#~ msgid "Register"
-#~ msgstr "Registrera"
-
-#~ msgid "Register New Volume"
-#~ msgstr "Registrera en ny volym"
-
-#~ msgid "Register Persistent Volume"
-#~ msgstr "Registrera en beständig volym"
-
-#~ msgid "Register oVirt"
-#~ msgstr "Registrera oVirt"
-
-#~ msgid "Register system"
-#~ msgstr "Registrera system"
-
-#~ msgid "Registering oVirt to Cockpit"
-#~ msgstr "Registrera oVirt i Cockpit"
-
-#~ msgid "Remote registry is insecure"
-#~ msgstr "Fjärregistret är osäkert"
-
-#~ msgid "Remove Group"
-#~ msgstr "Ta bort grupp"
-
-#~ msgid "Remove Member"
-#~ msgstr "Ta bort medlem"
-
-#~ msgid "Remove Role"
-#~ msgstr "Ta bort roll"
-
-#~ msgid "Remove User"
-#~ msgstr "Ta bort användare"
-
-#~ msgid "Remove image tag"
-#~ msgstr "Ta bort avbildstagg"
-
-#~ msgid "Remove membership"
-#~ msgstr "Ta bort medlemskap"
-
-#~ msgid "Replicas"
-#~ msgstr "Repliker"
-
-#~ msgid "Replication Controller"
-#~ msgstr "Replikeringsstyrare"
-
-#~ msgid "Replication Controllers"
-#~ msgstr "Replikeringsstyrare"
-
-#~ msgid ""
-#~ "Replication controllers dynamically create instances of pods from "
-#~ "templates, and remove pods when necessary."
-#~ msgstr ""
-#~ "Replikeringsstyrare skapar dynamiskt instanser av kapslar från mallar, "
-#~ "och tar bort kapslar vid behov."
-
-#~ msgid "Repository URL"
-#~ msgstr "Förråds-URL"
-
-#~ msgid "Requested"
-#~ msgstr "Begärd"
-
-#~ msgid "Requests"
-#~ msgstr "Begäranden"
-
-#~ msgid "Requires Authentication"
-#~ msgstr "Begär autentisering"
-
-#~ msgid "Restart Count"
-#~ msgstr "Omstartsräknare"
-
-#~ msgid "Retain"
-#~ msgstr "Behåll"
-
-#~ msgid "Retrieving subscription status..."
-#~ msgstr "Hämtar prenumerationsstatus …"
-
-#~ msgid "Revision"
-#~ msgstr "Revision"
-
-#~ msgid "Role"
-#~ msgstr "Roll"
-
-#~ msgid "Route"
-#~ msgstr "Rutt"
-
-#~ msgid "Run Here"
-#~ msgstr "Kör här"
-
-#~ msgid "Running Since:"
-#~ msgstr "Kör sedan:"
-
-#~ msgid "SET VCPU SETTINGS action failed"
-#~ msgstr "Åtgärden SET VCPU SETTINGS misslyckades"
-
-#~ msgid "SHUTDOWN action failed"
-#~ msgstr "Åtgärden SHUTDOWN misslyckades"
-
-#~ msgid "START action failed"
-#~ msgstr "Åtgärden START misslyckades"
-
-#~ msgid "SUSPEND action failed"
-#~ msgstr "Åtgärden SUSPEND misslyckades"
-
-#~ msgid "Scheduled Pods"
-#~ msgstr "Schemalagda kapslar"
-
-#~ msgid "Scheduling Disabled"
-#~ msgstr "Schemaläggningen avaktiverad"
-
-#~ msgid "Secret"
-#~ msgstr "Hemlighet"
-
-#~ msgid "Secret File"
-#~ msgstr "Hemlig fil"
-
-#~ msgid "Secret Name"
-#~ msgstr "Hemligt namn"
-
-#~ msgid "Secret Volume"
-#~ msgstr "Hemlig volym"
-
-#~ msgid "Select Manifest File..."
-#~ msgstr "Välj förteckningsfil …"
-
-#~ msgid "Select Member"
-#~ msgstr "Välj medlem"
-
-#~ msgid "Select Role"
-#~ msgstr "Välj roll"
-
-#~ msgid "Select an object to see more details."
-#~ msgstr "Välj ett objekt för att se fler detaljer."
-
-#~ msgid "Service Account"
-#~ msgstr "Tjänstekonto"
-
-#~ msgid ""
-#~ "Services group pods and provide a common DNS name and an optional, load-"
-#~ "balanced IP address to access them."
-#~ msgstr ""
-#~ "Tjänster grupperar kapslar och tillhandahåller ett gemensamt DNS-namn och "
-#~ "om så önskas en lastbalanserad IP-adress för att komma åt dem."
-
-#~ msgid "Session Affinity"
-#~ msgstr "Sessionsaffinitet"
-
-#~ msgid "Share Name"
-#~ msgstr "Delat namn"
-
-#~ msgid "Shared: Allow any authenticated user to pull images"
-#~ msgstr "Delat: tillåt alla autentiserade användare att hämta avbilder"
-
-#~ msgid "Shell"
-#~ msgstr "Skal"
-
-#~ msgid "Show all Containers"
-#~ msgstr "Visa alla behållare"
-
-#~ msgid "Show all Deployment Configs"
-#~ msgstr "Visa alla utplaceringskonfigurationer"
-
-#~ msgid "Show all Nodes"
-#~ msgstr "Visa alla noder"
-
-#~ msgid "Show all Persistent Volumes"
-#~ msgstr "Visa alla beständiga volymer"
-
-#~ msgid "Show all Pod Containers"
-#~ msgstr "Visa alla kapselbehållare"
-
-#~ msgid "Show all Pods"
-#~ msgstr "Visa alla kapslar"
-
-#~ msgid "Show all Projects"
-#~ msgstr "Visa alla projekt"
-
-#~ msgid "Show all Replication Controllers"
-#~ msgstr "Visa alla replikeringsstyrare"
-
-#~ msgid "Show all Routes"
-#~ msgstr "Visa alla rutter"
-
-#~ msgid "Show all Services"
-#~ msgstr "Visa alla tjänster"
-
-#~ msgid "Show all image streams"
-#~ msgstr "Visa alla avbildsströmmar"
-
-#~ msgid "Since"
-#~ msgstr "Sedan"
-
-#~ msgid "Skip Certificate Verification"
-#~ msgstr "Hoppa över certifikatverifikation"
-
-#~ msgid "Sorry, I don't know how to modify this volume"
-#~ msgstr "Ledsen, jag vet inte hur man ändrar denna volym"
-
-#~ msgid "Starts"
-#~ msgstr "Startar"
-
-#~ msgid "Stateless"
-#~ msgstr "Tillståndslös"
-
-#~ msgid "Stateless:"
-#~ msgstr "Tillståndslös:"
-
-#~ msgid "Status: $0"
-#~ msgstr "Status: $0"
-
-#~ msgid "Status: System isn't registered"
-#~ msgstr "Status: systemet är inte registrerat"
-
-#~ msgid "Strategy"
-#~ msgstr "Strategi"
-
-#~ msgid "Subscriptions"
-#~ msgstr "Prenumerationer"
-
-#~ msgid "Suspend"
-#~ msgstr "Vila"
-
-#~ msgid "Switch Host to Maintenance"
-#~ msgstr "Slå om värden till underhåll"
-
-#~ msgid "Switching host to maintenance mode failed. Received error: "
-#~ msgstr "Att slå om värden till underhållsläge misslyckades.  Mottog felet: "
-
-#~ msgid "Switching host to maintenance mode in progress ..."
-#~ msgstr "Att slå om värden till underhållsläge pågår …"
-
-#~ msgid "Sync all tags from a remote image repository"
-#~ msgstr "Synkronisera alla taggar från ett fjärravbildsförråd"
-
-#~ msgid "TLS Termination"
-#~ msgstr "TLS-avslutning"
-
-#~ msgid "Target Portal"
-#~ msgstr "Målportal"
-
-#~ msgid "Target World Wide Names"
-#~ msgstr "Målets världsvida namn"
-
-#~ msgid "Template"
-#~ msgstr "Mall"
-
-#~ msgid "Templates"
-#~ msgstr "Mallar"
-
-#~ msgid "Templates of $0 cluster"
-#~ msgstr "Mallar över $0 kluster"
-
-#~ msgid "The address contains invalid characters"
-#~ msgstr "Adressen innehåller otillåtna tecken"
-
-#~ msgid "The container '{{ target }}' does not exist."
-#~ msgstr "Behållaren ”{{ target }}” finns inte."
-
-#~ msgid "The current user isn't allowed to access system subscription status."
-#~ msgstr ""
-#~ "Den aktuella användaren har inte tillåtelse att komma åt systemets "
-#~ "prenumerationsstatus."
-
-#~ msgid "The deployment config '{{ target }}' does not exist."
-#~ msgstr "Utplaceringskonfigurationen ”{{ target }}” finns inte."
-
-#~ msgid "The group '{{ groupName }}' does not exist."
-#~ msgstr "Gruppen ”{{ groupName }}” finns inte."
-
-#~ msgid "The maximum number of replicas is 128"
-#~ msgstr "Det maximala antalet repliker är 128"
-
-#~ msgid "The name contains invalid characters"
-#~ msgstr "Namnet innehåller ogiltiga tecken"
-
-#~ msgid "The node '{{ target }}' does not exist."
-#~ msgstr "Noden ”{{ target }}” finns inte."
-
-#~ msgid "The node doesn't have enough disk space"
-#~ msgstr "Noden har inte tillräckligt med diskutrymme"
-
-#~ msgid "The node doesn't have enough free memory"
-#~ msgstr "Noden har inte tillräckligt med fritt minne"
-
-#~ msgid "The persistent volume '{{ target }}' does not exist."
-#~ msgstr "Den beständiga volymen ”{{ target }}” finns inte."
-
-#~ msgid "The pod '{{ target }}' does not exist."
-#~ msgstr "Kapseln ”{{ target }}” finns inte."
-
-#~ msgid "The project '{{ projName }}' does not exist."
-#~ msgstr "Projektet ”{{ projName }}” finns inte."
-
-#~ msgid "The replication controller '{{ target }}' does not exist."
-#~ msgstr "Replikeringsstyraren ”{{ target }}” finns inte."
-
-#~ msgid "The route '{{ target }}' does not exist."
-#~ msgstr "Rutten ”{{ target }}” finns inte."
-
-#~ msgid "The selected file is not a valid Kubernetes application manifest."
-#~ msgstr ""
-#~ "Den valda filen är inte en giltig programförteckning för Kubernetes."
-
-#~ msgid "The server uses a certificate signed by an unknown authority."
-#~ msgstr "Servern använder ett certifikat signerat av en okänd auktoritet."
-
-#~ msgid "The service '{{ target }}' does not exist."
-#~ msgstr "Tjänsten ”{{ target }}” finns inte."
-
-#~ msgid "The user '{{ userName }}' does not exist."
-#~ msgstr "Användaren ”{{ target }}” finns inte."
-
-#~ msgid ""
-#~ "This claim is in use. Deleting it may cause issues with the following pod:"
-#~ msgstr ""
-#~ "Detta anspråk används.  Att ta bort den kan orsaka problem med följande "
-#~ "kapsel:"
-
-#~ msgid ""
-#~ "This host is managed by a virtualization manager, so creation of new VMs "
-#~ "from the host is not possible."
-#~ msgstr ""
-#~ "Denna värd hanteras av en virtualiseringshanterare, så att skapa nya VM:"
-#~ "er av värden är inte möjligt."
-
-#~ msgid ""
-#~ "This option is for single node testing only – local storage will not work "
-#~ "in a multi-node cluster"
-#~ msgstr ""
-#~ "Denna flagga är endast för test av enstaka noder — lokal lagring kommer "
-#~ "inte fungera i ett flernodskluster"
-
-#~ msgid "This virtual machine is not managed by oVirt"
-#~ msgstr "Denna virtuella maskin hanteras inte av oVirt"
-
-#~ msgid ""
-#~ "This volume has been claimed by {{ item.item.spec.claimRef.namespace }} / "
-#~ "{{ item.item.spec.claimRef.name }}. Deleting it will break that claim and "
-#~ "may cause issues with any pods depending on it."
-#~ msgstr ""
-#~ "Denna volym har tagits i anspråk av {{ item.item.spec.claimRef."
-#~ "namespace }} / {{ item.item.spec.claimRef.name }}.  Att ta bort den "
-#~ "kommer bryta detta anspråk och kan orsaka problem med de kapslar som "
-#~ "beror på den."
-
-#~ msgid "This volume has not been claimed"
-#~ msgstr "Denna volym har inte tagits  anspråk"
-
-#~ msgid "Token"
-#~ msgstr "Symbol"
-
-#~ msgid "Topology"
-#~ msgstr "Topologi"
-
-#~ msgid "Trust this certificate for this connection"
-#~ msgstr "Lita på detta certifikat för denna anslutning"
-
-#~ msgid "Type:"
-#~ msgstr "Typ:"
-
-#~ msgid "Unable to connect"
-#~ msgstr "Kan inte ansluta"
-
-#~ msgid "Unable to decode Kubernetes application manifest."
-#~ msgstr "Kan inte avkoda programförteckningen för Kubernetes"
-
-#~ msgid "Unable to read the Kubernetes application manifest. Code $0."
-#~ msgstr "Kan inte läsa programförteckningen för Kubernetes.  Kod $0."
-
-#~ msgid "Unregister"
-#~ msgstr "Avregistrera"
-
-#~ msgid "Unregistering system..."
-#~ msgstr "Avregistrerar systemet …"
-
-#~ msgid "Updating $0..."
-#~ msgstr "Uppdaterar $0 …"
-
-#~ msgid "Use proxy server"
-#~ msgstr "Använd en proxyserver"
-
-#~ msgid "User or Group"
-#~ msgstr "Användare eller grupp"
-
-#~ msgid "Users"
-#~ msgstr "Användare"
-
-#~ msgid "VDSM"
-#~ msgstr "VDSM"
-
-#~ msgid "VDSM Service Management"
-#~ msgstr "VDSM tjänstehantering"
-
-#~ msgid "VM icon"
-#~ msgstr "VM-ikon"
-
-#~ msgid "Version num"
-#~ msgstr "Version nummer"
-
-#~ msgid "Virtual Machines of $0 cluster"
-#~ msgstr "Virtuella maskiner i klustret $0"
-
-#~ msgid "Volume ID"
-#~ msgstr "Volym-ID"
-
-#~ msgid "Volume Name"
-#~ msgstr "Volymnamn"
-
-#~ msgid "Volume Type"
-#~ msgstr "Volymtyp"
-
-#~ msgid "Warning:"
-#~ msgstr "Varning:"
-
-#~ msgid "Welcome to the Image Registry"
-#~ msgstr "Välkommen till avbildsregistret"
-
-#~ msgid "When"
-#~ msgstr "När"
-
-#~ msgid ""
-#~ "You can bypass the certificate check, but any data you send to the server "
-#~ "could be intercepted by others."
-#~ msgstr ""
-#~ "Du kan hoppa över certifikatkontrollen, men alla data du skickar till "
-#~ "servern skulle kunna avlyssnas av andra."
-
-#~ msgid "You can deploy an application to your cluster."
-#~ msgstr "Du kan placera ut ett program i ditt kluster."
-
-#~ msgid ""
-#~ "Your login credentials do not give you access to use the docker registry "
-#~ "from the command line."
-#~ msgstr ""
-#~ "Dina inloggningskreditiv ger dig inte åtkomst till att använda docker-"
-#~ "registret från kommandoraden."
-
-#~ msgid "connecting"
-#~ msgstr "ansluter"
-
-#~ msgid "cores"
-#~ msgstr "kärnor"
-
-#~ msgid "eg: my-image-stream"
-#~ msgstr "t.ex.: min-avbildsström"
-
-#~ msgid "error"
-#~ msgstr "fel"
-
-#~ msgid "initializing"
-#~ msgstr "initierar"
-
-#~ msgid "installation failed"
-#~ msgstr "installationen misslyckades"
-
-#~ msgid "installing OS"
-#~ msgstr "installerar OS"
-
-#~ msgid "kdumping"
-#~ msgstr "kdumpar"
-
-#~ msgid "maintenance"
-#~ msgstr "underhåll"
-
-#~ msgid "non operational"
-#~ msgstr "inte i drift"
-
-#~ msgid "non responsive"
-#~ msgstr "svarar inte"
-
-#~ msgid "oVirt"
-#~ msgstr "oVirt"
-
-#~ msgid "oVirt Host State:"
-#~ msgstr "oVirt-värdtillstånd:"
-
-#~ msgid "oVirt Provider installation script failed due to missing arguments."
-#~ msgstr ""
-#~ "oVirt-leverantörsinstallationsskript misslyckades på grund av saknade "
-#~ "argument."
-
-#~ msgid ""
-#~ "oVirt Provider installation script failed: Can't write to /etc/cockpit/"
-#~ "machines-ovirt.config, try as root."
-#~ msgstr ""
-#~ "oVirt-leverantörsinstallationsskript misslyckades: kan inte skriva till /"
-#~ "etc/cockpit/machines-ovirt.config, försök som root."
-
-#~ msgid "oVirt installation script failed with following output: "
-#~ msgstr "oVirt-installationsskript misslyckades med följande utdata: "
-
-#~ msgid "pending approval"
-#~ msgstr "väntande godkännande"
-
-#~ msgid "pending volume claims"
-#~ msgstr "väntande volymanspråk"
-
-#~ msgid "reboot"
-#~ msgstr "starta om"
-
-#~ msgid "sockets"
-#~ msgstr "uttag"
-
-#~ msgid "threads"
-#~ msgstr "trådar"
-
-#~ msgid "unassigned"
-#~ msgstr "ej tilldelad"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,11 +8,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-22 07:51+0000\n"
+"POT-Creation-Date: 2019-09-23 08:08+0000\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-08-16 05:45+0000\n"
+"PO-Revision-Date: 2019-09-21 01:39+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
 "Language: uk\n"
@@ -20,23 +20,30 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: pkg/docker/storage.jsx:259
+#: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
 msgstr " (спільний із операційною системою)"
+
+#: pkg/networkmanager/interfaces.js:2353
+msgid "$0 Active Rule"
+msgid_plural "$0 Active Rules"
+msgstr[0] "$0 активне правило"
+msgstr[1] "$0 активних правила"
+msgstr[2] "$0 активних правил"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
 msgstr "$0, блоковий пристрій"
 
-#: pkg/storaged/mdraid-details.jsx:192
+#: pkg/storaged/mdraid-details.jsx:187
 msgid "$0 Chunk Size"
 msgstr "Розмір фрагмента $0"
 
-#: pkg/storaged/mdraid-details.jsx:190
+#: pkg/storaged/mdraid-details.jsx:185
 msgid "$0 Disks"
 msgstr "Диски $0"
 
-#: pkg/storaged/content-views.jsx:334
+#: pkg/storaged/content-views.jsx:339
 msgctxt "storage-id-desc"
 msgid "$0 File System"
 msgstr "Файлова система $0"
@@ -45,34 +52,34 @@ msgstr "Файлова система $0"
 msgid "$0 Network"
 msgstr "Мережа $0"
 
-#: pkg/packagekit/history.jsx:101
+#: pkg/packagekit/history.jsx:100
 msgid "$0 Package"
 msgid_plural "$0 Packages"
 msgstr[0] "$0 пакунок"
 msgstr[1] "$0 пакунки"
 msgstr[2] "$0 пакунків"
 
-#: pkg/systemd/init.js:430 pkg/systemd/service-details.jsx:58
+#: pkg/systemd/init.js:478 pkg/systemd/service-details.jsx:58
 msgid "$0 Template"
 msgstr "Шаблон $0"
 
-#: src/base1/test-locale.js:80 src/base1/test-locale.js:81
-#: src/base1/test-locale.js:82 src/base1/test-locale.js:83
+#: src/base1/test-locale.js:83 src/base1/test-locale.js:84
+#: src/base1/test-locale.js:85 src/base1/test-locale.js:86
 msgid "$0 bit"
 msgid_plural "$0 bits"
 msgstr[0] "$0 біт"
 msgstr[1] "$0 біти"
 msgstr[2] "$0 бітів"
 
-#: src/base1/test-locale.js:71 src/base1/test-locale.js:72
-#: src/base1/test-locale.js:84 src/base1/test-locale.js:85
+#: src/base1/test-locale.js:74 src/base1/test-locale.js:75
+#: src/base1/test-locale.js:87 src/base1/test-locale.js:88
 msgid "$0 byte"
 msgid_plural "$0 bytes"
 msgstr[0] "$0 байт"
 msgstr[1] "$0 байти"
 msgstr[2] "$0 байтів"
 
-#: src/base1/test-locale.js:73 src/base1/test-locale.js:74
+#: src/base1/test-locale.js:76 src/base1/test-locale.js:77
 msgctxt "memory"
 msgid "$0 byte"
 msgid_plural "$0 bytes"
@@ -80,21 +87,28 @@ msgstr[0] "$0 байт"
 msgstr[1] "$0 байти"
 msgstr[2] "$0 байтів"
 
-#: pkg/storaged/vdo-details.jsx:280
+#: pkg/storaged/vdo-details.jsx:286
 msgid "$0 data + $1 overhead used of $2 ($3)"
 msgstr "$0 даних + $1 додатково використано з $2 ($3)"
 
-#: src/base1/test-locale.js:62 src/base1/test-locale.js:63
-#: src/base1/test-locale.js:64 pkg/playground/translate.js:26
-#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:212
+#: pkg/lib/plot.js:971
+msgid "$0 day"
+msgid_plural "$0 days"
+msgstr[0] "$0 день"
+msgstr[1] "$0 дні"
+msgstr[2] "$0 днів"
+
+#: src/base1/test-locale.js:65 src/base1/test-locale.js:66
+#: src/base1/test-locale.js:67 pkg/playground/translate.js:26
+#: pkg/playground/translate.js:29 pkg/storaged/mdraid-details.jsx:207
 msgid "$0 disk is missing"
 msgid_plural "$0 disks are missing"
 msgstr[0] "Не вистачає $0 диска"
 msgstr[1] "Не вистачає $0 дисків"
 msgstr[2] "Не вистачає $0 дисків"
 
-#: src/base1/test-locale.js:65 src/base1/test-locale.js:67
-#: src/base1/test-locale.js:69 pkg/playground/translate.js:32
+#: src/base1/test-locale.js:68 src/base1/test-locale.js:70
+#: src/base1/test-locale.js:72 pkg/playground/translate.js:32
 #: pkg/playground/translate.js:35
 msgctxt "disk-non-rotational"
 msgid "$0 disk is missing"
@@ -115,17 +129,24 @@ msgstr "$0 завершено роботу з кодом $1"
 msgid "$0 failed"
 msgstr "Помилка $0"
 
-#: pkg/storaged/lvol-tabs.jsx:159
+#: pkg/storaged/lvol-tabs.jsx:160
 msgid "$0 filesystems can not be made larger."
 msgstr "Файлові системи $0 не можна розширювати."
 
-#: pkg/storaged/lvol-tabs.jsx:156
+#: pkg/storaged/lvol-tabs.jsx:157
 msgid "$0 filesystems can not be made smaller."
 msgstr "Файлові системи $0 не можна звужувати."
 
-#: pkg/storaged/lvol-tabs.jsx:152
+#: pkg/storaged/lvol-tabs.jsx:153
 msgid "$0 filesystems can not be resized here."
 msgstr "Тут не можна змінювати розмір файлових систем $0."
+
+#: pkg/lib/plot.js:974
+msgid "$0 hour"
+msgid_plural "$0 hours"
+msgstr[0] "$0 година"
+msgstr[1] "$0 години"
+msgstr[2] "$0 годин"
 
 #: pkg/machines/components/desktopConsole.jsx:44
 msgid ""
@@ -136,21 +157,35 @@ msgstr ""
 "пакунок із програмою, знайдіть відповідний запис у Програмних засобах GNOME "
 "або віддайте таку команду:"
 
-#: pkg/storaged/content-views.jsx:283 pkg/storaged/content-views.jsx:505
-#: pkg/storaged/format-dialog.jsx:259 pkg/storaged/lvol-tabs.jsx:200
-#: pkg/storaged/lvol-tabs.jsx:259 pkg/storaged/mdraid-details.jsx:236
-#: pkg/storaged/mdraid-details.jsx:289 pkg/storaged/vdo-details.jsx:146
-#: pkg/storaged/vdo-details.jsx:175 pkg/storaged/vgroup-details.jsx:202
+#: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:511
+#: pkg/storaged/format-dialog.jsx:265 pkg/storaged/lvol-tabs.jsx:202
+#: pkg/storaged/lvol-tabs.jsx:264 pkg/storaged/mdraid-details.jsx:232
+#: pkg/storaged/mdraid-details.jsx:284 pkg/storaged/vdo-details.jsx:147
+#: pkg/storaged/vdo-details.jsx:178 pkg/storaged/vgroup-details.jsx:199
 msgid "$0 is in active use"
 msgstr "$0 активно використовується"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:150
+#: pkg/lib/cockpit-components-install-dialog.jsx:151
 msgid "$0 is not available from any repository."
 msgstr "$0 немає у жодному зі сховищ."
 
 #: src/base1/cockpit.js:2755
 msgid "$0 killed with signal $1"
 msgstr "$0 завершено з сигналом $1"
+
+#: pkg/lib/plot.js:977
+msgid "$0 minute"
+msgid_plural "$0 minutes"
+msgstr[0] "$0 хвилина"
+msgstr[1] "$0 хвилини"
+msgstr[2] "$0 хвилин"
+
+#: pkg/lib/plot.js:965
+msgid "$0 month"
+msgid_plural "$0 months"
+msgstr[0] "$0 місяць"
+msgstr[1] "$0 місяці"
+msgstr[2] "$0 місяців"
 
 #: pkg/selinux/setroubleshoot-view.jsx:439
 msgid "$0 occurrence"
@@ -163,11 +198,18 @@ msgstr[2] "$0 відповідників"
 msgid "$0 of $1"
 msgstr "$0 з $1"
 
+#: pkg/systemd/init.js:418
+msgid "$0 service has failed"
+msgid_plural "$0 services have failed"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
 #: pkg/docker/util.js:125
 msgid "$0 shares"
 msgstr "$0 спільних ресурсів"
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "$0 slots remain"
 msgstr "Лишилося $0 слотів"
 
@@ -178,15 +220,29 @@ msgstr[0] "$0 оновлення"
 msgstr[1] "$0 оновлення"
 msgstr[2] "$0 оновлень"
 
-#: pkg/storaged/vdo-details.jsx:292
+#: pkg/storaged/vdo-details.jsx:298
 msgid "$0 used of $1 ($2 saved)"
 msgstr "$0 використано з $1 ($2 заощаджено)"
+
+#: pkg/lib/plot.js:968
+msgid "$0 week"
+msgid_plural "$0 weeks"
+msgstr[0] "$0 тиждень"
+msgstr[1] "$0 тижні"
+msgstr[2] "$0 тижнів"
 
 #: pkg/lib/cockpit-components-install-dialog.jsx:106
 msgid "$0 will be installed."
 msgstr "Буде встановлено $0."
 
-#: pkg/storaged/vgroup-details.jsx:117
+#: pkg/lib/plot.js:962
+msgid "$0 year"
+msgid_plural "$0 years"
+msgstr[0] "$0 рік"
+msgstr[1] "$0 роки"
+msgstr[2] "$0 років"
+
+#: pkg/storaged/vgroup-details.jsx:111
 msgid "$0, $1 free"
 msgstr "$0, вільно $1"
 
@@ -197,7 +253,7 @@ msgstr[0] "$1 виправлення захисту"
 msgstr[1] "$1 виправлення захисту"
 msgstr[2] "$1 виправлень захисту"
 
-#: pkg/networkmanager/interfaces.js:2769
+#: pkg/networkmanager/interfaces.js:2777
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -213,16 +269,16 @@ msgstr "${hip}:${hport} -> $cport"
 msgid "${size} ${desc}"
 msgstr "${size} ${desc}"
 
-#: pkg/networkmanager/firewall.jsx:574
+#: pkg/networkmanager/firewall.jsx:576
 msgid "(Optional)"
 msgstr "(Необов’язково)"
 
-#: pkg/networkmanager/firewall.jsx:499 pkg/networkmanager/firewall.jsx:648
-#: pkg/storaged/fsys-tab.jsx:160
+#: pkg/networkmanager/firewall.jsx:501 pkg/networkmanager/firewall.jsx:650
+#: pkg/storaged/fsys-tab.jsx:163
 msgid "(default)"
 msgstr "(типовий)"
 
-#: pkg/storaged/crypto-tab.jsx:135
+#: pkg/storaged/crypto-tab.jsx:138
 msgid "(none)"
 msgstr "(немає)"
 
@@ -233,36 +289,43 @@ msgstr[0] ", включно із $1 виправленням захисту"
 msgstr[1] ", включно із $1 виправленнями захисту"
 msgstr[2] ", включно із $1 виправленнями захисту"
 
-#: pkg/storaged/nfs-details.jsx:325
+#: pkg/storaged/nfs-details.jsx:333
 msgid "--"
 msgstr "--"
 
-#: pkg/storaged/mdraids-panel.jsx:70
+#: pkg/storaged/mdraids-panel.jsx:86
 msgid "1 MiB"
 msgstr "1 МіБ"
 
-#: pkg/systemd/index.html:444 pkg/systemd/index.html:448
+#: pkg/systemd/index.html:455 pkg/systemd/index.html:459
 msgid "1 Minute"
 msgstr "1 хвилина"
 
+#: pkg/docker/containers-view.jsx:614
+msgid "1 Vulnerability"
+msgid_plural "$0 Vulnerabilities"
+msgstr[0] "$0 вразливість"
+msgstr[1] "$0 вразливості"
+msgstr[2] "$0 вразливостей"
+
 #: pkg/dashboard/index.html:55 pkg/networkmanager/index.html:68
-#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:183
+#: pkg/networkmanager/index.html:401 pkg/systemd/index.html:194
 #: pkg/storaged/plot.jsx:85
 msgid "1 day"
 msgstr "1 день"
 
 #: pkg/dashboard/index.html:51 pkg/networkmanager/index.html:66
-#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:179
+#: pkg/networkmanager/index.html:399 pkg/systemd/index.html:190
 #: pkg/storaged/plot.jsx:79
 msgid "1 hour"
 msgstr "1 година"
 
-#: pkg/systemd/host.js:1686
+#: pkg/systemd/host.js:1729
 msgid "1 min"
 msgstr "1 хв."
 
 #: pkg/dashboard/index.html:57 pkg/networkmanager/index.html:69
-#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:185
+#: pkg/networkmanager/index.html:402 pkg/systemd/index.html:196
 #: pkg/storaged/plot.jsx:88
 msgid "1 week"
 msgstr "1 тиждень"
@@ -275,7 +338,7 @@ msgstr "10-е"
 msgid "11th"
 msgstr "11-е"
 
-#: pkg/storaged/mdraids-panel.jsx:68
+#: pkg/storaged/mdraids-panel.jsx:84
 msgid "128 KiB"
 msgstr "128 КіБ"
 
@@ -295,7 +358,7 @@ msgstr "14-е"
 msgid "15th"
 msgstr "15-е"
 
-#: pkg/storaged/mdraids-panel.jsx:65
+#: pkg/storaged/mdraids-panel.jsx:81
 msgid "16 KiB"
 msgstr "16 КіБ"
 
@@ -319,15 +382,15 @@ msgstr "19-е"
 msgid "1st"
 msgstr "1-е"
 
-#: pkg/storaged/mdraids-panel.jsx:71
+#: pkg/storaged/mdraids-panel.jsx:87
 msgid "2 MiB"
 msgstr "2 МіБ"
 
-#: pkg/systemd/host.js:1685
+#: pkg/systemd/host.js:1728
 msgid "2 min"
 msgstr "2 хв."
 
-#: pkg/systemd/index.html:450
+#: pkg/systemd/index.html:461
 msgid "20 Minutes"
 msgstr "20 хвилин"
 
@@ -375,7 +438,7 @@ msgstr "29-е"
 msgid "2nd"
 msgstr "2-е"
 
-#: pkg/systemd/host.js:1684
+#: pkg/systemd/host.js:1727
 msgid "3 min"
 msgstr "3 хв."
 
@@ -387,7 +450,7 @@ msgstr "30-е"
 msgid "31st"
 msgstr "31-е"
 
-#: pkg/storaged/mdraids-panel.jsx:66
+#: pkg/storaged/mdraids-panel.jsx:82
 msgid "32 KiB"
 msgstr "32 КіБ"
 
@@ -395,15 +458,15 @@ msgstr "32 КіБ"
 msgid "3rd"
 msgstr "3-є"
 
-#: pkg/storaged/mdraids-panel.jsx:63
+#: pkg/storaged/mdraids-panel.jsx:79
 msgid "4 KiB"
 msgstr "4 КіБ"
 
-#: pkg/systemd/host.js:1683
+#: pkg/systemd/host.js:1726
 msgid "4 min"
 msgstr "4 хв."
 
-#: pkg/systemd/index.html:451
+#: pkg/systemd/index.html:462
 msgid "40 Minutes"
 msgstr "40 хвилин"
 
@@ -411,21 +474,21 @@ msgstr "40 хвилин"
 msgid "4th"
 msgstr "4-е"
 
-#: pkg/systemd/index.html:449
+#: pkg/systemd/index.html:460
 msgid "5 Minutes"
 msgstr "5 хвилин"
 
-#: pkg/systemd/host.js:1682
+#: pkg/systemd/host.js:1725
 msgid "5 min"
 msgstr "5 хв."
 
 #: pkg/dashboard/index.html:49 pkg/networkmanager/index.html:65
-#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:177
+#: pkg/networkmanager/index.html:398 pkg/systemd/index.html:188
 #: pkg/storaged/plot.jsx:76
 msgid "5 minutes"
 msgstr "5 хвилин"
 
-#: pkg/storaged/mdraids-panel.jsx:69
+#: pkg/storaged/mdraids-panel.jsx:85
 msgid "512 KiB"
 msgstr "512 КіБ"
 
@@ -434,16 +497,16 @@ msgid "5th"
 msgstr "5-е"
 
 #: pkg/dashboard/index.html:53 pkg/networkmanager/index.html:67
-#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:181
+#: pkg/networkmanager/index.html:400 pkg/systemd/index.html:192
 #: pkg/storaged/plot.jsx:82
 msgid "6 hours"
 msgstr "6 годин"
 
-#: pkg/systemd/index.html:452
+#: pkg/systemd/index.html:463
 msgid "60 Minutes"
 msgstr "60 хвилин"
 
-#: pkg/storaged/mdraids-panel.jsx:67
+#: pkg/storaged/mdraids-panel.jsx:83
 msgid "64 KiB"
 msgstr "64 КіБ"
 
@@ -455,15 +518,15 @@ msgstr "6"
 msgid "7th"
 msgstr "7"
 
-#: pkg/storaged/mdraids-panel.jsx:64
+#: pkg/storaged/mdraids-panel.jsx:80
 msgid "8 KiB"
 msgstr "8 КіБ"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1999
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:2016
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -482,7 +545,7 @@ msgid ""
 msgstr ""
 "У {{#strong}}{{host}}{{/strong}} не встановлено сумісної версії Cockpit."
 
-#: pkg/storaged/vdos-panel.jsx:59
+#: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "Потрібен диск."
 
@@ -493,19 +556,19 @@ msgstr ""
 "Для забезпечення безпеки, надійної роботи та швидкодії слід встановити "
 "сучасну програму для перегляду інтернету."
 
-#: pkg/storaged/mdraid-details.jsx:119
+#: pkg/storaged/mdraid-details.jsx:113
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Перш ніж вилучати цей диск, слід додати резервний диск."
 
-#: pkg/networkmanager/interfaces.js:1995
+#: pkg/networkmanager/interfaces.js:2007
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2806
 msgid "ARP Monitoring"
 msgstr "Стеження за ARP"
 
-#: pkg/networkmanager/interfaces.js:2016
+#: pkg/networkmanager/interfaces.js:2028
 msgid "ARP Ping"
 msgstr "Луна-імпульс ARP"
 
@@ -522,10 +585,6 @@ msgstr "Відсутній"
 msgid "Access"
 msgstr "Доступ"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:12
-msgid "Access Policy"
-msgstr "Правила доступу"
-
 #: pkg/users/index.html:249
 msgid "Account Expiration"
 msgstr "Строк дії облікового запису"
@@ -538,7 +597,8 @@ msgstr "Параметри облікового запису"
 msgid "Account not available or cannot be edited."
 msgstr "Обліковий запис недоступний або його не можна редагувати."
 
-#: pkg/users/index.html:71 pkg/users/manifest.json.in
+#: pkg/playground/translate.html:95 pkg/users/index.html:71
+#: pkg/users/manifest.json.in
 msgid "Accounts"
 msgstr "Облікові записи"
 
@@ -549,7 +609,7 @@ msgstr "Облікові записи"
 
 #: pkg/machines/components/networks/network.jsx:148
 #: pkg/machines/components/storagePools/storagePool.jsx:170
-#: pkg/storaged/content-views.jsx:256
+#: pkg/storaged/content-views.jsx:261
 msgid "Activate"
 msgstr "Задіяти"
 
@@ -557,11 +617,11 @@ msgstr "Задіяти"
 msgid "Activating $target"
 msgstr "Активуємо $target"
 
-#: pkg/networkmanager/interfaces.js:847 pkg/networkmanager/interfaces.js:2010
+#: pkg/networkmanager/interfaces.js:852 pkg/networkmanager/interfaces.js:2022
 msgid "Active"
 msgstr "Активний"
 
-#: pkg/networkmanager/interfaces.js:1984 pkg/networkmanager/interfaces.js:2001
+#: pkg/networkmanager/interfaces.js:1996 pkg/networkmanager/interfaces.js:2013
 msgid "Active Backup"
 msgstr "Активне резервування"
 
@@ -569,39 +629,40 @@ msgstr "Активне резервування"
 msgid "Active Pages"
 msgstr "Активні сторінки"
 
-#: pkg/storaged/dialog.jsx:1043 pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1044 pkg/storaged/dialog.jsx:1048
 msgid "Active since"
 msgstr "Активний з"
 
-#: pkg/systemd/service-details.jsx:352
+#: pkg/systemd/service-details.jsx:354
 msgid "Active since "
 msgstr "Активний з "
 
-#: pkg/networkmanager/firewall.jsx:954
+#: pkg/networkmanager/firewall.jsx:956
 msgid "Active zones"
 msgstr "Активні зони"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:2001
 msgid "Adaptive load balancing"
 msgstr "Адаптивне урівноваження навантаження"
 
-#: pkg/networkmanager/interfaces.js:1988
+#: pkg/networkmanager/interfaces.js:2000
 msgid "Adaptive transmit load balancing"
 msgstr "Адаптивне урівноваження навантаження за передаванням"
 
-#: pkg/lib/machine-add.html:43 pkg/shell/index.html:181
-#: pkg/machines/components/diskAdd.jsx:600 pkg/storaged/crypto-keyslots.jsx:228
-#: pkg/storaged/iscsi-panel.jsx:132 pkg/storaged/iscsi-panel.jsx:155
-#: pkg/storaged/mdraid-details.jsx:57 pkg/storaged/nfs-details.jsx:191
-#: pkg/storaged/vgroup-details.jsx:63
+#: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
+#: pkg/machines/components/diskAdd.jsx:471
+#: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
+#: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
+#: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:198
+#: pkg/storaged/vgroup-details.jsx:65
 msgid "Add"
 msgstr "Додати"
 
-#: pkg/networkmanager/interfaces.js:3115
+#: pkg/networkmanager/interfaces.js:3126
 msgid "Add $0"
 msgstr "Додати $0"
 
-#: pkg/docker/storage.jsx:378
+#: pkg/docker/storage.jsx:383
 msgid "Add Additional Storage"
 msgstr "Додати додаткове сховище"
 
@@ -613,15 +674,15 @@ msgstr "Додати зв’язок"
 msgid "Add Bridge"
 msgstr "Додати місток"
 
-#: pkg/machines/components/diskAdd.jsx:368
+#: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Додати диск"
 
-#: pkg/storaged/mdraid-details.jsx:44 pkg/storaged/vgroup-details.jsx:51
+#: pkg/storaged/mdraid-details.jsx:45 pkg/storaged/vgroup-details.jsx:52
 msgid "Add Disks"
 msgstr "Додати диски"
 
-#: pkg/storaged/crypto-keyslots.jsx:200
+#: pkg/storaged/crypto-keyslots.jsx:202
 msgid "Add Key"
 msgstr "Додати ключ"
 
@@ -629,16 +690,20 @@ msgstr "Додати ключ"
 msgid "Add Machine to Dashboard"
 msgstr "Додати запис комп’ютера на панель"
 
-#: pkg/networkmanager/firewall.jsx:482
+#: pkg/machines/components/nicAdd.jsx:218
+msgid "Add Network Interface"
+msgstr "Додати інтерфейс мережі"
+
+#: pkg/networkmanager/firewall.jsx:484
 msgid "Add Ports"
 msgstr "Додати порти"
 
-#: pkg/networkmanager/firewall.jsx:482 pkg/networkmanager/firewall.jsx:904
-#: pkg/networkmanager/firewall.jsx:916
+#: pkg/networkmanager/firewall.jsx:484 pkg/networkmanager/firewall.jsx:906
+#: pkg/networkmanager/firewall.jsx:918
 msgid "Add Services"
 msgstr "Додавання служб"
 
-#: pkg/docker/storage.jsx:217
+#: pkg/docker/storage.jsx:219
 msgid "Add Storage"
 msgstr "Додати сховище даних"
 
@@ -650,12 +715,12 @@ msgstr "Додати команду"
 msgid "Add VLAN"
 msgstr "Додати VLAN"
 
-#: pkg/networkmanager/firewall.jsx:730 pkg/networkmanager/firewall.jsx:910
-#: pkg/networkmanager/firewall.jsx:921
+#: pkg/networkmanager/firewall.jsx:732 pkg/networkmanager/firewall.jsx:912
+#: pkg/networkmanager/firewall.jsx:923
 msgid "Add Zone"
 msgstr "Додати зону"
 
-#: pkg/storaged/iscsi-panel.jsx:41
+#: pkg/storaged/iscsi-panel.jsx:42
 msgid "Add iSCSI Portal"
 msgstr "Додати портал iSCSI"
 
@@ -663,7 +728,7 @@ msgstr "Додати портал iSCSI"
 msgid "Add key"
 msgstr "Додати клавішу"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add ports to the following zones:"
 msgstr "Додати порти до таких записів зон:"
 
@@ -671,15 +736,15 @@ msgstr "Додати порти до таких записів зон:"
 msgid "Add public key"
 msgstr "Додати відкритий ключ"
 
-#: pkg/networkmanager/firewall.jsx:483
+#: pkg/networkmanager/firewall.jsx:485
 msgid "Add services to following zones:"
 msgstr "Додати служби до таких зон:"
 
-#: pkg/networkmanager/firewall.jsx:806
+#: pkg/networkmanager/firewall.jsx:808
 msgid "Add zone"
 msgstr "Додати зону"
 
-#: pkg/networkmanager/interfaces.js:3114
+#: pkg/networkmanager/interfaces.js:3125
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -687,7 +752,7 @@ msgstr ""
 "Додавання <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/firewall.jsx:586
+#: pkg/networkmanager/firewall.jsx:588
 msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
@@ -703,15 +768,15 @@ msgstr "Додавання ключа"
 msgid "Adding physical volume to $target"
 msgstr "Додаємо фізичний том до $target"
 
-#: pkg/machines/components/vmDisksTab.jsx:78
+#: pkg/machines/components/vmDisksTab.jsx:116
 msgid "Additional"
 msgstr "Додаткові"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "Additional DNS $val"
 msgstr "Додатковий DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "Additional DNS Search Domains $val"
 msgstr "Додаткові домени пошуку DNS $val"
 
@@ -723,7 +788,7 @@ msgstr "Додаткове сховище"
 msgid "Additional actions"
 msgstr "Додаткові дії"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Additional address $val"
 msgstr "Додаткова адреса $val"
 
@@ -734,20 +799,20 @@ msgstr "Додаткові пакунки:"
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
-#: pkg/machines/components/vmnetworktab.jsx:107
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:112
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Address"
 msgstr "Адреса"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2671
 msgid "Address $val"
 msgstr "Адреса $val"
 
-#: pkg/storaged/crypto-keyslots.jsx:192
+#: pkg/storaged/crypto-keyslots.jsx:193
 msgid "Address cannot be empty"
 msgstr "Адреса не може бути порожньою"
 
-#: pkg/storaged/crypto-keyslots.jsx:194
+#: pkg/storaged/crypto-keyslots.jsx:195
 msgid "Address is not a valid URL"
 msgstr "Адреса є некоректною"
 
@@ -762,7 +827,7 @@ msgstr "Адреса поза межами підмережі"
 msgid "Address:"
 msgstr "Адреса:"
 
-#: pkg/networkmanager/interfaces.js:3321
+#: pkg/networkmanager/interfaces.js:3332
 msgid "Addresses"
 msgstr "Адреси"
 
@@ -778,7 +843,7 @@ msgstr "Пароль адміністратора"
 msgid "Advanced TCA"
 msgstr "Розширене TCA"
 
-#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:428
+#: pkg/systemd/services.html:310 pkg/systemd/service-details.jsx:430
 msgid "After"
 msgstr "Після"
 
@@ -794,7 +859,7 @@ msgstr ""
 "та список довірених служб сертифікації."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
-#: pkg/systemd/init.js:902
+#: pkg/systemd/init.js:964
 msgid "After system boot"
 msgstr "Після завантаження системи"
 
@@ -802,7 +867,7 @@ msgstr "Після завантаження системи"
 msgid "Alert and above"
 msgstr "Тривога і вище"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:212 pkg/systemd/logs.js:382
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Всі"
 
@@ -810,7 +875,7 @@ msgstr "Всі"
 msgid "All In One"
 msgstr "Усе-в-одному"
 
-#: pkg/docker/storage.jsx:381
+#: pkg/docker/storage.jsx:386
 msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
@@ -822,11 +887,11 @@ msgstr ""
 msgid "Allow running (unmask)"
 msgstr "Дозволити запуск (зняти маску)"
 
-#: pkg/networkmanager/firewall.jsx:781
+#: pkg/networkmanager/firewall.jsx:783
 msgid "Allowed Addresses"
 msgstr "Дозволені адреси"
 
-#: pkg/networkmanager/firewall.jsx:967
+#: pkg/networkmanager/firewall.jsx:969
 msgid "Allowed Services"
 msgstr "Дозволені служби"
 
@@ -834,13 +899,10 @@ msgstr "Дозволені служби"
 msgid "Always"
 msgstr "Завжди"
 
-#: pkg/machines/components/diskAdd.jsx:116
+#: pkg/machines/components/diskAdd.jsx:117
+#: pkg/machines/components/nicAdd.jsx:86
 msgid "Always attach"
 msgstr "Завжди долучати"
-
-#: node_modules/registry-image-widgets/views/annotations.html:1
-msgid "Annotations"
-msgstr "Анотації"
 
 #: pkg/lib/cockpit-components-modifications.jsx:82
 msgid "Ansible Playbook"
@@ -859,10 +921,10 @@ msgstr "Програми"
 #: pkg/networkmanager/index.html:526 pkg/networkmanager/index.html:550
 #: pkg/networkmanager/index.html:574 pkg/networkmanager/index.html:598
 #: pkg/networkmanager/index.html:622 pkg/networkmanager/index.html:646
-#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:352
-#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:76
-#: pkg/storaged/crypto-tab.jsx:105 pkg/storaged/fsys-tab.jsx:78
-#: pkg/storaged/fsys-tab.jsx:126 pkg/storaged/nfs-details.jsx:191
+#: pkg/networkmanager/index.html:670 pkg/kdump/kdump-view.jsx:354
+#: pkg/machines/components/vcpuModal.jsx:235 pkg/storaged/crypto-tab.jsx:78
+#: pkg/storaged/crypto-tab.jsx:108 pkg/storaged/fsys-tab.jsx:80
+#: pkg/storaged/fsys-tab.jsx:129 pkg/storaged/nfs-details.jsx:198
 msgid "Apply"
 msgstr "Застосувати"
 
@@ -890,20 +952,16 @@ msgstr "Застосовуємо оновлення"
 msgid "Applying updates failed"
 msgstr "Не вдалося застосувати оновлення"
 
-#: node_modules/registry-image-widgets/views/image-config.html:16
-msgid "Architecture"
-msgstr "Архітектура"
-
 #: pkg/systemd/index.html:92
 msgid "Asset Tag"
 msgstr "Мітка активу"
 
-#: pkg/storaged/mdraids-panel.jsx:79
+#: pkg/storaged/mdraids-panel.jsx:96
 msgid "At least $0 disks are needed."
 msgstr "Потрібно принаймні $0 дисків."
 
-#: pkg/storaged/mdraid-details.jsx:51 pkg/storaged/vgroup-details.jsx:57
-#: pkg/storaged/vgroups-panel.jsx:63
+#: pkg/storaged/mdraid-details.jsx:52 pkg/storaged/vgroup-details.jsx:59
+#: pkg/storaged/vgroups-panel.jsx:66
 msgid "At least one disk is needed."
 msgstr "Потрібен принаймні один диск."
 
@@ -915,7 +973,7 @@ msgstr "У вказаний момент часу"
 msgid "Audit log"
 msgstr "Журнал інспектування"
 
-#: pkg/networkmanager/interfaces.js:839
+#: pkg/networkmanager/interfaces.js:844
 msgid "Authenticating"
 msgstr "Автентифікація"
 
@@ -944,13 +1002,11 @@ msgstr ""
 "Щоб отримати доступ до виконання привілейованих завдань за допомогою "
 "вебконсолі Cockpit, слід пройти розпізнавання"
 
-#: pkg/storaged/iscsi-panel.jsx:147
+#: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Слід пройти розпізнавання"
 
-#: pkg/docker/index.html:702
-#: node_modules/registry-image-widgets/views/image-body.html:12
-#: pkg/docker/containers-view.jsx:413
+#: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Автор"
 
@@ -959,22 +1015,22 @@ msgid "Authorized Public SSH Keys"
 msgstr "Уповноважені відкриті ключі SSH"
 
 #: pkg/networkmanager/index.html:176
-#: pkg/machines/components/networks/createNetworkDialog.jsx:176
-#: pkg/networkmanager/interfaces.js:1974 pkg/networkmanager/interfaces.js:2771
-#: pkg/networkmanager/interfaces.js:3329 pkg/networkmanager/interfaces.js:3333
-#: pkg/networkmanager/interfaces.js:3339 pkg/realmd/operation.js:338
+#: pkg/machines/components/networks/createNetworkDialog.jsx:162
+#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:3340 pkg/networkmanager/interfaces.js:3344
+#: pkg/networkmanager/interfaces.js:3350 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: pkg/networkmanager/interfaces.js:1975
+#: pkg/networkmanager/interfaces.js:1987
 msgid "Automatic (DHCP only)"
 msgstr "Автоматично (лише DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1965
+#: pkg/networkmanager/interfaces.js:1977
 msgid "Automatic (DHCP)"
 msgstr "Автоматично (DHCP)"
 
-#: pkg/systemd/init.js:295
+#: pkg/systemd/init.js:307
 msgid "Automatic Startup"
 msgstr "Автоматичний запуск"
 
@@ -986,15 +1042,15 @@ msgstr "Автоматичні оновлення"
 msgid "Automatically start libvirt on boot"
 msgstr "Автоматично запускати libvirt при завантаженні"
 
-#: pkg/systemd/service-details.jsx:396
+#: pkg/systemd/service-details.jsx:398
 msgid "Automatically starts"
 msgstr "Запускати автоматично"
 
-#: pkg/systemd/index.html:389
+#: pkg/systemd/index.html:400
 msgid "Automatically using NTP"
 msgstr "Автоматично на основі NTP"
 
-#: pkg/systemd/index.html:390
+#: pkg/systemd/index.html:401
 msgid "Automatically using specific NTP servers"
 msgstr "Автоматично за допомогою певних серверів NTP"
 
@@ -1014,11 +1070,11 @@ msgstr "Автозапуск"
 msgid "Available"
 msgstr "Доступні"
 
-#: pkg/packagekit/updates.jsx:824
+#: pkg/packagekit/updates.jsx:825
 msgid "Available Updates"
 msgstr "Доступні оновлення"
 
-#: pkg/storaged/iscsi-panel.jsx:124
+#: pkg/storaged/iscsi-panel.jsx:125
 msgid "Available targets on $0"
 msgstr "Доступні призначення на $0"
 
@@ -1026,15 +1082,15 @@ msgstr "Доступні призначення на $0"
 msgid "Avatar"
 msgstr "Аватар"
 
-#: pkg/systemd/hwinfo.jsx:92
+#: pkg/systemd/hwinfo.jsx:96
 msgid "BIOS"
 msgstr "BIOS"
 
-#: pkg/systemd/hwinfo.jsx:100
+#: pkg/systemd/hwinfo.jsx:104
 msgid "BIOS date"
 msgstr "Дата BIOS"
 
-#: pkg/systemd/hwinfo.jsx:96
+#: pkg/systemd/hwinfo.jsx:100
 msgid "BIOS version"
 msgstr "Версія BIOS"
 
@@ -1042,7 +1098,7 @@ msgstr "Версія BIOS"
 msgid "Back to Accounts"
 msgstr "Назад до облікових записів"
 
-#: pkg/storaged/vdo-details.jsx:270
+#: pkg/storaged/vdo-details.jsx:276
 msgid "Backing Device"
 msgstr "Резервний пристрій"
 
@@ -1054,11 +1110,11 @@ msgstr "Механізму passwd1 передано помилкові дані"
 msgid "Balancer"
 msgstr "Балансир"
 
-#: pkg/systemd/service-details.jsx:427
+#: pkg/systemd/service-details.jsx:429
 msgid "Before"
 msgstr "До"
 
-#: pkg/systemd/service-details.jsx:418
+#: pkg/systemd/service-details.jsx:420
 msgid "Binds To"
 msgstr "Пов'язано з"
 
@@ -1078,16 +1134,16 @@ msgstr "Обгортка Blade"
 msgid "Block"
 msgstr "Блок"
 
-#: pkg/storaged/content-views.jsx:649
+#: pkg/storaged/content-views.jsx:666
 msgid "Block device for filesystems"
 msgstr "Блоковий пристрій для файлових систем"
 
-#: pkg/storaged/mdraid-details.jsx:103
+#: pkg/storaged/mdraid-details.jsx:97
 msgid "Blocked"
 msgstr "Заблоковано"
 
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2803
+#: pkg/networkmanager/interfaces.js:2529 pkg/networkmanager/interfaces.js:2541
+#: pkg/networkmanager/interfaces.js:2811
 msgid "Bond"
 msgstr "Прив’язка"
 
@@ -1104,12 +1160,12 @@ msgstr "Порядок завантаження"
 msgid "Boot order settings could not be saved"
 msgstr "Не вдалося зберегти параметри порядку завантаження"
 
-#: pkg/systemd/service-details.jsx:423
+#: pkg/systemd/service-details.jsx:425
 msgid "Bound By"
 msgstr "Пов'язано"
 
-#: pkg/networkmanager/interfaces.js:2528 pkg/networkmanager/interfaces.js:2540
-#: pkg/networkmanager/interfaces.js:2880
+#: pkg/networkmanager/interfaces.js:2535 pkg/networkmanager/interfaces.js:2547
+#: pkg/networkmanager/interfaces.js:2888
 msgid "Bridge"
 msgstr "Міст"
 
@@ -1121,33 +1177,29 @@ msgstr "Параметри порту містка"
 msgid "Bridge Settings"
 msgstr "Параметри містка"
 
-#: pkg/networkmanager/interfaces.js:2901
+#: pkg/networkmanager/interfaces.js:2909
 msgid "Bridge port"
 msgstr "Порт містка"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1998 pkg/networkmanager/interfaces.js:2015
 msgid "Broadcast"
 msgstr "Трансляція"
 
-#: pkg/networkmanager/interfaces.js:2816 pkg/networkmanager/interfaces.js:2850
+#: pkg/networkmanager/interfaces.js:2824 pkg/networkmanager/interfaces.js:2858
 msgid "Broken configuration"
 msgstr "Помилки у налаштуваннях"
 
-#: pkg/systemd/host.js:508
+#: pkg/systemd/host.js:511
 msgid "Bug Fix Updates Available"
 msgstr "Доступні оновлення із виправленнями вад"
 
-#: pkg/packagekit/updates.jsx:314
+#: pkg/packagekit/updates.jsx:315
 msgid "Bugs:"
 msgstr "Вади:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:18
-msgid "Built"
-msgstr "Зібрано"
-
 #: pkg/machines/components/vm/bootOrderModal.jsx:109
 #: pkg/machines/components/vm/bootOrderModal.jsx:132
-#: pkg/machines/components/vmDisksTab.jsx:72
+#: pkg/machines/components/vmDisksTab.jsx:110
 msgid "Bus"
 msgstr "Канал"
 
@@ -1156,19 +1208,19 @@ msgid "Bus Expansion Chassis"
 msgstr "Апаратний блок розширення каналу"
 
 #: pkg/dashboard/index.html:70 pkg/docker/index.html:272
-#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:108
+#: pkg/docker/containers-view.jsx:359 pkg/systemd/hwinfo.jsx:112
 msgid "CPU"
 msgstr "Процесор"
 
-#: pkg/systemd/hwinfo.jsx:113
+#: pkg/systemd/hwinfo.jsx:117
 msgid "CPU Security"
 msgstr "Захист процесора"
 
-#: pkg/systemd/hwinfo.jsx:205
+#: pkg/systemd/hwinfo.jsx:209
 msgid "CPU Security Toggles"
 msgstr "Перемикачі захисту процесора"
 
-#: pkg/systemd/host.js:1565
+#: pkg/systemd/host.js:1603
 msgctxt "page-title"
 msgid "CPU Status"
 msgstr "Стан процесора"
@@ -1185,12 +1237,12 @@ msgstr "Пріоритетність процесора"
 msgid "CPU usage:"
 msgstr "Використання процесора:"
 
-#: pkg/machines/components/diskAdd.jsx:251
+#: pkg/machines/components/diskAdd.jsx:174
 #: pkg/machines/components/vmDiskColumns.jsx:75
 msgid "Cache"
 msgstr "Кеш"
 
-#: pkg/systemd/index.html:252 pkg/systemd/host.js:1696
+#: pkg/systemd/index.html:263 pkg/systemd/host.js:1739
 msgid "Cached"
 msgstr "Кеш"
 
@@ -1198,11 +1250,11 @@ msgstr "Кеш"
 msgid "Can&rsquo;t connect to Docker"
 msgstr "Не вдалося зв’язатися із Docker"
 
-#: pkg/storaged/content-views.jsx:313
+#: pkg/storaged/content-views.jsx:318
 msgid "Can't delete while unlocked"
 msgstr "Не можна вилучати, доки розблоковано"
 
-#: pkg/dashboard/list.js:212
+#: pkg/dashboard/list.js:220
 msgid "Can't load image"
 msgstr "Не вдалося завантажити образ"
 
@@ -1217,37 +1269,39 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/networkmanager/index.html:597 pkg/networkmanager/index.html:621
 #: pkg/networkmanager/index.html:645 pkg/networkmanager/index.html:669
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:332
-#: pkg/systemd/index.html:419 pkg/systemd/index.html:471
-#: pkg/systemd/index.html:487 pkg/systemd/services.html:377
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
+#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
+#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
 #: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
 #: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
 #: pkg/users/index.html:413 pkg/apps/utils.jsx:86
 #: pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:781
 #: pkg/machines/components/deleteDialog.jsx:158
-#: pkg/machines/components/diskAdd.jsx:597
-#: pkg/machines/components/networks/createNetworkDialog.jsx:486
+#: pkg/machines/components/diskAdd.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/networks/networkDelete.jsx:100
-#: pkg/machines/components/nicEdit.jsx:311
+#: pkg/machines/components/nicAdd.jsx:232
+#: pkg/machines/components/nicEdit.jsx:181
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:511
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:225
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:93
 #: pkg/machines/components/vcpuModal.jsx:232
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:590 pkg/networkmanager/firewall.jsx:658
-#: pkg/networkmanager/firewall.jsx:801 pkg/packagekit/updates.jsx:179
-#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:393
-#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/service-details.jsx:107
-#: pkg/systemd/hwinfo.jsx:216
+#: pkg/networkmanager/firewall.jsx:592 pkg/networkmanager/firewall.jsx:660
+#: pkg/networkmanager/firewall.jsx:803 pkg/packagekit/updates.jsx:179
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:394
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:220
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Скасувати"
 
-#: pkg/shell/indexes.js:421
+#: pkg/shell/indexes.js:472
 msgid "Cannot connect to an unknown machine"
 msgstr "Неможливо встановити з’єднання із невідомим комп’ютером"
 
-#: src/base1/cockpit.js:4031
+#: src/base1/cockpit.js:4035
 msgid "Cannot forward login credentials"
 msgstr "Не вдалося переспрямувати реєстраційні дані для входу"
 
@@ -1255,25 +1309,25 @@ msgstr "Не вдалося переспрямувати реєстраційн�
 msgid "Cannot schedule event in the past"
 msgstr "Не можна планувати подію на минуле"
 
-#: pkg/machines/components/vmDisksTab.jsx:70
+#: pkg/machines/components/vmDisksTab.jsx:108
 msgid "Capacity"
 msgstr "Місткість"
 
-#: pkg/networkmanager/interfaces.js:2602
+#: pkg/networkmanager/interfaces.js:2610
 msgid "Carrier"
 msgstr "Носій сигналу"
 
-#: pkg/docker/index.html:664 pkg/systemd/index.html:333
-#: pkg/systemd/index.html:420 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:181
+#: pkg/docker/index.html:664 pkg/systemd/index.html:344
+#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
+#: pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Змінити"
 
-#: pkg/systemd/index.html:289
+#: pkg/systemd/index.html:300
 msgid "Change Host Name"
 msgstr "Змінити назву вузла"
 
-#: pkg/shell/index.html:312
+#: pkg/shell/index.html:313
 msgid "Change Password"
 msgstr "Змінити пароль"
 
@@ -1281,19 +1335,19 @@ msgstr "Змінити пароль"
 msgid "Change Performance Profile"
 msgstr "Зміна профілю швидкодії"
 
-#: pkg/tuned/dialog.js:198
+#: pkg/tuned/dialog.js:199
 msgid "Change Profile"
 msgstr "Змінити профіль"
 
-#: pkg/systemd/index.html:358
+#: pkg/systemd/index.html:369
 msgid "Change System Time"
 msgstr "Змінити системний час"
 
-#: pkg/storaged/iscsi-panel.jsx:176
+#: pkg/storaged/iscsi-panel.jsx:183
 msgid "Change iSCSI Initiator Name"
 msgstr "Змінити назву ініціатора iSCSI"
 
-#: pkg/storaged/crypto-keyslots.jsx:247
+#: pkg/storaged/crypto-keyslots.jsx:255
 msgid "Change passphrase"
 msgstr "Змінити пароль"
 
@@ -1305,18 +1359,18 @@ msgstr "Змінити обмеження ресурсів"
 msgid "Change resources limits"
 msgstr "Змінити обмеження ресурсів"
 
-#: pkg/networkmanager/interfaces.js:3165
+#: pkg/networkmanager/interfaces.js:3176
 msgid "Change the settings"
 msgstr "Змінити параметри"
 
-#: pkg/machines/components/nicEdit.jsx:287
+#: pkg/machines/components/nicEdit.jsx:157
 #: pkg/machines/components/vcpuModal.jsx:183
 #: pkg/machines/components/vm/bootOrderModal.jsx:283
 #: pkg/machines/components/warningInactive.jsx:11
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Зміни буде застосовано після завершення роботи ВМ"
 
-#: pkg/networkmanager/interfaces.js:3164
+#: pkg/networkmanager/interfaces.js:3175
 msgid ""
 "Changing the settings will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1332,7 +1386,7 @@ msgstr "Перевірити наявність оновлень"
 msgid "Checking $target"
 msgstr "Перевіряємо $target"
 
-#: pkg/networkmanager/interfaces.js:843
+#: pkg/networkmanager/interfaces.js:848
 msgid "Checking IP"
 msgstr "Перевіряємо IP"
 
@@ -1352,11 +1406,11 @@ msgstr "Шукаємо нові програми"
 msgid "Checking for public keys"
 msgstr "Шукаємо відкриті ключі"
 
-#: pkg/systemd/host.js:537
+#: pkg/systemd/host.js:540
 msgid "Checking for updates…"
 msgstr "Шукаємо оновлення…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:142
+#: pkg/lib/cockpit-components-install-dialog.jsx:143
 msgid "Checking installed software"
 msgstr "Перевіряємо встановлене програмне забезпечення"
 
@@ -1368,11 +1422,11 @@ msgstr "Виберіть операційну систему"
 msgid "Choose the language to be used in the application"
 msgstr "Виберіть мову перекладу, яку буде використано для інтерфейсу програми"
 
-#: pkg/storaged/mdraids-panel.jsx:57
+#: pkg/storaged/mdraids-panel.jsx:72
 msgid "Chunk Size"
 msgstr "Розмір фрагмента"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Class"
 msgstr "Клас"
 
@@ -1382,13 +1436,13 @@ msgstr "Спорожнюємо для $target"
 
 #: pkg/systemd/service-details.jsx:188
 msgid "Clear 'Failed to start'"
-msgstr ""
+msgstr "Вилучити «Не вдалося запустити»"
 
 #: pkg/systemd/services.html:86
 msgid "Clear All Filters"
 msgstr "Зняти усі фільтри"
 
-#: pkg/systemd/host.js:750
+#: pkg/systemd/host.js:776
 msgid "Click to see system hardware information"
 msgstr "Натисніть, щоб побачити дані щодо обладнання системи"
 
@@ -1407,14 +1461,14 @@ msgstr "Клієнтське програмне забезпечення"
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
 #: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
 #: pkg/networkmanager/index.html:688 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:323 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:278 pkg/users/index.html:45 pkg/apps/utils.jsx:108
+#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
+#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
 #: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:393
+#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:394
 msgid "Close"
 msgstr "Закрити"
 
-#: pkg/shell/active-pages.js:103
+#: pkg/shell/active-pages.js:104
 msgid "Close Selected Pages"
 msgstr "Закрити позначені сторінки"
 
@@ -1422,7 +1476,7 @@ msgstr "Закрити позначені сторінки"
 msgid "Cockpit authentication is configured incorrectly."
 msgstr "Розпізнавання у Cockpit налаштовано з помилками."
 
-#: pkg/lib/machine-dialogs.js:427
+#: pkg/lib/machine-dialogs.js:429
 msgid ""
 "Cockpit could not contact the given host $0. Make sure it has ssh running on "
 "port $1, or specify another port in the address."
@@ -1430,11 +1484,11 @@ msgstr ""
 "Cockpit не вдалося встановити зв’язок із вказаним вузлом $0. Переконайтеся, "
 "що ssh запущено на порту $1 або вкажіть інший порт у адресі."
 
-#: src/base1/cockpit.js:4037
+#: src/base1/cockpit.js:4041
 msgid "Cockpit could not contact the given host."
 msgstr "Cockpit не вдалося встановити зв’язок із вказаним вузлом."
 
-#: pkg/shell/base_index.js:752
+#: pkg/shell/base_index.js:759
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
 "Cockpit by pressing refresh in your browser. The javascript console contains "
@@ -1465,7 +1519,7 @@ msgstr ""
 msgid "Cockpit is an interactive Linux server admin interface."
 msgstr "Cockpit — інтерактивний інтерфейс адміністратора сервера Linux."
 
-#: src/base1/cockpit.js:4035
+#: src/base1/cockpit.js:4039
 msgid "Cockpit is not compatible with the software on the system."
 msgstr "Cockpit є несумісним із програмним забезпеченням цієї системи."
 
@@ -1473,7 +1527,7 @@ msgstr "Cockpit є несумісним із програмним забезпе
 msgid "Cockpit is not installed"
 msgstr "Cockpit не встановлено"
 
-#: src/base1/cockpit.js:4029
+#: src/base1/cockpit.js:4033
 msgid "Cockpit is not installed on the system."
 msgstr "Cockpit у цій системі не встановлено."
 
@@ -1544,20 +1598,19 @@ msgstr "Колір"
 msgid "Combined memory usage"
 msgstr "Поєднане використання пам’яті"
 
-#: pkg/docker/overview.js:86
+#: pkg/docker/overview.js:88
 msgid "Combined usage of $0 CPU core"
 msgid_plural "Combined usage of $0 CPU cores"
 msgstr[0] "Комбіноване використання $0 ядра процесора"
 msgstr[1] "Комбіноване використання $0 ядер процесора"
 msgstr[2] "Комбіноване використання $0 ядер процесора"
 
-#: pkg/networkmanager/firewall.jsx:554
+#: pkg/networkmanager/firewall.jsx:556
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Відокремлені комами порти, діапазони і альтернативні назви прийнято"
 
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
 #: pkg/docker/index.html:708 pkg/systemd/services.html:282
-#: node_modules/registry-image-widgets/views/image-config.html:2
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
 #: pkg/docker/containers-view.jsx:411
 msgid "Command"
@@ -1571,7 +1624,7 @@ msgstr "Команда не може бути порожньою"
 msgid "Command:"
 msgstr "Команда:"
 
-#: pkg/shell/index.html:261
+#: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Коментар"
 
@@ -1592,11 +1645,11 @@ msgstr "Не вдалося обмінятися даними з tuned"
 msgid "Compact PCI"
 msgstr "Компактний PCI"
 
-#: pkg/storaged/content-views.jsx:522
+#: pkg/storaged/content-views.jsx:532
 msgid "Compatible with all systems and devices (MBR)"
 msgstr "Сумісний із усіма системами та пристроями (MBR)"
 
-#: pkg/storaged/content-views.jsx:524
+#: pkg/storaged/content-views.jsx:535
 msgid "Compatible with modern system and hard disks > 2TB (GPT)"
 msgstr "Сумісний зі сучасними системами та жорсткими дисками > 2 ТБ (GPT)"
 
@@ -1604,8 +1657,8 @@ msgstr "Сумісний зі сучасними системами та жор�
 msgid "Compress crash dumps to save space"
 msgstr "Стиснути дампи аварійних завершень для заощадження місця"
 
-#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:304
-#: pkg/storaged/vdos-panel.jsx:81
+#: pkg/kdump/kdump-view.jsx:156 pkg/storaged/vdo-details.jsx:310
+#: pkg/storaged/vdos-panel.jsx:87
 msgid "Compression"
 msgstr "Стискання"
 
@@ -1613,32 +1666,32 @@ msgstr "Стискання"
 msgid "Computer OU"
 msgstr "OU комп’ютера"
 
-#: pkg/systemd/service-details.jsx:442
+#: pkg/systemd/service-details.jsx:444
 msgid "Condition $0=$1 was not met"
 msgstr "Умову $0=$1 не виконано"
 
-#: pkg/systemd/service-details.jsx:492
+#: pkg/systemd/service-details.jsx:494
 msgid "Condition failed"
 msgstr "Не виконано умову"
 
-#: pkg/networkmanager/interfaces.js:2737
+#: pkg/networkmanager/interfaces.js:2745
 msgid "Configure"
 msgstr "Налаштувати"
 
-#: pkg/docker/storage.jsx:331
+#: pkg/docker/storage.jsx:335
 msgid "Configure storage..."
 msgstr "Налаштувати сховище даних…"
 
-#: pkg/networkmanager/interfaces.js:837
+#: pkg/networkmanager/interfaces.js:842
 msgid "Configuring"
 msgstr "Налаштовування"
 
-#: pkg/networkmanager/interfaces.js:841
+#: pkg/networkmanager/interfaces.js:846
 msgid "Configuring IP"
 msgstr "Налаштовуємо IP"
 
-#: pkg/shell/index.html:297 pkg/users/index.html:176
-#: pkg/storaged/format-dialog.jsx:303
+#: pkg/shell/index.html:298 pkg/users/index.html:176
+#: pkg/storaged/format-dialog.jsx:315
 msgid "Confirm"
 msgstr "Підтвердити"
 
@@ -1650,15 +1703,15 @@ msgstr "Підтвердження нового пароля"
 msgid "Confirm deletion of the Virtual Network"
 msgstr "Підтвердження вилучення віртуальної мережі"
 
-#: pkg/storaged/crypto-keyslots.jsx:364
+#: pkg/storaged/crypto-keyslots.jsx:372
 msgid "Confirm removal with passphrase"
 msgstr "Підтвердьте вилучення введенням пароля"
 
-#: pkg/systemd/service-details.jsx:426
+#: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
 msgstr "Конфліктує за"
 
-#: pkg/systemd/service-details.jsx:425
+#: pkg/systemd/service-details.jsx:427
 msgid "Conflicts"
 msgstr "Конфліктує"
 
@@ -1666,7 +1719,7 @@ msgstr "Конфліктує"
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: pkg/networkmanager/interfaces.js:2724
+#: pkg/networkmanager/interfaces.js:2732
 msgid "Connect automatically"
 msgstr "З’єднуватися автоматично"
 
@@ -1705,23 +1758,26 @@ msgstr "Встановлюємо з’єднання із фоновою слу�
 msgid "Connecting to Virtualization Service"
 msgstr "Встановлюємо зв'язок із службою віртуалізації"
 
-#: pkg/shell/indexes.js:416
+#: pkg/shell/indexes.js:467
 msgid "Connecting to the machine"
 msgstr "Встановлюємо з’єднання із комп’ютером"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:34
-#: pkg/machines/components/networks/createNetworkDialog.jsx:106
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
 #: pkg/machines/hostvmslist.jsx:83
 msgid "Connection"
 msgstr "З’єднання"
 
-#: pkg/dashboard/list.js:406
+#: pkg/dashboard/list.js:414
 msgid "Connection Error"
 msgstr "Помилка з'єднання"
 
-#: src/base1/cockpit.js:4027
+#: pkg/shell/index.html:396
+msgid "Connection failed"
+msgstr "Не вдалося встановити з'єднання"
+
+#: src/base1/cockpit.js:4031
 msgid "Connection has timed out."
 msgstr "Вичерпано час очікування на з’єднання."
 
@@ -1729,7 +1785,7 @@ msgstr "Вичерпано час очікування на з’єднання.
 msgid "Connection will be lost"
 msgstr "З’єднання буде розірвано"
 
-#: pkg/systemd/service-details.jsx:424
+#: pkg/systemd/service-details.jsx:426
 msgid "Consists Of"
 msgstr "Складається з"
 
@@ -1737,7 +1793,7 @@ msgstr "Складається з"
 msgid "Console Type"
 msgstr "Тип консолі"
 
-#: pkg/machines/components/vm/vm.jsx:51
+#: pkg/machines/components/vm/vm.jsx:53
 msgid "Consoles"
 msgstr "Консолі"
 
@@ -1746,7 +1802,6 @@ msgid "Contacted domain"
 msgstr "Пов'язаний домен"
 
 #: pkg/docker/console.html:4
-#: node_modules/registry-image-widgets/views/image-panel.html:12
 msgid "Container"
 msgstr "Контейнер"
 
@@ -1784,16 +1839,16 @@ msgctxt "page-title"
 msgid "Containers"
 msgstr "Контейнери"
 
-#: pkg/storaged/content-views.jsx:557
+#: pkg/storaged/content-views.jsx:570
 msgid "Content"
 msgstr "Вміст"
 
-#: src/base1/test-locale.js:42 src/base1/test-locale.js:53
+#: src/base1/test-locale.js:45 src/base1/test-locale.js:56
 #: pkg/playground/translate.js:20
 msgid "Control"
 msgstr "Керування"
 
-#: src/base1/test-locale.js:43 src/base1/test-locale.js:55
+#: src/base1/test-locale.js:46 src/base1/test-locale.js:58
 #: pkg/playground/translate.js:23
 msgctxt "key"
 msgid "Control"
@@ -1815,7 +1870,7 @@ msgstr "Копіювати до буфера"
 msgid "Cores per socket"
 msgstr "Кількість ядер на сокет"
 
-#: pkg/docker/storage.jsx:428
+#: pkg/docker/storage.jsx:438
 msgid "Could not add all disks"
 msgstr "Не вдалося додати усі диски"
 
@@ -1823,7 +1878,7 @@ msgstr "Не вдалося додати усі диски"
 msgid "Could not contact {{host}}"
 msgstr "Не вдалося встановити зв’язок із {{host}}"
 
-#: pkg/docker/storage.jsx:468
+#: pkg/docker/storage.jsx:484
 msgid "Could not reset the storage pool"
 msgstr "Не вдалося скинути резервне сховище даних"
 
@@ -1835,7 +1890,7 @@ msgstr "Не вдалося змінити групи користувачів"
 msgid "Couldn't change user password"
 msgstr "Не вдалося змінити пароль користувача"
 
-#: pkg/shell/indexes.js:419
+#: pkg/shell/indexes.js:470
 msgid "Couldn't connect to the machine"
 msgstr "Не вдалося встановити з’єднання із комп’ютером"
 
@@ -1855,29 +1910,30 @@ msgstr "Не вдалося побудувати список користува
 msgid "Couldn't load user data"
 msgstr "Не вдалося завантажити дані користувача"
 
-#: pkg/kdump/kdump-view.jsx:336 pkg/kdump/kdump-view.jsx:504
+#: pkg/kdump/kdump-view.jsx:337 pkg/kdump/kdump-view.jsx:506
 msgid "Crash dump location"
 msgstr "Розташування дампу аварійного завершення"
 
-#: pkg/kdump/kdump-view.jsx:304
+#: pkg/kdump/kdump-view.jsx:305
 msgid "Crash system"
 msgstr "Аварійно завершити роботу системи"
 
 #: pkg/users/index.html:199
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:786
-#: pkg/machines/components/networks/createNetworkDialog.jsx:491
+#: pkg/machines/components/networks/createNetworkDialog.jsx:482
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:514
-#: pkg/storaged/content-views.jsx:123 pkg/storaged/content-views.jsx:689
-#: pkg/storaged/lvol-tabs.jsx:352 pkg/storaged/mdraids-panel.jsx:86
-#: pkg/storaged/vdos-panel.jsx:105 pkg/storaged/vgroups-panel.jsx:69
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:96
+#: pkg/storaged/content-views.jsx:127 pkg/storaged/content-views.jsx:709
+#: pkg/storaged/lvol-tabs.jsx:360 pkg/storaged/mdraids-panel.jsx:103
+#: pkg/storaged/vdos-panel.jsx:113 pkg/storaged/vgroups-panel.jsx:72
 msgid "Create"
 msgstr "Створити"
 
-#: pkg/storaged/content-views.jsx:639
+#: pkg/storaged/content-views.jsx:653
 msgid "Create Logical Volume"
 msgstr "Створити логічний том"
 
-#: pkg/machines/components/diskAdd.jsx:552
+#: pkg/machines/components/diskAdd.jsx:423
 msgid "Create New"
 msgstr "Створити"
 
@@ -1885,19 +1941,23 @@ msgstr "Створити"
 msgid "Create New Account"
 msgstr "Створити новий рахунок"
 
-#: pkg/storaged/content-views.jsx:434 pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:443
+msgid "Create New Volume"
+msgstr "Створити том"
+
+#: pkg/storaged/content-views.jsx:439 pkg/storaged/format-dialog.jsx:336
 msgid "Create Partition"
 msgstr "Створити розділ"
 
-#: pkg/storaged/content-views.jsx:552
+#: pkg/storaged/content-views.jsx:565
 msgid "Create Partition Table"
 msgstr "Створити таблицю розділів"
 
-#: pkg/storaged/format-dialog.jsx:184
+#: pkg/storaged/format-dialog.jsx:189
 msgid "Create Partition on $0"
 msgstr "Створити розділ на $0"
 
-#: pkg/storaged/mdraids-panel.jsx:38
+#: pkg/storaged/mdraids-panel.jsx:39
 msgid "Create RAID Device"
 msgstr "Створити пристрій RAID"
 
@@ -1905,7 +1965,7 @@ msgstr "Створити пристрій RAID"
 msgid "Create Report"
 msgstr "Створити звіт"
 
-#: pkg/storaged/lvol-tabs.jsx:346 pkg/storaged/lvol-tabs.jsx:387
+#: pkg/storaged/lvol-tabs.jsx:354 pkg/storaged/lvol-tabs.jsx:395
 msgid "Create Snapshot"
 msgstr "Створення знімка"
 
@@ -1913,7 +1973,7 @@ msgstr "Створення знімка"
 msgid "Create Storage Pool"
 msgstr "Створити резервне сховище"
 
-#: pkg/storaged/content-views.jsx:109 pkg/storaged/content-views.jsx:134
+#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:138
 msgid "Create Thin Volume"
 msgstr "Створити тонкий том"
 
@@ -1925,7 +1985,7 @@ msgstr "Створити таймер"
 msgid "Create Timers"
 msgstr "Створити таймери"
 
-#: pkg/storaged/vdos-panel.jsx:46
+#: pkg/storaged/vdos-panel.jsx:47
 msgid "Create VDO Device"
 msgstr "Створити пристрій VDO"
 
@@ -1933,12 +1993,17 @@ msgstr "Створити пристрій VDO"
 msgid "Create VM"
 msgstr "Створення ВМ"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:477
-#: pkg/machines/components/networks/createNetworkDialog.jsx:525
+#: pkg/machines/components/networks/createNetworkDialog.jsx:468
+#: pkg/machines/components/networks/createNetworkDialog.jsx:516
 msgid "Create Virtual Network"
 msgstr "Створити віртуальну мережу"
 
-#: pkg/storaged/vgroups-panel.jsx:53
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:135
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:148
+msgid "Create Volume"
+msgstr "Створити том"
+
+#: pkg/storaged/vgroups-panel.jsx:54
 msgid "Create Volume Group"
 msgstr "Створити групу томів"
 
@@ -1946,12 +2011,12 @@ msgstr "Створити групу томів"
 msgid "Create diagnostic report"
 msgstr "Створити діагностичний звіт"
 
-#: pkg/networkmanager/interfaces.js:3834 pkg/networkmanager/interfaces.js:4033
-#: pkg/networkmanager/interfaces.js:4287 pkg/networkmanager/interfaces.js:4492
+#: pkg/networkmanager/interfaces.js:3850 pkg/networkmanager/interfaces.js:4050
+#: pkg/networkmanager/interfaces.js:4305 pkg/networkmanager/interfaces.js:4510
 msgid "Create it"
 msgstr "Створити"
 
-#: pkg/storaged/content-views.jsx:708
+#: pkg/storaged/content-views.jsx:728
 msgid "Create new Logical Volume"
 msgstr "Створити логічний том"
 
@@ -1984,7 +2049,7 @@ msgstr "Створюємо розділ $target"
 msgid "Creating snapshot of $target"
 msgstr "Створюємо знімок $target"
 
-#: pkg/networkmanager/interfaces.js:4491
+#: pkg/networkmanager/interfaces.js:4509
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -1992,7 +2057,7 @@ msgstr ""
 "Створення цієї VLAN  призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:3833
+#: pkg/networkmanager/interfaces.js:3849
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2000,7 +2065,7 @@ msgstr ""
 "Створення цього зв’язку призведе до розірвання з’єднання із сервером і "
 "зробить адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:4286
+#: pkg/networkmanager/interfaces.js:4304
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2008,7 +2073,7 @@ msgstr ""
 "Створення цього містка призведе до розірвання з’єднання із сервером і "
 "зробить адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:4032
+#: pkg/networkmanager/interfaces.js:4049
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2044,23 +2109,23 @@ msgstr "Поточне отримання"
 msgid "Current boot"
 msgstr "Поточне завантаження"
 
-#: pkg/storaged/format-dialog.jsx:69
+#: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Нетиповий"
 
-#: pkg/networkmanager/firewall.jsx:548
+#: pkg/networkmanager/firewall.jsx:550
 msgid "Custom Ports"
 msgstr "Нетипові порти"
 
-#: pkg/storaged/format-dialog.jsx:118
+#: pkg/storaged/format-dialog.jsx:122
 msgid "Custom encryption options"
 msgstr "Нетипові параметри шифрування"
 
-#: pkg/storaged/format-dialog.jsx:91 pkg/storaged/nfs-details.jsx:176
+#: pkg/storaged/format-dialog.jsx:95 pkg/storaged/nfs-details.jsx:183
 msgid "Custom mount options"
 msgstr "Нетипові параметри монтування"
 
-#: pkg/networkmanager/firewall.jsx:748
+#: pkg/networkmanager/firewall.jsx:750
 msgid "Custom zones"
 msgstr "Нетипові зони"
 
@@ -2073,19 +2138,19 @@ msgstr "Діапазон DHCP"
 msgid "DISK IS FAILING"
 msgstr "ДИСК НЕПРАЦЕЗДАТНИЙ"
 
-#: pkg/networkmanager/interfaces.js:3328
+#: pkg/networkmanager/interfaces.js:3339
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2668
+#: pkg/networkmanager/interfaces.js:2676
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3332
+#: pkg/networkmanager/interfaces.js:3343
 msgid "DNS Search Domains"
 msgstr "Домени пошуку DNS"
 
-#: pkg/networkmanager/interfaces.js:2671
+#: pkg/networkmanager/interfaces.js:2679
 msgid "DNS Search Domains $val"
 msgstr "Домени пошуку DNS $val"
 
@@ -2097,17 +2162,17 @@ msgstr "Темний"
 msgid "Dashboard"
 msgstr "Панель приладів"
 
-#: pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/lvol-tabs.jsx:463
 msgid "Data Used"
 msgstr "Використано даних"
 
 #: pkg/machines/components/networks/network.jsx:144
 #: pkg/machines/components/storagePools/storagePool.jsx:165
-#: pkg/storaged/content-views.jsx:254
+#: pkg/storaged/content-views.jsx:259
 msgid "Deactivate"
 msgstr "Вимкнути"
 
-#: pkg/networkmanager/interfaces.js:849
+#: pkg/networkmanager/interfaces.js:854
 msgid "Deactivating"
 msgstr "Деактивація"
 
@@ -2119,24 +2184,23 @@ msgstr "Деактивуємо $target"
 msgid "Debug and above"
 msgstr "Діагностика і вище"
 
-#: pkg/storaged/vdo-details.jsx:310 pkg/storaged/vdos-panel.jsx:84
+#: pkg/storaged/vdo-details.jsx:316 pkg/storaged/vdos-panel.jsx:91
 msgid "Deduplication"
 msgstr "Скасування дублювання"
 
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
-#: node_modules/registry-image-widgets/views/image-config.html:10
-#: pkg/storaged/format-dialog.jsx:68
+#: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
 msgstr "Типовий"
 
-#: pkg/systemd/index.html:438
+#: pkg/systemd/index.html:449
 msgid "Delay"
 msgstr "Затримка"
 
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:433 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
-#: pkg/docker/details.js:292 pkg/docker/util.js:641
+#: pkg/docker/details.js:293 pkg/docker/util.js:641
 #: pkg/machines/components/deleteDialog.jsx:145
 #: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/networks/networkDelete.jsx:86
@@ -2144,16 +2208,23 @@ msgstr "Затримка"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:293 pkg/storaged/content-views.jsx:314
-#: pkg/storaged/mdraid-details.jsx:299 pkg/storaged/mdraid-details.jsx:322
-#: pkg/storaged/vdo-details.jsx:199 pkg/storaged/vdo-details.jsx:262
-#: pkg/storaged/vgroup-details.jsx:213 pkg/storaged/vgroup-details.jsx:236
+#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:319
+#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
+#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
+#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Вилучити"
 
-#: pkg/networkmanager/interfaces.js:2447 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2454 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Вилучити $0"
+
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:67
+msgid "Delete $0 volume"
+msgid_plural "Delete $0 volumes"
+msgstr[0] "Вилучити $0 том"
+msgstr[1] "Вилучити $0 томи"
+msgstr[2] "Вилучити $0 томів"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:162
 msgid "Delete Content"
@@ -2183,7 +2254,7 @@ msgstr "Вилучити томи у цьому буфері"
 msgid "Deleting $target"
 msgstr "Вилучаємо $target"
 
-#: pkg/networkmanager/interfaces.js:2446
+#: pkg/networkmanager/interfaces.js:2453
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2191,33 +2262,33 @@ msgstr ""
 "Вилучення <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/storaged/mdraid-details.jsx:300
+#: pkg/storaged/mdraid-details.jsx:296
 msgid "Deleting a RAID device will erase all data on it."
 msgstr "Вилучення пристрою RAID призведе до витирання з нього усіх даних."
 
-#: pkg/storaged/vdo-details.jsx:200
+#: pkg/storaged/vdo-details.jsx:204
 msgid "Deleting a VDO device will erase all data on it."
 msgstr "Вилучення пристрою VDO призведе до витирання усіх даних на ньому."
 
-#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:291
+#: pkg/docker/containers-view.jsx:201 pkg/docker/details.js:292
 msgid "Deleting a container will erase all data in it."
 msgstr ""
 "Вилучення контейнера призведе до витирання усіх даних, що на ньому "
 "зберігаються."
 
-#: pkg/storaged/content-views.jsx:273
+#: pkg/storaged/content-views.jsx:278
 msgid "Deleting a logical volume will delete all data in it."
 msgstr ""
 "Вилучення логічного тому призведе до витирання усіх даних, що на ньому "
 "зберігаються."
 
-#: pkg/storaged/content-views.jsx:276
+#: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
 "Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
 ""
 
-#: pkg/storaged/vgroup-details.jsx:212
+#: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
 msgstr ""
 "Вилучення групи томів призведе до витирання усіх даних, що у ній "
@@ -2235,15 +2306,14 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Вилучаємо групу томів $target"
 
-#: pkg/systemd/services.html:268
-#: node_modules/registry-image-widgets/views/image-body.html:6
-#: pkg/networkmanager/firewall.jsx:757 pkg/systemd/init.js:289
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:759
+#: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Опис"
 
 #: pkg/playground/manifest.json.in
 msgid "Design Patterns"
-msgstr ""
+msgstr "Взірці дизайну"
 
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
@@ -2261,42 +2331,37 @@ msgstr ""
 msgid "Detachable"
 msgstr "Змінний"
 
-#: pkg/shell/index.html:229 pkg/docker/containers-view.jsx:336
+#: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
-#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:383
-#: pkg/systemd/host.js:762
+#: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:384
+#: pkg/systemd/host.js:786 pkg/systemd/host.js:797
 msgid "Details"
 msgstr "Подробиці"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:169
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:155
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
 #: pkg/machines/components/vmDiskColumns.jsx:43
-#: pkg/machines/components/vmDisksTab.jsx:58
+#: pkg/machines/components/vmDisksTab.jsx:96
 msgid "Device"
 msgstr "Пристрій"
 
-#: pkg/storaged/vdo-details.jsx:267
+#: pkg/storaged/vdo-details.jsx:273
 msgid "Device File"
 msgstr "Файл пристрою"
 
-#: pkg/storaged/content-views.jsx:551
+#: pkg/storaged/content-views.jsx:564
 msgid "Device is read-only"
 msgstr "Пристрій придатний лише для читання"
 
 #: pkg/sosreport/manifest.json.in
 msgid "Diagnostic Reports"
-msgstr ""
+msgstr "Діагностичні звіти"
 
 #: pkg/sosreport/index.html:22
 msgid "Diagnostic reports"
 msgstr "Діагностичні звіти"
 
-#: node_modules/registry-image-widgets/views/image-body.html:22
-msgid "Digest"
-msgstr "Контрольна сума"
-
-#: node_modules/registry-image-widgets/views/image-config.html:11
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Каталог"
@@ -2305,16 +2370,16 @@ msgstr "Каталог"
 msgid "Directory $0 isn't writable or doesn't exist."
 msgstr "Каталог $0 є непридатним до запису або не існує."
 
-#: pkg/systemd/hwinfo.jsx:191
+#: pkg/systemd/hwinfo.jsx:195
 msgid "Disable simultaneous multithreading"
 msgstr "Вимкнути багатопотоковість"
 
-#: pkg/tuned/dialog.js:232
+#: pkg/tuned/dialog.js:233
 msgid "Disable tuned"
 msgstr "Вимкнути tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1969
-#: pkg/systemd/init.js:218 pkg/systemd/service-details.jsx:331
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1981
+#: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Вимкнено"
 
@@ -2327,7 +2392,7 @@ msgid "Disconnect"
 msgstr "Від’єднатися"
 
 #: pkg/shell/simple.html:101 pkg/machines/components/vnc.jsx:107
-#: pkg/shell/indexes.js:155 pkg/shell/indexes.js:609
+#: pkg/shell/indexes.js:180 pkg/shell/indexes.js:660
 msgid "Disconnected"
 msgstr "Роз'єднано"
 
@@ -2336,7 +2401,7 @@ msgid "Disconnected from serial console. Click the Reconnect button."
 msgstr ""
 "Від'єднано від послідовної консолі. Натисніть кнопку «Повторно з'єднатися»."
 
-#: pkg/storaged/vdos-panel.jsx:55
+#: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Диск"
 
@@ -2344,15 +2409,15 @@ msgstr "Диск"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr "Не вдалося від'єднати диск $0 від віртуальної машини $1"
 
-#: pkg/dashboard/index.html:73 pkg/systemd/host.js:569
+#: pkg/dashboard/index.html:73 pkg/systemd/host.js:588
 msgid "Disk I/O"
 msgstr "Дисковий ввід/вивід"
 
-#: pkg/machines/components/diskAdd.jsx:525
+#: pkg/machines/components/diskAdd.jsx:396
 msgid "Disk failed to be attached"
 msgstr "Не вдалося долучити диск"
 
-#: pkg/machines/components/diskAdd.jsx:504
+#: pkg/machines/components/diskAdd.jsx:373
 msgid "Disk failed to be created"
 msgstr "Не вдалося створити диск"
 
@@ -2364,9 +2429,9 @@ msgstr "З диском усе гаразд"
 msgid "Disk passphrase"
 msgstr "Пароль до диска"
 
-#: pkg/machines/components/vm/vm.jsx:49 pkg/storaged/mdraid-details.jsx:46
-#: pkg/storaged/mdraid-details.jsx:153 pkg/storaged/mdraids-panel.jsx:73
-#: pkg/storaged/vgroup-details.jsx:53 pkg/storaged/vgroups-panel.jsx:59
+#: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
+#: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
+#: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
 msgid "Disks"
 msgstr "Диски"
 
@@ -2381,11 +2446,7 @@ msgstr "Мова перекладу"
 
 #: pkg/docker/manifest.json.in
 msgid "Docker Containers"
-msgstr ""
-
-#: node_modules/registry-image-widgets/views/image-meta.html:10
-msgid "Docker Version"
-msgstr "Версія Docker"
+msgstr "Контейнери Docker"
 
 #: pkg/docker/index.html:60
 msgid "Docker is not installed or activated on the system"
@@ -2395,7 +2456,7 @@ msgstr "Docker не встановлено або не активовано у �
 msgid "Docking Station"
 msgstr "Станція заряджання"
 
-#: pkg/realmd/operation.html:11 pkg/systemd/index.html:118
+#: pkg/realmd/operation.html:11 pkg/systemd/index.html:125
 #: pkg/realmd/operation.js:122
 msgid "Domain"
 msgstr "Домен"
@@ -2421,11 +2482,11 @@ msgid "Domain Administrator Password"
 msgstr "Пароль адміністратора домену"
 
 #: pkg/systemd/services.html:338 pkg/systemd/services.html:342
-#: pkg/systemd/init.js:1085
+#: pkg/systemd/init.js:1147
 msgid "Don't Repeat"
 msgstr "Не повторювати"
 
-#: pkg/storaged/content-views.jsx:516 pkg/storaged/format-dialog.jsx:280
+#: pkg/storaged/content-views.jsx:524 pkg/storaged/format-dialog.jsx:289
 msgid "Don't overwrite existing data"
 msgstr "Не перезаписувати наявні дані"
 
@@ -2457,20 +2518,15 @@ msgstr "Отримано"
 msgid "Downloading"
 msgstr "Отримуємо"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:179
+#: pkg/lib/cockpit-components-install-dialog.jsx:180
 msgid "Downloading $0"
 msgstr "Отримуємо $0"
 
-#: pkg/docker/storage.jsx:167 pkg/storaged/drive-details.jsx:68
+#: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Диск"
 
-#: pkg/storaged/drives-panel.jsx:97 pkg/storaged/drives-panel.jsx:99
-msgctxt "storage"
-msgid "Drive"
-msgstr "Диск"
-
-#: pkg/storaged/drives-panel.jsx:120
+#: pkg/storaged/drives-panel.jsx:102
 msgid "Drives"
 msgstr "Диски"
 
@@ -2486,8 +2542,8 @@ msgstr "Дублювання псевдоніма"
 msgid "Duplicate port"
 msgstr "Дублювання порту"
 
-#: pkg/machines/components/nicEdit.jsx:296 pkg/storaged/crypto-tab.jsx:128
-#: pkg/storaged/nfs-details.jsx:306
+#: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:131
+#: pkg/storaged/nfs-details.jsx:314
 msgid "Edit"
 msgstr "Змінити"
 
@@ -2495,15 +2551,11 @@ msgstr "Змінити"
 msgid "Edit Server"
 msgstr "Змінити сервер"
 
-#: pkg/storaged/crypto-keyslots.jsx:270
+#: pkg/storaged/crypto-keyslots.jsx:276
 msgid "Edit Tang keyserver"
 msgstr "Редагувати сервер ключів Tang"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:7
-msgid "Edit image stream"
-msgstr "Редагувати потік образу"
-
-#: pkg/storaged/crypto-keyslots.jsx:535
+#: pkg/storaged/crypto-keyslots.jsx:548
 msgid "Editing a key requires a free slot"
 msgstr "Редагування ключа потребує вільного слоту"
 
@@ -2515,13 +2567,13 @@ msgstr "Видобуваємо $target"
 msgid "Embedded PC"
 msgstr "Вбудований ПК"
 
-#: pkg/playground/translate.html:57 src/base1/test-locale.js:44
-#: src/base1/test-locale.js:54 pkg/playground/translate.js:11
+#: pkg/playground/translate.html:57 src/base1/test-locale.js:47
+#: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Порожній"
 
-#: pkg/playground/translate.html:62 src/base1/test-locale.js:45
-#: src/base1/test-locale.js:56 pkg/playground/translate.js:17
+#: pkg/playground/translate.html:62 src/base1/test-locale.js:48
+#: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
 msgid "Empty"
 msgstr "Спорожнити"
@@ -2538,54 +2590,54 @@ msgstr "Емульована машина"
 msgid "Enable Service"
 msgstr "Увімкнути службу"
 
-#: pkg/systemd/index.html:161
+#: pkg/systemd/index.html:168
 msgid "Enable stored metrics…"
 msgstr "Вмикання збереженої метрики…"
 
-#: pkg/systemd/services.html:66 pkg/systemd/init.js:215
+#: pkg/systemd/services.html:66 pkg/systemd/init.js:216
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: pkg/storaged/format-dialog.jsx:292
+#: pkg/storaged/format-dialog.jsx:303
 msgid "Encrypt data"
 msgstr "Зашифрувати дані"
 
-#: pkg/storaged/utils.js:273
+#: pkg/storaged/utils.js:274
 msgid "Encrypted $0"
 msgstr "Зашифрований $0"
 
-#: pkg/storaged/utils.js:265
+#: pkg/storaged/utils.js:266
 msgid "Encrypted Logical Volume of $0"
 msgstr "Зашифрований логічний том $0"
 
-#: pkg/storaged/utils.js:267
+#: pkg/storaged/utils.js:268
 msgid "Encrypted Partition of $0"
 msgstr "Шифрований розділ $0"
 
-#: pkg/storaged/content-views.jsx:348
+#: pkg/storaged/content-views.jsx:353
 msgctxt "storage-id-desc"
 msgid "Encrypted data"
 msgstr "Зашифровані дані"
 
-#: pkg/storaged/lvol-tabs.jsx:140
+#: pkg/storaged/lvol-tabs.jsx:141
 msgid "Encrypted volumes can not be resized here."
 msgstr "Тут не можна змінювати розмір шифрованих томів."
 
-#: pkg/storaged/lvol-tabs.jsx:143
+#: pkg/storaged/lvol-tabs.jsx:144
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr ""
 "Перш ніж можна буде змінювати розмір зашифрованих томів, такі томи слід "
 "розблокувати."
 
-#: pkg/storaged/content-views.jsx:147
+#: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Шифрування"
 
-#: pkg/storaged/crypto-tab.jsx:102
+#: pkg/storaged/crypto-tab.jsx:105
 msgid "Encryption Options"
 msgstr "Параметри шифрування"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:252
+#: pkg/machines/components/networks/createNetworkDialog.jsx:238
 msgid "End"
 msgstr "Кінець"
 
@@ -2598,11 +2650,11 @@ msgstr "Кінець не може бути порожнім"
 msgid "Enforcing"
 msgstr "Примусово"
 
-#: pkg/systemd/host.js:510
+#: pkg/systemd/host.js:513
 msgid "Enhancement Updates Available"
 msgstr "Доступні оновлення із поліпшеннями"
 
-#: pkg/lib/machine-dialogs.js:445
+#: pkg/lib/machine-dialogs.js:447
 msgid "Enter IP address or host name"
 msgstr "Введіть IP-адресу або назву вузла"
 
@@ -2615,7 +2667,7 @@ msgstr ""
 "вводити його кожного разу, коли ви повторно встановлюватимете з’єднання із "
 "цією машиною."
 
-#: pkg/networkmanager/firewall.jsx:784
+#: pkg/networkmanager/firewall.jsx:786
 msgid "Entire subnet"
 msgstr "Уся підмережа"
 
@@ -2628,15 +2680,14 @@ msgid "Entrypoint"
 msgstr "Точка входження"
 
 #: pkg/docker/index.html:528
-#: node_modules/registry-image-widgets/views/image-config.html:21
 msgid "Environment"
 msgstr "Середовище"
 
-#: pkg/storaged/content-views.jsx:514 pkg/storaged/format-dialog.jsx:278
+#: pkg/storaged/content-views.jsx:521 pkg/storaged/format-dialog.jsx:286
 msgid "Erase"
 msgstr "Витерти"
 
-#: pkg/docker/storage.jsx:447
+#: pkg/docker/storage.jsx:460
 msgid "Erase containers and reset storage pool"
 msgstr "Витерти контейнери і відновити початковий стан резервного сховища"
 
@@ -2644,14 +2695,14 @@ msgstr "Витерти контейнери і відновити початко
 msgid "Erasing $target"
 msgstr "Витираємо $target"
 
-#: pkg/packagekit/updates.jsx:312
+#: pkg/packagekit/updates.jsx:313
 msgid "Errata:"
 msgstr "Помилки:"
 
 #: pkg/playground/translate.html:100 pkg/playground/translate.html:105
 #: pkg/apps/utils.jsx:100 pkg/storaged/multipath.jsx:57
-#: pkg/storaged/storage-controls.jsx:99 pkg/storaged/storage-controls.jsx:192
-#: pkg/systemd/service-details.jsx:448 pkg/users/local.js:1476
+#: pkg/storaged/storage-controls.jsx:100 pkg/storaged/storage-controls.jsx:194
+#: pkg/systemd/service-details.jsx:450 pkg/users/local.js:1476
 msgid "Error"
 msgstr "Помилка"
 
@@ -2691,7 +2742,7 @@ msgstr "MAC Ethernet"
 msgid "Ethernet MTU"
 msgstr "MTU Ethernet"
 
-#: pkg/networkmanager/interfaces.js:2015
+#: pkg/networkmanager/interfaces.js:2027
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2699,11 +2750,11 @@ msgstr "Ethtool"
 msgid "Everything"
 msgstr "Все"
 
-#: pkg/networkmanager/firewall.jsx:561
+#: pkg/networkmanager/firewall.jsx:563
 msgid "Example: 22,ssh,8080,5900-5910"
 msgstr "Приклад: 22,ssh,8080,5900-5910"
 
-#: pkg/networkmanager/firewall.jsx:569
+#: pkg/networkmanager/firewall.jsx:571
 msgid "Example: 88,2019,nfs,rsync"
 msgstr "Приклад: 88,2019,nfs,rsync"
 
@@ -2713,7 +2764,7 @@ msgstr "Чудовий пароль"
 
 #: pkg/playground/manifest.json.in
 msgid "Exceptions"
-msgstr ""
+msgstr "Виключення"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:229
 msgid "Existing disk image on host's file system"
@@ -2731,19 +2782,19 @@ msgstr "Апаратний блок розширення"
 msgid "Expose container ports"
 msgstr "Відкрити порти контейнера"
 
-#: pkg/storaged/content-views.jsx:454 pkg/storaged/format-dialog.jsx:254
+#: pkg/storaged/content-views.jsx:459 pkg/storaged/format-dialog.jsx:259
 msgid "Extended Partition"
 msgstr "Розширений розділ"
 
-#: pkg/storaged/mdraid-details.jsx:99
+#: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "ПОМИЛКА"
 
-#: pkg/networkmanager/interfaces.js:851
+#: pkg/networkmanager/interfaces.js:856
 msgid "Failed"
 msgstr "Помилка"
 
-#: pkg/lib/machine-dialogs.js:410
+#: pkg/lib/machine-dialogs.js:412
 msgid "Failed to add machine: $0"
 msgstr "Не вдалося додати комп’ютер: $0"
 
@@ -2755,7 +2806,7 @@ msgstr "Не вдалося додати порт"
 msgid "Failed to add service"
 msgstr "Не вдалося додати службу"
 
-#: pkg/networkmanager/firewall.jsx:709
+#: pkg/networkmanager/firewall.jsx:711
 msgid "Failed to add zone"
 msgstr "Не вдалося додати зону"
 
@@ -2775,7 +2826,7 @@ msgstr "Не вдалося вимкнути tuned"
 msgid "Failed to disable tuned profile"
 msgstr "Невдалося вимкнути профіль tuned"
 
-#: pkg/lib/machine-dialogs.js:492
+#: pkg/lib/machine-dialogs.js:494
 msgid "Failed to edit machine: $0"
 msgstr "Не вдалося змінити запис комп’ютера: $0"
 
@@ -2783,7 +2834,7 @@ msgstr "Не вдалося змінити запис комп’ютера: $0"
 msgid "Failed to enable tuned"
 msgstr "Не вдалося увімкнути tuned"
 
-#: pkg/machines/components/vmnetworktab.jsx:55
+#: pkg/machines/components/vmnetworktab.jsx:60
 msgid "Failed to fetch the IP addresses of the interfaces present in $0"
 msgstr "Не вдалося отримати IP-адреси інтерфейсів, які є у $0"
 
@@ -2791,11 +2842,11 @@ msgstr "Не вдалося отримати IP-адреси інтерфейс�
 msgid "Failed to load authorized keys."
 msgstr "Не вдалося завантажити уповноважені ключі."
 
-#: pkg/networkmanager/firewall.jsx:621
+#: pkg/networkmanager/firewall.jsx:623
 msgid "Failed to remove service"
 msgstr "Не вдалося вилучити службу"
 
-#: pkg/systemd/service-details.jsx:340
+#: pkg/systemd/service-details.jsx:342
 msgid "Failed to start"
 msgstr "Не вдалося запустити"
 
@@ -2821,7 +2872,7 @@ msgstr ""
 msgid "File"
 msgstr "Файл"
 
-#: pkg/storaged/content-views.jsx:145
+#: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "Файлова система"
 
@@ -2829,11 +2880,11 @@ msgstr "Файлова система"
 msgid "Filesystem Directory"
 msgstr "Каталог файлової системи"
 
-#: pkg/storaged/fsys-tab.jsx:123
+#: pkg/storaged/fsys-tab.jsx:126
 msgid "Filesystem Mounting"
 msgstr "Монтування файлової системи"
 
-#: pkg/storaged/fsys-tab.jsx:70
+#: pkg/storaged/fsys-tab.jsx:71
 msgid "Filesystem Name"
 msgstr "Назва файлової системи"
 
@@ -2841,7 +2892,7 @@ msgstr "Назва файлової системи"
 msgid "Filesystems"
 msgstr "Файлові системи"
 
-#: pkg/networkmanager/firewall.jsx:516
+#: pkg/networkmanager/firewall.jsx:518
 msgid "Filter Services"
 msgstr "Фільтрувати служби"
 
@@ -2849,28 +2900,24 @@ msgstr "Фільтрувати служби"
 msgid "Filter by name or description..."
 msgstr "Фільтрувати за назвою або описом…"
 
-#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:269
+#: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Відбиток"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:97
-#: pkg/networkmanager/firewall.jsx:945 pkg/networkmanager/firewall.jsx:948
+#: pkg/networkmanager/firewall.jsx:947 pkg/networkmanager/firewall.jsx:950
 msgid "Firewall"
 msgstr "Брандмауер"
 
-#: pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:895
 msgid "Firewall is not available"
 msgstr "Брандмауер недоступний"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:35
-msgid "Follows docker repo"
-msgstr "Стежить за сховищем docker"
-
-#: pkg/storaged/vdos-panel.jsx:88
+#: pkg/storaged/vdos-panel.jsx:96
 msgid "For legacy applications only. Reduces performance."
 msgstr "Лише для застарілих програм. Знижує швидкодію."
 
-#: pkg/systemd/service-details.jsx:322
+#: pkg/systemd/service-details.jsx:324
 msgid "Forbidden from running"
 msgstr "Заборонено запускати"
 
@@ -2894,58 +2941,58 @@ msgstr "Примусово вимкнути"
 msgid "Force password change"
 msgstr "Примусова зміна пароля"
 
-#: pkg/storaged/crypto-keyslots.jsx:373
+#: pkg/storaged/crypto-keyslots.jsx:381
 msgid "Force remove passphrase in $0"
 msgstr "Примусово вилучити пароль у $0"
 
-#: pkg/machines/components/diskAdd.jsx:157
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
-#: pkg/storaged/content-views.jsx:318 pkg/storaged/content-views.jsx:530
-#: pkg/storaged/format-dialog.jsx:323
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
+#: pkg/storaged/content-views.jsx:323 pkg/storaged/content-views.jsx:542
+#: pkg/storaged/format-dialog.jsx:336
 msgid "Format"
 msgstr "Формат"
 
-#: pkg/storaged/format-dialog.jsx:186
+#: pkg/storaged/format-dialog.jsx:191
 msgid "Format $0"
 msgstr "Форматувати $0"
 
-#: pkg/storaged/content-views.jsx:511
+#: pkg/storaged/content-views.jsx:518
 msgid "Format Disk $0"
 msgstr "Форматувати диск $0"
 
-#: pkg/storaged/content-views.jsx:531
+#: pkg/storaged/content-views.jsx:543
 msgid "Formatting a disk will erase all data on it."
 msgstr ""
 "Форматування диска призведе до знищення даних, які на ньому зберігаються."
 
-#: pkg/storaged/format-dialog.jsx:325
+#: pkg/storaged/format-dialog.jsx:338
 msgid "Formatting a storage device will erase all data on it."
 msgstr ""
 "Форматування пристрою для зберігання даних призведе до знищення даних, які "
 "на ньому зберігаються."
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:147
+#: pkg/machines/components/networks/createNetworkDialog.jsx:133
 msgid "Forward Mode"
 msgstr "Режим переспрямовування"
 
-#: pkg/networkmanager/interfaces.js:2873
+#: pkg/networkmanager/interfaces.js:2881
 msgid "Forward delay $forward_delay"
 msgstr "Затримка переспрямування $forward_delay"
 
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:55
 msgid "Forwarding mode"
 msgstr "Режим переспрямовування"
 
-#: pkg/docker/storage.jsx:325 pkg/docker/storage.jsx:348
+#: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Вільно"
 
-#: pkg/storaged/content-views.jsx:440
+#: pkg/storaged/content-views.jsx:445
 msgid "Free Space"
 msgstr "Вільне місце"
 
-#: pkg/storaged/lvol-tabs.jsx:371
+#: pkg/storaged/lvol-tabs.jsx:379
 msgid ""
 "Free up space in this group: Shrink or delete other logical volumes or add "
 "another physical volume."
@@ -2961,10 +3008,6 @@ msgstr "п'ятниця"
 msgid "Fridays"
 msgstr "П'ятниці"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:6
-msgid "From"
-msgstr "З"
-
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
 msgstr "Повне ім'я"
@@ -2974,9 +3017,13 @@ msgid "Gateway:"
 msgstr "Шлюз:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2715 pkg/systemd/logs.js:486
+#: pkg/networkmanager/interfaces.js:2723 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Загальний"
+
+#: pkg/machines/components/nicAdd.jsx:49
+msgid "Generate automatically"
+msgstr "Створити автоматично"
 
 #: pkg/sosreport/index.html:55
 msgid "Generating report"
@@ -2986,15 +3033,15 @@ msgstr "Створюємо звіт"
 msgid "Get new image"
 msgstr "Отримати новий образ"
 
-#: pkg/machines/components/diskAdd.jsx:191
 #: pkg/machines/components/memorySelectRow.jsx:46
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
 #: pkg/machines/components/vm/memoryModal.jsx:191
-#: pkg/machines/components/vmDisksTab.jsx:44
+#: pkg/machines/components/vmDisksTab.jsx:51
 msgid "GiB"
 msgstr "ГіБ"
 
-#: pkg/systemd/logs.js:199
+#: pkg/systemd/logs.js:200
 msgid "Go to"
 msgstr "Перейти до"
 
@@ -3003,7 +3050,7 @@ msgid "Go to Application"
 msgstr "Перейти до програми"
 
 #: pkg/dashboard/index.html:46 pkg/networkmanager/index.html:63
-#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:174
+#: pkg/networkmanager/index.html:396 pkg/systemd/index.html:185
 #: pkg/storaged/plot.jsx:72
 msgid "Go to now"
 msgstr "Перейти зараз"
@@ -3016,21 +3063,21 @@ msgstr "Графічна консоль (VNC)"
 msgid "Graphics Console in Desktop Viewer"
 msgstr "Графічна консоль у перегляді стільниці"
 
-#: pkg/storaged/lvol-tabs.jsx:235 pkg/storaged/lvol-tabs.jsx:399
-#: pkg/storaged/lvol-tabs.jsx:451 pkg/storaged/vdo-details.jsx:229
-#: pkg/storaged/vdo-details.jsx:298
+#: pkg/storaged/lvol-tabs.jsx:239 pkg/storaged/lvol-tabs.jsx:407
+#: pkg/storaged/lvol-tabs.jsx:459 pkg/storaged/vdo-details.jsx:235
+#: pkg/storaged/vdo-details.jsx:304
 msgid "Grow"
 msgstr "Збільшити"
 
-#: pkg/storaged/lvol-tabs.jsx:417
+#: pkg/storaged/lvol-tabs.jsx:425
 msgid "Grow Content"
 msgstr "Збільшити вміст"
 
-#: pkg/storaged/lvol-tabs.jsx:231
+#: pkg/storaged/lvol-tabs.jsx:235
 msgid "Grow Logical Volume"
 msgstr "Збільшити логічний том"
 
-#: pkg/storaged/vdo-details.jsx:218
+#: pkg/storaged/vdo-details.jsx:223
 msgid "Grow logical size of $0"
 msgstr "Збільшити логічний розмір $0"
 
@@ -3042,7 +3089,7 @@ msgstr "Збільшити так, щоб використати усе місц
 msgid "Hair Pin mode"
 msgstr "Режим початкової зони"
 
-#: pkg/networkmanager/interfaces.js:2899
+#: pkg/networkmanager/interfaces.js:2907
 msgid "Hairpin mode"
 msgstr "Режим початкової зони (hairpin)"
 
@@ -3050,35 +3097,30 @@ msgstr "Режим початкової зони (hairpin)"
 msgid "Hand Held"
 msgstr "Портативний"
 
-#: pkg/docker/storage.jsx:166
+#: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Твердий диск"
-
-#: pkg/storaged/drives-panel.jsx:85
-msgctxt "storage"
-msgid "Hard Disk"
-msgstr "Жорсткий диск"
 
 #: pkg/systemd/index.html:87
 msgid "Hardware"
 msgstr "Обладнання"
 
-#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:270
+#: pkg/systemd/hwinfo.html:4 pkg/systemd/hwinfo.jsx:274
 msgid "Hardware Information"
 msgstr "Дані щодо обладнання"
 
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2883
 msgid "Hello time $hello_time"
 msgstr "Час вітання $hello_time"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Hide Performance Options"
 msgstr "Приховати параметри швидкодії"
 
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
-#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:338
+#: pkg/machines/components/vmDiskColumns.jsx:47 pkg/shell/indexes.js:389
 msgid "Host"
 msgstr "Вузол"
 
@@ -3086,16 +3128,16 @@ msgstr "Вузол"
 msgid "Host Device"
 msgstr "Пристрій основної системи"
 
-#: pkg/dashboard/index.html:137 pkg/systemd/index.html:113
+#: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
 msgstr "Назва вузла"
 
-#: src/base1/cockpit.js:4023
+#: src/base1/cockpit.js:4027
 msgid "Host key is incorrect"
 msgstr "Ключ вузла є неправильним"
 
-#: pkg/realmd/operation.js:601
+#: pkg/realmd/operation.js:603
 msgid "Host name should not be changed in a domain"
 msgstr "У домені не слід змінювати назву вузла"
 
@@ -3107,7 +3149,7 @@ msgstr "Вузол не повинен бути порожнім"
 msgid "Hour : Minute"
 msgstr "Година : Хвилина"
 
-#: pkg/systemd/init.js:1161 pkg/systemd/init.js:1190
+#: pkg/systemd/init.js:1223 pkg/systemd/init.js:1252
 msgid "Hour needs to be a number between 0-23"
 msgstr "Години слід вказувати у форматі числа від 0 до 23"
 
@@ -3115,16 +3157,16 @@ msgstr "Години слід вказувати у форматі числа в
 msgid "Hours"
 msgstr "Години"
 
-#: pkg/systemd/index.html:238 pkg/systemd/host.js:1599
+#: pkg/systemd/index.html:249 pkg/systemd/host.js:1642
 msgid "I/O Wait"
 msgstr "Очікування В-В"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "ID"
 msgstr "Ід."
 
 #: pkg/networkmanager/index.html:120 pkg/networkmanager/index.html:138
-#: pkg/machines/components/vmnetworktab.jsx:133
+#: pkg/machines/components/vmnetworktab.jsx:143
 msgid "IP Address"
 msgstr "IP-адреса"
 
@@ -3132,7 +3174,7 @@ msgstr "IP-адреса"
 msgid "IP Address:"
 msgstr "IP-адреса:"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:197
+#: pkg/machines/components/networks/createNetworkDialog.jsx:183
 msgid "IP Configuration"
 msgstr "Налаштування IP"
 
@@ -3140,7 +3182,7 @@ msgstr "Налаштування IP"
 msgid "IP Prefix Length:"
 msgstr "Довжина префікса IP:"
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "IP Range"
 msgstr "Діапазон IP"
 
@@ -3148,7 +3190,7 @@ msgstr "Діапазон IP"
 msgid "IP Settings"
 msgstr "Параметри IP"
 
-#: pkg/networkmanager/interfaces.js:2924
+#: pkg/networkmanager/interfaces.js:2932
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3156,7 +3198,7 @@ msgstr "IPv4"
 msgid "IPv4 Address"
 msgstr "Адреса IPv4"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:279
+#: pkg/machines/components/networks/createNetworkDialog.jsx:265
 msgid "IPv4 Network"
 msgstr "Мережа IPv4"
 
@@ -3164,19 +3206,19 @@ msgstr "Мережа IPv4"
 msgid "IPv4 Network should not be empty"
 msgstr "Мережа IPv4 не повинна бути порожньою"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv4 Settings"
 msgstr "Параметри IPv4"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:213
+#: pkg/machines/components/networks/createNetworkDialog.jsx:199
 msgid "IPv4 and IPv6"
 msgstr "IPv4 і IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:207
+#: pkg/machines/components/networks/createNetworkDialog.jsx:193
 msgid "IPv4 only"
 msgstr "Лише IPv4"
 
-#: pkg/networkmanager/interfaces.js:2925
+#: pkg/networkmanager/interfaces.js:2933
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3184,7 +3226,7 @@ msgstr "IPv6"
 msgid "IPv6 Address"
 msgstr "Адреса IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:323
+#: pkg/machines/components/networks/createNetworkDialog.jsx:309
 msgid "IPv6 Network"
 msgstr "Мережа IPv6"
 
@@ -3192,11 +3234,11 @@ msgstr "Мережа IPv6"
 msgid "IPv6 Network should not be empty"
 msgstr "Мережа IPv6 не повинна бути порожньою"
 
-#: pkg/networkmanager/interfaces.js:3371
+#: pkg/networkmanager/interfaces.js:3382
 msgid "IPv6 Settings"
 msgstr "Параметри IPv6"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:210
+#: pkg/machines/components/networks/createNetworkDialog.jsx:196
 msgid "IPv6 only"
 msgstr "Лише IPv6"
 
@@ -3204,7 +3246,7 @@ msgstr "Лише IPv6"
 msgid "Id"
 msgstr "Ід."
 
-#: pkg/networkmanager/interfaces.js:2916
+#: pkg/networkmanager/interfaces.js:2924
 msgid "Id $id"
 msgstr "Ід. $id"
 
@@ -3212,21 +3254,15 @@ msgstr "Ід. $id"
 msgid "Id:"
 msgstr "Ід.:"
 
-#: node_modules/registry-image-widgets/views/image-body.html:24
-#: node_modules/registry-image-widgets/views/image-listing.html:7
-msgid "Identifier"
-msgstr "Ідентифікатор"
-
-#: pkg/storaged/crypto-keyslots.jsx:325
+#: pkg/storaged/crypto-keyslots.jsx:333
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Якщо програма tang-show-keys є недоступною, віддайте таку команду:"
 
-#: pkg/networkmanager/interfaces.js:1978 pkg/packagekit/updates.jsx:496
+#: pkg/networkmanager/interfaces.js:1990 pkg/packagekit/updates.jsx:498
 msgid "Ignore"
 msgstr "Ігнорувати"
 
 #: pkg/docker/index.html:270 pkg/docker/index.html:433
-#: node_modules/registry-image-widgets/views/image-panel.html:9
 #: pkg/docker/containers-view.jsx:131 pkg/docker/containers-view.jsx:359
 msgid "Image"
 msgstr "Образ"
@@ -3242,14 +3278,6 @@ msgstr "Побудова образів"
 #: pkg/docker/index.html:580
 msgid "Image Search"
 msgstr "Пошук образів"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:41
-msgid "Image count"
-msgstr "Кількість образів"
-
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:12
-msgid "Image stream"
-msgstr "Потік образу"
 
 #: pkg/docker/index.html:157
 msgid "Image:"
@@ -3268,33 +3296,15 @@ msgstr "Образи"
 msgid "Images and running containers"
 msgstr "Образи і запущені контейнери"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:15
-#: node_modules/registry-image-widgets/views/imagestream-body.html:16
-msgid "Images may be pulled by anonymous users"
-msgstr "Обрати можуть отримувати анонімні користувачі"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:20
-#: node_modules/registry-image-widgets/views/imagestream-body.html:21
-msgid "Images may be pulled by any authenticated user or group"
-msgstr ""
-"Образи може бути отримати будь-яким розпізнаним користувачем або учасником "
-"групи"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:25
-#: node_modules/registry-image-widgets/views/imagestream-body.html:26
-msgid "Images may only be pulled by specific users or groups"
-msgstr ""
-"Образи може бути отримано лише вказаними користувачами або учасниками груп"
-
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:764
 msgid "Immediately Start VM"
 msgstr "Негайно запустити ВМ"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:831
 msgid "Import VM"
-msgstr ""
+msgstr "Імпортувати ВМ"
 
-#: pkg/storaged/mdraid-details.jsx:100
+#: pkg/storaged/mdraid-details.jsx:94
 msgid "In Sync"
 msgstr "Синхронізовано"
 
@@ -3314,16 +3324,16 @@ msgstr ""
 "Для синхронізації параметрів користувачів, слід увійти до "
 "{{#strong}}{{host}}{{/strong}}. "
 
-#: pkg/networkmanager/interfaces.js:833 pkg/networkmanager/interfaces.js:1426
-#: pkg/networkmanager/interfaces.js:1433 pkg/networkmanager/interfaces.js:2618
+#: pkg/networkmanager/interfaces.js:838 pkg/networkmanager/interfaces.js:1431
+#: pkg/networkmanager/interfaces.js:1438 pkg/networkmanager/interfaces.js:2626
 msgid "Inactive"
 msgstr "Неактивний"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Inactive volume"
 msgstr "Неактивний том"
 
-#: pkg/networkmanager/firewall.jsx:762
+#: pkg/networkmanager/firewall.jsx:764
 msgid "Included services"
 msgstr "Включені служби"
 
@@ -3331,7 +3341,7 @@ msgstr "Включені служби"
 msgid "Incorrect Host Key"
 msgstr "Неправильний ключ вузла"
 
-#: pkg/storaged/vdo-details.jsx:301 pkg/storaged/vdos-panel.jsx:69
+#: pkg/storaged/vdo-details.jsx:307 pkg/storaged/vdos-panel.jsx:73
 msgid "Index Memory"
 msgstr "Пам'ять покажчика"
 
@@ -3339,11 +3349,11 @@ msgstr "Пам'ять покажчика"
 msgid "Info and above"
 msgstr "Інформація і вище"
 
-#: pkg/docker/storage.jsx:309
+#: pkg/docker/storage.jsx:313
 msgid "Information about the Docker storage pool is not available."
 msgstr "Немає доступу до даних щодо резервного сховища даних Docker."
 
-#: pkg/packagekit/updates.jsx:453
+#: pkg/packagekit/updates.jsx:455
 msgid "Initializing..."
 msgstr "Ініціалізація…"
 
@@ -3356,12 +3366,12 @@ msgid "Initiator IQN should not be empty"
 msgstr "IQN ініціатора має бути непорожнімy"
 
 #: pkg/apps/application-list.jsx:87 pkg/apps/application.jsx:112
-#: pkg/lib/cockpit-components-install-dialog.jsx:115
+#: pkg/lib/cockpit-components-install-dialog.jsx:116
 #: pkg/machines/components/vm/vmActions.jsx:98
 msgid "Install"
 msgstr "Встановити"
 
-#: pkg/packagekit/updates.jsx:808
+#: pkg/packagekit/updates.jsx:809
 msgid "Install All Updates"
 msgstr "Встановити усі оновлення"
 
@@ -3369,7 +3379,7 @@ msgstr "Встановити усі оновлення"
 msgid "Install NFS Support"
 msgstr "Встановити підтримку NFS"
 
-#: pkg/packagekit/updates.jsx:808 pkg/packagekit/updates.jsx:814
+#: pkg/packagekit/updates.jsx:809 pkg/packagekit/updates.jsx:815
 msgid "Install Security Updates"
 msgstr "Встановити оновлення захисту"
 
@@ -3377,7 +3387,7 @@ msgstr "Встановити оновлення захисту"
 msgid "Install Software"
 msgstr "Встановити програмне забезпечення"
 
-#: pkg/storaged/vdos-panel.jsx:171
+#: pkg/storaged/vdos-panel.jsx:181
 msgid "Install VDO support"
 msgstr "Встановити підтримку VDO"
 
@@ -3408,11 +3418,11 @@ msgstr "Встановлено"
 msgid "Installing"
 msgstr "Встановлення"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:183
+#: pkg/lib/cockpit-components-install-dialog.jsx:184
 msgid "Installing $0"
 msgstr "Встановлюємо $0"
 
-#: pkg/systemd/service-details.jsx:487
+#: pkg/systemd/service-details.jsx:489
 msgid "Instance of template: "
 msgstr "Екземпляр шаблона: "
 
@@ -3420,13 +3430,13 @@ msgstr "Екземпляр шаблона: "
 msgid "Instantiate"
 msgstr "Створити екземпляр"
 
-#: pkg/machines/components/nicEdit.jsx:132
+#: pkg/machines/components/nicBody.jsx:131
 msgid "Interface Type"
 msgstr "Тип інтерфейсу"
 
 #: pkg/networkmanager/index.html:108 pkg/networkmanager/index.html:266
-#: pkg/networkmanager/firewall.jsx:767 pkg/networkmanager/firewall.jsx:955
-#: pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/firewall.jsx:769 pkg/networkmanager/firewall.jsx:957
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Interfaces"
 msgstr "Інтерфейси"
 
@@ -3434,7 +3444,7 @@ msgstr "Інтерфейси"
 msgid "Internal Error: Invalid challenge header"
 msgstr "Внутрішня помилка: некоректний заголовок виклику"
 
-#: src/base1/cockpit.js:4025
+#: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Внутрішня помилка"
 
@@ -3462,15 +3472,15 @@ msgstr "Некоректний префікс IPv6"
 msgid "Invalid address $0"
 msgstr "Некоректна адреса $0"
 
-#: pkg/systemd/shutdown.js:143 pkg/systemd/host.js:1469
+#: pkg/systemd/host.js:1506 pkg/systemd/shutdown.js:143
 msgid "Invalid date format"
 msgstr "Некоректний формат дати"
 
-#: pkg/systemd/shutdown.js:139 pkg/systemd/host.js:1465
+#: pkg/systemd/host.js:1502 pkg/systemd/shutdown.js:139
 msgid "Invalid date format and invalid time format"
 msgstr "Некоректний формат дати і часу"
 
-#: pkg/systemd/init.js:1196
+#: pkg/systemd/init.js:1258
 msgid "Invalid date format."
 msgstr "Некоректний формат дати."
 
@@ -3498,7 +3508,7 @@ msgstr "Некоректна метрика $0"
 msgid "Invalid number of days"
 msgstr "Некоректна кількість днів"
 
-#: pkg/systemd/init.js:1143
+#: pkg/systemd/init.js:1205
 msgid "Invalid number."
 msgstr "Некоректне число."
 
@@ -3522,15 +3532,15 @@ msgstr "Некоректний префікс або маска мережі $0"
 msgid "Invalid range"
 msgstr "Некоректний діапазон"
 
-#: pkg/systemd/shutdown.js:141 pkg/systemd/host.js:1467
+#: pkg/systemd/host.js:1504 pkg/systemd/shutdown.js:141
 msgid "Invalid time format"
 msgstr "Некоректний формат визначення часу"
 
-#: pkg/systemd/index.html:374
+#: pkg/systemd/index.html:385
 msgid "Invalid time zone"
 msgstr "Некоректний часовий пояс"
 
-#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:163
+#: pkg/storaged/iscsi-panel.jsx:80 pkg/storaged/iscsi-panel.jsx:169
 msgid "Invalid username or password"
 msgstr "Некоректне ім’я користувача чи пароль"
 
@@ -3554,7 +3564,7 @@ msgstr "Завдання"
 msgid "Join"
 msgstr "З'єднати"
 
-#: pkg/realmd/operation.js:596
+#: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Долучитися до домену"
 
@@ -3562,11 +3572,11 @@ msgstr "Долучитися до домену"
 msgid "Join a Domain"
 msgstr "Долучитися до домену"
 
-#: pkg/realmd/operation.js:505
+#: pkg/realmd/operation.js:507
 msgid "Joining this domain is not supported"
 msgstr "Підтримки долучення до цього домену не передбачено"
 
-#: pkg/systemd/service-details.jsx:434
+#: pkg/systemd/service-details.jsx:436
 msgid "Joins Namespace Of"
 msgstr "Долучається до простору назв"
 
@@ -3574,15 +3584,15 @@ msgstr "Долучається до простору назв"
 msgid "Journal"
 msgstr "Журнал"
 
-#: pkg/systemd/logs.js:407
+#: pkg/systemd/logs.js:409
 msgid "Journal entry"
 msgstr "Запис журналу"
 
-#: pkg/systemd/logs.js:438
+#: pkg/systemd/logs.js:440
 msgid "Journal entry not found"
 msgstr "Не знайдено запису журналу"
 
-#: pkg/kdump/kdump-view.jsx:459
+#: pkg/kdump/kdump-view.jsx:461
 msgid ""
 "Kdump service not installed. Please ensure package kexec-tools is installed."
 msgstr ""
@@ -3601,7 +3611,7 @@ msgstr "SSO на основі Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Квиток Kerberos"
 
-#: pkg/systemd/index.html:234 pkg/systemd/host.js:1600
+#: pkg/systemd/index.html:245 pkg/systemd/host.js:1643
 msgid "Kernel"
 msgstr "Ядро"
 
@@ -3609,27 +3619,27 @@ msgstr "Ядро"
 msgid "Kernel Dump"
 msgstr "Дамп ядра"
 
-#: pkg/storaged/crypto-keyslots.jsx:563
+#: pkg/storaged/crypto-keyslots.jsx:576
 msgid "Key slots with unknown types can not be edited here"
 msgstr "Тут не можна редагувати слоти ключів із невідомими типами"
 
-#: pkg/storaged/crypto-keyslots.jsx:202
+#: pkg/storaged/crypto-keyslots.jsx:204
 msgid "Key source"
 msgstr "Джерело ключа"
 
-#: pkg/storaged/crypto-keyslots.jsx:586
+#: pkg/storaged/crypto-keyslots.jsx:599
 msgid "Keys"
 msgstr "Ключі"
 
-#: pkg/storaged/crypto-keyslots.jsx:557
+#: pkg/storaged/crypto-keyslots.jsx:570
 msgid "Keyserver"
 msgstr "Сервер ключів"
 
-#: pkg/storaged/crypto-keyslots.jsx:222 pkg/storaged/crypto-keyslots.jsx:272
+#: pkg/storaged/crypto-keyslots.jsx:228 pkg/storaged/crypto-keyslots.jsx:278
 msgid "Keyserver address"
 msgstr "Адреса сервера ключів"
 
-#: pkg/storaged/crypto-keyslots.jsx:415
+#: pkg/storaged/crypto-keyslots.jsx:424
 msgid "Keyserver removal may prevent unlocking $0."
 msgstr "Вилучення сервера ключів може завадити розблокуванню $0."
 
@@ -3640,10 +3650,6 @@ msgstr "Ключ LACP"
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:66
 msgid "LVM Volume Group"
 msgstr "Група томів LVM"
-
-#: node_modules/registry-image-widgets/views/image-meta.html:3
-msgid "Labels"
-msgstr "Мітки"
 
 #: pkg/lib/machine-info.js:72
 msgid "Laptop"
@@ -3661,13 +3667,9 @@ msgstr "Попередні 7 днів"
 msgid "Last Login"
 msgstr "Останній вхід"
 
-#: pkg/systemd/init.js:293
+#: pkg/systemd/init.js:305
 msgid "Last Trigger"
 msgstr "Останній перемикач"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:8
-msgid "Last Updated"
-msgstr "Останнє оновлення"
 
 #: pkg/packagekit/updates.jsx:177
 msgid "Last checked: $0 ago"
@@ -3723,7 +3725,7 @@ msgstr "Спостереження за посиланнями"
 msgid "Link down delay"
 msgstr "Затримка розірвання зв’язку"
 
-#: pkg/networkmanager/interfaces.js:1966 pkg/networkmanager/interfaces.js:1976
+#: pkg/networkmanager/interfaces.js:1978 pkg/networkmanager/interfaces.js:1988
 msgid "Link local"
 msgstr "Пов’язати локальний"
 
@@ -3743,11 +3745,11 @@ msgstr "Посилання"
 msgid "Links:"
 msgstr "Посилання:"
 
-#: pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:2014
 msgid "Load Balancing"
 msgstr "Збалансовування навантаження"
 
-#: pkg/systemd/logs.js:138
+#: pkg/systemd/logs.js:139
 msgid "Load earlier entries"
 msgstr "Завантажити попередні записи"
 
@@ -3767,9 +3769,9 @@ msgstr "Завантажуємо доступні оновлення, зачек
 msgid "Loading system modifications..."
 msgstr "Завантажуємо модифікації системи…"
 
-#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:367
-#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:144 pkg/systemd/logs.js:159
-#: pkg/systemd/logs.js:206 pkg/systemd/logs.js:255 pkg/systemd/logs.js:317
+#: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:369
+#: pkg/storaged/devices.jsx:65 pkg/systemd/logs.js:145 pkg/systemd/logs.js:160
+#: pkg/systemd/logs.js:207 pkg/systemd/logs.js:256 pkg/systemd/logs.js:318
 msgid "Loading..."
 msgstr "Завантаження…"
 
@@ -3777,7 +3779,7 @@ msgstr "Завантаження…"
 msgid "Local Accounts"
 msgstr "Локальні облікові записи"
 
-#: pkg/docker/storage.jsx:198
+#: pkg/docker/storage.jsx:200
 msgid "Local Disks"
 msgstr "Локальні диски"
 
@@ -3789,7 +3791,7 @@ msgstr "Локальна файлова система"
 msgid "Local Install Media"
 msgstr "Локальні носії для встановлення"
 
-#: pkg/storaged/nfs-details.jsx:162
+#: pkg/storaged/nfs-details.jsx:167
 msgid "Local Mount Point"
 msgstr "Локальна точка монтування"
 
@@ -3797,7 +3799,7 @@ msgstr "Локальна точка монтування"
 msgid "Location"
 msgstr "Розташування"
 
-#: pkg/storaged/content-views.jsx:238
+#: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Заблокувати"
 
@@ -3841,23 +3843,23 @@ msgstr "Повідомлення журналу"
 msgid "Logged In"
 msgstr "Вхід"
 
-#: pkg/storaged/vdo-details.jsx:289
+#: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "Логічний"
 
-#: pkg/storaged/vdo-details.jsx:220 pkg/storaged/vdos-panel.jsx:63
+#: pkg/storaged/vdo-details.jsx:225 pkg/storaged/vdos-panel.jsx:66
 msgid "Logical Size"
 msgstr "Логічний розмір"
 
-#: pkg/storaged/utils.js:197
+#: pkg/storaged/utils.js:198
 msgid "Logical Volume"
 msgstr "Логічний том"
 
-#: pkg/storaged/utils.js:195
+#: pkg/storaged/utils.js:196
 msgid "Logical Volume (Snapshot)"
 msgstr "Логічний том (знімок)"
 
-#: pkg/storaged/utils.js:269
+#: pkg/storaged/utils.js:270
 msgid "Logical Volume of $0"
 msgstr "Логічний том $0"
 
@@ -3873,7 +3875,7 @@ msgstr "Формат входу"
 msgid "Login Password"
 msgstr "Пароль користувача"
 
-#: src/base1/cockpit.js:4015
+#: src/base1/cockpit.js:4019
 msgid "Login failed"
 msgstr "Невдала спроба увійти"
 
@@ -3902,10 +3904,12 @@ msgid "Lunch Box"
 msgstr "Пусковий комп'ютер"
 
 #: pkg/networkmanager/index.html:192 pkg/networkmanager/index.html:271
+#: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/vmnetworktab.jsx:132
+#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/vmnetworktab.jsx:141
 msgid "MAC Address"
 msgstr "MAC-адреса"
 
@@ -3913,35 +3917,27 @@ msgstr "MAC-адреса"
 msgid "MAC Address:"
 msgstr "MAC-адреса:"
 
-#: pkg/networkmanager/interfaces.js:1994
+#: pkg/networkmanager/interfaces.js:2006
 msgid "MII (Recommended)"
 msgstr "MII (рекомендоване)"
 
-#: pkg/networkmanager/interfaces.js:2773
+#: pkg/networkmanager/interfaces.js:2781
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4557
+#: pkg/networkmanager/interfaces.js:4575
 msgid "MTU must be a positive number"
 msgstr "MTU має бути додатнім числом"
-
-#: pkg/machines/components/vm/bootOrderModal.jsx:103
-msgid "Mac"
-msgstr "Mac"
-
-#: pkg/machines/components/nicEdit.jsx:169
-msgid "Mac Address"
-msgstr "Mac-адреса"
 
 #: pkg/systemd/index.html:95
 msgid "Machine ID"
 msgstr "Ід. комп’ютера"
 
-#: pkg/systemd/index.html:267
+#: pkg/systemd/index.html:278
 msgid "Machine SSH Key Fingerprints"
 msgstr "Відбитки ключів SSH комп’ютерів"
 
-#: pkg/shell/indexes.js:302
+#: pkg/shell/indexes.js:353
 msgid "Machines"
 msgstr "Машини"
 
@@ -3949,11 +3945,11 @@ msgstr "Машини"
 msgid "Main Server Chassis"
 msgstr "Апаратний блок основного сервера"
 
-#: pkg/storaged/crypto-keyslots.jsx:319
+#: pkg/storaged/crypto-keyslots.jsx:327
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Переконайтеся, що хеш ключа з сервера Tang є таким:"
 
-#: pkg/networkmanager/interfaces.js:1967 pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1979 pkg/networkmanager/interfaces.js:1989
 msgid "Manual"
 msgstr "Вручну"
 
@@ -3961,11 +3957,11 @@ msgstr "Вручну"
 msgid "Manual Connection"
 msgstr "З’єднання вручну"
 
-#: pkg/systemd/index.html:384 pkg/systemd/index.html:388
+#: pkg/systemd/index.html:395 pkg/systemd/index.html:399
 msgid "Manually"
 msgstr "Вручну"
 
-#: pkg/storaged/crypto-keyslots.jsx:322
+#: pkg/storaged/crypto-keyslots.jsx:330
 msgid "Manually check with SSH: "
 msgstr "Перевірка вручну за допомогою SSH: "
 
@@ -3977,7 +3973,7 @@ msgstr "Позначаємо $target як помилковий"
 msgid "Mask Service"
 msgstr "Замаскувати службу"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:293
+#: pkg/machines/components/networks/createNetworkDialog.jsx:279
 msgid "Mask or Prefix Length"
 msgstr "Довжина маски або префікса"
 
@@ -3985,7 +3981,7 @@ msgstr "Довжина маски або префікса"
 msgid "Mask or Prefix Length should not be empty"
 msgstr "Довжина маски або префікса повинна бути непорожньою"
 
-#: pkg/systemd/service-details.jsx:321
+#: pkg/systemd/service-details.jsx:323
 msgid "Masked"
 msgstr "Замасковано"
 
@@ -3999,7 +3995,7 @@ msgstr ""
 "значніші наслідки, ніж ви очікуєте. Будь ласка, підтвердьте, що ви хочете "
 "замаскувати цей модуль."
 
-#: pkg/networkmanager/interfaces.js:2779
+#: pkg/networkmanager/interfaces.js:2787
 msgid "Master"
 msgstr "Основний"
 
@@ -4015,7 +4011,7 @@ msgstr "Максимальна одиниця передавання"
 msgid "Maximum memory could not be saved"
 msgstr "Не вдалося зберегти дані щодо максимального обсягу пам'яті"
 
-#: pkg/networkmanager/interfaces.js:2877
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Maximum message age $max_age"
 msgstr "Максимальний вік повідомлення $max_age"
 
@@ -4027,32 +4023,32 @@ msgstr ""
 "Максимальна кількість віртуальних процесорів, наданих для гостьової "
 "операційної системи, має бути у межах від 1 до $0"
 
-#: pkg/storaged/content-views.jsx:345
+#: pkg/storaged/content-views.jsx:350
 msgid "Member of RAID Device"
 msgstr "Елемент пристрою RAID"
 
-#: pkg/storaged/content-views.jsx:341
+#: pkg/storaged/content-views.jsx:346
 msgid "Member of RAID Device $0"
 msgstr "Елемент пристрою RAID $0"
 
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
-#: pkg/playground/translate.html:90 pkg/systemd/index.html:204
+#: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:389
-#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmOverviewTab.jsx:74 pkg/systemd/hwinfo.jsx:263
 msgid "Memory"
 msgstr "Пам'ять"
 
-#: pkg/systemd/host.js:1658
+#: pkg/systemd/host.js:1701
 msgctxt "page-title"
 msgid "Memory"
 msgstr "Пам'ять"
 
-#: pkg/systemd/index.html:205
+#: pkg/systemd/index.html:216
 msgid "Memory & Swap"
 msgstr "Пам'ять і резерв"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Memory Technology"
 msgstr "Технологія пам'яті"
 
@@ -4081,18 +4077,17 @@ msgstr "Використання пам'яті:"
 msgid "Message to logged in users"
 msgstr "Повідомлення користувачам, які увійшли"
 
-#: node_modules/registry-image-widgets/views/image-panel.html:15
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:14
-msgid "Metadata"
-msgstr "Метадані"
+#: pkg/shell/index.html:399
+msgid "Messages related to the failure might be found in the journal:"
+msgstr "Повідомлення, пов'язані із аварією, яких може не бути у журналі:"
 
-#: pkg/storaged/lvol-tabs.jsx:458
+#: pkg/storaged/lvol-tabs.jsx:466
 msgid "Metadata Used"
 msgstr "Використано метаданих"
 
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
-#: pkg/machines/components/diskAdd.jsx:188
 #: pkg/machines/components/memorySelectRow.jsx:43
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
 #: pkg/machines/components/vm/memoryModal.jsx:150
 #: pkg/machines/components/vm/memoryModal.jsx:188
 msgid "MiB"
@@ -4106,7 +4101,7 @@ msgstr "Міні-ПК"
 msgid "Mini Tower"
 msgstr "Міні-башточка"
 
-#: pkg/systemd/init.js:1167 pkg/systemd/init.js:1176 pkg/systemd/init.js:1185
+#: pkg/systemd/init.js:1229 pkg/systemd/init.js:1238 pkg/systemd/init.js:1247
 msgid "Minute needs to be a number between 0-59"
 msgstr "Хвилини слід вказувати у форматі числа від 0 до 59"
 
@@ -4114,7 +4109,7 @@ msgstr "Хвилини слід вказувати у форматі числа 
 msgid "Minutes"
 msgstr "Хвилини"
 
-#: pkg/systemd/hwinfo.jsx:62 pkg/systemd/hwinfo.jsx:67
+#: pkg/systemd/hwinfo.jsx:66 pkg/systemd/hwinfo.jsx:71
 msgid "Mitigations"
 msgstr "Запобіжні заходи"
 
@@ -4122,11 +4117,11 @@ msgstr "Запобіжні заходи"
 msgid "Mode"
 msgstr "Режим"
 
-#: pkg/machines/components/nicEdit.jsx:55 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:254
 msgid "Model"
 msgstr "Модель"
 
-#: pkg/machines/components/vmnetworktab.jsx:123
+#: pkg/machines/components/vmnetworktab.jsx:131
 msgid "Model type"
 msgstr "Тип моделі"
 
@@ -4151,7 +4146,7 @@ msgstr "Інтервал оновлення"
 msgid "Monitoring Targets"
 msgstr "Спостерігаємо за цілями"
 
-#: pkg/realmd/operation.js:529
+#: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Більше"
 
@@ -4160,27 +4155,27 @@ msgstr "Більше"
 msgid "More Information"
 msgstr "Докладніше"
 
-#: pkg/kdump/kdump-view.jsx:448
+#: pkg/kdump/kdump-view.jsx:450
 msgid "More details"
 msgstr "Докладніше"
 
-#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:163
-#: pkg/storaged/fsys-tab.jsx:186 pkg/storaged/nfs-details.jsx:301
+#: pkg/kdump/kdump-view.jsx:99 pkg/storaged/fsys-tab.jsx:166
+#: pkg/storaged/fsys-tab.jsx:189 pkg/storaged/nfs-details.jsx:309
 msgid "Mount"
 msgstr "Змонтувати"
 
-#: pkg/storaged/format-dialog.jsx:81 pkg/storaged/fsys-tab.jsx:171
-#: pkg/storaged/nfs-details.jsx:172
+#: pkg/storaged/format-dialog.jsx:84 pkg/storaged/fsys-tab.jsx:174
+#: pkg/storaged/nfs-details.jsx:178
 msgid "Mount Options"
 msgstr "Параметри монтування"
 
-#: pkg/storaged/format-dialog.jsx:71 pkg/storaged/fsys-panel.jsx:109
-#: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:318
+#: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:109
+#: pkg/storaged/fsys-tab.jsx:160 pkg/storaged/nfs-details.jsx:326
 #: pkg/storaged/nfs-panel.jsx:102
 msgid "Mount Point"
 msgstr "Точка монтування"
 
-#: pkg/storaged/format-dialog.jsx:89 pkg/storaged/nfs-details.jsx:174
+#: pkg/storaged/format-dialog.jsx:93 pkg/storaged/nfs-details.jsx:181
 msgid "Mount at boot"
 msgstr "Змонтувати при завантаженні"
 
@@ -4188,23 +4183,23 @@ msgstr "Змонтувати при завантаженні"
 msgid "Mount container volumes"
 msgstr "Змонтувати томи контейнера"
 
-#: pkg/storaged/format-dialog.jsx:78
+#: pkg/storaged/format-dialog.jsx:81
 msgid "Mount point can not be empty"
 msgstr "Точка монтування не може бути порожньою"
 
-#: pkg/storaged/nfs-details.jsx:166
+#: pkg/storaged/nfs-details.jsx:172
 msgid "Mount point cannot be empty."
 msgstr "Точка монтування не може бути порожньою."
 
-#: pkg/storaged/nfs-details.jsx:168
+#: pkg/storaged/nfs-details.jsx:174
 msgid "Mount point must start with \"/\"."
 msgstr "Запис точки монтування має починатися з «/»."
 
-#: pkg/storaged/format-dialog.jsx:90 pkg/storaged/nfs-details.jsx:175
+#: pkg/storaged/format-dialog.jsx:94 pkg/storaged/nfs-details.jsx:182
 msgid "Mount read only"
 msgstr "Змонтувати лише для читання"
 
-#: pkg/storaged/fsys-tab.jsx:180
+#: pkg/storaged/fsys-tab.jsx:183
 msgid "Mounted At"
 msgstr "Змонтовано"
 
@@ -4224,7 +4219,7 @@ msgstr "Багатосистемний апаратний блок"
 msgid "NAT to $0"
 msgstr "NAT до $0"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "NFS Mount"
 msgstr "Змонтована NFS"
 
@@ -4236,47 +4231,45 @@ msgstr "Монтування NFS"
 msgid "NFS Support not installed"
 msgstr "Не встановлено підтримки NFS"
 
-#: pkg/machines/components/vmnetworktab.jsx:97
+#: pkg/machines/components/vmnetworktab.jsx:102
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "NIC $0 ВМ $1, не вдалося змінити стан"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:2029
 msgid "NSNA Ping"
 msgstr "Луна-імпульс NSNA"
 
-#: pkg/systemd/host.js:1531
+#: pkg/systemd/host.js:1569
 msgid "NTP Server"
 msgstr "Сервер NTP"
 
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:119
 #: pkg/networkmanager/index.html:137 pkg/networkmanager/index.html:165
 #: pkg/networkmanager/index.html:209 pkg/networkmanager/index.html:262
-#: pkg/networkmanager/index.html:319
-#: node_modules/registry-image-widgets/views/image-body.html:2
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:5
-#: pkg/docker/containers-view.jsx:359 pkg/docker/containers-view.jsx:683
+#: pkg/networkmanager/index.html:319 pkg/docker/containers-view.jsx:359
+#: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:191
-#: pkg/machines/components/diskAdd.jsx:126
-#: pkg/machines/components/networks/createNetworkDialog.jsx:122
-#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/createNetworkDialog.jsx:108
+#: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:380
-#: pkg/storaged/content-views.jsx:111 pkg/storaged/content-views.jsx:641
-#: pkg/storaged/format-dialog.jsx:286 pkg/storaged/fsys-panel.jsx:108
-#: pkg/storaged/fsys-tab.jsx:72 pkg/storaged/fsys-tab.jsx:150
-#: pkg/storaged/iscsi-panel.jsx:127 pkg/storaged/iscsi-panel.jsx:178
-#: pkg/storaged/lvol-tabs.jsx:33 pkg/storaged/lvol-tabs.jsx:348
-#: pkg/storaged/lvol-tabs.jsx:390 pkg/storaged/lvol-tabs.jsx:444
-#: pkg/storaged/mdraids-panel.jsx:40 pkg/storaged/part-tab.jsx:33
-#: pkg/storaged/vdos-panel.jsx:48 pkg/storaged/vgroup-details.jsx:180
-#: pkg/storaged/vgroups-panel.jsx:55 pkg/systemd/init.js:290
-#: pkg/systemd/hwinfo.jsx:79
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:33
+#: pkg/machines/hostvmslist.jsx:83 pkg/packagekit/updates.jsx:381
+#: pkg/storaged/content-views.jsx:113 pkg/storaged/content-views.jsx:655
+#: pkg/storaged/format-dialog.jsx:295 pkg/storaged/fsys-panel.jsx:108
+#: pkg/storaged/fsys-tab.jsx:73 pkg/storaged/fsys-tab.jsx:153
+#: pkg/storaged/iscsi-panel.jsx:128 pkg/storaged/iscsi-panel.jsx:185
+#: pkg/storaged/lvol-tabs.jsx:34 pkg/storaged/lvol-tabs.jsx:356
+#: pkg/storaged/lvol-tabs.jsx:398 pkg/storaged/lvol-tabs.jsx:452
+#: pkg/storaged/mdraids-panel.jsx:41 pkg/storaged/part-tab.jsx:33
+#: pkg/storaged/vdos-panel.jsx:49 pkg/storaged/vgroup-details.jsx:175
+#: pkg/storaged/vgroups-panel.jsx:56 pkg/systemd/hwinfo.jsx:83
+#: pkg/systemd/init.js:302
 msgid "Name"
 msgstr "Назва"
 
-#: pkg/storaged/vdos-panel.jsx:52
+#: pkg/storaged/vdos-panel.jsx:54
 msgid "Name can not be empty."
 msgstr "Назва не повинна бути порожньою."
 
@@ -4314,7 +4307,7 @@ msgstr "Назва має бути непорожньою"
 msgid "Name: "
 msgstr "Назва: "
 
-#: pkg/systemd/host.js:1365
+#: pkg/systemd/host.js:1402
 msgid "Need at least one NTP server"
 msgstr "Потрібен принаймні один сервер NTP"
 
@@ -4322,7 +4315,15 @@ msgstr "Потрібен принаймні один сервер NTP"
 msgid "Netmask"
 msgstr "Маска мережі"
 
-#: pkg/dashboard/index.html:72 pkg/playground/translate.html:95
+#: pkg/machines/components/aggregateStatusCards.jsx:72
+msgid "Network"
+msgid_plural "Networks"
+msgstr[0] "Мережі"
+msgstr[1] "Мережі"
+msgstr[2] "Мережі"
+
+#: pkg/dashboard/index.html:72
+msgctxt "label"
 msgid "Network"
 msgstr "Мережа"
 
@@ -4347,7 +4348,7 @@ msgstr ""
 msgid "Network File System"
 msgstr "Мережева файлова система"
 
-#: pkg/machines/components/vm/vm.jsx:50
+#: pkg/machines/components/vm/vm.jsx:52
 msgid "Network Interfaces"
 msgstr "Інтерфейси мережі"
 
@@ -4355,7 +4356,7 @@ msgstr "Інтерфейси мережі"
 msgid "Network Selection does not support PXE."
 msgstr "Для вибору мережі не передбачено підтримки PXE."
 
-#: pkg/systemd/host.js:570
+#: pkg/systemd/host.js:589
 msgid "Network Traffic"
 msgstr "Навантаження на мережу"
 
@@ -4365,7 +4366,8 @@ msgstr ""
 "Для отримання списку пристроїв мережі та графіків слід встановити "
 "NetworkManager."
 
-#: pkg/machines/components/nicEdit.jsx:245
+#: pkg/machines/components/nicAdd.jsx:176
+#: pkg/machines/components/nicEdit.jsx:119
 msgid "Network interface settings could not be saved"
 msgstr "Не вдалося зберегти параметри інтерфейсу мережі"
 
@@ -4374,11 +4376,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager не запущено."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:385
-#: pkg/networkmanager/firewall.jsx:944 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:946 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Робота у мережі"
 
-#: pkg/networkmanager/interfaces.js:1634 pkg/networkmanager/interfaces.js:2216
+#: pkg/networkmanager/interfaces.js:1645 pkg/networkmanager/interfaces.js:2228
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Робота у мережі"
@@ -4387,8 +4389,8 @@ msgstr "Робота у мережі"
 msgid "Networking Logs"
 msgstr "Журнали роботи у мережі"
 
-#: pkg/machines/components/networks/networkList.jsx:45
-#: pkg/machines/components/networks/networkList.jsx:49
+#: pkg/machines/components/networks/networkList.jsx:50
+#: pkg/machines/components/networks/networkList.jsx:54
 msgid "Networks"
 msgstr "Мережі"
 
@@ -4404,19 +4406,19 @@ msgstr "Необмежений строк дії пароля"
 msgid "Never lock account"
 msgstr "Ніколи не блокувати обліковий запис"
 
-#: pkg/storaged/nfs-details.jsx:140
+#: pkg/storaged/nfs-details.jsx:143
 msgid "New NFS Mount"
 msgstr "Нове монтування NFS"
 
-#: pkg/shell/index.html:289 pkg/users/index.html:218
+#: pkg/shell/index.html:290 pkg/users/index.html:218
 msgid "New Password"
 msgstr "Новий пароль"
 
-#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:39
 msgid "New Volume Name"
 msgstr "Назва нового тому"
 
-#: pkg/storaged/crypto-keyslots.jsx:210 pkg/storaged/crypto-keyslots.jsx:253
+#: pkg/storaged/crypto-keyslots.jsx:214 pkg/storaged/crypto-keyslots.jsx:260
 msgid "New passphrase"
 msgstr "Новий пароль"
 
@@ -4428,28 +4430,28 @@ msgstr "Новий пароль не прийнято"
 msgid "Next"
 msgstr "Далі"
 
-#: pkg/systemd/init.js:292
+#: pkg/systemd/init.js:304
 msgid "Next Run"
 msgstr "Наступний запуск"
 
-#: pkg/systemd/index.html:226 pkg/systemd/host.js:1602
+#: pkg/systemd/index.html:237 pkg/systemd/host.js:1645
 msgid "Nice"
 msgstr "Пріоритетність"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2606
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2614
 msgid "No"
 msgstr "Ні"
 
-#: pkg/systemd/index.html:454
+#: pkg/systemd/index.html:465
 msgid "No Delay"
 msgstr "Без затримки"
 
-#: pkg/storaged/format-dialog.jsx:252
+#: pkg/storaged/format-dialog.jsx:257
 msgid "No Filesystem"
 msgstr "Немає файлової системи"
 
-#: pkg/storaged/content-views.jsx:715
+#: pkg/storaged/content-views.jsx:735
 msgid "No Logical Volumes"
 msgstr "Немає логічних томів"
 
@@ -4461,7 +4463,7 @@ msgstr "Нічого не знайдено"
 msgid "No NFS mounts set up"
 msgstr "Монтувань NFS не налаштовано"
 
-#: pkg/machines/components/nicEdit.jsx:118
+#: pkg/machines/components/nicBody.jsx:117
 msgid "No Network Devices"
 msgstr "Немає пристроїв мережі"
 
@@ -4469,12 +4471,16 @@ msgstr "Немає пристроїв мережі"
 msgid "No SELinux alerts."
 msgstr "Немає сповіщень SELinux."
 
-#: pkg/machines/components/diskAdd.jsx:209
-#: pkg/machines/components/diskAdd.jsx:221
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:444
+msgid "No Storage"
+msgstr "Немає сховища даних"
+
+#: pkg/machines/components/diskAdd.jsx:132
+#: pkg/machines/components/diskAdd.jsx:144
 msgid "No Storage Pools available"
 msgstr "Немає доступних буферів зберігання даних"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:69
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:113
 msgid "No Storage Volumes defined for this Storage Pool"
 msgstr "Для цього буфера зберігання сховища не визначено томів сховища"
 
@@ -4486,15 +4492,15 @@ msgstr "Немає модифікацій системи"
 msgid "No VM is running or defined on this host"
 msgstr "У цій основній системі не запущено або не визначено віртуальних машин"
 
-#: pkg/machines/components/nicEdit.jsx:116
+#: pkg/machines/components/nicBody.jsx:115
 msgid "No Virtual Networks"
 msgstr "Немає віртуальних мереж"
 
-#: pkg/networkmanager/firewall.jsx:956
+#: pkg/networkmanager/firewall.jsx:958
 msgid "No active zones"
 msgstr "Немає активних зон"
 
-#: pkg/docker/storage.jsx:206
+#: pkg/docker/storage.jsx:208
 msgid "No additional local storage found."
 msgstr "Додаткових локальний сховищ даних не знайдено."
 
@@ -4510,7 +4516,7 @@ msgstr "Немає встановлених або доступних прогр
 msgid "No archive has been created."
 msgstr "Архів не було створено."
 
-#: pkg/storaged/crypto-keyslots.jsx:576
+#: pkg/storaged/crypto-keyslots.jsx:589
 msgid "No available slots"
 msgstr "Немає доступних слотів"
 
@@ -4518,11 +4524,11 @@ msgstr "Немає доступних слотів"
 msgid "No boot device found"
 msgstr "Не знайдено пристрою для завантаження"
 
-#: pkg/networkmanager/interfaces.js:1428
+#: pkg/networkmanager/interfaces.js:1433
 msgid "No carrier"
 msgstr "Немає сигналу"
 
-#: pkg/kdump/kdump-view.jsx:396
+#: pkg/kdump/kdump-view.jsx:398
 msgid "No configuration found"
 msgstr "Не знайдено налаштувань"
 
@@ -4542,7 +4548,7 @@ msgstr "Немає контейнерів"
 msgid "No containers that match the current filter"
 msgstr "Немає контейнерів, які проходять поточні умови фільтрування"
 
-#: pkg/networkmanager/firewall.jsx:759
+#: pkg/networkmanager/firewall.jsx:761
 msgid "No description available"
 msgstr "Немає опису"
 
@@ -4550,25 +4556,25 @@ msgstr "Немає опису"
 msgid "No description provided."
 msgstr "Опису не надано."
 
-#: pkg/storaged/mdraid-details.jsx:48 pkg/storaged/mdraids-panel.jsx:75
-#: pkg/storaged/vdos-panel.jsx:56 pkg/storaged/vgroup-details.jsx:54
-#: pkg/storaged/vgroups-panel.jsx:60
+#: pkg/storaged/mdraid-details.jsx:49 pkg/storaged/mdraids-panel.jsx:92
+#: pkg/storaged/vdos-panel.jsx:59 pkg/storaged/vgroup-details.jsx:56
+#: pkg/storaged/vgroups-panel.jsx:63
 msgid "No disks are available."
 msgstr "Немає доступних дисків."
 
-#: pkg/machines/components/vmDisksTab.jsx:85
+#: pkg/machines/components/vmDisksTab.jsx:121
 msgid "No disks defined for this VM"
 msgstr "Для цієї ВМ не визначено дисків"
 
-#: pkg/storaged/drives-panel.jsx:121
+#: pkg/storaged/drives-panel.jsx:103
 msgid "No drives attached"
 msgstr "Не долучено жодного диска"
 
-#: pkg/storaged/crypto-keyslots.jsx:581
+#: pkg/storaged/crypto-keyslots.jsx:594
 msgid "No free key slots"
 msgstr "Немає вільних слотів ключів"
 
-#: pkg/storaged/content-views.jsx:700
+#: pkg/storaged/content-views.jsx:720
 msgid "No free space"
 msgstr "Недостатньо вільного простору"
 
@@ -4576,13 +4582,9 @@ msgstr "Недостатньо вільного простору"
 msgid "No host keys found."
 msgstr "Не знайдено ключів вузлів."
 
-#: pkg/storaged/iscsi-panel.jsx:262
+#: pkg/storaged/iscsi-panel.jsx:269
 msgid "No iSCSI targets set up"
 msgstr "Призначень iSCSI не налаштовано"
-
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:43
-msgid "No image streams are present."
-msgstr "Немає потоків образів."
 
 #: pkg/docker/containers-view.jsx:705
 msgid "No images"
@@ -4596,19 +4598,15 @@ msgstr "Немає образів, які проходять поточні ум
 msgid "No installation package found for this application."
 msgstr "Для цієї програми не знайдено пакунка для встановлення."
 
-#: pkg/storaged/crypto-keyslots.jsx:520
+#: pkg/storaged/crypto-keyslots.jsx:533
 msgid "No keys added"
 msgstr "Не додано жодного ключа"
-
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:201
-msgid "No matching files found"
-msgstr "Відповідних файлів не знайдено"
 
 #: pkg/storaged/drive-details.jsx:75
 msgid "No media inserted"
 msgstr "Не виявлено носія даних"
 
-#: pkg/kdump/kdump-view.jsx:450
+#: pkg/kdump/kdump-view.jsx:452
 msgid ""
 "No memory reserved. Append a crashkernel option to the kernel command line "
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
@@ -4618,11 +4616,11 @@ msgstr ""
 "рядка ядра (наприклад у /etc/default/grub), щоб зарезервувати пам’ять під "
 "час завантаження. Приклад: crashkernel=512M"
 
-#: pkg/machines/components/vmnetworktab.jsx:70
+#: pkg/machines/components/vmnetworktab.jsx:75
 msgid "No network interfaces defined for this VM"
 msgstr "Немає інтерфейсів мережі, які визначено для цієї ВМ"
 
-#: pkg/machines/components/networks/networkList.jsx:51
+#: pkg/machines/components/networks/networkList.jsx:56
 msgid "No network is defined on this host"
 msgstr "У цій основній системі мережу не визначено"
 
@@ -4630,11 +4628,11 @@ msgstr "У цій основній системі мережу не визнач
 msgid "No networks available"
 msgstr "Немає доступних мереж"
 
-#: pkg/networkmanager/firewall.jsx:969
+#: pkg/networkmanager/firewall.jsx:971
 msgid "No open ports"
 msgstr "Немає відкрити портів"
 
-#: pkg/storaged/content-views.jsx:526
+#: pkg/storaged/content-views.jsx:537
 msgid "No partitioning"
 msgstr "Немає розподілу на розділи"
 
@@ -4654,25 +4652,21 @@ msgstr "Немає запущених контейнерів"
 msgid "No running containers that match the current filter"
 msgstr "Немає запущених контейнерів, які проходять поточні умови фільтрування"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:50
+#: pkg/machines/components/storagePools/storagePoolList.jsx:55
 msgid "No storage pool is defined on this host"
 msgstr "На цьому вузлі не визначено буфера зберігання даних"
 
-#: pkg/storaged/mdraids-panel.jsx:130
+#: pkg/storaged/mdraids-panel.jsx:147
 msgid "No storage set up as RAID"
 msgstr "Жодне зі сховищ даних не налаштовано як RAID"
 
-#: pkg/storaged/vdos-panel.jsx:167
+#: pkg/storaged/vdos-panel.jsx:177
 msgid "No storage set up as VDO"
 msgstr "Немає сховища даних налаштованого як VDO"
 
 #: pkg/lib/credentials.js:186
 msgid "No such file or directory"
 msgstr "Немає такого файла або каталогу"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:73
-msgid "No tags are present."
-msgstr "Немає міток."
 
 #: pkg/packagekit/updates.jsx:42
 msgid "No updates pending"
@@ -4682,14 +4676,13 @@ msgstr "У черзі немає оновлень"
 msgid "No user name specified"
 msgstr "Не вказано імені користувача"
 
-#: pkg/storaged/vgroups-panel.jsx:114
+#: pkg/storaged/vgroups-panel.jsx:116
 msgid "No volume groups created"
 msgstr "Груп томів не створено"
 
-#: node_modules/registry-image-widgets/views/image-config.html:29
-#: pkg/kdump/kdump-view.jsx:419
-#: pkg/machines/components/networks/createNetworkDialog.jsx:204
-#: pkg/networkmanager/firewall.jsx:764 pkg/tuned/dialog.js:231
+#: pkg/kdump/kdump-view.jsx:421
+#: pkg/machines/components/networks/createNetworkDialog.jsx:190
+#: pkg/networkmanager/firewall.jsx:766 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Немає"
 
@@ -4709,11 +4702,11 @@ msgstr "Некоректний закритий ключ"
 msgid "Not authorized to access Docker on this system"
 msgstr "Не уповноважено на доступ до Docker у цій системі"
 
-#: pkg/systemd/logs.js:527
+#: pkg/systemd/logs.js:529
 msgid "Not authorized to upload-report"
 msgstr "Не уповноважено на вивантаження звітів"
 
-#: pkg/networkmanager/interfaces.js:831
+#: pkg/networkmanager/interfaces.js:836
 msgid "Not available"
 msgstr "Недоступний"
 
@@ -4721,11 +4714,15 @@ msgstr "Недоступний"
 msgid "Not connected"
 msgstr "Не з’єднано"
 
-#: pkg/storaged/lvol-tabs.jsx:369
+#: pkg/systemd/host.js:577
+msgid "Not connected to Insights"
+msgstr "Не з'єднано із Insights"
+
+#: pkg/storaged/lvol-tabs.jsx:377
 msgid "Not enough space to grow."
 msgstr "Недостатньо місця для росту."
 
-#: pkg/docker/details.js:185 pkg/storaged/details.jsx:121
+#: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Не знайдено"
 
@@ -4733,11 +4730,11 @@ msgstr "Не знайдено"
 msgid "Not mounted"
 msgstr "Не змонтовано"
 
-#: src/base1/cockpit.js:4013
+#: src/base1/cockpit.js:4017
 msgid "Not permitted to perform this action."
 msgstr "Немає дозволу на виконання цієї дії."
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:359
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:361
 msgid "Not running"
 msgstr "Зупинено"
 
@@ -4745,11 +4742,7 @@ msgstr "Зупинено"
 msgid "Not synchronized"
 msgstr "Не синхронізовано"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:44
-msgid "Not yet synced"
-msgstr "Ще не синхронізовано"
-
-#: pkg/systemd/service-details.jsx:448
+#: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Примітка"
 
@@ -4760,6 +4753,14 @@ msgstr "Ноутбук"
 #: pkg/systemd/logs.html:61
 msgid "Notice and above"
 msgstr "Зауваження і вище"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications"
+msgstr "Сповіщення"
+
+#: pkg/playground/manifest.json.in
+msgid "Notifications Receiver"
+msgstr "Отримувач сповіщень"
 
 #: pkg/selinux/setroubleshoot-view.jsx:404
 msgid "Occurred $0"
@@ -4773,11 +4774,11 @@ msgstr "Сталося між $0 і $1"
 msgid "Ok"
 msgstr "Гаразд"
 
-#: pkg/shell/index.html:281 pkg/users/index.html:215
+#: pkg/shell/index.html:282 pkg/users/index.html:215
 msgid "Old Password"
 msgstr "Старий пароль"
 
-#: pkg/storaged/crypto-keyslots.jsx:249
+#: pkg/storaged/crypto-keyslots.jsx:257
 msgid "Old passphrase"
 msgstr "Старий пароль"
 
@@ -4785,15 +4786,11 @@ msgstr "Старий пароль"
 msgid "Old password not accepted"
 msgstr "Старий пароль не прийнято"
 
-#: node_modules/registry-image-widgets/views/image-meta.html:7
-msgid "On Build"
-msgstr "Збирання"
-
-#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:429
+#: pkg/docker/index.html:549 pkg/systemd/service-details.jsx:431
 msgid "On Failure"
 msgstr "Якщо помилка"
 
-#: pkg/kdump/kdump-view.jsx:393
+#: pkg/kdump/kdump-view.jsx:395
 msgid "On a mounted device"
 msgstr "На змонтованому пристрої"
 
@@ -4816,7 +4813,7 @@ msgstr ""
 msgid "One Time Password"
 msgstr "Одноразовий пароль"
 
-#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:77
+#: pkg/machines/components/storagePools/storageVolumeDelete.jsx:76
 msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
@@ -4832,7 +4829,7 @@ msgstr "Використано лише $0 з $1."
 msgid "Only Emergency"
 msgstr "Лише критичне"
 
-#: pkg/systemd/init.js:1117
+#: pkg/systemd/init.js:1179
 msgid "Only alphabets, numbers, : , _ , . , @ , - are allowed."
 msgstr "Можна використовувати лише літери, цифри, : , _ , . , @ , -."
 
@@ -4862,12 +4859,12 @@ msgstr "Дія «$operation» над $target"
 msgid "Operation is in progress"
 msgstr "Виконується дія"
 
-#: pkg/storaged/drives-panel.jsx:94
+#: pkg/storaged/drives-panel.jsx:76
 msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Пристрій читання оптичних дисків"
 
-#: pkg/storaged/crypto-tab.jsx:134 pkg/storaged/vdos-panel.jsx:78
+#: pkg/storaged/crypto-tab.jsx:137 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Параметри"
 
@@ -4879,7 +4876,7 @@ msgstr "Або скористайтеся комплектним браузер�
 msgid "Other"
 msgstr "Інше"
 
-#: pkg/storaged/content-views.jsx:353
+#: pkg/storaged/content-views.jsx:358
 msgctxt "storage-id-desc"
 msgid "Other Data"
 msgstr "Інші дані"
@@ -4894,19 +4891,19 @@ msgstr "Інші параметри"
 
 #: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:72
 #: pkg/machines/components/storagePools/storagePool.jsx:83
-#: pkg/machines/components/vm/vm.jsx:47
+#: pkg/machines/components/vm/vm.jsx:49
 msgid "Overview"
 msgstr "Огляд"
 
-#: pkg/storaged/content-views.jsx:517 pkg/storaged/format-dialog.jsx:281
+#: pkg/storaged/content-views.jsx:525 pkg/storaged/format-dialog.jsx:290
 msgid "Overwrite existing data with zeros"
 msgstr "Перезаписати наявні дані нулями"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "PCI"
 msgstr "PCI"
 
-#: pkg/packagekit/updates.jsx:501
+#: pkg/packagekit/updates.jsx:503
 msgid "Package information"
 msgstr "Дані щодо пакунка"
 
@@ -4914,11 +4911,11 @@ msgstr "Дані щодо пакунка"
 msgid "PackageKit crashed"
 msgstr "Аварійне завершення роботи PackageKit"
 
-#: pkg/packagekit/updates.jsx:564
+#: pkg/packagekit/updates.jsx:565
 msgid "PackageKit is not installed"
 msgstr "PackageKit не встановлено"
 
-#: pkg/packagekit/updates.jsx:718
+#: pkg/packagekit/updates.jsx:719
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit повідомлено про помилку із кодом $0"
 
@@ -4930,59 +4927,59 @@ msgstr "Пакунки"
 msgid "Parent"
 msgstr "Батьківський"
 
-#: pkg/networkmanager/interfaces.js:2915
+#: pkg/networkmanager/interfaces.js:2923
 msgid "Parent $parent"
 msgstr "Батьківський $parent"
 
-#: pkg/systemd/service-details.jsx:419
+#: pkg/systemd/service-details.jsx:421
 msgid "Part Of"
 msgstr "Частина"
 
-#: pkg/networkmanager/interfaces.js:1474
+#: pkg/networkmanager/interfaces.js:1479
 msgid "Part of "
 msgstr "Є частиною "
 
-#: pkg/storaged/content-views.jsx:141
+#: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "Розділ"
 
-#: pkg/storaged/utils.js:271
+#: pkg/storaged/utils.js:272
 msgid "Partition of $0"
 msgstr "Розділ $0"
 
-#: pkg/storaged/content-views.jsx:519
+#: pkg/storaged/content-views.jsx:528
 msgid "Partitioning"
 msgstr "Розподіл"
 
-#: pkg/networkmanager/interfaces.js:2009
+#: pkg/networkmanager/interfaces.js:2021
 msgid "Passive"
 msgstr "Неактивний"
 
-#: pkg/storaged/content-views.jsx:224 pkg/storaged/crypto-keyslots.jsx:206
-#: pkg/storaged/crypto-keyslots.jsx:552 pkg/storaged/format-dialog.jsx:296
+#: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
+#: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:307
 msgid "Passphrase"
 msgstr "Пароль"
 
-#: pkg/storaged/crypto-keyslots.jsx:157 pkg/storaged/crypto-keyslots.jsx:212
-#: pkg/storaged/crypto-keyslots.jsx:250 pkg/storaged/crypto-keyslots.jsx:254
-#: pkg/storaged/format-dialog.jsx:299
+#: pkg/storaged/crypto-keyslots.jsx:158 pkg/storaged/crypto-keyslots.jsx:217
+#: pkg/storaged/crypto-keyslots.jsx:258 pkg/storaged/crypto-keyslots.jsx:261
+#: pkg/storaged/format-dialog.jsx:311
 msgid "Passphrase cannot be empty"
 msgstr "Пароль не може бути порожнім"
 
-#: pkg/storaged/crypto-keyslots.jsx:356
+#: pkg/storaged/crypto-keyslots.jsx:364
 msgid "Passphrase removal may prevent unlocking $0."
 msgstr "Вилучення пароля може завадити розблокуванню $0."
 
-#: pkg/storaged/crypto-keyslots.jsx:219 pkg/storaged/crypto-keyslots.jsx:257
-#: pkg/storaged/format-dialog.jsx:306
+#: pkg/storaged/crypto-keyslots.jsx:225 pkg/storaged/crypto-keyslots.jsx:263
+#: pkg/storaged/format-dialog.jsx:319
 msgid "Passphrases do not match"
 msgstr "Паролі не збігаються"
 
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
-#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:203
-#: pkg/shell/index.html:231 pkg/shell/index.html:244 pkg/users/index.html:118
+#: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
+#: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
 #: pkg/users/index.html:173 src/ws/login.html:50
-#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:151
+#: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Пароль"
 
@@ -5022,7 +5019,7 @@ msgid "Paste the contents of your public SSH key file here"
 msgstr "Сюди слід вставити вміст файла вашого відкритого ключа SSH"
 
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/systemd/service-details.jsx:481
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Шлях"
 
@@ -5030,11 +5027,11 @@ msgstr "Шлях"
 msgid "Path cost"
 msgstr "Вартість маршруту"
 
-#: pkg/networkmanager/interfaces.js:2897
+#: pkg/networkmanager/interfaces.js:2905
 msgid "Path cost $path_cost"
 msgstr "Вартість шляху $path_cost"
 
-#: pkg/storaged/nfs-details.jsx:151
+#: pkg/storaged/nfs-details.jsx:155
 msgid "Path on Server"
 msgstr "Шлях на сервері"
 
@@ -5042,11 +5039,11 @@ msgstr "Шлях на сервері"
 msgid "Path on host's filesystem"
 msgstr "Шлях у файловій системі вузла"
 
-#: pkg/storaged/nfs-details.jsx:155
+#: pkg/storaged/nfs-details.jsx:160
 msgid "Path on server cannot be empty."
 msgstr "Шлях на сервері не може бути порожнім."
 
-#: pkg/storaged/nfs-details.jsx:157
+#: pkg/storaged/nfs-details.jsx:162
 msgid "Path on server must start with \"/\"."
 msgstr "Шлях на сервері має починатися з «/»."
 
@@ -5054,11 +5051,11 @@ msgstr "Шлях на сервері має починатися з «/»."
 msgid "Path to ISO file on host's file system"
 msgstr "Шлях до ISO у файловій системі основної системи"
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:261
+#: pkg/lib/cockpit-components-file-autocomplete.jsx:141
 msgid "Path to file"
 msgstr "Шлях до файла"
 
-#: pkg/systemd/services.jsx:42
+#: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Шляхи"
 
@@ -5066,7 +5063,7 @@ msgstr "Шляхи"
 msgid "Pause"
 msgstr "Призупинити"
 
-#: pkg/systemd/index.html:152
+#: pkg/systemd/index.html:159
 msgid "Performance Profile"
 msgstr "Профіль швидкодії"
 
@@ -5074,7 +5071,7 @@ msgstr "Профіль швидкодії"
 msgid "Peripheral Chassis"
 msgstr "Периферійний апаратний блок"
 
-#: pkg/networkmanager/interfaces.js:3642
+#: pkg/networkmanager/interfaces.js:3657
 msgid "Permanent"
 msgstr "Постійний"
 
@@ -5086,7 +5083,8 @@ msgstr "Доступ заборонено"
 msgid "Permissive"
 msgstr "Дозвільна"
 
-#: pkg/machines/components/diskAdd.jsx:110
+#: pkg/machines/components/diskAdd.jsx:111
+#: pkg/machines/components/nicAdd.jsx:80
 msgid "Persistence"
 msgstr "Сталість"
 
@@ -5095,7 +5093,7 @@ msgstr "Сталість"
 msgid "Persistent"
 msgstr "Постійний"
 
-#: pkg/storaged/vdo-details.jsx:277
+#: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "Фізичний"
 
@@ -5103,11 +5101,11 @@ msgstr "Фізичний"
 msgid "Physical Disk Device"
 msgstr "Фізичний пристрій диска"
 
-#: pkg/storaged/content-views.jsx:150 pkg/storaged/content-views.jsx:343
+#: pkg/storaged/content-views.jsx:154 pkg/storaged/content-views.jsx:348
 msgid "Physical Volume"
 msgstr "Фізичний том"
 
-#: pkg/storaged/vgroup-details.jsx:133
+#: pkg/storaged/vgroup-details.jsx:127
 msgid "Physical Volumes"
 msgstr "Фізичні томи"
 
@@ -5115,11 +5113,11 @@ msgstr "Фізичні томи"
 msgid "Physical disk device on host"
 msgstr "Фізичний пристрій у основній системі"
 
-#: pkg/storaged/content-views.jsx:338
+#: pkg/storaged/content-views.jsx:343
 msgid "Physical volume of $0"
 msgstr "Фізичний том $0"
 
-#: pkg/storaged/lvol-tabs.jsx:164
+#: pkg/storaged/lvol-tabs.jsx:165
 msgid "Physical volumes can not be resized here."
 msgstr "Тут не можна змінювати розміри фізичних томів."
 
@@ -5135,10 +5133,10 @@ msgstr "Ціль тестування луною"
 msgid "Pizza Box"
 msgstr "З коробку для піци"
 
-#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:290
-#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:289
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/vdo-details.jsx:195
-#: pkg/storaged/vgroup-details.jsx:209
+#: pkg/docker/containers-view.jsx:200 pkg/docker/details.js:291
+#: pkg/docker/util.js:612 pkg/storaged/content-views.jsx:296
+#: pkg/storaged/mdraid-details.jsx:291 pkg/storaged/vdo-details.jsx:199
+#: pkg/storaged/vgroup-details.jsx:207
 msgid "Please confirm deletion of $0"
 msgstr "Будь ласка, підтвердьте вилучення $0"
 
@@ -5146,19 +5144,19 @@ msgstr "Будь ласка, підтвердьте вилучення $0"
 msgid "Please confirm forced deletion of $0"
 msgstr "Будь ласка, підтвердьте примусове вилучення $0"
 
-#: pkg/storaged/mdraid-details.jsx:243 pkg/storaged/vdo-details.jsx:153
+#: pkg/storaged/mdraid-details.jsx:240 pkg/storaged/vdo-details.jsx:155
 msgid "Please confirm stopping of $0"
 msgstr "Будь ласка, підтвердьте зупинку $0"
 
-#: pkg/machines/components/diskAdd.jsx:483
+#: pkg/machines/components/diskAdd.jsx:350
 msgid "Please enter new volume name"
 msgstr "Будь ласка, введіть назву нового тому"
 
-#: pkg/machines/components/diskAdd.jsx:486
+#: pkg/machines/components/diskAdd.jsx:353
 msgid "Please enter new volume size"
 msgstr "Будь ласка, введіть розмір нового тому"
 
-#: pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:896
 msgid "Please install the $0 package"
 msgstr "Будь ласка, встановіть пакунок $0"
 
@@ -5179,29 +5177,33 @@ msgstr ""
 msgid "Please try another term"
 msgstr "Будь ласка, спробуйте інший ключ"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Plug"
 msgstr "З'єднати"
 
 #: pkg/machines/components/deleteDialog.jsx:53
-#: pkg/machines/components/diskAdd.jsx:204
+#: pkg/machines/components/diskAdd.jsx:127
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
-#: pkg/storaged/content-views.jsx:133
+#: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Буфер"
 
-#: pkg/storaged/utils.js:191
+#: pkg/storaged/utils.js:192
 msgid "Pool for Thin Logical Volumes"
 msgstr "Буфер для тонких логічних томів"
 
-#: pkg/storaged/content-views.jsx:594
+#: pkg/storaged/content-views.jsx:607
 msgid "Pool for Thin Volumes"
 msgstr "Буфер для тонких томів"
 
-#: pkg/storaged/content-views.jsx:651
+#: pkg/storaged/content-views.jsx:668
 msgid "Pool for thinly provisioned volumes"
 msgstr "Буфер для тонких резервованих томів"
+
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:142
+msgid "Pool type doesn't support volume creation"
+msgstr "Для типу буфера не пердебачено підтримки створення томів"
 
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:149
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:185
@@ -5212,8 +5214,8 @@ msgstr "Томи буфера використовуються ВМ"
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
 #: pkg/machines/components/vmDiskColumns.jsx:48
-#: pkg/machines/components/vmnetworktab.jsx:108
-#: pkg/storaged/iscsi-panel.jsx:127
+#: pkg/machines/components/vmnetworktab.jsx:113
+#: pkg/storaged/iscsi-panel.jsx:128
 msgid "Port"
 msgstr "Порт"
 
@@ -5226,9 +5228,8 @@ msgid "Portable"
 msgstr "Портативний"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:213
-#: pkg/networkmanager/index.html:323
-#: node_modules/registry-image-widgets/views/image-config.html:27
-#: pkg/docker/containers-view.jsx:414 pkg/networkmanager/interfaces.js:2998
+#: pkg/networkmanager/index.html:323 pkg/docker/containers-view.jsx:414
+#: pkg/networkmanager/interfaces.js:3006
 msgid "Ports"
 msgstr "Порти"
 
@@ -5236,7 +5237,7 @@ msgstr "Порти"
 msgid "Ports:"
 msgstr "Порти:"
 
-#: pkg/systemd/index.html:132
+#: pkg/systemd/index.html:139
 msgid "Power Options"
 msgstr "Параметри живлення"
 
@@ -5248,7 +5249,7 @@ msgstr "Бажана кількість сокетів, які слід нада
 msgid "Prefix"
 msgstr "Префікс"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:337
+#: pkg/machines/components/networks/createNetworkDialog.jsx:323
 msgid "Prefix Length"
 msgstr "Довжина префікса"
 
@@ -5256,19 +5257,19 @@ msgstr "Довжина префікса"
 msgid "Prefix Length should not be empty"
 msgstr "Довжина префікса повинна бути непорожньою"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length"
 msgstr "Довжина префікса"
 
-#: pkg/networkmanager/interfaces.js:3318
+#: pkg/networkmanager/interfaces.js:3329
 msgid "Prefix length or Netmask"
 msgstr "Довжина префікса або маска мережі"
 
 #: pkg/playground/manifest.json.in
 msgid "Preloaded"
-msgstr ""
+msgstr "Попередньо завантажене"
 
-#: pkg/networkmanager/interfaces.js:835
+#: pkg/networkmanager/interfaces.js:840
 msgid "Preparing"
 msgstr "Приготування"
 
@@ -5276,11 +5277,11 @@ msgstr "Приготування"
 msgid "Present"
 msgstr "Поточна"
 
-#: pkg/networkmanager/interfaces.js:3643
+#: pkg/networkmanager/interfaces.js:3658
 msgid "Preserve"
 msgstr "Зберегти"
 
-#: pkg/systemd/index.html:295
+#: pkg/systemd/index.html:306
 msgid "Pretty Host Name"
 msgstr "Зручна назва вузла"
 
@@ -5297,7 +5298,7 @@ msgstr "Основний"
 msgid "Priority"
 msgstr "Пріоритетність"
 
-#: pkg/networkmanager/interfaces.js:2871 pkg/networkmanager/interfaces.js:2895
+#: pkg/networkmanager/interfaces.js:2879 pkg/networkmanager/interfaces.js:2903
 msgid "Priority $priority"
 msgstr "Пріоритетність $priority"
 
@@ -5309,11 +5310,11 @@ msgstr "Закрита"
 msgid "Privileged"
 msgstr "Привілейований"
 
-#: pkg/systemd/logs.js:488
+#: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Подробиці щодо проблеми"
 
-#: pkg/systemd/logs.js:487
+#: pkg/systemd/logs.js:489
 msgid "Problem info"
 msgstr "Дані щодо проблеми"
 
@@ -5321,7 +5322,7 @@ msgstr "Дані щодо проблеми"
 msgid "Problems"
 msgstr "Проблеми"
 
-#: pkg/storaged/dialog.jsx:1043
+#: pkg/storaged/dialog.jsx:1044
 msgid "Process"
 msgstr "Процес"
 
@@ -5346,7 +5347,7 @@ msgstr "Час очікування відповіді на запит за до
 msgid "Prompting via ssh-keygen timed out"
 msgstr "Час очікування відповіді на запит за допомогою ssh-keygen вичерпано"
 
-#: pkg/systemd/service-details.jsx:432
+#: pkg/systemd/service-details.jsx:434
 msgid "Propagates Reload To"
 msgstr "Поширює перезавантаження на"
 
@@ -5356,67 +5357,63 @@ msgstr "Поширює перезавантаження на"
 msgid "Protocol"
 msgstr "Протокол"
 
-#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:230
+#: pkg/lib/machine-auth-failed.html:9 pkg/shell/index.html:231
 msgid "Public Key"
 msgstr "Відкритий ключ"
 
-#: node_modules/registry-image-widgets/views/imagestream-body.html:39
-msgid "Public pulling repo"
-msgstr "Відкрите сховище для отримання"
-
-#: pkg/storaged/content-views.jsx:645
+#: pkg/storaged/content-views.jsx:660
 msgid "Purpose"
 msgstr "Призначення"
 
-#: pkg/storaged/mdraid-details.jsx:185
+#: pkg/storaged/mdraid-details.jsx:180
 msgid "RAID ($0)"
 msgstr "RAID ($0)"
 
-#: pkg/storaged/mdraid-details.jsx:179
+#: pkg/storaged/mdraid-details.jsx:174
 msgid "RAID 0"
 msgstr "RAID 0"
 
-#: pkg/storaged/mdraids-panel.jsx:45
+#: pkg/storaged/mdraids-panel.jsx:48
 msgid "RAID 0 (Stripe)"
 msgstr "RAID 0 (Стрічка)"
 
-#: pkg/storaged/mdraid-details.jsx:180
+#: pkg/storaged/mdraid-details.jsx:175
 msgid "RAID 1"
 msgstr "RAID 1"
 
-#: pkg/storaged/mdraids-panel.jsx:47
+#: pkg/storaged/mdraids-panel.jsx:52
 msgid "RAID 1 (Mirror)"
 msgstr "RAID 1 (Дзеркало)"
 
-#: pkg/storaged/mdraid-details.jsx:184
+#: pkg/storaged/mdraid-details.jsx:179
 msgid "RAID 10"
 msgstr "RAID 10"
 
-#: pkg/storaged/mdraids-panel.jsx:55
+#: pkg/storaged/mdraids-panel.jsx:68
 msgid "RAID 10 (Stripe of Mirrors)"
 msgstr "RAID 10 (Стрічка дзеркал)"
 
-#: pkg/storaged/mdraid-details.jsx:181
+#: pkg/storaged/mdraid-details.jsx:176
 msgid "RAID 4"
 msgstr "RAID 4"
 
-#: pkg/storaged/mdraids-panel.jsx:49
+#: pkg/storaged/mdraids-panel.jsx:56
 msgid "RAID 4 (Dedicated Parity)"
 msgstr "RAID 4 (Пов’язана парність)"
 
-#: pkg/storaged/mdraid-details.jsx:182
+#: pkg/storaged/mdraid-details.jsx:177
 msgid "RAID 5"
 msgstr "RAID 5"
 
-#: pkg/storaged/mdraids-panel.jsx:51
+#: pkg/storaged/mdraids-panel.jsx:60
 msgid "RAID 5 (Distributed Parity)"
 msgstr "RAID 5 (Розподілена парність)"
 
-#: pkg/storaged/mdraid-details.jsx:183
+#: pkg/storaged/mdraid-details.jsx:178
 msgid "RAID 6"
 msgstr "RAID 6"
 
-#: pkg/storaged/mdraids-panel.jsx:53
+#: pkg/storaged/mdraids-panel.jsx:64
 msgid "RAID 6 (Double Distributed Parity)"
 msgstr "RAID 6 (Подвійна розподілена парність)"
 
@@ -5428,19 +5425,19 @@ msgstr "Апаратний блок RAID"
 msgid "RAID Device"
 msgstr "пристрій RAID"
 
-#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/utils.js:241
+#: pkg/storaged/mdraid-details.jsx:311 pkg/storaged/utils.js:242
 msgid "RAID Device $0"
 msgstr "Пристій RAID $0"
 
-#: pkg/storaged/mdraids-panel.jsx:129
+#: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "Пристрої RAID"
 
-#: pkg/storaged/mdraids-panel.jsx:41
+#: pkg/storaged/mdraids-panel.jsx:42
 msgid "RAID Level"
 msgstr "Рівень RAID"
 
-#: pkg/storaged/content-views.jsx:153
+#: pkg/storaged/content-views.jsx:157
 msgid "RAID Member"
 msgstr "Елемент RAID"
 
@@ -5448,11 +5445,11 @@ msgstr "Елемент RAID"
 msgid "Rack Mount Chassis"
 msgstr "Апаратний блок монтування стійок"
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3659
 msgid "Random"
 msgstr "Випадковий"
 
-#: pkg/networkmanager/firewall.jsx:789
+#: pkg/networkmanager/firewall.jsx:791
 msgid "Range"
 msgstr "Діапазон"
 
@@ -5460,23 +5457,23 @@ msgstr "Діапазон"
 msgid "Range must be strictly ordered"
 msgstr "Діапазон має бути строго упорядковано"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Rank"
 msgstr "Ранг"
 
-#: pkg/kdump/kdump-view.jsx:388
+#: pkg/kdump/kdump-view.jsx:390
 msgid "Raw to a device"
 msgstr "Без обробки на пристрій"
 
 #: pkg/playground/manifest.json.in
 msgid "React Patterns"
-msgstr ""
+msgstr "Взірці React"
 
-#: pkg/systemd/hwinfo.jsx:193
+#: pkg/systemd/hwinfo.jsx:197
 msgid "Read more..."
 msgstr "Докладніше…"
 
-#: pkg/systemd/service-details.jsx:386
+#: pkg/systemd/service-details.jsx:388
 msgid "Read-only"
 msgstr "Лише читання"
 
@@ -5488,15 +5485,15 @@ msgstr "Лише запис"
 msgid "ReadWrite"
 msgstr "Запис-читання"
 
-#: pkg/storaged/plot.jsx:310
+#: pkg/storaged/plot.jsx:312
 msgid "Reading"
 msgstr "Читання"
 
-#: pkg/kdump/kdump-view.jsx:413
+#: pkg/kdump/kdump-view.jsx:415
 msgid "Reading..."
 msgstr "Читання…"
 
-#: pkg/machines/components/vmDisksTab.jsx:74
+#: pkg/machines/components/vmDisksTab.jsx:112
 msgid "Readonly"
 msgstr "Лише запис"
 
@@ -5509,11 +5506,11 @@ msgctxt "verb"
 msgid "Ready"
 msgstr "Готово"
 
-#: pkg/systemd/index.html:304
+#: pkg/systemd/index.html:315
 msgid "Real Host Name"
 msgstr "Справжня назва вузла"
 
-#: pkg/systemd/host.js:1037
+#: pkg/systemd/host.js:1074
 msgid ""
 "Real host name can only contain lower-case characters, digits, dashes, and "
 "periods (with populated subdomains)"
@@ -5521,11 +5518,11 @@ msgstr ""
 "Назва справжнього вузла має складатися лише з літер у нижньому регістрі, "
 "цифр, дефісів та точок (із заповненими піддоменами)"
 
-#: pkg/systemd/host.js:1038
+#: pkg/systemd/host.js:1075
 msgid "Real host name must be 64 characters or less"
 msgstr "Назва справжнього вузла має складатися не більше ніж з 64 символів"
 
-#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:246
+#: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Перезавантажити"
 
@@ -5539,16 +5536,16 @@ msgstr "Отримання"
 msgid "Recent"
 msgstr "Нещодавні"
 
-#: pkg/storaged/format-dialog.jsx:248
+#: pkg/storaged/format-dialog.jsx:253
 msgid "Recommended default"
 msgstr "Рекомендоване типове значення"
 
-#: pkg/shell/index.html:381 pkg/shell/simple.html:138
+#: pkg/shell/index.html:382 pkg/shell/simple.html:138
 #: pkg/machines/components/serialConsole.jsx:138
 msgid "Reconnect"
 msgstr "Повторно з’єднатися"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Recovering"
 msgstr "Відновлюємо"
 
@@ -5556,7 +5553,7 @@ msgstr "Відновлюємо"
 msgid "Recovering RAID Device $target"
 msgstr "Відновлюємо пристрій RAID $target"
 
-#: pkg/docker/storage.jsx:389
+#: pkg/docker/storage.jsx:396
 msgid "Reformat and add disks"
 msgstr "Повторно форматувати і додати диски"
 
@@ -5576,7 +5573,7 @@ msgstr "Відмовляємо у з’єднанні. Ключі вузла н�
 msgid "Refusing to connect. Hostkey is unknown"
 msgstr "Відмовляємо у з’єднанні. Невідомий ключ вузла."
 
-#: pkg/packagekit/updates.jsx:779
+#: pkg/packagekit/updates.jsx:780
 msgid "Register…"
 msgstr "Зареєструвати…"
 
@@ -5584,7 +5581,7 @@ msgstr "Зареєструвати…"
 msgid "Reload"
 msgstr "Перезавантажити"
 
-#: pkg/systemd/service-details.jsx:433
+#: pkg/systemd/service-details.jsx:435
 msgid "Reload Propagated From"
 msgstr "Поширене перезавантаження з"
 
@@ -5592,15 +5589,15 @@ msgstr "Поширене перезавантаження з"
 msgid "Remote URL"
 msgstr "Віддалена адреса"
 
-#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:386
+#: pkg/kdump/kdump-view.jsx:137 pkg/kdump/kdump-view.jsx:388
 msgid "Remote over NFS"
 msgstr "Віддалене на основі NFS"
 
-#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:384
+#: pkg/kdump/kdump-view.jsx:138 pkg/kdump/kdump-view.jsx:386
 msgid "Remote over SSH"
 msgstr "Віддалене на основі SSH"
 
-#: pkg/storaged/drives-panel.jsx:90 pkg/storaged/drives-panel.jsx:92
+#: pkg/storaged/drives-panel.jsx:72 pkg/storaged/drives-panel.jsx:74
 msgctxt "storage"
 msgid "Removable Drive"
 msgstr "Портативний диск"
@@ -5610,20 +5607,20 @@ msgid "Removals:"
 msgstr "Вилучення:"
 
 #: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
-#: pkg/storaged/crypto-keyslots.jsx:393 pkg/storaged/crypto-keyslots.jsx:429
-#: pkg/storaged/nfs-details.jsx:308
+#: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
+#: pkg/storaged/nfs-details.jsx:316
 msgid "Remove"
 msgstr "Вилучити"
 
-#: pkg/networkmanager/interfaces.js:3067
+#: pkg/networkmanager/interfaces.js:3076
 msgid "Remove $0"
 msgstr "Вилучити $0"
 
-#: pkg/storaged/crypto-keyslots.jsx:414
+#: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
 msgstr "Вилучити $0?"
 
-#: pkg/storaged/crypto-keyslots.jsx:423
+#: pkg/storaged/crypto-keyslots.jsx:433
 msgid "Remove Tang keyserver"
 msgstr "Вилучити сервер ключів Tang"
 
@@ -5631,19 +5628,19 @@ msgstr "Вилучити сервер ключів Tang"
 msgid "Remove device"
 msgstr "Вилучити пристрій"
 
-#: pkg/storaged/crypto-keyslots.jsx:387
+#: pkg/storaged/crypto-keyslots.jsx:396
 msgid "Remove passphrase"
 msgstr "Вилучити пароль"
 
-#: pkg/storaged/crypto-keyslots.jsx:354
+#: pkg/storaged/crypto-keyslots.jsx:362
 msgid "Remove passphrase in $0?"
 msgstr "Вилучити пароль у $0?"
 
-#: pkg/networkmanager/firewall.jsx:661
+#: pkg/networkmanager/firewall.jsx:663
 msgid "Remove service"
 msgstr "Вилучити службу"
 
-#: pkg/networkmanager/firewall.jsx:640
+#: pkg/networkmanager/firewall.jsx:642
 msgid "Remove service from zones"
 msgstr "Вилучити службу з зон"
 
@@ -5651,7 +5648,7 @@ msgstr "Вилучити службу з зон"
 msgid "Removing"
 msgstr "Вилучаємо"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:181
+#: pkg/lib/cockpit-components-install-dialog.jsx:182
 msgid "Removing $0"
 msgstr "Вилучаємо $0"
 
@@ -5659,7 +5656,7 @@ msgstr "Вилучаємо $0"
 msgid "Removing $target from RAID Device"
 msgstr "Вилучаємо $target з пристрою RAID"
 
-#: pkg/networkmanager/interfaces.js:3066
+#: pkg/networkmanager/interfaces.js:3075
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5671,16 +5668,16 @@ msgstr ""
 msgid "Removing physical volume from $target"
 msgstr "Вилучаємо фізичний том з $target"
 
-#: pkg/storaged/lvol-tabs.jsx:37 pkg/storaged/vgroup-details.jsx:186
-#: pkg/storaged/vgroup-details.jsx:234
+#: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
+#: pkg/storaged/vgroup-details.jsx:231
 msgid "Rename"
 msgstr "Перейменувати"
 
-#: pkg/storaged/lvol-tabs.jsx:31
+#: pkg/storaged/lvol-tabs.jsx:32
 msgid "Rename Logical Volume"
 msgstr "Перейменувати логічний том"
 
-#: pkg/storaged/vgroup-details.jsx:178
+#: pkg/storaged/vgroup-details.jsx:173
 msgid "Rename Volume Group"
 msgstr "Перейменувати групу томів"
 
@@ -5712,30 +5709,29 @@ msgstr "Повторювати щотижня"
 msgid "Repeat Yearly"
 msgstr "Повторювати щороку"
 
-#: pkg/storaged/crypto-keyslots.jsx:204 pkg/storaged/crypto-keyslots.jsx:214
-#: pkg/storaged/crypto-keyslots.jsx:256
+#: pkg/storaged/crypto-keyslots.jsx:207 pkg/storaged/crypto-keyslots.jsx:219
+#: pkg/storaged/crypto-keyslots.jsx:262
 msgid "Repeat passphrase"
 msgstr "Повторіть пароль"
 
-#: pkg/systemd/logs.js:512
+#: pkg/systemd/logs.js:514
 msgid "Report"
 msgstr "Звіт"
 
-#: pkg/systemd/logs.js:507
+#: pkg/systemd/logs.js:509
 msgid "Reported"
 msgstr "Повідомлено"
 
-#: pkg/systemd/logs.js:529
+#: pkg/systemd/logs.js:531
 msgid "Reporter 'reporter-ureport' not found."
 msgstr "Не знайдено засіб звітування «reporter-ureport»."
 
-#: pkg/systemd/logs.js:531
+#: pkg/systemd/logs.js:533
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr ""
 "Не вдалося надіслати звіт. Спробуйте віддати команду «reporter-ureport -d "
 
 #: pkg/docker/index.html:690
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:7
 msgid "Repository"
 msgstr "Сховище"
 
@@ -5747,31 +5743,31 @@ msgstr "Вимагати зміну пароля кожні $0 днів"
 msgid "Require password change on $0"
 msgstr "Вимагати зміну пароля $0"
 
-#: pkg/systemd/service-details.jsx:420
+#: pkg/systemd/service-details.jsx:422
 msgid "Required By"
 msgstr "Потрібен для"
 
-#: pkg/systemd/service-details.jsx:372
+#: pkg/systemd/service-details.jsx:374
 msgid "Required by "
 msgstr "Потрібен для"
 
-#: pkg/systemd/service-details.jsx:415
+#: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "Потребує"
 
-#: pkg/systemd/service-details.jsx:387
+#: pkg/systemd/service-details.jsx:389
 msgid "Requires administration access to edit"
 msgstr "Потребує адміністративного доступу для редагування"
 
-#: pkg/systemd/service-details.jsx:416
+#: pkg/systemd/service-details.jsx:418
 msgid "Requisite"
 msgstr "Потрібний"
 
-#: pkg/systemd/service-details.jsx:421
+#: pkg/systemd/service-details.jsx:423
 msgid "Requisite Of"
 msgstr "Потрібний для"
 
-#: pkg/kdump/kdump-view.jsx:501
+#: pkg/kdump/kdump-view.jsx:503
 msgid "Reserved memory"
 msgstr "Зарезервована пам’ять"
 
@@ -5780,11 +5776,11 @@ msgstr "Зарезервована пам’ять"
 msgid "Reset"
 msgstr "Скинути"
 
-#: pkg/docker/storage.jsx:441
+#: pkg/docker/storage.jsx:452
 msgid "Reset Storage Pool"
 msgstr "Скинути резервне сховище"
 
-#: pkg/docker/storage.jsx:444
+#: pkg/docker/storage.jsx:455
 msgid ""
 "Resetting the storage pool will erase all containers and release disks in "
 "the pool."
@@ -5797,7 +5793,7 @@ msgstr ""
 msgid "Resizing $target"
 msgstr "Зміна розміру $target"
 
-#: pkg/storaged/lvol-tabs.jsx:225 pkg/storaged/lvol-tabs.jsx:307
+#: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
 "Resizing an encrypted filesystem requires unlocking the disk. Please provide "
 "a current disk passphrase."
@@ -5805,15 +5801,15 @@ msgstr ""
 "Зміна розмірів зашифрованої системи потребує розблокування диска. Будь "
 "ласка, вкажіть поточний пароль до диска."
 
-#: pkg/docker/index.html:138 pkg/systemd/index.html:134
-#: pkg/systemd/index.html:144 pkg/docker/containers-view.jsx:315
+#: pkg/docker/index.html:138 pkg/systemd/index.html:141
+#: pkg/systemd/index.html:151 pkg/docker/containers-view.jsx:315
 #: pkg/machines/components/vm/vmActions.jsx:42
 #: pkg/systemd/service-details.jsx:169 pkg/systemd/shutdown.js:95
 #: pkg/systemd/shutdown.js:96
 msgid "Restart"
 msgstr "Перезапустити"
 
-#: pkg/packagekit/updates.jsx:498
+#: pkg/packagekit/updates.jsx:500
 msgid "Restart Now"
 msgstr "Перезапустити зараз"
 
@@ -5825,11 +5821,11 @@ msgstr "Правила перезапуску"
 msgid "Restart Policy:"
 msgstr "Правила перезапуску:"
 
-#: pkg/packagekit/updates.jsx:493
+#: pkg/packagekit/updates.jsx:495
 msgid "Restart Recommended"
 msgstr "Рекомендовано перезапустити"
 
-#: pkg/packagekit/updates.jsx:866
+#: pkg/packagekit/updates.jsx:867
 msgid "Restarting"
 msgstr "Перезапускаємо"
 
@@ -5860,7 +5856,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Ролі"
 
-#: pkg/networkmanager/interfaces.js:1983 pkg/networkmanager/interfaces.js:2000
+#: pkg/networkmanager/interfaces.js:1995 pkg/networkmanager/interfaces.js:2012
 msgid "Round Robin"
 msgstr "Циклічне"
 
@@ -5872,7 +5868,7 @@ msgstr "Маршрут до $0"
 msgid "Routed Network"
 msgstr "Маршрутизована мережа"
 
-#: pkg/networkmanager/interfaces.js:3337
+#: pkg/networkmanager/interfaces.js:3348
 msgid "Routes"
 msgstr "Маршрути"
 
@@ -5885,10 +5881,6 @@ msgstr "Запустити"
 msgid "Run Image"
 msgstr "Запустити образ"
 
-#: node_modules/registry-image-widgets/views/image-config.html:8
-msgid "Run as"
-msgstr "Запустити від імені"
-
 #: pkg/machines/components/networks/networkOverviewTab.jsx:92
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:134
 msgid "Run when host boots"
@@ -5898,13 +5890,13 @@ msgstr "Запустити під час завантаження основно
 msgid "Runner"
 msgstr "Засіб для запуску"
 
-#: pkg/storaged/mdraid-details.jsx:342 pkg/systemd/service-details.jsx:351
+#: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Працює"
 
 #: pkg/selinux/manifest.json.in
 msgid "SELinux"
-msgstr ""
+msgstr "SELinux"
 
 #: pkg/selinux/setroubleshoot-view.jsx:374
 msgid "SELinux Access Control Errors"
@@ -5966,6 +5958,14 @@ msgstr "Максимальний вік повідомлення STP"
 msgid "STP Priority"
 msgstr "Пріоритет STP"
 
+#: pkg/shell/index.html:403
+msgid ""
+"Safari users need to import and trust the certificate of the self-signing CA:"
+""
+msgstr ""
+"Користувачам Safari слід імпортувати сертифікат самопідписаного CA і "
+"встановити довіру до нього:"
+
 #: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "субота"
@@ -5974,26 +5974,26 @@ msgstr "субота"
 msgid "Saturdays"
 msgstr "Суботи"
 
-#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:314
+#: pkg/systemd/services.html:378 pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
 #: pkg/machines/components/vm/memoryModal.jsx:217
-#: pkg/storaged/crypto-keyslots.jsx:261 pkg/storaged/crypto-keyslots.jsx:278
+#: pkg/storaged/crypto-keyslots.jsx:266 pkg/storaged/crypto-keyslots.jsx:285
 msgid "Save"
 msgstr "Зберегти"
 
-#: pkg/systemd/hwinfo.jsx:219
+#: pkg/systemd/hwinfo.jsx:223
 msgid "Save and reboot"
 msgstr "Зберегти і перезавантажити"
 
-#: pkg/storaged/vdos-panel.jsx:82
+#: pkg/storaged/vdos-panel.jsx:88
 msgid "Save space by compressing individual blocks with LZ4"
 msgstr "Заощаджувати місце стисканням окремих блоків за допомогою LZ4"
 
-#: pkg/storaged/vdos-panel.jsx:85
+#: pkg/storaged/vdos-panel.jsx:92
 msgid "Save space by storing identical data blocks just once"
 msgstr "Заощаджувати місце, зберігаючи ідентичні блоки даних лише раз"
 
-#: pkg/storaged/crypto-keyslots.jsx:226 pkg/storaged/crypto-keyslots.jsx:276
+#: pkg/storaged/crypto-keyslots.jsx:233 pkg/storaged/crypto-keyslots.jsx:283
 msgid ""
 "Saving a new passphrase requires unlocking the disk. Please provide a "
 "current disk passphrase."
@@ -6006,11 +6006,11 @@ msgid "Sealed-case PC"
 msgstr "ПК з опломбованим корпусом"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
-#: pkg/systemd/init.js:905
+#: pkg/systemd/init.js:967
 msgid "Seconds"
 msgstr "Секунди"
 
-#: pkg/systemd/index.html:106
+#: pkg/systemd/index.html:113
 msgid "Secure Shell Keys"
 msgstr "Ключі захищеної оболонки (SSH)"
 
@@ -6022,7 +6022,7 @@ msgstr "Безпечно витираємо $target"
 msgid "Security"
 msgstr "Безпека"
 
-#: pkg/systemd/host.js:506
+#: pkg/systemd/host.js:509
 msgid "Security Updates Available"
 msgstr "Доступні оновлення захисту"
 
@@ -6057,11 +6057,11 @@ msgid "Serial Console"
 msgstr "Послідовна консоль"
 
 #: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
-#: pkg/storaged/nfs-details.jsx:315 pkg/storaged/nfs-panel.jsx:101
+#: pkg/storaged/nfs-details.jsx:323 pkg/storaged/nfs-panel.jsx:101
 msgid "Server"
 msgstr "Сервер"
 
-#: pkg/storaged/iscsi-panel.jsx:43 pkg/storaged/nfs-details.jsx:143
+#: pkg/storaged/iscsi-panel.jsx:44 pkg/storaged/nfs-details.jsx:146
 msgid "Server Address"
 msgstr "Адреса сервера"
 
@@ -6073,15 +6073,15 @@ msgstr "Адміністратор сервера"
 msgid "Server Software"
 msgstr "Програмне забезпечення сервера"
 
-#: pkg/storaged/iscsi-panel.jsx:44
+#: pkg/storaged/iscsi-panel.jsx:45
 msgid "Server address cannot be empty."
 msgstr "Адреса сервера не може бути порожньою."
 
-#: pkg/storaged/nfs-details.jsx:147
+#: pkg/storaged/nfs-details.jsx:151
 msgid "Server cannot be empty."
 msgstr "Запис сервера не може бути порожнім."
 
-#: src/base1/cockpit.js:4033
+#: src/base1/cockpit.js:4037
 msgid "Server has closed the connection."
 msgstr "З’єднання розірвано сервером."
 
@@ -6089,8 +6089,8 @@ msgstr "З’єднання розірвано сервером."
 msgid "Servers"
 msgstr "Сервери"
 
-#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:968
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:970
+#: pkg/storaged/dialog.jsx:1048
 msgid "Service"
 msgstr "Служба"
 
@@ -6098,23 +6098,23 @@ msgstr "Служба"
 msgid "Service Logs"
 msgstr "Журнали служб"
 
-#: pkg/kdump/kdump-view.jsx:442
+#: pkg/kdump/kdump-view.jsx:444
 msgid "Service has an error"
 msgstr "Помилка у службі"
 
-#: pkg/kdump/kdump-view.jsx:438
+#: pkg/kdump/kdump-view.jsx:440
 msgid "Service is running"
 msgstr "Службу запущено"
 
-#: pkg/kdump/kdump-view.jsx:444
+#: pkg/kdump/kdump-view.jsx:446
 msgid "Service is starting"
 msgstr "Служба запускається"
 
-#: pkg/kdump/kdump-view.jsx:440
+#: pkg/kdump/kdump-view.jsx:442
 msgid "Service is stopped"
 msgstr "Службу зупинено"
 
-#: pkg/kdump/kdump-view.jsx:446
+#: pkg/kdump/kdump-view.jsx:448
 msgid "Service is stopping"
 msgstr "Служба зупиняється"
 
@@ -6123,12 +6123,12 @@ msgid "Service name"
 msgstr "Назва служби"
 
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
-#: pkg/networkmanager/firewall.jsx:508 pkg/systemd/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:510 pkg/systemd/manifest.json.in
 msgid "Services"
 msgstr "Служби"
 
 #: pkg/machines/components/machinesConnectionSelector.jsx:50
-#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1043
+#: pkg/machines/helpers.js:185 pkg/storaged/dialog.jsx:1044
 msgid "Session"
 msgstr "Сеанс"
 
@@ -6136,11 +6136,11 @@ msgstr "Сеанс"
 msgid "Set"
 msgstr "Встановити"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:231
+#: pkg/machines/components/networks/createNetworkDialog.jsx:217
 msgid "Set DHCP Range"
 msgstr "Встановити діапазон DHCP"
 
-#: pkg/systemd/host.js:781
+#: pkg/systemd/host.js:816
 msgid "Set Host name"
 msgstr "Встановити назву вузла"
 
@@ -6148,13 +6148,17 @@ msgstr "Встановити назву вузла"
 msgid "Set Password"
 msgstr "Встановити пароль"
 
-#: pkg/systemd/index.html:378
+#: pkg/systemd/index.html:389
 msgid "Set Time"
 msgstr "Встановити час"
 
 #: pkg/docker/index.html:532
 msgid "Set container environment variables"
 msgstr "Встановити змінні середовища контейнера"
+
+#: pkg/machines/components/nicAdd.jsx:60
+msgid "Set manually"
+msgstr "Встановити вручну"
 
 #: pkg/networkmanager/index.html:183
 msgid "Set to"
@@ -6179,15 +6183,15 @@ msgstr "Налаштовуємо"
 msgid "Setting up loop device $target"
 msgstr "Налаштовуємо петльовий пристрій $target"
 
-#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:382
+#: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:383
 msgid "Severity"
 msgstr "Важливість"
 
-#: pkg/packagekit/updates.jsx:310
+#: pkg/packagekit/updates.jsx:311
 msgid "Severity:"
 msgstr "Критичність:"
 
-#: pkg/networkmanager/interfaces.js:1968
+#: pkg/networkmanager/interfaces.js:1980
 msgid "Shared"
 msgstr "Спільний"
 
@@ -6199,15 +6203,15 @@ msgstr "Скрипт оболонки"
 msgid "Shift+Insert"
 msgstr "Shift+Insert"
 
-#: pkg/machines/components/diskAdd.jsx:243
+#: pkg/machines/components/diskAdd.jsx:166
 msgid "Show Performance Options"
 msgstr "Показати параметри швидкодії"
 
-#: pkg/storaged/overview.jsx:56
+#: pkg/storaged/overview.jsx:54
 msgid "Show all"
 msgstr "Показати усі"
 
-#: pkg/storaged/drives-panel.jsx:122
+#: pkg/storaged/drives-panel.jsx:104
 msgid "Show all $0 drives"
 msgstr "Показати усі диски $0"
 
@@ -6219,23 +6223,23 @@ msgstr "Показати усі контейнери"
 msgid "Show all images"
 msgstr "Показати усі образи"
 
-#: pkg/systemd/index.html:107
+#: pkg/systemd/index.html:114
 msgid "Show fingerprints"
 msgstr "Показати відбитки"
 
-#: pkg/storaged/lvol-tabs.jsx:317 pkg/storaged/lvol-tabs.jsx:398
+#: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Стиснути"
 
-#: pkg/storaged/lvol-tabs.jsx:313
+#: pkg/storaged/lvol-tabs.jsx:320
 msgid "Shrink Logical Volume"
 msgstr "Стиснути логічний том"
 
-#: pkg/storaged/lvol-tabs.jsx:415
+#: pkg/storaged/lvol-tabs.jsx:423
 msgid "Shrink Volume"
 msgstr "Стиснути том"
 
-#: pkg/systemd/index.html:147 pkg/machines/components/vm/vmActions.jsx:56
+#: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
 msgstr "Вимкнути"
@@ -6246,47 +6250,47 @@ msgstr "Єдиний ранг"
 
 #: pkg/docker/containers-view.jsx:683
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:475
-#: pkg/machines/components/diskAdd.jsx:172
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
-#: pkg/storaged/content-views.jsx:115 pkg/storaged/content-views.jsx:684
-#: pkg/storaged/format-dialog.jsx:271 pkg/storaged/fsys-panel.jsx:110
-#: pkg/storaged/lvol-tabs.jsx:210 pkg/storaged/lvol-tabs.jsx:269
-#: pkg/storaged/lvol-tabs.jsx:394 pkg/storaged/lvol-tabs.jsx:447
-#: pkg/storaged/nfs-details.jsx:321 pkg/storaged/nfs-panel.jsx:103
-#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
+#: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:79
+#: pkg/storaged/content-views.jsx:118 pkg/storaged/content-views.jsx:702
+#: pkg/storaged/format-dialog.jsx:278 pkg/storaged/fsys-panel.jsx:110
+#: pkg/storaged/lvol-tabs.jsx:212 pkg/storaged/lvol-tabs.jsx:274
+#: pkg/storaged/lvol-tabs.jsx:402 pkg/storaged/lvol-tabs.jsx:455
+#: pkg/storaged/nfs-details.jsx:329 pkg/storaged/nfs-panel.jsx:103
+#: pkg/storaged/part-tab.jsx:36 pkg/systemd/hwinfo.jsx:263
 msgid "Size"
 msgstr "Розмір"
 
-#: pkg/storaged/dialog.jsx:911
+#: pkg/storaged/dialog.jsx:912
 msgid "Size cannot be negative"
 msgstr "Розмір не може бути від’ємним"
 
-#: pkg/storaged/dialog.jsx:909
+#: pkg/storaged/dialog.jsx:910
 msgid "Size cannot be zero"
 msgstr "Розмір не може бути нульовим"
 
-#: pkg/storaged/dialog.jsx:913
+#: pkg/storaged/dialog.jsx:914
 msgid "Size is too large"
 msgstr "Розмір є надто великим"
 
-#: pkg/storaged/dialog.jsx:907
+#: pkg/storaged/dialog.jsx:908
 msgid "Size must be a number"
 msgstr "Розмір має бути числом"
 
-#: pkg/storaged/dialog.jsx:915
+#: pkg/storaged/dialog.jsx:916
 msgid "Size must be at least $0"
 msgstr "Розмір має бути не меншим за $0"
 
-#: pkg/systemd/hwinfo.jsx:250
+#: pkg/systemd/hwinfo.jsx:254
 msgid "Slot"
 msgstr "Слот"
 
-#: pkg/storaged/crypto-keyslots.jsx:531
+#: pkg/storaged/crypto-keyslots.jsx:544
 msgid "Slot $0"
 msgstr "Слот $0"
 
-#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:40
+#: pkg/machines/components/vcpuModal.jsx:206 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "Сокети"
 
@@ -6294,7 +6298,7 @@ msgstr "Сокети"
 msgid "Software Updates"
 msgstr "Оновлення програм"
 
-#: pkg/systemd/hwinfo.jsx:208
+#: pkg/systemd/hwinfo.jsx:212
 msgid ""
 "Software-based workarounds help prevent CPU security issues. These "
 "mitigations have the side effect of reducing performance. Change these "
@@ -6304,12 +6308,7 @@ msgstr ""
 "заходи мають побіжний ефект — зниження швидкодії. Змінюйте ці параметри, "
 "лише якщо повністю усвідомлюєте наслідки."
 
-#: pkg/docker/storage.jsx:165
-msgid "Solid-State Disk"
-msgstr "Твердотільний диск"
-
-#: pkg/storaged/drives-panel.jsx:87
-msgctxt "storage"
+#: pkg/docker/storage.jsx:167
 msgid "Solid-State Disk"
 msgstr "Твердотільний диск"
 
@@ -6332,15 +6331,15 @@ msgstr ""
 "Програмою для керування пакунків користується якась інша програма, будь "
 "ласка, зачекайте…"
 
-#: pkg/networkmanager/firewall.jsx:739
+#: pkg/networkmanager/firewall.jsx:741
 msgid "Sorted from least trusted to most trusted"
 msgstr "Упорядковано від найменшої до найбільшої довіри"
 
-#: pkg/machines/components/diskAdd.jsx:541
-#: pkg/machines/components/nicEdit.jsx:150
+#: pkg/machines/components/diskAdd.jsx:412
+#: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
-#: pkg/machines/components/vmDisksTab.jsx:76
-#: pkg/machines/components/vmnetworktab.jsx:148
+#: pkg/machines/components/vmDisksTab.jsx:114
+#: pkg/machines/components/vmnetworktab.jsx:160
 msgid "Source"
 msgstr "Джерело"
 
@@ -6354,10 +6353,6 @@ msgstr "Початковий формат"
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:47
 msgid "Source Path"
 msgstr "Шлях до джерела"
-
-#: node_modules/registry-image-widgets/views/image-body.html:8
-msgid "Source URL"
-msgstr "Початкова адреса"
 
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:272
 msgid "Source Volume Group"
@@ -6376,7 +6371,7 @@ msgstr "Адреса джерела має починатися із назви 
 msgid "Space-saving Computer"
 msgstr "Компактний комп'ютер"
 
-#: pkg/networkmanager/interfaces.js:2869
+#: pkg/networkmanager/interfaces.js:2877
 msgid "Spanning Tree Protocol"
 msgstr "Протокол пересування ієрархією"
 
@@ -6384,26 +6379,26 @@ msgstr "Протокол пересування ієрархією"
 msgid "Spanning Tree Protocol (STP)"
 msgstr "Протокол пересування ієрархією (STP)"
 
-#: pkg/storaged/mdraid-details.jsx:101
+#: pkg/storaged/mdraid-details.jsx:95
 msgid "Spare"
 msgstr "Запас"
 
-#: pkg/systemd/index.html:455
+#: pkg/systemd/index.html:466
 msgid "Specific Time"
 msgstr "У визначений час"
 
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Speed"
 msgstr "Швидкість"
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3660
 msgid "Stable"
 msgstr "Стабільний"
 
 #: pkg/docker/index.html:136 pkg/docker/containers-view.jsx:312
-#: pkg/machines/components/networks/createNetworkDialog.jsx:237
-#: pkg/storaged/mdraid-details.jsx:319 pkg/storaged/swap-tab.jsx:77
-#: pkg/storaged/vdo-details.jsx:259 pkg/systemd/service-details.jsx:176
+#: pkg/machines/components/networks/createNetworkDialog.jsx:223
+#: pkg/storaged/mdraid-details.jsx:315 pkg/storaged/swap-tab.jsx:77
+#: pkg/storaged/vdo-details.jsx:265 pkg/systemd/service-details.jsx:176
 msgid "Start"
 msgstr "Почати"
 
@@ -6415,11 +6410,11 @@ msgstr "Запустити Docker"
 msgid "Start Multipath"
 msgstr "Запустити Multipath"
 
-#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:341
+#: pkg/networkmanager/index.html:44 pkg/systemd/service-details.jsx:343
 msgid "Start Service"
 msgstr "Запустити службу"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Start and Enable"
 msgstr "Запустити і увімкнути"
 
@@ -6449,10 +6444,10 @@ msgid "Startup"
 msgstr "Запуск"
 
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
-#: pkg/machines/components/networks/networkList.jsx:50
-#: pkg/machines/components/storagePools/storagePoolList.jsx:49
-#: pkg/machines/components/vmnetworktab.jsx:172 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/init.js:294 pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/networks/networkList.jsx:55
+#: pkg/machines/components/storagePools/storagePoolList.jsx:54
+#: pkg/machines/components/vmnetworktab.jsx:186 pkg/machines/hostvmslist.jsx:83
+#: pkg/systemd/hwinfo.jsx:263 pkg/systemd/init.js:306
 msgid "State"
 msgstr "Стан"
 
@@ -6460,12 +6455,12 @@ msgstr "Стан"
 msgid "State:"
 msgstr "Стан:"
 
-#: pkg/systemd/services.html:68 pkg/systemd/init.js:212
-#: pkg/systemd/service-details.jsx:369
+#: pkg/systemd/services.html:68 pkg/systemd/init.js:213
+#: pkg/systemd/service-details.jsx:371
 msgid "Static"
 msgstr "Статичний"
 
-#: pkg/networkmanager/interfaces.js:2625 pkg/systemd/service-details.jsx:476
+#: pkg/networkmanager/interfaces.js:2633 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Стан"
 
@@ -6478,21 +6473,21 @@ msgid "Sticky"
 msgstr "Липкий"
 
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
-#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/swap-tab.jsx:76
-#: pkg/storaged/vdo-details.jsx:157 pkg/storaged/vdo-details.jsx:258
+#: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
+#: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
 #: pkg/systemd/service-details.jsx:172
 msgid "Stop"
 msgstr "Зупинити"
 
-#: pkg/storaged/mdraid-details.jsx:247
+#: pkg/storaged/mdraid-details.jsx:244
 msgid "Stop Device"
 msgstr "Зупинити пристрій"
 
-#: pkg/systemd/service-details.jsx:411
+#: pkg/systemd/service-details.jsx:413
 msgid "Stop and Disable"
 msgstr "Зупинити і вимкнути"
 
-#: pkg/storaged/nfs-details.jsx:259
+#: pkg/storaged/nfs-details.jsx:267
 msgid "Stop and Unmount"
 msgstr "Зупинити і демонтувати"
 
@@ -6500,13 +6495,9 @@ msgstr "Зупинити і демонтувати"
 msgid "Stop and delete"
 msgstr "Зупинити і вилучити"
 
-#: pkg/storaged/nfs-details.jsx:284
+#: pkg/storaged/nfs-details.jsx:292
 msgid "Stop and remove"
 msgstr "Зупинити і вилучити"
-
-#: node_modules/registry-image-widgets/views/image-config.html:14
-msgid "Stop with"
-msgstr "Зупинитися на"
 
 #: pkg/docker/util.js:231
 msgid "Stopped"
@@ -6530,6 +6521,13 @@ msgstr "Сховище даних"
 msgid "Storage Logs"
 msgstr "Журнали зберігання"
 
+#: pkg/machines/components/aggregateStatusCards.jsx:47
+msgid "Storage Pool"
+msgid_plural "Storage Pools"
+msgstr[0] "Буфери сховища"
+msgstr[1] "Буфери сховища"
+msgstr[2] "Буфери сховища"
+
 #: pkg/machines/components/storagePools/storagePool.jsx:139
 msgid "Storage Pool $0 failed to get activated"
 msgstr "Не вдалося активувати буфер сховища $0"
@@ -6546,8 +6544,8 @@ msgstr "Назва резервного сховища"
 msgid "Storage Pool failed to be created"
 msgstr "Не вдалося створити резервне сховище"
 
-#: pkg/machines/components/storagePools/storagePoolList.jsx:44
-#: pkg/machines/components/storagePools/storagePoolList.jsx:48
+#: pkg/machines/components/storagePools/storagePoolList.jsx:49
+#: pkg/machines/components/storagePools/storagePoolList.jsx:53
 msgid "Storage Pools"
 msgstr "Буфери даних"
 
@@ -6571,19 +6569,19 @@ msgstr "Буфер сховища"
 msgid "Storage size must not be 0"
 msgstr "Розмір сховища має бути ненульовим"
 
-#: pkg/systemd/index.html:155
+#: pkg/systemd/index.html:162
 msgid "Store Metrics"
 msgstr "Метрика зберігання"
 
-#: pkg/storaged/format-dialog.jsx:122
+#: pkg/storaged/format-dialog.jsx:126
 msgid "Store passphrase"
 msgstr "Зберігати пароль"
 
-#: pkg/storaged/crypto-tab.jsx:67 pkg/storaged/crypto-tab.jsx:69
+#: pkg/storaged/crypto-tab.jsx:68 pkg/storaged/crypto-tab.jsx:70
 msgid "Stored Passphrase"
 msgstr "Збережений пароль"
 
-#: pkg/storaged/crypto-tab.jsx:126
+#: pkg/storaged/crypto-tab.jsx:129
 msgid "Stored passphrase"
 msgstr "Збережений пароль"
 
@@ -6595,10 +6593,6 @@ msgstr "Підблок"
 msgid "Sub Notebook"
 msgstr "Підноутбук"
 
-#: node_modules/registry-image-widgets/views/image-body.html:4
-msgid "Summary"
-msgstr "Резюме"
-
 #: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "неділя"
@@ -6607,32 +6601,32 @@ msgstr "неділя"
 msgid "Sundays"
 msgstr "Неділі"
 
-#: pkg/storaged/optional-panel.jsx:95
+#: pkg/storaged/optional-panel.jsx:98
 msgid "Support is installed."
 msgstr "Підтримку встановлено."
 
-#: pkg/storaged/content-views.jsx:157
+#: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Свопінґ"
 
-#: pkg/storaged/content-views.jsx:351
+#: pkg/storaged/content-views.jsx:356
 msgctxt "storage-id-desc"
 msgid "Swap Space"
 msgstr "Резервна пам’ять"
 
-#: pkg/systemd/index.html:248 pkg/systemd/host.js:1709
+#: pkg/systemd/index.html:259 pkg/systemd/host.js:1756
 msgid "Swap Used"
 msgstr "Використано резерву"
 
-#: pkg/networkmanager/interfaces.js:2504 pkg/networkmanager/interfaces.js:3051
+#: pkg/networkmanager/interfaces.js:2511 pkg/networkmanager/interfaces.js:3060
 msgid "Switch off $0"
 msgstr "Вимкнути $0"
 
-#: pkg/networkmanager/interfaces.js:2479 pkg/networkmanager/interfaces.js:3039
+#: pkg/networkmanager/interfaces.js:2486 pkg/networkmanager/interfaces.js:3048
 msgid "Switch on $0"
 msgstr "Увімкнути $0"
 
-#: pkg/networkmanager/interfaces.js:2503
+#: pkg/networkmanager/interfaces.js:2510
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6640,7 +6634,7 @@ msgstr ""
 "Вимикання <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:3050
+#: pkg/networkmanager/interfaces.js:3059
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6648,7 +6642,7 @@ msgstr ""
 "Вимикання <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:2478 pkg/networkmanager/interfaces.js:3038
+#: pkg/networkmanager/interfaces.js:2485 pkg/networkmanager/interfaces.js:3047
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6678,12 +6672,16 @@ msgstr "Синхронізуємо пристрій RAID $target"
 
 #: pkg/systemd/index.html:4
 #: pkg/machines/components/machinesConnectionSelector.jsx:43
-#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:269
+#: pkg/machines/helpers.js:184 pkg/systemd/hwinfo.jsx:273
 #: pkg/systemd/manifest.json.in
 msgid "System"
 msgstr "Система"
 
-#: pkg/systemd/hwinfo.jsx:273
+#: pkg/systemd/index.html:171
+msgid "System Health"
+msgstr ""
+
+#: pkg/systemd/hwinfo.jsx:277
 msgid "System Information"
 msgstr "Дані щодо системи"
 
@@ -6691,28 +6689,28 @@ msgstr "Дані щодо системи"
 msgid "System Modifications"
 msgstr "Модифікації системи"
 
-#: pkg/systemd/host.js:490
+#: pkg/systemd/host.js:493
 msgid "System Not Registered"
 msgstr "Систему не зареєстровано"
 
-#: pkg/systemd/services.jsx:38
+#: pkg/systemd/services.jsx:47
 msgid "System Services"
 msgstr "Служби системи"
 
-#: pkg/systemd/index.html:121
+#: pkg/systemd/index.html:128
 msgid "System Time"
 msgstr "Системний час"
 
-#: pkg/systemd/host.js:496
+#: pkg/systemd/host.js:499
 msgid "System Up To Date"
 msgstr "Система не потребує оновлення"
 
-#: pkg/packagekit/updates.jsx:878
+#: pkg/packagekit/updates.jsx:879
 msgid "System is up to date"
 msgstr "Система не потребує оновлення"
 
 #: pkg/docker/index.html:329 pkg/docker/index.html:333
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "TCP"
 msgstr "TCP"
 
@@ -6721,18 +6719,14 @@ msgid "Tablet"
 msgstr "Планшет"
 
 #: pkg/docker/index.html:696
-#: node_modules/registry-image-widgets/views/image-listing.html:5
 msgid "Tag"
 msgstr "Мітка"
 
-#: node_modules/registry-image-widgets/views/image-body.html:29
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:6
-#: node_modules/registry-image-widgets/views/imagestream-panel.html:16
 #: pkg/docker/containers-view.jsx:409
 msgid "Tags"
 msgstr "Мітки"
 
-#: pkg/storaged/crypto-keyslots.jsx:207
+#: pkg/storaged/crypto-keyslots.jsx:210
 msgid "Tang keyserver"
 msgstr "Сервер ключів Tang"
 
@@ -6749,16 +6743,16 @@ msgstr "Шлях призначення"
 msgid "Target path should not be empty"
 msgstr "Шлях призначення не може бути порожнім"
 
-#: pkg/systemd/services.jsx:39
+#: pkg/systemd/services.jsx:48
 msgid "Targets"
 msgstr "Призначення"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
-#: pkg/networkmanager/interfaces.js:2826
+#: pkg/networkmanager/interfaces.js:2531 pkg/networkmanager/interfaces.js:2543
+#: pkg/networkmanager/interfaces.js:2834
 msgid "Team"
 msgstr "Команда"
 
-#: pkg/networkmanager/interfaces.js:2854
+#: pkg/networkmanager/interfaces.js:2862
 msgid "Team Port"
 msgstr "Порт команди"
 
@@ -6778,11 +6772,11 @@ msgstr "Термінал"
 msgid "Terminate Session"
 msgstr "Перервати сеанс"
 
-#: pkg/kdump/kdump-view.jsx:476 pkg/kdump/kdump-view.jsx:484
+#: pkg/kdump/kdump-view.jsx:478 pkg/kdump/kdump-view.jsx:486
 msgid "Test Configuration"
 msgstr "Налаштування перевірки"
 
-#: pkg/kdump/kdump-view.jsx:480
+#: pkg/kdump/kdump-view.jsx:482
 msgid "Test is only available while the kdump service is running."
 msgstr "Перевірка є доступною, лише якщо запущено службу kdump."
 
@@ -6794,23 +6788,23 @@ msgstr "Перевірити параметри kdump"
 msgid "Testing connection"
 msgstr "Перевіряємо з’єднання"
 
-#: pkg/docker/storage.jsx:507
+#: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr "У цій системі не можна керувати резервним сховищем даних Docker."
 
-#: pkg/lib/machine-dialogs.js:384
+#: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
 msgstr "У IP-адресі або назві вузла не повинно бути пробілів."
 
-#: pkg/storaged/mdraid-details.jsx:218
+#: pkg/storaged/mdraid-details.jsx:213
 msgid "The RAID Array is in a degraded state"
 msgstr "Масив RAID перебуває у стані із погіршеними властивостями"
 
-#: pkg/storaged/mdraid-details.jsx:148
+#: pkg/storaged/mdraid-details.jsx:142
 msgid "The RAID device must be running in order to add spare disks."
 msgstr "Для додавання резервних дисків має працювати пристрій RAID."
 
-#: pkg/storaged/mdraid-details.jsx:115
+#: pkg/storaged/mdraid-details.jsx:109
 msgid "The RAID device must be running in order to remove disks."
 msgstr "Для вилучення дисків має працювати пристрій RAID."
 
@@ -6889,7 +6883,7 @@ msgid ""
 msgstr ""
 "Створення цього пристрою VDO не завершено, ним не можна користуватися."
 
-#: pkg/storaged/crypto-keyslots.jsx:516
+#: pkg/storaged/crypto-keyslots.jsx:529
 msgid ""
 "The currently logged in user is not permitted to see information about keys."
 msgstr ""
@@ -6900,7 +6894,7 @@ msgstr ""
 msgid "The directory on the server being exported"
 msgstr "Каталог на сервері, який експортується"
 
-#: pkg/storaged/dialog.jsx:1012
+#: pkg/storaged/dialog.jsx:1013
 msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
@@ -6908,14 +6902,14 @@ msgstr ""
 "Файлова система використовується службами системи або сеансами користувачів. "
 "Виконання цієї дії призведе до припинення роботи цих служб та сеансів."
 
-#: pkg/storaged/dialog.jsx:1014
+#: pkg/storaged/dialog.jsx:1015
 msgid ""
 "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
 "Файлова система використовується сеансами користувачів. Виконання цієї дії "
 "призведе до припинення роботи цих сеансів."
 
-#: pkg/storaged/dialog.jsx:1016
+#: pkg/storaged/dialog.jsx:1017
 msgid ""
 "The filesystem is in use by system services. Proceeding will stop these."
 msgstr ""
@@ -6953,15 +6947,15 @@ msgstr ""
 msgid "The key you provided was not valid."
 msgstr "Наданий вами ключ є некоректним."
 
-#: pkg/storaged/mdraid-details.jsx:121
+#: pkg/storaged/mdraid-details.jsx:115
 msgid "The last disk of a RAID device cannot be removed."
 msgstr "Останній диск пристрою RAID вилучати не можна."
 
-#: pkg/storaged/crypto-keyslots.jsx:541
+#: pkg/storaged/crypto-keyslots.jsx:554
 msgid "The last key slot can not be removed"
 msgstr "Не можна вилучати останній слот ключів"
 
-#: pkg/storaged/vgroup-details.jsx:96
+#: pkg/storaged/vgroup-details.jsx:90
 msgid "The last physical volume of a volume group cannot be removed."
 msgstr "Не можна вилучати останній фізичний том із групи томів."
 
@@ -6971,7 +6965,7 @@ msgstr ""
 "Користувач, який увійшов до системи, не має права переглядати модифікації "
 "системи"
 
-#: pkg/shell/indexes.js:413
+#: pkg/shell/indexes.js:464
 msgid "The machine is restarting"
 msgstr "Комп’ютер перезавантажується"
 
@@ -6987,13 +6981,20 @@ msgstr "Паролі не збігаються"
 msgid "The passwords do not match."
 msgstr "Паролі не збігаються."
 
-#: pkg/machines/components/diskAdd.jsx:80
+#: pkg/machines/components/diskAdd.jsx:81
 msgid "The pool is empty"
 msgstr "Буфер порожній"
 
 #: pkg/docker/containers-view.jsx:434
 msgid "The scan from $time ($type) found no vulnerabilities."
 msgstr "Скануванням від $time ($type) вразливостей не знайдено."
+
+#: pkg/docker/containers-view.jsx:436
+msgid "The scan from $time ($type) found one vulnerability:"
+msgid_plural "The scan from $time ($type) found $count vulnerabilities:"
+msgstr[0] "Під час сканування $time ($type) виявлено $count помилку:"
+msgstr[1] "Під час сканування $time ($type) виявлено $count помилки:"
+msgstr[2] "Під час сканування $time ($type) виявлено $count помилок:"
 
 #: pkg/docker/containers-view.jsx:432
 msgid "The scan from $time ($type) was not successful."
@@ -7010,6 +7011,17 @@ msgstr ""
 "Для вибраної операційної системи мінімальним об'ємом пристрою накопичення "
 "даних є $0 $1"
 
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:382
+msgid "The selected Operating System has recommended memory $0 $1"
+msgstr ""
+"Для вибраної операційної системи рекомендації щодо пам'яті є такими: $0 $1"
+
+#: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:417
+msgid "The selected Operating System has recommended storage size of $0 $1"
+msgstr ""
+"Для вибраної операційної системи рекомендації щодо сховища даних є такими: "
+"$0 $1"
+
 #: src/ws/login.js:645
 msgid ""
 "The server refused to authenticate '$0' using password authentication, and "
@@ -7018,17 +7030,17 @@ msgstr ""
 "Сервером відмовлено у розпізнаванні «$0» за допомогою пароля. Інших "
 "підтримуваних способів розпізнавання не передбачено."
 
-#: src/base1/cockpit.js:4017
+#: src/base1/cockpit.js:4021
 msgid "The server refused to authenticate using any supported methods."
 msgstr ""
 "Сервер відмовився розпізнавати користувача за допомогою будь-якого з "
 "підтримуваних методів."
 
-#: pkg/systemd/hwinfo.jsx:65
+#: pkg/systemd/hwinfo.jsx:69
 msgid "The user $0 is not permitted to change cpu security mitigations"
 msgstr "Користувачу $0 заборонено змінювати заходи захисту процесора"
 
-#: pkg/systemd/init.js:751
+#: pkg/systemd/init.js:813
 msgid "The user <b>$0</b> does not have permissions for creating timers"
 msgstr "Користувачу <b>$0</b> заборонено створювати таймери"
 
@@ -7036,11 +7048,11 @@ msgstr "Користувачу <b>$0</b> заборонено створюват
 msgid "The user <b>$0</b> is not permitted to change profiles"
 msgstr "Користувачу <b>$0</b> заборонено змінювати профілі"
 
-#: pkg/systemd/host.js:70
+#: pkg/systemd/host.js:72
 msgid "The user <b>$0</b> is not permitted to change the system time"
 msgstr "Користувачу <b>$0</b> заборонено змінювати час системи"
 
-#: pkg/dashboard/list.js:223
+#: pkg/dashboard/list.js:231
 msgid "The user <b>$0</b> is not permitted to manage servers"
 msgstr "Користувачу <b>$0</b> заборонено керувати серверами"
 
@@ -7052,19 +7064,19 @@ msgstr "Користувачу <b>$0</b> не дозволено керуват�
 msgid "The user <b>$0</b> is not permitted to modify accounts"
 msgstr "Користувачу <b>$0</b> заборонено змінювати облікові записи"
 
-#: pkg/systemd/host.js:54
+#: pkg/systemd/host.js:56
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Користувачу <b>$0</b> не дозволено змінювати назви вузлів"
 
-#: pkg/networkmanager/interfaces.js:1525
+#: pkg/networkmanager/interfaces.js:1530
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Користувачу <b>$0</b> заборонено змінювати параметри роботи мережі"
 
-#: pkg/realmd/operation.js:642
+#: pkg/realmd/operation.js:644
 msgid "The user <b>$0</b> is not permitted to modify realms"
 msgstr "Користувачу <b>$0</b> не дозволено вносити зміни до областей"
 
-#: pkg/systemd/host.js:62
+#: pkg/systemd/host.js:64
 msgid "The user <b>$0</b> is not permitted to shutdown or restart this server"
 msgstr ""
 "Користувачеві <b>$0</b> заборонено вимикати або перезапускати цей сервер"
@@ -7101,7 +7113,7 @@ msgstr ""
 msgid "There are no authorized public keys for this account."
 msgstr "Для цього облікового запису немає уповноважених відкритих ключів."
 
-#: pkg/storaged/vgroup-details.jsx:102
+#: pkg/storaged/vgroup-details.jsx:96
 msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
@@ -7109,11 +7121,17 @@ msgstr ""
 "Для вилучення цього фізичного тому недостатньо вільного місця. Потрібно "
 "принаймні $0 вільного місця."
 
-#: pkg/storaged/utils.js:193
+#: pkg/shell/index.html:398
+msgid "There was an unexpected error while connecting to the machine."
+msgstr ""
+"Під час спроби встановити з'єднання із комп'ютером сталася неочікувана "
+"помилка."
+
+#: pkg/storaged/utils.js:194
 msgid "Thin Logical Volume"
 msgstr "Тонкий логічний том"
 
-#: pkg/storaged/nfs-details.jsx:118
+#: pkg/storaged/nfs-details.jsx:120
 msgid "This NFS mount is in use and only its options can be changed."
 msgstr ""
 "Це монтування NFS використовується; можна лише змінювати його параметри."
@@ -7122,7 +7140,7 @@ msgstr ""
 msgid "This VDO device does not use all of its backing device."
 msgstr "Цей пристрій VDO не використовує увесь об'єм резервного пристрою."
 
-#: pkg/systemd/init.js:1200
+#: pkg/systemd/init.js:1262
 msgid ""
 "This day doesn't exist in all months.<br> The timer will only be executed in "
 "months that have 31st."
@@ -7130,11 +7148,11 @@ msgstr ""
 "Цей день є не в усіх місяцях.<br> Таймер виконуватиметься лише у місяці, у "
 "яких є 31 день."
 
-#: pkg/networkmanager/interfaces.js:2636
+#: pkg/networkmanager/interfaces.js:2644
 msgid "This device cannot be managed here."
 msgstr "Тут не можна керувати цим пристроєм."
 
-#: pkg/storaged/dialog.jsx:997
+#: pkg/storaged/dialog.jsx:998
 msgid ""
 "This device has filesystems that are currently in use. Proceeding will "
 "unmount all filesystems on it."
@@ -7142,11 +7160,11 @@ msgstr ""
 "На цьому пристрої міститься файлова система, яка зараз використовується. "
 "Виконання дії призведе до демонтування усіх файлових систем на пристрої."
 
-#: pkg/storaged/dialog.jsx:976
+#: pkg/storaged/dialog.jsx:977
 msgid "This device is currently used for RAID devices."
 msgstr "Цей пристрій зараз використовується для пристроїв RAID."
 
-#: pkg/storaged/dialog.jsx:1005
+#: pkg/storaged/dialog.jsx:1006
 msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
@@ -7154,16 +7172,16 @@ msgstr ""
 "Цей пристрій зараз використовується для формування пристроїв RAID. Якщо дію "
 "буде виконано, пристрій буде вилучено із його пристроїв RAID."
 
-#: pkg/storaged/dialog.jsx:980
+#: pkg/storaged/dialog.jsx:981
 msgid "This device is currently used for VDO devices."
 msgstr ""
 "Цей пристрій зараз використовується для зберігання даних пристроїв VDO."
 
-#: pkg/storaged/dialog.jsx:972
+#: pkg/storaged/dialog.jsx:973
 msgid "This device is currently used for volume groups."
 msgstr "Цей пристрій зараза використовується для груп томів."
 
-#: pkg/storaged/dialog.jsx:1001
+#: pkg/storaged/dialog.jsx:1002
 msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
@@ -7171,12 +7189,12 @@ msgstr ""
 "Цей пристрій зараз використовується для груп томів. Якщо дію буде виконано, "
 "пристрій буде вилучено із його груп томів."
 
-#: pkg/storaged/mdraid-details.jsx:117
+#: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
 msgstr ""
 "Цей диск не можна вилучати, доки пристрій перебуває у стані відновлення."
 
-#: pkg/systemd/init.js:1112 pkg/systemd/init.js:1126 pkg/systemd/init.js:1135
+#: pkg/systemd/init.js:1174 pkg/systemd/init.js:1188 pkg/systemd/init.js:1197
 msgid "This field cannot be empty."
 msgstr "Вміст цього поля не може бути порожнім."
 
@@ -7184,13 +7202,13 @@ msgstr "Вміст цього поля не може бути порожнім."
 msgid "This image does not exist."
 msgstr "Цього образу не існує."
 
-#: pkg/storaged/lvol-tabs.jsx:408
+#: pkg/storaged/lvol-tabs.jsx:416
 msgid "This logical volume is not completely used by its content."
 msgstr ""
 "Місце на цьому логічному томі не повністю використано даними, які на ньому "
 "зберігаються."
 
-#: pkg/lib/machine-dialogs.js:362
+#: pkg/lib/machine-dialogs.js:364
 msgid "This machine has already been added."
 msgstr "Цей комп’ютер вже було додано."
 
@@ -7207,11 +7225,11 @@ msgstr "Цей пакунок несумісний із цією версією 
 msgid "This package requires Cockpit version %s or later"
 msgstr "Для цього пакунка потрібна версія Cockpit %s або новіша"
 
-#: pkg/machines/components/diskAdd.jsx:215
+#: pkg/machines/components/diskAdd.jsx:138
 msgid "This pool type does not support Storage Volume creation"
 msgstr "Для буферів цього типу не передбачено створення томів сховища даних"
 
-#: pkg/packagekit/updates.jsx:774
+#: pkg/packagekit/updates.jsx:775
 msgid "This system is not registered"
 msgstr "Цю систему не зареєстровано"
 
@@ -7239,7 +7257,7 @@ msgstr "Цей модуль не створено для вмикання явн
 msgid "This user name already exists"
 msgstr "Запис користувача із таким іменем уже існує"
 
-#: pkg/lib/machine-dialogs.js:378
+#: pkg/lib/machine-dialogs.js:380
 msgid ""
 "This version of cockpit-ws does not support connecting to a host with an "
 "alternate user or port"
@@ -7251,7 +7269,7 @@ msgstr ""
 msgid "This volume is already used by another VM."
 msgstr "Цей том вже використано іншою ВМ."
 
-#: pkg/storaged/lvol-tabs.jsx:186
+#: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
 msgstr ""
 "Перш ніж розмір цього тому можна буде змінювати, його слід активувати."
@@ -7262,7 +7280,7 @@ msgstr ""
 "Ця програма для перегляду інтернету є надто старою для роботи з Cockpit (не "
 "вистачає можливості $0)"
 
-#: pkg/packagekit/updates.jsx:834
+#: pkg/packagekit/updates.jsx:835
 msgid "This web console will be updated."
 msgstr "Цю вебконсоль буде оновлено."
 
@@ -7276,7 +7294,7 @@ msgstr ""
 "отже і системи. Залежно від параметрів, система може автоматично "
 "перезавантажитися, що потребуватиме певного часу."
 
-#: pkg/kdump/kdump-view.jsx:489
+#: pkg/kdump/kdump-view.jsx:491
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Перевіряє налаштування kdump, аварійно завершуючи роботу ядра."
 
@@ -7292,15 +7310,15 @@ msgstr "четвер"
 msgid "Thursdays"
 msgstr "Четверги"
 
-#: pkg/systemd/index.html:364
+#: pkg/systemd/index.html:375
 msgid "Time Zone"
 msgstr "Часовий пояс"
 
-#: pkg/systemd/services.jsx:41
+#: pkg/systemd/services.jsx:50
 msgid "Timers"
 msgstr "Таймери"
 
-#: pkg/shell/index.html:305
+#: pkg/shell/index.html:306
 msgid ""
 "Tip: Make your key password match your login password to automatically "
 "authenticate against other systems."
@@ -7308,7 +7326,7 @@ msgstr ""
 "Підказка: для автоматичного розпізнавання на інших системах встановіть "
 "однаковий пароль для ключа і для входу до системи."
 
-#: pkg/packagekit/updates.jsx:775
+#: pkg/packagekit/updates.jsx:776
 msgid ""
 "To get software updates, this system needs to be registered with Red Hat, "
 "either using the Red Hat Customer Portal or a local subscription server."
@@ -7317,29 +7335,17 @@ msgstr ""
 "зареєструвати у Red Hat або за допомогою порталу клієнтів Red Hat, або за "
 "допомогою локального сервера передплати."
 
-#: node_modules/registry-image-widgets/views/image-pull.html:4
-msgid "To pull this image:"
-msgstr "Для отримання цього образу:"
-
-#: node_modules/registry-image-widgets/views/imagestream-push.html:4
-msgid "To push an image to this image stream:"
-msgstr "Щоб записати образ до цього потоку образів:"
-
 #: pkg/lib/machine-change-port.html:11
 msgid ""
 "To try a different port you will need to upgrade cockpit-ws to a newer "
 "version."
 msgstr "Щоб спробувати інший порт, вам слід оновити cockpit-ws."
 
-#: pkg/lib/cockpit-components-file-autocomplete.jsx:148
-msgid "Too many files found"
-msgstr "Знайдено забагато файлів"
-
-#: src/base1/cockpit.js:4039
+#: src/base1/cockpit.js:4043
 msgid "Too much data"
 msgstr "Забагато даних"
 
-#: pkg/docker/storage.jsx:341
+#: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Загалом"
 
@@ -7353,26 +7359,26 @@ msgstr "Башточка"
 
 #: pkg/playground/manifest.json.in
 msgid "Translating"
-msgstr ""
+msgstr "Переклад"
 
-#: pkg/systemd/service-details.jsx:431
+#: pkg/systemd/service-details.jsx:433
 msgid "Triggered By"
 msgstr "Причина вмикання"
 
-#: pkg/systemd/service-details.jsx:430
+#: pkg/systemd/service-details.jsx:432
 msgid "Triggers"
 msgstr "Умовні зміни"
 
-#: pkg/shell/index.html:382 pkg/shell/simple.html:139
+#: pkg/shell/index.html:383 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:99
 msgid "Troubleshoot"
 msgstr "Діагностика проблем"
 
-#: pkg/storaged/crypto-keyslots.jsx:331
+#: pkg/storaged/crypto-keyslots.jsx:339
 msgid "Trust key"
 msgstr "Довіряти ключу"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:737
 msgid "Trust level"
 msgstr "Рівень довіри"
 
@@ -7400,7 +7406,7 @@ msgstr "вівторок"
 msgid "Tuesdays"
 msgstr "Вівторки"
 
-#: pkg/tuned/dialog.js:260
+#: pkg/tuned/dialog.js:261
 msgid "Tuned has failed to start"
 msgstr "Tuned не вдалося запустити"
 
@@ -7416,7 +7422,7 @@ msgstr "Tuned не запущено"
 msgid "Tuned is off"
 msgstr "Tuned вимкнено"
 
-#: pkg/shell/index.html:265
+#: pkg/shell/index.html:266
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
 #: pkg/machines/components/vm/bootOrderModal.jsx:108
@@ -7425,10 +7431,10 @@ msgstr "Tuned вимкнено"
 #: pkg/machines/components/vm/bootOrderModal.jsx:131
 #: pkg/machines/components/vm/bootOrderModal.jsx:138
 #: pkg/machines/components/vm/bootOrderModal.jsx:144
-#: pkg/machines/components/vmnetworktab.jsx:114
-#: pkg/storaged/format-dialog.jsx:283 pkg/storaged/part-tab.jsx:42
-#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:75
-#: pkg/systemd/hwinfo.jsx:259
+#: pkg/machines/components/vmnetworktab.jsx:120
+#: pkg/storaged/format-dialog.jsx:293 pkg/storaged/part-tab.jsx:42
+#: pkg/storaged/unrecognized-tab.jsx:33 pkg/systemd/hwinfo.jsx:79
+#: pkg/systemd/hwinfo.jsx:263
 msgid "Type"
 msgstr "Тип"
 
@@ -7444,7 +7450,7 @@ msgstr "Введіть пароль"
 msgid "Type to filter…"
 msgstr "Введіть щось для фільтрування…"
 
-#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:968
+#: pkg/docker/index.html:334 pkg/networkmanager/firewall.jsx:970
 msgid "UDP"
 msgstr "UDP"
 
@@ -7485,17 +7491,13 @@ msgstr "Не вдалося отримати нагадування: $0"
 msgid "Unable to reach server"
 msgstr "Не вдалося досягти сервера"
 
-#: pkg/storaged/nfs-details.jsx:282
+#: pkg/storaged/nfs-details.jsx:290
 msgid "Unable to remove mount"
 msgstr "Не вдалося вилучити монтування"
 
 #: pkg/users/local.js:60
 msgid "Unable to rename root account"
 msgstr "Неможливо перейменувати обліковий запис root"
-
-#: node_modules/registry-image-widgets/views/image-listing.html:41
-msgid "Unable to resolve"
-msgstr "Не вдалося визначити"
 
 #: pkg/selinux/setroubleshoot-client.js:173
 msgid "Unable to run fix: %0"
@@ -7505,7 +7507,7 @@ msgstr "Не вдалося виконати fix: %0"
 msgid "Unable to start setroubleshootd"
 msgstr "Не вдалося запустити setroubleshootd"
 
-#: pkg/storaged/nfs-details.jsx:257
+#: pkg/storaged/nfs-details.jsx:265
 msgid "Unable to unmount filesystem"
 msgstr "Не вдалося демонтувати файлову систему"
 
@@ -7514,11 +7516,11 @@ msgid "Unavailable"
 msgstr "Недоступний"
 
 #: pkg/docker/index.html:732 pkg/networkmanager/index.html:682
-#: pkg/shell/base_index.js:751 pkg/users/local.js:1485
+#: pkg/shell/base_index.js:758 pkg/users/local.js:1485
 msgid "Unexpected error"
 msgstr "Неочікувана помилка"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:128
+#: pkg/machines/components/networks/createNetworkDialog.jsx:114
 msgid "Unique Network Name"
 msgstr "Унікальна назва мережі"
 
@@ -7527,26 +7529,23 @@ msgid "Unique name"
 msgstr "Унікальна назва"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:134
-#: pkg/storaged/dialog.jsx:1047
+#: pkg/storaged/dialog.jsx:1048
 msgid "Unit"
 msgstr "Модуль"
 
-#: node_modules/registry-image-widgets/views/image-body.html:16
-#: node_modules/registry-image-widgets/views/imagestream-body.html:30
-#: node_modules/registry-image-widgets/views/imagestream-body.html:31
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
-#: pkg/machines/components/vmnetworktab.jsx:139
-#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1076
-#: pkg/networkmanager/interfaces.js:2544 pkg/networkmanager/interfaces.js:2546
+#: pkg/machines/components/vmnetworktab.jsx:149
+#: pkg/networkmanager/interfaces.js:605 pkg/networkmanager/interfaces.js:1081
+#: pkg/networkmanager/interfaces.js:2551 pkg/networkmanager/interfaces.js:2553
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: pkg/networkmanager/interfaces.js:2530 pkg/networkmanager/interfaces.js:2542
+#: pkg/networkmanager/interfaces.js:2537 pkg/networkmanager/interfaces.js:2549
 msgid "Unknown \"$0\""
 msgstr "Невідомий «$0»"
 
-#: pkg/storaged/mdraid-details.jsx:104
+#: pkg/storaged/mdraid-details.jsx:98
 msgid "Unknown ($0)"
 msgstr "Невідомий ($0)"
 
@@ -7558,7 +7557,7 @@ msgstr "Невідома програма"
 msgid "Unknown Host Key"
 msgstr "Невідомий ключ вузла"
 
-#: pkg/networkmanager/interfaces.js:2652
+#: pkg/networkmanager/interfaces.js:2660
 msgid "Unknown configuration"
 msgstr "Невідомі налаштування"
 
@@ -7570,7 +7569,7 @@ msgstr "Невідома назва вузла"
 msgid "Unknown service name"
 msgstr "Невідома назва служби"
 
-#: pkg/storaged/crypto-keyslots.jsx:562
+#: pkg/storaged/crypto-keyslots.jsx:575
 msgid "Unknown type"
 msgstr "Невідомий тип"
 
@@ -7578,20 +7577,20 @@ msgstr "Невідомий тип"
 msgid "Unless Stopped"
 msgstr "Якщо не зупинено"
 
-#: pkg/storaged/content-views.jsx:222 pkg/storaged/content-views.jsx:227
-#: pkg/storaged/content-views.jsx:240
+#: pkg/storaged/content-views.jsx:227 pkg/storaged/content-views.jsx:232
+#: pkg/storaged/content-views.jsx:245
 msgid "Unlock"
 msgstr "Розблокувати"
 
-#: pkg/shell/index.html:212 pkg/shell/index.html:253
+#: pkg/shell/index.html:213 pkg/shell/index.html:254
 msgid "Unlock Key"
 msgstr "Розблокувати ключ"
 
-#: pkg/storaged/format-dialog.jsx:116
+#: pkg/storaged/format-dialog.jsx:120
 msgid "Unlock at boot"
 msgstr "Розблокувати при завантаженні"
 
-#: pkg/storaged/format-dialog.jsx:117
+#: pkg/storaged/format-dialog.jsx:121
 msgid "Unlock read only"
 msgstr "Розблокувати лише для читання"
 
@@ -7599,7 +7598,7 @@ msgstr "Розблокувати лише для читання"
 msgid "Unlocking $target"
 msgstr "Розблокуємо $target"
 
-#: pkg/storaged/crypto-keyslots.jsx:173
+#: pkg/storaged/crypto-keyslots.jsx:174
 msgid "Unlocking disk..."
 msgstr "Розблоковуємо диск…"
 
@@ -7607,7 +7606,7 @@ msgstr "Розблоковуємо диск…"
 msgid "Unmanaged Interfaces"
 msgstr "Некеровані інтерфейси"
 
-#: pkg/storaged/fsys-tab.jsx:185 pkg/storaged/nfs-details.jsx:300
+#: pkg/storaged/fsys-tab.jsx:188 pkg/storaged/nfs-details.jsx:308
 msgid "Unmount"
 msgstr "Демонтувати"
 
@@ -7619,37 +7618,33 @@ msgstr "Демонтуємо $target"
 msgid "Unnamed"
 msgstr "Без назви"
 
-#: pkg/machines/components/vmnetworktab.jsx:190
+#: pkg/machines/components/vmnetworktab.jsx:206
 msgid "Unplug"
 msgstr "Від'єднати"
 
-#: pkg/storaged/content-views.jsx:159
+#: pkg/storaged/content-views.jsx:163
 msgid "Unrecognized Data"
 msgstr "Нерозпізнані дані"
 
-#: pkg/storaged/content-views.jsx:358
+#: pkg/storaged/content-views.jsx:363
 msgctxt "storage-id-desc"
 msgid "Unrecognized Data"
 msgstr "Нерозпізнані дані"
 
-#: pkg/storaged/lvol-tabs.jsx:89 pkg/storaged/lvol-tabs.jsx:178
+#: pkg/storaged/lvol-tabs.jsx:90 pkg/storaged/lvol-tabs.jsx:179
 msgid "Unrecognized data can not be made smaller here."
 msgstr "Тут не можна зменшити об'єм нерозпізнаних даних."
-
-#: node_modules/registry-image-widgets/views/image-listing.html:46
-msgid "Unresolved"
-msgstr "Не визначено"
 
 #: src/bridge/cockpitdbussetup.c:222 src/bridge/cockpitdbussetup.c:361
 #: src/bridge/cockpitdbussetup.c:625
 msgid "Unsupported setup mechanism"
 msgstr "Непідтримуваний механізм налаштовування"
 
-#: pkg/storaged/content-views.jsx:613
+#: pkg/storaged/content-views.jsx:626
 msgid "Unsupported volume"
 msgstr "Непідтримуваний том"
 
-#: src/base1/cockpit.js:4019 src/base1/cockpit.js:4021
+#: src/base1/cockpit.js:4023 src/base1/cockpit.js:4025
 msgid "Untrusted host"
 msgstr "Ненадійний вузол"
 
@@ -7669,11 +7664,11 @@ msgstr "У основній системі доступними є до $0 $1"
 msgid "Update"
 msgstr "Оновити"
 
-#: pkg/packagekit/history.jsx:126
+#: pkg/packagekit/history.jsx:125
 msgid "Update History"
 msgstr "Історія оновлень"
 
-#: pkg/packagekit/updates.jsx:471
+#: pkg/packagekit/updates.jsx:473
 msgid "Update Log"
 msgstr "Журнал оновлень"
 
@@ -7681,11 +7676,11 @@ msgstr "Журнал оновлень"
 msgid "Updated"
 msgstr "Оновлено"
 
-#: pkg/packagekit/updates.jsx:494
+#: pkg/packagekit/updates.jsx:496
 msgid "Updated packages may require a restart to take effect."
 msgstr "Використання оновлених пакунків може потребувати перезапуску."
 
-#: pkg/systemd/host.js:512
+#: pkg/systemd/host.js:515
 msgid "Updates Available"
 msgstr "Доступні оновлення"
 
@@ -7693,26 +7688,26 @@ msgstr "Доступні оновлення"
 msgid "Updating"
 msgstr "Оновлення"
 
-#: pkg/systemd/service-details.jsx:406
+#: pkg/systemd/service-details.jsx:408
 msgid "Updating status..."
 msgstr "Оновлюємо стан…"
 
-#: pkg/machines/components/vm/vm.jsx:48 pkg/storaged/unrecognized-tab.jsx:30
+#: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Використання"
 
-#: pkg/systemd/host.js:1630
+#: pkg/systemd/host.js:1673
 msgid "Usage of $0 CPU core"
 msgid_plural "Usage of $0 CPU cores"
 msgstr[0] "Використання $0 ядра процесора"
 msgstr[1] "Використання $0 ядер процесора"
 msgstr[2] "Використання $0 ядер процесора"
 
-#: pkg/storaged/vdos-panel.jsx:87
+#: pkg/storaged/vdos-panel.jsx:95
 msgid "Use 512 Byte emulation"
 msgstr "Емуляція 512 байтів"
 
-#: pkg/machines/components/diskAdd.jsx:561
+#: pkg/machines/components/diskAdd.jsx:432
 msgid "Use Existing"
 msgstr "Використати наявний"
 
@@ -7720,15 +7715,15 @@ msgstr "Використати наявний"
 msgid "Use the following keys to authenticate against other systems"
 msgstr "Використати вказані нижче ключі для розпізнавання у інших системах"
 
-#: pkg/systemd/index.html:256 pkg/docker/storage.jsx:340
+#: pkg/systemd/index.html:267 pkg/docker/storage.jsx:344
 #: pkg/machines/components/vm/vmUsageTab.jsx:64
 #: pkg/machines/components/vm/vmUsageTab.jsx:75
-#: pkg/machines/components/vmDisksTab.jsx:68 pkg/storaged/fsys-tab.jsx:193
-#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1695
+#: pkg/machines/components/vmDisksTab.jsx:106 pkg/storaged/fsys-tab.jsx:196
+#: pkg/storaged/swap-tab.jsx:81 pkg/systemd/host.js:1738
 msgid "Used"
 msgstr "Використано"
 
-#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:65
+#: pkg/machines/components/storagePools/storagePoolVolumesTab.jsx:84
 msgid "Used by"
 msgstr "Використовується"
 
@@ -7737,8 +7732,8 @@ msgid "Used by Containers"
 msgstr "Використано контейнерами"
 
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
-#: pkg/playground/translate.html:105 pkg/systemd/index.html:230
-#: pkg/systemd/host.js:1601
+#: pkg/playground/translate.html:105 pkg/systemd/index.html:241
+#: pkg/systemd/host.js:1644
 msgid "User"
 msgstr "Користувач"
 
@@ -7760,7 +7755,7 @@ msgstr "Ім'я користувача"
 msgid "User name cannot be empty"
 msgstr "Ім’я користувача не може бути порожнім"
 
-#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:149
+#: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Користувач"
 
@@ -7772,11 +7767,11 @@ msgstr "З використанням доступних реєстраційн�
 msgid "VCPU settings could not be saved"
 msgstr "Не вдалося зберегти параметри віртуальних процесорів"
 
-#: pkg/storaged/content-views.jsx:155
+#: pkg/storaged/content-views.jsx:159
 msgid "VDO Backing"
 msgstr "Резерв VDO"
 
-#: pkg/storaged/content-views.jsx:356
+#: pkg/storaged/content-views.jsx:361
 msgctxt "storage-id-desc"
 msgid "VDO Backing"
 msgstr "Резерв VDO"
@@ -7785,24 +7780,24 @@ msgstr "Резерв VDO"
 msgid "VDO Device"
 msgstr "Пристрій VDO"
 
-#: pkg/storaged/utils.js:252 pkg/storaged/vdo-details.jsx:255
+#: pkg/storaged/utils.js:253 pkg/storaged/vdo-details.jsx:261
 msgid "VDO Device $0"
 msgstr "Пристрій VDO $0"
 
-#: pkg/storaged/vdos-panel.jsx:166
+#: pkg/storaged/vdos-panel.jsx:176
 msgid "VDO Devices"
 msgstr "Пристрої VDO"
 
-#: pkg/storaged/lvol-tabs.jsx:84 pkg/storaged/lvol-tabs.jsx:171
+#: pkg/storaged/lvol-tabs.jsx:85 pkg/storaged/lvol-tabs.jsx:172
 msgid "VDO backing devices can not be made smaller"
 msgstr "Пристрої резервного копіювання VDO не можна звужувати"
 
-#: pkg/storaged/vdos-panel.jsx:172
+#: pkg/storaged/vdos-panel.jsx:182
 msgid "VDO support not installed"
 msgstr "Підтримку VDO не встановлено"
 
-#: pkg/networkmanager/interfaces.js:2526 pkg/networkmanager/interfaces.js:2538
-#: pkg/networkmanager/interfaces.js:2918
+#: pkg/networkmanager/interfaces.js:2533 pkg/networkmanager/interfaces.js:2545
+#: pkg/networkmanager/interfaces.js:2926
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7830,7 +7825,7 @@ msgstr "Не вдалося примусово вимкнути віртуаль
 msgid "VM $0 failed to get deleted"
 msgstr "Не вдалося вилучити віртуальну машину $0"
 
-#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1308
+#: pkg/machines/hostvmslist.jsx:110 pkg/machines/libvirt-common.js:1304
 msgid "VM $0 failed to get installed"
 msgstr "Не вдалося встановити віртуальну машину $0"
 
@@ -7883,7 +7878,7 @@ msgid "Validating key"
 msgstr "Перевірка ключа"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:250
+#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:254
 msgid "Vendor"
 msgstr "Постачальник"
 
@@ -7891,7 +7886,7 @@ msgstr "Постачальник"
 msgid "Verified"
 msgstr "Перевірено"
 
-#: pkg/storaged/crypto-keyslots.jsx:316
+#: pkg/storaged/crypto-keyslots.jsx:324
 msgid "Verify key"
 msgstr "Перевірити ключ"
 
@@ -7899,8 +7894,8 @@ msgstr "Перевірити ключ"
 msgid "Verifying"
 msgstr "Перевіряємо"
 
-#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:110
-#: pkg/packagekit/updates.jsx:381 pkg/systemd/hwinfo.jsx:83
+#: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
+#: pkg/packagekit/updates.jsx:382 pkg/systemd/hwinfo.jsx:87
 msgid "Version"
 msgstr "Версія"
 
@@ -7912,8 +7907,8 @@ msgstr "Дуже безпечно витираємо $target"
 msgid "View automation script"
 msgstr "Переглянути скрипт автоматизації"
 
-#: pkg/machines/components/networks/networkList.jsx:42
-#: pkg/machines/components/storagePools/storagePoolList.jsx:41
+#: pkg/machines/components/networks/networkList.jsx:47
+#: pkg/machines/components/storagePools/storagePoolList.jsx:46
 #: pkg/machines/hostvmslist.jsx:82 pkg/machines/manifest.json.in
 msgid "Virtual Machines"
 msgstr "Віртуальні машини"
@@ -7922,7 +7917,7 @@ msgstr "Віртуальні машини"
 msgid "Virtual Network"
 msgstr "Віртуальна мережа"
 
-#: pkg/machines/components/networks/createNetworkDialog.jsx:422
+#: pkg/machines/components/networks/createNetworkDialog.jsx:412
 msgid "Virtual Network failed to be created"
 msgstr "Не вдалося створити віртуальну мережу"
 
@@ -7936,10 +7931,10 @@ msgstr "Доступна служба віртуалізації"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:458
 #: pkg/machines/components/deleteDialog.jsx:50
-#: pkg/machines/components/diskAdd.jsx:89
+#: pkg/machines/components/diskAdd.jsx:90
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
-#: pkg/storaged/content-views.jsx:136
+#: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Том"
 
@@ -7947,7 +7942,7 @@ msgstr "Том"
 msgid "Volume Group"
 msgstr "Група томів"
 
-#: pkg/storaged/utils.js:247 pkg/storaged/vgroup-details.jsx:232
+#: pkg/storaged/utils.js:248 pkg/storaged/vgroup-details.jsx:229
 msgid "Volume Group $0"
 msgstr "Група томів $0"
 
@@ -7959,16 +7954,19 @@ msgstr "Назва групи томів"
 msgid "Volume Group name should not be empty"
 msgstr "Назва групи томів має бути непорожньою"
 
-#: pkg/storaged/vgroups-panel.jsx:113
+#: pkg/storaged/vgroups-panel.jsx:115
 msgid "Volume Groups"
 msgstr "Групи томів"
 
-#: pkg/storaged/lvol-tabs.jsx:410
+#: pkg/machines/components/storagePools/storageVolumeCreate.jsx:65
+msgid "Volume failed to be created"
+msgstr "Не вдалося створити том"
+
+#: pkg/storaged/lvol-tabs.jsx:418
 msgid "Volume size is $0. Content size is $1."
 msgstr "Розмір тому — $0. Розмір даних — $1."
 
 #: pkg/docker/index.html:517
-#: node_modules/registry-image-widgets/views/image-config.html:32
 msgid "Volumes"
 msgstr "Томи"
 
@@ -7980,7 +7978,7 @@ msgstr "Томи:"
 msgid "WWPN"
 msgstr "WWPN"
 
-#: pkg/networkmanager/interfaces.js:845
+#: pkg/networkmanager/interfaces.js:850
 msgid "Waiting"
 msgstr "Очікування"
 
@@ -7995,16 +7993,16 @@ msgstr ""
 "Очікуємо на завершення роботи з програмою для керування пакунками інших "
 "програм…"
 
-#: pkg/lib/cockpit-components-install-dialog.jsx:140
-#: pkg/lib/cockpit-components-install-dialog.jsx:175
+#: pkg/lib/cockpit-components-install-dialog.jsx:141
+#: pkg/lib/cockpit-components-install-dialog.jsx:176
 msgid "Waiting for other software management operations to finish"
 msgstr "Очікуємо на завершення інших дій із програмним забезпеченням"
 
-#: pkg/systemd/service-details.jsx:422
+#: pkg/systemd/service-details.jsx:424
 msgid "Wanted By"
 msgstr "Бажаний для"
 
-#: pkg/systemd/service-details.jsx:417
+#: pkg/systemd/service-details.jsx:419
 msgid "Wants"
 msgstr "Бажає"
 
@@ -8028,7 +8026,7 @@ msgstr "Середи"
 msgid "Weeks"
 msgstr "Тижні"
 
-#: pkg/storaged/crypto-keyslots.jsx:324
+#: pkg/storaged/crypto-keyslots.jsx:332
 msgid "What if tang-show-keys is not available?"
 msgstr "Що робити, якщо tang-show-keys є недоступною?"
 
@@ -8040,11 +8038,11 @@ msgstr "Білий"
 msgid "With terminal"
 msgstr "За допомогою термінала"
 
-#: pkg/storaged/mdraid-details.jsx:102
+#: pkg/storaged/mdraid-details.jsx:96
 msgid "Write-mostly"
 msgstr "Здебільшого запис"
 
-#: pkg/storaged/plot.jsx:313
+#: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Запис"
 
@@ -8052,11 +8050,11 @@ msgstr "Запис"
 msgid "Wrong user name or password"
 msgstr "Помилкове ім’я користувача чи пароль"
 
-#: pkg/networkmanager/interfaces.js:1985
+#: pkg/networkmanager/interfaces.js:1997
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2605
+#: pkg/networkmanager/interfaces.js:2613
 msgid "Yes"
 msgstr "Так"
 
@@ -8069,7 +8067,7 @@ msgstr ""
 "синхронізації даних користувачів потрібні права доступу адміністративного "
 "користувача."
 
-#: pkg/dashboard/list.js:440
+#: pkg/dashboard/list.js:448
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
@@ -8077,7 +8075,7 @@ msgstr ""
 "його вилучити."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:135
-#: pkg/networkmanager/firewall.jsx:903 pkg/networkmanager/firewall.jsx:909
+#: pkg/networkmanager/firewall.jsx:905 pkg/networkmanager/firewall.jsx:911
 msgid "You are not authorized to modify the firewall."
 msgstr "Вас не уповноважено на внесення змін до брандмауера."
 
@@ -8089,7 +8087,7 @@ msgstr ""
 "У вас немає прав доступу для перегляду уповноважених відкритих ключів для "
 "цього облікового запису."
 
-#: pkg/docker/storage.jsx:504
+#: pkg/docker/storage.jsx:520
 msgid "You don't have permission to manage the Docker storage pool."
 msgstr ""
 "У вас немає прав доступу до керування резервним сховищем даних Docker."
@@ -8102,7 +8100,7 @@ msgstr "Для зміни вашого пароля вам доведеться 
 msgid "You need to select the most closely matching Operating System"
 msgstr "Вам слід вибрати найвідповіднішу операційну систему"
 
-#: pkg/packagekit/updates.jsx:836
+#: pkg/packagekit/updates.jsx:837
 msgid ""
 "Your browser will disconnect, but this does not affect the update process. "
 "You can reconnect in a few moments to continue watching the progress."
@@ -8111,7 +8109,7 @@ msgstr ""
 "процес оновлення. Ви зможете з'єднатися знову за декілька секунд, щоб "
 "продовжити спостереження за поступом."
 
-#: pkg/packagekit/updates.jsx:867
+#: pkg/packagekit/updates.jsx:868
 msgid ""
 "Your server will close the connection soon. You can reconnect after it has "
 "restarted."
@@ -8119,33 +8117,33 @@ msgstr ""
 "Невдовзі ваш сервер розірве з’єднання. Ви можете відновити це з’єднання, "
 "щойно сервер буде перезапущено."
 
-#: src/base1/cockpit.js:4009
+#: src/base1/cockpit.js:4013
 msgid "Your session has been terminated."
 msgstr "Ваш сеанс перервано."
 
-#: src/base1/cockpit.js:4011
+#: src/base1/cockpit.js:4015
 msgid "Your session has expired. Please log in again."
 msgstr ""
 "Строк роботи у вашому сеансі вичерпано. Будь ласка, увійдіть до системи ще "
 "раз."
 
-#: pkg/networkmanager/firewall.jsx:955
+#: pkg/networkmanager/firewall.jsx:957
 msgid "Zone"
 msgstr "Зона"
 
-#: pkg/networkmanager/firewall.jsx:968
+#: pkg/networkmanager/firewall.jsx:970
 msgid "Zones"
 msgstr "Зони"
 
-#: pkg/lib/journal.js:215
+#: pkg/lib/journal.js:217
 msgid "[$0 bytes of binary data]"
 msgstr "[$0 байтів двійкових даних]"
 
-#: pkg/lib/journal.js:217
+#: pkg/lib/journal.js:219
 msgid "[binary data]"
 msgstr "[двійкові дані]"
 
-#: pkg/lib/journal.js:211
+#: pkg/lib/journal.js:213
 msgid "[no data]"
 msgstr "[немає даних]"
 
@@ -8171,7 +8169,7 @@ msgstr "на"
 msgid "bridge"
 msgstr "місток"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "bug fix"
 msgstr "виправлення вад"
 
@@ -8228,7 +8226,7 @@ msgstr "наприклад «$0»"
 msgid "enabled"
 msgstr "увімкнено"
 
-#: pkg/packagekit/updates.jsx:267
+#: pkg/packagekit/updates.jsx:268
 msgid "enhancement"
 msgstr "поліпшення"
 
@@ -8240,7 +8238,7 @@ msgstr "ethernet"
 msgid "every day"
 msgstr "кожного дня"
 
-#: pkg/systemd/host.js:903
+#: pkg/systemd/host.js:940
 msgid "failed to list ssh host keys: $0"
 msgstr "не вдалося побудувати список ключів SSH вузла: $0"
 
@@ -8264,7 +8262,7 @@ msgstr "IQN ініціатора iSCSI"
 msgid "iSCSI Target"
 msgstr "Ціль iSCSI"
 
-#: pkg/storaged/iscsi-panel.jsx:261
+#: pkg/storaged/iscsi-panel.jsx:268
 msgid "iSCSI Targets"
 msgstr "Призначення iSCSI"
 
@@ -8285,11 +8283,11 @@ msgstr "бездіяльний"
 msgid "inactive"
 msgstr "неактивний"
 
-#: pkg/kdump/kdump-view.jsx:376
+#: pkg/kdump/kdump-view.jsx:378
 msgid "invalid: multiple targets defined"
 msgstr "помилка: визначено декілька цілей"
 
-#: pkg/kdump/kdump-view.jsx:493
+#: pkg/kdump/kdump-view.jsx:495
 msgid "kdump status"
 msgstr "стан kdump"
 
@@ -8297,11 +8295,11 @@ msgstr "стан kdump"
 msgid "key"
 msgstr "ключ"
 
-#: pkg/storaged/crypto-keyslots.jsx:350
+#: pkg/storaged/crypto-keyslots.jsx:358
 msgid "key slot $0"
 msgstr "слот ключів $0"
 
-#: pkg/kdump/kdump-view.jsx:380 pkg/kdump/kdump-view.jsx:382
+#: pkg/kdump/kdump-view.jsx:382 pkg/kdump/kdump-view.jsx:384
 msgid "locally in $0"
 msgstr "локально у $0"
 
@@ -8321,17 +8319,16 @@ msgstr ""
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:234
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:234
 msgid "no"
 msgstr "ні"
 
-#: node_modules/registry-image-widgets/views/image-listing.html:53
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
 msgstr "немає"
 
-#: pkg/systemd/host.js:712
+#: pkg/systemd/host.js:738
 msgid "of $0 CPU core"
 msgid_plural "of $0 CPU cores"
 msgstr[0] "з $0 ядра процесора"
@@ -8358,7 +8355,7 @@ msgstr "працює"
 msgid "search by name, namespace or description"
 msgstr "шукати за назвою, простором назв або описом"
 
-#: pkg/packagekit/updates.jsx:261
+#: pkg/packagekit/updates.jsx:262
 msgid "security"
 msgstr "безпека"
 
@@ -8430,8 +8427,7 @@ msgstr "udp"
 msgid "undefined"
 msgstr "не визначено"
 
-#: node_modules/registry-image-widgets/views/imagestream-listing.html:31
-#: pkg/systemd/init.js:256 pkg/systemd/init.js:270
+#: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "невідомо"
 
@@ -8439,7 +8435,7 @@ msgstr "невідомо"
 msgid "unknown target"
 msgstr "невідоме призначення"
 
-#: pkg/storaged/utils.js:427
+#: pkg/storaged/utils.js:431
 msgid "unpartitioned space on $0"
 msgstr "нерозподілене місце на $0"
 
@@ -8482,14 +8478,6 @@ msgstr ""
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70
-#: pkg/machines/components/vmDisksTab.jsx:102 pkg/machines/helpers.js:233
+#: pkg/machines/components/vmDisksTab.jsx:143 pkg/machines/helpers.js:233
 msgid "yes"
 msgstr "так"
-
-#: node_modules/registry-image-widgets/views/imagestream-body.html:6
-msgid ""
-"{{ condition.message }}. Timestamp: {{ condition.lastTransitionTime }} Error "
-"count: {{ condition.generation }}"
-msgstr ""
-"{{ condition.message }}. Часова позначка: {{ condition.lastTransitionTime }} "
-"Кількість помилок: {{ condition.generation }}"


### PR DESCRIPTION
We don't have en_US.UTF-8 locale on our task bot and it breaks
translations.

 * [x] po-refresh

Fixes #12856
Closes #12865