### PR TITLE
Revert "tls: Change from epoll- to thread-based IO model"

### DIFF
--- a/src/tls/Makefile-tls.am
+++ b/src/tls/Makefile-tls.am
@@ -14,7 +14,6 @@ cockpit_tls_CFLAGS = 					\
 	$(COCKPIT_TLS_CFLAGS)				\
 	$(NULL)
 
-cockpit_tls_LDFLAGS = -pthread
 cockpit_tls_LDADD = 					\
 	libcockpit-common-nodeps.a			\
 	$(COCKPIT_TLS_LIBS)				\

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -17,708 +17,186 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifdef HAVE_CONFIG_H
-#include <config.h>
-#endif
-
 #include "connection.h"
 
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
-#include <netinet/in.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/epoll.h>
-#include <sys/param.h>
-#include <sys/poll.h>
-#include <sys/socket.h>
-#include <sys/timerfd.h>
-#include <sys/types.h>
-#include <sys/uio.h>
-#include <sys/un.h>
 #include <unistd.h>
+#include <sys/socket.h>
 
-#include <gnutls/gnutls.h>
-#include <gnutls/x509.h>
+#include "common/cockpitmemory.h"
 
-#include <common/cockpitwebcertificate.h>
 #include "utils.h"
 
-/* cockpit-tls TCP server state (singleton) */
-static struct {
-  gnutls_certificate_request_t request_mode;
-  gnutls_certificate_credentials_t x509_cred;
-  const char *wsinstance_sockdir;
-} parameters;
-
-typedef struct
+Connection *
+connection_new (int client_fd)
 {
-  char buffer[16u << 10]; /* 16KiB */
-  unsigned start, end;
-  bool eof, shut_rd, shut_wr;
-#ifdef DEBUG
-  const char *name;
-#endif
-} Buffer;
+  Connection *con;
 
-/* a single TCP connection between the client (browser) and cockpit-tls */
-typedef struct {
-  int client_fd;
-  int ws_fd;
+  con = callocx (1, sizeof (Connection));
+  con->client_fd = client_fd;
+  con->buf_client.connection = con;
+  con->buf_ws.connection = con;
+  con->ws_fd = -1;
 
-  gnutls_session_t tls;
-
-  Buffer client_to_ws_buffer;
-  Buffer ws_to_client_buffer;
-} Connection;
-
-#define BUFFER_SIZE (sizeof ((Buffer *) 0)->buffer)
-#define BUFFER_MASK (BUFFER_SIZE - 1)
-
-static_assert (!(BUFFER_SIZE & BUFFER_MASK), "buffer size not a power of 2");
-static_assert ((typeof (((Buffer *) 0)->start)) BUFFER_SIZE, "buffer is too big");
-
-static inline bool
-buffer_full (Buffer *self)
-{
-  return self->end - self->start == BUFFER_SIZE;
+  debug (CONNECTION, "new connection on fd %i", con->client_fd);
+  return con;
 }
 
-static inline bool
-buffer_empty (Buffer *self)
+void
+connection_set_tls_session (Connection *c, gnutls_session_t session)
 {
-  return self->end == self->start;
+  c->session = session;
+  c->is_tls = true;
 }
 
-static inline bool
-buffer_can_read (Buffer *self)
+void
+connection_free (Connection *c)
 {
-  return !self->shut_rd && !buffer_full (self);
-}
+  debug (CONNECTION, "freeing %s connection to client_fd %i ws_fd %i", c->is_tls ? "TLS" : "unencrypted", c->client_fd, c->ws_fd);
 
-static inline bool
-buffer_can_write (Buffer *self)
-{
-  return !self->shut_wr && !buffer_empty (self);
-}
+  /* do not wait for the peer to close the connection. */
+  if (c->is_tls)
+    gnutls_deinit (c->session);
 
-static inline bool
-buffer_needs_shut_rd (Buffer *self)
-{
-  return self->eof && !self->shut_rd;
-}
+  close (c->client_fd);
+  if (c->ws_fd)
+    close (c->ws_fd);
 
-static inline bool
-buffer_needs_shut_wr (Buffer *self)
-{
-  return self->eof && buffer_empty (self) && !self->shut_wr;
-}
-
-static inline bool
-buffer_alive (Buffer *self)
-{
-  return !self->shut_rd || !self->shut_wr;
-}
-
-static void
-buffer_shut_rd (Buffer *self)
-{
-  self->shut_rd = true;
-}
-
-static void
-buffer_shut_wr (Buffer *self)
-{
-  self->shut_wr = true;
-}
-
-static void
-buffer_eof (Buffer *self)
-{
-  self->eof = true;
-}
-
-static void
-buffer_epipe (Buffer *self)
-{
-  self->start = self->end;
-  self->eof = true;
-}
-
-static inline bool
-buffer_valid (Buffer *self)
-{
-  return self->end - self->start <= BUFFER_SIZE;
-}
-
-static short
-calculate_events (Buffer *reader,
-                  Buffer *writer)
-{
-  return buffer_can_read (reader) * POLLIN | buffer_can_write (writer) * POLLOUT;
-}
-
-static short
-calculate_revents (Buffer *reader,
-                   Buffer *writer)
-{
-  return buffer_needs_shut_rd (reader) * POLLIN | buffer_needs_shut_wr (writer) * POLLOUT;
-}
-
-static int
-get_iovecs (struct iovec *iov,
-            int           iov_length,
-            char         *buffer,
-            unsigned      start,
-            unsigned      end)
-{
-  int i = 0;
-
-  debug (IOVEC, "  get_iovecs (%p, %i, %p, 0x%x, 0x%x)", iov, iov_length, buffer, start, end);
-  assert (end - start >= 0);
-
-  for (i = 0; i < iov_length && start != end; i++)
-    {
-      unsigned start_offset = start & BUFFER_MASK;
-
-      iov[i].iov_base = &buffer[start_offset];
-      iov[i].iov_len = MIN(BUFFER_SIZE - start_offset, end - start);
-      start += iov[i].iov_len;
-
-      debug (IOVEC, "    iov[%i] = { 0x%zx, 0x%zx };  start = 0x%x;", i,
-             ((char *) iov[i].iov_base - buffer), iov[i].iov_len, start);
-    }
-
-  debug (IOVEC, "    return %i;", i);
-
-  return i;
-}
-
-static void
-buffer_write_to_fd (Buffer *self,
-                    int     fd)
-{
-  struct iovec iov[2];
-  ssize_t s;
-
-  debug (BUFFER, "buffer_write_to_fd (%s/0x%x/0x%x, %i)", self->name, self->start, self->end, fd);
-
-  struct msghdr msg = { .msg_iov = iov };
-  msg.msg_iovlen = get_iovecs (iov, 2, self->buffer, self->start, self->end);
-  if (msg.msg_iovlen)
-    {
-      do
-        s = sendmsg (fd, &msg, MSG_NOSIGNAL | MSG_DONTWAIT);
-      while (s == -1 && errno == EINTR);
-
-      debug (BUFFER, "  sendmsg returns %zi %s", s, (s == -1) ? strerror (errno) : "");
-
-      if (s == -1)
-        {
-          if (errno != EAGAIN)
-            /* Includes the expected case of EPIPE */
-            buffer_epipe (self);
-        }
-      else
-        self->start += s;
-    }
-
-  if (buffer_needs_shut_wr (self))
-    {
-      shutdown (fd, SHUT_WR);
-      buffer_shut_wr (self);
-    }
-
-  assert (buffer_valid (self));
-}
-
-static void
-buffer_read_from_fd (Buffer *self,
-                     int     fd)
-{
-  //debug ("buffer_read_from_fd (%s/0x%x/0x%x, %i)", self->name, self->start, self->end, fd);
-
-  if (buffer_needs_shut_rd (self))
-    {
-      shutdown (fd, SHUT_RD);
-      buffer_shut_rd (self);
-      return;
-    }
-
-  struct iovec iov[2];
-  ssize_t s;
-  int iovcnt = get_iovecs (iov, 2, self->buffer, self->end, self->start + BUFFER_SIZE);
-  assert (iovcnt > 0);
-
-  do
-    s = readv (fd, iov, iovcnt);
-  while (s == -1 && errno == EINTR);
-
-  //debug ("  readv returns %zi %s", s, (s == -1) ? strerror (errno) : "");
-
-  if (s == -1)
-    {
-      if (errno != EAGAIN)
-        buffer_eof (self);
-    }
-  else if (s == 0)
-    buffer_eof (self);
-  else
-    self->end += s;
-
-  assert (buffer_valid (self));
-}
-
-static void
-buffer_write_to_tls (Buffer           *self,
-                     gnutls_session_t  tls)
-{
-  struct iovec iov;
-  ssize_t s;
-
-  //debug ("buffer_write_to_tls (%s/0x%x/0x%x, %p)", self->name, self->start, self->end, tls);
-
-  if (get_iovecs (&iov, 1, self->buffer, self->start, self->end))
-    {
-      do
-        s = gnutls_record_send (tls, iov.iov_base, iov.iov_len);
-      while (s == -GNUTLS_E_INTERRUPTED);
-
-      //debug ("  gnutls_record_send returns %zi %s", s, (s < 0) ? gnutls_strerror (-s) : "");
-
-      if (s == -1)
-        {
-          if (s != -GNUTLS_E_AGAIN)
-            buffer_epipe (self);
-        }
-      else
-        self->start += s;
-    }
-
-  if (buffer_needs_shut_wr (self))
-    {
-      gnutls_bye (tls, GNUTLS_SHUT_WR);
-      buffer_shut_wr (self);
-    }
-
-  assert (buffer_valid (self));
-}
-
-static void
-buffer_read_from_tls (Buffer           *self,
-                      gnutls_session_t  tls)
-{
-  struct iovec iov;
-  ssize_t s;
-
-  //debug ("buffer_read_from_tls (%s/0x%x/0x%x, %p)", self->name, self->start, self->end, tls);
-
-  if (buffer_needs_shut_rd (self))
-    {
-      //gnutls_bye (tls, GNUTLS_SHUT_RD);
-      shutdown (gnutls_transport_get_int (tls), SHUT_RD);
-      buffer_shut_rd (self);
-      return;
-    }
-
-  int iovcnt = get_iovecs (&iov, 1, self->buffer, self->end, self->start + BUFFER_SIZE);
-  assert (iovcnt == 1);
-
-  do
-    s = gnutls_record_recv (tls, iov.iov_base, iov.iov_len);
-  while (s == -1 && errno == EINTR);
-
-  //debug ("  gnutls_record_recv returns %zi %s", s, (s < 0) ? gnutls_strerror (-s) : "");
-
-  if (s <= 0)
-    {
-      if (s != -GNUTLS_E_AGAIN)
-        buffer_epipe (self);
-    }
-  else
-    self->end += s;
-
-  assert (buffer_valid (self));
+  free (c);
 }
 
 /**
- * connection_init_ws: Connect to a cockpit-ws instance for a new Connection
+ * connection_read; Read a data block from source
+ *
+ * Buffer must be empty for this.
+ * Returns SUCCESS, CLOSED, FATAL, or RETRY.
  */
-static bool
-connection_init_ws (Connection *self)
+ConnectionResult
+connection_read (Connection *c, DataSource source)
 {
-  struct sockaddr_un sockaddr = { .sun_family = AF_UNIX };
-  const char *sockname;
   int r;
+  struct ConnectionBuffer *buf = source == CLIENT ? &c->buf_client : &c->buf_ws;
+  int fd = source == CLIENT ? c->client_fd : c->ws_fd;
 
-  if (parameters.x509_cred == NULL)
+  assert (buf->length == 0);
+  assert (buf->offset == 0);
+
+  if (c->is_tls && source == CLIENT)
     {
-      assert (!self->tls);
-      sockname = "http";
+      r = gnutls_record_recv (c->session, buf->data, sizeof (buf->data));
+      if (r == 0)
+        {
+          debug (CONNECTION, "client fd %i closed the TLS connection", fd);
+          do
+            {
+              r = gnutls_bye (c->session, GNUTLS_SHUT_WR);
+            } while (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED);
+          return CLOSED;
+        }
+      if (r < 0)
+        {
+          if (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED)
+            {
+              debug (CONNECTION, "reading from client fd %i TLS connection: %s; RETRY", fd, gnutls_strerror (r));
+              return RETRY;
+            }
+          warnx ("reading from client fd %i TLS connection failed: %s", fd, gnutls_strerror (r));
+          return FATAL;
+        }
+      debug (CONNECTION, "read %i bytes from client fd %i TLS connection", r, fd);
     }
   else
     {
-      if (self->tls)
-        sockname = "https";
-      else
-        sockname = "http-redirect";
+      r = recv (fd, buf->data, sizeof (buf->data), MSG_DONTWAIT);
+      if (r == 0)
+      {
+        debug (CONNECTION, "fd %i has closed the connection", fd);
+        return CLOSED;
+      }
+      if (r < 0)
+        {
+          if (errno == EAGAIN || errno == EINTR)
+            {
+              debug (CONNECTION, "reading from fd %i: %m; RETRY", fd);
+              return RETRY;
+            }
+          warn ("reading from fd %i failed", fd);
+          return FATAL;
+        }
+      debug (CONNECTION, "read %i bytes from fd %i", r, fd);
     }
 
-  r = snprintf (sockaddr.sun_path, sizeof sockaddr.sun_path,
-                "%s/%s.sock", parameters.wsinstance_sockdir,
-                sockname);
-  assert (r < sizeof sockaddr.sun_path);
-
-  debug (CONNECTION, "connection_init_ws: attempting to connect to socket %s", sockaddr.sun_path);
-
-  /* connect to ws instance */
-  self->ws_fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
-  if (self->ws_fd < 0)
-    {
-      warn ("failed to create cockpit-ws client socket");
-      return false;
-    }
-
-  if (connect (self->ws_fd, (struct sockaddr *) &sockaddr, sizeof sockaddr) < 0)
-    {
-      /* cockpit-ws crashed? */
-      warn ("failed to connect to cockpit-ws");
-      return false;
-    }
-
-  debug (CONNECTION, "  connected.");
-
-  return true;
+  buf->length = r;
+  return SUCCESS;
 }
 
 /**
- * connection_handshake: Handle first event on client fd
+ * connection_write: Write a previously read data block from source to the
+ * other peer
  *
- * Check the very first byte of a new connection to tell apart TLS from plain
- * HTTP. Initialize TLS and the ws instance.
+ * Buffer must be non-empty for this. This may do a partial write, in which
+ * case multiple calls are necessary.
+ * Returns SUCCESS, PARTIAL, FATAL, or RETRY.
  */
-static bool
-connection_handshake (Connection *self)
+ConnectionResult
+connection_write (Connection *c, DataSource source)
 {
-  char b;
-  int ret;
-
-  assert (self->ws_fd == -1);
-
-  /* Wait for up to 30 seconds to receive the first byte before shutting
-   * down the connection.
-   */
-  struct pollfd pfd = { .fd = self->client_fd, .events = POLLIN };
-  do
-    ret = poll (&pfd, 1, 30000); /* timeout is wrong on syscall restart, but it's fine */
-  while (ret == -1 && errno == EINTR);
-
-  if (ret < 0)
-    err (1, "poll() failed on client connection");
-
-  if (ret == 0)
-    {
-      debug (CONNECTION, "client sent no data in 30 seconds, dropping connection.");
-      return false;
-    }
-
-  /* peek the first byte and see if it's a TLS connection (starting with 22).
-     We can assume that there is some data to read, as this is called in response
-     to an epoll event. */
-  ret = recv (self->client_fd, &b, 1, MSG_PEEK);
-
-  if (ret < 0)
-    err (1, "failed to peek first byte");
-
-  if (ret == 0) /* EOF */
-    {
-      debug (CONNECTION, "client disconnected without sending any data");
-      return false;
-    }
-
-  if (b == 22)
-    {
-      debug (CONNECTION, "first byte is %i, initializing TLS", (int) b);
-
-      if (parameters.x509_cred == NULL)
-        {
-          warnx ("got TLS connection, but our server does not have a certificate/key; refusing");
-          return false;
-        }
-
-      ret = gnutls_init (&self->tls, GNUTLS_SERVER | MSG_NOSIGNAL);
-      if (ret != GNUTLS_E_SUCCESS)
-        {
-          warnx ("gnutls_init failed: %s", gnutls_strerror (ret));
-          return false;
-        }
-
-      ret = gnutls_set_default_priority (self->tls);
-      if (ret != GNUTLS_E_SUCCESS)
-        {
-          warnx ("gnutls_set_default_priority failed: %s", gnutls_strerror (ret));
-          return false;
-        }
-
-      ret = gnutls_credentials_set (self->tls, GNUTLS_CRD_CERTIFICATE, parameters.x509_cred);
-      if (ret != GNUTLS_E_SUCCESS)
-        {
-          warnx ("gnutls_credentials_set failed: %s", gnutls_strerror (ret));
-          return false;
-        }
-
-      gnutls_certificate_server_set_request (self->tls, parameters.request_mode);
-      gnutls_handshake_set_timeout (self->tls, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
-      gnutls_transport_set_int (self->tls, self->client_fd);
-
-      debug (CONNECTION, "TLS is initialised; doing handshake");
-
-      do
-        ret = gnutls_handshake (self->tls);
-      while (ret == GNUTLS_E_INTERRUPTED);
-
-      if (ret != GNUTLS_E_SUCCESS)
-        {
-          warnx ("gnutls_handshake failed: %s", gnutls_strerror (ret));
-          return false;
-        }
-
-      debug (CONNECTION, "TLS handshake completed");
-    }
-
-  return true;
-}
-
-static void
-connection_thread_loop (Connection *self)
-{
-  while (buffer_alive (&self->client_to_ws_buffer) || buffer_alive (&self->ws_to_client_buffer))
-    {
-      short client_events, ws_events;
-      short client_revents, ws_revents;
-      int n_ready;
-
-      client_events = calculate_events (&self->client_to_ws_buffer, &self->ws_to_client_buffer);
-      ws_events = calculate_events (&self->ws_to_client_buffer, &self->client_to_ws_buffer);
-      client_revents = calculate_revents (&self->client_to_ws_buffer, &self->ws_to_client_buffer);
-      ws_revents = calculate_revents (&self->ws_to_client_buffer, &self->client_to_ws_buffer);
-
-      if (self->tls && buffer_can_read (&self->client_to_ws_buffer))
-        client_revents |= POLLIN * gnutls_record_check_pending (self->tls);
-
-      debug (POLL, "poll | client %d/x%x/x%x | ws %d/x%x/x%x |",
-             self->client_fd, client_events, client_revents,
-             self->ws_fd, ws_events, ws_revents);
-
-      do
-        {
-          /* don't poll for no events, we'd spin in a POLLHUP loop otherwise */
-          struct pollfd fds[] = { { client_events ? self->client_fd : -1, client_events },
-                                  { ws_events ? self->ws_fd : -1, ws_events }};
-
-          n_ready = poll (fds, N_ELEMENTS (fds), (client_revents | ws_revents) ? 0 : -1);
-
-          client_revents |= fds[0].revents;
-          ws_revents |= fds[1].revents;
-        }
-      while (n_ready == -1 && errno == EINTR);
-
-      if (n_ready == -1)
-        {
-          if (errno == EINVAL) /* ran out of fds */
-            return;
-          err (1, "poll failed");
-        }
-
-      debug (POLL, "poll result %i | client %d/x%x | ws %d/x%x |", n_ready,
-             self->client_fd, client_revents, self->ws_fd, ws_revents);
-
-      if (self->tls)
-        {
-          if (client_revents & POLLIN)
-            buffer_read_from_tls (&self->client_to_ws_buffer, self->tls);
-
-          if (client_revents & POLLOUT)
-            buffer_write_to_tls (&self->ws_to_client_buffer, self->tls);
-        }
-      else
-        {
-          if (client_revents & POLLIN)
-            buffer_read_from_fd (&self->client_to_ws_buffer, self->client_fd);
-
-          if (client_revents & POLLOUT)
-            buffer_write_to_fd (&self->ws_to_client_buffer, self->client_fd);
-        }
-
-      if (ws_revents & POLLIN)
-        buffer_read_from_fd (&self->ws_to_client_buffer, self->ws_fd);
-
-      if (ws_revents & POLLOUT)
-        buffer_write_to_fd (&self->client_to_ws_buffer, self->ws_fd);
-    }
-}
-
-void
-connection_thread_main (int fd)
-{
-  Connection self = { .client_fd = fd, .ws_fd = -1 };
-
-  assert (!buffer_can_write (&self.client_to_ws_buffer));
-  assert (!buffer_can_write (&self.ws_to_client_buffer));
-  assert (!self.tls);
-
-#ifdef DEBUG
-  self.client_to_ws_buffer.name = "client-to-ws";
-  self.ws_to_client_buffer.name = "ws-to-client";
-#endif
-
-  debug (CONNECTION, "New thread for fd %i", fd);
-
-  if (connection_handshake (&self) && connection_init_ws (&self))
-    connection_thread_loop (&self);
-
-  debug (CONNECTION, "Thread for fd %i is going to exit now", fd);
-
-  if (self.tls)
-    /* XXX: bye? */
-    gnutls_deinit (self.tls);
-
-  if (self.client_fd != -1)
-    close (self.client_fd);
-
-  if (self.ws_fd != -1)
-    close (self.ws_fd);
-}
-
-/**
- * verify_peer_certificate: Custom client certificate validation function
- *
- * cockpit-tls ignores CA/trusted owner and leaves that to e. g. sssd. But
- * validate the other properties such as expiry, unsafe algorithms, etc.
- * This combination cannot be done with gnutls_session_set_verify_cert().
- */
-static int
-verify_peer_certificate (gnutls_session_t session)
-{
-  unsigned status;
-  int ret;
-
-  do
-    ret = gnutls_certificate_verify_peers2 (session, &status);
-  while (ret == GNUTLS_E_INTERRUPTED);
-
-  if (ret == 0)
-    {
-      /* ignore CA/trusted owner and leave that to e. g. sssd */
-      status &= ~(GNUTLS_CERT_INVALID | GNUTLS_CERT_SIGNER_NOT_FOUND | GNUTLS_CERT_SIGNER_NOT_CA);
-      if (status != 0)
-        {
-          gnutls_datum_t msg;
-          ret = gnutls_certificate_verification_status_print (status, gnutls_certificate_type_get (session), &msg, 0);
-          if (ret != GNUTLS_E_SUCCESS)
-            errx (1, "Failed to print verification status: %s", gnutls_strerror (ret));
-          warnx ("Invalid TLS peer certificate: %s", msg.data);
-          gnutls_free (msg.data);
-#ifdef GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR
-          return GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR;
-#else  /* fallback for GnuTLS < 3.4.4 */
-          return GNUTLS_E_CERTIFICATE_ERROR;
-#endif
-        }
-    }
-  else if (ret != GNUTLS_E_NO_CERTIFICATE_FOUND)
-    {
-      warnx ("Verifying TLS peer failed: %s", gnutls_strerror (ret));
-      return ret;
-    }
-
-  return GNUTLS_E_SUCCESS;
-}
-
-static int
-set_x509_key_from_combined_file (gnutls_certificate_credentials_t x509_cred,
-                                 const char *filename)
-{
-  gnutls_datum_t cert, key;
   int r;
+  ssize_t size;
+  struct ConnectionBuffer *buf = source == CLIENT ? &c->buf_client : &c->buf_ws;
+  /* write the buffer to the *other* peer */
+  int fd = source == CLIENT ? c->ws_fd : c->client_fd;
 
-  r = cockpit_certificate_parse (filename, (char**) &cert.data, (char**) &key.data);
-  if (r < 0)
-    errx (1,  "Invalid server certificate+key file %s: %s", filename, strerror (-r));
-  cert.size = strlen ((char*) cert.data);
-  key.size = strlen ((char*) key.data);
-  r = gnutls_certificate_set_x509_key_mem (parameters.x509_cred, &cert, &key, GNUTLS_X509_FMT_PEM);
-  free (cert.data);
-  free (key.data);
+  assert (buf->length > 0);
+  assert (buf->offset < buf->length);
+  size = buf->length - buf->offset;
 
-  return r;
-}
-
-/**
- * connection_crypto_init: Initialise TLS support
- *
- * This should be called after server_init() in order to enable TLS
- * support for connections. If this function is not called, the server
- * will only be able to handle http requests.
- *
- * @certfile: Server TLS certificate file; cannot be %NULL
- * @keyfile: Server TLS key file; if the key is merged into @certfile, set this
- *           to %NULL.
- * @request_mode: Whether to ask for client certificates
- */
-void
-connection_crypto_init (const char *certfile,
-                        const char *keyfile,
-                        gnutls_certificate_request_t request_mode)
-{
-  int ret;
-
-  assert (certfile != NULL);
-  assert (parameters.x509_cred == NULL);
-
-  ret = gnutls_certificate_allocate_credentials (&parameters.x509_cred);
-  if (ret != GNUTLS_E_SUCCESS)
-    errx (1, "gnutls_certificate_allocate_credentials failed: %s", gnutls_strerror (ret));
-
-  if (keyfile)
-    ret = gnutls_certificate_set_x509_key_file (parameters.x509_cred, certfile, keyfile, GNUTLS_X509_FMT_PEM);
-  else
-    ret = set_x509_key_from_combined_file (parameters.x509_cred, certfile);
-
-  if (ret != GNUTLS_E_SUCCESS)
-    errx (1, "Failed to initialize server certificate: %s", gnutls_strerror (ret));
-
-  gnutls_certificate_set_verify_function (parameters.x509_cred, verify_peer_certificate);
-
-#if GNUTLS_VERSION_NUMBER >= 0x030506 && GNUTLS_VERSION_NUMBER <= 0x030600
-  /* only available since GnuTLS 3.5.6, and deprecated in 3.6 */
-  gnutls_certificate_set_known_dh_params (parameters.x509_cred, GNUTLS_SEC_PARAM_MEDIUM);
-#endif
-
-  parameters.request_mode = request_mode;
-}
-
-void
-connection_set_wsinstance_sockdir (const char *wsinstance_sockdir)
-{
-  assert (parameters.wsinstance_sockdir == NULL);
-  assert (wsinstance_sockdir != NULL);
-
-  parameters.wsinstance_sockdir = wsinstance_sockdir;
-}
-
-void
-connection_cleanup (void)
-{
-  assert (parameters.wsinstance_sockdir != NULL);
-
-  parameters.wsinstance_sockdir = NULL;
-
-  if (parameters.x509_cred)
+  if (c->is_tls && source == WS)
     {
-      gnutls_certificate_free_credentials (parameters.x509_cred);
-      parameters.x509_cred = NULL;
+      r = gnutls_record_send (c->session, buf->data + buf->offset, size);
+      if (r == 0) /* Should Not Happen™, as data_size > 0 */
+        return FATAL;
+      if (r < 0)
+        {
+          if (r == GNUTLS_E_AGAIN || r == GNUTLS_E_INTERRUPTED)
+            {
+              debug (CONNECTION, "writing to client fd %i TLS connection: %s; RETRY", fd, gnutls_strerror (r));
+              return RETRY;
+            }
+          warnx ("writing to client fd %i TLS connection failed: %s", fd, gnutls_strerror (r));
+          return FATAL;
+        }
+
+      debug (CONNECTION, "wrote %i bytes out of %zi to TLS connection client fd %i", r, size, fd);
     }
+  else
+  {
+    r = send (fd, buf->data + buf->offset, size, 0);
+    if (r == 0) /* Should Not Happen™, as data_size > 0 */
+      return FATAL;
+    if (r < 0)
+      {
+        if (errno == EAGAIN || errno == EINTR)
+          {
+            debug (CONNECTION, "writing to fd %i: %m; RETRY", fd);
+            return RETRY;
+          }
+        warn ("writing to fd %i failed", fd);
+        return FATAL;
+      }
+    debug (CONNECTION, "wrote %i bytes out of %zi to fd %i", r, size, fd);
+  }
+
+  assert (r <= size);
+  buf->offset += r;
+  if (buf->offset < buf->length)
+    return PARTIAL;
+
+  /* all written, reset indexes */
+  buf->offset = buf->length = 0;
+  return SUCCESS;
 }

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -430,10 +430,7 @@ connection_handshake (Connection *self)
   ret = recv (self->client_fd, &b, 1, MSG_PEEK);
 
   if (ret < 0)
-    {
-      debug (CONNECTION, "could not read first byte: %s", strerror (errno));
-      return false;
-    }
+    err (1, "failed to peek first byte");
 
   if (ret == 0) /* EOF */
     {

--- a/src/tls/main.c
+++ b/src/tls/main.c
@@ -29,7 +29,6 @@
 #include <common/cockpitwebcertificate.h>
 #include "utils.h"
 #include "server.h"
-#include "connection.h"
 
 /* CLI arguments */
 struct arguments {
@@ -67,7 +66,7 @@ parse_opt (int key, char *arg, struct argp_state *state)
         arguments->port = arg_parse_int (arg, state, 1, UINT16_MAX, "Invalid port");
         break;
       case OPT_IDLE_TIMEOUT:
-        arguments->idle_timeout = arg_parse_int (arg, state, 0, INT_MAX, "Invalid idle timeout");
+        arguments->idle_timeout = arg_parse_int (arg, state, 0, (INT_MAX / 1000) - 1, "Invalid idle timeout") * 1000;
         break;
       default:
         return ARGP_ERR_UNKNOWN;
@@ -92,32 +91,29 @@ int
 main (int argc, char **argv)
 {
   struct arguments arguments;
+  char *error = NULL;
+  char *certfile = NULL;
 
   /* default option values */
   arguments.no_tls = false;
   arguments.port = 9090;
-  arguments.idle_timeout = 90;
+  arguments.idle_timeout = 90000;
 
   argp_parse (&argp, argc, argv, 0, 0, &arguments);
 
-  server_init ("/run/cockpit/wsinstance", arguments.idle_timeout, arguments.port);
-
   if (!arguments.no_tls)
     {
-      char *error = NULL;
-      char *certfile = cockpit_certificate_locate (&error);
-
+      certfile = cockpit_certificate_locate (&error);
       if (error)
         errx (1, "Could not locate server certificate: %s", error);
       debug (SERVER, "Using certificate %s", certfile);
-
-      /* TODO: Add cockpit.conf option to enable client-certificate auth, once we support that */
-      connection_crypto_init (certfile, NULL, GNUTLS_CERT_IGNORE);
-      free (certfile);
     }
 
-  server_run ();
-  server_cleanup ();
+  /* TODO: Add cockpit.conf option to enable client-certificate auth, once we support that */
+  server_init ("/run/cockpit/wsinstance", arguments.port, certfile, NULL, CERT_NONE);
+  free (certfile);
 
+  server_run (arguments.idle_timeout);
+  server_cleanup ();
   return 0;
 }

--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -24,40 +24,62 @@
 #include <config.h>
 #endif
 
-#include "server.h"
-
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
-#include <netinet/in.h>
-#include <pthread.h>
-#include <stdio.h>
+#include <signal.h>
 #include <stdlib.h>
-#include <sys/epoll.h>
-#include <sys/param.h>
-#include <sys/socket.h>
-#include <sys/timerfd.h>
-#include <sys/types.h>
-#include <sys/un.h>
 #include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/epoll.h>
+#include <sys/wait.h>
 
-#include "connection.h"
+#include <gnutls/gnutls.h>
+#include <gnutls/x509.h>
+
+#include <common/cockpitmemory.h>
+#include <common/cockpitwebcertificate.h>
 #include "utils.h"
+#include "connection.h"
+
+#include "server.h"
+
+#define MAX_LISTEN_FDS 10
 
 /* cockpit-tls TCP server state (singleton) */
 static struct {
-  /* only used from main thread */
   bool initialized;
-  int first_listener;
-  int last_listener;
+  const char *ws_path;
+  enum ClientCertMode client_cert_mode;
+  int listen_fds[MAX_LISTEN_FDS];
+  gnutls_certificate_credentials_t x509_cred;
+  gnutls_priority_t priority_cache;
+  Connection *connections;
   int epollfd;
-
-  /* rw, protected by mutex */
-  pthread_mutex_t connection_mutex;
-  unsigned int connection_count;
-  int idle_timerfd;
-  struct itimerspec idle_timeout;
 } server;
+
+/***********************************
+ *
+ * Helper functions
+ *
+ ***********************************/
+
+#define RETRY(rval, cmd) \
+        do { \
+                rval = cmd; \
+        } while(rval < 0  && errno == EINTR)
+#define TLS_RETRY(rval, cmd) \
+        do { \
+                rval = cmd; \
+        } while(rval == GNUTLS_E_INTERRUPTED)
+#define TLS_RETRY_BLOCK(rval, cmd) \
+        do { \
+                rval = cmd; \
+        } while(rval == GNUTLS_E_AGAIN || rval == GNUTLS_E_INTERRUPTED)
 
 /**
  * check_sd_listen_pid: Verify that systemd-activated socket is for us
@@ -89,31 +111,98 @@ check_sd_listen_pid (void)
   return true;
 }
 
-static void *
-server_connection_thread_start_routine (void *data)
+/**
+ * remove_connection: stop tracking and clean up connection(s)
+ *
+ * Remove all #Connections which either have the given @fd (client or ws), or
+ * the given #WsInstance. This happens when encountering EOF or SIGCHLD.
+ *
+ * @fd: file descriptor from client (browser) or ws connection, or ≤ 0 for "unspecified"
+ * @ws: If given, all connections related to this #WsInstance get removed
+ */
+static void
+remove_connection (int fd)
 {
-  int fd = (uintptr_t) data;
+  Connection *c, *cprev;
+  bool found = false;
 
-  connection_thread_main (fd);
+  for (c = server.connections, cprev = NULL; c; )
+    {
+      Connection *cnext = c->next;
 
-  /* teardown */
-  {
-    pthread_mutex_lock (&server.connection_mutex);
+      if (fd > 0 && (c->client_fd == fd || c->ws_fd == fd))
+        {
+          /* stop polling it */
+          if (epoll_ctl (server.epollfd, EPOLL_CTL_DEL, c->client_fd, NULL) < 0)
+            err (1, "Failed to remove epoll connection fd");
+          if (c->ws_fd != -1)
+            {
+              if (epoll_ctl (server.epollfd, EPOLL_CTL_DEL, c->ws_fd, NULL) < 0)
+                err (1, "Failed to remove epoll connection ws fd");
+            }
 
-    server.connection_count--;
+          /* remove connection from our list */
+          if (cprev == NULL) /* first connection */
+            server.connections = c->next;
+          else
+            cprev->next = c->next;
 
-    debug (CONNECTION, "Server.connection_count decreased to %i", server.connection_count);
+          connection_free (c);
+          found = true;
+        }
+      else
+        cprev = c;
 
-    if (server.connection_count == 0 && server.idle_timerfd != -1)
-      {
-        debug (CONNECTION, "  -> setting idle timeout");
-        timerfd_settime (server.idle_timerfd, 0, &server.idle_timeout, NULL);
-      }
+      c = cnext;
+    }
 
-    pthread_mutex_unlock (&server.connection_mutex);
-  }
+  if (!found)
+    debug (CONNECTION, "remove_connection: fd %i not found in connections", fd);
+}
 
-  return NULL;
+/**
+ * connection_init_ws: Find or launch a cockpit-ws instance for a new Connection
+ *
+ * Find the responsible cockpit-ws instance for a new server connection, i. e.
+ * by connection type (https/http) and client-side certificate. If none exists,
+ * create one. Set server.wss or server.ws_notls.
+ */
+static void
+connection_init_ws (Connection *c)
+{
+  int fd;
+  struct epoll_event ev = { .events = EPOLLIN };
+  struct sockaddr_un sockaddr = { .sun_family = AF_UNIX };
+  const char *sockname;
+  int r;
+
+  if (c->is_tls)
+    sockname = "https";
+  else
+    sockname = server.x509_cred ? "http-redirect" : "http";
+
+  r = snprintf (sockaddr.sun_path, sizeof sockaddr.sun_path, "%s/%s.sock", server.ws_path, sockname);
+  assert (r < sizeof sockaddr.sun_path);
+
+  debug (CONNECTION, "connection_init_ws: assigned ws %s", sockaddr.sun_path);
+
+  /* connect to ws instance */
+  fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
+  if (fd < 0)
+    err (1, "failed to create cockpit-ws client socket");
+  if (connect (fd, (struct sockaddr *) &sockaddr, sizeof sockaddr) < 0)
+    {
+      /* cockpit-ws crashed? */
+      warn ("failed to connect to cockpit-ws");
+      return;
+    }
+
+  /* epoll the fd */
+  ev.data.ptr = &c->buf_ws;
+  if (epoll_ctl (server.epollfd, EPOLL_CTL_ADD, fd, &ev) < 0)
+    err (1, "Failed to epoll cockpit-ws client fd");
+
+  c->ws_fd = fd;
 }
 
 /**
@@ -125,10 +214,10 @@ static void
 handle_accept (int listen_fd)
 {
   int fd;
-  pthread_attr_t attr;
-  pthread_t thread;
+  Connection *con;
+  struct epoll_event ev = { .events = EPOLLIN };
 
-  debug (CONNECTION, "epoll_wait event on server listen fd %i", listen_fd);
+  debug (SERVER, "epoll_wait event on server listen fd %i", listen_fd);
 
   /* accept and create new connection */
   fd = accept4 (listen_fd, NULL, NULL, SOCK_CLOEXEC);
@@ -138,41 +227,181 @@ handle_accept (int listen_fd)
         warn ("failed to accept connection");
       return;
     }
+  con = connection_new (fd);
 
-  debug (CONNECTION, "New connection accepted, fd %i", fd);
+  /* epoll the connection fd */
+  ev.data.ptr = &con->buf_client;
+  if (epoll_ctl (server.epollfd, EPOLL_CTL_ADD, fd, &ev) < 0)
+    err (1, "Failed to epoll connection fd");
 
-  {
-    pthread_mutex_lock (&server.connection_mutex);
+  /* add to our Connections list */
+  con->next = server.connections;
+  server.connections = con;
+}
 
-    if (server.connection_count == 0 && server.idle_timerfd != -1)
-      {
-        const struct itimerspec zero = { { 0 }, };
-        debug (CONNECTION, "  -> clearing idle timeout.");
-        timerfd_settime (server.idle_timerfd, 0, &zero, NULL);
-      }
+/**
+ * verify_peer_certificate: Custom client certificate validation function
+ *
+ * cockpit-tls ignores CA/trusted owner and leaves that to e. g. sssd. But
+ * validate the other properties such as expiry, unsafe algorithms, etc.
+ * This combination cannot be done with gnutls_session_set_verify_cert().
+ */
+static int
+verify_peer_certificate (gnutls_session_t session)
+{
+  int ret;
+  unsigned status;
 
-    server.connection_count++;
-
-    debug (CONNECTION, "  -> server.connection_count is now %i", server.connection_count);
-
-    pthread_mutex_unlock (&server.connection_mutex);
-  }
-
-  pthread_attr_init (&attr);
-  pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
-
-  int r = pthread_create (&thread, &attr,
-                          server_connection_thread_start_routine,
-                          (void *) (uintptr_t) fd);
-
-  if (r != 0)
+  TLS_RETRY_BLOCK (ret, gnutls_certificate_verify_peers2 (session, &status));
+  if (ret >= 0)
     {
-      errno = r;
-      warn ("pthread_create() failed.  dropping connection");
-      close (fd);
+      /* ignore CA/trusted owner and leave that to e. g. sssd */
+      status &= ~(GNUTLS_CERT_INVALID | GNUTLS_CERT_SIGNER_NOT_FOUND | GNUTLS_CERT_SIGNER_NOT_CA);
+      if (status != 0)
+        {
+          gnutls_datum_t msg;
+          ret = gnutls_certificate_verification_status_print (status, gnutls_certificate_type_get (session), &msg, 0);
+          if (ret != GNUTLS_E_SUCCESS)
+            errx (1, "Failed to print verification status: %s", gnutls_strerror (ret));
+          warnx ("Invalid TLS peer certificate: %s", msg.data);
+          gnutls_free (msg.data);
+#ifdef GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR
+          return GNUTLS_E_CERTIFICATE_VERIFICATION_ERROR;
+#else  /* fallback for GnuTLS < 3.4.4 */
+          return GNUTLS_E_CERTIFICATE_ERROR;
+#endif
+        }
+    }
+  else if (ret != GNUTLS_E_NO_CERTIFICATE_FOUND)
+    {
+      warnx ("Verifying TLS peer failed: %s", gnutls_strerror (ret));
+      return ret;
     }
 
-  pthread_attr_destroy (&attr);
+  return GNUTLS_E_SUCCESS;
+}
+
+/**
+ * handle_connection_data_first: Handle first event on client fd
+ *
+ * Check the very first byte of a new connection to tell apart TLS from plain
+ * HTTP. Initialize TLS and the ws instance.
+ */
+static void
+handle_connection_data_first (Connection *con)
+{
+  char b;
+  int ret;
+
+  assert (con->ws_fd == -1);
+
+  /* peek the first byte and see if it's a TLS connection (starting with 22).
+     We can assume that there is some data to read, as this is called in response
+     to an epoll event. */
+  ret = recv (con->client_fd, &b, 1, MSG_PEEK);
+  if (ret < 0)
+    err (1, "failed to peek first byte");
+  if (ret == 0) /* EOF */
+    {
+      debug (CONNECTION, "client disconnected without sending any data");
+      remove_connection (con->client_fd);
+      return;
+    }
+
+  if (b == 22)
+    {
+      gnutls_session_t session;
+
+      debug (CONNECTION, "first byte is %i, initializing TLS", (int) b);
+
+      if (!server.x509_cred)
+        {
+          warnx ("got TLS connection, but our server does not have a certificate/key; refusing");
+          remove_connection (con->client_fd);
+          return;
+        }
+
+      gnutls_check (gnutls_init (&session, GNUTLS_SERVER));
+      gnutls_check (gnutls_priority_set (session, server.priority_cache));
+      gnutls_check (gnutls_credentials_set (session, GNUTLS_CRD_CERTIFICATE, server.x509_cred));
+
+      gnutls_certificate_server_set_request (
+          session,
+          (server.client_cert_mode == CERT_REQUEST) ? GNUTLS_CERT_REQUEST : GNUTLS_CERT_IGNORE);
+      gnutls_certificate_set_verify_function (server.x509_cred, verify_peer_certificate);
+      gnutls_handshake_set_timeout (session, GNUTLS_DEFAULT_HANDSHAKE_TIMEOUT);
+
+      gnutls_transport_set_int (session, con->client_fd);
+
+      connection_set_tls_session (con, session);
+
+      TLS_RETRY_BLOCK (ret, gnutls_handshake (session));
+      if (ret < 0)
+        {
+          warnx ("TLS handshake failed: %s", gnutls_strerror (ret));
+          remove_connection (con->client_fd);
+          return;
+        }
+
+      debug (CONNECTION, "TLS handshake completed");
+    }
+
+  connection_init_ws (con);
+  if (con->ws_fd == -1)
+    remove_connection (con->client_fd);
+}
+
+/**
+ * handle_connection_data: Handle event on client or ws fd
+ *
+ * We want to avoid any interpretation of data to avoid vulnerabilities, so for
+ * the most part this just means shovelling data between the client and ws. The
+ * only exception is the very first byte of a new connection, to tell apart TLS
+ * from plain HTTP (handled by handle_connection_data_first).
+ */
+static void
+handle_connection_data (struct ConnectionBuffer *buf)
+{
+  Connection *con = buf->connection;
+  DataSource src = buf == &con->buf_client ? CLIENT : WS;
+  ConnectionResult r;
+
+  assert (con);
+  debug (CONNECTION, "%s connection fd %i has data from %s",
+         con->is_tls ? "TLS" : "unencrypted", con->client_fd,
+         src == WS ? "ws" : "client");
+
+  /* first data on a new connection; determine if TLS, init TLS, and assign a ws */
+  if (con->ws_fd == -1)
+    {
+      assert (src == CLIENT);
+      handle_connection_data_first (con);
+      return;
+    }
+
+  do
+    {
+      r = connection_read (con, src);
+    } while (r == RETRY);
+  if (r == SUCCESS)
+    {
+      do
+        {
+          r = connection_write (con, src);
+        } while (r == RETRY || r == PARTIAL);
+    }
+
+  if (r != SUCCESS)
+    remove_connection (con->client_fd);
+}
+
+static void
+handle_hangup (struct ConnectionBuffer *buf)
+{
+  Connection *con = buf->connection;
+  int fd = buf == &con->buf_client ? con->client_fd : con->ws_fd;
+  debug (CONNECTION, "hangup on fd %i", fd);
+  remove_connection (fd);
 }
 
 /***********************************
@@ -188,38 +417,77 @@ handle_accept (int listen_fd)
  * is an error.
  *
  * @ws_path: Path to cockpit-wsinstance sockets directory
- * @idle_timeout: When positive, stop server after given number of seconds with
- *                no connections
  * @port: Port to listen to; ignored when the listening socket is handed over
  *        through the systemd socket activation protocol
+ * @certfile: Server TLS certificate file; if %NULL, TLS is not supported.
+ * @keyfile: Server TLS key file; if the key is merged into @certfile, set this
+ *           to %NULL.
+ * @client_cert_mode: Whether to ask for client certificates
  */
 void
-server_init (const char *wsinstance_sockdir,
-             int idle_timeout,
-             uint16_t port)
+server_init (const char *ws_path,
+             uint16_t port,
+             const char *certfile,
+             const char* keyfile,
+             enum ClientCertMode client_cert_mode)
 {
+  int ret;
   const char *env_listen_fds;
   struct epoll_event ev = { .events = EPOLLIN };
 
   assert (!server.initialized);
-  server.initialized = true;
 
-  connection_set_wsinstance_sockdir (wsinstance_sockdir);
+  server.ws_path = ws_path;
+  server.client_cert_mode = client_cert_mode;
 
-  pthread_mutex_init (&server.connection_mutex, NULL);
+  /* Initialize TLS */
+  if (certfile)
+    {
+      gnutls_check (gnutls_certificate_allocate_credentials (&server.x509_cred));
+
+      if (keyfile)
+        {
+          ret = gnutls_certificate_set_x509_key_file (server.x509_cred, certfile, keyfile, GNUTLS_X509_FMT_PEM);
+        }
+      else
+        {
+          /* without keyfile, certfile must include the key */
+          gnutls_datum_t cert, key;
+          int r;
+
+          r = cockpit_certificate_parse (certfile, (char**) &cert.data, (char**) &key.data);
+          if (r < 0)
+            errx (1,  "Invalid server certificate+key file %s: %s", certfile, strerror (-r));
+          cert.size = strlen ((char*) cert.data);
+          key.size = strlen ((char*) key.data);
+          ret = gnutls_certificate_set_x509_key_mem (server.x509_cred, &cert, &key, GNUTLS_X509_FMT_PEM);
+          free (cert.data);
+          free (key.data);
+        }
+      if (ret != GNUTLS_E_SUCCESS)
+        errx (1, "Failed to initialize server certificate: %s", gnutls_strerror (ret));
+      gnutls_check (gnutls_priority_init (&server.priority_cache, NULL, NULL));
+
+#if GNUTLS_VERSION_NUMBER >= 0x030506 && GNUTLS_VERSION_NUMBER <= 0x030600
+      /* only available since GnuTLS 3.5.6, and deprecated in 3.6 */
+      gnutls_certificate_set_known_dh_params (server.x509_cred, GNUTLS_SEC_PARAM_MEDIUM);
+#endif
+    }
 
   /* systemd socket activated? */
   env_listen_fds = secure_getenv ("LISTEN_FDS");
   if (env_listen_fds && check_sd_listen_pid ())
     {
       char *endptr = NULL;
-      unsigned long n = strtoul (env_listen_fds, &endptr, 10);
-
-      if (n < 1 || n > INT_MAX || *endptr != '\0')
-        errx (1, "Invalid $LISTEN_FDS value '%s'", env_listen_fds);
-
-      server.first_listener = SD_LISTEN_FDS_START;
-      server.last_listener = SD_LISTEN_FDS_START + (n - 1);
+      long n = strtol (env_listen_fds, &endptr, 10);
+      if (n < 1 || n > MAX_LISTEN_FDS || *endptr != '\0')
+        errx (1, "Invalid $LISTEN_FDS value '%s'; this program supports up to 10 fds", env_listen_fds);
+      for (int i = 0, fd = SD_LISTEN_FDS_START; i < n; ++i, ++fd)
+        {
+          server.listen_fds[i] = fd;
+          debug (SERVER, "Listening to systemd activated socket fd %i", fd);
+        }
+      server.listen_fds[n] = -1;
     }
   else
     {
@@ -227,51 +495,37 @@ server_init (const char *wsinstance_sockdir,
       int optval = 1;
 
       /* Listen to our port; on the command line and our API we just support one */
-      server.first_listener = socket (AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
-      if (server.first_listener < 0)
+      server.listen_fds[0] = socket (AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+      if (server.listen_fds[0] < 0)
         err (1, "failed to create server listening fd");
-      server.last_listener = server.first_listener;
+      server.listen_fds[1] = -1;
 
       memset (&sa_serv, '\0', sizeof (sa_serv));
       sa_serv.sin_family = AF_INET;
       sa_serv.sin_addr.s_addr = INADDR_ANY;
       sa_serv.sin_port = htons (port);
 
-      if (setsockopt (server.first_listener, SOL_SOCKET, SO_REUSEADDR, (void *) &optval, sizeof (int)) < 0)
+      if (setsockopt (server.listen_fds[0], SOL_SOCKET, SO_REUSEADDR, (void *) &optval, sizeof (int)) < 0)
         err (1, "failed to set socket option");
-      if (bind (server.first_listener, (struct sockaddr *) &sa_serv, sizeof (sa_serv)) < 0)
+      if (bind (server.listen_fds[0], (struct sockaddr *) &sa_serv, sizeof (sa_serv)) < 0)
         err (1, "failed to bind to port %hu", port);
-      if (listen (server.first_listener, 1024) < 0)
+      if (listen (server.listen_fds[0], 1024) < 0)
         err (1, "failed to listen to server port");
-      debug (SERVER, "Server ready. Listening on port %hu, fd %i", port, server.first_listener);
+      debug (SERVER, "Server ready. Listening on port %hu, fd %i", port, server.listen_fds[0]);
     }
 
   /* epoll the listening fds */
   server.epollfd = epoll_create1 (EPOLL_CLOEXEC);
   if (server.epollfd < 0)
     err (1, "Failed to create epoll fd");
-  for (int fd = server.first_listener; fd <= server.last_listener; fd++)
+  for (int i = 0; i < MAX_LISTEN_FDS && server.listen_fds[i] >= 0; ++i)
     {
-      ev.data.fd = fd;
-      if (epoll_ctl (server.epollfd, EPOLL_CTL_ADD, fd, &ev) < 0)
+      ev.data.ptr = &server.listen_fds[i];
+      if (epoll_ctl (server.epollfd, EPOLL_CTL_ADD, server.listen_fds[i], &ev) < 0)
         err (1, "Failed to epoll server listening fd");
     }
 
-  /* we use timerfd for idle timeout.  epoll that too. */
-  if (idle_timeout > 0)
-    {
-      server.idle_timerfd = timerfd_create (CLOCK_MONOTONIC, TFD_CLOEXEC);
-      if (server.idle_timerfd == -1)
-        err (1, "Failed to create timerfd");
-
-      server.idle_timeout.it_value.tv_sec = idle_timeout;
-      if (timerfd_settime (server.idle_timerfd, 0, &server.idle_timeout, NULL) != 0)
-        err (1, "Failed to set timerfd");
-
-      ev.data.fd = server.idle_timerfd;
-      if (epoll_ctl (server.epollfd, EPOLL_CTL_ADD, server.idle_timerfd, &ev) < 0)
-        err (1, "Failed to epoll idle timerfd");
-    }
+  server.initialized = true;
 }
 
 /**
@@ -283,34 +537,38 @@ server_init (const char *wsinstance_sockdir,
 void
 server_cleanup (void)
 {
-  assert (server.initialized);
-  assert (server.connection_count == 0);
-
-  if (server.idle_timerfd != -1)
-    close (server.idle_timerfd);
-
-  for (int fd = server.first_listener; fd <= server.last_listener; fd++)
-    close (fd);
-
   close (server.epollfd);
+  for (int i = 0; i < MAX_LISTEN_FDS && server.listen_fds[i] >= 0; ++i)
+    close (server.listen_fds[i]);
 
-  pthread_mutex_destroy (&server.connection_mutex);
+  assert (server.initialized);
 
-  connection_cleanup ();
+  for (Connection *c = server.connections; c; )
+    {
+      Connection *cnext = c->next;
+      connection_free (c);
+      c = cnext;
+    }
 
-  memset (&server, 0, sizeof server);
+  if (server.x509_cred)
+    {
+      gnutls_certificate_free_credentials (server.x509_cred);
+      gnutls_priority_deinit (server.priority_cache);
+    }
+
+  memset (&server, 0, sizeof (server));
 }
 
 /**
  * server_poll_event: Wait for and process one event
  *
  * @timeout: number of milliseconds to wait for an event to happen; after that,
- * the function will return false. -1 will to block until an event occurs.
+ * the function will return 0. -1 will to block forever
  *
- * This can be an event on a listening socket, or the idle timeout if no
- * clients are connected.
+ * This can be any event on the listening socket, on connected client sockets,
+ * or from cockpit-ws children.
  *
- * Returns: false on timeout, true if some (other) event was handled.
+ * Returns: false on timeout, true if some event was handled.
  */
 bool
 server_poll_event (int timeout)
@@ -321,46 +579,61 @@ server_poll_event (int timeout)
   assert (server.initialized);
 
   ret = epoll_wait (server.epollfd, &ev, 1, timeout);
-  if (ret == 0)
-    return false; /* hit timeout */
-
-  if (ret == 1)
+  if (ret < 0)
     {
-      int fd = ev.data.fd;
-
-      if (fd == server.idle_timerfd)
-        return false; /* hit the other timeout */
-
-      assert (server.first_listener <= fd && fd <= server.last_listener);
-
-      handle_accept (fd);
+      if (errno == EINTR)
+        return true;
+      err (1, "Failed to epoll_wait");
     }
-  else if (errno != EINTR)
-    err (1, "Failed to epoll_wait");
+  else if (ret > 0)
+    {
+      if (ev.data.ptr >= (void *) server.listen_fds && ev.data.ptr < (void *) &server.listen_fds[MAX_LISTEN_FDS])
+        handle_accept (* ((int *) ev.data.ptr));
+      else if (ev.events & EPOLLIN)
+        handle_connection_data (ev.data.ptr);
+      else if (ev.events & EPOLLHUP)
+        /* this ought to be handled by recv() == 0 (EOF) already, but make sure
+         * we clean up hanged up connections */
+        handle_hangup (ev.data.ptr);
 
-  return true; /* did something */
+      return true;
+    }
+
+  return false;
 }
 
 /**
  * server_run: Server main loop
  *
+ * @idle_timeout: If > 0, the timeout in milliseconds after which #server_run()
+ *                returns -- i. e. no events happened in that time and there are
+ *                no connections.
+ *
  * Returns if the server reached the idle timeout, otherwise runs forever.
  */
 void
-server_run (void)
+server_run (int idle_timeout)
 {
-  while (server_poll_event (-1))
-    ;
+  for (;;) {
+    if (!server_poll_event (idle_timeout) && idle_timeout > 0)
+      {
+        if (server_num_connections () == 0)
+          {
+            debug (SERVER, "reached idle time and no existing connections");
+            break;
+          }
+
+        debug (SERVER, "server_poll_event reached idle time, but there are existing connections");
+      }
+  }
 }
 
 unsigned
 server_num_connections (void)
 {
-  unsigned count;
+  unsigned count = 0;
 
-  pthread_mutex_lock (&server.connection_mutex);
-  count = server.connection_count;
-  pthread_mutex_unlock (&server.connection_mutex);
-
+  for (Connection *c = server.connections; c; c = c->next)
+    count++;
   return count;
 }

--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -300,7 +300,11 @@ handle_connection_data_first (Connection *con)
      to an epoll event. */
   ret = recv (con->client_fd, &b, 1, MSG_PEEK);
   if (ret < 0)
-    err (1, "failed to peek first byte");
+    {
+      debug (CONNECTION, "failed to peek first byte: %m");
+      remove_connection (con->client_fd);
+      return;
+    }
   if (ret == 0) /* EOF */
     {
       debug (CONNECTION, "client disconnected without sending any data");

--- a/src/tls/server.h
+++ b/src/tls/server.h
@@ -22,22 +22,23 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <gnutls/gnutls.h>
 
-void
-server_init (const char *wsinstance_sockdir,
-             int idle_timeout,
-             uint16_t port);
+enum ClientCertMode { CERT_NONE, CERT_REQUEST };
 
-void
-server_run (void);
+//struct Server;
+//typedef struct Server Server;
 
-void
-server_cleanup (void);
+void server_init (const char *ws_path,
+                  uint16_t port,
+                  const char *certfile,
+                  const char* keyfile,
+                  enum ClientCertMode);
+void server_cleanup (void);
+bool server_poll_event (int timeout);
+void server_run (int idle_timeout);
+void server_remove_ws (pid_t ws_pid);
 
 /* these are for unit tests only */
-bool
-server_poll_event (int timeout);
-
-unsigned
-server_num_connections (void);
+unsigned server_num_connections (void);
+unsigned server_num_ws (void);
+size_t server_get_ws_pids (pid_t* pids, size_t pids_length);

--- a/src/tls/test-connection.c
+++ b/src/tls/test-connection.c
@@ -19,13 +19,195 @@
 
 #include "config.h"
 
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/socket.h>
+
+#include "connection.h"
 #include "common/cockpittest.h"
+
+/* create a valid throwaway fd */
+static int get_fd (void)
+{
+  int fd = open ("/dev/zero", O_RDWR);
+  g_assert_cmpint (fd, >, 0);
+  return fd;
+}
+
+static void
+test_no_ws (void)
+{
+  int fd = get_fd ();
+  Connection *c;
+
+  c = connection_new (fd);
+  g_assert (c);
+  g_assert_cmpint (c->client_fd, ==, fd);
+  /* back references from buffer to connection */
+  g_assert (c->buf_client.connection == c);
+  g_assert (c->buf_ws.connection == c);
+
+  /* other fields are clear */
+  g_assert (!c->is_tls);
+  g_assert_cmpint (c->ws_fd, ==, -1);
+
+  connection_free (c);
+  /* closes fd */
+  g_assert_cmpint (fcntl (fd, F_GETFD), ==, -1);
+  g_assert_cmpint (errno, ==, EBADF);
+}
+
+static void
+test_with_ws (void)
+{
+  int client_fd, ws_fd;
+  Connection *c;
+
+  client_fd = get_fd ();
+  ws_fd = get_fd ();
+
+  c = connection_new (client_fd);
+  g_assert (c);
+  c->ws_fd = ws_fd;
+
+  connection_free (c);
+  /* closes both fds */
+  g_assert_cmpint (fcntl (client_fd, F_GETFD), ==, -1);
+  g_assert_cmpint (errno, ==, EBADF);
+  g_assert_cmpint (fcntl (ws_fd, F_GETFD), ==, -1);
+  g_assert_cmpint (errno, ==, EBADF);
+}
+
+static void
+test_tls_session (void)
+{
+  Connection *c;
+  gnutls_session_t session;
+
+  c = connection_new (-1);
+  g_assert (c);
+  g_assert (!c->is_tls);
+
+  g_assert_cmpint (gnutls_init (&session, GNUTLS_SERVER), ==, GNUTLS_E_SUCCESS);
+
+  connection_set_tls_session (c, session);
+  g_assert (c->is_tls);
+
+  /* releases the session; valgrind will complain otherwise */
+  connection_free (c);
+}
+
+static void
+test_read_write (void)
+{
+  int client_fds[2]; /* [Connection client fd, our 'browser' client fd] */
+  int ws_fds[2];     /* [Connection ws fd, our 'ws' side fd] */
+  int sendbuf;
+  char buffer[10];
+  const char *msg = "hello";
+  const size_t msglen = strlen (msg);
+  char bigmsg[16384];
+  Connection *c;
+
+  g_assert_cmpint (socketpair (AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, client_fds), ==, 0);
+  g_assert_cmpint (socketpair (AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, ws_fds), ==, 0);
+
+  /* limit socket buffer size, so that we can test partial writes */
+  sendbuf = 4096;
+  g_assert_cmpint (setsockopt (ws_fds[0], SOL_SOCKET, SO_SNDBUF, &sendbuf, sizeof (sendbuf)), ==, 0);
+
+  c = connection_new (client_fds[0]);
+  g_assert (c);
+  c->ws_fd = ws_fds[0];
+
+  /* client → ws */
+  g_assert_cmpint (connection_read (c, CLIENT), ==, RETRY);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+  g_assert_cmpint (send (client_fds[1], msg, msglen, 0), ==, msglen);
+  g_assert_cmpint (connection_read (c, CLIENT), ==, SUCCESS);
+  g_assert_cmpint (c->buf_client.length, ==, msglen);
+  g_assert_cmpint (c->buf_ws.length, ==, 0);
+
+  g_assert_cmpint (connection_write (c, CLIENT), ==, SUCCESS);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+  g_assert_cmpint (c->buf_client.offset, ==, 0);
+
+  g_assert_cmpint (recv (ws_fds[1], buffer, sizeof (buffer), 0), ==, msglen);
+  buffer[msglen] = '\0';
+  g_assert_cmpstr (buffer, ==, msg);
+
+  g_assert_cmpint (connection_read (c, CLIENT), ==, RETRY);
+
+  /* ws → client */
+  g_assert_cmpint (connection_read (c, WS), ==, RETRY);
+
+  g_assert_cmpint (send (ws_fds[1], msg, msglen, 0), ==, msglen);
+  g_assert_cmpint (connection_read (c, WS), ==, SUCCESS);
+  g_assert_cmpint (c->buf_ws.length, ==, msglen);
+  g_assert_cmpint (c->buf_client.length, ==, 0);
+
+  g_assert_cmpint (connection_write (c, WS), ==, SUCCESS);
+  g_assert_cmpint (c->buf_ws.length, ==, 0);
+
+  bzero (buffer, sizeof (buffer));
+  g_assert_cmpint (recv (client_fds[1], buffer, sizeof (buffer), 0), ==, msglen);
+  buffer[msglen] = '\0';
+  g_assert_cmpstr (buffer, ==, msg);
+
+  g_assert_cmpint (connection_read (c, WS), ==, RETRY);
+
+  /* test partial writes: send a large block */
+  memset (bigmsg, 42, sizeof (bigmsg));
+  g_assert_cmpint (send (client_fds[1], bigmsg, sizeof (bigmsg), 0), ==, sizeof (bigmsg));
+  g_assert_cmpint (connection_read (c, CLIENT), ==, SUCCESS);
+  g_assert_cmpint (c->buf_client.length, ==, sizeof (bigmsg));
+  /* write from client to ws should be partial due to our SO_SNDBUF from above */
+  g_assert_cmpint (connection_write (c, CLIENT), ==, PARTIAL);
+  g_assert_cmpint (c->buf_client.offset, >, 0);
+  g_assert_cmpint (c->buf_client.offset, <, sizeof (bigmsg));
+  /* flush the bigmsg to ws */
+  while (c->buf_client.offset > 0)
+    {
+      int len;
+
+      ConnectionResult r = connection_write (c, CLIENT);
+      if (r != SUCCESS && r != RETRY)
+        g_assert_cmpint (r, ==, PARTIAL);
+
+      for (;;)
+        {
+          len = recv (ws_fds[1], buffer, sizeof (buffer), 0);
+          if (len < 0)
+            {
+              g_assert_cmpint (errno, ==, EAGAIN);
+              break;
+            }
+          /* we never expect 0 here, as that'd be EOF */
+          g_assert_cmpint (len, >, 0);
+          /* the buffer is full of 42 bytes, compare the current slice */
+          g_assert_cmpint (memcmp (buffer, bigmsg, len), ==, 0);
+        }
+    }
+
+  /* EOF detection */
+  close (client_fds[1]);
+  g_assert_cmpint (connection_read (c, CLIENT), ==, CLOSED);
+  close (ws_fds[1]);
+  g_assert_cmpint (connection_read (c, WS), ==, CLOSED);
+
+  connection_free (c);
+}
 
 int
 main (int argc,
       char *argv[])
 {
   cockpit_test_init (&argc, &argv);
+
+  g_test_add_func ("/connection/no-ws", test_no_ws);
+  g_test_add_func ("/connection/with-ws", test_with_ws);
+  g_test_add_func ("/connection/tls-session", test_tls_session);
+  g_test_add_func ("/connection/read-write", test_read_write);
 
   return g_test_run ();
 }

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -32,7 +32,6 @@
 #include <glib/gstdio.h>
 #include <gnutls/x509.h>
 
-#include "connection.h"
 #include "server.h"
 #include "common/cockpittest.h"
 
@@ -58,7 +57,7 @@ typedef struct {
 typedef struct {
   const char *certfile;
   const char *keyfile;
-  int cert_request_mode;
+  enum ClientCertMode client_certs;
 } TestFixture;
 
 static const TestFixture fixture_separate_crt_key = {
@@ -69,7 +68,7 @@ static const TestFixture fixture_separate_crt_key = {
 static const TestFixture fixture_separate_crt_key_client_cert = {
   .certfile = CERTFILE,
   .keyfile = KEYFILE,
-  .cert_request_mode = GNUTLS_CERT_REQUEST,
+  .client_certs = CERT_REQUEST,
 };
 
 static const TestFixture fixture_combined_crt_key = {
@@ -132,8 +131,8 @@ do_request (TestCase *tc, const char *request)
 
   send_request (fd, request);
   /* wait until data is available */
-  for (int timeout = 0; timeout < 100 && recv (fd, buf, 100, MSG_PEEK | MSG_DONTWAIT) < 100; ++timeout)
-    server_poll_event (100);
+  for (int timeout = 0; timeout < 10 && recv (fd, buf, 100, MSG_PEEK | MSG_DONTWAIT) < 100; ++timeout)
+    server_poll_event (1000);
 
   return recv_reply (fd, buf, sizeof (buf));
 }
@@ -280,10 +279,11 @@ setup (TestCase *tc, gconstpointer data)
     }
   close (socket_dir_fd);
 
-  server_init (tc->ws_socket_dir, 1, server_port);
-  if (fixture && fixture->certfile)
-    connection_crypto_init (fixture->certfile, fixture->keyfile, fixture->cert_request_mode);
-
+  server_init (tc->ws_socket_dir,
+               server_port,
+               fixture ? fixture->certfile : NULL,
+               fixture ? fixture->keyfile : NULL,
+               fixture ? fixture->client_certs : CERT_NONE);
   tc->server_addr.sin_family = AF_INET;
   tc->server_addr.sin_port = htons (server_port);
   tc->server_addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK);
@@ -292,9 +292,6 @@ setup (TestCase *tc, gconstpointer data)
 static void
 teardown (TestCase *tc, gconstpointer data)
 {
-  for (int i = 0; i < 100 && server_num_connections (); i++) /* 10s */
-    g_usleep (100000); /* 0.1s */
-
   server_cleanup ();
   g_assert_cmpint (kill (tc->ws_spawner, SIGTERM), ==, 0);
   g_assert_cmpint (waitpid (tc->ws_spawner, NULL, 0), ==, tc->ws_spawner);
@@ -317,14 +314,13 @@ teardown (TestCase *tc, gconstpointer data)
 }
 
 static void
-test_no_tls_single (TestCase *tc, gconstpointer data)
+test_no_tls_con_shutdown (TestCase *tc, gconstpointer data)
 {
-  g_assert_cmpuint (server_num_connections (), ==, 0);
   assert_http (tc);
 
   /* let the server process "peer has closed connection" */
   for (int retries = 0; retries < 10 && server_num_connections () == 1; ++retries)
-    server_poll_event (100);
+    server_run (100);
   g_assert_cmpuint (server_num_connections (), ==, 0);
 }
 
@@ -470,11 +466,11 @@ static void
 test_run_idle (TestCase *tc, gconstpointer data)
 {
   /* exits after idle without any connections */
-  server_run ();
+  server_run (100);
 
   /* exits after idle after processing an event */
   assert_http (tc);
-  server_run ();
+  server_run (100);
 }
 
 int
@@ -482,8 +478,8 @@ main (int argc, char *argv[])
 {
   cockpit_test_init (&argc, &argv);
 
-  g_test_add ("/server/no-tls/single-request", TestCase, NULL,
-              setup, test_no_tls_single, teardown);
+  g_test_add ("/server/no-tls/process-connection-shutdown", TestCase, NULL,
+              setup, test_no_tls_con_shutdown, teardown);
   g_test_add ("/server/no-tls/many-serial", TestCase, NULL,
               setup, test_no_tls_many_serial, teardown);
   g_test_add ("/server/no-tls/many-parallel", TestCase, NULL,

--- a/src/tls/utils.h
+++ b/src/tls/utils.h
@@ -25,9 +25,6 @@
 #define DEBUG 0
 
 /* messages can be disabled per-domain */
-#define DEBUG_POLL 1
-#define DEBUG_BUFFER 1
-#define DEBUG_IOVEC 1
 #define DEBUG_CONNECTION 1
 #define DEBUG_SERVER 1
 
@@ -42,6 +39,14 @@
 #else
 #define debug(...)
 #endif
+
+#define gnutls_check(expr) { \
+  int r = expr; \
+  if (r < 0) {  \
+    fprintf (stderr, "cockpit-tls: %s failed: %s\n", #expr, gnutls_strerror (r)); \
+    abort ();   \
+  }             \
+}
 
 #define N_ELEMENTS(arr) (sizeof (arr) / sizeof ((arr)[0]))
 


### PR DESCRIPTION
This currently causes assertion crashes due to some buggy iovec ring
buffer housekeeping, see issue #12987.