### PR TITLE
selinux: Describe state of boolean with Allow/Disallow

### DIFF
--- a/pkg/selinux/selinux-client.js
+++ b/pkg/selinux/selinux-client.js
@@ -113,15 +113,20 @@ export function init(statusChangedCallback) {
         if (item) {
             const match = item.match(/(\S*)\s*\((\S*)\s*,.*\)\s*(.*)/);
             if (match) {
-                const state = match[2] === "on" ? "yes" : "no";
+                let description = match[3];
+                let state = "yes";
+                if (match[2] !== "on") {
+                    state = "no";
+                    description = description.replace("Allow", "Disallow");
+                }
                 const ansible = `
-- name: ${match[3]}
+- name: ${description}
   seboolean:
     name: ${match[1]}
     state: ${state}
     persistent: yes
 `;
-                result.push({ description: match[3], ansible: ansible });
+                result.push({ description, ansible });
             }
         }
         return result;

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -196,7 +196,7 @@ class TestSelinux(MachineCase):
         m.execute("semanage boolean --modify --off zebra_write_config")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
+        b.wait_visible("tr.modification-row > td:contains(Disallow zebra to write config)")
         b.click(".modifications-export")
         b.click("button:contains('Ansible')")
         ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))


### PR DESCRIPTION
Every boolean rule description has form `Allow sth to do sth`.
It however does not describe if this rule is on or off. I think it makes
sense to change `Allow` to `Disallow` when the rule is turned off.

Two boolean rules are on and one is off.
![twoononeoff](https://user-images.githubusercontent.com/12330670/71243947-ba958a00-2311-11ea-9b79-bcb97dd35892.png)
