### PR TITLE
po: Use `zanata` instead of `zanata-cli`.

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -114,22 +114,20 @@ update-po: po/cockpit.pot
 		$(MSGMERGE) --output-file=$(srcdir)/po/$$lang.po $(srcdir)/po/$$lang.po $<; \
 	done
 
-ZANATA_CLI = LANG=C.UTF-8 LC_ALL=C.UTF-8 zanata-cli -B
+ZANATA_CLI = LANG=C.UTF-8 LC_ALL=C.UTF-8 zanata
 
 upload-pot: po/cockpit.pot
-	$(ZANATA_CLI) push --includes cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
-		-s "$(builddir)/po"
+	$(ZANATA_CLI) push -f --srcdir=$(builddir)/po --push-type=source --project-config=$(srcdir)/po/zanata.xml cockpit.pot
 
-upload-translations:
-	$(ZANATA_CLI) push --includes=cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
-		--push-type trans -s "$(builddir)/po" -t "$(srcdir)/po"
+upload-translations: po/cockpit.pot
+	$(ZANATA_CLI) push -f --srcdir=$(srcdir)/po --push-type=target \
+		--transdir=$(srcdir)/po --project-config=$(srcdir)/po/zanata.xml
 
 clean-po:
 	rm $(srcdir)/po/*.po
 
 download-po:
-	$(ZANATA_CLI) pull --includes=cockpit.pot --project-config "$(srcdir)/po/zanata.xml" \
-		--min-doc-percent 50 -s "$(builddir)/po" -t "$(srcdir)/po"
+	$(ZANATA_CLI) pull --min-doc-percent 50 --transdir=$(srcdir)/po --project-config=$(srcdir)/po/zanata.xml
 
 CLEANFILES += \
 	$(MO_FILES) \

--- a/po/cs.po
+++ b/po/cs.po
@@ -10,16 +10,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 10:45+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-10-16 10:33+0000\n"
+"POT-Creation-Date: 2019-10-30 17:14+0000\n"
+"PO-Revision-Date: 2019-10-25 11:47+0000\n"
 "Last-Translator: Pavel Borecki <pavel.borecki@gmail.com>\n"
 "Language-Team: Czech\n"
 "Language: cs\n"
-"X-Generator: Zanata 4.6.2\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
@@ -31,13 +31,13 @@ msgstr ""
 "Jeho připojení udělá tento disk sdílitelný pro každý virt. stroj, který ho "
 "používá."
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zone"
-msgstr ""
+msgstr "$0 aktivní zóna"
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zones"
-msgstr ""
+msgstr "$0 aktivní zóny"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
@@ -165,8 +165,8 @@ msgid ""
 "$0 is available for most operating systems. To install it, search for it in "
 "GNOME Software or run the following:"
 msgstr ""
-"$0 je k dispozici pro většinu operačních systémů. Pro instalaci vyhledejte v "
-"GNOME Software nebo spusťte následující:"
+"$0 je k dispozici pro většinu operačních systémů. Pro instalaci vyhledejte v"
+" GNOME Software nebo spusťte následující:"
 
 #: pkg/storaged/content-views.jsx:289 pkg/storaged/content-views.jsx:508
 #: pkg/storaged/format-dialog.jsx:221 pkg/storaged/lvol-tabs.jsx:202
@@ -264,7 +264,7 @@ msgstr[0] "$1 oprava zabezpečení"
 msgstr[1] "$1 opravy zabezpečení"
 msgstr[2] "$1 oprav zabezpečení"
 
-#: pkg/networkmanager/interfaces.js:2764
+#: pkg/networkmanager/interfaces.js:2739
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -532,11 +532,11 @@ msgstr "7."
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:1966
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:1983
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -550,8 +550,8 @@ msgstr "9."
 
 #: pkg/lib/machine-not-supported.html:5
 msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
+"A compatible version of Cockpit is not installed on "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Na {{#strong}}{{host}}{{/strong}} není nainstalovaná kompatibilní verze "
 "Cockpit."
@@ -560,7 +560,7 @@ msgstr ""
 msgid "A disk is needed."
 msgstr "Je zapotřebí disk."
 
-#: src/ws/login.html:115
+#: src/ws/login.html:102
 msgid ""
 "A modern browser is required for security, reliability, and performance."
 msgstr ""
@@ -571,15 +571,15 @@ msgstr ""
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Před odebráním tohoto disku je třeba přidat náhradní."
 
-#: pkg/networkmanager/interfaces.js:1997
+#: pkg/networkmanager/interfaces.js:1974
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2793
+#: pkg/networkmanager/interfaces.js:2768
 msgid "ARP Monitoring"
 msgstr "ARP monitorování"
 
-#: pkg/networkmanager/interfaces.js:2018
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP Ping"
 msgstr "ARP ping"
 
@@ -630,12 +630,13 @@ msgstr "Aktivovat"
 msgid "Activating $target"
 msgstr "Aktivuje se $target"
 
-# auto translated by TM merge from project: ibus-libpinyin, version: master, DocId: ibus-libpinyin
-#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:2012
+# auto translated by TM merge from project: ibus-libpinyin, version: master,
+# DocId: ibus-libpinyin
+#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:1989
 msgid "Active"
 msgstr "Aktivní"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1963 pkg/networkmanager/interfaces.js:1980
 msgid "Active Backup"
 msgstr "Aktivní záloha"
 
@@ -651,17 +652,18 @@ msgstr "Aktivní od"
 msgid "Active since "
 msgstr "Aktivní od"
 
-#: pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Adaptive load balancing"
 msgstr "Přizpůsobující se rozkládání zátěže"
 
-#: pkg/networkmanager/interfaces.js:1990
+#: pkg/networkmanager/interfaces.js:1967
 msgid "Adaptive transmit load balancing"
 msgstr "Přizpůsobující se rozkládání přenosové zátěže odesílání"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
-#: pkg/machines/components/diskAdd.jsx:522
+#: pkg/machines/components/diskAdd.jsx:521
 #: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
 #: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
 #: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:197
@@ -669,7 +671,7 @@ msgstr "Přizpůsobující se rozkládání přenosové zátěže odesílání"
 msgid "Add"
 msgstr "Přidat"
 
-#: pkg/networkmanager/interfaces.js:3113
+#: pkg/networkmanager/interfaces.js:3088
 msgid "Add $0"
 msgstr "Přidat $0"
 
@@ -685,7 +687,7 @@ msgstr "Přidat sloučení linek"
 msgid "Add Bridge"
 msgstr "Přidat síťový most"
 
-#: pkg/machines/components/diskAdd.jsx:510
+#: pkg/machines/components/diskAdd.jsx:509
 #: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Přidat disk"
@@ -731,8 +733,8 @@ msgstr "Přidat VLAN"
 msgid "Add Virtual Network Interface"
 msgstr "Přidat virtuální síťové rozhraní"
 
-#: pkg/networkmanager/firewall.jsx:659 pkg/networkmanager/firewall.jsx:828
-#: pkg/networkmanager/firewall.jsx:834
+#: pkg/networkmanager/firewall.jsx:666 pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:900
 msgid "Add Zone"
 msgstr "Přidat zónu"
 
@@ -756,11 +758,11 @@ msgstr "Přidat veřejnou část klíče"
 msgid "Add services to $0 zone"
 msgstr "Přidat služby do zóny $0"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:743
 msgid "Add zone"
 msgstr "Přidat zónu"
 
-#: pkg/networkmanager/interfaces.js:3112
+#: pkg/networkmanager/interfaces.js:3087
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -773,8 +775,8 @@ msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
 msgstr ""
-"Přidání uživatelsky určených portů znovunačte firewalld. To povede ke ztrátě "
-"jakéhokoli nastavení, které bylo učiněno za běhu a neuloženo!"
+"Přidání uživatelsky určených portů znovunačte firewalld. To povede ke ztrátě"
+" jakéhokoli nastavení, které bylo učiněno za běhu a neuloženo!"
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -788,11 +790,11 @@ msgstr "Přidává se fyzický svazek do $target"
 msgid "Additional"
 msgstr "Další"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "Additional DNS $val"
 msgstr "Další DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "Additional DNS Search Domains $val"
 msgstr "Další DNS domény k prohledávání $val"
 
@@ -804,7 +806,7 @@ msgstr "Další úložiště"
 msgid "Additional actions"
 msgstr "Další akce"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Additional address $val"
 msgstr "Další adresa $val"
 
@@ -812,7 +814,8 @@ msgstr "Další adresa $val"
 msgid "Additional packages:"
 msgstr "Další balíčky:"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
 #: pkg/lib/machine-add.html:11
 #: pkg/machines/components/networks/networkOverviewTab.jsx:107
 #: pkg/machines/components/networks/networkOverviewTab.jsx:130
@@ -821,7 +824,7 @@ msgstr "Další balíčky:"
 msgid "Address"
 msgstr "Adresa"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Address $val"
 msgstr "Adresa $val"
 
@@ -840,13 +843,15 @@ msgstr "Do adresy nebyla vyplněná platná URL"
 msgid "Address not within subnet"
 msgstr "Adresa se nenachází v podsíti"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/machines/components/desktopConsole.jsx:153
 msgid "Address:"
 msgstr "Adresa:"
 
-# auto translated by TM merge from project: Spacewalk Web UI, version: master, DocId: java/code/src/com/redhat/rhn/frontend/strings/java/StringResource
-#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3319
+# auto translated by TM merge from project: Spacewalk Web UI, version: master,
+# DocId: java/code/src/com/redhat/rhn/frontend/strings/java/StringResource
+#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3294
 msgid "Addresses"
 msgstr "Adresy"
 
@@ -869,18 +874,18 @@ msgstr "Později"
 #: pkg/systemd/services.html:310
 msgctxt "time-delay"
 msgid "After"
-msgstr ""
+msgstr "Po"
 
 #: pkg/realmd/operation.html:27
 msgid ""
 "After leaving the domain, only users with local credentials will be able to "
-"log into this machine. This may also affect other services as DNS resolution "
-"settings and the list of trusted CAs may change."
+"log into this machine. This may also affect other services as DNS resolution"
+" settings and the list of trusted CAs may change."
 msgstr ""
 "Po opuštění domény se do tohoto stroje budou moci přihlásit jen ti "
 "uživatelé, kteří mají účet přímo na něm. Může to postihnout také ostatní "
-"služby, jako je nastavení DNS překladu a může se změnit seznam důvěryhodných "
-"cert. autorit."
+"služby, jako je nastavení DNS překladu a může se změnit seznam důvěryhodných"
+" cert. autorit."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
 #: pkg/systemd/init.js:964
@@ -891,7 +896,8 @@ msgstr "Po startu systému"
 msgid "Alert and above"
 msgstr "Výstraha a závažnější"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213
+#: pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Vše"
 
@@ -911,7 +917,7 @@ msgstr ""
 msgid "Allow running (unmask)"
 msgstr "Umožnit spouštění (odmaskovat)"
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Allowed Addresses"
 msgstr "Adresy, které umožněny"
 
@@ -938,7 +944,8 @@ msgstr "Vzhled:"
 msgid "Applications"
 msgstr "Aplikace"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/networkmanager/index.html:481 pkg/networkmanager/index.html:505
 #: pkg/networkmanager/index.html:529 pkg/networkmanager/index.html:553
 #: pkg/networkmanager/index.html:577 pkg/networkmanager/index.html:601
@@ -1024,12 +1031,14 @@ msgstr ""
 "Pro provádění privilegovaných úloh pomocí webové konzole Cockpit je třeba "
 "ověření totožnosti"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/storaged/iscsi-panel.jsx:153
 msgid "Authentication required"
 msgstr "Nutné ověření"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/docker/index.html:702 pkg/docker/containers-view.jsx:413
 msgid "Author"
 msgstr "Autor"
@@ -1038,20 +1047,21 @@ msgstr "Autor"
 msgid "Authorized Public SSH Keys"
 msgstr "Pověřené veřejné SSH klíče"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/networkmanager/index.html:179
 #: pkg/machines/components/networks/createNetworkDialog.jsx:162
-#: pkg/networkmanager/interfaces.js:1976 pkg/networkmanager/interfaces.js:2766
-#: pkg/networkmanager/interfaces.js:3327 pkg/networkmanager/interfaces.js:3331
-#: pkg/networkmanager/interfaces.js:3337 pkg/realmd/operation.js:338
+#: pkg/networkmanager/interfaces.js:1953 pkg/networkmanager/interfaces.js:2741
+#: pkg/networkmanager/interfaces.js:3302 pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3312 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automaticky"
 
-#: pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1954
 msgid "Automatic (DHCP only)"
 msgstr "Automaticky (pouze DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1944
 msgid "Automatic (DHCP)"
 msgstr "Automaticky (DHCP)"
 
@@ -1089,7 +1099,8 @@ msgstr "Automatizační skript"
 msgid "Autostart"
 msgstr "Automatické spouštění"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-change-auth.html:66
 #: pkg/machines/components/vm/vmUsageTab.jsx:65
 #: pkg/machines/components/vm/vmUsageTab.jsx:76
@@ -1168,9 +1179,10 @@ msgstr "Blokové zařízení pro souborové systémy"
 msgid "Blocked"
 msgstr "Blokované"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2798
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
+#: pkg/networkmanager/interfaces.js:2493 pkg/networkmanager/interfaces.js:2505
+#: pkg/networkmanager/interfaces.js:2773
 msgid "Bond"
 msgstr "Vazba"
 
@@ -1191,9 +1203,10 @@ msgstr "Nastavení pořadí zavádění se nepodařilo uložit"
 msgid "Bound By"
 msgstr "Spojeno"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2875
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
+#: pkg/networkmanager/interfaces.js:2499 pkg/networkmanager/interfaces.js:2511
+#: pkg/networkmanager/interfaces.js:2850
 msgid "Bridge"
 msgstr "Most"
 
@@ -1205,16 +1218,17 @@ msgstr "Nastavení portu mostu"
 msgid "Bridge Settings"
 msgstr "Nastavení mostu"
 
-#: pkg/networkmanager/interfaces.js:2896
+#: pkg/networkmanager/interfaces.js:2871
 msgid "Bridge port"
 msgstr "Port mostu"
 
-# auto translated by TM merge from project: tvtime, version: 1.0.7, DocId: tvtime
-#: pkg/networkmanager/interfaces.js:1988 pkg/networkmanager/interfaces.js:2005
+# auto translated by TM merge from project: tvtime, version: 1.0.7, DocId:
+# tvtime
+#: pkg/networkmanager/interfaces.js:1965 pkg/networkmanager/interfaces.js:1982
 msgid "Broadcast"
 msgstr "Vysílání"
 
-#: pkg/networkmanager/interfaces.js:2811 pkg/networkmanager/interfaces.js:2845
+#: pkg/networkmanager/interfaces.js:2786 pkg/networkmanager/interfaces.js:2820
 msgid "Broken configuration"
 msgstr "Chybné nastavení"
 
@@ -1294,17 +1308,16 @@ msgstr "Obraz se nedaří smazat"
 #: pkg/networkmanager/index.html:600 pkg/networkmanager/index.html:624
 #: pkg/networkmanager/index.html:648 pkg/networkmanager/index.html:672
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
-#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
-#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/index.html:343 pkg/systemd/index.html:430
+#: pkg/systemd/index.html:482 pkg/systemd/index.html:498
+#: pkg/systemd/services.html:377 pkg/users/index.html:198
+#: pkg/users/index.html:237 pkg/users/index.html:276 pkg/users/index.html:315
+#: pkg/users/index.html:332 pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/apps/utils.jsx:86 pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:818
-#: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/deleteResource.jsx:108
-#: pkg/machines/components/diskAdd.jsx:519
+#: pkg/machines/components/diskAdd.jsx:518
 #: pkg/machines/components/diskEdit.jsx:173
 #: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/nicAdd.jsx:232
@@ -1315,10 +1328,12 @@ msgstr "Obraz se nedaří smazat"
 #: pkg/machines/components/vcpuModal.jsx:257
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:730
-#: pkg/packagekit/updates.jsx:182 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:399 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:221 pkg/systemd/service-details.jsx:107
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:738
+#: pkg/networkmanager/firewall.jsx:763 pkg/packagekit/updates.jsx:182
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:399
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:221
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Storno"
 
@@ -1334,18 +1349,19 @@ msgstr "Nedaří přeposlat přístupové údaje"
 msgid "Cannot schedule event in the past"
 msgstr "Nelze naplánovat událost v minulosti"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/machines/components/vmDisksTab.jsx:111
 msgid "Capacity"
 msgstr "Kapacita"
 
-#: pkg/networkmanager/interfaces.js:2597
+#: pkg/networkmanager/interfaces.js:2572
 msgid "Carrier"
 msgstr "Nosný signál"
 
 #: pkg/docker/index.html:664 pkg/systemd/index.html:344
-#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:188
+#: pkg/systemd/index.html:431 pkg/users/index.html:277
+#: pkg/users/index.html:316 pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Změnit"
 
@@ -1385,7 +1401,7 @@ msgstr "Změnit limity prostředku"
 msgid "Change resources limits"
 msgstr "Změnit limity prostředků"
 
-#: pkg/networkmanager/interfaces.js:3163
+#: pkg/networkmanager/interfaces.js:3138
 msgid "Change the settings"
 msgstr "Změnit nastavení"
 
@@ -1397,10 +1413,10 @@ msgstr "Změnit nastavení"
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Změny se projeví až po vypnutí virt. stroje"
 
-#: pkg/networkmanager/interfaces.js:3162
+#: pkg/networkmanager/interfaces.js:3137
 msgid ""
-"Changing the settings will break the connection to the server, and will make "
-"the administration UI unavailable."
+"Changing the settings will break the connection to the server, and will make"
+" the administration UI unavailable."
 msgstr ""
 "Změna nastavení přeruší spojení se serverem a znepřístupní tak uživatelské "
 "rozhraní pro jeho správu."
@@ -1449,7 +1465,8 @@ msgstr "Vyberte jazyk aplikace"
 msgid "Chunk Size"
 msgstr "Velikost bloku"
 
-# auto translated by TM merge from project: libosinfo, version: master, DocId: libosinfo
+# auto translated by TM merge from project: libosinfo, version: master, DocId:
+# libosinfo
 #: pkg/systemd/hwinfo.jsx:255
 msgid "Class"
 msgstr "Třída"
@@ -1475,8 +1492,7 @@ msgid "Click to see system hardware information"
 msgstr "Kliknutím zobrazíte informace o hardware"
 
 #: pkg/machines/components/desktopConsole.jsx:41
-msgid ""
-"Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
+msgid "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
 "Kliknutím na „Spustit vzdálený prohlížeč“ se stáhne soubor ve formátu .vv a "
 "spustí se $0."
@@ -1485,15 +1501,17 @@ msgstr ""
 msgid "Client Software"
 msgstr "Klientský software"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:691 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:399
+#: pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/networkmanager/index.html:691
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:325
+#: pkg/shell/simple.html:72 pkg/systemd/index.html:289 pkg/users/index.html:45
+#: pkg/apps/utils.jsx:108 pkg/lib/cockpit-components-modifications.jsx:109
+#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
+#: pkg/storaged/dialog.jsx:399
 msgid "Close"
 msgstr "Zavřít"
 
@@ -1511,8 +1529,8 @@ msgstr "Cockpit ověřování není nastaveno správně."
 
 #: pkg/lib/machine-dialogs.js:429
 msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
+"Cockpit could not contact the given host $0. Make sure it has ssh running on"
+" port $1, or specify another port in the address."
 msgstr ""
 "Cockpit se nepodařilo kontaktovat uvedený stroj $0. Ověřte, že je ssh "
 "spuštěno na portu $1 nebo v jeho adrese zadejte jiný port."
@@ -1524,11 +1542,11 @@ msgstr "Cockpit se nepodařilo daný stroj kontaktovat."
 #: pkg/shell/base_index.js:765
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
-"Cockpit by pressing refresh in your browser. The javascript console contains "
-"details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
+"Cockpit by pressing refresh in your browser. The javascript console contains"
+" details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
-"V Cockpit nastala neočekávaná vnitřní chyba. <br/><br/>Můžete zkusit Cockpit "
-"restartovat kliknutím na opětovné načtení stránky ve svém prohlížeči. "
+"V Cockpit nastala neočekávaná vnitřní chyba. <br/><br/>Můžete zkusit Cockpit"
+" restartovat kliknutím na opětovné načtení stránky ve svém prohlížeči. "
 "Podrobnější informace o této chybě jsou vypsány v javascript konzoli "
 "(<b>Ctrl-Shift-J</b> ve většině prohlížečů)."
 
@@ -1564,8 +1582,8 @@ msgstr "Cockpit není v systému nainstalován."
 
 #: src/ws/cockpit.appdata.xml.in:18
 msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple"
+" tasks such as storage administration, inspecting journals and starting and "
 "stopping services. You can monitor and administer several servers at the "
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
@@ -1583,14 +1601,14 @@ msgstr "Cockpit se nepodařilo spojit s {{#strong}}{{host}}{{/strong}}."
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
 "Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize "
+"users{{/sync_link}}.{{/can_sync}} For more authentication options and "
 "troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit se nepodařilo přihlásit k {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Můžete vyzkoušet {{#sync_link}}synchronizovat uživatele{{/"
-"sync_link}}.{{/can_sync}} Pro více možností ověřování a podporu řešení "
-"problémů přejděte na novější verzi součásti cockpit-ws."
+"{{#can_sync}}Můžete vyzkoušet {{#sync_link}}synchronizovat "
+"uživatele{{/sync_link}}.{{/can_sync}} Pro více možností ověřování a podporu "
+"řešení problémů přejděte na novější verzi součásti cockpit-ws."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1609,14 +1627,16 @@ msgstr ""
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
 "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+"change your authentication credentials below. {{#can_sync}}You may prefer to"
+" {{#sync_link}}synchronize accounts and "
+"passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit se nepodařilo přihlásit k {{#strong}}{{host}}{{/strong}}. Své "
 "přihlašovací údaje můžete změnit níže. {{#can_sync}}Namísto toho můžete "
 "chtít {{#sync_link}}synchronizovat účty a hesla{{/sync_link}}.{{/can_sync}}"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
 msgstr "Barva"
@@ -1636,7 +1656,8 @@ msgstr[2] "Kombinované využití $0 jader procesoru"
 msgid "Comma-separated ports, ranges, and aliases are accepted"
 msgstr "Jsou přijímány čárkou oddělované porty, rozsahy a alternativní názvy"
 
-# auto translated by TM merge from project: SETroubleShoot, version: master, DocId: framework/po/setroubleshoot
+# auto translated by TM merge from project: SETroubleShoot, version: master,
+# DocId: framework/po/setroubleshoot
 #: pkg/docker/index.html:271 pkg/docker/index.html:447
 #: pkg/docker/index.html:708 pkg/systemd/services.html:282
 #: pkg/docker/containers-view.jsx:132 pkg/docker/containers-view.jsx:359
@@ -1652,7 +1673,8 @@ msgstr "Příkaz je třeba vyplnit"
 msgid "Command:"
 msgstr "Příkaz:"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/shell/index.html:262
 msgid "Comment"
 msgstr "Komentář"
@@ -1703,8 +1725,9 @@ msgstr "Podmínka $0=$1 nebyla splněna"
 msgid "Condition failed"
 msgstr "Podmínka nebyla úspěšná"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
-#: pkg/networkmanager/interfaces.js:2732
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
+#: pkg/networkmanager/interfaces.js:2707
 msgid "Configure"
 msgstr "Nastavit"
 
@@ -1720,7 +1743,8 @@ msgstr "Nastavuje se"
 msgid "Configuring IP"
 msgstr "Nastavuje se IP adresa"
 
-# auto translated by TM merge from project: ibus-input-pad, version: head, DocId: ibus-input-pad
+# auto translated by TM merge from project: ibus-input-pad, version: head,
+# DocId: ibus-input-pad
 #: pkg/shell/index.html:298 pkg/users/index.html:176
 #: pkg/storaged/format-dialog.jsx:271
 msgid "Confirm"
@@ -1736,7 +1760,7 @@ msgstr "Potvrdit odebrání pomocí heslové fráze"
 
 #: pkg/machines/components/deleteResource.jsx:103
 msgid "Confirm this action"
-msgstr ""
+msgstr "Potvrďte tuto akci"
 
 #: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
@@ -1746,17 +1770,18 @@ msgstr "V konfliktu s"
 msgid "Conflicts"
 msgstr "Konflikty"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/lib/machine-unknown-hostkey.html:22
 #: pkg/machines/components/serialConsole.jsx:82
 msgid "Connect"
 msgstr "Připojit"
 
-#: pkg/networkmanager/interfaces.js:2719
+#: pkg/networkmanager/interfaces.js:2694
 msgid "Connect automatically"
 msgstr "Připojit se automaticky"
 
-#: src/ws/login.html:74
+#: src/ws/login.html:63
 msgid "Connect to"
 msgstr "Připojit se k"
 
@@ -1793,7 +1818,8 @@ msgstr "Připojuje se ke službě virtualizace"
 msgid "Connecting to the machine"
 msgstr "Připojování ke stroji"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/machines/components/machinesConnectionSelector.jsx:34
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
@@ -1860,13 +1886,15 @@ msgstr "Kontejner je v tuto chvíli spuštěný."
 msgid "Container:"
 msgstr "Kontejner:"
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Containers
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f24, DocId: pot/Containers
 #: pkg/docker/index.html:23 pkg/docker/index.html:289
 #: pkg/docker/containers-view.jsx:375
 msgid "Containers"
 msgstr "Kontejnery"
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Containers
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f24, DocId: pot/Containers
 #: pkg/docker/details.js:46
 msgctxt "page-title"
 msgid "Containers"
@@ -1876,7 +1904,8 @@ msgstr "Kontejnery"
 msgid "Contains"
 msgstr "Obsahuje"
 
-# auto translated by TM merge from project: comps, version: master, DocId: po/comps
+# auto translated by TM merge from project: comps, version: master, DocId:
+# po/comps
 #: pkg/storaged/content-views.jsx:567
 msgid "Content"
 msgstr "Obsah"
@@ -1971,7 +2000,7 @@ msgstr "Vytvořit"
 msgid "Create Logical Volume"
 msgstr "Vytvořit logický svazek"
 
-#: pkg/machines/components/diskAdd.jsx:473
+#: pkg/machines/components/diskAdd.jsx:472
 msgid "Create New"
 msgstr "Vytvořit nový"
 
@@ -1987,7 +2016,8 @@ msgstr "Vytvořit nový virtuální stroj"
 msgid "Create New Volume"
 msgstr "Vytvořit nový svazek"
 
-# auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel6-branch,
+# DocId: anaconda
 #: pkg/storaged/content-views.jsx:436 pkg/storaged/format-dialog.jsx:292
 msgid "Create Partition"
 msgstr "Vytvořit oddíl"
@@ -2059,8 +2089,8 @@ msgstr "Vytvořit skupinu svazků"
 msgid "Create diagnostic report"
 msgstr "Vytvořit diagnostické hlášení"
 
-#: pkg/networkmanager/interfaces.js:3837 pkg/networkmanager/interfaces.js:4037
-#: pkg/networkmanager/interfaces.js:4292 pkg/networkmanager/interfaces.js:4497
+#: pkg/networkmanager/interfaces.js:3810 pkg/networkmanager/interfaces.js:4010
+#: pkg/networkmanager/interfaces.js:4265 pkg/networkmanager/interfaces.js:4470
 msgid "Create it"
 msgstr "Vytvořit to"
 
@@ -2097,7 +2127,7 @@ msgstr "Vytváří se oddíl $target"
 msgid "Creating snapshot of $target"
 msgstr "Pořizování zachyceného stavu $target"
 
-#: pkg/networkmanager/interfaces.js:4496
+#: pkg/networkmanager/interfaces.js:4469
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2105,7 +2135,7 @@ msgstr ""
 "Vytvoření této VLAN přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:3836
+#: pkg/networkmanager/interfaces.js:3809
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2113,7 +2143,7 @@ msgstr ""
 "Vytvoření tohoto sdružení linek přeruší spojení se serverem a znepřístupní "
 "tak rozhraní pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:4291
+#: pkg/networkmanager/interfaces.js:4264
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2121,7 +2151,7 @@ msgstr ""
 "Vytvoření tohoto mostu přeruší spojení se serverem a znepřístupní tak "
 "rozhraní pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:4036
+#: pkg/networkmanager/interfaces.js:4009
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2157,7 +2187,8 @@ msgstr "Stávající přiřazení"
 msgid "Current boot"
 msgstr "Od tohoto spuštění systému"
 
-# auto translated by TM merge from project: libreport, version: rhel6, DocId: libreport
+# auto translated by TM merge from project: libreport, version: rhel6, DocId:
+# libreport
 #: pkg/storaged/format-dialog.jsx:70
 msgid "Custom"
 msgstr "Uživatelsky určené"
@@ -2174,7 +2205,7 @@ msgstr "Uživatelsky určené předvolby šifrování"
 msgid "Custom mount options"
 msgstr "Uživatelsky určené předvolby připojení"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:684
 msgid "Custom zones"
 msgstr "Uživatelsky určené zóny"
 
@@ -2187,20 +2218,21 @@ msgstr "DHCP rozsah"
 msgid "DISK IS FAILING"
 msgstr "DISK SELHÁVÁ"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:3326
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
+#: pkg/networkmanager/interfaces.js:3301
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3330
+#: pkg/networkmanager/interfaces.js:3305
 msgid "DNS Search Domains"
 msgstr "DNS prohledávané domény"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "DNS Search Domains $val"
 msgstr "Prohledávat DNS domény $val"
 
@@ -2238,7 +2270,8 @@ msgstr "Ladící a závažnější"
 msgid "Deduplication"
 msgstr "Deduplikace"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/index.html:359 pkg/docker/index.html:363
 #: pkg/storaged/format-dialog.jsx:69
 msgid "Default"
@@ -2248,13 +2281,12 @@ msgstr "Výchozí"
 msgid "Delay"
 msgstr "Prodleva"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/index.html:139 pkg/docker/index.html:251
 #: pkg/networkmanager/index.html:436 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
 #: pkg/docker/details.js:293 pkg/docker/util.js:641
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/deleteResource.jsx:77
 #: pkg/machines/components/deleteResource.jsx:87
 #: pkg/machines/components/deleteResource.jsx:100
@@ -2262,14 +2294,17 @@ msgstr "Prodleva"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:316
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
-#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
-#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/networkmanager/firewall.jsx:766 pkg/storaged/content-views.jsx:300
+#: pkg/storaged/content-views.jsx:316 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/vdo-details.jsx:203
+#: pkg/storaged/vdo-details.jsx:268 pkg/storaged/vgroup-details.jsx:211
+#: pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Smazat"
 
-#: pkg/networkmanager/interfaces.js:2441 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2418 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Smazat $0"
 
@@ -2304,7 +2339,7 @@ msgstr "Smazat svazek v tomto fondu"
 msgid "Deleting $target"
 msgstr "Maže se $target"
 
-#: pkg/networkmanager/interfaces.js:2440
+#: pkg/networkmanager/interfaces.js:2417
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2348,13 +2383,15 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Maže se skupina svazků $target"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:686
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:693
 #: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Popis"
 
-# auto translated by TM merge from project: Fedora Websites, version: arm.fedoraproject.org, DocId: po/arm.fedoraproject.org
+# auto translated by TM merge from project: Fedora Websites, version:
+# arm.fedoraproject.org, DocId: po/arm.fedoraproject.org
 #: pkg/lib/machine-info.js:66
 msgid "Desktop"
 msgstr "Desktop"
@@ -2371,7 +2408,8 @@ msgstr ""
 msgid "Detachable"
 msgstr "Odpojitelné"
 
-# auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: master,
+# DocId: po/blivet-gui
 #: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:387
@@ -2383,7 +2421,8 @@ msgstr "Podrobnosti"
 msgid "Development"
 msgstr "Vývoj"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/machines/components/networks/createNetworkDialog.jsx:155
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/vm/bootOrderModal.jsx:93
@@ -2408,7 +2447,8 @@ msgstr "Diagnostická hlášení"
 msgid "Diagnostic reports"
 msgstr "Diagnostická hlášení"
 
-# auto translated by TM merge from project: usermode, version: default, DocId: usermode
+# auto translated by TM merge from project: usermode, version: default, DocId:
+# usermode
 #: pkg/kdump/kdump-view.jsx:86 pkg/kdump/kdump-view.jsx:126
 msgid "Directory"
 msgstr "Složka"
@@ -2425,7 +2465,7 @@ msgstr "Vypnout souběžné vícevláknové zpracovávání"
 msgid "Disable tuned"
 msgstr "Vypnout proces služby tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1971
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1948
 #: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Vypnuto"
@@ -2447,7 +2487,8 @@ msgstr "Odpojeno"
 msgid "Disconnected from serial console. Click the Connect button."
 msgstr "Odpojeno od sériové konzole. Klikněte na tlačítko Připojit."
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/storaged/vdos-panel.jsx:57
 msgid "Disk"
 msgstr "Disk"
@@ -2456,7 +2497,8 @@ msgstr "Disk"
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr "Disk $0 se nepodařilo odpojit od virt. stroje $1"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/dashboard/index.html:73 pkg/systemd/host.js:515
 msgid "Disk I/O"
 msgstr "Diskový vst/výst."
@@ -2482,7 +2524,8 @@ msgstr "Heslová fráze k disku"
 msgid "Disk settings could not be saved"
 msgstr "Nastavení disku nebylo možné uložit"
 
-# auto translated by TM merge from project: blivet-gui, version: master, DocId: po/blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: master,
+# DocId: po/blivet-gui
 #: pkg/machines/components/vm/vm.jsx:51 pkg/storaged/mdraid-details.jsx:47
 #: pkg/storaged/mdraid-details.jsx:147 pkg/storaged/mdraids-panel.jsx:90
 #: pkg/storaged/vgroup-details.jsx:54 pkg/storaged/vgroups-panel.jsx:61
@@ -2540,17 +2583,19 @@ msgstr "Neopakovat"
 msgid "Don't overwrite existing data"
 msgstr "Nepřepisovat existující data"
 
-# auto translated by TM merge from project: appstream-glib, version: master, DocId: appstream-glib
+# auto translated by TM merge from project: appstream-glib, version: master,
+# DocId: appstream-glib
 #: pkg/sosreport/index.html:63
 msgid "Done!"
 msgstr "Hotovo!"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/index.html:600
 msgid "Download"
 msgstr "Stáhnout"
 
-#: src/ws/login.html:118
+#: src/ws/login.html:105
 msgid "Download a new browser for free"
 msgstr "Zdarma si stáhnout nový prohlížeč"
 
@@ -2570,7 +2615,8 @@ msgstr "Stáhnout MSI z $0"
 msgid "Downloaded"
 msgstr "Staženo"
 
-# auto translated by TM merge from project: Fedora Websites, version: spins.fedoraproject.org, DocId: po/spins.fedoraproject.org
+# auto translated by TM merge from project: Fedora Websites, version:
+# spins.fedoraproject.org, DocId: po/spins.fedoraproject.org
 #: pkg/packagekit/updates.jsx:51
 msgid "Downloading"
 msgstr "Stahuje se"
@@ -2579,7 +2625,8 @@ msgstr "Stahuje se"
 msgid "Downloading $0"
 msgstr "Stahuje se $0"
 
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
+# auto translated by TM merge from project: udisks, version: udisks, DocId:
+# udisks2
 #: pkg/docker/storage.jsx:169 pkg/storaged/drive-details.jsx:68
 msgid "Drive"
 msgstr "Jednotka"
@@ -2600,7 +2647,8 @@ msgstr "Duplikovat alternativní názvy"
 msgid "Duplicate port"
 msgstr "Duplikovat port"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/components/diskEdit.jsx:211
 #: pkg/machines/components/nicEdit.jsx:166 pkg/storaged/crypto-tab.jsx:129
 #: pkg/storaged/nfs-details.jsx:313
@@ -2627,13 +2675,15 @@ msgstr "Vysouvání $target"
 msgid "Embedded PC"
 msgstr "Jednodeskový počítač"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/playground/translate.html:57 src/base1/test-locale.js:47
 #: src/base1/test-locale.js:57 pkg/playground/translate.js:11
 msgid "Empty"
 msgstr "Prázdný"
 
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
+# auto translated by TM merge from project: udisks, version: udisks, DocId:
+# udisks2
 #: pkg/playground/translate.html:62 src/base1/test-locale.js:48
 #: src/base1/test-locale.js:59 pkg/playground/translate.js:17
 msgctxt "verb"
@@ -2689,7 +2739,8 @@ msgstr "Zde není možné upravovat velikost šifrovaných svazků."
 msgid "Encrypted volumes need to be unlocked before they can be resized."
 msgstr "Šifrované svazky je třeba před změnou velikosti odemknout."
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/storaged/content-views.jsx:151
 msgid "Encryption"
 msgstr "Šifrování"
@@ -2727,11 +2778,12 @@ msgstr ""
 "Zadání jiného hesla zde znamená, že ho bude třeba zadávat pokaždé znovu při "
 "připojování k tomuto stroji"
 
-#: pkg/networkmanager/firewall.jsx:713
+#: pkg/networkmanager/firewall.jsx:721
 msgid "Entire subnet"
 msgstr "Celá podsíť"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/systemd/logs.html:83
 msgid "Entry"
 msgstr "Položka"
@@ -2744,7 +2796,8 @@ msgstr "Koncový bod"
 msgid "Environment"
 msgstr "Prostředí"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/storaged/content-views.jsx:518 pkg/storaged/format-dialog.jsx:242
 msgid "Erase"
 msgstr "Smazat"
@@ -2804,11 +2857,12 @@ msgstr "Ethernet MAC adresa"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:1994
 msgid "Ethtool"
 msgstr "Ethtool"
 
-# auto translated by TM merge from project: Fedora Websites, version: alt.fedoraproject.org, DocId: po/alt.fedoraproject.org
+# auto translated by TM merge from project: Fedora Websites, version:
+# alt.fedoraproject.org, DocId: po/alt.fedoraproject.org
 #: pkg/systemd/logs.html:55 pkg/docker/containers-view.jsx:108
 msgid "Everything"
 msgstr "Vše"
@@ -2845,12 +2899,14 @@ msgstr "Odhalit porty kontejneru"
 msgid "Extended Partition"
 msgstr "Rozšířený oddíl"
 
-# auto translated by TM merge from project: appstream-glib, version: master, DocId: appstream-glib
+# auto translated by TM merge from project: appstream-glib, version: master,
+# DocId: appstream-glib
 #: pkg/storaged/mdraid-details.jsx:93
 msgid "FAILED"
 msgstr "NEZDAŘILO SE"
 
-# auto translated by TM merge from project: retrace-server, version: master, DocId: retrace-server
+# auto translated by TM merge from project: retrace-server, version: master,
+# DocId: retrace-server
 #: pkg/networkmanager/interfaces.js:846
 msgid "Failed"
 msgstr "Neúspěšné"
@@ -2867,7 +2923,7 @@ msgstr "Přidání portu se nezdařilo"
 msgid "Failed to add service"
 msgstr "Službu se nepodařilo přidat"
 
-#: pkg/networkmanager/firewall.jsx:638
+#: pkg/networkmanager/firewall.jsx:645
 msgid "Failed to add zone"
 msgstr "Zónu se nepodařilo přidat"
 
@@ -2923,13 +2979,15 @@ msgstr "Nepodařilo se přepnout profil"
 msgid "Fewer than the maximum number of virtual CPUs should be enabled."
 msgstr "Mělo by být zapnuto méně než maximální počet virtuálních procesorů."
 
-# auto translated by TM merge from project: system-config-firewall, version: master, DocId: po/system-config-firewall
+# auto translated by TM merge from project: system-config-firewall, version:
+# master, DocId: po/system-config-firewall
 #: pkg/machines/components/vm/bootOrderModal.jsx:92
 #: pkg/machines/components/vmDiskColumns.jsx:42
 msgid "File"
 msgstr "Soubor"
 
-# auto translated by TM merge from project: usermode, version: default, DocId: usermode
+# auto translated by TM merge from project: usermode, version: default, DocId:
+# usermode
 #: pkg/storaged/content-views.jsx:149
 msgid "Filesystem"
 msgstr "Souborový systém"
@@ -2946,7 +3004,8 @@ msgstr "Připojování souborového systému"
 msgid "Filesystem Name"
 msgstr "Název souborového systému"
 
-# auto translated by TM merge from project: comps, version: master, DocId: comps
+# auto translated by TM merge from project: comps, version: master, DocId:
+# comps
 #: pkg/storaged/fsys-panel.jsx:97
 msgid "Filesystems"
 msgstr "Souborové systémy"
@@ -2959,17 +3018,18 @@ msgstr "Filtrovat služby"
 msgid "Filter by name or description..."
 msgstr "Filtrovat podle názvu nebo popisu…"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-unknown-hostkey.html:10 pkg/shell/index.html:270
 msgid "Fingerprint"
 msgstr "Otisk"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:99
-#: pkg/networkmanager/firewall.jsx:874 pkg/networkmanager/firewall.jsx:878
+#: pkg/networkmanager/firewall.jsx:940 pkg/networkmanager/firewall.jsx:944
 msgid "Firewall"
 msgstr "Brána firewall"
 
-#: pkg/networkmanager/firewall.jsx:817
+#: pkg/networkmanager/firewall.jsx:883
 msgid "Firewall is not available"
 msgstr "Brána firewall není k dispozici"
 
@@ -3005,7 +3065,8 @@ msgstr "Vynutit změnu hesla"
 msgid "Force remove passphrase in $0"
 msgstr "Vynutit odebrání heslové fráze v $0"
 
-# auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: f23-branch,
+# DocId: blivet-gui
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:249
 #: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:64
 #: pkg/storaged/content-views.jsx:320 pkg/storaged/content-views.jsx:539
@@ -3034,7 +3095,7 @@ msgstr ""
 msgid "Forward Mode"
 msgstr "Režim přeposílání"
 
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2843
 msgid "Forward delay $forward_delay"
 msgstr "Prodleva přeposlání $forward_delay"
 
@@ -3042,13 +3103,15 @@ msgstr "Prodleva přeposlání $forward_delay"
 msgid "Forwarding mode"
 msgstr "Režim přeposílání"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/docker/storage.jsx:329 pkg/docker/storage.jsx:352
 #: pkg/storaged/pvol-tabs.jsx:44
 msgid "Free"
 msgstr "Volno"
 
-# auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel6-branch,
+# DocId: anaconda
 #: pkg/storaged/content-views.jsx:442
 msgid "Free Space"
 msgstr "Volné místo"
@@ -3061,7 +3124,8 @@ msgstr ""
 "Uvolněte prostor v této skupině: zmenšete nebo smažte nějaké logické svazky "
 "nebo přidejte fyzický svazek."
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:131
 msgid "Friday"
 msgstr "pátek"
@@ -3070,19 +3134,22 @@ msgstr "pátek"
 msgid "Fridays"
 msgstr "Pátky"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/users/index.html:86 pkg/users/index.html:167
 msgid "Full Name"
 msgstr "Celé jméno"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "Brána:"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2710 pkg/systemd/logs.js:488
+#: pkg/networkmanager/interfaces.js:2685 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Obecné"
 
@@ -3098,7 +3165,8 @@ msgstr "Vytváření výkazu"
 msgid "Get new image"
 msgstr "Získat nový obraz"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/machines/components/memorySelectRow.jsx:46
 #: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:98
 #: pkg/machines/components/vm/memoryModal.jsx:153
@@ -3155,7 +3223,7 @@ msgstr "Zvětšit a využít veškerý dostupný prostor"
 msgid "Hair Pin mode"
 msgstr "Hair Pin režim"
 
-#: pkg/networkmanager/interfaces.js:2894
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Hairpin mode"
 msgstr "Hair Pin režim"
 
@@ -3163,12 +3231,14 @@ msgstr "Hair Pin režim"
 msgid "Hand Held"
 msgstr "Pro držení v rukou"
 
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
+# auto translated by TM merge from project: udisks, version: udisks, DocId:
+# udisks2
 #: pkg/docker/storage.jsx:168
 msgid "Hard Disk"
 msgstr "Pevný disk"
 
-# auto translated by TM merge from project: accessibility-guide, version: master, DocId: Tools
+# auto translated by TM merge from project: accessibility-guide, version:
+# master, DocId: Tools
 #: pkg/systemd/index.html:87
 msgid "Hardware"
 msgstr "Hardware"
@@ -3177,7 +3247,7 @@ msgstr "Hardware"
 msgid "Hardware Information"
 msgstr "Informace o hardware"
 
-#: pkg/networkmanager/interfaces.js:2870
+#: pkg/networkmanager/interfaces.js:2845
 msgid "Hello time $hello_time"
 msgstr "Oznamovací čas $hello_time"
 
@@ -3185,7 +3255,8 @@ msgstr "Oznamovací čas $hello_time"
 msgid "Hide Performance Options"
 msgstr "Předvolby pro výkonnost"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:137
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:35
 #: pkg/machines/components/vm/bootOrderModal.jsx:97
@@ -3197,7 +3268,8 @@ msgstr "Počítač"
 msgid "Host Device"
 msgstr "Zařízení hostitele"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/dashboard/index.html:137 pkg/systemd/index.html:120
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:142
 msgid "Host Name"
@@ -3223,7 +3295,8 @@ msgstr "Hodina:minuta"
 msgid "Hour needs to be a number between 0-23"
 msgstr "Je třeba, aby hodina bylo číslo z rozmezí 0 až 23"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/systemd/services.html:320
 msgid "Hours"
 msgstr "Hodin"
@@ -3236,13 +3309,15 @@ msgstr "Čekání na vst./výst."
 msgid "ID"
 msgstr "Identif."
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/networkmanager/index.html:122 pkg/networkmanager/index.html:140
 #: pkg/machines/components/vmnetworktab.jsx:140
 msgid "IP Address"
 msgstr "IP adresa"
 
-# auto translated by TM merge from project: Spacewalk Backend, version: master, DocId: client/rhel/rhn-client-tools/po/rhn-client-tools
+# auto translated by TM merge from project: Spacewalk Backend, version:
+# master, DocId: client/rhel/rhn-client-tools/po/rhn-client-tools
 #: pkg/docker/index.html:176
 msgid "IP Address:"
 msgstr "IP adresa:"
@@ -3259,8 +3334,9 @@ msgstr "Délka předpony IP adresy:"
 msgid "IP Settings"
 msgstr "Nastavení IP"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:2919
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
+#: pkg/networkmanager/interfaces.js:2894
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3276,7 +3352,7 @@ msgstr "IPv4 síť"
 msgid "IPv4 Network should not be empty"
 msgstr "IPv4 síť je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv4 Settings"
 msgstr "Nastavení IPv4"
 
@@ -3288,8 +3364,9 @@ msgstr "IPv4 a IPv6"
 msgid "IPv4 only"
 msgstr "Pouze IPv4"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:2920
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
+#: pkg/networkmanager/interfaces.js:2895
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3305,7 +3382,7 @@ msgstr "IPv6 síť"
 msgid "IPv6 Network should not be empty"
 msgstr "IPv6 síť je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv6 Settings"
 msgstr "Nastavení IPv6"
 
@@ -3313,17 +3390,19 @@ msgstr "Nastavení IPv6"
 msgid "IPv6 only"
 msgstr "Pouze IPv6"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 #: pkg/machines/components/diskEdit.jsx:34
 msgid "Id"
 msgstr "Identif."
 
-#: pkg/networkmanager/interfaces.js:2911
+#: pkg/networkmanager/interfaces.js:2886
 msgid "Id $id"
 msgstr "Identif. $id"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/docker/index.html:149
 msgid "Id:"
 msgstr "Identif.:"
@@ -3332,8 +3411,9 @@ msgstr "Identif.:"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Pokud tang-show-keys není k dispozici, spusťte následující:"
 
-# auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
-#: pkg/networkmanager/interfaces.js:1980 pkg/packagekit/updates.jsx:501
+# auto translated by TM merge from project: authconfig, version: master,
+# DocId: po/authconfig
+#: pkg/networkmanager/interfaces.js:1957 pkg/packagekit/updates.jsx:501
 msgid "Ignore"
 msgstr "Ignorovat"
 
@@ -3392,15 +3472,16 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
-"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
-"strong}}."
+"In order to synchronize users, you need to log in to "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
-"Pro synchronizaci uživatelů je třeba se přihlásit k {{#strong}}{{host}}{{/"
-"strong}}."
+"Pro synchronizaci uživatelů je třeba se přihlásit k "
+"{{#strong}}{{host}}{{/strong}}."
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
-#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1421
-#: pkg/networkmanager/interfaces.js:1428 pkg/networkmanager/interfaces.js:2613
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
+#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1398
+#: pkg/networkmanager/interfaces.js:1405 pkg/networkmanager/interfaces.js:2588
 msgid "Inactive"
 msgstr "Neaktivní"
 
@@ -3408,7 +3489,7 @@ msgstr "Neaktivní"
 msgid "Inactive volume"
 msgstr "Neaktivní svazek"
 
-#: pkg/networkmanager/firewall.jsx:691
+#: pkg/networkmanager/firewall.jsx:698
 msgid "Included services"
 msgstr "Obsažené služby"
 
@@ -3471,7 +3552,8 @@ msgstr "Nainstalovat podporu pro VDO"
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr "Nainstalovat setroubleshoot-server pro řešení potíží s SELinux."
 
-# auto translated by TM merge from project: Fedora Installation Guide, version: f22, DocId: pot/SourceSpoke
+# auto translated by TM merge from project: Fedora Installation Guide,
+# version: f22, DocId: pot/SourceSpoke
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:303
 msgid "Installation Source"
 msgstr "Zdroj instalace"
@@ -3484,12 +3566,14 @@ msgstr "Zdroj pro instalaci je třeba vyplnit"
 msgid "Installation Type"
 msgstr "Typ instalace"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/packagekit/updates.jsx:60
 msgid "Installed"
 msgstr "Nainstalováno"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/apps/application-list.jsx:47 pkg/apps/application.jsx:55
 #: pkg/packagekit/updates.jsx:52
 msgid "Installing"
@@ -3511,10 +3595,11 @@ msgstr "Vytvořit instanci a spustit"
 msgid "Interface Type"
 msgstr "Typ rozhraní"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
 #: pkg/networkmanager/index.html:110 pkg/networkmanager/index.html:269
-#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:696
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:704
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Interfaces"
 msgstr "Rozhraní"
 
@@ -3522,7 +3607,8 @@ msgstr "Rozhraní"
 msgid "Internal Error: Invalid challenge header"
 msgstr "Vnitřní chyba: neplatná hlavička výzvy"
 
-# auto translated by TM merge from project: Pulseaudio, version: 6.0, DocId: pulseaudio.pot
+# auto translated by TM merge from project: Pulseaudio, version: 6.0, DocId:
+# pulseaudio.pot
 #: src/base1/cockpit.js:4029
 msgid "Internal error"
 msgstr "Vnitřní chyba"
@@ -3639,17 +3725,20 @@ msgstr "Izolovaná síť"
 msgid "Jobs"
 msgstr "Úlohy"
 
-# auto translated by TM merge from project: Fedora Websites, version: alt.fedoraproject.org, DocId: po/alt.fedoraproject.org
+# auto translated by TM merge from project: Fedora Websites, version:
+# alt.fedoraproject.org, DocId: po/alt.fedoraproject.org
 #: pkg/realmd/operation.js:116
 msgid "Join"
 msgstr "Spojit"
 
-# auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
+# auto translated by TM merge from project: authconfig, version: master,
+# DocId: po/authconfig
 #: pkg/realmd/operation.js:598
 msgid "Join Domain"
 msgstr "Připojit se k doméně"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/realmd/operation.js:115
 msgid "Join a Domain"
 msgstr "Připojit se k doméně"
@@ -3662,7 +3751,8 @@ msgstr "Připojení se do této domény není podporováno"
 msgid "Joins Namespace Of"
 msgstr "Připojuje jmenný prostor od"
 
-# auto translated by TM merge from project: Fedora Websites, version: spins.fedoraproject.org, DocId: po/spins.fedoraproject.org
+# auto translated by TM merge from project: Fedora Websites, version:
+# spins.fedoraproject.org, DocId: po/spins.fedoraproject.org
 #: pkg/systemd/logs.html:23
 msgid "Journal"
 msgstr "Žurnál"
@@ -3694,7 +3784,8 @@ msgstr "Sjednocené přihlašování (SSO), založené na Kerberos"
 msgid "Kerberos Ticket"
 msgstr "Kerberos tiket"
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Kernel
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f23, DocId: pot/Kernel
 #: pkg/systemd/index.html:245 pkg/systemd/host.js:1570
 msgid "Kernel"
 msgstr "Jádro"
@@ -3773,16 +3864,16 @@ msgid ""
 "you enter a different username, that user will always be used when "
 "connecting to this machine."
 msgstr ""
-"Nevyplňujte pro připojení se k tomuto stroji jako právě přihlášený uživatel. "
-"Pokud zadáte jiné uživatelské jméno, takový uživatel bude vždy použit při "
+"Nevyplňujte pro připojení se k tomuto stroji jako právě přihlášený uživatel."
+" Pokud zadáte jiné uživatelské jméno, takový uživatel bude vždy použit při "
 "připojování k tomuto stroji."
 
 #: pkg/lib/machine-change-auth.html:23
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
-"different username, that user will always be used connecting to this machine."
-""
+"different username, that user will always be used connecting to this "
+"machine."
 msgstr ""
 "Nevyplňujte pro připojení k tomuto stroji jako právě přihlášený "
 "uživatel{{#default_user}} ({{default_user}}){{/default_user}}. Pokud zadáte "
@@ -3809,7 +3900,7 @@ msgstr "Hlídání linky"
 msgid "Link down delay"
 msgstr "Prodleva neaktivní linky"
 
-#: pkg/networkmanager/interfaces.js:1968 pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1945 pkg/networkmanager/interfaces.js:1955
 msgid "Link local"
 msgstr "Lokální propoj"
 
@@ -3829,7 +3920,7 @@ msgstr "Linky"
 msgid "Links:"
 msgstr "Linky:"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:1981
 msgid "Load Balancing"
 msgstr "Rozkládání zátěže"
 
@@ -3839,7 +3930,7 @@ msgstr "Načíst dřívější položky"
 
 #: pkg/machines/components/libvirtSlate.jsx:81
 msgid "Loading Resources"
-msgstr ""
+msgstr "Načítání prostředků"
 
 #: pkg/packagekit/updates.jsx:47
 msgid "Loading available updates failed"
@@ -3880,12 +3971,14 @@ msgstr "Místní instalační médium"
 msgid "Local Mount Point"
 msgstr "Místní přípojný bod"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/kdump/kdump-view.jsx:145
 msgid "Location"
 msgstr "Umístění"
 
-# auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
+# auto translated by TM merge from project: authconfig, version: master,
+# DocId: po/authconfig
 #: pkg/storaged/content-views.jsx:243
 msgid "Lock"
 msgstr "Uzamknout"
@@ -3902,12 +3995,15 @@ msgstr "Uzamknout účet na $0"
 msgid "Locking $target"
 msgstr "Uzamyká se $target"
 
-# auto translated by TM merge from project: python-fedora, version: 0.4.0, DocId: python-fedora
-#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:490
+# auto translated by TM merge from project: python-fedora, version: 0.4.0,
+# DocId: python-fedora
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:73
+#: src/ws/login.js:490
 msgid "Log In"
 msgstr "Přihlásit"
 
-# auto translated by TM merge from project: im-chooser , version: master, DocId: im-chooser
+# auto translated by TM merge from project: im-chooser , version: master,
+# DocId: im-chooser
 #: pkg/shell/index.html:70 pkg/shell/simple.html:46
 msgid "Log Out"
 msgstr "Odhlásit"
@@ -3932,7 +4028,8 @@ msgstr "Zprávy záznamu událostí"
 msgid "Logged In"
 msgstr "Přihlášeni"
 
-# auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: f23-branch,
+# DocId: blivet-gui
 #: pkg/storaged/vdo-details.jsx:295
 msgid "Logical"
 msgstr "Logický"
@@ -3998,8 +4095,10 @@ msgstr "Kufříkový počítač"
 msgid "MAC"
 msgstr "MAC"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
-#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
+#: pkg/machines/components/nicAdd.jsx:40
+#: pkg/machines/components/nicEdit.jsx:43
 #: pkg/machines/components/vmnetworktab.jsx:138
 msgid "MAC Address"
 msgstr "MAC adresa"
@@ -4008,15 +4107,15 @@ msgstr "MAC adresa"
 msgid "MAC Address:"
 msgstr "MAC adresa"
 
-#: pkg/networkmanager/interfaces.js:1996
+#: pkg/networkmanager/interfaces.js:1973
 msgid "MII (Recommended)"
 msgstr "MII (doporučeno)"
 
-#: pkg/networkmanager/interfaces.js:2768
+#: pkg/networkmanager/interfaces.js:2743
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4562
+#: pkg/networkmanager/interfaces.js:4535
 msgid "MTU must be a positive number"
 msgstr "Je třeba, aby MTU bylo kladné číslo"
 
@@ -4040,8 +4139,9 @@ msgstr "Hlavní skříň serveru"
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Ověřte, že otisk klíče z Tang serveru odpovídá:"
 
-# auto translated by TM merge from project: Entangle, version: master, DocId: entangle
-#: pkg/networkmanager/interfaces.js:1969 pkg/networkmanager/interfaces.js:1979
+# auto translated by TM merge from project: Entangle, version: master, DocId:
+# entangle
+#: pkg/networkmanager/interfaces.js:1946 pkg/networkmanager/interfaces.js:1956
 msgid "Manual"
 msgstr "Ruční"
 
@@ -4086,7 +4186,7 @@ msgstr ""
 "Maskování služby zabrání všem závislým jednotkám ve spouštění. To může mít "
 "větší dopad, než zamýšleno. Potvrďte, že chcete tuto jednotku maskovat."
 
-#: pkg/networkmanager/interfaces.js:2774
+#: pkg/networkmanager/interfaces.js:2749
 msgid "Master"
 msgstr "Hlavní"
 
@@ -4102,7 +4202,7 @@ msgstr "Přenosová jednotka nejvýše"
 msgid "Maximum memory could not be saved"
 msgstr "Paměťové maximum se nepodařilo uložit"
 
-#: pkg/networkmanager/interfaces.js:2872
+#: pkg/networkmanager/interfaces.js:2847
 msgid "Maximum message age $max_age"
 msgstr "Maximální stáří zpráv $max_age"
 
@@ -4111,8 +4211,8 @@ msgid ""
 "Maximum number of virtual CPUs allocated for the guest OS, which must be "
 "between 1 and $0"
 msgstr ""
-"Maximální počet virtuálních procesorů, přiřazených operačnímu systému hosta. "
-"Je třeba, aby bylo z rozmezí 1 až $0"
+"Maximální počet virtuálních procesorů, přiřazených operačnímu systému hosta."
+" Je třeba, aby bylo z rozmezí 1 až $0"
 
 #: pkg/storaged/content-views.jsx:347
 msgid "Member of RAID Device"
@@ -4122,7 +4222,8 @@ msgstr "Člen RAID zařízení"
 msgid "Member of RAID Device $0"
 msgstr "Člen RAID zařízení $0"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/dashboard/index.html:71 pkg/docker/index.html:273
 #: pkg/playground/translate.html:90 pkg/systemd/index.html:215
 #: pkg/docker/containers-view.jsx:359
@@ -4131,7 +4232,8 @@ msgstr "Člen RAID zařízení $0"
 msgid "Memory"
 msgstr "Paměť"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/systemd/host.js:1628
 msgctxt "page-title"
 msgid "Memory"
@@ -4178,7 +4280,8 @@ msgstr "Zprávy týkající se nezdaru se mohou nacházet v žurnálu:"
 msgid "Metadata Used"
 msgstr "Využito metadat"
 
-# auto translated by TM merge from project: libbytesize, version: master, DocId: libbytesize
+# auto translated by TM merge from project: libbytesize, version: master,
+# DocId: libbytesize
 #: pkg/docker/index.html:468 pkg/docker/index.html:640
 #: pkg/machines/components/memorySelectRow.jsx:43
 #: pkg/machines/components/storagePools/storageVolumeCreateBody.jsx:95
@@ -4199,7 +4302,8 @@ msgstr "Mini věž"
 msgid "Minute needs to be a number between 0-59"
 msgstr "Je třeba, aby minuta bylo číslo z rozmezí 0-59"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/systemd/services.html:319
 msgid "Minutes"
 msgstr "Minut"
@@ -4212,7 +4316,8 @@ msgstr "Zmírnění dopadu"
 msgid "Mode"
 msgstr "Režim"
 
-# auto translated by TM merge from project: Cockpit, version: master, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: master, DocId:
+# cockpit
 #: pkg/machines/components/nicBody.jsx:45 pkg/systemd/hwinfo.jsx:256
 msgid "Model"
 msgstr "Model"
@@ -4226,7 +4331,8 @@ msgstr "Typ modelu"
 msgid "Modifying $target"
 msgstr "Upravuje se $target"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:127
 msgid "Monday"
 msgstr "pondělí"
@@ -4243,7 +4349,8 @@ msgstr "Interval monitorování"
 msgid "Monitoring Targets"
 msgstr "Cíle monitorování"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/realmd/operation.js:531
 msgid "More"
 msgstr "Další"
@@ -4253,7 +4360,8 @@ msgstr "Další"
 msgid "More Information"
 msgstr "Více informací"
 
-# auto translated by TM merge from project: Fedora Websites, version: getfedora.org, DocId: po/getfedora
+# auto translated by TM merge from project: Fedora Websites, version:
+# getfedora.org, DocId: po/getfedora
 #: pkg/kdump/kdump-view.jsx:451
 msgid "More details"
 msgstr "Další podrobnosti"
@@ -4268,7 +4376,8 @@ msgstr "Připojit (mount)"
 msgid "Mount Options"
 msgstr "Předvolby připojení"
 
-# auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel6-branch,
+# DocId: anaconda
 #: pkg/storaged/format-dialog.jsx:73 pkg/storaged/fsys-panel.jsx:103
 #: pkg/storaged/fsys-tab.jsx:157 pkg/storaged/nfs-details.jsx:325
 #: pkg/storaged/nfs-panel.jsx:96
@@ -4335,7 +4444,7 @@ msgstr "Podpora pro NFS není nainstalovaná"
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "Nepodařilo se změnit stav síť. rozhraní $0 virt. stroje $1 "
 
-#: pkg/networkmanager/interfaces.js:2019
+#: pkg/networkmanager/interfaces.js:1996
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
@@ -4343,7 +4452,8 @@ msgstr "NSNA Ping"
 msgid "NTP Server"
 msgstr "NTP server"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/docker/index.html:269 pkg/networkmanager/index.html:121
 #: pkg/networkmanager/index.html:139 pkg/networkmanager/index.html:168
 #: pkg/networkmanager/index.html:212 pkg/networkmanager/index.html:265
@@ -4419,7 +4529,8 @@ msgstr "Je třeba alespoň jeden NTP server"
 msgid "Netmask"
 msgstr "Maska sítě"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/machines/components/aggregateStatusCards.jsx:72
 msgid "Network"
 msgid_plural "Networks"
@@ -4478,14 +4589,16 @@ msgstr "Nastavení síťového rozhraní se nepodařilo uložit"
 msgid "NetworkManager is not running."
 msgstr "NetworkManager není spuštěný."
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Networking
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f24, DocId: pot/Networking
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:388
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:939 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Síť"
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f24, DocId: pot/Networking
-#: pkg/networkmanager/interfaces.js:1635 pkg/networkmanager/interfaces.js:2218
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f24, DocId: pot/Networking
+#: pkg/networkmanager/interfaces.js:1612 pkg/networkmanager/interfaces.js:2195
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Síť"
@@ -4531,7 +4644,8 @@ msgstr "Nová heslová fráze"
 msgid "New password was not accepted"
 msgstr "Nové heslo nebylo přijato"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/realmd/operation.html:82 pkg/storaged/iscsi-panel.jsx:50
 msgid "Next"
 msgstr "Další"
@@ -4545,7 +4659,7 @@ msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2601
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2576
 msgid "No"
 msgstr "Ne"
 
@@ -4626,7 +4740,7 @@ msgstr "Nejsou k dispozici žádné sloty"
 msgid "No boot device found"
 msgstr "Nenalezeno žádné zařízení pro zavádění"
 
-#: pkg/networkmanager/interfaces.js:1423
+#: pkg/networkmanager/interfaces.js:1400
 msgid "No carrier"
 msgstr "Bez signálu"
 
@@ -4650,7 +4764,7 @@ msgstr "Žádné kontejnery"
 msgid "No containers that match the current filter"
 msgstr "Žádné kontejnery, které by odpovídaly stávajícímu filtru"
 
-#: pkg/networkmanager/firewall.jsx:688
+#: pkg/networkmanager/firewall.jsx:695
 msgid "No description available"
 msgstr "Není k dispozici žádný popis"
 
@@ -4676,7 +4790,8 @@ msgstr "Nejsou připojené žádné jednotky"
 msgid "No free key slots"
 msgstr "Žádné volné sloty klíčů"
 
-# auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel6-branch,
+# DocId: anaconda
 #: pkg/storaged/content-views.jsx:717
 msgid "No free space"
 msgstr "Žádné volné místo"
@@ -4785,7 +4900,7 @@ msgstr "Nejsou vytvořené žádné skupiny svazků"
 
 #: pkg/kdump/kdump-view.jsx:422
 #: pkg/machines/components/networks/createNetworkDialog.jsx:190
-#: pkg/networkmanager/firewall.jsx:693 pkg/tuned/dialog.js:232
+#: pkg/networkmanager/firewall.jsx:700 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Žádný"
 
@@ -4829,7 +4944,8 @@ msgstr "Nepřipojeno k Insights"
 msgid "Not enough space to grow."
 msgstr "Pro zvětšení není k dispozici dostatek prostoru."
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/docker/details.js:186 pkg/storaged/details.jsx:121
 msgid "Not found"
 msgstr "Nenalezeno"
@@ -4850,7 +4966,8 @@ msgstr "Není spuštěné"
 msgid "Not synchronized"
 msgstr "Nesynchronizováno"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/systemd/service-details.jsx:450
 msgid "Note"
 msgstr "Poznámka"
@@ -4904,8 +5021,8 @@ msgstr[2] "V případě nezdaru, zkusit znovu $0 krát"
 
 #: src/ws/cockpit.appdata.xml.in:26
 msgid ""
-"Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
-"socket\"."
+"Once Cockpit is installed, enable it with \"systemctl enable --now "
+"cockpit.socket\"."
 msgstr ""
 "Jakmile bude Cockpit nainstalovaný, zapněte ho pomocí příkazu „systemctl "
 "enable --now cockpit.socket“."
@@ -4919,8 +5036,8 @@ msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
 msgstr ""
-"Jeden či více z vybraných svazků je používán doménami. Aby bylo možné svazek "
-"smazat, je třeba nejprve odpojit disky."
+"Jeden či více z vybraných svazků je používán doménami. Aby bylo možné svazek"
+" smazat, je třeba nejprve odpojit disky."
 
 #: pkg/storaged/vdo-details.jsx:134
 msgid "Only $0 of $1 are used."
@@ -4966,12 +5083,13 @@ msgctxt "storage"
 msgid "Optical Drive"
 msgstr "Mechanika optických disků"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/storaged/crypto-tab.jsx:131 pkg/storaged/vdos-panel.jsx:83
 msgid "Options"
 msgstr "Přepínače"
 
-#: src/ws/login.html:125
+#: src/ws/login.html:112
 msgid "Or use a bundled browser"
 msgstr "Nebo použijte přibalený prohlížeč"
 
@@ -4988,11 +5106,12 @@ msgstr "Ostatní data"
 msgid "Other Devices"
 msgstr "Ostatní zařízení"
 
-#: src/ws/login.html:69
+#: src/ws/login.html:59
 msgid "Other Options"
 msgstr "Ostatní volby"
 
-# auto translated by TM merge from project: Fedora Release Notes, version: f23, DocId: pot/Overview
+# auto translated by TM merge from project: Fedora Release Notes, version:
+# f23, DocId: pot/Overview
 #: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:73
 #: pkg/machines/components/storagePools/storagePool.jsx:83
 #: pkg/machines/components/vm/vm.jsx:49
@@ -5023,12 +5142,13 @@ msgstr "PackageKit není nainstalovaný"
 msgid "PackageKit reported error code $0"
 msgstr "PackageKit ohlásilo chybový kód $0"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/networkmanager/index.html:159
 msgid "Parent"
 msgstr "Nadřazené"
 
-#: pkg/networkmanager/interfaces.js:2910
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Parent $parent"
 msgstr "Nadřazené $parent"
 
@@ -5036,11 +5156,12 @@ msgstr "Nadřazené $parent"
 msgid "Part Of"
 msgstr "Součástí"
 
-#: pkg/networkmanager/interfaces.js:1469
+#: pkg/networkmanager/interfaces.js:1446
 msgid "Part of "
 msgstr "Součástí"
 
-# auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: f23-branch,
+# DocId: blivet-gui
 #: pkg/storaged/content-views.jsx:145
 msgid "Partition"
 msgstr "Oddíl"
@@ -5049,16 +5170,18 @@ msgstr "Oddíl"
 msgid "Partition of $0"
 msgstr "Oddíl na $0"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/storaged/content-views.jsx:525
 msgid "Partitioning"
 msgstr "Vytváření oddílů"
 
-#: pkg/networkmanager/interfaces.js:2011
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Passive"
 msgstr "Pasivní"
 
-# auto translated by TM merge from project: anaconda, version: f22-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: f22-branch,
+# DocId: anaconda
 #: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
 #: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:263
 msgid "Passphrase"
@@ -5079,11 +5202,12 @@ msgstr "Odebrání heslové fráze může bránit odemknutí $0."
 msgid "Passphrases do not match"
 msgstr "Zadání heslové fráze se neshodují"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
 #: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
 #: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:173 src/ws/login.html:44
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Heslo"
@@ -5123,9 +5247,11 @@ msgstr "Vložit"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Sem vložte obsah veřejné části svého ssh klíče"
 
-# auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
+# auto translated by TM merge from project: selinux (policycoreutils),
+# version: master, DocId: policycoreutils
+#: pkg/machines/components/diskEdit.jsx:36
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/machines/components/diskEdit.jsx:36 pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Popis umístění"
 
@@ -5133,7 +5259,7 @@ msgstr "Popis umístění"
 msgid "Path cost"
 msgstr "Náklady trasy"
 
-#: pkg/networkmanager/interfaces.js:2892
+#: pkg/networkmanager/interfaces.js:2867
 msgid "Path cost $path_cost"
 msgstr "Náklady trasy $path_cost"
 
@@ -5161,7 +5287,8 @@ msgstr "Popis umístění ISO souboru na souborovém systému hostitele"
 msgid "Path to file"
 msgstr "Popis umístění serveru"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/systemd/services.jsx:51
 msgid "Paths"
 msgstr "Popisy umístění"
@@ -5178,12 +5305,14 @@ msgstr "Výkonnostní profil"
 msgid "Peripheral Chassis"
 msgstr "Skříň periferií"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
-#: pkg/networkmanager/interfaces.js:3644
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
+#: pkg/networkmanager/interfaces.js:3619
 msgid "Permanent"
 msgstr "Trvalá"
 
-# auto translated by TM merge from project: Linux PAM, version: master, DocId: po/Linux-PAM
+# auto translated by TM merge from project: Linux PAM, version: master, DocId:
+# po/Linux-PAM
 #: src/ws/login.js:663
 msgid "Permission denied"
 msgstr "Přístup zamítnut"
@@ -5265,7 +5394,7 @@ msgstr "Zadejte název pro nový svazek"
 msgid "Please enter new volume size"
 msgstr "Zadejte velikost nového svazku"
 
-#: pkg/networkmanager/firewall.jsx:818
+#: pkg/networkmanager/firewall.jsx:884
 msgid "Please install the $0 package"
 msgstr "Nainstalujte balíček $0"
 
@@ -5289,11 +5418,12 @@ msgstr "Zkuste jiný pojem"
 msgid "Plug"
 msgstr "Připojit"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/machines/components/deleteDialog.jsx:53
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/machines/components/diskAdd.jsx:128
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Úložiště"
@@ -5319,7 +5449,8 @@ msgstr "Typ fondu nepodporuje vytvoření svazku"
 msgid "Pool's volumes are used by VMs "
 msgstr "Svazky fondu jsou využívány virt. stroji"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-change-port.html:23
 #: pkg/machines/components/vm/bootOrderModal.jsx:98
 #: pkg/machines/components/vm/bootOrderModal.jsx:110
@@ -5333,15 +5464,17 @@ msgstr "Port"
 msgid "Port number and type do not match"
 msgstr "Číslo a typ portu si neodpovídají"
 
-# auto translated by TM merge from project: PulseAudio for RHEL, version: 6.0, DocId: pulseaudio.pot
+# auto translated by TM merge from project: PulseAudio for RHEL, version: 6.0,
+# DocId: pulseaudio.pot
 #: pkg/lib/machine-info.js:71
 msgid "Portable"
 msgstr "Přenosný"
 
-# auto translated by TM merge from project: firewalld, version: master, DocId: po/firewalld
+# auto translated by TM merge from project: firewalld, version: master, DocId:
+# po/firewalld
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:216
 #: pkg/networkmanager/index.html:326 pkg/docker/containers-view.jsx:414
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Ports"
 msgstr "Porty"
 
@@ -5369,11 +5502,11 @@ msgstr "Délka předpony"
 msgid "Prefix Length should not be empty"
 msgstr "Délku předpony je třeba vyplnit"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length"
 msgstr "Délka předpony"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length or Netmask"
 msgstr "Délka předpony nebo maska sítě"
 
@@ -5386,8 +5519,9 @@ msgstr "Příprava"
 msgid "Present"
 msgstr "Přítomno"
 
-# auto translated by TM merge from project: anaconda, version: master, DocId: main
-#: pkg/networkmanager/interfaces.js:3645
+# auto translated by TM merge from project: anaconda, version: master, DocId:
+# main
+#: pkg/networkmanager/interfaces.js:3620
 msgid "Preserve"
 msgstr "Zachovat"
 
@@ -5399,18 +5533,20 @@ msgstr "Hezký název stroje"
 msgid "Previous boot"
 msgstr "Předchozí zavedení"
 
-# auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: f23-branch,
+# DocId: blivet-gui
 #: pkg/networkmanager/index.html:292
 msgid "Primary"
 msgstr "Primární"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/networkmanager/index.html:247 pkg/networkmanager/index.html:366
 #: pkg/networkmanager/index.html:376
 msgid "Priority"
 msgstr "Priorita"
 
-#: pkg/networkmanager/interfaces.js:2866 pkg/networkmanager/interfaces.js:2890
+#: pkg/networkmanager/interfaces.js:2841 pkg/networkmanager/interfaces.js:2865
 msgid "Priority $priority"
 msgstr "Priorita $priority"
 
@@ -5422,7 +5558,8 @@ msgstr "Soukromé"
 msgid "Privileged"
 msgstr "Privilegované"
 
-# auto translated by TM merge from project: libreport, version: master, DocId: libreport
+# auto translated by TM merge from project: libreport, version: master, DocId:
+# libreport
 #: pkg/systemd/logs.js:490
 msgid "Problem details"
 msgstr "Podrobnosti o problému"
@@ -5464,7 +5601,8 @@ msgstr "Časový limit výzvy prostřednictvím ssh-keygen překročen"
 msgid "Propagates Reload To"
 msgstr "Propaguje načíst znovu k"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/components/vm/bootOrderModal.jsx:94
 #: pkg/machines/components/vm/bootOrderModal.jsx:139
 #: pkg/machines/components/vmDiskColumns.jsx:44
@@ -5535,7 +5673,8 @@ msgstr "RAID 6 (dvojitá distribuovaná parita)"
 msgid "RAID Chassis"
 msgstr "RAID skříň"
 
-# auto translated by TM merge from project: anaconda, version: master, DocId: main
+# auto translated by TM merge from project: anaconda, version: master, DocId:
+# main
 #: pkg/storaged/pvol-tabs.jsx:59
 msgid "RAID Device"
 msgstr "RAID zařízení"
@@ -5544,7 +5683,8 @@ msgstr "RAID zařízení"
 msgid "RAID Device $0"
 msgstr "RAID zařízení $0"
 
-# auto translated by TM merge from project: anaconda, version: rhel6-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel6-branch,
+# DocId: anaconda
 #: pkg/storaged/mdraids-panel.jsx:146
 msgid "RAID Devices"
 msgstr "RAID zařízení"
@@ -5561,11 +5701,11 @@ msgstr "Člen RAID"
 msgid "Rack Mount Chassis"
 msgstr "Skříň do stojanu"
 
-#: pkg/networkmanager/interfaces.js:3646
+#: pkg/networkmanager/interfaces.js:3621
 msgid "Random"
 msgstr "Náhodné"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:726
 msgid "Range"
 msgstr "Rozsah"
 
@@ -5632,7 +5772,8 @@ msgstr ""
 msgid "Real host name must be 64 characters or less"
 msgstr "Je třeba, aby skutečný název stroje byl nanejvýš 64 znaků dlouhý"
 
-# auto translated by TM merge from project: system-config-kdump, version: master, DocId: system-config-kdump
+# auto translated by TM merge from project: system-config-kdump, version:
+# master, DocId: system-config-kdump
 #: pkg/lib/cockpit-components-logs-panel.jsx:82 pkg/lib/journal.js:248
 msgid "Reboot"
 msgstr "Restartovat"
@@ -5716,7 +5857,8 @@ msgstr "Vyjímatelná jednotka"
 msgid "Removals:"
 msgstr "Odebrání:"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/apps/application-list.jsx:85 pkg/apps/application.jsx:109
 #: pkg/machines/components/vmDisksTab.jsx:177
 #: pkg/storaged/crypto-keyslots.jsx:402 pkg/storaged/crypto-keyslots.jsx:439
@@ -5724,9 +5866,13 @@ msgstr "Odebrání:"
 msgid "Remove"
 msgstr "Odebrat"
 
-#: pkg/networkmanager/interfaces.js:3063
+#: pkg/networkmanager/interfaces.js:3038
 msgid "Remove $0"
 msgstr "Odebrat $0"
+
+#: pkg/networkmanager/firewall.jsx:834
+msgid "Remove $0 service from $1 zone"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
@@ -5748,6 +5894,10 @@ msgstr "Odebrat heslovou frázi"
 msgid "Remove passphrase in $0?"
 msgstr "Odebrat heslovou frázi v $0?"
 
+#: pkg/networkmanager/firewall.jsx:818
+msgid "Remove zone $0"
+msgstr ""
+
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
@@ -5761,7 +5911,7 @@ msgstr "Odebírá se $0"
 msgid "Removing $target from RAID Device"
 msgstr "Odebírání $target z RAID zařízení"
 
-#: pkg/networkmanager/interfaces.js:3062
+#: pkg/networkmanager/interfaces.js:3037
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5772,6 +5922,17 @@ msgstr ""
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr "Odebírání fyzického svazku z $target"
+
+#: pkg/networkmanager/firewall.jsx:832
+msgid ""
+"Removing the cockpit service might result in the web console becoming "
+"unreachable. Make sure that this zone does not apply to your current web "
+"console connection."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:816
+msgid "Removing the zone will remove all services within it."
+msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
 #: pkg/storaged/vgroup-details.jsx:231
@@ -5824,7 +5985,8 @@ msgstr "Zopakovat heslovou frázi"
 msgid "Report"
 msgstr "Nahlásit"
 
-# auto translated by TM merge from project: gnome-abrt, version: master, DocId: gnome-abrt
+# auto translated by TM merge from project: gnome-abrt, version: master,
+# DocId: gnome-abrt
 #: pkg/systemd/logs.js:509
 msgid "Reported"
 msgstr "Nahlášeno"
@@ -5837,7 +5999,8 @@ msgstr "Hlásič „reporter-ureport“ nenalezen."
 msgid "Reporting was unsucessful. Try running `reporter-ureport -d "
 msgstr "Hlášení nebylo úspěšné. Zkuste spustit `reporter-ureport -d "
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/docker/index.html:690
 msgid "Repository"
 msgstr "Repozitář"
@@ -5878,7 +6041,8 @@ msgstr "Závislost pro"
 msgid "Reserved memory"
 msgstr "Vyhrazená paměť"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/index.html:303 pkg/users/index.html:333
 #: pkg/systemd/terminal.jsx:106
 msgid "Reset"
@@ -5902,8 +6066,8 @@ msgstr "Mění se velikost $target"
 
 #: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
-"Resizing an encrypted filesystem requires unlocking the disk. Please provide "
-"a current disk passphrase."
+"Resizing an encrypted filesystem requires unlocking the disk. Please provide"
+" a current disk passphrase."
 msgstr ""
 "Změna velikost šifrovaného souborového systému vyžaduje jeho odemčení. "
 "Zadejte heslovou frázi."
@@ -5948,7 +6112,7 @@ msgstr "Obnovit chod"
 msgid "Retries:"
 msgstr "Opětovných pokusů:"
 
-#: src/ws/login.html:57
+#: src/ws/login.html:48
 msgid "Reuse my password for privileged tasks"
 msgstr "Použít mé heslo i pro privilegované úlohy"
 
@@ -5962,7 +6126,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Role"
 
-#: pkg/networkmanager/interfaces.js:1985 pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:1962 pkg/networkmanager/interfaces.js:1979
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5974,11 +6138,12 @@ msgstr "Trasa na $0"
 msgid "Routed Network"
 msgstr "Směrovaná síť"
 
-#: pkg/networkmanager/interfaces.js:3335
+#: pkg/networkmanager/interfaces.js:3310
 msgid "Routes"
 msgstr "Trasy"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/docker/index.html:253 pkg/docker/index.html:566
 #: pkg/systemd/services.html:296 pkg/machines/components/vm/vmActions.jsx:91
 msgid "Run"
@@ -5997,7 +6162,8 @@ msgstr "Spustit při startu stroje"
 msgid "Runner"
 msgstr "Spouštěč"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/storaged/mdraid-details.jsx:338 pkg/systemd/service-details.jsx:353
 msgid "Running"
 msgstr "Spuštěné"
@@ -6068,13 +6234,14 @@ msgstr "STP priorita"
 
 #: pkg/shell/index.html:407
 msgid ""
-"Safari users need to import and trust the certificate of the self-signing CA:"
-""
+"Safari users need to import and trust the certificate of the self-signing "
+"CA:"
 msgstr ""
-"Uživatelé prohlížeče Safari budou potřebovat naimportovat si certifikát samu "
-"sebe podepisující certifikační autority a nastavit ji jako důvěryhodnou:"
+"Uživatelé prohlížeče Safari budou potřebovat naimportovat si certifikát samu"
+" sebe podepisující certifikační autority a nastavit ji jako důvěryhodnou:"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/systemd/services.html:132
 msgid "Saturday"
 msgstr "sobota"
@@ -6083,7 +6250,8 @@ msgstr "sobota"
 msgid "Saturdays"
 msgstr "Soboty"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/systemd/services.html:378 pkg/machines/components/diskEdit.jsx:176
 #: pkg/machines/components/nicEdit.jsx:184
 #: pkg/machines/components/vm/bootOrderModal.jsx:330
@@ -6118,7 +6286,7 @@ msgstr "Počítač se zapečetěnou skříní"
 
 #: pkg/shell/index.html:363
 msgid "Search"
-msgstr ""
+msgstr "Hledat"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
 #: pkg/systemd/init.js:967
@@ -6133,7 +6301,8 @@ msgstr "Klíče zabezpečeného shellu"
 msgid "Securely erasing $target"
 msgstr "Jisté vymazávání $target"
 
-# auto translated by TM merge from project: Fedora OpenSSH Guide, version: master, DocId: Security
+# auto translated by TM merge from project: Fedora OpenSSH Guide, version:
+# master, DocId: Security
 #: pkg/docker/containers-view.jsx:506 pkg/docker/containers-view.jsx:649
 msgid "Security"
 msgstr "Zabezpečení"
@@ -6151,8 +6320,8 @@ msgid ""
 "Select the users that you would like to be synchronized with "
 "{{#strong}}{{host}}{{/strong}}"
 msgstr ""
-"Vyberte uživatele které chcete synchronizovat s {{#strong}}{{host}}{{/"
-"strong}}"
+"Vyberte uživatele které chcete synchronizovat s "
+"{{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -6172,8 +6341,9 @@ msgstr "Odchozí"
 msgid "Serial Console"
 msgstr "Sériová konzole"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
+#: src/ws/login.html:81 pkg/kdump/kdump-view.jsx:116
 #: pkg/storaged/nfs-details.jsx:322 pkg/storaged/nfs-panel.jsx:95
 msgid "Server"
 msgstr "Server"
@@ -6202,12 +6372,14 @@ msgstr "Server je třeba vyplnit."
 msgid "Server has closed the connection."
 msgstr "Server zavřel spojení."
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/dashboard/index.html:86
 msgid "Servers"
 msgstr "Servery"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/systemd/logs.html:66 pkg/networkmanager/firewall.jsx:167
 #: pkg/storaged/dialog.jsx:1030
 msgid "Service"
@@ -6241,7 +6413,8 @@ msgstr "Služba se zastavuje"
 msgid "Service name"
 msgstr "Název služby"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/systemd/services.html:4 pkg/systemd/services.html:222
 #: pkg/networkmanager/firewall.jsx:505 pkg/systemd/manifest.json.in
 msgid "Services"
@@ -6252,7 +6425,8 @@ msgstr "Služby"
 msgid "Session"
 msgstr "Sezení"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/dashboard/index.html:176 pkg/users/index.html:238
 msgid "Set"
 msgstr "Nastavit"
@@ -6313,8 +6487,9 @@ msgstr "Závažnost"
 msgid "Severity:"
 msgstr "Závažnost:"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:1970
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
+#: pkg/networkmanager/interfaces.js:1947
 msgid "Shared"
 msgstr "Sdílené"
 
@@ -6350,7 +6525,8 @@ msgstr "Zobrazit všechny obrazy"
 msgid "Show fingerprints"
 msgstr "Zobrazit otisky"
 
-# auto translated by TM merge from project: anaconda, version: master, DocId: main
+# auto translated by TM merge from project: anaconda, version: master, DocId:
+# main
 #: pkg/storaged/lvol-tabs.jsx:324 pkg/storaged/lvol-tabs.jsx:406
 msgid "Shrink"
 msgstr "Zmenšit"
@@ -6363,7 +6539,8 @@ msgstr "Zmenšit logický svazek"
 msgid "Shrink Volume"
 msgstr "Zmenšit oddíl"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
@@ -6373,7 +6550,8 @@ msgstr "Vypnout"
 msgid "Single Rank"
 msgstr "Single Rank"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/docker/containers-view.jsx:687
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:486
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
@@ -6456,12 +6634,12 @@ msgid ""
 msgstr ""
 "Správa balíčků je v tuto chvíli používána nějakým jiným programem, vyčkejte…"
 
-#: pkg/networkmanager/firewall.jsx:668
+#: pkg/networkmanager/firewall.jsx:675
 msgid "Sorted from least trusted to most trusted"
 msgstr "Seřazeno od nejméně po nejvíce důvěryhodné"
 
 # auto translated by TM merge from project: dnf, version: master, DocId: dnf
-#: pkg/machines/components/diskAdd.jsx:462
+#: pkg/machines/components/diskAdd.jsx:461
 #: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:117
@@ -6497,7 +6675,7 @@ msgstr "Zdroj by měl začínat na http, ftp nebo nfs protokol"
 msgid "Space-saving Computer"
 msgstr "Prostorově úsporný počítač"
 
-#: pkg/networkmanager/interfaces.js:2864
+#: pkg/networkmanager/interfaces.js:2839
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
@@ -6517,7 +6695,7 @@ msgstr "Konkrétní čas"
 msgid "Speed"
 msgstr "Rychlost"
 
-#: pkg/networkmanager/interfaces.js:3647
+#: pkg/networkmanager/interfaces.js:3622
 msgid "Stable"
 msgstr "Stabilní"
 
@@ -6569,16 +6747,19 @@ msgstr "Spouštění odkládacího prostoru $target"
 msgid "Startup"
 msgstr "Při spuštění"
 
-# auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
+# auto translated by TM merge from project: selinux (policycoreutils),
+# version: master, DocId: policycoreutils
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
-#: pkg/machines/components/vmnetworktab.jsx:183 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:269 pkg/systemd/init.js:306
+#: pkg/machines/components/vmnetworktab.jsx:183
+#: pkg/machines/hostvmslist.jsx:83 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/init.js:306
 msgid "State"
 msgstr "Stav"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/docker/index.html:168
 msgid "State:"
 msgstr "Stav:"
@@ -6588,8 +6769,9 @@ msgstr "Stav:"
 msgid "Static"
 msgstr "Statické"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
-#: pkg/networkmanager/interfaces.js:2620 pkg/systemd/service-details.jsx:478
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
+#: pkg/networkmanager/interfaces.js:2595 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Stav"
 
@@ -6601,7 +6783,8 @@ msgstr "Počítač v klíčence"
 msgid "Sticky"
 msgstr "Lepkavé"
 
-# auto translated by TM merge from project: Fedora Media Writer, version: master, DocId: mediawriter
+# auto translated by TM merge from project: Fedora Media Writer, version:
+# master, DocId: mediawriter
 #: pkg/docker/index.html:137 pkg/docker/containers-view.jsx:310
 #: pkg/storaged/mdraid-details.jsx:314 pkg/storaged/swap-tab.jsx:76
 #: pkg/storaged/vdo-details.jsx:159 pkg/storaged/vdo-details.jsx:264
@@ -6629,7 +6812,8 @@ msgstr "Zastavit a smazat"
 msgid "Stop and remove"
 msgstr "Zastavit a odebrat"
 
-# auto translated by TM merge from project: system-config-printer, version: master, DocId: system-config-printer
+# auto translated by TM merge from project: system-config-printer, version:
+# master, DocId: system-config-printer
 #: pkg/docker/util.js:231
 msgid "Stopped"
 msgstr "Zastaveno"
@@ -6642,7 +6826,8 @@ msgstr "Zastavování RAID zařízení $target"
 msgid "Stopping swapspace $target"
 msgstr "Zastavování odkládacího prostoru $target"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/docker/index.html:290 pkg/storaged/index.html:23
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:449
 #: pkg/storaged/details.jsx:127 pkg/storaged/manifest.json.in
@@ -6729,7 +6914,8 @@ msgstr "Dílčí skříň"
 msgid "Sub Notebook"
 msgstr "Zmenšený notebook"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:133
 msgid "Sunday"
 msgstr "neděle"
@@ -6742,7 +6928,8 @@ msgstr "Neděle"
 msgid "Support is installed."
 msgstr "Podpora je nainstalovaná."
 
-# auto translated by TM merge from project: udisks, version: udisks, DocId: udisks2
+# auto translated by TM merge from project: udisks, version: udisks, DocId:
+# udisks2
 #: pkg/storaged/content-views.jsx:161
 msgid "Swap"
 msgstr "Odkládací oddíl"
@@ -6756,15 +6943,15 @@ msgstr "Odkládací prostor"
 msgid "Swap Used"
 msgstr "Využití odkládacího prostoru"
 
-#: pkg/networkmanager/interfaces.js:2498 pkg/networkmanager/interfaces.js:3047
+#: pkg/networkmanager/interfaces.js:2475 pkg/networkmanager/interfaces.js:3022
 msgid "Switch off $0"
 msgstr "Vypnout $0"
 
-#: pkg/networkmanager/interfaces.js:2473 pkg/networkmanager/interfaces.js:3035
+#: pkg/networkmanager/interfaces.js:2450 pkg/networkmanager/interfaces.js:3010
 msgid "Switch on $0"
 msgstr "Zapnout $0"
 
-#: pkg/networkmanager/interfaces.js:2497
+#: pkg/networkmanager/interfaces.js:2474
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6772,7 +6959,7 @@ msgstr ""
 "Vypnutí <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:3046
+#: pkg/networkmanager/interfaces.js:3021
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6780,7 +6967,7 @@ msgstr ""
 "Vypnutí <b>$0</b> přeruší spojení se serverem a znepřístupní tak rozhraní "
 "pro jeho správu."
 
-#: pkg/networkmanager/interfaces.js:2472 pkg/networkmanager/interfaces.js:3034
+#: pkg/networkmanager/interfaces.js:2449 pkg/networkmanager/interfaces.js:3009
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6808,7 +6995,8 @@ msgstr "Synchronizováno s {{Server}}"
 msgid "Synchronizing RAID Device $target"
 msgstr "Synchronizuje se RAID zařízení $target"
 
-# auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
+# auto translated by TM merge from project: selinux (policycoreutils),
+# version: master, DocId: policycoreutils
 #: pkg/systemd/index.html:4
 #: pkg/machines/components/machinesConnectionSelector.jsx:43
 #: pkg/machines/helpers.js:191 pkg/systemd/hwinfo.jsx:280
@@ -6849,7 +7037,8 @@ msgstr "Systém je aktuální"
 msgid "TCP"
 msgstr "TCP"
 
-# auto translated by TM merge from project: virt-manager, version: master, DocId: virt-manager
+# auto translated by TM merge from project: virt-manager, version: master,
+# DocId: virt-manager
 #: pkg/lib/machine-info.js:93
 msgid "Tablet"
 msgstr "Tablet"
@@ -6867,7 +7056,8 @@ msgstr "Šítky"
 msgid "Tang keyserver"
 msgstr "Tang server s klíči"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/components/vm/bootOrderModal.jsx:133
 msgid "Target"
 msgstr "Cíl"
@@ -6885,13 +7075,14 @@ msgstr "Popis umístění cíle je třeba vyplnit"
 msgid "Targets"
 msgstr "Cíle"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
-#: pkg/networkmanager/interfaces.js:2821
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
+#: pkg/networkmanager/interfaces.js:2495 pkg/networkmanager/interfaces.js:2507
+#: pkg/networkmanager/interfaces.js:2796
 msgid "Team"
 msgstr "Tým"
 
-#: pkg/networkmanager/interfaces.js:2849
+#: pkg/networkmanager/interfaces.js:2824
 msgid "Team Port"
 msgstr "Port týmu"
 
@@ -6929,7 +7120,7 @@ msgstr "Zkouška spojení"
 
 #: pkg/machines/components/deleteResource.jsx:46
 msgid "The $0 could not be deleted"
-msgstr ""
+msgstr "$0 nebylo možné smazat"
 
 #: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
@@ -6999,6 +7190,8 @@ msgstr "Virt. stroj je uspaný svou vlastní správou napájení."
 #: pkg/machines/components/vmnetworktab.jsx:207
 msgid "The VM needs to be running or shut off to detach this device"
 msgstr ""
+"Pro odpojení tohoto zařízení je třeba, aby virt. stroj byl spuštěný nebo "
+"vypnutý"
 
 #: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
@@ -7006,11 +7199,15 @@ msgstr "Účet „$0“ bude při příštím přihlášení vyzván k vynucené
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Nepodvrženost totožnosti stroje {{#strong}}{{host}}{{/strong}} se nedaří "
 "ověřit. Opravdu chcete pokračovat v připojování?"
+
+#: pkg/networkmanager/firewall.jsx:701
+msgid "The cockpit service is automatically included"
+msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -7039,15 +7236,15 @@ msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
 msgstr ""
-"Souborový systém je používán přihlašovacími sezeními a systémovými službami. "
-"Pokračování je zastaví."
+"Souborový systém je používán přihlašovacími sezeními a systémovými službami."
+" Pokračování je zastaví."
 
 #: pkg/storaged/dialog.jsx:997
 msgid ""
 "The filesystem is in use by login sessions. Proceeding will stop these."
 msgstr ""
-"Souborový systém je používán přihlašovacími sezeními. Pokračování je zastaví."
-""
+"Souborový systém je používán přihlašovacími sezeními. Pokračování je "
+"zastaví."
 
 #: pkg/storaged/dialog.jsx:999
 msgid ""
@@ -7067,15 +7264,15 @@ msgid ""
 "should be reviewed by the originating organization before being passed to "
 "any third party."
 msgstr ""
-"Vytvořený archiv obsahuje data považovaná za citlivá a jeho obsah by měl být "
-"zrevidován organizací, ze které pochází předtím, než bude předán jakékoli "
+"Vytvořený archiv obsahuje data považovaná za citlivá a jeho obsah by měl být"
+" zrevidován organizací, ze které pochází předtím, než bude předán jakékoli "
 "třetí straně."
 
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
+"in use. Unless this machine was recently replaced, it is likely that someone"
+" is trying to attack your connection to this machine."
 msgstr ""
 "Klíč {{#strong}}{{host}}{{/strong}} neodpovídá dříve používanému klíči. "
 "Pokud tento stroj nebyl nedávno nahrazen, je pravděpodobné, že se někdo "
@@ -7196,7 +7393,7 @@ msgstr "Uživatel <b>$0</b> není oprávněn upravovat účty"
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat názvy strojů"
 
-#: pkg/networkmanager/interfaces.js:1520
+#: pkg/networkmanager/interfaces.js:1497
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Uživatel <b>$0</b> není oprávněn upravovat nastavení sítě"
 
@@ -7210,8 +7407,8 @@ msgstr "Uživatel <b>$0</b> není oprávněn vypínat či restartovat tento serv
 
 #: pkg/users/local.js:553
 msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+"The user name can only consist of letters from a-z, digits, dots, dashes and"
+" underscores."
 msgstr ""
 "Uživatelské jméno se může sestávat pouze z písmen a-z (bez diakritiky), "
 "číslic, teček, spojovníků a podtržítek."
@@ -7232,8 +7429,8 @@ msgid ""
 "There are devices with multiple paths on the system, but the multipath "
 "service is not running."
 msgstr ""
-"V systému jsou zařízení s vícero cestami, ale služba multipath není spuštěná."
-""
+"V systému jsou zařízení s vícero cestami, ale služba multipath není "
+"spuštěná."
 
 #: pkg/networkmanager/firewall.jsx:168
 msgid "There are no active services in this zone"
@@ -7248,8 +7445,8 @@ msgid ""
 "There is not enough free space elsewhere to remove this physical volume. At "
 "least $0 more free space is needed."
 msgstr ""
-"Pro odebrání tohoto fyzického svazku není k dispozici dostatek volného místa."
-" Je třeba alespoň $0 dalšího volného prostoru."
+"Pro odebrání tohoto fyzického svazku není k dispozici dostatek volného "
+"místa. Je třeba alespoň $0 dalšího volného prostoru."
 
 #: pkg/shell/index.html:402
 msgid "There was an unexpected error while connecting to the machine."
@@ -7269,13 +7466,13 @@ msgstr "Toto VDO zařízení nepoužívá ze svého podkladového zařízení v�
 
 #: pkg/systemd/init.js:1262
 msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
+"This day doesn't exist in all months.<br> The timer will only be executed in"
+" months that have 31st."
 msgstr ""
 "Tento den neexistuje ve všech měsících.<br> Časovač bude vykonán pouze v "
 "měsících, které mají 31. den"
 
-#: pkg/networkmanager/interfaces.js:2631
+#: pkg/networkmanager/interfaces.js:2606
 msgid "This device cannot be managed here."
 msgstr "Toto zařízení zde nelze spravovat."
 
@@ -7296,8 +7493,8 @@ msgid ""
 "This device is currently used for RAID devices. Proceeding will remove it "
 "from its RAID devices."
 msgstr ""
-"Toto zařízení je v tuto chvíli používáno pro RAID zařízení. Pokračování ho z "
-"nich odebere."
+"Toto zařízení je v tuto chvíli používáno pro RAID zařízení. Pokračování ho z"
+" nich odebere."
 
 #: pkg/storaged/dialog.jsx:963
 msgid "This device is currently used for VDO devices."
@@ -7312,8 +7509,8 @@ msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
 msgstr ""
-"Toto zařízení je v tuto chvíli používáno ve skupinách svazků. Pokračování ho "
-"odebere z jeho skupin svazků."
+"Toto zařízení je v tuto chvíli používáno ve skupinách svazků. Pokračování ho"
+" odebere z jeho skupin svazků."
 
 #: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
@@ -7400,8 +7597,8 @@ msgstr "Tento svazek je zrovna používán:"
 #: pkg/storaged/lvol-tabs.jsx:187
 msgid "This volume needs to be activated before it can be resized."
 msgstr ""
-"Než bude možné změnit jeho velikost je třeba, aby tento svazek byl aktivován."
-""
+"Než bude možné změnit jeho velikost je třeba, aby tento svazek byl "
+"aktivován."
 
 #: src/ws/login.js:122
 msgid "This web browser is too old to run Cockpit (missing $0)"
@@ -7414,8 +7611,8 @@ msgstr "Tato webová konzole bude aktualizována"
 
 #: pkg/kdump/kdump-view.jsx:296
 msgid ""
-"This will test kdump settings by crashing the kernel and thereby the system. "
-"Depending on the settings, the system may not automatically reboot and the "
+"This will test kdump settings by crashing the kernel and thereby the system."
+" Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
 "Toto vyzkouší nastavení kdump vyvoláním havárie jádra a tím i systému. V "
@@ -7426,11 +7623,18 @@ msgstr ""
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Toto vyzkouší nastavení kdump vyvoláním havárie jádra."
 
+#: pkg/networkmanager/firewall.jsx:814
+msgid ""
+"This zone contains the cockpit service. Make sure that this zone does not "
+"apply to your current web console connection."
+msgstr ""
+
 #: pkg/machines/components/vcpuModal.jsx:237
 msgid "Threads per core"
 msgstr "Vláken na jádro"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:130
 msgid "Thursday"
 msgstr "čtvrtek"
@@ -7474,7 +7678,8 @@ msgstr ""
 msgid "Too much data"
 msgstr "Příliš mnoho dat"
 
-# auto translated by TM merge from project: retrace-server, version: master, DocId: retrace-server
+# auto translated by TM merge from project: retrace-server, version: master,
+# DocId: retrace-server
 #: pkg/docker/storage.jsx:345
 msgid "Total"
 msgstr "Celkem"
@@ -7495,7 +7700,8 @@ msgstr "Spuštěno na základě"
 msgid "Triggers"
 msgstr "Spouštěče"
 
-# auto translated by TM merge from project: SETroubleShoot, version: master, DocId: framework/po/setroubleshoot
+# auto translated by TM merge from project: SETroubleShoot, version: master,
+# DocId: framework/po/setroubleshoot
 #: pkg/shell/index.html:387 pkg/shell/simple.html:139
 #: pkg/machines/components/libvirtSlate.jsx:103
 msgid "Troubleshoot"
@@ -7505,11 +7711,11 @@ msgstr "Řešit potíže"
 msgid "Trust key"
 msgstr "Důvěryhodný klíč"
 
-#: pkg/networkmanager/firewall.jsx:664
+#: pkg/networkmanager/firewall.jsx:671
 msgid "Trust level"
 msgstr "Stupeň důvěryhodnosti"
 
-#: src/ws/login.html:111
+#: src/ws/login.html:98
 msgid "Try Again"
 msgstr "Zkusit znovu"
 
@@ -7525,7 +7731,8 @@ msgstr "Pokusit se znovu spojit"
 msgid "Trying to synchronize with {{Server}}"
 msgstr "Pokus o synchronizaci se {{Server}}"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:128
 msgid "Tuesday"
 msgstr "úterý"
@@ -7550,7 +7757,8 @@ msgstr "Tuned není spuštěné"
 msgid "Tuned is off"
 msgstr "Tuned je vypnuté"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/shell/index.html:266
 #: pkg/machines/components/storagePools/createStoragePoolDialog.jsx:85
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:72
@@ -7583,12 +7791,14 @@ msgstr "Filtrujte psaním…"
 msgid "UDP"
 msgstr "UDP"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:290
 msgid "URL"
 msgstr "URL"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/storaged/part-tab.jsx:39
 msgid "UUID"
 msgstr "UUID:"
@@ -7642,7 +7852,8 @@ msgstr "Nedaří se spustit setroubleshootd"
 msgid "Unable to unmount filesystem"
 msgstr "Nedaří se odpojit souborový systém"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/playground/translate.html:34 pkg/playground/translate.html:39
 msgid "Unavailable"
 msgstr "Nedostupné"
@@ -7665,16 +7876,17 @@ msgstr "Neopakující se název"
 msgid "Unit"
 msgstr "Jednotka"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:146
 #: pkg/networkmanager/interfaces.js:595 pkg/networkmanager/interfaces.js:1071
-#: pkg/networkmanager/interfaces.js:2538 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2515 pkg/networkmanager/interfaces.js:2517
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Neznámé"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2501 pkg/networkmanager/interfaces.js:2513
 msgid "Unknown \"$0\""
 msgstr "Neznámé „$0“"
 
@@ -7690,7 +7902,7 @@ msgstr "Neznámá aplikace"
 msgid "Unknown Host Key"
 msgstr "Neznámý klíč stroje"
 
-#: pkg/networkmanager/interfaces.js:2647
+#: pkg/networkmanager/interfaces.js:2622
 msgid "Unknown configuration"
 msgstr "Neznámé nastavení"
 
@@ -7739,7 +7951,8 @@ msgstr "Odemykání disku…"
 msgid "Unmanaged Interfaces"
 msgstr "Nespravovaná rozhraní"
 
-# auto translated by TM merge from project: blivet-gui, version: f23-branch, DocId: blivet-gui
+# auto translated by TM merge from project: blivet-gui, version: f23-branch,
+# DocId: blivet-gui
 #: pkg/storaged/fsys-tab.jsx:183 pkg/storaged/nfs-details.jsx:307
 msgid "Unmount"
 msgstr "Odpojit"
@@ -7794,7 +8007,8 @@ msgstr "Ve výchozím umístění je k dipozici až $0 $1"
 msgid "Up to $0 $1 available on the host"
 msgstr "Až $0 $1 k dispozici na tomto stroji"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/lib/machine-change-port.html:41
 msgid "Update"
 msgstr "Aktualizovat"
@@ -7807,7 +8021,8 @@ msgstr "Historie aktualizací"
 msgid "Update Log"
 msgstr "Záznam událostí aktualizací"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/packagekit/updates.jsx:61
 msgid "Updated"
 msgstr "Aktualizováno"
@@ -7832,7 +8047,8 @@ msgstr "Aktualizace stavu…"
 msgid "Url"
 msgstr "URL adresa"
 
-# auto translated by TM merge from project: audit-viewer, version: default, DocId: audit-viewer
+# auto translated by TM merge from project: audit-viewer, version: default,
+# DocId: audit-viewer
 #: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "Použití"
@@ -7848,7 +8064,7 @@ msgstr[2] "Využití $0 jader procesoru"
 msgid "Use 512 Byte emulation"
 msgstr "Použít emulaci 512 bajtů"
 
-#: pkg/machines/components/diskAdd.jsx:482
+#: pkg/machines/components/diskAdd.jsx:481
 msgid "Use Existing"
 msgstr "Použít existující"
 
@@ -7872,14 +8088,16 @@ msgstr "Používá"
 msgid "Used by Containers"
 msgstr "Využito kontejnery"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/dashboard/index.html:144 pkg/playground/translate.html:85
 #: pkg/playground/translate.html:105 pkg/systemd/index.html:241
 #: pkg/systemd/host.js:1571
 msgid "User"
 msgstr "Uživatel"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/realmd/operation.html:56 pkg/users/index.html:90
 #: pkg/users/index.html:170
 msgid "User Name"
@@ -7889,9 +8107,10 @@ msgstr "Uživatelské jméno"
 msgid "User Password"
 msgstr "Heslo uživatele"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
-#: src/ws/login.html:43
+#: src/ws/login.html:39
 msgid "User name"
 msgstr "Uživatelské jméno"
 
@@ -7899,7 +8118,8 @@ msgstr "Uživatelské jméno"
 msgid "User name cannot be empty"
 msgstr "Uživatelské jméno je třeba vyplnit"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/storaged/iscsi-panel.jsx:46 pkg/storaged/iscsi-panel.jsx:155
 msgid "Username"
 msgstr "Uživatelské jméno"
@@ -7941,9 +8161,10 @@ msgstr "Zařízení, která jsou podkladem pro VDO, není možné zmenšovat"
 msgid "VDO support not installed"
 msgstr "Podpora pro VDO není nainstalovaná"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2913
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
+#: pkg/networkmanager/interfaces.js:2497 pkg/networkmanager/interfaces.js:2509
+#: pkg/networkmanager/interfaces.js:2888
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7995,7 +8216,8 @@ msgstr "Virt. stroj $0 se nepodařilo vypnout"
 msgid "VM $0 failed to start"
 msgstr "Virt. stroj $0 se nepodařilo zapnout"
 
-# auto translated by TM merge from project: anaconda, version: f25, DocId: main
+# auto translated by TM merge from project: anaconda, version: f25, DocId:
+# main
 #: pkg/machines/components/desktopConsole.jsx:187
 msgid "VNC"
 msgstr "VNC"
@@ -8016,7 +8238,7 @@ msgstr "VNC TLS port:"
 msgid "Validating address"
 msgstr "Ověřuje se adresa"
 
-#: src/ws/login.html:101
+#: src/ws/login.html:88
 msgid "Validating authentication token"
 msgstr "Kontroluje se ověřovací token"
 
@@ -8024,9 +8246,11 @@ msgstr "Kontroluje se ověřovací token"
 msgid "Validating key"
 msgstr "Ověřuje se klíč"
 
-# auto translated by TM merge from project: libosinfo, version: master, DocId: libosinfo
+# auto translated by TM merge from project: libosinfo, version: master, DocId:
+# libosinfo
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:257
+#: pkg/machines/components/vm/bootOrderModal.jsx:126
+#: pkg/systemd/hwinfo.jsx:257
 msgid "Vendor"
 msgstr "Výrobce"
 
@@ -8038,12 +8262,14 @@ msgstr "Ověřeno"
 msgid "Verify key"
 msgstr "Ověřit klíč"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/packagekit/updates.jsx:55
 msgid "Verifying"
 msgstr "Ověřuje se"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/shell/index.html:88 pkg/shell/simple.html:64 pkg/systemd/index.html:117
 #: pkg/packagekit/updates.jsx:385 pkg/systemd/hwinfo.jsx:88
 msgid "Version"
@@ -8079,17 +8305,19 @@ msgstr "Služba virtualizace (libvirt) není aktivní"
 msgid "Virtualization Service is Available"
 msgstr "Virtualizační služba je k dispozici"
 
-# auto translated by TM merge from project: anaconda, version: master, DocId: main
+# auto translated by TM merge from project: anaconda, version: master, DocId:
+# main
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
-#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:91
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Svazek"
 
-# auto translated by TM merge from project: anaconda, version: master, DocId: main
+# auto translated by TM merge from project: anaconda, version: master, DocId:
+# main
 #: pkg/storaged/pvol-tabs.jsx:35
 msgid "Volume Group"
 msgstr "Skupina oddílů"
@@ -8164,7 +8392,8 @@ msgstr "Varování a závažnější"
 msgid "Web Console for Linux servers"
 msgstr "Webová konzole pro linuxové servery"
 
-# auto translated by TM merge from project: docbook-locales, version: master, DocId: locale
+# auto translated by TM merge from project: docbook-locales, version: master,
+# DocId: locale
 #: pkg/systemd/services.html:129
 msgid "Wednesday"
 msgstr "středa"
@@ -8203,7 +8432,8 @@ msgstr "Zapisovatelné"
 msgid "Writeable and shared"
 msgstr "Zapisovatelné a sdílené"
 
-# auto translated by TM merge from project: asknot-ng, version: 0.1, DocId: locale/asknot-ng
+# auto translated by TM merge from project: asknot-ng, version: 0.1, DocId:
+# locale/asknot-ng
 #: pkg/storaged/plot.jsx:315
 msgid "Writing"
 msgstr "Zapisování"
@@ -8212,12 +8442,13 @@ msgstr "Zapisování"
 msgid "Wrong user name or password"
 msgstr "Chybné uživatelské jméno nebo heslo"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1964
 msgid "XOR"
 msgstr "XOR"
 
-# auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
-#: pkg/networkmanager/interfaces.js:2600
+# auto translated by TM merge from project: selinux (policycoreutils),
+# version: master, DocId: policycoreutils
+#: pkg/networkmanager/interfaces.js:2575
 msgid "Yes"
 msgstr "Ano"
 
@@ -8234,12 +8465,12 @@ msgstr ""
 msgid ""
 "You are currently connected directly to this server. You cannot delete it."
 msgstr ""
-"V tuto chvíli jste připojení přímo na tento server. Nemůžete ho proto smazat."
-""
+"V tuto chvíli jste připojení přímo na tento server. Nemůžete ho proto "
+"smazat."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:131
-#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:827
-#: pkg/networkmanager/firewall.jsx:859
+#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:925
 msgid "You are not authorized to modify the firewall."
 msgstr "Nemáte oprávnění upravovat bránu firewall"
 
@@ -8305,7 +8536,8 @@ msgstr "abrt"
 msgid "access"
 msgstr "přístup"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/machines/components/networks/network.jsx:60
 #: pkg/machines/components/storagePools/storagePool.jsx:70
 #: pkg/shell/active-pages-dialog.jsx:39
@@ -8364,7 +8596,8 @@ msgstr "spřažení"
 msgid "boot"
 msgstr "boot"
 
-# auto translated by TM merge from project: libguestfs, version: master, DocId: po/libguestfs
+# auto translated by TM merge from project: libguestfs, version: master,
+# DocId: po/libguestfs
 #: pkg/machines/helpers.js:219 pkg/networkmanager/manifest.json.in
 msgid "bridge"
 msgstr "most"
@@ -8373,7 +8606,8 @@ msgstr "most"
 msgid "bug fix"
 msgstr "oprava chyby"
 
-# auto translated by TM merge from project: Blivet, version: master, DocId: blivet
+# auto translated by TM merge from project: Blivet, version: master, DocId:
+# blivet
 #: pkg/storaged/utils.js:97
 msgctxt "format-bytes"
 msgid "bytes"
@@ -8403,7 +8637,8 @@ msgstr "procesor"
 msgid "crash"
 msgstr "pád"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/machines/helpers.js:200
 msgid "crashed"
 msgstr "zhavarovalo"
@@ -8420,7 +8655,8 @@ msgstr "datum"
 msgid "debug"
 msgstr "ladění"
 
-# auto translated by TM merge from project: IBus-Chewing, version: master, DocId: ibus-chewing
+# auto translated by TM merge from project: IBus-Chewing, version: master,
+# DocId: ibus-chewing
 #: pkg/docker/util.js:124
 msgid "default"
 msgstr "výchozí"
@@ -8437,7 +8673,8 @@ msgstr "přímé"
 msgid "disable"
 msgstr "vypnout"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/machines/helpers.js:184 pkg/machines/helpers.js:187
 msgid "disabled"
 msgstr "zakázáno"
@@ -8475,7 +8712,8 @@ msgstr "např. „$0“"
 msgid "enable"
 msgstr "zapnout"
 
-# auto translated by TM merge from project: dnf, version: master, DocId: po/dnf
+# auto translated by TM merge from project: dnf, version: master, DocId:
+# po/dnf
 #: pkg/machines/helpers.js:185 pkg/machines/helpers.js:188
 msgid "enabled"
 msgstr "povoleno"
@@ -8488,7 +8726,8 @@ msgstr "šifrování"
 msgid "enhancement"
 msgstr "vylepšení"
 
-# auto translated by TM merge from project: SSSD, version: master, DocId: po/sssd
+# auto translated by TM merge from project: SSSD, version: master, DocId:
+# po/sssd
 #: pkg/systemd/manifest.json.in
 msgid "error"
 msgstr "chyba"
@@ -8561,7 +8800,8 @@ msgstr "Přímý cíl iSCSI"
 msgid "iSCSI target IQN"
 msgstr "IQN název iSCSI cíle"
 
-# auto translated by TM merge from project: libvirt, version: master, DocId: libvirt
+# auto translated by TM merge from project: libvirt, version: master, DocId:
+# libvirt
 #: pkg/machines/helpers.js:196
 msgid "idle"
 msgstr "nečinný"
@@ -8577,7 +8817,7 @@ msgstr "nainstalovat"
 
 #: pkg/networkmanager/manifest.json.in
 msgid "interface"
-msgstr ""
+msgstr "rozhraní"
 
 #: pkg/kdump/kdump-view.jsx:379
 msgid "invalid: multiple targets defined"
@@ -8699,7 +8939,8 @@ msgstr "cíl výpisu nfs nemá podobu server:umisteni"
 msgid "no"
 msgstr "ne"
 
-# auto translated by TM merge from project: anaconda, version: rhel8-alpha-branch, DocId: anaconda
+# auto translated by TM merge from project: anaconda, version: rhel8-alpha-
+# branch, DocId: anaconda
 #: pkg/docker/run.js:419 pkg/docker/run.js:475 pkg/docker/run.js:529
 #: pkg/docker/run.js:574 pkg/tuned/dialog.js:105
 msgid "none"
@@ -8800,7 +9041,8 @@ msgstr "restartovat"
 msgid "roles"
 msgstr "role"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/machines/helpers.js:195
 msgid "running"
 msgstr "spuštěné"
@@ -8857,7 +9099,8 @@ msgstr "zobrazit více"
 msgid "shut"
 msgstr "shut"
 
-# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId: cockpit
+# auto translated by TM merge from project: Cockpit, version: rhel-7.4, DocId:
+# cockpit
 #: pkg/machines/helpers.js:199
 msgid "shut off"
 msgstr "vypnuto"
@@ -8946,7 +9189,8 @@ msgstr "přeložitelné"
 msgid "udisks"
 msgstr "udisks"
 
-# auto translated by TM merge from project: selinux (policycoreutils), version: master, DocId: policycoreutils
+# auto translated by TM merge from project: selinux (policycoreutils),
+# version: master, DocId: policycoreutils
 #: pkg/machines/helpers.js:225 pkg/networkmanager/manifest.json.in
 msgid "udp"
 msgstr "udp"
@@ -8959,7 +9203,8 @@ msgstr "nedefinované"
 msgid "unit"
 msgstr "jednotka"
 
-# auto translated by TM merge from project: Spacewalk Backend, version: master, DocId: client/rhel/rhn-client-tools/po/rhn-client-tools
+# auto translated by TM merge from project: Spacewalk Backend, version:
+# master, DocId: client/rhel/rhn-client-tools/po/rhn-client-tools
 #: pkg/systemd/init.js:257 pkg/systemd/init.js:271
 msgid "unknown"
 msgstr "neznámý"
@@ -8984,7 +9229,8 @@ msgstr "nerozdělené místo na $0"
 msgid "up"
 msgstr "zapnuto"
 
-# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId: po/ipa
+# auto translated by TM merge from project: FreeIPA, version: ipa-4-5, DocId:
+# po/ipa
 #: pkg/machines/helpers.js:220 pkg/users/manifest.json.in
 msgid "user"
 msgstr "uživatel"
@@ -9049,7 +9295,8 @@ msgstr "svazek"
 msgid "warning"
 msgstr "varování"
 
-# auto translated by TM merge from project: Pulseaudio, version: master, DocId: pulseaudio.pot
+# auto translated by TM merge from project: Pulseaudio, version: master,
+# DocId: pulseaudio.pot
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:67
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:70

--- a/po/ko.po
+++ b/po/ko.po
@@ -9,16 +9,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 10:45+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2019-10-30 17:14+0000\n"
 "PO-Revision-Date: 2019-09-20 11:25+0000\n"
 "Last-Translator: MinWoo Joh <igtzhsou@naver.com>\n"
 "Language-Team: Korean\n"
 "Language: ko\n"
-"X-Generator: Zanata 4.6.2\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0\n"
+"X-Generator: Zanata 4.6.2\n"
 
 #: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
@@ -28,11 +28,11 @@ msgstr " (OS와 공유)"
 msgid " Attaching it will make this disk shareable for every VM using it."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zone"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zones"
 msgstr ""
 
@@ -227,7 +227,7 @@ msgid "$1 security fix"
 msgid_plural "$1 security fixes"
 msgstr[0] "$1 보안 수정"
 
-#: pkg/networkmanager/interfaces.js:2764
+#: pkg/networkmanager/interfaces.js:2739
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -491,11 +491,11 @@ msgstr "7일 "
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:1966
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:1983
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -509,15 +509,15 @@ msgstr "9일 "
 
 #: pkg/lib/machine-not-supported.html:5
 msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
+"A compatible version of Cockpit is not installed on "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr "Cockpit 호환 버전이 {{#strong}}{{host}}{{/strong}} 에 설치되어 있지 않습니다. "
 
 #: pkg/storaged/vdos-panel.jsx:62
 msgid "A disk is needed."
 msgstr "디스크가 필요합니다."
 
-#: src/ws/login.html:115
+#: src/ws/login.html:102
 msgid ""
 "A modern browser is required for security, reliability, and performance."
 msgstr "보안, 안정성, 성능을 위해 최신 브라우저가 필요합니다. "
@@ -526,15 +526,15 @@ msgstr "보안, 안정성, 성능을 위해 최신 브라우저가 필요합니�
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "디스크를 제거하기 전 예비용 디스크를 추가해야 합니다. "
 
-#: pkg/networkmanager/interfaces.js:1997
+#: pkg/networkmanager/interfaces.js:1974
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2793
+#: pkg/networkmanager/interfaces.js:2768
 msgid "ARP Monitoring"
 msgstr "ARP 모니터링"
 
-#: pkg/networkmanager/interfaces.js:2018
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP Ping"
 msgstr "ARP Ping"
 
@@ -585,11 +585,11 @@ msgstr "활성화"
 msgid "Activating $target"
 msgstr " $target 활성화 중 "
 
-#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:2012
+#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:1989
 msgid "Active"
 msgstr "활성"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1963 pkg/networkmanager/interfaces.js:1980
 msgid "Active Backup"
 msgstr "활성화된 백업"
 
@@ -605,16 +605,16 @@ msgstr "이후 활성화 "
 msgid "Active since "
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Adaptive load balancing"
 msgstr "적응형 로드 밸런싱"
 
-#: pkg/networkmanager/interfaces.js:1990
+#: pkg/networkmanager/interfaces.js:1967
 msgid "Adaptive transmit load balancing"
 msgstr "적응형 전송 로드 밸런싱"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
-#: pkg/machines/components/diskAdd.jsx:522
+#: pkg/machines/components/diskAdd.jsx:521
 #: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
 #: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
 #: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:197
@@ -622,7 +622,7 @@ msgstr "적응형 전송 로드 밸런싱"
 msgid "Add"
 msgstr "추가"
 
-#: pkg/networkmanager/interfaces.js:3113
+#: pkg/networkmanager/interfaces.js:3088
 msgid "Add $0"
 msgstr "$0 추가 "
 
@@ -638,7 +638,7 @@ msgstr "본드 추가"
 msgid "Add Bridge"
 msgstr "브릿지 추가"
 
-#: pkg/machines/components/diskAdd.jsx:510
+#: pkg/machines/components/diskAdd.jsx:509
 #: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "디스크 추가"
@@ -684,8 +684,8 @@ msgstr "VLAN 추가"
 msgid "Add Virtual Network Interface"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:659 pkg/networkmanager/firewall.jsx:828
-#: pkg/networkmanager/firewall.jsx:834
+#: pkg/networkmanager/firewall.jsx:666 pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:900
 msgid "Add Zone"
 msgstr "영역 추가 "
 
@@ -709,11 +709,11 @@ msgstr "공개 키 추가 "
 msgid "Add services to $0 zone"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:743
 msgid "Add zone"
 msgstr "영역 추가 "
 
-#: pkg/networkmanager/interfaces.js:3112
+#: pkg/networkmanager/interfaces.js:3087
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -737,11 +737,11 @@ msgstr "$target에 물리 볼륨 추가 중 "
 msgid "Additional"
 msgstr "추가 "
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "Additional DNS $val"
 msgstr "추가 DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "Additional DNS Search Domains $val"
 msgstr "추가 DNS 검색 도메인 $val"
 
@@ -753,7 +753,7 @@ msgstr "추가 스토리지 "
 msgid "Additional actions"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Additional address $val"
 msgstr "추가 주소 $val"
 
@@ -769,7 +769,7 @@ msgstr "추가 패키지 :"
 msgid "Address"
 msgstr "주소"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Address $val"
 msgstr "주소 $val"
 
@@ -792,7 +792,7 @@ msgstr ""
 msgid "Address:"
 msgstr "주소:"
 
-#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3319
+#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3294
 msgid "Addresses"
 msgstr "주소"
 
@@ -820,8 +820,8 @@ msgstr ""
 #: pkg/realmd/operation.html:27
 msgid ""
 "After leaving the domain, only users with local credentials will be able to "
-"log into this machine. This may also affect other services as DNS resolution "
-"settings and the list of trusted CAs may change."
+"log into this machine. This may also affect other services as DNS resolution"
+" settings and the list of trusted CAs may change."
 msgstr ""
 "도메인 종료 후 로컬 인증 정보가 있는 사용자만 시스템에 로그인할 수 있습니다. 이 경우 DNS 확인 설정 및 신뢰할 수 있는 CA "
 "목록이 변경될 수 있으므로 다른 서비스에도 영향을 미칠 수 있습니다. "
@@ -835,7 +835,8 @@ msgstr "시스템 부팅 후"
 msgid "Alert and above"
 msgstr "경고 이상의 수준 "
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213
+#: pkg/systemd/logs.js:384
 msgid "All"
 msgstr "모두"
 
@@ -853,7 +854,7 @@ msgstr "선택된 디스크의 모든 데이터가 삭제되며 디스크는 스
 msgid "Allow running (unmask)"
 msgstr ""
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Allowed Addresses"
 msgstr "허용된 주소 "
 
@@ -977,17 +978,17 @@ msgstr "승인된 공개 SSH 키"
 
 #: pkg/networkmanager/index.html:179
 #: pkg/machines/components/networks/createNetworkDialog.jsx:162
-#: pkg/networkmanager/interfaces.js:1976 pkg/networkmanager/interfaces.js:2766
-#: pkg/networkmanager/interfaces.js:3327 pkg/networkmanager/interfaces.js:3331
-#: pkg/networkmanager/interfaces.js:3337 pkg/realmd/operation.js:338
+#: pkg/networkmanager/interfaces.js:1953 pkg/networkmanager/interfaces.js:2741
+#: pkg/networkmanager/interfaces.js:3302 pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3312 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "자동"
 
-#: pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1954
 msgid "Automatic (DHCP only)"
 msgstr "자동(DHCP만)"
 
-#: pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1944
 msgid "Automatic (DHCP)"
 msgstr "자동(DHCP)"
 
@@ -1103,8 +1104,8 @@ msgstr "파일 시스템의 블록 장치 "
 msgid "Blocked"
 msgstr "차단됨 "
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2493 pkg/networkmanager/interfaces.js:2505
+#: pkg/networkmanager/interfaces.js:2773
 msgid "Bond"
 msgstr "본드"
 
@@ -1125,8 +1126,8 @@ msgstr "부팅 순서 설정을 저장하지 못했습니다 "
 msgid "Bound By"
 msgstr "바인딩됨 "
 
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2499 pkg/networkmanager/interfaces.js:2511
+#: pkg/networkmanager/interfaces.js:2850
 msgid "Bridge"
 msgstr "브릿지"
 
@@ -1138,15 +1139,15 @@ msgstr "브릿지 포트 설정"
 msgid "Bridge Settings"
 msgstr "브릿지 설정"
 
-#: pkg/networkmanager/interfaces.js:2896
+#: pkg/networkmanager/interfaces.js:2871
 msgid "Bridge port"
 msgstr "브릿지 포트"
 
-#: pkg/networkmanager/interfaces.js:1988 pkg/networkmanager/interfaces.js:2005
+#: pkg/networkmanager/interfaces.js:1965 pkg/networkmanager/interfaces.js:1982
 msgid "Broadcast"
 msgstr "브로트캐스트"
 
-#: pkg/networkmanager/interfaces.js:2811 pkg/networkmanager/interfaces.js:2845
+#: pkg/networkmanager/interfaces.js:2786 pkg/networkmanager/interfaces.js:2820
 msgid "Broken configuration"
 msgstr "손상된 설정 "
 
@@ -1227,17 +1228,16 @@ msgstr "이미지를 로드할 수 없습니다."
 #: pkg/networkmanager/index.html:600 pkg/networkmanager/index.html:624
 #: pkg/networkmanager/index.html:648 pkg/networkmanager/index.html:672
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
-#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
-#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/index.html:343 pkg/systemd/index.html:430
+#: pkg/systemd/index.html:482 pkg/systemd/index.html:498
+#: pkg/systemd/services.html:377 pkg/users/index.html:198
+#: pkg/users/index.html:237 pkg/users/index.html:276 pkg/users/index.html:315
+#: pkg/users/index.html:332 pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/apps/utils.jsx:86 pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:818
-#: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/deleteResource.jsx:108
-#: pkg/machines/components/diskAdd.jsx:519
+#: pkg/machines/components/diskAdd.jsx:518
 #: pkg/machines/components/diskEdit.jsx:173
 #: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/nicAdd.jsx:232
@@ -1248,10 +1248,12 @@ msgstr "이미지를 로드할 수 없습니다."
 #: pkg/machines/components/vcpuModal.jsx:257
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:730
-#: pkg/packagekit/updates.jsx:182 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:399 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:221 pkg/systemd/service-details.jsx:107
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:738
+#: pkg/networkmanager/firewall.jsx:763 pkg/packagekit/updates.jsx:182
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:399
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:221
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "취소"
 
@@ -1271,13 +1273,13 @@ msgstr "이전 이벤트를 예약할 수 없습니다. "
 msgid "Capacity"
 msgstr "용량"
 
-#: pkg/networkmanager/interfaces.js:2597
+#: pkg/networkmanager/interfaces.js:2572
 msgid "Carrier"
 msgstr "캐리어"
 
 #: pkg/docker/index.html:664 pkg/systemd/index.html:344
-#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:188
+#: pkg/systemd/index.html:431 pkg/users/index.html:277
+#: pkg/users/index.html:316 pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "변경 "
 
@@ -1317,7 +1319,7 @@ msgstr "리소스 제한 변경"
 msgid "Change resources limits"
 msgstr "리소스 제한 변경"
 
-#: pkg/networkmanager/interfaces.js:3163
+#: pkg/networkmanager/interfaces.js:3138
 msgid "Change the settings"
 msgstr "설정 변경"
 
@@ -1329,10 +1331,10 @@ msgstr "설정 변경"
 msgid "Changes will take effect after shutting down the VM"
 msgstr "VM 종료 후 변경사항이 적용됩니다. "
 
-#: pkg/networkmanager/interfaces.js:3162
+#: pkg/networkmanager/interfaces.js:3137
 msgid ""
-"Changing the settings will break the connection to the server, and will make "
-"the administration UI unavailable."
+"Changing the settings will break the connection to the server, and will make"
+" the administration UI unavailable."
 msgstr "설정을 변경하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
 #: pkg/packagekit/updates.jsx:178
@@ -1404,8 +1406,7 @@ msgid "Click to see system hardware information"
 msgstr "시스템 하드웨어 정보를 보려면 클릭하십시오."
 
 #: pkg/machines/components/desktopConsole.jsx:41
-msgid ""
-"Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
+msgid "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr "\"원격 뷰어 시작\"을 클릭하면 .vv 파일을 다운로드하여 $0을 시작합니다. "
 
 #: pkg/realmd/operation.html:20
@@ -1414,12 +1415,13 @@ msgstr "클라이언트 소프트웨어 "
 
 #: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:691 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:399
+#: pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/networkmanager/index.html:691
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:325
+#: pkg/shell/simple.html:72 pkg/systemd/index.html:289 pkg/users/index.html:45
+#: pkg/apps/utils.jsx:108 pkg/lib/cockpit-components-modifications.jsx:109
+#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
+#: pkg/storaged/dialog.jsx:399
 msgid "Close"
 msgstr "닫기"
 
@@ -1437,8 +1439,8 @@ msgstr "Cockpit 인증이 잘못 설정되어 있습니다. "
 
 #: pkg/lib/machine-dialogs.js:429
 msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
+"Cockpit could not contact the given host $0. Make sure it has ssh running on"
+" port $1, or specify another port in the address."
 msgstr ""
 "Cockpit은 지정된 호스트 $0에 연결할 수 없습니다. 포트 $1에서 ssh가 실행되고 있는지 확인하거나 주소에서 다른 포트를 "
 "지정합니다. "
@@ -1450,8 +1452,8 @@ msgstr "Cockpit을 지정된 호스트에 연결할 수 없습니다. "
 #: pkg/shell/base_index.js:765
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
-"Cockpit by pressing refresh in your browser. The javascript console contains "
-"details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
+"Cockpit by pressing refresh in your browser. The javascript console contains"
+" details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 "Cockpit에서 예상치 못한 내부 오류가 발생했습니다.  <br/><br/>브라우저에서 업데이트를 눌러 Cockpit 재부팅을 시도할 "
 "수 있습니다. javascript 콘솔에는 이러한 오류에 대한 상세 정보가 포함되어 있습니다 (대부분의 브라우저에서 <b>Ctrl-"
@@ -1471,7 +1473,8 @@ msgstr ""
 
 #: pkg/shell/index.html:85 pkg/shell/simple.html:61
 msgid "Cockpit is an interactive Linux server admin interface."
-msgstr "Cockpit은 대화형 Linux 서버 관리 인터페이스입니다.\n"
+msgstr ""
+"Cockpit은 대화형 Linux 서버 관리 인터페이스입니다.\n"
 "            "
 
 #: src/base1/cockpit.js:4039
@@ -1488,15 +1491,15 @@ msgstr "시스템에 Cockpit이 설치되어 있지 않습니다. "
 
 #: src/ws/cockpit.appdata.xml.in:18
 msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple"
+" tasks such as storage administration, inspecting journals and starting and "
 "stopping services. You can monitor and administer several servers at the "
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
 msgstr ""
-"Cockpit은 경험이 적은 시스템 관리자에게 적합합니다. 시스템 관리자는 스토리지 관리, 저널 검사, 서비스 시작 및 중지 등의 간단한 "
-"작업을 쉽게 수행할 수 있으며 여러 서버를 동시에 모니터링 및 관리할 수 ​​있습니다. 간단하게 서버를 클릭하여 서버를 추가할 수 있으며 "
-"추가 후 다른 기기를 관리할 수 ​​있습니다."
+"Cockpit은 경험이 적은 시스템 관리자에게 적합합니다. 시스템 관리자는 스토리지 관리, 저널 검사, 서비스 시작 및 중지 등의 간단한"
+" 작업을 쉽게 수행할 수 있으며 여러 서버를 동시에 모니터링 및 관리할 수 ​​있습니다. 간단하게 서버를 클릭하여 서버를 추가할 수 "
+"있으며 추가 후 다른 기기를 관리할 수 ​​있습니다."
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1505,8 +1508,8 @@ msgstr "Cockpit은 {{#strong}}{{host}}{{/strong}}에 연결할 수 없습니다.
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
 "Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize "
+"users{{/sync_link}}.{{/can_sync}} For more authentication options and "
 "troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. {{#can_sync}} "
@@ -1529,12 +1532,13 @@ msgstr ""
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
 "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+"change your authentication credentials below. {{#can_sync}}You may prefer to"
+" {{#sync_link}}synchronize accounts and "
+"passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
-"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. 다음에서 인증 정보를 변경할 수 있습니다."
-" {{#can_sync}}{{#sync_link}}계정과 암호 동기화{{/sync_link}}를 실행할 수 있습니다.{{/"
-"can_sync}}"
+"Cockpit은 {{#strong}}{{host}}{{/strong}}에 로그인할 수 없습니다. 다음에서 인증 정보를 변경할 수 "
+"있습니다. {{#can_sync}}{{#sync_link}}계정과 암호 동기화{{/sync_link}}를 실행할 수 "
+"있습니다.{{/can_sync}}"
 
 #: pkg/dashboard/index.html:157 pkg/lib/machine-add.html:27
 msgid "Color"
@@ -1618,7 +1622,7 @@ msgstr "조건 $0=$1이 충족되지 않았습니다. "
 msgid "Condition failed"
 msgstr "조건이 충족되지 않았습니다 "
 
-#: pkg/networkmanager/interfaces.js:2732
+#: pkg/networkmanager/interfaces.js:2707
 msgid "Configure"
 msgstr "설정"
 
@@ -1664,11 +1668,11 @@ msgstr "충돌"
 msgid "Connect"
 msgstr "연결"
 
-#: pkg/networkmanager/interfaces.js:2719
+#: pkg/networkmanager/interfaces.js:2694
 msgid "Connect automatically"
 msgstr "자동으로 연결"
 
-#: src/ws/login.html:74
+#: src/ws/login.html:63
 msgid "Connect to"
 msgstr "연결 대상 "
 
@@ -1785,7 +1789,8 @@ msgstr "컨테이너"
 msgid "Contains"
 msgstr ""
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/storaged/content-views.jsx:567
 msgid "Content"
 msgstr "컨텐츠"
@@ -1880,7 +1885,7 @@ msgstr "생성"
 msgid "Create Logical Volume"
 msgstr "논리 볼륨 만들기 "
 
-#: pkg/machines/components/diskAdd.jsx:473
+#: pkg/machines/components/diskAdd.jsx:472
 msgid "Create New"
 msgstr "새로 만들기 "
 
@@ -1967,8 +1972,8 @@ msgstr "볼륨 그룹 생성"
 msgid "Create diagnostic report"
 msgstr "진단 보고서 작성 "
 
-#: pkg/networkmanager/interfaces.js:3837 pkg/networkmanager/interfaces.js:4037
-#: pkg/networkmanager/interfaces.js:4292 pkg/networkmanager/interfaces.js:4497
+#: pkg/networkmanager/interfaces.js:3810 pkg/networkmanager/interfaces.js:4010
+#: pkg/networkmanager/interfaces.js:4265 pkg/networkmanager/interfaces.js:4470
 msgid "Create it"
 msgstr "만들기 "
 
@@ -1976,7 +1981,8 @@ msgstr "만들기 "
 msgid "Create new Logical Volume"
 msgstr "새 볼륨 그룹 만들기 "
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/docker/containers-view.jsx:129 pkg/docker/containers-view.jsx:412
 #: pkg/docker/containers-view.jsx:687
 msgid "Created"
@@ -2006,25 +2012,25 @@ msgstr "파티션 $target 생성 중 "
 msgid "Creating snapshot of $target"
 msgstr "$target 스냅샷 생성 중"
 
-#: pkg/networkmanager/interfaces.js:4496
+#: pkg/networkmanager/interfaces.js:4469
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "이 VLAN을 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
-#: pkg/networkmanager/interfaces.js:3836
+#: pkg/networkmanager/interfaces.js:3809
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "이 본드를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
-#: pkg/networkmanager/interfaces.js:4291
+#: pkg/networkmanager/interfaces.js:4264
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
 msgstr "이 브릿지를 생성하면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
-#: pkg/networkmanager/interfaces.js:4036
+#: pkg/networkmanager/interfaces.js:4009
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2074,7 +2080,7 @@ msgstr "사용자 지정 암호화 옵션 "
 msgid "Custom mount options"
 msgstr "사용자 정의 마운트 옵션 "
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:684
 msgid "Custom zones"
 msgstr "사용자 지정 영역 "
 
@@ -2087,19 +2093,19 @@ msgstr "DHCP 범위 "
 msgid "DISK IS FAILING"
 msgstr "디스크에 오류 발생 "
 
-#: pkg/networkmanager/interfaces.js:3326
+#: pkg/networkmanager/interfaces.js:3301
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3330
+#: pkg/networkmanager/interfaces.js:3305
 msgid "DNS Search Domains"
 msgstr "DNS 검색 도메인 "
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "DNS Search Domains $val"
 msgstr "DNS 검색 도메인 $val"
 
@@ -2107,7 +2113,9 @@ msgstr "DNS 검색 도메인 $val"
 msgid "Dark"
 msgstr "진하게 "
 
-# auto translated by TM merge from project: RHEV Administration Guide, version: 4.0, DocId: chap-Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
+# auto translated by TM merge from project: RHEV Administration Guide,
+# version: 4.0, DocId: chap-
+# Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
 #: pkg/dashboard/index.html:22
 msgid "Dashboard"
 msgstr "대시보드"
@@ -2151,8 +2159,6 @@ msgstr "지연 "
 #: pkg/networkmanager/index.html:436 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
 #: pkg/docker/details.js:293 pkg/docker/util.js:641
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/deleteResource.jsx:77
 #: pkg/machines/components/deleteResource.jsx:87
 #: pkg/machines/components/deleteResource.jsx:100
@@ -2160,14 +2166,17 @@ msgstr "지연 "
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:316
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
-#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
-#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/networkmanager/firewall.jsx:766 pkg/storaged/content-views.jsx:300
+#: pkg/storaged/content-views.jsx:316 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/vdo-details.jsx:203
+#: pkg/storaged/vdo-details.jsx:268 pkg/storaged/vgroup-details.jsx:211
+#: pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "삭제"
 
-#: pkg/networkmanager/interfaces.js:2441 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2418 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "$0 삭제 "
 
@@ -2200,7 +2209,7 @@ msgstr "풀 내에 있는 볼륨을 삭제합니다 "
 msgid "Deleting $target"
 msgstr "$target 삭제 중 "
 
-#: pkg/networkmanager/interfaces.js:2440
+#: pkg/networkmanager/interfaces.js:2417
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2240,7 +2249,7 @@ msgstr "비활성화된 스토리지 풀을 삭제하려면 풀 정의를 해제
 msgid "Deleting volume group $target"
 msgstr "볼륨 그룹 $target 삭제 중 "
 
-#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:686
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:693
 #: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "설명"
@@ -2259,7 +2268,8 @@ msgstr ""
 msgid "Detachable"
 msgstr "분리 가능 "
 
-# translation auto-copied from project libreport, version master, document libreport
+# translation auto-copied from project libreport, version master, document
+# libreport
 #: pkg/shell/index.html:230 pkg/docker/containers-view.jsx:336
 #: pkg/docker/containers-view.jsx:504 pkg/docker/containers-view.jsx:514
 #: pkg/docker/containers-view.jsx:642 pkg/packagekit/updates.jsx:387
@@ -2311,7 +2321,7 @@ msgstr "동시 멀티스레딩 비활성화 "
 msgid "Disable tuned"
 msgstr "tuned 비활성화 "
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1971
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1948
 #: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "사용 안함"
@@ -2341,7 +2351,8 @@ msgstr "디스크 "
 msgid "Disk $0 fail to get detached from VM $1"
 msgstr "디스크 $ 0이/가 VM $ 1에서 분리되지 않음"
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/dashboard/index.html:73 pkg/systemd/host.js:515
 msgid "Disk I/O"
 msgstr "디스크 I/O"
@@ -2428,12 +2439,13 @@ msgstr "기존 데이터를 덮어쓰지 않습니다 "
 msgid "Done!"
 msgstr "완료"
 
-# translation auto-copied from project CFSE, version sam-1.2, document app, author eukim
+# translation auto-copied from project CFSE, version sam-1.2, document app,
+# author eukim
 #: pkg/docker/index.html:600
 msgid "Download"
 msgstr "다운로드 "
 
-#: src/ws/login.html:118
+#: src/ws/login.html:105
 msgid "Download a new browser for free"
 msgstr "새 브라우저를 다운로드합니다 (무료)"
 
@@ -2602,7 +2614,7 @@ msgid ""
 "time you reconnect to this machine"
 msgstr "여기에 다른 암호를 입력하면 이 컴퓨터에 연결할 때 마다 암호를 다시 입력해야 합니다"
 
-#: pkg/networkmanager/firewall.jsx:713
+#: pkg/networkmanager/firewall.jsx:721
 msgid "Entire subnet"
 msgstr "전체 서브넷 "
 
@@ -2614,7 +2626,8 @@ msgstr "항목"
 msgid "Entrypoint"
 msgstr "시작점"
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/docker/index.html:528
 msgid "Environment"
 msgstr "환경"
@@ -2678,7 +2691,7 @@ msgstr "Ethernet MAC"
 msgid "Ethernet MTU"
 msgstr "Ethernet MTU"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:1994
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2738,7 +2751,7 @@ msgstr "포트를 추가하지 못했습니다     "
 msgid "Failed to add service"
 msgstr "서비스 추가 실패 "
 
-#: pkg/networkmanager/firewall.jsx:638
+#: pkg/networkmanager/firewall.jsx:645
 msgid "Failed to add zone"
 msgstr "영역 추가 실패 "
 
@@ -2832,11 +2845,11 @@ msgid "Fingerprint"
 msgstr "지문 "
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:99
-#: pkg/networkmanager/firewall.jsx:874 pkg/networkmanager/firewall.jsx:878
+#: pkg/networkmanager/firewall.jsx:940 pkg/networkmanager/firewall.jsx:944
 msgid "Firewall"
 msgstr "방화벽"
 
-#: pkg/networkmanager/firewall.jsx:817
+#: pkg/networkmanager/firewall.jsx:883
 msgid "Firewall is not available"
 msgstr "방화벽을 사용할 수 없습니다 "
 
@@ -2899,7 +2912,7 @@ msgstr "장치를 포멧하면 내부의 모든 데이터를 지우게 됩니다
 msgid "Forward Mode"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2843
 msgid "Forward delay $forward_delay"
 msgstr "포워드 딜레이 $forward_delay"
 
@@ -2934,13 +2947,14 @@ msgstr "금요일 "
 msgid "Full Name"
 msgstr "성명"
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/docker/index.html:184
 msgid "Gateway:"
 msgstr "게이트웨이:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2710 pkg/systemd/logs.js:488
+#: pkg/networkmanager/interfaces.js:2685 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "일반"
 
@@ -3012,7 +3026,7 @@ msgstr "모든 공간을 사용하여 확장하기 "
 msgid "Hair Pin mode"
 msgstr "Hair Pin 모드"
 
-#: pkg/networkmanager/interfaces.js:2894
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Hairpin mode"
 msgstr "Hairpin 모드"
 
@@ -3032,7 +3046,7 @@ msgstr "하드웨어"
 msgid "Hardware Information"
 msgstr "하드웨어 정보 "
 
-#: pkg/networkmanager/interfaces.js:2870
+#: pkg/networkmanager/interfaces.js:2845
 msgid "Hello time $hello_time"
 msgstr "Hello 타임 $hello_time"
 
@@ -3109,7 +3123,7 @@ msgstr "IP 접두어 길이:"
 msgid "IP Settings"
 msgstr "IP 설정"
 
-#: pkg/networkmanager/interfaces.js:2919
+#: pkg/networkmanager/interfaces.js:2894
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3125,7 +3139,7 @@ msgstr ""
 msgid "IPv4 Network should not be empty"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv4 Settings"
 msgstr "IPv4 설정"
 
@@ -3137,7 +3151,7 @@ msgstr ""
 msgid "IPv4 only"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2920
+#: pkg/networkmanager/interfaces.js:2895
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3153,7 +3167,7 @@ msgstr ""
 msgid "IPv6 Network should not be empty"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv6 Settings"
 msgstr "IPv6 설정"
 
@@ -3161,13 +3175,14 @@ msgstr "IPv6 설정"
 msgid "IPv6 only"
 msgstr ""
 
-# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version
+# 6.1, document hammer-cli-foreman
 #: pkg/docker/containers-view.jsx:128 pkg/docker/containers-view.jsx:408
 #: pkg/machines/components/diskEdit.jsx:34
 msgid "Id"
 msgstr "ID "
 
-#: pkg/networkmanager/interfaces.js:2911
+#: pkg/networkmanager/interfaces.js:2886
 msgid "Id $id"
 msgstr "Id $id"
 
@@ -3179,7 +3194,7 @@ msgstr "Id:"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "tang-show-keys를 사용할 수 없는 경우 다음을 실행합니다:"
 
-#: pkg/networkmanager/interfaces.js:1980 pkg/packagekit/updates.jsx:501
+#: pkg/networkmanager/interfaces.js:1957 pkg/packagekit/updates.jsx:501
 msgid "Ignore"
 msgstr "무시"
 
@@ -3237,12 +3252,12 @@ msgstr "대부분의 설정에서 macvtap는 호스트와 게스트 간 네트�
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
-"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
-"strong}}."
+"In order to synchronize users, you need to log in to "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr "사용자를 동기화하려면 {{#strong}}{{host}}{{/strong}}에 로그인해야 합니다. "
 
-#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1421
-#: pkg/networkmanager/interfaces.js:1428 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1398
+#: pkg/networkmanager/interfaces.js:1405 pkg/networkmanager/interfaces.js:2588
 msgid "Inactive"
 msgstr "비활성"
 
@@ -3250,7 +3265,7 @@ msgstr "비활성"
 msgid "Inactive volume"
 msgstr "비활성 볼륨 "
 
-#: pkg/networkmanager/firewall.jsx:691
+#: pkg/networkmanager/firewall.jsx:698
 msgid "Included services"
 msgstr "포함된 서비스 "
 
@@ -3324,7 +3339,8 @@ msgstr ""
 msgid "Installation Type"
 msgstr ""
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/packagekit/updates.jsx:60
 msgid "Installed"
 msgstr "설치됨"
@@ -3351,8 +3367,8 @@ msgid "Interface Type"
 msgstr "인터페이스 유형"
 
 #: pkg/networkmanager/index.html:110 pkg/networkmanager/index.html:269
-#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:696
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:704
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Interfaces"
 msgstr "인터페이스"
 
@@ -3611,11 +3627,11 @@ msgstr ""
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
-"different username, that user will always be used connecting to this machine."
-""
+"different username, that user will always be used connecting to this "
+"machine."
 msgstr ""
-"컴퓨터에 현재 로그인한 사용자{{#default_user}} ({{default_user}}){{/default_user}}로 연결하려면 "
-"비워두십시오. 다른 사용자 이름을 입력하면 이 컴퓨터에 연결할 때 입력한 사용자가 항상 사용됩니다."
+"컴퓨터에 현재 로그인한 사용자{{#default_user}} ({{default_user}}){{/default_user}}로 연결하려면"
+" 비워두십시오. 다른 사용자 이름을 입력하면 이 컴퓨터에 연결할 때 입력한 사용자가 항상 사용됩니다."
 
 #: pkg/shell/index.html:90 pkg/shell/simple.html:66
 msgid "Licensed under:"
@@ -3637,7 +3653,7 @@ msgstr "링크 보기 "
 msgid "Link down delay"
 msgstr "링크 다운 딜레이"
 
-#: pkg/networkmanager/interfaces.js:1968 pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1945 pkg/networkmanager/interfaces.js:1955
 msgid "Link local"
 msgstr "로컬 링크"
 
@@ -3657,7 +3673,7 @@ msgstr "링크"
 msgid "Links:"
 msgstr "링크: "
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:1981
 msgid "Load Balancing"
 msgstr "로드 밸런싱 "
 
@@ -3681,7 +3697,8 @@ msgstr "사용 가능한 업데이트를 로딩하고 있습니다. 잠시만 �
 msgid "Loading system modifications..."
 msgstr "시스템 수정 로딩 중 "
 
-# translation auto-copied from project oVirt, version ovirt-3.5, document frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/frontend/org.ovirt.engine.ui.webadmin.ApplicationConstants
+# translation auto-copied from project oVirt, version ovirt-3.5, document
+# frontend/webadmin/modules/webadmin/src/main/resources/org/ovirt/engine/ui/frontend/org.ovirt.engine.ui.webadmin.ApplicationConstants
 #: pkg/systemd/services.html:78 pkg/kdump/kdump-view.jsx:370
 #: pkg/machines/components/serialConsole.jsx:65 pkg/storaged/devices.jsx:65
 #: pkg/systemd/logs.js:145 pkg/systemd/logs.js:160 pkg/systemd/logs.js:207
@@ -3730,7 +3747,8 @@ msgstr " $0의 계정 잠금 "
 msgid "Locking $target"
 msgstr "$target 잠금 중 "
 
-#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:490
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:73
+#: src/ws/login.js:490
 msgid "Log In"
 msgstr "로그인"
 
@@ -3818,14 +3836,17 @@ msgstr "낮은 프로파일 데스크탑 "
 msgid "Lunch Box"
 msgstr "Lunch Box"
 
-# translation auto-copied from project Satellite6 Hammer CLI Foreman, version 6.1, document hammer-cli-foreman
+# translation auto-copied from project Satellite6 Hammer CLI Foreman, version
+# 6.1, document hammer-cli-foreman
 #: pkg/networkmanager/index.html:195 pkg/networkmanager/index.html:274
 #: pkg/machines/components/vm/bootOrderModal.jsx:103
 msgid "MAC"
 msgstr "MAC"
 
-# auto translated by TM merge from project: RHOSP Director Installation and Usage , version: 11-Korean, DocId: master
-#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+# auto translated by TM merge from project: RHOSP Director Installation and
+# Usage , version: 11-Korean, DocId: master
+#: pkg/machines/components/nicAdd.jsx:40
+#: pkg/machines/components/nicEdit.jsx:43
 #: pkg/machines/components/vmnetworktab.jsx:138
 msgid "MAC Address"
 msgstr "MAC 주소"
@@ -3834,15 +3855,15 @@ msgstr "MAC 주소"
 msgid "MAC Address:"
 msgstr "MAC 주소:"
 
-#: pkg/networkmanager/interfaces.js:1996
+#: pkg/networkmanager/interfaces.js:1973
 msgid "MII (Recommended)"
 msgstr "MII (권장 사항)"
 
-#: pkg/networkmanager/interfaces.js:2768
+#: pkg/networkmanager/interfaces.js:2743
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4562
+#: pkg/networkmanager/interfaces.js:4535
 msgid "MTU must be a positive number"
 msgstr "MTU는 양수여야 합니다 "
 
@@ -3866,7 +3887,7 @@ msgstr "메인 서버 섀시 "
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Tang 서버의 키 해시가 일치하는지 확인합니다."
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1946 pkg/networkmanager/interfaces.js:1956
 msgid "Manual"
 msgstr "수동"
 
@@ -3909,7 +3930,7 @@ msgid ""
 "unit."
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:2774
+#: pkg/networkmanager/interfaces.js:2749
 msgid "Master"
 msgstr "마스터"
 
@@ -3925,7 +3946,7 @@ msgstr "MTU (Maximum Transmission Unit)"
 msgid "Maximum memory could not be saved"
 msgstr "최대 메모리는 저장할 수 없습니다 "
 
-#: pkg/networkmanager/interfaces.js:2872
+#: pkg/networkmanager/interfaces.js:2847
 msgid "Maximum message age $max_age"
 msgstr "최대 메세지 수명 $max_age"
 
@@ -4147,7 +4168,7 @@ msgstr "NFS 지원이 설치되어 있지 않습니다 "
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "VM $1의 NIC $0은 상태 변경에 실패했습니다 "
 
-#: pkg/networkmanager/interfaces.js:2019
+#: pkg/networkmanager/interfaces.js:1996
 msgid "NSNA Ping"
 msgstr "NSNA Ping"
 
@@ -4287,11 +4308,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager가 실행되고 있지 않습니다."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:388
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:939 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "네트워킹"
 
-#: pkg/networkmanager/interfaces.js:1635 pkg/networkmanager/interfaces.js:2218
+#: pkg/networkmanager/interfaces.js:1612 pkg/networkmanager/interfaces.js:2195
 msgctxt "page-title"
 msgid "Networking"
 msgstr "네트워킹"
@@ -4350,7 +4371,7 @@ msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2601
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2576
 msgid "No"
 msgstr "아니오"
 
@@ -4431,7 +4452,7 @@ msgstr "사용 가능한 슬롯이 없습니다 "
 msgid "No boot device found"
 msgstr "부팅 장치를 찾을 수 없습니다 "
 
-#: pkg/networkmanager/interfaces.js:1423
+#: pkg/networkmanager/interfaces.js:1400
 msgid "No carrier"
 msgstr "캐리어가 없습니다"
 
@@ -4455,7 +4476,7 @@ msgstr "컨테이너 없음 "
 msgid "No containers that match the current filter"
 msgstr "현재 필터에 일치하는 컨테이너가 없습니다 "
 
-#: pkg/networkmanager/firewall.jsx:688
+#: pkg/networkmanager/firewall.jsx:695
 msgid "No description available"
 msgstr "사용 가능한 설명이 없음"
 
@@ -4588,7 +4609,7 @@ msgstr "생성된 볼륨 그룹이 없습니다 "
 
 #: pkg/kdump/kdump-view.jsx:422
 #: pkg/machines/components/networks/createNetworkDialog.jsx:190
-#: pkg/networkmanager/firewall.jsx:693 pkg/tuned/dialog.js:232
+#: pkg/networkmanager/firewall.jsx:700 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "없음"
 
@@ -4703,10 +4724,9 @@ msgstr[0] "오류 발생 시, $0 번 다시 시도 "
 
 #: src/ws/cockpit.appdata.xml.in:26
 msgid ""
-"Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
-"socket\"."
-msgstr ""
-"Cockpit이 설치되면 \"systemctl enable --now cockpit.socket\"을 사용하여 이를 활성화합니다. "
+"Once Cockpit is installed, enable it with \"systemctl enable --now "
+"cockpit.socket\"."
+msgstr "Cockpit이 설치되면 \"systemctl enable --now cockpit.socket\"을 사용하여 이를 활성화합니다. "
 
 #: pkg/realmd/operation.html:68 pkg/realmd/operation.js:337
 msgid "One Time Password"
@@ -4765,7 +4785,7 @@ msgstr "광학 드라이브 "
 msgid "Options"
 msgstr "옵션"
 
-#: src/ws/login.html:125
+#: src/ws/login.html:112
 msgid "Or use a bundled browser"
 msgstr "번들된 브라우저 사용 "
 
@@ -4782,11 +4802,12 @@ msgstr "다른 데이터 "
 msgid "Other Devices"
 msgstr "다른 장치 "
 
-#: src/ws/login.html:69
+#: src/ws/login.html:59
 msgid "Other Options"
 msgstr "기타 옵션 "
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/docker/index.html:299 pkg/machines/components/networks/network.jsx:73
 #: pkg/machines/components/storagePools/storagePool.jsx:83
 #: pkg/machines/components/vm/vm.jsx:49
@@ -4821,7 +4842,7 @@ msgstr "PackageKit가 오류 코드 $0을/를 보고했습니다 "
 msgid "Parent"
 msgstr "부모"
 
-#: pkg/networkmanager/interfaces.js:2910
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Parent $parent"
 msgstr "부모 $parent"
 
@@ -4829,7 +4850,7 @@ msgstr "부모 $parent"
 msgid "Part Of"
 msgstr "일부분"
 
-#: pkg/networkmanager/interfaces.js:1469
+#: pkg/networkmanager/interfaces.js:1446
 msgid "Part of "
 msgstr "일부분"
 
@@ -4845,11 +4866,12 @@ msgstr "$0의 파티션"
 msgid "Partitioning"
 msgstr "파티션"
 
-#: pkg/networkmanager/interfaces.js:2011
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Passive"
 msgstr "수동 "
 
-# translation auto-copied from project Anaconda, version master, document anaconda
+# translation auto-copied from project Anaconda, version master, document
+# anaconda
 #: pkg/storaged/content-views.jsx:229 pkg/storaged/crypto-keyslots.jsx:209
 #: pkg/storaged/crypto-keyslots.jsx:565 pkg/storaged/format-dialog.jsx:263
 msgid "Passphrase"
@@ -4873,7 +4895,7 @@ msgstr "암호가 일치하지 않습니다 "
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
 #: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
 #: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:173 src/ws/login.html:44
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "암호"
@@ -4911,8 +4933,9 @@ msgstr "붙여넣기 "
 msgid "Paste the contents of your public SSH key file here"
 msgstr "SSH 공개키 파일 내용을 여기에 붙여넣기합니다"
 
+#: pkg/machines/components/diskEdit.jsx:36
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/machines/components/diskEdit.jsx:36 pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "경로"
 
@@ -4920,7 +4943,7 @@ msgstr "경로"
 msgid "Path cost"
 msgstr "Path cost"
 
-#: pkg/networkmanager/interfaces.js:2892
+#: pkg/networkmanager/interfaces.js:2867
 msgid "Path cost $path_cost"
 msgstr "Path cost $path_cost"
 
@@ -4964,7 +4987,7 @@ msgstr "성능 프로파일"
 msgid "Peripheral Chassis"
 msgstr "주변 장치 섀시 "
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3619
 msgid "Permanent"
 msgstr "영구적 "
 
@@ -4986,7 +5009,8 @@ msgstr "영구적 "
 msgid "Persistent"
 msgstr "영구적 "
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/storaged/vdo-details.jsx:283
 msgid "Physical"
 msgstr "물리"
@@ -5050,7 +5074,7 @@ msgstr "새 볼륨 이름을 입력해 주십시오"
 msgid "Please enter new volume size"
 msgstr "새 볼륨 크기를 입력해 주십시오 "
 
-#: pkg/networkmanager/firewall.jsx:818
+#: pkg/networkmanager/firewall.jsx:884
 msgid "Please install the $0 package"
 msgstr "$0 패키지를 설치해 주십시오 "
 
@@ -5074,10 +5098,10 @@ msgstr "다른 용어를 사용해 보십시오 "
 msgid "Plug"
 msgstr "플러그 "
 
-#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/diskAdd.jsx:128
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "풀"
@@ -5122,7 +5146,7 @@ msgstr "이동식 "
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:216
 #: pkg/networkmanager/index.html:326 pkg/docker/containers-view.jsx:414
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Ports"
 msgstr "포트"
 
@@ -5150,11 +5174,11 @@ msgstr ""
 msgid "Prefix Length should not be empty"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length"
 msgstr "접두 길이"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length or Netmask"
 msgstr "접두 길이 또는 넷마스크"
 
@@ -5166,7 +5190,7 @@ msgstr "준비 중입니다"
 msgid "Present"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3620
 msgid "Preserve"
 msgstr "저장 "
 
@@ -5187,7 +5211,7 @@ msgstr "주"
 msgid "Priority"
 msgstr "우선순위"
 
-#: pkg/networkmanager/interfaces.js:2866 pkg/networkmanager/interfaces.js:2890
+#: pkg/networkmanager/interfaces.js:2841 pkg/networkmanager/interfaces.js:2865
 msgid "Priority $priority"
 msgstr "우선순위 $priority"
 
@@ -5335,11 +5359,11 @@ msgstr "RAID 멤버 "
 msgid "Rack Mount Chassis"
 msgstr "랙 마운트 섀시 "
 
-#: pkg/networkmanager/interfaces.js:3646
+#: pkg/networkmanager/interfaces.js:3621
 msgid "Random"
 msgstr "임의"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:726
 msgid "Range"
 msgstr "범위 "
 
@@ -5494,9 +5518,13 @@ msgstr "삭제: "
 msgid "Remove"
 msgstr "제거 "
 
-#: pkg/networkmanager/interfaces.js:3063
+#: pkg/networkmanager/interfaces.js:3038
 msgid "Remove $0"
 msgstr "$0 삭제 "
+
+#: pkg/networkmanager/firewall.jsx:834
+msgid "Remove $0 service from $1 zone"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
@@ -5518,7 +5546,12 @@ msgstr "암호문 삭제 "
 msgid "Remove passphrase in $0?"
 msgstr "$0에서 암호를 삭제하시겠습니까?"
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+#: pkg/networkmanager/firewall.jsx:818
+msgid "Remove zone $0"
+msgstr ""
+
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
 msgstr "삭제 중"
@@ -5531,7 +5564,7 @@ msgstr " $0 삭제 중 "
 msgid "Removing $target from RAID Device"
 msgstr "RAID 장치에서 $target 삭제 중 "
 
-#: pkg/networkmanager/interfaces.js:3062
+#: pkg/networkmanager/interfaces.js:3037
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5540,6 +5573,17 @@ msgstr "<b>$0</b>을/를 삭제하면 서버와의 연결이 끊어지고 관리
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr "$target에서 물리 볼륨 삭제 중 "
+
+#: pkg/networkmanager/firewall.jsx:832
+msgid ""
+"Removing the cockpit service might result in the web console becoming "
+"unreachable. Make sure that this zone does not apply to your current web "
+"console connection."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:816
+msgid "Removing the zone will remove all services within it."
+msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
 #: pkg/storaged/vgroup-details.jsx:231
@@ -5623,7 +5667,8 @@ msgstr "필요 사항 "
 msgid "Required by "
 msgstr ""
 
-# translation auto-copied from project Satellite6 Katello CLI, version 6.0, document keys, author eukim
+# translation auto-copied from project Satellite6 Katello CLI, version 6.0,
+# document keys, author eukim
 #: pkg/systemd/service-details.jsx:417
 msgid "Requires"
 msgstr "요구 사항 "
@@ -5666,8 +5711,8 @@ msgstr "$target 크기 변경 중 "
 
 #: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
-"Resizing an encrypted filesystem requires unlocking the disk. Please provide "
-"a current disk passphrase."
+"Resizing an encrypted filesystem requires unlocking the disk. Please provide"
+" a current disk passphrase."
 msgstr "암호화된 파일 시스템의 크기를 변경하려면 디스크 잠금을 해제해야 합니다. 현재 디스크의 암호를 입력하십시오."
 
 # ctx::sourcefile::/rhn/admin/config/Restart.do
@@ -5711,7 +5756,7 @@ msgstr "다시 시작"
 msgid "Retries:"
 msgstr "재시도 횟수: "
 
-#: src/ws/login.html:57
+#: src/ws/login.html:48
 msgid "Reuse my password for privileged tasks"
 msgstr "권한 작업 실행을 위해 암호 재사용 "
 
@@ -5720,12 +5765,14 @@ msgid ""
 "Reuse my password for privileged tasks and to connect to other machines"
 msgstr "권한 작업 실행 또는 다른 컴퓨터에 연결을 위해 암호를 재사용합니다 "
 
-# auto translated by TM merge from project: RHEV Administration Guide, version: 4.0, DocId: chap-Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
+# auto translated by TM merge from project: RHEV Administration Guide,
+# version: 4.0, DocId: chap-
+# Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
 #: pkg/users/index.html:94
 msgid "Roles"
 msgstr "역할"
 
-#: pkg/networkmanager/interfaces.js:1985 pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:1962 pkg/networkmanager/interfaces.js:1979
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5737,7 +5784,7 @@ msgstr "$0로 라우팅 "
 msgid "Routed Network"
 msgstr "라우팅된 네트워크"
 
-#: pkg/networkmanager/interfaces.js:3335
+#: pkg/networkmanager/interfaces.js:3310
 msgid "Routes"
 msgstr "경로 "
 
@@ -5829,8 +5876,8 @@ msgstr "STP 우선순위"
 
 #: pkg/shell/index.html:407
 msgid ""
-"Safari users need to import and trust the certificate of the self-signing CA:"
-""
+"Safari users need to import and trust the certificate of the self-signing "
+"CA:"
 msgstr ""
 
 #: pkg/systemd/services.html:132
@@ -5924,8 +5971,9 @@ msgstr "전송 중입니다"
 msgid "Serial Console"
 msgstr "직렬 콘솔 "
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
+#: src/ws/login.html:81 pkg/kdump/kdump-view.jsx:116
 #: pkg/storaged/nfs-details.jsx:322 pkg/storaged/nfs-panel.jsx:95
 msgid "Server"
 msgstr "서버"
@@ -6051,7 +6099,8 @@ msgstr "설정 중 "
 msgid "Setting up loop device $target"
 msgstr "루프 장치 $target 설정 중 "
 
-# translation auto-copied from project Customer Portal Translations, version PCM_template, document template, author eukim
+# translation auto-copied from project Customer Portal Translations, version
+# PCM_template, document template, author eukim
 #: pkg/systemd/logs.html:48 pkg/packagekit/updates.jsx:386
 msgid "Severity"
 msgstr "심각도"
@@ -6060,7 +6109,7 @@ msgstr "심각도"
 msgid "Severity:"
 msgstr "심각도: "
 
-#: pkg/networkmanager/interfaces.js:1970
+#: pkg/networkmanager/interfaces.js:1947
 msgid "Shared"
 msgstr "공유됨"
 
@@ -6108,7 +6157,8 @@ msgstr "논리 볼륨 축소 "
 msgid "Shrink Volume"
 msgstr "볼륨 축소 "
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/systemd/index.html:154 pkg/machines/components/vm/vmActions.jsx:56
 #: pkg/systemd/shutdown.js:92 pkg/systemd/shutdown.js:93
 msgid "Shut Down"
@@ -6160,7 +6210,8 @@ msgstr "슬롯 "
 msgid "Slot $0"
 msgstr "슬롯 $0"
 
-# translation auto-copied from project Satellite6 Katello, version Sam-1.3.0, document katello, author eukim
+# translation auto-copied from project Satellite6 Katello, version Sam-1.3.0,
+# document katello, author eukim
 #: pkg/machines/components/vcpuModal.jsx:220 pkg/systemd/services.jsx:49
 msgid "Sockets"
 msgstr "소켓 "
@@ -6199,11 +6250,11 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "다른 프로그램이 패키지 관리자를 사용 중입니다. 잠시만 기다려주십시오..."
 
-#: pkg/networkmanager/firewall.jsx:668
+#: pkg/networkmanager/firewall.jsx:675
 msgid "Sorted from least trusted to most trusted"
 msgstr "신뢰성이 가장 낮은 순서에서 가장 높은 순으로 정렬"
 
-#: pkg/machines/components/diskAdd.jsx:462
+#: pkg/machines/components/diskAdd.jsx:461
 #: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:117
@@ -6239,7 +6290,7 @@ msgstr "소스는 http, ftp, nfs 프로토콜로 시작해야 합니다  "
 msgid "Space-saving Computer"
 msgstr "공간 절약형 컴퓨터 "
 
-#: pkg/networkmanager/interfaces.js:2864
+#: pkg/networkmanager/interfaces.js:2839
 msgid "Spanning Tree Protocol"
 msgstr "Spanning Tree Protocol"
 
@@ -6259,7 +6310,7 @@ msgstr "특정 시간  "
 msgid "Speed"
 msgstr ""
 
-#: pkg/networkmanager/interfaces.js:3647
+#: pkg/networkmanager/interfaces.js:3622
 msgid "Stable"
 msgstr "안정적 "
 
@@ -6314,12 +6365,14 @@ msgstr "시작 "
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
-#: pkg/machines/components/vmnetworktab.jsx:183 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:269 pkg/systemd/init.js:306
+#: pkg/machines/components/vmnetworktab.jsx:183
+#: pkg/machines/hostvmslist.jsx:83 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/init.js:306
 msgid "State"
 msgstr "상태"
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/docker/index.html:168
 msgid "State:"
 msgstr "상태:"
@@ -6329,7 +6382,7 @@ msgstr "상태:"
 msgid "Static"
 msgstr "정적"
 
-#: pkg/networkmanager/interfaces.js:2620 pkg/systemd/service-details.jsx:478
+#: pkg/networkmanager/interfaces.js:2595 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "상태"
 
@@ -6489,27 +6542,27 @@ msgstr "스왑 공간 "
 msgid "Swap Used"
 msgstr "사용된 스왑 "
 
-#: pkg/networkmanager/interfaces.js:2498 pkg/networkmanager/interfaces.js:3047
+#: pkg/networkmanager/interfaces.js:2475 pkg/networkmanager/interfaces.js:3022
 msgid "Switch off $0"
 msgstr "$0 끄기 "
 
-#: pkg/networkmanager/interfaces.js:2473 pkg/networkmanager/interfaces.js:3035
+#: pkg/networkmanager/interfaces.js:2450 pkg/networkmanager/interfaces.js:3010
 msgid "Switch on $0"
 msgstr "$0 켜기 "
 
-#: pkg/networkmanager/interfaces.js:2497
+#: pkg/networkmanager/interfaces.js:2474
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr "<b>$0</b>을/를 끄면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
-#: pkg/networkmanager/interfaces.js:3046
+#: pkg/networkmanager/interfaces.js:3021
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
 msgstr "<b>$0</b>을/를 끄면 서버와의 연결이 끊어지고 관리 UI를 사용할 수 없게 됩니다. "
 
-#: pkg/networkmanager/interfaces.js:2472 pkg/networkmanager/interfaces.js:3034
+#: pkg/networkmanager/interfaces.js:2449 pkg/networkmanager/interfaces.js:3009
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6535,7 +6588,8 @@ msgstr "{{Server}}와 동기화됨 "
 msgid "Synchronizing RAID Device $target"
 msgstr "RAID 장치 $target 동기화 "
 
-# translation auto-copied from project virt-manager, version 0.10.0, document virt-manager
+# translation auto-copied from project virt-manager, version 0.10.0, document
+# virt-manager
 #: pkg/systemd/index.html:4
 #: pkg/machines/components/machinesConnectionSelector.jsx:43
 #: pkg/machines/helpers.js:191 pkg/systemd/hwinfo.jsx:280
@@ -6610,12 +6664,12 @@ msgstr "대상 경로를 비워둘 수 없습니다 "
 msgid "Targets"
 msgstr "대상 "
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
-#: pkg/networkmanager/interfaces.js:2821
+#: pkg/networkmanager/interfaces.js:2495 pkg/networkmanager/interfaces.js:2507
+#: pkg/networkmanager/interfaces.js:2796
 msgid "Team"
 msgstr " 팀"
 
-#: pkg/networkmanager/interfaces.js:2849
+#: pkg/networkmanager/interfaces.js:2824
 msgid "Team Port"
 msgstr "팀 포트"
 
@@ -6727,9 +6781,13 @@ msgstr " '$0' 계정은 다음 로그인 시 암호를 변경해야 합니다. "
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr "호스트 {{#strong}}{{host}}{{/strong}} 인증을 설정할 수 없습니다. 연결을 유지하시겠습니까?"
+
+#: pkg/networkmanager/firewall.jsx:701
+msgid "The cockpit service is automatically included"
+msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -6785,8 +6843,8 @@ msgstr ""
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
+"in use. Unless this machine was recently replaced, it is likely that someone"
+" is trying to attack your connection to this machine."
 msgstr ""
 "{{#strong}}{{host}}{{/strong}}의 키가 이전에 사용된 키와 일치하지 않습니다. 이 컴퓨터가 최근에 교체된 것이 "
 "아닌 경우 누군가가 이 컴퓨터에 대한 연결을 공격할 가능성이 있습니다."
@@ -6899,7 +6957,7 @@ msgstr "사용자 <b>$0</b>는 계정을 수정할 수 없습니다."
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "사용자 <b>$0</b>는 호스트 이름을 변경할 수 없습니다. "
 
-#: pkg/networkmanager/interfaces.js:1520
+#: pkg/networkmanager/interfaces.js:1497
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "사용자 <b>$0</b> 는 네트워크 설정 권한이 없습니다"
 
@@ -6913,8 +6971,8 @@ msgstr "사용자 <b>$0</b>는 이 서버를 종료 또는 재시작할 수 없�
 
 #: pkg/users/local.js:553
 msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+"The user name can only consist of letters from a-z, digits, dots, dashes and"
+" underscores."
 msgstr "사용자 이름에는 a~z 문자, 숫자, 점, 대시, 밑줄만 사용할 수 있습니다. "
 
 #: src/ws/login.js:134 src/ws/login.js:157
@@ -6965,11 +7023,11 @@ msgstr "이 VDO 장치는 백업 장치를 사용하지 않습니다."
 
 #: pkg/systemd/init.js:1262
 msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
+"This day doesn't exist in all months.<br> The timer will only be executed in"
+" months that have 31st."
 msgstr "이 날은 모든 달에 존재하지 않습니다.<br> 타이머는 31일이 있는 달에만 실행됩니다. "
 
-#: pkg/networkmanager/interfaces.js:2631
+#: pkg/networkmanager/interfaces.js:2606
 msgid "This device cannot be managed here."
 msgstr "이 장치는 여기서 관리할 수 없습니다. "
 
@@ -7094,8 +7152,8 @@ msgstr "이 웹 콘솔은 업데이트됩니다."
 
 #: pkg/kdump/kdump-view.jsx:296
 msgid ""
-"This will test kdump settings by crashing the kernel and thereby the system. "
-"Depending on the settings, the system may not automatically reboot and the "
+"This will test kdump settings by crashing the kernel and thereby the system."
+" Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
 "kdump 설정은 커널을 크래시햐여 테스트합니다. 설정에 따라 재부팅이 자동으로 수행되지 않고 처리 시간이 길어질 수 있습니다. "
@@ -7103,6 +7161,12 @@ msgstr ""
 #: pkg/kdump/kdump-view.jsx:492
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "kdump 설정은 커널을 크래시햐여 테스트합니다. "
+
+#: pkg/networkmanager/firewall.jsx:814
+msgid ""
+"This zone contains the cockpit service. Make sure that this zone does not "
+"apply to your current web console connection."
+msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:237
 msgid "Threads per core"
@@ -7177,11 +7241,11 @@ msgstr "문제 해결"
 msgid "Trust key"
 msgstr "신뢰 키 "
 
-#: pkg/networkmanager/firewall.jsx:664
+#: pkg/networkmanager/firewall.jsx:671
 msgid "Trust level"
 msgstr "신뢰 레벨 "
 
-#: src/ws/login.html:111
+#: src/ws/login.html:98
 msgid "Try Again"
 msgstr "다시 시도"
 
@@ -7257,7 +7321,8 @@ msgstr "UDP"
 msgid "URL"
 msgstr "URL"
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/storaged/part-tab.jsx:39
 msgid "UUID"
 msgstr "UUID"
@@ -7336,12 +7401,12 @@ msgstr "단위"
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:146
 #: pkg/networkmanager/interfaces.js:595 pkg/networkmanager/interfaces.js:1071
-#: pkg/networkmanager/interfaces.js:2538 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2515 pkg/networkmanager/interfaces.js:2517
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "알 수 없음"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2501 pkg/networkmanager/interfaces.js:2513
 msgid "Unknown \"$0\""
 msgstr "알 수 없는 \"$0\""
 
@@ -7357,7 +7422,7 @@ msgstr "알 수 없는 애플리케이션 "
 msgid "Unknown Host Key"
 msgstr "알 수 없는 호스트 키 "
 
-#: pkg/networkmanager/interfaces.js:2647
+#: pkg/networkmanager/interfaces.js:2622
 msgid "Unknown configuration"
 msgstr "알 수 없는 설정"
 
@@ -7460,7 +7525,8 @@ msgstr "기본 위치에서 $0 $1까지 사용 가능 "
 msgid "Up to $0 $1 available on the host"
 msgstr "호스트에서 $0 $1 까지 사용 가능 "
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/lib/machine-change-port.html:41
 msgid "Update"
 msgstr "업데이트"
@@ -7497,7 +7563,8 @@ msgstr ""
 msgid "Url"
 msgstr ""
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/machines/components/vm/vm.jsx:50 pkg/storaged/unrecognized-tab.jsx:30
 msgid "Usage"
 msgstr "사용법"
@@ -7511,7 +7578,7 @@ msgstr[0] "$0 CPU 코어의 사용량"
 msgid "Use 512 Byte emulation"
 msgstr "512 바이트 에뮬레이션 사용 "
 
-#: pkg/machines/components/diskAdd.jsx:482
+#: pkg/machines/components/diskAdd.jsx:481
 msgid "Use Existing"
 msgstr "기존 사용 "
 
@@ -7551,7 +7618,7 @@ msgid "User Password"
 msgstr "사용자 암호 "
 
 #: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
-#: src/ws/login.html:43
+#: src/ws/login.html:39
 msgid "User name"
 msgstr "사용자 이름 "
 
@@ -7600,8 +7667,8 @@ msgstr "VDO 백업 장치를 작게 할 수 없습니다 "
 msgid "VDO support not installed"
 msgstr "VDO 지원이 설치되어 있지 않습니다 "
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/networkmanager/interfaces.js:2497 pkg/networkmanager/interfaces.js:2509
+#: pkg/networkmanager/interfaces.js:2888
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7673,7 +7740,7 @@ msgstr "VNC TLS 포트:"
 msgid "Validating address"
 msgstr "주소 확인 "
 
-#: src/ws/login.html:101
+#: src/ws/login.html:88
 msgid "Validating authentication token"
 msgstr "인증 토큰 확인 "
 
@@ -7681,9 +7748,11 @@ msgstr "인증 토큰 확인 "
 msgid "Validating key"
 msgstr "키 확인 "
 
-# translation auto-copied from project subscription-manager, version 1.11.X, document keys
+# translation auto-copied from project subscription-manager, version 1.11.X,
+# document keys
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:257
+#: pkg/machines/components/vm/bootOrderModal.jsx:126
+#: pkg/systemd/hwinfo.jsx:257
 msgid "Vendor"
 msgstr "벤더"
 
@@ -7735,10 +7804,10 @@ msgid "Virtualization Service is Available"
 msgstr "가상화 서비스를 사용할 수 있습니다 "
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
-#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:91
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "볼륨"
@@ -7863,11 +7932,11 @@ msgstr "쓰기 "
 msgid "Wrong user name or password"
 msgstr "잘못된 사용자 이름 또는 암호 "
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1964
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2600
+#: pkg/networkmanager/interfaces.js:2575
 msgid "Yes"
 msgstr "네"
 
@@ -7876,8 +7945,8 @@ msgid ""
 "You are connected to {{#strong}}{{host}}{{/strong}}, however in order to "
 "synchronize users, a user with superuser privileges is required."
 msgstr ""
-"{{#strong}}{{host}}{{/strong}}에 연결되어 있지만 사용자를 동기화하려면 수퍼 유저 권한을 가진 사용자가 필요합니다."
-" "
+"{{#strong}}{{host}}{{/strong}}에 연결되어 있지만 사용자를 동기화하려면 수퍼 유저 권한을 가진 사용자가 "
+"필요합니다. "
 
 #: pkg/dashboard/list.js:448
 msgid ""
@@ -7885,8 +7954,8 @@ msgid ""
 msgstr "현재 직접적으로 이 서버에 연결되어 있습니다. 삭제하실 수 없습니다."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:131
-#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:827
-#: pkg/networkmanager/firewall.jsx:859
+#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:925
 msgid "You are not authorized to modify the firewall."
 msgstr "방화벽을 수정할 수있는 권한이 없습니다."
 
@@ -7983,7 +8052,9 @@ msgstr ""
 msgid "asset tag"
 msgstr ""
 
-# translation auto-copied from project Customer Portal Translations, version PortalCaseManagementStrings, document PortalCaseManagementStrings, author eukim
+# translation auto-copied from project Customer Portal Translations, version
+# PortalCaseManagementStrings, document PortalCaseManagementStrings, author
+# eukim
 #: pkg/packagekit/autoupdates.jsx:328
 msgid "at"
 msgstr "시간:"
@@ -8633,7 +8704,9 @@ msgstr "vCPU 개수"
 msgid "vCPU Maximum"
 msgstr "vCPU 최대 "
 
-# auto translated by TM merge from project: RHEV Administration Guide, version: 3.6-async1, DocId: chap-Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
+# auto translated by TM merge from project: RHEV Administration Guide,
+# version: 3.6-async1, DocId: chap-
+# Administering_and_Maintaining_the_Red_Hat_Enterprise_Virtualization_Environment
 #: pkg/machines/components/vmOverviewTab.jsx:75
 msgid "vCPUs"
 msgstr "vCPU"

--- a/po/pl.po
+++ b/po/pl.po
@@ -12,16 +12,15 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 10:45+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-10-19 12:18+0000\n"
+"POT-Creation-Date: 2019-10-30 17:14+0000\n"
+"PO-Revision-Date: 2019-10-24 01:36+0000\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: pl\n"
-"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
-"|| n%100>=20) ? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Zanata 4.6.2\n"
 
 #: pkg/docker/storage.jsx:261
@@ -31,16 +30,16 @@ msgstr " (współdzielone z systemem operacyjnym)"
 #: pkg/machines/components/diskAdd.jsx:236
 msgid " Attaching it will make this disk shareable for every VM using it."
 msgstr ""
-" Podłączenie spowoduje, że ten dysk będzie udostępniany każdej używającej go "
-"maszynie wirtualnej."
+" Podłączenie spowoduje, że ten dysk będzie udostępniany każdej używającej go"
+" maszynie wirtualnej."
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zone"
-msgstr ""
+msgstr "Aktywna strefa: $0"
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zones"
-msgstr ""
+msgstr "Aktywne strefy: $0"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
@@ -267,7 +266,7 @@ msgstr[0] "$1 poprawka zabezpieczeń"
 msgstr[1] "$1 poprawki zabezpieczeń"
 msgstr[2] "$1 poprawek zabezpieczeń"
 
-#: pkg/networkmanager/interfaces.js:2764
+#: pkg/networkmanager/interfaces.js:2739
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -535,11 +534,11 @@ msgstr "7."
 msgid "8 KiB"
 msgstr "8 KiB"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:1966
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:1983
 msgid "802.3ad LACP"
 msgstr "LACP 802.3ad"
 
@@ -553,8 +552,8 @@ msgstr "9."
 
 #: pkg/lib/machine-not-supported.html:5
 msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
+"A compatible version of Cockpit is not installed on "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Na {{#strong}}{{host}}{{/strong}} nie zainstalowano zgodnej wersji Cockpit."
 
@@ -562,7 +561,7 @@ msgstr ""
 msgid "A disk is needed."
 msgstr "Wymagany jest dysk."
 
-#: src/ws/login.html:115
+#: src/ws/login.html:102
 msgid ""
 "A modern browser is required for security, reliability, and performance."
 msgstr ""
@@ -573,15 +572,15 @@ msgstr ""
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Przed usunięciem tego dysku należy najpierw dodać dysk zapasowy."
 
-#: pkg/networkmanager/interfaces.js:1997
+#: pkg/networkmanager/interfaces.js:1974
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2793
+#: pkg/networkmanager/interfaces.js:2768
 msgid "ARP Monitoring"
 msgstr "Monitorowanie ARP"
 
-#: pkg/networkmanager/interfaces.js:2018
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP Ping"
 msgstr "Ping ARP"
 
@@ -632,11 +631,11 @@ msgstr "Aktywuj"
 msgid "Activating $target"
 msgstr "Aktywowanie $target"
 
-#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:2012
+#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:1989
 msgid "Active"
 msgstr "Aktywne"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1963 pkg/networkmanager/interfaces.js:1980
 msgid "Active Backup"
 msgstr "Aktywna kopia zapasowa"
 
@@ -652,16 +651,16 @@ msgstr "Aktywne od"
 msgid "Active since "
 msgstr "Aktywna od "
 
-#: pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Adaptive load balancing"
 msgstr "Adaptacyjne równoważenie obciążenia"
 
-#: pkg/networkmanager/interfaces.js:1990
+#: pkg/networkmanager/interfaces.js:1967
 msgid "Adaptive transmit load balancing"
 msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
-#: pkg/machines/components/diskAdd.jsx:522
+#: pkg/machines/components/diskAdd.jsx:521
 #: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
 #: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
 #: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:197
@@ -669,7 +668,7 @@ msgstr "Adaptacyjne równoważenie obciążenia przesyłu"
 msgid "Add"
 msgstr "Dodaj"
 
-#: pkg/networkmanager/interfaces.js:3113
+#: pkg/networkmanager/interfaces.js:3088
 msgid "Add $0"
 msgstr "Dodaj $0"
 
@@ -685,7 +684,7 @@ msgstr "Dodaj węzeł"
 msgid "Add Bridge"
 msgstr "Dodaj mostek"
 
-#: pkg/machines/components/diskAdd.jsx:510
+#: pkg/machines/components/diskAdd.jsx:509
 #: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Dodaj dysk"
@@ -731,8 +730,8 @@ msgstr "Dodaj VLAN"
 msgid "Add Virtual Network Interface"
 msgstr "Dodaj wirtualny interfejs sieciowy"
 
-#: pkg/networkmanager/firewall.jsx:659 pkg/networkmanager/firewall.jsx:828
-#: pkg/networkmanager/firewall.jsx:834
+#: pkg/networkmanager/firewall.jsx:666 pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:900
 msgid "Add Zone"
 msgstr "Dodaj strefę"
 
@@ -756,11 +755,11 @@ msgstr "Dodaj klucz publiczny"
 msgid "Add services to $0 zone"
 msgstr "Dodaj usługi do strefy $0"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:743
 msgid "Add zone"
 msgstr "Dodaj strefę"
 
-#: pkg/networkmanager/interfaces.js:3112
+#: pkg/networkmanager/interfaces.js:3087
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -773,9 +772,9 @@ msgid ""
 "Adding custom ports will reload firewalld. A reload will result in the loss "
 "of any runtime-only configuration!"
 msgstr ""
-"Dodanie niestandardowych portów spowoduje ponowne wczytanie zapory sieciowej."
-" Ponowne wczytanie spowoduje utratę całej konfiguracji tylko dla obecnej "
-"sesji."
+"Dodanie niestandardowych portów spowoduje ponowne wczytanie zapory "
+"sieciowej. Ponowne wczytanie spowoduje utratę całej konfiguracji tylko dla "
+"obecnej sesji."
 
 #: pkg/users/authorized-keys.js:113
 msgid "Adding key"
@@ -789,11 +788,11 @@ msgstr "Dodawanie woluminu fizycznego do $target"
 msgid "Additional"
 msgstr "Dodatkowe"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "Additional DNS $val"
 msgstr "Dodatkowy DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "Additional DNS Search Domains $val"
 msgstr "Dodatkowe domeny wyszukiwania DNS $val"
 
@@ -805,7 +804,7 @@ msgstr "Dodatkowe urządzenia do przechowywania danych"
 msgid "Additional actions"
 msgstr "Dodatkowe działania"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Additional address $val"
 msgstr "Dodatkowy adres $val"
 
@@ -821,7 +820,7 @@ msgstr "Dodatkowe pakiety:"
 msgid "Address"
 msgstr "Adres"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Address $val"
 msgstr "Adres $val"
 
@@ -844,7 +843,7 @@ msgstr "Adres nie jest w podsieci"
 msgid "Address:"
 msgstr "Adres:"
 
-#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3319
+#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3294
 msgid "Addresses"
 msgstr "Adresy"
 
@@ -867,18 +866,18 @@ msgstr "Po"
 #: pkg/systemd/services.html:310
 msgctxt "time-delay"
 msgid "After"
-msgstr ""
+msgstr "Po"
 
 #: pkg/realmd/operation.html:27
 msgid ""
 "After leaving the domain, only users with local credentials will be able to "
-"log into this machine. This may also affect other services as DNS resolution "
-"settings and the list of trusted CAs may change."
+"log into this machine. This may also affect other services as DNS resolution"
+" settings and the list of trusted CAs may change."
 msgstr ""
-"Po opuszczeniu domeny, tylko użytkownicy z lokalnymi danymi uwierzytelniania "
-"będą mogli zalogować się do tego komputera. Może to mieć wpływ także na inne "
-"usługi, ponieważ ustawienia rozwiązywania DNS i listy zaufanych CA mogą ulec "
-"zmianie."
+"Po opuszczeniu domeny, tylko użytkownicy z lokalnymi danymi uwierzytelniania"
+" będą mogli zalogować się do tego komputera. Może to mieć wpływ także na "
+"inne usługi, ponieważ ustawienia rozwiązywania DNS i listy zaufanych CA mogą"
+" ulec zmianie."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
 #: pkg/systemd/init.js:964
@@ -889,7 +888,8 @@ msgstr "Po uruchomieniu systemu"
 msgid "Alert and above"
 msgstr "Alarmy i powyżej"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213
+#: pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Wszystkie"
 
@@ -902,14 +902,14 @@ msgid ""
 "All data on selected disks will be erased and disks will be added to the "
 "storage pool."
 msgstr ""
-"Wszystkie dane na wybranych dyskach zostaną usunięte, a dyski zostaną dodane "
-"do puli urządzeń do przechowywania danych."
+"Wszystkie dane na wybranych dyskach zostaną usunięte, a dyski zostaną dodane"
+" do puli urządzeń do przechowywania danych."
 
 #: pkg/systemd/service-details.jsx:159
 msgid "Allow running (unmask)"
 msgstr "Zezwolenie na uruchamianie (odmaskowanie)"
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Allowed Addresses"
 msgstr "Dozwolone adresy"
 
@@ -1034,17 +1034,17 @@ msgstr "Upoważnione publiczne klucze SSH"
 
 #: pkg/networkmanager/index.html:179
 #: pkg/machines/components/networks/createNetworkDialog.jsx:162
-#: pkg/networkmanager/interfaces.js:1976 pkg/networkmanager/interfaces.js:2766
-#: pkg/networkmanager/interfaces.js:3327 pkg/networkmanager/interfaces.js:3331
-#: pkg/networkmanager/interfaces.js:3337 pkg/realmd/operation.js:338
+#: pkg/networkmanager/interfaces.js:1953 pkg/networkmanager/interfaces.js:2741
+#: pkg/networkmanager/interfaces.js:3302 pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3312 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Automatyczne"
 
-#: pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1954
 msgid "Automatic (DHCP only)"
 msgstr "Automatyczne (tylko DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1944
 msgid "Automatic (DHCP)"
 msgstr "Automatyczne (DHCP)"
 
@@ -1160,8 +1160,8 @@ msgstr "Urządzenie blokowe dla systemów plików"
 msgid "Blocked"
 msgstr "Zablokowane"
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2493 pkg/networkmanager/interfaces.js:2505
+#: pkg/networkmanager/interfaces.js:2773
 msgid "Bond"
 msgstr "Wiązanie"
 
@@ -1182,8 +1182,8 @@ msgstr "Nie można zapisać ustawień kolejności uruchamiania"
 msgid "Bound By"
 msgstr "Dowiązane przez"
 
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2499 pkg/networkmanager/interfaces.js:2511
+#: pkg/networkmanager/interfaces.js:2850
 msgid "Bridge"
 msgstr "Mostek"
 
@@ -1195,15 +1195,15 @@ msgstr "Ustawienia portu mostku"
 msgid "Bridge Settings"
 msgstr "Ustawienia mostka"
 
-#: pkg/networkmanager/interfaces.js:2896
+#: pkg/networkmanager/interfaces.js:2871
 msgid "Bridge port"
 msgstr "Port mostku"
 
-#: pkg/networkmanager/interfaces.js:1988 pkg/networkmanager/interfaces.js:2005
+#: pkg/networkmanager/interfaces.js:1965 pkg/networkmanager/interfaces.js:1982
 msgid "Broadcast"
 msgstr "Broadcast"
 
-#: pkg/networkmanager/interfaces.js:2811 pkg/networkmanager/interfaces.js:2845
+#: pkg/networkmanager/interfaces.js:2786 pkg/networkmanager/interfaces.js:2820
 msgid "Broken configuration"
 msgstr "Uszkodzona konfiguracja"
 
@@ -1283,17 +1283,16 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/networkmanager/index.html:600 pkg/networkmanager/index.html:624
 #: pkg/networkmanager/index.html:648 pkg/networkmanager/index.html:672
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
-#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
-#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/index.html:343 pkg/systemd/index.html:430
+#: pkg/systemd/index.html:482 pkg/systemd/index.html:498
+#: pkg/systemd/services.html:377 pkg/users/index.html:198
+#: pkg/users/index.html:237 pkg/users/index.html:276 pkg/users/index.html:315
+#: pkg/users/index.html:332 pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/apps/utils.jsx:86 pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:818
-#: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/deleteResource.jsx:108
-#: pkg/machines/components/diskAdd.jsx:519
+#: pkg/machines/components/diskAdd.jsx:518
 #: pkg/machines/components/diskEdit.jsx:173
 #: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/nicAdd.jsx:232
@@ -1304,10 +1303,12 @@ msgstr "Nie można wczytać obrazu"
 #: pkg/machines/components/vcpuModal.jsx:257
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:730
-#: pkg/packagekit/updates.jsx:182 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:399 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:221 pkg/systemd/service-details.jsx:107
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:738
+#: pkg/networkmanager/firewall.jsx:763 pkg/packagekit/updates.jsx:182
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:399
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:221
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Anuluj"
 
@@ -1327,13 +1328,13 @@ msgstr "Nie można planować zdarzeń w przeszłości"
 msgid "Capacity"
 msgstr "Pojemność"
 
-#: pkg/networkmanager/interfaces.js:2597
+#: pkg/networkmanager/interfaces.js:2572
 msgid "Carrier"
 msgstr "Operator"
 
 #: pkg/docker/index.html:664 pkg/systemd/index.html:344
-#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:188
+#: pkg/systemd/index.html:431 pkg/users/index.html:277
+#: pkg/users/index.html:316 pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Zmień"
 
@@ -1373,7 +1374,7 @@ msgstr "Zmień ograniczenia zasobów"
 msgid "Change resources limits"
 msgstr "Zmień ograniczenia zasobów"
 
-#: pkg/networkmanager/interfaces.js:3163
+#: pkg/networkmanager/interfaces.js:3138
 msgid "Change the settings"
 msgstr "Zmień ustawienia"
 
@@ -1385,10 +1386,10 @@ msgstr "Zmień ustawienia"
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Zmiany zostaną uwzględnione po wyłączeniu maszyny wirtualnej"
 
-#: pkg/networkmanager/interfaces.js:3162
+#: pkg/networkmanager/interfaces.js:3137
 msgid ""
-"Changing the settings will break the connection to the server, and will make "
-"the administration UI unavailable."
+"Changing the settings will break the connection to the server, and will make"
+" the administration UI unavailable."
 msgstr ""
 "Zmiana ustawień zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
@@ -1462,8 +1463,7 @@ msgid "Click to see system hardware information"
 msgstr "Kliknięcie wyświetli informacje o sprzęcie komputera"
 
 #: pkg/machines/components/desktopConsole.jsx:41
-msgid ""
-"Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
+msgid "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
 "Kliknięcie „Uruchom zdalną przeglądarkę” pobierze plik .vv i uruchomi $0."
 
@@ -1473,12 +1473,13 @@ msgstr "Oprogramowanie klienta"
 
 #: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:691 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:399
+#: pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/networkmanager/index.html:691
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:325
+#: pkg/shell/simple.html:72 pkg/systemd/index.html:289 pkg/users/index.html:45
+#: pkg/apps/utils.jsx:108 pkg/lib/cockpit-components-modifications.jsx:109
+#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
+#: pkg/storaged/dialog.jsx:399
 msgid "Close"
 msgstr "Zamknij"
 
@@ -1496,8 +1497,8 @@ msgstr "Uwierzytelnianie Cockpit jest niepoprawnie skonfigurowane."
 
 #: pkg/lib/machine-dialogs.js:429
 msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
+"Cockpit could not contact the given host $0. Make sure it has ssh running on"
+" port $1, or specify another port in the address."
 msgstr ""
 "Cockpit nie może skontaktować się z podanym komputerem $0. Proszę się "
 "upewnić, że ma on uruchomioną usługę ssh na porcie $1 lub podać inny port "
@@ -1510,8 +1511,8 @@ msgstr "Cockpit nie może skontaktować się z podanym komputerem."
 #: pkg/shell/base_index.js:765
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
-"Cockpit by pressing refresh in your browser. The javascript console contains "
-"details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
+"Cockpit by pressing refresh in your browser. The javascript console contains"
+" details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 "Wystąpił nieoczekiwany wewnętrzny błąd w programie Cockpit. <br/><br/>Można "
 "spróbować ponownie uruchomić program Cockpit przez odświeżenie strony "
@@ -1550,8 +1551,8 @@ msgstr "Cockpit nie jest zainstalowany w systemie."
 
 #: src/ws/cockpit.appdata.xml.in:18
 msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple"
+" tasks such as storage administration, inspecting journals and starting and "
 "stopping services. You can monitor and administer several servers at the "
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
@@ -1569,14 +1570,15 @@ msgstr "Cockpit nie może skontaktować się z {{#strong}}{{host}}{{/strong}}."
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
 "Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize "
+"users{{/sync_link}}.{{/can_sync}} For more authentication options and "
 "troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit nie może zalogować do {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}Można spróbować {{#sync_link}}synchronizować użytkowników{{/"
-"sync_link}}.{{/can_sync}} Zaktualizowanie cockpit-ws do nowszej wersji "
-"udostępni więcej opcji uwierzytelniania i pomocy w rozwiązywaniu problemów."
+"{{#can_sync}}Można spróbować {{#sync_link}}synchronizować "
+"użytkowników{{/sync_link}}.{{/can_sync}} Zaktualizowanie cockpit-ws do "
+"nowszej wersji udostępni więcej opcji uwierzytelniania i pomocy "
+"w rozwiązywaniu problemów."
 
 #: pkg/lib/machine-change-auth.html:9
 msgid "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}."
@@ -1588,16 +1590,17 @@ msgid ""
 "machine with cockpit you will need to enable one of the following "
 "authentication methods in the sshd config on {{#strong}}{{host}}{{/strong}}:"
 msgstr ""
-"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Aby używać "
-"tego komputera za pomocą programu Cockpit, należy włączyć jedną z poniższych "
-"metod uwierzytelniania w konfiguracji usługi sshd w {{#strong}}{{host}}{{/"
-"strong}}:"
+"Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Aby używać"
+" tego komputera za pomocą programu Cockpit, należy włączyć jedną "
+"z poniższych metod uwierzytelniania w konfiguracji usługi sshd "
+"w {{#strong}}{{host}}{{/strong}}:"
 
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
 "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+"change your authentication credentials below. {{#can_sync}}You may prefer to"
+" {{#sync_link}}synchronize accounts and "
+"passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit nie może zalogować się do {{#strong}}{{host}}{{/strong}}. Poniżej "
 "można zmienić dane uwierzytelniające. {{#can_sync}}Można też "
@@ -1687,7 +1690,7 @@ msgstr "Warunek $0=$1 nie został spełniony"
 msgid "Condition failed"
 msgstr "Warunek się nie powiódł"
 
-#: pkg/networkmanager/interfaces.js:2732
+#: pkg/networkmanager/interfaces.js:2707
 msgid "Configure"
 msgstr "Skonfiguruj"
 
@@ -1718,7 +1721,7 @@ msgstr "Potwierdź usunięcie hasłem"
 
 #: pkg/machines/components/deleteResource.jsx:103
 msgid "Confirm this action"
-msgstr ""
+msgstr "Potwierdź to działanie"
 
 #: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
@@ -1733,11 +1736,11 @@ msgstr "Powoduje konflikt z"
 msgid "Connect"
 msgstr "Połącz"
 
-#: pkg/networkmanager/interfaces.js:2719
+#: pkg/networkmanager/interfaces.js:2694
 msgid "Connect automatically"
 msgstr "Łączenie automatyczne"
 
-#: src/ws/login.html:74
+#: src/ws/login.html:63
 msgid "Connect to"
 msgstr "Połącz z"
 
@@ -1951,7 +1954,7 @@ msgstr "Utwórz"
 msgid "Create Logical Volume"
 msgstr "Utwórz wolumin logiczny"
 
-#: pkg/machines/components/diskAdd.jsx:473
+#: pkg/machines/components/diskAdd.jsx:472
 msgid "Create New"
 msgstr "Utwórz nowy"
 
@@ -2038,8 +2041,8 @@ msgstr "Utwórz grupę woluminów"
 msgid "Create diagnostic report"
 msgstr "Utwórz raport diagnostyczny"
 
-#: pkg/networkmanager/interfaces.js:3837 pkg/networkmanager/interfaces.js:4037
-#: pkg/networkmanager/interfaces.js:4292 pkg/networkmanager/interfaces.js:4497
+#: pkg/networkmanager/interfaces.js:3810 pkg/networkmanager/interfaces.js:4010
+#: pkg/networkmanager/interfaces.js:4265 pkg/networkmanager/interfaces.js:4470
 msgid "Create it"
 msgstr "Utwórz"
 
@@ -2076,7 +2079,7 @@ msgstr "Tworzenie partycji $target"
 msgid "Creating snapshot of $target"
 msgstr "Tworzenie migawki $target"
 
-#: pkg/networkmanager/interfaces.js:4496
+#: pkg/networkmanager/interfaces.js:4469
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2084,7 +2087,7 @@ msgstr ""
 "Utworzenie tej sieci VLAN zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:3836
+#: pkg/networkmanager/interfaces.js:3809
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2092,7 +2095,7 @@ msgstr ""
 "Utworzenie tego wiązania zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:4291
+#: pkg/networkmanager/interfaces.js:4264
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2100,7 +2103,7 @@ msgstr ""
 "Utworzenie tego mostka zerwie połączenie z serwerem i uniemożliwi "
 "korzystanie z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:4036
+#: pkg/networkmanager/interfaces.js:4009
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2152,7 +2155,7 @@ msgstr "Niestandardowe opcje szyfrowania"
 msgid "Custom mount options"
 msgstr "Niestandardowe opcje montowania"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:684
 msgid "Custom zones"
 msgstr "Niestandardowe strefy"
 
@@ -2165,19 +2168,19 @@ msgstr "Zakres DHCP"
 msgid "DISK IS FAILING"
 msgstr "NA DYSKU WYSTĘPUJĄ BŁĘDY"
 
-#: pkg/networkmanager/interfaces.js:3326
+#: pkg/networkmanager/interfaces.js:3301
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3330
+#: pkg/networkmanager/interfaces.js:3305
 msgid "DNS Search Domains"
 msgstr "Domeny wyszukiwania DNS"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "DNS Search Domains $val"
 msgstr "Domeny wyszukiwania DNS $val"
 
@@ -2228,8 +2231,6 @@ msgstr "Opóźnienie"
 #: pkg/networkmanager/index.html:436 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
 #: pkg/docker/details.js:293 pkg/docker/util.js:641
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/deleteResource.jsx:77
 #: pkg/machines/components/deleteResource.jsx:87
 #: pkg/machines/components/deleteResource.jsx:100
@@ -2237,14 +2238,17 @@ msgstr "Opóźnienie"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:316
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
-#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
-#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/networkmanager/firewall.jsx:766 pkg/storaged/content-views.jsx:300
+#: pkg/storaged/content-views.jsx:316 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/vdo-details.jsx:203
+#: pkg/storaged/vdo-details.jsx:268 pkg/storaged/vgroup-details.jsx:211
+#: pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Usuń"
 
-#: pkg/networkmanager/interfaces.js:2441 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2418 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Usuń $0"
 
@@ -2279,7 +2283,7 @@ msgstr "Usuń woluminy wewnątrz tej puli"
 msgid "Deleting $target"
 msgstr "Usuwanie $target"
 
-#: pkg/networkmanager/interfaces.js:2440
+#: pkg/networkmanager/interfaces.js:2417
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2319,14 +2323,14 @@ msgid ""
 "Deleting an inactive Storage Pool will only undefine the Pool. Its content "
 "will not be deleted."
 msgstr ""
-"Usunięcie nieaktywnej puli urządzeń do przechowywania danych spowoduje tylko "
-"usunięcie określenia puli. Jej zawartość nie zostanie usunięta."
+"Usunięcie nieaktywnej puli urządzeń do przechowywania danych spowoduje tylko"
+" usunięcie określenia puli. Jej zawartość nie zostanie usunięta."
 
 #: pkg/storaged/jobs-panel.jsx:72
 msgid "Deleting volume group $target"
 msgstr "Usuwanie grupy woluminów $target"
 
-#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:686
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:693
 #: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Opis"
@@ -2340,8 +2344,8 @@ msgstr "Komputer stacjonarny"
 msgid ""
 "Detach the disks using this pool from any VMs before attempting deletion."
 msgstr ""
-"Przed próbą usunięcia należy odłączyć dyski używające tej puli ze wszystkich "
-"maszyn wirtualnych."
+"Przed próbą usunięcia należy odłączyć dyski używające tej puli ze wszystkich"
+" maszyn wirtualnych."
 
 #: pkg/lib/machine-info.js:95
 msgid "Detachable"
@@ -2398,7 +2402,7 @@ msgstr "Wyłącz wielowątkowość współbieżną"
 msgid "Disable tuned"
 msgstr "Wyłącz tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1971
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1948
 #: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Wyłączone"
@@ -2518,7 +2522,7 @@ msgstr "Gotowe."
 msgid "Download"
 msgstr "Pobierz"
 
-#: src/ws/login.html:118
+#: src/ws/login.html:105
 msgid "Download a new browser for free"
 msgstr "Pobierz nową przeglądarkę za darmo"
 
@@ -2689,7 +2693,7 @@ msgstr ""
 "Wpisanie tutaj innego hasła oznacza, że będzie wymagane jego wpisanie za "
 "każdym połączeniem do tej maszyny"
 
-#: pkg/networkmanager/firewall.jsx:713
+#: pkg/networkmanager/firewall.jsx:721
 msgid "Entire subnet"
 msgstr "Cała podsieć"
 
@@ -2765,7 +2769,7 @@ msgstr "MAC ethernetu"
 msgid "Ethernet MTU"
 msgstr "MTU ethernetu"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:1994
 msgid "Ethtool"
 msgstr "ethtool"
 
@@ -2825,7 +2829,7 @@ msgstr "Dodanie portu się nie powiodło"
 msgid "Failed to add service"
 msgstr "Dodanie usługi się nie powiodło"
 
-#: pkg/networkmanager/firewall.jsx:638
+#: pkg/networkmanager/firewall.jsx:645
 msgid "Failed to add zone"
 msgstr "Dodanie strefy się nie powiodło"
 
@@ -2920,11 +2924,11 @@ msgid "Fingerprint"
 msgstr "Odcisk"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:99
-#: pkg/networkmanager/firewall.jsx:874 pkg/networkmanager/firewall.jsx:878
+#: pkg/networkmanager/firewall.jsx:940 pkg/networkmanager/firewall.jsx:944
 msgid "Firewall"
 msgstr "Zapora sieciowa"
 
-#: pkg/networkmanager/firewall.jsx:817
+#: pkg/networkmanager/firewall.jsx:883
 msgid "Firewall is not available"
 msgstr "Zapora sieciowa jest niedostępna"
 
@@ -2989,7 +2993,7 @@ msgstr ""
 msgid "Forward Mode"
 msgstr "Tryb przekierowania"
 
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2843
 msgid "Forward delay $forward_delay"
 msgstr "Opóźnienie w przód $forward_delay"
 
@@ -3031,7 +3035,7 @@ msgid "Gateway:"
 msgstr "Brama:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2710 pkg/systemd/logs.js:488
+#: pkg/networkmanager/interfaces.js:2685 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Ogólne"
 
@@ -3103,7 +3107,7 @@ msgstr "Powiększ do użycia całego miejsca"
 msgid "Hair Pin mode"
 msgstr "Tryb Hairpin"
 
-#: pkg/networkmanager/interfaces.js:2894
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Hairpin mode"
 msgstr "Tryb Hairpin"
 
@@ -3123,7 +3127,7 @@ msgstr "Sprzęt"
 msgid "Hardware Information"
 msgstr "Informacje o sprzęcie"
 
-#: pkg/networkmanager/interfaces.js:2870
+#: pkg/networkmanager/interfaces.js:2845
 msgid "Hello time $hello_time"
 msgstr "Czas powitania $hello_time"
 
@@ -3200,7 +3204,7 @@ msgstr "Długość przedrostka IP:"
 msgid "IP Settings"
 msgstr "Ustawienia IP"
 
-#: pkg/networkmanager/interfaces.js:2919
+#: pkg/networkmanager/interfaces.js:2894
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3216,7 +3220,7 @@ msgstr "Sieć IPv4"
 msgid "IPv4 Network should not be empty"
 msgstr "Sieć IPv4 nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv4 Settings"
 msgstr "Ustawienia IPv4"
 
@@ -3228,7 +3232,7 @@ msgstr "IPv4 i IPv6"
 msgid "IPv4 only"
 msgstr "Tylko IPv4"
 
-#: pkg/networkmanager/interfaces.js:2920
+#: pkg/networkmanager/interfaces.js:2895
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3244,7 +3248,7 @@ msgstr "Sieć IPv6"
 msgid "IPv6 Network should not be empty"
 msgstr "Sieć IPv6 nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv6 Settings"
 msgstr "Ustawienia IPv6"
 
@@ -3257,7 +3261,7 @@ msgstr "Tylko IPv6"
 msgid "Id"
 msgstr "Identyfikator"
 
-#: pkg/networkmanager/interfaces.js:2911
+#: pkg/networkmanager/interfaces.js:2886
 msgid "Id $id"
 msgstr "Identyfikator $id"
 
@@ -3269,7 +3273,7 @@ msgstr "Identyfikator:"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Jeśli tang-show-keys jest niedostępne, należy wykonać:"
 
-#: pkg/networkmanager/interfaces.js:1980 pkg/packagekit/updates.jsx:501
+#: pkg/networkmanager/interfaces.js:1957 pkg/packagekit/updates.jsx:501
 msgid "Ignore"
 msgstr "Ignorowanie"
 
@@ -3329,14 +3333,14 @@ msgstr ""
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
-"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
-"strong}}."
+"In order to synchronize users, you need to log in to "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Aby synchronizować użytkowników, należy się zalogować "
 "w {{#strong}}{{host}}{{/strong}}."
 
-#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1421
-#: pkg/networkmanager/interfaces.js:1428 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1398
+#: pkg/networkmanager/interfaces.js:1405 pkg/networkmanager/interfaces.js:2588
 msgid "Inactive"
 msgstr "Nieaktywne"
 
@@ -3344,7 +3348,7 @@ msgstr "Nieaktywne"
 msgid "Inactive volume"
 msgstr "Nieaktywny wolumin"
 
-#: pkg/networkmanager/firewall.jsx:691
+#: pkg/networkmanager/firewall.jsx:698
 msgid "Included services"
 msgstr "Dołączone usługi"
 
@@ -3447,8 +3451,8 @@ msgid "Interface Type"
 msgstr "Typ interfejsu"
 
 #: pkg/networkmanager/index.html:110 pkg/networkmanager/index.html:269
-#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:696
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:704
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Interfaces"
 msgstr "Interfejsy"
 
@@ -3710,8 +3714,8 @@ msgstr ""
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
-"different username, that user will always be used connecting to this machine."
-""
+"different username, that user will always be used connecting to this "
+"machine."
 msgstr ""
 "Pozostawienie pustego pola spowoduje łączenie z tą maszyną jako obecnie "
 "zalogowany użytkownik {{#default_user}}({{default_user}}){{/default_user}}. "
@@ -3738,7 +3742,7 @@ msgstr "Obserwacja łącza"
 msgid "Link down delay"
 msgstr "Opóźnienie łącza w dół"
 
-#: pkg/networkmanager/interfaces.js:1968 pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1945 pkg/networkmanager/interfaces.js:1955
 msgid "Link local"
 msgstr "Link-local"
 
@@ -3758,7 +3762,7 @@ msgstr "Łącza"
 msgid "Links:"
 msgstr "Odnośniki:"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:1981
 msgid "Load Balancing"
 msgstr "Równoważenie obciążenia"
 
@@ -3768,7 +3772,7 @@ msgstr "Wczytaj wcześniejsze wpisy"
 
 #: pkg/machines/components/libvirtSlate.jsx:81
 msgid "Loading Resources"
-msgstr ""
+msgstr "Wczytywanie zasobów"
 
 #: pkg/packagekit/updates.jsx:47
 msgid "Loading available updates failed"
@@ -3829,7 +3833,8 @@ msgstr "Zablokowanie konta w dniu $0"
 msgid "Locking $target"
 msgstr "Blokowanie $target"
 
-#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:490
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:73
+#: src/ws/login.js:490
 msgid "Log In"
 msgstr "Zaloguj"
 
@@ -3922,7 +3927,8 @@ msgstr "Lunch Box"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/nicAdd.jsx:40
+#: pkg/machines/components/nicEdit.jsx:43
 #: pkg/machines/components/vmnetworktab.jsx:138
 msgid "MAC Address"
 msgstr "Adres MAC"
@@ -3931,15 +3937,15 @@ msgstr "Adres MAC"
 msgid "MAC Address:"
 msgstr "Adres MAC:"
 
-#: pkg/networkmanager/interfaces.js:1996
+#: pkg/networkmanager/interfaces.js:1973
 msgid "MII (Recommended)"
 msgstr "MII (zalecane)"
 
-#: pkg/networkmanager/interfaces.js:2768
+#: pkg/networkmanager/interfaces.js:2743
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4562
+#: pkg/networkmanager/interfaces.js:4535
 msgid "MTU must be a positive number"
 msgstr "MTU musi być liczbą dodatnią"
 
@@ -3964,7 +3970,7 @@ msgid "Make sure the key hash from the Tang server matches:"
 msgstr ""
 "Proszę się upewnić, że suma kontrolna klucza z serwera Tang się zgadza:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1946 pkg/networkmanager/interfaces.js:1956
 msgid "Manual"
 msgstr "Ręczne"
 
@@ -4010,7 +4016,7 @@ msgstr ""
 "Może to mieć większy efekt, niż się wydaje. Proszę potwierdzić, że ta "
 "jednostka ma zostać zamaskowana."
 
-#: pkg/networkmanager/interfaces.js:2774
+#: pkg/networkmanager/interfaces.js:2749
 msgid "Master"
 msgstr "Główne"
 
@@ -4026,7 +4032,7 @@ msgstr "MTU"
 msgid "Maximum memory could not be saved"
 msgstr "Nie można zapisać maksymalnej ilości pamięci"
 
-#: pkg/networkmanager/interfaces.js:2872
+#: pkg/networkmanager/interfaces.js:2847
 msgid "Maximum message age $max_age"
 msgstr "Maksymalny wiek komunikatu $max_age"
 
@@ -4251,7 +4257,7 @@ msgstr "Obsługa NFS nie jest zainstalowana"
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "Zmiana stanu NIC $0 maszyny wirtualnej $1 się nie powiodła"
 
-#: pkg/networkmanager/interfaces.js:2019
+#: pkg/networkmanager/interfaces.js:1996
 msgid "NSNA Ping"
 msgstr "Ping NSNA"
 
@@ -4394,11 +4400,11 @@ msgid "NetworkManager is not running."
 msgstr "Usługa NetworkManager nie jest uruchomiona."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:388
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:939 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Sieć"
 
-#: pkg/networkmanager/interfaces.js:1635 pkg/networkmanager/interfaces.js:2218
+#: pkg/networkmanager/interfaces.js:1612 pkg/networkmanager/interfaces.js:2195
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Sieć"
@@ -4457,7 +4463,7 @@ msgid "Nice"
 msgstr "Nice"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2601
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2576
 msgid "No"
 msgstr "Nie"
 
@@ -4542,7 +4548,7 @@ msgstr "Brak dostępnych gniazd"
 msgid "No boot device found"
 msgstr "Nie odnaleziono żadnego urządzenia startowego"
 
-#: pkg/networkmanager/interfaces.js:1423
+#: pkg/networkmanager/interfaces.js:1400
 msgid "No carrier"
 msgstr "Brak operatora"
 
@@ -4566,7 +4572,7 @@ msgstr "Brak kontenerów"
 msgid "No containers that match the current filter"
 msgstr "Brak kontenerów pasujących do obecnego filtru"
 
-#: pkg/networkmanager/firewall.jsx:688
+#: pkg/networkmanager/firewall.jsx:695
 msgid "No description available"
 msgstr "Brak dostępnego opisu"
 
@@ -4630,9 +4636,9 @@ msgid ""
 "(e.g. in /etc/default/grub) to reserve memory at boot time. Example: "
 "crashkernel=512M"
 msgstr ""
-"Brak zastrzeżonej pamięci. Proszę dodać opcję crashkernel do wiersza poleceń "
-"jądra (tzn. w /etc/default/grub), aby zastrzec pamięć w czasie uruchamiania. "
-"Przykład: crashkernel=512M"
+"Brak zastrzeżonej pamięci. Proszę dodać opcję crashkernel do wiersza poleceń"
+" jądra (tzn. w /etc/default/grub), aby zastrzec pamięć w czasie "
+"uruchamiania. Przykład: crashkernel=512M"
 
 #: pkg/machines/components/vmnetworktab.jsx:72
 msgid "No network interfaces defined for this VM"
@@ -4702,7 +4708,7 @@ msgstr "Nie utworzono grup woluminów"
 
 #: pkg/kdump/kdump-view.jsx:422
 #: pkg/machines/components/networks/createNetworkDialog.jsx:190
-#: pkg/networkmanager/firewall.jsx:693 pkg/tuned/dialog.js:232
+#: pkg/networkmanager/firewall.jsx:700 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Brak"
 
@@ -4819,8 +4825,8 @@ msgstr[2] "Po niepowodzeniu próbowanie ponownie $0 razy"
 
 #: src/ws/cockpit.appdata.xml.in:26
 msgid ""
-"Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
-"socket\"."
+"Once Cockpit is installed, enable it with \"systemctl enable --now "
+"cockpit.socket\"."
 msgstr ""
 "Po zainstalowaniu programu Cockpit należy go włączyć za pomocą polecenia "
 "„systemctl enable --now cockpit.socket”."
@@ -4884,7 +4890,7 @@ msgstr "Napęd optyczny"
 msgid "Options"
 msgstr "Opcje"
 
-#: src/ws/login.html:125
+#: src/ws/login.html:112
 msgid "Or use a bundled browser"
 msgstr "Lub użyj dołączonej przeglądarki"
 
@@ -4901,7 +4907,7 @@ msgstr "Inne dane"
 msgid "Other Devices"
 msgstr "Inne urządzenia"
 
-#: src/ws/login.html:69
+#: src/ws/login.html:59
 msgid "Other Options"
 msgstr "Inne opcje"
 
@@ -4939,7 +4945,7 @@ msgstr "Usługa PackageKit zgłosiła kod błędu $0"
 msgid "Parent"
 msgstr "Nadrzędne"
 
-#: pkg/networkmanager/interfaces.js:2910
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Parent $parent"
 msgstr "Nadrzędne $parent"
 
@@ -4947,7 +4953,7 @@ msgstr "Nadrzędne $parent"
 msgid "Part Of"
 msgstr "Część"
 
-#: pkg/networkmanager/interfaces.js:1469
+#: pkg/networkmanager/interfaces.js:1446
 msgid "Part of "
 msgstr "Część "
 
@@ -4963,7 +4969,7 @@ msgstr "Partycja $0"
 msgid "Partitioning"
 msgstr "Partycjonowanie"
 
-#: pkg/networkmanager/interfaces.js:2011
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Passive"
 msgstr "Pasywnie"
 
@@ -4990,7 +4996,7 @@ msgstr "Hasła się nie zgadzają"
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
 #: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
 #: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:173 src/ws/login.html:44
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Hasło"
@@ -5030,8 +5036,9 @@ msgstr "Wklej"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Proszę tutaj wkleić zawartość pliku publicznego klucza SSH"
 
+#: pkg/machines/components/diskEdit.jsx:36
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/machines/components/diskEdit.jsx:36 pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Ścieżka"
 
@@ -5039,7 +5046,7 @@ msgstr "Ścieżka"
 msgid "Path cost"
 msgstr "Koszt ścieżki"
 
-#: pkg/networkmanager/interfaces.js:2892
+#: pkg/networkmanager/interfaces.js:2867
 msgid "Path cost $path_cost"
 msgstr "Koszt ścieżki $path_cost"
 
@@ -5083,7 +5090,7 @@ msgstr "Profil wydajności"
 msgid "Peripheral Chassis"
 msgstr "Obudowa peryferyjna"
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3619
 msgid "Permanent"
 msgstr "Trwałe"
 
@@ -5168,7 +5175,7 @@ msgstr "Proszę podać nazwę nowego woluminu"
 msgid "Please enter new volume size"
 msgstr "Proszę podać rozmiar nowego woluminu"
 
-#: pkg/networkmanager/firewall.jsx:818
+#: pkg/networkmanager/firewall.jsx:884
 msgid "Please install the $0 package"
 msgstr "Proszę zainstalować pakiet $0"
 
@@ -5193,10 +5200,10 @@ msgstr "Proszę spróbować innego terminu"
 msgid "Plug"
 msgstr "Podłącz"
 
-#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/diskAdd.jsx:128
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Pula"
@@ -5241,7 +5248,7 @@ msgstr "Przenośne"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:216
 #: pkg/networkmanager/index.html:326 pkg/docker/containers-view.jsx:414
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Ports"
 msgstr "Porty"
 
@@ -5269,11 +5276,11 @@ msgstr "Długość przedrostka"
 msgid "Prefix Length should not be empty"
 msgstr "Długość przedrostka nie może być pusta"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length"
 msgstr "Długość przedrostka"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length or Netmask"
 msgstr "Długość przedrostka lub maska sieci"
 
@@ -5285,7 +5292,7 @@ msgstr "Przygotowywanie"
 msgid "Present"
 msgstr "Obecne"
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3620
 msgid "Preserve"
 msgstr "Zachowaj"
 
@@ -5306,7 +5313,7 @@ msgstr "Główne"
 msgid "Priority"
 msgstr "Priorytet"
 
-#: pkg/networkmanager/interfaces.js:2866 pkg/networkmanager/interfaces.js:2890
+#: pkg/networkmanager/interfaces.js:2841 pkg/networkmanager/interfaces.js:2865
 msgid "Priority $priority"
 msgstr "Priorytet $priority"
 
@@ -5453,11 +5460,11 @@ msgstr "Element macierzy RAID"
 msgid "Rack Mount Chassis"
 msgstr "Obudowa do montowania w szafie"
 
-#: pkg/networkmanager/interfaces.js:3646
+#: pkg/networkmanager/interfaces.js:3621
 msgid "Random"
 msgstr "Losowo"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:726
 msgid "Range"
 msgstr "Zakres"
 
@@ -5614,9 +5621,13 @@ msgstr "Usuwane:"
 msgid "Remove"
 msgstr "Usuń"
 
-#: pkg/networkmanager/interfaces.js:3063
+#: pkg/networkmanager/interfaces.js:3038
 msgid "Remove $0"
 msgstr "Usuń $0"
+
+#: pkg/networkmanager/firewall.jsx:834
+msgid "Remove $0 service from $1 zone"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
@@ -5638,6 +5649,10 @@ msgstr "Usuń hasło"
 msgid "Remove passphrase in $0?"
 msgstr "Usunąć hasło w $0?"
 
+#: pkg/networkmanager/firewall.jsx:818
+msgid "Remove zone $0"
+msgstr ""
+
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
 msgstr "Usuwanie"
@@ -5650,7 +5665,7 @@ msgstr "Usuwanie $0"
 msgid "Removing $target from RAID Device"
 msgstr "Usuwanie $target z urządzenia RAID"
 
-#: pkg/networkmanager/interfaces.js:3062
+#: pkg/networkmanager/interfaces.js:3037
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5661,6 +5676,17 @@ msgstr ""
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr "Usuwanie woluminu fizycznego z $target"
+
+#: pkg/networkmanager/firewall.jsx:832
+msgid ""
+"Removing the cockpit service might result in the web console becoming "
+"unreachable. Make sure that this zone does not apply to your current web "
+"console connection."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:816
+msgid "Removing the zone will remove all services within it."
+msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
 #: pkg/storaged/vgroup-details.jsx:231
@@ -5788,8 +5814,8 @@ msgstr "Zmienianie rozmiaru $target"
 
 #: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
-"Resizing an encrypted filesystem requires unlocking the disk. Please provide "
-"a current disk passphrase."
+"Resizing an encrypted filesystem requires unlocking the disk. Please provide"
+" a current disk passphrase."
 msgstr ""
 "Zmiana rozmiaru zaszyfrowanego systemu plików wymaga odblokowania dysku. "
 "Proszę podać obecne hasło dysku."
@@ -5834,7 +5860,7 @@ msgstr "Wznów"
 msgid "Retries:"
 msgstr "Próby:"
 
-#: src/ws/login.html:57
+#: src/ws/login.html:48
 msgid "Reuse my password for privileged tasks"
 msgstr "Użycie istniejącego hasła do zadań wymagających uprawnień"
 
@@ -5849,7 +5875,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Role"
 
-#: pkg/networkmanager/interfaces.js:1985 pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:1962 pkg/networkmanager/interfaces.js:1979
 msgid "Round Robin"
 msgstr "Round Robin"
 
@@ -5861,7 +5887,7 @@ msgstr "Trasa do $0"
 msgid "Routed Network"
 msgstr "Trasowana sieć"
 
-#: pkg/networkmanager/interfaces.js:3335
+#: pkg/networkmanager/interfaces.js:3310
 msgid "Routes"
 msgstr "Trasy"
 
@@ -5953,8 +5979,8 @@ msgstr "Priorytet STP"
 
 #: pkg/shell/index.html:407
 msgid ""
-"Safari users need to import and trust the certificate of the self-signing CA:"
-""
+"Safari users need to import and trust the certificate of the self-signing "
+"CA:"
 msgstr ""
 "Użytkownicy przeglądarki Safari muszą zaimportować certyfikat "
 "samopodpisującego CA i oznaczyć go jako zaufany:"
@@ -6002,7 +6028,7 @@ msgstr "Sealed-case PC"
 
 #: pkg/shell/index.html:363
 msgid "Search"
-msgstr ""
+msgstr "Szukaj"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
 #: pkg/systemd/init.js:967
@@ -6034,8 +6060,8 @@ msgid ""
 "Select the users that you would like to be synchronized with "
 "{{#strong}}{{host}}{{/strong}}"
 msgstr ""
-"Proszę wybrać użytkowników do synchronizacji z {{#strong}}{{host}}{{/"
-"strong}}"
+"Proszę wybrać użytkowników do synchronizacji "
+"z {{#strong}}{{host}}{{/strong}}"
 
 #: pkg/machines/components/vm/vmActions.jsx:66
 msgid "Send Non-Maskable Interrupt"
@@ -6055,7 +6081,7 @@ msgstr "Wysyłanie"
 msgid "Serial Console"
 msgstr "Konsola szeregowa"
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:81 pkg/kdump/kdump-view.jsx:116
 #: pkg/storaged/nfs-details.jsx:322 pkg/storaged/nfs-panel.jsx:95
 msgid "Server"
 msgstr "Serwer"
@@ -6190,7 +6216,7 @@ msgstr "Ważność"
 msgid "Severity:"
 msgstr "Ważność:"
 
-#: pkg/networkmanager/interfaces.js:1970
+#: pkg/networkmanager/interfaces.js:1947
 msgid "Shared"
 msgstr "Współdzielone"
 
@@ -6328,11 +6354,11 @@ msgid ""
 "Some other program is currently using the package manager, please wait..."
 msgstr "Inny program obecnie używa menedżera pakietów, proszę czekać…"
 
-#: pkg/networkmanager/firewall.jsx:668
+#: pkg/networkmanager/firewall.jsx:675
 msgid "Sorted from least trusted to most trusted"
 msgstr "Uporządkowane od najmniej do najbardziej zaufanych"
 
-#: pkg/machines/components/diskAdd.jsx:462
+#: pkg/machines/components/diskAdd.jsx:461
 #: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:117
@@ -6368,7 +6394,7 @@ msgstr "Źródło musi zaczynać się od protokołu http, ftp lub nfs"
 msgid "Space-saving Computer"
 msgstr "Komputer oszczędzający miejsce"
 
-#: pkg/networkmanager/interfaces.js:2864
+#: pkg/networkmanager/interfaces.js:2839
 msgid "Spanning Tree Protocol"
 msgstr "Protokół STP"
 
@@ -6388,7 +6414,7 @@ msgstr "Podany czas"
 msgid "Speed"
 msgstr "Prędkość"
 
-#: pkg/networkmanager/interfaces.js:3647
+#: pkg/networkmanager/interfaces.js:3622
 msgid "Stable"
 msgstr "Stabilna"
 
@@ -6443,8 +6469,9 @@ msgstr "Uruchamianie"
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
-#: pkg/machines/components/vmnetworktab.jsx:183 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:269 pkg/systemd/init.js:306
+#: pkg/machines/components/vmnetworktab.jsx:183
+#: pkg/machines/hostvmslist.jsx:83 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/init.js:306
 msgid "State"
 msgstr "Stan"
 
@@ -6457,7 +6484,7 @@ msgstr "Stan:"
 msgid "Static"
 msgstr "Statyczne"
 
-#: pkg/networkmanager/interfaces.js:2620 pkg/systemd/service-details.jsx:478
+#: pkg/networkmanager/interfaces.js:2595 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Stan"
 
@@ -6621,15 +6648,15 @@ msgstr "Przestrzeń wymiany"
 msgid "Swap Used"
 msgstr "Używana przestrzeń wymiany"
 
-#: pkg/networkmanager/interfaces.js:2498 pkg/networkmanager/interfaces.js:3047
+#: pkg/networkmanager/interfaces.js:2475 pkg/networkmanager/interfaces.js:3022
 msgid "Switch off $0"
 msgstr "Wyłącz $0"
 
-#: pkg/networkmanager/interfaces.js:2473 pkg/networkmanager/interfaces.js:3035
+#: pkg/networkmanager/interfaces.js:2450 pkg/networkmanager/interfaces.js:3010
 msgid "Switch on $0"
 msgstr "Włącz $0"
 
-#: pkg/networkmanager/interfaces.js:2497
+#: pkg/networkmanager/interfaces.js:2474
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6637,7 +6664,7 @@ msgstr ""
 "Wyłączenie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:3046
+#: pkg/networkmanager/interfaces.js:3021
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6645,7 +6672,7 @@ msgstr ""
 "Wyłączenie <b>$0</b> zerwie połączenie z serwerem i uniemożliwi korzystanie "
 "z interfejsu administracji."
 
-#: pkg/networkmanager/interfaces.js:2472 pkg/networkmanager/interfaces.js:3034
+#: pkg/networkmanager/interfaces.js:2449 pkg/networkmanager/interfaces.js:3009
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6746,12 +6773,12 @@ msgstr "Ścieżka docelowa nie może być pusta"
 msgid "Targets"
 msgstr "Cele"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
-#: pkg/networkmanager/interfaces.js:2821
+#: pkg/networkmanager/interfaces.js:2495 pkg/networkmanager/interfaces.js:2507
+#: pkg/networkmanager/interfaces.js:2796
 msgid "Team"
 msgstr "Zespół"
 
-#: pkg/networkmanager/interfaces.js:2849
+#: pkg/networkmanager/interfaces.js:2824
 msgid "Team Port"
 msgstr "Port zespołu"
 
@@ -6789,13 +6816,13 @@ msgstr "Testowanie połączenia"
 
 #: pkg/machines/components/deleteResource.jsx:46
 msgid "The $0 could not be deleted"
-msgstr ""
+msgstr "Nie można usunąć $0"
 
 #: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
 msgstr ""
-"Pula urządzeń do przechowywania danych Docker nie może być zarządzana na tym "
-"systemie."
+"Pula urządzeń do przechowywania danych Docker nie może być zarządzana na tym"
+" systemie."
 
 #: pkg/lib/machine-dialogs.js:386
 msgid "The IP address or host name cannot contain whitespace."
@@ -6847,8 +6874,8 @@ msgstr "Maszyna wirtualna jest wstrzymana."
 #: pkg/machines/components/deleteDialog.jsx:64
 msgid "The VM is running and will be forced off before deletion."
 msgstr ""
-"Maszyna wirtualna jest uruchomiona i przed jej usunięciem zostanie wymuszone "
-"jej wyłączenie."
+"Maszyna wirtualna jest uruchomiona i przed jej usunięciem zostanie wymuszone"
+" jej wyłączenie."
 
 #: pkg/machines/components/vm/stateIcon.jsx:35
 msgid "The VM is running."
@@ -6862,6 +6889,8 @@ msgstr "Maszyna wirtualna jest uśpiona przez zarządzanie zasilaniem."
 #: pkg/machines/components/vmnetworktab.jsx:207
 msgid "The VM needs to be running or shut off to detach this device"
 msgstr ""
+"Maszyna wirtualna musi być uruchomiona lub wyłączona, aby odłączyć to "
+"urządzenie"
 
 #: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
@@ -6870,11 +6899,15 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Nie można ustalić autentyczności komputera {{#strong}}{{host}}{{/strong}}. "
 "Na pewno kontynuować łączenie?"
+
+#: pkg/networkmanager/firewall.jsx:701
+msgid "The cockpit service is automatically included"
+msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -6883,8 +6916,8 @@ msgstr "Zebrane informacje będą przechowywane lokalnie w systemie."
 #: pkg/selinux/setroubleshoot-view.jsx:292
 msgid "The configured state is unknown, it might change on the next boot."
 msgstr ""
-"Nieznany stan konfiguracji, może zostać zmieniony po następnych uruchomieniu."
-""
+"Nieznany stan konfiguracji, może zostać zmieniony po następnych "
+"uruchomieniu."
 
 #: pkg/storaged/vdo-details.jsx:119
 msgid ""
@@ -6943,8 +6976,8 @@ msgstr ""
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
+"in use. Unless this machine was recently replaced, it is likely that someone"
+" is trying to attack your connection to this machine."
 msgstr ""
 "Klucz {{#strong}}{{host}}{{/strong}} nie pasuje do poprzednio używanego "
 "klucza. Jeśli ten komputer nie został niedawno wymieniany, może to oznaczać "
@@ -7074,7 +7107,7 @@ msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr ""
 "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie nazw komputerów"
 
-#: pkg/networkmanager/interfaces.js:1520
+#: pkg/networkmanager/interfaces.js:1497
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr ""
 "Użytkownik <b>$0</b> nie ma zezwolenia na modyfikowanie ustawień sieci"
@@ -7090,8 +7123,8 @@ msgstr ""
 
 #: pkg/users/local.js:553
 msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+"The user name can only consist of letters from a-z, digits, dots, dashes and"
+" underscores."
 msgstr ""
 "Nazwa użytkownika może składać się tylko z liter od A do Z, cyfr, kropek, "
 "myślników i podkreślników."
@@ -7151,13 +7184,13 @@ msgstr "To urządzenie VDO nie używa całości swojego urządzenia podstawowego
 
 #: pkg/systemd/init.js:1262
 msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
+"This day doesn't exist in all months.<br> The timer will only be executed in"
+" months that have 31st."
 msgstr ""
 "Ten dzień nie istnieje we wszystkich miesiącach.<br> Licznik będzie "
 "wykonywany tylko w miesiącach z 31. dniem."
 
-#: pkg/networkmanager/interfaces.js:2631
+#: pkg/networkmanager/interfaces.js:2606
 msgid "This device cannot be managed here."
 msgstr "Tutaj nie można zarządzać tym urządzeniem."
 
@@ -7194,8 +7227,8 @@ msgid ""
 "This device is currently used for volume groups. Proceeding will remove it "
 "from its volume groups."
 msgstr ""
-"To urządzenie jest obecnie używane dla grup woluminów. Kontynuacja usunie je "
-"z jego grup woluminów."
+"To urządzenie jest obecnie używane dla grup woluminów. Kontynuacja usunie je"
+" z jego grup woluminów."
 
 #: pkg/storaged/mdraid-details.jsx:111
 msgid "This disk cannot be removed while the device is recovering."
@@ -7294,8 +7327,8 @@ msgstr "Ta konsola internetowa zostanie zaktualizowana."
 
 #: pkg/kdump/kdump-view.jsx:296
 msgid ""
-"This will test kdump settings by crashing the kernel and thereby the system. "
-"Depending on the settings, the system may not automatically reboot and the "
+"This will test kdump settings by crashing the kernel and thereby the system."
+" Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
 "Przetestuje to ustawienia kdump przez zawieszenie jądra, a razem z tym "
@@ -7305,6 +7338,12 @@ msgstr ""
 #: pkg/kdump/kdump-view.jsx:492
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Przetestuje to konfigurację kdump przez zawieszenie jądra."
+
+#: pkg/networkmanager/firewall.jsx:814
+msgid ""
+"This zone contains the cockpit service. Make sure that this zone does not "
+"apply to your current web console connection."
+msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:237
 msgid "Threads per core"
@@ -7384,11 +7423,11 @@ msgstr "Rozwiązywanie problemów"
 msgid "Trust key"
 msgstr "Zaufaj kluczowi"
 
-#: pkg/networkmanager/firewall.jsx:664
+#: pkg/networkmanager/firewall.jsx:671
 msgid "Trust level"
 msgstr "Poziom zaufania"
 
-#: src/ws/login.html:111
+#: src/ws/login.html:98
 msgid "Try Again"
 msgstr "Spróbuj ponownie"
 
@@ -7542,12 +7581,12 @@ msgstr "Jednostka"
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:146
 #: pkg/networkmanager/interfaces.js:595 pkg/networkmanager/interfaces.js:1071
-#: pkg/networkmanager/interfaces.js:2538 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2515 pkg/networkmanager/interfaces.js:2517
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Nieznane"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2501 pkg/networkmanager/interfaces.js:2513
 msgid "Unknown \"$0\""
 msgstr "Nieznane „$0”"
 
@@ -7563,7 +7602,7 @@ msgstr "Nieznana aplikacja"
 msgid "Unknown Host Key"
 msgstr "Nieznany klucz komputera"
 
-#: pkg/networkmanager/interfaces.js:2647
+#: pkg/networkmanager/interfaces.js:2622
 msgid "Unknown configuration"
 msgstr "Nieznana konfiguracja"
 
@@ -7717,7 +7756,7 @@ msgstr[2] "Użycie $0 rdzeni procesora"
 msgid "Use 512 Byte emulation"
 msgstr "Użycie emulacji 512 bajtów"
 
-#: pkg/machines/components/diskAdd.jsx:482
+#: pkg/machines/components/diskAdd.jsx:481
 msgid "Use Existing"
 msgstr "Użyj istniejącej"
 
@@ -7757,7 +7796,7 @@ msgid "User Password"
 msgstr "Hasło użytkownika"
 
 #: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
-#: src/ws/login.html:43
+#: src/ws/login.html:39
 msgid "User name"
 msgstr "Nazwa użytkownika"
 
@@ -7806,8 +7845,8 @@ msgstr "Urządzenia mechanizmu VDO nie mogą być zmniejszane"
 msgid "VDO support not installed"
 msgstr "Obsługa VDO nie jest zainstalowana"
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/networkmanager/interfaces.js:2497 pkg/networkmanager/interfaces.js:2509
+#: pkg/networkmanager/interfaces.js:2888
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7880,7 +7919,7 @@ msgstr "Port TLS VNC:"
 msgid "Validating address"
 msgstr "Sprawdzanie poprawności adresu"
 
-#: src/ws/login.html:101
+#: src/ws/login.html:88
 msgid "Validating authentication token"
 msgstr "Sprawdzanie poprawności tokenu uwierzytelniania"
 
@@ -7889,7 +7928,8 @@ msgid "Validating key"
 msgstr "Sprawdzanie poprawności klucza"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:257
+#: pkg/machines/components/vm/bootOrderModal.jsx:126
+#: pkg/systemd/hwinfo.jsx:257
 msgid "Vendor"
 msgstr "Producent"
 
@@ -7941,10 +7981,10 @@ msgid "Virtualization Service is Available"
 msgstr "Usługa wirtualizacji jest dostępna"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
-#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:91
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Wolumin"
@@ -8070,11 +8110,11 @@ msgstr "Zapisywanie"
 msgid "Wrong user name or password"
 msgstr "Błędna nazwa użytkownika lub hasło"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1964
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2600
+#: pkg/networkmanager/interfaces.js:2575
 msgid "Yes"
 msgstr "Tak"
 
@@ -8092,8 +8132,8 @@ msgid ""
 msgstr "Obecnie połączono bezpośrednio z tym serwerem. Nie można go usunąć."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:131
-#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:827
-#: pkg/networkmanager/firewall.jsx:859
+#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:925
 msgid "You are not authorized to modify the firewall."
 msgstr "Brak upoważnienia do modyfikacji zapory sieciowej."
 
@@ -8425,7 +8465,7 @@ msgstr "zainstaluj"
 
 #: pkg/networkmanager/manifest.json.in
 msgid "interface"
-msgstr ""
+msgstr "interfejs"
 
 #: pkg/kdump/kdump-view.jsx:379
 msgid "invalid: multiple targets defined"
@@ -8872,8 +8912,8 @@ msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
-"Aby tworzyć nowe maszyny wirtualne, w systemie musi być zainstalowany pakiet "
-"virt-install"
+"Aby tworzyć nowe maszyny wirtualne, w systemie musi być zainstalowany pakiet"
+" virt-install"
 
 #: pkg/networkmanager/manifest.json.in
 msgid "vlan"

--- a/po/uk.po
+++ b/po/uk.po
@@ -8,17 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-24 10:45+0000\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2019-10-16 09:01+0000\n"
+"POT-Creation-Date: 2019-10-30 17:14+0000\n"
+"PO-Revision-Date: 2019-10-25 03:29+0000\n"
 "Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
 "Language-Team: Ukrainian <kde-i18n-uk@kde.org>\n"
 "Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 "X-Generator: Zanata 4.6.2\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
 #: pkg/docker/storage.jsx:261
 msgid " (shared with the OS)"
@@ -27,16 +26,16 @@ msgstr " (спільний із операційною системою)"
 #: pkg/machines/components/diskAdd.jsx:236
 msgid " Attaching it will make this disk shareable for every VM using it."
 msgstr ""
-" Долучення диска надасть доступ до нього для усіх віртуальних машин, які ним "
-"користуватимуться."
+" Долучення диска надасть доступ до нього для усіх віртуальних машин, які ним"
+" користуватимуться."
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zone"
-msgstr ""
+msgstr "Активна зона $0"
 
-#: pkg/networkmanager/interfaces.js:2340
+#: pkg/networkmanager/interfaces.js:2317
 msgid "$0 Active Zones"
-msgstr ""
+msgstr "Активні зони $0"
 
 #: pkg/storaged/others-panel.jsx:57
 msgid "$0 Block Device"
@@ -264,7 +263,7 @@ msgstr[0] "$1 виправлення захисту"
 msgstr[1] "$1 виправлення захисту"
 msgstr[2] "$1 виправлень захисту"
 
-#: pkg/networkmanager/interfaces.js:2764
+#: pkg/networkmanager/interfaces.js:2739
 msgid "$mtu"
 msgstr "$mtu"
 
@@ -532,11 +531,11 @@ msgstr "7"
 msgid "8 KiB"
 msgstr "8 КіБ"
 
-#: pkg/networkmanager/interfaces.js:1989
+#: pkg/networkmanager/interfaces.js:1966
 msgid "802.3ad"
 msgstr "802.3ad"
 
-#: pkg/networkmanager/interfaces.js:2006
+#: pkg/networkmanager/interfaces.js:1983
 msgid "802.3ad LACP"
 msgstr "802.3ad LACP"
 
@@ -550,8 +549,8 @@ msgstr "9-е"
 
 #: pkg/lib/machine-not-supported.html:5
 msgid ""
-"A compatible version of Cockpit is not installed on {{#strong}}{{host}}{{/"
-"strong}}."
+"A compatible version of Cockpit is not installed on "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "У {{#strong}}{{host}}{{/strong}} не встановлено сумісної версії Cockpit."
 
@@ -559,7 +558,7 @@ msgstr ""
 msgid "A disk is needed."
 msgstr "Потрібен диск."
 
-#: src/ws/login.html:115
+#: src/ws/login.html:102
 msgid ""
 "A modern browser is required for security, reliability, and performance."
 msgstr ""
@@ -570,15 +569,15 @@ msgstr ""
 msgid "A spare disk needs to be added first before this disk can be removed."
 msgstr "Перш ніж вилучати цей диск, слід додати резервний диск."
 
-#: pkg/networkmanager/interfaces.js:1997
+#: pkg/networkmanager/interfaces.js:1974
 msgid "ARP"
 msgstr "ARP"
 
-#: pkg/networkmanager/interfaces.js:2793
+#: pkg/networkmanager/interfaces.js:2768
 msgid "ARP Monitoring"
 msgstr "Стеження за ARP"
 
-#: pkg/networkmanager/interfaces.js:2018
+#: pkg/networkmanager/interfaces.js:1995
 msgid "ARP Ping"
 msgstr "Луна-імпульс ARP"
 
@@ -629,11 +628,11 @@ msgstr "Задіяти"
 msgid "Activating $target"
 msgstr "Активуємо $target"
 
-#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:2012
+#: pkg/networkmanager/interfaces.js:842 pkg/networkmanager/interfaces.js:1989
 msgid "Active"
 msgstr "Активний"
 
-#: pkg/networkmanager/interfaces.js:1986 pkg/networkmanager/interfaces.js:2003
+#: pkg/networkmanager/interfaces.js:1963 pkg/networkmanager/interfaces.js:1980
 msgid "Active Backup"
 msgstr "Активне резервування"
 
@@ -649,16 +648,16 @@ msgstr "Активний з"
 msgid "Active since "
 msgstr "Активний з "
 
-#: pkg/networkmanager/interfaces.js:1991
+#: pkg/networkmanager/interfaces.js:1968
 msgid "Adaptive load balancing"
 msgstr "Адаптивне урівноваження навантаження"
 
-#: pkg/networkmanager/interfaces.js:1990
+#: pkg/networkmanager/interfaces.js:1967
 msgid "Adaptive transmit load balancing"
 msgstr "Адаптивне урівноваження навантаження за передаванням"
 
 #: pkg/lib/machine-add.html:43 pkg/shell/index.html:180
-#: pkg/machines/components/diskAdd.jsx:522
+#: pkg/machines/components/diskAdd.jsx:521
 #: pkg/machines/components/nicAdd.jsx:235 pkg/storaged/crypto-keyslots.jsx:235
 #: pkg/storaged/iscsi-panel.jsx:137 pkg/storaged/iscsi-panel.jsx:161
 #: pkg/storaged/mdraid-details.jsx:58 pkg/storaged/nfs-details.jsx:197
@@ -666,7 +665,7 @@ msgstr "Адаптивне урівноваження навантаження �
 msgid "Add"
 msgstr "Додати"
 
-#: pkg/networkmanager/interfaces.js:3113
+#: pkg/networkmanager/interfaces.js:3088
 msgid "Add $0"
 msgstr "Додати $0"
 
@@ -682,7 +681,7 @@ msgstr "Додати зв’язок"
 msgid "Add Bridge"
 msgstr "Додати місток"
 
-#: pkg/machines/components/diskAdd.jsx:510
+#: pkg/machines/components/diskAdd.jsx:509
 #: pkg/machines/components/vmDisksTab.jsx:93
 msgid "Add Disk"
 msgstr "Додати диск"
@@ -728,8 +727,8 @@ msgstr "Додати VLAN"
 msgid "Add Virtual Network Interface"
 msgstr "Додати інтерфейс віртуальної мережі"
 
-#: pkg/networkmanager/firewall.jsx:659 pkg/networkmanager/firewall.jsx:828
-#: pkg/networkmanager/firewall.jsx:834
+#: pkg/networkmanager/firewall.jsx:666 pkg/networkmanager/firewall.jsx:894
+#: pkg/networkmanager/firewall.jsx:900
 msgid "Add Zone"
 msgstr "Додати зону"
 
@@ -753,11 +752,11 @@ msgstr "Додати відкритий ключ"
 msgid "Add services to $0 zone"
 msgstr "Додати служби до зони $0"
 
-#: pkg/networkmanager/firewall.jsx:735
+#: pkg/networkmanager/firewall.jsx:743
 msgid "Add zone"
 msgstr "Додати зону"
 
-#: pkg/networkmanager/interfaces.js:3112
+#: pkg/networkmanager/interfaces.js:3087
 msgid ""
 "Adding <b>$0</b> will break the connection to the server, and will make the "
 "administration UI unavailable."
@@ -785,11 +784,11 @@ msgstr "Додаємо фізичний том до $target"
 msgid "Additional"
 msgstr "Додаткові"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "Additional DNS $val"
 msgstr "Додатковий DNS $val"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "Additional DNS Search Domains $val"
 msgstr "Додаткові домени пошуку DNS $val"
 
@@ -801,7 +800,7 @@ msgstr "Додаткове сховище"
 msgid "Additional actions"
 msgstr "Додаткові дії"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Additional address $val"
 msgstr "Додаткова адреса $val"
 
@@ -817,7 +816,7 @@ msgstr "Додаткові пакунки:"
 msgid "Address"
 msgstr "Адреса"
 
-#: pkg/networkmanager/interfaces.js:2658
+#: pkg/networkmanager/interfaces.js:2633
 msgid "Address $val"
 msgstr "Адреса $val"
 
@@ -840,7 +839,7 @@ msgstr "Адреса поза межами підмережі"
 msgid "Address:"
 msgstr "Адреса:"
 
-#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3319
+#: pkg/networkmanager/firewall.jsx:161 pkg/networkmanager/interfaces.js:3294
 msgid "Addresses"
 msgstr "Адреси"
 
@@ -863,18 +862,18 @@ msgstr "Після"
 #: pkg/systemd/services.html:310
 msgctxt "time-delay"
 msgid "After"
-msgstr ""
+msgstr "ПІсля"
 
 #: pkg/realmd/operation.html:27
 msgid ""
 "After leaving the domain, only users with local credentials will be able to "
-"log into this machine. This may also affect other services as DNS resolution "
-"settings and the list of trusted CAs may change."
+"log into this machine. This may also affect other services as DNS resolution"
+" settings and the list of trusted CAs may change."
 msgstr ""
 "Після полишення цього домену лише користувачі із локальними реєстраційними "
 "даними зможуть входити до системи на цій машині. Це також може вплинути на "
-"роботу інших служб, оскільки можуть змінитися параметри визначення адрес DNS "
-"та список довірених служб сертифікації."
+"роботу інших служб, оскільки можуть змінитися параметри визначення адрес DNS"
+" та список довірених служб сертифікації."
 
 #: pkg/systemd/services.html:301 pkg/systemd/services.html:305
 #: pkg/systemd/init.js:964
@@ -885,7 +884,8 @@ msgstr "Після завантаження системи"
 msgid "Alert and above"
 msgstr "Тривога і вище"
 
-#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213 pkg/systemd/logs.js:384
+#: pkg/systemd/services.html:65 pkg/systemd/logs.js:213
+#: pkg/systemd/logs.js:384
 msgid "All"
 msgstr "Всі"
 
@@ -905,7 +905,7 @@ msgstr ""
 msgid "Allow running (unmask)"
 msgstr "Дозволити запуск (зняти маску)"
 
-#: pkg/networkmanager/firewall.jsx:710
+#: pkg/networkmanager/firewall.jsx:718
 msgid "Allowed Addresses"
 msgstr "Дозволені адреси"
 
@@ -1030,17 +1030,17 @@ msgstr "Уповноважені відкриті ключі SSH"
 
 #: pkg/networkmanager/index.html:179
 #: pkg/machines/components/networks/createNetworkDialog.jsx:162
-#: pkg/networkmanager/interfaces.js:1976 pkg/networkmanager/interfaces.js:2766
-#: pkg/networkmanager/interfaces.js:3327 pkg/networkmanager/interfaces.js:3331
-#: pkg/networkmanager/interfaces.js:3337 pkg/realmd/operation.js:338
+#: pkg/networkmanager/interfaces.js:1953 pkg/networkmanager/interfaces.js:2741
+#: pkg/networkmanager/interfaces.js:3302 pkg/networkmanager/interfaces.js:3306
+#: pkg/networkmanager/interfaces.js:3312 pkg/realmd/operation.js:338
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: pkg/networkmanager/interfaces.js:1977
+#: pkg/networkmanager/interfaces.js:1954
 msgid "Automatic (DHCP only)"
 msgstr "Автоматично (лише DHCP)"
 
-#: pkg/networkmanager/interfaces.js:1967
+#: pkg/networkmanager/interfaces.js:1944
 msgid "Automatic (DHCP)"
 msgstr "Автоматично (DHCP)"
 
@@ -1156,8 +1156,8 @@ msgstr "Блоковий пристрій для файлових систем"
 msgid "Blocked"
 msgstr "Заблоковано"
 
-#: pkg/networkmanager/interfaces.js:2516 pkg/networkmanager/interfaces.js:2528
-#: pkg/networkmanager/interfaces.js:2798
+#: pkg/networkmanager/interfaces.js:2493 pkg/networkmanager/interfaces.js:2505
+#: pkg/networkmanager/interfaces.js:2773
 msgid "Bond"
 msgstr "Прив’язка"
 
@@ -1178,8 +1178,8 @@ msgstr "Не вдалося зберегти параметри порядку �
 msgid "Bound By"
 msgstr "Пов'язано"
 
-#: pkg/networkmanager/interfaces.js:2522 pkg/networkmanager/interfaces.js:2534
-#: pkg/networkmanager/interfaces.js:2875
+#: pkg/networkmanager/interfaces.js:2499 pkg/networkmanager/interfaces.js:2511
+#: pkg/networkmanager/interfaces.js:2850
 msgid "Bridge"
 msgstr "Міст"
 
@@ -1191,15 +1191,15 @@ msgstr "Параметри порту містка"
 msgid "Bridge Settings"
 msgstr "Параметри містка"
 
-#: pkg/networkmanager/interfaces.js:2896
+#: pkg/networkmanager/interfaces.js:2871
 msgid "Bridge port"
 msgstr "Порт містка"
 
-#: pkg/networkmanager/interfaces.js:1988 pkg/networkmanager/interfaces.js:2005
+#: pkg/networkmanager/interfaces.js:1965 pkg/networkmanager/interfaces.js:1982
 msgid "Broadcast"
 msgstr "Трансляція"
 
-#: pkg/networkmanager/interfaces.js:2811 pkg/networkmanager/interfaces.js:2845
+#: pkg/networkmanager/interfaces.js:2786 pkg/networkmanager/interfaces.js:2820
 msgid "Broken configuration"
 msgstr "Помилки у налаштуваннях"
 
@@ -1279,17 +1279,16 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/networkmanager/index.html:600 pkg/networkmanager/index.html:624
 #: pkg/networkmanager/index.html:648 pkg/networkmanager/index.html:672
 #: pkg/playground/translate.html:39 pkg/realmd/operation.html:81
-#: pkg/shell/index.html:122 pkg/shell/simple.html:90 pkg/systemd/index.html:343
-#: pkg/systemd/index.html:430 pkg/systemd/index.html:482
-#: pkg/systemd/index.html:498 pkg/systemd/services.html:377
-#: pkg/users/index.html:198 pkg/users/index.html:237 pkg/users/index.html:276
-#: pkg/users/index.html:315 pkg/users/index.html:332 pkg/users/index.html:356
-#: pkg/users/index.html:413 pkg/apps/utils.jsx:86
-#: pkg/lib/cockpit-components-dialog.jsx:159
+#: pkg/shell/index.html:122 pkg/shell/simple.html:90
+#: pkg/systemd/index.html:343 pkg/systemd/index.html:430
+#: pkg/systemd/index.html:482 pkg/systemd/index.html:498
+#: pkg/systemd/services.html:377 pkg/users/index.html:198
+#: pkg/users/index.html:237 pkg/users/index.html:276 pkg/users/index.html:315
+#: pkg/users/index.html:332 pkg/users/index.html:356 pkg/users/index.html:413
+#: pkg/apps/utils.jsx:86 pkg/lib/cockpit-components-dialog.jsx:159
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:818
-#: pkg/machines/components/deleteDialog.jsx:158
 #: pkg/machines/components/deleteResource.jsx:108
-#: pkg/machines/components/diskAdd.jsx:519
+#: pkg/machines/components/diskAdd.jsx:518
 #: pkg/machines/components/diskEdit.jsx:173
 #: pkg/machines/components/networks/createNetworkDialog.jsx:477
 #: pkg/machines/components/nicAdd.jsx:232
@@ -1300,10 +1299,12 @@ msgstr "Не вдалося завантажити образ"
 #: pkg/machines/components/vcpuModal.jsx:257
 #: pkg/machines/components/vm/bootOrderModal.jsx:327
 #: pkg/machines/components/vm/memoryModal.jsx:214
-#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:730
-#: pkg/packagekit/updates.jsx:182 pkg/sosreport/index.js:51
-#: pkg/storaged/dialog.jsx:399 pkg/storaged/jobs-panel.jsx:123
-#: pkg/systemd/hwinfo.jsx:221 pkg/systemd/service-details.jsx:107
+#: pkg/machines/components/deleteDialog.jsx:158
+#: pkg/networkmanager/firewall.jsx:587 pkg/networkmanager/firewall.jsx:738
+#: pkg/networkmanager/firewall.jsx:763 pkg/packagekit/updates.jsx:182
+#: pkg/sosreport/index.js:51 pkg/storaged/dialog.jsx:399
+#: pkg/storaged/jobs-panel.jsx:123 pkg/systemd/hwinfo.jsx:221
+#: pkg/systemd/service-details.jsx:107
 msgid "Cancel"
 msgstr "Скасувати"
 
@@ -1323,13 +1324,13 @@ msgstr "Не можна планувати подію на минуле"
 msgid "Capacity"
 msgstr "Місткість"
 
-#: pkg/networkmanager/interfaces.js:2597
+#: pkg/networkmanager/interfaces.js:2572
 msgid "Carrier"
 msgstr "Носій сигналу"
 
 #: pkg/docker/index.html:664 pkg/systemd/index.html:344
-#: pkg/systemd/index.html:431 pkg/users/index.html:277 pkg/users/index.html:316
-#: pkg/storaged/iscsi-panel.jsx:188
+#: pkg/systemd/index.html:431 pkg/users/index.html:277
+#: pkg/users/index.html:316 pkg/storaged/iscsi-panel.jsx:188
 msgid "Change"
 msgstr "Змінити"
 
@@ -1369,7 +1370,7 @@ msgstr "Змінити обмеження ресурсів"
 msgid "Change resources limits"
 msgstr "Змінити обмеження ресурсів"
 
-#: pkg/networkmanager/interfaces.js:3163
+#: pkg/networkmanager/interfaces.js:3138
 msgid "Change the settings"
 msgstr "Змінити параметри"
 
@@ -1381,10 +1382,10 @@ msgstr "Змінити параметри"
 msgid "Changes will take effect after shutting down the VM"
 msgstr "Зміни буде застосовано після завершення роботи ВМ"
 
-#: pkg/networkmanager/interfaces.js:3162
+#: pkg/networkmanager/interfaces.js:3137
 msgid ""
-"Changing the settings will break the connection to the server, and will make "
-"the administration UI unavailable."
+"Changing the settings will break the connection to the server, and will make"
+" the administration UI unavailable."
 msgstr ""
 "Зміна параметрів призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
@@ -1458,11 +1459,10 @@ msgid "Click to see system hardware information"
 msgstr "Натисніть, щоб побачити дані щодо обладнання системи"
 
 #: pkg/machines/components/desktopConsole.jsx:41
-msgid ""
-"Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
+msgid "Clicking \"Launch Remote Viewer\" will download a .vv file and launch $0."
 msgstr ""
-"У результаті натискання «Запустити віддалений переглядач» буде отримано файл "
-".vv і запущено $0."
+"У результаті натискання «Запустити віддалений переглядач» буде отримано файл"
+" .vv і запущено $0."
 
 #: pkg/realmd/operation.html:20
 msgid "Client Software"
@@ -1470,12 +1470,13 @@ msgstr "Клієнтське програмне забезпечення"
 
 #: pkg/docker/index.html:738 pkg/lib/machine-auth-failed.html:20
 #: pkg/lib/machine-change-port.html:45 pkg/lib/machine-invalid-hostkey.html:12
-#: pkg/lib/machine-not-supported.html:8 pkg/lib/machine-unknown-hostkey.html:19
-#: pkg/networkmanager/index.html:691 pkg/shell/index.html:96
-#: pkg/shell/index.html:139 pkg/shell/index.html:325 pkg/shell/simple.html:72
-#: pkg/systemd/index.html:289 pkg/users/index.html:45 pkg/apps/utils.jsx:108
-#: pkg/lib/cockpit-components-modifications.jsx:109 pkg/sosreport/index.js:45
-#: pkg/sosreport/index.js:127 pkg/storaged/dialog.jsx:399
+#: pkg/lib/machine-not-supported.html:8
+#: pkg/lib/machine-unknown-hostkey.html:19 pkg/networkmanager/index.html:691
+#: pkg/shell/index.html:96 pkg/shell/index.html:139 pkg/shell/index.html:325
+#: pkg/shell/simple.html:72 pkg/systemd/index.html:289 pkg/users/index.html:45
+#: pkg/apps/utils.jsx:108 pkg/lib/cockpit-components-modifications.jsx:109
+#: pkg/sosreport/index.js:45 pkg/sosreport/index.js:127
+#: pkg/storaged/dialog.jsx:399
 msgid "Close"
 msgstr "Закрити"
 
@@ -1493,8 +1494,8 @@ msgstr "Розпізнавання у Cockpit налаштовано з поми
 
 #: pkg/lib/machine-dialogs.js:429
 msgid ""
-"Cockpit could not contact the given host $0. Make sure it has ssh running on "
-"port $1, or specify another port in the address."
+"Cockpit could not contact the given host $0. Make sure it has ssh running on"
+" port $1, or specify another port in the address."
 msgstr ""
 "Cockpit не вдалося встановити зв’язок із вказаним вузлом $0. Переконайтеся, "
 "що ssh запущено на порту $1 або вкажіть інший порт у адресі."
@@ -1506,8 +1507,8 @@ msgstr "Cockpit не вдалося встановити зв’язок із в
 #: pkg/shell/base_index.js:765
 msgid ""
 "Cockpit had an unexpected internal error. <br/><br/>You can try restarting "
-"Cockpit by pressing refresh in your browser. The javascript console contains "
-"details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
+"Cockpit by pressing refresh in your browser. The javascript console contains"
+" details about this error (<b>Ctrl-Shift-J</b> in most browsers)."
 msgstr ""
 "У Cockpit сталася неочікувана внутрішня помилка. <br/><br/>Ви можете "
 "спробувати перезапустити Cockpit натисканням кнопки оновлення у вашій "
@@ -1548,8 +1549,8 @@ msgstr "Cockpit у цій системі не встановлено."
 
 #: src/ws/cockpit.appdata.xml.in:18
 msgid ""
-"Cockpit is perfect for new sysadmins, allowing them to easily perform simple "
-"tasks such as storage administration, inspecting journals and starting and "
+"Cockpit is perfect for new sysadmins, allowing them to easily perform simple"
+" tasks such as storage administration, inspecting journals and starting and "
 "stopping services. You can monitor and administer several servers at the "
 "same time. Just add them with a single click and your machines will look "
 "after its buddies."
@@ -1557,9 +1558,9 @@ msgstr ""
 "Cockpit — чудовий інструмент для системних адміністраторів-початківців. За "
 "його допомогою вони без проблем впораються із простими завданнями, зокрема "
 "адмініструванням сховищ даних, інспектуванням журналів та запуском і "
-"зупиненням служб. Ви зможете одночасно стежити за роботою декількох серверів "
-"і адмініструвати ці сервери. Просто додайте їх одним клацанням кнопкою миші "
-"і ваш комп’ютер сам нагляне за своїми приятелями."
+"зупиненням служб. Ви зможете одночасно стежити за роботою декількох серверів"
+" і адмініструвати ці сервери. Просто додайте їх одним клацанням кнопкою миші"
+" і ваш комп’ютер сам нагляне за своїми приятелями."
 
 #: pkg/lib/machine-change-port.html:9
 msgid "Cockpit was unable to contact {{#strong}}{{host}}{{/strong}}."
@@ -1569,8 +1570,8 @@ msgstr ""
 #: pkg/lib/machine-auth-failed.html:15
 msgid ""
 "Cockpit was unable to log in to {{#strong}}{{host}}{{/strong}}. "
-"{{#can_sync}}You may want to try to {{#sync_link}}synchronize users{{/"
-"sync_link}}.{{/can_sync}} For more authentication options and "
+"{{#can_sync}}You may want to try to {{#sync_link}}synchronize "
+"users{{/sync_link}}.{{/can_sync}} For more authentication options and "
 "troubleshooting support please upgrade cockpit-ws to a newer version."
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. "
@@ -1597,8 +1598,9 @@ msgstr ""
 #: pkg/lib/machine-change-auth.html:13
 msgid ""
 "Cockpit was unable to log into {{#strong}}{{host}}{{/strong}}. You can "
-"change your authentication credentials below. {{#can_sync}}You may prefer to "
-"{{#sync_link}}synchronize accounts and passwords{{/sync_link}}.{{/can_sync}}"
+"change your authentication credentials below. {{#can_sync}}You may prefer to"
+" {{#sync_link}}synchronize accounts and "
+"passwords{{/sync_link}}.{{/can_sync}}"
 msgstr ""
 "Cockpit не вдалося увійти до {{#strong}}{{host}}{{/strong}}. Ви можете "
 "змінити ваші реєстраційні дані для розпізнавання нижче. "
@@ -1689,7 +1691,7 @@ msgstr "Умову $0=$1 не виконано"
 msgid "Condition failed"
 msgstr "Не виконано умову"
 
-#: pkg/networkmanager/interfaces.js:2732
+#: pkg/networkmanager/interfaces.js:2707
 msgid "Configure"
 msgstr "Налаштувати"
 
@@ -1720,7 +1722,7 @@ msgstr "Підтвердьте вилучення введенням парол�
 
 #: pkg/machines/components/deleteResource.jsx:103
 msgid "Confirm this action"
-msgstr ""
+msgstr "Підтвердьте цю дію"
 
 #: pkg/systemd/service-details.jsx:428
 msgid "Conflicted By"
@@ -1735,11 +1737,11 @@ msgstr "Конфліктує"
 msgid "Connect"
 msgstr "З'єднатися"
 
-#: pkg/networkmanager/interfaces.js:2719
+#: pkg/networkmanager/interfaces.js:2694
 msgid "Connect automatically"
 msgstr "З’єднуватися автоматично"
 
-#: src/ws/login.html:74
+#: src/ws/login.html:63
 msgid "Connect to"
 msgstr "З’єднатися з"
 
@@ -1953,7 +1955,7 @@ msgstr "Створити"
 msgid "Create Logical Volume"
 msgstr "Створити логічний том"
 
-#: pkg/machines/components/diskAdd.jsx:473
+#: pkg/machines/components/diskAdd.jsx:472
 msgid "Create New"
 msgstr "Створити"
 
@@ -2040,8 +2042,8 @@ msgstr "Створити групу томів"
 msgid "Create diagnostic report"
 msgstr "Створити діагностичний звіт"
 
-#: pkg/networkmanager/interfaces.js:3837 pkg/networkmanager/interfaces.js:4037
-#: pkg/networkmanager/interfaces.js:4292 pkg/networkmanager/interfaces.js:4497
+#: pkg/networkmanager/interfaces.js:3810 pkg/networkmanager/interfaces.js:4010
+#: pkg/networkmanager/interfaces.js:4265 pkg/networkmanager/interfaces.js:4470
 msgid "Create it"
 msgstr "Створити"
 
@@ -2078,7 +2080,7 @@ msgstr "Створюємо розділ $target"
 msgid "Creating snapshot of $target"
 msgstr "Створюємо знімок $target"
 
-#: pkg/networkmanager/interfaces.js:4496
+#: pkg/networkmanager/interfaces.js:4469
 msgid ""
 "Creating this VLAN will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2086,7 +2088,7 @@ msgstr ""
 "Створення цієї VLAN  призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:3836
+#: pkg/networkmanager/interfaces.js:3809
 msgid ""
 "Creating this bond will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2094,7 +2096,7 @@ msgstr ""
 "Створення цього зв’язку призведе до розірвання з’єднання із сервером і "
 "зробить адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:4291
+#: pkg/networkmanager/interfaces.js:4264
 msgid ""
 "Creating this bridge will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2102,7 +2104,7 @@ msgstr ""
 "Створення цього містка призведе до розірвання з’єднання із сервером і "
 "зробить адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:4036
+#: pkg/networkmanager/interfaces.js:4009
 msgid ""
 "Creating this team will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2154,7 +2156,7 @@ msgstr "Нетипові параметри шифрування"
 msgid "Custom mount options"
 msgstr "Нетипові параметри монтування"
 
-#: pkg/networkmanager/firewall.jsx:677
+#: pkg/networkmanager/firewall.jsx:684
 msgid "Custom zones"
 msgstr "Нетипові зони"
 
@@ -2167,19 +2169,19 @@ msgstr "Діапазон DHCP"
 msgid "DISK IS FAILING"
 msgstr "ДИСК НЕПРАЦЕЗДАТНИЙ"
 
-#: pkg/networkmanager/interfaces.js:3326
+#: pkg/networkmanager/interfaces.js:3301
 msgid "DNS"
 msgstr "DNS"
 
-#: pkg/networkmanager/interfaces.js:2663
+#: pkg/networkmanager/interfaces.js:2638
 msgid "DNS $val"
 msgstr "DNS $val"
 
-#: pkg/networkmanager/interfaces.js:3330
+#: pkg/networkmanager/interfaces.js:3305
 msgid "DNS Search Domains"
 msgstr "Домени пошуку DNS"
 
-#: pkg/networkmanager/interfaces.js:2666
+#: pkg/networkmanager/interfaces.js:2641
 msgid "DNS Search Domains $val"
 msgstr "Домени пошуку DNS $val"
 
@@ -2230,8 +2232,6 @@ msgstr "Затримка"
 #: pkg/networkmanager/index.html:436 pkg/users/index.html:79
 #: pkg/users/index.html:357 pkg/docker/containers-view.jsx:202
 #: pkg/docker/details.js:293 pkg/docker/util.js:641
-#: pkg/machines/components/deleteDialog.jsx:145
-#: pkg/machines/components/deleteDialog.jsx:161
 #: pkg/machines/components/deleteResource.jsx:77
 #: pkg/machines/components/deleteResource.jsx:87
 #: pkg/machines/components/deleteResource.jsx:100
@@ -2239,14 +2239,17 @@ msgstr "Затримка"
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:194
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:204
 #: pkg/machines/components/storagePools/storagePoolDelete.jsx:230
-#: pkg/storaged/content-views.jsx:300 pkg/storaged/content-views.jsx:316
-#: pkg/storaged/mdraid-details.jsx:295 pkg/storaged/mdraid-details.jsx:318
-#: pkg/storaged/vdo-details.jsx:203 pkg/storaged/vdo-details.jsx:268
-#: pkg/storaged/vgroup-details.jsx:211 pkg/storaged/vgroup-details.jsx:233
+#: pkg/machines/components/deleteDialog.jsx:145
+#: pkg/machines/components/deleteDialog.jsx:161
+#: pkg/networkmanager/firewall.jsx:766 pkg/storaged/content-views.jsx:300
+#: pkg/storaged/content-views.jsx:316 pkg/storaged/mdraid-details.jsx:295
+#: pkg/storaged/mdraid-details.jsx:318 pkg/storaged/vdo-details.jsx:203
+#: pkg/storaged/vdo-details.jsx:268 pkg/storaged/vgroup-details.jsx:211
+#: pkg/storaged/vgroup-details.jsx:233
 msgid "Delete"
 msgstr "Вилучити"
 
-#: pkg/networkmanager/interfaces.js:2441 pkg/users/local.js:1183
+#: pkg/networkmanager/interfaces.js:2418 pkg/users/local.js:1183
 msgid "Delete $0"
 msgstr "Вилучити $0"
 
@@ -2281,7 +2284,7 @@ msgstr "Вилучити томи у цьому буфері"
 msgid "Deleting $target"
 msgstr "Вилучаємо $target"
 
-#: pkg/networkmanager/interfaces.js:2440
+#: pkg/networkmanager/interfaces.js:2417
 msgid ""
 "Deleting <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -2312,8 +2315,8 @@ msgstr ""
 #: pkg/storaged/content-views.jsx:281
 msgid "Deleting a partition will delete all data in it."
 msgstr ""
-"Вилучення розділу призведе до вилучення усіх даних, що на ньому зберігаються."
-""
+"Вилучення розділу призведе до вилучення усіх даних, що на ньому "
+"зберігаються."
 
 #: pkg/storaged/vgroup-details.jsx:210
 msgid "Deleting a volume group will erase all data on it."
@@ -2333,7 +2336,7 @@ msgstr ""
 msgid "Deleting volume group $target"
 msgstr "Вилучаємо групу томів $target"
 
-#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:686
+#: pkg/systemd/services.html:268 pkg/networkmanager/firewall.jsx:693
 #: pkg/systemd/init.js:301
 msgid "Description"
 msgstr "Опис"
@@ -2405,7 +2408,7 @@ msgstr "Вимкнути багатопотоковість"
 msgid "Disable tuned"
 msgstr "Вимкнути tuned"
 
-#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1971
+#: pkg/systemd/services.html:67 pkg/networkmanager/interfaces.js:1948
 #: pkg/systemd/init.js:219 pkg/systemd/service-details.jsx:333
 msgid "Disabled"
 msgstr "Вимкнено"
@@ -2525,7 +2528,7 @@ msgstr "Готово!"
 msgid "Download"
 msgstr "Отримати"
 
-#: src/ws/login.html:118
+#: src/ws/login.html:105
 msgid "Download a new browser for free"
 msgstr "Отримайте новий браузер безкоштовно"
 
@@ -2699,7 +2702,7 @@ msgstr ""
 "вводити його кожного разу, коли ви повторно встановлюватимете з’єднання із "
 "цією машиною."
 
-#: pkg/networkmanager/firewall.jsx:713
+#: pkg/networkmanager/firewall.jsx:721
 msgid "Entire subnet"
 msgstr "Уся підмережа"
 
@@ -2774,7 +2777,7 @@ msgstr "MAC Ethernet"
 msgid "Ethernet MTU"
 msgstr "MTU Ethernet"
 
-#: pkg/networkmanager/interfaces.js:2017
+#: pkg/networkmanager/interfaces.js:1994
 msgid "Ethtool"
 msgstr "Ethtool"
 
@@ -2834,7 +2837,7 @@ msgstr "Не вдалося додати порт"
 msgid "Failed to add service"
 msgstr "Не вдалося додати службу"
 
-#: pkg/networkmanager/firewall.jsx:638
+#: pkg/networkmanager/firewall.jsx:645
 msgid "Failed to add zone"
 msgstr "Не вдалося додати зону"
 
@@ -2929,11 +2932,11 @@ msgid "Fingerprint"
 msgstr "Відбиток"
 
 #: pkg/networkmanager/firewall.html:22 pkg/networkmanager/index.html:99
-#: pkg/networkmanager/firewall.jsx:874 pkg/networkmanager/firewall.jsx:878
+#: pkg/networkmanager/firewall.jsx:940 pkg/networkmanager/firewall.jsx:944
 msgid "Firewall"
 msgstr "Брандмауер"
 
-#: pkg/networkmanager/firewall.jsx:817
+#: pkg/networkmanager/firewall.jsx:883
 msgid "Firewall is not available"
 msgstr "Брандмауер недоступний"
 
@@ -2999,7 +3002,7 @@ msgstr ""
 msgid "Forward Mode"
 msgstr "Режим переспрямовування"
 
-#: pkg/networkmanager/interfaces.js:2868
+#: pkg/networkmanager/interfaces.js:2843
 msgid "Forward delay $forward_delay"
 msgstr "Затримка переспрямування $forward_delay"
 
@@ -3041,7 +3044,7 @@ msgid "Gateway:"
 msgstr "Шлюз:"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:80
-#: pkg/networkmanager/interfaces.js:2710 pkg/systemd/logs.js:488
+#: pkg/networkmanager/interfaces.js:2685 pkg/systemd/logs.js:488
 msgid "General"
 msgstr "Загальний"
 
@@ -3113,7 +3116,7 @@ msgstr "Збільшити так, щоб використати усе місц
 msgid "Hair Pin mode"
 msgstr "Режим початкової зони"
 
-#: pkg/networkmanager/interfaces.js:2894
+#: pkg/networkmanager/interfaces.js:2869
 msgid "Hairpin mode"
 msgstr "Режим початкової зони (hairpin)"
 
@@ -3133,7 +3136,7 @@ msgstr "Обладнання"
 msgid "Hardware Information"
 msgstr "Дані щодо обладнання"
 
-#: pkg/networkmanager/interfaces.js:2870
+#: pkg/networkmanager/interfaces.js:2845
 msgid "Hello time $hello_time"
 msgstr "Час вітання $hello_time"
 
@@ -3210,7 +3213,7 @@ msgstr "Довжина префікса IP:"
 msgid "IP Settings"
 msgstr "Параметри IP"
 
-#: pkg/networkmanager/interfaces.js:2919
+#: pkg/networkmanager/interfaces.js:2894
 msgid "IPv4"
 msgstr "IPv4"
 
@@ -3226,7 +3229,7 @@ msgstr "Мережа IPv4"
 msgid "IPv4 Network should not be empty"
 msgstr "Мережа IPv4 не повинна бути порожньою"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv4 Settings"
 msgstr "Параметри IPv4"
 
@@ -3238,7 +3241,7 @@ msgstr "IPv4 і IPv6"
 msgid "IPv4 only"
 msgstr "Лише IPv4"
 
-#: pkg/networkmanager/interfaces.js:2920
+#: pkg/networkmanager/interfaces.js:2895
 msgid "IPv6"
 msgstr "IPv6"
 
@@ -3254,7 +3257,7 @@ msgstr "Мережа IPv6"
 msgid "IPv6 Network should not be empty"
 msgstr "Мережа IPv6 не повинна бути порожньою"
 
-#: pkg/networkmanager/interfaces.js:3369
+#: pkg/networkmanager/interfaces.js:3344
 msgid "IPv6 Settings"
 msgstr "Параметри IPv6"
 
@@ -3267,7 +3270,7 @@ msgstr "Лише IPv6"
 msgid "Id"
 msgstr "Ід."
 
-#: pkg/networkmanager/interfaces.js:2911
+#: pkg/networkmanager/interfaces.js:2886
 msgid "Id $id"
 msgstr "Ід. $id"
 
@@ -3279,7 +3282,7 @@ msgstr "Ід.:"
 msgid "If tang-show-keys is not available, run the following:"
 msgstr "Якщо програма tang-show-keys є недоступною, віддайте таку команду:"
 
-#: pkg/networkmanager/interfaces.js:1980 pkg/packagekit/updates.jsx:501
+#: pkg/networkmanager/interfaces.js:1957 pkg/packagekit/updates.jsx:501
 msgid "Ignore"
 msgstr "Ігнорувати"
 
@@ -3334,19 +3337,19 @@ msgid ""
 "In most configurations, macvtap does not work for host to guest network "
 "communication."
 msgstr ""
-"У більшості конфігурацій macvtap не працює для обміну мережею між основною і "
-"гостьовою системами."
+"У більшості конфігурацій macvtap не працює для обміну мережею між основною і"
+" гостьовою системами."
 
 #: pkg/lib/machine-sync-users.html:50
 msgid ""
-"In order to synchronize users, you need to log in to {{#strong}}{{host}}{{/"
-"strong}}."
+"In order to synchronize users, you need to log in to "
+"{{#strong}}{{host}}{{/strong}}."
 msgstr ""
 "Для синхронізації параметрів користувачів, слід увійти до "
 "{{#strong}}{{host}}{{/strong}}. "
 
-#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1421
-#: pkg/networkmanager/interfaces.js:1428 pkg/networkmanager/interfaces.js:2613
+#: pkg/networkmanager/interfaces.js:828 pkg/networkmanager/interfaces.js:1398
+#: pkg/networkmanager/interfaces.js:1405 pkg/networkmanager/interfaces.js:2588
 msgid "Inactive"
 msgstr "Неактивний"
 
@@ -3354,7 +3357,7 @@ msgstr "Неактивний"
 msgid "Inactive volume"
 msgstr "Неактивний том"
 
-#: pkg/networkmanager/firewall.jsx:691
+#: pkg/networkmanager/firewall.jsx:698
 msgid "Included services"
 msgstr "Включені служби"
 
@@ -3415,8 +3418,8 @@ msgstr "Встановити підтримку VDO"
 #: pkg/selinux/setroubleshoot-view.jsx:389
 msgid "Install setroubleshoot-server to troubleshoot SELinux events."
 msgstr ""
-"Встановіть setroubleshoot-server, щоб мати змогу діагностувати причини подій "
-"SELinux."
+"Встановіть setroubleshoot-server, щоб мати змогу діагностувати причини подій"
+" SELinux."
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:303
 msgid "Installation Source"
@@ -3456,8 +3459,8 @@ msgid "Interface Type"
 msgstr "Тип інтерфейсу"
 
 #: pkg/networkmanager/index.html:110 pkg/networkmanager/index.html:269
-#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:696
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/firewall.jsx:160 pkg/networkmanager/firewall.jsx:704
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Interfaces"
 msgstr "Інтерфейси"
 
@@ -3718,8 +3721,8 @@ msgstr ""
 msgid ""
 "Leave blank to connect to this machine as the currently logged in "
 "user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a "
-"different username, that user will always be used connecting to this machine."
-""
+"different username, that user will always be used connecting to this "
+"machine."
 msgstr ""
 "Не заповнюйте, щоб встановити з’єднання із цією машиною від імені поточного "
 "користувача системи{{#default_user}} ({{default_user}}){{/default_user}}. "
@@ -3746,7 +3749,7 @@ msgstr "Спостереження за посиланнями"
 msgid "Link down delay"
 msgstr "Затримка розірвання зв’язку"
 
-#: pkg/networkmanager/interfaces.js:1968 pkg/networkmanager/interfaces.js:1978
+#: pkg/networkmanager/interfaces.js:1945 pkg/networkmanager/interfaces.js:1955
 msgid "Link local"
 msgstr "Пов’язати локальний"
 
@@ -3766,7 +3769,7 @@ msgstr "Посилання"
 msgid "Links:"
 msgstr "Посилання:"
 
-#: pkg/networkmanager/interfaces.js:2004
+#: pkg/networkmanager/interfaces.js:1981
 msgid "Load Balancing"
 msgstr "Збалансовування навантаження"
 
@@ -3776,7 +3779,7 @@ msgstr "Завантажити попередні записи"
 
 #: pkg/machines/components/libvirtSlate.jsx:81
 msgid "Loading Resources"
-msgstr ""
+msgstr "Завантаження ресурсів"
 
 #: pkg/packagekit/updates.jsx:47
 msgid "Loading available updates failed"
@@ -3837,7 +3840,8 @@ msgstr "Заблокувати обліковий запис $0"
 msgid "Locking $target"
 msgstr "Блокуємо $target"
 
-#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:85 src/ws/login.js:490
+#: pkg/lib/machine-change-auth.html:81 src/ws/login.html:73
+#: src/ws/login.js:490
 msgid "Log In"
 msgstr "Увійти"
 
@@ -3930,7 +3934,8 @@ msgstr "Пусковий комп'ютер"
 msgid "MAC"
 msgstr "MAC"
 
-#: pkg/machines/components/nicAdd.jsx:40 pkg/machines/components/nicEdit.jsx:43
+#: pkg/machines/components/nicAdd.jsx:40
+#: pkg/machines/components/nicEdit.jsx:43
 #: pkg/machines/components/vmnetworktab.jsx:138
 msgid "MAC Address"
 msgstr "MAC-адреса"
@@ -3939,15 +3944,15 @@ msgstr "MAC-адреса"
 msgid "MAC Address:"
 msgstr "MAC-адреса:"
 
-#: pkg/networkmanager/interfaces.js:1996
+#: pkg/networkmanager/interfaces.js:1973
 msgid "MII (Recommended)"
 msgstr "MII (рекомендоване)"
 
-#: pkg/networkmanager/interfaces.js:2768
+#: pkg/networkmanager/interfaces.js:2743
 msgid "MTU"
 msgstr "MTU"
 
-#: pkg/networkmanager/interfaces.js:4562
+#: pkg/networkmanager/interfaces.js:4535
 msgid "MTU must be a positive number"
 msgstr "MTU має бути додатнім числом"
 
@@ -3971,7 +3976,7 @@ msgstr "Апаратний блок основного сервера"
 msgid "Make sure the key hash from the Tang server matches:"
 msgstr "Переконайтеся, що хеш ключа з сервера Tang є таким:"
 
-#: pkg/networkmanager/interfaces.js:1969 pkg/networkmanager/interfaces.js:1979
+#: pkg/networkmanager/interfaces.js:1946 pkg/networkmanager/interfaces.js:1956
 msgid "Manual"
 msgstr "Вручну"
 
@@ -4013,11 +4018,11 @@ msgid ""
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""
-"Маскування служби забороняє запуск усіх залежних модулів. Це може спричинити "
-"значніші наслідки, ніж ви очікуєте. Будь ласка, підтвердьте, що ви хочете "
+"Маскування служби забороняє запуск усіх залежних модулів. Це може спричинити"
+" значніші наслідки, ніж ви очікуєте. Будь ласка, підтвердьте, що ви хочете "
 "замаскувати цей модуль."
 
-#: pkg/networkmanager/interfaces.js:2774
+#: pkg/networkmanager/interfaces.js:2749
 msgid "Master"
 msgstr "Основний"
 
@@ -4033,7 +4038,7 @@ msgstr "Максимальна одиниця передавання"
 msgid "Maximum memory could not be saved"
 msgstr "Не вдалося зберегти дані щодо максимального обсягу пам'яті"
 
-#: pkg/networkmanager/interfaces.js:2872
+#: pkg/networkmanager/interfaces.js:2847
 msgid "Maximum message age $max_age"
 msgstr "Максимальний вік повідомлення $max_age"
 
@@ -4257,7 +4262,7 @@ msgstr "Не встановлено підтримки NFS"
 msgid "NIC $0 of VM $1 failed to change state"
 msgstr "NIC $0 ВМ $1, не вдалося змінити стан"
 
-#: pkg/networkmanager/interfaces.js:2019
+#: pkg/networkmanager/interfaces.js:1996
 msgid "NSNA Ping"
 msgstr "Луна-імпульс NSNA"
 
@@ -4401,11 +4406,11 @@ msgid "NetworkManager is not running."
 msgstr "NetworkManager не запущено."
 
 #: pkg/networkmanager/index.html:23 pkg/networkmanager/index.html:388
-#: pkg/networkmanager/firewall.jsx:873 pkg/networkmanager/manifest.json.in
+#: pkg/networkmanager/firewall.jsx:939 pkg/networkmanager/manifest.json.in
 msgid "Networking"
 msgstr "Робота у мережі"
 
-#: pkg/networkmanager/interfaces.js:1635 pkg/networkmanager/interfaces.js:2218
+#: pkg/networkmanager/interfaces.js:1612 pkg/networkmanager/interfaces.js:2195
 msgctxt "page-title"
 msgid "Networking"
 msgstr "Робота у мережі"
@@ -4464,7 +4469,7 @@ msgid "Nice"
 msgstr "Пріоритетність"
 
 #: pkg/docker/index.html:544 pkg/docker/index.html:548 pkg/docker/run.js:239
-#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2601
+#: pkg/docker/util.js:103 pkg/networkmanager/interfaces.js:2576
 msgid "No"
 msgstr "Ні"
 
@@ -4545,7 +4550,7 @@ msgstr "Немає доступних слотів"
 msgid "No boot device found"
 msgstr "Не знайдено пристрою для завантаження"
 
-#: pkg/networkmanager/interfaces.js:1423
+#: pkg/networkmanager/interfaces.js:1400
 msgid "No carrier"
 msgstr "Немає сигналу"
 
@@ -4569,7 +4574,7 @@ msgstr "Немає контейнерів"
 msgid "No containers that match the current filter"
 msgstr "Немає контейнерів, які проходять поточні умови фільтрування"
 
-#: pkg/networkmanager/firewall.jsx:688
+#: pkg/networkmanager/firewall.jsx:695
 msgid "No description available"
 msgstr "Немає опису"
 
@@ -4703,7 +4708,7 @@ msgstr "Груп томів не створено"
 
 #: pkg/kdump/kdump-view.jsx:422
 #: pkg/machines/components/networks/createNetworkDialog.jsx:190
-#: pkg/networkmanager/firewall.jsx:693 pkg/tuned/dialog.js:232
+#: pkg/networkmanager/firewall.jsx:700 pkg/tuned/dialog.js:232
 msgid "None"
 msgstr "Немає"
 
@@ -4820,8 +4825,8 @@ msgstr[2] "Якщо помилка, повторити $0 разів"
 
 #: src/ws/cockpit.appdata.xml.in:26
 msgid ""
-"Once Cockpit is installed, enable it with \"systemctl enable --now cockpit."
-"socket\"."
+"Once Cockpit is installed, enable it with \"systemctl enable --now "
+"cockpit.socket\"."
 msgstr ""
 "Після встановлення Cockpit його можна увімкнути за допомогою команди "
 "«systemctl enable --now cockpit.socket»."
@@ -4835,8 +4840,8 @@ msgid ""
 "One or more selected volumes are used by domains. Detach the disks first to "
 "allow volume deletion."
 msgstr ""
-"Один або декілька позначених томів використовуються доменами. Щоб уможливити "
-"вилучення цих томів, спочатку від'єднайте диски."
+"Один або декілька позначених томів використовуються доменами. Щоб уможливити"
+" вилучення цих томів, спочатку від'єднайте диски."
 
 #: pkg/storaged/vdo-details.jsx:134
 msgid "Only $0 of $1 are used."
@@ -4885,7 +4890,7 @@ msgstr "Пристрій читання оптичних дисків"
 msgid "Options"
 msgstr "Параметри"
 
-#: src/ws/login.html:125
+#: src/ws/login.html:112
 msgid "Or use a bundled browser"
 msgstr "Або скористайтеся комплектним браузером"
 
@@ -4902,7 +4907,7 @@ msgstr "Інші дані"
 msgid "Other Devices"
 msgstr "Інші пристрої"
 
-#: src/ws/login.html:69
+#: src/ws/login.html:59
 msgid "Other Options"
 msgstr "Інші параметри"
 
@@ -4940,7 +4945,7 @@ msgstr "PackageKit повідомлено про помилку із кодом 
 msgid "Parent"
 msgstr "Батьківський"
 
-#: pkg/networkmanager/interfaces.js:2910
+#: pkg/networkmanager/interfaces.js:2885
 msgid "Parent $parent"
 msgstr "Батьківський $parent"
 
@@ -4948,7 +4953,7 @@ msgstr "Батьківський $parent"
 msgid "Part Of"
 msgstr "Частина"
 
-#: pkg/networkmanager/interfaces.js:1469
+#: pkg/networkmanager/interfaces.js:1446
 msgid "Part of "
 msgstr "Є частиною "
 
@@ -4964,7 +4969,7 @@ msgstr "Розділ $0"
 msgid "Partitioning"
 msgstr "Розподіл"
 
-#: pkg/networkmanager/interfaces.js:2011
+#: pkg/networkmanager/interfaces.js:1988
 msgid "Passive"
 msgstr "Неактивний"
 
@@ -4991,7 +4996,7 @@ msgstr "Паролі не збігаються"
 #: pkg/lib/machine-auth-failed.html:8 pkg/lib/machine-change-auth.html:52
 #: pkg/lib/machine-sync-users.html:61 pkg/shell/index.html:204
 #: pkg/shell/index.html:232 pkg/shell/index.html:245 pkg/users/index.html:118
-#: pkg/users/index.html:173 src/ws/login.html:50
+#: pkg/users/index.html:173 src/ws/login.html:44
 #: pkg/storaged/iscsi-panel.jsx:47 pkg/storaged/iscsi-panel.jsx:157
 msgid "Password"
 msgstr "Пароль"
@@ -5031,8 +5036,9 @@ msgstr "Вставити"
 msgid "Paste the contents of your public SSH key file here"
 msgstr "Сюди слід вставити вміст файла вашого відкритого ключа SSH"
 
+#: pkg/machines/components/diskEdit.jsx:36
 #: pkg/machines/components/deleteDialog.jsx:45
-#: pkg/machines/components/diskEdit.jsx:36 pkg/systemd/service-details.jsx:483
+#: pkg/systemd/service-details.jsx:483
 msgid "Path"
 msgstr "Шлях"
 
@@ -5040,7 +5046,7 @@ msgstr "Шлях"
 msgid "Path cost"
 msgstr "Вартість маршруту"
 
-#: pkg/networkmanager/interfaces.js:2892
+#: pkg/networkmanager/interfaces.js:2867
 msgid "Path cost $path_cost"
 msgstr "Вартість шляху $path_cost"
 
@@ -5084,7 +5090,7 @@ msgstr "Профіль швидкодії"
 msgid "Peripheral Chassis"
 msgstr "Периферійний апаратний блок"
 
-#: pkg/networkmanager/interfaces.js:3644
+#: pkg/networkmanager/interfaces.js:3619
 msgid "Permanent"
 msgstr "Постійний"
 
@@ -5169,7 +5175,7 @@ msgstr "Будь ласка, введіть назву нового тому"
 msgid "Please enter new volume size"
 msgstr "Будь ласка, введіть розмір нового тому"
 
-#: pkg/networkmanager/firewall.jsx:818
+#: pkg/networkmanager/firewall.jsx:884
 msgid "Please install the $0 package"
 msgstr "Будь ласка, встановіть пакунок $0"
 
@@ -5194,10 +5200,10 @@ msgstr "Будь ласка, спробуйте інший ключ"
 msgid "Plug"
 msgstr "З'єднати"
 
-#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/machines/components/diskAdd.jsx:128
 #: pkg/machines/components/vm/bootOrderModal.jsx:95
 #: pkg/machines/components/vmDiskColumns.jsx:45
+#: pkg/machines/components/deleteDialog.jsx:53
 #: pkg/storaged/content-views.jsx:137
 msgid "Pool"
 msgstr "Буфер"
@@ -5242,7 +5248,7 @@ msgstr "Портативний"
 
 #: pkg/docker/index.html:506 pkg/networkmanager/index.html:216
 #: pkg/networkmanager/index.html:326 pkg/docker/containers-view.jsx:414
-#: pkg/networkmanager/interfaces.js:2993
+#: pkg/networkmanager/interfaces.js:2968
 msgid "Ports"
 msgstr "Порти"
 
@@ -5270,11 +5276,11 @@ msgstr "Довжина префікса"
 msgid "Prefix Length should not be empty"
 msgstr "Довжина префікса повинна бути непорожньою"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length"
 msgstr "Довжина префікса"
 
-#: pkg/networkmanager/interfaces.js:3316
+#: pkg/networkmanager/interfaces.js:3291
 msgid "Prefix length or Netmask"
 msgstr "Довжина префікса або маска мережі"
 
@@ -5286,7 +5292,7 @@ msgstr "Приготування"
 msgid "Present"
 msgstr "Поточна"
 
-#: pkg/networkmanager/interfaces.js:3645
+#: pkg/networkmanager/interfaces.js:3620
 msgid "Preserve"
 msgstr "Зберегти"
 
@@ -5307,7 +5313,7 @@ msgstr "Основний"
 msgid "Priority"
 msgstr "Пріоритетність"
 
-#: pkg/networkmanager/interfaces.js:2866 pkg/networkmanager/interfaces.js:2890
+#: pkg/networkmanager/interfaces.js:2841 pkg/networkmanager/interfaces.js:2865
 msgid "Priority $priority"
 msgstr "Пріоритетність $priority"
 
@@ -5454,11 +5460,11 @@ msgstr "Елемент RAID"
 msgid "Rack Mount Chassis"
 msgstr "Апаратний блок монтування стійок"
 
-#: pkg/networkmanager/interfaces.js:3646
+#: pkg/networkmanager/interfaces.js:3621
 msgid "Random"
 msgstr "Випадковий"
 
-#: pkg/networkmanager/firewall.jsx:718
+#: pkg/networkmanager/firewall.jsx:726
 msgid "Range"
 msgstr "Діапазон"
 
@@ -5615,9 +5621,13 @@ msgstr "Вилучення:"
 msgid "Remove"
 msgstr "Вилучити"
 
-#: pkg/networkmanager/interfaces.js:3063
+#: pkg/networkmanager/interfaces.js:3038
 msgid "Remove $0"
 msgstr "Вилучити $0"
+
+#: pkg/networkmanager/firewall.jsx:834
+msgid "Remove $0 service from $1 zone"
+msgstr ""
 
 #: pkg/storaged/crypto-keyslots.jsx:423
 msgid "Remove $0?"
@@ -5639,6 +5649,10 @@ msgstr "Вилучити пароль"
 msgid "Remove passphrase in $0?"
 msgstr "Вилучити пароль у $0?"
 
+#: pkg/networkmanager/firewall.jsx:818
+msgid "Remove zone $0"
+msgstr ""
+
 #: pkg/apps/application-list.jsx:51 pkg/apps/application.jsx:59
 msgid "Removing"
 msgstr "Вилучаємо"
@@ -5651,7 +5665,7 @@ msgstr "Вилучаємо $0"
 msgid "Removing $target from RAID Device"
 msgstr "Вилучаємо $target з пристрою RAID"
 
-#: pkg/networkmanager/interfaces.js:3062
+#: pkg/networkmanager/interfaces.js:3037
 msgid ""
 "Removing <b>$0</b> will break the connection to the server, and will make "
 "the administration UI unavailable."
@@ -5662,6 +5676,17 @@ msgstr ""
 #: pkg/storaged/jobs-panel.jsx:74
 msgid "Removing physical volume from $target"
 msgstr "Вилучаємо фізичний том з $target"
+
+#: pkg/networkmanager/firewall.jsx:832
+msgid ""
+"Removing the cockpit service might result in the web console becoming "
+"unreachable. Make sure that this zone does not apply to your current web "
+"console connection."
+msgstr ""
+
+#: pkg/networkmanager/firewall.jsx:816
+msgid "Removing the zone will remove all services within it."
+msgstr ""
 
 #: pkg/storaged/lvol-tabs.jsx:38 pkg/storaged/vgroup-details.jsx:182
 #: pkg/storaged/vgroup-details.jsx:231
@@ -5790,8 +5815,8 @@ msgstr "Зміна розміру $target"
 
 #: pkg/storaged/lvol-tabs.jsx:228 pkg/storaged/lvol-tabs.jsx:313
 msgid ""
-"Resizing an encrypted filesystem requires unlocking the disk. Please provide "
-"a current disk passphrase."
+"Resizing an encrypted filesystem requires unlocking the disk. Please provide"
+" a current disk passphrase."
 msgstr ""
 "Зміна розмірів зашифрованої системи потребує розблокування диска. Будь "
 "ласка, вкажіть поточний пароль до диска."
@@ -5836,7 +5861,7 @@ msgstr "Відновити"
 msgid "Retries:"
 msgstr "Кількість спроб:"
 
-#: src/ws/login.html:57
+#: src/ws/login.html:48
 msgid "Reuse my password for privileged tasks"
 msgstr "Повторно використати ваш пароль для привілейованих завдань"
 
@@ -5851,7 +5876,7 @@ msgstr ""
 msgid "Roles"
 msgstr "Ролі"
 
-#: pkg/networkmanager/interfaces.js:1985 pkg/networkmanager/interfaces.js:2002
+#: pkg/networkmanager/interfaces.js:1962 pkg/networkmanager/interfaces.js:1979
 msgid "Round Robin"
 msgstr "Циклічне"
 
@@ -5863,7 +5888,7 @@ msgstr "Маршрут до $0"
 msgid "Routed Network"
 msgstr "Маршрутизована мережа"
 
-#: pkg/networkmanager/interfaces.js:3335
+#: pkg/networkmanager/interfaces.js:3310
 msgid "Routes"
 msgstr "Маршрути"
 
@@ -5955,8 +5980,8 @@ msgstr "Пріоритет STP"
 
 #: pkg/shell/index.html:407
 msgid ""
-"Safari users need to import and trust the certificate of the self-signing CA:"
-""
+"Safari users need to import and trust the certificate of the self-signing "
+"CA:"
 msgstr ""
 "Користувачам Safari слід імпортувати сертифікат самопідписаного CA і "
 "встановити довіру до нього:"
@@ -6003,7 +6028,7 @@ msgstr "ПК з опломбованим корпусом"
 
 #: pkg/shell/index.html:363
 msgid "Search"
-msgstr ""
+msgstr "Пошук"
 
 #: pkg/systemd/services.html:314 pkg/systemd/services.html:318
 #: pkg/systemd/init.js:967
@@ -6056,7 +6081,7 @@ msgstr "Надсилання"
 msgid "Serial Console"
 msgstr "Послідовна консоль"
 
-#: src/ws/login.html:94 pkg/kdump/kdump-view.jsx:116
+#: src/ws/login.html:81 pkg/kdump/kdump-view.jsx:116
 #: pkg/storaged/nfs-details.jsx:322 pkg/storaged/nfs-panel.jsx:95
 msgid "Server"
 msgstr "Сервер"
@@ -6191,7 +6216,7 @@ msgstr "Важливість"
 msgid "Severity:"
 msgstr "Критичність:"
 
-#: pkg/networkmanager/interfaces.js:1970
+#: pkg/networkmanager/interfaces.js:1947
 msgid "Shared"
 msgstr "Спільний"
 
@@ -6331,11 +6356,11 @@ msgstr ""
 "Програмою для керування пакунків користується якась інша програма, будь "
 "ласка, зачекайте…"
 
-#: pkg/networkmanager/firewall.jsx:668
+#: pkg/networkmanager/firewall.jsx:675
 msgid "Sorted from least trusted to most trusted"
 msgstr "Упорядковано від найменшої до найбільшої довіри"
 
-#: pkg/machines/components/diskAdd.jsx:462
+#: pkg/machines/components/diskAdd.jsx:461
 #: pkg/machines/components/nicBody.jsx:149
 #: pkg/machines/components/storagePools/storagePoolOverviewTab.jsx:52
 #: pkg/machines/components/vmDisksTab.jsx:117
@@ -6371,7 +6396,7 @@ msgstr "Адреса джерела має починатися із назви 
 msgid "Space-saving Computer"
 msgstr "Компактний комп'ютер"
 
-#: pkg/networkmanager/interfaces.js:2864
+#: pkg/networkmanager/interfaces.js:2839
 msgid "Spanning Tree Protocol"
 msgstr "Протокол пересування ієрархією"
 
@@ -6391,7 +6416,7 @@ msgstr "У визначений час"
 msgid "Speed"
 msgstr "Швидкість"
 
-#: pkg/networkmanager/interfaces.js:3647
+#: pkg/networkmanager/interfaces.js:3622
 msgid "Stable"
 msgstr "Стабільний"
 
@@ -6446,8 +6471,9 @@ msgstr "Запуск"
 #: pkg/docker/containers-view.jsx:133 pkg/docker/containers-view.jsx:359
 #: pkg/machines/components/networks/networkList.jsx:55
 #: pkg/machines/components/storagePools/storagePoolList.jsx:54
-#: pkg/machines/components/vmnetworktab.jsx:183 pkg/machines/hostvmslist.jsx:83
-#: pkg/systemd/hwinfo.jsx:269 pkg/systemd/init.js:306
+#: pkg/machines/components/vmnetworktab.jsx:183
+#: pkg/machines/hostvmslist.jsx:83 pkg/systemd/hwinfo.jsx:269
+#: pkg/systemd/init.js:306
 msgid "State"
 msgstr "Стан"
 
@@ -6460,7 +6486,7 @@ msgstr "Стан:"
 msgid "Static"
 msgstr "Статичний"
 
-#: pkg/networkmanager/interfaces.js:2620 pkg/systemd/service-details.jsx:478
+#: pkg/networkmanager/interfaces.js:2595 pkg/systemd/service-details.jsx:478
 msgid "Status"
 msgstr "Стан"
 
@@ -6622,15 +6648,15 @@ msgstr "Резервна пам’ять"
 msgid "Swap Used"
 msgstr "Використано резерву"
 
-#: pkg/networkmanager/interfaces.js:2498 pkg/networkmanager/interfaces.js:3047
+#: pkg/networkmanager/interfaces.js:2475 pkg/networkmanager/interfaces.js:3022
 msgid "Switch off $0"
 msgstr "Вимкнути $0"
 
-#: pkg/networkmanager/interfaces.js:2473 pkg/networkmanager/interfaces.js:3035
+#: pkg/networkmanager/interfaces.js:2450 pkg/networkmanager/interfaces.js:3010
 msgid "Switch on $0"
 msgstr "Увімкнути $0"
 
-#: pkg/networkmanager/interfaces.js:2497
+#: pkg/networkmanager/interfaces.js:2474
 msgid ""
 "Switching off <b>$0</b>  will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6638,7 +6664,7 @@ msgstr ""
 "Вимикання <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:3046
+#: pkg/networkmanager/interfaces.js:3021
 msgid ""
 "Switching off <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6646,7 +6672,7 @@ msgstr ""
 "Вимикання <b>$0</b> призведе до розірвання з’єднання із сервером і зробить "
 "адміністративний інтерфейс користувача недоступним."
 
-#: pkg/networkmanager/interfaces.js:2472 pkg/networkmanager/interfaces.js:3034
+#: pkg/networkmanager/interfaces.js:2449 pkg/networkmanager/interfaces.js:3009
 msgid ""
 "Switching on <b>$0</b> will break the connection to the server, and will "
 "make the administration UI unavailable."
@@ -6747,12 +6773,12 @@ msgstr "Шлях призначення не може бути порожнім"
 msgid "Targets"
 msgstr "Призначення"
 
-#: pkg/networkmanager/interfaces.js:2518 pkg/networkmanager/interfaces.js:2530
-#: pkg/networkmanager/interfaces.js:2821
+#: pkg/networkmanager/interfaces.js:2495 pkg/networkmanager/interfaces.js:2507
+#: pkg/networkmanager/interfaces.js:2796
 msgid "Team"
 msgstr "Команда"
 
-#: pkg/networkmanager/interfaces.js:2849
+#: pkg/networkmanager/interfaces.js:2824
 msgid "Team Port"
 msgstr "Порт команди"
 
@@ -6790,7 +6816,7 @@ msgstr "Перевіряємо з’єднання"
 
 #: pkg/machines/components/deleteResource.jsx:46
 msgid "The $0 could not be deleted"
-msgstr ""
+msgstr "Не вдалося вилучити $0"
 
 #: pkg/docker/storage.jsx:523
 msgid "The Docker storage pool cannot be managed on this system."
@@ -6855,13 +6881,15 @@ msgstr "Віртуальна машина працює."
 #: pkg/machines/components/vm/stateIcon.jsx:47
 msgid "The VM is suspended by guest power management."
 msgstr ""
-"Роботу віртуальної машини призупинено засобами керування живленням гостьової "
-"системи."
+"Роботу віртуальної машини призупинено засобами керування живленням гостьової"
+" системи."
 
 #: pkg/machines/components/vmDisksTab.jsx:176
 #: pkg/machines/components/vmnetworktab.jsx:207
 msgid "The VM needs to be running or shut off to detach this device"
 msgstr ""
+"Віртуальну машину має бути запущено або вимкнено, щоб можна було від'єднати "
+"цей пристрій"
 
 #: pkg/users/local.js:1342
 msgid "The account '$0' will be forced to change their password on next login"
@@ -6870,11 +6898,15 @@ msgstr ""
 
 #: pkg/lib/machine-unknown-hostkey.html:6
 msgid ""
-"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be established."
-" Are you sure you want to continue connecting?"
+"The authenticity of host {{#strong}}{{host}}{{/strong}} can't be "
+"established. Are you sure you want to continue connecting?"
 msgstr ""
 "Не вдалося встановити ідентичність вузла {{#strong}}{{host}}{{/strong}}. Ви "
 "справді хочете продовжити спробу встановити з’єднання?"
+
+#: pkg/networkmanager/firewall.jsx:701
+msgid "The cockpit service is automatically included"
+msgstr ""
 
 #: pkg/sosreport/index.html:35
 msgid "The collected information will be stored locally on the system."
@@ -6908,8 +6940,8 @@ msgid ""
 "The filesystem is in use by login sessions and system services. Proceeding "
 "will stop these."
 msgstr ""
-"Файлова система використовується службами системи або сеансами користувачів. "
-"Виконання цієї дії призведе до припинення роботи цих служб та сеансів."
+"Файлова система використовується службами системи або сеансами користувачів."
+" Виконання цієї дії призведе до припинення роботи цих служб та сеансів."
 
 #: pkg/storaged/dialog.jsx:997
 msgid ""
@@ -6945,12 +6977,12 @@ msgstr ""
 #: pkg/lib/machine-invalid-hostkey.html:8
 msgid ""
 "The key of {{#strong}}{{host}}{{/strong}} does not match the key previously "
-"in use. Unless this machine was recently replaced, it is likely that someone "
-"is trying to attack your connection to this machine."
+"in use. Unless this machine was recently replaced, it is likely that someone"
+" is trying to attack your connection to this machine."
 msgstr ""
-"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному ключу."
-" Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є спроба "
-"атаки на ваше з’єднання із цим комп’ютером."
+"Ключ {{#strong}}{{host}}{{/strong}} не відповідає раніше використаному "
+"ключу. Якщо нещодавно ніхто не міняв цього комп’ютера, ймовірною причиною є "
+"спроба атаки на ваше з’єднання із цим комп’ютером."
 
 #: pkg/users/authorized-keys.js:124
 msgid "The key you provided was not valid."
@@ -7073,7 +7105,7 @@ msgstr "Користувачу <b>$0</b> заборонено змінювати
 msgid "The user <b>$0</b> is not permitted to modify hostnames"
 msgstr "Користувачу <b>$0</b> не дозволено змінювати назви вузлів"
 
-#: pkg/networkmanager/interfaces.js:1520
+#: pkg/networkmanager/interfaces.js:1497
 msgid "The user <b>$0</b> is not permitted to modify network settings"
 msgstr "Користувачу <b>$0</b> заборонено змінювати параметри роботи мережі"
 
@@ -7088,11 +7120,11 @@ msgstr ""
 
 #: pkg/users/local.js:553
 msgid ""
-"The user name can only consist of letters from a-z, digits, dots, dashes and "
-"underscores."
+"The user name can only consist of letters from a-z, digits, dots, dashes and"
+" underscores."
 msgstr ""
-"Ім’я користувача може складатися лише із літер a-z, цифр, крапок, дефісів та "
-"символів підкреслювання."
+"Ім’я користувача може складатися лише із літер a-z, цифр, крапок, дефісів та"
+" символів підкреслювання."
 
 #: src/ws/login.js:134 src/ws/login.js:157
 msgid ""
@@ -7151,13 +7183,13 @@ msgstr "Цей пристрій VDO не використовує увесь о�
 
 #: pkg/systemd/init.js:1262
 msgid ""
-"This day doesn't exist in all months.<br> The timer will only be executed in "
-"months that have 31st."
+"This day doesn't exist in all months.<br> The timer will only be executed in"
+" months that have 31st."
 msgstr ""
 "Цей день є не в усіх місяцях.<br> Таймер виконуватиметься лише у місяці, у "
 "яких є 31 день."
 
-#: pkg/networkmanager/interfaces.js:2631
+#: pkg/networkmanager/interfaces.js:2606
 msgid "This device cannot be managed here."
 msgstr "Тут не можна керувати цим пристроєм."
 
@@ -7299,8 +7331,8 @@ msgstr "Цю вебконсоль буде оновлено."
 
 #: pkg/kdump/kdump-view.jsx:296
 msgid ""
-"This will test kdump settings by crashing the kernel and thereby the system. "
-"Depending on the settings, the system may not automatically reboot and the "
+"This will test kdump settings by crashing the kernel and thereby the system."
+" Depending on the settings, the system may not automatically reboot and the "
 "process may take a while."
 msgstr ""
 "Виконати тестування параметрів kdump, аварійно завершивши роботу ядра, а "
@@ -7310,6 +7342,12 @@ msgstr ""
 #: pkg/kdump/kdump-view.jsx:492
 msgid "This will test the kdump configuration by crashing the kernel."
 msgstr "Перевіряє налаштування kdump, аварійно завершуючи роботу ядра."
+
+#: pkg/networkmanager/firewall.jsx:814
+msgid ""
+"This zone contains the cockpit service. Make sure that this zone does not "
+"apply to your current web console connection."
+msgstr ""
 
 #: pkg/machines/components/vcpuModal.jsx:237
 msgid "Threads per core"
@@ -7387,11 +7425,11 @@ msgstr "Діагностика проблем"
 msgid "Trust key"
 msgstr "Довіряти ключу"
 
-#: pkg/networkmanager/firewall.jsx:664
+#: pkg/networkmanager/firewall.jsx:671
 msgid "Trust level"
 msgstr "Рівень довіри"
 
-#: src/ws/login.html:111
+#: src/ws/login.html:98
 msgid "Try Again"
 msgstr "Спробувати ще раз"
 
@@ -7545,12 +7583,12 @@ msgstr "Модуль"
 #: pkg/lib/machine-info.js:65 pkg/lib/machine-info.js:238
 #: pkg/machines/components/vmnetworktab.jsx:146
 #: pkg/networkmanager/interfaces.js:595 pkg/networkmanager/interfaces.js:1071
-#: pkg/networkmanager/interfaces.js:2538 pkg/networkmanager/interfaces.js:2540
+#: pkg/networkmanager/interfaces.js:2515 pkg/networkmanager/interfaces.js:2517
 #: pkg/storaged/fsys-tab.jsx:64 pkg/storaged/swap-tab.jsx:57
 msgid "Unknown"
 msgstr "Невідомий"
 
-#: pkg/networkmanager/interfaces.js:2524 pkg/networkmanager/interfaces.js:2536
+#: pkg/networkmanager/interfaces.js:2501 pkg/networkmanager/interfaces.js:2513
 msgid "Unknown \"$0\""
 msgstr "Невідомий «$0»"
 
@@ -7566,7 +7604,7 @@ msgstr "Невідома програма"
 msgid "Unknown Host Key"
 msgstr "Невідомий ключ вузла"
 
-#: pkg/networkmanager/interfaces.js:2647
+#: pkg/networkmanager/interfaces.js:2622
 msgid "Unknown configuration"
 msgstr "Невідомі налаштування"
 
@@ -7720,7 +7758,7 @@ msgstr[2] "Використання $0 ядер процесора"
 msgid "Use 512 Byte emulation"
 msgstr "Емуляція 512 байтів"
 
-#: pkg/machines/components/diskAdd.jsx:482
+#: pkg/machines/components/diskAdd.jsx:481
 msgid "Use Existing"
 msgstr "Використати наявний"
 
@@ -7760,7 +7798,7 @@ msgid "User Password"
 msgstr "Пароль користувача"
 
 #: pkg/lib/machine-change-auth.html:18 pkg/lib/machine-sync-users.html:54
-#: src/ws/login.html:43
+#: src/ws/login.html:39
 msgid "User name"
 msgstr "Ім'я користувача"
 
@@ -7809,8 +7847,8 @@ msgstr "Пристрої резервного копіювання VDO не мо
 msgid "VDO support not installed"
 msgstr "Підтримку VDO не встановлено"
 
-#: pkg/networkmanager/interfaces.js:2520 pkg/networkmanager/interfaces.js:2532
-#: pkg/networkmanager/interfaces.js:2913
+#: pkg/networkmanager/interfaces.js:2497 pkg/networkmanager/interfaces.js:2509
+#: pkg/networkmanager/interfaces.js:2888
 msgid "VLAN"
 msgstr "VLAN"
 
@@ -7882,7 +7920,7 @@ msgstr "Порт TLS VNC:"
 msgid "Validating address"
 msgstr "Перевіряємо чинність адреси"
 
-#: src/ws/login.html:101
+#: src/ws/login.html:88
 msgid "Validating authentication token"
 msgstr "Перевіряємо ключ розпізнавання"
 
@@ -7891,7 +7929,8 @@ msgid "Validating key"
 msgstr "Перевірка ключа"
 
 #: pkg/machines/components/vm/bootOrderModal.jsx:120
-#: pkg/machines/components/vm/bootOrderModal.jsx:126 pkg/systemd/hwinfo.jsx:257
+#: pkg/machines/components/vm/bootOrderModal.jsx:126
+#: pkg/systemd/hwinfo.jsx:257
 msgid "Vendor"
 msgstr "Постачальник"
 
@@ -7943,10 +7982,10 @@ msgid "Virtualization Service is Available"
 msgstr "Доступна служба віртуалізації"
 
 #: pkg/machines/components/create-vm-dialog/createVmDialog.jsx:469
-#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/machines/components/diskAdd.jsx:91
 #: pkg/machines/components/vm/bootOrderModal.jsx:96
 #: pkg/machines/components/vmDiskColumns.jsx:46
+#: pkg/machines/components/deleteDialog.jsx:50
 #: pkg/storaged/content-views.jsx:140
 msgid "Volume"
 msgstr "Том"
@@ -8073,11 +8112,11 @@ msgstr "Запис"
 msgid "Wrong user name or password"
 msgstr "Помилкове ім’я користувача чи пароль"
 
-#: pkg/networkmanager/interfaces.js:1987
+#: pkg/networkmanager/interfaces.js:1964
 msgid "XOR"
 msgstr "XOR"
 
-#: pkg/networkmanager/interfaces.js:2600
+#: pkg/networkmanager/interfaces.js:2575
 msgid "Yes"
 msgstr "Так"
 
@@ -8098,8 +8137,8 @@ msgstr ""
 "його вилучити."
 
 #: pkg/networkmanager/firewall.jsx:77 pkg/networkmanager/firewall.jsx:131
-#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:827
-#: pkg/networkmanager/firewall.jsx:859
+#: pkg/networkmanager/firewall.jsx:143 pkg/networkmanager/firewall.jsx:893
+#: pkg/networkmanager/firewall.jsx:925
 msgid "You are not authorized to modify the firewall."
 msgstr "Вас не уповноважено на внесення змін до брандмауера."
 
@@ -8434,7 +8473,7 @@ msgstr "встановити"
 
 #: pkg/networkmanager/manifest.json.in
 msgid "interface"
-msgstr ""
+msgstr "інтерфейс"
 
 #: pkg/kdump/kdump-view.jsx:379
 msgid "invalid: multiple targets defined"
@@ -8882,8 +8921,8 @@ msgid ""
 "virt-install package needs to be installed on the system in order to create "
 "new VMs"
 msgstr ""
-"Для створення нових віртуальних машин у системі має бути встановлено пакунок "
-"virt-install"
+"Для створення нових віртуальних машин у системі має бути встановлено пакунок"
+" virt-install"
 
 #: pkg/networkmanager/manifest.json.in
 msgid "vlan"


### PR DESCRIPTION
This is provided by `python3-zanata-client`.

Needs https://github.com/cockpit-project/cockpituous/pull/298

 * [x] po-refresh

(no `bots` label for now, since I need to deploy new task container first)