### PR TITLE
test: Make testAddDisk nondestructive (variant without test split)

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1807,7 +1807,7 @@ class TestMachinesDBus(machineslib.TestMachines):
 
             target_iqn = "iqn.2019-09.cockpit.lan"
             orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
-            machineslib.prepareStorageDeviceOnISCSI(m, target_iqn, orig_iqn)
+            self.prepareStorageDeviceOnISCSI(target_iqn, orig_iqn)
 
             StoragePoolCreateDialog(
                 self,

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -207,6 +207,9 @@ class TestMachines(NetworkCase, StorageHelpers):
         # Stop all networks
         self.addCleanup(m.execute, "for n in $(virsh net-list --all --name); do virsh net-destroy $n || true; done")
 
+        # Stop all domains
+        self.addCleanup(m.execute, "for d in $(virsh list --name); do virsh destroy $d || true; done")
+
         # we don't have configuration to open the firewall for local libvirt machines, so just stop firewalld
         m.execute("systemctl stop firewalld; systemctl try-restart libvirtd")
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -35,23 +35,6 @@ def readFile(name):
     return content
 
 
-# Preparations for iscsi storage pool
-def prepareStorageDeviceOnISCSI(m, target_iqn, orig_iqn=None):
-    if orig_iqn is None:
-        orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
-
-    # Increase the iSCSI timeouts for heavy load during our testing
-    m.execute("""sed -i 's|^\(node\..*log.*_timeout = \).*|\\1 60|' /etc/iscsi/iscsid.conf""")
-
-    # Setup a iSCSI target
-    m.execute("""
-              targetcli /backstores/ramdisk create test 50M
-              targetcli /iscsi create %(tgt)s
-              targetcli /iscsi/%(tgt)s/tpg1/luns create /backstores/ramdisk/test
-              targetcli /iscsi/%(tgt)s/tpg1/acls create %(ini)s
-              """ % {"tgt": target_iqn, "ini": orig_iqn})
-
-
 SPICE_XML = """
     <video>
       <model type='vga' heads='1' primary='yes'/>
@@ -279,6 +262,26 @@ class TestMachines(NetworkCase, StorageHelpers):
         self.allow_journal_messages('.*denied.*comm="pmsignal".*')
 
         return args
+
+    # Preparations for iscsi storage pool
+    def prepareStorageDeviceOnISCSI(self, target_iqn, orig_iqn=None):
+        m = self.machine
+
+        if orig_iqn is None:
+            orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
+
+        # Increase the iSCSI timeouts for heavy load during our testing
+        m.execute("""sed -i 's|^\(node\..*log.*_timeout = \).*|\\1 60|' /etc/iscsi/iscsid.conf""")
+
+        # Setup a iSCSI target
+        m.execute("""
+                  targetcli /backstores/ramdisk create test 50M
+                  targetcli /iscsi create %(tgt)s
+                  targetcli /iscsi/%(tgt)s/tpg1/luns create /backstores/ramdisk/test
+                  targetcli /iscsi/%(tgt)s/tpg1/acls create %(ini)s
+                  """ % {"tgt": target_iqn, "ini": orig_iqn})
+
+        self.addCleanup(m.execute, "targetcli /backstores/ramdisk delete test && targetcli /iscsi delete %s" % target_iqn)
 
     @nondestructive
     def testState(self):
@@ -801,7 +804,7 @@ class TestMachines(NetworkCase, StorageHelpers):
             # Preparations for testing ISCSI pools
 
             target_iqn = "iqn.2019-09.cockpit.lan"
-            prepareStorageDeviceOnISCSI(m, target_iqn)
+            self.prepareStorageDeviceOnISCSI(target_iqn)
 
             m.execute("virsh pool-define-as iscsi-pool --type iscsi --target /dev/disk/by-path --source-host 127.0.0.1 --source-dev {0} && virsh pool-start iscsi-pool".format(target_iqn))
             wait(lambda: "unit:0:0:0" in self.machine.execute("virsh pool-refresh iscsi-pool && virsh vol-list iscsi-pool"), delay=3)
@@ -1709,7 +1712,7 @@ class TestMachines(NetworkCase, StorageHelpers):
         if "debian" not in self.machine.image and "ubuntu" not in self.machine.image:
             # Test create VM with disk of type "network"
             target_iqn = "iqn.2019-09.cockpit.lan"
-            prepareStorageDeviceOnISCSI(self.machine, target_iqn)
+            self.prepareStorageDeviceOnISCSI(target_iqn)
 
             cmds = [
                 "virsh pool-define-as --name poolIscsi --type iscsi --source-host 127.0.0.1 --source-dev {0} --target /dev/disk/by-path/".format(target_iqn),

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -604,6 +604,7 @@ class TestMachines(NetworkCase, StorageHelpers):
 
     # Test Add Disk via dialog
     @timeout(900)
+    @nondestructive
     def testAddDisk(self):
         b = self.browser
         m = self.machine
@@ -780,10 +781,13 @@ class TestMachines(NetworkCase, StorageHelpers):
             used_targets.remove(target)
 
         # prepare libvirt storage pools
-        m.execute("mkdir /mnt/vm_one ; mkdir /mnt/vm_two ; mkdir /mnt/default_tmp ; chmod a+rwx /mnt/vm_one /mnt/vm_two /mnt/default_tmp")
-        m.execute("virsh pool-define-as default_tmp --type dir --target /mnt/default_tmp && virsh pool-start default_tmp")
-        m.execute("virsh pool-define-as myPoolOne --type dir --target /mnt/vm_one && virsh pool-start myPoolOne")
-        m.execute("virsh pool-define-as myPoolTwo --type dir --target /mnt/vm_two && virsh pool-start myPoolTwo")
+        v1 = os.path.join(self.tmp_storage, "vm_one")
+        v2 = os.path.join(self.tmp_storage, "vm_two")
+        default_tmp = os.path.join(self.tmp_storage, "default_tmp")
+        m.execute("mkdir --mode 777 {0} {1} {2}".format(v1, v2, default_tmp))
+        m.execute("virsh pool-define-as default_tmp --type dir --target {0} && virsh pool-start default_tmp".format(default_tmp))
+        m.execute("virsh pool-define-as myPoolOne --type dir --target {0} && virsh pool-start myPoolOne".format(v1))
+        m.execute("virsh pool-define-as myPoolTwo --type dir --target {0} && virsh pool-start myPoolTwo".format(v2))
 
         m.execute("virsh vol-create-as default_tmp defaultVol --capacity 1G --format raw")
         m.execute("virsh vol-create-as myPoolTwo mydiskofpooltwo_temporary --capacity 1G --format qcow2")
@@ -791,9 +795,13 @@ class TestMachines(NetworkCase, StorageHelpers):
         wait(lambda: "mydiskofpooltwo_permanent" in m.execute("virsh vol-list myPoolTwo"))
 
         # Prepare a local NFS pool
-        m.execute("mkdir /mnt/nfs-pool && mkdir /mnt/exports && echo '/mnt/exports 127.0.0.1/24(rw,sync,no_root_squash,no_subtree_check,fsid=0)' > /etc/exports")
+        m.execute("mv /etc/exports /etc/exports.backup")
+        self.addCleanup(m.execute, "mv /etc/exports.backup /etc/exports")
+        nfs_pool = os.path.join(self.tmp_storage, "nfs_pool")
+        mnt_exports = os.path.join(self.tmp_storage, "mnt_exports")
+        m.execute("mkdir {0} {1} && echo '{1} 127.0.0.1/24(rw,sync,no_root_squash,no_subtree_check,fsid=0)' > /etc/exports".format(nfs_pool, mnt_exports))
         m.execute("systemctl restart nfs-server")
-        m.execute("virsh pool-define-as nfs-pool --type netfs --target /mnt/nfs-pool --source-host 127.0.0.1 --source-path /mnt/exports && virsh pool-start nfs-pool")
+        m.execute("virsh pool-define-as nfs-pool --type netfs --target {0} --source-host 127.0.0.1 --source-path {1} && virsh pool-start nfs-pool".format(nfs_pool, mnt_exports))
         # And create a volume on it in order to test use existing volume dialog
         m.execute("virsh vol-create-as --pool nfs-pool --name nfs-volume-0 --capacity 1M --format qcow2")
 
@@ -1013,6 +1021,9 @@ class TestMachines(NetworkCase, StorageHelpers):
             volume_size_unit='MiB',
             expected_target=get_next_free_target(),
         ).execute()
+
+        # avoid error noise about resources getting cleaned up
+        b.logout()
 
     @nondestructive
     def testVmNICs(self):

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -181,7 +181,7 @@ class TestMachines(NetworkCase, StorageHelpers):
 
         # Prepare tmp directory
         m.execute("mkdir {0}".format(self.tmp_storage))
-        self.addCleanup(m.execute, "rm -rf {0}".format(self.tmp_storage))
+        self.addCleanup(m.execute, "findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount && rm -rf {0}".format(self.tmp_storage))
 
         # Keep pristine state of libvirt
         orig = "/var/lib/libvirt"


### PR DESCRIPTION
This is a variant of PR #13696 that keeps the test structure as-is. I was debugging in the wrong direction, so I think the test split is not actually necessary. Now it's a matter of taste, but let's first see what the tests have to say.