### PR TITLE
machines: fix CPU statistics

### DIFF
--- a/pkg/machines/components/vm/vmUsageTab.jsx
+++ b/pkg/machines/components/vm/vmUsageTab.jsx
@@ -52,9 +52,7 @@ class VmUsageTab extends React.Component {
         available = available < 0 ? 0 : available;
 
         const totalCpus = vm.vcpus && vm.vcpus.count > 0 ? vm.vcpus.count : 0;
-        // 4 CPU system can have usage 400%, let's keep % between 0..100
-        let cpuUsage = vm.cpuUsage / (totalCpus > 0 ? totalCpus : 1);
-        cpuUsage = isNaN(cpuUsage) ? 0 : cpuUsage;
+        let cpuUsage = isNaN(vm.cpuUsage) ? 0 : vm.cpuUsage;
         cpuUsage = toFixedPrecision(cpuUsage, 1);
 
         logDebug(`VmUsageTab.render(): rssMem: ${rssMem} KiB, memTotal: ${memTotal} KiB, available: ${available} KiB, totalCpus: ${totalCpus}, cpuUsage: ${cpuUsage}`);

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -503,7 +503,14 @@ function parseDomstats(dispatch, connectionName, name, domstats) {
 
     const lines = parseLines(domstats);
 
-    const cpuTime = getValueFromLine(lines, 'cpu.time=');
+    let totalCpuTime = 0;
+    for (let i = 0; i < getValueFromLine(lines, 'vcpu.maximum='); i++) {
+        if (isNaN(getValueFromLine(lines, `vcpu.${i}.time=`)))
+            continue;
+        totalCpuTime += Number(getValueFromLine(lines, `vcpu.${i}.time=`));
+    }
+    const cpuTime = totalCpuTime / getValueFromLine(lines, 'vcpu.current=');
+
     // TODO: Add network usage statistics
     const retParams = { connectionName, name, actualTimeInMs, disksStats: parseDomstatsForDisks(lines) };
 


### PR DESCRIPTION
We would incorrecly divide cpuTime supplied by libvirt-dbus by number of
vCPUs to get an average of all vCPUs.
Number supplied by libvirt-dbus is already average.
This is probably caused by the fact that code was written for older
virsh provider, which supplied sum of all vCPUs times. Update virsh
provider too.

fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1763641