### PR TITLE
tests: CentOS can manage docker storage

### DIFF
--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -31,14 +31,8 @@ non_manageable_images = [
     "ubuntu-stable",
 ]
 
-rootfs_not_in_volume_group_images = [
-    "centos-7",
-]
-
-
 def can_manage(machine):
-    return (machine.image not in non_manageable_images and
-            machine.image not in rootfs_not_in_volume_group_images)
+    return (machine.image not in non_manageable_images)
 
 
 @skipImage("No cockpit-docker on i386", "fedora-i386")


### PR DESCRIPTION
This is part of https://github.com/cockpit-project/bots/pull/104 where it should fix 2 out of 3 failing tests.
`testNodeNavigation (check_openshift.TestOpenshift)` still needs fixing. I'll push it here once I find the solution (draft for now - I am opening it so I won't forget about it ;) )