### PR TITLE
cockpituous: Stop releasing to Fedora 30

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -24,7 +24,6 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k master
-job release-koji f30
 job release-koji f31
 job release-koji f32
 
@@ -39,7 +38,6 @@ job release-dockerhub cockpit-project/cockpit-container
 job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
-job release-bodhi F30
 job release-bodhi F31
 job release-bodhi F32
 


### PR DESCRIPTION
Fedora 32 is around the corner, let's not burden ourselves with too many
parallel versions. Those users who want the latest stuff can upgrade to
Fedora 31 now.