### PR TITLE
firewall: Use ids for zones instead of names

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -147,7 +147,7 @@ function ZoneSection(props) {
         );
     } else {
         addServiceAction = (
-            <Button variant="primary" onClick={() => props.openServicesDialog(props.zone.id, props.zone.name)} className="add-services-button" aria-label={cockpit.format(_("Add services to zone $0"), props.zone.id)}>
+            <Button variant="primary" onClick={() => props.openServicesDialog(props.zone.id, props.zone.id)} className="add-services-button" aria-label={cockpit.format(_("Add services to zone $0"), props.zone.id)}>
                 {_("Add Services")}
             </Button>
         );
@@ -156,7 +156,7 @@ function ZoneSection(props) {
     return <div className="zone-section" data-id={props.zone.id}>
         <div className="zone-section-heading">
             <span>
-                <h4>{ cockpit.format(_("$0 Zone"), props.zone.name) }</h4>
+                <h4>{ cockpit.format(_("$0 zone"), props.zone.id) }</h4>
                 <div className="zone-section-targets">
                     { props.zone.interfaces.length > 0 && <span className="zone-section-target"><strong>{_("Interfaces")}</strong> {props.zone.interfaces.join(", ")}</span> }
                     { props.zone.source.length > 0 && <span className="zone-section-target"><strong>{_("Addresses")}</strong> {props.zone.source.join(", ")}</span> }
@@ -915,11 +915,7 @@ export class Firewall extends React.Component {
 
         var zones = [...this.state.firewall.activeZones].sort((z1, z2) =>
             z1 === firewall.defaultZone ? -1 : z2 === firewall.defaultZone ? 1 : 0
-        ).map(id => {
-            const zone = this.state.firewall.zones[id];
-            zone.name = zone.name || id;
-            return zone;
-        });
+        ).map(id => this.state.firewall.zones[id]);
 
         var enabled = this.state.pendingTarget !== null ? this.state.pendingTarget : this.state.firewall.enabled;
 

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -48,9 +48,11 @@ class TestFirewall(NetworkCase):
         if self.machine.image not in ["rhel-8-2-distropkg"]:
             self.btn_danger = "pf-m-danger"
             self.btn_primary = "pf-m-primary"
+            self.default_zone = "public zone"
         else:
             self.btn_danger = "btn-danger"
             self.btn_primary = "btn-primary"
+            self.default_zone = "Public Zone"
 
     def testNetworkingPage(self):
         b = self.browser
@@ -113,7 +115,7 @@ class TestFirewall(NetworkCase):
             self.wait_onoff("#firewall-heading-title-group", False)
             wait_unit_state(m, "firewalld", "active")
             # Wait until the default zone is listed
-            b.wait_in_text("#zones-listing .zone-section[data-id='public']", "public Zone")
+            b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
             b.wait_present("#add-zone-button:disabled")
             # "Add Services" button should be disabled
             b.wait_present(".zone-section[data-id='public'] .add-services-button:disabled")
@@ -132,7 +134,7 @@ class TestFirewall(NetworkCase):
         wait_unit_state(m, "firewalld", "active")
 
         # Wait until the default zone is listed
-        b.wait_in_text("#zones-listing .zone-section[data-id='public']", "Public Zone")
+        b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
 
         # "Add Services" button should be enabled
         b.wait_present(".zone-section[data-id='public'] .add-services-button:enabled")
@@ -173,7 +175,7 @@ class TestFirewall(NetworkCase):
         m = self.machine
 
         self.login_and_go("/network/firewall")
-        b.wait_in_text("#zones-listing .zone-section[data-id='public']", "Public Zone")
+        b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
 
         # add a service to the runtime configuration via the cli, after all the
         # operations it should still be there, indicating no reload took place
@@ -276,7 +278,7 @@ class TestFirewall(NetworkCase):
         m = self.machine
 
         self.login_and_go("/network/firewall")
-        b.wait_in_text("#zones-listing .zone-section[data-id='public']", "Public Zone")
+        b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
         # wait until all zones are present, including the ones added at runtime
         if m.image in ["rhel-8-2", "fedora-31", "fedora-testing", "fedora-32"]:
             b.wait_present("#zones-listing .zone-section[data-id='libvirt']")
@@ -414,14 +416,14 @@ class TestFirewall(NetworkCase):
             b.wait_not_present(".zone-section[data-id='{}']".format(zone))
 
         self.login_and_go("/network/firewall")
-        b.wait_in_text("#zones-listing .zone-section[data-id='public']", "Public Zone")
+        b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
 
         # add predefined work zone
         addZone("work", sources="192.168.1.0/24")
 
         addServiceToZone("pop3", "work")
         b.wait_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
-        self.assertNotIn("Public", b.text("tr[data-row-id='pop3']"))
+        self.assertNotIn(self.default_zone.split(" ")[0], b.text("tr[data-row-id='pop3']"))
         addServiceToZone("pop3", "public")
         b.wait_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 


### PR DESCRIPTION
Both the cli and gui of firewalld use the zone id, and not the name to
identify zones. Cockpit should do the same to avoid confusion.