### PR TITLE
build: Consistently use absolute source and build dir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -176,7 +176,7 @@ V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/stamp=%)";
 
-WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(abs_builddir) \
+WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(abspath $(builddir)) \
 	       timeout 15m $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js


### PR DESCRIPTION
`$(abspath $(srcdir))` and `$(abs_srcdir)` don't do the same thing if
there are symbolic links in the path. In particular, if /home is a
symlink to /var/home (like on OSTree), the former is
`/var/home/<user>/...`, while the latter is `/home/<user>/...`
This caused broken tarball builds.

Consistently use the `$(abs_*)` make variables so that the values agree
on the same prefix.