### PR TITLE
ws: Add unit tests for loading combined certificates

### DIFF
--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -41,6 +41,7 @@ typedef struct {
 typedef struct {
   const gchar **files;
   const gchar *expected_message;
+  const gchar *preinstall;
   gboolean readonly_dir;
   gboolean ensure;
 } TestFixture;
@@ -96,6 +97,20 @@ setup (TestCase *tc,
     {
       g_assert (g_mkdir_with_parents (tc->cert_dir, 0755) == 0);
       g_assert (g_chmod (tc->cert_dir, 0555) == 0);
+    }
+
+  if (fix->preinstall)
+    {
+      GError *error = NULL;
+      g_autofree gchar *contents = NULL;
+      g_autofree gchar *dest = g_build_filename (tc->cert_dir, "1.crt", NULL);
+
+      g_assert (g_mkdir_with_parents (tc->cert_dir, 0755) == 0);
+      g_file_get_contents (fix->preinstall, &contents, NULL, &error);
+      g_assert_no_error (error);
+      g_assert (contents);
+      g_file_set_contents (dest, contents, -1, &error);
+      g_assert_no_error (error);
     }
 
   g_ptr_array_add (ptr, "certificate");
@@ -176,6 +191,10 @@ const gchar *invalid_files2[] = { SRCDIR "/src/bridge/mock-server.crt",
                                   SRCDIR "/src/bridge/mock-client.crt", NULL };
 const gchar *invalid_files3[] = { SRCDIR "/src/bridge/mock-client.key", NULL };
 
+/* test both possible orders in combined files: certs|key and key|certs */
+#define combined_key_first SRCDIR "/src/ws/mock-combined.crt"
+#define combined_key_last SRCDIR "/test/verify/files/cert-chain.cert"
+
 static const TestFixture fixture_good_rsa_file = {
   .expected_message = NULL,
   .files = good_rsa_files
@@ -218,6 +237,16 @@ static const TestFixture fixture_create_no_permission = {
   .ensure = TRUE
 };
 
+static const TestFixture fixture_preinstall_combined_key_first = {
+    .preinstall = combined_key_first,
+    .files = no_files,
+};
+
+static const TestFixture fixture_preinstall_combined_key_last = {
+    .preinstall = combined_key_last,
+    .files = no_files,
+};
+
 int
 main (int argc,
       char *argv[])
@@ -240,5 +269,9 @@ main (int argc,
               setup, test_combine_bad, teardown);
   g_test_add ("/remotectl-certificate/create-no-permission", TestCase, &fixture_create_no_permission,
               setup, test_combine_bad, teardown);
+  g_test_add ("/remotectl-certificate/load-combined-key-first", TestCase, &fixture_preinstall_combined_key_first,
+              setup, test_combine_good, teardown);
+  g_test_add ("/remotectl-certificate/load-combined-key-last", TestCase, &fixture_preinstall_combined_key_last,
+              setup, test_combine_good, teardown);
   return g_test_run ();
 }


### PR DESCRIPTION
This covers loading an existing certificate, not building one from given
parts. These can have the key first and then the certs, or the other way
round, so cover both orders.

See issue #13411