### PR TITLE
machines: make sure to delete a volume that got created even though t…

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1498,6 +1498,10 @@ export function storageVolumeCreate(connectionName, poolName, volName, size, for
                 return call(connectionName, path[0], 'org.libvirt.StoragePool', 'StorageVolCreateXML', [volXmlDesc, 0], TIMEOUT)
                         .then(() => {
                             return storagePoolRefresh(connectionName, path[0]);
+                        }, ex => {
+                            storagePoolRefresh(connectionName, path[0])
+                                    .then(() => storageVolumeDelete(connectionName, poolName, volName));
+                            return Promise.reject(ex);
                         });
             });
 }

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1649,6 +1649,12 @@ class TestMachinesDBus(machineslib.TestMachines):
                         b.wait_present(".modal-footer div.spinner")
                         b.wait_present(".modal-footer button:contains(Create):disabled")
                     b.wait_not_present("#create-volume-dialog-modal")
+                else:
+                    m.execute("virsh pool-refresh {0}".format(self.pool_name))
+                    b.wait_in_text(".modal-footer .pf-c-alert__description", self.xfail_error)
+                    b.click(".modal-footer button:contains(Cancel)")
+                    b.wait_not_present("#create-volume-dialog-modal")
+                    b.wait_not_present("#pool-{0}-system-volume-{1}-name".format(self.pool_name, self.vol_name))
 
             def verify(self):
                 # Check that the defined volume is now visible
@@ -1679,6 +1685,18 @@ class TestMachinesDBus(machineslib.TestMachines):
                 b.click("tbody tr[data-row-id=pool-{0}-system] th".format(self.pool_name)) # click on the row header
 
         # Check volume creation for various pool types
+        StorageVolumeCreateDialog(
+            self,
+            pool_name="dir-pool",
+            vol_name="enormous-sized-vol",
+            size="10000000",
+            unit="GiB",
+            format="qcow2",
+            remove=True,
+            xfail=True,
+            xfail_error="The image size is too large",
+        ).execute()
+
         StorageVolumeCreateDialog(
             self,
             pool_name="dir-pool",


### PR DESCRIPTION
…he API return failure

volCreateXML API seems to sometimes fail but the volume gets defined
anyway.
Libvirt documentation does not seem to explicitely forbid this behavior so
let's handle it here.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1784282