### PR TITLE
login: Show content of /etc/issue on login screen

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -196,6 +196,19 @@ ProtocolHeader = X-Forwarded-Proto
     </variablelist>
   </refsect1>
 
+  <refsect1 id="cockpit-conf-session">
+    <title>Session</title>
+    <variablelist>
+      <varlistentry>
+        <term><option>Banner</option></term>
+        <listitem>
+          <para>The contents of the specified file (commonly <literal>/etc/issue</literal>) are shown on the login page.
+          By default, no banner is displayed.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+
   <refsect1 id="cockpit-conf-bugs">
     <title>BUGS</title>
     <para>

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -341,6 +341,21 @@ build_environment (GHashTable *os_release)
   if (ca_path)
     json_object_set_string_member (object, "CACertUrl", "/ca.cer");
 
+  g_autofree gchar *contents = NULL;
+  g_autoptr(GError) error = NULL;
+  gsize len;
+
+  const gchar *banner = cockpit_conf_string ("Session", "Banner");
+  if (banner)
+    {
+      // TODO: parse macros (see `man agetty` for possible macros)
+      g_file_get_contents (banner, &contents, &len, &error);
+      if (error)
+        g_message ("error loading contents of banner: %s", error->message);
+      else
+        json_object_set_string_member (object, "banner", contents);
+    }
+
   bytes = cockpit_json_write_bytes (object);
   json_object_unref (object);
 

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -964,6 +964,11 @@ label.checkbox {
   @media (max-width: 1023px) {
     body.login-pf {
       justify-items: center;
+      grid-gap: 0.5rem;
+    }
+
+    #badge {
+      background-position: center;
     }
   }
 

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -366,6 +366,10 @@ label.checkbox {
   text-align: center;
 }
 
+.login-pf #banner {
+  margin-top: 20px;
+}
+
 .login-pf .container {
   background-color: rgba(255, 255, 255, .055);
   clear: right;
@@ -453,6 +457,7 @@ label.checkbox {
   grid-area: title;
   font-size: 1rem;
   margin: 1rem;
+  background-color: #fff;
 }
 
 .pf-c-alert.pf-m-inline.pf-m-danger::before {
@@ -876,8 +881,7 @@ label.checkbox {
   body.login-pf {
     color: #151515;
     display: grid;
-    grid-template-columns: 34rem minmax(34rem, auto);
-    grid-template-areas: "login" "logo";
+    grid-template-areas: "alert" "login" "logo";
     grid-template-columns: 1fr;
     grid-template-rows: minmax(min-content, max-content);
     background-position: 0 0 !important;
@@ -986,8 +990,8 @@ label.checkbox {
     }
 
     body.login-pf {
-      grid-template-areas: ". . . ." ". login logo ." ". . . . ";
-      grid-template-rows: 1fr minmax(min-content,max-content) 1fr;
+      grid-template-areas: ". alert alert ." ". . . ." ". login logo ." ". . . . ";
+      grid-template-rows: auto 1fr minmax(min-content,max-content) 1fr;
       grid-template-columns: minmax(0, 2.125rem) 35rem 1fr minmax(0, 2.125rem);
     }
   }
@@ -1013,4 +1017,17 @@ label.checkbox {
     display: flex;
     justify-content: space-around;
   }
+}
+
+.dialog-error {
+  grid-area: alert;
+  margin: 0px;
+}
+
+#banner-message {
+  white-space: pre-wrap;
+  max-height: 12em;
+  overflow: auto;
+  padding: 1.5em 1em;
+  margin: 0;
 }

--- a/src/ws/login.html
+++ b/src/ws/login.html
@@ -13,6 +13,11 @@
     <link href="cockpit/static/branding.css" type="text/css" rel="stylesheet">
   </head>
   <body class="login-pf">
+    <div id="banner" class="pf-c-alert pf-m-info pf-m-inline dialog-error group-hidden" aria-label="inline danger alert">
+      <svg fill="currentColor" viewBox="0 0 448 512" aria-hidden="true"><path d="M224 512c35.32 0 63.97-28.65 63.97-64H160.03c0 35.35 28.65 64 63.97 64zm215.39-149.71c-19.32-20.76-55.47-51.99-55.47-154.29 0-77.7-54.48-139.9-127.94-155.16V32c0-17.67-14.32-32-31.98-32s-31.98 14.33-31.98 32v20.84C118.56 68.1 64.08 130.3 64.08 208c0 102.3-36.15 133.53-55.47 154.29-6 6.45-8.66 14.16-8.61 21.71.11 16.4 12.98 32 32.1 32h383.8c19.12 0 32-15.6 32.1-32 .05-7.55-2.61-15.27-8.61-21.71z"/></svg>
+      <pre id="banner-message" class="pf-c-alert__title"></pre>
+    </div>
+
     <span id="badge">
     </span>
     <div class="container">

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -270,6 +270,11 @@
         if (!requisites())
             return;
 
+        if (environment.banner) {
+            id("banner").classList.remove("group-hidden");
+            id("banner-message").textContent = environment.banner.trimEnd();
+        }
+
         id("show-other-login-options").addEventListener("click", toggle_options);
         id("show-other-login-options").addEventListener("keypress", toggle_options);
         id("server-clear").addEventListener("click", function () {

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -60,6 +60,27 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.set_checked('#authorized-input', True)
             b.click('#login-button')
 
+        # Test banner
+        if m.image != "rhel-8-1-distropkg": # Added in #13237
+            # Test that we don't show banner when not specified
+            b.wait_visible("#login-user-input")
+            b.wait_not_visible("#banner")
+
+            m.execute("printf '[Session]\nBanner = /etc/issue\n' > /etc/cockpit/cockpit.conf")
+            m.restart_cockpit()
+            b.reload()
+            b.wait_visible("#login-user-input")
+            b.wait_visible("#banner")
+            self.assertEqual(b.text("#banner pre"), m.execute("cat /etc/issue").rstrip())
+
+            # Test non existent file
+            m.execute("printf '[Session]\nBanner = /etc/non-existing-file\n' > /etc/cockpit/cockpit.conf")
+            self.allow_journal_messages("error loading contents of banner: Failed to open file “/etc/non-existing-file”: No such file or directory")
+            m.restart_cockpit()
+            b.reload()
+            b.wait_visible("#login-user-input")
+            b.wait_not_visible("#banner")
+
         # Try to login as a non-existing user
         login("nonexisting", "blahblah")
         b.wait_text_not("#login-error-message", "")


### PR DESCRIPTION
This is very WIP, there are still missing features, needs cleaning up... but opening so we can get some styling done.
We need bell icon and not info icon as now is present. Also there is border around the alert body and I haven't yet figure out how to fix it and it also needs to float in the middle of page with some margins.

![styling](https://user-images.githubusercontent.com/12330670/70139152-20d3a900-1692-11ea-9c8d-7ad7334c9e13.png)

(for some reason I cannot open draft PR)
