### PR TITLE
po: Pickup also strings with specified context

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -91,7 +91,7 @@ po/cockpit.html.pot: po/POTFILES.html.in
 # Extract cockpit style javascript translations
 po/cockpit.js.pot: po/POTFILES.js.in
 	$(XGETTEXT) --default-domain=cockpit --output=- --language=C --keyword= \
-		--keyword=_:1,1t --keyword=_:1c,2,1t --keyword=C_:1c,2 \
+		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
 		--keyword=ngettext:1,2,3t --keyword=ngettext:1c,2,3,4t \


### PR DESCRIPTION
Strings like `_("Context", "String to translate")` were not picked up.

TBH I don't understand this syntax fully (can someone point me to some doc?). But there is `gettext:1c,2,2t` and we use `_` as synonym for `gettext`. And when I compared `po/cockpit.pot` with this and without this patch, nothing was dropped, only a few new strings were picked up (mostly from storage).