### PR TITLE
tls: Increase timeout in HTTPS response test

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -247,7 +247,7 @@ assert_https_outcome (TestCase *tc,
     }
 
   for (int retry = 0; retry < 100 && waitpid (pid, &status, WNOHANG) <= 0; ++retry)
-    server_poll_event (50);
+    server_poll_event (200);
   g_assert_cmpint (status, ==, 0);
 }
 


### PR DESCRIPTION
The tls unit tests often fail under valgrind. Quadruple the timeout so
that they work more reliably.