### PR TITLE
Make attachments great again

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -727,48 +727,9 @@ class MachineCase(unittest.TestCase):
         return browser
 
     def checkSuccess(self):
-        if self._outcome:
-            # errors is a list of (method, exception) calls (usually multiple
-            # per method); None exception means success
-            return not any(e[1] for e in self._outcome.errors)
-
-        if not self.currentResult:
-            return False
-        for error in self.currentResult.errors:
-            if self == error[0]:
-                return False
-        for failure in self.currentResult.failures:
-            if self == failure[0]:
-                return False
-        for success in self.currentResult.unexpectedSuccesses:
-            if self == success:
-                return False
-        for skipped in self.currentResult.skipped:
-            if self == skipped[0]:
-                return False
-        return True
-
-    def run(self, result=None):
-        self.currentResult = result
-
-        # Here's the loop to actually retry running the test. It's an awkward
-        # place for this loop, since it only applies to MachineCase based
-        # TestCases. However for the time being there is no better place for it.
-        #
-        # Policy actually dictates retries.  The number here is an upper bound to
-        # prevent endless retries if Policy.check_retry is buggy.
-        max_retry_hard_limit = 10
-        for retry in range(0, max_retry_hard_limit):
-            try:
-                super().run(result)
-            except RetryError as ex:
-                assert retry < max_retry_hard_limit
-                sys.stderr.write("{0}\n".format(ex))
-                sleep(retry * 10)
-            else:
-                break
-
-        self.currentResult = None
+        # errors is a list of (method, exception) calls (usually multiple
+        # per method); None exception means success
+        return not any(e[1] for e in self._outcome.errors)
 
     def setUp(self):
         if opts.address and self.provision is not None:
@@ -835,10 +796,7 @@ class MachineCase(unittest.TestCase):
 
         def sitter():
             if opts.sit and not self.checkSuccess():
-                if self._outcome:
-                    [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
-                else:
-                    self.currentResult.printErrors()
+                [traceback.print_exception(*e[1]) for e in self._outcome.errors if e[1]]
                 sit(self.machines)
         self.addCleanup(sitter)
 
@@ -1467,10 +1425,6 @@ class Error(Exception):
 
     def __str__(self):
         return self.msg
-
-
-class RetryError(Error):
-    pass
 
 
 def wait(func, msg=None, delay=1, tries=60):

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -33,6 +33,14 @@ class TestExample(MachineCase):
         self.login_and_go("/system")
         self.assertFalse(True)
 
+    @unittest.skip
+    def testSkip(self):
+        self.login_and_go("/system")
+        self.assertFalse(True)
+
+    def testRaiseSkip(self):
+        raise unittest.SkipTest("dynamic skip")
+
     @nondestructive
     def testNondestructive(self):
         self.login_and_go("/system")


### PR DESCRIPTION
See individual commits.

I tested this with a simple
```diff
--- test/verify/machineslib.py
+++ test/verify/machineslib.py
@@ -295,6 +295,7 @@ class TestMachines(NetworkCase, StorageHelpers):
         b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         b.click("tbody tr[data-row-id=vm-subVmTest1] th") # click on the row header
+        self.assertTrue(False)
         b.wait_in_text("#vm-subVmTest1-state", "running")
 
         m.execute('[ "$(virsh domstate {0})" = running ] || '

```
And now on failure I get a screenshot that shows the running VM, instead of the "no VMs defined" after cleanup.

The verbose test log shows the correct order now: fail, do snapshots/sit, then clean up:
```
-> ph_mouse("tbody tr[data-row-id=vm-subVmTest1] th:not([disabled])","click",0,0,0,false,false,false,false)
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/test/common/testlib.py", line 733, in debugWrapper
    fn()
  File "/var/home/martin/upstream/cockpit/test/verify/machineslib.py", line 298, in testState
    self.assertTrue(False)
  File "/usr/lib64/python3.7/unittest/case.py", line 705, in assertTrue
    raise self.failureException(msg)
AssertionError: False is not true
Wrote screenshot to TestMachinesDBus-testState-fedora-31-127.0.0.2-2201-FAIL.png
Wrote HTML dump to TestMachinesDBus-testState-fedora-31-127.0.0.2-2201-FAIL.html
Wrote JS log to TestMachinesDBus-testState-fedora-31-127.0.0.2-2201-FAIL.js.log
+ journalctl
Journal extracted to TestMachinesDBus-testState-fedora-31-127.0.0.2-2201-FAIL.log
Downloading /var/lib/systemd/coredump
scp -B -P 2201 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o ControlPath=/var/home/martin/upstream/cockpit/tmp/ssh-%h-%p-%r-9280 -o BatchMode=yes -r root@[127.0.0.2]:/var/lib/systemd/coredump /var/home/martin/upstream/cockpit/TestMachinesDBus-testState-fedora-31-127.0.0.2-2201-FAIL.core
+ for d in $(virsh list --name); do virsh destroy $d || true; done
Domain subVmTest1 destroyed

+ for n in $(virsh net-list --all --name); do virsh net-destroy $n || true; done
Network default destroyed

+ systemctl stop libvirtd
Warning: Stopping libvirtd.service, but it can still be activated by:
  libvirtd-ro.socket
  libvirtd-admin.socket
  libvirtd.socket
+ rm -rf /run/libvirt/network/test_network*
+ rm -rf /run/libvirt/storage/*
+ umount -lf /etc/libvirt
+ umount -lf /var/lib/libvirt
+ findmnt --list --noheadings --output TARGET | grep ^/mnt/libvirt | xargs -r umount && rm -rf /mnt/libvirt
+ set -e; [ -e /sys/module/scsi_debug ] || exit 0; for dev in $(ls /sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block); do    umount /dev/$dev 2>/dev/null || true; done; until rmmod scsi_debug; do sleep 1; done
+ systemctl stop cockpit
Warning: Stopping cockpit.service, but it can still be activated by:
  cockpit.socket
+ mv /etc/fstab.test /etc/fstab && mv /etc/crypttab.test /etc/crypttab
+ rm -f /etc/cockpit/cockpit.conf
+ ls /home
admin
builder
+ mv /etc/passwd.test /etc/passwd && mv /etc/shadow.test /etc/shadow && mv /etc/group.test /etc/group
Killing browser (pid 9340)
killing ssh master process 9283
# Result testState (__main__.TestMachinesDBus) failed
# 1 TEST FAILED [39s on toolbox]
```

The only little wart is that the stack trace now shows an extra `debugWrapper()`, this may break naughties. Hence keeping this as a draft for now.