### PR TITLE
build: force `npm install` after package.json changes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ MAINTAINERCLEANFILES = \
 EXTRA_DIST = \
 	package.json \
 	package-lock.json \
+	node_modules/.stamp \
 	README.md \
 	$(NULL)
 
@@ -219,7 +220,7 @@ dist/%/Makefile.deps:
 
 # This is the primary rule for running webpack; some pkgs like ssh or pcp only
 # have a manifest, no actual webpack, so don't call webpack-make for these
-dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make
+dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/node_modules/.stamp
 	$(V_WEBPACK) $(MKDIR_P) dist/$* && \
 	(if ls $(srcdir)/pkg/$*/*.js >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
 	  touch $@
@@ -235,6 +236,16 @@ clean-local::
 
 maintainer-clean-local::
 	rm -rf dist/ node_modules/ package-lock.json
+
+node_modules/.stamp: package.json
+	@echo ''
+	@echo '    package.json changed'
+	@echo ''
+	@echo '    Please run:'
+	@echo ''
+	@echo '        tools/npm-install'
+	@echo ''
+	@false
 
 install-data-local:: $(WEBPACK_INSTALL)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -135,6 +135,8 @@ with open(template_file, encoding='UTF-8') as f:
 license_ids = template_licenses(template)
 paragraphs = []
 for module in sorted(os.listdir(args.node_modules)):
+    if module.startswith('.'):
+        continue
     if module == 'README':
         continue
     moddir = os.path.join(args.node_modules, module)

--- a/tools/npm-install
+++ b/tools/npm-install
@@ -34,3 +34,5 @@ while ! npm install; do
 
   rm -rf node_modules
 done
+
+touch node_modules/.stamp


### PR DESCRIPTION
It's a reasonably common problem to pull, switch branches, or rebase on
top of new changes from master, and have changes to node module
dependencies which will cause the build to fail if `npm install` isn't
run again.  Even worse: sometimes the build succeeds, only to cause
runtime javascript errors during testing.

This is almost always indicated by a corresponding change in
package.json.

Make sure package-lock.json is newer than package.json, and if not,
display a warning about it, asking the user to fix it.  Use a ridiculous
amount of whitespace to make sure the message sticks out from the noise
and to make it easier to copy/paste the suggested command.

Also: add a new Makefile target `make npm` to explicitly touch
package-lock.json after a sucessful `npm install` (since npm won't do it
for itself if there are no changes).