### PR TITLE
test: Make session timeout test a bit more robust

### DIFF
--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -56,7 +56,7 @@ class TestMenu(MachineCase):
             time.sleep(35)
             with b.wait_timeout(3):
                 b.wait_popup("session-timeout-dialog")
-                self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 20)
+                self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 15)
             b.click("#keep-session-alive")
             b.wait_popdown("session-timeout-dialog")
             time.sleep(30)


### PR DESCRIPTION
I have seen a few time that this test failed with condition `20 > 20`.
Checking the test, it makes perfect sense this can happen. We reset
timer every 5 seconds and we sleep in test for 35 seconds, which in worst
case adds up to 40 seconds and in one minute timeout it indeed is 20
remaining seconds.
So it should be good enough to replace `20` with `19`, but assuming there
can be some delay while tests read the value, I dropped it down to 15.
It still safely asserts that moving mouse resets the timer, as we do
`sleep(20)` and `sleep(35)` which adds up to 55 seconds and in worst
case would still have only 10 seconds remaining.

Example failure: https://209.132.184.41:8493/logs/pull-13329-20191222-070505-798acd37-cockpit-project-cockpit--fedora-30/log.html#109-2