### PR TITLE
all: stop using en_US.UTF-8 as a default locale

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -96,7 +96,7 @@ dist/guide/html/%.woff2: dist/static/fonts/%.woff2
 dist/guide/html/index.html: $(GUIDE_DOCBOOK) $(GUIDE_INCLUDES) $(man_MANS) $(GUIDE_STATIC) $(GUIDE_XSLT) $(GUIDE_FONTS)
 	$(AM_V_GEN) $(MKDIR_P) dist/guide/html/ && \
 	cp $(addprefix $(srcdir)/,$(GUIDE_STATIC)) dist/guide/html/
-	$(AM_V_GEN) LANG=en_US.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o dist/guide/html/ \
+	$(AM_V_GEN) LANG=C.UTF-8 $(XMLTO) html -m $(srcdir)/doc/guide/gtk-doc.xsl -o dist/guide/html/ \
 		--searchpath $(abs_builddir):$(abs_srcdir):$(abs_builddir)/doc/guide \
 		$(srcdir)/$(GUIDE_DOCBOOK)
 	rm -f dist/guide/html/cockpit-guide.proc

--- a/examples/gtk-broadway/gtk.html
+++ b/examples/gtk-broadway/gtk.html
@@ -71,7 +71,7 @@ body { overflow: hidden; }
     }
 
     function applications() {
-        var environ = [ "GDK_BACKEND=broadway", "BROADWAY_DISPLAY=:5", "LANG=en_US.UTF-8" ];
+        var environ = [ "GDK_BACKEND=broadway", "BROADWAY_DISPLAY=:5", "LANG=C.UTF-8" ];
         process(["nautilus"], environ);
         process(["gnome-calculator"], environ);
     }

--- a/pkg/machines/components/create-vm-dialog/createVmDialogUtils.js
+++ b/pkg/machines/components/create-vm-dialog/createVmDialogUtils.js
@@ -37,7 +37,7 @@ export function autodetectOS(url) {
     // which blocked us from using GIO calls over cockpit-bridge.
     // Overwrite the env vars here, until commit https://github.com/cockpit-project/cockpit/commit/86c1fcb46291c83d6c6903e60fe4bee82598d3a9
     // exists in all supported distros.
-    return python.spawn(autoDetectOSScript, url, { environ: ['GIO_USE_VFS=gvfs', 'LC_ALL=en_US.UTF-8'], err: 'message' })
+    return python.spawn(autoDetectOSScript, url, { environ: ['GIO_USE_VFS=gvfs', 'LC_ALL=C.UTF-8'], err: 'message' })
             .then(out => out.trim());
 }
 

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -1350,7 +1350,7 @@ export function GET_LOGGED_IN_USER() {
 
 export function GET_OS_INFO_LIST () {
     logDebug(`${this.name}.GET_OS_INFO_LIST():`);
-    return dispatch => python.spawn(getOSListScript, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+    return dispatch => python.spawn(getOSListScript, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] })
             .then(osList => {
                 parseOsInfoList(dispatch, osList);
             })
@@ -1365,7 +1365,7 @@ export function INIT_DATA_RETRIEVAL () {
     return dispatch => {
         dispatch(getOsInfoList());
         dispatch(getLoggedInUser());
-        return cockpit.script(getLibvirtServiceNameScript, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+        return cockpit.script(getLibvirtServiceNameScript, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] })
                 .then(serviceName => {
                     const match = serviceName.match(/([^\s]+)/);
                     const name = match ? match[0] : null;

--- a/pkg/machines/libvirt-virsh.js
+++ b/pkg/machines/libvirt-virsh.js
@@ -290,7 +290,7 @@ LIBVIRT_PROVIDER = {
         const command = `virsh ${connection} -q pool-refresh ${poolName} && virsh ${connection} -q -r vol-list ${poolName} --details`;
         let data = '';
         return dispatch => cockpit
-                .script(command, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+                .script(command, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] })
                 .stream(output => { data += output })
                 .then(() => parseStorageVolumes(dispatch, connectionName, poolName, data))
                 .fail((exception, data) => {
@@ -308,7 +308,7 @@ LIBVIRT_PROVIDER = {
         const formatArg = format ? `--format ${format}` : '';
         const command = `(virsh ${connection} -q vol-create-as ${poolName} ${volumeName} --capacity ${size}M ${formatArg} && virsh ${connection} -q vol-path ${volumeName} --pool ${poolName}) | grep -v 'Vol ${volumeName} created'`;
         logDebug('CREATE_AND_ATTACH_VOLUME command: ', command);
-        return dispatch => cockpit.script(command, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+        return dispatch => cockpit.script(command, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] })
                 .then(() => {
                     logDebug('Storage volume created, poolName: ', poolName, ', volumeName: ', volumeName);
                     return dispatch(attachDisk({ connectionName, poolName, volumeName, format, target, vmName, permanent, hotplug }));
@@ -320,7 +320,7 @@ LIBVIRT_PROVIDER = {
         const connection = VMS_CONFIG.Virsh.connections[connectionName].params.join(' ');
         const volpathCommand = `virsh ${connection} vol-path --pool ${poolName} ${volumeName}`;
 
-        return () => cockpit.script(volpathCommand, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] })
+        return () => cockpit.script(volpathCommand, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] })
                 .then((volPath) => {
                     let scope = permanent ? '--config' : '';
                     scope = scope + (hotplug ? ' --live' : '');
@@ -328,7 +328,7 @@ LIBVIRT_PROVIDER = {
                     const command = `virsh ${connection} attach-disk ${vmName} --driver qemu ${subdriver} ${volPath.trim()} ${target} ${scope}`;
 
                     logDebug('ATTACH_DISK command: ', command);
-                    return cockpit.script(command, null, { err: "message", environ: ['LC_ALL=en_US.UTF-8'] });
+                    return cockpit.script(command, null, { err: "message", environ: ['LC_ALL=C.UTF-8'] });
                 });
     },
 

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -403,9 +403,8 @@ function instance(realmd, mode, realm, state) {
         script += 'kinit ' + user + '@' + kerberos.RealmName + ' || exit 0; ';
 
         // ensure this gets run with a non-C locale; ipa fails otherwise
-        // C.UTF-8 exists on most OSes now, except for RHEL 7
         script += "if [ $(sh -c 'eval `locale`; echo $LC_CTYPE') = 'C' ]; then " +
-                  "    locale -a | grep -iq ^'C.utf' && export LC_CTYPE=C.UTF-8 || export LC_CTYPE=en_US.UTF-8; " +
+                  "    export LC_CTYPE=C.UTF-8; " +
                   "fi; ";
 
         // create a kerberos Service Principal Name for cockpit-ws, unless already present

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -719,7 +719,7 @@ main (int argc,
   if (!g_getenv ("XDG_DATA_DIRS") && !g_str_equal (DATADIR, "/usr/share"))
     g_setenv ("XDG_DATA_DIRS", DATADIR, TRUE);
 
-  g_setenv ("LANG", "en_US.UTF-8", FALSE);
+  g_setenv ("LANG", "C.UTF-8", FALSE);
   g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
 
   context = g_option_context_new (NULL);

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -674,8 +674,8 @@ class TestUpdatesSubscriptions(PackageCase):
     def register(self):
         # this fails with "Unable to find available subscriptions for all your installed products", but works anyway
         self.machine.execute(
-            "LC_ALL=en_US.UTF-8 subscription-manager register --insecure --serverurl https://10.111.112.100:8443/candlepin --org=admin --activationkey=awesome_os_pool || true")
-        self.machine.execute("LC_ALL=en_US.UTF-8 subscription-manager attach --auto")
+            "LC_ALL=C.UTF-8 subscription-manager register --insecure --serverurl https://10.111.112.100:8443/candlepin --org=admin --activationkey=awesome_os_pool || true")
+        self.machine.execute("LC_ALL=C.UTF-8 subscription-manager attach --auto")
 
     def setUp(self):
         super().setUp()

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -614,16 +614,9 @@ for x in $(seq 1 20); do
     fi
 done
 
-# C.UTF-8 has existed for a long time, but still not on RHEL 7
-if locale -a | grep -iq ^'C\.utf'; then
-   loc=C.UTF-8
-else
-   loc=en_US.UTF-8
-fi
-
 # create SPN and keytab for ws
 if type ipa >/dev/null 2>&1; then
-    LC_ALL=$loc ipa service-add --ok-as-delegate=true --force HTTP/x0.cockpit.lan@COCKPIT.LAN
+    LC_ALL=C.UTF-8 ipa service-add --ok-as-delegate=true --force HTTP/x0.cockpit.lan@COCKPIT.LAN
 else
     curl --insecure -s --negotiate -u : https://services.cockpit.lan/ipa/json --header 'Referer: https://services.cockpit.lan/ipa' --header "Content-Type: application/json" --header "Accept: application/json" --data '{"params": [["HTTP/x0.cockpit.lan@COCKPIT.LAN"], {"raw": false, "all": false, "version": "2.101", "force": true, "no_members": false, "ipakrbokasdelegate": true}], "method": "service_add", "id": 0}'
 fi


### PR DESCRIPTION
We were mostly doing this for the sake of RHEL 7, which lacked C.UTF-8,
which is what we actually want to be using.

This should fix issues with some of the test machines not having
en_US.UTF-8 installed, and allows removal of a few workarounds that
tested for C.UTF-8 with a fallback to en_US.UTF-8.