### PR TITLE
cockpit-session: correct utmp entry writing

### DIFF
--- a/src/ws/session-utils.c
+++ b/src/ws/session-utils.c
@@ -408,7 +408,9 @@ utmp_log (int login,
 
   strncpy (ut.ut_id, id, sizeof (ut.ut_id));
   ut.ut_id[sizeof (ut.ut_id) - 1] = 0;
-  ut.ut_line[0] = 0;
+
+  strncpy (ut.ut_line, "web console", sizeof ut.ut_line);
+  ut.ut_line[sizeof ut.ut_line - 1] = 0;
 
   if (login)
     {
@@ -422,7 +424,7 @@ utmp_log (int login,
   ut.ut_tv.tv_sec = tv.tv_sec;
   ut.ut_tv.tv_usec = tv.tv_usec;
 
-  ut.ut_type = login ? LOGIN_PROCESS : DEAD_PROCESS;
+  ut.ut_type = login ? USER_PROCESS : DEAD_PROCESS;
   ut.ut_pid = pid;
 
   pututline (&ut);

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -31,6 +31,10 @@ class TestLogin(MachineCase):
         m = self.machine
         b = self.browser
 
+        # rhel-8-1-distropkg: utmp/who(1) output fixed in PR #13242
+        # fedora-coreos: logs in via ssh, not cockpit-session
+        utmp_works = m.image not in ['rhel-8-1-distropkg', 'fedora-coreos']
+
         # Setup users and passwords
         m.execute("useradd user -c 'Barney Bär' || true")
         m.execute("echo user:abcdefg | chpasswd")
@@ -63,10 +67,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Try to login as a non-existing user
         login("nonexisting", "blahblah")
         b.wait_text_not("#login-error-message", "")
+        self.assertNotIn("web", m.execute("who"))
 
         # Try to login as user with a wrong password
         login("user", "gfedcba")
         b.wait_text_not("#login-error-message", "")
+        self.assertNotIn("web", m.execute("who"))
 
         # Try to login as user with correct password
         login("user", "abcdefg")
@@ -74,6 +80,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_in_text("#login-error-message", "Server closed connection")
         else:
             b.wait_text("#login-error-message", "Permission denied")
+        self.assertNotIn("web", m.execute("who"))
 
         # Try to login with disabled shell; this does not work on OSTree where
         # we log in through ssh
@@ -91,10 +98,16 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
 
+        if utmp_works:
+            self.assertRegex(m.execute("who"), "^admin *web")
+
         # reload, which should log us in with the cookie
         b.reload()
         b.wait_present("#content")
         b.wait_text('#content-user-name', 'Administrator')
+
+        if utmp_works:
+            self.assertRegex(m.execute("who"), "^admin *web")
 
         b.click("#content-user-name")
         b.click('#go-account')
@@ -108,6 +121,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Change login screen options
         b.logout()
+        b.wait(lambda: "web console" not in m.execute("who"))
         b.wait_visible("#option-group")
         m.execute("printf '[WebService]\nLoginTo = false\n' > /etc/cockpit/cockpit.conf")
         m.restart_cockpit()


### PR DESCRIPTION
`LOGIN_PROCESS` seems to be intended to be used for login(1)-style
processes that are showing a login prompt on a given tty.  One can see
this from the current code in the output of `who -a`.

Use `LOGIN_USER` instead.

Additionally, set the "line" field to "web console" to provide a hint
about the nature of the login.