### PR TITLE
machines: Fix issue with Virtual Network being configured with a reserved address

### DIFF
--- a/pkg/machines/components/networks/createNetworkDialog.jsx
+++ b/pkg/machines/components/networks/createNetworkDialog.jsx
@@ -50,6 +50,8 @@ function validateParams(dialogValues) {
             validationFailed.netmask = _("Mask or Prefix Length should not be empty");
         else if (!utils.validateNetmask(dialogValues.netmask))
             validationFailed.netmask = _("Invalid IPv4 mask or prefix length");
+        else if (!utils.ipv4FirstUsableAddress(dialogValues.ipv4, dialogValues.netmask))
+            validationFailed.netmask = _("There are not any usable addresses within this subnet");
 
         if (dialogValues.ipv4DhcpEnabled) {
             if (isEmpty(dialogValues.ipv4DhcpRangeStart.trim()))
@@ -406,7 +408,7 @@ class CreateNetworkModal extends React.Component {
 
             this.setState({ createInProgress: true });
             networkCreate({
-                connectionName, name, forwardMode, device, ipv4, netmask, ipv6, prefix,
+                connectionName, name, forwardMode, device, ipv4: utils.ipv4FirstUsableAddress(ipv4, netmask), netmask, ipv6, prefix,
                 ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd
             })
                     .fail(exc => {

--- a/pkg/machines/components/networks/utils.js
+++ b/pkg/machines/components/networks/utils.js
@@ -229,3 +229,34 @@ export function isIpv6InNetwork(network, prefix, ip) {
 
     return network == ip;
 }
+
+/* If you take an IP address an apply the network mask (bitwise and) then you get the network address - no host can have such address
+ * This function returns the first usable address of the block
+ * @param {string} ipv4
+ * @param {string} netmask
+ */
+export function ipv4FirstUsableAddress(ipv4, netmask) {
+    // Within a subnet, two host addresses - all-zeros and one all-ones are reserved as network address and broadcast, respectively.
+    if (!ipv4)
+        return undefined;
+
+    let mask = netmask;
+    if (netmask.split(".").length == 4)
+        mask = netmaskToCIDR(netmask);
+    // For a /31 subnet the number of usable addresses is zero.
+    if (mask > 30)
+        return undefined;
+
+    return ipv4.split(".")
+            .map((item, index) => (item & netmask.split(".")[index]) + Number(index == 3))
+            .join(".");
+}
+
+function netmaskToCIDR(mask) {
+    const maskNodes = mask.match(/(\d+)/g);
+    let cidr = 0;
+    for (const i in maskNodes)
+        cidr += (((maskNodes[i] >>> 0).toString(2)).match(/1/g) || []).length;
+
+    return cidr;
+}

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -19,6 +19,7 @@
 
 import machineslib
 import parent
+import ipaddress
 from testlib import *
 
 TEST_NETWORK_XML = """
@@ -1182,6 +1183,8 @@ class TestMachinesDBus(machineslib.TestMachines):
                 self.xfail_objects = xfail_objects
                 self.xfail_error = xfail_error
                 self.remove = remove
+                if self.ip_conf and "4" in self.ip_conf and not self.xfail:
+                    self.host_addresses = list(ipaddress.ip_network("{0}/{1}".format(self.ipv4_address, self.ipv4_netmask)).hosts())
 
             def execute(self):
                 self.open()
@@ -1282,7 +1285,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
                 if (self.ip_conf != "None"):
                     if "4" in self.ip_conf:
-                        self.test_obj.assertEqual(self.ipv4_address, m.execute(xmllint_element.format(prop='ip/@address')).strip())
+                        self.test_obj.assertEqual(str(self.host_addresses[0]), m.execute(xmllint_element.format(prop='ip/@address')).strip())
                         self.test_obj.assertEqual(self.ipv4_netmask, m.execute(xmllint_element.format(prop='ip/@netmask')).strip())
                         if self.ipv4_dhcp_start and self.ipv4_dhcp_start:
                             self.test_obj.assertEqual(self.ipv4_dhcp_start, m.execute(xmllint_element.format(prop='ip/dhcp/range/@start')).strip())
@@ -1306,7 +1309,7 @@ class TestMachinesDBus(machineslib.TestMachines):
                 b.click("tbody tr[data-row-id=network-{0}-{1}] th".format(self.name, connectionName)) # open network tab
                 if self.ip_conf != "None":
                     if "4" in self.ip_conf:
-                        b.wait_in_text("#network-{0}-{1}-ipv4-address".format(self.name, connectionName), self.ipv4_address)
+                        b.wait_in_text("#network-{0}-{1}-ipv4-address".format(self.name, connectionName), str(self.host_addresses[0]))
                         b.wait_in_text("#network-{0}-{1}-ipv4-netmask".format(self.name, connectionName), self.ipv4_netmask)
                         if self.ipv4_dhcp_start and self.ipv4_dhcp_start:
                             b.wait_in_text("#network-{0}-{1}-ipv4-dhcp-range".format(self.name, connectionName), self.ipv4_dhcp_start + " - " + self.ipv4_dhcp_end)


### PR DESCRIPTION
When creating a Virtual Network make sure to use as 'address' the first
available host address calculated from the network IP and the netmask.

Use ipaddress python lib so that we can verify that the address got
correctly calculated in the tests.

Fixes #13506