### PR TITLE
storage: Don't duplicate descriptions

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -618,6 +618,8 @@ export const SelectSpaces = (tag, title, options) => {
                     data-field={tag} data-field-type="select-spaces">
                     { options.spaces.map(spc => {
                         const selected = (val.indexOf(spc) >= 0);
+                        const block = spc.block ? block_name(spc.block) : "";
+                        const desc = block === spc.desc ? "" : spc.desc;
 
                         const on_change = (event) => {
                             if (event.target.checked && !selected)
@@ -630,8 +632,8 @@ export const SelectSpaces = (tag, title, options) => {
                             <li key={spc.block ? spc.block.Device : spc.desc} className="list-group-item">
                                 <label className="select-space-row">
                                     <input type="checkbox" checked={selected} onChange={on_change} />
-                                    <span className="select-space-name">{format_size_and_text(spc.size, spc.desc)}</span>
-                                    <span className="select-space-details">{spc.block ? block_name(spc.block) : ""}</span>
+                                    <span className="select-space-name">{format_size_and_text(spc.size, desc)}</span>
+                                    <span className="select-space-details">{block}</span>
                                 </label>
                             </li>
                         );
@@ -658,6 +660,8 @@ export const SelectSpace = (tag, title, options) => {
                 <ul className="list-group dialog-list-ct"
                     data-field={tag} data-field-type="select-spaces">
                     { options.spaces.map(spc => {
+                        const block = spc.block ? block_name(spc.block) : "";
+                        const desc = block === spc.desc ? "" : spc.desc;
                         const on_change = (event) => {
                             if (event.target.checked)
                                 change(spc);
@@ -667,8 +671,8 @@ export const SelectSpace = (tag, title, options) => {
                             <li key={spc.block ? spc.block.Device : spc.desc} className="list-group-item">
                                 <label className="select-space-row">
                                     <input type="radio" checked={val == spc} onChange={on_change} />
-                                    <span className="select-space-name">{format_size_and_text(spc.size, spc.desc)}</span>
-                                    <span className="select-space-details">{spc.block ? block_name(spc.block) : ""}</span>
+                                    <span className="select-space-name">{format_size_and_text(spc.size, desc)}</span>
+                                    <span className="select-space-details">{block}</span>
                                 </label>
                             </li>
                         );


### PR DESCRIPTION
Fixes #3739

Before:
![beforeduplicated](https://user-images.githubusercontent.com/12330670/73741207-0e392700-474a-11ea-9827-ed46b50e1bd8.png)
After:
![after](https://user-images.githubusercontent.com/12330670/73741210-12654480-474a-11ea-94c7-e6529b3154a1.png)
 
And see the original issue for how it looked with long names.