### PR TITLE
test: Disable packagekit preloading in some more cases

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -23,6 +23,7 @@ import subprocess
 import atomiclib
 import parent
 from testlib import *
+from hacklib import *
 
 
 class DashBoardHelpers:
@@ -83,18 +84,12 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
     def setUp(self):
         super(TestBasicDashboard, self).setUp()
         atomiclib.overlay_dashboard(self.machine)
+        HACK_disable_problematic_preloads(self.machines["machine2"])
+        HACK_disable_problematic_preloads(self.machines["machine3"])
 
     def testBasic(self):
         b = self.browser
         m = self.machine
-
-        # HACK - There is something about page pre-loading that breaks
-        # the CDP of Chromium completely, so we avoid packagekit
-        # completely on machine2.
-        #
-        machine2 = self.machines["machine2"]
-        machine2.needs_writable_usr()
-        machine2.execute("rm -rf /usr/share/cockpit/packagekit")
 
         self.login_and_go("/dashboard")
 

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -24,6 +24,7 @@ import time
 import atomiclib
 import parent
 from testlib import *
+from hacklib import *
 
 
 def break_hostkey(m, address, filename=None):
@@ -140,6 +141,8 @@ class TestMultiMachineAdd(MachineCase):
         self.machine3 = self.machines['machine3']
         self.machine3.execute("hostnamectl set-hostname machine3")
         atomiclib.overlay_dashboard(self.machine)
+        HACK_disable_problematic_preloads(self.machine2)
+        HACK_disable_problematic_preloads(self.machine3)
 
     def testBasic(self):
         b = self.browser
@@ -231,6 +234,8 @@ class TestMultiMachine(MachineCase):
         self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")
         atomiclib.overlay_dashboard(self.machine)
+        HACK_disable_problematic_preloads(self.machine2)
+        HACK_disable_problematic_preloads(self.machines["machine3"])
 
     def checkDirectLogin(self, root='/'):
         b = self.browser

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -23,6 +23,7 @@ import subprocess
 import atomiclib
 import parent
 from testlib import *
+from hacklib import *
 
 
 def kill_user_admin(machine):
@@ -106,13 +107,7 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.execute(
             "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
         self.machine2.wait_execute()
-
-        # HACK - There is something about page pre-loading that breaks
-        # the CDP of Chromium completely, so we avoid packagekit
-        # completely on machine2.
-        #
-        self.machine2.needs_writable_usr()
-        self.machine2.execute("rm -rf /usr/share/cockpit/packagekit")
+        HACK_disable_problematic_preloads(self.machine2)
 
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -21,6 +21,7 @@ import time
 
 import parent
 from testlib import *
+from hacklib import *
 
 
 class TestShutdownRestart(MachineCase):
@@ -33,6 +34,7 @@ class TestShutdownRestart(MachineCase):
         MachineCase.setUp(self)
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machines['machine2'].execute("hostnamectl set-hostname machine2")
+        HACK_disable_problematic_preloads(self.machines['machine2'])
 
     def testNoAdminGroup(self):
         m = self.machine

--- a/test/verify/hacklib.py
+++ b/test/verify/hacklib.py
@@ -1,0 +1,27 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2017 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+
+def HACK_disable_problematic_preloads(machine):
+    # There is something about pre-loading the packagekit page that
+    # breaks the CDP of Chromium completely.  There need to be
+    # multiple machines on Cockpit's dashboard, and Cockpit needs to
+    # have been build with --enable-debug for this to actually
+    # trigger.  Thus, we only disable packagekit preloading on
+    # selected machines, and only for selected images.
+    if machine.image in ["fedora-30"]:
+        machine.write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')


### PR DESCRIPTION
Otherwise, the CDP protocol might just hang and cause the test run to
timeout globally.