### PR TITLE
machines: Fix ubuntu-stable race condition in tests

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -488,12 +488,11 @@ class TestMachines(NetworkCase):
         b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
         b.click("#start-libvirt")
-
-        b.wait_in_text("body", "Virtual Machines")
+        b.wait(lambda: checkLibvirtEnabled())
         # HACK: https://launchpad.net/bugs/1802005
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
-        b.wait(lambda: checkLibvirtEnabled())
+        b.wait_in_text("body", "Virtual Machines")
         with b.wait_timeout(10):
             b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
@@ -502,11 +501,11 @@ class TestMachines(NetworkCase):
         b.wait_present("#enable-libvirt:checked")
         b.click("#enable-libvirt") # uncheck it ; ; TODO: fix this, do not assume initial state of the checkbox
         b.click("#start-libvirt")
-        b.wait_in_text("body", "Virtual Machines")
+        b.wait(lambda: not checkLibvirtEnabled())
         # HACK: https://launchpad.net/bugs/1802005
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
-        b.wait(lambda: not checkLibvirtEnabled())
+        b.wait_in_text("body", "Virtual Machines")
         with b.wait_timeout(10):
             b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 


### PR DESCRIPTION
There was a beautiful race condition in tests:
First the file permissions of /run/libvirt/libvirt-socked were
changed and then we checked (and waited) if libvirtd service was
started.
In some cases however this would lead to situation where we changed
permissions before libvirtd was started, and the start of libvirtd
would overwrite our file permission change.

This should fix ubuntu-stable specific flake:
https://logs-https-cockpit.apps.ci.centos.org/logs/pull-12988-20191016-130101-8ccb0965-cockpit-project-cockpit--ubuntu-stable/log.html#230-2