### PR TITLE
tests: Check naughties also on third retry

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1287,8 +1287,8 @@ class TapRunner(object):
         # "output" is bytes, grab corresponding stream
         out = _PY3 and sys.stdout.buffer or sys.stdout
 
-        # Didn't fail or retried too much, just print output and continue
-        if tries >= 3 or not failed:
+        # Didn't fail, just print output and continue
+        if not failed:
             out.write(output)
             return failed, False
 
@@ -1303,8 +1303,8 @@ class TapRunner(object):
             if ex.errno != errno.ENOENT:
                 sys.stderr.write("Couldn't run tests-policy: {0}\n".format(str(ex)))
 
-        # Just retry failures always, we don't need to be precious about flakes
-        if b"# SKIP " not in output:
+        # Just retry failures always (but maximum 3 times), we don't need to be precious about flakes
+        if b"# SKIP " not in output and tries < 3:
             output += b"\n# RETRY \n"
 
         # Write the output bytes


### PR DESCRIPTION
We did not check naughties on last retry, which meant that if first two
runs of test failed in normal way and third failed with something that
naughty would caught, we would not catch that.

Cherry-picked from master commit 408add42b39.