### PR TITLE
tls: add connectat() and bindat()-style wrappers

### DIFF
--- a/src/tls/connection.h
+++ b/src/tls/connection.h
@@ -26,7 +26,8 @@
 
 /* init/teardown */
 void
-connection_set_wsinstance_sockdir (const char *wsinstance_sockdir);
+connection_set_directories (const char *wsinstance_sockdir,
+                            const char *cert_session_dir);
 
 void
 connection_crypto_init (const char *certfile,

--- a/src/tls/main.c
+++ b/src/tls/main.c
@@ -94,6 +94,7 @@ main (int argc, char **argv)
 {
   struct arguments arguments;
   gnutls_certificate_request_t client_cert_mode = GNUTLS_CERT_IGNORE;
+  const char *runtimedir;
 
   /* default option values */
   arguments.no_tls = false;
@@ -102,7 +103,11 @@ main (int argc, char **argv)
 
   argp_parse (&argp, argc, argv, 0, 0, &arguments);
 
-  server_init ("/run/cockpit/wsinstance", arguments.idle_timeout, arguments.port);
+  runtimedir = secure_getenv ("RUNTIME_DIRECTORY");
+  if (!runtimedir)
+    errx (EXIT_FAILURE, "$RUNTIME_DIRECTORY environment variable must be set to a private directory");
+
+  server_init ("/run/cockpit/wsinstance", runtimedir, arguments.idle_timeout, arguments.port);
 
   if (!arguments.no_tls)
     {

--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -33,12 +33,12 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/epoll.h>
 #include <sys/param.h>
 #include <sys/socket.h>
 #include <sys/timerfd.h>
 #include <sys/types.h>
-#include <sys/un.h>
 #include <unistd.h>
 
 #include "connection.h"
@@ -187,7 +187,8 @@ handle_accept (int listen_fd)
  * There is only one instance of this. Trying to initialize it more than once
  * is an error.
  *
- * @ws_path: Path to cockpit-wsinstance sockets directory
+ * @wsinstance_sockdir: Path to cockpit-wsinstance sockets directory
+ * @cert_session_dir: Path to store session certificates
  * @idle_timeout: When positive, stop server after given number of seconds with
  *                no connections
  * @port: Port to listen to; ignored when the listening socket is handed over
@@ -195,6 +196,7 @@ handle_accept (int listen_fd)
  */
 void
 server_init (const char *wsinstance_sockdir,
+             const char *cert_session_dir,
              int idle_timeout,
              uint16_t port)
 {
@@ -205,7 +207,7 @@ server_init (const char *wsinstance_sockdir,
   server.initialized = true;
   server.idle_timerfd = -1;
 
-  connection_set_wsinstance_sockdir (wsinstance_sockdir);
+  connection_set_directories (wsinstance_sockdir, cert_session_dir);
 
   pthread_mutex_init (&server.connection_mutex, NULL);
 

--- a/src/tls/server.h
+++ b/src/tls/server.h
@@ -26,6 +26,7 @@
 
 void
 server_init (const char *wsinstance_sockdir,
+             const char *cert_session_dir,
              int idle_timeout,
              uint16_t port);
 

--- a/src/tls/socket-activation-helper.c
+++ b/src/tls/socket-activation-helper.c
@@ -124,9 +124,13 @@ spawn_cockpit_ws (const char *ws_path, int fd,
       duped_fd = dup (fd);
       if (duped_fd < 0)
         err (EXIT_FAILURE, "dup() failed");
-      if (dup2 (duped_fd, SD_LISTEN_FDS_START) < 0)
-        err (EXIT_FAILURE, "dup2() failed");
-      assert (close (duped_fd) == 0);
+
+      if (duped_fd != SD_LISTEN_FDS_START)
+        {
+          if (dup2 (duped_fd, SD_LISTEN_FDS_START) < 0)
+            err (EXIT_FAILURE, "dup2() failed");
+          assert (close (duped_fd) == 0);
+        }
 
       setenv ("LISTEN_FDS", "1", 1);
       res = snprintf (pid_str, sizeof (pid_str), "%i", getpid ());

--- a/src/tls/socket-io.h
+++ b/src/tls/socket-io.h
@@ -22,7 +22,6 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <sys/un.h>
 #include <sys/types.h>
 #include <time.h>
 
@@ -43,7 +42,12 @@ send_all (int fd,
           size_t size,
           int timeout);
 
-void
-sockaddr_printf (struct sockaddr_un *addr,
-                 const char *format,
-                 ...) __attribute__((format(printf, 2, 3)));
+int
+af_unix_connectat (int sockfd,
+                   int dirfd,
+                   const char *pathname);
+
+int
+af_unix_bindat (int sockfd,
+                int dirfd,
+                const char *pathname);

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -331,8 +331,6 @@ setup (TestCase *tc, gconstpointer data)
   tc->runtime_dir = g_dir_make_tmp ("server.runtime.XXXXXX", NULL);
   g_assert (tc->runtime_dir);
 
-  g_assert (g_setenv ("RUNTIME_DIRECTORY", tc->runtime_dir, TRUE));
-
   const char *fingerprint;
   if (fixture && fixture->client_fingerprint)
     fingerprint = fixture->client_fingerprint;
@@ -356,7 +354,7 @@ setup (TestCase *tc, gconstpointer data)
     }
   close (socket_dir_fd);
 
-  server_init (tc->ws_socket_dir, fixture ? fixture->idle_timeout : 0, server_port);
+  server_init (tc->ws_socket_dir, tc->runtime_dir, fixture ? fixture->idle_timeout : 0, server_port);
   if (fixture && fixture->certfile)
     connection_crypto_init (fixture->certfile, fixture->keyfile, fixture->cert_request_mode);
 


### PR DESCRIPTION
This lets us remove all sockaddr_un handling from the code and avoids an
issue when the pasted-together paths overrun the (relatively small)
buffer.

Comments welcome.  Note that bindat_printf() is never used because we only bind to static example paths (ie: hardcoded key fingerprints) from the socket activation helper.

Fixes #13220