### PR TITLE
a11y: Use button instead of anchor when not used as hyperlink

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -54,7 +54,7 @@ class ApplicationRow extends React.Component {
         var name, summary_or_progress, button;
 
         if (comp.installed) {
-            name = <a role="link" tabIndex="0" onClick={left_click(() => launch(comp))}>{comp.name}</a>;
+            name = <button role="link" className="link-button" onClick={left_click(() => launch(comp))}>{comp.name}</button>;
         } else {
             name = comp.name;
         }

--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -105,7 +105,7 @@ export class Application extends React.Component {
                 progress_or_launch = <ProgressBar title={self.state.progress_title} data={self.state.progress} />;
                 button = <CancelButton data={self.state.progress} />;
             } else if (comp.installed) {
-                progress_or_launch = <a role="link" tabIndex="0" onClick={left_click(() => launch(comp))}>{_("Go to Application")}</a>;
+                progress_or_launch = <button role="link" className="link-button" onClick={left_click(() => launch(comp))}>{_("Go to Application")}</button>;
                 button = <button className="btn btn-danger" onClick={left_click(remove)}>{_("Remove")}</button>;
             } else {
                 progress_or_launch = null;
@@ -140,7 +140,7 @@ export class Application extends React.Component {
         return (
             <div>
                 <ol className="breadcrumb">
-                    <li><a role="link" tabIndex="0" onClick={left_click(navigate_up)}>{_("Applications")}</a></li>
+                    <li><button role="link" className="link-button" onClick={left_click(navigate_up)}>{_("Applications")}</button></li>
                     <li className="active">{comp ? comp.name : this.props.id}</li>
                 </ol>
                 {render_comp()}

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -676,9 +676,13 @@ export class ImageList extends React.Component {
 
         var imageRows = filtered.map(this.renderRow, this);
 
-        var getNewImageAction = <a role="link" tabIndex="0" onClick={this.handleSearchImageClick} className="card-pf-link-with-icon pull-right">
-            <span className="pficon pficon-add-circle-o" />{_("Get new image")}
-        </a>;
+        var getNewImageAction = <div className="pull-right">
+            <button onClick={this.handleSearchImageClick} className="link-button">
+                <span className="pficon pficon-add-circle-o" />
+                {" "}
+                {_("Get new image")}
+            </button>
+        </div>;
 
         var columnTitles = [_("Name"), '', _("Created"), _("Size"), ''];
 

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -327,6 +327,7 @@ export class KdumpPage extends React.Component {
         // only consider primary mouse button
         if (!e || e.button !== 0)
             return;
+        e.preventDefault();
         var self = this;
         var settings = { };
         Object.keys(self.props.kdumpStatus.config).forEach((key) => {
@@ -403,7 +404,7 @@ export class KdumpPage extends React.Component {
         // this.storeLocation(this.props.kdumpStatus.config);
         var settingsLink;
         if (targetCanChange)
-            settingsLink = <a href="#" tabIndex="0" onClick={this.handleSettingsClick}>{ kdumpLocation }</a>;
+            settingsLink = <span><button className="link-button" onClick={this.handleSettingsClick}>{ kdumpLocation }</button></span>;
         else
             settingsLink = <span>{ kdumpLocation }</span>;
         var reservedMemory;
@@ -456,14 +457,14 @@ export class KdumpPage extends React.Component {
                     </OverlayTrigger>
                 );
             }
-            kdumpServiceDetails = <a className="popover-ct-kdump" href="#" tabIndex="0" onClick={this.handleServiceDetailsClick}>{serviceDescription}{serviceHint}</a>;
+            kdumpServiceDetails = <button role="link" className="popover-ct-kdump link-button" onClick={this.handleServiceDetailsClick}>{serviceDescription}{serviceHint}</button>;
         } else if (this.props.kdumpStatus && !this.props.kdumpStatus.installed) {
             const tooltip = _("Kdump service not installed. Please ensure package kexec-tools is installed.");
             kdumpServiceDetails = (
                 <OverlayTrigger overlay={ <Tooltip id="tip-service">{tooltip}</Tooltip> } placement="bottom">
-                    <a tabIndex="0" className="popover-ct-kdump">
+                    <button className="popover-ct-kdump link-button">
                         <span className="fa fa-lg fa-info-circle" />
-                    </a>
+                    </button>
                 </OverlayTrigger>
             );
         }
@@ -508,11 +509,11 @@ export class KdumpPage extends React.Component {
 
                     <div role="group">
                         {testButton}
-                        <a tabIndex="0" className="popover-ct-kdump">
+                        <button className="popover-ct-kdump link-button">
                             <OverlayTrigger overlay={ <Tooltip id="tip-test-info">{tooltip_info}</Tooltip> } placement="top">
                                 <span className="fa fa-lg fa-info-circle" />
                             </OverlayTrigger>
-                        </a>
+                        </button>
                     </div>
                 </form>
             </div>

--- a/pkg/lib/cockpit-components-inline-notification.css
+++ b/pkg/lib/cockpit-components-inline-notification.css
@@ -1,4 +1,4 @@
-.more-button {
+.alert-link.more-button {
     padding-left: 10px;
 }
 .notification-message {

--- a/pkg/lib/cockpit-components-inline-notification.jsx
+++ b/pkg/lib/cockpit-components-inline-notification.jsx
@@ -60,8 +60,8 @@ export class InlineNotification extends React.Component {
                 detailButtonText = _("show less");
             }
 
-            detailButton = (<a href='#' className='alert-link more-button'
-                onClick={mouseClick(this.toggleDetail)}>{detailButtonText}</a>);
+            detailButton = (<button className='alert-link more-button link-button'
+                onClick={mouseClick(this.toggleDetail)}>{detailButtonText}</button>);
         }
 
         return (

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -170,7 +170,7 @@ export class Modifications extends React.Component {
                     <h3 className="listing-ct-heading">{this.props.title}</h3>
                     <div className="listing-ct-actions">
                         { !emptyRow &&
-                            <a className="modifications-export" onClick={ () => this.setState({ showDialog: true }) }>{_("View automation script")}</a>
+                            <button className="link-button modifications-export" onClick={ () => this.setState({ showDialog: true }) }>{_("View automation script")}</button>
                         }
                     </div>
                 </header>

--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -138,6 +138,30 @@ a.disabled:hover {
    background-color: #e0e0e0;
 }
 
+.link-button {
+    background-color: transparent;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--pf-global--link--Color);
+    border: none;
+    display: inline;
+    margin: 0;
+    padding: 0;
+}
+
+.link-button:hover,
+.link-button:focus {
+    text-decoration: underline;
+    outline: 0;
+    color: var(--pf-global--link--Color--hover);
+}
+
+.link-button.disabled {
+    pointer-events: none;
+    cursor: default;
+    color: var(--pf-global--disabled-color--100);
+}
+
 /* Small list inside a dialog */
 /* Alert fixups */
 

--- a/pkg/machines/components/aggregateStatusCards.jsx
+++ b/pkg/machines/components/aggregateStatusCards.jsx
@@ -38,7 +38,7 @@ export class AggregateStatusCards extends React.Component {
             <div className='cards-pf grid-cards-ct cards-ct-hybrid'>
                 <Card accented aggregated id='card-pf-storage-pools'>
                     <CardTitle onClick={ () => cockpit.location.go(['storages']) }>
-                        <a>
+                        <button role="link" className="link-button">
                             <Icon type='pf' name='server' />
                             <AggregateStatusCount>
                                 { this.props.storagePools.length }
@@ -46,7 +46,7 @@ export class AggregateStatusCards extends React.Component {
                             <span className="card-pf-title-link">
                                 {cockpit.ngettext("Storage Pool", "Storage Pools", this.props.storagePools.length)}
                             </span>
-                        </a>
+                        </button>
                     </CardTitle>
                     <CardBody>
                         <AggregateStatusNotifications>
@@ -63,7 +63,7 @@ export class AggregateStatusCards extends React.Component {
                 </Card>
                 <Card accented aggregated id='card-pf-networks'>
                     <CardTitle onClick={ () => cockpit.location.go(['networks']) }>
-                        <a>
+                        <button role="link" className="link-button">
                             <Icon type='pf' name='network' />
                             <AggregateStatusCount>
                                 { this.props.networks.length }
@@ -71,7 +71,7 @@ export class AggregateStatusCards extends React.Component {
                             <span className="card-pf-title-link">
                                 {cockpit.ngettext("Network", "Networks", this.props.networks.length)}
                             </span>
-                        </a>
+                        </button>
                     </CardTitle>
                     <CardBody>
                         <AggregateStatusNotifications>

--- a/pkg/machines/components/desktopConsole.jsx
+++ b/pkg/machines/components/desktopConsole.jsx
@@ -97,18 +97,18 @@ class MoreInformation extends React.Component {
     render() {
         if (!this.state.expanded) {
             return (
-                <a href='#' tabIndex="0" onClick={this.onClick}>
+                <button className="link-button" onClick={this.onClick}>
                     <span className='fa fa-angle-right' />&nbsp;
                     {_("More Information")}
-                </a>);
+                </button>);
         }
 
         return (
             <div className='machines-desktop-more-info-container'>
-                <a href='#' tabIndex="0" onClick={this.onClick}>
+                <button className="link-button" onClick={this.onClick}>
                     <span className='fa fa-angle-down' />&nbsp;
                     {_("More Information")}
-                </a>
+                </button>
                 {this.getContent()}
             </div>);
     }

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -137,22 +137,22 @@ class VmOverviewTabLibvirt extends React.Component {
 
             bootOrder = (
                 <div>
-                    <a id={`${vmId(vm.name)}-boot-order`} onClick={this.openBootOrder}>
+                    <button className="link-button" id={`${vmId(vm.name)}-boot-order`} onClick={this.openBootOrder}>
                         {getBootOrder(vm)}
-                    </a>
+                    </button>
                     { vm.state === "running" && bootOrderChanged() && <WarningInactive iconId="boot-order-tooltip" tooltipId="tip-boot-order" /> }
                 </div>
             );
 
             memoryLink = (
-                <a id={`${idPrefix}-memory-count`} onClick={this.openMemory}>
+                <button className="link-button" id={`${idPrefix}-memory-count`} onClick={this.openMemory}>
                     {memoryLink}
-                </a>
+                </button>
             );
         }
         const vcpuLink = (
             <>
-                <a id={`${vmId(vm.name)}-vcpus-count`} onClick={this.openVcpu}>{vm.vcpus.count}</a>
+                <button className="link-button" id={`${vmId(vm.name)}-vcpus-count`} onClick={this.openVcpu}>{vm.vcpus.count}</button>
                 { vm.state === "running" && vcpusChanged && <WarningInactive iconId="vcpus-tooltip" tooltipId="tip-vcpus" /> }
             </>
         );

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -943,7 +943,7 @@ export class Firewall extends React.Component {
         return (
             <div className="container-fluid page-ct">
                 <ol className="breadcrumb">
-                    <li><a tabIndex="0" onClick={go_up}>{_("Networking")}</a></li>
+                    <li><button role="link" className="link-button" onClick={go_up}>{_("Networking")}</button></li>
                     <li className="active">{_("Firewall")}</li>
                 </ol>
                 <h1>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -118,7 +118,7 @@ class Expander extends React.Component {
     }
 
     render() {
-        const title = <a href="#">{this.props.title}</a>;
+        const title = <button className="link-button">{this.props.title}</button>;
         const cls = "expander-caret fa " + (this.state.expanded ? "fa-angle-down" : "fa-angle-right");
         return (
             <>

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -93,7 +93,7 @@ export function showListingDemo (rootElement, rootElementSelectable, rootElement
         },
     ];
 
-    var addLink = <a className="pull-right" role="link" tabIndex="0" onClick={handleAddClick}>Add Row</a>;
+    var addLink = <button className="pull-right link-button" onClick={handleAddClick}>Add Row</button>;
 
     var rowAction = {
         element: <button className="btn btn-default btn-control fa fa-play" onClick={handlePlayClick} />,

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -121,7 +121,7 @@ class SELinuxEventDetails extends React.Component {
                     </div>
                 );
             }
-            var detailsLink = <a href="#" tabIndex="0" onClick={ self.handleSolutionDetailsClick.bind(self, itmIdx) }>{ _("solution details") }</a>;
+            var detailsLink = <button className="link-button" onClick={ self.handleSolutionDetailsClick.bind(self, itmIdx) }>{ _("solution details") }</button>;
             var doState;
             var doElem;
             var caret;

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -306,9 +306,9 @@ class Revealer extends React.Component {
             return <div>{this.props.children}</div>;
         else
             return (
-                <a tabIndex="0" onClick={event => { if (event.button == 0) this.setState({ revealed: true }); }}>
+                <button className="button-link" onClick={event => { if (event.button == 0) this.setState({ revealed: true }); }}>
                     {this.props.summary}
-                </a>
+                </button>
             );
     }
 }

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -124,7 +124,7 @@ export class Details extends React.Component {
             <div id="storage-detail">
                 <div className="col-md-12">
                     <ol className="breadcrumb">
-                        <li><a role="link" tabIndex="0" onClick={go_up}>{_("Storage")}</a></li>
+                        <li><button role="link" className="link-button" onClick={go_up}>{_("Storage")}</button></li>
                         <li className="active">{name}</li>
                     </ol>
                 </div>

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -704,9 +704,9 @@ const CheckBoxComponent = ({ tag, val, title, tooltip, update_function }) => {
                 {title}
             </label>
             { tooltip && <OverlayTrigger overlay={ <Tooltip id="tip-service">{tooltip}</Tooltip> } placement="right">
-                <a tabIndex="0" className="dialog-item-tooltip">
+                <button className="dialog-item-tooltip link-button">
                     <span className="fa fa-lg fa-info-circle" />
-                </a>
+                </button>
             </OverlayTrigger>
             }
         </div>

--- a/pkg/storaged/pvol-tabs.jsx
+++ b/pkg/storaged/pvol-tabs.jsx
@@ -34,9 +34,9 @@ export class PVolTab extends React.Component {
                 <div className="ct-form">
                     <label className="control-label">{_("Volume Group")}</label>
                     <div>{vgroup
-                        ? <a role="link" tabIndex="0" onClick={() => cockpit.location.go(["vg", vgroup.Name])}>
+                        ? <button role="link" className="link-button" onClick={() => cockpit.location.go(["vg", vgroup.Name])}>
                             {vgroup.Name}
-                        </a>
+                        </button>
                         : "-"
                     }
                     </div>
@@ -58,9 +58,9 @@ export class MDRaidMemberTab extends React.Component {
                 <div className="ct-form">
                     <label className="control-label">{_("RAID Device")}</label>
                     <div>{mdraid
-                        ? <a role="link" tabIndex="0" onClick={() => cockpit.location.go(["mdraid", mdraid.UUID])}>
+                        ? <button role="link" className="link-button" onClick={() => cockpit.location.go(["mdraid", mdraid.UUID])}>
                             {utils.mdraid_name(mdraid)}
-                        </a>
+                        </button>
                         : "-"
                     }
                     </div>
@@ -79,9 +79,9 @@ export class VDOBackingTab extends React.Component {
                 <div className="ct-form">
                     <label className="control-label">{_("VDO Device")}</label>
                     <div>{vdo
-                        ? <a role="link" tabIndex="0" onClick={() => cockpit.location.go(["vdo", vdo.name])}>
+                        ? <button role="link" className="link-button" onClick={() => cockpit.location.go(["vdo", vdo.name])}>
                             {vdo.name}
-                        </a>
+                        </button>
                         : "-"
                     }
                     </div>

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -132,12 +132,10 @@ export class StorageLink extends React.Component {
         return (
             <StorageControl excuse={this.props.excuse}
                             content={(excuse) => (
-                                <a onClick={checked(this.props.onClick)}
-                                       role="link"
-                                       tabIndex="0"
-                                       className={excuse ? " disabled" : ""}>
+                                <button onClick={checked(this.props.onClick)}
+                                        className={excuse ? " disabled link-button" : "link-button"}>
                                     {this.props.children}
-                                </a>
+                                </button>
                             )} />
         );
     }
@@ -164,9 +162,9 @@ export class StorageBlockNavLink extends React.Component {
         var parts = utils.get_block_link_parts(client, block.path);
 
         var link = (
-            <a role="link" tabIndex="0" onClick={() => { cockpit.location.go(parts.location) }}>
+            <button role="link" className="link-button" onClick={() => { cockpit.location.go(parts.location) }}>
                 {parts.link}
-            </a>
+            </button>
         );
 
         return <span>{fmt_to_fragments(parts.format, link)}</span>;

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -63,7 +63,7 @@ class SystemInfo extends React.Component {
         }
         const onSecurityClick = this.props.onSecurityClick;
 
-        const mitigations = this.state.allowed ? (<a role="link" onClick={onSecurityClick}>{ _("Mitigations") }</a>)
+        const mitigations = this.state.allowed ? (<button className="link-button" onClick={onSecurityClick}>{ _("Mitigations") }</button>)
             : (<OverlayTrigger overlay={
                 <Tooltip id="tip-cpu-security">
                     { cockpit.format(_("The user $0 is not permitted to change cpu security mitigations"), permission.user ? permission.user.name : '') }
@@ -270,7 +270,7 @@ class HardwareInfo extends React.Component {
             <div className="page-ct container-fluid">
                 <CPUSecurityMitigationsDialog show={this.state.showCpuSecurityDialog} onClose={ () => this.setState({ showCpuSecurityDialog: false }) } />
                 <ol className="breadcrumb">
-                    <li><a role="link" tabIndex="0" onClick={ () => cockpit.jump("/system", cockpit.transport.host) }>{ _("System") }</a></li>
+                    <li><button role="link" className="link-button" onClick={ () => cockpit.jump("/system", cockpit.transport.host) }>{ _("System") }</button></li>
                     <li className="active">{ _("Hardware Information") }</li>
                 </ol>
 

--- a/test/selenium/selenium-docker.py
+++ b/test/selenium/selenium-docker.py
@@ -22,7 +22,7 @@ class DockerTestSuite(SeleniumTest):
             self.click(self.wait_xpath("//*[@data-action='docker-start']", cond=clickable))
         self.wait_id('containers')
         self.wait_id('containers-images')
-        self.click(self.wait_link('Get new image', cond=clickable))
+        self.click(self.wait_css(".link-button", cond=clickable))
         self.wait_id('containers-search-image-dialog')
         self.send_keys(self.wait_id('containers-search-image-search'), "fedora")
         self.wait_id('containers-search-image-results')
@@ -30,7 +30,7 @@ class DockerTestSuite(SeleniumTest):
         self.click(self.wait_xpath(
             "//div[@id='containers-search-image-dialog']//button[contains(text(), '%s')]" % "Cancel", cond=clickable))
         self.wait_id('containers-search-image-dialog', cond=invisible)
-        self.click(self.wait_link('Get new image', cond=clickable))
+        self.click(self.wait_css(".link-button", cond=clickable))
         self.wait_id('containers-search-image-dialog')
         self.send_keys(self.wait_id('containers-search-image-search'), "cockpit")
         self.wait_id('containers-search-image-results')

--- a/test/selenium/selenium-firewalld-zones.py
+++ b/test/selenium/selenium-firewalld-zones.py
@@ -15,7 +15,7 @@ class FirewalldZones(SeleniumTest):
     def setUp(self):
         super().setUp()
         self.login()
-        self.click(self.wait_link('Network', cond=clickable))
+        self.click(self.wait_text("Network", cond=clickable))
         self.wait_frame("network")
         self.wait_id("networking", jscheck=True)
         self.machine.execute("sudo systemctl start firewalld")

--- a/test/selenium/selenium-hwinfo.py
+++ b/test/selenium/selenium-hwinfo.py
@@ -48,10 +48,10 @@ class TestHWinfo(SeleniumTest):
 
     def testSMT(self):
 
-        self.click(self.wait_link("Mitigations"))
+        self.click(self.wait_text("Mitigations", element="button", cond=clickable))
         self.wait_id("cpu-mitigations-dialog", jscheck=True)
         self.click(self.wait_id("nosmt-switch"))
         self.wait_text("Save and reboot", cond=clickable)
         self.click(self.wait_text("Cancel", cond=clickable))
-        self.click(self.wait_link("Mitigations", cond=clickable))
+        self.click(self.wait_text("Mitigations", element="button", cond=clickable))
         self.mainframe()

--- a/test/selenium/selenium-machines-consoles.py
+++ b/test/selenium/selenium-machines-consoles.py
@@ -43,7 +43,7 @@ class MachinesConsolesTestSuite(MachinesLib):
                         "%0Ahost%3D127.0.0.1%0Aport%3D5900%0Adelete-this-file%3D1%0Afullscreen%3D0%0A")
         self.wait_css('a[href="{}"]'.format(vv_file_attr), cond=present)
         # Check more info link
-        self.click(self.wait_css('.machines-desktop-viewer-block a[href="#"]', cond=clickable))
+        self.click(self.wait_css('.machines-desktop-viewer-block .link-button', cond=clickable))
         # Check manual connection info
         self.wait_css("#vm-{}-consoles-manual-address".format(name), cond=text_in, text_="127.0.0.1")
         self.wait_css("#vm-{}-consoles-manual-port-spice".format(name), cond=text_in, text_="5900")

--- a/test/selenium/selenium-machines-storage-pool.py
+++ b/test/selenium/selenium-machines-storage-pool.py
@@ -22,7 +22,7 @@ class MachinesStoragePoolTestSuite(MachinesLib):
         inactive = int(self.wait_css(
             '#card-pf-storage-pools > div > p > span:nth-child(2)').text)
         total = int(self.wait_css(
-            '#card-pf-storage-pools > h2 > a > span.card-pf-aggregate-status-count').text)
+            '#card-pf-storage-pools > h2 > button > span.card-pf-aggregate-status-count').text)
         self.assertEqual(total, active + inactive,
                          "Storage pools' total num is not the same as the sum of active and inactive")
 

--- a/test/selenium/selenium-storage.py
+++ b/test/selenium/selenium-storage.py
@@ -28,6 +28,6 @@ class StorageTestSuite(SeleniumTest):
         self.wait_xpath("//*[@id='storage-detail']//div[contains(text(), '%s')]" % other_discname)
         self.wait_text("Capacity", element="label")
         self.wait_text("1000 MiB", element="span")
-        self.click(self.wait_link('Storage', cond=clickable))
+        self.click(self.wait_text("Storage", element="button", cond=clickable))
         self.wait_xpath("//*[@data-testkey='%s']" % other_shortname)
         self.mainframe()

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -100,7 +100,7 @@ class TestApps(PackageCase):
         b.click(".app-list tr:contains('An application for testing')")
         b.wait_present('.app-links a[href="https://app-1.com"]')
         b.wait_present('.app img[src^="%s/cockpit/channel/"]' % urlroot)
-        b.click(".breadcrumb a:contains('Applications')")
+        b.click(".breadcrumb button:contains('Applications')")
 
         b.wait_visible("#list-page")
         b.wait_not_visible("#app-page")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -100,7 +100,10 @@ class TestKdump(MachineCase):
         self.enableLocalSsh()
 
         # minimal nfs validation
-        settingsLink = "a:contains('locally in /var/crash')"
+        settingsLink = "button:contains('locally in /var/crash')"
+        if m.image == "rhel-8-1-distropkg":
+            settingsLink = "a:contains('locally in /var/crash')"
+
         b.click(settingsLink)
         b.set_val("#kdump-settings-location", "nfs")
         mountInput = "#kdump-settings-nfs-mount"
@@ -140,7 +143,9 @@ class TestKdump(MachineCase):
 
         # try to change the path to a directory that doesn't exist
         customPath = "/var/crash2"
-        settingsLink = "a:contains('Remote over SSH')"
+        settingsLink = "button:contains('Remote over SSH')"
+        if m.image == "rhel-8-1-distropkg":
+            settingsLink = "a:contains('Remote over SSH')"
         b.click(settingsLink)
         b.set_val("#kdump-settings-location", "local")
         pathInput = "#kdump-settings-local-directory"
@@ -154,7 +159,10 @@ class TestKdump(MachineCase):
         m.execute("mkdir -p {0}".format(customPath))
         b.click("button.btn-primary:contains('Apply')")
         b.wait_not_present(pathInput)
-        b.wait_present("a:contains('locally in {0}')".format(customPath))
+        if m.image == "rhel-8-1-distropkg":
+            b.wait_present("a:contains('locally in {0}')".format(customPath))
+        else:
+            b.wait_present("button:contains('locally in {0}')".format(customPath))
 
         # service has to restart after changing the config, wait for it to be running
         # otherwise the button to test will be disabled

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -74,7 +74,10 @@ class TestFirewall(NetworkCase):
         b.click("#networking-firewall-link")
         b.enter_page("/network/firewall")
 
-        b.click(".breadcrumb li:first a")
+        if m.image == "rhel-8-1-distropkg":
+            b.click(".breadcrumb li:first a")
+        else:
+            b.click(".breadcrumb li:first button")
         b.enter_page("/network")
 
         self.allow_journal_messages(".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*",

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -139,7 +139,7 @@ class TestSelinux(MachineCase):
         b.wait_in_text(panel_selector, "you can run restorecon")
 
         # and it can be applied
-        btn_sel = "div.list-group-item:contains('you can run restorecon') button"
+        btn_sel = "div.list-group-item:contains('you can run restorecon') button.btn-default"
         b.click(btn_sel)
 
         # the fix should be applied

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -50,7 +50,7 @@ class TestStorage(StorageCase):
 
         b.click('#vgroups tr:contains("TEST")')
         b.wait_present('#storage-detail')
-        b.click("a:contains(Create new Logical Volume)")
+        b.click("button:contains(Create new Logical Volume)")
         self.dialog({'purpose': "block",
                      'name': "lvol",
                      'size': 48})

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -108,7 +108,7 @@ class TestStorage(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Mount Options", "_netdev")
 
         # Add the target a second time, just to check that the sorting function works
-        b.click('#storage-detail .breadcrumb a')
+        b.click('#storage-detail .breadcrumb button')
         b.wait_visible('#storage')
         b.click('#add-iscsi-portal')
         self.dialog_wait_open()

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -128,14 +128,14 @@ class TestStorage(StorageCase):
         b.wait_present('#storage-detail')
 
         # create a logical volume
-        b.click("a:contains(Create new Logical Volume)")
+        b.click("button:contains(Create new Logical Volume)")
         self.dialog(expect={"name": "lvol0"},
                     values={"purpose": "block",
                             "size": 20})
         self.content_row_wait_in_col(1, 2, "/dev/vgroup0/lvol0")
 
         # check that the next default name is "lvol1"
-        b.click("a:contains(Create new Logical Volume)")
+        b.click("button:contains(Create new Logical Volume)")
         self.dialog_wait_open()
         self.dialog_wait_val("name", "lvol1")
         self.dialog_cancel()
@@ -170,13 +170,13 @@ class TestStorage(StorageCase):
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_one), "")
 
         # remove disk
-        b.click('#detail-sidebar tr:nth-child(2) button')
+        b.click('#detail-sidebar tr:nth-child(2) button.btn-default')
         b.wait_not_in_text("#detail-sidebar", "DISK2")
         b.wait_in_text("#detail-header label:contains(Capacity) + div", "48 MiB")
 
         # create thin pool and volume
         # the pool will be maximum size, 48 MiB
-        b.click("a:contains(Create new Logical Volume)")
+        b.click("button:contains(Create new Logical Volume)")
         self.dialog(expect={"size": 48},
                     values={"purpose": "pool",
                             "name": "pool",

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -35,7 +35,7 @@ class TestStorage(StorageCase):
           var trs = ph_select('#detail-sidebar tr');
           for (i = 0; i < trs.length; ++i) {
             var cell = trs[i].querySelector('td:nth-child(2)');
-            var name = cell.querySelector('a').textContent;
+            var name = cell.querySelector('button').textContent;
             var state = cell.querySelector('.state').textContent;
             found[name] = state;
           };
@@ -53,7 +53,7 @@ class TestStorage(StorageCase):
         self.dialog_apply_with_retry()
 
     def raid_remove_disk(self, name):
-        self.browser.click('#detail-sidebar tr:contains("%s") button' % name)
+        self.browser.click('#detail-sidebar tr:contains("%s") button.btn-default' % name)
 
     def raid_action(self, action):
         self.browser.click('.panel-heading:contains("RAID Device") button:contains(%s)' % action)

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -428,7 +428,10 @@ class TestSystemInfo(MachineCase):
         b.wait_not_in_text(pci_selector + ' .listing-ct tbody:last-of-type td:nth-of-type(2)', "Unclassified")
 
         # go back to system page
-        b.click('.breadcrumb a')
+        if m.image == "rhel-8-1-distropkg":
+            b.click('.breadcrumb a')
+        else:
+            b.click('.breadcrumb button')
         b.enter_page("/system")
 
         # now pretend this is a system without DMI; fixed in PR #11005
@@ -520,7 +523,10 @@ class TestSystemInfo(MachineCase):
                 b.wait_present('#hwinfo th:contains(CPU)')
                 b.wait_not_present('#hwinfo th:contains(CPU Security)')
             else:
-                b.click('#hwinfo a:contains(Mitigations)')
+                if m.image == "rhel-8-1-distropkg":
+                    b.click('#hwinfo a:contains(Mitigations)')
+                else:
+                    b.click('#hwinfo button:contains(Mitigations)')
 
             if expect_smt_state is not None:
                 b.wait_present('#cpu-mitigations-dialog span:contains(nosmt)')
@@ -541,7 +547,10 @@ class TestSystemInfo(MachineCase):
         # Enable nosmt option
         b.reload()
         b.enter_page('/system/hwinfo')
-        b.click('#hwinfo a:contains(Mitigations)')
+        if m.image == "rhel-8-1-distropkg":
+            b.click('#hwinfo a:contains(Mitigations)')
+        else:
+            b.click('#hwinfo button:contains(Mitigations)')
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
@@ -589,7 +598,10 @@ fi
 
         # Disable nosmt option
         self.login_and_go('/system/hwinfo')
-        b.click('#hwinfo a:contains(Mitigations)')
+        if m.image == "rhel-8-1-distropkg":
+            b.click('#hwinfo a:contains(Mitigations)')
+        else:
+            b.click('#hwinfo button:contains(Mitigations)')
         b.wait_present('#cpu-mitigations-dialog span:contains(nosmt)')
         b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
@@ -610,7 +622,10 @@ fi
         m.write('/tmp/grubby', '#!/bin/sh\necho 0')
         m.execute('[ ! -f /usr/sbin/grubby ] || mount --bind /tmp/grubby /usr/sbin/grubby')
         self.login_and_go('/system/hwinfo')
-        b.click('#hwinfo a:contains(Mitigations)')
+        if m.image == "rhel-8-1-distropkg":
+            b.click('#hwinfo a:contains(Mitigations)')
+        else:
+            b.click('#hwinfo button:contains(Mitigations)')
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -392,20 +392,19 @@ class TestMachines(NetworkCase):
         # inline notification with error
         b.wait_in_text("div.alert.alert-danger strong", "VM subVmTest2 failed to start")
 
-        b.wait_in_text("a.alert-link.more-button", "show more") # more/less button
-        b.click("a.alert-link.more-button")
-        b.wait_present("a.alert-link + p")
-
         # the message when trying to start active VM differs between virsh and libvirt-dbus provider
         if (self.provider == "libvirt-dbus"):
-            b.wait_in_text("a.alert-link + p",
-                           "domain is already running")
+            message = "domain is already running"
         else:
-            b.wait_in_text("a.alert-link + p",
-                           "Domain is already active")
+            message = "Domain is already active"
 
-        b.wait_in_text("a.alert-link.more-button", "show less")
-        b.click("div.alert.alert-danger button") # close button
+        b.wait_in_text("button.alert-link.more-button", "show more") # more/less button
+        b.click("button.alert-link.more-button")
+        b.wait_present("button.alert-link + p")
+        b.wait_in_text("button.alert-link + p", message)
+        b.wait_in_text("button.alert-link.more-button", "show less")
+
+        b.click("div.alert.alert-danger button.close") # close button
         # inline notification is gone
         b.wait_not_present("div.alert.alert-danger")
         # triangle by status is gone
@@ -1987,8 +1986,8 @@ class TestMachines(NetworkCase):
             try:
                 with b.wait_timeout(10):
                     b.wait_present(error_location)
-                    b.wait_in_text("a.alert-link.more-button", "show more")
-                    b.click("a.alert-link.more-button")
+                    b.wait_in_text("button.alert-link.more-button", "show more")
+                    b.click("button.alert-link.more-button")
                     waitForError(errors, error_location)
 
                 # dialog can complete if the error was not returned immediately
@@ -2002,8 +2001,8 @@ class TestMachines(NetworkCase):
                     try:
                         with b.wait_timeout(20):
                             b.wait_present(error_location)
-                            b.wait_in_text("a.alert-link.more-button", "show more")
-                            b.click("a.alert-link.more-button")
+                            b.wait_in_text("button.alert-link.more-button", "show more")
+                            b.click("button.alert-link.more-button")
                             waitForError(errors, error_location)
                     except Error as x2:
                         # allow CPU errors in the notification area
@@ -2113,7 +2112,7 @@ class TestMachines(NetworkCase):
             b.click("#vm-{0}-overview".format(name)) # open the "overView" subtab
 
             b.wait_in_text("div.alert.alert-danger strong", "VM {0} failed to get installed".format(name))
-            b.wait_in_text("a.alert-link.more-button", "show more")
+            b.wait_in_text("button.alert-link.more-button", "show more")
 
             return self
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -171,9 +171,9 @@ class StorageCase(MachineCase):
     def content_tab_info_action(self, row_index, tab_index, title, wrapped=False):
         label = self.content_tab_info_label(row_index, tab_index, title)
         if wrapped:
-            link = label + " + div a"
+            link = label + " + div button.link-button"
         else:
-            link = label + " + a"
+            link = label + " + button.link-button"
         self.browser.click(link)
 
     # Dialogs


### PR DESCRIPTION
To keep the same visual style, define class `.link-button` and style it
to look like regular link.

When it is used for redirection within `onClick`, then also specify `role=link`.

I check all affected elements (or at least try to locate them, sometime some element is used on many places and not possible to find all occurences).

This is related to  #12854, where it fixes 62 out of 121 finds. I thought I'll try to get this landed separately, since this is a rather big change on its own. There are some left anchors that are used wrongly, but they are either used in our implementations of dropdowns (we really should go to native select) or in our implementation of tabs (we should use PF component for this).

This is gonna break tests - so I'll let only F30 run and then fix it and once I think F30 is gonna be green I'll trigger all tests.