### PR TITLE
test: Make check-networking-basic nondestructive

### DIFF
--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -21,22 +21,17 @@ import parent
 from netlib import *
 from testlib import *
 
-from machine_core.constants import TEST_OS_DEFAULT
-
-
+@nondestructive
 class TestNetworking(NetworkCase):
-    provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
-    }
-
     def testBasic(self):
         b = self.browser
         m = self.machine
 
         self.login_and_go("/network")
 
-        iface = self.add_iface()
+        iface = 'cockpit1'
+        self.add_veth(iface, dhcp_cidr="10.111.113.2/20")
+        self.nm_activate_eth(iface)
         self.wait_for_iface(iface)
         b.wait_not_visible("#network-interface")
 
@@ -128,13 +123,6 @@ class TestNetworking(NetworkCase):
 
         self.login_and_go("/network")
         assert_running()
-
-        # Disable NM D-Bus activation; it auto-starts at unpredictable times from background actions,
-        # which makes it impossible/meaningless to write a test; copy the full unit file, Alias= cannot
-        # be reliably disabled with drop-ins
-        m.execute("""systemctl cat NetworkManager.service | sed '/Alias=/d' > /etc/systemd/system/NetworkManager.service
-rm -f --verbose /etc/systemd/system/dbus-org.freedesktop.NetworkManager.service
-systemctl daemon-reload""")
 
         # stop/start NM on CLI, page should notice
         m.execute("systemctl stop NetworkManager")

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -24,7 +24,7 @@ from testlib import *
 class NetworkHelpers:
     '''Mix-in class for tests that require network setup'''
 
-    def add_veth(self, name):
+    def add_veth(self, name, dhcp_cidr=None, dhcp_range=['10.111.112.2', '10.111.127.254']):
         '''Add a veth device that is manageable with NetworkManager
 
         This is safe for @nondestructive tests, the interface gets cleaned up automatically.
@@ -33,9 +33,18 @@ class NetworkHelpers:
             mkdir -p /run/udev/rules.d/ &&
             echo 'ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="%(name)s", ENV{NM_UNMANAGED}="0"' > /run/udev/rules.d/99-nm-veth-%(name)s-test.rules &&
             udevadm control --reload &&
-            ip link add name %(name)s type veth
+            ip link add name %(name)s type veth peer name v_%(name)s
             """ % {"name": name})
         self.addCleanup(self.machine.execute, "rm /run/udev/rules.d/99-nm-veth-{0}-test.rules; ip link del dev {0}".format(name))
+        if dhcp_cidr:
+            # up the router end, give it an IP, and start DHCP server
+            self.machine.execute("ip a add {0} dev v_{1} && ip link set v_{1} up".format(dhcp_cidr, name))
+            server = self.machine.spawn("dnsmasq --keep-in-foreground --log-queries --log-facility=- "
+                                        "--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{0} "
+                                        "--bind-interfaces --interface=v_{0} --dhcp-range={1},{2},4h".format(name, dhcp_range[0], dhcp_range[1]),
+                                        "dhcp.log")
+            self.addCleanup(self.machine.execute, "kill %i" % server)
+            self.machine.execute("if firewall-cmd --state >/dev/null 3>&1; then firewall-cmd --add-service=dhcp; fi")
 
     def nm_activate_eth(self, iface):
         '''Create an NM connection for a given interface'''

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -41,7 +41,7 @@ class NetworkHelpers:
         '''Create an NM connection for a given interface'''
 
         m = self.machine
-        wait(lambda: m.execute('nmcli device | grep %s | grep -v unavailable' % iface))
+        wait(lambda: m.execute('nmcli device | grep "%s.*disconnected"' % iface))
         m.execute("nmcli con add type ethernet ifname %s con-name %s" % (iface, iface))
         m.execute("nmcli con up %s ifname %s" % (iface, iface))
         self.addCleanup(m.execute, "nmcli con delete %s" % iface)


### PR DESCRIPTION
Replace the provisioning of a second VM with a local DHCP server, and
use a veth instead of a QEMU device.

Drop the Alias= hacking; it's obsolete, NM does not do D-Bus activation
any more on any of our current images.

 - [x] Builds on top of PR #13788
 - [x] Add dnsmasq to fedora-coreos: https://github.com/cockpit-project/bots/pull/684