### PR TITLE
networking: Add ipv6 methods 'disabled' and 'shared'

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1961,7 +1961,9 @@ var ipv6_method_choices =
         { choice: 'dhcp', title: _("Automatic (DHCP only)") },
         { choice: 'link-local', title: _("Link local") },
         { choice: 'manual', title: _("Manual") },
-        { choice: 'ignore', title: _("Ignore") }
+        { choice: 'ignore', title: _("Ignore") },
+        { choice: 'shared', title: _("Shared") },
+        { choice: 'disabled', title: _("Disabled") }
     ];
 
 var bond_mode_choices =


### PR DESCRIPTION
As of NetworkManager 1.20.0 'disabled' and 'shared' are valid ipv6.method
values.

Signed-off-by: Patrick Talbert <ptalbert@redhat.com>