### PR TITLE
avocado: Ensure that libvirtd.service is running for Machines tests

### DIFF
--- a/test/avocado/testlib_avocado/machineslib.py
+++ b/test/avocado/testlib_avocado/machineslib.py
@@ -164,6 +164,10 @@ class MachinesLib(SeleniumTest):
         self.storage_pool = {}
         self.vm_stop_list = []
 
+        self.machine.execute("sudo systemctl start libvirtd.service")
+        # Wait until we can get a list of domains
+        self.machine.execute("until virsh list > /dev/null; do sleep 0.5; done")
+
         self.login()
         self.click(self.wait_link('Virtual Machines', cond=clickable))
         self.wait_frame("machines")


### PR DESCRIPTION
The Selenium tests assume that libvirtd.service is already running (they
don't test the "no service" empy state). This is true for RHEL and
Fedora ≤ 30, but in Fedora 31 libvirt moved to being socket activated.
As the current code does not look at libvirtd.socket, just start the
service manually.

This only matters for the fedora-31/selenium tests, not for real-life
usage on RHEL 7, so we don't need to fix that on the Machines page on
this branch.

See https://github.com/cockpit-project/bots/pull/501 and
https://github.com/cockpit-project/cockpit/issues/13563 for details.