### PR TITLE
machines: Support transient virtual networks and storage pools

### DIFF
--- a/pkg/machines/components/networks/network.jsx
+++ b/pkg/machines/components/networks/network.jsx
@@ -160,7 +160,9 @@ class NetworkActions extends React.Component {
                 <DeleteResource objectType="Network"
                     objectId={id}
                     objectName={network.name}
-                    deleteHandler={() => deleteHandler(network)} />;
+                    deleteHandler={() => deleteHandler(network)}
+                    overlayText={_("Non-persistent network cannot be deleted. It ceases to exists when it's deactivated.")}
+                    disabled={!network.persistent} />
             </>
         );
     }

--- a/pkg/machines/components/networks/networkOverviewTab.jsx
+++ b/pkg/machines/components/networks/networkOverviewTab.jsx
@@ -83,14 +83,16 @@ export class NetworkOverviewTab extends React.Component {
                         <label className='control-label' htmlFor={`${idPrefix}-persistent`}> {_("Persistent")} </label>
                         <div id={`${idPrefix}-persistent`}> {network.persistent ? _("yes") : _("no")} </div>
 
-                        <label className='control-label' htmlFor={`${idPrefix}-autostart`}> {_("Autostart")} </label>
-                        <label className='checkbox-inline'>
-                            <input id={`${idPrefix}-autostart-checkbox`}
-                                   type="checkbox"
-                                   checked={network.autostart}
-                                   onChange={this.onAutostartChanged} />
-                            {_("Run when host boots")}
-                        </label>
+                        {network.persistent && <>
+                            <label className='control-label' htmlFor={`${idPrefix}-autostart`}> {_("Autostart")} </label>
+                            <label className='checkbox-inline'>
+                                <input id={`${idPrefix}-autostart-checkbox`}
+                                       type="checkbox"
+                                       checked={network.autostart}
+                                       onChange={this.onAutostartChanged} />
+                                {_("Run when host boots")}
+                            </label>
+                        </>}
 
                         { network.mtu && <>
                             <label className='control-label' htmlFor={`${idPrefix}-mtu`}> {_("Maximum Transmission Unit")} </label>

--- a/pkg/machines/components/storagePools/storagePoolDelete.jsx
+++ b/pkg/machines/components/storagePools/storagePoolDelete.jsx
@@ -176,15 +176,23 @@ export class StoragePoolDelete extends React.Component {
                 { storagePool.active && showWarning() }
             </>
         );
-
         const deleteButton = () => {
+            let tooltipText;
             if (!canDelete(storagePool, vms)) {
+                tooltipText = (<>
+                    {_("Pool's volumes are used by VMs ")}
+                    <b> {vmsUsage + ". "} </b>
+                    {_("Detach the disks using this pool from any VMs before attempting deletion.")}
+                </>);
+            } else if (!storagePool.persistent) {
+                tooltipText = _("Non-persistent storage pool cannot be deleted. It ceases to exists when it's deactivated.");
+            }
+
+            if (!canDelete(storagePool, vms) || !storagePool.persistent) {
                 return (
                     <OverlayTrigger overlay={
                         <Tooltip id='delete-tooltip'>
-                            {_("Pool's volumes are used by VMs ")}
-                            <b> {vmsUsage + "."} </b>
-                            {_("Detach the disks using this pool from any VMs before attempting deletion.")}
+                            { tooltipText }
                         </Tooltip> } placement='top'>
                         <span>
                             <Button id={`delete-${id}`}

--- a/pkg/machines/components/storagePools/storagePoolOverviewTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolOverviewTab.jsx
@@ -66,8 +66,10 @@ export const StoragePoolOverviewTab = ({ storagePool }) => {
             <label className='control-label' htmlFor={`${idPrefix}-persistent`}> {_("Persistent")} </label>
             <div id={`${idPrefix}-persistent`}> {storagePool.persistent ? _("yes") : _("no")} </div>
 
-            <label className='control-label' htmlFor={`${idPrefix}-autostart`}> {_("Autostart")} </label>
-            <div id={`${idPrefix}-autostart`}> {storagePool.autostart ? _("yes") : _("no")} </div>
+            {storagePool.persistent && <>
+                <label className='control-label' htmlFor={`${idPrefix}-autostart`}> {_("Autostart")} </label>
+                <div id={`${idPrefix}-autostart`}> {storagePool.autostart ? _("yes") : _("no")} </div>
+            </>}
 
             <label className='control-label' htmlFor={`${idPrefix}-type`}> {_("Type")} </label>
             <div id={`${idPrefix}-type`}> {storagePool.type} </div>

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -69,6 +69,13 @@ TEST_NETWORK3_XML = """
   <bridge name='br0'/>
 </network>
 """
+
+TEST_NETWORK4_XML = """
+<network>
+  <name>test_network4</name>
+</network>
+"""
+
 @skipImage("LibvirtDBus is not available", "ubuntu-1804")
 class TestMachinesDBus(machineslib.TestMachines):
     def setUp(self):
@@ -660,10 +667,11 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text(".cards-pf #card-pf-networks .card-pf-aggregate-status-count", "1")
 
         # Create dummy network
-        m.execute("echo \"{0}\" > /tmp/xml && virsh net-create /tmp/xml".format(TEST_NETWORK2_XML))
+        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK2_XML))
         b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Networks")
         b.wait_in_text(".cards-pf #card-pf-networks .card-pf-aggregate-status-count", "2")
-        m.execute("echo \"{0}\" > /tmp/xml && virsh net-create /tmp/xml".format(TEST_NETWORK3_XML))
+        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK3_XML))
+        m.execute("echo \"{0}\" > /tmp/xml && virsh net-create /tmp/xml".format(TEST_NETWORK4_XML))
 
         # Click on Networks card
         b.click(".cards-pf .card-pf-title span:contains(Networks)")
@@ -685,7 +693,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("tbody tr[data-row-id=network-test_network2-{0}] th".format(connectionName)) # click on the row header
 
         # Check overview network properties are present
-        b.wait_in_text("#network-test_network2-{0}-persistent".format(connectionName), "no")
+        b.wait_in_text("#network-test_network2-{0}-persistent".format(connectionName), "yes")
         b.wait_present("#network-test_network2-{0}-autostart-checkbox:not(:checked)".format(connectionName))
         b.wait_in_text("#network-test_network2-{0}-ipv4-address".format(connectionName), "192.168.100.1")
         b.wait_in_text("#network-test_network2-{0}-ipv4-netmask".format(connectionName), "255.255.255.0")
@@ -704,7 +712,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("tbody tr[data-row-id=network-test_network3-{0}] th".format(connectionName)) # click on the row header
 
         # Check overview network properties are present
-        b.wait_in_text("#network-test_network3-{0}-persistent".format(connectionName), "no")
+        b.wait_in_text("#network-test_network3-{0}-persistent".format(connectionName), "yes")
         b.wait_present("#network-test_network3-{0}-autostart-checkbox:not(:checked)".format(connectionName))
 
         # Check overview network properties are not present
@@ -716,6 +724,14 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_not_present("#network-test_network3-{0}-ipv6-prefix".format(connectionName))
         b.wait_not_present("#network-test_network3-{0}-ipv6-dhcp-range".format(connectionName))
         b.wait_not_present("#network-test_network3-{0}-ipv6-dhcp-host-0".format(connectionName))
+
+        # Transient network
+        b.click("tbody tr[data-row-id=network-test_network4-{0}] th".format(connectionName)) # click on the row header
+        b.wait_in_text("#network-test_network4-{0}-persistent".format(connectionName), "no")
+        b.wait_not_present("#network-test_network4-{0}-autostart-checkbox".format(connectionName)) # Transient network shouldn't have autostart option
+        b.wait_present('#delete-network-test_network4-{0}:disabled'.format(connectionName)) # Transient network cannot be deleted
+        b.click('#deactivate-network-test_network4-{0}'.format(connectionName)) # Deactivate transient network
+        b.wait_not_present("tbody tr[data-row-id=network-test_network4-{0}] th".format(connectionName)) # Check it's not present after deactivation
 
     def testPause(self):
         b = self.browser

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -773,9 +773,10 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text(".cards-pf #card-pf-storage-pools .card-pf-title-link", "Storage Pool")
 
         # prepare libvirt storage pools
-        m.execute("mkdir /mnt/vm_one; mkdir /mnt/vm_two; chmod a+rwx /mnt/vm_one /mnt/vm_two")
+        m.execute("mkdir /mnt/vm_one; mkdir /mnt/vm_two; mkdir /mnt/vm_three; chmod a+rwx /mnt/vm_one /mnt/vm_two /mnt/vm_three")
         m.execute("virsh pool-define-as myPoolOne --type dir --target /mnt/vm_one; virsh pool-start myPoolOne")
         m.execute("virsh pool-define-as myPoolTwo --type dir --target /mnt/vm_two; virsh pool-start myPoolTwo")
+        m.execute("virsh pool-create-as myPoolThree --type dir --target /mnt/vm_three") # Transient pool
 
         b.wait_in_text("#card-pf-storage-pools .card-pf-aggregate-status-count", "3")
         b.wait_in_text(".cards-pf #card-pf-storage-pools .card-pf-title-link", "Storage Pools")
@@ -943,6 +944,14 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("tbody tr[data-row-id=pool-mypool-system] td.listing-ct-toggle") # click on the row header
         b.click("#activate-pool-mypool-system")
         b.wait_present("#activate-pool-mypool-system:disabled")
+
+        # Transient network
+        b.click("tbody tr[data-row-id=pool-myPoolThree-{0}] td.listing-ct-toggle".format(connectionName)) # click on the row header
+        b.wait_not_present("#pool-myPoolThree-{0}-autostart".format(connectionName)) # Transient pool shouldn't have autostart option
+        b.wait_present('#delete-pool-myPoolThree-{0}:disabled'.format(connectionName)) # Transient pool cannot be deleted
+        b.click('#deactivate-pool-myPoolThree-{0}'.format(connectionName)) # Deactivate transient pool
+        # Check it's not present after deactivation
+        b.wait_not_present("tbody tr[data-row-id=pool-myPoolThree-{0}] td.listing-ct-toggle".format(connectionName)) # click on the row header
 
     def testNetworksCreate(self):
         b = self.browser


### PR DESCRIPTION
Transient resources are resources which exist only while they are running and cease to exists once they stop running/are deactivated.
Disable or hide functionalities which would result in error for transient resources:
- Autostart
- Deletion

@andreasn @garrett WDYT about these design changes?

Heres screenshot of **persistent** virtual network:
![Screenshot from 2019-11-18 17-08-40](https://user-images.githubusercontent.com/42733240/69069496-d95ce400-0a26-11ea-9dda-61c0a121a9b7.png)

And **transient** virtual network
![Screenshot from 2019-11-18 17-09-18](https://user-images.githubusercontent.com/42733240/69069455-c64a1400-0a26-11ea-9750-5f2c01476bf5.png)


(changes shown in screenshot for virtual network are the same also for storage pools).