### PR TITLE
test: Fix race condition in test15BaseSSHKeyAdded

### DIFF
--- a/test/selenium/testlib_avocado/seleniumlib.py
+++ b/test/selenium/testlib_avocado/seleniumlib.py
@@ -428,6 +428,7 @@ parameters:
             self.send_keys(self.wait_id("authorized-keys-text", cond=visible), ssh_public_key)
             self.click((self.wait_id("add-authorized-key", cond=clickable)))
             self.wait_id("authorized-key-add", cond=clickable)
+            self.wait_xpath("//div[@class='comment' and contains(text(), '%s')]" % ssh_key_name)
         self.mainframe()
 
     def logout(self):


### PR DESCRIPTION
Wait until the key actually got added, instead of immediately tearing
down the browser. The latter does not get far enough to actually add the
key (at least when running under Edge).

-----

Example: https://209.132.184.41:8493/logs/pull-12972-20191027-104444-8ed348fd-cockpit-project-cockpit--fedora-30-selenium-edge/log.html#2  → this happens in *every* current Edge test, and is trivial to reproduce locally