### PR TITLE
machines: Fix lost of configuration changes made before installation

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -704,8 +704,9 @@ class CreateVmModal extends React.Component {
                     close();
 
                     if (providerName == 'LibvirtDBus' && this.state.storagePool === "NewVolume") {
-                        const storagePool = storagePools.find(pool => pool.connectioName === this.state.connectioName && pool.name === "default");
-                        storagePoolRefresh(storagePool.connectionName, storagePool.id);
+                        const storagePool = storagePools.find(pool => pool.connectionName === this.state.connectionName && pool.name === "default");
+                        if (storagePool)
+                            storagePoolRefresh(storagePool.connectionName, storagePool.id);
                     }
                 },
                 (exception) => {

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -31,6 +31,9 @@ import {
 import {
     prepareDisksParam,
     prepareDisplaysParam,
+    prepareNICParam,
+    prepareVcpuParam,
+    prepareMemoryParam,
 } from './libvirtUtils.js';
 
 import {
@@ -1360,7 +1363,7 @@ export function INIT_DATA_RETRIEVAL () {
     };
 }
 
-export function INSTALL_VM({ name, vcpus, currentMemory, metadata, disks, displays, connectionName, onAddErrorNotification }) {
+export function INSTALL_VM({ name, vcpus, cpu, currentMemory, memory, metadata, disks, displays, interfaces, autostart, connectionName, onAddErrorNotification }) {
     logDebug(`${this.name}.INSTALL_VM(${name}):`);
     return dispatch => {
         // shows dummy vm until we get vm from virsh (cleans up inProgress)
@@ -1373,10 +1376,12 @@ export function INSTALL_VM({ name, vcpus, currentMemory, metadata, disks, displa
             metadata.installSourceType,
             metadata.installSource,
             metadata.osVariant,
-            convertToUnit(currentMemory, units.KiB, units.MiB),
-            vcpus.count,
+            prepareMemoryParam(convertToUnit(currentMemory, units.KiB, units.MiB), convertToUnit(memory, units.KiB, units.MiB)),
+            prepareVcpuParam(vcpus, cpu),
             prepareDisksParam(disks),
             prepareDisplaysParam(displays),
+            prepareNICParam(interfaces),
+            autostart,
         ], { err: "message", environ: ['LC_ALL=C'] })
                 .done(() => clearVmUiState(dispatch, name))
                 .fail(ex => {

--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -7,10 +7,12 @@ VM_NAME="$2"
 SOURCE_TYPE="$3"
 SOURCE="$4"
 OS="$5"
-MEMORY_SIZE="$6" # in Mib
+MEMORY="$6"
 VCPUS="$7"
 DISKS="$8"
 DISPLAYS="$9"
+VNICS="${10}"
+AUTOSTART="${11}"
 
 # prepare virt-install parameters
 
@@ -37,6 +39,13 @@ else
     DISKS_PARAM="$CREATE_OPTIONS_RESULT"
 fi
 
+if [ -z "$VNICS" ]; then
+    VNICS_PARAM="--network none"
+else
+    createOptions "$VNICS" "--network"
+    VNICS_PARAM="$CREATE_OPTIONS_RESULT"
+fi
+
 if [ -z "$DISPLAYS" ]; then
     GRAPHICS_PARAM="--graphics none"
 else
@@ -45,13 +54,29 @@ else
 fi
 
 if [ "$SOURCE_TYPE" = "pxe" ]; then
-    INSTALL_METHOD="--pxe --network $SOURCE"
+    INSTALL_METHOD="--pxe"
 elif [ "$SOURCE_TYPE" = "os" ]; then
     INSTALL_METHOD="--install os=$OS"
 elif ( [ "${SOURCE#/}" != "$SOURCE" ] && [ -f "${SOURCE}" ] ) || ( [ "$SOURCE_TYPE" = "url" ] && [ "${SOURCE%.iso}" != "$SOURCE" ] ); then
     INSTALL_METHOD="--cdrom $SOURCE"
 else
     INSTALL_METHOD="--location $SOURCE"
+fi
+
+if [ "$AUTOSTART" = "true" ]; then
+    AUTOSTART_PARAM="--autostart"
+else
+    AUTOSTART_PARAM=""
+fi
+
+createOptions "$MEMORY" "--memory"
+MEMORY_PARAM="$CREATE_OPTIONS_RESULT"
+
+if [ -z "$VCPUS" ]; then
+    VCPUS_PARAM=""
+else
+    createOptions "$VCPUS" "--vcpus"
+    VCPUS_PARAM="$CREATE_OPTIONS_RESULT"
 fi
 
 # backup
@@ -65,16 +90,18 @@ virt-install \
     --connect "$CONNECTION_URI" \
     --name "$VM_NAME" \
     --os-variant "$OS" \
-    --memory "$MEMORY_SIZE" \
-    --vcpus "$VCPUS" \
     --quiet \
     --wait -1 \
     --noautoconsole \
     --noreboot \
     --check path_in_use=off \
+    $MEMORY_PARAM \
     $DISKS_PARAM \
     $INSTALL_METHOD \
-    $GRAPHICS_PARAM
+    $GRAPHICS_PARAM \
+    $VNICS_PARAM \
+    $VCPUS_PARAM \
+    $AUTOSTART_PARAM
 EXIT_STATUS=$?
 
 if [ "$EXIT_STATUS" -eq 0 ] && vmExists "$VM_NAME"; then

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -195,6 +195,114 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
         b.wait_not_present("#boot-order-tooltip")
 
+    # Check various configuration changes made before VM installation persist after installation
+    def testConfigureBeforeInstall(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+
+        b.click("#create-new-vm")
+        b.wait_present("#create-vm-dialog")
+        b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create New Virtual Machine")
+
+        b.set_input_text("#vm-name", "VmNotInstalled")
+        m.execute("touch /var/lib/libvirt/novell.iso")
+        b.select_from_dropdown("#source-type", "Local Install Media")
+        b.set_file_autocomplete_val("source-file", "/var/lib/libvirt/novell.iso")
+        b.select_from_dropdown("#storage-size-unit-select", "MiB")
+        b.set_input_text("#storage-size", "256", value_check=True)
+        b.select_from_dropdown("#memory-size-unit-select", "MiB")
+        b.set_input_text("#memory-size", "128", value_check=True)
+        b.focus("label:contains('Operating System') + div > div > div > input")
+        b.key_press("CirrOS")
+        b.key_press("\t")
+        b.set_checked("#start-vm", False)
+
+        b.click(".modal-footer button:contains(Create)")
+        b.wait_not_present("#create-vm-dialog")
+
+        b.wait_in_text("tbody tr[data-row-id=vm-VmNotInstalled] th", "VmNotInstalled")
+
+        # Change autostart
+        autostart = not b.get_checked("#vm-VmNotInstalled-autostart-checkbox")
+        b.set_checked("#vm-VmNotInstalled-autostart-checkbox", autostart)
+
+        # Change memory settings
+        b.click("#vm-VmNotInstalled-memory-count")
+        b.wait_present("#vm-memory-modal")
+        b.set_input_text("#vm-VmNotInstalled-memory-modal-max-memory", "400")
+        b.blur("#vm-VmNotInstalled-memory-modal-max-memory")
+        b.set_input_text("#vm-VmNotInstalled-memory-modal-memory", "300")
+        b.blur("#vm-VmNotInstalled-memory-modal-memory")
+        b.click("#vm-VmNotInstalled-memory-modal-save")
+        b.wait_not_present(".modal-body")
+
+        # Change vCPUs setting
+        b.click("#vm-VmNotInstalled-vcpus-count")
+        b.wait_present(".modal-body")
+        b.set_input_text("#machines-vcpu-max-field", "8")
+        b.blur("#machines-vcpu-max-field")
+        b.set_input_text("#machines-vcpu-count-field", "2")
+        b.blur("#machines-vcpu-count-field")
+        b.select_from_dropdown("#socketsSelect", "2")
+        b.select_from_dropdown("#coresSelect", "2")
+        b.select_from_dropdown("#threadsSelect", "2")
+        b.click("#machines-vcpu-modal-dialog-apply")
+        b.wait_not_present(".modal-body")
+
+        # Change Boot Order setting
+        bootOrder = b.text("#vm-VmNotInstalled-boot-order")
+        b.click("#vm-VmNotInstalled-boot-order")
+        b.wait_present(".modal-body")
+        b.set_checked("#vm-VmNotInstalled-order-modal-device-row-1-checkbox", True)
+        b.click("#vm-VmNotInstalled-order-modal-device-row-0 #vm-VmNotInstalled-order-modal-down")
+        b.click("#vm-VmNotInstalled-order-modal-save")
+        b.wait_not_present(".modal-body")
+
+        # Attach some interface
+        m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
+
+        # Install the VM
+        b.click("#vm-VmNotInstalled-install")
+        b.wait_present("li.active #vm-VmNotInstalled-consoles")
+        b.click("#vm-VmNotInstalled-off-caret")
+        b.click("#vm-VmNotInstalled-forceOff")
+        b.wait_in_text("#vm-VmNotInstalled-state", "shut off")
+
+        # Check configuration changes survived installation
+        b.click("#vm-VmNotInstalled-overview")
+
+        # Check memory settings have persisted
+        b.click("#vm-VmNotInstalled-memory-count")
+        b.wait_present("#vm-VmNotInstalled-memory-modal-memory")
+        b.wait_val("#vm-VmNotInstalled-memory-modal-max-memory", "400")
+        b.wait_val("#vm-VmNotInstalled-memory-modal-memory", "300")
+        b.click("#vm-VmNotInstalled-memory-modal-cancel")
+        b.wait_not_present(".modal-body")
+
+        # Check vCPU settings have persisted
+        b.click("#vm-VmNotInstalled-vcpus-count")
+        b.wait_present(".modal-body")
+        b.wait_val("#machines-vcpu-max-field", "8")
+        b.wait_val("#machines-vcpu-count-field", "2")
+        b.wait_val("#socketsSelect", "2")
+        b.wait_val("#coresSelect", "2")
+        b.wait_val("#threadsSelect", "2")
+        b.click("#machines-vcpu-modal-dialog-cancel")
+        b.wait_not_present(".modal-body")
+
+        # Check changed boot order have persisted
+        b.wait_text_not("#vm-VmNotInstalled-boot-order", bootOrder)
+
+        # Check autostart have persisted
+        self.assertEqual(b.get_checked("#vm-VmNotInstalled-autostart-checkbox"), autostart)
+
+        # Check new vNIC have persisted
+        b.click("#vm-VmNotInstalled-networks")
+        b.wait_present("#vm-VmNotInstalled-network-1-type")
+
     def testDiskEdit(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
If user tries to configure memory params, vcpus, bootorder, autostart
or vNICs param before installing VM, they would loose changes after
installation.
The reason is that we pass all the important VM's settings to
virt-install script. We were not passing all of the mentioned options,
virt-install would default them.
    
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1780449
