### PR TITLE
kdump: Apply width to the modal-dialog class instead of modal in kdump dialog

### DIFF
--- a/pkg/kdump/kdump.scss
+++ b/pkg/kdump/kdump.scss
@@ -30,7 +30,7 @@
     white-space: nowrap;
 }
 
-#kdump-settings-dialog {
+#kdump-settings-dialog .modal-dialog {
     width: 400px;
 }
 


### PR DESCRIPTION
The previous code led to the dialog being moved to the left side of the
screen.

Fixes #12771