### PR TITLE
tls: Allow full buffer read in test.

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -225,7 +225,7 @@ assert_https_outcome (TestCase *tc,
       if (len < 0 && expect_tls_failure)
         exit (0);
       g_assert_cmpint (len, >=, 100);
-      g_assert_cmpint (len, <, sizeof (buf) - 1);
+      g_assert_cmpint (len, <=, sizeof (buf) - 1);
 
       buf[len] = '\0'; /* so that we can use string functions on it */
       /* This succeeds (200 OK) when building in-tree, but fails with dist-check due to missing doc root */


### PR DESCRIPTION
I have seen this error, but I guess returning sizeof(buf)-1 bytes is alright.

```
ERROR:src/tls/test-server.c:228:assert_https_outcome: assertion failed (len < sizeof (buf) - 1): (4095 < 4095)
```

(The test did hang at this point.  That's not expected, right?)