### PR TITLE
storage: Make adding to fstab optional during Format

### DIFF
--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -226,15 +226,15 @@ export function mounting_dialog(client, block, mode) {
                           value: old_dir,
                           validate: val => is_valid_mount_point(client, block, val)
                       }),
-            CheckBoxes("mount_options", _("Mount Options"),
+            CheckBoxes("mount_options", "",
                        {
                            value: {
                                ro: opt_ro,
                                extra: extra_options === "" ? false : extra_options
                            },
                            fields: [
-                               { title: _("Mount read only"), tag: "ro" },
-                               { title: _("Custom mount options"), tag: "extra", type: "checkboxWithInput" },
+                               { title: _("Read only"), tag: "ro" },
+                               { title: _("Custom options"), tag: "extra", type: "checkboxWithInput" },
                            ]
                        },
             ),


### PR DESCRIPTION
This covers the "I want to format a block device but don't want to add it to fstab" case.

This doesn't give us "I want to remove an entry from fstab but want to keep the formatted block device".

![image](https://user-images.githubusercontent.com/3228183/69045003-a0a91480-09fe-11ea-9f02-f31ba570f4f7.png)
