### PR TITLE
Revert "test: Skip Machines selenium tests on Edge for now"

### DIFF
--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -173,12 +173,7 @@ class AvocadoTestSuite:
         cmd_output = self.machine_avocado.execute(self.base_cmd + " list " + " ".join(test_abspaths))
         output_list = []
         for line in cmd_output.splitlines():
-            t = line.split(" ", 1)[1].strip()
-            if self.browser == "edge" and "/selenium-machines-" in t:
-                # HACK: https://github.com/cockpit-project/cockpit/issues/12864
-                print("SKIP:", t, "because of https://github.com/cockpit-project/cockpit/issues/12864")
-                continue
-            output_list.append(t)
+            output_list.append(line.split(" ", 1)[1].strip())
         return output_list
 
 
@@ -245,7 +240,6 @@ class SeleniumTestSuite(AvocadoTestSuite):
                       ]
 
     def __init__(self, browser, **kwargs):
-        self.browser = browser
         super().__init__(**kwargs)
         self.env["HUB"] = self.ipaddr_selenium
         self.env["GUEST"] = self.ipaddr_cockpit

--- a/test/selenium/selenium-machines-basic.py
+++ b/test/selenium/selenium-machines-basic.py
@@ -123,6 +123,8 @@ class MachinesBasicTestSuite(MachinesLib):
             self.machine.execute('sudo virsh domstate {}'.format(name)).rstrip(),
             self.wait_css('#vm-{}-state'.format(name)).text)
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13072")
     def testCreateVMWithISO(self):
         name = 'test_iso'
         iso = '/home/{}.iso'.format(name + str(time.time()).split('.')[0])

--- a/test/selenium/selenium-machines-storage-pool.py
+++ b/test/selenium/selenium-machines-storage-pool.py
@@ -11,6 +11,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
     :avocado: tags=machines
     """
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testCheckStoragePool(self):
         self.wait_css('#card-pf-storage-pools')
         cmd_active = int(self.machine.execute('virsh pool-list | awk \'NR>=3{if($0!="")print}\' | wc -l')) + int(
@@ -51,6 +53,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
         self.wait_css('#storage-pools-listing', cond=invisible)
         self.wait_css('#virtual-machines-listing')
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testCreateDirStoragePool(self):
         name = 'test_storage_pool_' + MachinesLib.random_string()
         path = '/home/test_' + MachinesLib.random_string()
@@ -125,6 +129,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
         self.assertEqual(allocation_from_page, allocation_from_cmd)
         self.assertEqual(capacity_from_page, capacity_from_cmd)
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testAddAllPhysicalDiskDevice(self):
         name = 'pdd_' + MachinesLib.random_string()
         pdd = Disc(self.machine)
@@ -155,6 +161,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
 
         pdd.clear()
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testAddISCSIStoragePool(self):
         self.click(self.wait_text('Storage Pools', cond=clickable))
         self.wait_css('#storage-pools-listing')
@@ -173,6 +181,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
 
         disc.clear()
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testCheckStateOfStoragePool(self):
         name = 'test_act_' + MachinesLib.random_string()
         path = '/home/' + name
@@ -203,6 +213,8 @@ class MachinesStoragePoolTestSuite(MachinesLib):
         self.assertEqual('active', self.machine.execute(
             'sudo virsh pool-list --all | grep %s | awk \'{print $2}\'' % name).strip())
 
+    @skipIf(os.environ.get("BROWSER") == 'edge',
+            "fails too often, https://github.com/cockpit-project/cockpit/issues/13073")
     def testDeleteStoragePool(self):
         name = 'test_act_' + MachinesLib.random_string()
         path = '/home/' + name


### PR DESCRIPTION
These work again since fixing issue #12864 in commit 6cee1e455.

Skip two tests which fail very often with Edge, with issue references.

This reverts commit fcdca949ef26ad5ea8c67fda19f4662194a30e4c.