### PR TITLE
test: Fix excessive timeout in check-realms waitTooltip()

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -768,16 +768,18 @@ class TestPackageInstall(packagelib.PackageCase):
 
     def waitTooltip(self, text):
         b = self.browser
-        def check():
-            try:
-                b.wait_present("#system_information_domain_tooltip")
-                b.mouse("#system_information_domain_tooltip", "mouseover")
-                b.wait_in_text(".tooltip-inner", text)
-                b.mouse("#system_information_domain_tooltip", "mouseout")
-                return True
-            except:
-                return False
-        self.browser.wait(check)
+
+        # the wait_timeout affects both the waiting in b.mouse() and the b.wait() (times 5!), thus is quadratic
+        with b.wait_timeout(4):
+            def check():
+                try:
+                    b.mouse("#system_information_domain_tooltip", "mouseover")
+                    b.wait_in_text(".tooltip-inner", text)
+                    b.mouse("#system_information_domain_tooltip", "mouseout")
+                    return True
+                except (RuntimeError, Error):
+                    return False
+            b.wait(check)
 
     def testInstall(self):
         m = self.machine


### PR DESCRIPTION
The `b.mouse()` waits until the timeout, and the whole thing is retried
5*timeout times by b.wait(). When the test failed this led to timeouts of
half an hour due to that quadratic behaviour.

Lower the timeout to 4s, so that in total this waits 4*4*5=80s,
comparable to our standard 60s timeout.

Also drop the redundant wait_present() (mouse() already does that) and
avoid a blanket except:.

Fixes #13519