### PR TITLE
test: Be a bit less demanding on full CPU usage in metrics test

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -244,7 +244,7 @@ class TestMetrics(MachineCase):
         # first wait until system settles down
         wait(lambda: progressValue(1) < 20)
         m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done", "cpu_hog.log")
-        wait(lambda: progressValue(1) > 90)
+        wait(lambda: progressValue(1) > 75)
         m.execute("pkill -e -f cat.*urandom")
         # should go back to idle usage
         wait(lambda: progressValue(1) < 20)


### PR DESCRIPTION
On our shared infrastructure the VM's CPU usage often can't climb over
90%, and so TestMetrics.testOverview fails very often. Be content with
> 75%, it's enough to demonstrate that CPU usage is high.