### PR TITLE
.tasks: Drop learning trigger

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -24,5 +24,4 @@ fi
 if [ $chance -gt 9 ]; then
     bots/po-trigger
     bots/npm-trigger
-    bots/learn-trigger
 fi


### PR DESCRIPTION
This has been broken for quite a while now. Let's disable it to prevent
issue spam.