### PR TITLE
machines: Fix duplication in a list of VMs using a pool

### DIFF
--- a/pkg/machines/components/storagePools/storagePoolDelete.jsx
+++ b/pkg/machines/components/storagePools/storagePoolDelete.jsx
@@ -140,6 +140,7 @@ export class StoragePoolDelete extends React.Component {
         for (const property in usage)
             vmsUsage = vmsUsage.concat(usage[property]);
 
+        vmsUsage = [...new Set(vmsUsage)]; // remove duplicates
         vmsUsage = vmsUsage.join(', ');
         const showWarning = () => {
             if (canDeleteOnlyWithoutVolumes(storagePool, vms) && this.state.deleteVolumes) {


### PR DESCRIPTION
Remove duplication of list of VMs using storage pool in a deletion tooltip.

### Before:
![Screenshot from 2019-11-18 13-45-48](https://user-images.githubusercontent.com/42733240/69053538-ec14f000-0a09-11ea-86b2-f4910fba998c.png)

### After:
![Screenshot from 2019-11-18 13-46-53](https://user-images.githubusercontent.com/42733240/69053544-ef0fe080-0a09-11ea-9371-3f0376950f8d.png)
