### PR TITLE
ws: Fix error message on missing browser APIs

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -136,7 +136,7 @@
                 throw ex;
             }
             if (ret === undefined) {
-                disableLogin();
+                disableLogin(name);
                 return false;
             }
             return true;


### PR DESCRIPTION
Call `disableLogin()` with the missing name as argument, so that the
error message can print it properly.