### PR TITLE
[r82] Drop less markers from *.css imports

### DIFF
--- a/pkg/machines/machines.less
+++ b/pkg/machines/machines.less
@@ -1,8 +1,8 @@
-@import (less) "../lib/page.css";
+@import "../lib/page.css";
 @import "../lib/cards.less";
-@import (less) "../lib/table.css";
+@import "../lib/table.css";
 
-@import (less) "../../node_modules/c3/c3.css";
+@import "../../node_modules/c3/c3.css";
 
 // For patternfly-react and @patternfly/react-console
 @import "~xterm/lib/xterm.css";

--- a/pkg/shell/shell.less
+++ b/pkg/shell/shell.less
@@ -19,8 +19,8 @@
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-@import (less) "../lib/page.css";
-@import (less) "../lib/table.css";
+@import "../lib/page.css";
+@import "../lib/table.css";
 @import "variables.less";
 @import "switcher.less";
 @import "active-pages.less";


### PR DESCRIPTION
less ≥ 3.11 will try to look for a <filename>.less (e. g.
"page.css.less") which does not exist.

Cherry-picked from master commit 65dfb4fc17790