### PR TITLE
tls: fix another race in the test-server unit test

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -670,14 +670,22 @@ test_tls_client_cert_parallel (TestCase *tc, gconstpointer data)
            * other connections exited, which is a race that we've seen in practice).  Wait
            * for it, as above.
            */
-          for (int retry = 0; retry < 100; ++retry)
+          for (int retry = 0;; ++retry)
             {
+              g_assert_cmpint (retry, <, 100);
+
               if (access (tc->cert_file_path, F_OK) == 0)
                 break;
               g_usleep (10000);
             }
         }
-      g_assert_cmpint (access (tc->cert_file_path, F_OK), ==, 0);
+      else
+        {
+          /* In the "alternate" case there should be no such strange
+           * races.
+           */
+          g_assert_cmpint (access (tc->cert_file_path, F_OK), ==, 0);
+        }
 
       /* closing last connection removes it */
       g_assert_cmpint (gnutls_bye (sessions[n_connections - 1], GNUTLS_SHUT_RDWR), ==, GNUTLS_E_SUCCESS);


### PR DESCRIPTION
It might be possible that one of the exiting threads hasn't deleted the
certificate file yet by the time the loop runs (causing the loop to
successfully exit) but erases it by the time of the assert, while all
the while the final thread hasn't created it again yet.

This extremely unlikely race was found after 30 minutes of grinding on
my laptop vs. 10 webpack threads.

Avoid the issue by just using the loop itself as the verification.
If we hit the retry limit we've failed, but if we see the file at any
point before, then we're successful.

The "alternate" approach doesn't suffer this race.