### PR TITLE
storage: Use TypeAheadSelect instead of our implementation of ComboBox

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -214,10 +214,11 @@
 import cockpit from "cockpit";
 
 import React from "react";
-import { OverlayTrigger, Tooltip } from "patternfly-react";
+import { OverlayTrigger, Tooltip, TypeAheadSelect } from "patternfly-react";
 
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { StatelessSelect, SelectEntry } from "cockpit-components-select.jsx";
+
 import { fmt_size, block_name, format_size_and_text } from "./utils.js";
 
 import "form-layout.less";
@@ -483,51 +484,6 @@ export const PassInput = (tag, title, options) => {
     };
 };
 
-class ComboboxElement extends React.Component {
-    constructor(props) {
-        super();
-        this.state = { open: false };
-    }
-
-    render() {
-        const { value, onChange, disabled, choices } = this.props;
-
-        const toggle_open = (event) => {
-            if (event.button === 0)
-                this.setState({ open: !this.state.open });
-        };
-
-        const set_from_menu = (event, text) => {
-            if (event.button === 0) {
-                this.setState({ open: false });
-                onChange(text);
-            }
-        };
-
-        return (
-            <div className="combobox-container">
-                <div className={"input-group" + (this.state.open ? " open" : "")}>
-                    <input className="combobox form-control" type="text"
-                       disabled={disabled} value={value}
-                           onChange={event => onChange(event.target.value)} />
-                    { choices.length > 0 && !disabled
-                        ? <>
-                            <span className="input-group-addon"
-                              onClick={toggle_open}>
-                                <span className="caret" />
-                            </span>
-                            <ul className="typeahead typeahead-long dropdown-menu">
-                                { choices.map(c => <li key={c}><a tabIndex="0" onClick={ev => set_from_menu(ev, c)}>{c}</a></li>) }
-                            </ul>
-                        </>
-                        : null
-                    }
-                </div>
-            </div>
-        );
-    }
-}
-
 export const ComboBox = (tag, title, options) => {
     return {
         tag: tag,
@@ -537,8 +493,30 @@ export const ComboBox = (tag, title, options) => {
 
         render: (val, change) =>
             <div data-field={tag} data-field-type="combobox">
-                <ComboboxElement value={val} choices={options.choices}
-                                 disabled={options.disabled} onChange={change} />
+                <TypeAheadSelect
+                    id="nfs-path-on-server"
+                    labelKey="path"
+                    placeholder=""
+                    paginate={false}
+                    onChange={value => change(value[0])}
+                    onInputChange={change}
+                    options={options.choices}
+                    disabled={options.disabled}
+                    onKeyDown={ev => { // Capture ESC event
+                        if (ev.keyCode == 27) {
+                            ev.persist();
+                            ev.nativeEvent.stopImmediatePropagation();
+                            ev.stopPropagation();
+                        }
+                    }}
+                    renderMenu={(results, menuProps) => {
+                        // Hide the menu when there are no results.
+                        if (!results.length) {
+                            return null;
+                        }
+                        return <TypeAheadSelect.TypeaheadMenu {...menuProps} labelKey='path' options={results} />;
+                    }}
+                />
             </div>
     };
 };

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -168,6 +168,7 @@ class TestStorage(StorageCase):
                 return len(choices) == 2 and "/home/foo" in choices and "/home/bar" in choices
             self.retry(None, check, None)
 
+        b.click('#dialog [data-field="remote"] input.rbt-input-main')
         wait_for_exports()
 
     def testNfsBusy(self):


### PR DESCRIPTION
While fixing rule in #12854, I got to this component about which the linter said is not accessible and was right - you can just navigate into the input, but you cannot access the button to open the dropdown (once you open it by mouse you can use tab to move through these items but still cannot use enter to select this items).

With this component I can access it by keyboard, use arrows to navigate though items, use enter to select these items... so it is very nicely accessible by keyboard.

It is PF3 component - we use it on two another places, so I think it is fine to use this version. Or @KKoukiou do you have some idea about this component in PF3 vs PF4?