### PR TITLE
bridge: Explicitly cancel fswatch GFileMonitor before unreffing

### DIFF
--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -276,22 +276,10 @@ cockpit_fslist_dispose (GObject *object)
         g_signal_handler_disconnect (self->monitor, self->sig_changed);
       self->sig_changed = 0;
 
-      // HACK - It is not generally safe to just unref a GFileMonitor.
-      // Some events might be on their way to the main loop from its
-      // worker thread and if they arrive after the GFileMonitor has
-      // been destroyed, bad things will happen.
-      //
-      // As a workaround, we cancel the monitor and then spin the main
-      // loop a bit until nothing is pending anymore.
-      //
-      // https://bugzilla.gnome.org/show_bug.cgi?id=740491
-
+      /* HACK - It is not generally safe to just unref a GFileMonitor:
+       * https://gitlab.gnome.org/GNOME/glib/issues/1941
+       */
       g_file_monitor_cancel (self->monitor);
-      for (int tries = 0; tries < 10; tries ++)
-        {
-          if (!g_main_context_iteration (NULL, FALSE))
-            break;
-        }
     }
 
   G_OBJECT_CLASS (cockpit_fslist_parent_class)->dispose (object);

--- a/src/bridge/cockpitfswatch.c
+++ b/src/bridge/cockpitfswatch.c
@@ -223,6 +223,11 @@ cockpit_fswatch_dispose (GObject *object)
         g_signal_handler_disconnect (self->monitor, self->sig_changed);
       self->sig_changed = 0;
 
+      /* HACK - It is not generally safe to just unref a GFileMonitor:
+       * https://gitlab.gnome.org/GNOME/glib/issues/1941
+       */
+      g_file_monitor_cancel (self->monitor);
+
       g_object_unref (self->monitor);
       self->monitor = NULL;
     }


### PR DESCRIPTION
When GFileMonitor uses inotify, it asynchronously cancels the monitor on
disposing. This races with creating a new monitor somewhere else, and
frequently runs into deadlocks when the cancellation of the old and the
creation of the new monitor both try to acquire their internal mutex.
See https://gitlab.gnome.org/GNOME/glib/issues/1941 for details.

Interestingly there was a related bug in 2017
(https://bugzilla.gnome.org/show_bug.cgi?id=740491) for which we still
had a workaround in fslist. That exact same workaround applies to this
fswatch  deadlock as well.

Fixes #13146