### PR TITLE
machines: Robustify checks for creating a VM with the same name with …

### DIFF
--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -29,6 +29,7 @@ import { CreateVmAction } from "./components/create-vm-dialog/createVmDialog.jsx
 import { AggregateStatusCards } from "./components/aggregateStatusCards.jsx";
 import { isObjectEmpty } from "./helpers.js";
 import { InlineNotification } from 'cockpit-components-inline-notification.jsx';
+import { dummyVmsConvert } from './components/vm/dummyVm.jsx';
 
 var permission = cockpit.permission({ admin: true });
 
@@ -106,11 +107,12 @@ class App extends React.Component {
         const { vms, config, storagePools, systemInfo, ui, networks, nodeDevices, interfaces } = this.props.store.getState();
         const path = this.state.path;
         const dispatch = this.props.store.dispatch;
+        const combinedVms = [...vms, ...dummyVmsConvert(vms, ui.vms)];
         const properties = {
             dispatch, providerName:config.provider ? config.provider.name : 'Libvirt',
             networks, nodeDevices, nodeMaxMemory: config.nodeMaxMemory,
             onAddErrorNotification: this.onAddErrorNotification,
-            storagePools, systemInfo, vms
+            storagePools, systemInfo, vms: combinedVms,
         };
         const createVmAction = <CreateVmAction {...properties} mode='create' />;
         const importDiskAction = <CreateVmAction {...properties} mode='import' />;

--- a/pkg/machines/components/vm/dummyVm.jsx
+++ b/pkg/machines/components/vm/dummyVm.jsx
@@ -30,7 +30,7 @@ import StateIcon from './stateIcon.jsx';
 
 /** One Ui Dummy VM in the list (a row)
  */
-const DummyVm = ({ vm }) => {
+export const DummyVm = ({ vm }) => {
     let state = null;
 
     if (vm.installInProgress) {
@@ -43,12 +43,12 @@ const DummyVm = ({ vm }) => {
 
     const stateIcon = (<StateIcon state={state} valueId={`${vmId(vm.name)}-state`} />);
 
-    const name = (<span id={`${vmId(vm.name)}-row`}>{vm.name}</span>);
+    const name = (<span id={`${vmId(vm.name)}-${vm.connectionName}-row`}>{vm.name}</span>);
 
     return (<ListingRow
         columns={[
             { name, header: true },
-            rephraseUI('connections', null),
+            rephraseUI('connections', vm.connectionName),
             stateIcon,
         ]}
         rowId={`${vmId(vm.name)}`}
@@ -59,4 +59,6 @@ DummyVm.propTypes = {
     vm: PropTypes.object.isRequired,
 };
 
-export default DummyVm;
+export function dummyVmsConvert(vms, uiVms) {
+    return uiVms.filter(uiVm => vms.find(vm => vm.name == uiVm.name && vm.connectionName == uiVm.connectionName) === undefined);
+}

--- a/pkg/machines/hostvmslist.jsx
+++ b/pkg/machines/hostvmslist.jsx
@@ -38,7 +38,7 @@ import { vmId } from "./helpers.js";
 
 import { Listing } from "cockpit-components-listing.jsx";
 import Vm from './components/vm/vm.jsx';
-import DummyVm from './components/vm/dummyVm.jsx';
+import { dummyVmsConvert, DummyVm } from './components/vm/dummyVm.jsx';
 
 const _ = cockpit.gettext;
 
@@ -63,18 +63,9 @@ class HostVmsList extends React.Component {
         this.forceUpdate();
     }
 
-    asDummVms(vms, uiVms) {
-        const result = Object.assign({}, uiVms);
-        vms.forEach(vm => {
-            delete result[vm.name];
-        });
-
-        return Object.keys(result).map((k) => result[k]);
-    }
-
     render() {
         const { vms, config, ui, storagePools, dispatch, actions, networks, nodeDevices, interfaces } = this.props;
-        const combinedVms = [...vms, ...this.asDummVms(vms, ui.vms)];
+        const combinedVms = [...vms, ...dummyVmsConvert(vms, ui.vms)];
 
         const sortFunction = (vmA, vmB) => vmA.name.localeCompare(vmB.name);
 
@@ -86,12 +77,12 @@ class HostVmsList extends React.Component {
                 {combinedVms
                         .sort(sortFunction)
                         .map(vm => {
+                            const connectionName = vm.connectionName;
                             if (vm.isUi) {
                                 return (
-                                    <DummyVm vm={vm} key={`${vmId(vm.name)}`} />
+                                    <DummyVm vm={vm} key={`${vmId(vm.name)}-${connectionName}`} />
                                 );
                             }
-                            const connectionName = vm.connectionName;
 
                             return (
                                 <Vm vm={vm} vms={vms} config={config}

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -797,7 +797,7 @@ LIBVIRT_DBUS_PROVIDER = {
                             props.persistent = returnProps[0].Persistent.v.v;
                         if ("Autostart" in returnProps[0])
                             props.autostart = returnProps[0].Autostart.v.v;
-                        props.ui = resolveUiState(dispatch, props.name);
+                        props.ui = resolveUiState(dispatch, props.name, props.connectionName);
 
                         logDebug(`${this.name}.GET_VM(${objPath}, ${connectionName}): update props ${JSON.stringify(props)}`);
 

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -176,7 +176,7 @@ LIBVIRT_PROVIDER = {
                             const dumpxmlParams = parseDumpxml(dispatch, connectionName, xmlDesc);
                             const domInfoParams = parseDominfo(dispatch, connectionName, name, domInfo);
 
-                            dumpxmlParams.ui = resolveUiState(dispatch, name);
+                            dumpxmlParams.ui = resolveUiState(dispatch, name, connectionName);
                             dumpxmlParams.inactiveXML = parseDumpxml(dispatch, connectionName, xmlInactiveDesc);
 
                             if (updateOnly)

--- a/pkg/machines/reducers.js
+++ b/pkg/machines/reducers.js
@@ -369,35 +369,32 @@ function ui(state, action) {
     // transient properties
     state = state || {
         notifications: [],
-        vms: {}, // transient property
+        vms: [], // transient property
     };
     const addVm = () => {
-        const newState = Object.assign({}, state);
-        newState.vms = Object.assign({}, state.vms);
-        const oldVm = newState.vms[action.vm.name];
-        const vm = Object.assign({}, oldVm, action.vm);
-
-        newState.vms = Object.assign({}, newState.vms, {
-            [action.vm.name]: vm,
-        });
-        return newState;
+        const existingVm = state.vms.find(vm => vm.name == action.vm.name && vm.connectionName == action.vm.connectionName);
+        if (existingVm === undefined) {
+            return {
+                ...state,
+                vms: [...state.vms, action.vm]
+            };
+        } else {
+            if (existingVm.isUi) {
+                const updatedVm = Object.assign(existingVm, action.vm);
+                return {
+                    ...state,
+                    vms: [...state.vms.filter(vm => !(vm.name == action.vm.name && vm.connectionName == action.vm.connectionName)), updatedVm]
+                };
+            }
+        }
     };
 
     switch (action.type) {
-    case ADD_UI_VM: {
+    case ADD_UI_VM:
+    case UPDATE_UI_VM:
         return addVm();
-    }
-    case UPDATE_UI_VM: {
-        if (state.vms[action.vm.name] && state.vms[action.vm.name].isUi) {
-            return addVm();
-        }
-        return state;
-    }
     case DELETE_UI_VM: {
-        const newState = Object.assign({}, state);
-        newState.vms = Object.assign({}, state.vms);
-        delete newState.vms[action.vm.name];
-        return newState;
+        return { ...state, vms: state.vms.filter(vm => !(vm.name == action.vm.name && vm.connectionName == action.vm.connectionName)) };
     }
     default:
         return state;

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1292,7 +1292,8 @@ class TestMachines(NetworkCase):
                 .fill() \
                 .createAndExpectInlineValidationErrors(errors) \
                 .cancel(True)
-            runner.assertScriptFinished()
+            if dialog.check_script_finished:
+                runner.assertScriptFinished()
             if dialog.env_is_empty:
                 runner.checkEnvIsEmpty()
 
@@ -1308,7 +1309,9 @@ class TestMachines(NetworkCase):
             dialog.open() \
                 .fill() \
                 .createAndVerifyVirtInstallArgs()
-            runner.checkEnvIsEmpty()
+            if dialog.delete:
+                self.machine.execute("killall -9 virt-install")
+                runner.checkEnvIsEmpty()
 
         def createTest(dialog):
             runner.tryCreate(dialog) \
@@ -1408,10 +1411,29 @@ class TestMachines(NetworkCase):
                                          location=config.VALID_URL, storage_size=1,
                                          delete=False))
 
-        checkDialogFormValidationTest(TestMachines.VmDialog(self, "existing-name", storage_size=1,
-                                                            env_is_empty=False), {"Name": "already exists"})
-
         self.machine.execute("virsh undefine existing-name")
+
+        # name already used from a VM that is currently being created
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1780451
+        # downloadOS option exists only in virt-install >= 2.2.1 which is the reason we have the condition for the OSes list below
+        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', 'fedora-testing', "centos-8-stream"]:
+            self.browser.wait_not_present('select option[data-value="Download an OS"]')
+        else:
+            createDownloadAnOSTest(TestMachines.VmDialog(self, name='existing-name', sourceType='downloadOS',
+                                                         expected_memory_size=256,
+                                                         expected_storage_size=256,
+                                                         os_name=config.FEDORA_28,
+                                                         os_short_id=config.FEDORA_28_SHORTID,
+                                                         start_vm=True, delete=False))
+
+            checkDialogFormValidationTest(TestMachines.VmDialog(self, "existing-name", storage_size=1,
+                                                                check_script_finished=False, env_is_empty=False), {"Name": "already exists"})
+
+            self.machine.execute("killall -9 virt-install")
+
+            # Close the notificaton which will appear for the failed installation
+            self.browser.click(".toast-notifications-list-pf div.pf-c-alert button.pf-c-button")
+            self.browser.wait_not_present(".toast-notifications-list-pf div.pf-c-alert")
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, sourceType='url',
@@ -1817,6 +1839,7 @@ class TestMachines(NetworkCase):
                      start_vm=False,
                      delete=True,
                      env_is_empty=True,
+                     check_script_finished=True,
                      connection=None):
 
             TestMachines.VmDialog.vmId += 1 # This variable is static - don't use self here
@@ -1847,6 +1870,7 @@ class TestMachines(NetworkCase):
             self.storage_volume = storage_volume
             self.delete = delete
             self.env_is_empty = env_is_empty
+            self.check_script_finished = check_script_finished
             self.connection = connection
             if self.connection:
                 self.connectionText = TestMachines.TestCreateConfig.LIBVIRT_CONNECTION[connection]
@@ -1901,8 +1925,6 @@ class TestMachines(NetworkCase):
             wait(lambda: self.machine.execute(virt_install_cmd), delay=3)
             virt_install_cmd_out = self.machine.execute(virt_install_cmd)
             self.assertIn("--install os={}".format(self.os_short_id), virt_install_cmd_out)
-
-            self.machine.execute("killall -9 virt-install")
 
         def fill(self):
             def getSourceTypeLabel(sourceType):


### PR DESCRIPTION
…an existing one

Previously we were checking only the VMs list that libvirt provides us
to disallow same name VM creation. However, when a VM gets created
there is some time frame between the time that the user clicked 'Create'
in the dialog until libvirt is aware of the VM.
For these VMs we need to check as well name conflicts.
In addition we need to make sure that for these intermediate state VMs
(dummy VMs in the code) we take into consideration the connection name
as well, since having VMs with the same name but different connection is
not an issue.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1780451