### PR TITLE
test: Robustify testSessionRecordingShell

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -333,10 +333,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m.execute("echo user:abcdefg | chpasswd")
         # this doesn't actually record anything, but logging into cockpit should work
         m.start_cockpit()
-        b.login_and_go(user="user", password="abcdefg")
+        b.login_and_go("/system", user="user", password="abcdefg")
+        b.wait_present("#restart-button[disabled][data-stable=yes]")
         b.logout()
 
         self.allow_journal_messages(".*value for the SHELL variable was not found the /etc/shells.*")
+        self.allow_authorize_journal_messages()
 
     def curl_auth(self, url, userpass):
         header = "Authorization: Basic " + base64.b64encode(userpass.encode()).decode()


### PR DESCRIPTION
Wait until the page built up instead of logging in and immediately out
again. login_and_go() does not wait very long, so that the subsequent
logout() can often cause a lot of unexpected message noise about
terminated channels and prematurely aborted resource loading.