### PR TITLE
test: Don't let global timeout interfere with testvm.Timeout, fix debian/ubuntu tests

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -813,7 +813,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         self.addCleanup(m.execute, "virsh net-start default")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(1)", "0")
         m.execute("virsh net-undefine test_network && virsh net-undefine default")
-        self.addCleanup(m.execute, "virsh net-define /tmp/net-default.xml")
+        self.addCleanup(m.execute, "virsh net-define /tmp/net-default.xml && virsh net-autostart default")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-notification:nth-of-type(2)", "0")
         b.wait_in_text("#card-pf-networks .card-pf-aggregate-status-count", "0")
 

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -224,7 +224,7 @@ def run(opts):
     details = "[{0}s on {1}]".format(duration, hostname)
     print()
     if result > 0:
-        print("# {0} TESTS FAILED {1}".format(result, duration))
+        print("# {0} TESTS FAILED {1}".format(result, details))
     else:
         print("# TESTS PASSED {0}".format(details))
     print("Test run finished, return code: {0}".format(result))

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -60,8 +60,7 @@ def finish_test(opts, test):
 
     Return (retry_reason, exit_code). retry_reason can be None or a string.
     """
-
-    if test.process.returncode != 1:
+    if test.process.returncode in [0, 77]:
         print_test(test, not opts.list)
         return None, 0
 

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -28,6 +28,7 @@ os.environ['PYTHONUNBUFFERED'] = '1'
 class Test:
     test_id: int
     command: list
+    timeout: int
     process: subprocess.Popen = None
     retries: int = 0
     output: bytes = b""
@@ -141,9 +142,13 @@ def run(opts):
             for test in test_suite:
                 test_method = getattr(test.__class__, test._testMethodName)
                 test_str = "{0}.{1}".format(test.__class__.__name__, test._testMethodName)
+                # most tests should take much less than 10mins, so default to that;
+                # longer tests can be annotated with @timeout(seconds)
+                # check the test function first, fall back to the class'es timeout
+                test_timeout = getattr(test_method, "__timeout", getattr(test, "__timeout", 600))
                 if opts.tests and not any([t in test_str for t in opts.tests]):
                     continue
-                test = Test(test_id, build_command(filename, test_str, opts))
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout)
                 if getattr(test_method, "_testlib__non_destructive", False):
                     serial_tests.append(test)
                 else:
@@ -178,7 +183,8 @@ def run(opts):
             if test:
                 made_progress = True
                 test.outfile = tempfile.TemporaryFile()
-                test.process = subprocess.Popen(test.command, stdout=test.outfile, stderr=subprocess.STDOUT)
+                test.process = subprocess.Popen(["timeout", str(test.timeout)] + test.command,
+                                                stdout=test.outfile, stderr=subprocess.STDOUT)
                 running_tests.append(test)
 
 


### PR DESCRIPTION
When writing commit 58e661870, I failed to notice
bots/machine/machine_core/timeout.py which also uses SIGALRM. Setting
one for each test breaks the `testvm.Timeout` invocations in the bots
machinery and various tests, as they would not set a timeout of their
own, and thus they all timed out after 10 mins instead of the originally
intended much shorter timeout.

Thus revert the part that sets an alarm in MachineCase, and move that to
test/verify/run-tests. Call the individual test through timeout(1), to
avoid using alarm() in the run-tests process as well (as handling the
global Machine instance also involves Timeouts).