### PR TITLE
machines: When deleting a Resource don't attempt to close the modal a…

### DIFF
--- a/pkg/machines/components/deleteResource.jsx
+++ b/pkg/machines/components/deleteResource.jsx
@@ -43,8 +43,7 @@ export class DeleteResource extends React.Component {
 
     delete() {
         this.props.deleteHandler()
-                .fail(exc => this.dialogErrorSet(cockpit.format(_("The $0 could not be deleted"), this.props.objectType.toLowerCase()), exc.message))
-                .then(exc => this.close());
+                .fail(exc => this.dialogErrorSet(cockpit.format(_("The $0 could not be deleted"), this.props.objectType.toLowerCase()), exc.message));
     }
 
     open() {


### PR DESCRIPTION
…fter that

The modal is child of the component specified by the resource we are
trying to delete and it will be automatically unmounted when the
resource is successfully deleted.
Attempting to execute the `close` function after the resource  was
deleted results in React warnings in the browser console, like the
following:
'Can't perform a React state update on an unmounted component'.