### PR TITLE
overview: Drop MOTD's bottom margin; use grid gap

### DIFF
--- a/pkg/systemd/overview.less
+++ b/pkg/systemd/overview.less
@@ -316,3 +316,8 @@
 .pf-c-button.no-left-padding {
     padding-left: 0;
 }
+
+#motd-box > .pf-c-alert {
+  /* Spacing between the MOTD is handled by the .pf-l-gallery grid */
+  margin-bottom: 0;
+}


### PR DESCRIPTION
PatternFly's `.pf-c-alert` rightfully has `margin-bottom` set. However, we're using it in a grid on the overview, so we should rely on `grid-gap` for proper spacing. Therefore, `margin-bottom` is redundant and adds too much space.

Test this with content in an `/etc/motd`.