### PR TITLE
test: Reduce chromium cdp logging

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -102,8 +102,10 @@ function setupLogging(client) {
         let msg = entry["entry"];
         messages.push([ "cdp", msg ]);
         /* Ignore authentication failure log lines that don't denote failures */
-        if (!(msg.url || "").endsWith("/login") || (msg.text || "").indexOf("401") === -1)
-            process.stderr.write("CDP: " + JSON.stringify(msg) + "\n");
+        if (!(msg.url || "").endsWith("/login") || (msg.text || "").indexOf("401") === -1 ||
+            (msg.text || "").indexOf("Refused to apply inline style") === -1) {
+            process.stderr.write("CDP: " + msg + "\n");
+        }
         resolveLogPromise();
     });
 }


### PR DESCRIPTION
This particular error (refused to apply inline style) clogs up the logs, especially running locally.

Not sure if we should fix the inline styles instead of just ignoring it though.