### PR TITLE
ws: Add optional remote ssh host argument to cockpit-desktop

### DIFF
--- a/doc/man/cockpit-desktop.xml
+++ b/doc/man/cockpit-desktop.xml
@@ -39,6 +39,7 @@
     <cmdsynopsis>
       <command>cockpit-desktop</command>
        <arg choice="req">URLPATH</arg>
+       <arg choice="opt">SSH_HOST</arg>
     </cmdsynopsis>
   </refsynopsisdiv>
 
@@ -70,6 +71,17 @@
       <literal>/cockpit/@localhost/storage/index.html</literal> will open the Storage
       page.  It is also possible to give abbreviated forms of urls, such as "<literal>storage</literal>"
       or "<literal>network/firewall</literal>".
+    </para>
+
+    <para>
+      <literal>SSH_HOST</literal> is an optional SSH remote host specification
+        (<code>hostname</code> or <code>username@hostname</code>). If given,
+        <literal>cockpit-bridge</literal> will be started on the remote host through
+        <citerefentry>
+          <refentrytitle>ssh</refentrytitle><manvolnum>1</manvolnum>
+        </citerefentry>
+        instead, i. e. the Cockpit web browser will show that remote host.
+        Note that this is more of an experimental/demo feature.
     </para>
   </refsect1>
 

--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -26,6 +26,14 @@
 #   cockpit-desktop /cockpit/@localhost/system/index.html
 #   cockpit-desktop network/firewall
 #   cockpit-desktop users
+#
+# As an experimental/demo feature, the bridge can also be started on a remote
+# ssh host. The host name is given as (optional) second argument, which is
+# passed verbatim to ssh.
+#
+# Example:
+#   cockpit-desktop system svr1
+#   cockpit-desktop / username@svr1
 set -eu
 
 # minimalistic WebKit browser
@@ -130,7 +138,7 @@ detect_browser()
 
 
 if [ -z "${1:-}" ]; then
-    echo "Usage: $0 <Cockpit path>" >&2
+    echo "Usage: $0 <Cockpit path> [ssh host]" >&2
     exit 1
 fi
 
@@ -153,7 +161,7 @@ esac
 detect_browser
 
 # start the bridge; this needs to run in the normal user session/namespace
-coproc cockpit-bridge
+coproc ${2:+ssh "$2"} cockpit-bridge
 trap "kill $COPROC_PID; wait $COPROC_PID || true" EXIT INT QUIT PIPE
 
 # start ws and browser in a detached network namespace

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -581,7 +581,26 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
                  (['/cockpit/@localhost/playground/react-patterns.html', 'playground/react-patterns'],
                   ['script src="react-patterns.js"']
                  ),
+                 # no ssh host
+                 (['/cockpit/@localhost/manifests.json'], ['"system"', '"Overview"', '"Dashboard"']
+                 ),
                 ]
+
+        if m.image not in ["rhel-8-2-distropkg"]:
+             # remote ssh host; added in PR #13754
+             cases.append( (['/cockpit/@localhost/manifests.json test1@localhost'], ['"system"', '"Overview"', '"HACK"']) )
+
+        # prepare fake ssh target; to verify that we really use that, override dashboard manifest
+        m.execute("""set -e; useradd test1
+                  [ -f ~admin/.ssh/id_rsa ] || su -c "ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa" admin
+                  mkdir -p ~test1/.ssh ~test1/.local/share/cockpit/dashboard
+                  echo '{ "version": "42", "dashboard": { "index": { "label": "HACK" } } }' > ~test1/.local/share/cockpit/dashboard/manifest.json
+                  cp ~admin/.ssh/id_rsa.pub ~test1/.ssh/authorized_keys
+                  ssh-keyscan localhost >> ~admin/.ssh/known_hosts
+                  chown admin:admin ~admin/.ssh/known_hosts
+                  chown -R test1:test1 ~test1
+                  su -c "ssh test1@localhost cockpit-bridge --packages" admin | grep -q test1.*dashboard  # validate setup
+                  """)
 
         if "debian" in m.image or "ubuntu" in m.image:
             cockpit_desktop = "/usr/lib/cockpit/cockpit-desktop"


### PR DESCRIPTION
If given, cockpit-bridge will be started on the remote host through
ssh instead.

This is an experimental/demo feature for now, mostly to understand how
cockpit's parts can be plugged together in a very flexible manner.