### PR TITLE
systemd: Don't trim initial motd whitespace

### DIFF
--- a/pkg/systemd/host.js
+++ b/pkg/systemd/host.js
@@ -251,7 +251,7 @@ PageServer.prototype = {
 
         cockpit.file("/etc/motd").watch(function(content) {
             if (content)
-                content = $.trim(content);
+                content = content.trimRight();
             if (content && content != cockpit.localStorage.getItem('dismissed-motd')) {
                 $('#motd').text(content);
                 $('#motd-box').show();

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -367,9 +367,13 @@ class TestSystemInfo(MachineCase):
         b.wait_present('#motd-box[data-stable=yes]')
         b.wait_not_visible('#motd-box')
 
-        m.execute("echo Hello >/etc/motd")
+        m.execute(r"printf '  Hello\n  World\n\n' >/etc/motd")
         b.wait_visible('#motd-box')
-        b.wait_in_text('#motd', "Hello")
+        if m.image == 'rhel-8-1-distropkg':
+            # fixed in PR #13021
+            b.wait_text('#motd', "Hello\n  World")
+        else:
+            b.wait_text('#motd', "  Hello\n  World")
 
         b.click('#motd-box button.close')
         b.wait_not_visible('#motd-box')
@@ -382,7 +386,7 @@ class TestSystemInfo(MachineCase):
 
         m.execute("echo Hello again >/etc/motd")
         b.wait_visible('#motd-box')
-        b.wait_in_text('#motd', "Hello again")
+        b.wait_text('#motd', "Hello again")
 
         # because of the reload
         self.allow_restart_journal_messages()


### PR DESCRIPTION
This is often being used for ASCII art or other indentation, and Cockpit
shows it in a `<pre>` for that reason. Do what the shell does and leave
leading whitespace intact.

Fixes #11680