### PR TITLE
doc: provide example of disabling session timeout

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -213,8 +213,14 @@ ProtocolHeader = X-Forwarded-Proto
           has been performed in the given time. This idle timeout only applies to interactive password logins.
           With non-interactive authentication methods like Kerberos, OAuth, or certificate login, the browser
           cannot forget credentials, and thus automatic logouts are not useful for protecting credentials
-          of forgotten sessions. Set to <literal>0</literal> to disable session timeout.
-          When not specified, the default is <literal>15</literal> minutes.</para>
+          of forgotten sessions. Set to <literal>0</literal> to disable session timeout.</para>
+          <informalexample>
+<programlisting language="js">
+[Session]
+IdleTimeout=0
+</programlisting>
+          </informalexample>		
+          <para>When not specified, the default is <literal>15</literal> minutes.</para>
         </listitem>
       </varlistentry>
     </variablelist>


### PR DESCRIPTION
I attempted to disable session timeout, and was wondering why it wasn't working; I had:

[WebService]
IdleTimeout=0

On re-reading, it looks like it should be:

[Session]
IdleTimeout=0

[caveats: am still waiting the 15 minutes to see if this works; I edited the XML by hand in github UI, so I'm not sure if well-formed/valid]

If I'm reading it right, all of the existing examples are for WebService, which threw me.