### PR TITLE
test: Test large requests through cockpit-tls as well

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -457,6 +457,14 @@ class TestConnection(MachineCase):
         if m.image not in ["rhel-8-1-distropkg"]:  # fixed in PR #13351
             self.assertIn('A Custom Title', m.execute('''curl -s -S -k -H "Authorization: Negotiate $(printf '%0.7000i' 1)" https://localhost:9000/'''))
 
+        # Large requests are processed correctly with plain HTTP through cockpit-tls
+        m.start_cockpit(tls=True)
+        self.assertIn('id="login"', m.execute('''curl -s -S -H "Authorization: Negotiate $(printf '%0.7000i' 1)" http://localhost:9090/'''))
+
+        # Large requests are processed correctly with TLS through cockpit-tls
+        if m.image not in ["rhel-8-1-distropkg"]:  # fixed in PR #13351, and 8.1 is not using cockpit-tls yet
+            self.assertIn('id="login"', m.execute('''curl -s -S -k -H "Authorization: Negotiate $(printf '%0.7000i' 1)" https://localhost:9090/'''))
+
     def testHeadRequest(self):
         m = self.machine
         m.start_cockpit()


### PR DESCRIPTION
Commit 8a0edfbc4afa introduced an integration test for doing large
requests directly to cockpit-ws. Add another pair through cockpit-tls.
Buffer handling in cockpit-tls is totally independent, but let's cover
all bases.

This will still fail on rhel-8-1-distropkg: While cockpit-tls is not
affected by the Gio bug, RHEL 8.1's cockpit does not yet have
cockpit-tls.