### PR TITLE
Machines networking tests nondestructive

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -664,6 +664,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
         b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
 
+    @nondestructive
     def testNetworkSettings(self):
         b = self.browser
         m = self.machine
@@ -672,6 +673,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Create dummy network
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network".format(TEST_NETWORK_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network; virsh net-undefine test_network")
 
         # Create a second bridge to LAN NIC, virbr0 does not make sense but let's use it for test purposes
         m.execute("virsh attach-interface --persistent subVmTest1 bridge virbr0")
@@ -804,10 +806,14 @@ class TestMachinesDBus(machineslib.TestMachines):
         # Remove all Virtual Networks and confirm that trying to choose
         # Virtual Networks type for a NIC disables the save button
         m.execute("virsh net-dumpxml default > /tmp/net-default.xml")
+        self.addCleanup(m.execute, "rm /tmp/net-default.xml")
         m.execute("virsh net-dumpxml test_network > /tmp/net-test-network.xml")
+        self.addCleanup(m.execute, "rm /tmp/net-test-network.xml")
         m.execute("virsh net-destroy test_network && virsh net-destroy default")
+        self.addCleanup(m.execute, "virsh net-start default")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(1)", "0")
         m.execute("virsh net-undefine test_network && virsh net-undefine default")
+        self.addCleanup(m.execute, "virsh net-define /tmp/net-default.xml")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(2)", "0")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-count", "0")
 
@@ -819,6 +825,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Create a second bridge to LAN NIC
         m.execute("ip link add name br1 type bridge && virsh attach-interface --current subVmTest1 bridge br1")
+        self.addCleanup(m.execute, "ip link delete br1")
 
         # Open the modal dialog
         b.click("#vm-subVmTest1-network-1-edit-dialog")

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -906,12 +906,14 @@ class TestMachinesDBus(machineslib.TestMachines):
         autostartState = m.execute("virsh net-info test_network2 | grep 'Autostart:' | awk '{print $2}'").strip()
         self.assertEqual(autostartState, "yes")
 
+    @nondestructive
     def testNetworkState(self):
         b = self.browser
         m = self.machine
 
         # Create dummy network
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK2_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network2; virsh net-undefine test_network2 || true")
 
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1263,9 +1263,11 @@ class TestMachinesDBus(machineslib.TestMachines):
         # Check it's not present after deactivation
         b.wait_not_present("tbody tr[data-row-id=pool-myPoolThree-{0}] td.listing-ct-toggle".format(connectionName)) # click on the row header
 
+    @nondestructive
     def testNetworksCreate(self):
         b = self.browser
         m = self.machine
+        test_self = self
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
@@ -1376,6 +1378,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
                     self.cancel()
                 else:
+                    test_self.addCleanup(m.execute, "virsh net-destroy {0}; virsh net-undefine {0} || true".format(self.name))
                     b.wait_not_present("#create-network-dialog")
 
             def verify_dialog(self):

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -959,6 +959,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click(".modal-footer button:contains(Delete)")
         b.wait_not_present("tbody tr[data-row-id=network-test_network2-{0}] th".format(connectionName))
 
+    @nondestructive
     def testNetworks(self):
         b = self.browser
         m = self.machine
@@ -973,10 +974,13 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # Create dummy network
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK2_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network2; virsh net-undefine test_network2")
         b.wait_in_text(".cards-pf #card-pf-networks .card-pf-title-link", "Networks")
         b.wait_in_text(".cards-pf #card-pf-networks .card-pf-aggregate-status-count", "2")
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK3_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network3; virsh net-undefine test_network3")
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-create /tmp/xml".format(TEST_NETWORK4_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network4; virsh net-undefine test_network4 || true")
 
         # Click on Networks card
         b.click(".cards-pf .card-pf-title span:contains(Networks)")

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -2008,6 +2008,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         ).execute()
 
 
+    @nondestructive
     def testNICAdd(self):
         b = self.browser
         m = self.machine
@@ -2144,6 +2145,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_present("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
         # Test network type source
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network".format(TEST_NETWORK_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network; virsh net-undefine test_network")
 
         NICAddDialog(
             self,

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -858,12 +858,14 @@ class TestMachinesDBus(machineslib.TestMachines):
         m.execute("virsh undefine subVmTest1")
         b.wait_not_present("#vm-subVmTest1-network-1-edit-dialog")
 
+    @nondestructive
     def testNetworkAutostart(self):
         b = self.browser
         m = self.machine
 
         # Create dummy network
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK2_XML))
+        self.addCleanup(m.execute, "virsh net-destroy test_network2; virsh net-undefine test_network2")
 
         connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -988,6 +988,7 @@ class TestMachines(NetworkCase):
             expected_target=get_next_free_target(),
         ).execute()
 
+    @nondestructive
     def testVmNICs(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This is second batch of making machines tests nondestructive.
It fixes networking related tests. There are still 3 pools related, 4 disks related and testCreate.