### PR TITLE
EdgeHTML: Un-shorthand grid-template-area

### DIFF
--- a/pkg/shell/switcher.scss
+++ b/pkg/shell/switcher.scss
@@ -518,7 +518,7 @@ $mobile-button-size: 56px;
         background: transparent;
         border: none;
 
-        grid-template:
+        grid-template-areas:
             "notmenu menu menu"
             "notheader notheader header";
 

--- a/pkg/systemd/graphs.scss
+++ b/pkg/systemd/graphs.scss
@@ -134,7 +134,7 @@
   &-container {
     --graph-padding: var(--pf-l-gallery--m-gutter--GridGap);
     display: grid;
-    grid-template: "title" "graph" "legend";
+    grid-template-areas: "title" "graph" "legend";
     grid-template-rows: max-content 1fr max-content;
     padding: var(--graph-padding);
     height: 100%;


### PR DESCRIPTION
Non-Chromium Edge doesn't support grid-template-area specification in grid-template. This is a feature bug in the browser (and other browsers support it fine).

The solution is to specify `grid-template-area` instead of `grid-template` when using named grid areas.