### PR TITLE
users: Fix crash on incomplete /etc/passwd entries

### DIFF
--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -189,9 +189,9 @@ function parse_passwd_content(content) {
             password: column[1],
             uid: parseInt(column[2], 10),
             gid: parseInt(column[3], 10),
-            gecos: column[4].replace(/,*$/, ''),
-            home: column[5],
-            shell: column[6],
+            gecos: (column[4] || '').replace(/,*$/, ''),
+            home: column[5] || '',
+            shell: column[6] || '',
         });
     }
 

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -207,6 +207,15 @@ class TestAccounts(MachineCase):
         b.expect_load()
         b.wait_present('#content')
 
+        # incomplete passwd entry; fixed in PR #13384
+        if m.image not in ["rhel-8-1-distropkg"]:
+            m.execute('echo "damaged:x:1234:1234:Damaged" >> /etc/passwd')
+            b.go("/users")
+            b.enter_page("/users")
+            b.wait_in_text('#accounts-list', "damaged")
+            b.click('.cockpit-account-user-name[href="#/damaged"]')
+            b.wait_in_text("#account-title", "Damaged")
+
         self.allow_journal_messages("Password quality check failed:")
         self.allow_journal_messages("The password is a palindrome")
         self.allow_journal_messages("passwd: user.*does not exist")


### PR DESCRIPTION
Apparently some users have /etc/passwd entries without a 7th field for
the shell. This actually works, and uses /bin/sh as default.

But it caused the Accounts page to crash due to account.shell being
`undefined`. Provide empty string defaults to prevent that.

Fixes #13111
Closes #13384