### PR TITLE
test: Enable socat metrics test on fedora-coreos

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -585,7 +585,7 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
-    @skipImage("missing socat", "fedora-coreos")
+    @skipImage("does not use cockpit-ws package", "fedora-coreos")
     @skipImage("Added in PR #11813 and #12141", "rhel-8-1-distropkg")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -130,44 +130,42 @@ class TestMetrics(MachineCase):
 
         # Network traffic through Ethernet.  Anything above 300 kb/s is good for now.
         #
-        # HACK: This will only work on Fedora 31 based coreos images, see https://github.com/cockpit-project/bots/pull/305
-        if m.image not in ["fedora-coreos"]:
-            ifaces = m.execute(r"ip -o a | awk '{print $2}'")
-            iface = None
-            for i in ifaces.split('\n'):
-                if i.startswith("eth") or i.startswith("ens"):
-                    iface = i
-                    break
+        ifaces = m.execute(r"ip -o a | awk '{print $2}'")
+        iface = None
+        for i in ifaces.split('\n'):
+            if i.startswith("eth") or i.startswith("ens"):
+                iface = i
+                break
 
-            if not iface:
-                raise Exception("Couldn't find interface to sample")
+        if not iface:
+            raise Exception("Couldn't find interface to sample")
 
-            m.execute("if firewall-cmd --state >/dev/null 2>&1; then firewall-cmd --permanent --zone=public --add-port=2000/tcp && firewall-cmd --reload; fi")
+        m.execute("if firewall-cmd --state >/dev/null 2>&1; then firewall-cmd --permanent --zone=public --add-port=2000/tcp && firewall-cmd --reload; fi")
 
-            (eth_before, lo_before) = m.execute(r"grep -E '\b" + iface + r":' /proc/net/dev | awk '{print $2 + $10}'; "
-                                                r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
-            time_before = time.time()
+        (eth_before, lo_before) = m.execute(r"grep -E '\b" + iface + r":' /proc/net/dev | awk '{print $2 + $10}'; "
+                                            r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
+        time_before = time.time()
 
-            net_pid = m.spawn("socat TCP-LISTEN:2000 PIPE", "load-net.log")
+        net_pid = m.spawn("socat TCP-LISTEN:2000 PIPE", "load-net.log")
 
-            # might take several attemps until server-side is listening
-            (host, port) = m.forward["2000"].split(":")
-            client = subprocess.Popen(
-                "for retry in `seq 10`; do nc {0} {1} </dev/zero >/dev/null; sleep 1; done".format(host, port), shell=True)
+        # might take several attemps until server-side is listening
+        (host, port) = m.forward["2000"].split(":")
+        client = subprocess.Popen(
+            "for retry in `seq 10`; do nc {0} {1} </dev/zero >/dev/null; sleep 1; done".format(host, port), shell=True)
 
-            try:
-                b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300 * 1000, None, 5, "net io")
-            finally:
-                time_after = time.time()
-                (eth_after, lo_after) = m.execute(r"grep -E '" + iface + r"' /proc/net/dev | awk '{print $2 + $10}'; "
-                                                  r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
-                print(("Measured {0:.1f}s of network traffic; {3}: {1} bytes, lo: {2} bytes".format(
-                    time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before), iface)))
+        try:
+            b.wait_js_func("ph_flot_data_plateau", "#server_network_traffic_graph", 300 * 1000, None, 5, "net io")
+        finally:
+            time_after = time.time()
+            (eth_after, lo_after) = m.execute(r"grep -E '" + iface + r"' /proc/net/dev | awk '{print $2 + $10}'; "
+                                              r"grep '\blo:' /proc/net/dev | awk '{print $2 + $10}'").strip().split()
+            print(("Measured {0:.1f}s of network traffic; {3}: {1} bytes, lo: {2} bytes".format(
+                time_after - time_before, int(eth_after) - int(eth_before), int(lo_after) - int(lo_before), iface)))
 
-                client.terminate()
-                client.wait()
+            client.terminate()
+            client.wait()
 
-            m.execute("kill %d" % net_pid)
+        m.execute("kill %d" % net_pid)
 
     @skipImage("No PCP available", "fedora-coreos")
     def testPcp(self):


### PR DESCRIPTION
Now that https://github.com/cockpit-project/bots/pull/305 landed, our
fedora-coreos image has socat installed, so we can re-enable the network
load test in check-metrics (temporarily disabled in commit f3c331c).

Also adjust the comment in check-connection, as the reason for skipping
that is not the missing socat.
