### PR TITLE
systemd: Specify context for `After`

### DIFF
--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -307,7 +307,7 @@
                   </ul>
                 </div>
                 <div id="boot">
-                  <label class="control-label" id="boot-label" for="boot-time" translate>After</label>
+                  <label class="control-label" id="boot-label" for="boot-time" translate-context="time-delay" translate>After</label>
                   <input type="text" id="boot-time" value="00" class="form-control">
                   <div class="btn-group bootstrap-select dropdown form-control" id="drop-time">
                     <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">


### PR DESCRIPTION
Fixes #12019