### PR TITLE
systemd: Turn crash reporting cancel button into secondary

### DIFF
--- a/pkg/systemd/reporting.jsx
+++ b/pkg/systemd/reporting.jsx
@@ -415,7 +415,7 @@ function WorkflowRow(props) {
     if (props.problemState === ProblemState.REPORTING) {
         button = (
             <Button key={"cancel_" + props.label}
-                    variant="danger"
+                    variant="secondary"
                     onClick={props.onCancelButtonClick}>
                 {_("Cancel")}
             </Button>


### PR DESCRIPTION
Cancel button should not be "danger".