### PR TITLE
Drop cockpit-docker for Debian/Ubuntu development series, some packaging cleanups

### DIFF
--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -25,6 +25,7 @@ from testlib import *
 @skipPackage("cockpit-docker")
 @skipImage("No docker packaged", "rhel-8-2", "rhel-8-2-distropkg", "centos-8-stream")
 @skipImage("Not supporting cockpit-docker on CoreOS", "fedora-coreos")
+@skipImage("Not supporting cockpit-docker on Debian >= 11 and Ubuntu >= 20.04", "debian-testing", "ubuntu-2004")
 @skipImage("Docker not available", "fedora-31", "fedora-testing", "fedora-32") # https://github.com/cockpit-project/cockpit/issues/12670
 class TestDocker(MachineCase):
 

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -44,7 +44,6 @@ Recommends: cockpit-storaged,
             cockpit-packagekit,
 Suggests: cockpit-doc,
           cockpit-pcp,
-          cockpit-docker,
           cockpit-machines,
           xdg-utils,
 Description: Web Console for Linux servers

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -25,7 +25,7 @@ Build-Depends: debhelper (>= 10),
                glib-networking,
                openssh-client <!nocheck>,
                python3,
-Standards-Version: 4.4.0
+Standards-Version: 4.5.0
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
 Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -2,12 +2,6 @@
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
-# only build cockpit-pcp if pcp is available
-ifneq ($(shell dpkg -s libpcp3-dev >/dev/null 2>&1 && echo yes),yes)
-	export DH_OPTIONS = -Ncockpit-pcp
-	CONFIG_OPTIONS = --disable-pcp
-endif
-
 # newer firewalld ships cockpit.xml, but keep it for backports
 FIREWALLD_SERVICE = $(findstring $(shell . /etc/os-release; echo $$VERSION_ID),9 18.04)
 ifeq ($(FIREWALLD_SERVICE),)

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,6 +8,12 @@ ifeq ($(FIREWALLD_SERVICE),)
 	WS_CONFLICTS = firewalld (<< 0.6.0)
 endif
 
+# only build deprecated cockpit-docker for stable releases (backports); Debian sid/testing has no VERSION_ID
+BUILD_DOCKER = $(findstring $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),10 18.04 19.10)
+ifeq ($(BUILD_DOCKER),)
+       export DH_OPTIONS = -Ncockpit-docker
+endif
+
 %:
 	dh $@
 


### PR DESCRIPTION
 - [x] Fix pbuilder on debian-testing: https://github.com/cockpit-project/bots/pull/634