### PR TITLE
Empty state factorization

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -20,6 +20,8 @@
 import React from 'react';
 import cockpit from 'cockpit';
 
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+
 import $ from "jquery";
 import { docker } from './docker';
 import { atomic } from './atomic';
@@ -28,6 +30,7 @@ import { search } from "./search";
 
 import * as Listing from 'cockpit-components-listing.jsx';
 import * as Select from 'cockpit-components-select.jsx';
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import moment from 'moment';
 
 const _ = cockpit.gettext;
@@ -487,16 +490,8 @@ export class ImageInline extends React.Component {
     render() {
         var image = this.props.image;
 
-        if (!image) {
-            return (
-                <div className="curtains-ct blank-slate-pf">
-                    <div className="blank-slate-pf-icon">
-                        <i className="fa fa-exclamation-circle" />
-                    </div>
-                    <h1>{_("This image does not exist.")}</h1>
-                </div>
-            );
-        }
+        if (!image)
+            return <EmptyStatePanel icon={ExclamationCircleIcon} title={ _("This image does not exist.") } />;
 
         var vulnerableInfo = this.state.vulnerableInfos[image.Id.replace(/^sha256:/, '')];
 

--- a/pkg/lib/cockpit-components-empty-state.css
+++ b/pkg/lib/cockpit-components-empty-state.css
@@ -1,5 +1,3 @@
-@import "../../node_modules/@patternfly/patternfly/components/Spinner/spinner.css";
-
 .pf-c-empty-state .pf-c-button.pf-m-primary.slim {
     margin: 0px;
 }

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -31,23 +31,21 @@ import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import "./cockpit-components-empty-state.css";
 
-export class EmptyStatePanel extends React.Component {
-    render() {
-        const slimType = this.props.title || this.props.paragraph ? "" : "slim";
-        return (
-            <EmptyState variant={EmptyStateVariant.full}>
-                { this.props.showIcon && (this.props.loading ? <Spinner size="xl" /> : <EmptyStateIcon icon={ExclamationCircleIcon} />) }
-                <Title headingLevel="h5" size="lg">
-                    {this.props.title}
-                </Title>
-                <EmptyStateBody>
-                    {this.props.paragraph}
-                </EmptyStateBody>
-                {this.props.action && <Button variant="primary" className={slimType} onClick={this.props.onAction}>{this.props.action}</Button>}
-            </EmptyState>
-        );
-    }
-}
+export const EmptyStatePanel = ({ title, paragraph, loading, showIcon, action, onAction }) => {
+    const slimType = title || paragraph ? "" : "slim";
+    return (
+        <EmptyState variant={EmptyStateVariant.full}>
+            { showIcon && (loading ? <Spinner size="xl" /> : <EmptyStateIcon icon={ExclamationCircleIcon} />) }
+            <Title headingLevel="h5" size="lg">
+                {title}
+            </Title>
+            <EmptyStateBody>
+                {paragraph}
+            </EmptyStateBody>
+            { action && <Button variant="primary" className={slimType} onClick={onAction}>{action}</Button> }
+        </EmptyState>
+    );
+};
 
 EmptyStatePanel.propTypes = {
     loading: PropTypes.bool,

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -28,14 +28,14 @@ import {
     EmptyStateBody,
 } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import "./cockpit-components-empty-state.css";
 
-export const EmptyStatePanel = ({ title, paragraph, loading, showIcon, action, onAction }) => {
+export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAction }) => {
     const slimType = title || paragraph ? "" : "slim";
     return (
         <EmptyState variant={EmptyStateVariant.full}>
-            { showIcon && (loading ? <Spinner size="xl" /> : <EmptyStateIcon icon={ExclamationCircleIcon} />) }
+            { loading && <Spinner size="xl" /> }
+            { icon && <EmptyStateIcon icon={icon} /> }
             <Title size="lg">
                 {title}
             </Title>
@@ -49,7 +49,7 @@ export const EmptyStatePanel = ({ title, paragraph, loading, showIcon, action, o
 
 EmptyStatePanel.propTypes = {
     loading: PropTypes.bool,
-    showIcon: PropTypes.bool,
+    icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     title: PropTypes.string,
     paragraph: PropTypes.string,
     action: PropTypes.string,

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -26,11 +26,12 @@ import {
     EmptyStateVariant,
     EmptyStateIcon,
     EmptyStateBody,
+    EmptyStateSecondaryActions,
 } from '@patternfly/react-core';
 import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import "./cockpit-components-empty-state.css";
 
-export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAction }) => {
+export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAction, secondary }) => {
     const slimType = title || paragraph ? "" : "slim";
     return (
         <EmptyState variant={EmptyStateVariant.full}>
@@ -43,6 +44,7 @@ export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAct
                 {paragraph}
             </EmptyStateBody>
             { action && <Button variant="primary" className={slimType} onClick={onAction}>{action}</Button> }
+            { secondary && <EmptyStateSecondaryActions>{secondary}</EmptyStateSecondaryActions> }
         </EmptyState>
     );
 };
@@ -54,4 +56,5 @@ EmptyStatePanel.propTypes = {
     paragraph: PropTypes.string,
     action: PropTypes.string,
     onAction: PropTypes.func,
+    secondary: PropTypes.arrayOf(PropTypes.object),
 };

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -36,7 +36,7 @@ export const EmptyStatePanel = ({ title, paragraph, loading, showIcon, action, o
     return (
         <EmptyState variant={EmptyStateVariant.full}>
             { showIcon && (loading ? <Spinner size="xl" /> : <EmptyStateIcon icon={ExclamationCircleIcon} />) }
-            <Title headingLevel="h5" size="lg">
+            <Title size="lg">
                 {title}
             </Title>
             <EmptyStateBody>

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -27,22 +27,16 @@ import {
     EmptyStateIcon,
     EmptyStateBody,
 } from '@patternfly/react-core';
+import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import "./cockpit-components-empty-state.css";
 
 export class EmptyStatePanel extends React.Component {
     render() {
-        const Spinner = () => (
-            <span className="pf-c-spinner" role="progressbar" aria-valuetext="Loading...">
-                <span className="pf-c-spinner__clipper" />
-                <span className="pf-c-spinner__lead-ball" />
-                <span className="pf-c-spinner__tail-ball" />
-            </span>
-        );
         const slimType = this.props.title || this.props.paragraph ? "" : "slim";
         return (
             <EmptyState variant={EmptyStateVariant.full}>
-                {this.props.showIcon && (this.props.loading ? <EmptyStateIcon variant="container" component={Spinner} /> : <EmptyStateIcon icon={ExclamationCircleIcon} />)}
+                { this.props.showIcon && (this.props.loading ? <Spinner size="xl" /> : <EmptyStateIcon icon={ExclamationCircleIcon} />) }
                 <Title headingLevel="h5" size="lg">
                     {this.props.title}
                 </Title>

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -32,6 +32,8 @@ import firewall from "./firewall-client.js";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import { ModalError } from "cockpit-components-inline-notification.jsx";
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import "page.scss";
 import "table.css";
@@ -39,16 +41,6 @@ import "form-layout.scss";
 import "./networking.css";
 
 const _ = cockpit.gettext;
-
-function EmptyState(props) {
-    return (
-        <div className="curtains-ct blank-slate-pf">
-            {props.icon && <div className={"blank-slate-pf-icon " + props.icon} />}
-            <h1>{props.title}</h1>
-            {props.children}
-        </div>
-    );
-}
 
 function ServiceRow(props) {
     var tcp = props.service.ports.filter(p => p.protocol.toUpperCase() == 'TCP');
@@ -882,11 +874,9 @@ export class Firewall extends React.Component {
         }
 
         if (!this.state.firewall.installed) {
-            return (
-                <EmptyState title={_("Firewall is not available")} icon="fa fa-exclamation-circle">
-                    <p>{cockpit.format(_("Please install the $0 package"), "firewalld")}</p>
-                </EmptyState>
-            );
+            return <EmptyStatePanel title={ _("Firewall is not available") }
+                                    paragraph={ cockpit.format(_("Please install the $0 package"), "firewalld") }
+                                    icon={ ExclamationCircleIcon } />;
         }
 
         var addZoneAction;

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -24,13 +24,13 @@ import ReactDOM from 'react-dom';
 
 import moment from "moment";
 import { OverlayTrigger, Tooltip } from "patternfly-react";
-import { Button, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
-import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
+import { Button } from '@patternfly/react-core';
 import { RebootingIcon, CheckIcon, ExclamationCircleIcon } from "@patternfly/react-icons";
 import { Remarkable } from "remarkable";
 import AutoUpdates from "./autoupdates.jsx";
 import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import * as PK from "packagekit.js";
 
@@ -496,23 +496,20 @@ class ApplyUpdates extends React.Component {
     }
 }
 
-const AskRestart = ({ onIgnore, onRestart, history }) => (
-    <EmptyState variant={EmptyStateVariant.full}>
-        <EmptyStateIcon icon={RebootingIcon} />
-        <Title headingLevel="h1" size="lg">{_("Restart Recommended")}</Title>
-        <EmptyStateBody>{_("Updated packages may require a restart to take effect.")}</EmptyStateBody>
+const AskRestart = ({ onIgnore, onRestart, history }) => <>
+    <EmptyStatePanel icon={RebootingIcon}
+                     title={ _("Restart Recommended") }
+                     paragraph={ _("Updated packages may require a restart to take effect.") }
+                     action={ _("Restart Now") }
+                     onAction={ onRestart}
+                     secondary={ [<Button key="ignore" variant="secondary" onClick={onIgnore}>{_("Ignore")}</Button>] } />
 
-        <Button variant="secondary" onClick={onIgnore}>{_("Ignore")}</Button>
-        &nbsp;
-        <Button variant="primary" onClick={onRestart}>{_("Restart Now")}</Button>
-
-        <div className="flow-list-blank-slate">
-            <Expander title={_("Package information")}>
-                <PackageList packages={history[0]} />
-            </Expander>
-        </div>
-    </EmptyState>
-);
+    <div className="flow-list-blank-slate">
+        <Expander title={_("Package information")}>
+            <PackageList packages={history[0]} />
+        </Expander>
+    </div>
+</>;
 
 class OsUpdates extends React.Component {
     constructor() {
@@ -796,15 +793,12 @@ class OsUpdates extends React.Component {
                 }
             });
 
-            return (
-                <EmptyState variant={EmptyStateVariant.full}>
-                    <EmptyStateIcon icon={ExclamationCircleIcon} />
-                    <Title headingLevel="h1" size="lg">{_("This system is not registered")}</Title>
-                    <EmptyStateBody>{_("To get software updates, this system needs to be registered with Red Hat, either using the Red Hat Customer Portal or a local subscription server.")}</EmptyStateBody>
-                    <Button variant="primary" onClick={ () => cockpit.jump("/subscriptions", cockpit.transport.host) }>
-                        {_("Register…")}
-                    </Button>
-                </EmptyState>);
+            return <EmptyStatePanel
+                title={_("This system is not registered")}
+                paragraph={ _("To get software updates, this system needs to be registered with Red Hat, either using the Red Hat Customer Portal or a local subscription server.") }
+                icon={ExclamationCircleIcon}
+                action={ _("Register…") }
+                onAction={ () => cockpit.jump("/subscriptions", cockpit.transport.host) } />;
         }
 
         switch (this.state.state) {
@@ -829,7 +823,7 @@ class OsUpdates extends React.Component {
                     </div>
                 );
             else
-                return <div className="spinner spinner-lg progress-main-view" />;
+                return <EmptyStatePanel loading />;
 
         case "available":
             {
@@ -925,12 +919,8 @@ class OsUpdates extends React.Component {
 
         case "restart":
             page_status.set_own(null);
-            return (
-                <EmptyState variant={EmptyStateVariant.full}>
-                    <Spinner size="xl" />
-                    <Title headingLevel="h1" size="lg">{_("Restarting")}</Title>
-                    <EmptyStateBody>{_("Your server will close the connection soon. You can reconnect after it has restarted.")}</EmptyStateBody>
-                </EmptyState>);
+            return <EmptyStatePanel loading title={ _("Restarting") }
+                                    paragraph={ _("Your server will close the connection soon. You can reconnect after it has restarted.") } />;
 
         case "uptodate":
             page_status.set_own({
@@ -944,10 +934,7 @@ class OsUpdates extends React.Component {
             return (
                 <>
                     <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } />
-                    <EmptyState variant={EmptyStateVariant.full}>
-                        <EmptyStateIcon icon={CheckIcon} />
-                        <Title headingLevel="h1" size="lg">{_("System is up to date")}</Title>
-                    </EmptyState>
+                    <EmptyStatePanel icon={CheckIcon} title={ _("System is up to date") } />
 
                     { // automatic updates are not tracked by PackageKit, hide history when they are enabled
                         (this.state.autoUpdatesEnabled !== undefined) &&

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -272,20 +272,6 @@ tr.security.listing-ct-item {
     }
 }
 
-.blank-slate-pf {
-    /* PatternFly empty state has a gray background which we don't want here */
-    background: inherit;
-    border: none;
-
-    /* standard blank-slate-pf does not limit width of paragraph, which looks ugly */
-    p {
-        max-width: 50rem;
-        margin: 0 auto;
-        text-align: center;
-    }
-}
-
-
 .flow-list-blank-slate {
     padding-top: 8em;
     margin: 0 auto;

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -21,10 +21,12 @@ import cockpit from "cockpit";
 
 import React from "react";
 import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
 
 import * as cockpitListing from "cockpit-components-listing.jsx";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import { Modifications } from "cockpit-components-modifications.jsx";
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 const _ = cockpit.gettext;
 
@@ -67,15 +69,12 @@ class SELinuxEventDetails extends React.Component {
     render() {
         if (!this.props.details) {
             // details should be requested by default, so we just need to wait for them
-            var waiting = (this.props.details === undefined);
-            return (
-                <EmptyState
-                    icon={ waiting ? 'waiting' : 'error' }
-                    description={ waiting ? _("Waiting for details...") : _("Unable to get alert details.") }
-                    message={null}
-                    relative />
-            );
+            if (this.props.details === undefined)
+                return <EmptyStatePanel loading title={ _("Waiting for details...") } />;
+            else
+                return <EmptyStatePanel icon={ExclamationCircleIcon} title={ _("Unable to get alert details.") } />;
         }
+
         var self = this;
         var fixEntries = this.props.details.pluginAnalysis.map(function(itm, itmIdx) {
             var fixit = null;
@@ -159,68 +158,22 @@ class SELinuxEventDetails extends React.Component {
 }
 
 /* Show the audit log events for an alert */
-class SELinuxEventLog extends React.Component {
-    render() {
-        if (!this.props.details) {
-            // details should be requested by default, so we just need to wait for them
-            var waiting = (this.props.details === undefined);
-            return (
-                <EmptyState
-                    icon={ waiting ? 'waiting' : 'error' }
-                    description={ waiting ? _("Waiting for details...") : _("Unable to get alert details.") }
-                    message={null}
-                    relative />
-            );
-        }
-        var self = this;
-        var logEntries = this.props.details.auditEvent.map(function(itm, idx) {
-            // use the alert id and index in the event log array as the data key for react
-            // if the log becomes dynamic, the entire log line might need to be considered as the key
-            return (<div key={ self.props.details.localId + "." + idx }>{itm}</div>);
-        });
-        return (
-            <div className="setroubleshoot-log">{logEntries}</div>
-        );
+const SELinuxEventLog = ({ details }) => {
+    if (!details) {
+        // details should be requested by default, so we just need to wait for them
+        if (details === undefined)
+            return <EmptyStatePanel loading title={ _("Waiting for details...") } />;
+        else
+            return <EmptyStatePanel icon={ExclamationCircleIcon} title={ _("Unable to get alert details.") } />;
     }
-}
 
-/* Implements a subset of the PatternFly Empty State pattern
- * https://www.patternfly.org/v3/pattern-library/communication/empty-state/index.html
- * Special values for icon property:
- *   - 'waiting' - display spinner
- *   - 'error'   - display error icon
- */
-class EmptyState extends React.Component {
-    render() {
-        var description = null;
-        if (this.props.description)
-            description = <h1>{this.props.description}</h1>;
-
-        var message = null;
-        if (this.props.message)
-            message = <p>{this.props.message}</p>;
-
-        var curtains = "curtains-ct";
-        if (this.props.relative)
-            curtains = "curtains-relative";
-
-        var icon = this.props.icon;
-        if (icon == 'waiting')
-            icon = <div className="spinner spinner-lg" />;
-        else if (icon == 'error')
-            icon = <div className="pficon pficon-error-circle-o" />;
-
-        return (
-            <div className={ curtains + " blank-slate-pf" }>
-                <div className="blank-slate-pf-icon">
-                    {icon}
-                </div>
-                {description}
-                {message}
-            </div>
-        );
-    }
-}
+    const logEntries = details.auditEvent.map((itm, idx) => {
+        // use the alert id and index in the event log array as the data key for react
+        // if the log becomes dynamic, the entire log line might need to be considered as the key
+        return <div key={ details.localId + "." + idx }>{itm}</div>;
+    });
+    return <div className="setroubleshoot-log">{logEntries}</div>;
+};
 
 /* Component to show a dismissable error, message as child text
  * dismissError callback function triggered when the close button is pressed
@@ -354,13 +307,7 @@ export class SETroubleshootPage extends React.Component {
     render() {
         // if selinux is disabled, we only show EmptyState
         if (this.props.selinuxStatus.enabled === false) {
-            return (
-                <EmptyState
-                    icon={ <div className="fa fa-exclamation-circle" /> }
-                    description={ _("SELinux is disabled on the system") }
-                    message={null}
-                    relative={false} />
-            );
+            return <EmptyStatePanel icon={ ExclamationCircleIcon } title={ _("SELinux is disabled on the system") } />;
         }
         var self = this;
         var entries;

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -20,6 +20,9 @@
 import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import client from "./client";
 import { MultipathAlert } from "./multipath.jsx";
@@ -59,24 +62,14 @@ class StoragePage extends React.Component {
         const { inited, slow_init, path } = this.state;
 
         if (!inited) {
-            if (slow_init) {
-                return (
-                    <div className="curtains-ct blank-slate-pf">
-                        <h1>{_("Loading...")}</h1>
-                    </div>
-                );
-            } else {
+            if (slow_init)
+                return <EmptyStatePanel loading title={ _("Loading...") } />;
+            else
                 return null;
-            }
         }
 
-        if (client.features == false || client.older_than("2.6")) {
-            return (
-                <div className="curtains-ct blank-slate-pf">
-                    <h1>{_("Storage can not be managed on this system.")}</h1>
-                </div>
-            );
-        }
+        if (client.features == false || client.older_than("2.6"))
+            return <EmptyStatePanel icon={ExclamationCircleIcon} title={ _("Storage can not be managed on this system.") } />;
 
         let detail;
 

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -163,7 +163,7 @@ $(function() {
                              () => {
                                  var count = 0;
                                  var stopped = null;
-                                 manage_start_box(true, false, _("Loading..."), "", "");
+                                 manage_start_box(true, false, no_logs ? ("Loading...") : null, "", "");
                                  procs.push(journal.journalctl(match, { follow: false, reverse: true, cursor: first })
                                          .fail(query_error)
                                          .stream(function(entries) {

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -26,6 +26,7 @@ import { init_reporting } from "./reporting.jsx";
 import ReactDOM from 'react-dom';
 import React from 'react';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 $(function() {
     cockpit.translate();
@@ -103,7 +104,7 @@ $(function() {
         ReactDOM.render(
             React.createElement(EmptyStatePanel, {
                 loading: loading,
-                showIcon: show_icon,
+                icon: show_icon ? ExclamationCircleIcon : undefined,
                 title: title,
                 paragraph: text,
                 action: action,
@@ -162,7 +163,7 @@ $(function() {
                              () => {
                                  var count = 0;
                                  var stopped = null;
-                                 manage_start_box(true, true, "Loading...", "", "");
+                                 manage_start_box(true, false, "Loading...", "", "");
                                  procs.push(journal.journalctl(match, { follow: false, reverse: true, cursor: first })
                                          .fail(query_error)
                                          .stream(function(entries) {
@@ -279,7 +280,7 @@ $(function() {
                     });
         }
 
-        manage_start_box(true, true, "Loading...", "", "");
+        manage_start_box(true, false, "Loading...", "", "");
 
         $('#journal-service-menu').on("click", "a", function() {
             update_services_list = false;

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -163,7 +163,7 @@ $(function() {
                              () => {
                                  var count = 0;
                                  var stopped = null;
-                                 manage_start_box(true, false, "Loading...", "", "");
+                                 manage_start_box(true, false, _("Loading..."), "", "");
                                  procs.push(journal.journalctl(match, { follow: false, reverse: true, cursor: first })
                                          .fail(query_error)
                                          .stream(function(entries) {
@@ -280,7 +280,7 @@ $(function() {
                     });
         }
 
-        manage_start_box(true, false, "Loading...", "", "");
+        manage_start_box(true, false, _("Loading..."), "", "");
 
         $('#journal-service-menu').on("click", "a", function() {
             update_services_list = false;


### PR DESCRIPTION
We've had pkg/lib/cockpit-components-empty-state.jsx for a while, but so far it was only being used on the Logs page. I generalized it and converted most of our React pages to it.

The only place that's left is pkg/machines/components/libvirtSlate.jsx (the "service is not active" curtain), that will require some further extension to also allow the check box. That's a pattern that we have on more than one place, so that should get some deeper thought. This PR is big enough as it is already, so let's handle this separately.