### PR TITLE
package.json: Pin down eslint-plugin-react version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-node": "^9.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-react": "^7.15.1",
+    "eslint-plugin-react": "7.18.0",
     "eslint-plugin-react-hooks": "^2.1.2",
     "eslint-plugin-standard": "^4.0.1",
     "html-webpack-plugin": "^3.2.0",


### PR DESCRIPTION
7.18.1 or .2 has a major regression with tons of false positives for
react/jsx-indent.

See https://github.com/yannickcr/eslint-plugin-react/issues/2563