### PR TITLE
test: Fix wrong alert selector

### DIFF
--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -367,8 +367,8 @@ class TestKeys(MachineCase):
             b.set_val(new_key_tbody + " .credential-password", "badbad")
             b.click(new_key_tbody + " .credential-unlock .btn")
 
-            b.wait_visible(new_key_tbody + " .alert")
-            b.wait_in_text(new_key_tbody + " .alert", "Password")
+            b.wait_visible(new_key_tbody + " .credential-alert")
+            b.wait_in_text(new_key_tbody + " .credential-alert", "Password")
             b.set_val(new_key_tbody + " .credential-password", "foobar")
             b.click(new_key_tbody + " .credential-unlock .btn")
 


### PR DESCRIPTION
In #13038 alerts were changed from PF3 component to PF4 but this test
was forgotten and not updated.