### PR TITLE
machines: Convert LibvirtSlate to PF4-React

### DIFF
--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -53,8 +53,8 @@ EmptyStatePanel.propTypes = {
     loading: PropTypes.bool,
     icon: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
     title: PropTypes.string,
-    paragraph: PropTypes.string,
+    paragraph: PropTypes.node,
     action: PropTypes.string,
     onAction: PropTypes.func,
-    secondary: PropTypes.arrayOf(PropTypes.object),
+    secondary: PropTypes.node,
 };

--- a/pkg/machines/components/libvirtSlate.css
+++ b/pkg/machines/components/libvirtSlate.css
@@ -1,3 +1,0 @@
-.header {
-    padding-bottom: 10px;
-}

--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -27,7 +27,9 @@ import {
     enableLibvirt,
 } from "../actions/provider-actions.js";
 
-import './libvirtSlate.css';
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
+import { Button } from "@patternfly/react-core";
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
 
 const _ = cockpit.gettext;
 
@@ -71,66 +73,40 @@ class LibvirtSlate extends React.Component {
     }
 
     render() {
-        const activeState = this.props.libvirtService.activeState;
         const name = this.props.libvirtService.name;
-        const loadingResources = this.props.loadingResources;
-        let message;
-        let icon;
-        let detail;
-        let action;
 
-        if (activeState === 'running') {
-            message = _("Virtualization Service is Available");
-            icon = (<span className="pficon-ok" />);
-        } else if (name && activeState === 'unknown') { // name === 'unknown' first
-            message = _("Connecting to Virtualization Service");
-            icon = (<div className="spinner spinner-lg" />);
-        } else if (loadingResources) {
-            message = _("Loading Resources");
-            icon = (<div className="spinner spinner-lg" />);
-        } else {
-            this.checkStatus();
-            message = _("Virtualization Service (libvirt) is Not Active");
-            icon = (<span className="fa fa-exclamation-circle" />);
-            detail = (
-                <div className="checkbox">
-                    <label>
-                        <input type="checkbox"
-                               id="enable-libvirt"
-                               disabled={!name}
-                               checked={this.state.libvirtEnabled}
-                               onChange={this.onLibvirtEnabledChanged} />
-                        {_("Automatically start libvirt on boot")}
-                    </label>
-                </div>
-            );
-            action = (
-                <div className="blank-slate-pf-main-action">
-                    <button className="pf-c-button pf-m-secondary btn-lg"
-                            id="troubleshoot"
-                            onClick={mouseClick(this.goToServicePage)}>
-                        {_("Troubleshoot")}
-                    </button>
-                    <button className="pf-c-button pf-m-primary btn-lg"
-                            id="start-libvirt"
-                            disabled={!name}
-                            onClick={mouseClick(this.startService)}>
-                        {_("Start libvirt")}
-                    </button>
-                </div>
-            );
-        }
-        return (
-            <div className="curtains-ct blank-slate-pf">
-                <div className="blank-slate-pf-icon">
-                    {icon}
-                </div>
-                <h1 className="header" id="slate-header">
-                    {message}
-                </h1>
-                {detail}
-                {action}
-            </div>);
+        if (name && this.props.libvirtService.activeState === 'unknown')
+            return <EmptyStatePanel title={ _("Connecting to Virtualization Service") } loading />;
+
+        if (this.props.loadingResources)
+            return <EmptyStatePanel title={ _("Loading Resources") } loading />;
+
+        this.checkStatus();
+        // TODO: Convert to PF4-React Checkbox, but this is badly aligned
+        const detail = (
+            <div className="checkbox">
+                <label>
+                    <input type="checkbox"
+                           id="enable-libvirt"
+                           disabled={!name}
+                           checked={this.state.libvirtEnabled}
+                           onChange={this.onLibvirtEnabledChanged} />
+                    {_("Automatically start libvirt on boot")}
+                </label>
+            </div>
+        );
+
+        const troubleshoot_btn = (
+            <Button variant="secondary" onClick={ mouseClick(this.goToServicePage) }>
+                { _("Troubleshoot") }
+            </Button>);
+
+        return <EmptyStatePanel icon={ ExclamationCircleIcon }
+                                title={ _("Virtualization Service (libvirt) is Not Active") }
+                                paragraph={ detail }
+                                action={ name ? _("Start libvirt") : null }
+                                onAction={ mouseClick(this.startService) }
+                                secondary={ troubleshoot_btn } />;
     }
 }
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -502,7 +502,7 @@ const AskRestart = ({ onIgnore, onRestart, history }) => <>
                      paragraph={ _("Updated packages may require a restart to take effect.") }
                      action={ _("Restart Now") }
                      onAction={ onRestart}
-                     secondary={ [<Button key="ignore" variant="secondary" onClick={onIgnore}>{_("Ignore")}</Button>] } />
+                     secondary={ <Button variant="secondary" onClick={onIgnore}>{_("Ignore")}</Button> } />
 
     <div className="flow-list-blank-slate">
         <Expander title={_("Package information")}>

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -379,7 +379,7 @@ class TestMachines(NetworkCase, StorageHelpers):
 
         # restart libvirtd
         m.execute("systemctl stop libvirtd.service")
-        b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
+        b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         m.execute("systemctl start libvirtd.service")
         # HACK: https://launchpad.net/bugs/1802005
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
@@ -500,9 +500,9 @@ class TestMachines(NetworkCase, StorageHelpers):
         m.execute("systemctl disable {0}".format(libvirtServiceName))
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
-        b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
+        b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
-        b.click("#start-libvirt")
+        b.click(".pf-c-empty-state button.pf-m-primary")  # Start libvirt
         b.wait(lambda: checkLibvirtEnabled())
         # HACK: https://launchpad.net/bugs/1802005
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
@@ -513,10 +513,10 @@ class TestMachines(NetworkCase, StorageHelpers):
             b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         m.execute("systemctl stop {0}".format(libvirtServiceName))
-        b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
+        b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
         b.click("#enable-libvirt") # uncheck it ; ; TODO: fix this, do not assume initial state of the checkbox
-        b.click("#start-libvirt")
+        b.click(".pf-c-empty-state button.pf-m-primary")  # Start libvirt
         b.wait(lambda: not checkLibvirtEnabled())
         # HACK: https://launchpad.net/bugs/1802005
         if self.provider == "libvirt-dbus" and m.image == "ubuntu-stable":
@@ -529,10 +529,10 @@ class TestMachines(NetworkCase, StorageHelpers):
         m.execute("systemctl enable {0}".format(libvirtServiceName))
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
-        b.wait_in_text("#slate-header", "Virtualization Service (libvirt) is Not Active")
+        b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
 
-        b.click("#troubleshoot")
+        b.click(".pf-c-empty-state button.pf-m-secondary")  # Troubleshoot
         b.leave_page()
         url_location = "/system/services#/{0}".format(libvirtServiceName)
         b.wait(lambda: url_location in b.eval_js("window.location.href"))


### PR DESCRIPTION
Use our common EmptyStatePanel and PF4's Button components. Leave the
checkbox for now, as PF4's Checkbox component is badly aligned (grid
layout within the EmptyStateBody doesn't work right).
