### PR TITLE
Format logs better

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -506,10 +506,16 @@ $(function() {
             if (key !== 'MESSAGE') {
                 out.append(
                     $('<tr>').append(
-                        $('<td>').css('text-align', 'right')
-                                .text(key),
-                        $('<td>').css('text-align', 'left')
-                                .text(journal.printable(entry[key]))));
+                        $('<td>', {
+                            class: "journal-entry-key",
+                            text: key
+                        }),
+                        $('<td>', {
+                            class: "journal-entry-value",
+                            text: journal.printable(entry[key])
+                        })
+                    )
+                );
             }
         });
     }

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -8,7 +8,7 @@
 }
 
 #journal-entry-message:not(:empty) {
-    margin: 10px;
+    padding: 10px;
 }
 
 #journal-entry-fields {

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -2,14 +2,8 @@
 @import "../lib/journal.css";
 @import "./system-global.scss";
 
-/* Make sure to not break log message lines in order to preserve information */
-#journal-entry .info-table-ct td {
-    white-space: normal;
-    word-break: break-all;
-}
-
+/* Do not break labels */
 #journal-entry .info-table-ct td:first-child {
-    white-space: normal;
     word-break: keep-all;
 }
 
@@ -24,6 +18,16 @@
 
 #journal-entry-fields th {
     font-weight: normal;
+}
+
+.journal-entry-value,
+#journal-entry-message {
+    word-break: break-all;
+    white-space: pre-wrap !important;
+}
+
+.journal-entry-value {
+    font-family: monospace, monospace;
 }
 
 .other-threads-btn {


### PR DESCRIPTION
Fixes #11665
@garrett WDYT?

Before:
![Screenshot from 2020-03-23 11-46-21](https://user-images.githubusercontent.com/12330670/77310164-2961f500-6cfe-11ea-8653-3ffb3cd00e0c.png)

After: 
![Screenshot from 2020-03-23 11-57-20](https://user-images.githubusercontent.com/12330670/77310161-28c95e80-6cfe-11ea-92fb-a9887aa7f69b.png)

After in reasonable resolution:
![Screenshot from 2020-03-23 11-58-19](https://user-images.githubusercontent.com/12330670/77310156-27983180-6cfe-11ea-96e8-6a41c90ba0be.png)


