### PR TITLE
system: Fix breadcrumb on graphs subpages

### DIFF
--- a/pkg/systemd/graphs.html
+++ b/pkg/systemd/graphs.html
@@ -22,7 +22,7 @@
                         <nav class="pf-c-breadcrumb" aria-label="breadcrumb">
                             <ol class="pf-c-breadcrumb__list">
                                 <li class="pf-c-breadcrumb__item">
-                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link" id="system-link">Overview</a>
+                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link system-link">Overview</a>
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>
@@ -106,13 +106,13 @@
                         <nav class="pf-c-breadcrumb" aria-label="breadcrumb">
                             <ol class="pf-c-breadcrumb__list">
                                 <li class="pf-c-breadcrumb__item">
-                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link" id="system-link">Overview</a>
+                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link system-link">Overview</a>
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>
                                 </li>
                                 <li class="pf-c-breadcrumb__item">
-                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link" id="graphs-link">Usage Graphs</a>
+                                    <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link graphs-link">Usage Graphs</a>
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>

--- a/pkg/systemd/graphs.js
+++ b/pkg/systemd/graphs.js
@@ -468,8 +468,8 @@ $(function() {
     cpu_page = new PageCpuStatus();
     memory_page = new PageMemoryStatus();
 
-    $("#system-link").on("click", () => cockpit.jump('/system'));
-    $("#graphs-link").on("click", () => cockpit.jump('/system/graphs'));
+    $(".system-link").on("click", () => cockpit.jump('/system'));
+    $(".graphs-link").on("click", () => cockpit.jump('/system/graphs'));
 
     function navigate() {
         var path = cockpit.location.path;

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -184,7 +184,10 @@ class TestMetrics(MachineCase):
         b.wait_visible(".server-graph-legend .cpu-kernel")
 
         # go back to graphs overview
-        b.click("#graphs-link")
+        if m.image != "rhel-8-2-distropkg": # Changed in #13589
+            b.click(".graphs-link")
+        else:
+            b.click("#graphs-link")
         b.wait_visible(".ct-graph-memory")
         b.wait_visible(".ct-graph-cpu")
 
@@ -202,6 +205,13 @@ class TestMetrics(MachineCase):
         self.assertGreater(b.call_js_func(el_width, "#memory_status_graph"), 500)
         self.assertGreater(b.call_js_func(el_height, "#memory_status_graph"), 300)
         b.wait_visible(".server-graph-legend .memory-used")
+
+        # go back to overview
+        if m.image != "rhel-8-2-distropkg": # Changed in #13589
+            b.click("#complicated_graphs .system-link")
+            b.wait_not_visible("#memory_status_graph")
+            b.enter_page("/system")
+            b.wait_visible(".ct-overview-header-hostname")
 
     @skipImage("No PCP available", "fedora-coreos")
     def testPcp(self):


### PR DESCRIPTION
There were two elements with ID `system-link`. One was always hidden,
but since every ID needs to be unique, it was not behaving as expected.

Fixes #13578