### PR TITLE
build: Don't clobber an existing bots checkout

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -432,13 +432,7 @@ distcheck-hook::
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
 bots:
-	if [ ! -d bots ]; then \
-		git clone --depth=1 https://github.com/cockpit-project/bots.git; \
-	else \
-		cd bots && git fetch && git reset --hard origin/master; \
-        fi
-
-.PHONY: bots
+	[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git;
 
 include po/Makefile.am
 include pkg/Makefile.am

--- a/autogen.sh
+++ b/autogen.sh
@@ -105,11 +105,7 @@ if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
     fi
 fi
 
-if [ ! -d bots ]; then
-    git clone --depth=1 https://github.com/cockpit-project/bots.git
-else
-    cd bots && git fetch && git reset --hard origin/master
-fi
+[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git
 
 echo
 echo "Now type 'make' to compile $PKG_NAME."


### PR DESCRIPTION
Commit cea63000a was a thinko -- for our CI we *don't* want our test to
clobber a pre-existing bots/ checkout, as we often use this to run tests
against an updated image or to validate a changes to the bots project.

On developer machines, bots may also be a symlink to an actual bots
directory in development, so don't clobber that.