### PR TITLE
login: make default choice in login page the 'Reuse my password for p…

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -279,8 +279,8 @@
         });
 
         /* Setup the user's last choice about the authorized button */
-        var authorized = localStorage.getItem('authorized-default') || "";
-        if (authorized.indexOf("password") !== -1)
+        var authorized = localStorage.getItem('authorized-default');
+        if (authorized === null || authorized.indexOf("password") !== -1)
             id("authorized-input").checked = true;
 
         var os_release = environment["os-release"];


### PR DESCRIPTION
…riviledged tasks'

This was done by adjusting the authorized-default variable from local
storage, to have three values disabled/enabled/not set. The first two
are remembered from previous session, and when it's just not set we
enable it.

Fixes #9435