### PR TITLE
machines: When validation succeeds don't try to validate `Create VM` dialog again

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -682,7 +682,7 @@ class CreateVmModal extends React.Component {
             // leave dialog open to show immediate errors from the backend
             // close the dialog after VMS_CONFIG.LeaveCreateVmDialogVisibleAfterSubmit
             // then show errors in the notification area
-            this.setState({ inProgress: true });
+            this.setState({ inProgress: true, validate: false });
 
             const vmParams = {
                 connectionName: this.state.connectionName,


### PR DESCRIPTION
This commit fixes the following problematic workflow:

* The user makes the validation of the fields of Create VM dialog to
fail (ex: leaving an empty field)
* Then successfully creates a VM

Result: They will shortly notice an inline validation error that the VM
name already exists, because the new VM list causes the dialog to
re-render and the validation to fail on existing VM name.
Expected result: The dialog should not do any inline validation after it
was successfully submitted and before it closes.