### PR TITLE
cockpituous: Disable releasing to COPR

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -18,6 +18,3 @@ job release-srpm
 
 # Upload release to github, using tarball
 job release-github
-
-# Push to COPR builds
-job release-copr @cockpit/cockpit-preview


### PR DESCRIPTION
Our cockpit-preview COPR is configured for current Fedora and RHEL 8
now, it doesn't build for CentOS/RHEL 7.