### PR TITLE
test: Run translations tests on RHEL images

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -225,7 +225,7 @@ OnCalendar=daily
         # Test all languages
         # Test that pages do not oops and that locale is valid
 
-        if m.image not in [TEST_OS_DEFAULT]:
+        if m.image not in [TEST_OS_DEFAULT] and not m.image.startswith("rhel-"):
             return
 
         def line_sel(i):


### PR DESCRIPTION
Our stable branches don't run fedora-31, thus never validate translation
updates. Let's run them on rhel-* images as well to fix this.

 - [x] Add naughty: https://github.com/cockpit-project/bots/pull/584