### PR TITLE
bridge: Add internal D-Bus API to read cockpit.conf

### DIFF
--- a/src/base1/test-permissions.js
+++ b/src/base1/test-permissions.js
@@ -13,12 +13,12 @@ var priv_user = {
 };
 
 QUnit.module("Permission tests", {
-    setup: function() {
+    before: () => {
         this.old_dbus = cockpit.dbus;
         this.old_is_superuser = cockpit._is_superuser;
         cockpit._is_superuser = false;
     },
-    teardown: function() {
+    after: () => {
         cockpit.dbus = this.old_dbus;
         cockpit._is_superuser = this.old_is_superuser;
     }

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -31,6 +31,7 @@ libcockpit_bridge_a_SOURCES = \
 	src/bridge/cockpitconnect.h \
 	src/bridge/cockpitdbuscache.c \
 	src/bridge/cockpitdbuscache.h \
+	src/bridge/cockpitdbusconfig.c \
 	src/bridge/cockpitdbusinternal.c \
 	src/bridge/cockpitdbusinternal.h \
 	src/bridge/cockpitdbusjson.c \

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -576,6 +576,7 @@ run_bridge (const gchar *interactive,
   cockpit_dbus_setup_startup ();
   cockpit_dbus_process_startup ();
   cockpit_dbus_machines_startup ();
+  cockpit_dbus_config_startup ();
   cockpit_packages_dbus_startup (packages);
 
   call_update_router_data.router = router;

--- a/src/bridge/cockpitdbusconfig.c
+++ b/src/bridge/cockpitdbusconfig.c
@@ -1,0 +1,171 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "cockpitdbusinternal.h"
+#include "common/cockpitconf.h"
+
+static void
+config_method_call (GDBusConnection *connection,
+                    const gchar *sender,
+                    const gchar *object_path,
+                    const gchar *interface_name,
+                    const gchar *method_name,
+                    GVariant *parameters,
+                    GDBusMethodInvocation *invocation,
+                    gpointer user_data)
+{
+  if (g_str_equal (method_name, "Reload"))
+    {
+      cockpit_conf_cleanup ();
+      g_dbus_method_invocation_return_value (invocation, NULL);
+    }
+  else if (g_str_equal (method_name, "GetString"))
+    {
+      const gchar *section, *key;
+      const char *result;
+
+      g_variant_get (parameters, "(&s&s)", &section, &key);
+
+      result = cockpit_conf_string (section, key);
+      if (result)
+        g_dbus_method_invocation_return_value (invocation, g_variant_new ("(s)", result));
+      else
+        g_dbus_method_invocation_return_error (invocation, G_DBUS_ERROR, G_DBUS_ERROR_FAILED,
+                                               "key '%s' in section '%s' does not exist",
+                                               key, section);
+    }
+  else if (g_str_equal (method_name, "GetUInt"))
+    {
+      const gchar *section, *key;
+      unsigned _default, max, min;
+      unsigned result;
+
+      g_variant_get (parameters, "(&s&suuu)", &section, &key, &_default, &max, &min);
+      result = cockpit_conf_uint (section, key, _default, max, min);
+      g_dbus_method_invocation_return_value (invocation, g_variant_new ("(u)", result));
+    }
+  else
+    {
+      g_return_if_reached ();
+    }
+}
+
+static GDBusInterfaceVTable config_vtable = {
+  .method_call = config_method_call,
+};
+
+static GDBusArgInfo config_section_arg = {
+  -1, "section", "s", NULL
+};
+
+static GDBusArgInfo config_key_arg = {
+  -1, "key", "s", NULL
+};
+
+static GDBusArgInfo config_default_uint_arg = {
+  -1, "default", "u", NULL
+};
+
+static GDBusArgInfo config_max_uint_arg = {
+  -1, "max", "u", NULL
+};
+
+static GDBusArgInfo config_min_uint_arg = {
+  -1, "min", "u", NULL
+};
+
+static GDBusArgInfo *config_getstring_in_args[] = {
+  &config_section_arg,
+  &config_key_arg,
+  NULL
+};
+
+static GDBusArgInfo config_string_value_arg = {
+  -1, "value", "s", NULL
+};
+
+static GDBusArgInfo *config_string_value_out_args[] = {
+  &config_string_value_arg,
+  NULL
+};
+
+static GDBusArgInfo config_uint_value_arg = {
+  -1, "value", "u", NULL
+};
+
+static GDBusArgInfo *config_uint_value_out_args[] = {
+  &config_uint_value_arg,
+  NULL
+};
+
+static GDBusArgInfo *config_getuint_in_args[] = {
+  &config_section_arg,
+  &config_key_arg,
+  &config_default_uint_arg,
+  &config_max_uint_arg,
+  &config_min_uint_arg,
+  NULL
+};
+
+static GDBusMethodInfo config_reload_method = {
+  -1, "Reload", NULL, NULL, NULL
+};
+
+static GDBusMethodInfo config_getstring_method = {
+  -1, "GetString", config_getstring_in_args, config_string_value_out_args, NULL
+};
+
+static GDBusMethodInfo config_getuint_method = {
+  -1, "GetUInt", config_getuint_in_args, config_uint_value_out_args, NULL
+};
+
+static GDBusMethodInfo *config_methods[] = {
+  &config_reload_method,
+  &config_getstring_method,
+  &config_getuint_method,
+  NULL
+};
+
+static GDBusInterfaceInfo config_interface = {
+  -1, "cockpit.Config", config_methods, NULL, NULL, NULL
+};
+
+void
+cockpit_dbus_config_startup (void)
+{
+  GDBusConnection *connection;
+  GError *error = NULL;
+
+  connection = cockpit_dbus_internal_server ();
+  g_return_if_fail (connection != NULL);
+
+  g_dbus_connection_register_object (connection, "/config", &config_interface,
+                                     &config_vtable, NULL, NULL, &error);
+
+  if (error != NULL)
+    {
+      g_critical ("couldn't register DBus cockpit.Config object: %s", error->message);
+      g_error_free (error);
+      return;
+    }
+
+  g_object_unref (connection);
+}

--- a/src/bridge/cockpitdbusinternal.h
+++ b/src/bridge/cockpitdbusinternal.h
@@ -45,6 +45,8 @@ void                  cockpit_dbus_machines_startup      (void);
 
 void                  cockpit_dbus_machines_cleanup      (void);
 
+void                  cockpit_dbus_config_startup        (void);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_DBUS_INTERNAL_H */

--- a/src/common/cockpitmachinesjson.c
+++ b/src/common/cockpitmachinesjson.c
@@ -18,6 +18,7 @@
  */
 
 #include "cockpitmachinesjson.h"
+#include "common/cockpitconf.h"
 
 #include <errno.h>
 #include <glob.h>
@@ -142,7 +143,7 @@ get_machines_json_dir (void)
 {
   static gchar *path = NULL;
   if (path == NULL)
-    path = g_strdup_printf ("%s/machines.d", g_getenv ("COCKPIT_TEST_CONFIG_DIR") ?: "/etc/cockpit");
+    path = g_build_filename (cockpit_conf_get_dirs ()[0], "cockpit", "machines.d", NULL);
   return path;
 }
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -844,13 +844,13 @@ main (int argc,
   /* playground config directory */
   config_dir = g_dir_make_tmp ("cockpit.config.XXXXXX", NULL);
   g_assert (config_dir);
-  machines_dir = g_build_filename (config_dir, "machines.d", NULL);
-  g_assert (g_mkdir (machines_dir, 0755) == 0);
+  machines_dir = g_build_filename (config_dir, "cockpit", "machines.d", NULL);
+  g_assert (g_mkdir_with_parents (machines_dir, 0755) == 0);
   g_free (machines_dir);
 
   g_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
   g_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
-  g_setenv ("COCKPIT_TEST_CONFIG_DIR", config_dir, TRUE);
+  g_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
 
   setup_path (argv[0]);
 


### PR DESCRIPTION
Add a new cockpit.Config.Get{String,UInt}() methods on the internal
bridge D-Bus server that provides an interface to
`cockpit_conf_{string,uint}()` for JavaScript.

This will be used for implementing the customization of the automatic
logout on idle.
