### PR TITLE
Variables should not be fetched from base1/patternfly.css because it …

### DIFF
--- a/pkg/lib/page.css
+++ b/pkg/lib/page.css
@@ -1,3 +1,5 @@
+@import "../../node_modules/@patternfly/react-styles/css/patternfly-variables.css";
+
 a {
     cursor: pointer;
 }


### PR DESCRIPTION
…can be outdated

base1 directory comes from cockpit-bridge, which is allowed to be in
older version than the packages for plugins.

In many places we use PF4 variables, (see page.css) which in older
versions of patternfly.css didn't exist.

Solve this issue by importing the PF4 variables inside page.css which is
bundled with the extra packages' code.

Fixes #13088
Relevant to: https://bugzilla.redhat.com/show_bug.cgi?id=1777683

Note: This fix is just a quick solution but ideally we need to get rid
of all the CSS inside base1 directory because it can be terribly
outdated.