### PR TITLE
WIP: containers: Cache docker image and node_modules in Semaphore unit test runs

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -27,20 +27,6 @@ git clone /source /tmp/source
 [ ! -d /source/node_modules ] || cp -r /source/node_modules /tmp/source/
 cd /tmp/source
 
-if [ -d bots ]; then
-    # Set GITHUB_BASE so that "import task" works without failure.
-    # https://github.com/cockpit-project/cockpit/issues/10578
-    GITHUB_BASE=unused bots/test-bots
-fi
-
-# bots/ is by and large an independent project, and for supporting stable
-# ranches, we want build/check/dist to work without it; so run everything
-# without bots/ in one run (to make sure this works), and keep it in the
-# others (to make sure its existence does not break anything)
-if [ "${CC:-}" = clang ]; then
-    rm -rf bots
-fi
-
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
 
 make V=1 all

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -24,10 +24,15 @@ if [ ! -e /source/.git ]; then
     exit 1
 fi
 git clone /source /tmp/source
-[ ! -d /source/node_modules ] || cp -r /source/node_modules /tmp/source/
 cd /tmp/source
 
+# /source/node_modules is a bind mount to the host, for caching
+rm -r node_modules
+ln -s /source/node_modules
+
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
+chmod -R o+rwX node_modules || true  # make it writable for the unpriv user on the host
+exit 0 # XXX
 
 make V=1 all
 

--- a/containers/unit-tests/semaphore-cache
+++ b/containers/unit-tests/semaphore-cache
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eux
+
+item="$2"
+item_esc="${item//\//_}"
+item_esc="${item_esc//:/_}"
+
+case "${1:-}" in
+    docker-load)
+        for f in $SEMAPHORE_CACHE_DIR/docker/$item_esc-*; do
+            [ -e "$f" ] || continue
+            echo "Restoring cached Docker image $f..."
+            docker load < "$f"
+        done
+        ;;
+
+    docker-save)
+        mkdir -p $SEMAPHORE_CACHE_DIR/docker
+        hash=$(docker images -q "$item")
+        cache_file="$SEMAPHORE_CACHE_DIR/docker/${item_esc}-$hash"
+        if ! [ -e "$cache_file" ]; then
+            # remove any older hash of that image
+            rm -f --verbose "$SEMAPHORE_CACHE_DIR/docker/${item_esc}"-*
+            echo "Caching docker image $cache_file ..."
+            docker save -o "${cache_file}.tmp" "$item"
+            mv "${cache_file}.tmp" "$cache_file"
+        else
+            # mark cached image as current
+            touch "$cache_file"
+        fi
+
+        echo "Cleaning old cached docker images..."
+        find "$SEMAPHORE_CACHE_DIR/docker" -type f -mtime +7 -print -delete
+        ;;
+
+    *)
+        echo "Usage: $0 docker-load|docker-save <image>" >&2
+        exit 1
+esac

--- a/containers/unit-tests/semaphore-cache
+++ b/containers/unit-tests/semaphore-cache
@@ -33,7 +33,25 @@ case "${1:-}" in
         find "$SEMAPHORE_CACHE_DIR/docker" -type f -mtime +7 -print -delete
         ;;
 
+    dir-load)
+        cache="$SEMAPHORE_CACHE_DIR/$(basename "$item")"
+        if [ -e "$cache" ]; then
+            echo "Restoring cached directory $item ..."
+            mkdir -p "$item"
+            cp -a "$cache" "$(dirname "$item")"
+            # allow container bind mount to read/write it
+            chmod -R o+rwX "$item"
+        fi
+        ;;
+
+    dir-save)
+        dest="$SEMAPHORE_CACHE_DIR/$(basename "$item")"
+        rm -rf "$dest"
+        echo "Caching directory $item to $dest ..."
+        cp -a "$item" "$dest"
+        ;;
+
     *)
-        echo "Usage: $0 docker-load|docker-save <image>" >&2
+        echo "Usage: $0 docker-load|docker-save|dir-load|dir-save <item>" >&2
         exit 1
 esac

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -24,11 +24,26 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
   exit 1
 fi
 
+# bind-mounted into the container, needs to be able to write
+mkdir -p -m 777 node_modules_cache
+
 if [ -d "${SEMAPHORE_CACHE_DIR:-}" ]; then
     $srcdir/semaphore-cache docker-load "$image"
     trap "$srcdir/semaphore-cache docker-save '$image'" EXIT
+    $srcdir/semaphore-cache dir-load node_modules_cache
 fi
 
 set -x
 ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+       --volume `pwd`/node_modules_cache:/source/node_modules:rw \
        ${ccarg:+"$ccarg"} $flags -- "$image" $cmd
+
+# cache node_modules on successful master builds
+if [ -d "${SEMAPHORE_CACHE_DIR:-}" -a -z "${PULL_REQUEST_NUMBER_XXXDISABLED:-}" ]; then
+    # HACK: the file:eslint-plugin-cockpit symlink must be created inside the
+    # container, otherwise npm install fails on EACCESS on the root-owned link
+    find node_modules_cache -type l -delete
+    $srcdir/semaphore-cache dir-save node_modules_cache
+fi
+
+rm -rf node_modules_cache

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,6 +1,8 @@
-#!/bin/sh -e
+#!/bin/sh
+set -eu
 
-top_srcdir=$(realpath -m "$0"/../../..)
+srcdir=$(realpath -m "$0"/..)
+top_srcdir=$(dirname $(dirname $srcdir))
 image=cockpit/unit-tests:latest
 flags=''
 cmd=''
@@ -11,7 +13,7 @@ while test $# -gt 0; do
     --podman) docker="podman";;
     CC=*) ccarg="--env=$1";;
     shell) flags=-it; cmd=/bin/bash;;
-    :*) image=cockpit/unit-tests"$1";;
+    :*) image=cockpit/unit-tests"${1:-}";;
     *) echo "Unknown option '$1'"; exit 1;;
   esac
   shift
@@ -22,6 +24,11 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
   exit 1
 fi
 
-set -ex
-exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+if [ -d "${SEMAPHORE_CACHE_DIR:-}" ]; then
+    $srcdir/semaphore-cache docker-load "$image"
+    trap "$srcdir/semaphore-cache docker-save '$image'" EXIT
+fi
+
+set -x
+${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
        ${ccarg:+"$ccarg"} $flags -- "$image" $cmd


### PR DESCRIPTION
Use docker save/load to cache the test image in `$SEMAPHORE_CACHE_DIR`
if that is set. Ensure to not needlessly re-save an already cached
current image.

Also make the script work with `set -u`.

Change the hashbang to bash so that we can use the `${var/x/y}`
substitution, which is a bashism.