### PR TITLE
systemd: More robust detection of template unit files

### DIFF
--- a/pkg/systemd/init.js
+++ b/pkg/systemd/init.js
@@ -128,6 +128,12 @@ $(function() {
             return name_esc(str);
     }
 
+    function is_template(id) {
+        const tp = id.indexOf("@");
+        const sp = id.lastIndexOf(".");
+        return (tp != -1 && (tp + 1 == sp || tp + 1 == id.length));
+    }
+
     var systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
     var systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
                                                "/org/freedesktop/systemd1");
@@ -471,7 +477,7 @@ $(function() {
 
                 seen_ids[name] = true;
 
-                if (name.indexOf("@") != -1) {
+                if (is_template(name)) {
                     // A template, create a fake unit for it
                     units_by_path[name] = {
                         Id: name,

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -483,7 +483,7 @@ export class ServiceDetails extends React.Component {
                             <label className="control-label" htmlFor="path">{ _("Path") }</label>
                             <span id="path">{this.props.unit.FragmentPath}</span>
                             <hr />
-                            { this.props.originTemplate &&
+                            { this.props.originTemplate && this.props.isValid(this.props.originTemplate) &&
                                 <>
                                     <label className="control-label" />
                                     <span>{_("Instance of template: ")}<a href={"#/" + this.props.originTemplate}>{this.props.originTemplate}</a></span>


### PR DESCRIPTION
Not all unit files that contain a "@" character are templates.  The
systemd-cryptsetup-generator writes those, for example.