### PR TITLE
test: Compress journals

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1169,9 +1169,9 @@ class MachineCase(unittest.TestCase):
     def copy_journal(self, title, label=None):
         for name, m in self.machines.items():
             if m.ssh_reachable:
-                log = "%s-%s-%s.log" % (label or self.label(), m.label, title)
+                log = "%s-%s-%s.log.gz" % (label or self.label(), m.label, title)
                 with open(log, "w") as fp:
-                    m.execute("journalctl", stdout=fp)
+                    m.execute("journalctl|gzip", stdout=fp)
                     print("Journal extracted to %s" % (log))
                     attach(log)
 


### PR DESCRIPTION
They take up 60% of our total log space and compress really well. E. g.
20 MB → 380 kB gzipped.

 - [x] Support compressed logs in logs.html: https://github.com/cockpit-project/bots/pull/657