### PR TITLE
Change vague "Internal error in login process" error

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -879,7 +879,7 @@ on_transport_closed (CockpitTransport *transport,
           g_set_error (&error, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,
                        g_strcmp0 (problem, "no-cockpit") == 0
                            ? "The cockpit package is not installed"
-                           : "Internal error in login process");
+                           : "Failed to execute cockpit-session");
         }
       else
         {


### PR DESCRIPTION
Signed-off-by: NanoSector <rick@nanosector.nl>

After spending literal weeks trying to find out what this error exactly means, I decided to dig into the source code to where it was triggered. Here I found a note that was way more helpful than anything Cockpit was saying, namely that it is related to `cockpit-session`.

Therefore this PR changes the error message so that it actually means something.