### PR TITLE
Optimize Overview page for narrow screens around 1024 px

### DIFF
--- a/pkg/systemd/overview.less
+++ b/pkg/systemd/overview.less
@@ -144,7 +144,8 @@
   }
 }
 
-@media (max-width: 640px) {
+/* 640 + 200 + 11(scrollbar) */
+@media (max-width: 851px) {
   .ct-system-overview {
     /* Allow cards to be narrower on very narrow viewports */
     --card-width: 15rem;


### PR DESCRIPTION
So I played with browser to see why we sometimes show too wide cards on the overview page.
I noticed that this is happening in range of widths from 874 to 1071 when dashboard is not available and from 973 to 1170 when dashboard is available. When I changed `max-width` to 800, the range where it was broken was much smaller. That way I got to 851. I figured out that 11 stands for width of scrollbar. When scrollbar is not present, then 840 would do. 851 works with and without scrollbar. The rest 200 (640 from what it used to be) is magic number for me and I haven't figured out why 840 is the number we want. I recorded video where I show it for every width in all 4 cases.
1024x768:
![1024768](https://user-images.githubusercontent.com/12330670/71089317-e04f5180-21a0-11ea-8136-750b4c1974e2.png)



See video: https://youtu.be/ljXWngxtdSw (easily one of the most boring videos ever)
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1783676
