### PR TITLE
machines: Fix libvirtd service restart bug/flake

### DIFF
--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -22,6 +22,7 @@ import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 import { mouseClick } from "../helpers.js";
 import {
+    checkLibvirtStatus,
     startLibvirt,
     enableLibvirt,
 } from "../actions/provider-actions.js";
@@ -39,6 +40,7 @@ class LibvirtSlate extends React.Component {
 
         this.onLibvirtEnabledChanged = this.onLibvirtEnabledChanged.bind(this);
         this.startService = this.startService.bind(this);
+        this.checkStatus = this.checkStatus.bind(this);
         this.goToServicePage = this.goToServicePage.bind(this);
     }
 
@@ -48,6 +50,12 @@ class LibvirtSlate extends React.Component {
                 libvirtEnabled: e.target.checked,
             });
         }
+    }
+
+    checkStatus() {
+        const service = this.props.libvirtService;
+
+        this.props.dispatch(checkLibvirtStatus(service.name));
     }
 
     startService() {
@@ -81,6 +89,7 @@ class LibvirtSlate extends React.Component {
             message = _("Loading Resources");
             icon = (<div className="spinner spinner-lg" />);
         } else {
+            this.checkStatus();
             message = _("Virtualization Service (libvirt) is Not Active");
             icon = (<span className="fa fa-exclamation-circle" />);
             detail = (

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -14,7 +14,6 @@ import {
 } from './actions/store-actions.js';
 
 import {
-    checkLibvirtStatus,
     getApiData,
     getHypervisorMaxVCPU,
     getLoggedInUser,
@@ -1370,9 +1369,6 @@ export function START_LIBVIRT({ serviceName }) {
     logDebug(`${this.name}.START_LIBVIRT`);
     return dispatch => {
         return service.proxy(serviceName).start()
-                .done(() => {
-                    dispatch(checkLibvirtStatus(serviceName));
-                })
                 .fail(exception => {
                     console.info(`starting libvirt failed: "${JSON.stringify(exception)}"`);
                 });

--- a/pkg/machines/selectors.js
+++ b/pkg/machines/selectors.js
@@ -28,6 +28,10 @@ export function getRefreshInterval(state) {
     return state.config.refreshInterval;
 }
 
+export function getLibvirtServiceState(state) {
+    return state.systemInfo.libvirtService.activeState;
+}
+
 export function usagePollingEnabled(state, name, connectionName) {
     for (var i = 0; i < state.vms.length; i++) {
         const vm = state.vms[i];


### PR DESCRIPTION
After libvirtd service is stopped, we call startEventMonitorLibvirtd() which in turn calls delayPolling(). This delays polling of libvirt resources by 10 seconds. However if libvirtd service is not started in next 10 seconds, polling of libvirt resources is called nevertheless, which will result in a failure.

This created a bug: when user turned off libvirtd service and didn't start it in next 10 seconds, they would never get resource polled. It was also causing a flake in tests if libvird service took longer than 10 seconds to start.

Fix this by making delayPolling recursively call itself until libvirtd service is running again. Thus it will loop until it can poll libvirt resources.

This should fix LibvirtTest flakes:
https://209.132.184.41:8493/logs/pull-12972-20191014-130202-133aef01-cockpit-project-cockpit--rhel-8-1/log.html#67-2
https://209.132.184.41:8493/logs/pull-12972-20191014-130202-133aef01-cockpit-project-cockpit--fedora-30/log.html#67-2