### PR TITLE
firewall: more clicks before deleting a zone or service

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -257,9 +257,14 @@ export class ListingRow extends React.Component {
 
             let simpleBody, heading;
             if ('simpleBody' in this.props) {
-                simpleBody = (
-                    <div className="listing-ct-body" key="simplebody">{this.props.simpleBody}</div>
-                );
+                heading =
+                    <div className="listing-ct-actions listing-ct-simplebody-actions">
+                        {this.props.listingActions}
+                    </div>;
+                simpleBody =
+                    <div className="listing-ct-body" key="simplebody">
+                        {this.props.simpleBody}
+                    </div>;
             } else {
                 heading = (<div className="listing-ct-head">
                     <div className="listing-ct-actions">

--- a/pkg/lib/listing.less
+++ b/pkg/lib/listing.less
@@ -29,7 +29,8 @@
     margin: 0.5rem 0;
 }
 
-.listing-ct-heading {
+.listing-ct-heading,
+.listing-ct-simplebody-actions {
     flex: auto;
     padding: 0.25rem 1em 0.25rem 0;
 }

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -348,6 +348,16 @@ h1 .onoff-ct {
     font-weight: bold;
 }
 
+#delete-confirmation-dialog .fa-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+    font-size: 300%;
+    margin-right: 1rem;
+}
+
+#delete-confirmation-dialog .delete-confirmation-body {
+    display: flex;
+}
+
 #add-zone-dialog .add-zone-zones legend {
     all: unset;
     color: var(--color-subtle-copy);

--- a/test/selenium/selenium-firewalld-zones.py
+++ b/test/selenium/selenium-firewalld-zones.py
@@ -41,6 +41,7 @@ class FirewalldZones(SeleniumTest):
 
     def remove_custom_zone(self, zone):
         self.click(self.wait_xpath("//div[@data-id='{}']//button".format(self.zone_custom), cond=visible))
+        self.click(self.wait_xpath("//div[@id='delete-confirmation-dialog']//button[contains(text(), 'Delete')]"))
         self.wait_id("firewall", jscheck=True)
         self.assertNotIn(self.zone_custom, self.machine.execute("firewall-cmd --get-active-zones"))
 

--- a/test/selenium/selenium-firewalld.py
+++ b/test/selenium/selenium-firewalld.py
@@ -88,5 +88,6 @@ class FirewalldPage(FirewalldBasePage):
         service = "amqp"
         self.machine.execute("sudo firewall-cmd --add-service={}".format(service))
         self.assertIn(service, self.machine.execute("sudo firewall-cmd --list-services"))
-        self.click(self.wait_xpath("//div[@data-id='{}']//tr[@data-row-id='{}']//button[contains(@class, 'btn-danger')]".format(self.zone_default, service)))
+        self.click(self.wait_xpath("//div[@data-id='{}']//tr[@data-row-id='{}']".format(self.zone_default, service)))
+        self.click(self.wait_xpath("//div[@data-id='{}']//tr[@data-row-id='{}']/following-sibling::tr[1]//button[contains(@class, 'btn-danger')]".format(self.zone_default, service)))
         self.assertFalse(self.wait_id("firewall-service-{}".format(service), cond=clickable, overridetry=3, fatal=False))

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -113,10 +113,10 @@ class TestFirewall(NetworkCase):
         active_rules = get_active_rules(m)
         b.wait_js_func("((sel, count) => ph_count(sel) == count)", ".zone-section table.listing tbody", len(active_rules))
 
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] .listing-ct-toggle")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         b.wait_in_text(".zone-section[data-id='public'] tbody.open tr.listing-ct-panel", "Post Office Protocol")
 
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] .btn.pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .btn.pficon-delete")
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
 
@@ -191,6 +191,7 @@ class TestFirewall(NetworkCase):
             addService('public', 'freeipa-4')
             b.click(".zone-section[data-id='public'] tr[data-row-id='freeipa-4']")
             b.wait_present(".zone-section[data-id='public'] tbody.open .listing-ct-body:contains(Included Services)")
+            b.click(".zone-section[data-id='public'] tr[data-row-id='freeipa-4']")
 
         # pop3 should now not appear any more in Add Services dialog
         b.click(".zone-section[data-id='public'] #add-services-button")
@@ -216,7 +217,11 @@ class TestFirewall(NetworkCase):
         # requiring checkboxes to be clicked), then remove all the services
         # belonging either libvirt or public
         for service in services:
-            b.click(".zone-section[data-id='public'] tr[data-row-id='{}'] .btn.pficon-delete".format(service))
+            b.click(".zone-section[data-id='public'] tr[data-row-id='{}']".format(service))
+            b.click(".zone-section[data-id='public'] tr[data-row-id='{}'] + tr button.btn-danger".format(service))
+            # removing cockpit services requires confirmation
+            if service == "cockpit":
+                b.click("#delete-confirmation-dialog button.btn-danger")
             b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='{}']".format(service))
         self.assertEqual(m.execute("firewall-cmd --list-services").strip(), "")
 
@@ -225,7 +230,8 @@ class TestFirewall(NetworkCase):
         b.wait_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         # remove service via cli and cockpit
         m.execute("firewall-cmd --remove-service=pop3")
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] .btn.pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .btn.pficon-delete")
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 
     def testAddCustomServices(self):
@@ -366,6 +372,7 @@ class TestFirewall(NetworkCase):
 
         def removeZone(zone):
             b.click(".zone-section[data-id='{}'] .zone-section-buttons button.btn-danger".format(zone))
+            b.click("#delete-confirmation-dialog button.btn-danger")
             b.wait_not_present(".zone-section[data-id='{}']".format(zone))
 
         self.login_and_go("/network/firewall")
@@ -381,12 +388,14 @@ class TestFirewall(NetworkCase):
         b.wait_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 
         # Remove the service from public zone
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] .btn.pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .btn.pficon-delete")
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         b.wait_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # Remove the service from the work zone
-        b.click(".zone-section[data-id='work'] tr[data-row-id='pop3'] .btn.pficon-delete")
+        b.click(".zone-section[data-id='work'] tr[data-row-id='pop3']")
+        b.click(".zone-section[data-id='work'] tr[data-row-id='pop3'] + tr .btn.pficon-delete")
         b.wait_not_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # remove predefined work zone


### PR DESCRIPTION
For zones:
![image](https://user-images.githubusercontent.com/11140201/67691655-4092f580-f99f-11e9-933c-73fa4afa3b68.png)

For zones with cockpit:
![image](https://user-images.githubusercontent.com/11140201/67691631-37098d80-f99f-11e9-8f83-0a8d8273d6f6.png)


For services (button moved to expander):

![image](https://user-images.githubusercontent.com/11140201/67090323-1aed3b80-f1aa-11e9-8bc8-dc0ec2654702.png)

For the cockpit service (expander + confirmation):
![image](https://user-images.githubusercontent.com/11140201/67691692-4be62100-f99f-11e9-9666-b852bcf3c8f9.png)

