### PR TITLE
test: Clean up inheritance of TestMachines

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -969,14 +969,14 @@ export class CreateVmAction extends React.Component {
     }
 
     componentDidMount() {
-        cockpit.spawn(['which', 'virt-install'], { err: 'message' })
+        cockpit.spawn(['which', 'virt-install'], { err: 'ignore' })
                 .then(() => {
                     this.setState({ virtInstallAvailable: true });
-                    cockpit.spawn(['virt-install', '--install=?'])
+                    cockpit.spawn(['virt-install', '--install=?'], { err: 'ignore' })
                             .then(() => this.setState({ downloadOSSupported: true }),
                                   () => this.setState({ downloadOSSupported: false }));
 
-                    cockpit.spawn(['virt-install', '--unattended=?'])
+                    cockpit.spawn(['virt-install', '--unattended=?'], { err: 'ignore' })
                             .then(() => this.setState({ unattendedSupported: true }),
                                   () => this.setState({ unattendedSupported: false }));
                 },

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1147,11 +1147,21 @@ class MachineCase(unittest.TestCase):
             title: Used for the filename.
         """
         if self.browser is not None:
-            self.browser.snapshot(title, label)
+            try:
+                self.browser.snapshot(title, label)
+            except RuntimeError:
+                # this usually runs in exception handlers; raising an exception here skips cleanup handlers, so don't
+                sys.stderr.write("Unexpected exception in snapshot():\n")
+                sys.stderr.write(traceback.format_exc())
 
     def copy_js_log(self, title, label=None):
         if self.browser is not None:
-            self.browser.copy_js_log(title, label)
+            try:
+                self.browser.copy_js_log(title, label)
+            except RuntimeError:
+                # this usually runs in exception handlers; raising an exception here skips cleanup handlers, so don't
+                sys.stderr.write("Unexpected exception in copy_js_log():\n")
+                sys.stderr.write(traceback.format_exc())
 
     def copy_journal(self, title, label=None):
         for name, m in self.machines.items():

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -371,6 +371,10 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.click("#vm-VmNotInstalled-networks")
         b.wait_present("#vm-VmNotInstalled-network-1-type")
 
+        self.allow_browser_errors("Failed when connecting: Connection closed")
+        self.allow_browser_errors("Tried changing state of a disconnected RFB object")
+        self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
+
     @nondestructive
     def testDiskEdit(self):
         b = self.browser


### PR DESCRIPTION
Since commit 70894926b7, TestMachines does not need `NetworkCase` any
more, so the inheritance hacks can be dropped. Eventually we want to
move addIface() into a more generic class, but that should happen
similar to StorageHelpers.