### PR TITLE
machines: Support transient VMs

### DIFF
--- a/pkg/machines/actions/provider-actions.js
+++ b/pkg/machines/actions/provider-actions.js
@@ -126,8 +126,8 @@ export function deleteVm(vm, options, storagePools) {
     return virt(DELETE_VM, { name: vm.name, id: vm.id, connectionName: vm.connectionName, options, storagePools });
 }
 
-export function detachDisk({ connectionName, target, name, id, live = false }) {
-    return virt(DETACH_DISK, { connectionName, target, name, id, live });
+export function detachDisk({ connectionName, target, name, id, live = false, persistent }) {
+    return virt(DETACH_DISK, { connectionName, target, name, id, live, persistent });
 }
 
 export function enableLibvirt(enable, serviceName) {

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { Modal, Button } from 'patternfly-react';
+import { Button, Modal, OverlayTrigger, Tooltip } from 'patternfly-react';
 
 import { vmId } from '../helpers.js';
 import { deleteVm } from '../actions/provider-actions.js';
@@ -139,11 +139,34 @@ export class DeleteDialog extends React.Component {
 
     render() {
         const id = vmId(this.props.vm.name);
+
+        let deleteButton = (
+            <Button id={`${id}-delete`} bsStyle='danger' onClick={this.open}>
+                {_("Delete")}
+            </Button>
+        );
+
+        if (!this.props.vm.persistent) {
+            deleteButton = (
+                <OverlayTrigger overlay={
+                    <Tooltip id={`${id}-delete-tooltip`}>
+                        {_("This VM is transient. Shut it down if you wish to delete it.")}
+                    </Tooltip> } placement='top'>
+                    <span>
+                        <Button id={`${id}-delete`}
+                            bsStyle='danger'
+                            style={{ pointerEvents: 'none' }}
+                            disabled>
+                            {_("Delete")}
+                        </Button>
+                    </span>
+                </OverlayTrigger>
+            );
+        }
+
         return (
             <span>
-                <Button id={`${id}-delete`} bsStyle='danger' onClick={this.open}>
-                    {_("Delete")}
-                </Button>
+                { deleteButton }
 
                 <Modal id={`${id}-delete-modal-dialog`} show={this.state.showModal} onHide={this.close}>
                     <Modal.Header>

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -509,12 +509,14 @@ export class AddDiskModalBody extends React.Component {
                                      vms={vms}
                                      vm={vm} />
                 )}
-                <hr />
-                <PermanentChange idPrefix={idPrefix}
-                                 permanent={this.state.permanent}
-                                 onValueChanged={this.onValueChanged}
-                                 provider={provider}
-                                 vm={vm} />
+                {vm.persistent && <>
+                    <hr />
+                    <PermanentChange idPrefix={idPrefix}
+                                     permanent={this.state.permanent}
+                                     onValueChanged={this.onValueChanged}
+                                     provider={provider}
+                                     vm={vm} />
+                </>}
                 {provider.name == 'LibvirtDBus' && <AdditionalOptions cacheMode={this.state.cacheMode}
                                     onValueChanged={this.onValueChanged}
                                     busType={this.state.busType} />}

--- a/pkg/machines/components/nicAdd.jsx
+++ b/pkg/machines/components/nicAdd.jsx
@@ -174,12 +174,14 @@ export class AddNIC extends React.Component {
                 <NetworkMacRow idPrefix={idPrefix}
                                dialogValues={this.state}
                                onValueChanged={this.onValueChanged} />
-                <hr />
-                <PermanentChange idPrefix={idPrefix}
-                                 dialogValues={this.state}
-                                 onValueChanged={this.onValueChanged}
-                                 provider={provider}
-                                 vm={vm} />
+                {vm.persistent && <>
+                    <hr />
+                    <PermanentChange idPrefix={idPrefix}
+                                     dialogValues={this.state}
+                                     onValueChanged={this.onValueChanged}
+                                     provider={provider}
+                                     vm={vm} />
+                </>}
             </form>
         );
 

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -156,7 +156,7 @@ class VmDisksTab extends React.Component {
 
             if (provider.name === 'LibvirtDBus') {
                 const onRemoveDisk = () => {
-                    return dispatch(detachDisk({ connectionName:vm.connectionName, id:vm.id, name:vm.name, target: disk.target, live: vm.state == 'running' }))
+                    return dispatch(detachDisk({ connectionName:vm.connectionName, id:vm.id, name:vm.name, target: disk.target, live: vm.state == 'running', persistent: vm.persistent }))
                             .catch(ex => {
                                 onAddErrorNotification({
                                     text: cockpit.format(_("Disk $0 fail to get detached from VM $1"), disk.target, vm.name),
@@ -176,7 +176,7 @@ class VmDisksTab extends React.Component {
                            overlayText={_("The VM needs to be running or shut off to detach this device")}
                            actionName={_("Remove")}
                            deleteHandler={() => onRemoveDisk()} />
-                        { vm.inactiveXML.disks[disk.target] && // supported only  for persistent disks
+                        { vm.persistent && vm.inactiveXML.disks[disk.target] && // supported only  for persistent disks
                         <EditDiskAction disk={disk}
                             vm={vm}
                             provider={provider}

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -188,7 +188,7 @@ class VmOverviewTabLibvirt extends React.Component {
         const vcpuLink = (
             <div>
                 { <Button variant="link" isInline isDisabled={!vm.persistent} id={`${idPrefix}-vcpus-count`} onClick={this.openVcpu}>{vm.vcpus.count}</Button> }
-                { vm.persitent && vm.state === "running" && vcpusChanged && <WarningInactive iconId="vcpus-tooltip" tooltipId="tip-vcpus" /> }
+                { vm.persistent && vm.state === "running" && vcpusChanged && <WarningInactive iconId="vcpus-tooltip" tooltipId="tip-vcpus" /> }
             </div>
         );
 

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -172,23 +172,23 @@ class VmOverviewTabLibvirt extends React.Component {
         );
         const bootOrder = (
             <div>
-                <Button variant="link" isInline isDisabled={config.provider.name !== "LibvirtDBus"} id={`${idPrefix}-boot-order`} onClick={this.openBootOrder}>
+                <Button variant="link" isInline isDisabled={config.provider.name !== "LibvirtDBus" || !vm.persistent} id={`${idPrefix}-boot-order`} onClick={this.openBootOrder}>
                     {getBootOrder(vm)}
                 </Button>
-                { vm.state === "running" && bootOrderChanged() && <WarningInactive iconId="boot-order-tooltip" tooltipId="tip-boot-order" /> }
+                { vm.persistent && vm.state === "running" && bootOrderChanged() && <WarningInactive iconId="boot-order-tooltip" tooltipId="tip-boot-order" /> }
             </div>
         );
         const memoryLink = (
             <div>
-                <Button variant="link" isInline isDisabled={config.provider.name !== "LibvirtDBus"} id={`${idPrefix}-memory-count`} onClick={this.openMemory}>
+                <Button variant="link" isInline isDisabled={config.provider.name !== "LibvirtDBus" || !vm.persistent} id={`${idPrefix}-memory-count`} onClick={this.openMemory}>
                     {cockpit.format_bytes(vm.currentMemory * 1024)}
                 </Button>
             </div>
         );
         const vcpuLink = (
             <div>
-                <Button variant="link" isInline id={`${idPrefix}-vcpus-count`} onClick={this.openVcpu}>{vm.vcpus.count}</Button>
-                { vm.state === "running" && vcpusChanged && <WarningInactive iconId="vcpus-tooltip" tooltipId="tip-vcpus" /> }
+                { <Button variant="link" isInline isDisabled={!vm.persistent} id={`${idPrefix}-vcpus-count`} onClick={this.openVcpu}>{vm.vcpus.count}</Button> }
+                { vm.persitent && vm.state === "running" && vcpusChanged && <WarningInactive iconId="vcpus-tooltip" tooltipId="tip-vcpus" /> }
             </div>
         );
 
@@ -223,11 +223,19 @@ class VmOverviewTabLibvirt extends React.Component {
                 };
 
                 if (vm.state != "shut off") {
-                    firmwareLinkWrapper = (
-                        <OverlayTrigger overlay={ <Tooltip id='firmware-edit-disabled-on-running'>{ _("Shut off the VM in order to edit firmware configuration") }</Tooltip> } placement='top'>
-                            {firmwareLink(true)}
-                        </OverlayTrigger>
-                    );
+                    if (vm.persistent) {
+                        firmwareLinkWrapper = (
+                            <OverlayTrigger overlay={ <Tooltip id='firmware-edit-disabled-on-running'>{ _("Shut off the VM in order to edit firmware configuration") }</Tooltip> } placement='top'>
+                                {firmwareLink(true)}
+                            </OverlayTrigger>
+                        );
+                    } else {
+                        firmwareLinkWrapper = (
+                            <OverlayTrigger overlay={ <Tooltip id='firmware-edit-disabled-on-transient'>{ _("Transient VMs don't support editting firmware configuration") }</Tooltip> } placement='top'>
+                                {firmwareLink(true)}
+                            </OverlayTrigger>
+                        );
+                    }
                 } else if (!supportsUefiXml(this.state.loaderElems[0])) {
                     firmwareLinkWrapper = (
                         <OverlayTrigger overlay={ <Tooltip id='missing-uefi-support'>{ _("Libvirt or hypervisor does not support UEFI") }</Tooltip> } placement='top'>
@@ -260,8 +268,10 @@ class VmOverviewTabLibvirt extends React.Component {
                         <div id={`${idPrefix}-cpu-model`}>{vm.cpu.model}</div>
                         <label className='control-label' htmlFor={`${idPrefix}-boot-order`}>{_("Boot Order")}</label>
                         {bootOrder}
-                        <label className='control-label' htmlFor={`${idPrefix}-autostart-checkbox`}>{_("Autostart")}</label>
-                        {autostart}
+                        {vm.persistent && <>
+                            <label className='control-label' htmlFor={`${idPrefix}-autostart-checkbox`}>{_("Autostart")}</label>
+                            {autostart}
+                        </>}
                     </div>
                     <div className="ct-form">
                         <label className='control-label label-title'> {_("Hypervisor Details")} </label>

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -210,7 +210,7 @@ class VmNetworkTab extends React.Component {
                 name: "", value: (network, networkId) => {
                     const isUp = network.state === 'up';
                     const editNICAction = (providerName) => {
-                        if (providerName === "LibvirtDBus" && this.state.networkDevices !== undefined)
+                        if (providerName === "LibvirtDBus" && vm.persistent && this.state.networkDevices !== undefined)
                             return <EditNICAction dispatch={dispatch}
                                        idPrefix={`${id}-network-${networkId}`}
                                        vm={vm}
@@ -227,7 +227,7 @@ class VmNetworkTab extends React.Component {
                                        objectId={`${id}-iface-${networkId}`}
                                        disabled={vm.state != 'shut off' && vm.state != 'running'}
                                        overlayText={_("The VM needs to be running or shut off to detach this device")}
-                                       deleteHandler={() => detachIface(network.mac, vm.connectionName, vm.id, vm.state === "running", dispatch)} />;
+                                       deleteHandler={() => detachIface(network.mac, vm.connectionName, vm.id, vm.state === "running", vm.persistent, dispatch)} />;
                     };
 
                     return (

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -133,8 +133,13 @@ class TestMachinesDBus(machineslib.TestMachines):
         autostartState = m.execute("virsh dominfo subVmTest1 | grep 'Autostart:' | awk '{print $2}'").strip()
         self.assertEqual(autostartState, "enable")
 
+        # non-persistent VM doesn't have autostart
+        m.execute("virsh undefine subVmTest1")
+        b.wait_not_present("#vm-subVmTest1-autostart-checkbox")
+
     def testBootOrder(self):
         b = self.browser
+        m = self.machine
 
         self.startVm("subVmTest1")
 
@@ -194,6 +199,13 @@ class TestMachinesDBus(machineslib.TestMachines):
         # Check boot order has changed and no warning is shown
         b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
         b.wait_not_present("#boot-order-tooltip")
+
+        # Run VM
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+        # Non-persistent VM doesn't have configurable boot order
+        m.execute("virsh undefine subVmTest1")
+        b.wait_not_present("button#vm-subVmTest1-boot-order")
 
     # Check various configuration changes made before VM installation persist after installation
     def testConfigureBeforeInstall(self):
@@ -439,8 +451,13 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_present("#vm-subVmTest1-disks-sda-edit-dialog")
         b.wait_present("#vm-subVmTest1-disks-sda-edit-bus-type:disabled")
 
+        # Disks on non-persistent VM cannot be edited
+        m.execute("virsh undefine subVmTest1")
+        b.wait_not_present("#vm-subVmTest1-disks-vde-edit")
+
     def testDomainMemorySettings(self):
         b = self.browser
+        m = self.machine
 
         args = self.startVm("subVmTest1")
 
@@ -503,6 +520,13 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.select_from_dropdown("#vm-subVmTest1-memory-modal-memory-unit-select", "GiB")
         b.wait_attr("#vm-subVmTest1-memory-modal-memory", "value", "0")
 
+        # Run VM
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+        # Non-persistent VM doesn't have configurable memory
+        m.execute("virsh undefine subVmTest1")
+        b.wait_not_present("button#vm-subVmTest1-memory-count")
+
     def testDetachDisk(self):
         b = self.browser
         m = self.machine
@@ -537,7 +561,8 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
         b.wait_present("#vm-subVmTest1-disks-vdd-device")
-        b.click("#delete-subVmTest1-disk-vdd")
+        with b.wait_timeout(2):
+            b.click("#delete-subVmTest1-disk-vdd")
         b.wait_present(".modal-dialog")
         b.click(".modal-footer button:contains(Remove)")
         b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
@@ -560,6 +585,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_not_present(".modal-dialog")
 
         # Test detaching disk of a paused domain
+        if args["logfile"] is not None:
+            m.execute("> {0}".format(args["logfile"])) # clear logfile
         m.execute("virsh start subVmTest1")
         # Make sure that the VM booted normally before attempting to suspend it
         if args["logfile"] is not None:
@@ -567,6 +594,20 @@ class TestMachinesDBus(machineslib.TestMachines):
         m.execute("virsh suspend subVmTest1")
         b.wait_in_text("#vm-subVmTest1-state", "paused")
         b.wait_attr("#delete-subVmTest1-disk-vdf", "disabled", "")
+        m.execute("virsh resume subVmTest1")
+
+        # Test detaching of disk on non-persistent VM
+        m.execute("virsh undefine subVmTest1")
+        m.execute("virsh attach-disk --domain subVmTest1 --source /mnt/vm_one/mydiskofpoolone_1 --target vdd --targetbus virtio")
+        b.wait_present("#vm-subVmTest1-disks-vdd-device")
+        b.click("#delete-subVmTest1-disk-vdd")
+        b.wait_present(".modal-dialog")
+        b.click(".modal-footer button:contains(Remove)")
+        i = 0
+        while b.is_present(".modal-dialog") and i < 3:
+            i += 1
+            b.click(".modal-footer button:contains(Remove)")
+        b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
 
     def testMultipleSettings(self):
         b = self.browser
@@ -787,6 +828,10 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.select_from_dropdown("#vm-subVmTest1-network-1-select-source", "test_network")
         b.click("#vm-subVmTest1-network-1-edit-dialog-save")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "test_network")
+
+        # Test detaching of disk on non-persistent VM
+        m.execute("virsh undefine subVmTest1")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog")
 
     def testNetworkAutostart(self):
         b = self.browser
@@ -1939,7 +1984,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b = self.browser
         m = self.machine
 
-        self.startVm("subVmTest1")
+        args = self.startVm("subVmTest1")
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
@@ -1955,8 +2000,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         class NICAddDialog(object):
             def __init__(
                 # We have always have to specify mac and source_type to identify the device in xml and $virsh detach-interface
-                self, test_obj, source_type="Direct attachment", source=None, model=None,
-                permanent=False, mac="52:54:00:a5:f8:c0", remove=True,
+                self, test_obj, source_type="Direct attachment", source=None, model=None, nic_num=2,
+                permanent=False, mac="52:54:00:a5:f8:c0", remove=True, persistent_vm=True
             ):
                 self.test_obj = test_obj
                 self.source_type = source_type
@@ -1965,6 +2010,8 @@ class TestMachinesDBus(machineslib.TestMachines):
                 self.permanent = permanent
                 self.mac = mac
                 self.remove = remove
+                self.persistent_vm = persistent_vm
+                self.nic_num = nic_num
 
             def execute(self):
                 self.open()
@@ -1992,6 +2039,9 @@ class TestMachinesDBus(machineslib.TestMachines):
 
                 if self.permanent:
                     b.click("#vm-subVmTest1-add-iface-permanent")
+
+                if not self.persistent_vm:
+                    b.wait_not_present("#vm-subVmTest1-add-iface-permanent")
 
             def cancel(self):
                 b.click(".modal-footer button:contains(Cancel)")
@@ -2023,15 +2073,15 @@ class TestMachinesDBus(machineslib.TestMachines):
             def verify_overview(self):
                 # The first NIC is default, our new NIC is second in row
                 if (self.source_type == "Virtual network"):
-                    b.wait_in_text("#vm-subVmTest1-network-2-type", "network")
+                    b.wait_in_text("#vm-subVmTest1-network-{0}-type".format(self.nic_num), "network")
                 elif (self.source_type == "Direct attachment"):
-                    b.wait_in_text("#vm-subVmTest1-network-2-type", "direct")
+                    b.wait_in_text("#vm-subVmTest1-network-{0}-type".format(self.nic_num), "direct")
                 if self.model:
-                    b.wait_in_text("#vm-subVmTest1-network-2-model", self.model)
+                    b.wait_in_text("#vm-subVmTest1-network-{0}-model".format(self.nic_num), self.model)
                 if self.source:
-                    b.wait_in_text("#vm-subVmTest1-network-2-source", self.source)
+                    b.wait_in_text("#vm-subVmTest1-network-{0}-source".format(self.nic_num), self.source)
                 if self.mac:
-                    b.wait_in_text("#vm-subVmTest1-network-2-mac", self.mac)
+                    b.wait_in_text("#vm-subVmTest1-network-{0}-mac".format(self.nic_num), self.mac)
 
             def cleanup(self):
                 if self.permanent:
@@ -2049,13 +2099,13 @@ class TestMachinesDBus(machineslib.TestMachines):
                     b.click("tbody tr[data-row-id=vm-subVmTest1] th")
                     b.click("#vm-subVmTest1-networks") # open the Network Interfaces subtab
                 else:
-                    b.click("#delete-vm-subVmTest1-iface-2")
+                    b.click("#delete-vm-subVmTest1-iface-{0}".format(self.nic_num))
                     # Confirm in confirmation windown
                     b.wait_in_text(".modal-dialog .modal-header .modal-title", "Delete Network Interface")
                     b.click(".modal-footer button:contains(Delete)")
 
                     # Check NIC is no longer in list
-                    b.wait_not_present("#vm-subVmTest1-network-2-mac")
+                    b.wait_not_present("#vm-subVmTest1-network-{0}-mac".format(self.nic_num))
                     b.wait_not_present(".modal-dialog")
 
         # No NICs present
@@ -2088,18 +2138,28 @@ class TestMachinesDBus(machineslib.TestMachines):
             model="e1000e",
         ).execute()
 
-        # Test permanent attachment to running VM
+        # Start vm and wait until kernel is booted
+        m.execute("> {0}".format(args["logfile"])) # clear logfile
         b.click("#vm-subVmTest1-run")
         b.wait_in_text("#vm-subVmTest1-state", "running")
+        wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
 
+        # Test permanent attachment to running VM
         NICAddDialog(
             self,
             permanent=True,
         ).execute()
 
-        b.click("#vm-subVmTest1-off-caret")
-        b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+        # Test NIC attaching to non-persistent VM
+        m.execute("virsh undefine subVmTest1")
+        NICAddDialog(
+            self,
+            source_type="Virtual network",
+            source="test_network",
+            mac="52:54:00:a5:f8:c1",
+            nic_num=3,
+            persistent_vm=False,
+        ).execute()
 
         NICAddDialog(
             self,

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -594,6 +594,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-state", "paused")
         b.wait_attr("#delete-subVmTest1-disk-vdf", "disabled", "")
         m.execute("virsh resume subVmTest1")
+        wait(lambda: "login as 'cirros' user" in  m.execute("cat /var/log/libvirt/console-subVmTest1.log"), delay=3)
 
         # Test detaching of disk on non-persistent VM
         m.execute("virsh undefine subVmTest1")

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -2147,7 +2147,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         ).execute()
 
         # Test NIC attaching to non-persistent VM
-        m.execute("virsh undefine subVmTest1")
+        m.execute("virsh dumpxml --inactive subVmTest1 > /tmp/subVmTest1.xml; virsh undefine subVmTest1")
         NICAddDialog(
             self,
             source_type="Virtual network",
@@ -2156,6 +2156,11 @@ class TestMachinesDBus(machineslib.TestMachines):
             nic_num=3,
             persistent_vm=False,
         ).execute()
+        m.execute("virsh define /tmp/subVmTest1.xml")
+
+        b.click("#vm-subVmTest1-off-caret")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
 
         NICAddDialog(
             self,

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -205,7 +205,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-state", "running")
         # Non-persistent VM doesn't have configurable boot order
         m.execute("virsh undefine subVmTest1")
-        b.wait_not_present("button#vm-subVmTest1-boot-order")
+        b.wait_present("button#vm-subVmTest1-boot-order:disabled")
 
     # Check various configuration changes made before VM installation persist after installation
     def testConfigureBeforeInstall(self):
@@ -525,7 +525,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-state", "running")
         # Non-persistent VM doesn't have configurable memory
         m.execute("virsh undefine subVmTest1")
-        b.wait_not_present("button#vm-subVmTest1-memory-count")
+        b.wait_present("button#vm-subVmTest1-memory-count:disabled")
 
     def testDetachDisk(self):
         b = self.browser

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -561,8 +561,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         b.click("#vm-subVmTest1-disks") # open the "Disks" subtab
         b.wait_present("#vm-subVmTest1-disks-vdd-device")
-        with b.wait_timeout(2):
-            b.click("#delete-subVmTest1-disk-vdd")
+        b.click("#delete-subVmTest1-disk-vdd")
         b.wait_present(".modal-dialog")
         b.click(".modal-footer button:contains(Remove)")
         b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
@@ -603,11 +602,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("#delete-subVmTest1-disk-vdd")
         b.wait_present(".modal-dialog")
         b.click(".modal-footer button:contains(Remove)")
-        i = 0
-        while b.is_present(".modal-dialog") and i < 3:
-            i += 1
-            b.click(".modal-footer button:contains(Remove)")
         b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
+        b.wait_not_present(".modal-dialog")
 
     def testMultipleSettings(self):
         b = self.browser

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -931,7 +931,7 @@ class TestMachines(NetworkCase):
 
             # Apparmor on debian and ubuntu may prevent access to /dev/sdb1 when starting VM,
             # https://bugs.launchpad.net/ubuntu/+source/libvirt/+bug/1677398
-            if not "debian" in m.image and not "ubuntu" in m.image:
+            if "debian" not in m.image and "ubuntu" not in m.image:
                 # Run VM
                 b.click("#vm-subVmTest1-run")
                 b.wait_in_text("#vm-subVmTest1-state", "running")
@@ -979,9 +979,9 @@ class TestMachines(NetworkCase):
         ]
         self.machine.execute(" && ".join(cmds))
         partition = str(self.machine.execute("readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 | cut -d '/' -f 3").strip()) + "1"
-        next_target='vdf'
+        next_target = 'vdf'
         if not self.provider == "libvirt-dbus" or "debian" in m.image or "ubuntu" in m.image:
-            next_target='vdc'
+            next_target = 'vdc'
         VMAddDiskDialog(
             self,
             pool_name='pool-disk',

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1156,7 +1156,7 @@ class TestMachines(NetworkCase):
         if self.provider == "libvirt-dbus":
             # non-persistent VM doesn't have configurable vcpu
             m.execute("virsh undefine subVmTest1")
-            b.wait_not_present("button#vm-subVmTest1-vcpus-count")
+            b.wait_present("button#vm-subVmTest1-vcpus-count:disabled")
 
     # HACK: broken with Chromium > 63, see https://github.com/cockpit-project/cockpit/pull/9229
     @unittest.skip("Broken with current chromium, see PR #9229")


### PR DESCRIPTION
Transient VM will differ in:
- It's deletion is disabled. It ceases to exist once it's turned off
- Memory, vCPU and Bootorder are not configurable.
- Autostart property is not shown at all
- Added support for adding and removing disks for transient VM (until now it resulted in error)
- Added support for adding and removing vNICs for transient VM (until now it resulted in error)
- Disk and vNIC configuration is disabled
