### PR TITLE
machines: decompress ipv6 addresses before validating them

### DIFF
--- a/pkg/machines/components/networks/utils.js
+++ b/pkg/machines/components/networks/utils.js
@@ -188,15 +188,29 @@ export function validateIpv6Prefix(prefix) {
  * @param {string} ip
  * @returns {string}
  */
-export function ipv6ToBinStr(ip) {
-    const parts = [];
-    ip.split(":").forEach(part => {
-        let bin = parseInt(part, 16).toString(2);
+function ipv6ToBinStr(ip) {
+    const validGroupCount = 8;
+    /* Split address by `:`
+     * Then check if the array contains an empty string (happens at ::), and if so
+     * replace it with the appropriate number of 0 entries.
+     */
+    const arrAddr = ip.split(":");
+    const arrAddrExpanded = arrAddr.reduce((accum, hexNum) => {
+        if (hexNum)
+            accum.push(hexNum);
+        else
+            for (let i = 0; i < (validGroupCount - arrAddr.length + 1); i++)
+                accum.push("0");
+        return accum;
+    }, []);
+
+    /* Convert the array of 8 hex entries into a 128 bits binary string */
+    return arrAddrExpanded.map(num => {
+        let bin = parseInt(num, 16).toString(2);
         while (bin.length < 16)
             bin = "0" + bin;
-        parts.push(bin);
-    });
-    return parts.join("");
+        return bin;
+    }).join("");
 }
 
 /**

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1199,6 +1199,18 @@ class TestMachinesDBus(machineslib.TestMachines):
             ipv6_prefix="64",
         ).execute()
 
+        # Compressed IPv6 addresses should work as well
+        NetworkCreateDialog(
+            self,
+            name="test_network",
+            forward_mode="open",
+            ip_conf="IPv6 only",
+            ipv6_address="fec0::1",
+            ipv6_prefix="48",
+            ipv6_dhcp_start="fec0::1",
+            ipv6_dhcp_end="fec0::10",
+        ).execute()
+
         tmp = NetworkCreateDialog(
             self,
             name="test_network",


### PR DESCRIPTION
Relevant to: https://bugzilla.redhat.com/show_bug.cgi?id=1784289