### PR TITLE
test: Avoid RPM database corruption in testPackageKitCrash()

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -546,6 +546,11 @@ class TestUpdates(NoSubManCase):
         b = self.browser
         m = self.machine
 
+        # this tends to corrupt the rpm database, so do a backup/restore
+        if self.backend == 'dnf':
+            m.execute("cp -a /var/lib/rpm /var/lib/rpm.testbackup")
+            self.addCleanup(m.execute, "rm -rf /var/lib/rpm; mv /var/lib/rpm.testbackup /var/lib/rpm")
+
         # make sure we have enough time to crash PK
         self.createPackage("slow", "1", "1", install=True)
         # we don't want this installation to finish


### PR DESCRIPTION
Crashing PackageKit in the middle of an rpm install tends to corrupt the
RPM database (observed a lot on RHEL 8.2). Backup/restore it in that
test.