### PR TITLE
systemd: Drop graphs CSS hack that causes crash

### DIFF
--- a/pkg/systemd/graphs.less
+++ b/pkg/systemd/graphs.less
@@ -139,8 +139,6 @@
     > * {
       flex: auto;
       display: flex;
-      width: 100% !important;
-      height: 100% !important;
       max-height: 100%;
       max-width: 100%;
     }


### PR DESCRIPTION
This hack got introduced in commit 83bd249 without explanation or bug
reference. It causes the CPU or memory graph page to crash with

    Error: Invalid dimensions for plot, width = 647, height = 0 36 graphs.js:230:10
    resize http://localhost:9090/cockpit/@localhost/system/graphs.js:230

Drop the hack, which fixes the crash.

Fixes #13290
https://bugzilla.redhat.com/show_bug.cgi?id=1792623