### PR TITLE
[8.2] Adjust to new version of eslint

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -530,8 +530,7 @@ class AddServicesModal extends React.Component {
                                                                                                 onChange={this.onToggleService} /> }
                                                                         stacked
                                                                         heading={ <label htmlFor={"firewall-service-" + s.id}>{s.name}</label> }
-                                                                        description={ renderPorts(s) }>
-                                                            </ListView.Item>
+                                                                        description={ renderPorts(s) } />
                                                         ))
                                                     }
                                                 </ListView>

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -199,8 +199,7 @@ class CPUSecurityMitigationsDialog extends React.Component {
                 </small></span> }
                                actions={ <div id="nosmt-switch">
                                    <OnOffSwitch disabled={this.state.rebooting} onChange={ value => this.setState({ nosmt: value }) } state={ this.state.nosmt } />
-                               </div> }>
-                </ListView.Item>
+                               </div> } />
             ));
 
         return (


### PR DESCRIPTION
New version of `eslint-plugin-react` was released and it was reporting
these two cases as `Empty components are self-closing`.

Cherry-picked from master commit 8940569939