### PR TITLE
tests: Always prepare bots

### DIFF
--- a/test/run
+++ b/test/run
@@ -5,6 +5,8 @@
 
 set -eu
 
+tools/make-bots
+
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 case $TEST_SCENARIO in
     verify)


### PR DESCRIPTION
Image preparing needs bots to be present.
`tools/make-bots` does nothing when `bots/` exists.