### PR TITLE
build: Fix building of react-core-base.css

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -62,7 +62,7 @@ dist/base1/patternfly.min.css.map: dist/base1/patternfly.min.css
 # PatternFly 4 base.css: remove external font declarations, re-using the ones from our PatternFly 3 patternfly.min.css above for now
 # once that goes away, use the above seddery instead
 dist/base1/react-core-base.css:
-	$(AM_V_GEN) sed '/^@font-face/,/^$$/d' $< > $@.tmp && mv $@.tmp $@
+	$(AM_V_GEN) sed '/^@font-face/,/^$$/d' $(srcdir)/node_modules/@patternfly/react-core/dist/styles/base.css > $@.tmp && mv $@.tmp $@
 
 # PatternFly 3 with hacked CSS to look like PF4
 dist/base1/patternfly.css.map: dist/base1/patternfly-base.css


### PR DESCRIPTION
Commit 3e697de5ed got broken after updating it to not include the
original base.css as a rule dependency (which does not work in released
tarballs). Fix the input of sed to be the actual file instead of the now
non-existing rule dependency.