### PR TITLE
lib: Use patternfly-react Modal components to construct our dialogs

### DIFF
--- a/pkg/lib/cockpit-components-dialog.css
+++ b/pkg/lib/cockpit-components-dialog.css
@@ -1,4 +1,4 @@
-#cockpit_modal_dialog .modal-body.scroll {
+.modal-body.scroll {
     max-height: calc(75vh - 10rem);
     overflow: auto;
 }

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -22,6 +22,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
 import { Alert } from "@patternfly/react-core";
+import { Modal } from 'patternfly-react';
 
 import "page.css";
 import "cockpit-components-dialog.css";
@@ -219,7 +220,7 @@ export class DialogFooter extends React.Component {
         if (error_message)
             error_element = <Alert variant='danger' isInline title={React.isValidElement(error_message) ? error_message : error_message.toString() } />;
         return (
-            <div className="modal-footer">
+            <Modal.Footer>
                 { error_element }
                 { this.props.extra_element }
                 { wait_element }
@@ -229,7 +230,7 @@ export class DialogFooter extends React.Component {
                     disabled={ cancel_disabled }
                 >{ cancel_caption }</button>
                 { action_buttons }
-            </div>
+            </Modal.Footer>
         );
     }
 }
@@ -248,7 +249,6 @@ DialogFooter.propTypes = {
  * Removes focus on other elements on showing
  * Expected props:
  *  - title (string)
- *  - no_backdrop optional, skip backdrop if true
  *  - body (react element, top element should be of class modal-body)
  *      It is recommended for information gathering dialogs to pass references
  *      to the input components to the controller. That way, the controller can
@@ -265,32 +265,20 @@ export class Dialog extends React.Component {
     }
 
     render() {
-        var backdrop;
-        if (!this.props.no_backdrop) {
-            backdrop = <div className="modal-backdrop fade in" />;
-        }
         return (
-            <div>
-                { backdrop }
-                <div className="modal fade in dialog-ct-visible" tabIndex="-1">
-                    <div id={this.props.id} className="modal-dialog">
-                        <div className="modal-content">
-                            <div className="modal-header">
-                                <h4 className="modal-title">{ this.props.title }</h4>
-                            </div>
-                            { this.props.body }
-                            { this.props.footer }
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <Modal id={this.props.id} show animation={false}>
+                <Modal.Header>
+                    <Modal.Title>{ this.props.title }</Modal.Title>
+                </Modal.Header>
+                { this.props.body }
+                { this.props.footer }
+            </Modal>
         );
     }
 }
 Dialog.propTypes = {
     // TODO: fix following by refactoring the logic showing modal dialog (recently show_modal_dialog())
     title: PropTypes.string, // is effectively required, but show_modal_dialog() provides initially no props and resets them later.
-    no_backdrop: PropTypes.bool,
     body: PropTypes.element, // is effectively required, see above
     footer: PropTypes.element, // is effectively required, see above
     id: PropTypes.string

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -512,18 +512,18 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         test_user = 'correcthorsebatterystaple'
 
         for purpose in ['text', 'password']:
-            b.wait_visible("#cockpit_modal_dialog .modal-content input[type='%s']" % (purpose))
+            b.wait_visible(".modal-content input[type='%s']" % (purpose))
 
-            sel = "#cockpit_modal_dialog .modal-content input"
+            sel = ".modal-content input"
             b.set_val(sel, test_user)
 
-            sel = "#cockpit_modal_dialog .modal-footer button:contains('Send')"
+            sel = ".modal-footer button:contains('Send')"
             b.click(sel)
 
-        sel = "#cockpit_modal_dialog .modal-content p:contains('Password')"
+        sel = ".modal-content p:contains('Password')"
         b.wait_not_present(sel)
 
-        sel = "#cockpit_modal_dialog .modal-footer button:contains('No')"
+        sel = ".modal-footer button:contains('No')"
         b.click(sel)
 
         sel = "table.reporting-table tr:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']"

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -146,42 +146,42 @@ class TestFirewall(NetworkCase):
 
         # click on the "Add Services" button
         b.click(".zone-section[data-id='public'] .add-services-button")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='pop3']")
 
         # filter for pop3
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='imap']")
         b.set_input_text("#filter-services-input", "pop")
-        b.wait_not_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
-        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
-        b.wait_not_present("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
+        b.wait_not_present(".modal-dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='pop3']")
+        self.assertIn("TCP: 110", b.text(".modal-dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
+        b.wait_not_present(".modal-dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
         # clear filter
         b.set_input_text("#filter-services-input", "")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='pop3']")
 
         # filter for port 110
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='imap']")
         b.set_input_text("#filter-services-input", "110")
-        b.wait_not_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
-        self.assertIn("TCP: 110", b.text("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
-        b.wait_not_present("#cockpit_modal_dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
+        b.wait_not_present(".modal-dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='pop3']")
+        self.assertIn("TCP: 110", b.text(".modal-dialog .list-view-pf .list-group-item:first-child .service-ports.tcp"))
+        b.wait_not_present(".modal-dialog .list-view-pf .list-group-item:first-child .service-ports.udp")
         # clear filter
         b.set_input_text("#filter-services-input", "")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='imap']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='pop3']")
 
         # don't select anything in the dialog
         b.click("#add-services-dialog .modal-footer .btn-primary")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_not_present(".modal-dialog")
 
 
         def addService(zone, service):
             b.click(".zone-section[data-id='{}'] .add-services-button".format(zone))
             b.click("#add-services-dialog .list-view-pf input[data-id='{}']".format(service))
             b.click("#add-services-dialog .modal-footer .btn-primary")
-            b.wait_not_present("#cockpit_modal_dialog")
+            b.wait_not_present(".modal-dialog")
             b.wait_present(".zone-section[data-id='{}'] tr[data-row-id='{}']".format(zone, service))
             self.assertIn(service, m.execute("firewall-cmd --zone={} --list-services".format(zone)))
 
@@ -196,10 +196,10 @@ class TestFirewall(NetworkCase):
 
         # pop3 should now not appear any more in Add Services dialog
         b.click(".zone-section[data-id='public'] .add-services-button")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='imap']")
-        b.wait_not_present("#cockpit_modal_dialog .list-view-pf input[data-id='pop3']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='imap']")
+        b.wait_not_present(".modal-dialog .list-view-pf input[data-id='pop3']")
         b.click("#add-services-dialog .modal-footer .btn-cancel")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_not_present(".modal-dialog")
 
         # should still be here
         b.wait_present(".zone-section[data-id='public'] tr[data-row-id='http']")
@@ -207,9 +207,9 @@ class TestFirewall(NetworkCase):
         # Service without name should appear in the dialog
         m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
         b.click(".zone-section[data-id='public'] .add-services-button")
-        b.wait_present("#cockpit_modal_dialog .list-view-pf input[data-id='empty']")
+        b.wait_present(".modal-dialog .list-view-pf input[data-id='empty']")
         b.click("#add-services-dialog .modal-footer .btn-cancel")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_not_present(".modal-dialog")
 
         # remove all services
         services = set(m.execute("firewall-cmd --list-services").strip().split(" "))
@@ -340,7 +340,7 @@ class TestFirewall(NetworkCase):
             b.click(".zone-section[data-id='{}'] .add-services-button".format(zone))
             b.click("#add-services-dialog .list-view-pf input[data-id='{}']".format(service))
             b.click("#add-services-dialog .modal-footer .btn-primary")
-            b.wait_not_present("#cockpit_modal_dialog")
+            b.wait_not_present(".modal-dialog")
             b.wait_present(".zone-section[data-id='{}'] tr[data-row-id='{}']".format(zone, service))
             self.assertIn(service, m.execute("firewall-cmd --zone={} --list-services".format(zone)))
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -578,13 +578,10 @@ class TestPackageInstall(packagelib.PackageCase):
         b.mouse("#system-info-domain span", "mouseout")
 
         b.click("#system-info-domain a")
-        if m.image == "rhel-8-1-distropkg":
-            b.wait_in_text("#cockpit_modal_dialog .dialog-error", "realmd is not available")
-        else:
-            b.wait_in_text("#cockpit_modal_dialog .pf-c-alert__title", "realmd is not available")
-        b.wait_present("#cockpit_modal_dialog .modal-footer button.btn-primary:disabled")
-        b.click("#cockpit_modal_dialog .modal-footer button.cancel")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.wait_in_text(".modal-dialog:contains('Install Software')", "realmd is not available")
+        b.wait_present(".modal-dialog:contains('Install Software') .modal-footer button.btn-primary:disabled")
+        b.click(".modal-dialog:contains('Install Software') .modal-footer button.cancel")
+        b.wait_not_present(".modal-dialog:contains('Install Software')")
         b.logout()
 
         # case 3: provide an available realmd package
@@ -603,8 +600,8 @@ class TestPackageInstall(packagelib.PackageCase):
         b.mouse("#system-info-domain span", "mouseout")
 
         b.click("#system-info-domain a")
-        b.click("#cockpit_modal_dialog .modal-footer button.btn-primary")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.click(".modal-dialog:contains('Install Software') .modal-footer button.btn-primary")
+        b.wait_not_present(".modal-dialog:contains('Install Software')")
 
         # the stub package doesn't provide a realmd D-Bus service, so the "join
         # domain" dialog won't ever appear; just check that it was installed
@@ -631,8 +628,8 @@ class TestPackageInstall(packagelib.PackageCase):
         b.click("#system-info-domain a")
         # restore realmd service, to pretend that package install completed
         m.execute("systemctl unmask realmd")
-        b.click("#cockpit_modal_dialog .modal-footer button.btn-primary")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.click(".modal-dialog .modal-footer button:contains('Install')")
+        b.wait_not_present(".modal-dialog:contains('Install Software')")
 
         # should continue straight to join dialog
         b.wait_present("#realms-op")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -751,8 +751,8 @@ class TestPcp(packagelib.PackageCase):
         b.wait_not_visible("#server-pmlogger-switch")
         b.wait_in_text("#system-information-enable-pcp-link", "Enable stored metrics…")
         b.click("#system-information-enable-pcp-link")
-        b.click("#cockpit_modal_dialog .modal-footer button.btn-primary")
-        b.wait_not_present("#cockpit_modal_dialog")
+        b.click(".modal-footer button.btn-primary:contains('Install')")
+        b.wait_not_present(".modal-dialog:contains('Install Software')")
 
         b.wait_visible("#server-pmlogger-switch")
         b.wait_not_visible("#system-information-enable-pcp-link")


### PR DESCRIPTION
This will make them scroll properly.

Not that with this change, the ".modal" DOM element is no longer a
child of the #cockpit_modal_dialog div.

Fixes #13193