### PR TITLE
machines: Fix default bridge selection for `Bridge to LAN` NIC

### DIFF
--- a/pkg/machines/components/nicEdit.jsx
+++ b/pkg/machines/components/nicEdit.jsx
@@ -56,14 +56,17 @@ class EditNICModal extends React.Component {
         let defaultNetworkSource;
         let currentSource;
         let availableSources = [];
-        if (props.network.type === "network") {
-            availableSources = props.networks.map(network => network.name);
-            currentSource = props.network.source.network;
-        } else if (props.network.type === "direct" || props.network.type === "bridge") {
-            availableSources = props.nodeDevices.map(dev => dev.name);
-            currentSource = props.network.source.dev;
-        }
 
+        if (props.network.type === "network") {
+            currentSource = props.network.source.network;
+            availableSources = props.availableSources.network;
+        } else if (props.network.type === "direct") {
+            currentSource = props.network.source.dev;
+            availableSources = props.availableSources.device;
+        } else if (props.network.type === "bridge") {
+            currentSource = props.network.source.bridge;
+            availableSources = props.availableSources.device;
+        }
         if (availableSources.includes(currentSource))
             defaultNetworkSource = currentSource;
         else
@@ -227,7 +230,7 @@ export class EditNICAction extends React.Component {
 }
 
 EditNICAction.propTypes = {
-    availableSources: PropTypes.array.isRequired,
+    availableSources: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     idPrefix: PropTypes.string.isRequired,
     vm: PropTypes.object.isRequired,

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -683,6 +683,12 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_in_text("#vm-subVmTest1-network-1-type", "bridge")
         b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
 
+        b.click("#vm-subVmTest1-network-1-edit-dialog")
+        b.wait_in_text("#vm-subVmTest1-network-1-select-source", "virbr0")
+        b.click("#vm-subVmTest1-network-1-edit-dialog-save")
+        b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog-modal-window")
+        b.wait_in_text("#vm-subVmTest1-network-1-source", "virbr0")
+
         # Change interface type to network
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")


### PR DESCRIPTION
Previously we were checking only node devices list, but we should also
check the interfaces list when showing the list of the available resources.

In addition if the current NIC was `Bridge to LAN` it was parsed improperly.
This commit fixes that as well.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1791543
Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1791537