### PR TITLE
machines: Refresh default storage pool after VM creation or deletion

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -122,8 +122,8 @@ export function createVm(vmParams) {
     return virt(CREATE_VM, vmParams);
 }
 
-export function deleteVm(vm, options) {
-    return virt(DELETE_VM, { name: vm.name, id: vm.id, connectionName: vm.connectionName, options: options });
+export function deleteVm(vm, options, storagePools) {
+    return virt(DELETE_VM, { name: vm.name, id: vm.id, connectionName: vm.connectionName, options, storagePools });
 }
 
 export function detachDisk({ connectionName, target, name, id, live = false }) {

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -131,7 +131,7 @@ export class DeleteDialog extends React.Component {
     delete() {
         const storage = this.state.disks.filter(d => d.checked);
 
-        return this.props.dispatch(deleteVm(this.props.vm, { destroy: this.state.destroy, storage: storage }))
+        return this.props.dispatch(deleteVm(this.props.vm, { destroy: this.state.destroy, storage: storage }, this.props.storagePools))
                 .catch(exc => {
                     this.dialogErrorSet(cockpit.format(_("VM $0 failed to get deleted"), this.props.vm.name), exc.message);
                 });

--- a/pkg/machines/components/vm/vm.jsx
+++ b/pkg/machines/components/vm/vm.jsx
@@ -102,6 +102,7 @@ const Vm = ({
             vm,
             config,
             dispatch,
+            storagePools,
             onStart,
             onInstall,
             onReboot,

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -30,7 +30,7 @@ import DropdownButtons from '../dropdownButtons.jsx';
 
 const _ = cockpit.gettext;
 
-const VmActions = ({ vm, config, dispatch, onStart, onInstall, onReboot, onForceReboot, onShutdown, onPause, onResume, onForceoff, onSendNMI }) => {
+const VmActions = ({ vm, config, dispatch, storagePools, onStart, onInstall, onReboot, onForceReboot, onShutdown, onPause, onResume, onForceoff, onSendNMI }) => {
     const id = vmId(vm.name);
     const state = vm.state;
     const hasInstallPhase = vm.metadata.hasInstallPhase;
@@ -108,7 +108,7 @@ const VmActions = ({ vm, config, dispatch, onStart, onInstall, onReboot, onForce
     let deleteAction = null;
     if (state !== undefined && config.provider.canDelete && config.provider.canDelete(state, vm.id, config.providerState)) {
         deleteAction = (
-            <DeleteDialog key='action-delete' vm={vm} dispatch={dispatch} />
+            <DeleteDialog key='action-delete' vm={vm} dispatch={dispatch} storagePools={storagePools} />
         );
     }
 
@@ -128,6 +128,7 @@ VmActions.propTypes = {
     vm: PropTypes.object.isRequired,
     config: PropTypes.string.isRequired,
     dispatch: PropTypes.func.isRequired,
+    storagePools: PropTypes.array.isRequired,
     onStart: PropTypes.func.isRequired,
     onReboot: PropTypes.func.isRequired,
     onForceReboot: PropTypes.func.isRequired,


### PR DESCRIPTION
If user deletes a VM and also decides to remove it's associated
storages, storage pools containing these storages are not refreshed,
thus deletion is not reflected in the UI.
Also if user creates a new VM with it's own new storage, this storage
change is not represented in the UI.
Fix this.

 - [x] PR #12913