### PR TITLE
test: Update documentation for moving tests to Fedora 31

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,6 @@ You can set these environment variables to configure the test suite:
                   "centos-8-stream"
                   "debian-stable"
                   "debian-testing"
-                  "fedora-30"
                   "fedora-31"
                   "fedora-coreos"
                   "fedora-testing"
@@ -78,7 +77,7 @@ You can set these environment variables to configure the test suite:
                   "rhel-atomic"
                   "ubuntu-1804"
                   "ubuntu-stable"
-               "fedora-30" is the default (bots/machine/machine_core/constants.py)
+               "fedora-31" is the default (bots/machine/machine_core/constants.py)
 
     TEST_DATA  Where to find and store test machine images.  The
                default is the same directory that this README file is in.

--- a/test/selenium/README.md
+++ b/test/selenium/README.md
@@ -12,19 +12,19 @@ Currently, these tests run on Fedora 30. Other images don't have selenium and
 avocado installed.
 
 ``` bash
-$ test/image-prepare fedora-30 # Install code to test
+$ test/image-prepare fedora-31 # Install code to test
 ```
 
 Run the [run-tests script](https://github.com/cockpit-project/cockpit/blob/master/test/selenium/run-tests) with appropriate parameters.
 
   - `bots/image-download services # Download a VM image with pre-installed selenium`
-  - `TEST_OS=fedora-30 test/selenium/run-tests --browser firefox -v`
+  - `TEST_OS=fedora-31 test/selenium/run-tests --browser firefox -v`
 
 Although this is the default way to run selenium tests the run-tests script is configurable and can be changed to run tests against different machines. This can be useful for developing or debugging tests. Check bellow the HACKING section for more details.
 
 ### Debugging tests:
 When running selenium tests with ``run-tests`` you can debug them in the following ways.
-  - Run just selected (one or more) tests via listing them on the command line, tests are relative to ``test/selenium/`` directory (for example: ``TEST_OS=fedora-30 test/selenium/run-tests --browser firefox -v selenium-base.py``) test filename is relative to ``test/selenium/`` directory
+  - Run just selected (one or more) tests via listing them on the command line, tests are relative to ``test/selenium/`` directory (for example: ``TEST_OS=fedora-31 test/selenium/run-tests --browser firefox -v selenium-base.py``) test filename is relative to ``test/selenium/`` directory
   - Pass ``--sit`` parameter to ``run-tests`` which will leave all test machines running after the tests finish.
   - Use own selenium grid via option ``--hub``
 


### PR DESCRIPTION
Selenium and the default OS were moved in
https://github.com/cockpit-project/bots/pull/501

fedora-30 testing was dropped in
https://github.com/cockpit-project/bots/pull/563