### PR TITLE
logs: Show empty state when no logs found

### DIFF
--- a/pkg/lib/cockpit-components-empty-state.css
+++ b/pkg/lib/cockpit-components-empty-state.css
@@ -1,0 +1,5 @@
+@import "../../node_modules/@patternfly/patternfly/components/Spinner/spinner.css";
+
+.pf-c-empty-state .pf-c-button.pf-m-primary.slim {
+    margin: 0px;
+}

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from 'prop-types';
+import {
+    Title,
+    Button,
+    EmptyState,
+    EmptyStateVariant,
+    EmptyStateIcon,
+    EmptyStateBody,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import "./cockpit-components-empty-state.css";
+
+export class EmptyStatePanel extends React.Component {
+    render() {
+        const Spinner = () => (
+            <span className="pf-c-spinner" role="progressbar" aria-valuetext="Loading...">
+                <span className="pf-c-spinner__clipper" />
+                <span className="pf-c-spinner__lead-ball" />
+                <span className="pf-c-spinner__tail-ball" />
+            </span>
+        );
+        const slimType = this.props.title || this.props.paragraph ? "" : "slim";
+        return (
+            <EmptyState variant={EmptyStateVariant.full}>
+                {this.props.showIcon && (this.props.loading ? <EmptyStateIcon variant="container" component={Spinner} /> : <EmptyStateIcon icon={ExclamationCircleIcon} />)}
+                <Title headingLevel="h5" size="lg">
+                    {this.props.title}
+                </Title>
+                <EmptyStateBody>
+                    {this.props.paragraph}
+                </EmptyStateBody>
+                {this.props.action && <Button variant="primary" className={slimType} onClick={this.props.onAction}>{this.props.action}</Button>}
+            </EmptyState>
+        );
+    }
+}
+
+EmptyStatePanel.propTypes = {
+    loading: PropTypes.bool,
+    showIcon: PropTypes.bool,
+    title: PropTypes.string,
+    paragraph: PropTypes.string,
+    action: PropTypes.string,
+    onAction: PropTypes.func,
+};

--- a/pkg/systemd/host.css
+++ b/pkg/systemd/host.css
@@ -5,6 +5,7 @@
 @import "../lib/plot.css";
 @import "../lib/table.css";
 @import "../lib/tooltip.css";
+@import "../lib/cockpit-components-empty-state.css";
 
 @import "./timer.css";
 

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -24,6 +24,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta charset="utf-8">
   <link href="../base1/patternfly.css" rel="stylesheet">
   <link href="system.css" rel="stylesheet">
+  <link href="logs.css" rel="stylesheet">
   <script type="text/javascript" src="../base1/jquery.js"></script>
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script src="../*/po.js"></script>

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -160,7 +160,11 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         })""", expected)
 
         def wait_journal_empty():
-            wait_log_lines([])
+            # Changed in #13039
+            if m.image == "rhel-8-1-distropkg":
+                wait_log_lines([])
+            else:
+                wait_log_lines(["No Logs FoundCan not find any logs using the current combination of filters."])
 
         b.go("#/?prio=*&service=log123.service")
         wait_journal_empty()
@@ -273,7 +277,12 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         "Load earlier entries",
                         ])
 
-        b.click('#journal-load-earlier')
+        # Changed in #13039
+        if m.image == "rhel-8-1-distropkg":
+            b.click('#journal-load-earlier')
+        else:
+            b.click('#start-box button:contains("Load earlier entries")')
+
         wait_log_lines([expected_date,
                         ["check-journal", "AFTER BOOT", ""],
                         ["", "Reboot", ""],


### PR DESCRIPTION
I wanted to do implement https://github.com/cockpit-project/cockpit/issues/8271 but there is problem that if someone jumps to logs from service which did not log anything, only empty page was shown.

@andreasn can you please review design-wise? And @KKoukiou can you please check the code?
I did new component, because I was implementing this `empty state` a few times already and we still miss it on many places, so I hope it makes it easier to use on other places as well.
No tests yet, I'll adjust them in meantime.

This PR implements:
Showing that something is loading: (before it was just one line of text saying `Loading...` on the top left)
![loadingpanel](https://user-images.githubusercontent.com/12330670/67570433-ad08bd00-f731-11e9-917f-324eb5b573f3.png)

Properly showing that there are no logs: (before it was just blank screen)
![andreallynone](https://user-images.githubusercontent.com/12330670/67570483-cf9ad600-f731-11e9-9161-eabd4c35d6c5.png)

When there are no logs, but there are more to be loaded: (Before it shown button on top left saying `Load more`) [disclaimer: There is no change in logic how we load logs. I know this use case is not ideal, but it may happen. We may think about it later and fix it, but not in this PR]. Also I was not sure if there should be icon as well or not.
![nologsfound-earlier](https://user-images.githubusercontent.com/12330670/67570521-e93c1d80-f731-11e9-8bde-51c26e3702c2.png)

When there are some logs, but we still can load more: (before it was the same button but floating left and no panel)
![loadmorebitte](https://user-images.githubusercontent.com/12330670/67570557-0244ce80-f732-11e9-8ee7-53e67df2d8b2.png)
And when we hit the button from prev. image, it loads a bit more items and then hides the panel:
![anddone](https://user-images.githubusercontent.com/12330670/67570583-12f54480-f732-11e9-9a62-fd927d42ed15.png)

