### PR TITLE
test: Fix cleanup in TestStoragePackages.testNfsMissingPackages

### DIFF
--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -239,6 +239,7 @@ class TestStoragePackages(PackageCase, StorageHelpers):
         self.addCleanup(self.machine.execute, "rm /usr/share/cockpit/storaged/override.json")
 
         m.execute("mv /sbin/mount.nfs /sbin/mount.nfs.off")
+        self.addCleanup(m.execute, "mv /sbin/mount.nfs.off /sbin/mount.nfs")
 
         self.login_and_go("/storage")
 


### PR DESCRIPTION
Re-enable /sbin/mount.nfs after the test ran.