### PR TITLE
test: Change `print_exc()` to `format_exc()`

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1286,7 +1286,7 @@ class TapRunner:
         except Exception:
             result.addError(test, sys.exc_info())
             sys.stderr.write("Unexpected exception while running {0}\n".format(test))
-            sys.stderr.write(traceback.print_exc())
+            sys.stderr.write(traceback.format_exc())
             return result
         else:
             result.printErrors()


### PR DESCRIPTION
`print_exc()` prints to given fd and returns None. `format_exc()`
returns the string, that `print_exc()` would print.