### PR TITLE
fix(makefile): use copy rule for unmodified files

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -13,6 +13,33 @@ playground_DATA = \
 dist/playground/extra.de.po: pkg/playground/extra.de.po
 	$(COPY_RULE)
 
+dist/playground/hammer.gif: pkg/playground/hammer.gif
+	$(COPY_RULE)
+
+dist/sosreport/sosreport.png: pkg/sosreport/sosreport.png
+	$(COPY_RULE)
+
+dist/apps/default.png: pkg/apps/default.png
+	$(COPY_RULE)
+
+dist/storaged/images/storage-array.png: pkg/storaged/images/storage-array.png
+	$(COPY_RULE)
+
+dist/storaged/images/storage-disk.png: pkg/storaged/images/storage-disk.png
+	$(COPY_RULE)
+
+dist/shell/images/server-error.png: pkg/shell/images/server-error.png
+	$(COPY_RULE)
+
+dist/shell/images/server-large.png: pkg/shell/images/server-large.png
+	$(COPY_RULE)
+
+dist/shell/images/server-small.png: pkg/shell/images/server-small.png
+	$(COPY_RULE)
+
+dist/shell/index.html: pkg/shell/index.html
+	$(COPY_RULE)
+
 metainfodir = ${datarootdir}/metainfo
 metainfo_DATA = pkg/sosreport/org.cockpit-project.cockpit-sosreport.metainfo.xml \
 		pkg/kdump/org.cockpit-project.cockpit-kdump.metainfo.xml \


### PR DESCRIPTION
Several elements were not handled correctly in the Makefiles. This led to different behavior in different environments. 
This fix applies the copy rule to all unchanged files between dist and pkg folders.
Fixes #13554 