### PR TITLE
test: Add expected AppArmor messages for TestMachines.testAddDisk on ubuntu-stable

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1053,8 +1053,8 @@ class TestMachines(MachineCase, StorageHelpers):
         b.logout()
 
         # AppArmor doesn't like the non-standard path for our storage pools
-        if m.image in ["debian-testing"]:
-            self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="%s.*denied_mask="r".*' % self.tmp_storage)
+        if m.image in ["debian-testing", "ubuntu-stable"]:
+            self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="libvirt.* name="%s.*' % self.tmp_storage)
 
     @nondestructive
     def testVmNICs(self):


### PR DESCRIPTION
This has a similar profile as debian-testing, and it sometimes also
happens for `denied_mask="wr"`.