### PR TITLE
package.json: Unpin eslint-plugin-react

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "7.14.3",
+    "eslint-plugin-react": "^7.15.1",
     "eslint-plugin-standard": "^4.0.1",
     "html-webpack-plugin": "^3.2.0",
     "htmlparser": "^1.7.7",


### PR DESCRIPTION
Regression from 7.15.0 was fixed.

Please feel free to review but don't merge. I need this PR for testing of some changes in bots. I'll self-land once I won't need it anymore.