### PR TITLE
test: Cleanup fedora-testing skips

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -406,7 +406,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*/var/lib/cockpit/machines.json.*Permission denied")
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
-        if m.image in ["fedora-30", "fedora-testing", "centos-8-stream"]:
+        if m.image in ["fedora-30", "centos-8-stream"]:
             # older releases have more noise
             self.allow_journal_messages("sudo: .*setresuid.*: Operation not permitted")
             self.allow_journal_messages("sudo: no valid sudoers.*")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -300,7 +300,7 @@ class TestSystemInfo(MachineCase):
         b.wait_not_present(tooltip_sel)
 
     @skipImage("Uses timedatex, no NTP servers config", "rhel-8-2", "rhel-8-2-distropkg", "centos-8-stream",
-               "fedora-30", "fedora-testing")
+               "fedora-30")
     def testTimeServers(self):
         m = self.machine
         b = self.browser

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1480,7 +1480,7 @@ class TestMachines(NetworkCase):
         # name already used from a VM that is currently being created
         # https://bugzilla.redhat.com/show_bug.cgi?id=1780451
         # downloadOS option exists only in virt-install >= 2.2.1 which is the reason we have the condition for the OSes list below
-        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', 'fedora-testing', "centos-8-stream"]:
+        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', "centos-8-stream"]:
             self.browser.wait_not_present('select option[data-value="Download an OS"]')
         else:
             createDownloadAnOSTest(TestMachines.VmDialog(self, name='existing-name', sourceType='downloadOS',
@@ -1522,7 +1522,7 @@ class TestMachines(NetworkCase):
                                       {"Operating System": "You need to select the most closely matching Operating System"})
 
         # try to CREATE few machines
-        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', 'fedora-testing', "centos-8-stream"]:
+        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'fedora-30', "centos-8-stream"]:
             self.browser.wait_not_present('select option[data-value="Download an OS"]')
         else:
             createDownloadAnOSTest(TestMachines.VmDialog(self, sourceType='downloadOS',


### PR DESCRIPTION
These were there for when fedora-testing was based on fedora 30, but now
is based on fedora 31 and these conditions are obsolete.

  - [ ] actually move f-testing to F 31