### PR TITLE
test: Clarify test failures on unexpected journal messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -961,14 +961,13 @@ class MachineCase(unittest.TestCase):
             if not found:
                 all_found = False
                 if not first:
-                    print("Unexpected journal messages:")
                     first = m
                 print(m)
         if not all_found:
             self.copy_js_log("FAIL")
             self.copy_journal("FAIL")
             self.copy_cores("FAIL")
-            raise Error(first)
+            raise Error("FAIL: Test completed, but found unexpected journal messages:\n" + first)
 
     def allow_browser_errors(self, *patterns):
         """Don't fail if the test caused a console error contains the given regexp"""


### PR DESCRIPTION
Previously the "Unexpected journal messages" message appeared above all
unexpected messages and the stack trace, which makes it visually hard to
spot when just looking at the end. Change it to become part of the
actual exception message and clarify it a bit.

Fixes #11726