### PR TITLE
machines: Fix NIC edit for NICs without source

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1324,7 +1324,7 @@ function updateNetworkIface({ domXml, networkMac, networkState, networkModelType
                 let sourceElem = getSingleOptionalElem(interfaceElem, 'source');
                 // Source elements of different iface types might contain differently named attributes,
                 // so we delete whole element and create a new one
-                if (typeChanged) {
+                if (typeChanged && sourceElem) {
                     sourceElem.remove();
                     sourceElem = undefined;
                 }


### PR DESCRIPTION
How to reproduce:
1. Attach NIC of type which doesn't require source (e.g. NIC type 'user' for
session connection VM)
2. Go to NIC Edit dialog, change NIC type to something which requires
source

Expected result: NIC configuration is changed
Actual result: Oops, Cannot read property 'remove' of undefined