### PR TITLE
systemd: Ignore failures of hidden units

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -5,7 +5,7 @@ import cockpit from "cockpit";
 import moment from "moment";
 import React from "react";
 import ReactDOM from 'react-dom';
-import { ServiceTabs } from "./services.jsx";
+import { ServiceTabs, service_tabs_suffixes } from "./services.jsx";
 import { ServiceDetails, ServiceTemplate } from "./service-details.jsx";
 import { journal } from "journal";
 import { page_status } from "notifications";
@@ -403,11 +403,11 @@ $(function() {
             for (const p in units_by_path) {
                 const u = units_by_path[p];
                 if (u.ActiveState == "failed") {
-                    failed.add(u.Id);
-                    // The suffix of the unit id determines in which
-                    // tab it shows up.  For example, the unit with id
-                    // "foo.timer" will show up in the "Timers" tab.
-                    tab_warnings[u.Id.substr(u.Id.lastIndexOf('.') + 1)] = true;
+                    const suffix = u.Id.substr(u.Id.lastIndexOf('.') + 1);
+                    if (service_tabs_suffixes.has(suffix)) {
+                        failed.add(u.Id);
+                        tab_warnings[suffix] = true;
+                    }
                 }
             }
 

--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -25,6 +25,8 @@ import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
+export const service_tabs_suffixes = new Set(["service", "target", "socket", "timer", "path"]);
+
 /*
  * React component showing services tabs
  * Required props:

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -892,5 +892,35 @@ ExecStart=/usr/bin/false
         b.enter_page('/system')
         b.wait_not_present('#page_status_notifications:contains("1 service has failed")')
 
+    def testHiddenFailure(self):
+        m = self.machine
+        b = self.browser
+
+        m.write("/etc/systemd/system/fail.mount",
+                """
+[Unit]
+Description=Failing Mount
+
+[Mount]
+What=wrong
+Where=/fail
+""")
+
+        m.execute("systemctl daemon-reload")
+        self.machine.execute("systemctl start default.target")
+        self.machine.execute("systemctl reset-failed")
+        m.execute("systemctl start fail.mount || true")
+
+        self.login_and_go("/system/services")
+
+        # Nav link should not have icon
+        b.switch_to_top()
+        b.wait_not_present('a[href="/system/services"] .fa-exclamation-triangle')
+
+        # System page should not have notification
+        b.click('#host-apps a[href="/system"]')
+        b.enter_page('/system')
+        b.wait_not_present('#page_status_notifications:contains("failed")')
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
If a unit fails that we don't show in any of the tabs, such as
foo.mount, we should also ignore that it has failed.  Otherwise, we
warn people about things that they can't find.