### PR TITLE
machines: Support bus type configuration for disks

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -77,8 +77,8 @@ import {
  *  The naming convention for action creator names is: <verb><Noun>
  *  with the present tense.
  */
-export function attachDisk({ connectionName, poolName, volumeName, format, target, permanent, hotplug, cacheMode, vmName, vmId, shareable }) {
-    return virt(ATTACH_DISK, { connectionName, poolName, volumeName, format, target, permanent, hotplug, cacheMode, vmName, vmId, shareable });
+export function attachDisk({ connectionName, poolName, volumeName, format, target, permanent, hotplug, cacheMode, vmName, vmId, shareable, busType }) {
+    return virt(ATTACH_DISK, { connectionName, poolName, volumeName, format, target, permanent, hotplug, cacheMode, vmName, vmId, shareable, busType });
 }
 
 export function changeBootOrder({ vm, devices }) {
@@ -291,8 +291,8 @@ export function vmDesktopConsole(vm, consoleDetail) {
     return virt(CONSOLE_VM, { name: vm.name, id: vm.id, connectionName: vm.connectionName, consoleDetail });
 }
 
-export function volumeCreateAndAttach({ connectionName, poolName, volumeName, size, format, target, permanent, hotplug, cacheMode, vmName, vmId }) {
-    return virt(CREATE_AND_ATTACH_VOLUME, { connectionName, poolName, volumeName, size, format, target, permanent, hotplug, cacheMode, vmName, vmId });
+export function volumeCreateAndAttach({ connectionName, poolName, volumeName, size, format, target, permanent, hotplug, cacheMode, vmName, vmId, busType }) {
+    return virt(CREATE_AND_ATTACH_VOLUME, { connectionName, poolName, volumeName, size, format, target, permanent, hotplug, cacheMode, vmName, vmId, busType });
 }
 
 function delayPollingHelper(action, timeout) {

--- a/pkg/machines/components/vcpuModal.css
+++ b/pkg/machines/components/vcpuModal.css
@@ -15,7 +15,3 @@
 .vcpu-modal-grid {
     line-height: inherit;
 }
-
-.info-circle {
-    padding: .5rem
-}

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -778,3 +778,17 @@ export function getDiskPrettyName(disk) {
 
     return name;
 }
+
+export function getNextAvailableTarget(existingTargets, busType) {
+    let i = 0;
+    let prefix = 'vd';
+    if (busType !== 'virtio')
+        prefix = 'sd';
+
+    while (i < 26) {
+        const target = prefix + `${String.fromCharCode(97 + i)}`;
+        if (!existingTargets.includes(target))
+            return target;
+        i++;
+    }
+}

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -22,6 +22,7 @@ import {
 
 import {
     convertToUnit,
+    getNextAvailableTarget,
     logDebug,
     fileDownload,
     rephraseUI,
@@ -913,7 +914,7 @@ export function resolveUiState(dispatch, name) {
     return result;
 }
 
-export function updateDisk(domXml, diskTarget, readonly, shareable) {
+export function updateDisk({ domXml, diskTarget, readonly, shareable, busType, existingTargets }) {
     const domainElem = getDomainElem(domXml);
     if (!domainElem)
         throw new Error("updateBootOrder: domXML has no domain element");
@@ -939,6 +940,17 @@ export function updateDisk(domXml, diskTarget, readonly, shareable) {
                 disk.appendChild(readOnlyElem);
             } else if (readOnlyElem && !readonly) {
                 readOnlyElem.remove();
+            }
+
+            const targetElem = disk.getElementsByTagName("target")[0];
+            const oldBusType = targetElem.getAttribute("bus");
+            if (busType && oldBusType !== busType) {
+                targetElem.setAttribute("bus", busType);
+                const newTarget = getNextAvailableTarget(existingTargets, busType);
+                targetElem.setAttribute("dev", newTarget);
+
+                const addressElem = getSingleOptionalElem(disk, "address");
+                addressElem.remove();
             }
         }
     }

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -205,8 +205,9 @@ LIBVIRT_DBUS_PROVIDER = {
         hotplug,
         cacheMode,
         shareable,
+        busType,
     }) {
-        const xmlDesc = getDiskXML(poolName, volumeName, format, target, cacheMode, shareable);
+        const xmlDesc = getDiskXML(poolName, volumeName, format, target, cacheMode, shareable, busType);
 
         return attachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
     },
@@ -298,6 +299,7 @@ LIBVIRT_DBUS_PROVIDER = {
         permanent,
         hotplug,
         cacheMode,
+        busType,
     }) {
         const volXmlDesc = getVolumeXML(volumeName, size, format);
 
@@ -309,7 +311,7 @@ LIBVIRT_DBUS_PROVIDER = {
                             });
                 })
                 .then((volPath) => {
-                    return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmId, permanent, hotplug, cacheMode }));
+                    return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmId, permanent, hotplug, cacheMode, busType }));
                 });
     },
 
@@ -1393,10 +1395,10 @@ export function attachIface({ connectionName, vmId, mac, permanent, hotplug, sou
     return attachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
 }
 
-export function changeDiskAccessPolicy(connectionName, objPath, target, readonly, shareable) {
+export function updateDiskAttributes({ connectionName, objPath, target, readonly, shareable, busType, existingTargets }) {
     return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], TIMEOUT)
             .then(domXml => {
-                const updatedXML = updateDisk(domXml, target, readonly, shareable);
+                const updatedXML = updateDisk({ diskTarget: target, domXml, readonly, shareable, busType, existingTargets });
                 return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], TIMEOUT);
             });
 }

--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -399,3 +399,7 @@ td > .utilization-bar-pf {
         transform: scaleY(1);
     }
 }
+
+.info-circle {
+    padding: .5rem
+}

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -1,4 +1,4 @@
-export function getDiskXML(poolName, volumeName, format, target, cacheMode, shareable) {
+export function getDiskXML(poolName, volumeName, format, target, cacheMode, shareable, busType) {
     var doc = document.implementation.createDocument('', '', null);
 
     var diskElem = doc.createElement('disk');
@@ -19,7 +19,7 @@ export function getDiskXML(poolName, volumeName, format, target, cacheMode, shar
 
     var targetElem = doc.createElement('target');
     targetElem.setAttribute('dev', target);
-    targetElem.setAttribute('bus', 'virtio');
+    targetElem.setAttribute('bus', busType);
     diskElem.appendChild(targetElem);
 
     if (shareable) {

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -274,6 +274,27 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-disks-vde-access", "Writeable and shared")
         b.wait_not_present("#vm-subVmTest1-disks-vde-access-tooltip")
 
+        b.wait_in_text("#vm-subVmTest1-disks-vde-bus", "virtio")
+        # Change bus type to scsi
+        b.click("#vm-subVmTest1-disks-vde-edit")
+        b.wait_present("#vm-subVmTest1-disks-vde-edit-dialog")
+        b.select_from_dropdown("#vm-subVmTest1-disks-vde-edit-bus-type", "scsi")
+
+        # Close dialog
+        b.click("#vm-subVmTest1-disks-vde-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-disks-vde-edit-dialog")
+        # Target has changed from vdX to sdX
+        b.wait_in_text("#vm-subVmTest1-disks-sda-bus", "scsi")
+
+        # Start Vm
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Test disk's bus cannot be changed on running VM
+        b.click("#vm-subVmTest1-disks-sda-edit")
+        b.wait_present("#vm-subVmTest1-disks-sda-edit-dialog")
+        b.wait_present("#vm-subVmTest1-disks-sda-edit-bus-type:disabled")
+
     def testDomainMemorySettings(self):
         b = self.browser
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1671144

Explanation of disk bus from libvirt documentation:
`The optional bus attribute specifies the type of disk device to emulate`

I also changed Show/Hide Performance Options -> Show/Hide Additional Options. People who want to change cache options do not need to be told that it's "Performance" option, and I think having it as Additinal Options makes more sense.

![Screenshot from 2019-11-28 12-43-28](https://user-images.githubusercontent.com/42733240/69804063-030fcb00-11de-11ea-9b10-beb517bed7ca.png)

![Screenshot from 2019-11-28 12-44-49](https://user-images.githubusercontent.com/42733240/69803831-79f89400-11dd-11ea-8781-3cf0ac1d5444.png)
