### PR TITLE
lib: Give more space to cockpit-log-time columns

### DIFF
--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -104,7 +104,7 @@
 }
 
 .cockpit-log-time {
-    min-width: 6em;
+    min-width: 7em;
     font-family: monospace;
     display: inline-block;
     vertical-align: middle;


### PR DESCRIPTION
So that things like "12:01 PM" will fit without wrapping.

Before:
![image](https://user-images.githubusercontent.com/3228183/66557038-ef3ed580-eb59-11e9-9b3f-6d94c2cab296.png)

After:
![image](https://user-images.githubusercontent.com/3228183/66557237-36c56180-eb5a-11e9-95b2-0ee1fa4e4ca0.png)
