### PR TITLE
test: Enable Machines iSCSI tests on Ubuntu

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1808,9 +1808,9 @@ class TestMachinesDBus(machineslib.TestMachines):
             source={"source_path": dev, "format": "gpt"},
         ).execute()
 
-        # Debian and ubuntu images don't have open-iscsi already installed
-        # FIXME: Add open-iscsi to debian and ubuntu images
-        if "debian" not in m.image and "ubuntu" not in m.image:
+        # Debian images' -cloud kernel don't have target-cli-mod kmod
+        # Ubuntu 19.10 is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1659195
+        if "debian" not in m.image and m.image != "ubuntu-stable":
             # Preparations for testing ISCSI pools
 
             target_iqn = "iqn.2019-09.cockpit.lan"
@@ -1824,8 +1824,8 @@ class TestMachinesDBus(machineslib.TestMachines):
                 source={"host": "127.0.0.1", "source_path": target_iqn}
             ).execute()
 
-            if float(m.execute("virsh --version").strip()[:3]) >= 4.7:
-                # iscsi-direct pool type is available since libvirt 4.7
+            if "debian" not in m.image and "ubuntu" not in m.image and float(m.execute("virsh --version").strip()[:3]) >= 4.7:
+                # iscsi-direct pool type is available since libvirt 4.7, but not in Debian/Ubuntu (https://bugs.debian.org/918728)
                 StoragePoolCreateDialog(
                     self,
                     name="my_iscsi_direct_pool",

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -819,9 +819,9 @@ class TestMachines(MachineCase, StorageHelpers):
         m.execute("virsh vol-create-as --pool nfs-pool --name nfs-volume-0 --capacity 1M --format qcow2")
 
         # Prepare an iscsi pool
-        # Debian and ubuntu images don't have open-iscsi already installed
-        # FIXME: Add open-iscsi to debian and ubuntu images
-        if "debian" not in m.image and "ubuntu" not in m.image:
+        # Debian images' -cloud kernel don't have target-cli-mod kmod
+        # Ubuntu 19.10 is affected by https://bugzilla.redhat.com/show_bug.cgi?id=1659195
+        if "debian" not in m.image and m.image != "ubuntu-stable":
             # Preparations for testing ISCSI pools
 
             target_iqn = "iqn.2019-09.cockpit.lan"


### PR DESCRIPTION
The packages are on the images now [1], and the tests got adjusted to
also work on Debian/Ubuntu [2]. The Debian images only ship the -cloud
kernel which doesn't provide the `target_core_mod` kernel, so the tests
don't currently work there.

Debian/Ubuntu's libvirt does not provide the iscsi-direct backend
(https://bugs.debian.org/918728), only the iscsi backend, so only test
that one.

Ubuntu 19.10's targetcli has a broken `targetcli delete` command
(https://bugzilla.redhat.com/show_bug.cgi?id=1659195). As this breaks
nondestructive cleanup, just skip the test here. Let's just make sure it
keeps working on the LTSes.

[1] https://github.com/cockpit-project/bots/pull/651
[2] https://github.com/cockpit-project/cockpit/pull/13749