### PR TITLE
machines: Fix 'disk used by:' showing when it's not used

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -227,7 +227,7 @@ const ChangeShareable = ({ idPrefix, vms, storagePool, volumeName, onValueChange
     const isVolumeUsed = getStorageVolumesUsage(vms, storagePool);
     const volume = storagePool.volumes.find(vol => vol.name === volumeName);
 
-    if (!isVolumeUsed[volumeName])
+    if (!isVolumeUsed[volumeName] || (isVolumeUsed[volumeName].length === 0))
         return null;
 
     const vmsUsing = isVolumeUsed[volumeName].join(', ') + '.';


### PR DESCRIPTION
Quick fix of bug introduced by me in https://github.com/cockpit-project/cockpit/pull/12314

How to reproduce:
Go to Vm -> Disks -> Add Disk -> Use Existing 
Choose any volume which is not used by any VM, text saying 'disk used by: .' is shown.