### PR TITLE
ws: Stop ws instance socket when cockpit.service stops by itself

### DIFF
--- a/src/ws/cockpit-wsinstance-http-redirect.service.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cockpit Web Service http-redirect instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Service]

--- a/src/ws/cockpit-wsinstance-http-redirect.socket.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.socket.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Socket for Cockpit Web Service http-redirect instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Socket]

--- a/src/ws/cockpit-wsinstance-http.service.in
+++ b/src/ws/cockpit-wsinstance-http.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cockpit Web Service http instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Service]

--- a/src/ws/cockpit-wsinstance-http.socket.in
+++ b/src/ws/cockpit-wsinstance-http.socket.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Socket for Cockpit Web Service http instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Socket]

--- a/src/ws/cockpit-wsinstance-https.service.in
+++ b/src/ws/cockpit-wsinstance-https.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Cockpit Web Service https instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Service]

--- a/src/ws/cockpit-wsinstance-https.socket.in
+++ b/src/ws/cockpit-wsinstance-https.socket.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=Socket for Cockpit Web Service https instance
-PartOf=cockpit.service
+BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Socket]

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -184,6 +184,16 @@ class TestConnection(MachineCase):
         m.stop_cockpit()
         expect_actives(False, False, [])
 
+        # cleans up also when cockpit-tls crashes or idle-exits, not just by explicit stop request
+        m.start_cockpit(tls=False)
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
+        m.execute("pkill -e cockpit-tls")
+        expect_actives(True, False, [])
+
+        # and recovers from that
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
+        expect_actives(True, True, ["http"])
+
         # https mode
 
         m.start_cockpit(tls=True)
@@ -206,6 +216,14 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
 
         expect_actives(True, True, ["http-redirect"])
+
+        # cleans up also when cockpit-tls crashes or idle-exits, not just by explicit stop request
+        m.execute("pkill -e cockpit-tls")
+        expect_actives(True, False, [])
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
+        expect_actives(True, True, ["http-redirect"])
+        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent -k --head https://127.0.0.1:9090"))
+        expect_actives(True, True, ["http-redirect", "https"])
 
     def testTls(self):
         m = self.machine


### PR DESCRIPTION
Use the stronger `BindsTo=` for the wsinstance units towards
cockpit.service. With that, these units get stopped also when
cockpit-tls exits by itself (idle timeout, crash, etc.), and not just
with an explicit `systemctl stop cockpit.service`.

Spotted in PR #12972