### PR TITLE
ws: Lock down cockpit.service privileges

### DIFF
--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -13,3 +13,11 @@ ExecStartPre=+@sbindir@/remotectl certificate --ensure --user=root --group=@grou
 ExecStart=@libexecdir@/cockpit-tls
 User=@user@
 Group=@group@
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+PrivateDevices=true
+ProtectKernelTunables=true
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+MemoryDenyWriteExecute=true


### PR DESCRIPTION
Now that cockpit-ws (with cockpit-session) runs in a separate unit,
cockpit.service itself (which just runs cockpit-tls) does not need a lot
of privileges any more. Lock down everything that systemd can throw at
it.

This depends on a fixed SELinux policy that now landed in Fedora.
(https://bugzilla.redhat.com/show_bug.cgi?id=1761765)