### PR TITLE
overview: Links should open link target on a new window when using mi…

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -77,7 +77,10 @@ export class HealthCard extends React.Component {
                             <>
                                 {this.state.updateDetails !== undefined ? <>
                                     <span id="system_information_updates_icon" className={updateDetails.icon || ""} />
-                                    <a role="link" tabIndex="0" id="system_information_updates_text" onClick={() => cockpit.jump("/" + (updateDetails.link || "updates"))}>{updateDetails.text || this.state.updateStatus.title || ""}</a>
+                                    <a href={"/" + (updateDetails.link || "updates")} id="system_information_updates_text" onClick={ev => {
+                                        cockpit.jump("/" + (updateDetails.link || "updates"));
+                                        ev.preventDefault();
+                                    }}>{updateDetails.text || this.state.updateStatus.title || ""}</a>
                                 </> : <>
                                     <span className="spinner spinner-xs" />
                                     <span>{_("Checking for package updates...")}</span>
@@ -87,7 +90,10 @@ export class HealthCard extends React.Component {
                         {this.state.insightsLinkVisible && <li className="system-health-insights">
                             <span className="fa fa-exclamation-triangle" />
                             { cockpit.manifests.subscriptions
-                                ? <a id="insights_text" tabIndex='0' role="button" onClick={() => cockpit.jump("/subscriptions")}>{_("Not connected to Insights")}</a>
+                                ? <a id="insights_text" href="/subscriptions" onClick={ ev => {
+                                    cockpit.jump("/subscriptions");
+                                    ev.preventDefault();
+                                }}>{_("Not connected to Insights")}</a>
                                 : <span id="insights_text">{_("Not connected to Insights")}</span>}
                         </li>}
                     </ul>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -110,7 +110,10 @@ export class SystemInfomationCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a role="link" tabIndex="0" className="no-left-padding" onClick={() => cockpit.jump("/system/hwinfo", cockpit.transport.host)}>
+                    <a className="no-left-padding" href="/system/hwinfo" onClick={ ev => {
+                        cockpit.jump("/system/hwinfo");
+                        ev.preventDefault();
+                    }}>
                         {_("View hardware details")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -143,7 +143,10 @@ export class UsageCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a role="link" tabIndex="0" className="no-left-padding" onClick={() => cockpit.jump("/system/graphs", cockpit.transport.host)}>
+                    <a className="no-left-padding" href="/system/graphs" onClick={ ev => {
+                        cockpit.jump("/system/graphs");
+                        ev.preventDefault();
+                    }}>
                         {_("View graphs")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -52,11 +52,14 @@ export class PageStatusNotifications extends React.Component {
         const status = page_status.get(page);
         if (status && status.type && status.title) {
             this.props.toggle_label && this.props.toggle_label(true);
-            const jump = () => cockpit.jump("/" + page);
+            const jump = (ev) => {
+                cockpit.jump("/" + page);
+                ev.preventDefault();
+            };
             return (
                 <>
                     <span className={icon_class_for_type(status.type)} />
-                    <a role="button" tabIndex="0" onClick={jump}>{status.title}</a>
+                    <a href={"/" + page} onClick={jump}>{status.title}</a>
                 </>);
         } else {
             this.props.toggle_label && this.props.toggle_label(false);


### PR DESCRIPTION
…ddle click

This will also fix right clicking, which will now show link-related
actions.

Keep onClick method for left click, since we want to handle that with
cockpit.jump and not default hyperlinking with href, since we need to
let know the shell to navigate between components.

Fixes #13396