### PR TITLE
packagekit: Leave some space between "available" and "history" tables

### DIFF
--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -34,6 +34,7 @@
 /* override default cockpit CSS, as this doesn't fit our table */
 table.listing-ct {
     margin-top: 0;
+    margin-bottom: 3rem;
     width: 100%;
 }
 


### PR DESCRIPTION
This apparently got lost somewhere in the PF4 conversion.

Current master:
![updates-master](https://user-images.githubusercontent.com/200109/76171647-d7619100-618d-11ea-9ed4-c07a85f9fd09.png)

With this fix:
![updates-fix](https://user-images.githubusercontent.com/200109/76171649-da5c8180-618d-11ea-9d07-8745f3ca7c3b.png)
