### PR TITLE
machines: Fix NIC creation for 'user' network type

### DIFF
--- a/pkg/machines/components/nicAdd.jsx
+++ b/pkg/machines/components/nicAdd.jsx
@@ -198,7 +198,10 @@ export class AddNIC extends React.Component {
                     <Button id={`${idPrefix}-cancel`} bsStyle='default' className='btn-cancel' onClick={this.props.close}>
                         {_("Cancel")}
                     </Button>
-                    <Button disabled={this.state.networkSource === undefined } id={`${idPrefix}-add`} bsStyle='primary' onClick={this.add}>
+                    <Button disabled={["network", "direct", "bridge"].includes(this.state.networkType) && this.state.networkSource === undefined}
+                            id={`${idPrefix}-add`}
+                            bsStyle='primary'
+                            onClick={this.add}>
                         {_("Add")}
                     </Button>
                 </Modal.Footer>


### PR DESCRIPTION
We would not allow vNIC creation if no network source is specified.
However 'user' network type doesn't require source.
Fix this.