### PR TITLE
tests: Run many package related tests in persistent testbeds

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -541,63 +541,6 @@ class TestUpdates(NoSubManCase):
         # not expecting any buttons
         self.assertFalse(b.is_present("#app button"))
 
-    def testRunningUpdate(self):
-        # The main case for this is that cockpit-ws itself gets upgraded, which
-        # restarts the service and terminates the connection. As we can't
-        # (efficiently) build a newer working cockpit-ws package, test the two
-        # parts (reconnect and warning about disconnect) separately.
-
-        # no security updates, no changelogs
-        b = self.browser
-        m = self.machine
-
-        install_lockfile = "/tmp/finish-pk"
-        # updating this package takes longer than a cockpit start and building the page
-        self.createPackage("slow", "1", "1", install=True)
-        self.createPackage(
-            "slow", "1", "2", postinst="while [ ! -e {0} ]; do sleep 1; done; rm -f {0}".format(install_lockfile))
-        self.enableRepo()
-        m.execute("pkcon refresh")
-
-        m.start_cockpit()
-        b.login_and_go("/updates")
-
-        b.click("#app .container-fluid button")
-        b.wait_in_text("#state", "Applying updates")
-        b.wait_in_text("#app div.progress-description", "slow")
-
-        # restarting should pick up that install progress
-        m.restart_cockpit()
-        b.login_and_go("/updates")
-        b.wait_in_text("#state", "Applying updates")
-        b.wait_present("#app div.progress-bar")
-
-        # finish the package installation
-        m.execute("touch {0}".format(install_lockfile))
-
-        # should have succeeded and show restart page; cancel
-        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
-        b.click("#app .container-fluid button.btn-default")
-        b.wait_in_text("#state", "No updates pending")
-
-        # now pretend that there is a newer cockpit-ws available, warn about disconnect
-        self.createPackage("cockpit-ws", "999", "1")
-        # these have strict version dependencies to cockpit-ws, don't get in the way
-        self.createPackage("cockpit", "999", "1")
-        self.createPackage("cockpit-dashboard", "999", "1")
-        m.execute("if type apt; then dpkg -P cockpit-ws-dbgsym; fi")
-        self.enableRepo()
-        b.wait_in_text(".content-header-extra button", "Check for Updates")
-        b.click(".content-header-extra button")
-
-        b.wait_in_text(".container-fluid #available h2", "Available Updates")
-        self.assertEqual(b.text("#state"), "3 updates")
-        b.wait_in_text("table.available", "cockpit-ws")
-        b.wait_in_text("table.available", "cockpit-dashboard")
-        b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
-
-        self.allow_restart_journal_messages()
-
     def testPackageKitCrash(self):
         b = self.browser
         m = self.machine
@@ -650,6 +593,67 @@ class TestUpdates(NoSubManCase):
         b.enter_page("/system")
         b.wait_text(self.update_text, "Loading available updates failed")
         self.assertIn("exclamation", b.attr(self.update_icon, "class"))
+
+
+@skipImage("Image uses OSTree", "fedora-coreos")
+class TestWsUpdate(NoSubManCase):
+    def testBasic(self):
+        # The main case for this is that cockpit-ws itself gets upgraded, which
+        # restarts the service and terminates the connection. As we can't
+        # (efficiently) build a newer working cockpit-ws package, test the two
+        # parts (reconnect and warning about disconnect) separately.
+        # This test is destructive and thus must run last.
+
+        # no security updates, no changelogs
+        b = self.browser
+        m = self.machine
+
+        install_lockfile = "/tmp/finish-pk"
+        # updating this package takes longer than a cockpit start and building the page
+        self.createPackage("slow", "1", "1", install=True)
+        self.createPackage(
+            "slow", "1", "2", postinst="while [ ! -e {0} ]; do sleep 1; done; rm -f {0}".format(install_lockfile))
+        self.enableRepo()
+        m.execute("pkcon refresh")
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        b.click("#app .container-fluid button")
+        b.wait_in_text("#state", "Applying updates")
+        b.wait_in_text("#app div.progress-description", "slow")
+
+        # restarting should pick up that install progress
+        m.restart_cockpit()
+        b.login_and_go("/updates")
+        b.wait_in_text("#state", "Applying updates")
+        b.wait_present("#app div.progress-bar")
+
+        # finish the package installation
+        m.execute("touch {0}".format(install_lockfile))
+
+        # should have succeeded and show restart page; cancel
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        b.click("#app .container-fluid button.btn-default")
+        b.wait_in_text("#state", "No updates pending")
+
+        # now pretend that there is a newer cockpit-ws available, warn about disconnect
+        self.createPackage("cockpit-ws", "999", "1")
+        # these have strict version dependencies to cockpit-ws, don't get in the way
+        self.createPackage("cockpit", "999", "1")
+        self.createPackage("cockpit-dashboard", "999", "1")
+        m.execute("if type apt; then dpkg -P cockpit-ws-dbgsym; fi")
+        self.enableRepo()
+        b.wait_in_text(".content-header-extra button", "Check for Updates")
+        b.click(".content-header-extra button")
+
+        b.wait_in_text(".container-fluid #available h2", "Available Updates")
+        self.assertEqual(b.text("#state"), "3 updates")
+        b.wait_in_text("table.available", "cockpit-ws")
+        b.wait_in_text("table.available", "cockpit-dashboard")
+        b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
+
+        self.allow_restart_journal_messages()
 
 
 @skipImage("Image uses OSTree", "fedora-coreos")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -53,6 +53,7 @@ class NoSubManCase(PackageCase):
 
 
 @skipImage("Image uses OSTree", "fedora-coreos")
+@nondestructive
 class TestUpdates(NoSubManCase):
 
     def setUp(self):
@@ -659,6 +660,7 @@ class TestWsUpdate(NoSubManCase):
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "fedora-31", "centos-8-stream",
            "fedora-30", "fedora-testing", "ubuntu-1804", "ubuntu-stable")
+@nondestructive
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
@@ -790,6 +792,7 @@ class TestUpdatesSubscriptions(PackageCase):
 
 
 @skipImage("Image uses OSTree", "fedora-coreos")
+@nondestructive
 class TestAutoUpdates(NoSubManCase):
 
     def setUp(self):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -37,8 +37,7 @@ done
 """
 
 
-@skipImage("Image uses OSTree", "fedora-coreos")
-class TestUpdates(PackageCase):
+class NoSubManCase(PackageCase):
 
     def setUp(self):
         super().setUp()
@@ -48,6 +47,16 @@ class TestUpdates(PackageCase):
         if self.machine.image.startswith("rhel") or self.machine.image.startswith("centos-8"):
             self.machine.execute("mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
             self.addCleanup(self.machine.execute, "mv /usr/libexec/rhsmd.disabled /usr/libexec/rhsmd")
+
+        # expected journal messages from enabling/disabling auto upgrade services
+        self.allow_journal_messages("(Created symlink|Removed).*dnf-automatic-install.timer.*")
+
+
+@skipImage("Image uses OSTree", "fedora-coreos")
+class TestUpdates(NoSubManCase):
+
+    def setUp(self):
+        super().setUp()
 
         # only the yum backend properly recognizes "enhancement" severity; apt
         # does not have that metadata and PackageKit-dnf does not parse it
@@ -776,26 +785,13 @@ class TestUpdatesSubscriptions(PackageCase):
         self.assertIn("fa-bug", b.attr(self.update_icon, "class"))
 
 
-class NoSubManCase(PackageCase):
+@skipImage("Image uses OSTree", "fedora-coreos")
+class TestAutoUpdates(NoSubManCase):
 
     def setUp(self):
         super().setUp()
-
-        # Disable Subscription Manager on RHEL for these tests; subscriptions are tested in a separate class
-        # On other OSes (Fedora/CentOS) we expect sub-man to be disabled in yum, so it should not get in the way there
-        if self.machine.image.startswith("rhel") or self.machine.image.startswith("centos-8"):
-            self.machine.execute("mv /usr/libexec/rhsmd /usr/libexec/rhsmd.disabled")
-            self.addCleanup(self.machine.execute, "mv /usr/libexec/rhsmd.disabled /usr/libexec/rhsmd")
-
         # not implemented for yum and apt yet, only dnf
         self.supported_backend = self.backend in ["dnf"]
-
-        # expected journal messages from enabling/disabling auto upgrade services
-        self.allow_journal_messages("(Created symlink|Removed).*dnf-automatic-install.timer.*")
-
-
-@skipImage("Image uses OSTree", "fedora-coreos")
-class TestAutoUpdates(NoSubManCase):
 
     def testBasic(self):
         b = self.browser

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -45,9 +45,10 @@ class PackageCase(MachineCase):
 
         # PackageKit refuses to work when offline
         if self.image in ["ubuntu-1804", "ubuntu-stable"]:
-            # just waiting for NM to get online does not suffice on these images. So disable NM and let PackageKit fall
-            # back to the "unix" network stack; add a bogus default route to coerce it into being "online".
-            self.machine.execute("systemctl disable --now NetworkManager; ip route add default via 172.27.0.1 dev eth0")
+            # on these images, PackageKit insists on a default route, so add a fake one to virbr0
+            self.machine.execute("until nmcli c show virbr0 >/dev/null 2>&1; do sleep 1; done; nmcli c modify virbr0 ipv4.gateway 192.168.122.1")
+            # this is a dynamic interface, next reboot will shadow the static file anyway, so clean it up
+            self.machine.execute("rm /etc/NetworkManager/system-connections/virbr0*")
         else:
             # PackageKit refuses to work when offline; unfortunately nm-online does not wait enough
             # https://developer.gnome.org/NetworkManager/unstable/nm-dbus-types.html#NMConnectivityState


### PR DESCRIPTION
This allows us to run these for downstream gating, and also speeds up the tests.

 - [x] Add PersistentMachineCase: PR #13406
 - [x] Fix leaf classes: PR #13460
 - [x] Various preparatory test fixes: PR #13465
 - [x] Rework this using the `@nonDestructive` decorator: PR #13467