### PR TITLE
test: Enable selecting if machines' network should be restricted

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -664,7 +664,7 @@ class MachineCase(unittest.TestCase):
         (unused, sep, label) = self.id().partition(".")
         return label.replace(".", "-")
 
-    def new_machine(self, image=None, forward={}, **kwargs):
+    def new_machine(self, image=None, forward={}, restrict=True, **kwargs):
         machine_class = self.machine_class
         if image is None:
             image = self.image
@@ -680,7 +680,7 @@ class MachineCase(unittest.TestCase):
                 network = testvm.VirtNetwork(image=image)
                 self.addCleanup(lambda: network.kill())
                 self.network = network
-            networking = self.network.host(restrict=True, forward=forward)
+            networking = self.network.host(restrict=restrict, forward=forward)
             machine = machine_class(verbose=opts.trace, networking=networking, image=image, **kwargs)
             if opts.fetch and not os.path.exists(machine.image_file):
                 machine.pull(machine.image_file)


### PR DESCRIPTION
With this small patch it is possible to change `restrict` with `provision` map.

I noticed that when VM is started with `restrict=True` (which is the same as doing `./bots/vm-run --no-network`) then `composer-lorax` never initializes. I could not figure out why, so I came with this workaround. I am of course happy to close this, if someone can figure out why is this happening or if it is not a good practice to run VMs in CI with `restrict=False`.

@larskarlitski This is the last missing step and then I have working demo of testing cockpit-composer with cockpit tests :)