### PR TITLE
docker: Add appstream

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -19,6 +19,7 @@ metainfo_DATA = pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml
 		pkg/selinux/org.cockpit-project.cockpit-selinux.metainfo.xml \
 		pkg/machines/org.cockpit-project.cockpit-machines.metainfo.xml \
 		pkg/storaged/org.cockpit-project.cockpit-storaged.metainfo.xml \
+		pkg/docker/org.cockpit-project.cockpit-docker.metainfo.xml \
 		$(NULL)
 
 pixmapsdir = ${datarootdir}/pixmaps

--- a/pkg/docker/org.cockpit-project.cockpit-docker.metainfo.xml
+++ b/pkg/docker/org.cockpit-project.cockpit-docker.metainfo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>org.cockpit_project.cockpit_docker</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <name>Docker Containers</name>
+  <summary>Manage your Docker containers</summary>
+  <description>
+    <p>
+      This tool manages Docker containers. With it, you can create,
+      monitor, and control Docker containers.
+    </p>
+  </description>
+  <extends>org.cockpit_project.cockpit</extends>
+  <launchable type="cockpit-manifest">docker</launchable>
+  <url type="homepage">https://cockpit-project.org/</url>
+  <update_contact>cockpit-devel_AT_lists.fedorahosted.org</update_contact>
+</component>

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -204,15 +204,17 @@ echo '%dir %{_datadir}/cockpit/playground' > tests.list
 find %{buildroot}%{_datadir}/cockpit/playground -type f >> tests.list
 
 %ifarch x86_64 %{arm} aarch64 ppc64le i686 s390x
-%if 0%{?fedora}
+%if 0%{?fedora} && 0%{?build_optional}
+%define build_docker 1
+%endif
+%endif
+
+%if 0%{?build_docker}
 echo '%dir %{_datadir}/cockpit/docker' > docker.list
 find %{buildroot}%{_datadir}/cockpit/docker -type f >> docker.list
 %else
 rm -rf %{buildroot}/%{_datadir}/cockpit/docker
-touch docker.list
-%endif
-%else
-rm -rf %{buildroot}/%{_datadir}/cockpit/docker
+rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
 touch docker.list
 %endif
 
@@ -250,6 +252,8 @@ rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib
 rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-machines.metainfo.xml
 # files from -storaged
 rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-storaged.metainfo.xml
+# files from -docker
+rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
 %endif
 
 sed -i "s|%{buildroot}||" *.list
@@ -626,8 +630,7 @@ bastion hosts, and a basic dashboard.
 
 %endif
 
-%ifarch x86_64 %{arm} aarch64 ppc64le i686 s390x
-%if 0%{?fedora}
+%if 0%{?build_docker}
 %package -n cockpit-docker
 Summary: Cockpit user interface for Docker containers
 Requires: cockpit-bridge >= %{required_base}
@@ -640,8 +643,7 @@ The Cockpit components for interacting with Docker and user interface.
 This package is not yet complete.
 
 %files -n cockpit-docker -f docker.list
-
-%endif
+%{_datadir}/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml
 %endif
 
 %package -n cockpit-packagekit

--- a/tools/debian/cockpit-docker.install
+++ b/tools/debian/cockpit-docker.install
@@ -1,1 +1,2 @@
 usr/share/cockpit/docker/
+usr/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml


### PR DESCRIPTION
Tested locally by adding the file to `usr/share/metainfo/org.cockpit-project.cockpit-docker.metainfo.xml`

Fixes #13416.