### PR TITLE
test: Use super() consistently

### DIFF
--- a/test/common/tap.py
+++ b/test/common/tap.py
@@ -24,7 +24,7 @@ class TapResult(unittest.TestResult):
     def __init__(self, verbosity):
         self.offset = 0
         self.start_time = 0
-        super(TapResult, self).__init__(sys.stderr, False, verbosity)
+        super().__init__(sys.stderr, False, verbosity)
 
     @staticmethod
     def plan(testable):
@@ -54,39 +54,39 @@ class TapResult(unittest.TestResult):
     def stop(self):
         sys.stdout.write("Bail out!\n")
         sys.stdout.flush()
-        super(TapResult, self).stop()
+        super().stop()
 
     def startTest(self, test):
         self.start_time = time.time()
         self.offset += 1
-        super(TapResult, self).startTest(test)
+        super().startTest(test)
 
     def stopTest(self, test):
-        super(TapResult, self).stopTest(test)
+        super().stopTest(test)
 
     def addError(self, test, err):
         self.not_ok(test, err)
-        super(TapResult, self).addError(test, err)
+        super().addError(test, err)
 
     def addFailure(self, test, err):
         self.not_ok(test, err)
-        super(TapResult, self).addError(test, err)
+        super().addError(test, err)
 
     def addSuccess(self, test):
         self.ok(test)
-        super(TapResult, self).addSuccess(test)
+        super().addSuccess(test)
 
     def addSkip(self, test, reason):
         self.skip(test, reason)
-        super(TapResult, self).addSkip(test, reason)
+        super().addSkip(test, reason)
 
     def addExpectedFailure(self, test, err):
         self.ok(test)
-        super(TapResult, self).addExpectedFailure(test, err)
+        super().addExpectedFailure(test, err)
 
     def addUnexpectedSuccess(self, test):
         self.not_ok(test, None)
-        super(TapResult, self).addUnexpectedSuccess(test)
+        super().addUnexpectedSuccess(test)
 
 
 class TapRunner(object):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -729,7 +729,7 @@ class MachineCase(unittest.TestCase):
         max_retry_hard_limit = 10
         for retry in range(0, max_retry_hard_limit):
             try:
-                super(MachineCase, self).run(result)
+                super().run(result)
             except RetryError as ex:
                 assert retry < max_retry_hard_limit
                 sys.stderr.write("{0}\n".format(ex))
@@ -1149,17 +1149,17 @@ def enableAxe(method):
 class TestResult(tap.TapResult):
     def __init__(self, stream, descriptions, verbosity):
         self.policy = None
-        super(TestResult, self).__init__(verbosity)
+        super().__init__(verbosity)
 
     def startTest(self, test):
         sys.stdout.write("# {0}\n# {1}\n#\n".format('-' * 70, str(test)))
         sys.stdout.flush()
-        super(TestResult, self).startTest(test)
+        super().startTest(test)
 
     def stopTest(self, test):
         sys.stdout.write("\n")
         sys.stdout.flush()
-        super(TestResult, self).stopTest(test)
+        super().stopTest(test)
 
 
 class OutputBuffer(object):

--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -342,7 +342,7 @@ class SeleniumWinTestSuite(SeleniumTestSuite):
 
 class SeleniumOwnHub(SeleniumTestSuite):
     def __init__(self, address_string, browser, **kwargs):
-        super(SeleniumTestSuite, self).__init__(**kwargs)
+        super().__init__(**kwargs)
         self.browser = browser
         address_option_list = address_string.split(":")
         hub_address = address_option_list[0]

--- a/test/selenium/selenium-network.py
+++ b/test/selenium/selenium-network.py
@@ -14,7 +14,7 @@ class NeworkTestSuite(SeleniumTest):
     """
 
     def setUp(self):
-        super(NeworkTestSuite, self).setUp()
+        super().setUp()
         self.login()
         self.reload_frame()
 

--- a/test/selenium/selenium-tuned.py
+++ b/test/selenium/selenium-tuned.py
@@ -13,7 +13,7 @@ class TunedProfiles(SeleniumTest):
     """
 
     def setUp(self):
-        super(TunedProfiles, self).setUp()
+        super().setUp()
         self.balanced_profile = "balanced"
         self.desktop_profile = "desktop"
         self.prepare_machine_execute()

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -27,7 +27,7 @@ from testlib import *
 class TestApps(PackageCase):
 
     def setUp(self):
-        PackageCase.setUp(self)
+        super().setUp()
         self.appstream_collection = set()
         self.machine.upload([ "verify/files/test.png" ], "/var/tmp/")
 

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -82,7 +82,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
     }
 
     def setUp(self):
-        super(TestBasicDashboard, self).setUp()
+        super().setUp()
         HACK_disable_problematic_preloads(self.machines["machine2"])
         HACK_disable_problematic_preloads(self.machines["machine3"])
 

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-
 # This file is part of Cockpit.
 #
 # Copyright (C) 2014 Red Hat, Inc.
@@ -31,7 +30,7 @@ from testlib import *
 class TestDocker(MachineCase):
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
         m = self.machine
 
         m.execute("systemctl start docker || systemctl start docker-latest")
@@ -595,7 +594,7 @@ CMD ["/bin/sh"]
 class TestAtomicScan(MachineCase):
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
 
         self.machine.execute("systemctl start docker")
 

--- a/test/verify/check-docker-storage
+++ b/test/verify/check-docker-storage
@@ -63,7 +63,7 @@ class TestDockerStorage(MachineCase):
     def setUp(self):
         self.allow_journal_messages('.*refusing to connect to unknown host.*')
         self.allow_journal_messages('.*host key for server is not known.*')
-        MachineCase.setUp(self)
+        super().setUp()
 
     def login(self):
         m = self.machines["machine1"]

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -12,7 +12,7 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(TEST_DIR), "examples")
 class TestPinger(MachineCase):
 
     def setUp(self):
-        super(TestPinger, self).setUp()
+        super().setUp()
         self.machine.execute("mkdir -p ~admin/.local/share/cockpit")
         self.machine.upload([os.path.join(EXAMPLES_DIR, "pinger")], "~admin/.local/share/cockpit/")
 

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -24,7 +24,7 @@ from testlib import *
 class TestJournal(MachineCase):
 
     def setUp(self):
-        super(TestJournal, self).setUp()
+        super().setUp()
         self.crash_fn = "__nanosleep"
 
     def select_from_dropdown(self, browser, selector, value, click=True):

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -90,7 +90,7 @@ def getNetworkDevice(m):
 @skipImage("LibvirtDBus is not available", "ubuntu-1804")
 class TestMachinesDBus(machineslib.TestMachines):
     def setUp(self):
-        super(TestMachinesDBus, self).setUp()
+        super().setUp()
 
         self.provider = "libvirt-dbus"
 

--- a/test/verify/check-machines-virsh
+++ b/test/verify/check-machines-virsh
@@ -33,7 +33,7 @@ class TestMachinesVirsh(machineslib.TestMachines):
             m.execute("rpm -e --nodeps libvirt-dbus || true")
 
     def setUp(self):
-        super(TestMachinesVirsh, self).setUp()
+        super().setUp()
 
         self.removeLibvirtDBus()
         self.provider = "virsh"

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -137,7 +137,7 @@ class TestMultiMachineAdd(MachineCase):
     }
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
         self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")
         self.machine3 = self.machines['machine3']
@@ -232,7 +232,7 @@ class TestMultiMachine(MachineCase):
     }
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -94,7 +94,7 @@ class TestMultiMachineKeyAuth(MachineCase):
                        normalize("\n".join(keys) + "\n")])
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
         self.machine2 = self.machines['machine2']
 
         # Add user

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -41,7 +41,7 @@ done
 class TestUpdates(PackageCase):
 
     def setUp(self):
-        PackageCase.setUp(self)
+        super().setUp()
 
         # Disable Subscription Manager on RHEL for these tests; subscriptions are tested in a separate class
         # On other OSes (Fedora/CentOS) we expect sub-man to be disabled in yum, so it should not get in the way there
@@ -660,7 +660,7 @@ class TestUpdatesSubscriptions(PackageCase):
         self.machine.execute("LC_ALL=en_US.UTF-8 subscription-manager attach --auto")
 
     def setUp(self):
-        PackageCase.setUp(self)
+        super().setUp()
         self.candlepin = self.machines['services']
         m = self.machine
 
@@ -786,7 +786,7 @@ class TestUpdatesSubscriptions(PackageCase):
 class TestAutoUpdates(PackageCase):
 
     def setUp(self):
-        PackageCase.setUp(self)
+        super().setUp()
 
         # Disable Subscription Manager on RHEL for these tests; subscriptions are tested in a separate class
         # On other OSes (Fedora/CentOS) we expect sub-man to be disabled in yum, so it should not get in the way there

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -25,7 +25,7 @@ from testlib import *
 class TestServices(MachineCase):
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
 
         # Make sure the system finishes "booting" so that
         # when we add additional services to this target below

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -31,7 +31,7 @@ class TestShutdownRestart(MachineCase):
     }
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machines['machine2'].execute("hostnamectl set-hostname machine2")
         HACK_disable_problematic_preloads(self.machine)

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -95,7 +95,7 @@ def ssh_reconnect(machine, timeout_sec=120):
 
 class TestSystemInfo(MachineCase):
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
 
         # Debian will not allow timesyncd to start if any other NTP packge is installed
         # We only support timesyncd for NTP configuration, so make sure chrony

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -195,6 +195,7 @@ class TestMachines(NetworkCase):
     provider = None
 
     def setUp(self):
+        # HACK: fix this to get along with NetworkCase.setUp(), and use super()
         MachineCase.setUp(self)
         self.startLibvirt()
 

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -24,7 +24,7 @@ from testlib import *
 class NetworkCase(MachineCase):
 
     def setUp(self):
-        MachineCase.setUp(self)
+        super().setUp()
 
         m = self.machine
 

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -23,7 +23,7 @@ from testlib import *
 
 class PackageCase(MachineCase):
     def setUp(self):
-        super(PackageCase, self).setUp()
+        super().setUp()
 
         self.repo_dir = "/var/tmp/repo"
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -27,7 +27,7 @@ class StorageCase(MachineCase):
         if self.image in ["fedora-coreos"]:
             self.skipTest("No udisks/cockpit-storaged on OSTree images")
 
-        super(StorageCase, self).setUp()
+        super().setUp()
         self.storagectl_cmd = "udisksctl"
 
         ver = self.machine.execute("busctl --system get-property org.freedesktop.UDisks2 /org/freedesktop/UDisks2/Manager org.freedesktop.UDisks2.Manager Version || true")


### PR DESCRIPTION
This avoids hardcoding/repeating the parent class name, and thus avoids
subtle bugs.

Only keep the explicit grandparent class call in `TestMachines.setUp()`,
as `NetworkCase.setUp()` breaks testCreate().