### PR TITLE
firewall: Show ports that were directly added to the firewall

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -116,6 +116,33 @@ function initFirewalldDbus() {
     });
 
     firewalld_dbus.subscribe({
+        interface: 'org.fedoraproject.FirewallD1.zone',
+        path: '/org/fedoraproject/FirewallD1',
+        member: 'PortAdded'
+    }, (path, iface, signal, args) => {
+        const zone = args[0];
+        const port = args[1];
+        const protocol = args[2];
+        if (!firewall.zones[zone].ports.some(p => p.port === port && p.protocol === protocol)) {
+            firewall.zones[zone].ports.push({ port, protocol });
+            firewall.debouncedEvent('changed');
+        }
+    });
+
+    firewalld_dbus.subscribe({
+        interface: 'org.fedoraproject.FirewallD1.zone',
+        path: '/org/fedoraproject/FirewallD1',
+        member: 'PortRemoved'
+    }, (path, iface, signal, args) => {
+        const zone = args[0];
+        const port = args[1];
+        const protocol = args[2];
+        firewall.zones[zone].ports = firewall.zones[zone].ports
+                .filter(p => p.port !== port || p.protocol !== protocol);
+        firewall.debouncedEvent('changed');
+    });
+
+    firewalld_dbus.subscribe({
         interface: 'org.fedoraproject.FirewallD1',
         path: '/org/fedoraproject/FirewallD1',
         member: 'Reloaded'

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -116,6 +116,24 @@ function ServiceRow(props) {
                        listingActions={[deleteButton]} />;
 }
 
+function PortRow(props) {
+    const columns = [
+        <i key={props.zone.id + "-additional-ports"}>{ _("Additional ports") }</i>,
+        props.zone.ports
+                .filter(p => p.protocol === "tcp")
+                .map(p => p.port)
+                .join(", "),
+        props.zone.ports
+                .filter(p => p.protocol === "udp")
+                .map(p => p.port)
+                .join(", "),
+        null
+    ];
+    return <ListingRow key={props.zone.id + "-ports"}
+                       rowId={props.zone.id + "-ports"}
+                       columns={columns} />;
+}
+
 function ZoneSection(props) {
     function onRemoveZone(event) {
         if (event.button !== 0)
@@ -175,6 +193,11 @@ function ZoneSection(props) {
                                        readonly={firewall.readonly} />;
             })
             }
+            { props.zone.ports.length > 0 &&
+            <PortRow key={props.zone.id + "-ports"}
+                     zone={props.zone}
+                     readonly={firewall.readonly} />}
+
         </Listing>
         }
     </div>;

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -342,6 +342,10 @@ h1 .onoff-ct {
     box-shadow: var(--pf-global--BoxShadow--sm);
 }
 
+.zone-section > .ct-listing {
+    margin-top: 0;
+}
+
 .zone-section-heading {
     margin: 0;
     padding: 0.5rem 0.75rem;

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -39,6 +39,9 @@ def get_active_rules(machine):
     active_rules = []
     for zone in active_zones:
         active_rules += machine.execute("firewall-cmd --zone '{}' --list-services".format(zone)).split()
+        ports = machine.execute("firewall-cmd --zone '{}' --list-ports".format(zone)).strip()
+        if ports and machine.image not in ["rhel-8-2-distropkg"]: # Changed in #13686
+            active_rules += [ports]
     return active_rules
 
 @skipImage("no firewalld", "fedora-coreos")
@@ -110,6 +113,11 @@ class TestFirewall(NetworkCase):
         m = self.machine
 
         if m.image not in ["rhel-8-2-distropkg"]: # Changed in #13555
+            # Changed in #13686, remove all existing ports before testing
+            for port in m.execute("firewall-cmd --zone 'public' --list-ports").split():
+                m.execute("firewall-cmd --remove-port='{}' --zone 'public'".format(port))
+                m.execute("firewall-cmd --permanent --remove-port='{}' --zone 'public'".format(port))
+
             # Zones should be visible as unprivileged user
             self.login_and_go("/network/firewall", authorized=False)
             self.wait_onoff("#firewall-heading-title-group", False)
@@ -160,6 +168,13 @@ class TestFirewall(NetworkCase):
         # Test that service without name is shown properly
         m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload && firewall-cmd --add-service=empty")
         b.wait_present(".zone-section[data-id='public'] tr[data-row-id='empty']")
+
+        if m.image not in ["rhel-8-2-distropkg"]: # Changed in #13686
+            m.execute("firewall-cmd --add-port=9998/udp --add-port=9999/udp --add-port=6666/tcp")
+            b.wait_in_text(".zone-section[data-id='public'] tr[data-row-id='public-ports'] > td:nth-of-type(3)", "6666")
+            b.wait_in_text(".zone-section[data-id='public'] tr[data-row-id='public-ports'] > td:nth-of-type(4)", "9998, 9999")
+            m.execute("firewall-cmd --remove-port=9998/udp --remove-port=9999/udp --remove-port=6666/tcp")
+            b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='public-ports']")
 
         # switch service off again
         self.toggle_onoff("#firewall-heading-title-group")


### PR DESCRIPTION
So ports can also directly be added to firewalls. So far this PR doesn't allow you to add or remove them, it just shows them. I'm not sure if we want to support modifying them because feature creep on the firewall page wouldn't really have an end as there's so much we could support.

![image](https://user-images.githubusercontent.com/11140201/76610432-2e15f480-6519-11ea-8a88-c098135f1bee.png)
