### PR TITLE
machines: Wait until all libvirt resources are loaded

### DIFF
--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -27,6 +27,7 @@ import { NetworkList } from "./components/networks/networkList.jsx";
 import LibvirtSlate from "./components/libvirtSlate.jsx";
 import { CreateVmAction } from "./components/create-vm-dialog/createVmDialog.jsx";
 import { AggregateStatusCards } from "./components/aggregateStatusCards.jsx";
+import { isObjectEmpty } from "./helpers.js";
 import { InlineNotification } from 'cockpit-components-inline-notification.jsx';
 
 var permission = cockpit.permission({ admin: true });
@@ -114,10 +115,15 @@ class App extends React.Component {
         const createVmAction = <CreateVmAction {...properties} mode='create' />;
         const importDiskAction = <CreateVmAction {...properties} mode='import' />;
         const vmActions = <div> {createVmAction} {importDiskAction} </div>;
+        const resources = [...storagePools, ...networks, ...nodeDevices, ...interfaces, ...vms];
+        const loadingResources = resources.some(resource => isObjectEmpty(resource));
 
         // Show libvirtSlate component if libvirtd is not running only to users that are allowed to start the service.
-        if (systemInfo.libvirtService.activeState !== 'running' && (this.state.allowed === undefined || this.state.allowed)) {
-            return (<LibvirtSlate libvirtService={systemInfo.libvirtService} dispatch={dispatch} />);
+        if ((systemInfo.libvirtService.activeState !== 'running' && (this.state.allowed === undefined || this.state.allowed)) ||
+            loadingResources) {
+            return (<LibvirtSlate libvirtService={systemInfo.libvirtService}
+                        loadingResources={loadingResources}
+                        dispatch={dispatch} />);
         }
 
         const pathVms = path.length == 0 || (path.length > 0 && path[0] == 'vms');

--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -65,6 +65,7 @@ class LibvirtSlate extends React.Component {
     render() {
         const activeState = this.props.libvirtService.activeState;
         const name = this.props.libvirtService.name;
+        const loadingResources = this.props.loadingResources;
         let message;
         let icon;
         let detail;
@@ -75,6 +76,9 @@ class LibvirtSlate extends React.Component {
             icon = (<span className="pficon-ok" />);
         } else if (name && activeState === 'unknown') { // name === 'unknown' first
             message = _("Connecting to Virtualization Service");
+            icon = (<div className="spinner spinner-lg" />);
+        } else if (loadingResources) {
+            message = _("Loading Resources");
             icon = (<div className="spinner spinner-lg" />);
         } else {
             message = _("Virtualization Service (libvirt) is Not Active");

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -131,6 +131,13 @@ export function isEmpty(str) {
     return (!str || str.length === 0);
 }
 
+export function isObjectEmpty(obj) {
+    if (!obj)
+        return false;
+
+    return Object.keys(obj).length === 0;
+}
+
 export function arrayEquals(arr1, arr2) {
     if (arr1.length !== arr2.length) {
         return false;

--- a/pkg/machines/index.js
+++ b/pkg/machines/index.js
@@ -62,14 +62,14 @@ function render() {
 }
 
 function renderApp() {
+    // initiate data retrieval
+    store.dispatch(initDataRetrieval());
+
     // re-render app every time the state changes
     store.subscribe(render);
 
     // do initial render
     render();
-
-    // initiate data retrieval
-    store.dispatch(initDataRetrieval());
 }
 
 /**

--- a/pkg/machines/reducers.js
+++ b/pkg/machines/reducers.js
@@ -18,7 +18,7 @@
  */
 import { combineReducers } from 'redux/dist/redux';
 import VMS_CONFIG from "./config.js";
-import { logDebug } from './helpers.js';
+import { logDebug, isObjectEmpty } from './helpers.js';
 import {
     ADD_UI_VM,
     DELETE_UI_VM,
@@ -105,9 +105,15 @@ function interfaces(state, action) {
     case UPDATE_ADD_INTERFACE: {
         const { iface } = action.payload;
 
+        if (isObjectEmpty(iface))
+            return [...state, iface]; // initialize iface to empty object
+
         const connectionName = iface.connectionName;
         const index = getFirstIndexOfResource(state, 'name', iface.name, connectionName);
         if (index < 0) { // add
+            const initObjIndex = state.findIndex(obj => isObjectEmpty(obj));
+            if (initObjIndex >= 0)
+                state.splice(initObjIndex, 1); // remove empty initial object
             return [...state, iface];
         }
 
@@ -131,14 +137,23 @@ function networks(state, action) {
     }
     case UPDATE_ADD_NETWORK: {
         const { network, updateOnly } = action.payload;
+
+        if (isObjectEmpty(network))
+            return [...state, network]; // initialize network to empty object
+
         const connectionName = network.connectionName;
         const index = network.id ? getFirstIndexOfResource(state, 'id', network.id, connectionName)
             : getFirstIndexOfResource(state, 'name', network.name, connectionName);
-        if (index < 0)
-            if (!updateOnly)
+        if (index < 0) {
+            if (!updateOnly) {
+                const initObjIndex = state.findIndex(obj => isObjectEmpty(obj));
+                if (initObjIndex >= 0)
+                    state.splice(initObjIndex, 1); // remove empty initial object
                 return [...state, network];
-            else
+            } else {
                 return state;
+            }
+        }
 
         const updatedNetwork = Object.assign({}, state[index], network);
         return replaceResource({ state, updatedResource: updatedNetwork, index });
@@ -154,9 +169,16 @@ function nodeDevices(state, action) {
     switch (action.type) {
     case UPDATE_ADD_NODE_DEVICE: {
         const { nodedev } = action.payload;
+
+        if (isObjectEmpty(nodedev))
+            return [...state, nodedev]; // initialize nodedev to empty object
+
         const connectionName = nodedev.connectionName;
         const index = getFirstIndexOfResource(state, 'name', nodedev.name, connectionName);
         if (index < 0) { // add
+            const initObjIndex = state.findIndex(obj => isObjectEmpty(obj));
+            if (initObjIndex >= 0)
+                state.splice(initObjIndex, 1); // remove empty initial object
             return [...state, nodedev];
         }
 
@@ -191,10 +213,16 @@ function vms(state, action) {
 
     switch (action.type) {
     case UPDATE_ADD_VM: {
+        if (isObjectEmpty(action.vm))
+            return [...state, action.vm]; // initialize vm to empty object
+
         const connectionName = action.vm.connectionName;
         const index = action.vm.id ? getFirstIndexOfResource(state, 'id', action.vm.id, connectionName)
             : getFirstIndexOfResource(state, 'name', action.vm.name, connectionName);
         if (index < 0) { // add
+            const initObjIndex = state.findIndex(obj => isObjectEmpty(obj));
+            if (initObjIndex >= 0)
+                state.splice(initObjIndex, 1); // remove empty initial object
             return [...state, action.vm];
         }
 
@@ -299,13 +327,22 @@ function storagePools(state, action) {
     }
     case UPDATE_ADD_STORAGE_POOL: {
         const { storagePool, updateOnly, } = action.payload;
+
+        if (isObjectEmpty(storagePool))
+            return [...state, storagePool]; // initialize pool to empty object
+
         const connectionName = storagePool.connectionName;
         const index = getFirstIndexOfResource(state, 'id', storagePool.id, connectionName);
-        if (index < 0)
-            if (!updateOnly)
+        if (index < 0) {
+            if (!updateOnly) {
+                const initObjIndex = state.findIndex(obj => isObjectEmpty(obj));
+                if (initObjIndex >= 0)
+                    state.splice(initObjIndex, 1); // remove empty initial object
                 return [...state, storagePool];
-            else
+            } else {
                 return state;
+            }
+        }
 
         const updatedStoragePool = Object.assign({}, state[index], storagePool);
         return replaceResource({ state, updatedResource: updatedStoragePool, index });


### PR DESCRIPTION
Should fix several race conditions in our tests.
Increasingly we began to encounter errors in our tests when not all libvirt resources (like storage pools, interfaces...) were loaded but our tests already tried to use them. This resulted in test failure.
Waiting for loading of libvirt resource does not take more than a few fractions of second (no matter number of resources or network speed).