### PR TITLE
systemd: Fix kernelopt.sh to recognize options at the beginning of line

### DIFF
--- a/pkg/systemd/kernelopt.sh
+++ b/pkg/systemd/kernelopt.sh
@@ -53,8 +53,8 @@ grub() {
     # on OSTree, the kernel config is inside the image
     elif cur=$(rpm-ostree kargs 2>&1); then
         if [ "$1" = set ]; then
-            # replace if already present
-            if [ "${cur% $key *}" != "$cur" ] || [ "${cur% $key=*}" != "$cur" ]; then
+            # replace if already present; can happen in the middle (must be separated by space) or at the beginning of line
+            if [ "${cur% $key *}" != "$cur" ] || [ "${cur% $key=*}" != "$cur" ] || [ "${cur#$key[ =]}" != "$cur" ]; then
                 rpm-ostree kargs --replace="$2"
             else
                 rpm-ostree kargs --append="$2"


### PR DESCRIPTION
In that case there won't be a space in front of the key. We still want
to retain that check to make sure that we don't catch a key which is a
suffix of the given one, so explicitly add a test for the key being at
the beginning of the line.

Current fedora-coreos exposes that, as the "mitigations=" option is the
very first one now.