### PR TITLE
machines: Fix undesirable IPv4 configuration for IPv6 only network

### DIFF
--- a/pkg/machines/components/networks/createNetworkDialog.jsx
+++ b/pkg/machines/components/networks/createNetworkDialog.jsx
@@ -397,9 +397,11 @@ class CreateNetworkModal extends React.Component {
             this.setState({ inProgress: false, validate: true });
         } else {
             const {
-                connectionName, name, forwardMode, ipv4, ipv6, prefix, device,
+                connectionName, name, forwardMode, ip, prefix, device,
                 ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd
             } = this.state;
+            const ipv6 = ip === "IPv4 only" ? undefined : this.state.ipv6;
+            const ipv4 = ip === "IPv6 only" ? undefined : this.state.ipv4;
             const netmask = utils.netmaskConvert(this.state.netmask);
 
             this.setState({ createInProgress: true });

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1179,6 +1179,11 @@ class TestMachinesDBus(machineslib.TestMachines):
                         if self.ipv6_dhcp_start and self.ipv6_dhcp_start:
                             b.wait_in_text("#network-{0}-{1}-ipv6-dhcp-range".format(self.name, connectionName), self.ipv6_dhcp_start + " - " + self.ipv6_dhcp_end)
 
+                    if not "4" in self.ip_conf:
+                        b.wait_not_present("#network-{0}-{1}-ipv4-address".format(self.name, connectionName))
+                    if not "6" in self.ip_conf:
+                        b.wait_not_present("#network-{0}-{1}-ipv6-address".format(self.name, connectionName))
+
             def cleanup(self):
                 m.execute("virsh net-undefine {0}".format(self.name))
 


### PR DESCRIPTION
After creating a new virtual network, IPv4 configuration would be
present even when "IPv6 Only" was chosen.