### PR TITLE
branding: Cover login page with background image

### DIFF
--- a/doc/branding.md
+++ b/doc/branding.md
@@ -51,7 +51,7 @@ The branding.css file should override the following areas of the login screen:
     /* Background of the login prompt */
     body.login-pf {
         background: url("my-background-image.jpg");
-        background-size: auto;
+        background-size: cover;
     }
 
     /* Upper right logo of login screen */

--- a/src/branding/centos/branding.css
+++ b/src/branding/centos/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/debian/branding.css
+++ b/src/branding/debian/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/default/branding.css
+++ b/src/branding/default/branding.css
@@ -6,7 +6,7 @@
 
 body.login-pf {
     background: url("bg-login.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/fedora/branding.css
+++ b/src/branding/fedora/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/kubernetes/branding.css
+++ b/src/branding/kubernetes/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/registry/branding.css
+++ b/src/branding/registry/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/rhel/branding.css
+++ b/src/branding/rhel/branding.css
@@ -6,7 +6,7 @@
 
 body.login-pf {
     background: url("bg-login.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 

--- a/src/branding/scientific/branding.css
+++ b/src/branding/scientific/branding.css
@@ -1,5 +1,5 @@
 body.login-pf {
-    background-size: auto;
+    background-size: cover;
     background-color: #777777;
 }
 

--- a/src/branding/ubuntu/branding.css
+++ b/src/branding/ubuntu/branding.css
@@ -1,6 +1,6 @@
 body.login-pf {
     background: url("bg-plain.jpg") no-repeat 50% 0;
-    background-size: auto;
+    background-size: cover;
     background-color: #101010;
 }
 


### PR DESCRIPTION
Fixes #12984

@garrett @andreasn you know better what would be the right solution. I just picked the most obvious one - comments?
@iokaravas  can you verify it fixes your issue?

Before:
![smallold](https://user-images.githubusercontent.com/12330670/66841223-a926af00-ef69-11e9-862f-4e95672d83e6.png)
![bigold](https://user-images.githubusercontent.com/12330670/66841227-a926af00-ef69-11e9-8acf-204243fc3d04.png)
After:
![bignew](https://user-images.githubusercontent.com/12330670/66841229-a926af00-ef69-11e9-9e3a-ee1e082d7f13.png)
![smallnew](https://user-images.githubusercontent.com/12330670/66841230-a9bf4580-ef69-11e9-8bf4-f98f68dfe20d.png)
