### PR TITLE
test: fix selenium test MachinesStoragePoolTestSuite.testCheckStorage…

### DIFF
--- a/test/selenium/selenium-machines-storage-pool.py
+++ b/test/selenium/selenium-machines-storage-pool.py
@@ -47,7 +47,7 @@ class MachinesStoragePoolTestSuite(MachinesLib):
         self.assertEqual(cmd_total, page_active + page_inactive)
         self.assertEqual(active, page_active)
         self.assertEqual(inactive, page_inactive)
-        self.click(self.wait_css('#app > div > ol > li > a'))
+        self.click(self.wait_css('#app > div > nav > ol > li > a'))
         self.wait_css('#storage-pools-listing', cond=invisible)
         self.wait_css('#virtual-machines-listing')
 


### PR DESCRIPTION
…Pool

Commit e25b0d adjusted the breadcrumbs but didn't adjust the
testCheckStoragePool which started failing.

Fixes failures like https://209.132.184.41:8493/logs/pull-12958-20191017-094848-78ebf298-cockpit-project-cockpit--fedora-30-selenium-firefox/log.html#54