### PR TITLE
build: Don't produce cockpit-cache.tar.gz in dist-gzip mode

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -421,7 +421,6 @@ XZ_COMPRESS_FLAGS = --extreme
 
 dist-gzip: distdir
 	$(DIST_TAR_MAIN) | GZIP=$(GZIP_ENV) gzip -c > $(distdir).tar.gz
-	$(DIST_TAR_CACHE) | GZIP=$(GZIP_ENV) gzip -c > cockpit-cache-$(VERSION).tar.gz
 	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 dist-xz: distdir
 	$(DIST_TAR_MAIN) | xz $(XZ_COMPRESS_FLAGS) > $(distdir).tar.xz


### PR DESCRIPTION
This speeds up test/image-prepare for humans and CI. Official releases
use "dist" and build xz tarballs, and we only want the -cache for these
for license reasons.