### PR TITLE
tools: add support for yocto

### DIFF
--- a/tools/git-version-gen
+++ b/tools/git-version-gen
@@ -10,9 +10,8 @@ if [ $# -ne 1 ]; then
 fi
 
 generate() {
-	if [ -e $BASE/../.git ]; then
-        cd $BASE/..
-		git describe | sed 's/-[0-9]\+-g.*/.x/'
+	if desc=$(git -C "$BASE/.." describe); then
+		echo "$desc" | sed 's/-[0-9]\+-g.*/.x/'
 	else
 		cat $1
 	fi


### PR DESCRIPTION
When the TAR sources are modified with Yocto (devtool modify) a temporary repository is created. Therefore the check must be extended to avoid errors.