### PR TITLE
packagekit: Recognize "daily" OnCalendar= specification for dnf-automatic  timer

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -117,10 +117,14 @@ class DnfImpl extends ImplBase {
                 .split(/\s+/);
 
         // check if we have a day of week
-        if (daysOfWeek.indexOf(words[0]) >= 0)
+        if (daysOfWeek.indexOf(words[0]) >= 0) {
             this.day = words.shift();
-        else
-            this.day = ""; // daily
+        } else if (words[0] === '*-*-*') {
+            this.day = ""; // daily with "all matches" date specification
+            words.shift();
+        } else {
+            this.day = ""; // daily without date specification
+        }
 
         // now there should only be a time left
         if (words.length == 1 && validTime.test(words[0]))

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -913,6 +913,43 @@ class TestAutoUpdates(PackageCase):
         self.assertFalse(b.is_present("#auto-update-type"))
         assertTimer(None)
 
+        # OnCalendar= parsing: only time
+        m.execute("mkdir -p /etc/systemd/system/dnf-automatic.timer.d")
+        m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=08:00\n" > '
+                  r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+        b.reload()
+        b.enter_page("/updates")
+        b.click("#automatic .onoff-ct input")
+        b.wait_present("#automatic .onoff-ct input:checked")
+        b.wait_in_text("#auto-update-time", "08:00")
+        b.wait_in_text("#auto-update-day", "every day")
+
+        # OnCalendar= parsing: weekday and time
+        m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=Tue 20:00\n" > '
+                  r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+        b.reload()
+        b.enter_page("/updates")
+        b.wait_present("#automatic .onoff-ct input:checked")
+        b.wait_in_text("#auto-update-time", "20:00")
+        b.wait_in_text("#auto-update-day", "Tuesday")
+
+        # OnCalendar= parsing: "every day" calendar and time
+        m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-*-* 07:00\n" > '
+                  r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+        b.reload()
+        b.enter_page("/updates")
+        b.wait_present("#automatic .onoff-ct input:checked")
+        b.wait_in_text("#auto-update-time", "07:00")
+        b.wait_in_text("#auto-update-day", "every day")
+
+        # OnCalendar= parsing: unsupported
+        m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-02-* 11:00\n" > '
+                  r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+        b.reload()
+        b.enter_page("/updates")
+        b.wait_in_text(".container-fluid div.blank-slate-pf", "up to date")
+        b.wait_not_present("#automatic")
+
     def testWithAvailableUpdates(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
RHEL 8.2's dnf-automatic defaults to `OnCalendar=*-*-* 06:00` now,
recognize this.

-----

This blocks https://github.com/cockpit-project/bots/pull/292