### PR TITLE
Localize times

### DIFF
--- a/pkg/systemd/overview-cards/serverTime.js
+++ b/pkg/systemd/overview-cards/serverTime.js
@@ -17,6 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import cockpit from "cockpit";
+import moment from "moment";
 import * as service from "service.js";
 import $ from "jquery";
 
@@ -61,13 +62,9 @@ export function ServerTime() {
     });
 
     self.format = function format(and_time) {
-        var string = self.utc_fake_now.toISOString();
-        if (!and_time)
-            return string.split('T')[0];
-        var pos = string.lastIndexOf(':');
-        if (pos !== -1)
-            string = string.substring(0, pos);
-        return string.replace('T', ' ');
+        if (and_time)
+            return moment.utc(self.utc_fake_now).format('lll');
+        return moment.utc(self.utc_fake_now).format('ll');
     };
 
     self.updateInterval = window.setInterval(function() {

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -19,6 +19,7 @@
 
 import 'polyfills.js';
 import cockpit from "cockpit";
+import moment from "moment";
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -166,6 +167,7 @@ class OverviewPage extends React.Component {
 
 function init() {
     cockpit.translate();
+    moment.locale(cockpit.language);
     ReactDOM.render(<OverviewPage />, document.getElementById("overview"));
 }
 

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -894,14 +894,14 @@ PageAccount.prototype = {
                     } else if (line[1].indexOf("password must be changed") === 0) {
                         password_expiration = _("Password must be changed");
                     } else {
-                        password_expiration = cockpit.format(_("Require password change on $0"), line[1]);
+                        password_expiration = cockpit.format(_("Require password change on $0"), moment(line[1]).format('LL'));
                     }
                 } else if (line[0] && line[0].indexOf("Account expires") === 0) {
                     if (line[1].indexOf("never") === 0) {
                         account_expiration = _("Never lock account");
                     } else {
                         account_date = new Date(line[1] + " 12:00:00 UTC");
-                        account_expiration = cockpit.format(_("Lock account on $0"), line[1]);
+                        account_expiration = cockpit.format(_("Lock account on $0"), moment(line[1]).format('LL'));
                     }
                 } else if (line[0] && line[0].indexOf("Maximum number of days between password change") === 0) {
                     password_days = line[1];

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -19,6 +19,7 @@
 
 import $ from 'jquery';
 import cockpit from 'cockpit';
+import moment from "moment";
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -28,6 +29,8 @@ import * as authorized_keys from './authorized-keys.js';
 import 'patterns';
 import 'bootstrap-datepicker/dist/js/bootstrap-datepicker';
 import 'form-layout.less';
+
+moment.locale(cockpit.language);
 
 const _ = cockpit.gettext;
 const C_ = cockpit.gettext;
@@ -982,7 +985,7 @@ PageAccount.prototype = {
             else if (!this.lastLogin)
                 $('#account-last-login').text(_("Never"));
             else
-                $('#account-last-login').text(this.lastLogin.toLocaleString());
+                $('#account-last-login').text(moment(this.lastLogin).format('LLL'));
 
             if (typeof this.locked != 'undefined') {
                 $('#account-locked').prop('checked', this.locked);

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -252,7 +252,10 @@ class TestSystemInfo(MachineCase):
         b.click("#systime-apply-button")
         b.wait_popdown("system_information_change_systime")
 
-        b.wait_text("#system_information_systime_button", "2020-01-24 08:03")
+        if m.image == "rhel-8-2-distropkg": # Changed in #13489
+            b.wait_text("#system_information_systime_button", "2020-01-24 08:03")
+        else:
+            b.wait_text("#system_information_systime_button", "Jan 24, 2020 8:03 AM")
 
         self.assertFalse(ntp_enabled())
         self.assertIn("Fri Jan 24 08:03:", m.execute("date"))


### PR DESCRIPTION
Fixes #8583 
I haven't found any other place, where the format would not be localized. If you find something, please point it out, and I'll fix it out.
The only other place related to time, that should be localized, are calendars:
![calendarbefore](https://user-images.githubusercontent.com/12330670/73750030-c7086180-475c-11ea-99e9-35ad7fe33f3d.png)
(names of days, on which day week starts... - this can be done with setting up `language` but it requires to import all locale files - which cannot be automated... But there are  also other options, so I just plan to open issue for that and take a look at it separately).

I am not sure about that change on the overview page. It seems so obvious that I doubt it was not purposely that way? Now looks like this in English and is localized: 
![timeformat](https://user-images.githubusercontent.com/12330670/73750243-21092700-475d-11ea-8d44-98afb901a960.png)
Is that right?


Likely breaks tests, so spinning them out