### PR TITLE
storage: Integrate encryption better

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -128,7 +128,28 @@ export function clevis_recover_passphrase(block, just_type) {
             .then(output => output.trim());
 }
 
-/* Passphrase and slot operations
+function clevis_unlock(block) {
+    var dev = decode_filename(block.Device);
+    var clear_dev = "luks-" + block.IdUUID;
+    return cockpit.spawn(["clevis", "luks", "unlock", "-d", dev, "-n", clear_dev],
+                         { superuser: true });
+}
+
+export function unlock_with_type(client, block, passphrase, passphrase_type) {
+    const crypto = client.blocks_crypto[block.path];
+    if (passphrase)
+        return crypto.Unlock(passphrase, {});
+    else if (passphrase_type == "stored")
+        return crypto.Unlock("", {});
+    else if (passphrase_type == "clevis")
+        return clevis_unlock(block);
+    else {
+        // This should always be caught and should never show up in the UI
+        return Promise.reject(new Error("No passphrase"));
+    }
+}
+
+/* Passphrase operations
  */
 
 function passphrase_add(block, new_passphrase, old_passphrase) {

--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -24,6 +24,7 @@ import { cellWidth, SortByDirection } from '@patternfly/react-table';
 import { ListingTable } from "cockpit-components-table.jsx";
 import { block_name, get_block_link_parts, go_to_block } from "./utils.js";
 import { OptionalPanel } from "./optional-panel.jsx";
+import { get_fstab_config } from "./fsys-tab.jsx";
 
 const _ = cockpit.gettext;
 
@@ -35,7 +36,11 @@ export class LockedCryptoPanel extends React.Component {
             var block = client.blocks[path];
             var crypto = client.blocks_crypto[path];
             var cleartext = client.blocks_cleartext[path];
-            return crypto && !cleartext && !block.HintIgnore;
+            if (crypto && !cleartext && !block.HintIgnore) {
+                const [, mount_point] = get_fstab_config(block, true);
+                return !mount_point;
+            }
+            return false;
         }
 
         function make_locked_crypto(path) {

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -521,6 +521,7 @@ export const PassInput = (tag, title, options) => {
         render: (val, change, validated) =>
             <TextInputPF4 data-field={tag} data-field-type="text-input"
                    validated={validated}
+                   disabled={options.disabled}
                    aria-label={title}
                    type="password" value={val}
                    onChange={change} />
@@ -635,6 +636,10 @@ export const SelectRow = (tag, headers, options) => {
     };
 };
 
+function nice_block_name(block) {
+    return block_name(client.blocks[block.CryptoBackingDevice] || block);
+}
+
 export const SelectSpaces = (tag, title, options) => {
     return {
         tag: tag,
@@ -651,7 +656,7 @@ export const SelectSpaces = (tag, title, options) => {
                     data-field={tag} data-field-type="select-spaces">
                     { options.spaces.map(spc => {
                         const selected = (val.indexOf(spc) >= 0);
-                        const block = spc.block ? block_name(spc.block) : "";
+                        const block = spc.block ? nice_block_name(spc.block) : "";
                         const desc = block === spc.desc ? "" : spc.desc;
 
                         const on_change = (checked) => {
@@ -705,7 +710,7 @@ export const SelectSpace = (tag, title, options) => {
                 <DataList isCompact
                     data-field={tag} data-field-type="select-spaces">
                     { options.spaces.map(spc => {
-                        const block = spc.block ? block_name(spc.block) : "";
+                        const block = spc.block ? nice_block_name(spc.block) : "";
                         const desc = block === spc.desc ? "" : spc.desc;
                         const on_change = (event) => {
                             if (event.target.checked)

--- a/pkg/storaged/jobs-panel.jsx
+++ b/pkg/storaged/jobs-panel.jsx
@@ -92,7 +92,7 @@ function make_description(client, job) {
 
     var target = job.Objects.map(function (path) {
         if (client.blocks[path])
-            return block_name(client.blocks[path]);
+            return block_name(client.blocks[client.blocks[path].CryptoBackingDevice] || client.blocks[path]);
         else if (client.mdraids[path])
             return mdraid_name(client.mdraids[path]);
         else if (client.vgroups[path])
@@ -213,10 +213,10 @@ export class JobsPanel extends React.Component {
     }
 }
 
-export function job_progress_wrapper(client, path) {
+export function job_progress_wrapper(client, path1, path2) {
     return function (vals, progress_callback, action_function) {
         function client_changed() {
-            const job = client.path_jobs[path];
+            const job = client.path_jobs[path1] || client.path_jobs[path2];
             if (job) {
                 let desc = make_description(client, job);
                 if (job.ProgressValid)

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -54,13 +54,6 @@ function lvol_rename(lvol) {
     });
 }
 
-function is_mounted_synch(block) {
-    return (cockpit.spawn(["findmnt", "-S", utils.decode_filename(block.Device)],
-                          { superuser: true, err: "message" })
-            .then(() => true)
-            .catch(() => false));
-}
-
 function lvol_and_fsys_resize(client, lvol, size, offline, passphrase) {
     var block, crypto, fsys;
     var crypto_overhead;
@@ -102,7 +95,7 @@ function lvol_and_fsys_resize(client, lvol, size, offline, passphrase) {
             // filesystem back if that's what we expect, to undo the
             // bug mentioned above. But let's be a bit more passive
             // here and hope the bug gets fixed eventually.
-            return (is_mounted_synch(client.blocks[fsys.path])
+            return (utils.is_mounted_synch(client.blocks[fsys.path])
                     .then(is_mounted => {
                         // When doing an offline resize, we need to first repair the filesystem.
                         if (!is_mounted) {

--- a/pkg/storaged/side-panel.jsx
+++ b/pkg/storaged/side-panel.jsx
@@ -138,10 +138,11 @@ export class SidePanelBlockRow extends React.Component {
 
         const parts = get_block_link_parts(client, block.path);
         const name = cockpit.format(parts.format, parts.link);
+        const backing = client.blocks[block.CryptoBackingDevice];
 
         return <SidePanelRow client={client}
                              name={name}
-                             devname={block_name(block)}
+                             devname={block_name(backing || block)}
                              detail={detail}
                              go={() => { cockpit.location.go(parts.location) }}
                              actions={actions} />;

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -638,7 +638,7 @@ export function get_active_usage(client, path) {
 
         if (use.usage == 'mounted') {
             res.Teardown.Mounts.push({
-                Name: block_name(use.block),
+                Name: block_name(client.blocks[use.block.CryptoBackingDevice] || use.block),
                 MountPoint: decode_filename(use.fsys.MountPoints[0])
             });
         } else if (use.usage == 'mdraid-member') {
@@ -770,4 +770,11 @@ export function fmt_to_array(fmt, arg) {
 
 export function reload_systemd() {
     return cockpit.spawn(["systemctl", "daemon-reload"], { superuser: "require", err: "message" });
+}
+
+export function is_mounted_synch(block) {
+    return (cockpit.spawn(["findmnt", "-n", "-o", "TARGET", "-S", decode_filename(block.Device)],
+                          { superuser: true, err: "message" })
+            .then(data => data.trim())
+            .catch(() => false));
 }

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -64,15 +64,13 @@ class TestStorageHidden(StorageCase):
                      "passphrase2": "einszweidrei",
                      "mount_point": mount_point_1,
                      "mount_options.auto": False,
-                     "crypto_options.extra": "my-crypto-tag"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+                     "crypto_options": "my-crypto-tag"})
+        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
         self.wait_in_storaged_configuration(mount_point_1)
         self.wait_in_storaged_configuration("my-crypto-tag")
 
-        # Now doubly hide the clear text block device by locking the
-        # crypto backing device and deactivating /dev/TEST/lvol
-        self.content_dropdown_action(1, "Lock")
-        b.wait_not_in_text("#detail-content", "Filesystem")
+        # Now the filesystem is hidden because the LUKS device is
+        # locked.  Doubly hide it by deactivating /dev/TEST/lvol
         self.content_dropdown_action(1, "Deactivate")
         self.content_row_wait_in_col(1, 1, "48 MiB Inactive volume")
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -59,26 +59,27 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("store_passphrase.on", True)
-        self.dialog_set_val("crypto_options.extra", "crypto,options")
+        self.dialog_set_val("crypto_options", "crypto,options")
         self.dialog_set_val("mount_point", mount_point_secret)
         self.dialog_set_val("mount_options.auto", True)
         b.assert_pixels("#dialog", "format")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
+        self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_secret)
 
         if self.default_crypto_type == "luks1":
-            self.content_tab_wait_in_info(1, 2, "Encryption type", "LUKS1")
+            self.content_tab_wait_in_info(1, 3, "Encryption type", "LUKS1")
         elif self.default_crypto_type == "luks2":
-            self.content_tab_wait_in_info(1, 2, "Encryption type", "LUKS2")
+            self.content_tab_wait_in_info(1, 3, "Encryption type", "LUKS2")
 
         # cut off minutes, to avoid a too wide race condition in the test
         date_no_mins = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format()").split(':')[0]
-        self.content_tab_wait_in_info(1, 2, "Stored passphrase", "Last modified: %s:" % date_no_mins)
+        self.content_tab_wait_in_info(1, 3, "Stored passphrase", "Last modified: %s:" % date_no_mins)
 
-        tab = self.content_tab_expand(1, 2)
-        b.assert_pixels(tab, "tab", ignore=["dt:contains(Stored passphrase) + dd"])
+        tab = self.content_tab_expand(1, 3)
+        b.assert_pixels(tab, "tab", ignore=["dt:contains(Stored passphrase) + dd",
+                                            "dt:contains(Cleartext device) + dd"])
 
         self.wait_in_storaged_configuration(mount_point_secret)
         self.wait_in_storaged_configuration("crypto,options")
@@ -87,63 +88,73 @@ class TestStorageLuks(StorageCase):
         self.assertNotEqual(m.execute("grep %s /etc/fstab" % mount_point_secret), "")
         self.assertEqual(m.execute("cat /etc/luks-keys/*"), "vainu-reku-toma-rolle-kaja")
 
-        # Unmount and Lock it
-        self.content_dropdown_action(2, "Unmount")
-        self.content_tab_wait_in_info(2, 1, "Mount point", "The filesystem is not mounted")
-        self.content_dropdown_action(1, "Lock")
-        b.wait_not_in_text("#detail-content", "ext4 file system")
+        # Unmount. this locks it
+        self.content_dropdown_action(1, "Unmount")
+        self.content_tab_wait_in_info(1, 2, "Mount point", "The filesystem is not mounted")
 
         # It should be listed on the Overview. Click it to come back
         # here.
         b.go("#/")
-        b.mousedown("#locked-cryptos tr:contains(MYDISK)")
+        b.mousedown("#mounts tr:contains(%s)" % mount_point_secret)
         b.wait_visible("#storage-detail")
 
-        # Unlock, this uses the stored passphrase
-        self.content_row_action(1, "Unlock")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        # Mount, this uses the stored passphrase for unlocking
+        self.content_row_action(1, "Mount")
+        self.dialog_wait_open()
+        self.dialog_wait_val("mount_point", mount_point_secret)
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
 
         # Change options.  We keep trying until the stack has synched
         # up with crypttab and we see the old options.
-        self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 2, "Options"),
-                               expect={"crypto_options.extra": "crypto,options"},
-                               values={"crypto_options.extra": "weird,options"})
+        self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 3, "Options"),
+                               expect={"options": "crypto,options"},
+                               values={"options": "weird,options"})
 
         self.assertNotEqual(m.execute("grep 'weird,options' /etc/crypttab"), "")
         self.wait_in_storaged_configuration("weird,options")
 
         # Change stored passphrase
-        edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + dd button"
+        edit_button = self.content_tab_info_label(1, 3, "Stored passphrase") + " + dd button"
         self.dialog_with_retry(trigger=lambda: b.click(edit_button),
                                expect={"passphrase": "vainu-reku-toma-rolle-kaja"},
                                values={"passphrase": "wrong-passphrase"})
 
         self.assertEqual(m.execute("cat /etc/luks-keys/*"), "wrong-passphrase")
 
-        # Lock it
-        self.content_dropdown_action(1, "Lock")
+        # Unmount it
+        self.content_dropdown_action(1, "Unmount")
         b.wait_not_in_text("#detail-content", "ext4 file system")
 
-        # Unlock, this tries the wrong passphrase but eventually prompts.
-        self.content_row_action(1, "Unlock")
-        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        # Mount, this tries the wrong passphrase but eventually prompts.
+        self.content_row_action(1, "Mount")
+        self.dialog_wait_open()
+        self.dialog_apply()
+        b.wait_in_text("#dialog", "Failed to activate device:")
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
 
         # Remove passphrase
-        edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + dd button"
+        edit_button = self.content_tab_info_label(1, 3, "Stored passphrase") + " + dd button"
         self.dialog_with_retry(trigger=lambda: b.click(edit_button),
                                expect={"passphrase": "wrong-passphrase"},
                                values={"passphrase": ""})
         self.wait_in_storaged_configuration("'passphrase-path': <b''>")
 
-        # Lock it
-        self.content_dropdown_action(1, "Lock")
+        # Unmount it
+        self.content_dropdown_action(1, "Unmount")
         b.wait_not_in_text("#detail-content", "ext4 file system")
 
-        # Unlock, this asks for a passphrase
-        self.content_row_action(1, "Unlock")
-        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        # Mount it readonly.  This asks for a passphrase.
+        self.content_row_action(1, "Mount")
+        self.dialog({"mount_options.ro": True,
+                     "passphrase": "vainu-reku-toma-rolle-kaja"})
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
+        self.assertIn("ro", m.execute("findmnt -s -n -o OPTIONS %s" % mount_point_secret))
+        self.assertNotEqual(m.execute("grep readonly /etc/crypttab"), "")
 
         # Delete the partition.
         self.content_dropdown_action(1, "Delete")
@@ -167,6 +178,8 @@ class TestStorageLuks(StorageCase):
         m = self.machine
         b = self.browser
 
+        mount_point_secret = "/run/secret"
+
         if m.image == "ubuntu-stable":
             # ubuntu-stable needs this workaround.
             m.execute("mkdir -p /var/db/tang")
@@ -185,20 +198,15 @@ class TestStorageLuks(StorageCase):
         self.dialog({"type": "ext4",
                      "crypto": self.default_crypto_type,
                      "name": "ENCRYPTED",
-                     "mount_point": "/foo",
+                     "mount_point": mount_point_secret,
                      "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 
-        # Lock the disk
-        #
-        self.content_dropdown_action(1, "Lock")
-        b.wait_not_in_text("#detail-content", "ext4 file system")
-
-        self.content_tab_wait_in_info(1, 1, "Options", "none")
-        tab = self.content_tab_expand(1, 1)
+        self.content_tab_wait_in_info(1, 2, "Options", "none")
+        tab = self.content_tab_expand(1, 2)
         panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_visible(panel)
         b.wait_in_text(panel + "ul li:nth-child(1)", "Passphrase")
@@ -222,10 +230,14 @@ class TestStorageLuks(StorageCase):
         b.wait_visible(panel + "ul li:nth-child(2)")
         b.wait_in_text(panel + "ul li:nth-child(2)", "127.0.0.1")
 
-        # Unlock it.  This should succeed without prompting.
+        # Mount it.  This should succeed without passphrase.
         #
-        self.content_row_action(1, "Unlock")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_action(1, "Mount")
+        self.dialog_wait_open()
+        self.dialog_wait_val("mount_point", mount_point_secret)
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
 
         # Edit the key, without providing an existing passphrase
         #
@@ -253,6 +265,8 @@ class TestStorageLuks(StorageCase):
         m = self.machine
         b = self.browser
 
+        mount_point_secret = "/run/secret"
+
         error_base = "Error unlocking /dev/sda: Failed to activate device: "
         error_messages = [error_base + "Operation not permitted",
                           error_base + "Incorrect passphrase."]
@@ -268,15 +282,16 @@ class TestStorageLuks(StorageCase):
         self.dialog({"type": "ext4",
                      "crypto": "luks1",
                      "name": "ENCRYPTED",
-                     "mount_point": "/foo",
+                     "mount_point": mount_point_secret,
                      "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
-        self.content_tab_wait_in_info(1, 1, "Options", "none")
+        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+        self.content_tab_wait_in_info(1, 2, "Options", "none")
+
         # add one more passphrase
-        tab = self.content_tab_expand(1, 1)
+        tab = self.content_tab_expand(1, 2)
         panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_visible(panel)
         b.click(panel + "[aria-label=Add]")
@@ -289,17 +304,15 @@ class TestStorageLuks(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         # unlock with first passphrase
-        self.content_dropdown_action(1, "Lock")
-        b.wait_not_in_text("#detail-content", "ext4 file system")
-        self.content_row_action(1, "Unlock")
+        self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
         # unlock with second passphrase
-        self.content_dropdown_action(1, "Lock")
+        self.content_dropdown_action(1, "Unmount")
         b.wait_not_in_text("#detail-content", "ext4 file system")
-        self.content_row_action(1, "Unlock")
+        self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
         # delete second key slot
         b.click(panel + "li:nth-child(2) button[aria-label=Remove]")
         # do not accept the same passphrase
@@ -311,9 +324,9 @@ class TestStorageLuks(StorageCase):
         b.click("button:contains('Remove')")
         b.wait_not_present("#remove-passphrase")
         # check that it is not possible to unlock with deleted passphrase
-        self.content_dropdown_action(1, "Lock")
+        self.content_dropdown_action(1, "Unmount")
         b.wait_not_in_text("#detail-content", "ext4 file system")
-        self.content_row_action(1, "Unlock")
+        self.content_row_action(1, "Mount")
         self.dialog_wait_open()
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja-1")
         self.dialog_apply()
@@ -355,7 +368,7 @@ class TestStorageLuks(StorageCase):
         b.click("button:contains('Remove')")
         b.wait_not_present("#remove-passphrase")
         # check that it is not possible to unlock with deleted passphrase
-        self.content_row_action(1, "Unlock")
+        self.content_row_action(1, "Mount")
         self.dialog_wait_open()
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
@@ -373,9 +386,9 @@ class TestStorageLuks(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         # unlock volume with the newly created passphrase
-        self.content_row_action(1, "Unlock")
+        self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
 
     def testNoFsys(self):
         m = self.machine
@@ -394,16 +407,34 @@ class TestStorageLuks(StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_row_wait_in_col(2, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 1, "Unrecognized data (encrypted)")
 
-    def testNoauto(self):
+        # Lock it
+        self.content_dropdown_action(1, "Lock")
+        self.content_row_wait_in_col(1, 1, "Locked encrypted data")
+
+        # Make it readonly
+        self.content_tab_info_action(1, 1, "Options")
+        self.dialog({"options": "readonly"})
+        self.assertNotEqual(m.execute("grep readonly /etc/crypttab"), "")
+
+        # Unlock it
+        self.content_row_action(1, "Unlock")
+        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
+
+        # Try to format it, just for kicks
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
+
+    def testKeepKeys(self):
         m = self.machine
         b = self.browser
 
         self.login_and_go("/storage")
 
-        # Add a disk and format it with luks and a filesystem, but without "Unlock at boot"
+        # Add a disk and format it with luks and a filesystem
 
         m.add_disk("50M", serial="MYDISK")
         b.wait_in_text("#drives", "MYDISK")
@@ -413,43 +444,36 @@ class TestStorageLuks(StorageCase):
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "crypto": self.default_crypto_type,
-                     "crypto_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_options.auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_tab_wait_in_info(1, 1, "Options", "noauto")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
 
-        # The filesystem should be mounted but have the "noauto" option
-        self.wait_mounted(2, 1)
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        # Format it again but keep the keys
 
-        # Unmounting should keep the noauto option, as always
-        self.content_dropdown_action(2, "Unmount")
-        self.content_tab_wait_in_info(2, 1, "Mount point", "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.content_dropdown_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "crypto": " keep",
+                     "mount_options.auto": True,
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
 
-        # Mounting should also keep the "noauto", but it should not show up in the extra options
-        self.content_row_action(2, "Mount")
-        self.dialog_check({"mount_options.extra": False})
-        self.dialog_apply()
-        self.wait_mounted(2, 1)
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        # Unmount (and lock) it
 
-        # As should updating the mount information
-        self.content_tab_info_action(2, 1, "Mount point", wrapped=True)
-        self.dialog_check({"mount_options.extra": False})
-        self.dialog_apply()
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.content_dropdown_action(1, "Unmount")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 
-        # Removing "noauto" externally should show a warning
-        m.execute("sed -i -e 's/noauto//' /etc/fstab")
-        fsys_tab = self.content_tab_expand(2, 1)
-        b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
-        b.click(fsys_tab + " button:contains(Do not mount automatically)")
-        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
+        # Format it again and keep the keys.  Because it's locked, we
+        # need the old passphrase.
+
+        self.content_dropdown_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "crypto": " keep",
+                     "old_passphrase": "vainu-reku-toma-rolle-kaja",
+                     "mount_options.auto": True,
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -86,6 +86,12 @@ class TestStorageMounting(StorageCase):
         self.confirm()
         self.wait_mounted(1, 1)
 
+        # Set the "Never unlock at boot option"
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog({"mount_options.never_auto": True})
+        self.assertIn("noauto", m.execute("findmnt -s -n -o OPTIONS %s" % mount_point_bar))
+        self.assertIn("x-cockpit-never-auto", m.execute("findmnt -s -n -o OPTIONS %s" % mount_point_bar))
+
         # Go to overview page and check that the filesystem usage is
         # displayed correctly.
 
@@ -114,68 +120,6 @@ class TestStorageMounting(StorageCase):
             return b.wait_text('#detail-header dt:contains("%s") + dd' % name, value)
 
         wait_info_field_value("Serial number", "MYDISK")
-
-    def testMountOptions(self):
-        m = self.machine
-        b = self.browser
-
-        self.login_and_go("/storage")
-
-        # Add a disk
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('#drives .sidepanel-row:contains("MYDISK")')
-        b.wait_visible('#storage-detail')
-
-        # Open format dialog and play with the checkboxes
-
-        self.content_row_action(1, "Format")
-        self.dialog_wait_open()
-        self.dialog_set_val("type", "ext4")
-        self.dialog_set_val("crypto", self.default_crypto_type)
-
-        def wait_checked(field):
-            b.wait_visible(self.dialog_field(field) + ":checked")
-
-        def wait_not_checked(field):
-            b.wait_visible(self.dialog_field(field) + ":not(:checked)")
-
-        wait_checked("crypto_options.auto")
-        wait_checked("mount_options.auto")
-        wait_not_checked("crypto_options.ro")
-        wait_not_checked("mount_options.ro")
-
-        # Check crypto ro.  This gets propagated to mount ro.
-        self.dialog_set_val("crypto_options.ro", True)
-        wait_checked("mount_options.ro")
-
-        # Uncheck mount ro.  This gets propagated to crypto ro.
-        self.dialog_set_val("mount_options.ro", False)
-        wait_not_checked("crypto_options.ro")
-
-        # Uncheck crypto auto and check crypto_ro again to verify that
-        # they have the expected effect.
-        self.dialog_set_val("crypto_options.auto", False)
-        self.dialog_set_val("crypto_options.ro", True)
-
-        # Set extra options.
-        self.dialog_set_val("crypto_options.extra", "x-foo")
-        self.dialog_set_val("mount_options.extra", "x-foo")
-
-        # Fill in the erst and do the format
-        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
-        self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
-        self.dialog_set_val("mount_point", "/data")
-        self.dialog_apply()
-        self.dialog_wait_close()
-
-        self.content_row_wait_in_col(1, 1, "Encrypted data")
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
-        self.wait_in_storaged_configuration("/data")
-        self.wait_mounted(2, 1)
-
-        m.execute("grep 'noauto,readonly,x-foo' /etc/crypttab")
-        m.execute("grep 'noauto,ro,x-foo' /etc/fstab")
 
     def testMountingHelp(self):
         m = self.machine
@@ -249,6 +193,81 @@ class TestStorageMounting(StorageCase):
         m.execute("sed -i -e 's/noauto/noauto,x-systemd.automount/' /etc/fstab")
         b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
 
+    def testEncryptedMountingHelp(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk
+        m.add_disk("50M", serial="MYDISK")
+        dev = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_MYDISK"
+
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('#drives .sidepanel-row:contains("MYDISK")')
+        b.wait_visible('#storage-detail')
+
+        # Format it with encryption
+
+        self.content_row_action(1, "Format")
+        self.dialog_wait_open()
+        self.dialog_set_val("type", "ext4")
+        self.dialog_set_val("name", "FILESYSTEM")
+        self.dialog_set_val("crypto", self.default_crypto_type)
+        self.dialog_set_val("crypto_options", "xxx")
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
+        self.dialog_set_val("mount_point", "/run/foo")
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "/run/foo")
+
+        fsys_tab = self.content_tab_expand(1, 1)
+
+        # Unmount and lock externally, unlock and remount with Cockpit
+
+        m.execute("umount /run/foo")
+        m.execute("udisksctl lock -b %s" % dev)
+        b.click(fsys_tab + " button:contains(Mount now)")
+        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
+        b.wait_not_present(fsys_tab + " button:contains(Mount now)")
+        self.wait_mounted(1, 1)
+
+        # Unmount and lock externally, adjust fstab with Cockpit
+
+        m.execute("umount /run/foo")
+        m.execute("udisksctl lock -b %s" % dev)
+        b.click(fsys_tab + " button:contains(Do not mount automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically on boot)")
+
+        # Unlock and mount externally, unmount and lock with Cockpit
+
+        m.execute("echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b %s" % dev)
+        m.execute("mount /run/foo")
+        b.click(fsys_tab + " button:contains(Unmount now)")
+        b.wait_not_present(fsys_tab + " button:contains(Unmount now)")
+
+        # Unlock and mount externally, adjust fstab with Cockpit
+
+        m.execute("echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b %s" % dev)
+        m.execute("mount /run/foo")
+        b.click(fsys_tab + " button:contains(Mount also automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
+
+        # Add noauto to crypttab (but not fstab), remove with Cockpit
+
+        m.execute("sed -i -e 's/xxx/xxx,noauto/' /etc/crypttab")
+        b.click(fsys_tab + " button:contains(Unlock automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Unlock automatically on boot)")
+
+        # Add noauto to crypttab (but not fstab), add also to fstab with Cockpit
+
+        m.execute("sed -i -e 's/xxx/xxx,noauto/' /etc/crypttab")
+        b.click(fsys_tab + " button:contains(Do not mount automatically on boot)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically on boot)")
+
     def testDuplicateMountPoints(self):
         m = self.machine
         b = self.browser
@@ -271,16 +290,16 @@ class TestStorageMounting(StorageCase):
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_point": "/run/data"})
-        self.content_row_wait_in_col(2, 1, "ext4 file system")
-        self.content_tab_wait_in_info(2, 1, "Mount point", "/run/data")
+        self.content_row_wait_in_col(1, 1, "ext4 file system")
+        self.content_tab_wait_in_info(1, 2, "Mount point", "/run/data")
 
         # Format the second and also try to use /run/data as the mount point
-        self.content_row_action(3, "Format")
+        self.content_row_action(2, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
         self.dialog_set_val("mount_point", "/run/data")
         self.dialog_apply()
-        self.dialog_wait_error("mount_point", "Mount point is already used for /dev/mapper/luks-")
+        self.dialog_wait_error("mount_point", "Mount point is already used for /dev/test/one")
         self.dialog_cancel()
         self.dialog_wait_close()
 
@@ -311,6 +330,67 @@ class TestStorageMounting(StorageCase):
                      "mount_options.extra": "x-foo"})
         m.execute("grep /run/data /etc/fstab")
         m.execute("grep 'x-foo' /etc/fstab")
+
+    def testNeverAuto(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk and format it with luks and a filesystem, but with "Never unlock at boot"
+
+        m.add_disk("50M", serial="MYDISK")
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('.sidepanel-row:contains("MYDISK")')
+        b.wait_visible("#storage-detail")
+
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "crypto": self.default_crypto_type,
+                     "passphrase": "vainu-reku-toma-rolle-kaja",
+                     "passphrase2": "vainu-reku-toma-rolle-kaja",
+                     "mount_options.auto": True,
+                     "mount_options.never_auto": True,
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 1, "ext4 file system (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "never mounted at boot")
+
+        # The filesystem should be mounted but have the "noauto"
+        # option in both fstab and crypttab
+        self.wait_mounted(1, 1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Unmounting should keep the noauto option, as always
+        self.content_dropdown_action(1, "Unmount")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Mounting should also keep the "noauto", but it should not show up in the extra options
+        self.content_row_action(1, "Mount")
+        self.dialog_check({"mount_options.extra": False})
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.wait_mounted(1, 1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # As should updating the mount information
+        self.content_tab_info_action(1, 1, "Mount point", wrapped=True)
+        self.dialog_check({"mount_options.extra": False})
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Removing "noauto" from fstab but not from crypttab externally should show a warning
+        m.execute("sed -i -e 's/noauto//' /etc/fstab")
+        fsys_tab = self.content_tab_expand(1, 1)
+        b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
+        b.click(fsys_tab + " button:contains(Do not mount automatically)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -36,12 +36,8 @@ class TestStorageResize(StorageCase):
         m = self.machine
         b = self.browser
 
-        if crypto:
-            fsys_row = 2
-            fsys_tab = 1
-        else:
-            fsys_row = 1
-            fsys_tab = 2
+        fsys_row = 1
+        fsys_tab = 2
 
         need_passphrase = crypto and self.default_crypto_type == "luks2"
 
@@ -249,8 +245,8 @@ class TestStorageResize(StorageCase):
         self.dialog_set_val("mount_point", mountpoint)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_tab_wait_in_info(2, 1, "Name", "FSYS")
-        self.content_tab_wait_in_info(2, 1, "Mount point", mountpoint)
+        self.content_tab_wait_in_info(1, 2, "Name", "FSYS")
+        self.content_tab_wait_in_info(1, 2, "Mount point", mountpoint)
 
         vol_tab = self.content_tab_expand(1, 1)
 
@@ -278,10 +274,11 @@ class TestStorageResize(StorageCase):
 
         fs_dev = m.execute("lsblk -pnl /dev/TEST/vol -o NAME | tail -1").strip()
         self.shrink_extfs(fs_dev, "200M")
-        self.content_row_action(2, "Mount")
+        self.content_row_action(1, "Mount")
         self.confirm()
-        self.wait_mounted(2, 1)
+        self.wait_mounted(1, 2)
 
+        vol_tab = self.content_tab_expand(1, 1)
         b.wait_visible(vol_tab + " button:contains(Shrink volume)")
         self.content_tab_action(1, 1, "Shrink volume")
         confirm_with_passphrase()
@@ -305,10 +302,11 @@ class TestStorageResize(StorageCase):
 
         self.shrink_extfs(fs_dev, "198M")
         m.execute("echo vainu-reku-toma-rolle-kaja | cryptsetup resize '%s' 200M" % fs_dev)
-        self.content_row_action(2, "Mount")
+        self.content_row_action(1, "Mount")
         self.confirm()
-        self.wait_mounted(2, 1)
+        self.wait_mounted(1, 2)
 
+        vol_tab = self.content_tab_expand(1, 1)
         b.wait_visible(vol_tab + " button:contains(Shrink volume)")
         self.content_tab_action(1, 1, "Shrink volume")
         confirm_with_passphrase()

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -47,7 +47,7 @@ class TestStorageUsed(StorageCase):
         b.click('.sidepanel-row:contains("%s")' % disk)
         b.wait_visible("#storage-detail")
 
-        self.content_dropdown_action(2, "Format")
+        self.content_dropdown_action(1, "Format")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_cancel()


### PR DESCRIPTION
Cockpit used to expose the device mapper device that implements encryption.  Now we fold that away and pretend the content sits directly in the backing device.

First demo: https://www.youtube.com/watch?v=DASfi39YGZ8
Second demo: https://www.youtube.com/watch?v=kSYuO0WZHWU
Third demo: https://www.youtube.com/watch?v=VnzG2VcDyik
Fourth demo: https://www.youtube.com/watch?v=-1L71pzWdhs

Release notes:

### Storage: Encryption is presented as a property of a Filesystem

Cockpit used to make the encryption layer of a encrypted filesystem explicit: It had its own row in the content table and it would be referred to in other places in the UI.  Now the encryption layer is hidden away and Cockpit pretends encryption is a inherent property of a Filesystem.

![image](https://user-images.githubusercontent.com/3228183/130061042-e43c98c5-2e50-495a-8c53-f2ab70a0cf6a.png)
