### PR TITLE
playground: Don't rely on /etc/hostname

### DIFF
--- a/pkg/playground/preloaded.js
+++ b/pkg/playground/preloaded.js
@@ -9,9 +9,9 @@ import cockpit from "cockpit";
 // and not recover automatically.
 
 function init_1() {
-    return (cockpit.file("/etc/hostname").read()
+    return (cockpit.spawn(["hostname"])
             .then(data => {
-                document.getElementById("host").innerText = data;
+                document.getElementById("host").innerText = data.trim();
             }));
 }
 


### PR DESCRIPTION
It does not exist on e. g. Fedora CoreOS. Just call the `hostname`
program both in the playground page and in the corresponding test
(`testShellPreload`), to ensure they will be identical.