### PR TITLE
machines: Fix default volume format detection in Disk Add dialog

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -325,10 +325,19 @@ export class AddDiskModalBody extends React.Component {
 
     onValueChanged(key, value) {
         let stateDelta = {};
+        const { storagePools, vm } = this.props;
 
         switch (key) {
         case 'storagePoolName': {
+            const currentPool = storagePools.find(pool => pool.name === value && pool.connectionName === vm.connectionName);
+            const prevPool = storagePools.find(pool => pool.name === this.state.storagePoolName && pool.connectionName === vm.connectionName);
+
             this.setState({ storagePoolName: value });
+            // Reset the format only when the Format selection dropdown changes entries - otherwise just keep the old selection
+            // All pool types apart from 'disk' have either 'raw' or 'qcow2' format
+            if ((currentPool.type == 'disk' && prevPool.type != 'disk') || (currentPool.type != 'disk' && prevPool.type == 'disk'))
+                this.onValueChanged('format', getDefaultVolumeFormat(value));
+
             if (this.state.mode === USE_EXISTING) { // user changed pool
                 this.onValueChanged('existingVolumeName', this.getDefaultVolumeName(value));
             }
@@ -337,7 +346,6 @@ export class AddDiskModalBody extends React.Component {
         case 'existingVolumeName': {
             stateDelta.existingVolumeName = value;
             this.setState(prevState => { // to prevent asynchronous for recursive call with existingVolumeName as a key
-                const { storagePools, vm } = this.props;
                 const pool = storagePools.find(pool => pool.name === prevState.storagePoolName && pool.connectionName === vm.connectionName);
                 stateDelta.format = getDefaultVolumeFormat(pool);
                 if (['dir', 'fs', 'netfs', 'gluster', 'vstorage'].indexOf(pool.type) > -1) {

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -718,6 +718,9 @@ class TestMachines(NetworkCase):
                     else:
                         expected_format = 'qcow2'
 
+                    if self.pool_type == 'disk':
+                        expected_format = 'none'
+
                     # Unknown pool format isn't present in xml anymore
                     if expected_format == "unknown" and m.execute("virsh --version") >= "5.6.0":
                         m.execute(detect_format_cmd.format(self.volume_name, self.pool_name, "/volume/target") + " | grep -qv format")
@@ -904,21 +907,20 @@ class TestMachines(NetworkCase):
 
         prepareDisk(self.machine)
         cmds = [
-            "virsh pool-define-as disk-pool disk - - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 - /tmp/poolDiskImages",
-            "virsh pool-build disk-pool --overwrite",
-            "virsh pool-start disk-pool",
+            "virsh pool-define-as pool-disk disk - - /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 - /tmp/poolDiskImages",
+            "virsh pool-build pool-disk --overwrite",
+            "virsh pool-start pool-disk",
         ]
         self.machine.execute(" && ".join(cmds))
         partition = str(self.machine.execute("readlink -f /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 | cut -d '/' -f 3").strip()) + "1"
         VMAddDiskDialog(
             self,
-            pool_name='disk-pool',
+            pool_name='pool-disk',
             pool_type='disk',
             volume_name=partition,
             volume_size=10,
             volume_size_unit='MiB',
             expected_target='vdc',
-            volume_format='none',
         ).execute()
 
     def testVmNICs(self):


### PR DESCRIPTION
Previously we were correctly calling the getDefaultVolumeFormat when
opening the dialog, thus the default format for the preselected pool was
correctly detected. However, when a user changed so some other pool,
we didn't re-detect the default format, which was problematic if the
user didn't change the preseleted format afterwards.

This commit also adjusts the relevant test which didn't fail before
because the problematic pool was first on the list so the
getDefaultVolumeFormat was correctly called in the dialog constructor.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1784304