### PR TITLE
test: Aachen the failing service so that it is first

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -834,7 +834,19 @@ WantedBy=default.target
         m = self.machine
         b = self.browser
 
-        m.write("/etc/systemd/system/test-fail.service",
+        # We use two services with oprefix "aaa" and "aab" so that
+        # they always occupy the first two rows and we can check their
+        # relative order depending on whether "aab" has failed or not.
+
+        m.write("/etc/systemd/system/aaa.service",
+                """
+[Unit]
+Description=First Row Service
+
+[Service]
+ExecStart=/usr/bin/true
+""")
+        m.write("/etc/systemd/system/aab-fail.service",
                 """
 [Unit]
 Description=Failing Test Service
@@ -849,15 +861,19 @@ ExecStart=/usr/bin/false
 
         self.login_and_go("/system/services")
 
-        def svc_sel(service):
-            return 'tr[data-goto-unit="%s"]' % service
+        def health_message():
+            n_failures = int(m.execute("systemctl --failed --plain --no-legend | wc -l"))
+            if n_failures == 1:
+                return "1 service has failed"
+            else:
+                return "%s services have failed" % n_failures
 
         # Start test-fail
-        m.execute("systemctl start test-fail")
+        m.execute("systemctl start aab-fail")
 
-        # Test-fail should be at the top, and have failed
-        b.wait_present('tr:nth-child(1)[data-goto-unit="test-fail.service"]')
-        b.wait_present('tr[data-goto-unit="test-fail.service"] td:contains("failed")')
+        # Aab-fail should be at the top, and have failed
+        b.wait_present('tr:nth-child(1)[data-goto-unit="aab-fail.service"]')
+        b.wait_present('tr[data-goto-unit="aab-fail.service"] td:contains("failed")')
 
         # Services tab should have icon
         b.wait_present('a:contains("System Services") .fa-exclamation-triangle')
@@ -869,16 +885,16 @@ ExecStart=/usr/bin/false
         # System page should have notification
         b.click('#host-apps a[href="/system"]')
         b.enter_page('/system')
-        b.wait_present('#page_status_notifications:contains("1 service has failed")')
+        b.wait_present('#page_status_notifications:contains("%s")' % health_message())
 
-        # Clear test-fail
-        m.execute("systemctl reset-failed test-fail")
+        # Clear aab-fail
+        m.execute("systemctl reset-failed aab-fail")
 
-        # Test-fail should not be at the top
+        # aab-fail should not be at the top
         b.switch_to_top()
         b.click('#host-apps a[href="/system/services"]')
         b.enter_page('/system/services')
-        b.wait_not_present('tr:nth-child(1)[data-goto-unit="test-fail.service"]')
+        b.wait_not_present('tr:nth-child(1)[data-goto-unit="aab-fail.service"]')
 
         # Services tab should not have icon
         b.wait_not_present('a:contains("System Services") .fa-exclamation-triangle')
@@ -890,7 +906,7 @@ ExecStart=/usr/bin/false
         # System page should not have notification
         b.click('#host-apps a[href="/system"]')
         b.enter_page('/system')
-        b.wait_not_present('#page_status_notifications:contains("1 service has failed")')
+        b.wait_not_present('#page_status_notifications:contains("failed")')
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
In particular, the "sssd" service seems to fail sometimes on Debian,
which would take the first row.

aachen (v) - Seinen Namen ändern, um eher dranzukommen.