### PR TITLE
systemd: Support `mitigations=` kernel parameter to disable SMT

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -529,7 +529,6 @@ class TestSystemInfo(MachineCase):
 
             m.execute('umount $(which dmidecode)')
 
-    @skipImage("mitigations=nosmt not recognized, #13138", "fedora-coreos")
     def testCPUSecurityMitigations(self):
         b = self.browser
         m = self.machine
@@ -565,11 +564,14 @@ class TestSystemInfo(MachineCase):
                 m.execute('while ! umount /proc/cmdline; do sleep 1; done')
                 m.execute('rm /run/cmdline')
 
-        # We expect our test VMs to not set nosmt
         spoof_threads(1, False)
         spoof_threads(2, True, True, 'param1 param2 nosmt param3=value3')
         spoof_threads(2, True, True, 'param1 param2 nosmt=force param3=value3')
+        spoof_threads(2, True, True, 'param1 mitigations=auto,nosmt param3=value3')
+        spoof_threads(2, True, True, 'param1 mitigations=nosmt,something param3=value3')
+        spoof_threads(2, True, False, 'param1 mitigations=something param3=value3')
         spoof_threads(2, False, cmdline='param1 nosmt=someunknown param3=value3')
+        # Most OSes don't set nosmt by default, but there are some exceptions
         expect_smt_default = m.image in ["fedora-coreos"]
         spoof_threads(2, True, expect_smt_default, None)
 
@@ -580,10 +582,18 @@ class TestSystemInfo(MachineCase):
             b.click('#hwinfo a:contains(Mitigations)')
         else:
             b.click('#hwinfo button:contains(Mitigations)')
+
+
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_present('#cpu-mitigations-dialog #nosmt-switch input' +
                        (expect_smt_default and ':not(:checked)' or ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
+
+        if self.image in ["fedora-coreos"]:
+            # no way to set kernel options: https://github.com/coreos/fedora-coreos-config/issues/234
+            b.wait_present('#cpu-mitigations-dialog .pf-c-alert__title:contains(No supported grub update mechanism found)')
+            return
+
         m.wait_reboot()
         if expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -658,6 +658,23 @@ fi
         else:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
 
+        # updates mitigations=nosmt when that is present
+        if m.image != "rhel-8-1-distropkg":  # fixed in PR #13166
+            m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
+            m.execute("/tmp/kernelopt.sh remove nosmt && /tmp/kernelopt.sh set mitigations=auto,nosmt")
+            m.spawn("sync && sleep 0.1 && reboot", "reboot")
+            m.wait_reboot()
+            self.login_and_go('/system/hwinfo')
+            b.click('#hwinfo button:contains(Mitigations)')
+            b.wait_present('#cpu-mitigations-dialog span:contains(nosmt)')
+            b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:checked')
+            b.click('#cpu-mitigations-dialog #nosmt-switch input')
+            b.wait_present('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
+            b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
+            m.wait_reboot()
+            self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
+            self.assertIn('mitigations=auto', m.execute('cat /proc/cmdline'))
+
         # Behaviour for non-admins
         self.login_and_go('/system/hwinfo', authorized=False)
         b.wait_present('#hwinfo th:contains(CPU)')


### PR DESCRIPTION
See individual commits for details.

Fixes #13138