### PR TITLE
tls: Fix comment on connection_handshake()

### DIFF
--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -397,7 +397,7 @@ connection_init_ws (Connection *self)
  * connection_handshake: Handle first event on client fd
  *
  * Check the very first byte of a new connection to tell apart TLS from plain
- * HTTP. Initialize TLS and the ws instance.
+ * HTTP. Initialize TLS.
  */
 static bool
 connection_handshake (Connection *self)


### PR DESCRIPTION
This doesn't initialize the ws instance, it's done in
connection_thread_main().