### PR TITLE
accounts: Properly dismiss tooltips

### DIFF
--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -426,7 +426,7 @@
   <script id="role-entry-tmpl" type="x-template/mustache">
     {{#roles}}
     <div class="checkbox accounts-privileged">
-      <label data-container="body" data-toggle="tooltip" data-original-title="Unix group: {{name}}" data-placement="right">
+      <label data-toggle="tooltip" data-original-title="Unix group: {{name}}" data-placement="right">
         <input type="checkbox" name="account-role-checkbox-{{id}}"
                data-gid="{{id}}" data-name="{{name}}"
                id="account-role-checkbox-{{id}}" {{#member}}checked{{/member}}/>


### PR DESCRIPTION
The tooltips were places at the end of the body element on hover. When
someone clicked on the checkbox, that triggered actions and the groups were
re-rendered. By re-rendering, the page lost the context of which tooltip
belongs to which element (as those elements were created from scratch).
That kept dangling tooltip at the end of the body after each click on
these checkboxes.

With this patch the tooltips are rendered in the same DOM element, so when
groups are destroyed, those tooltips are destroyed as well.

Fixes #12262