### PR TITLE
test: Make bigger screenhots

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -177,7 +177,7 @@ class CDP:
                 [exe, "--headless", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
                     "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
                     "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
-                    "--window-size=1280x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"],
+                    "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"],
                 env=environ, close_fds=True, preexec_fn=lambda: resource.setrlimit(resource.RLIMIT_CORE, (0, 0)))
             if self.verbose:
                 sys.stderr.write("Started %s (pid %i) on port %i\n" % (exe, self._browser.pid, cdp_port))


### PR DESCRIPTION
Otherwise the layout of the storage page (for exmaple) now goes to its
broken single column layout and we can't see the state of sidebar
panels.