### PR TITLE
bridge: Ignore missing system SSL cert database in unit tests

### DIFF
--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -485,6 +485,9 @@ setup_tls (TestTls *test,
 {
   GError *error = NULL;
 
+  /* don't require system SSL cert database in build environments */
+  cockpit_expect_possible_log ("GLib-Net", G_LOG_LEVEL_WARNING, "couldn't load TLS file database: * No such file or directory");
+
   test->certificate = g_tls_certificate_new_from_files (SRCDIR "/src/bridge/mock-server.crt",
                                                         SRCDIR "/src/bridge/mock-server.key", &error);
   g_assert_no_error (error);
@@ -684,6 +687,9 @@ test_tls_certificate (TestTls *test,
 
   /* tell server to request client cert */
   cockpit_webserver_want_certificate = TRUE;
+
+  /* this happens twice, so once more in addition to the ignore in setup_tls */
+  cockpit_expect_possible_log ("GLib-Net", G_LOG_LEVEL_WARNING, "couldn't load TLS file database: * No such file or directory");
 
   tls = cockpit_json_parse_object (json, -1, &error);
   g_assert_no_error (error);


### PR DESCRIPTION
The tests don't need a system SSL database, but if it's not present,
they fail with

    (test-httpstream:12379): GLib-Net-WARNING **: 08:40:04.701: couldn't load TLS file database:
        Failed to open file ?/etc/ssl/certs/ca-certificates.crt?: No such file or directory
    Trace/breakpoint trap (core dumped)

Ignore the warning, to avoid a build dependency on ca-certificates.