### PR TITLE
test: Check cockpit login with SELinux restricted user

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -914,6 +914,8 @@ class MachineCase(unittest.TestCase):
                                     "user user was reauthorized",
                                     "sudo: no password was provided",
                                     "sudo: unable to resolve host .*",
+                                    "sudo: unable to open /run/sudo/ts/unpriv: Permission denied",
+                                    "sudo: unable to stat /var/db/sudo: Permission denied",
                                     ".*: sorry, you must have a tty to run sudo",
                                     ".*/pkexec: bridge exited",
                                     "We trust you have received the usual lecture from the local System",

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -330,6 +330,44 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     "couldn't parse login input: Malformed input",
                                     "couldn't parse login input: Authentication failed")
 
+    @skipImage("No SELinux", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-1804")
+    @skipImage("Only supported for Fedora >= 30", "fedora-atomic")
+    def testSELinuxRestrictedUser(self):
+        m = self.machine
+        b = self.browser
+
+        # non-admin user_u
+        m.execute("useradd unpriv; echo 'unpriv:foobar' | chpasswd; semanage login -a -s user_u unpriv")
+        m.start_cockpit()
+        b.login_and_go("/system", user="unpriv")
+        # not an admin
+        b.wait_present("#shutdown-group button[data-action=restart][data-stable=yes]")
+        b.wait_present("#shutdown-group button.disabled")
+        b.wait_not_present("#shutdown-group button:not(.disabled)")
+        b.logout()
+        self.allow_authorize_journal_messages()
+        # not allowed to restricted users
+        self.allow_journal_messages(".*/var/lib/cockpit/machines.json.*Permission denied")
+        self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
+        self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
+        if m.image in ["fedora-30", "fedora-testing", "rhel-8-1", "rhel-8-1-distropkg"]:
+            # older releases have more noise
+            self.allow_journal_messages("sudo: .*setresuid.*: Operation not permitted")
+            self.allow_journal_messages("sudo: no valid sudoers.*")
+            self.allow_journal_messages("sudo: unable to initialize policy plugin")
+            self.allow_journal_messages("sudo: unable to initialize policy plugin")
+            self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="pkexec".* scontext=user_u.*')
+
+        # sysadm_u
+        m.execute("semanage login -a -s sysadm_u admin")
+        b.login_and_go("/system")
+        # shutdown button should be enabled and working
+        b.click("#shutdown-group button[data-action=restart][data-stable=yes]")
+        b.wait_popup("shutdown-dialog")
+        b.wait_in_text("#shutdown-dialog .btn-danger", 'Restart')
+        b.click('#shutdown-dialog button[data-dismiss="modal"]')
+        b.wait_popdown("shutdown-dialog")
+
     def testUnsupportedBrowser(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Check that users with a SELinux role other than unconfined_u (in
particular, user_u and sysadm_u) can log into Cockpit. This validates
the various bug dependencies of
https://bugzilla.redhat.com/show_bug.cgi?id=1727382
and ensures that they stay fixed in the future.