### PR TITLE
machines: add sliders in Create VM dialog for memory and disk size

### DIFF
--- a/pkg/machines/components/memorySelectRow.css
+++ b/pkg/machines/components/memorySelectRow.css
@@ -1,0 +1,41 @@
+.slider-input-group {
+    align-items: center;
+    display: flex;
+    flex-flow: wrap;
+}
+
+/* Sadly, the PF3 slider is wrapped in an empty <div> */
+.slider-input-group > :first-child:not([class]) {
+    flex: auto;
+    min-width: 8rem;
+    max-width: 15rem;
+}
+
+/* The PF3 slider also uses Bootstrap layout; (mostly) nullify this */
+.slider-input-group .col-xs-12 {
+    padding: 0;
+    margin: 0 0.25rem 0 0;
+}
+
+/* Custom grouping of number input & dropdown elements */
+.slider-input-group > [role=group] {
+    display: grid;
+    grid-gap: 0.25rem;
+    grid-template-columns: repeat(2, max-content);
+}
+
+/* Constrain number width */
+.slider-input-group input[type=number] {
+    max-width: 5rem;
+}
+
+/* WebKit does funky things with spinners; hide so Epiphany can show the input */
+.slider-input-group input[type=number]::-webkit-inner-spin-button, 
+.slider-input-group input[type=number]::-webkit-outer-spin-button { 
+  -webkit-appearance: none; 
+  margin: 0; 
+}
+
+.slider-input-group.disabled {
+    pointer-events: none;
+}

--- a/pkg/machines/components/vm/memoryModal.css
+++ b/pkg/machines/components/vm/memoryModal.css
@@ -1,8 +1,0 @@
-/* Standard dialog is too wide */
-#vm-memory-modal > .modal-dialog {
-    max-width: 50rem;
-}
-
-#memory-config-dialog input[type=number] {
-    max-width: 7rem;
-}

--- a/pkg/machines/components/vm/memoryModal.jsx
+++ b/pkg/machines/components/vm/memoryModal.jsx
@@ -169,8 +169,8 @@ export class MemoryModal extends React.Component {
                         <input id={`${idPrefix}-max-memory`}
                             className='form-control ct-form-split'
                             type='number'
-                            value={toFixedPrecision(convertToUnit(this.state.maxMemory, 'KiB', this.state.maxMemoryUnit))}
-                            min={toFixedPrecision(convertToUnit(128, 'MiB', this.state.memoryUnit))}
+                            value={toFixedPrecision(convertToUnit(this.state.maxMemory, 'KiB', this.state.memoryUnit))}
+                            min={toFixedPrecision(convertToUnit(128, 'MiB', this.state.maxMemoryUnit))}
                             step={1}
                             onChange={e => this.onValueChanged('maxMemory', e.target.value)}
                             onClick={e => { // onInput does not trigger a seperate on blur event

--- a/src/base1/patternfly-overrides.less
+++ b/src/base1/patternfly-overrides.less
@@ -621,6 +621,96 @@ th > label {
   margin-top: 1rem;
 }
 
+// Restyle slider to look more modern (PF4-like)
+.slider {
+  &-selection {
+    background: var(--pf-global--active-color--100);
+  }
+
+  &-track {
+    border: none;
+    background: var(--pf-global--BorderColor--100);
+  }
+
+  &.slider-horizontal .slider-track {
+    height: 0.25rem;
+    margin-top: -0.125rem;
+  }
+
+  &-handle {
+    background: var(--pf-global--primary-color--100);
+    border: none;
+    width: 0.75rem;
+    height: 0.75rem;
+    margin: 0.125rem 0 0 0.125rem;
+    position: relative;
+
+    &.slider-horizontal {
+      /* Move right by half the width */
+      margin-left: -0.375rem;
+    }
+
+    /* Replace native outline with a stylized one */
+    &:focus {
+      --focus-offset: -3px;
+      outline: none;
+
+      &::after {
+        content: '';
+        position: absolute;
+        top: var(--focus-offset);
+        left: var(--focus-offset);
+        right: var(--focus-offset);
+        bottom: var(--focus-offset);
+        border: 2px solid var(--pf-global--primary-color--100);
+        border-radius: 50%;
+        opacity: 0.5;
+      }
+    }
+
+    &:focus,
+    &:active {
+      background: var(--pf-global--primary-color--200);
+    }
+  }
+
+  &-pf {
+    margin: 0 1rem 0 0;
+    min-height: 2.25rem;
+    position: relative;
+
+    > * {
+      margin: 0;
+    }
+
+    /* Slider labels */
+    > b {
+      color: var(--pf-global--Color--300);
+      font: inherit;
+      font-size: var(--pf-global--FontSize--xs);
+      position: absolute;
+      top: 1.5rem;
+
+      &:first-child {
+        left: 0;
+      }
+
+      &:last-child {
+        right: 0;
+      }
+    }
+
+    /* Readjust the tooltip for our needs */
+    .tooltip {
+        margin: -2.75rem 0 0 -2px !important;
+        /* Center horizontally based on its own width */
+        transform: translateX(-50%);
+        /* Don't trap mouse hovering */
+        pointer-events: none;
+    }
+  }
+}
+
 /* Round off badges, similar to PF4 */
 .badge {
   border-radius: 30em;

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -278,7 +278,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         # VM initially should have 256MiB
         current_memory = int(b.attr("#vm-subVmTest1-memory-modal-memory", "value"))
         self.assertEqual(current_memory, 256)
-        b.wait_attr("#vm-subVmTest1-memory-modal-max-memory", "readonly", "")
+        b.wait_attr("#vm-subVmTest1-memory-modal-max-memory", "disabled", "")
 
         # Check memory hotunplugging
         # The balloon driver needs to be loaded to descrease memory

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -275,6 +275,10 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Change memory
         b.wait_present("#vm-subVmTest1-memory-modal-memory")
+
+        b.wait_attr("#vm-subVmTest1-memory-modal-memory-slider  div[role=slider].hide", "aria-valuemin", "128")
+        b.wait_attr("#vm-subVmTest1-memory-modal-max-memory-slider  div[role=slider].hide", "aria-valuemin", "128")
+
         # VM initially should have 256MiB
         current_memory = int(b.attr("#vm-subVmTest1-memory-modal-memory", "value"))
         self.assertEqual(current_memory, 256)
@@ -285,6 +289,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
 
         b.set_input_text("#vm-subVmTest1-memory-modal-memory", str(current_memory - 10))
+        b.blur("#vm-subVmTest1-memory-modal-memory")
         # Save the memory settings
         b.click("#vm-subVmTest1-memory-modal-save")
         b.wait_not_present("#vm-memory-modal")
@@ -308,17 +313,12 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Verify that increasing current memory in offline VMs above max memory will increase max memory as well
         b.set_input_text("#vm-subVmTest1-memory-modal-memory", str(current_memory))
+        b.blur("#vm-subVmTest1-memory-modal-memory")
         b.wait_attr("#vm-subVmTest1-memory-modal-max-memory", "value", str(current_memory))
 
         # Verify that unit conversions work
-        b.select_from_dropdown("#vm-subVmTest1-memory-modal-memory-unit", "GiB")
-        b.set_input_text("#vm-subVmTest1-memory-modal-memory", "1")
-        b.wait_attr("#vm-subVmTest1-memory-modal-max-memory", "value", "1024")
-
-        # Save the memory settings
-        b.click("#vm-subVmTest1-memory-modal-save")
-        b.wait_not_present("#vm-memory-modal")
-        b.wait_in_text("#vm-subVmTest1-memory-count", "1 GiB")
+        b.select_from_dropdown("#vm-subVmTest1-memory-modal-memory-unit-select", "GiB")
+        b.wait_attr("#vm-subVmTest1-memory-modal-memory", "value", "0")
 
     def testDetachDisk(self):
         b = self.browser

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1338,6 +1338,19 @@ class TestMachines(NetworkCase):
             "virsh pool-start default"
         ]
         self.machine.execute(" && ".join(cmds))
+
+        # Fake the osinfo-db data in order that it will allow spawn the installation - of course we don't expect it to succeed -
+        # we just need to check that the VM was spawned
+        fedora_28_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
+        self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml > /tmp/fedora-28.xml")
+        root = ET.fromstring(fedora_28_xml)
+        root.find('os').find('resources').find('minimum').find('ram').text = '134217750'
+        root.find('os').find('resources').find('minimum').find('storage').text = '134217750'
+        root.find('os').find('resources').find('recommended').find('ram').text = '268435500'
+        root.find('os').find('resources').find('recommended').find('storage').text = '268435500'
+        new_fedora_28_xml = ET.tostring(root)
+        self.machine.execute("echo \'{0}\' > /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml".format(str(new_fedora_28_xml, 'utf-8')))
+
         self.browser.reload()
         self.browser.enter_page('/machines')
         self.browser.wait_in_text("body", "Virtual Machines")
@@ -1350,23 +1363,22 @@ class TestMachines(NetworkCase):
         print("    *\n    * validation errors and ui info/warn messages expected:\n    * ")
         cancelDialogTest(TestMachines.VmDialog(self, sourceType='file',
                                                location=config.NOVELL_MOCKUP_ISO_PATH,
-                                               memory_size=1, memory_size_unit='MiB',
+                                               memory_size=128, memory_size_unit='MiB',
                                                storage_size=12500, storage_size_unit='GiB',
                                                start_vm=True))
 
         cancelDialogTest(TestMachines.VmDialog(self, sourceType='url',
                                                location=config.VALID_URL,
                                                memory_size=256, memory_size_unit='MiB',
-                                               storage_size=0, storage_size_unit='MiB',
                                                os_name=config.FEDORA_28,
                                                start_vm=False))
 
         # check if older os are filtered
-        checkFilteredOsTest(TestMachines.VmDialog(self, storage_size=1, os_name=config.REDHAT_RHEL_4_7_FILTERED_OS))
+        checkFilteredOsTest(TestMachines.VmDialog(self, os_name=config.REDHAT_RHEL_4_7_FILTERED_OS))
 
-        checkFilteredOsTest(TestMachines.VmDialog(self, storage_size=1, os_name=config.MANDRIVA_2011_FILTERED_OS))
+        checkFilteredOsTest(TestMachines.VmDialog(self, os_name=config.MANDRIVA_2011_FILTERED_OS))
 
-        checkFilteredOsTest(TestMachines.VmDialog(self, storage_size=1, os_name=config.MAGEIA_3_FILTERED_OS))
+        checkFilteredOsTest(TestMachines.VmDialog(self, os_name=config.MAGEIA_3_FILTERED_OS))
 
         # try to CREATE WITH DIALOG ERROR
         # name
@@ -1384,23 +1396,14 @@ class TestMachines(NetworkCase):
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, sourceType='url',
-                                                            location="invalid/url", storage_size=1,
+                                                            location="invalid/url",
                                                             os_name=config.FEDORA_28), {"Source": "Source should start with"})
 
         # memory
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1, memory_size=0), {"Memory": "Memory must not be 0"})
-
-        # memory
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1,
-                                                            os_name=config.FEDORA_28,
-                                                            memory_size=256, memory_size_unit='MiB'), {"Memory": "minimum memory requirement of 1024 MiB"})
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, memory_size=0, os_name=None), {"Memory": "Memory must not be 0"})
 
         # storage
         checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=0), {"Size": "Storage size must not be 0"})
-
-        # storage
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, os_name=config.FEDORA_28,
-                                                            storage_size=1, storage_size_unit='GiB'), {"Size": "minimum storage size requirement"})
 
         # start vm
         checkDialogFormValidationTest(TestMachines.VmDialog(self, storage_size=1,
@@ -1417,21 +1420,6 @@ class TestMachines(NetworkCase):
         if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', 'fedora-testing']:
             self.browser.wait_not_present('select option[data-value="Download an OS"]')
         else:
-            # Fake the osinfo-db data in order that it will allow spawn the installation - of course we don't expect it to succeed -
-            # we just need to check that the VM was spawned
-            fedora_28_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
-            self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml > /tmp/fedora-28.xml")
-            root = ET.fromstring(fedora_28_xml)
-            root.find('os').find('resources').find('minimum').find('ram').text = '134217750'
-            root.find('os').find('resources').find('minimum').find('storage').text = '134217750'
-            root.find('os').find('resources').find('recommended').find('ram').text = '268435500'
-            root.find('os').find('resources').find('recommended').find('storage').text = '268435500'
-            new_fedora_28_xml = ET.tostring(root)
-            self.machine.execute("echo \'{0}\' > /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml".format(str(new_fedora_28_xml, 'utf-8')))
-            self.browser.reload()
-            self.browser.enter_page('/machines')
-            self.browser.wait_in_text("body", "Virtual Machines")
-
             createDownloadAnOSTest(TestMachines.VmDialog(self, sourceType='downloadOS',
                                                          expected_memory_size=256,
                                                          expected_storage_size=256,
@@ -1947,19 +1935,20 @@ class TestMachines(NetworkCase):
                         b.wait_visible("#storage-volume-select")
                         b.select_from_dropdown("#storage-volume-select", self.storage_volume)
 
-                    if self.storage_size is None or self.storage_pool != 'Create New Volume':
+                    if self.storage_pool != 'Create New Volume':
                         b.wait_not_present("#storage-size")
                     else:
                         b.select_from_dropdown("#storage-size-unit-select", self.storage_size_unit)
-                        b.set_input_text("#storage-size", str(self.storage_size), value_check=False)
-                        # helpblock will be missing if available storage size could not be calculated (no default storage pool found)
-                        # test images sometimes may not have default storage pool defined for session connection
-                        if self.connection != "session":
-                            help_block_line = b.text("#storage-size-helpblock")
-                            space_available = [int(s) for s in help_block_line.split() if s.isdigit()][0]
-                            # Write the final storage size back to self so that other function can read it
-                            self.storage_size = min(self.storage_size, space_available)
-                            b.wait_val("#storage-size", self.storage_size)
+                        if self.storage_size:
+                            b.set_input_text("#storage-size", str(self.storage_size), value_check=False)
+                            b.blur("#storage-size")
+                            # helpblock will be missing if available storage size could not be calculated (no default storage pool found)
+                            # test images sometimes may not have default storage pool defined for session connection
+                            if self.connection != "session":
+                                space_available = int(b.text("#storage-size-slider ~ b"))
+                                # Write the final storage size back to self so that other function can read it
+                                self.storage_size = min(self.storage_size, space_available)
+                                b.wait_val("#storage-size", self.storage_size)
                 else:
                     b.wait_val("#storage-size", self.expected_storage_size)
 
@@ -1968,13 +1957,17 @@ class TestMachines(NetworkCase):
             if not self.expected_memory_size:
                 b.select_from_dropdown("#memory-size-unit-select", self.memory_size_unit)
                 b.set_input_text("#memory-size", str(self.memory_size), value_check=False)
-                help_block_line = b.text("#memory-size-helpblock")
-                host_total_memory = [int(s) for s in help_block_line.split() if s.isdigit()][0]
+                b.blur('#memory-size')
+                host_total_memory = int(b.text("#memory-size-slider ~ b"))
                 # Write the final memory back to self so that other function can read it
                 self.memory_size = min(self.memory_size, host_total_memory)
                 b.wait_val("#memory-size", self.memory_size)
             else:
                 b.wait_val("#memory-size", self.expected_memory_size)
+
+            # check minimum memory is correctly set in the slider - the following are fake data
+            if self.os_name in [TestMachines.TestCreateConfig.CIRROS, TestMachines.TestCreateConfig.FEDORA_28]:
+                b.wait_attr("#memory-size-slider  div[role=slider].hide", "aria-valuemin", "128")
 
             b.wait_visible("#start-vm")
             if not self.start_vm:


### PR DESCRIPTION
This allows us to remove the text bellow the input fields for
recommended and minumum values, since the slider incorporates these
information.

The tests had to be adjusted to ensured that the limits on the sliders
are respected.