### PR TITLE
Fix testTimeServers flake

### DIFF
--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -143,7 +143,7 @@ export class ConfigurationCard extends React.Component {
 
         function update_ntp_status() {
             // flag for tests that timedated proxy got activated
-            if (self.server_time.timedate.CanNTP !== undefined)
+            if (self.server_time.timedate.CanNTP !== undefined && self.server_time.timedate1_service.unit && self.server_time.timedate1_service.unit.Id)
                 $('#system_information_systime_button').attr("data-timedated-initialized", true);
 
             if (!self.server_time.timedate.NTP) {

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -299,16 +299,13 @@ class TestSystemInfo(MachineCase):
         b.mouse('#systime-tooltip', 'mouseout')
         b.wait_not_present('#systime-tooltip ~ div.tooltip')
 
-    @skipImage("No NTP servers config", "rhel-8-1", "rhel-8-1-distropkg", "rhel-8-2", "centos-8-stream")
+    @skipImage("Uses timedatex, no NTP servers config", "rhel-8-1", "rhel-8-1-distropkg", "rhel-8-2", "centos-8-stream",
+               "fedora-30", "fedora-testing")
     def testTimeServers(self):
         m = self.machine
         b = self.browser
 
         conf = "/etc/systemd/timesyncd.conf.d/50-cockpit.conf"
-
-        # Use systemd-timedated as the provider of
-        # org.freedesktop.timedate1 instead of timedatex.
-        m.execute("systemctl disable timedatex; systemctl stop timedatex; systemctl unmask systemd-timedated")
 
         self.login_and_go("/system")
 


### PR DESCRIPTION
testTimeServers [fails](https://209.132.184.41:8493/logs/pull-13306-20191217-174646-5648bf62-cockpit-project-cockpit--ubuntu-stable/log.html#245-2) very often, particularly on ubuntu-stable. There's something wrong with waiting properly for timedated to initialize, and the "custom NTP" options is sometimes not available even after `data-timedated-initialized` gets set.

I have some trouble reproducing this locally, so trying on the infra in parallel.