### PR TITLE
test: Skip NetworkManager-team tests on fedora-coreos

### DIFF
--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -24,6 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
+@skipImage("NetworkManager-team not installed", "fedora-coreos")
 class TestNetworking(NetworkCase):
     provision = {
         "machine1": {},


### PR DESCRIPTION
The NetworkManager-team package is not present any more in current
Fedora CoreOS images.