### PR TITLE
test: Skip Machines selenium tests on Edge for now

### DIFF
--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -172,7 +172,12 @@ class AvocadoTestSuite:
         cmd_output = self.machine_avocado.execute(self.base_cmd + " list " + " ".join(test_abspaths))
         output_list = []
         for line in cmd_output.splitlines():
-            output_list.append(line.split(" ", 1)[1].strip())
+            t = line.split(" ", 1)[1].strip()
+            if self.browser == "edge" and "/selenium-machines-" in t:
+                # HACK: https://github.com/cockpit-project/cockpit/issues/12864
+                print("SKIP:", t, "because of https://github.com/cockpit-project/cockpit/issues/12864")
+                continue
+            output_list.append(t)
         return output_list
 
 
@@ -239,6 +244,7 @@ class SeleniumTestSuite(AvocadoTestSuite):
                       ]
 
     def __init__(self, browser, **kwargs):
+        self.browser = browser
         super().__init__(**kwargs)
         self.env["HUB"] = self.ipaddr_selenium
         self.env["GUEST"] = self.ipaddr_cockpit


### PR DESCRIPTION
Since PR #12573 (PatternFly 4 Tables), the Machines page crashes on the
old Edge 42 on our windows-10 image. Edge refuses to update on that test
image, so we currently have no way of testing with 44 (where this crash
does not happen). See issue #12864 for details.

Until we have a better fix for that, skip the Machines page tests on
Edge. We've ignored the Edge test for some weeks now, it's too dangerous
to introduce regressions to other pages now.