### PR TITLE
doc: Update cockpit/ws documentation

### DIFF
--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -21,9 +21,11 @@
       system or you can setup a <link linkend="sso">Kerberos based SSO
       solution</link>.</para>
 
-    <para>The web server can also be run from the <filename>cockpit/ws</filename> docker
-      container. If you are running cockpit on an <ulink url="https://www.projectatomic.io/">
-      Atomic Host</ulink> this will be the default. In this setup, cockpit establishes an
+    <para>The web server can also be run from the
+      <ulink url="https://hub.docker.com/r/cockpit/ws/">cockpit/ws</ulink>
+      container. If you are running cockpit on a container host operating system like
+      <ulink url="https://getfedora.org/coreos/">Fedora CoreOS</ulink>
+      this will be the only supported mode. In this setup, cockpit establishes an
       SSH connection from the container to the underlying host, meaning that it is up to
       your SSH server to grant access. To login with a local account, <filename>sshd
       </filename> will need to be configured to allow password based authentication.


### PR DESCRIPTION
 * Project Atomic was superseded by Fedora CoreOS.
 * It's not a "docker" container, it's just a container.
 * Speaking about "the default" is misleading, as the container isn't
   installed by default. But we only support the container there, not
   trying to squeeze the web server into an OSTree overlay.