### PR TITLE
ws, ssh: Drop "remote peer address" concept and env variable

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -173,10 +173,6 @@ for more details. This will affect how many custom authentication processes can 
 Environment Variables
 ---------------------
 
-The following environment variables are set by cockpit-ws when spawning an auth process:
-
- * **COCKPIT_REMOTE_PEER** Set to the ip address of the connecting user.
-
 The following environment variables are used to set options for the `cockpit-ssh` process:
 
  * **COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS** Set to `1` to  allow connecting to

--- a/src/ssh/cockpitsshoptions.c
+++ b/src/ssh/cockpitsshoptions.c
@@ -97,7 +97,6 @@ cockpit_ssh_options_from_env (gchar **env)
   CockpitSshOptions *options = g_new0 (CockpitSshOptions, 1);
   options->knownhosts_file = get_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE", NULL);
   options->command = get_environment_val (env, "COCKPIT_SSH_BRIDGE_COMMAND", default_command);
-  options->remote_peer = get_environment_val (env, "COCKPIT_REMOTE_PEER", "localhost");
   options->connect_to_unknown_hosts = get_connect_to_unknown_hosts (env);
 
   return options;
@@ -111,8 +110,6 @@ cockpit_ssh_options_to_env (CockpitSshOptions *options,
                               options->connect_to_unknown_hosts);
   env = set_environment_val (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE",
                              options->knownhosts_file);
-  env = set_environment_val (env, "COCKPIT_REMOTE_PEER",
-                             options->remote_peer);
 
   /* Don't reset these vars unless we have values for them */
   if (options->command)

--- a/src/ssh/cockpitsshoptions.h
+++ b/src/ssh/cockpitsshoptions.h
@@ -27,7 +27,6 @@ G_BEGIN_DECLS
 typedef struct {
   const gchar *knownhosts_file;
   const gchar *command;
-  const gchar *remote_peer;
   gboolean connect_to_unknown_hosts;
 } CockpitSshOptions;
 

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -1522,22 +1522,6 @@ cockpit_ssh_connect (CockpitSshData *data,
       goto out;
     }
 
-  if (data->ssh_options->remote_peer)
-    {
-      /* Try to set the remote peer env var, this will
-       * often fail as ssh servers have to be configured
-       * to allow it.
-       */
-      rc = ssh_channel_request_env (channel, "COCKPIT_REMOTE_PEER",
-                                    data->ssh_options->remote_peer);
-      if (rc != SSH_OK)
-        {
-          g_debug ("%s: Couldn't set COCKPIT_REMOTE_PEER: %s",
-                   data->logname,
-                   ssh_get_error (data->session));
-        }
-    }
-
   g_debug ("%s: opened channel", data->logname);
 
   *out_channel = channel;

--- a/src/ssh/test-sshoptions.c
+++ b/src/ssh/test-sshoptions.c
@@ -34,20 +34,17 @@ test_ssh_options (void)
   CockpitSshOptions *options = NULL;
 
   options = cockpit_ssh_options_from_env (env);
-  g_assert_cmpstr (options->remote_peer, ==, "localhost");
   g_assert_cmpstr (options->knownhosts_file, ==, NULL);
   g_assert_cmpstr (options->command, ==, "cockpit-bridge");
 
   options->knownhosts_file = "other-known";
   options->command = "other-command";
-  options->remote_peer = "other";
 
   env = cockpit_ssh_options_to_env (options, NULL);
 
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS"), ==, "");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_KNOWN_HOSTS_FILE"), ==, "other-known");
   g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_SSH_BRIDGE_COMMAND"), ==, "other-command");
-  g_assert_cmpstr (g_environ_getenv (env, "COCKPIT_REMOTE_PEER"), ==, "other");
 
   options->connect_to_unknown_hosts = TRUE;
 

--- a/src/ws/cockpitcreds.c
+++ b/src/ws/cockpitcreds.c
@@ -32,7 +32,6 @@ struct _CockpitCreds {
   gchar *user;
   gchar *application;
   GBytes *password;
-  gchar *rhost;
   gchar *csrf_token;
   JsonObject *login_data;
   GList *bytes;
@@ -51,7 +50,6 @@ cockpit_creds_free (gpointer data)
 
   g_free (creds->user);
   g_free (creds->application);
-  g_free (creds->rhost);
   g_free (creds->csrf_token);
 
   if (creds->login_data)
@@ -66,8 +64,7 @@ cockpit_creds_free (gpointer data)
  * @...: multiple credentials, followed by NULL
  *
  * Create a new set of credentials for a user. Each vararg should be
- * a COCKPIT_CRED_PASSWORD, COCKPIT_CRED_RHOST, or similar constant
- * followed by the value.
+ * a COCKPIT_CRED_PASSWORD or similar constant followed by the value.
  *
  * COCKPIT_CRED_PASSWORD is a GBytes and should contain a null terminated
  * string with the terminator not included in the count.
@@ -100,8 +97,6 @@ cockpit_creds_new (const gchar *application,
         cockpit_creds_set_user (creds, va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_PASSWORD))
         password = va_arg (va, GBytes *);
-      else if (g_str_equal (type, COCKPIT_CRED_RHOST))
-        creds->rhost = g_strdup (va_arg (va, const char *));
       else if (g_str_equal (type, COCKPIT_CRED_CSRF_TOKEN))
         creds->csrf_token = g_strdup (va_arg (va, const char *));
       else
@@ -236,22 +231,6 @@ cockpit_creds_set_login_data (CockpitCreds *creds,
   creds->login_data = login_data;
 }
 
-
-/**
- * cockpit_creds_get_rhost:
- * @creds: the credentials
- *
- * Get the remote host credential, or NULL
- * if none present.
- *
- * Returns: the remote host or NULL
- */
-const gchar *
-cockpit_creds_get_rhost (CockpitCreds *creds)
-{
-  g_return_val_if_fail (creds != NULL, NULL);
-  return creds->rhost;
-}
 
 JsonObject *
 cockpit_creds_to_json (CockpitCreds *creds)

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -31,7 +31,6 @@ typedef struct _CockpitCreds       CockpitCreds;
 
 #define COCKPIT_CRED_USER         "user"
 #define COCKPIT_CRED_PASSWORD     "password"
-#define COCKPIT_CRED_RHOST        "rhost"
 #define COCKPIT_CRED_CSRF_TOKEN   "csrf-token"
 
 #define         COCKPIT_TYPE_CREDS           (cockpit_creds_get_type ())
@@ -56,8 +55,6 @@ GBytes *        cockpit_creds_get_password   (CockpitCreds *creds);
 
 void            cockpit_creds_set_password   (CockpitCreds *creds,
                                               GBytes *password);
-
-const gchar *   cockpit_creds_get_rhost      (CockpitCreds *creds);
 
 const gchar *   cockpit_creds_get_csrf_token (CockpitCreds *creds);
 

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -929,12 +929,12 @@ process_logout (CockpitWebService *self,
   /* Destroys our web service, disconnects everything */
   if (disconnect)
     {
-      g_info ("Logging out session from %s", cockpit_creds_get_rhost (self->creds));
+      g_info ("Logging out session");
       g_object_run_dispose (G_OBJECT (self));
     }
   else
     {
-      g_info ("Deauthorizing session from %s", cockpit_creds_get_rhost (self->creds));
+      g_info ("Deauthorizing session");
     }
 
   send_socket_hints (self, "credential", "none");
@@ -1116,10 +1116,7 @@ on_web_socket_open (WebSocketConnection *connection,
   JsonObject *object;
   JsonObject *info;
 
-  if (cockpit_creds_get_rhost (self->creds))
-      g_info ("New connection to session from %s", cockpit_creds_get_rhost (self->creds));
-  else
-      g_info ("New connection to session");
+  g_info ("New connection to session");
 
   socket = cockpit_socket_lookup_by_connection (&self->sockets, connection);
   g_return_if_fail (socket != NULL);
@@ -1204,7 +1201,7 @@ on_web_socket_close (WebSocketConnection *connection,
 {
   CockpitSocket *socket;
 
-  g_info ("WebSocket from %s for session closed", cockpit_creds_get_rhost (self->creds));
+  g_info ("WebSocket from session closed");
 
   g_signal_handlers_disconnect_by_func (connection, on_web_socket_open, self);
   g_signal_handlers_disconnect_by_func (connection, on_web_socket_closing, self);

--- a/src/ws/session-utils.c
+++ b/src/ws/session-utils.c
@@ -388,8 +388,7 @@ fork_session (char **env, int (*session)(char**))
 }
 
 void
-utmp_log (int login,
-          const char *rhost)
+utmp_log (int login)
 {
   char id[UT_LINESIZE + 1];
   struct utmp ut;
@@ -414,8 +413,6 @@ utmp_log (int login,
     {
       strncpy (ut.ut_user, pwd->pw_name, sizeof(ut.ut_user));
       ut.ut_user[sizeof (ut.ut_user) - 1] = 0;
-      strncpy (ut.ut_host, rhost, sizeof(ut.ut_host));
-      ut.ut_host[sizeof (ut.ut_host) - 1] = 0;
     }
 
   gettimeofday (&tv, NULL);
@@ -530,7 +527,6 @@ static const char *env_names[] = {
   "G_MESSAGES_DEBUG",
   "G_SLICE",
   "PATH",
-  "COCKPIT_REMOTE_PEER",
   NULL
 };
 

--- a/src/ws/session-utils.h
+++ b/src/ws/session-utils.h
@@ -60,7 +60,7 @@ void build_string (char **buf, size_t *size, const char *str, size_t len);
 void authorize_logger (const char *data);
 void save_environment (void);
 void pass_to_child (int signo);
-void utmp_log (int login, const char *rhost);
+void utmp_log (int login);
 #ifndef HAVE_FDWALK
 int fdwalk (int (*cb)(void *data, int fd), void *data);
 #endif

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -258,8 +258,7 @@ pam_conv_func (int num_msg,
 }
 
 static pam_handle_t *
-perform_basic (const char *rhost,
-               const char *authorization)
+perform_basic (const char *authorization)
 {
   struct pam_conv conv = { pam_conv_func, };
   pam_handle_t *pamh;
@@ -283,9 +282,6 @@ perform_basic (const char *rhost,
   res = pam_start ("cockpit", user, &conv, &pamh);
   if (res != PAM_SUCCESS)
     errx (EX, "couldn't start pam: %s", pam_strerror (NULL, res));
-
-  if (pam_set_item (pamh, PAM_RHOST, rhost) != PAM_SUCCESS)
-    errx (EX, "couldn't setup pam");
 
   debug ("authenticating");
 
@@ -380,8 +376,7 @@ map_gssapi_to_local (gss_name_t name,
 
 
 static pam_handle_t *
-perform_gssapi (const char *rhost,
-                const char *authorization)
+perform_gssapi (const char *authorization)
 {
   struct pam_conv conv = { pam_conv_func, };
   OM_uint32 major, minor;
@@ -491,8 +486,6 @@ perform_gssapi (const char *rhost,
 
   if (res != PAM_SUCCESS)
     errx (EX, "couldn't start pam: %s", pam_strerror (NULL, res));
-  if (pam_set_item (pamh, PAM_RHOST, rhost) != PAM_SUCCESS)
-    errx (EX, "couldn't setup pam");
 
   res = open_session (pamh);
   if (res != PAM_SUCCESS)
@@ -535,7 +528,7 @@ pam_conv_func_dummy (int num_msg,
 }
 
 static pam_handle_t *
-perform_tlscert (const char *rhost)
+perform_tlscert (void)
 {
   struct pam_conv conv = { pam_conv_func_dummy, };
   pam_handle_t *pamh;
@@ -547,9 +540,6 @@ perform_tlscert (const char *rhost)
   res = pam_start ("cockpit", NULL, &conv, &pamh);
   if (res != PAM_SUCCESS)
     errx (EX, "couldn't start pam: %s", pam_strerror (NULL, res));
-
-  if (pam_set_item (pamh, PAM_RHOST, rhost) != PAM_SUCCESS)
-    errx (EX, "couldn't setup pam rhost");
 
   res = pam_authenticate (pamh, 0);
   if (res == PAM_SUCCESS)
@@ -630,7 +620,6 @@ main (int argc,
 {
   pam_handle_t *pamh = NULL;
   OM_uint32 minor;
-  const char *rhost;
   char *authorization;
   char *type = NULL;
   char **env;
@@ -649,8 +638,6 @@ main (int argc,
 
   /* Cleanup the umask */
   umask (077);
-
-  rhost = getenv ("COCKPIT_REMOTE_PEER") ?: "";
 
   save_environment ();
 
@@ -687,11 +674,11 @@ main (int argc,
     errx (EX, "invalid authorization header received");
 
   if (strcmp (type, "basic") == 0)
-    pamh = perform_basic (rhost, authorization);
+    pamh = perform_basic (authorization);
   else if (strcmp (type, "negotiate") == 0)
-    pamh = perform_gssapi (rhost, authorization);
+    pamh = perform_gssapi (authorization);
   else if (strcmp (type, "tls-cert") == 0)
-    pamh = perform_tlscert (rhost);
+    pamh = perform_tlscert ();
 
   cockpit_memory_clear (authorization, -1);
   free (authorization);
@@ -719,11 +706,11 @@ main (int argc,
       signal (SIGINT, pass_to_child);
       signal (SIGQUIT, pass_to_child);
 
-      utmp_log (1, rhost);
+      utmp_log (1);
 
       status = fork_session (env, session);
 
-      utmp_log (0, rhost);
+      utmp_log (0);
 
       signal (SIGTERM, SIG_DFL);
       signal (SIGINT, SIG_DFL);

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -115,20 +115,6 @@ test_poison (void)
 }
 
 static void
-test_rhost (void)
-{
-  CockpitCreds *creds;
-
-  creds = cockpit_creds_new ("app", COCKPIT_CRED_RHOST, "remote", NULL);
-  g_assert (creds != NULL);
-
-  g_assert_cmpstr ("remote", ==, cockpit_creds_get_rhost (creds));
-  g_assert_cmpstr ("app", ==, cockpit_creds_get_application (creds));
-
-  cockpit_creds_unref (creds);
-}
-
-static void
 test_multiple (void)
 {
   CockpitCreds *creds;
@@ -137,11 +123,9 @@ test_multiple (void)
   password = g_bytes_new_take (g_strdup ("password"), 8);
   creds = cockpit_creds_new ("app",
                              COCKPIT_CRED_PASSWORD, password,
-                             COCKPIT_CRED_RHOST, "remote",
                              NULL);
   g_assert (creds != NULL);
 
-  g_assert_cmpstr ("remote", ==, cockpit_creds_get_rhost (creds));
   g_assert_cmpstr ("password", ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
   g_assert_cmpstr ("app", ==, cockpit_creds_get_application (creds));
 
@@ -183,7 +167,6 @@ main (int argc,
   g_test_add_func ("/creds/basic-password", test_password);
   g_test_add_func ("/creds/set-password", test_set_password);
   g_test_add_func ("/creds/poison", test_poison);
-  g_test_add_func ("/creds/rhost", test_rhost);
   g_test_add_func ("/creds/multiple", test_multiple);
   g_test_add_func ("/creds/login-data", test_login_data);
 


### PR DESCRIPTION
This has never been a reliable piece of information -- NAT, VPNs,
or reverse proxies all destroy the actual IP of the browser's machine.
Since we use a reverse proxy (cockpit-tls) by default, the "remote peer
address" has lost all meaning, so let's just stop exporting it.

This was only being used by cockpit-session to set `PAM_RHOST`.
`pam_rhosts` isn't in any PAM stack by default (particularly not in
cockpit's), and the whole concept of /etc/hosts.equiv is just painfully
insecure these days; so almost nobody should actually notice the
difference. For those people who actually *do* use `pam_rhosts`, this
fixes the wrong/dangerous information that every cockpit session
originates from localhost. It's better to not set this field at all to
point out that it's not available/not reliable.