### PR TITLE
test: Do not blur input after setting up text

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -290,7 +290,6 @@ class Browser:
 
         if value_check:
             self.wait_val(selector, val)
-        self.blur(selector)
 
     def set_file_autocomplete_val(self, identifier, location):
         file_item_selector_template = "#{0} li a:contains({1})"

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -303,6 +303,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Verify that limiting max memory in offline VMs bellow memory will decrease memory as well
         b.set_input_text("#vm-subVmTest1-memory-modal-max-memory", str(current_memory - 20))
+        b.blur("#vm-subVmTest1-memory-modal-max-memory")
         self.assertEqual(int(b.attr("#vm-subVmTest1-memory-modal-memory", "value")), current_memory - 20)
 
         # Verify that increasing current memory in offline VMs above max memory will increase max memory as well


### PR DESCRIPTION
Lets see what tests have to say to this.
This is very likely culprit why testCreate in Firefox is failing - the input is blured before the last character is set up. It is just timing thing.
My thinking is that user also would not blur output, so we should not rely on that.
Introduced [here](https://github.com/cockpit-project/cockpit/commit/18f54c12422a90108d932d3ae33e1ce1719c106d)