### PR TITLE
test: Support podman in containers/check-bastion

### DIFF
--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -106,6 +106,7 @@ class TestBastion(MachineCase):
         m.execute("chown admin /home/admin/.ssh")
 
         m.upload([PUB_AUTH_KEY], "/home/admin/.ssh/authorized_keys")
+        m.execute("chown admin:admin /home/admin/.ssh/authorized_keys && chmod 600 /home/admin/.ssh/authorized_keys")
 
         # works with authorized key
         b.set_val("#login-password-input", "fubar")

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -41,12 +41,16 @@ class BastionContainerMachine(VirtMachine):
             extra = " -e COCKPIT_SSH_KEY_PATH='/var/secret/enc_rsa' -v /tmp/enc_rsa:/var/secret/enc_rsa"
             self.upload([AUTH_KEY], "/tmp")
 
-        self.execute("""#!/bin/sh
-            systemctl start docker
-            # HACK: Allow container to talk to the host
-            iptables -I INPUT 4 -i docker0 -j ACCEPT
-            /usr/bin/docker run -d -e G_MESSAGES_DEBUG=all -e COCKPIT_SSH_ALLOW_UNKNOWN=1{} -p 9090:9090 cockpit/bastion /usr/libexec/cockpit-ws --no-tls
-            """.format(extra))
+        if self.image == 'fedora-30':
+            self.execute("""#!/bin/sh
+                systemctl start docker
+                # HACK: Allow container to talk to the host
+                iptables -I INPUT 4 -i docker0 -j ACCEPT
+                /usr/bin/docker run -d -e G_MESSAGES_DEBUG=all -e COCKPIT_SSH_ALLOW_UNKNOWN=1{} -p 9090:9090 cockpit/bastion /usr/libexec/cockpit-ws --no-tls
+                """.format(extra))
+        else:
+            self.execute("podman run -d -e G_MESSAGES_DEBUG=all -e COCKPIT_SSH_ALLOW_UNKNOWN=1{} -p 9090:9090 "
+                         "cockpit/bastion /usr/libexec/cockpit-ws --no-tls """.format(extra))
         self.wait_for_cockpit_running(seconds=180)
 
 class TestBastion(MachineCase):


### PR DESCRIPTION
Use podman for Fedora ≥ 31.
That also doesn't need the iptables hack.

 - [x] Prepare fedora-31 image for container/podman tests: https://github.com/cockpit-project/bots/pull/562