### PR TITLE
test: Fix check-{accounts,login} to get along with root login

### DIFF
--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -76,7 +76,11 @@ class TestAccounts(MachineCase):
         # some operations are not allowed for root user
         b.wait_present("#account-delete[disabled]")
         b.wait_present("#account-real-name-wrapper[disabled]")
-        b.wait_attr("#account-logout", "disabled", "disabled")
+        # when running against existing machines there might be an ssh root session
+        if "root" in m.execute("who"):
+            b.wait_visible("#account-logout:not([disabled])")
+        else:
+            b.wait_visible("#account-logout[disabled]")
         b.wait_present("#account-locked:not(:checked)")
         # root account should not be locked by default on our images
         self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -104,7 +104,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#content-user-name', 'Administrator')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), "^admin *web")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web")
 
         # reload, which should log us in with the cookie
         b.reload()
@@ -112,7 +112,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#content-user-name', 'Administrator')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), "^admin *web")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web")
 
         b.click("#content-user-name")
         b.click('#go-account')


### PR DESCRIPTION
This happens when running the tests in downstream dist-git gating, or
against an existing --machine/--browser where the root user is already
logged in.

In that case, `who` output might not start with the admin session, and
the "Terminate Session" button is not disabled.