### PR TITLE
Fix broken OverlayTrigger tooltips

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -891,14 +891,20 @@ export class CreateVmAction extends React.Component {
                     testdata={testdata}
                     id={this.props.mode == 'create' ? 'create-new-vm' : 'import-vm-disk'}
                     bsStyle='default'
+                    style={!this.state.virtInstallAvailable ? { pointerEvents: 'none' } : null} // Fixes OverlayTrigger not showing up
                     onClick={this.open}>
                 {this.props.mode == 'create' ? _("Create VM") : _("Import VM")}
             </Button>
         );
         if (!this.state.virtInstallAvailable)
             createButton = (
-                <OverlayTrigger overlay={ <Tooltip id='virt-install-not-available-tooltip'>{ _("virt-install package needs to be installed on the system in order to create new VMs") }</Tooltip> } placement='top'>
-                    {createButton}
+                <OverlayTrigger overlay={
+                    <Tooltip id='virt-install-not-available-tooltip'>
+                        {_("virt-install package needs to be installed on the system in order to create new VMs")}
+                    </Tooltip>} placement='top'>
+                    <span>
+                        {createButton}
+                    </span>
                 </OverlayTrigger>
             );
 

--- a/pkg/machines/components/storagePools/storagePool.jsx
+++ b/pkg/machines/components/storagePools/storagePool.jsx
@@ -161,24 +161,34 @@ class StoragePoolActions extends React.Component {
         const { storagePool, vms } = this.props;
         const id = storagePoolId(storagePool.name, storagePool.connectionName);
         let deactivateButton = (
-            <Button id={`deactivate-${id}`} disabled={this.state.operationInProgress} onClick={this.onDeactivate}>
+            <Button id={`deactivate-${id}`}
+                disabled={this.state.operationInProgress}
+                style={this.state.operationInProgress ? { pointerEvents: 'none' } : null} // Fixes OverlayTrigger not showing up
+                onClick={this.onDeactivate}>
                 {_("Deactivate")}
             </Button>
         );
         let activateButton = (
-            <Button id={`activate-${id}`} disabled={this.state.operationInProgress} onClick={this.onActivate}>
+            <Button id={`activate-${id}`}
+                disabled={this.state.operationInProgress}
+                style={this.state.operationInProgress ? { pointerEvents: 'none' } : null} // Fixes OverlayTrigger not showing up
+                onClick={this.onActivate}>
                 {_("Activate")}
             </Button>
         );
         if (this.state.operationInProgress) {
             deactivateButton = (
                 <OverlayTrigger overlay={ <Tooltip id="tip-in-progress">{_("Operation is in progress")}</Tooltip> } placement="top">
-                    {deactivateButton}
+                    <span>
+                        {deactivateButton}
+                    </span>
                 </OverlayTrigger>
             );
             activateButton = (
                 <OverlayTrigger overlay={ <Tooltip id="tip-in-progress">{_("Operation is in progress")}</Tooltip> } placement="top">
-                    {activateButton}
+                    <span>
+                        {activateButton}
+                    </span>
                 </OverlayTrigger>
             );
         }

--- a/pkg/machines/components/storagePools/storageVolumeCreate.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreate.jsx
@@ -144,6 +144,7 @@ export class StorageVolumeCreate extends React.Component {
                         <span>
                             <Button id={`${idPrefix}-button`}
                                 bsStyle='default'
+                                style={{ pointerEvents: 'none' }}
                                 disabled>
                                 {_("Create Volume")}
                             </Button>

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -75,7 +75,9 @@ function ServiceRow(props) {
         deleteButton = (
             <OverlayTrigger className="pull-right" placement="top"
                             overlay={ <Tooltip id="tip-auth">{ _("You are not authorized to modify the firewall.") }</Tooltip> }>
-                <button key={props.service.id + "-delete-button"} className="btn btn-danger pficon pficon-delete" aria-label={cockpit.format(_("Not authorized to remove service $0"), props.service.id)} disabled />
+                <span>
+                    <button key={props.service.id + "-delete-button"} className="btn btn-danger pficon pficon-delete" aria-label={cockpit.format(_("Not authorized to remove service $0"), props.service.id)} style={{ pointerEvents: 'none' }} disabled />
+                </span>
             </OverlayTrigger>
         );
     } else {

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -60,7 +60,9 @@ class StorageControl extends React.Component {
             return (
                 <OverlayTrigger overlay={ <Tooltip id="tip-storage">{excuse}</Tooltip> }
                                 placement={this.props.excuse_placement || "top"}>
-                    { this.props.content(excuse) }
+                    <span>
+                        { this.props.content(excuse) }
+                    </span>
                 </OverlayTrigger>
             );
         } else {
@@ -100,6 +102,7 @@ export class StorageButton extends React.Component {
                                 <button id={this.props.id}
                                             onClick={checked(this.props.onClick)}
                                             className={classes + (excuse ? " disabled" : "")}
+                                            style={excuse ? { pointerEvents: 'none' } : null}
                                             disabled={excuse}>
                                     {this.props.children}
                                 </button>
@@ -114,6 +117,7 @@ export class StorageLink extends React.Component {
             <StorageControl excuse={this.props.excuse}
                             content={(excuse) => (
                                 <button onClick={checked(this.props.onClick)}
+                                        style={excuse ? { pointerEvents: 'none' } : null}
                                         className={"link-button ct-form-relax" + (excuse ? " disabled" : "")}>
                                     {this.props.children}
                                 </button>
@@ -186,6 +190,7 @@ export class StorageOnOff extends React.Component {
                                     ? this.state.promise_goal_state
                                     : this.props.state}
                                                  disabled={!!(excuse || this.state.promise)}
+                                                 style={(excuse || this.state.promise) ? { pointerEvents: 'none' } : null}
                                                  onChange={onChange} />
                             )} />
         );


### PR DESCRIPTION
If you put OverlayTrigger over a DISABLED button, then overlay tooltip
won't show up. The Reason is probably that a disabled button doesn't
have a pointer event, therefore OverlayTrigger doesn't know when
to showa  tooltip.
Fix this by setting pointerEvents to "none", which will "trigger event
listeners on parent element".