### PR TITLE
"Autofocus" on "Verification Code / Conversation Input"

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -550,7 +550,6 @@
         if (prompt_data.default)
             ei.value = prompt_data.default;
         ei.setAttribute('type', type);
-        ei.focus();
 
         login_failure("");
 
@@ -571,6 +570,7 @@
         id("conversation-input").addEventListener("keydown", key_down);
         id("login-button").addEventListener("click", call_converse);
         show_form(true);
+        ei.focus();
     }
 
     function utf8(str) {


### PR DESCRIPTION
When using two factor authentication (Google Authenticator) I noticed that the verification code field wasn't focused although code existed to do that precisely. Tested in Chrome/Firefox in Windows and Debian, focus didn't work properly.

The issue is that the code to focus the element is executed before the element appears on screen, which from experience and testing proved to not work at all. I removed this line of code and placed one that focuses the element immediately after it appears. Tested to work in the same systems.