### PR TITLE
test: Fix flake in TestMachines.testLibvirt

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -497,6 +497,12 @@ class TestMachines(NetworkCase, StorageHelpers):
         b.wait_in_text("body", "Virtual Machines")
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
+        # newer libvirtd versions use socket activation
+        # we should test that separately, but here we test only using the service unit
+        if m.image not in ["debian-stable", "ubuntu-1804", "ubuntu-stable", "rhel-8-2-distropkg", "rhel-8-2", "centos-8-stream"]:
+            m.execute("systemctl stop libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
+            self.addCleanup(m.execute, "systemctl start libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
+
         m.execute("systemctl disable {0}".format(libvirtServiceName))
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 


### PR DESCRIPTION
On current Fedora, libvirt ships socket units that auto-activate
libvirtd.service. This means that even when stopping libvirtd.service,
our page is still connected to libvirt and its requests cause the
service to auto-restart. Thus the empty state goes away all by itself
without having to press a button.

We should handle socket activation properly (issue #13563), but for now
just robustify that test case to really only test the service in
isolation.