### PR TITLE
containers/ws: Unbreak for docker

### DIFF
--- a/containers/ws/atomic-install
+++ b/containers/ws/atomic-install
@@ -48,7 +48,7 @@ chown root:wheel /host/var/lib/cockpit
 mkdir -p /etc/ssh
 
 # For podman, generate a systemd unit for starting on boot
-if [ "$container" = podman ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
+if [ "${container:-}" = podman ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
     mkdir -p /host/etc/systemd/system/
     cat << EOF > /host/etc/systemd/system/cockpit.service
 [Unit]


### PR DESCRIPTION
docker does not set the `$container` env variable.