### PR TITLE
test: Fix race condition in TestFirewall.testNetworkingPage

### DIFF
--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -47,6 +47,10 @@ class TestFirewall(NetworkCase):
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine
+        # on images with libvirt, wait until libvirt adds its zone (older versions don't do that yet), so that we get a stable count
+        if m.image not in ["debian-stable", "ubuntu-1804", "ubuntu-stable"]:
+            m.execute("until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done")
+
         active_zones = len(m.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split())
 
         if m.image not in ["rhel-8-2-distropkg"]: # Changed in #13555


### PR DESCRIPTION
firewalld and libvirt start up in parallel, and libvirtd asynchronously
adds its zone into firewalld after starting up. So wait until it did
that, so that we get a stable zone count.

Otherwise it often happened that the initial `--get-active-zones` did
not yet include the libvirt zone, and the later assertion about what's
shown on the Networking page failed due to a number mismatch.

Conditionalize the waiting on libvirt being available, as not all images
have it.