### PR TITLE
test: Fix uninstalling of test packages on Debian

### DIFF
--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -147,7 +147,7 @@ class PackageCase(MachineCase):
         if install:
             cmd += "dpkg -i " + deb
         self.machine.execute(cmd)
-        self.addCleanup(self.machine.execute, "dpkg -P --force-depends %s 2>/dev/null || true" % name)
+        self.addCleanup(self.machine.execute, "dpkg -P --force-depends --force-remove-reinstreq %s 2>/dev/null || true" % name)
 
     def createRpm(self, name, version, release, requires, post, install, content, arch):
         '''Create a dummy rpm in repo_dir on self.machine


### PR DESCRIPTION
Sometimes the automatic uninstalling of our test packages failed on
Debina/Ubuntu, when testPackagekitCrash() killed PackageKit/dpkg on a
bad time:
```
dpkg: error processing package slow (--purge):
 package is in a very bad inconsistent state; you should
 reinstall it before attempting a removal
```

Use `--force-remove-reinstreq` to override this, so that it doesn't
bleed into and break the next test.