### PR TITLE
Bump libssh dependency to >= 0.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,7 +66,7 @@ AC_MSG_RESULT($enable_prefix_only)
 #
 
 GLIB_VERSION="2.44"
-LIBSSH_VERSION="0.6.0"
+LIBSSH_VERSION="0.8"
 GIO_VERSION="2.37.4" # For appropriate version of TLS logic
 
 GIO_REQUIREMENT="gio-unix-2.0 >= $GIO_VERSION gio-2.0 >= $GIO_VERSION"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -72,7 +72,7 @@ BuildRequires: autoconf automake
 BuildRequires: /usr/bin/python3
 BuildRequires: gettext >= 0.19.7
 %if %{defined build_dashboard}
-BuildRequires: libssh-devel >= 0.7.1
+BuildRequires: libssh-devel >= 0.8
 %endif
 BuildRequires: openssl-devel
 BuildRequires: gnutls-devel >= 3.4.3

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -5,7 +5,7 @@ Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: debhelper (>= 10),
                dpkg-dev (>= 1.17.14),
                gettext (>= 0.19.7),
-               libssh-dev,
+               libssh-dev (>= 0.8),
                zlib1g-dev,
                libkrb5-dev (>= 1.11),
                libxslt1-dev,


### PR DESCRIPTION
We don't support building against libssh 0.7 (or older) any more. We
just barely support 0.8.0 on Ubuntu 18.04 (which already has some
serious deficiencies)

Fixes #11052