### PR TITLE
naughty: Close 12597: kexec: failed to load kdump kernel in 4.18.0-131 

### DIFF
--- a/bots/naughty/rhel-8/12597-kdump-fails-to-start
+++ b/bots/naughty/rhel-8/12597-kdump-fails-to-start
@@ -1,3 +1,0 @@
-Traceback (most recent call last):
-  File "test/verify/check-kdump", line *, in testBasic
-    b.wait_in_text("#app", "Service is running")


### PR DESCRIPTION
Known issue which has not occurred in 27 days

kexec: failed to load kdump kernel in 4.18.0-131 

Fixes #12597