### PR TITLE
test: Make check-accounts nondestructive

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -901,6 +901,9 @@ class MachineCase(unittest.TestCase):
         # ssh messages may be dropped when closing
         '10.*: dropping message while waiting for child to exit',
 
+        # pkg/packagekit/autoupdates.jsx backend check often gets interrupted by logout
+        "xargs: basename: terminated by signal 13",
+
         # SELinux messages to ignore
         "(audit: )?type=1403 audit.*",
         "(audit: )?type=1404 audit.*",

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -23,6 +23,7 @@ import parent
 from testlib import *
 
 
+@nondestructive
 class TestAccounts(MachineCase):
 
     def testBasic(self):
@@ -88,7 +89,8 @@ class TestAccounts(MachineCase):
         b.wait_present("#accounts-create")
 
         # Create a user from the UI
-        m.execute("sed -i 's/^SHELL=.*$/SHELL=\/bin\/true/' /etc/default/useradd")
+        m.execute("sed -i.bak 's/^SHELL=.*$/SHELL=\/bin\/true/' /etc/default/useradd")
+        self.addCleanup(m.execute, "mv {0}.bak {0}".format("/etc/default/useradd"))
         b.click('#accounts-create')
         b.wait_popup('accounts-create-dialog')
         b.set_val('#accounts-create-user-name', "berta")


### PR DESCRIPTION
Fortunately, commit dcb23b1ab2cb already does the heavy lifting.


----

I also added a second commit which fixes a common test flake. It's conceptually unrelated, but I ran into it twice locally, and indeed it also [happens on CI](https://logs.cockpit-project.org/logs/pull-532-20200217-071414-d7ba954f-ubuntu-1804-cockpit-project-cockpit/log.html) [quite often](https://logs.cockpit-project.org/logs/pull-554-20200224-070033-5f67f5d8-debian-stable-cockpit-project-cockpit/log.html#132).