### PR TITLE
tests: Fedora testing does not support `Download an OS`

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1403,7 +1403,7 @@ class TestMachines(NetworkCase):
                                       {"Operating System": "You need to select the most closely matching Operating System"})
 
         # try to CREATE few machines
-        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30']:
+        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', 'fedora-testing']:
             self.browser.wait_not_present('select option[data-value="Download an OS"]')
         else:
             # Fake the osinfo-db data in order that it will allow spawn the installation - of course we don't expect it to succeed -


### PR DESCRIPTION
Since it is Fedora 30 with updates-testing repos.

Fixes https://github.com/cockpit-project/bots/pull/127