### PR TITLE
networking: Increase checkpoint settle time

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2088,8 +2088,8 @@ function choice_title(choices, choice, def) {
  *                          less patience than Linux in this regard.
  */
 
-var curtain_time = 1.5;
-var settle_time = 1.0;
+var curtain_time = 4.0;
+var settle_time = 3.0;
 var rollback_time = 7.0;
 
 function with_checkpoint(model, modify, options) {


### PR DESCRIPTION
Similar to commit f1d06abedaee50d, but bump it harder. Right after
starting the test and cockpit, the VMs are fairly loaded (particularly
rhel-8-2), so that eth0 does not get shut down quickly enough and the
checkpoint_destroy() succeeds. As a result, Cockpit just disconnects,
the curtain never comes up, and there is never a restore.

Fixes #13532