### PR TITLE
selinux: Generate ansible script

### DIFF
--- a/pkg/lib/cockpit-components-modifications.css
+++ b/pkg/lib/cockpit-components-modifications.css
@@ -20,10 +20,16 @@
 
 .automation-script-modal pre {
     max-height: 20em;
+    margin-bottom: 5px;
 }
 
-.automation-script-modal .fa {
-    padding-right: 5px;
+.automation-script-modal span.fa {
+    margin-right: 5px;
+}
+
+.automation-script-modal i.fa {
+    margin-right: 2px;
+    margin-left: 5px;
 }
 
 .automation-script-modal .modal-footer button:first-child {

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -19,7 +19,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, Modal, Nav, NavItem, TabContent, TabPane, TabContainer } from 'patternfly-react';
+import { Button, Modal } from 'patternfly-react';
+import { Tabs, Tab } from '@patternfly/react-core';
 
 import cockpit from "cockpit";
 import './listing.less';
@@ -45,13 +46,13 @@ class ModificationsExportDialog extends React.Component {
         this.copyToClipboard = this.copyToClipboard.bind(this);
     }
 
-    handleSelect(active_tab) {
+    handleSelect(event, active_tab) {
         this.setState({ active_tab });
     }
 
     copyToClipboard() {
         try {
-            navigator.clipboard.writeText(this.props[this.state.active_tab])
+            navigator.clipboard.writeText(this.props[this.state.active_tab].trim())
                     .then(() => {
                         this.setState({ copied: true });
                         setTimeout(() => {
@@ -71,34 +72,27 @@ class ModificationsExportDialog extends React.Component {
                     <Modal.Title>{ _("Automation Script") }</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
-                    <TabContainer id="basic-tabs-pf" defaultActiveKey="shell">
-                        <>
-                            <Nav bsClass="nav nav-tabs nav-tabs-pf" onSelect={this.handleSelect}>
-                                <NavItem eventKey="shell">
-                                    {_("Shell Script")}
-                                </NavItem>
-                                {this.props.ansible &&
-                                    <NavItem eventKey="ansible">
-                                        {_("Ansible Playbook")}
-                                    </NavItem>
-                                }
-                            </Nav>
-                            <TabContent animation>
-                                <TabPane eventKey="shell">
-                                    <pre>
-                                        {this.props.shell}
-                                    </pre>
-                                </TabPane>
-                                {this.props.ansible &&
-                                    <TabPane eventKey="ansible">
-                                        <pre>
-                                            {this.props.ansible}
-                                        </pre>
-                                    </TabPane>
-                                }
-                            </TabContent>
-                        </>
-                    </TabContainer>
+                    <Tabs activeKey={this.state.active_tab} onSelect={this.handleSelect}>
+                        <Tab eventKey="shell" title={_("Shell Script")}>
+                            <pre>
+                                {this.props.shell.trim()}
+                            </pre>
+                        </Tab>
+                        <Tab eventKey="ansible" title={_("Ansible")}>
+                            <pre>
+                                {this.props.ansible.trim()}
+                            </pre>
+                            <div>
+                                <span className="fa fa-question-circle fa-xs" />
+                                { _("Create new task file with this content.") }
+                                <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html"
+                                    target="_blank" rel="noopener noreferrer">
+                                    <i className="fa fa-external-link fa-xs" />
+                                    { _("Ansible roles documentation") }
+                                </a>
+                            </div>
+                        </Tab>
+                    </Tabs>
                 </Modal.Body>
                 <Modal.Footer>
                     <Button bsStyle='default' className='btn' onClick={this.copyToClipboard}>

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -462,6 +462,7 @@ export class SETroubleshootPage extends React.Component {
                 title={ _("System Modifications") }
                 permitted={ this.props.selinuxStatus.permitted }
                 shell={ "semanage import <<EOF\n" + this.props.selinuxStatus.shell.trim() + "\nEOF" }
+                ansible={ this.props.selinuxStatus.ansible }
                 entries={ this.props.selinuxStatus.modifications }
                 failed={ this.props.selinuxStatus.failed }
             />

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -54,6 +54,10 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 
 
 class TestSelinux(MachineCase):
+    provision = {
+        "0": {},
+        "ansible_machine": {"image": "fedora-30"}
+    }
 
     @skipImage("No setroubleshoot", "debian-stable", "debian-testing", "fedora-coreos", "ubuntu-1804", "ubuntu-stable")
     @skipBrowser("Firefox needs http to access clipboard", "firefox")
@@ -160,13 +164,53 @@ class TestSelinux(MachineCase):
         b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
         b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
         b.click(".modifications-export")
-        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "boolean -D")
-        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -D")
-        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "boolean -m -1 zebra_write_config")
-        b.wait_in_text("#basic-tabs-pf-pane-shell > pre:nth-child(1)", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
-        b.click(".automation-script-modal .fa-clipboard")
+        shell_script_sel = ".automation-script-modal .modal-body section:nth-child(2) pre"
+        ansible_script_sel = ".automation-script-modal .modal-body section:nth-child(3) pre"
+        b.wait_in_text(shell_script_sel, "boolean -D")
+        b.wait_in_text(shell_script_sel, "fcontext -D")
+        b.wait_in_text(shell_script_sel, "boolean -m -1 zebra_write_config")
+        b.wait_in_text(shell_script_sel, "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
+
+        # Check ansible
+        b.click("button:contains('Ansible')")
+        b.wait_in_text(ansible_script_sel, "- name: Allow zebra to write config")
+
+        ansible_m = self.machines["ansible_machine"]
+        ansible_m.execute("mkdir -p roles/selinux/tasks/")
+        ansible_m.write("tests.yml",
+"""
+- hosts: localhost
+  connection: local
+  roles:
+    - selinux
+""")
+        ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
+        se_before = ansible_m.execute("semanage export")
+        ansible_m.execute("ansible-playbook tests.yml")
+        se_after = ansible_m.execute("semanage export")
+        local = m.execute("semanage export")
+        self.assertNotEqual(se_before, se_after)
+        self.assertEqual(local, se_after)
+
+        # Check that ansible is idempotent
+        m.execute("semanage boolean --modify --off zebra_write_config")
+        b.reload()
+        b.enter_page("/selinux/setroubleshoot")
+        b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
+        b.click(".modifications-export")
+        b.click("button:contains('Ansible')")
+        ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
+        se_before = se_after
+        ansible_m.execute("ansible-playbook tests.yml")
+        se_after = ansible_m.execute("semanage export")
+        local = m.execute("semanage export")
+        self.assertNotEqual(se_before, se_after)
+        self.assertEqual(local, se_after)
 
         # Check the content of clipboard by pasting the clipboard to the terminal
+        b.click("button:contains('Shell Script')")
+        b.wait_in_text(shell_script_sel, "boolean -D")
+        b.click(".automation-script-modal .fa-clipboard")
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
         b.focus('.terminal')
@@ -176,7 +220,7 @@ class TestSelinux(MachineCase):
         b.click('.contextMenu .contextMenuOption:nth-child(2)')
         b.wait_in_text(".xterm-accessibility-tree", "semanage import <<EOF")
         b.wait_in_text(".xterm-accessibility-tree", "boolean -D")
-        b.wait_in_text(".xterm-accessibility-tree", "boolean -m -1 zebra_write_config")
+        b.wait_in_text(".xterm-accessibility-tree", "boolean -m -0 zebra_write_config")
         b.wait_in_text(".xterm-accessibility-tree", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
 
         m.execute("semanage boolean -D && semanage fcontext -D")


### PR DESCRIPTION
This needs mostly to decide what exactly we want to output. Currently it outputs list of tasks, so when you take it and add
```
- hosts: localhost
  tasks:
``` 
before it into file, it works just fine. But this does not seem like best practice for ansible. I should talk to someone who knows ansible and see what would be best to generate.
Also, parsing all rules is rather a lot of work, so this introduces structure and boolean parser and then we can add parser for another classes.
Looks like this: (I also switched from PF3 tabs to PF4 tabs as PF3 tabs were misbehaving a bit)
![ansiblestuiff](https://user-images.githubusercontent.com/12330670/70715019-aa662500-1ce9-11ea-941e-3ec3b59d3dc5.png)
Generates script like this:
```
    - name: Clean all existing selinux rules
      shell: |
        semanage boolean -D
        semanage login -D
        semanage interface -D
        semanage user -D
        semanage port -D
        semanage node -D
        semanage fcontext -D
        semanage module -D
        semanage ibendport -D
        semanage ibpkey -D
    - name: Allow virt to sandbox use all caps
      seboolean:
        name: virt_sandbox_use_all_caps
        state: yes
        persistent: yes
    - name: Allow virt to use nfs
      seboolean:
        name: virt_use_nfs
        state: yes
        persistent: yes
    - name: Set up remaining rules
      shell: |
        semanage fcontext -a -f a -t chrome_sandbox_exec_t -r 's0' '/usr/lib/chrome-sandbox'
        semanage fcontext -a -f a -t bin_t -r 's0' '/usr/lib/chromium-browser'
        semanage fcontext -a -f a -t bin_t -r 's0' '/usr/lib/chromium-browser/chromium-browser.sh'
        semanage fcontext -a -f a -t cockpit_ws_exec_t -r 's0' '/usr/libexec/cockpit-wsinstance-factory'

```