### PR TITLE
test: Implement Firefox testing with CDP

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -14,8 +14,26 @@ import time
 TEST_DIR = os.path.normpath(os.path.dirname(os.path.realpath(os.path.join(__file__, ".."))))
 
 
-def browser_path():
-    """Return path to CDP browser.
+def browser_path(browser):
+    if browser == "chromium":
+        return browser_path_chromium()
+    elif browser == "firefox":
+        return browser_path_firefox()
+    else:
+        raise SystemError("Unsupported browser")
+
+
+def browser_path_firefox():
+    """ Return path to Firefox browser """
+    p = subprocess.check_output("which firefox || true",
+                                shell=True, universal_newlines=True).strip()
+    if p:
+        return p
+    return None
+
+
+def browser_path_chromium():
+    """Return path to chromium browser.
 
     Support the following locations:
      - /usr/lib*/chromium-browser/headless_shell (chromium-headless RPM)
@@ -52,6 +70,8 @@ class CDP:
         self.verbose = verbose
         self.trace = trace
         self.inject_helpers = inject_helpers
+        self.browser = os.environ.get("TEST_BROWSER", "chromium")
+        self.download_dir = tempfile.mkdtemp()
         self._driver = None
         self._browser = None
         self._browser_home = None
@@ -74,7 +94,7 @@ class CDP:
         # frame support for Runtime.evaluate(): map frame name to
         # executionContextId and insert into argument object; this must not be quoted
         # see "Frame tracking" in cdp-driver.js for how this works
-        if fn == 'Runtime.evaluate' and self.cur_frame:
+        if fn == 'Runtime.evaluate':
             cmd = "%s, contextId: getFrameExecId(%s)%s" % (cmd[:-2], jsquote(self.cur_frame), cmd[-2:])
 
         if trace:
@@ -137,9 +157,38 @@ class CDP:
 
     def get_browser_path(self):
         if self._browser_path is None:
-            self._browser_path = browser_path()
+            self._browser_path = browser_path(self.browser)
 
         return self._browser_path
+
+    def browser_cmd(self, cdp_port, env):
+        exe = self.get_browser_path()
+        if not exe:
+            raise SystemError(self.browser + " is not installed")
+
+        if self.browser == "chromium":
+            return [exe, "--headless", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
+                    "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
+                    "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
+                    "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"]
+        elif self.browser == "firefox":
+            subprocess.Popen(["firefox", "--headless", "--no-remote", "-CreateProfile", "blank"], env=env).communicate()
+            profile = glob.glob(os.path.join(self._browser_home, ".mozilla/firefox/*.blank"))[0]
+
+            with open(os.path.join(profile, "user.js"), "w") as f:
+                f.write("""
+                    user_pref("remote.enabled", true);
+                    user_pref("datareporting.policy.dataSubmissionEnabled", false);
+                    user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
+                    user_pref("dom.disable_beforeunload", true);
+                    user_pref("browser.download.dir", "{0}");
+                    user_pref("browser.download.folderList", 2);
+                    """.format(self.download_dir))
+
+            with open(os.path.join(profile, "handlers.json"), "w") as f:
+                f.write('{"defaultHandlersVersion":{"en-US":4},"mimeTypes":{"application/xz":{"action":0,"extensions":["xz"]}}}')
+
+            return [exe, "-P", "blank", "--headless", "--window-size=1920,1200", "--remote-debugging-port=%i" % cdp_port, "--no-remote", "localhost"]
 
     def start(self):
         environ = os.environ.copy()
@@ -168,19 +217,12 @@ class CDP:
             except KeyError:
                 pass
 
-            exe = self.get_browser_path()
-            if not exe:
-                raise SystemError("chromium not installed")
-
             # sandboxing does not work in Docker container
             self._browser = subprocess.Popen(
-                [exe, "--headless", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
-                    "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
-                    "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
-                    "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"],
-                env=environ, close_fds=True, preexec_fn=lambda: resource.setrlimit(resource.RLIMIT_CORE, (0, 0)))
+                self.browser_cmd(cdp_port, environ), env=environ, close_fds=True,
+                preexec_fn=lambda: resource.setrlimit(resource.RLIMIT_CORE, (0, 0)))
             if self.verbose:
-                sys.stderr.write("Started %s (pid %i) on port %i\n" % (exe, self._browser.pid, cdp_port))
+                sys.stderr.write("Started %s (pid %i) on port %i\n" % (self._browser_path, self._browser.pid, cdp_port))
 
         # wait for CDP to be up
         s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
@@ -197,7 +239,7 @@ class CDP:
         if self.trace:
             # enable frame/execution context debugging if tracing is on
             environ["TEST_CDP_DEBUG"] = "1"
-        self._driver = subprocess.Popen(["%s/chromium-cdp-driver.js" % os.path.dirname(__file__), str(cdp_port)],
+        self._driver = subprocess.Popen(["{0}/{1}-cdp-driver.js".format(os.path.dirname(__file__), self.browser), str(cdp_port)],
                                         env=environ,
                                         stdout=subprocess.PIPE,
                                         stdin=subprocess.PIPE,
@@ -209,6 +251,10 @@ class CDP:
                 src = f.read()
             # HACK: injecting sizzle fails on missing `document` in assert()
             src = src.replace('function assert( fn ) {', 'function assert( fn ) { return true;')
+            # HACK: sizzle tracks document and when we switch frames, it sees the old document
+            # although we execute it in different context.
+            if (self.browser == "firefox"):
+                src = src.replace('context = context || document;', 'context = context || window.document;')
             self.invoke("Page.addScriptToEvaluateOnNewDocument", source=src, no_trace=True)
 
     def kill(self):
@@ -218,6 +264,8 @@ class CDP:
             self._driver.stdin.close()
             self._driver.wait()
             self._driver = None
+
+        shutil.rmtree(self.download_dir, ignore_errors=True)
 
         if self._browser:
             if self.verbose:

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -167,8 +167,7 @@ function setupFrameTracking(client) {
     // map frame names to frame IDs; root frame has no name, no need to track that
     client.Page.frameNavigated(info => {
         debug("frameNavigated " + JSON.stringify(info));
-        if (info.frame.name)
-            frameNameToFrameId[info.frame.name] = info.frame.id;
+        frameNameToFrameId[info.frame.name || "cockpit1"] = info.frame.id;
 
         // were we waiting for this frame to be loaded?
         if (frameWaitPromiseResolve && frameWaitName === info.frame.name) {
@@ -208,6 +207,8 @@ function setupFrameTracking(client) {
 
 // helper functions for testlib.py which are too unwieldy to be poked in from Python
 function getFrameExecId(frame) {
+    if (frame === null)
+        frame = "cockpit1";
     var frameId = frameNameToFrameId[frame];
     if (!frameId)
         throw Error(`Frame ${frame} is unknown`);

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -1,0 +1,425 @@
+#!/usr/bin/env node
+
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* firefox-cdp-driver -- A command-line JSON input/output wrapper around
+ * chrome-remote-interface (Chrome Debug Protocol).
+ * See https://chromedevtools.github.io/devtools-protocol/
+ * This needs support for protocol version 1.3.
+ *
+ * Set $TEST_CDP_DEBUG environment variable to enable additional
+ * frame/execution context debugging.
+ */
+
+const CDP = require('chrome-remote-interface');
+
+var enable_debug = false;
+var the_client = null;
+var last_frame_name = "";
+
+function debug(msg) {
+    if (enable_debug)
+        process.stderr.write("CDP: " + msg + "\n");
+}
+
+/**
+ * Format response to the client
+ */
+
+function fatal() {
+    console.error.apply(console.error, arguments);
+    process.exit(1);
+}
+
+function fail(err) {
+    if (typeof err === 'undefined')
+        err = null;
+    process.stdout.write(JSON.stringify({"error": err}) + '\n');
+}
+
+function success(result) {
+    if (typeof result === 'undefined')
+        result = null;
+    process.stdout.write(JSON.stringify({"result": result}) + '\n');
+}
+
+/**
+ * Record console.*() calls and Log messages so that we can forward them to
+ * stderr and dump them on test failure
+ */
+var messages = [];
+var logPromiseResolver;
+var nReportedLogMessages = 0;
+var unhandledExceptions = [];
+
+function clearExceptions() {
+    unhandledExceptions.length = 0;
+    return Promise.resolve();
+}
+
+function setupLogging(client) {
+    client.Runtime.enable();
+
+    client.Runtime.consoleAPICalled(info => {
+        let msg = info.args.map(v => (v.value || "").toString()).join(" ");
+        messages.push([ info.type, msg ]);
+        process.stderr.write("> " + info.type + ": " + msg + "\n")
+
+        resolveLogPromise();
+    });
+
+    function processException(info) {
+        let details = info.exceptionDetails;
+        // don't log test timeouts, they already get handled
+        if (details.exception && details.exception.className === "PhWaitCondTimeout")
+            return;
+
+        process.stderr.write(details.description || JSON.stringify(details) + "\n");
+
+        unhandledExceptions.push(details.exception.message ||
+                                 details.exception.description ||
+                                 details.exception.value ||
+                                 JSON.stringify(details.exception));
+    }
+
+    client.Runtime.exceptionThrown(info => processException(info));
+
+    client.Log.enable();
+    client.Log.entryAdded(entry => {
+        // HACK: Firefox does not implement `Runtime.exceptionThrown` but logs it
+        // Lets parse it to have at least some basic check that code did not throw
+        // exception
+        if (entry.entry.stackTrace !== undefined &&
+            typeof entry.entry.text === "string" &&
+            entry.entry.text.indexOf("Error: ") !== -1) {
+            trace = entry.entry.text.split(": ", 1);
+            processException({exceptionDetails: {
+                exception: {
+                    className: trace[0],
+                    message: trace.length > 1 ? trace[1] : "",
+                    stacktrace: entry.entry.stackTrace,
+                    entry: entry.entry,
+                },
+            }
+            });
+        } else {
+            let msg = entry["entry"];
+            messages.push([ "cdp", msg ]);
+            /* Ignore authentication failure log lines that don't denote failures */
+            if (!(msg.url || "").endsWith("/login") || (msg.text || "").indexOf("401") === -1)
+                process.stderr.write("CDP: " + JSON.stringify(msg) + "\n");
+            resolveLogPromise();
+        }
+    });
+}
+
+/**
+ * Resolve the log promise created with waitLog().
+ */
+function resolveLogPromise() {
+    if (logPromiseResolver) {
+        logPromiseResolver(messages.slice(nReportedLogMessages));
+        nReportedLogMessages = messages.length;
+        logPromiseResolver = undefined;
+    }
+}
+
+/**
+ * Returns a promise that resolves when log messages are available. If there
+ * are already some unreported ones in the global messages variable, resolves
+ * immediately.
+ *
+ * Only one such promise can be active at a given time. Once the promise is
+ * resolved, this function can be called again to wait for further messages.
+ */
+function waitLog() {
+    console.assert(logPromiseResolver === undefined);
+
+    return new Promise((resolve, reject) => {
+        logPromiseResolver = resolve;
+
+        if (nReportedLogMessages < messages.length)
+            resolveLogPromise();
+    });
+}
+
+/**
+ * Frame tracking
+ *
+ * For tests to be able to select the current frame (by its name) and make
+ * subsequent queries apply to that, we need to track frame name → frameId →
+ * executionContextId. Frame and context IDs can even change through page
+ * operations (e. g. in systemd/logs.js when reporting a crash is complete),
+ * so we also need a helper function to explicitly wait for a particular frame
+ * to load. This is very laborious, see this issue for discussing improvements:
+ * https://github.com/ChromeDevTools/devtools-protocol/issues/72
+ */
+var frameNameToContextId = {};
+var scriptsOnNewContext = [];
+
+// set these to wait for a frame to be loaded
+var frameWaitName = null;
+var frameWaitPromiseResolve = null;
+// set this to wait for a page load
+var pageLoadPromise = null;
+var pageLoadResolve = null;
+var pageLoadReject = null;
+
+function setupFrameTracking(client) {
+    client.Page.enable();
+
+    client.Page.loadEventFired(() => {
+        if (pageLoadResolve) {
+            debug("loadEventFired (waited for)");
+            pageLoadResolve();
+            pageLoadResolve = null;
+            pageLoadReject = null;
+        } else {
+            debug("loadEventFired (no listener)");
+        }
+    });
+
+    // track execution contexts so that we can map between context and frame IDs
+    // Also since firefox does not send frames names in FrameNavigated, nor it does
+    // not send all frameNavigated, just read it from context
+    client.Runtime.executionContextCreated(info => {
+        debug("executionContextCreated " + JSON.stringify(info));
+        scriptsOnNewContext.forEach(s => {
+            client.Runtime.evaluate({expression: s, contextId:info.context.id});
+        });
+        client.Runtime.evaluate({expression: "window.name", contextId:info.context.id}).then(r => {
+            // HACK: window.name of the topmost/login window on first login is "",
+            // but when relogin or refresh it is "cockpit1"
+            const frame_name = r.result.value || "cockpit1";
+            frameNameToContextId[frame_name] = info.context.id;
+
+            // were we waiting for this frame to be loaded?
+            if (frameWaitPromiseResolve && frameWaitName === frame_name) {
+                frameWaitPromiseResolve();
+                frameWaitPromiseResolve = null;
+            }
+        });
+    });
+}
+
+// helper functions for testlib.py which are too unwieldy to be poked in from Python
+function getFrameExecId(frame) {
+    if (frame === null)
+        frame = "cockpit1";
+    // HACK: Remember the frame name that was last resolved in case it was unusable
+    // In that case we should try to resolve it a bit later - but we don't have the name anymore
+    last_frame_name = frame;
+    return frameNameToContextId[frame];
+}
+
+function expectLoad(timeout) {
+    var tm = setTimeout( () => pageLoadReject("timed out waiting for page load"), timeout);
+    pageLoadPromise.then( () => { clearTimeout(tm); pageLoadPromise = null; });
+    return pageLoadPromise;
+}
+
+function expectLoadFrame(name, timeout) {
+    return new Promise((resolve, reject) => {
+        let tm = setTimeout( () => reject("timed out waiting for frame load"), timeout );
+
+        // we can only have one Page.frameNavigated() handler, so let our handler above resolve this promise
+        frameWaitName = name;
+        new Promise((fwpResolve, fwpReject) => { frameWaitPromiseResolve = fwpResolve })
+            .then(() => {
+                // For the frame to be fully valid for queries, it also needs the corresponding
+                // executionContextCreated() signal. This might happen before or after frameNavigated(), so wait in case
+                // it happens afterwards.
+               function pollExecId() {
+                    if (frameNameToContextId[name]) {
+                        clearTimeout(tm);
+                        resolve();
+                    } else {
+                        setTimeout(pollExecId, 100);
+                    }
+                }
+                pollExecId();
+            });
+    });
+}
+
+/**
+ * Main input/process loop
+ *
+ * Read one line with a JS expression, eval() it, and respond with the result:
+ *    success <JSON formatted return value>
+ *    fail <JSON formatted error>
+ * EOF shuts down the client.
+ */
+process.stdin.setEncoding('utf8');
+
+if (process.env["TEST_CDP_DEBUG"])
+    enable_debug = true;
+
+options = { };
+if (process.argv.length >= 3) {
+    options.port = parseInt(process.argv[2]);
+    if (!options.port) {
+        process.stderr.write("Usage: firefox-cdp-driver.js [port]\n");
+        process.exit(1);
+    }
+}
+
+// HACK
+// `addScriptToEvaluateOnNewDocument` is not implemented in Firefox
+// thus save all scripts in array and on each new context just execute these
+// scripts in them
+function addScriptToEvaluateOnNewDocument(script) {
+    return new Promise((resolve, reject) => {
+        scriptsOnNewContext.push(script.source);
+        resolve();
+    });
+}
+
+// HACK
+// We cannot use 'Runtime.evaluate' when it return promise in Firefox because:
+// 1. https://chromedevtools.github.io/devtools-protocol/tot/Runtime#method-evaluate
+//  has `awaitPromise` but it is not implemented (so it return RemoteObject
+//  (https://chromedevtools.github.io/devtools-protocol/tot/Runtime#type-RemoteObject) with
+//  subtype=promise. We could use https://chromedevtools.github.io/devtools-protocol/tot/Runtime#method-awaitPromise
+//  but it is not implemented in Firefox. We can do this manually.
+function evaluate(cmd) {
+    return new Promise((resolve, reject) => {
+        const match_exp = cmd.expression.match(/ph_wait_cond[^=]*=>\s*([\s\S]*),\s*(\d*)/);
+        let stepTimer = null;
+        let tm = setTimeout( () => {
+                if (stepTimer)
+                    clearTimeout(stepTimer);
+                resolve({exceptionDetails: {
+                    exception: {
+                        type: "string",
+                        value: "timeout",
+                    }
+                }});
+            }, parseInt(match_exp[2]));
+        function step() {
+            let context = getFrameExecId(last_frame_name);
+            the_client.Runtime.evaluate({expression: match_exp[1], contextId: context}).then(r => {
+                if (r && r.result && r.result.value === true) {
+                    clearTimeout(tm);
+                    resolve(r);
+                } else {
+                    stepTimer = setTimeout(step, 100);
+                }
+            })
+            .catch(e => {
+                if (e.response.message.indexOf("Unable to find execution context with id")) {
+                    stepTimer = setTimeout(step, 100);
+                } else {
+                    resolve({exceptionDetails: {
+                        exception: {
+                            type: "string",
+                            value: "timeout",
+                        }
+                    }});
+                }
+            });
+        }
+        step();
+    });
+}
+
+// This should work on different targets (meaning tabs)
+// CDP takes {target:target} so we can pick target
+// Problem is that CDP.New() which creates new target works only for chrome/ium
+// But we should be able to use CPD.List to list all targets and then pick one
+// Firefox just gives them ascending numbers, so we can pick the one with highest number
+// and if we feel fancy we can check that url is `about:newtab`.
+// That still though does not create new tab - but we can just call `firefox about:blank`
+// from cdline and since firefox would open it in the same browser, it should work.
+// This would work just fine in CI (as there would be only one browser) but on our machines it may
+// pick a wrong window (no idea if they can be somehow distinguish and execute it in a specific
+// one). But I guess we can live with it (and it seems it picks the last opened window anyway,
+// so having your own browser running should not interfere)
+//
+// Just calling executable to open another tab in the same browser works also for chromium, so
+// should be fine
+CDP(options)
+    .then(client => {
+        the_client = client;
+        setupLogging(client);
+        setupFrameTracking(client);
+        // TODO: Security handling not yet supported in Firefox
+
+        let input_buf = '';
+        process.stdin
+            .on('data', chunk => {
+                input_buf += chunk;
+                while (true) {
+                    let i = input_buf.indexOf('\n');
+                    if (i < 0)
+                        break;
+                    let command = input_buf.slice(0, i);
+
+                    // initialize loadEventFired promise for every command except expectLoad() itself (as that
+                    // waits for a load event from the *previous* command); but if the previous command already
+                    // was an expectLoad(), reinitialize also, as there are sometimes two consecutive expectLoad()s
+                    if (!pageLoadPromise || !command.startsWith("expectLoad("))
+                        pageLoadPromise = new Promise((resolve, reject) => { pageLoadResolve = resolve; pageLoadReject = reject; });
+
+                    // HACKS: See description of related functions
+                    if (command.startsWith("client.Page.addScriptToEvaluateOnNewDocument"))
+                        command = command.substring(12);
+                    if (command.startsWith("client.Runtime.evaluate") && command.indexOf("ph_wait_cond") !== -1)
+                        command = command.substring(15);
+
+                    // run the command
+                    eval(command).then(reply => {
+                        // HACK: Runtime.evaluate has option returnByValue but Firefox does not
+                        // implement it and thus returns just RemoteObject of type 'array' with no
+                        // data. These data need to be gathered differently.
+                        if (reply && reply.result && reply.result.subtype === "array") {
+                            client.Runtime.getProperties({objectId: reply.result.objectId}).then(r => {
+                                if (unhandledExceptions.length === 0) {
+                                    success({result: {
+                                        type: "array",
+                                        // HACK: getProperties has two ways how to get only own
+                                        // properties, but neither is implemented in Firefox
+                                        value: r.result.filter(x => x.isOwn && x.configurable).map(x => x.value.value),
+                                        }
+                                    });
+                                } else {
+                                    let message = unhandledExceptions[0];
+                                    fail(message.split("\n")[0]);
+                                    clearExceptions();
+                                }
+                            });
+                        } else {
+                            if (unhandledExceptions.length === 0) {
+                                success(reply);
+                            } else {
+                                let message = unhandledExceptions[0];
+                                fail(message.split("\n")[0]);
+                                clearExceptions();
+                            }
+                        }
+                    }, fail);
+
+                    input_buf = input_buf.slice(i+1);
+                }
+
+            })
+           .on('end', () => { process.exit(0) });
+    })
+    .catch(fatal);

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -59,6 +59,7 @@ __all__ = (
     'Browser',
     'MachineCase',
     'skipImage',
+    'skipBrowser',
     'allowImage',
     'skipPackage',
     'enableAxe',
@@ -249,7 +250,14 @@ class Browser:
         self.wait_visible(selector + ':not([disabled])')
         self.call_js_func('ph_blur', selector)
 
+    # TODO: Unify them so we can have only one
     def key_press(self, keys, modifiers=0, use_ord=False):
+        if self.cdp.browser == "chromium":
+            self.key_press_chromium(keys, modifiers, use_ord)
+        else:
+            self.key_press_firefox(keys, modifiers, use_ord)
+
+    def key_press_chromium(self, keys, modifiers=0, use_ord=False):
         for key in keys:
             args = {"type": "keyDown", "modifiers": modifiers}
 
@@ -262,6 +270,27 @@ class Browser:
                 args["windowsVirtualKeyCode"] = ord(key.upper())
             else:
                 args["key"] = key
+
+            self.cdp.invoke("Input.dispatchKeyEvent", **args)
+            args["type"] = "keyUp"
+            self.cdp.invoke("Input.dispatchKeyEvent", **args)
+
+    def key_press_firefox(self, keys, modifiers=0, use_ord=False):
+        # https://github.com/GoogleChrome/puppeteer/blob/master/lib/USKeyboardLayout.js
+        keyMap = {
+            8: "Backspace",  # Backspace key
+            9: "Tab",        # Tab key
+            13: "Enter",     # Enter key
+            27: "Escape",    # Escape key
+            40: "ArrowDown", # Arrow key down
+            45: "Insert",    # Insert key
+        }
+        for key in keys:
+            args = {"type": "keyDown", "modifiers": modifiers}
+
+            args["key"] = key
+            if ord(key) < 32 or use_ord:
+                args["key"] = keyMap[ord(key)]
 
             self.cdp.invoke("Input.dispatchKeyEvent", **args)
             args["type"] = "keyUp"
@@ -571,14 +600,22 @@ class Browser:
             self.cdp.command("clearExceptions()")
 
             filename = "{0}-{1}.png".format(label or self.label, title)
-            ret = self.cdp.invoke("Page.captureScreenshot", no_trace=True)
-            if "data" in ret:
-                with open(filename, 'wb') as f:
-                    f.write(base64.standard_b64decode(ret["data"]))
-                attach(filename)
-                print("Wrote screenshot to " + filename)
-            else:
-                print("Screenshot not available")
+            if self.cdp.browser == "chromium":
+                ret = self.cdp.invoke("Page.captureScreenshot", no_trace=True)
+                ret = ""
+                if "data" in ret:
+                    with open(filename, 'wb') as f:
+                        f.write(base64.standard_b64decode(ret["data"]))
+                    attach(filename)
+                    print("Wrote screenshot to " + filename)
+                else:
+                    print("Screenshot not available")
+            elif self.cdp.browser == "firefox":
+                # API not yet supported
+                # https://bugzilla.mozilla.org/show_bug.cgi?id=1549466
+                # TODO: Possible workaround could be something like:
+                # Runtime.execute(':screenshot --file <path>)
+                pass
 
             filename = "{0}-{1}.html".format(label or self.label, title)
             html = self.cdp.invoke("Runtime.evaluate", expression="document.documentElement.outerHTML",
@@ -999,6 +1036,10 @@ class MachineCase(unittest.TestCase):
         # only run this on the default OS test, that's enough
         if os.getenv("TEST_OS") not in [None, testvm.TEST_OS_DEFAULT]:
             return
+        # HACK: We cannot test axe on Firefox since `axe.run()` returns promise
+        # and Firefox CDP cannot wait for it to resolve
+        if self.browser.cdp.browser == "firefox":
+            return
 
         report = self.browser.eval_js("axe.run()", no_trace=True)
 
@@ -1082,6 +1123,13 @@ some_failed = False
 
 def jsquote(str):
     return json.dumps(str)
+
+
+def skipBrowser(reason, *args):
+    browser = os.environ.get("TEST_BROWSER", "chromium")
+    if browser in args:
+        return unittest.skip("{0}: {1}".format(browser, reason))
+    return lambda func: func
 
 
 def skipImage(reason, *args):

--- a/test/run
+++ b/test/run
@@ -13,6 +13,10 @@ case $TEST_SCENARIO in
         test/image-prepare --verbose $TEST_OS
         test/verify/run-tests --jobs ${TEST_JOBS:-1}
         ;;
+    firefox)
+        test/image-prepare --verbose $TEST_OS
+        TEST_BROWSER=firefox test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        ;;
     selenium-*)
         test/image-prepare --verbose $TEST_OS
         test/selenium/run-tests --browser ${TEST_SCENARIO#*-}

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -33,6 +33,7 @@ class TestConnection(MachineCase):
         if "debian" in self.machine.image or "ubuntu" in self.machine.image:
             self.ws_executable = "/usr/lib/cockpit/cockpit-ws"
 
+    @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -287,6 +288,7 @@ class TestConnection(MachineCase):
         out = m.execute("curl --silent --show-error --head --unix /run/cockpit/wsinstance/https@new.sock http://dummy")
         self.assertIn("HTTP/1.1 200 OK", out)
 
+    @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testTls(self):
         m = self.machine
         b = self.browser
@@ -578,6 +580,7 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
     @skipImage("missing socat", "fedora-atomic")
     @skipImage("Added in PR #11813 and #12141", "rhel-8-1-distropkg")
+    @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -74,6 +74,7 @@ class DashBoardHelpers:
         b.wait_popdown('dashboard_setup_server_dialog')
 
 
+@skipBrowser("Firefox looses track of contexts", "firefox")
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     provision = {
         'machine1': {"address": "10.111.113.1/20"},

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -23,6 +23,7 @@ from testlib import *
 
 class TestEmbed(MachineCase):
 
+    @skipBrowser("Firefox does not fire executionContextCreated and also does not have valid context", "firefox")
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -150,6 +150,8 @@ class TestKeys(MachineCase):
         self.allow_journal_messages('Missing callback called fullpath = /home/user/.ssh/authorized_keys')
         self.allow_journal_messages('')
 
+    # Possible workaround - ssh as `admin` and just do `m.execute()`
+    @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
     def testPrivateKeys(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -420,10 +420,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         else:
             b.wait_not_visible("#safari-cert-help")
 
+    @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
     @skipImage("Starting on Atomic is weird", "fedora-atomic")
     def testFailingWebsocketSafari(self):
         self.testFailingWebsocket(safari=True, cacert=True)
 
+    @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
     @skipImage("Starting on Atomic is weird", "fedora-atomic")
     def testFailingWebsocketSafariNoCA(self):
         self.testFailingWebsocket(safari=True, cacert=False)

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -109,6 +109,8 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.wait_execute()
         HACK_disable_problematic_preloads(self.machine2)
 
+    # Possible workaround - ssh as `admin` and just do `m.execute()`
+    @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
     def testBasic(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -56,6 +56,9 @@ class TestMultiOS(MachineCase):
         atomiclib.overlay_dashboard(self.machine)
 
     def check_spawn(self, b, address):
+        # Firefox cannot do `cockpit.spawn` as it returns promise
+        if b.cdp.browser == "firefox":
+            return
         result = b.call_js_func("""(function(address) {
             return cockpit.spawn(['echo', 'hi'], { host: address });
         })""", address)

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -437,6 +437,7 @@ class TestKerberos(MachineCase):
         self.machine.execute(script=JOIN_SCRIPT % args, timeout=1800)
         self.machine.execute(script=WAIT_KRB_SCRIPT.format("admin"), timeout=300)
 
+    @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testNegotiate(self):
         self.allow_authorize_journal_messages()
         self.allow_hostkey_messages()

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -56,6 +56,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 class TestSelinux(MachineCase):
 
     @skipImage("No setroubleshoot", "debian-stable", "debian-testing", "fedora-atomic", "ubuntu-1804", "ubuntu-stable")
+    @skipBrowser("Firefox needs http to access clipboard", "firefox")
     def testTroubleshootAlerts(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -19,8 +19,6 @@
 
 import glob
 import os.path
-import shutil
-import tempfile
 import tarfile
 
 import parent
@@ -52,14 +50,13 @@ threads=2
             b.wait(lambda: b.eval_js('ph_find(".progress-bar").offsetWidth') > 0)
             b.wait_visible("#sos-download")
 
-        download_dir = tempfile.mkdtemp()
-        self.addCleanup(shutil.rmtree, download_dir)
-        b.cdp.invoke("Page.setDownloadBehavior", behavior="allow", downloadPath=download_dir)
+        if b.cdp.browser == "chromium":
+            b.cdp.invoke("Page.setDownloadBehavior", behavior="allow", downloadPath=b.cdp.download_dir)
 
         b.click("#sos-download button")
         # while the download is ongoing, it will have an *.xz.tmpsuffix name, gets renamed to *.xz when done
-        wait(lambda: len(glob.glob(os.path.join(download_dir, "sosreport-*.xz"))) > 0)
-        report = glob.glob(os.path.join(download_dir, "sosreport-*.xz"))[0]
+        wait(lambda: len(glob.glob(os.path.join(b.cdp.download_dir, "sosreport-*.xz"))) > 0)
+        report = glob.glob(os.path.join(b.cdp.download_dir, "sosreport-*.xz"))[0]
         # Check that /etc/release was saved. It the files does not exist, getmember raises KeyError
         with tarfile.open(report) as tar:
             tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -24,6 +24,7 @@ from testlib import *
 class TestTerminal(MachineCase):
     provision = {"machine1": {"dns": "127.0.0.1"}}
 
+    @skipBrowser("Firefox needs http to access clipboard", "firefox")
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -99,28 +100,31 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
             b.mouse(sel, "mousemove", 10 + width, 17)
             b.mouse(sel, "mouseup", 10 + width, 17)
 
-        b.grant_permissions("clipboardRead", "clipboardWrite")
+        # Firefox does not support setting of permissions
+        # and therefore we cannot test copy/paste with context menu
+        if b.cdp.browser != "firefox":
+            b.grant_permissions("clipboardRead", "clipboardWrite")
 
-        # Execute command
-        wait_line(n, prompt)
-        b.key_press('echo "XYZ"\r')
-        wait_line(n + 1, "XYZ")
+            # Execute command
+            wait_line(n, prompt)
+            b.key_press('echo "XYZ"\r')
+            wait_line(n + 1, "XYZ")
 
-        sel = line_sel(n + 1)
+            sel = line_sel(n + 1)
 
-        # Highlight 40px (3 letters, never wider that ~14px)
-        select_line(sel, 40)
+            # Highlight 40px (3 letters, never wider that ~14px)
+            select_line(sel, 40)
 
-        # Right click and pick copy
-        b.mouse(sel, "contextmenu", btn=2)
-        b.click('.contextMenu .contextMenuOption:first-child')
+            # Right click and pick copy
+            b.mouse(sel, "contextmenu", btn=2)
+            b.click('.contextMenu .contextMenuOption:first-child')
 
-        # Right click and pick paste
-        b.mouse(sel, "contextmenu", btn=2)
-        b.click('.contextMenu .contextMenuOption:nth-child(2)')
+            # Right click and pick paste
+            b.mouse(sel, "contextmenu", btn=2)
+            b.click('.contextMenu .contextMenuOption:nth-child(2)')
 
-        # Wait for text to show up
-        wait_line(n + 2, "XYZ")
+            # Wait for text to show up
+            wait_line(n + 2, "XYZ")
 
         # now reset terminal
         b.click('.btn:contains("Reset")')
@@ -133,6 +137,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         b.key_press('echo "foo"\r')
         wait_line(n + 1, "foo")
 
+        sel = line_sel(n + 1)
         # Highlight 40px (3 letters, never wider that ~14px)
         select_line(sel, 40)
 

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -55,12 +55,14 @@ def main():
     image = opts.image or testvm.DEFAULT_IMAGE
 
     revision = os.environ.get("TEST_REVISION")
+    test_browser = os.environ.get("TEST_BROWSER", "chromium")
     if not revision:
         revision = subprocess.check_output(["git", "rev-parse", "HEAD"],
                                            universal_newlines=True).strip()
 
     # Tell any subprocesses what we are testing
     os.environ["TEST_REVISION"] = revision
+    os.environ["TEST_BROWSER"] = test_browser
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image
 


### PR DESCRIPTION
Firefox CDP is only partially implemented and some major features are missing. Also `chrome-remote-interface` misses some features on Firefox. Therefore I've created new cdp-driver which contains some hacks and workarounds. Since it uses very small subset of cdp protocol, it could be used for chrome as well, but lets keep also the proper driver and hopefully one day we can use that one for all browsers.

How to run this: (see note below)
prerequisite: Firefox browser (tested with current F31 Firefox build `69.0.1-3`)

`TEST_BROWSER=firefox ./test/verify/check-pages TestPages.testBasic -vt`

TODO:
- [ ] Implement screenshots
- [ ] opening new tabs in Firefox (not needed for CI or for TEST_WITH_UI, but when connecting to running browser)
- [x] testBasic (check_dashboard.TestBasicDashboard)
- [x] testNoConnectionSettings (check_networking_settings.TestNetworking)

[1](https://209.132.184.41:8493/logs/pull-12971-20191029-135353-b0973c96-cockpit-project-cockpit--fedora-30-firefox/log.html#105-2) [2](https://209.132.184.41:8493/logs/pull-12971-20191105-091919-295c0d2c-cockpit-project-cockpit--fedora-30-firefox/log.html)