### PR TITLE
test: Allow some capacity wiggle room in check-storage-lvm2 testLvm

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -192,7 +192,9 @@ class TestStorage(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_in_text("#detail-sidebar", dev_2)
-        b.wait_in_text("#detail-header label:contains(Capacity) + div", "96 MiB")
+        # this is sometimes 92, sometimes 96 MiB
+        b.wait_js_cond("Number(ph_text('#detail-header label:contains(Capacity) + div').split(' ')[0]) >= 92")
+        b.wait_js_cond("Number(ph_text('#detail-header label:contains(Capacity) + div').split(' ')[0]) <= 96")
 
         self.content_tab_action(1, 1, "Grow")
         self.dialog({"size": 70})


### PR DESCRIPTION
Sometimes the resized pool's capacity is only 92 instead of 96 MiB,
so allow anything in that range.