### PR TITLE
machines: Avoid virt-install journal noise for unsupported options

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -969,14 +969,14 @@ export class CreateVmAction extends React.Component {
     }
 
     componentDidMount() {
-        cockpit.spawn(['which', 'virt-install'], { err: 'message' })
+        cockpit.spawn(['which', 'virt-install'], { err: 'ignore' })
                 .then(() => {
                     this.setState({ virtInstallAvailable: true });
-                    cockpit.spawn(['virt-install', '--install=?'])
+                    cockpit.spawn(['virt-install', '--install=?'], { err: 'ignore' })
                             .then(() => this.setState({ downloadOSSupported: true }),
                                   () => this.setState({ downloadOSSupported: false }));
 
-                    cockpit.spawn(['virt-install', '--unattended=?'])
+                    cockpit.spawn(['virt-install', '--unattended=?'], { err: 'ignore' })
                             .then(() => this.setState({ unattendedSupported: true }),
                                   () => this.setState({ unattendedSupported: false }));
                 },


### PR DESCRIPTION
For libvirt versions that don't yet support these options, don't log the
error messages (i.e. the virt-install help) to the journal. It's nothing
that the user did wrong, and is both confusing admins and failing our
tests on the unexpected messages.