### PR TITLE
machines: fix typo in CSS which broke ToastNotifications

### DIFF
--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -301,7 +301,7 @@ td > .utilization-bar-pf {
         top: 0.5rem - @toast-stack-offset;
     }
 
-    .toast-notification-list-pf .pf-c-alert {
+    .toast-notifications-list-pf .pf-c-alert {
         // Animation for toasts fading & sliding in
         animation: toast-fade-in @toast-anim-speed ease-out;
         // Animations should happen from the top


### PR DESCRIPTION
This got introduced in 687b83ac7e.