### PR TITLE
test: Fix NTP tests on Ubuntu 19.10

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -100,7 +100,7 @@ class TestSystemInfo(MachineCase):
         # Debian will not allow timesyncd to start if any other NTP packge is installed
         # We only support timesyncd for NTP configuration, so make sure chrony
         # is not installed in the debian test images
-        if self.machine.image in ["debian-stable", "debian-testing"]:
+        if self.machine.image in ["debian-stable", "debian-testing", "ubuntu-stable"]:
             self.machine.execute("dpkg --remove chrony");
 
     @enableAxe


### PR DESCRIPTION
Our new Ubuntu 19.10 test image now also has chrony installed through a
transitive Recommends:, like on Debian. This makes timesyncd not start,
so remove chrony for the timesyncd tests.

See https://github.com/cockpit-project/bots/pull/151