### PR TITLE
machines: Pass only active storage pools to the Add Disk dialog compo…

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -454,7 +454,6 @@ export class AddDiskModalBody extends React.Component {
     render() {
         const { vm, storagePools, provider, vms } = this.props;
         const idPrefix = `${this.props.idPrefix}-adddisk`;
-        const storagePoolsFiltered = storagePools.filter(pool => pool && pool.active);
 
         const defaultBody = (
             <div className='ct-form'>
@@ -487,7 +486,7 @@ export class AddDiskModalBody extends React.Component {
                     <CreateNewDisk idPrefix={`${idPrefix}-new`}
                                    onValueChanged={this.onValueChanged}
                                    dialogValues={this.state}
-                                   vmStoragePools={storagePoolsFiltered}
+                                   vmStoragePools={storagePools}
                                    provider={provider}
                                    vm={vm} />
                 )}
@@ -495,7 +494,7 @@ export class AddDiskModalBody extends React.Component {
                     <UseExistingDisk idPrefix={`${idPrefix}-existing`}
                                      onValueChanged={this.onValueChanged}
                                      dialogValues={this.state}
-                                     vmStoragePools={storagePoolsFiltered}
+                                     vmStoragePools={storagePools}
                                      provider={provider}
                                      vms={vms}
                                      vm={vm} />

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -92,7 +92,7 @@ class VmDisksTab extends React.Component {
                 <Button id={`${idPrefix}-adddisk`} bsStyle='primary' onClick={this.open} className='pull-right'>
                     {_("Add Disk")}
                 </Button>
-                {this.state.showModal && <AddDiskModalBody close={this.close} dispatch={dispatch} idPrefix={idPrefix} vm={vm} vms={vms} storagePools={storagePools} provider={provider} />}
+                {this.state.showModal && <AddDiskModalBody close={this.close} dispatch={dispatch} idPrefix={idPrefix} vm={vm} vms={vms} storagePools={storagePools.filter(pool => pool && pool.active)} provider={provider} />}
             </>
         );
         let renderCapacityUsed, renderAccess, renderAdditional;


### PR DESCRIPTION
…nent

The filtering previously was done inside the component itself before
rendering, but all initialization actions in constructor were also
counting with inactive pools which led to issues.
E.g. when the first pool alphabetically was inactive, it would result
being considered as the default pool, but it would not be present on the UI
list for available pools.