### PR TITLE
test: Slow down sosreport a bit

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -38,8 +38,8 @@ class TestSOS(MachineCase):
         m.write("/etc/sos.conf",
                 """
 [general]
-only-plugins=release,date,host
-threads=2
+only-plugins=release,date,host,cgroups,networking
+threads=1
 """)
 
         if urlroot != "":


### PR DESCRIPTION
Only run one module in parallel and add two of the more expensive
modules. The previous configuration was so fast that there's a high
chance to not ever get a progress bar, which our test expects.