### PR TITLE
test: Allow "unknown device" message in check-storage-luks

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -115,6 +115,8 @@ class TestStorage(StorageCase):
         self.confirm()
         self.content_row_wait_in_col(1, 1, "Free Space")
         b.wait_not_in_text("#detail-content", "ext4 File System")
+        # luksmeta-monitor-hack.py races with the partition deletion
+        self.allow_journal_messages('Unknown device .*: No such file or directory')
 
         assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
         assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""


### PR DESCRIPTION
The test removes the partition, which races with
luksmeta-monitor-hack.py trying to probe it. The latter then complains
in the journal.

Fixes #12957