### PR TITLE
test: Fix cleanup in TestStorage.testLvm

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -42,7 +42,7 @@ class TestStorage(StorageCase):
         # Create a volume group out of two disks
         m.execute("vgcreate TEST1 %s %s" % (dev_1, dev_2))
         # just in case the test fails
-        self.addCleanup(m.execute, "vgremove --force TEST 2>/dev/null || true")
+        self.addCleanup(m.execute, "vgremove --force TEST1 2>/dev/null || true")
         b.wait_in_text("#devices", "TEST1")
         b.wait_in_text("#devices", "/dev/TEST1/")
         b.click('tr:contains("TEST1")')


### PR DESCRIPTION
If the test fails, actually clean up the VG, to avoid keeping scsi_debug
busy. Speling is improtant!