### PR TITLE
machines: Fix incorrect format when adding existing disk to VM

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -350,14 +350,18 @@ export class AddDiskModalBody extends React.Component {
             break;
         }
         case 'mode': {
-            stateDelta = this.initialState;
-            if (value === USE_EXISTING) { // user moved to USE_EXISTING subtab
-                stateDelta.mode = value;
-                const poolName = this.state.storagePoolName;
-                if (poolName)
-                    stateDelta.existingVolumeName = this.getDefaultVolumeName(poolName);
-            }
-            this.setState(stateDelta);
+            this.setState(prevState => { // to prevent asynchronous for recursive call with existingVolumeName as a key
+                stateDelta = this.initialState;
+                if (value === USE_EXISTING) { // user moved to USE_EXISTING subtab
+                    stateDelta.mode = value;
+                    const poolName = stateDelta.storagePoolName;
+                    if (poolName)
+                        this.onValueChanged('existingVolumeName', this.getDefaultVolumeName(poolName));
+                }
+
+                return stateDelta;
+            });
+
             break;
         }
         case 'busType': {

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -379,6 +379,10 @@ export class AddDiskModalBody extends React.Component {
     onAddClicked() {
         const { vm, dispatch, provider, close, vms, storagePools } = this.props;
 
+        // validate
+        if (!this.state.storagePoolName)
+            return this.dialogErrorSet(_("Please choose a storage pool"));
+
         if (this.state.mode === CREATE_NEW) {
             // validate
             if (!this.state.volumeName) {
@@ -415,6 +419,9 @@ export class AddDiskModalBody extends React.Component {
         }
 
         // use existing volume
+        if (!this.state.existingVolumeName)
+            return this.dialogErrorSet(_("Please choose a volume"));
+
         const storagePool = storagePools.find(pool => pool.name === this.state.storagePoolName);
         const volume = storagePool.volumes.find(vol => vol.name === this.state.existingVolumeName);
         const isVolumeUsed = getStorageVolumesUsage(vms, storagePool);
@@ -430,7 +437,7 @@ export class AddDiskModalBody extends React.Component {
             vmName: vm.name,
             vmId: vm.id,
             cacheMode: this.state.cacheMode,
-            shareable: provider.name == 'LibvirtDBus' && volume.format === "raw" && isVolumeUsed[this.state.existingVolumeName],
+            shareable: provider.name == 'LibvirtDBus' && volume && volume.format === "raw" && isVolumeUsed[this.state.existingVolumeName],
             busType: this.state.busType
         }))
                 .fail(exc => {

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -776,7 +776,7 @@ class TestMachines(NetworkCase):
         m.execute("virsh pool-define-as myPoolOne --type dir --target /mnt/vm_one && virsh pool-start myPoolOne")
         m.execute("virsh pool-define-as myPoolTwo --type dir --target /mnt/vm_two && virsh pool-start myPoolTwo")
 
-        m.execute("virsh vol-create-as default_tmp defaultVol --capacity 1G --format qcow2")
+        m.execute("virsh vol-create-as default_tmp defaultVol --capacity 1G --format raw")
         m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo_temporary --capacity 1G --format qcow2")
         m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo_permanent --capacity 1G --format qcow2")
         wait(lambda: "mydiskofpooltwo_permanent" in m.execute("virsh vol-list myPoolTwo"))
@@ -856,14 +856,15 @@ class TestMachines(NetworkCase):
         # check the autoselected options
         # default_tmp pool should be autoselected since it's the first in alphabetical order
         # defaultVol volume should be autoselected since it's the only volume in default_tmp pool
-        VMAddDiskDialog(
-            self,
-            pool_name='default_tmp',
-            volume_name='defaultVol',
-            use_existing_volume=True,
-            expected_target=get_next_free_target(),
-            volume_format='raw',
-        ).open().add_disk().verify_disk_added()
+        if self.provider == "libvirt-dbus": # defaultVol has raw format and virsh provider doesn't parse format info
+            VMAddDiskDialog(
+                self,
+                pool_name='default_tmp',
+                volume_name='defaultVol',
+                use_existing_volume=True,
+                expected_target=get_next_free_target(),
+                volume_format='raw',
+            ).open().add_disk().verify_disk_added()
 
         VMAddDiskDialog(
             self,


### PR DESCRIPTION
If you try to add disk to VM, and switch to "Use existing" without
changing anything else in the UI (keep default pool and volume),
the format is not updated into correct value.
Fix this.

https://bugzilla.redhat.com/show_bug.cgi?id=1792319