### PR TITLE
test: Robustify check-machines iSCSI tests

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1815,8 +1815,7 @@ class TestMachinesDBus(machineslib.TestMachines):
             # Preparations for testing ISCSI pools
 
             target_iqn = "iqn.2019-09.cockpit.lan"
-            orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
-            self.prepareStorageDeviceOnISCSI(target_iqn, orig_iqn)
+            orig_iqn = self.prepareStorageDeviceOnISCSI(target_iqn)
 
             StoragePoolCreateDialog(
                 self,


### PR DESCRIPTION
 * Don't duplicate the initiator name detection in
   testStoragePoolsCreate(); instead, let prepareStorageDeviceOnISCSI()
   return the initiator IQN and re-use that.

 * Refine the sed expression to only accept `InitiatorName=`. On
   Debian/Ubuntu, if the daemon has never run, the file contains
   "GenerateName=yes", and we really don't want to use "yes" as an
   initiator name.

 * Ensure that we have an initiator name by starting iscsid before
   reading the name.