### PR TITLE
systemd: Replace OS updates health card entry with a page notification

### DIFF
--- a/pkg/lib/notifications.js
+++ b/pkg/lib/notifications.js
@@ -55,7 +55,11 @@ fields:
  An arbitrary value.  The "System" overview page might monitor a
  couple of pages for their status and it will use 'details' to display
  a richer version of the status than possible with just type and
- title.
+ title. The recognized properties are:
+
+   * icon: custom icon name (defaults to standard icon corresponding to type)
+   * link: custom link target (defaults to page name); if false, the
+     notification will not be a link
 
 Usage:
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -814,7 +814,15 @@ class OsUpdates extends React.Component {
         case "loading":
         case "refreshing":
         case "locked":
-            page_status.set_own(null);
+            page_status.set_own({
+                type: null,
+                title: _("Checking for package updates..."),
+                details: {
+                    link: false,
+                    icon: "spinner spinner-xs",
+                }
+            });
+
             if (this.state.loadPercent)
                 return (
                     <div className="progress-main-view">
@@ -931,9 +939,9 @@ class OsUpdates extends React.Component {
 
         case "uptodate":
             page_status.set_own({
+                title: _("System is up to date"),
                 details: {
-                    text: _("System is up to date"),
-                    link: "",
+                    link: false,
                     icon: "fa fa-check-circle-o"
                 }
             });

--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -21,7 +21,6 @@ import React from 'react';
 import { Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
 
 import cockpit from "cockpit";
-import { page_status } from "notifications";
 import { PageStatusNotifications } from "../page-status.jsx";
 import * as service from "service.js";
 
@@ -32,15 +31,11 @@ const _ = cockpit.gettext;
 export class HealthCard extends React.Component {
     constructor() {
         super();
-        this.state = { insightsLinkVisible: false, updateDetails: undefined };
-        this.refresh_os_updates_state = this.refresh_os_updates_state.bind(this);
+        this.state = { insightsLinkVisible: false };
         this.refresh_insights_status = this.refresh_insights_status.bind(this);
     }
 
     componentDidMount() {
-        page_status.addEventListener("changed", this.refresh_os_updates_state);
-        this.refresh_os_updates_state();
-
         this.insights_client_timer = service.proxy("insights-client.timer");
         this.insights_client_timer.addEventListener("changed", this.refresh_insights_status);
         this.refresh_insights_status();
@@ -54,35 +49,13 @@ export class HealthCard extends React.Component {
             this.setState({ insightsLinkVisible: false });
     }
 
-    refresh_os_updates_state() {
-        const status = page_status.get("updates") || { };
-        const details = status.details;
-
-        this.setState({
-            updateDetails: details,
-            updateStatus: status,
-        });
-    }
-
     render() {
-        const updateDetails = this.state.updateDetails || { };
         return (
             <Card className="system-health">
                 <CardHeader>{_("Health")}</CardHeader>
                 <CardBody>
                     <ul className="system-health-events">
                         <PageStatusNotifications />
-                        <li>
-                            <>
-                                {this.state.updateDetails !== undefined ? <>
-                                    <span id="system_information_updates_icon" className={updateDetails.icon || ""} />
-                                    <a role="link" tabIndex="0" id="system_information_updates_text" onClick={() => cockpit.jump("/" + (updateDetails.link || "updates"))}>{updateDetails.text || this.state.updateStatus.title || ""}</a>
-                                </> : <>
-                                    <span className="spinner spinner-xs" />
-                                    <span>{_("Checking for package updates...")}</span>
-                                </>}
-                            </>
-                        </li>
                         {this.state.insightsLinkVisible && <li className="system-health-insights">
                             <span className="fa fa-exclamation-triangle" />
                             { cockpit.manifests.subscriptions

--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -65,14 +65,13 @@ export class HealthCard extends React.Component {
     }
 
     render() {
-        const pageStatusNotifications = React.createElement(PageStatusNotifications);
         const updateDetails = this.state.updateDetails || { };
         return (
             <Card className="system-health">
                 <CardHeader>{_("Health")}</CardHeader>
                 <CardBody>
                     <ul className="system-health-events">
-                        <li id="page_status_notifications">{pageStatusNotifications}</li>
+                        <PageStatusNotifications />
                         <li>
                             <>
                                 {this.state.updateDetails !== undefined ? <>

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -51,8 +51,6 @@ export class PageStatusNotifications extends React.Component {
         return ["system/services", "updates"].map(page => {
             const status = page_status.get(page);
             if (status && (status.type || status.details) && status.title) {
-                this.props.toggle_label && this.props.toggle_label(true);
-
                 let action;
                 if (status.details && status.details.link !== undefined) {
                     if (status.details.link)
@@ -74,7 +72,6 @@ export class PageStatusNotifications extends React.Component {
                         {action}
                     </li>);
             } else {
-                this.props.toggle_label && this.props.toggle_label(false);
                 return null;
             }
         });

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -54,10 +54,10 @@ export class PageStatusNotifications extends React.Component {
             this.props.toggle_label && this.props.toggle_label(true);
             const jump = () => cockpit.jump("/" + page);
             return (
-                <>
+                <li id={ "page_status_notification_" + page.replace('/', '_') } key={page}>
                     <span className={icon_class_for_type(status.type)} />
                     <a role="button" tabIndex="0" onClick={jump}>{status.title}</a>
-                </>);
+                </li>);
         } else {
             this.props.toggle_label && this.props.toggle_label(false);
             return null;

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -50,13 +50,28 @@ export class PageStatusNotifications extends React.Component {
         // Just this one for now
         const page = "system/services";
         const status = page_status.get(page);
-        if (status && status.type && status.title) {
+        if (status && (status.type || status.details) && status.title) {
             this.props.toggle_label && this.props.toggle_label(true);
-            const jump = () => cockpit.jump("/" + page);
+
+            let action;
+            if (status.details && status.details.link !== undefined) {
+                if (status.details.link)
+                    action = <a role="button" tabIndex="0"
+                                onClick={ () => cockpit.jump("/" + status.details.link) }>{status.title}</a>;
+                else
+                    action = <span>{status.title}</span>; // no link
+            } else {
+                action = <a role="button" tabIndex="0"
+                            onClick={ () => cockpit.jump("/" + page) }>{status.title}</a>;
+            }
+
+            let icon = status.details && status.details.icon;
+            if (!icon)
+                icon = icon_class_for_type(status.type);
             return (
                 <li id={ "page_status_notification_" + page.replace('/', '_') } key={page}>
-                    <span className={icon_class_for_type(status.type)} />
-                    <a role="button" tabIndex="0" onClick={jump}>{status.title}</a>
+                    <span className={icon} />
+                    {action}
                 </li>);
         } else {
             this.props.toggle_label && this.props.toggle_label(false);

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -47,35 +47,36 @@ export class PageStatusNotifications extends React.Component {
     }
 
     render() {
-        // Just this one for now
-        const page = "system/services";
-        const status = page_status.get(page);
-        if (status && (status.type || status.details) && status.title) {
-            this.props.toggle_label && this.props.toggle_label(true);
+        // Explicit whitelist for now, until we can get a dynamic list
+        return ["system/services", "updates"].map(page => {
+            const status = page_status.get(page);
+            if (status && (status.type || status.details) && status.title) {
+                this.props.toggle_label && this.props.toggle_label(true);
 
-            let action;
-            if (status.details && status.details.link !== undefined) {
-                if (status.details.link)
+                let action;
+                if (status.details && status.details.link !== undefined) {
+                    if (status.details.link)
+                        action = <a role="button" tabIndex="0"
+                                    onClick={ () => cockpit.jump("/" + status.details.link) }>{status.title}</a>;
+                    else
+                        action = <span>{status.title}</span>; // no link
+                } else {
                     action = <a role="button" tabIndex="0"
-                                onClick={ () => cockpit.jump("/" + status.details.link) }>{status.title}</a>;
-                else
-                    action = <span>{status.title}</span>; // no link
-            } else {
-                action = <a role="button" tabIndex="0"
-                            onClick={ () => cockpit.jump("/" + page) }>{status.title}</a>;
-            }
+                                onClick={ () => cockpit.jump("/" + page) }>{status.title}</a>;
+                }
 
-            let icon = status.details && status.details.icon;
-            if (!icon)
-                icon = icon_class_for_type(status.type);
-            return (
-                <li id={ "page_status_notification_" + page.replace('/', '_') } key={page}>
-                    <span className={icon} />
-                    {action}
-                </li>);
-        } else {
-            this.props.toggle_label && this.props.toggle_label(false);
-            return null;
-        }
+                let icon = status.details && status.details.icon;
+                if (!icon)
+                    icon = icon_class_for_type(status.type);
+                return (
+                    <li id={ "page_status_notification_" + page.replace('/', '_') } key={page}>
+                        <span className={icon} />
+                        {action}
+                    </li>);
+            } else {
+                this.props.toggle_label && this.props.toggle_label(false);
+                return null;
+            }
+        });
     }
 }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -56,6 +56,15 @@ class TestUpdates(PackageCase):
         else:
             self.enhancement_severity = "bug"
 
+        if self.machine.image in ["rhel-8-1-distropkg", "rhel-8-2-distropkg"]:
+            self.update_icon = "#system_information_updates_icon"
+            self.update_text = "#system_information_updates_text"
+            self.update_text_action = "#system_information_updates_text"
+        else:
+            self.update_icon = "#page_status_notification_updates span:first-child"
+            self.update_text = "#page_status_notification_updates"
+            self.update_text_action = "#page_status_notification_updates a"
+
     def check_nth_update(self, index, pkgname, version, severity="bug",
                          num_issues=None, desc_matches=[], cves=[], bugs=[], arch=None):
         """Check the contents of the package update table row at index
@@ -97,11 +106,11 @@ class TestUpdates(PackageCase):
         return row
 
     def wait_checking_updates(self):
-        '''Wait until spinner is gone from #system_information_updates_icon for 3 s'''
+        '''Wait until spinner is gone from updates icon for 3 s'''
 
         good_count = 0
         for retry in range(60):
-            classes = self.browser.attr("#system_information_updates_icon", "class")
+            classes = self.browser.attr(self.update_icon, "class")
             if classes is None or "spinner" in classes:
                 good_count = 0
             else:
@@ -126,11 +135,11 @@ class TestUpdates(PackageCase):
         b.login_and_go("/system")
         # status on /system front page: no repos at all, thus no updates
         self.wait_checking_updates()
-        b.wait_text("#system_information_updates_text", up_to_date_text)
+        b.wait_text(self.update_text, up_to_date_text)
         if m.image == "rhel-8-1-distropkg":
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+            self.assertEqual(b.attr(self.update_icon, "class"), "")
         else:
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "fa fa-check-circle-o")
+            self.assertEqual(b.attr(self.update_icon, "class"), "fa fa-check-circle-o")
 
         # no updates on the Software Updates page
         b.go("/updates")
@@ -169,15 +178,12 @@ class TestUpdates(PackageCase):
         b.enter_page("/system")
         self.wait_checking_updates()
         if m.image == "rhel-8-1-distropkg": #12620
-            b.wait_text("#system_information_updates_text", "Updates Available")
+            b.wait_text(self.update_text, "Updates Available")
         else:
-            b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
-        self.assertIn("fa-bug", b.attr("#system_information_updates_icon", "class"))
+            b.wait_text(self.update_text, "Bug Fix Updates Available")
+        self.assertIn("fa-bug", b.attr(self.update_icon, "class"))
         # should be a link, click on it to go to /updates
-        if m.image == "rhel-8-1-distropkg":
-            b.click("#system_information_updates_text a")
-        else:
-            b.click("#system_information_updates_text")
+        b.click(self.update_text_action)
         b.enter_page("/updates")
 
         # old versions are still installed
@@ -236,10 +242,10 @@ class TestUpdates(PackageCase):
         b.enter_page("/system")
         self.wait_checking_updates()
         if m.image == "rhel-8-1-distropkg":
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+            self.assertEqual(b.attr(self.update_icon, "class"), "")
         else:
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "fa fa-check-circle-o")
-        b.wait_text("#system_information_updates_text", up_to_date_text)
+            self.assertEqual(b.attr(self.update_icon, "class"), "fa fa-check-circle-o")
+        b.wait_text(self.update_text, up_to_date_text)
 
     def testInfoSecurity(self):
         b = self.browser
@@ -336,17 +342,14 @@ class TestUpdates(PackageCase):
         b.enter_page("/system")
         self.wait_checking_updates()
         if m.image == "rhel-8-1-distropkg": #12620
-            b.wait_text("#system_information_updates_text", "Updates Available")
-            self.assertIn("bug", b.attr("#system_information_updates_icon", "class"))
+            b.wait_text(self.update_text, "Updates Available")
+            self.assertIn("bug", b.attr(self.update_icon, "class"))
         else:
-            b.wait_text("#system_information_updates_text", "Security Updates Available")
-            self.assertIn("security", b.attr("#system_information_updates_icon", "class"))
+            b.wait_text(self.update_text, "Security Updates Available")
+            self.assertIn("security", b.attr(self.update_icon, "class"))
 
         # should be a link, click on it to go to back to /updates
-        if m.image == "rhel-8-1-distropkg":
-            b.click("#system_information_updates_text a")
-        else:
-            b.click("#system_information_updates_text")
+        b.click(self.update_text_action)
         b.enter_page("/updates")
 
         # install only security updates
@@ -652,11 +655,11 @@ class TestUpdates(PackageCase):
         b.go("/system")
         b.enter_page("/system")
         if m.image == "rhel-8-1-distropkg": #12620
-            b.wait_not_visible("#system_information_updates_text")
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+            b.wait_not_visible(self.update_text)
+            self.assertEqual(b.attr(self.update_icon, "class"), "")
         else:
-            b.wait_text("#system_information_updates_text", "Loading available updates failed")
-            self.assertIn("exclamation", b.attr("#system_information_updates_icon", "class"))
+            b.wait_text(self.update_text, "Loading available updates failed")
+            self.assertIn("exclamation", b.attr(self.update_icon, "class"))
 
 
 @skipImage("Image uses OSTree", "fedora-coreos")
@@ -698,6 +701,14 @@ class TestUpdatesSubscriptions(PackageCase):
 
         # Wait for the web service to be accessible
         m.execute(script=WAIT_SCRIPT % {"addr": "10.111.112.100"})
+        if self.machine.image in ["rhel-8-1-distropkg", "rhel-8-2-distropkg"]:
+            self.update_icon = "#system_information_updates_icon"
+            self.update_text = "#system_information_updates_text"
+            self.update_text_action = "#system_information_updates_text"
+        else:
+            self.update_icon = "#page_status_notification_updates span:first-child"
+            self.update_text = "#page_status_notification_updates"
+            self.update_text_action = "#page_status_notification_updates a"
 
     def testNoUpdates(self):
         m = self.machine
@@ -712,8 +723,8 @@ class TestUpdatesSubscriptions(PackageCase):
         m.start_cockpit()
         b.login_and_go("/system")
         # show unregistered status on system front page
-        b.wait_in_text("#system_information_updates_text", "Not Registered")
-        self.assertIn("triangle", b.attr("#system_information_updates_icon", "class"))
+        b.wait_in_text(self.update_text, "Not Registered")
+        self.assertIn("triangle", b.attr(self.update_icon, "class"))
 
         # software updates page also shows unregistered
         b.go("/updates")
@@ -741,10 +752,10 @@ class TestUpdatesSubscriptions(PackageCase):
         b.go("/system")
         b.enter_page("/system")
         if m.image == "rhel-8-1-distropkg":
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "")
+            self.assertEqual(b.attr(self.update_icon, "class"), "")
         else:
-            self.assertEqual(b.attr("#system_information_updates_icon", "class"), "fa fa-check-circle-o")
-        b.wait_text("#system_information_updates_text", up_to_date_text)
+            self.assertEqual(b.attr(self.update_icon, "class"), "fa fa-check-circle-o")
+        b.wait_text(self.update_text, up_to_date_text)
 
     def testAvailableUpdates(self):
         m = self.machine
@@ -759,13 +770,10 @@ class TestUpdatesSubscriptions(PackageCase):
 
         b.login_and_go("/system")
         # by default our rhel-* images are not registered; show warning on system page
-        b.wait_in_text("#system_information_updates_text", "Not Registered")
-        self.assertIn("triangle", b.attr("#system_information_updates_icon", "class"))
+        b.wait_in_text(self.update_text, "Not Registered")
+        self.assertIn("triangle", b.attr(self.update_icon, "class"))
         # should be a link leading to subscriptions page
-        if m.image == "rhel-8-1-distropkg":
-            b.click("#system_information_updates_text a")
-        else:
-            b.click("#system_information_updates_text")
+        b.click(self.update_text_action)
         b.enter_page("/subscriptions")
 
         # software updates page also shows unregistered
@@ -797,10 +805,10 @@ class TestUpdatesSubscriptions(PackageCase):
         b.go("/system")
         b.enter_page("/system")
         if m.image == "rhel-8-1-distropkg": #12620
-            b.wait_text("#system_information_updates_text", "Updates Available")
+            b.wait_text(self.update_text, "Updates Available")
         else:
-            b.wait_text("#system_information_updates_text", "Bug Fix Updates Available")
-        self.assertIn("fa-bug", b.attr("#system_information_updates_icon", "class"))
+            b.wait_text(self.update_text, "Bug Fix Updates Available")
+        self.assertIn("fa-bug", b.attr(self.update_icon, "class"))
 
 
 @skipImage("Image uses OSTree", "fedora-coreos")

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -889,7 +889,7 @@ ExecStart=/usr/bin/false
         # System page should have notification
         b.click('#host-apps a[href="/system"]')
         b.enter_page('/system')
-        b.wait_present('#page_status_notifications:contains("%s")' % health_message)
+        b.wait_in_text(".system-health-events", health_message)
 
         # Clear aab-fail
         m.execute("systemctl reset-failed aab-fail")
@@ -912,7 +912,7 @@ ExecStart=/usr/bin/false
             # System page should not have notification
             b.click('#host-apps a[href="/system"]')
             b.enter_page('/system')
-            b.wait_not_present('#page_status_notifications:contains("failed")')
+            b.wait_not_in_text(".system-health-events", "failed")
 
     def testHiddenFailure(self):
         m = self.machine
@@ -944,7 +944,7 @@ Where=/fail
             # System page should not have notification
             b.click('#host-apps a[href="/system"]')
             b.enter_page('/system')
-            b.wait_not_present('#page_status_notifications:contains("failed")')
+            b.wait_not_in_text(".system-health-events", "failed")
 
         self.allow_journal_messages(".*type=1400 audit(.*): avc:  denied  { create } .* comm=\"systemd\" name=\"fail\".*")
 


### PR DESCRIPTION
The visual UX should be exactly the same as now, this also does not change strings. But this fixes #13400 and simplifies the code.