### PR TITLE
test: Obsolete sizzle

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "mini-css-extract-plugin": "^0.8.0",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^0.5.1",
-    "sizzle": "^2.1.0",
     "stdio": "^0.2.7",
     "strict-loader": "^1.1.0",
     "style-loader": "^0.13.1",

--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -207,8 +207,6 @@ class CDP:
         for inject in self.inject_helpers:
             with open(inject) as f:
                 src = f.read()
-            # HACK: injecting sizzle fails on missing `document` in assert()
-            src = src.replace('function assert( fn ) {', 'function assert( fn ) { return true;')
             self.invoke("Page.addScriptToEvaluateOnLoad", scriptSource=src, no_trace=True)
 
     def kill(self):

--- a/test/common/sizzle.js
+++ b/test/common/sizzle.js
@@ -1,1 +1,0 @@
-../../node_modules/sizzle/dist/sizzle.js

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -6,9 +6,7 @@
  */
 
 function ph_select(sel) {
-    if (!window.Sizzle)
-        throw "Sizzle was not properly loaded"
-    return window.Sizzle(sel);
+    return document.querySelectorAll(sel);
 }
 
 function ph_only(els, sel)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -102,7 +102,7 @@ class Browser:
         self.label = label
         path = os.path.dirname(__file__)
         self.cdp = cdp.CDP("C.utf8", verbose=opts.trace, trace=opts.trace,
-                           inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")])
+                           inject_helpers=[os.path.join(path, "test-functions.js")])
         self.password = "foobar"
 
     def title(self):
@@ -135,7 +135,7 @@ class Browser:
 
     def reload(self, ignore_cache=False):
         self.switch_to_top()
-        self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")
+        self.wait_js_cond("Array.from(ph_select('iframe.container-frame')).every(function (e) { return e.getAttribute('data-loaded'); })")
         self.cdp.invoke("Page.reload", ignoreCache=ignore_cache)
         self.expect_load()
 


### PR DESCRIPTION
We use it only for one type of query and we can use
`querySelectorAll` instead.
See https://github.com/jquery/sizzle/wiki#sizzle-string-selector-domnode-context-array-results-

`querySelectorAll` returns `NodeList` (https://developer.mozilla.org/en-US/docs/Web/API/NodeList)
which does not support `.every()`, thus that conversion to Array.

(Purpose of this change is mainly to enable Firefox CDP testing and
Firefox was not happy with sizzle and iframes.)

Although this is needed for https://github.com/cockpit-project/cockpit/pull/12971 (with this change it seems to work rather nice and I have high hopes for it), I am sending it as separate PR, since I need to check if this works with chromium and our current tests. (I ran a few tests, but there may be some selector that would be "special" sizzle thing or maybe I need to convert to Array on more places)