### PR TITLE
tools: Introduce make-bots script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -433,9 +433,7 @@ distcheck-hook::
 # must be from master, as only that has current and existing images; but testvm.py API is stable
 # support CI testing against a bots change
 bots:
-	git clone --quiet --reference-if-able $${XDG_CACHE_HOME:-$$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
-	if [ -n "$$COCKPIT_BOTS_REF" ]; then git -C bots fetch --quiet --depth=1 origin "$$COCKPIT_BOTS_REF"; git -C bots checkout --quiet FETCH_HEAD; fi
-	@echo "checked out bots/ ref $$(git -C bots rev-parse HEAD)"
+	tools/make-bots
 
 include po/Makefile.am
 include pkg/Makefile.am

--- a/autogen.sh
+++ b/autogen.sh
@@ -76,6 +76,8 @@ if test -z "${NOCONFIGURE:-}"; then
     fi
 fi
 
+tools/make-bots
+
 if test -n "${NOCONFIGURE:-}"; then
     exit 0
 fi
@@ -104,8 +106,6 @@ if [ -z "${NOREDIRECTMAKEFILE:-}" ]; then
         ln -s "$srcdir/node_modules" "$olddir/node_modules"
     fi
 fi
-
-make bots
 
 echo
 echo "Now type 'make' to compile $PKG_NAME."

--- a/tools/make-bots
+++ b/tools/make-bots
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Prepare bots by creating ./bots directory
+# Specify $COCKPIT_BOTS_REF to checkout non-master branch
+
+set -e
+
+if [ ! -d bots ]; then
+    git clone --quiet --reference-if-able ${XDG_CACHE_HOME:-$HOME/.cache}/cockpit-project/bots https://github.com/cockpit-project/bots.git
+    if [ -n "$COCKPIT_BOTS_REF" ]; then
+        git -C bots fetch --quiet --depth=1 origin $COCKPIT_BOTS_REF
+        git -C bots checkout --quiet FETCH_HEAD
+    fi
+    echo "checked out bots/ ref $(git -C bots rev-parse HEAD)"
+else
+    echo "bots/ already exists, skipping"
+fi


### PR DESCRIPTION
Projects should be able to prepare bots on their own without running
`./configure` first. Therefore introduce this tool which can do exactly
that.