### PR TITLE
build: Support CI testing against a bots project PR

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -431,8 +431,11 @@ distcheck-hook::
 
 # checkout Cockpit's bots for standard test VM images and API to launch them
 # must be from master, as only that has current and existing images; but testvm.py API is stable
+# support CI testing against a bots change
 bots:
-	[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git;
+	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
+	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
+	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
 
 include po/Makefile.am
 include pkg/Makefile.am

--- a/autogen.sh
+++ b/autogen.sh
@@ -105,7 +105,7 @@ if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
     fi
 fi
 
-[ -d bots ] || git clone --depth=1 https://github.com/cockpit-project/bots.git
+make bots
 
 echo
 echo "Now type 'make' to compile $PKG_NAME."


### PR DESCRIPTION
 * If `$COCKPIT_BOTS_REF` is set, check out that bots version instead of
   master.

 * Use git cache in $XDG_CACHE_HOME if available. Our CI uses that to
   save downloads, and it does not get in the way for local developers.

 * Stop duplicating code in autogen.sh, just call `make bots`. The tree
   is configured at this point.

Ported from https://github.com/cockpit-project/starter-kit/pull/233