### PR TITLE
machines: Bridge forward mode to support macvtap

### DIFF
--- a/pkg/lib/cockpit-components-selectable-listing.jsx
+++ b/pkg/lib/cockpit-components-selectable-listing.jsx
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import PropTypes from 'prop-types';
+import React from 'react';
+import './listing.scss';
+import '../../node_modules/@patternfly/patternfly/components/Check/check.scss';
+
+/* Implements PF4-compatible listing with clickable rows
+ * Intended for use in modal dialogs
+ *
+ * - rows {object}: with properties: name
+ * - onRowToggle {function}: toggle handler which takes row name as an argument
+ * - idPrefix {string}
+ */
+export const SelectableListing = ({ rows, onRowToggle, idPrefix }) => {
+    return (
+        <fieldset className="list-group dialog-list-ct pf-c-select" id={idPrefix + "-selectable-listing"}>
+            {rows.map(row => {
+                return (
+                    <label className="pf-c-check pf-c-select__menu-item" htmlFor={idPrefix + "-" + row.id} key={row.id}>
+                        <input className="pf-c-check__input"
+                            name="select-checkbox-expanded-active"
+                            onChange={() => onRowToggle(row.id)}
+                            type="checkbox"
+This conversation was marked as resolved by skobyda
+                            id={idPrefix + "-" + row.id}
+                            checked={row.selected} />
+                        <span className="pf-c-check__label">{row.name}</span>
+                    </label>);
+            })}
+        </fieldset>
+    );
+};
+
+SelectableListing.propTypes = {
+    rows: PropTypes.array,
+    idPrefix: PropTypes.string,
+    onRowToggle: PropTypes.func,
+};

--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -51,10 +51,19 @@ class App extends React.Component {
             notificationIdCnt: 0,
             path: cockpit.location.path,
         };
+        this.deviceProxyHandler = this.deviceProxyHandler.bind(this);
+        this.client = cockpit.dbus("org.freedesktop.NetworkManager", {});
+        this.deviceProxies = this.client.proxies("org.freedesktop.NetworkManager.Device");
+        this.deviceProxies.addEventListener('changed', this.deviceProxyHandler);
+        this.deviceProxies.addEventListener('removed', this.deviceProxyHandler);
         this.onAddErrorNotification = this.onAddErrorNotification.bind(this);
         this.onDismissErrorNotification = this.onDismissErrorNotification.bind(this);
         this.onNavigate = () => this.setState({ path: cockpit.location.path });
         this.onSuperuserChanged = this.onSuperuserChanged.bind(this);
+    }
+
+    deviceProxyHandler() {
+        this.forceUpdate();
     }
 
     componentDidMount() {
@@ -65,6 +74,7 @@ class App extends React.Component {
     componentWillUnmount() {
         cockpit.removeEventListener("locationchanged", this.onNavigate);
         superuser.removeEventListener("changed", this.onSuperuserChanged);
+        this.client.close();
     }
 
     onSuperuserChanged() {
@@ -216,6 +226,7 @@ class App extends React.Component {
                     actions={vmActions}
                     resourceHasError={this.state.resourceHasError}
                     onAddErrorNotification={this.onAddErrorNotification}
+                    hostDevices={this.deviceProxies}
                     nodeDevices={nodeDevices} />
                 }
                 {path.length > 0 && path[0] == 'vms' && vmContent}
@@ -234,6 +245,7 @@ class App extends React.Component {
                     onAddErrorNotification={this.onAddErrorNotification}
                     vms={vms}
                     nodeDevices={nodeDevices}
+                    hostDevices={this.deviceProxies}
                     interfaces={interfaces} />
                 }
             </>

--- a/pkg/machines/components/networks/network.jsx
+++ b/pkg/machines/components/networks/network.jsx
@@ -38,7 +38,7 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-export const getNetworkRow = ({ dispatch, network, onAddErrorNotification }) => {
+export const getNetworkRow = ({ dispatch, network, onAddErrorNotification, hostDevices }) => {
     const idPrefix = `${networkId(network.name, network.connectionName)}`;
     const name = (
         <span id={`${idPrefix}-name`}>
@@ -79,7 +79,7 @@ export const getNetworkRow = ({ dispatch, network, onAddErrorNotification }) => 
         {
             name: overviewTabName,
             renderer: NetworkOverviewTab,
-            data: { network, dispatch, }
+            data: { network, dispatch, hostDevices }
         },
     ];
 

--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -42,7 +42,7 @@ export class NetworkList extends React.Component {
     }
 
     render() {
-        const { dispatch, networks, resourceHasError, onAddErrorNotification, vms, nodeDevices, interfaces } = this.props;
+        const { dispatch, networks, resourceHasError, onAddErrorNotification, vms, nodeDevices, interfaces, hostDevices } = this.props;
         const sortFunction = (networkA, networkB) => networkA.name.localeCompare(networkB.name);
         const devices = getNetworkDevices(vms, nodeDevices, interfaces);
         const actions = (<CreateNetworkAction devices={devices} dispatch={dispatch} />);
@@ -82,7 +82,7 @@ export class NetworkList extends React.Component {
                                 emptyCaption={_("No network is defined on this host")}
                                 rows={networks
                                         .sort(sortFunction)
-                                        .map(network => getNetworkRow({ dispatch, network, resourceHasError, onAddErrorNotification }))
+                                        .map(network => getNetworkRow({ dispatch, network, resourceHasError, onAddErrorNotification, hostDevices }))
                                 } />
                         </CardBody>
                     </Card>
@@ -99,4 +99,5 @@ NetworkList.propTypes = {
     vms: PropTypes.array.isRequired,
     nodeDevices: PropTypes.array.isRequired,
     interfaces: PropTypes.array.isRequired,
+    hostDevices: PropTypes.array.isRequired,
 };

--- a/pkg/machines/components/networks/networkOverviewTab.jsx
+++ b/pkg/machines/components/networks/networkOverviewTab.jsx
@@ -76,7 +76,7 @@ export class NetworkOverviewTab extends React.Component {
         ip[0] = network.ip.find(ip => ip.family === "ipv4");
         ip[1] = network.ip.find(ip => ip.family === "ipv6");
         let interfaceDevices;
-        if (network.forward.interfaces && network.forward.interfaces.length > 0)
+        if (network.forward && network.forward.interfaces && network.forward.interfaces.length > 0)
             interfaceDevices = network.forward.interfaces.map(iface => iface.dev);
 
         return (

--- a/pkg/machines/components/vm/nics/vmNicsCard.jsx
+++ b/pkg/machines/components/vm/nics/vmNicsCard.jsx
@@ -22,7 +22,7 @@ import { Button } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
 import { changeNetworkState, getVm } from "../../../actions/provider-actions.js";
-import { rephraseUI, vmId } from "../../../helpers.js";
+import { rephraseUI, networkDeviceLink, vmId } from "../../../helpers.js";
 import AddNIC from './nicAdd.jsx';
 import { EditNICModal } from './nicEdit.jsx';
 import WarningInactive from '../../common/warningInactive.jsx';
@@ -143,6 +143,7 @@ export class VmNetworkTab extends React.Component {
     }
 
     render() {
+        const hostDevices = this.hostDevices;
         const { vm, dispatch, networks, nodeDevices, interfaces, onAddErrorNotification } = this.props;
         const id = vmId(vm.name);
         const availableSources = {
@@ -152,23 +153,6 @@ export class VmNetworkTab extends React.Component {
 
         const nicLookupByMAC = (interfacesList, mac) => {
             return interfacesList.filter(iface => iface.mac == mac)[0];
-        };
-
-        const checkDeviceAviability = (network) => {
-            for (const i in this.hostDevices) {
-                if (this.hostDevices[i].valid && this.hostDevices[i].Interface == network) {
-                    return true;
-                }
-            }
-            return false;
-        };
-
-        const sourceJump = (source) => {
-            return () => {
-                if (source !== null && checkDeviceAviability(source)) {
-                    cockpit.jump(`/network#/${source}`, cockpit.transport.host);
-                }
-            };
         };
 
         const onChangeState = (network) => {
@@ -237,11 +221,10 @@ export class VmNetworkTab extends React.Component {
             },
             {
                 name: _("Source"), value: (network, networkId) => {
-                    const sourceElem = source => checkDeviceAviability(source) ? <button role="link" className='machines-network-source-link link-button' onClick={sourceJump(source)}>{source}</button> : source;
                     const mapSource = {
-                        direct: (source) => sourceElem(source.dev),
-                        network: (source) => sourceElem(source.network),
-                        bridge: (source) => sourceElem(source.bridge),
+                        direct: (source) => networkDeviceLink(source.dev, hostDevices),
+                        network: (source) => networkDeviceLink(source.network, hostDevices),
+                        bridge: (source) => networkDeviceLink(source.bridge, hostDevices),
                         mcast: addressPortSource,
                         server: addressPortSource,
                         client: addressPortSource,

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -16,6 +16,8 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+import React from 'react';
+
 import cockpit from 'cockpit';
 import VMS_CONFIG from './config.js';
 
@@ -797,3 +799,33 @@ export function getNextAvailableTarget(existingTargets, busType) {
         i++;
     }
 }
+
+const checkDeviceAviability = (network, hostDevices) => {
+    for (const i in hostDevices) {
+        if (hostDevices[i].valid && hostDevices[i].Interface == network) {
+            return true;
+        }
+    }
+    return false;
+};
+
+const sourceJump = (source, hostDevices) => {
+    return () => {
+        if (source !== null && checkDeviceAviability(source, hostDevices)) {
+            cockpit.jump(`/network#/${source}`, cockpit.transport.host);
+        }
+    };
+};
+
+/**
+ * Provides redirection link to network device's page
+ *
+ * @param {string} source
+ * @param {array} hostDevices
+ * @return {DOMElement}
+ */
+export const networkDeviceLink = (source, hostDevices) => {
+    return (checkDeviceAviability(source, hostDevices)
+        ? <button role="link" className='machines-network-source-link link-button' onClick={sourceJump(source, hostDevices)}>{source}</button>
+        : source);
+};

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -678,11 +678,13 @@ export function parseNetDumpxml(netXml) {
 
     // if mode is not specified, "nat" is assumed, see https://libvirt.org/formatnetwork.html#elementsConnect
     if (forwardElem) {
-        const ifaceElem = forwardElem.getElementsByTagName("interface")[0];
-        if (ifaceElem)
-            retObj.interface = { interface: { dev: ifaceElem.getAttribute("dev") } };
+        const ifaceElems = forwardElem.getElementsByTagName("interface");
+        retObj.forward = { mode: (forwardElem.getAttribute("mode") || "nat"), interfaces: [] };
 
-        retObj.forward = { mode: (forwardElem.getAttribute("mode") || "nat") };
+        if (ifaceElems) {
+            for (let i = 0; i < ifaceElems.length; i++)
+                retObj.forward.interfaces.push({ dev: ifaceElems[i].getAttribute("dev") });
+        }
     }
 
     return retObj;

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1527,11 +1527,11 @@ export function networkActivate(connectionName, objPath) {
 }
 
 export function networkCreate({
-    connectionName, name, forwardMode, device, ipv4, netmask, ipv6, prefix,
+    connectionName, name, forwardMode, device, checkedIfaces, ipv4, netmask, ipv6, prefix,
     ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd
 }) {
     const netXmlDesc = getNetworkXML({
-        name, forwardMode, ipv4, netmask, ipv6, prefix, device,
+        name, forwardMode, ipv4, netmask, ipv6, prefix, device, checkedIfaces,
         ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd
     });
 

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -66,7 +66,7 @@ export function getIfaceXML(sourceType, source, model, mac) {
     return new XMLSerializer().serializeToString(doc.documentElement);
 }
 
-export function getNetworkXML({ name, forwardMode, device, ipv4, netmask, ipv6, prefix, ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd }) {
+export function getNetworkXML({ name, forwardMode, device, checkedIfaces, ipv4, netmask, ipv6, prefix, ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd }) {
     const doc = document.implementation.createDocument('', '', null);
 
     const networkElem = doc.createElement('network');
@@ -81,6 +81,14 @@ export function getNetworkXML({ name, forwardMode, device, ipv4, netmask, ipv6, 
         if ((forwardMode === 'nat' || forwardMode === 'route') && device !== 'automatic')
             forwardElem.setAttribute('dev', device);
         networkElem.appendChild(forwardElem);
+
+        if (forwardMode === 'bridge') {
+            checkedIfaces.forEach(iface => {
+                const interfaceElem = doc.createElement('interface');
+                interfaceElem.setAttribute('dev', iface);
+                forwardElem.appendChild(interfaceElem);
+            });
+        }
     }
 
     if (forwardMode === 'none' ||
@@ -93,7 +101,7 @@ export function getNetworkXML({ name, forwardMode, device, ipv4, netmask, ipv6, 
         networkElem.appendChild(domainElem);
     }
 
-    if (ipv4) {
+    if (ipv4 && forwardMode !== 'bridge') {
         const dnsElem = doc.createElement('dns');
         const hostElem = doc.createElement('host');
         hostElem.setAttribute('ip', ipv4);
@@ -121,7 +129,7 @@ export function getNetworkXML({ name, forwardMode, device, ipv4, netmask, ipv6, 
         }
     }
 
-    if (ipv6) {
+    if (ipv6 && forwardMode !== 'bridge') {
         const ipv6Elem = doc.createElement('ip');
         ipv6Elem.setAttribute('family', 'ipv6');
         ipv6Elem.setAttribute('address', ipv6);

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -53,7 +53,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         # Create dummy network
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK2_XML))
         b.wait_in_text("#card-pf-networks .card-pf-title-link", "2 Networks")
-        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK3_XML))
+        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml".format(TEST_NETWORK3_XML.format(getNetworkDevice(m))))
         m.execute("echo \"{0}\" > /tmp/xml && virsh net-create /tmp/xml".format(TEST_NETWORK4_XML))
 
         # Click on Networks card
@@ -69,7 +69,6 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_in_text("#network-test_network2-{0}-device".format(connectionName), "virbr1")
         b.wait_in_text("#network-test_network2-{0}-forwarding".format(connectionName), "None (isolated network)")
         b.wait_in_text("#network-test_network3-{0}-name".format(connectionName), "test_network3")
-        b.wait_in_text("#network-test_network3-{0}-device".format(connectionName), "br0")
         b.wait_in_text("#network-test_network3-{0}-forwarding".format(connectionName), "Bridge")
 
         # Expand row for first network
@@ -97,6 +96,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         # Check overview network properties are present
         b.wait_in_text("#network-test_network3-{0}-persistent".format(connectionName), "yes")
         b.wait_visible("#network-test_network3-{0}-autostart-checkbox:not(:checked)".format(connectionName))
+        b.wait_in_text("#network-test_network3-{0}-interfaces".format(connectionName), getNetworkDevice(m))
 
         # Check overview network properties are not present
         b.wait_not_present("#network-test_network3-{0}-ipv4-address".format(connectionName))

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -174,7 +174,10 @@ class TestMachinesNetworks(VirtualMachinesCase):
                     b.set_val("#create-network-forward-mode", self.forward_mode)
 
                 if self.device:
-                    b.select_from_dropdown("#create-network-device", self.device)
+                    if self.forward_mode == "bridge":
+                        b.click("#create-network-bridge-iface-{0}".format(self.device))
+                    else:
+                        b.select_from_dropdown("#create-network-device", self.device)
 
                 if self.ip_conf:
                     b.select_from_dropdown("#create-network-ip-configuration", self.ip_conf)
@@ -254,7 +257,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
                 if self.device:
                     self.test_obj.assertEqual(self.device, m.execute(xmllint_element.format(prop='forward/interface/@dev')).strip())
 
-                if (self.ip_conf != "None"):
+                if self.ip_conf and self.ip_conf != "None":
                     if "4" in self.ip_conf:
                         self.test_obj.assertEqual(self.ipv4_address, m.execute(xmllint_element.format(prop='ip/@address')).strip())
                         self.test_obj.assertEqual(self.ipv4_netmask, m.execute(xmllint_element.format(prop='ip/@netmask')).strip())
@@ -285,7 +288,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
                     if self.xfail_objects and 'danger_alert' in self.xfail_objects:
                         self.verify_expected_error_on_head(self.xfail_error)
 
-                if self.ip_conf != "None":
+                if self.ip_conf and self.ip_conf != "None":
                     if "4" in self.ip_conf:
                         b.wait_in_text("#network-{0}-{1}-ipv4-address".format(self.name, connectionName), self.ipv4_address)
                         b.wait_in_text("#network-{0}-{1}-ipv4-netmask".format(self.name, connectionName), self.ipv4_netmask)
@@ -454,7 +457,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
             xfail_error = "Address not within subnet",
         ).execute()
 
-        # Test network devices
+        # Test network NAT devices
         device = getNetworkDevice(m)
         NetworkCreateDialog(
             self,
@@ -480,6 +483,16 @@ class TestMachinesNetworks(VirtualMachinesCase):
             xfail_objects = ["ipv4_dhcp_start", "ipv4_dhcp_end"],
             xfail_error = "Address not within subnet",
         ).execute()
+
+        # Test network Bridge interface devices (macvtap)
+        device = getNetworkDevice(m)
+        NetworkCreateDialog(
+            self,
+            name="test_network",
+            forward_mode="bridge",
+            device=device,
+        ).execute()
+
 
     def testNetworkSettings(self):
         b = self.browser

--- a/test/verify/machinesxmls.py
+++ b/test/verify/machinesxmls.py
@@ -59,8 +59,9 @@ TEST_NETWORK2_XML = """
 TEST_NETWORK3_XML = """
 <network>
   <name>test_network3</name>
-  <forward mode='bridge'/>
-  <bridge name='br0'/>
+  <forward mode='bridge'>
+    <interface dev='{0}'/>
+  </forward>
 </network>
 """
 


### PR DESCRIPTION
This introduces another forward option for Virtual Network Creation: "bridge".
For this option IP configuration is not allowed. User however can choose one or multiple network devices to "be used as direct connection via macvtap" (https://libvirt.org/formatnetwork.html)

Solves: https://github.com/cockpit-project/cockpit/issues/13558

![Screenshot from 2020-02-28 15-25-45](https://user-images.githubusercontent.com/42733240/75556662-ea15f080-5a3e-11ea-95ea-71b31718bc79.png)
