### PR TITLE
test: Check for value in input before blurring it

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1956,7 +1956,7 @@ class TestMachines(NetworkCase):
             # value according to the available total memory on the host
             if not self.expected_memory_size:
                 b.select_from_dropdown("#memory-size-unit-select", self.memory_size_unit)
-                b.set_input_text("#memory-size", str(self.memory_size), value_check=False)
+                b.set_input_text("#memory-size", str(self.memory_size), value_check=True)
                 b.blur('#memory-size')
                 host_total_memory = int(b.text("#memory-size-slider ~ b"))
                 # Write the final memory back to self so that other function can read it


### PR DESCRIPTION
I noticed that almost all `fedora-30/firefox` tests failed on `testCreate` lately. ([example](https://209.132.184.41:8493/logs/pull-13218-20191129-165151-c6218999-cockpit-project-cockpit--fedora-30-firefox/log.html#74-2))

This is due to race in Firefox, that input is blurred before the
last character is written.

In this specific test there was `value_check=False` because if user
inputs value that is bigger than maximum possible value it is rounded
down. This however happens on blur.