### PR TITLE
Replace center tag with text-center class

### DIFF
--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -126,9 +126,9 @@ export class Application extends React.Component {
                     </table>
                     {render_homepage_link(comp.urls)}
                     <div className="app-description">{render_description(comp.description)}</div>
-                    <center>
+                    <div className="text-center">
                         { comp.screenshots.map((s, index) => <img key={`comp-${index}`} className="app-screenshot" role="presentation" alt="" src={s.full} />) }
-                    </center>
+                    </div>
                 </div>
             );
         }

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -53,19 +53,15 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
               <h4 class="pf-c-alert__title alert-message" translate="yes">The generated archive contains data considered sensitive and its content should be reviewed by the originating organization before being passed to any third party.</span>
               </h4>
             </div>
-            <div id="sos-progress">
-              <center>
-                <div translate="yes">Generating report</div>
-                <div class="progress">
-                  <div class="progress-bar" role="progressbar"></div>
-                </div>
-              </center>
+            <div id="sos-progress" class="text-center">
+              <div translate="yes">Generating report</div>
+              <div class="progress">
+                <div class="progress-bar" role="progressbar"></div>
+              </div>
             </div>
-            <div id="sos-download">
-              <center>
-                <div translate="yes">Done!</div>
-                <button class="btn btn-primary" translate>Download report</button>
-              </center>
+            <div id="sos-download" class="text-center">
+              <div translate="yes">Done!</div>
+              <button class="btn btn-primary" translate>Download report</button>
             </div>
             <div id="sos-error">
               <div class="pf-c-alert pf-m-danger pf-m-inline" aria-label="inline danger alert">

--- a/pkg/sosreport/sosreport.css
+++ b/pkg/sosreport/sosreport.css
@@ -13,7 +13,9 @@
     text-align: center;
 }
 
-center > div:first-child {
+#sos-progress > div:first-child,
+#sos-download > div:first-child
+{
     margin-bottom: 5px;
 }
 


### PR DESCRIPTION
Tag `<center>` has been deprecated for a while (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/center), instead just rely on `text-center` class. Found these while checking the hidden attributes.
