### PR TITLE
machines: Don't create VM with name which is already used

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -121,6 +121,8 @@ function validateParams(vmParams) {
 
     if (isEmpty(vmParams.vmName.trim()))
         validationFailed.vmName = _("Name must not be empty");
+    else if (vmParams.vms.some(vm => vm.name === vmParams.vmName))
+        validationFailed.vmName = cockpit.format(_("VM $0 already exists"), vmParams.vmName);
 
     if (vmParams.os == undefined)
         validationFailed.os = _("You need to select the most closely matching Operating System");
@@ -685,9 +687,9 @@ class CreateVmModal extends React.Component {
     }
 
     onCreateClicked() {
-        const { dispatch, providerName, storagePools, close, onAddErrorNotification, osInfoList } = this.props;
+        const { dispatch, providerName, storagePools, close, onAddErrorNotification, osInfoList, vms } = this.props;
 
-        const validation = validateParams({ ...this.state, osInfoList: osInfoList });
+        const validation = validateParams({ ...this.state, osInfoList, vms: vms.filter(vm => vm.connectionName == this.state.connectionName) });
         if (Object.getOwnPropertyNames(validation).length > 0) {
             this.setState({ inProgress: false, validate: true });
         } else {
@@ -732,7 +734,7 @@ class CreateVmModal extends React.Component {
 
     render() {
         const { nodeMaxMemory, nodeDevices, networks, osInfoList, loggedUser, providerName, storagePools, vms } = this.props;
-        const validationFailed = this.state.validate && validateParams({ ...this.state, osInfoList });
+        const validationFailed = this.state.validate && validateParams({ ...this.state, osInfoList, vms: vms.filter(vm => vm.connectionName == this.state.connectionName) });
 
         const dialogBody = (
             <form className="ct-form">

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1286,8 +1286,9 @@ class TestMachines(NetworkCase):
                 .fill() \
                 .createAndExpectInlineValidationErrors(errors) \
                 .cancel(True)
-            runner.assertScriptFinished() \
-                .checkEnvIsEmpty()
+            runner.assertScriptFinished()
+            if dialog.env_is_empty:
+                runner.checkEnvIsEmpty()
 
         def checkDialogErrorTest(dialog, errors):
             dialog.open() \
@@ -1371,6 +1372,16 @@ class TestMachines(NetworkCase):
         # try to CREATE WITH DIALOG ERROR
         # name
         checkDialogFormValidationTest(TestMachines.VmDialog(self, "", storage_size=1), {"Name": "Name must not be empty"})
+
+        # name already exists
+        createTest(TestMachines.VmDialog(self, name='existing-name', sourceType='url',
+                                         location=config.VALID_URL, storage_size=1,
+                                         delete=False))
+
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, "existing-name", storage_size=1,
+                                                            env_is_empty=False), {"Name": "already exists"})
+
+        self.machine.execute("virsh undefine existing-name")
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, sourceType='url',
@@ -1799,6 +1810,7 @@ class TestMachines(NetworkCase):
                      storage_pool='Create New Volume', storage_volume='',
                      start_vm=False,
                      delete=True,
+                     env_is_empty=True,
                      connection=None):
 
             TestMachines.VmDialog.vmId += 1 # This variable is static - don't use self here
@@ -1828,6 +1840,7 @@ class TestMachines(NetworkCase):
             self.storage_pool = storage_pool
             self.storage_volume = storage_volume
             self.delete = delete
+            self.env_is_empty = env_is_empty
             self.connection = connection
             if self.connection:
                 self.connectionText = TestMachines.TestCreateConfig.LIBVIRT_CONNECTION[connection]


### PR DESCRIPTION
When user creates a new VM and spends some time filling in all the details, after clicking Create, modal is closed with error message from libvirt "this vm name is already used" resulting in them loosing all the data they have filled into the modal.
We can check this in the UI.

![Screenshot from 2019-11-07 15-26-57](https://user-images.githubusercontent.com/42733240/68397358-5eb4de80-0173-11ea-960b-8bbad9655185.png)
