### PR TITLE
test: Add tests for CPU and memory graph pages

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -168,6 +168,41 @@ class TestMetrics(MachineCase):
 
         m.execute("kill %d" % net_pid)
 
+        if m.image in ["rhel-8-2-distropkg"]:
+            return  # HACK: individual graph pages broken, fixed in PR #13438
+
+        el_width = "(function (sel) { return ph_find(sel).offsetWidth; })"
+        el_height = "(function (sel) { return ph_find(sel).offsetHeight; })"
+
+        # CPU graph page
+        b.click("#link-cpu")
+        b.wait_not_visible(".ct-graph-memory")
+        b.wait_visible("#cpu_status_title")
+        b.wait_visible("#cpu_status_graph")
+        self.assertGreater(b.call_js_func(el_width, "#cpu_status_graph"), 500)
+        self.assertGreater(b.call_js_func(el_height, "#cpu_status_graph"), 300)
+        b.wait_visible(".server-graph-legend .cpu-kernel")
+
+        # go back to graphs overview
+        b.click("#graphs-link")
+        b.wait_visible(".ct-graph-memory")
+        b.wait_visible(".ct-graph-cpu")
+
+        # memory graph page
+        if m.image in ["fedora-coreos", "ubuntu-1804", "ubuntu-stable", "debian-stable", "debian-testing"]:
+            # no swap on these
+            b.wait_not_visible("#link-memory-and-swap")
+            b.click("#link-memory")
+        else:
+            b.wait_not_visible("#link-memory")
+            b.click("#link-memory-and-swap")
+        b.wait_not_visible(".ct-graph-cpu")
+        b.wait_visible("#memory_status_title")
+        b.wait_visible("#memory_status_graph")
+        self.assertGreater(b.call_js_func(el_width, "#memory_status_graph"), 500)
+        self.assertGreater(b.call_js_func(el_height, "#memory_status_graph"), 300)
+        b.wait_visible(".server-graph-legend .memory-used")
+
     @skipImage("No PCP available", "fedora-coreos")
     def testPcp(self):
         m = self.machine


### PR DESCRIPTION
This makes sure that the page configures as expected and doesn't crash.

Don't test the innards of the graph again, as they are exactly the same
widgets as the ones already tested further above.

Reproduces https://bugzilla.redhat.com/show_bug.cgi?id=1792623

 - [x] Fix oops on graphs page: PR #13438 