### PR TITLE
test: Make check-networking-firewall nondestructive

### DIFF
--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -42,9 +42,13 @@ def get_active_rules(machine):
     return active_rules
 
 @skipImage("no firewalld", "fedora-coreos")
+@nondestructive
 class TestFirewall(NetworkCase):
     def setUp(self):
         MachineCase.setUp(self)
+        self.machine.execute("cp -a /etc/firewalld /etc/firewalld.test")
+        self.addCleanup(self.machine.execute, "systemctl stop firewalld && rm -rf  /etc/firewalld && mv /etc/firewalld.test /etc/firewalld")
+        self.machine.execute("systemctl start firewalld")
         if self.machine.image not in ["rhel-8-2-distropkg"]:
             self.btn_danger = "pf-m-danger"
             self.btn_primary = "pf-m-primary"
@@ -59,7 +63,7 @@ class TestFirewall(NetworkCase):
         m = self.machine
         # on images with libvirt, wait until libvirt adds its zone (older versions don't do that yet), so that we get a stable count
         if m.image not in ["debian-stable", "ubuntu-1804", "ubuntu-2004", "ubuntu-stable"]:
-            m.execute("until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done")
+            m.execute("systemctl start libvirtd; until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done")
 
         active_zones = len(m.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split())
 
@@ -281,6 +285,7 @@ class TestFirewall(NetworkCase):
         b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
         # wait until all zones are present, including the ones added at runtime
         if m.image in ["rhel-8-2", "fedora-31", "fedora-testing", "fedora-32"]:
+            m.execute("systemctl start libvirtd")
             b.wait_present("#zones-listing .zone-section[data-id='libvirt']")
 
         # add a service to the runtime configuration via the cli, after all the


### PR DESCRIPTION
Save/restore firewalld configuration in between tests.

libvirtd.service times out after 2 minutes when not used, and thus tears
down the libvirt firewalld zone. Make sure it is running in the tests
that assume the libvirt zone.