### PR TITLE
ws, bridge: Move AppStream metadata and polkit i18n from intltool to gettext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,6 @@ depcomp
 /src/ws/cockpit-tempfiles.conf
 src/common/cockpitassets.c
 src/common/cockpitassets.h
-/po/.intltool-merge-cache
 !/test-avocado
 /test-avocado/lib/var.env
 /test-avocado/lib/var.envc

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ addons:
     - git
     - glib-networking
     - gtk-doc-tools
-    - intltool
+    - gettext
     - libfontconfig1
     - libglib2.0-dev
     - libgudev-1.0-dev

--- a/configure.ac
+++ b/configure.ac
@@ -261,19 +261,6 @@ else
   AC_MSG_ERROR([no. Please install gettext tools])
 fi
 
-AC_PATH_PROG(INTLTOOL_EXTRACT, intltool-extract)
-AC_PATH_PROG(INTLTOOL_MERGE, intltool-merge)
-AC_PATH_PROG(INTLTOOL_UPDATE, intltool-update)
-AC_MSG_CHECKING(for intltool binaries)
-if test -x "$INTLTOOL_EXTRACT" -a -x "$INTLTOOL_MERGE" -a -x "$INTLTOOL_UPDATE"; then
-  AC_SUBST(INTLTOOL_EXTRACT)
-  AC_SUBST(INTLTOOL_MERGE)
-  AC_SUBST(INTLTOOL_UPDATE)
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_ERROR(no. Please install intltool package)
-fi
-
 # go
 
 AC_PATH_PROG([GOLANG], [go])

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -17,7 +17,7 @@ dependencies="\
     glib-networking \
     glib-networking-dbgsym\
     gtk-doc-tools \
-    intltool \
+    gettext \
     libc6-dbg \
     libfontconfig1 \
     libglib2.0-0-dbgsym \

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -49,6 +49,7 @@ uninstall-local::
 # General code packages to translate
 TRANSLATE = \
 	pkg/ \
+	src/bridge/ \
 	src/ws/ \
 	$(NULL)
 
@@ -65,10 +66,11 @@ po/POTFILES.js.in:
 po/POTFILES.manifest.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json.in' ) > $@
-po/POTFILES.pre.in: prepare-po
-	$(MKDIR_P) $(notdir $@)
-	( cd tmp/ && find . -type f ) > $@
-.PHONY: po/POTFILES.c.in po/POTFILES.html.in po/POTFILES.js.in po/POTFILES.manifest.in po/POTFILES.pre.in
+po/POTFILES.appstream.in:
+	( cd $(srcdir) && find $(TRANSLATE) -name '*.appdata.xml.in' ) > $@
+po/POTFILES.polkit.in:
+	( cd $(srcdir) && find $(TRANSLATE) -name '*.policy.in' ) > $@
+.PHONY: po/POTFILES.c.in po/POTFILES.html.in po/POTFILES.js.in po/POTFILES.manifest.in po/POTFILES.appstream.in po/POTFILES.polkit.in
 
 # Extract from GLib based C code files
 po/cockpit.c.pot: po/POTFILES.c.in
@@ -96,14 +98,14 @@ po/cockpit.js.pot: po/POTFILES.js.in
 po/cockpit.manifest.pot: po/POTFILES.manifest.in
 	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -f $^ -o $@
 
-# Extract pre-processed prepare-po data in tmp/
-po/cockpit.pre.pot: po/POTFILES.pre.in
-	$(XGETTEXT) --default-domain=cockpit --output=$@ \
-		--language=C --keyword=N_ \
-		--from-code=UTF-8 --directory=$(builddir)/tmp --files-from=$^
+po/cockpit.appstream.pot: po/POTFILES.appstream.in
+	$(XGETTEXT) --output=$@ --files-from=$^
+
+po/cockpit.polkit.pot: po/POTFILES.polkit.in
+	GETTEXTDATADIRS=$(srcdir)/po $(XGETTEXT) --output=$@ --files-from=$^
 
 # Combine the above pot files into one
-po/cockpit.pot: po/cockpit.c.pot po/cockpit.html.pot po/cockpit.js.pot po/cockpit.manifest.pot po/cockpit.pre.pot
+po/cockpit.pot: po/cockpit.c.pot po/cockpit.html.pot po/cockpit.js.pot po/cockpit.manifest.pot po/cockpit.appstream.pot po/cockpit.polkit.pot
 	$(MSGCAT) --sort-output --output-file=$@ $^
 
 # Actually update the old translations with new translatable text
@@ -146,4 +148,6 @@ EXTRA_DIST += \
 	po/po.empty.js \
 	po/po2json \
 	po/zanata.xml \
+	po/its/polkit.its \
+	po/its/polkit.loc \
 	$(NULL)

--- a/po/its/polkit.its
+++ b/po/its/polkit.its
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<its:rules xmlns:its="http://www.w3.org/2005/11/its"
+           version="2.0">
+  <its:translateRule selector="//*" translate="no"/>
+  <its:translateRule selector="//action/description |
+                               //action/message"
+                     translate="yes"/>
+</its:rules>

--- a/po/its/polkit.loc
+++ b/po/its/polkit.loc
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<locatingRules>
+  <locatingRule name="polkit policy" pattern="*.policy">
+    <documentRule localName="policyconfig" target="polkit.its"/>
+  </locatingRule>
+</locatingRules>

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -260,18 +260,11 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_in_files  = src/bridge/org.cockpit-project.cockpit-bridge.policy.in
 polkit_DATA = $(polkit_in_files:.policy.in=.policy)
 
-# gettext-domain= must only occur on C strings, not translated ones
 %.policy: %.policy.in $(PO_FILES)
-	$(AM_V_GEN) $(INTLTOOL_MERGE) -q -x $(top_srcdir)/po $< - | sed '/xml:lang=/ s/\ gettext-domain=".*"//' > $@
+	GETTEXTDATADIRS=$(srcdir)/po $(MSGFMT) --xml -d $(top_srcdir)/po --template $< --output $@
 
 EXTRA_DIST += $(polkit_in_files)
 CLEANFILES += $(polkit_DATA)
-
-prepare-po-bridge-policy: $(polkit_in_files)
-	cp $< .
-	$(AM_V_GEN) $(INTLTOOL_EXTRACT) -l --type=gettext/xml $(notdir $<)
-
-prepare-po:: prepare-po-bridge-policy
 
 # -----------------------------------------------------------------------------
 # PCP

--- a/src/bridge/org.cockpit-project.cockpit-bridge.policy.in
+++ b/src/bridge/org.cockpit-project.cockpit-bridge.policy.in
@@ -7,8 +7,8 @@
     <vendor_url>https://www.cockpit-project.org</vendor_url>
 
     <action id="org.cockpit-project.cockpit.root-bridge">
-        <_description gettext-domain="cockpit">Administration with Cockpit Web Console</_description>
-        <_message gettext-domain="cockpit">Authentication is required to perform privileged tasks with the Cockpit Web Console</_message>
+        <description gettext-domain="cockpit">Administration with Cockpit Web Console</description>
+        <message gettext-domain="cockpit">Authentication is required to perform privileged tasks with the Cockpit Web Console</message>
         <defaults>
             <allow_any>auth_admin</allow_any>
             <allow_inactive>auth_admin</allow_inactive>

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -239,7 +239,7 @@ nodist_appdata_DATA = src/ws/cockpit.appdata.xml
 appdata_in = src/ws/cockpit.appdata.xml.in
 
 $(nodist_appdata_DATA): $(appdata_in) $(PO_FILES)
-	$(AM_V_GEN) LC_ALL=C $(INTLTOOL_MERGE) -q -x -u $(top_srcdir)/po $< $@
+	$(AM_V_GEN) $(MSGFMT) --xml -d $(top_srcdir)/po --template $< --output $@
 
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = src/ws/cockpit.png
@@ -459,9 +459,3 @@ install-tests::
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
 	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
-
-prepare-po-appdata: $(appdata_in)
-	cp $< .
-	$(INTLTOOL_EXTRACT) -l --type=gettext/xml $(notdir $(appdata_in))
-
-prepare-po:: prepare-po-appdata

--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -5,27 +5,27 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>LGPL-2.0+</project_license>
   <name>Cockpit</name>
-  <_summary>Web Console for Linux servers</_summary>
+  <summary>Web Console for Linux servers</summary>
   <description>
-    <_p>
+    <p>
       Cockpit is a server manager that makes it easy to administer your Linux
       servers via a web browser.
       Jumping between the terminal and the web tool is no problem.
       A service started via Cockpit can be stopped via the terminal.
       Likewise, if an error occurs in the terminal, it can be seen in the
       Cockpit journal interface.
-    </_p>
-    <_p>
+    </p>
+    <p>
       Cockpit is perfect for new sysadmins, allowing them to easily perform
       simple tasks such as storage administration, inspecting journals and
       starting and stopping services.
       You can monitor and administer several servers at the same time.
       Just add them with a single click and your machines will look after its
       buddies.
-    </_p>
-    <_p>
+    </p>
+    <p>
       Once Cockpit is installed, enable it with "systemctl enable --now cockpit.socket".
-    </_p>
+    </p>
   </description>
   <categories>
     <category>System</category>

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -70,7 +70,7 @@ BuildRequires: pam-devel
 
 BuildRequires: autoconf automake
 BuildRequires: /usr/bin/python3
-BuildRequires: intltool
+BuildRequires: gettext >= 0.19.7
 %if %{defined build_dashboard}
 BuildRequires: libssh-devel >= 0.7.1
 %endif

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: debhelper (>= 10),
                dpkg-dev (>= 1.17.14),
-               intltool,
+               gettext (>= 0.19.7),
                libssh-dev,
                zlib1g-dev,
                libkrb5-dev (>= 1.11),


### PR DESCRIPTION
intltool has been deprecated for a while [1], in favor of gettext being
able to handle XML and other files natively.

Use xgettext/msgfmt for extracting/merging translations of our AppStream
metadata and polkit policy. Use W3C ITS [2] files instead of the
intltool-specific `<_tag>` format. gettext ships appstream ITS files by
default; copy the polkit ones from gettext 0.20 for now to avoid having
to build-depend on policykit-1 just for these on Debian/Ubuntu.

This avoids having to build intermediate files, copy the original files
around, and keep their format valid (without mutilated tags). It also
drops the intltool dependency. Add an explicity gettext build dependency
(which previously was transitive through intltool).

This also drops the post-processing seddery of the polkit file; msgfmt
does the right thing wrt. handling the `gettext-domain=` attribute.

[1] https://wiki.gnome.org/MigratingFromIntltoolToGettext
[2] https://www.w3.org/TR/its/#trans-datacat