### PR TITLE
websocket: Allow UTF-8 header values

### DIFF
--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -304,6 +304,7 @@ test_parse_headers (void)
       "Header2:  field\r\n"
       "Head3:  Another \r\n"
       "Host:https://cockpit-project.org\r\n"
+      "Funny:  a☺b\r\n"
       "\r\n"
       "BODY  ";
 
@@ -313,6 +314,7 @@ test_parse_headers (void)
   g_assert_cmpstr (g_hash_table_lookup (headers, "Header2"), ==, "field");
   g_assert_cmpstr (g_hash_table_lookup (headers, "hEAD3"), ==, "Another");
   g_assert_cmpstr (g_hash_table_lookup (headers, "Host"), ==, "https://cockpit-project.org");
+  g_assert_cmpstr (g_hash_table_lookup (headers, "Funny"), ==, "a☺b");
   g_assert (g_hash_table_lookup (headers, "Something else") == NULL);
   g_hash_table_unref (headers);
 }
@@ -377,8 +379,10 @@ test_header_equals (void)
 {
   GHashTable *headers = web_socket_util_new_headers ();
   g_hash_table_insert (headers, g_strdup ("Blah"), g_strdup ("VALUE"));
+  g_hash_table_insert (headers, g_strdup ("Funny"), g_strdup ("a☺b"));
 
   g_assert (_web_socket_util_header_equals (headers, "blah", "Value"));
+  g_assert (_web_socket_util_header_equals (headers, "Funny", "a☺b"));
 
   g_test_expect_message (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
                          "received invalid or missing Blah header*");

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -351,7 +351,13 @@ static void
 test_parse_headers_bad (void)
 {
   const gchar *input[] = {
+      /* missing : */
       "Header1 value3\r\n"
+      "\r\n"
+      "BODY  ",
+
+      /* binary garbage (not even UTF8) */
+      "Header1: a\xFF\x01b\r\n"
       "\r\n"
       "BODY  ",
   };

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -296,30 +296,25 @@ test_parse_version_1_1 (void)
 static void
 test_parse_headers (void)
 {
-  const gchar *input[] = {
+  GHashTable *headers;
+  gssize ret;
+
+  const gchar *input =
       "Header1: value3\r\n"
       "Header2:  field\r\n"
       "Head3:  Another \r\n"
       "Host:https://cockpit-project.org\r\n"
       "\r\n"
-      "BODY  ",
-  };
+      "BODY  ";
 
-  GHashTable *headers;
-  gssize ret;
-  gint i;
-
-  for (i = 0; i < G_N_ELEMENTS (input); i++)
-    {
-      ret = web_socket_util_parse_headers (input[i], strlen (input[i]), &headers);
-      g_assert_cmpint (ret, ==, strlen (input[i]) - 6);
-      g_assert_cmpstr (g_hash_table_lookup (headers, "header1"), ==, "value3");
-      g_assert_cmpstr (g_hash_table_lookup (headers, "Header2"), ==, "field");
-      g_assert_cmpstr (g_hash_table_lookup (headers, "hEAD3"), ==, "Another");
-      g_assert_cmpstr (g_hash_table_lookup (headers, "Host"), ==, "https://cockpit-project.org");
-      g_assert (g_hash_table_lookup (headers, "Something else") == NULL);
-      g_hash_table_unref (headers);
-    }
+  ret = web_socket_util_parse_headers (input, strlen (input), &headers);
+  g_assert_cmpint (ret, ==, strlen (input) - 6);
+  g_assert_cmpstr (g_hash_table_lookup (headers, "header1"), ==, "value3");
+  g_assert_cmpstr (g_hash_table_lookup (headers, "Header2"), ==, "field");
+  g_assert_cmpstr (g_hash_table_lookup (headers, "hEAD3"), ==, "Another");
+  g_assert_cmpstr (g_hash_table_lookup (headers, "Host"), ==, "https://cockpit-project.org");
+  g_assert (g_hash_table_lookup (headers, "Something else") == NULL);
+  g_hash_table_unref (headers);
 }
 
 static void

--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -366,7 +366,7 @@ web_socket_util_parse_headers (const gchar *data,
           g_strstrip (value);
           g_hash_table_insert (parsed_headers, name, value);
 
-          if (!is_valid_line (name, -1) || !is_valid_line (value, -1))
+          if (!is_valid_line (name, -1) || !g_utf8_validate (value, -1, NULL))
             {
               g_debug ("received invalid header");
               consumed = -1;

--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -1875,6 +1875,13 @@ _web_socket_connection_choose_protocol (WebSocketConnection *self,
     }
 
   /* Choose one from what client/server agree on */
+  if (!g_str_is_ascii (value))
+    {
+      /* splitting into words by comma might interfere with multi-byte characters,
+       * and they are invalid here anyway */
+      g_message ("received invalid Sec-WebSocket-Protocol, must be ASCII: %s", value);
+      return FALSE;
+    }
   values = g_strsplit_set (value, ", ", -1);
 
   /* Accept any protocol */

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -374,6 +374,13 @@ cockpit_auth_steal_authorization (GHashTable *headers,
     {
       g_hash_table_steal (headers, "Authorization");
       g_free (key);
+
+      /* This is being parsed heavily, enforce ASCII */
+      if (!g_str_is_ascii (line))
+        {
+          g_message ("received invalid Authorize header, must be ASCII");
+          goto out;
+        }
     }
   else
     {

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -735,6 +735,13 @@ static const ErrorFixture fixture_auth_timeout = {
   .header = "timeout-scheme too-slow",
 };
 
+static const ErrorFixture fixture_non_ascii = {
+  .error_code = COCKPIT_ERROR_AUTHENTICATION_FAILED,
+  .error_message = "Authentication required",
+  .header = "testscheme süccëss",
+};
+
+
 typedef struct {
   const gchar **headers;
   const gchar **prompts;
@@ -1203,6 +1210,8 @@ main (int argc,
               setup_normal, test_custom_fail, teardown_normal);
   g_test_add ("/auth/custom-timeout", Test, &fixture_auth_timeout,
               setup_normal, test_custom_timeout, teardown_normal);
+  g_test_add ("/auth/non-ascii", Test, &fixture_non_ascii,
+              setup_normal, test_custom_fail, teardown_normal);
 
   g_test_add ("/auth/custom-ssh-basic-success", Test, &fixture_ssh_basic,
               setup_normal, test_custom_success, teardown_normal);


### PR DESCRIPTION
The headers we look at should all be fine with plain ASCII values. But
it can happen that reverse proxies add extra headers with non-ASCII
values. UTF-8 should be safe with our code also for the headers Cockpit
looks at by itself, so allow these.

Fixes #12192

 - [x] audit all code that looks at headers for whether they assume ASCIIness 
 - [x] enforce ASCIIness of `Sec-WebSocket-Protocol` header
 - [x] enforce ASCIIness of `Authorization` header