### PR TITLE
test: Allow more sudo noise for SELinux restricted users

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -403,6 +403,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.logout()
         self.allow_authorize_journal_messages()
         # not allowed to restricted users
+        self.allow_journal_messages("sudo: setrlimit.*: Operation not permitted")
+        self.allow_journal_messages("sudo: unable to open /var/db/sudo: Permission denied")
         self.allow_journal_messages(".*/var/lib/cockpit/machines.json.*Permission denied")
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
@@ -410,7 +412,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             # older releases have more noise
             self.allow_journal_messages("sudo: .*setresuid.*: Operation not permitted")
             self.allow_journal_messages("sudo: no valid sudoers.*")
-            self.allow_journal_messages("sudo: unable to initialize policy plugin")
             self.allow_journal_messages("sudo: unable to initialize policy plugin")
             self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="pkexec".* scontext=user_u.*')
 


### PR DESCRIPTION
On Fedora 32, these cause some more messages.

Also remove a duplicated message.