### PR TITLE
test: Introduce hard timeout for an individual test

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -36,6 +36,7 @@ import time
 import unittest
 import gzip
 import inspect
+import signal
 
 import testvm
 import cdp
@@ -57,6 +58,7 @@ __all__ = (
     'allowImage',
     'skipPackage',
     'enableAxe',
+    'timeout',
     'Error',
 
     'sit',
@@ -655,6 +657,7 @@ class MachineCase(unittest.TestCase):
     browser = None
     network = None
     journal_start = None
+    test_timeout_orig_sighand = None
 
     # provision is a dictionary of dictionaries, one for each additional machine to be created, e.g.:
     # provision = { 'openshift' : { 'image': 'openshift', 'memory_mb': 1024 } }
@@ -739,6 +742,28 @@ class MachineCase(unittest.TestCase):
                 return False
         return True
 
+    def armTestTimeout(self):
+        assert self.test_timeout_orig_sighand is None
+
+        # most tests should take much less than 10mins, so default to that;
+        # longer tests can be annotated with @timeout(seconds)
+        # check the test function first, fall back to the class'es timeout
+        test_method = getattr(self.__class__, self._testMethodName)
+        timeout = getattr(test_method, "__timeout", getattr(self, "__timeout", 600))
+
+        def timeout_handler(signum, frame):
+            raise Error("%s timed out after %is" % (self, timeout))
+
+        self.test_timeout_orig_sighand = signal.signal(signal.SIGALRM, timeout_handler)
+        signal.alarm(timeout)
+
+    def disarmTestTimeout(self):
+        # this may be called multiple times
+        if self.test_timeout_orig_sighand is not None:
+            signal.alarm(0)
+            signal.signal(signal.SIGALRM, self.test_timeout_orig_sighand)
+            self.test_timeout_orig_sighand = None
+
     def run(self, result=None):
         self.currentResult = result
 
@@ -751,7 +776,11 @@ class MachineCase(unittest.TestCase):
         max_retry_hard_limit = 10
         for retry in range(0, max_retry_hard_limit):
             try:
-                super().run(result)
+                self.armTestTimeout()
+                try:
+                    super().run(result)
+                finally:
+                    self.disarmTestTimeout()
             except RetryError as ex:
                 assert retry < max_retry_hard_limit
                 sys.stderr.write("{0}\n".format(ex))
@@ -821,6 +850,7 @@ class MachineCase(unittest.TestCase):
                     [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
                 else:
                     self.currentResult.printErrors()
+                self.disarmTestTimeout()
                 sit(self.machines)
         self.addCleanup(sitter)
 
@@ -1237,6 +1267,18 @@ def enableAxe(method):
         # first method argument is "self", a MachineCase instance
         args[0].browser.cdp.invoke("Page.addScriptToEvaluateOnNewDocument", source=script, no_trace=True)
         return method(*args)
+
+    return wrapper
+
+
+def timeout(seconds):
+    """Change default test timeout of 600s, for long running tests
+
+    Can be applied to an individual test method or the entire class.
+    """
+    def wrapper(testEntity):
+        testEntity.__timeout = seconds
+        return testEntity
 
     return wrapper
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -23,6 +23,7 @@ from testlib import *
 
 @skipImage("kexec-tools not installed", "fedora-coreos", "debian-stable",
            "debian-testing", "ubuntu-1804", "ubuntu-stable")
+@timeout(900)
 class TestKdump(MachineCase):
 
     def rreplace(self, s, old, new, count):

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -571,6 +571,7 @@ class TestMachines(NetworkCase):
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
 
     # Test Add Disk via dialog
+    @timeout(900)
     def testAddDisk(self):
         b = self.browser
         m = self.machine
@@ -1319,6 +1320,7 @@ class TestMachines(NetworkCase):
                                     ".*Connection reset by peer")
         self.allow_browser_errors("Disconnection timed out.")
 
+    @timeout(1200)
     def testCreate(self):
         """
         this test will print many expected error messages


### PR DESCRIPTION
In the past we had all too many tests which got stuck on mis-handling VM
boot timeouts, quadratic timeout loops, and similar. These are a bit
hard to spot.

Introduce a second line of defense and hard-limit each individual test
to 10 minutes.

The vast majority of our tests take less than 5 minutes. Some tests
legitimately take longer, though -- provide a `@timeout(seconds)`
decorator that can override the 10min default on a class or method
level. Mark the three tests which are known to take > 5 mins
accordingly.