### PR TITLE
Port more buttons to PF4 React component

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -56,7 +56,7 @@ class ApplicationRow extends React.Component {
         var name, summary_or_progress, button;
 
         if (comp.installed) {
-            name = <button role="link" className="link-button" onClick={left_click(() => launch(comp))}>{comp.name}</button>;
+            name = <Button variant="link" onClick={left_click(() => launch(comp))}>{comp.name}</Button>;
         } else {
             name = comp.name;
         }

--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -106,7 +106,7 @@ export class Application extends React.Component {
                 progress_or_launch = <ProgressBar title={self.state.progress_title} data={self.state.progress} />;
                 button = <CancelButton data={self.state.progress} />;
             } else if (comp.installed) {
-                progress_or_launch = <button role="link" className="link-button" onClick={left_click(() => launch(comp))}>{_("Go to Application")}</button>;
+                progress_or_launch = <Button variant="link" onClick={left_click(() => launch(comp))}>{_("Go to Application")}</Button>;
                 button = <Button variant="danger" onClick={left_click(remove)}>{_("Remove")}</Button>;
             } else {
                 progress_or_launch = null;
@@ -141,7 +141,7 @@ export class Application extends React.Component {
         return (
             <div>
                 <ol className="breadcrumb">
-                    <li><button role="link" className="link-button" onClick={left_click(navigate_up)}>{_("Applications")}</button></li>
+                    <li><Button variant="link" onClick={left_click(navigate_up)}>{_("Applications")}</Button></li>
                     <li className="active">{comp ? comp.name : this.props.id}</li>
                 </ol>
                 {render_comp()}

--- a/pkg/apps/utils.jsx
+++ b/pkg/apps/utils.jsx
@@ -19,6 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
+import { Button } from "@patternfly/react-core";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 
 const _ = cockpit.gettext;
@@ -78,15 +79,10 @@ export const ProgressBar = ({ title, data }) => {
     }
 };
 
-export const CancelButton = ({ data }) => {
-    return (
-        <button className="pf-c-button pf-m-secondary"
-                disabled={!data.cancel}
-                onClick={left_click(data.cancel)}>
-            {_("Cancel")}
-        </button>
-    );
-};
+export const CancelButton = ({ data }) => (
+    <Button variant="secondary" isDisabled={!data.cancel} onClick={left_click(data.cancel)}>
+        {_("Cancel")}
+    </Button>);
 
 export const show_error = ex => {
     if (ex.code == "cancelled")

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -27,12 +27,12 @@ import {
     Tooltip
 } from "patternfly-react";
 import { Alert, Button } from '@patternfly/react-core';
+import { ExclamationCircleIcon, TrashIcon } from '@patternfly/react-icons';
 
 import firewall from "./firewall-client.js";
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import { ModalError } from "cockpit-components-inline-notification.jsx";
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import "page.scss";
@@ -67,12 +67,12 @@ function ServiceRow(props) {
             <OverlayTrigger className="pull-right" placement="top"
                             overlay={ <Tooltip id="tip-auth">{ _("You are not authorized to modify the firewall.") }</Tooltip> }>
                 <span>
-                    <button key={props.service.id + "-delete-button"} className="pf-c-button pf-m-danger" aria-label={cockpit.format(_("Not authorized to remove service $0"), props.service.id)} style={{ pointerEvents: 'none' }} disabled><span className="pficon pficon-delete" /></button>
+                    <Button key={props.service.id + "-delete-button"} variant="danger" aria-label={cockpit.format(_("Not authorized to remove service $0"), props.service.id)} style={{ pointerEvents: 'none' }} isDisabled><TrashIcon /></Button>
                 </span>
             </OverlayTrigger>
         );
     } else {
-        deleteButton = <button key={props.service.id + "-delete-button"} className="pf-c-button pf-m-danger" onClick={onRemoveService} aria-label={cockpit.format(_("Remove service $0"), props.service.id)}><span className="pficon pficon-delete" /></button>;
+        deleteButton = <Button key={props.service.id + "-delete-button"} variant="danger" onClick={onRemoveService} aria-label={cockpit.format(_("Remove service $0"), props.service.id)}><TrashIcon /></Button>;
     }
 
     var columns = [

--- a/pkg/playground/react-demo-listing.jsx
+++ b/pkg/playground/react-demo-listing.jsx
@@ -20,6 +20,8 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
+import { Button } from "@patternfly/react-core";
+import { PlayIcon } from "@patternfly/react-icons";
 
 import * as cockpitListing from "cockpit-components-listing.jsx";
 
@@ -93,10 +95,12 @@ export function showListingDemo (rootElement, rootElementSelectable, rootElement
         },
     ];
 
-    var addLink = <button className="pull-right link-button" onClick={handleAddClick}>Add Row</button>;
+    var addLink = <Button variant="link" isInline className="pull-right" onClick={handleAddClick}>Add Row</Button>;
 
     var rowAction = {
-        element: <button className="pf-c-button pf-m-secondary btn-control" onClick={handlePlayClick}><i className="fa fa-play" /></button>,
+        element: <Button variant="secondary" isInline className="btn-control"
+                         aria-label="row specific action"
+                         onClick={handlePlayClick}><PlayIcon /></Button>,
         tight: true
     };
 

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -20,8 +20,8 @@
 import cockpit from "cockpit";
 
 import React from "react";
-import { Alert, AlertActionCloseButton } from "@patternfly/react-core";
-import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { Alert, AlertActionCloseButton, Button } from "@patternfly/react-core";
+import { ExclamationCircleIcon, TrashIcon } from "@patternfly/react-icons";
 
 import * as cockpitListing from "cockpit-components-listing.jsx";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
@@ -106,10 +106,9 @@ class SELinuxEventDetails extends React.Component {
                 }
                 fixit = (
                     <div className="setroubleshoot-listing-action">
-                        <button className="pf-c-button pf-m-secondary"
-                                onClick={ self.runFix.bind(self, itmIdx) }
-                        >{ _("Apply this solution") }
-                        </button>
+                        <Button variant="secondary" onClick={ self.runFix.bind(self, itmIdx) }>
+                            { _("Apply this solution") }
+                        </Button>
                     </div>
                 );
             } else {
@@ -119,7 +118,7 @@ class SELinuxEventDetails extends React.Component {
                     </div>
                 );
             }
-            var detailsLink = <button className="link-button" onClick={ self.handleSolutionDetailsClick.bind(self, itmIdx) }>{ _("solution details") }</button>;
+            var detailsLink = <Button variant="link" isInline onClick={ self.handleSolutionDetailsClick.bind(self, itmIdx) }>{ _("solution details") }</Button>;
             var doState;
             var doElem;
             var caret;
@@ -350,14 +349,14 @@ export class SETroubleshootPage extends React.Component {
                 if (itm.details)
                     onDeleteClick = self.handleDeleteAlert.bind(self, itm.details.localId);
                 var dismissAction = (
-                    <button
-                        id="selinux-alert-dismiss"
-                        title="Dismiss"
-                        className="pf-c-button pf-m-danger btn-sm"
-                        onClick={onDeleteClick}
-                        disabled={ !onDeleteClick || !self.props.deleteAlert }>
-                        <i className="pficon pficon-delete" />
-                    </button>
+                    <Button id="selinux-alert-dismiss"
+                            className="btn-sm"
+                            variant="danger"
+                            aria-label={ _("Dismiss") }
+                            onClick={onDeleteClick}
+                            isDisabled={ !onDeleteClick || !self.props.deleteAlert }>
+                        <TrashIcon />
+                    </Button>
                 );
                 var tabRenderers = [
                     {

--- a/pkg/storaged/multipath.jsx
+++ b/pkg/storaged/multipath.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { Alert } from "@patternfly/react-core";
+import { Alert, Button } from "@patternfly/react-core";
 
 import { get_multipathd_service } from "./utils.js";
 import { dialog_open } from "./dialog.jsx";
@@ -66,7 +66,7 @@ export class MultipathAlert extends React.Component {
                 <div className="container-fluid page-ct">
                     <Alert isInline variant='danger' title={
                         <>
-                            <button onClick={activate} className="pf-c-button pf-m-secondary pull-right">{_("Start Multipath")}</button>
+                            <Button onClick={activate} variant="secondary" className="pull-right">{_("Start Multipath")}</Button>
                             <span className="alert-message">
                                 {_("There are devices with multiple paths on the system, but the multipath service is not running.")}
                             </span>

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -153,7 +153,7 @@ class TestFirewall(NetworkCase):
         b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         b.wait_in_text(".zone-section[data-id='public'] tbody.open tr.listing-ct-panel", "Post Office Protocol")
 
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr ." + self.btn_danger)
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
 
@@ -270,7 +270,7 @@ class TestFirewall(NetworkCase):
         # remove service via cli and cockpit
         m.execute("firewall-cmd --remove-service=pop3")
         b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr ."  + self.btn_danger)
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 
     def testAddCustomServices(self):
@@ -429,13 +429,13 @@ class TestFirewall(NetworkCase):
 
         # Remove the service from public zone
         b.click(".zone-section[data-id='public'] tr[data-row-id='pop3']")
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr .pficon-delete")
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr ." + self.btn_danger)
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
         b.wait_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # Remove the service from the work zone
         b.click(".zone-section[data-id='work'] tr[data-row-id='pop3']")
-        b.click(".zone-section[data-id='work'] tr[data-row-id='pop3'] + tr .pficon-delete")
+        b.click(".zone-section[data-id='work'] tr[data-row-id='pop3'] + tr ." + self.btn_danger)
         b.wait_not_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # remove predefined work zone

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -202,9 +202,9 @@ class StorageHelpers:
     def content_tab_info_action(self, row_index, tab_index, title, wrapped=False):
         label = self.content_tab_info_label(row_index, tab_index, title)
         if wrapped:
-            link = label + " + div button.link-button"
+            link = label + " + div button.pf-m-link"
         else:
-            link = label + " + button.link-button"
+            link = label + " + button.pf-m-link"
         self.browser.click(link)
 
     # Dialogs


### PR DESCRIPTION
This covers most buttons except for Machines. I kept pkg/storaged/plot.jsx as-is as that's a bit arcane, and docker as I just didn't get to that. I'll handle that in a separate PR, if we even still care.

 -  [x] Move from disabled class to attribute: PR #13687 13552