### PR TITLE
Run browser visibly

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -90,6 +90,11 @@ You can set these environment variables to configure the test suite:
                    the Chrome Debug Protocol, on the given port. Don't use this
                    with parallel tests.
 
+    TEST_BROWSER  What browser should be used for testing. Currently supported values:
+                     "chromium"
+                     "firefox"
+                  "chromium" is the default.
+
 In addition, you can also set the `cockpit.bots.images-data-dir` variable with
 `git config` to the location to store the (unprepared) virtual machine images.
 This takes precedence over `TEST_DATA`.  For example:

--- a/test/README.md
+++ b/test/README.md
@@ -95,6 +95,9 @@ You can set these environment variables to configure the test suite:
                      "firefox"
                   "chromium" is the default.
 
+    TEST_SHOW_BROWSER  Set to run browser interactively. When not specified,
+                       browser is run in headless mode.
+
 In addition, you can also set the `cockpit.bots.images-data-dir` variable with
 `git config` to the location to store the (unprepared) virtual machine images.
 This takes precedence over `TEST_DATA`.  For example:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -765,15 +765,6 @@ class MachineCase(unittest.TestCase):
                 print("Starting {0} {1}".format(key, machine.label))
             machine.start()
 
-        def sitter():
-            if opts.sit and not self.checkSuccess():
-                if self._outcome:
-                    [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
-                else:
-                    self.currentResult.printErrors()
-                sit(self.machines)
-        self.addCleanup(sitter)
-
         # Now wait for the other machines to be up
         for key in self.machines.keys():
             machine = self.machines[key]
@@ -792,6 +783,15 @@ class MachineCase(unittest.TestCase):
             self.journal_start = self.machine.journal_cursor()
             self.browser = self.new_browser()
         self.tmpdir = tempfile.mkdtemp()
+
+        def sitter():
+            if opts.sit and not self.checkSuccess():
+                if self._outcome:
+                    [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
+                else:
+                    self.currentResult.printErrors()
+                sit(self.machines)
+        self.addCleanup(sitter)
 
         def intercept():
             if not self.checkSuccess():


### PR DESCRIPTION
When I was working on Firefox CDP I got used to starting browser in !headless mode. So I though we could have it as option.
SO you can run `TEST_SHOW_BROWSER=True ./test/verify/check-menu` and it starts new browser and it is visible. So when you do sit, or even when it fails and you used `-s`, the browser stays opened and you can interact with it.
It needed just one hack, as we first checked for headless chrome executable. And then I switched order in which things are cleaned, so we don't close browser before final sit is running.

And I noticed that I forgot to document TEST_BROWSER so I did that as well.
Running a few tests to see that the browser starts correctly in tasks.