### PR TITLE
a11y: Add role=link to links without href

### DIFF
--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -101,7 +101,7 @@
     <script id="dashboard-hosts-tmpl" type="x-template/mustache">
         {{#machines}}
             {{! state can be 'failed' or 'connected' }}
-            <a role="link" tabindex="0" data-address="{{address}}" class="list-group-item {{state}}"
+            <a data-address="{{address}}" class="list-group-item {{state}}"
                 data-color="{{ color }}" target="_parent" href="/@{{address}}">
                 <button class="btn btn-danger edit-button servers-privileged pficon btn-delete pficon-delete delete-{{address}}"></button>
                 <button class="btn btn-default edit-button servers-privileged pficon pficon-edit"></button>

--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -67,10 +67,10 @@
                     </div>
                 </div>
                 <ul class="nav nav-tabs">
-                    <li data-monitor-id="0"><a tabindex="0"><span translate="yes">CPU</span></a></li>
-                    <li data-monitor-id="1"><a tabindex="0"><span translate="yes">Memory</span></a></li>
-                    <li data-monitor-id="2"><a tabindex="0"><span translate="yes" context="label">Network</span></a></li>
-                    <li data-monitor-id="3"><a tabindex="0"><span translate="yes">Disk I/O</span></a></li>
+                    <li data-monitor-id="0"><a role="link" tabindex="0"><span translate="yes">CPU</span></a></li>
+                    <li data-monitor-id="1"><a role="link" tabindex="0"><span translate="yes">Memory</span></a></li>
+                    <li data-monitor-id="2"><a role="link" tabindex="0"><span translate="yes" context="label">Network</span></a></li>
+                    <li data-monitor-id="3"><a role="link" tabindex="0"><span translate="yes">Disk I/O</span></a></li>
                 </ul>
                 <br>
                 <div class="dashboard-plot zoomable-plot" id="dashboard-plot-0"></div>
@@ -101,7 +101,7 @@
     <script id="dashboard-hosts-tmpl" type="x-template/mustache">
         {{#machines}}
             {{! state can be 'failed' or 'connected' }}
-            <a tabindex="0" data-address="{{address}}" class="list-group-item {{state}}"
+            <a role="link" tabindex="0" data-address="{{address}}" class="list-group-item {{state}}"
                 data-color="{{ color }}" target="_parent" href="/@{{address}}">
                 <button class="btn btn-danger edit-button servers-privileged pficon btn-delete pficon-delete delete-{{address}}"></button>
                 <button class="btn btn-default edit-button servers-privileged pficon pficon-edit"></button>
@@ -171,7 +171,7 @@
                 </div>
                 </div>
                 <div class="modal-footer">
-                    <div class="pull-left"><a tabindex="0" id="host-edit-sync-users" translate="yes">Synchronize users</a></div>
+                    <div class="pull-left"><a role="link" tabindex="0" id="host-edit-sync-users" translate="yes">Synchronize users</a></div>
                     <button class="btn btn-default" data-dismiss="modal" translate="yes">Cancel</button>
                     <button class="btn btn-primary" id="host-edit-apply" translate="yes">Set</button>
                 </div>

--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -125,7 +125,7 @@
         <i class="fa fa-cube fa-fw"></i>
         <span></span>
       </h3>
-      <a tabindex="0" translate="yes">Show all containers</a>
+      <a role="link" tabindex="0" translate="yes">Show all containers</a>
     </div>
     <div class="container-fluid">
       <div class="panel-default panel">
@@ -246,7 +246,7 @@
         <i class="pficon pficon-image"></i>
         <span></span>
       </h3>
-      <a tabindex="0" translate="yes">Show all images</a>
+      <a role="link" tabindex="0" translate="yes">Show all images</a>
       <div class="content-filter-actions" id="image-details-buttons">
         <button  title="Delete" translate="title" id="image-details-delete"
             class="btn btn-danger btn-delete pficon pficon-delete"></button>
@@ -286,7 +286,7 @@
 
   <div id="storage" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a tabindex="0" translate="yes">Containers</a></li>
+      <li><a role="link" tabindex="0" translate="yes">Containers</a></li>
       <li class="active" translate>Storage</li>
     </ol>
 
@@ -330,8 +330,8 @@
                   <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
               </button>
               <ul class="dropdown-menu">
-                  <li><a tabindex="0" value="TCP" translate>TCP</a></li>
-                  <li><a tabindex="0" value="UDP" translate>UDP</a></li>
+                  <li><a role="link" tabindex="0" value="TCP" translate>TCP</a></li>
+                  <li><a role="link" tabindex="0" value="UDP" translate>UDP</a></li>
               </ul>
           </div>
       </div>
@@ -360,9 +360,9 @@
             <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
           </button>
           <ul class="dropdown-menu">
-            <li><a tabindex="0" translate="yes">Default</a></li>
-            <li><a tabindex="0" translate="yes">ReadWrite</a></li>
-            <li><a tabindex="0" translate="yes">ReadOnly</a></li>
+            <li><a role="link" tabindex="0" translate="yes">Default</a></li>
+            <li><a role="link" tabindex="0" translate="yes">ReadWrite</a></li>
+            <li><a role="link" tabindex="0" translate="yes">ReadOnly</a></li>
           </ul>
         </div>
       </div>
@@ -407,7 +407,7 @@
                   <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
               </button>
               <ul class="dropdown-menu">
-                  {{#containers}}<li><a tabindex="0" value="{{.}}">{{.}}</a></li>{{/containers}}
+                  {{#containers}}<li><a role="link" tabindex="0" value="{{.}}">{{.}}</a></li>{{/containers}}
               </ul>
           </div>
       </div>
@@ -545,10 +545,10 @@
                         <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                       </button>
                       <ul class="dropdown-menu" id="restart-policy-dropdown">
-                        <li><a tabindex="0" translate="yes" data-value="no">No</a></li>
-                        <li><a tabindex="0" translate="yes" data-value="on-failure">On Failure</a></li>
-                        <li><a tabindex="0" translate="yes" data-value="always">Always</a></li>
-                        <li><a tabindex="0" translate="yes" data-value="unless-stopped">Unless Stopped</a></li>
+                        <li><a role="link" tabindex="0" translate="yes" data-value="no">No</a></li>
+                        <li><a role="link" tabindex="0" translate="yes" data-value="on-failure">On Failure</a></li>
+                        <li><a role="link" tabindex="0" translate="yes" data-value="always">Always</a></li>
+                        <li><a role="link" tabindex="0" translate="yes" data-value="unless-stopped">Unless Stopped</a></li>
                       </ul>
                     </div>
                     <div id="restart-policy-retries-container" class="hidden">

--- a/pkg/lib/machine-change-auth.html
+++ b/pkg/lib/machine-change-auth.html
@@ -20,7 +20,7 @@
                     <input class="form-control" id="login-custom-user" type="text" value="{{machine_user}}" placeholder="{{ default_user }}"/>
                 </td>
                 <td>
-                    <a tabindex="0" tabindex="0" role="button" data-toggle="popover"
+                    <a tabindex="0" role="button" data-toggle="popover"
                         data-trigger="focus" data-placement="bottom" translate="data-content"
                         data-content="Leave blank to connect to this machine as the currently logged in user{{#default_user}} ({{default_user}}){{/default_user}}. If you enter a different username, that user will always be used connecting to this machine.">
                         <span class="fa fa-lg fa-info-circle"></span>
@@ -39,9 +39,9 @@
                         </button>
                         <ul class="dropdown-menu">
                             {{#password}}
-                            <li value="password"><a tabindex="0" translate>Type a password</a></li>
+                            <li value="password"><a role="link" tabindex="0" translate>Type a password</a></li>
                             {{/password}}
-                            <li value="stored"><a tabindex="0" translate>Using available credentials</a></li>
+                            <li value="stored"><a role="link" tabindex="0" translate>Using available credentials</a></li>
                         </ul>
                     </div>
                 </td>
@@ -54,7 +54,7 @@
                     <input class="form-control" id="login-custom-password" type="password" />
                 </td>
                 <td>
-                    <a tabindex="0" tabindex="0" role="button" data-toggle="popover"
+                    <a tabindex="0" role="button" data-toggle="popover"
                         data-trigger="focus" data-placement="bottom" translate="data-content"
                         data-content="Entering a different password here means you will need to retype it every time you reconnect to this machine">
                         <span class="fa fa-lg fa-info-circle"></span>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -100,7 +100,7 @@
       <div class="panel panel-default" id="networking-firewall" hidden>
         <div class="panel-heading">
           <h2 class="panel-title">
-            <a tabindex="0" id="networking-firewall-link" translate="yes">Firewall</a>
+            <a role="link" tabindex="0" id="networking-firewall-link" translate="yes">Firewall</a>
           </h2>
           <div class="panel-actions">
           </div>
@@ -389,7 +389,7 @@
 
   <div id="network-interface" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a tabindex="0" translate="yes">Networking</a></li>
+      <li><a role="link" tabindex="0" translate="yes">Networking</a></li>
       <li class="active"></li>
     </ol>
     <div class="row">

--- a/pkg/playground/jquery-patterns.html
+++ b/pkg/playground/jquery-patterns.html
@@ -46,8 +46,8 @@
                                         <span class="caret"></span>
                                     </button>
                                     <ul class="dropdown-menu">
-                                        <li value="one"><a tabindex="0">One</a></li>
-                                        <li value="two"><a tabindex="0">Two</a></li>
+                                        <li value="one"><a role="link" tabindex="0">One</a></li>
+                                        <li value="two"><a role="link" tabindex="0">Two</a></li>
                                     </ul>
                                 </div>
                             </td>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -40,35 +40,35 @@
                 </span>
               </li>
               <li id="navbar-oops" hidden>
-                <a tabindex="0"><span class="oops-status" translate="yes">Ooops!</span></a>
+                <a role="link" tabindex="0"><span class="oops-status" translate="yes">Ooops!</span></a>
               </li>
               <li class="dropdown">
-                <a tabindex="0" id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
+                <a role="link" tabindex="0" id="navbar-dropdown" class="dropdown-toggle" data-toggle="dropdown">
                   <span class="pficon pficon-user"></span>
                   <span id="content-user-name"></span>
                   <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                 </a>
                 <ul class="dropdown-menu">
                   <li class="display-language-menu">
-                    <a tabindex="0" data-toggle="modal" data-target="#display-language" translate="yes">Display Language</a>
+                    <a role="link" tabindex="0" data-toggle="modal" data-target="#display-language" translate="yes">Display Language</a>
                   </li>
                   <li class="divider display-language-menu"></li>
                   <li>
-                    <a tabindex="0" data-toggle="modal" data-target="#about" translate="yes">About Cockpit</a>
+                    <a role="link" tabindex="0" data-toggle="modal" data-target="#about" translate="yes">About Cockpit</a>
                   </li>
                   <li>
-                    <a tabindex="0" id="active-pages" translate="yes" class="navbar-advanced">Active Pages</a>
+                    <a role="link" tabindex="0" id="active-pages" translate="yes" class="navbar-advanced">Active Pages</a>
                   </li>
                   <li class="divider"></li>
                   <li id="go-account" hidden>
-                    <a tabindex="0" translate="yes">Account Settings</a>
+                    <a role="link" tabindex="0" translate="yes">Account Settings</a>
                   </li>
                   <li>
-                      <a tabindex="0" data-toggle="modal" data-target="#credentials-dialog"
+                      <a role="link" tabindex="0" data-toggle="modal" data-target="#credentials-dialog"
                           id="credentials-item" translate="yes">Authentication</a>
                   </li>
                   <li>
-                    <a tabindex="0" id="go-logout" translate="yes">Log Out</a>
+                    <a role="link" tabindex="0" id="go-logout" translate="yes">Log Out</a>
                   </li>
                 </ul>
               </li>
@@ -168,7 +168,7 @@
                                 <tr id="credential-keys">
                                     <td colspan="2" translate>Use the following keys to authenticate against other systems</td>
                                     <td class="listing-ct-actions">
-                                        <a tabindex="0">
+                                        <a role="link" tabindex="0">
                                             <i translate class="pficon pficon-add-circle-o"></i>
                                             <span translate>Add key</span>
                                         </a>
@@ -342,7 +342,7 @@
                 <nav class="nav-sidebar nav-pf-vertical">
                     <ul id="main-navbar" class="main-navbar list-group">
                         <li id="host-nav-item" class="list-group-item dashboard-link has-menu">
-                            <a tabindex="0" id="host-nav-link">
+                            <a role="link" tabindex="0" id="host-nav-link">
                                 <span class="fa pficon-container-node"></span>
                                 <span class="list-group-item-value"></span>
                             </a>
@@ -353,7 +353,7 @@
 
             <div id="host-nav" class="area-ct-subnav">
                 <div id="machine-dropdown" class="nav-item-pf-header machine-dropdown">
-                    <a tabindex="0" id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
+                    <a role="link" tabindex="0" id="machine-link" class="dropdown-toggle" data-toggle="dropdown"
                         aria-haspopup="true" role="button" aria-expanded="false">
                       <img src="../shell/images/server-small.png" id="machine-avatar" role="presentation" alt="" class="machine-avatar single-dashboard">
                       <span></span>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -39,11 +39,11 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
         </button>
         <ul class="dropdown-menu" role="menu">
-          <li><a tabindex="0" data-op="recent" translate="yes">Recent</a></li>
-          <li><a tabindex="0" data-op="boot" translate="yes">Current boot</a></li>
-          <li><a tabindex="0" data-op="previous-boot" translate="yes">Previous boot</a></li>
-          <li><a tabindex="0" data-op="last-24h" translate="yes">Last 24 hours</a></li>
-          <li><a tabindex="0" data-op="last-week" translate="yes">Last 7 days</a></li>
+          <li><a role="link" tabindex="0" data-op="recent" translate="yes">Recent</a></li>
+          <li><a role="link" tabindex="0" data-op="boot" translate="yes">Current boot</a></li>
+          <li><a role="link" tabindex="0" data-op="previous-boot" translate="yes">Previous boot</a></li>
+          <li><a role="link" tabindex="0" data-op="last-24h" translate="yes">Last 24 hours</a></li>
+          <li><a role="link" tabindex="0" data-op="last-week" translate="yes">Last 7 days</a></li>
         </ul>
       </div>
       <span class="" translate>Severity</span>
@@ -53,15 +53,15 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
           <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
         </button>
         <ul id="prio-lists" class="dropdown-menu" role="menu">
-          <li><a tabindex="0" data-prio="*" translate="yes">Everything</a></li>
-          <li><a tabindex="0" data-prio="0" translate="yes">Only Emergency</a></li>
-          <li><a tabindex="0" data-prio="1" translate="yes">Alert and above</a></li>
-          <li><a tabindex="0" data-prio="2" translate="yes">Critical and above</a></li>
-          <li><a tabindex="0" data-prio="3" translate="yes">Error and above</a></li>
-          <li><a tabindex="0" data-prio="4" translate="yes">Warning and above</a></li>
-          <li><a tabindex="0" data-prio="5" translate="yes">Notice and above</a></li>
-          <li><a tabindex="0" data-prio="6" translate="yes">Info and above</a></li>
-          <li><a tabindex="0" data-prio="7" translate="yes">Debug and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="*" translate="yes">Everything</a></li>
+          <li><a role="link" tabindex="0" data-prio="0" translate="yes">Only Emergency</a></li>
+          <li><a role="link" tabindex="0" data-prio="1" translate="yes">Alert and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="2" translate="yes">Critical and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="3" translate="yes">Error and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="4" translate="yes">Warning and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="5" translate="yes">Notice and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="6" translate="yes">Info and above</a></li>
+          <li><a role="link" tabindex="0" data-prio="7" translate="yes">Debug and above</a></li>
         </ul>
       </div>
       <span translate="yes">Service</span>
@@ -80,7 +80,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
   <div id="journal-entry" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a tabindex="0" id="journal-navigate-home" translate="yes">Logs</a></li>
+      <li><a role="link" tabindex="0" id="journal-navigate-home" translate="yes">Logs</a></li>
       <li id="journal-entry-crumb" class="active" translate="yes">Entry</li>
     </ol>
     <h2 id="journal-entry-heading"></h2>

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -124,13 +124,13 @@
           <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
         </button>
         <ul class="dropdown-menu">
-          <li value="1"><a tabindex="0" translate>Monday</a></li>
-          <li value="2"><a tabindex="0" translate>Tuesday</a></li>
-          <li value="3"><a tabindex="0" translate>Wednesday</a></li>
-          <li value="4"><a tabindex="0" translate>Thursday</a></li>
-          <li value="5"><a tabindex="0" translate>Friday</a></li>
-          <li value="6"><a tabindex="0" translate>Saturday</a></li>
-          <li value="7"><a tabindex="0" translate>Sunday</a></li>
+          <li value="1"><a role="link" tabindex="0" translate>Monday</a></li>
+          <li value="2"><a role="link" tabindex="0" translate>Tuesday</a></li>
+          <li value="3"><a role="link" tabindex="0" translate>Wednesday</a></li>
+          <li value="4"><a role="link" tabindex="0" translate>Thursday</a></li>
+          <li value="5"><a role="link" tabindex="0" translate>Friday</a></li>
+          <li value="6"><a role="link" tabindex="0" translate>Saturday</a></li>
+          <li value="7"><a role="link" tabindex="0" translate>Sunday</a></li>
         </ul>
       </div>
       <input type="text" value="{{hours}}" data-index="{{index}}" data-content="hours" class="form-control" >
@@ -153,37 +153,37 @@
           <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
         </button>
         <ul class="dropdown-menu vertical-scroll">
-          <li value="1"><a tabindex="0" translate>1st</a></li>
-          <li value="2"><a tabindex="0" translate>2nd</a></li>
-          <li value="3"><a tabindex="0" translate>3rd</a></li>
-          <li value="4"><a tabindex="0" translate>4th</a></li>
-          <li value="5"><a tabindex="0" translate>5th</a></li>
-          <li value="6"><a tabindex="0" translate>6th</a></li>
-          <li value="7"><a tabindex="0" translate>7th</a></li>
-          <li value="8"><a tabindex="0" translate>8th</a></li>
-          <li value="9"><a tabindex="0" translate>9th</a></li>
-          <li value="10"><a tabindex="0" translate>10th</a></li>
-          <li value="11"><a tabindex="0" translate>11th</a></li>
-          <li value="12"><a tabindex="0" translate>12th</a></li>
-          <li value="13"><a tabindex="0" translate>13th</a></li>
-          <li value="14"><a tabindex="0" translate>14th</a></li>
-          <li value="15"><a tabindex="0" translate>15th</a></li>
-          <li value="16"><a tabindex="0" translate>16th</a></li>
-          <li value="17"><a tabindex="0" translate>17th</a></li>
-          <li value="18"><a tabindex="0" translate>18th</a></li>
-          <li value="19"><a tabindex="0" translate>19th</a></li>
-          <li value="20"><a tabindex="0" translate>20th</a></li>
-          <li value="21"><a tabindex="0" translate>21st</a></li>
-          <li value="22"><a tabindex="0" translate>22nd</a></li>
-          <li value="23"><a tabindex="0" translate>23rd</a></li>
-          <li value="24"><a tabindex="0" translate>24th</a></li>
-          <li value="25"><a tabindex="0" translate>25th</a></li>
-          <li value="26"><a tabindex="0" translate>26th</a></li>
-          <li value="27"><a tabindex="0" translate>27th</a></li>
-          <li value="28"><a tabindex="0" translate>28th</a></li>
-          <li value="29"><a tabindex="0" translate>29th</a></li>
-          <li value="30"><a tabindex="0" translate>30th</a></li>
-          <li value="31"><a tabindex="0" translate>31st</a></li>
+          <li value="1"><a role="link" tabindex="0" translate>1st</a></li>
+          <li value="2"><a role="link" tabindex="0" translate>2nd</a></li>
+          <li value="3"><a role="link" tabindex="0" translate>3rd</a></li>
+          <li value="4"><a role="link" tabindex="0" translate>4th</a></li>
+          <li value="5"><a role="link" tabindex="0" translate>5th</a></li>
+          <li value="6"><a role="link" tabindex="0" translate>6th</a></li>
+          <li value="7"><a role="link" tabindex="0" translate>7th</a></li>
+          <li value="8"><a role="link" tabindex="0" translate>8th</a></li>
+          <li value="9"><a role="link" tabindex="0" translate>9th</a></li>
+          <li value="10"><a role="link" tabindex="0" translate>10th</a></li>
+          <li value="11"><a role="link" tabindex="0" translate>11th</a></li>
+          <li value="12"><a role="link" tabindex="0" translate>12th</a></li>
+          <li value="13"><a role="link" tabindex="0" translate>13th</a></li>
+          <li value="14"><a role="link" tabindex="0" translate>14th</a></li>
+          <li value="15"><a role="link" tabindex="0" translate>15th</a></li>
+          <li value="16"><a role="link" tabindex="0" translate>16th</a></li>
+          <li value="17"><a role="link" tabindex="0" translate>17th</a></li>
+          <li value="18"><a role="link" tabindex="0" translate>18th</a></li>
+          <li value="19"><a role="link" tabindex="0" translate>19th</a></li>
+          <li value="20"><a role="link" tabindex="0" translate>20th</a></li>
+          <li value="21"><a role="link" tabindex="0" translate>21st</a></li>
+          <li value="22"><a role="link" tabindex="0" translate>22nd</a></li>
+          <li value="23"><a role="link" tabindex="0" translate>23rd</a></li>
+          <li value="24"><a role="link" tabindex="0" translate>24th</a></li>
+          <li value="25"><a role="link" tabindex="0" translate>25th</a></li>
+          <li value="26"><a role="link" tabindex="0" translate>26th</a></li>
+          <li value="27"><a role="link" tabindex="0" translate>27th</a></li>
+          <li value="28"><a role="link" tabindex="0" translate>28th</a></li>
+          <li value="29"><a role="link" tabindex="0" translate>29th</a></li>
+          <li value="30"><a role="link" tabindex="0" translate>30th</a></li>
+          <li value="31"><a role="link" tabindex="0" translate>31st</a></li>
         </ul>
       </div>
       <input type="text" value="{{hours}}" data-index="{{index}}" data-content="hours" class="form-control" >
@@ -219,7 +219,7 @@
 
   <div id="service" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a tabindex="0" id="service-navigate-home" translate="yes">Services</a></li>
+      <li><a role="link" tabindex="0" id="service-navigate-home" translate="yes">Services</a></li>
       <li class="active"></li>
     </ol>
 
@@ -302,8 +302,8 @@
                     <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                   </button>
                   <ul class="dropdown-menu">
-                    <li value="1"><a tabindex="0" translate="yes">After system boot</a></li>
-                    <li value="2"><a tabindex="0" translate="yes">At specific time</a></li>
+                    <li value="1"><a role="link" tabindex="0" translate="yes">After system boot</a></li>
+                    <li value="2"><a role="link" tabindex="0" translate="yes">At specific time</a></li>
                   </ul>
                 </div>
                 <div id="boot">
@@ -315,10 +315,10 @@
                       <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                     </button>
                     <ul class="dropdown-menu">
-                      <li value="1"><a tabindex="0" translate="yes">Seconds</a></li>
-                      <li value="60"><a tabindex="0" translate="yes">Minutes</a></li>
-                      <li value="3600"><a tabindex="0" translate="yes">Hours</a></li>
-                      <li value="604800"><a tabindex="0" translate="yes">Weeks</a></li>
+                      <li value="1"><a role="link" tabindex="0" translate="yes">Seconds</a></li>
+                      <li value="60"><a role="link" tabindex="0" translate="yes">Minutes</a></li>
+                      <li value="3600"><a role="link" tabindex="0" translate="yes">Hours</a></li>
+                      <li value="604800"><a role="link" tabindex="0" translate="yes">Weeks</a></li>
                     </ul>
                   </div>
                 </div>
@@ -339,12 +339,12 @@
                     <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                   </button>
                   <ul class="dropdown-menu">
-                    <li value="0"><a tabindex="0" translate="yes">Don't Repeat</a></li>
-                    <li value="60"><a tabindex="0" translate="yes">Repeat Hourly</a></li>
-                    <li value="1440"><a tabindex="0" translate="yes">Repeat Daily</a></li>
-                    <li value="10080"><a tabindex="0" translate="yes">Repeat Weekly</a></li>
-                    <li value="44640"><a tabindex="0" translate="yes">Repeat Monthly</a></li>
-                    <li value="525600"><a tabindex="0" translate="yes">Repeat Yearly</a></li>
+                    <li value="0"><a role="link" tabindex="0" translate="yes">Don't Repeat</a></li>
+                    <li value="60"><a role="link" tabindex="0" translate="yes">Repeat Hourly</a></li>
+                    <li value="1440"><a role="link" tabindex="0" translate="yes">Repeat Daily</a></li>
+                    <li value="10080"><a role="link" tabindex="0" translate="yes">Repeat Weekly</a></li>
+                    <li value="44640"><a role="link" tabindex="0" translate="yes">Repeat Monthly</a></li>
+                    <li value="525600"><a role="link" tabindex="0" translate="yes">Repeat Yearly</a></li>
                   </ul>
                 </div>
               </td>

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -68,7 +68,7 @@
 
   <div id="account" class="container-fluid" hidden>
     <ol class="breadcrumb">
-      <li><a tabindex="0" translate="yes">Accounts</a></li>
+      <li><a role="link" tabindex="0" translate="yes">Accounts</a></li>
       <li class="active"></li>
     </ol>
 
@@ -110,7 +110,7 @@
                   </label>
                 </div>
               </div>
-              <a tabindex="0" id="account-expiration-button" class="accounts-privileged" data-toggle="modal"
+              <a role="link" tabindex="0" id="account-expiration-button" class="accounts-privileged" data-toggle="modal"
                    data-target="#account-expiration"></a>
             </td>
           </tr>
@@ -123,7 +123,7 @@
                     id="password-reset-button" data-toggle="modal" data-target="#password-reset"
                     data-container="body">Force Change</button>
               </div>
-              <a tabindex="0" id="password-expiration-button" class="accounts-privileged" data-toggle="modal"
+              <a role="link" tabindex="0" id="password-expiration-button" class="accounts-privileged" data-toggle="modal"
                  data-target="#password-expiration"></a>
             </td>
           </tr>


### PR DESCRIPTION
React was complaining about links without href having tabindex; adding a role to the link of link fixes the issue.

I decided to replicate that across our HTML files too.

This change affects all of the instances where we have `<a tabindex=0>` in our HTML files, with the exception of the system overview page. That has been dealt with in the overview PR @ https://github.com/cockpit-project/cockpit/pull/13186/commits/9ebb2c1a2a097b6944f9c1d04f55b43c66ee6e18.