### PR TITLE
machines: Fix disabling of Create VM button

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -868,10 +868,17 @@ export class CreateVmAction extends React.Component {
         if (this.props.systemInfo.osInfoList == null)
             return null;
 
+        let testdata;
+        if (!this.props.systemInfo.osInfoList)
+            testdata = "disabledOsInfo";
+        else if (!this.state.virtInstallAvailable)
+            testdata = "disabledVirtInstall";
+        else if (this.state.downloadOSSupported === undefined)
+            testdata = "disabledDownloadOS";
         let createButton = (
-            <Button disabled={!(this.props.systemInfo.osInfoList &&
-                               (this.state.virtInstallAvailable != undefined ||
-                               (this.state.virtInstallAvailable && this.state.downloadOSSupported === undefined)))}
+            <Button disabled={!this.props.systemInfo.osInfoList || !this.state.virtInstallAvailable ||
+                              this.state.downloadOSSupported === undefined}
+                    testdata={testdata}
                     id={this.props.mode == 'create' ? 'create-new-vm' : 'import-vm-disk'}
                     bsStyle='default'
                     onClick={this.open}>

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1733,6 +1733,8 @@ class TestMachines(NetworkCase):
         self.browser.reload()
         self.browser.enter_page('/machines')
         self.browser.wait_visible("#create-new-vm:disabled")
+        # There are many reason why the button would be disabled, so check if it's correct one
+        self.browser.wait_attr("#create-new-vm", "testdata", "disabledVirtInstall")
 
         # TODO: add use cases with start_vm=True and check that vm started
         # - for install when creating vm


### PR DESCRIPTION
This should also fix a flake in our tests:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.7/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib64/python3.7/unittest/case.py", line 628, in run
    testMethod()
  File "/home/skobyda/Work/cockpit/test/verify/machineslib.py", line 1340., in testCreate
    self.browser.wait_visible("#create-new-vm:disabled")
  File "/home/skobyda/Work/cockpit/test/common/testlib.py", line 361, in wait_visible
    self.wait_present(selector)
  File "/home/skobyda/Work/cockpit/test/common/testlib.py", line 352, in wait_present
    self.wait_js_func('ph_is_present', selector)
  File "/home/skobyda/Work/cockpit/test/common/testlib.py", line 346, in wait_js_func
    self.wait_js_cond("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/home/skobyda/Work/cockpit/test/common/testlib.py", line 343, in wait_js_cond
    self.raise_cdp_exception("timeout\nwait_js_cond", cond, result["exceptionDetails"], trailer)
  File "/home/skobyda/Work/cockpit/test/common/testlib.py", line 175, in raise_cdp_exception
    raise Error("%s(%s): %s" % (func, arg, msg))
testlib.Error: timeout
```

Because of incorrect condition the "Create VM" button would not get
disabled when virt-install is not available.

But how does this create a flake in test? The reason is that virt-install not being available is not only reason to disable "Create VM" button. Other reason is: libosinfo data are not loaded yet. Some distros take a fraction of second to load libosinfo data and because of that for a fraction of second a "Create VM" button is always disabled.

Our tests expected "Create VM" button to be disabled when virt-install
was unavaible. Sometimes our test were too fast and would caught "Create VM" button disabled because libosinfo data were not loaded yet and tests would pass thus providing false positive. Sometimes however our tests were too slow, libosinfo data were already loaded, and because there was a bug which did not disable the button when virt-install was unavaible, then the button would never get disabled and tests would fail.
~                  