### PR TITLE
test: Fix TAP output for infrastructure retries in run-tests

### DIFF
--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -83,14 +83,17 @@ def finish_test(opts, test):
             print_test(test, print_tap=False)
             return None, 0
 
+    # do we get a specific retry reason from tests-policy?
+    m = re.search(b"\s*# RETRY (.*)$", test.output, re.MULTILINE)
+    if m:
+        retry_reason = m.group(1)
+        # remove it from test output; we must not print it after the 3rd time, and going to print it separately
+        test.output = re.sub(b"\s*# RETRY .*\\n", b"", test.output)
+    else:
+        # HACK: many tests are unstable, always retry them 3 times
+        retry_reason = b"be robust against unstable tests"
+
     if test.retries < 2:
-        # do we get a specific retry reason from tests-policy?
-        m = re.search(b"# RETRY (.*)$", test.output, re.MULTILINE)
-        if m:
-            retry_reason = m.group(1)
-        else:
-            # HACK: many tests are unstable, always retry them 3 times
-            retry_reason = b"be robust against unstable tests"
         test.retries += 1
         test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
         print_test(test, print_tap=opts.thorough)


### PR DESCRIPTION
tests-policy has no idea about the current retry count, it just always
adds the `# RETRY` reason to the output. This caused it to appear in the
log even after the 3rd run, after which we don't actually retry any
more. But log.html still considered it as a retry instead of a failure,
and then not ever showed the failure.

Always filter out test-policy's retry reason. For the actual retries,
it's printed again anyway (previously leading to duplication), and for
the last one don't print it any more.

Fixes #13697