### PR TITLE
realm: Don't show error alert on an freshly open 'Join Domain' dialog

### DIFF
--- a/pkg/realmd/operation.html
+++ b/pkg/realmd/operation.html
@@ -72,7 +72,7 @@
         </div>
       </div>
       <div class="modal-footer">
-        <div class="pf-c-alert pf-m-danger pf-m-inline realms-op-error" aria-label="inline danger alert" hidden>
+        <div class="pf-c-alert pf-m-danger pf-m-inline realms-op-error" aria-label="inline danger alert">
           <div class="pf-c-alert__icon">
             <span class="fa fa-exclamation-circle"></span>
           </div>

--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -33,6 +33,9 @@ function instance(realmd, mode, realm, button) {
     var kerberos_membership = null;
     var kerberos = null;
 
+    // Hidden attribute does not work because .pf-c-class has diplay: grid
+    $(".realms-op-error").hide();
+
     /* If in an operation first time cancel is clicked, cancel operation */
     $(".realms-op-cancel").on("click", function() {
         if (!cancel())


### PR DESCRIPTION
Fixes #13157