### PR TITLE
Standard alerts on login page

### DIFF
--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -2415,7 +2415,7 @@ function factory() {
         };
     }
 
-    cockpit.logout = function logout(reload) {
+    cockpit.logout = function logout(reload, reason) {
         /* fully clear session storage */
         cockpit.sessionStorage.clear(true);
 
@@ -2431,6 +2431,8 @@ function factory() {
                 window.location.reload(reload_after_disconnect);
         });
         window.sessionStorage.setItem("logout-intent", "explicit");
+        if (reason)
+            window.sessionStorage.setItem("logout-reason", reason);
     };
 
     /* Not public API ... yet? */

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -411,18 +411,72 @@ label.checkbox {
   margin: 0.25rem 1rem;
 }
 
-.alert {
-  padding: 7px 11px;
-  margin-bottom: 20px;
-  border: 2px solid transparent;
-  border-radius: 1px;
+.group-hidden {
+    display: none !important;
 }
 
-.alert-danger {
-  background: #c00;
-  border-color: #c00;
-  color: #fff;
-  font-weight: 700;
+/* Alerts */
+.pf-c-alert {
+    color: #151515;
+    position: relative;
+    grid-template-columns: repeat(2, max-content) 1fr max-content;
+    grid-template-rows: 1fr auto;
+    grid-template-areas: "icon title action" ". content content";
+    background-color: #fff;
+    margin: 0 0 1.5rem;
+    align-items: center;
+    display: grid;
+}
+
+.pf-c-alert.pf-m-inline {
+    border: solid #ededed;
+    border-width: 1px 1px 1px 0;
+}
+
+.pf-c-alert.pf-m-inline::before {
+    position: absolute;
+    top: -1px;
+    bottom: -1px;
+    left: 0;
+    width: 3px;
+    content: "";
+}
+
+.pf-c-alert > svg {
+  grid-area: icon;
+  height: 18px;
+  width: 18px;
+  margin: 1rem 0 1rem 1rem;
+}
+
+.pf-c-alert__title {
+  grid-area: title;
+  font-size: 1rem;
+  margin: 1rem;
+}
+
+.pf-c-alert.pf-m-inline.pf-m-danger::before {
+    background-color: #c9190b;
+}
+
+.pf-c-alert.pf-m-danger > svg {
+  color: #c9190b;
+}
+
+.pf-c-alert.pf-m-danger .pf-c-alert__title {
+    color: #a30000;
+}
+
+.pf-c-alert.pf-m-inline.pf-m-info::before {
+    background-color: #73bcf7;
+}
+
+.pf-c-alert.pf-m-info > svg {
+  color: #73bcf7;
+}
+
+.pf-c-alert.pf-m-info .pf-c-alert__title {
+    color: #004368;
 }
 
 #server-group:before {

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -30,6 +30,11 @@
               <h4 id="login-error-message" class="pf-c-alert__title"></h4>
             </div>
 
+            <div id="info-group" class="pf-c-alert pf-m-info pf-m-inline dialog-error group-hidden" aria-label="inline danger alert">
+              <svg fill="currentColor" viewBox="0 0 512 512" aria-hidden="true"><path d="M256 8C119.043 8 8 119.083 8 256c0 136.997 111.043 248 248 248s248-111.003 248-248C504 119.083 392.957 8 256 8zm0 110c23.196 0 42 18.804 42 42s-18.804 42-42 42-42-18.804-42-42 18.804-42 42-42zm56 254c0 6.627-5.373 12-12 12h-88c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h12v-64h-12c-6.627 0-12-5.373-12-12v-24c0-6.627 5.373-12 12-12h64c6.627 0 12 5.373 12 12v100h12c6.627 0 12 5.373 12 12v24z"/></svg>
+              <h4 id="login-info-message" class="pf-c-alert__title"></h4>
+            </div>
+
             <div id="conversation-group" class="form-group" hidden>
               <div id="conversation-message"></div>
               <label id="conversation-prompt" for="conversation-input"></label>

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -25,8 +25,9 @@
         <div id="login" class="login-area" style="visibility: hidden;">
           <div role="form">
 
-            <div id="error-group" class="alert alert-danger" hidden>
-              <span id="login-error-message"></span>
+            <div id="error-group" class="pf-c-alert pf-m-danger pf-m-inline dialog-error group-hidden" aria-label="inline danger alert">
+              <svg fill="currentColor" viewBox="0 0 512 512" aria-hidden="true"><path d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"/></svg>
+              <h4 id="login-error-message" class="pf-c-alert__title"></h4>
             </div>
 
             <div id="conversation-group" class="form-group" hidden>

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -393,7 +393,7 @@
     }
 
     function clear_errors() {
-        id("error-group").style.display = "none";
+        id("error-group").classList.add("group-hidden");
         id("login-error-message").textContent = "";
     }
 
@@ -406,7 +406,7 @@
             } else {
                 show_form(in_conversation);
                 id("login-error-message").textContent = msg;
-                id("error-group").style.display = "block";
+                id("error-group").classList.remove("group-hidden");
             }
         }
     }
@@ -418,7 +418,7 @@
         } else {
             clear_errors();
             id("login-error-message").textContent = msg;
-            id("error-group").style.display = "block";
+            id("error-group").classList.remove("group-hidden");
             toggle_options(null, true);
             show_form();
         }

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -291,6 +291,10 @@
         if (logout_intent)
             window.sessionStorage.removeItem("logout-intent");
 
+        var logout_reason = window.sessionStorage.getItem("logout-reason");
+        if (logout_reason)
+            window.sessionStorage.removeItem("logout-reason");
+
         /* Try automatic/kerberos authentication? */
         if (oauth) {
             id("login-details").style.display = 'none';
@@ -303,7 +307,7 @@
                 oauth_auto_login();
             }
         } else if (logout_intent) {
-            show_login();
+            show_login(logout_reason);
         } else {
             standard_auto_login();
         }
@@ -397,6 +401,11 @@
         id("login-error-message").textContent = "";
     }
 
+    function clear_info() {
+        id("info-group").classList.add("group-hidden");
+        id("login-info-message").textContent = "";
+    }
+
     function login_failure(msg, in_conversation) {
         clear_errors();
         if (msg) {
@@ -408,6 +417,14 @@
                 id("login-error-message").textContent = msg;
                 id("error-group").classList.remove("group-hidden");
             }
+        }
+    }
+
+    function login_info(msg) {
+        clear_info();
+        if (msg) {
+            id("login-info-message").textContent = msg;
+            id("info-group").classList.remove("group-hidden");
         }
     }
 
@@ -509,12 +526,14 @@
             id("login-button").addEventListener("click", call_login);
     }
 
-    function show_login() {
+    function show_login(message) {
         /* Show the login screen */
+        login_info(message);
         id("server-name").textContent = document.title;
         login_note(_("Log in with your server user account."));
         id("login-user-input").addEventListener("keydown", function(e) {
             login_failure(null);
+            clear_info();
             if (e.which == 13)
                 id("login-password-input").focus();
         }, false);


### PR DESCRIPTION
I was working on session timeout and I needed to show a info alert on the login page. We had only support for error alerts. So I decided we could just use the same style of alerts on the login page as we do in the rest of the Cockpit.
Before:
![oldalert](https://user-images.githubusercontent.com/12330670/69411496-5df08080-0d0d-11ea-8f76-32f3fb4a866e.png)
Now:
![newalert](https://user-images.githubusercontent.com/12330670/69411512-647ef800-0d0d-11ea-8a79-cd39fb197d8c.png)

Also I am sending here showing of info messages. Nothing uses it yet, but I think it is simple enough to review. Looks like this:
![andinfo](https://user-images.githubusercontent.com/12330670/69411552-7eb8d600-0d0d-11ea-8f76-ce20efc7a0a4.png)

no-test since it needs Closes and very likely breaks tests anyway. So running F30 just to get list of what I need to fix.

@garrett WDYT? The css is mostly stolen from PF4 alerts with tiny tweaks. I guess that part of it is not needed?
