### PR TITLE
common: Stop reading /var/lib/cockpit/machines.json

### DIFF
--- a/src/common/cockpitmachinesjson.c
+++ b/src/common/cockpitmachinesjson.c
@@ -150,13 +150,13 @@ JsonNode *
 read_machines_json (void)
 {
   gchar *glob_str;
-  glob_t conf_glob = { .gl_offs = 1 };
+  glob_t conf_glob;
   int res;
   JsonNode *machines = NULL;
 
   /* find json config files */
   glob_str = g_build_filename (get_machines_json_dir (), "*.json", NULL);
-  res = glob (glob_str, GLOB_DOOFFS, glob_err_func, &conf_glob);
+  res = glob (glob_str, 0, glob_err_func, &conf_glob);
   if (G_UNLIKELY (res != 0 && res != GLOB_NOMATCH))
     {
       g_critical ("glob %s failed with return code %i", glob_str, res);
@@ -165,14 +165,10 @@ read_machines_json (void)
       return NULL;
     }
 
-  /* also read /var/lib/cockpit/machines.json for backwards compat; except when
-   * running unit tests, then disable this (this is covered by an integration test) */
-  conf_glob.gl_pathv[0] = g_getenv ("COCKPIT_TEST_CONFIG_DIR") ? "/dev/null" : "/var/lib/cockpit/machines.json";
-
   /* start with an empty object */
   machines = new_object_node ();
 
-  for (size_t i = 0; i < conf_glob.gl_pathc + 1; ++i)
+  for (size_t i = 0; i < conf_glob.gl_pathc; ++i)
     {
       JsonNode *j = parse_json_file (conf_glob.gl_pathv[i]);
       if (j)


### PR DESCRIPTION
This got obsoleted in commit 3986d994f, and commit eae85c6b1d12e
migrated the old file into /etc/cockpit/machines.d/. That commit has
been in all supported OS releases for a long time now.

Commit a1e7a09 already removed the migration.