### PR TITLE
selinux: Do not wrap text around button on small screens

### DIFF
--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -134,12 +134,11 @@ class SELinuxEventDetails extends React.Component {
                 doElem = null;
             }
             return (
-                <div className="list-group-item" key={itm.analysisId}>
+                <div className="list-group-item selinux-details" key={itm.analysisId}>
                     <div>
                         <div>
                             <span>{itm.ifText}</span>
                         </div>
-                        {fixit}
                         <div>
                             {itm.thenText}
                         </div>
@@ -147,6 +146,7 @@ class SELinuxEventDetails extends React.Component {
                         {doElem}
                         {msg}
                     </div>
+                    {fixit}
                 </div>
             );
         });

--- a/pkg/selinux/setroubleshoot.css
+++ b/pkg/selinux/setroubleshoot.css
@@ -23,18 +23,6 @@
     font-family: monospace;
 }
 
-/* from patternfly .list-view-pf-actions
- * update this when we update patternfly
- */
-.setroubleshoot-listing-action {
-    float: right;
-    margin-bottom: 20px;
-    margin-left: 20px;
-    margin-top: 20px;
-    -ms-flex-order: 2;
-    order: 2;
-}
-
 .setroubleshoot-progress-spinner {
     display: inline-block;
 }
@@ -74,6 +62,12 @@
 
 .list-group-item .alert {
     margin-top: 10px;
+}
+
+.selinux-details {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .selinux-state {


### PR DESCRIPTION
Fixes #11602

@garrett what do you think? I put it into flex - the text is one box and the button (or the text `Unable to apply this solution automatically`) another. Would it be better if only the first line of the text and the button would be in flex? (Sounds silly, but when you check the source code, the first line and the second line are two separate elements)


On wide screen:
![nowwidescreen](https://user-images.githubusercontent.com/12330670/68668310-2b45cb80-0548-11ea-8f18-14ef990566b9.png)

On phone:
![onphone](https://user-images.githubusercontent.com/12330670/68668308-2aad3500-0548-11ea-812e-e3ac4f1d0834.png)

