### PR TITLE
Validate urls

### DIFF
--- a/.tasks
+++ b/.tasks
@@ -24,4 +24,5 @@ fi
 if [ $chance -gt 9 ]; then
     bots/po-trigger
     bots/npm-trigger
+    ./tools/urls-check
 fi

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -403,7 +403,7 @@ docker.console = function console_(container_id, command, options) {
      * protocol. It starts with a HTTP POST, and then quickly
      * degenerates into a stream sometimes binary.
      *
-     * See: http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.8/#attach-to-a-container
+     * See: https://docs.docker.com/engine/api/v1.40/#operation/ContainerAttach
      */
     function attach(request) {
         if (view)

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -323,7 +323,7 @@ ListingRow.propTypes = {
     simpleBody: PropTypes.node,
 };
 /* Implements a PatternFly 'List View' pattern
- * https://www.patternfly.org/list-view/
+ * https://www.patternfly.org/v3/pattern-library/content-views/list-view/index.html
  * Properties (all optional):
  * - title
  * - fullWidth: set width to 100% of parent, defaults to true

--- a/pkg/machines/selectors.js
+++ b/pkg/machines/selectors.js
@@ -21,7 +21,7 @@
  * the state in Redux store. This also enables to put derived (computed) data on the same level
  * as the objects stored in the store directly.
  *
- * Reference: http://redux.js.org/docs/recipes/ComputingDerivedData.html
+ * Reference: https://redux.js.org/recipes/computing-derived-data/
  */
 
 export function getRefreshInterval(state) {

--- a/pkg/packagekit/mock-updates.js
+++ b/pkg/packagekit/mock-updates.js
@@ -19,7 +19,7 @@ export function injectMockUpdates(updates) {
         bug_urls: [],
         cve_urls: ["https://cve.example.com?name=CVE-2014-123456", "https://cve.example.com?name=CVE-2017-9999"],
         vendor_urls: ["https://access.redhat.com/security/updates/classification/#critical", "critical",
-            "https://access.redhat.com/errata/RHSA-2000:0001", "https://access.redhat.com/errata/RHSA-2000:0002"],
+            "https://access.redhat.example.com/errata/RHSA-2000:0001", "https://access.redhat.example.com/errata/RHSA-2000:0002"],
         severity: 8,
         description: "This will wreck your data center!",
     };

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -185,7 +185,7 @@ class SELinuxEventLog extends React.Component {
 }
 
 /* Implements a subset of the PatternFly Empty State pattern
- * https://www.patternfly.org/patterns/empty-state/
+ * https://www.patternfly.org/v3/pattern-library/communication/empty-state/index.html
  * Special values for icon property:
  *   - 'waiting' - display spinner
  *   - 'error'   - display error icon

--- a/pkg/storaged/jobs-panel.jsx
+++ b/pkg/storaged/jobs-panel.jsx
@@ -28,7 +28,7 @@ const _ = cockpit.gettext;
  * property of job objects.  These are from the storaged
  * documentation at
  *
- *   http://storaged.org/doc/udisks2-api/gdbus-org.freedesktop.UDisks2.Job.html
+ * http://storaged.org/doc/udisks2-api/latest/gdbus-org.freedesktop.UDisks2.Job.html
  */
 
 var descriptions = {

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2020 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+
+import os
+from os.path import dirname, abspath
+import sys
+import time
+import argparse
+import subprocess
+import urllib
+from urllib.request import urlopen, Request
+
+sys.path.append(os.path.join(dirname(dirname(abspath(__file__))), "bots"))
+import task
+
+sys.dont_write_bytecode = True
+
+DAYS = 7
+TASK_NAME = "Validate all URLs"
+
+def main():
+    parser = argparse.ArgumentParser(description=TASK_NAME)
+    parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
+    opts = parser.parse_args()
+
+    task.verbose = opts.verbose
+
+    since = time.time() - (DAYS * 86400)
+
+    # When there is an open issue, don't do anything
+    issues = task.api.issues(state="open")
+    issues = [i for i in issues if i["title"] == TASK_NAME]
+    if issues:
+        return
+
+    issues = task.api.issues(state="closed", since=since)
+    issues = [i for i in issues if i["title"] == TASK_NAME]
+
+    # If related issue was not modified in last n-DAYS, then do your thing
+    if not issues:
+        (success, err) = check_urls(opts.verbose)
+        if err:
+            # Create a new issue
+            data = {
+                "title": TASK_NAME,
+                "body": err,
+                "labels": ["bot"]
+            }
+            task.api.post("issues", data)
+        else:
+            # Try to comment on the last issue (look in the last 4*DAYS)
+            # If there is not issue to be found, then just open a new one and close it
+            success = success or "Task hasn't produced any output"
+            since = time.time() - (DAYS * 4 * 86400)
+            issues = task.api.issues(state="closed", since=since)
+            issues = [i for i in issues if i["title"] == TASK_NAME]
+            if issues:
+                task.comment(issues[0], success)
+            else:
+                data = {
+                    "title": TASK_NAME,
+                    "body": success,
+                    "labels": ["bot"]
+                }
+                new_issue = task.api.post("issues", data)
+                task.api.post("issues/{0}".format(new_issue["number"]), {"state": "closed"})
+
+def check_urls(verbose):
+    command = r'git grep -IEho "(https?)://[-a-zA-Z0-9@:%_\+.~#?&=/]+" pkg | sort -u'
+    urls = subprocess.check_output(command, shell=True, universal_newlines=True).split("\n")
+    failed = []
+    for url in urls:
+        if not url:
+            continue
+
+        if "example.com" in url: # Some tests use demo urls
+            continue
+
+        if "sodipodi.sourceforge.net" in url: # Some .svg files contain url that does not exist
+            continue
+
+        if verbose:
+            print("Checking: {0}".format(url))
+
+        try:
+            # Specify agent as some websites otherwise block requests
+            req = Request(url=url, headers={"User-Agent": "Mozilla/5.0"})
+            if urlopen(req).getcode() >= 400:
+                failed.append(url)
+        except urllib.error.URLError:
+            failed.append(url)
+
+    err = ""
+    success = ""
+    if failed:
+        err = "Checked {0} URLs out of which {1} is/are invalid:\n{2}".format(len(urls), len(failed), "\n".join(failed))
+    else:
+        success = "Checked {0} URLs and all are valid".format(len(urls))
+    return (success, err)
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
1. There was no issue, so it opened and immeditally closed one: https://github.com/marusak/cockpit/issues/25
2. There was closed issue that was modified less than 7 days ago - it did nothing

_I removed the check for 7 days so I don't need to wait a week to test it :)_

3. The task succeeded, so it just commented on the last issue: https://github.com/marusak/cockpit/issues/25#issuecomment-579714251
4. The task failed, so it opened a new issue: https://github.com/marusak/cockpit/issues/27 and kept it open (while opened, the task would not run again)

I also added it into `.tasks` file and fixed some non-existent URLs. It needs https://github.com/cockpit-project/bots/pull/470 or if we agree that it is a not good change, than I need to implement different `issues` method for this PR.
Also `check_urls()` is the only specific piece for this task. So it would be very simple to reuse this logic (commenting on PRs, opening on fails...) for similar problems (lorax was (is?) solving something very similar).