### PR TITLE
Session timeout

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -206,6 +206,17 @@ ProtocolHeader = X-Forwarded-Proto
           By default, no banner is displayed.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>IdleTimeout</option></term>
+        <listitem>
+          <para>Time in minutes after which session expires and user is logged out if no user action
+          has been performed in the given time. This idle timeout only applies to interactive password logins.
+          With non-interactive authentication methods like Kerberos, OAuth, or certificate login, the browser
+          cannot forget credentials, and thus automatic logouts are not useful for protecting credentials
+          of forgotten sessions. Set to <literal>0</literal> to disable session timeout.
+          When not specified, the default is <literal>15</literal> minutes.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -127,6 +127,22 @@
           </div>
         </div>
 
+        <div class="modal" id="session-timeout-dialog" tabindex="-1" role="dialog" data-backdrop="static">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h4 class="modal-title" translate="yes">Session is about to expire</h4>
+              </div>
+              <div class="modal-body">
+                  <p id="timeout-message" />
+              </div>
+              <div class="modal-footer">
+                <button class="btn btn-primary" id="keep-session-alive" translate="yes">Continue Session</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
           <div class="modal-dialog">
             <div class="modal-content">

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -7,6 +7,7 @@
     try {
         localStorage = window.localStorage;
         window.localStorage.removeItem('url-root');
+        window.localStorage.removeItem('standard-login');
     } catch (ex) {
         localStorage = window.sessionStorage;
         console.warn(String(ex));
@@ -486,6 +487,9 @@
             var authorized = id("authorized-input").checked ? "password" : "";
             var password = id("login-password-input").value;
             localStorage.setItem('authorized-default', authorized);
+
+            /* Keep information if login page was used */
+            localStorage.setItem('standard-login', true);
 
             var headers = {
                 Authorization: "Basic " + window.btoa(utf8(user + ":" + password)),

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -34,6 +34,7 @@ class TestMenu(MachineCase):
         m.execute("mkdir -p /usr/local/share/cockpit/systemd && cp -rp /usr/share/cockpit/systemd/* /usr/local/share/cockpit/systemd")
         m.execute(
             """sed -i '/"menu"/a "memory": { "label": "Memory", "path": "#/memory" },' /usr/local/share/cockpit/systemd/manifest.json""")
+        m.execute("printf '[Session]\nIdleTimeout = 1\n' >> /etc/cockpit/cockpit.conf")
 
         self.login_and_go("/system")
 
@@ -43,6 +44,37 @@ class TestMenu(MachineCase):
         b.wait_popup('about')
         b.click('#about button[data-dismiss="modal"]')
         b.wait_popdown("about")
+
+        # Test session timeout
+        if m.image != "rhel-8-1-distropkg": # Added in #13251
+            time.sleep(20)
+            b.wait_not_visible("#session-timeout-dialog")
+            b.wait_visible("#filter-menus")
+            b.enter_page("/system")
+            b.mouse("#system_information_hardware_text", "mousemove", 24, 24)
+            b.switch_to_top()
+            time.sleep(35)
+            with b.wait_timeout(3):
+                b.wait_popup("session-timeout-dialog")
+                self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 20)
+            b.click("#keep-session-alive")
+            b.wait_popdown("session-timeout-dialog")
+            time.sleep(30)
+            with b.wait_timeout(8):
+                b.wait_popup("session-timeout-dialog")
+                self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 20)
+            time.sleep(30)
+            b.wait_visible("#login")
+            b.wait_visible("#login-info-message")
+            b.wait_text("#login-info-message", "You have been logged out due to inactivity.")
+            m.execute("sed -i 's/IdleTimeout = 1/IdleTimeout = 0/' /etc/cockpit/cockpit.conf")
+            m.restart_cockpit()
+            b.reload()
+            self.login_and_go("/system")
+            b.switch_to_top()
+            time.sleep(75)
+            b.wait_not_visible("#session-timeout-dialog")
+            b.wait_visible("#filter-menus")
 
         self.check_axe("Test-navigation")
 


### PR DESCRIPTION
Settable in `cockpit.conf`.
Default is 15 minutes. Disable by setting to 0.
For last 30 seconds a dialog is opened that does counting down. Session can be kept only by clicking the 'Continue Session' in this stage. Otherwise session is kept alive by user doing either of `mousemove`, `mousedown`, `keypress`, `touchmove`, `onscroll`.
![Screenshot from 2019-12-06 08-49-19](https://user-images.githubusercontent.com/12330670/70306327-e3445c80-1806-11ea-8fcd-0b7b67e49559.png)
When logged out, you are shown message why you were logged out:
![logoutduetoinactivity](https://user-images.githubusercontent.com/12330670/70306356-f22b0f00-1806-11ea-82f7-c261899680a5.png)
When you did not use password to log in (SSO or so) then you would never be logged out.

@garrett had idea that we should somehow notify user that there are only 30s remaining in the session even if the user is in different tab. There were 2 ideas:
1. **Play some sound** - I did not do it for two reasons - Firstly any page that does any sounds is super annoying and I believe users hate it - lets not be those guys :) Secondly browsers are starting to block any random sounds playing by default. (at least firefox had done some great work lately)
2. **Change/Animate favicon** - This would be great, but I did not find any way of doing this. The main problem is that we mostly do not own the icons - we use something from system - so we cannot slightly edit them and then switch between two or three versions. I did not found any way how to do it only by CSS.

However since I was not able to do any of those ideas, I came up with a different one. It shows the running down time in the tab text (see first picture). It is something that is moving so it catches user's attention and it also provides additional info about how much time is remaining.