### PR TITLE
storage: Improve composite actions

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -37,9 +37,22 @@ var hacks = { };
 if (cockpit.manifests.storage && cockpit.manifests.storage.hacks)
     hacks = cockpit.manifests.storage.hacks;
 
-var client = { };
+var client = {
+    busy: 0
+};
 
 cockpit.event_target(client);
+
+client.run = (func) => {
+    const prom = func();
+    if (prom) {
+        client.busy += 1;
+        return prom.finally(() => {
+            client.busy -= 1;
+            client.dispatchEvent("changed");
+        });
+    }
+};
 
 /* Metrics
  */

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -38,7 +38,7 @@ class StoragePage extends React.Component {
     constructor() {
         super();
         this.state = { inited: false, slow_init: false, path: cockpit.location.path };
-        this.on_client_changed = () => { this.setState({}) };
+        this.on_client_changed = () => { if (!this.props.client.busy) this.setState({}); };
         this.on_navigate = () => { this.setState({ path: cockpit.location.path }) };
     }
 
@@ -103,6 +103,18 @@ class StoragePage extends React.Component {
 function init() {
     ReactDOM.render(<StoragePage client={client} />, document.getElementById("storage"));
     document.body.style.display = "block";
+
+    window.addEventListener('beforeunload', event => {
+        if (client.busy) {
+            // Firefox requires this when the page is in an iframe
+            event.preventDefault();
+
+            // see "an almost cross-browser solution" at
+            // https://developer.mozilla.org/en-US/docs/Web/Events/beforeunload
+            event.returnValue = '';
+            return '';
+        }
+    });
 }
 
 document.addEventListener("DOMContentLoaded", init);

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -22,6 +22,7 @@ import { OverlayTrigger, Tooltip } from "patternfly-react";
 
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
+import client from "./client.js";
 
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 
@@ -93,7 +94,7 @@ function checked(callback) {
         // only consider primary mouse button
         if (!event || event.button !== 0)
             return;
-        var promise = callback();
+        var promise = client.run(callback);
         if (promise)
             promise.fail(function (error) {
                 dialog_open({


### PR DESCRIPTION
Some actions are composed of multiple actions and while they were
running, the page used to follow along flickeringly as well as it
could.

For example, resizing an encrypted filesystem in a logical volume does
a number individual resizes one after the other.  The intermediate
states are inconsistent, and Cockpit would warn about them briefly.

Now, we suspend page updates during all actions triggered by
StorageButtons and dialogs.  Also, we try to stop the user from
aborting the composite action by unloading the page.