### PR TITLE
systemd: Add rpm-ostree backend to CPU mitigations

### DIFF
--- a/pkg/systemd/kernelopt.sh
+++ b/pkg/systemd/kernelopt.sh
@@ -49,8 +49,21 @@ grub() {
     # on Debian/Ubuntu, use update-grub, which reads from /etc/default/grub
     elif [ -e /etc/default/grub ] && type update-grub >/dev/null 2>&1; then
         update-grub
+
+    # on OSTree, the kernel config is inside the image
+    elif cur=$(rpm-ostree kargs 2>&1); then
+        if [ "$1" = set ]; then
+            # replace if already present
+            if [ "${cur% $key *}" != "$cur" ] || [ "${cur% $key=*}" != "$cur" ]; then
+                rpm-ostree kargs --replace="$2"
+            else
+                rpm-ostree kargs --append="$2"
+            fi
+        else
+            rpm-ostree kargs --delete="$key"
+        fi
     else
-        error "No supported grub update mechanism found (grubby or update-grub)"
+        error "No supported grub update mechanism found (grubby, update-grub, or rpm-ostree)"
     fi
 }
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -589,11 +589,6 @@ class TestSystemInfo(MachineCase):
                        (expect_smt_default and ':not(:checked)' or ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
 
-        if self.image in ["fedora-coreos"]:
-            # no way to set kernel options: https://github.com/coreos/fedora-coreos-config/issues/234
-            b.wait_present('#cpu-mitigations-dialog .pf-c-alert__title:contains(No supported grub update mechanism found)')
-            return
-
         m.wait_reboot()
         if expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
@@ -686,6 +681,7 @@ fi
         m.execute('mv /etc/default/grub /etc/default/grub.bak || true')
         m.write('/tmp/grubby', '#!/bin/sh\necho 0')
         m.execute('[ ! -f /usr/sbin/grubby ] || mount --bind /tmp/grubby /usr/sbin/grubby')
+        m.execute('systemctl stop rpm-ostreed.service || true; systemctl mask rpm-ostreed.service')
         self.login_and_go('/system/hwinfo')
         if m.image == "rhel-8-1-distropkg":
             b.click('#hwinfo a:contains(Mitigations)')


### PR DESCRIPTION
On Fedora CoreOS and other rpm-ostree based OSes, the kernel config is
inside the image, and not directly accessible through editing files,
calling grubby, or similar. Instead, `rpm-ostree kargs` creates a new
overlay with the changed arguments.

Add this to kernelopt.sh and enable the full SMT mitigation test case on
fedora-coreos.