### PR TITLE
Fix SELinux launchable link

### DIFF
--- a/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
+++ b/pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml
@@ -11,7 +11,7 @@
     </p>
   </description>
   <extends>org.cockpit_project.cockpit</extends>
-  <launchable type="cockpit-manifest">setroubleshoot</launchable>
+  <launchable type="cockpit-manifest">selinux/setroubleshoot</launchable>
   <url type="homepage">https://cockpit-project.org/</url>
   <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
 </component>


### PR DESCRIPTION
I didn't test this locally since I am not sure how to.

Anyhow, if you go to Applications and click SELinux it tries to go to `/setroubleshoot` but it should be `/selinux/setroubleshoot`. Thus rendering a Not Found page.