### PR TITLE
Fix typo es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1412,7 +1412,7 @@ msgstr ""
 
 #: pkg/packagekit/updates.jsx:178
 msgid "Check for Updates"
-msgstr "Comprobacióin de Actualizaciones"
+msgstr "Comprobación de Actualizaciones"
 
 #: pkg/storaged/jobs-panel.jsx:47
 msgid "Checking $target"


### PR DESCRIPTION
Under /updates, there are two spanish typos, 

1.-
Ultima revisión: 18 minutes atrás

I can't figure out where is defined "minutes", maybe $ago variable ?
msgid_plural "$0 minutes"
msgid "5 minutes"


2.-
Comprobacióin de Actualizaciones

s/Comprobacióin/Comprobación