### PR TITLE
Use our terminal implementation in vms

### DIFF
--- a/pkg/lib/cockpit-components-context-menu.jsx
+++ b/pkg/lib/cockpit-components-context-menu.jsx
@@ -28,9 +28,10 @@ const _ = cockpit.gettext;
 /*
  * A context menu component that contains copy and paste fields.
  *
- * It requires two properties:
+ * It requires three properties:
  *  - getText, method which is called when copy is clicked
  *  - setText, method which is called when paste is clicked
+ *  - parentId, area in which it listens to left button clicks
  */
 export class ContextMenu extends React.Component {
     constructor() {
@@ -41,12 +42,14 @@ export class ContextMenu extends React.Component {
     }
 
     componentDidMount() {
-        document.addEventListener('contextmenu', this._handleContextMenu);
+        const parent = document.getElementById(this.props.parentId);
+        parent.addEventListener('contextmenu', this._handleContextMenu);
         document.addEventListener('click', this._handleClick);
     }
 
     componentWillUnmount() {
-        document.removeEventListener('contextmenu', this._handleContextMenu);
+        const parent = document.getElementById(this.props.parentId);
+        parent.removeEventListener('contextmenu', this._handleContextMenu);
         document.removeEventListener('click', this._handleClick);
     }
 
@@ -110,5 +113,6 @@ export class ContextMenu extends React.Component {
 
 ContextMenu.propTypes = {
     getText: PropTypes.func.isRequired,
-    setText: PropTypes.func.isRequired
+    setText: PropTypes.func.isRequired,
+    parentId: PropTypes.string.isRequired
 };

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -179,7 +179,7 @@ export class Terminal extends React.Component {
                         onFocus={this.onFocusIn}
                         onContextMenu={this.contextMenu}
                         onBlur={this.onFocusOut} />
-                <ContextMenu setText={this.setText} getText={this.getText} />
+                <ContextMenu parentId={this.props.parentId} setText={this.setText} getText={this.getText} />
             </>
         );
     }
@@ -284,5 +284,6 @@ Terminal.propTypes = {
     rows: PropTypes.number,
     channel: PropTypes.object.isRequired,
     onTitleChanged: PropTypes.func,
-    theme: PropTypes.string
+    theme: PropTypes.string,
+    parentId: PropTypes.string.isRequired
 };

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -131,7 +131,7 @@ export class Terminal extends React.Component {
     }
 
     componentDidMount() {
-        this.state.terminal.open(this.refs.terminal);
+        this.state.terminal.open(this.refs[this.props.refName || "terminal"]);
         this.connectChannel();
 
         if (!this.props.rows) {
@@ -173,7 +173,7 @@ export class Terminal extends React.Component {
     render() {
         return (
             <>
-                <div ref="terminal"
+                <div ref={this.props.refName || "terminal"}
                         key={this.state.terminal}
                         className="console-ct"
                         onFocus={this.onFocusIn}
@@ -285,5 +285,6 @@ Terminal.propTypes = {
     channel: PropTypes.object.isRequired,
     onTitleChanged: PropTypes.func,
     theme: PropTypes.string,
+    refName: PropTypes.string,
     parentId: PropTypes.string.isRequired
 };

--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -237,6 +237,7 @@ export class Terminal extends React.Component {
             channel.removeEventListener('message', this.onChannelMessage);
             channel.removeEventListener('close', this.onChannelClose);
         }
+        channel.close();
     }
 
     focus() {

--- a/pkg/machines/components/consoles.css
+++ b/pkg/machines/components/consoles.css
@@ -3,3 +3,18 @@
     margin-bottom: -10px;
     margin-top: -3px;
 }
+
+.vm-terminal {
+    padding-top: 20px;
+}
+
+.terminal-control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+}
+
+.terminal-control .form-table-ct {
+    width: unset;
+}

--- a/pkg/machines/components/serialConsole.jsx
+++ b/pkg/machines/components/serialConsole.jsx
@@ -20,14 +20,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
-import { SerialConsole } from '@patternfly/react-console';
+import { Terminal } from "cockpit-components-terminal.jsx";
 
 const _ = cockpit.gettext;
-
-const XTERM_FONT_FAMILY = 'Menlo, Monaco, Consolas, monospace';
-const XTERM_FONT_SIZE = 12;
-const XTERM_COLS = 90;
-const XTERM_ROWS = 30;
 
 class SerialConsoleCockpit extends React.Component {
     constructor (props) {
@@ -37,42 +32,21 @@ class SerialConsoleCockpit extends React.Component {
             channel: undefined,
         };
 
-        this.onConnect = this.onConnect.bind(this);
+        this.createChannel = this.createChannel.bind(this);
         this.onDisconnect = this.onDisconnect.bind(this);
-        this.onResize = this.onResize.bind(this);
-
-        this.onData = this.onData.bind(this);
-        this.onChannelMessage = this.onChannelMessage.bind(this);
-        this.onChannelClose = this.onChannelClose.bind(this);
-
-        this.getStatus = this.getStatus.bind(this);
     }
 
-    /**
-     * Use Cockpit channel
-     */
-    onConnect () {
+    componentDidMount() {
+        this.createChannel();
+    }
+
+    createChannel () {
         const channel = cockpit.channel({
             payload: "stream",
             spawn: this.props.spawnArgs,
             pty: true,
         });
-
-        channel.addEventListener('message', this.onChannelMessage);
-        channel.addEventListener('close', this.onChannelClose);
-
         this.setState({ channel });
-    }
-
-    /**
-     * Terminal component emitted data, like user key press.
-     * Send them to the backend.
-     */
-    onData (data) {
-        const channel = this.state.channel;
-        if (channel && channel.valid) {
-            channel.send(data);
-        }
     }
 
     onDisconnect () {
@@ -86,58 +60,31 @@ class SerialConsoleCockpit extends React.Component {
         }
     }
 
-    onChannelMessage (event, data) {
-        if (this.refs.serialconsole) {
-            this.refs.serialconsole.onDataReceived(data);
-        }
-    }
-
-    onChannelClose (event, options) {
-        if (this.refs.serialconsole) {
-            this.refs.serialconsole.onConnectionClosed(options.problem);
-        }
-    }
-
-    onResize (rows, cols) {
-        if (this.state.channel) {
-            this.state.channel.control({
-                window: {
-                    rows,
-                    cols,
-                }
-            });
-        }
-    }
-
-    getStatus () {
-        if (this.state.channel)
-            return 'connected';
-
-        if (this.state.channel === null)
-            return 'disconnected';
-
-        return 'loading';
-    }
-
     render () {
+        const pid = this.props.vmName + "-terminal";
+        let t = <span>{_("Loading...")}</span>;
+        if (this.state.channel) {
+            t = <Terminal
+             refName={this.props.vmName}
+             channel={this.state.channel}
+             parentId={pid}
+            />;
+        } else if (this.state.channel === null) {
+            t = <span>{_("Disconnected from serial console. Click the Connect button.")}</span>;
+        }
+
         return (
             <>
-                {this.props.children}
-                <SerialConsole id={this.props.vmName} ref='serialconsole'
-                    rows={XTERM_ROWS}
-                    cols={XTERM_COLS}
-                    fontFamily={XTERM_FONT_FAMILY}
-                    fontSize={XTERM_FONT_SIZE}
-                    status={this.getStatus()}
-                    onConnect={this.onConnect}
-                    onDisconnect={this.onDisconnect}
-                    onResize={this.onResize}
-                    onData={this.onData}
-                    textDisconnect={_("Disconnect")}
-                    textDisconnected={_("Disconnected from serial console. Click the Reconnect button.")}
-                    textReconnect={_("Reconnect")}
-                    textLoading={_("Loading ...")}
-                    topClassName="" />
+                <div className="terminal-control">
+                    {this.props.children}
+                    {this.state.channel
+                        ? <button id={this.props.vmName + "-serialconsole-disconnect"} className="btn btn-default" onClick={this.onDisconnect}>{_("Disconnect")}</button>
+                        : <button id={this.props.vmName + "-serialconsole-connect"} className="btn btn-default" onClick={this.createChannel}>{_("Connect")}</button>
+                    }
+                </div>
+                <div id={pid} className="vm-terminal">
+                    {t}
+                </div>
             </>
         );
     }

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -82,6 +82,7 @@ const _ = cockpit.gettext;
                 terminal = (<Terminal ref="terminal"
                      channel={this.state.channel}
                      theme={this.state.theme}
+                     parentId="the-terminal"
                      onTitleChanged={this.onTitleChanged} />);
             else
                 terminal = <span>Loading...</span>;
@@ -104,7 +105,7 @@ const _ = cockpit.gettext;
                             className="btn btn-default terminal-reset"
                             onClick={this.onResetClick}>{_("Reset")}</button>
                     </div>
-                    <div className={"panel-body " + this.state.theme}>
+                    <div className={"panel-body " + this.state.theme} id="the-terminal">
                         {terminal}
                     </div>
                 </div>

--- a/test/selenium/selenium-machines-consoles.py
+++ b/test/selenium/selenium-machines-consoles.py
@@ -2,7 +2,7 @@ import os
 from avocado import skipIf
 from selenium.webdriver.support.select import Select
 from testlib_avocado.timeoutlib import wait
-from testlib_avocado.seleniumlib import clickable, present, invisible, text_in
+from testlib_avocado.seleniumlib import clickable, present, text_in
 from testlib_avocado.machineslib import MachinesLib
 
 
@@ -57,18 +57,12 @@ class MachinesConsolesTestSuite(MachinesLib):
         # Open serial console
         self.click(self.wait_css('#vm-{}-consoles'.format(name), cond=clickable))
         self.select_by_text(self.wait_id('console-type-select'), 'Serial Console')
-        self.wait_css('div.terminal canvas.xterm-text-layer')
+        self.wait_css(".xterm-accessibility-tree")
+
         # Disconnect
         self.click(self.wait_css("#{}-serialconsole-disconnect".format(name), cond=clickable))
-        self.wait_css('div.terminal canvas.xterm-text-layer', cond=invisible)
-        self.wait_css('div.blank-slate-pf')
-        self.wait_css('p.blank-slate-pf-info', cond=text_in,
-                      text_='Disconnected from serial console. Click the Reconnect button.')
+        self.wait_text("Disconnected from serial console. Click the Connect button.")
+
         # Reconnect
-        self.click(self.wait_css('div.console-terminal-pf button', cond=clickable))
-        self.wait_css('div.terminal canvas.xterm-text-layer')
-        # Disconnect again and reconnect using reconnect button
-        self.click(self.wait_css("#{}-serialconsole-disconnect".format(name), cond=clickable))
-        self.wait_css('div.terminal canvas.xterm-text-layer', cond=invisible)
-        self.click(self.wait_css('#{}-serialconsole-reconnect'.format(name), cond=clickable))
-        self.wait_css('div.terminal canvas.xterm-text-layer')
+        self.click(self.wait_css("#{}-serialconsole-connect".format(name), cond=clickable))
+        self.wait_css(".xterm-accessibility-tree")

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1236,18 +1236,13 @@ class TestMachines(NetworkCase):
         b.click("#vm-{0}-consoles".format(name)) # open the "Console" subtab
 
         b.set_val("#console-type-select", "serial-browser")
-        b.wait_present("div.terminal canvas.xterm-text-layer") # if connected the xterm canvas is rendered
-
-        b.click("#{0}-serialconsole-reconnect".format(name))
-        b.wait_present("div.terminal canvas.xterm-text-layer")
+        b.wait_in_text("#{0}-terminal .xterm-accessibility-tree > div:nth-child(1)".format(name), "Connected to domain")
 
         b.click("#{0}-serialconsole-disconnect".format(name))
-        b.wait_not_present("div.terminal canvas.xterm-text-layer")
-        b.wait_present("div.blank-slate-pf")
-        b.wait_present("p.blank-slate-pf-info:contains(Disconnected from serial console. Click the Reconnect button.)")
+        b.wait_text("#{0}-terminal".format(name), "Disconnected from serial console. Click the Connect button.")
 
-        b.click("#{0}-serialconsole-reconnect".format(name))
-        b.wait_present("div.terminal canvas.xterm-text-layer")
+        b.click("#{0}-serialconsole-connect".format(name))
+        b.wait_in_text("#{0}-terminal .xterm-accessibility-tree > div:nth-child(1)".format(name), "Connected to domain")
 
         # disconnecting the serial console closes the pty channel
         self.allow_journal_messages("connection unexpectedly closed by peer",


### PR DESCRIPTION
Our console:
1. Is accessible
2. Does not use deprecated react methods
3. Supports copy and paste
4. Does not depend on old xterm.js
5. Is simpler to use

This would also hopefully unblock https://github.com/cockpit-project/cockpit/pull/12736 (hopefully because I hope that webpack is smart enough not to get dirty with serialConsole when we don't import it, but we import other components from the same package).
EDIT: - no, it does not unblock #12736 : 
```
ERROR in ./node_modules/@patternfly/react-console/dist/esm/SerialConsole/XTerm.js
Module not found: Error: Can't resolve 'xterm/lib/addons/fit/fit' in '/home/mmarusak/cockpit/cockpit1/node_modules/@patternfly/react-console/dist/esm/SerialConsole'
```
is there way how to stop compiling SerialConsole?