### PR TITLE
maint: mini-css-extract-plugin prints too many logs in console

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -291,9 +291,27 @@ info.files.forEach(function(value) {
 });
 info.files = files;
 
+// Hide mini-css-extract-plugin spam logs
+class CleanUpStatsPlugin {
+  shouldPickStatChild(child) {
+    return child.name.indexOf('mini-css-extract-plugin') !== 0;
+  }
+
+  apply(compiler) {
+    compiler.hooks.done.tap('CleanUpStatsPlugin', (stats) => {
+      const children = stats.compilation.children;
+      if (Array.isArray(children)) {
+        stats.compilation.children = children
+          .filter(child => this.shouldPickStatChild(child));
+      }
+    });
+  }
+}
+
 var plugins = [
     new copy(info.files),
     new miniCssExtractPlugin("[name].css"),
+    new CleanUpStatsPlugin(),
 ];
 
 var output = {


### PR DESCRIPTION
The solution originates from https://github.com/webpack-contrib/mini-css-extract-plugin/issues/168