### PR TITLE
test: Fix race condition in check-storage-lvm2 testUnpartitionedSpace

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -235,7 +235,8 @@ class TestStorage(StorageCase):
 
         # Create a volume group out of disk1
         self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create Volume Group'),
-                               expect=lambda: self.dialog_is_present('disks', disk1),
+                               expect=lambda: self.dialog_is_present('disks', disk1) and
+                                              self.dialog_is_present('disks', "unpartitioned space on Linux scsi_debug"),
                                values={"disks": {disk1: True}})
 
         b.wait_in_text("#devices", "vgroup0")


### PR DESCRIPTION
Creating the partition table takes some time to propagate trough udev
and udisks. Make sure that the VG creation dialog sees the partition
table on the scsi_debug device, and not just the original raw device.
Otherwise the PV initialization will overwrite the partition table
instead of creating a partition.