### PR TITLE
test: Make testAddDisk nondestructive (variant with splitting out iSCSI test)

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1807,7 +1807,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
             target_iqn = "iqn.2019-09.cockpit.lan"
             orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
-            machineslib.prepareStorageDeviceOnISCSI(m, target_iqn, orig_iqn)
+            self.prepareStorageDeviceOnISCSI(target_iqn, orig_iqn)
 
             StoragePoolCreateDialog(
                 self,

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -207,6 +207,9 @@ class TestMachines(NetworkCase, StorageHelpers):
         # Stop all networks
         self.addCleanup(m.execute, "for n in $(virsh net-list --all --name); do virsh net-destroy $n || true; done")
 
+        # Stop all domains
+        self.addCleanup(m.execute, "for d in $(virsh list --name); do virsh destroy $d || true; done")
+
         # we don't have configuration to open the firewall for local libvirt machines, so just stop firewalld
         m.execute("systemctl stop firewalld; systemctl try-restart libvirtd")
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -181,7 +181,7 @@ class TestMachines(NetworkCase, StorageHelpers):
 
         # Prepare tmp directory
         m.execute("mkdir {0}".format(self.tmp_storage))
-        self.addCleanup(m.execute, "rm -rf {0}".format(self.tmp_storage))
+        self.addCleanup(m.execute, "findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount && rm -rf {0}".format(self.tmp_storage))
 
         # Keep pristine state of libvirt
         orig = "/var/lib/libvirt"


### PR DESCRIPTION
 - Turn prepareStorageDeviceOnISCSI() into a TestMachines method, and
   make it clean up after itself.

 - Move directory based storage pools into temp dir.

 - Restore NFS exports after the test.

 - Delay creation of the scsi_debug drive until when it's actually
   needed. This avoids that disk already being present for the iSCSI
   test, which caused the scsi_module being busy.

Co-Authored-By: Martin Pitt <mpitt@redhat.com>