### PR TITLE
[8.2] test: Wait default time for machine to reboot

### DIFF
--- a/test/selenium/selenium-machines-basic.py
+++ b/test/selenium/selenium-machines-basic.py
@@ -50,7 +50,7 @@ class MachinesBasicTestSuite(MachinesLib):
             self.click(self.wait_css('#vm-{}-reboot-caret'.format(name), cond=clickable))
             self.click(self.wait_css('#vm-{}-forceReboot'.format(name), cond=clickable))
             wait(lambda: re.search("login:.*Initializing cgroup",
-                                   self.machine.execute("sudo cat {0}".format(args.get('logfile')))), tries=10)
+                                   self.machine.execute("sudo cat {0}".format(args.get('logfile')))))
 
         # Retry when running in edge
         # because the first operations will not take effect in some edge browser


### PR DESCRIPTION
Seems that just 10s don't cut the mustard all the time. Let's use
the default.

Cherry-picked from master: d100d3d (TODO: check after it lands)