### PR TITLE
build: Fix Edge crash on PF4's collapsible decorator

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -383,9 +383,9 @@ module.exports = {
                 exclude: /\/node_modules\/.*\//, // exclude external dependencies
                 loader: 'strict-loader' // Adds "use strict"
             },
-            /* these are called *.js, but are ES6 */
+            /* these modules need to be babel'ed, they cause bugs in their dist'ed form */
             {
-                test: /\/node_modules\/@novnc.*\.js$/,
+                test: /\/node_modules\/.*(@novnc|react-table).*\.js$/,
                 use: babel_loader
             },
             {


### PR DESCRIPTION
The `const expandedRow` in the ES6 variant of PF4's collapsible.js
upsets Edge 16, it cashes with

    SCRIPT1003: Expected ':'

Our build system seems to favor dist/esm (where PF4 ships its ES6
modules) over dist/js (where they ship pre-babelled ES5, which works),
but we generally skip running babel on node_modules. Add react-table to
the whitelist so that we avoid the problematic arrow function in our
generated webpacks that trigger the Edge bug.

Fixes #12864

---

Split out from PR #13052, as fixing the selenium tests takes way more work than anticipated.