### PR TITLE
storage: Fix layout of StorageLink:s in content tabs

### DIFF
--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -134,7 +134,7 @@ export class StorageLink extends React.Component {
             <StorageControl excuse={this.props.excuse}
                             content={(excuse) => (
                                 <button onClick={checked(this.props.onClick)}
-                                        className={excuse ? " disabled link-button" : "link-button"}>
+                                        className={"link-button ct-form-relax" + (excuse ? " disabled" : "")}>
                                     {this.props.children}
                                 </button>
                             )} />


### PR DESCRIPTION
They always filled the whole row, which is wrong.  Te text was left
aligned, which made it look correct.  Now the text is centered, and it
also looks wrong.

Wrapping them all in a extra `<div>` seems to magically fix the layout.