### PR TITLE
test: Avoid reboot hangs after iSCSI tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1237,6 +1237,11 @@ class MachineCase(unittest.TestCase):
         if not self.is_nondestructive():
             return  # skip for efficiency reasons
 
+        exists = self.machine.execute("if test -e %s; then echo yes; fi" % path).strip() != ""
+        if not exists:
+            self.addCleanup(self.machine.execute, "rm -rf {0}".format(path))
+            return
+
         backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))
         self.machine.execute("mkdir -p %(vm_tmpdir)s && cp -a %(path)s/ %(backup)s/" % {
             "vm_tmpdir": self.vm_tmpdir, "path": path, "backup": backup})

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -61,6 +61,15 @@ class TestNondestructiveExample(MachineCase):
         # nonexisting file
         self.restore_file("/var/lib/cockpittest.txt")
         self.machine.execute("echo data > /var/lib/cockpittest.txt")
+
+        # existing dir
+        self.machine.execute("mkdir -p /var/lib/cockpittestdir && echo hello > /var/lib/cockpittestdir/original")
+        self.restore_dir("/var/lib/cockpittestdir")
+        self.machine.execute("rm /var/lib/cockpittestdir/original && echo pwned > /var/lib/cockpittestdir/new")
+        # nonexisting dir
+        self.restore_dir("/var/lib/cockpittestnew")
+        self.machine.execute("mkdir -p /var/lib/cockpittestnew && echo hello > /var/lib/cockpittestnew/cruft")
+
         # NSS is backed up by default
         self.machine.execute("useradd cockpittest")
         # marker that VM stays running in between tests
@@ -72,9 +81,17 @@ class TestNondestructiveExample(MachineCase):
         self.assertEqual("original", self.machine.execute("cat /etc/someconfig").strip())
         # testOne correctly cleaned up nonexisting file
         self.machine.execute("test ! -e /var/lib/cockpittest.txt")
+
+        # testOne correctly restored existing dir
+        self.assertEqual("original", self.machine.execute("ls /var/lib/cockpittestdir").strip())
+        self.assertEqual("hello\n", self.machine.execute("cat /var/lib/cockpittestdir/original"))
+        # testOne correctly removed nonexisting dir
+        self.machine.execute("test ! -e /var/lib/cockpittestnew")
+
         # NSS/home got restored
         self.assertNotIn("cockpittest", self.machine.execute("cat /etc/passwd"))
         self.machine.execute("test ! -e /home/cockpittest")
+
         # machine was not reset after testOne
         self.machine.execute("[ -f /root/the_file ] || exit 1")
 

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -54,10 +54,28 @@ class TestNondestructiveExample(MachineCase):
 
     def testOne(self):
         self.assertEqual(self.machine.execute("whoami").strip(), "root")
+        # existing file
+        self.machine.execute("echo original > /etc/someconfig")
+        self.restore_file("/etc/someconfig")
+        self.machine.execute("echo changed > /etc/someconfig")
+        # nonexisting file
+        self.restore_file("/var/lib/cockpittest.txt")
+        self.machine.execute("echo data > /var/lib/cockpittest.txt")
+        # NSS is backed up by default
+        self.machine.execute("useradd cockpittest")
+        # marker that VM stays running in between tests
         self.machine.execute("touch /root/the_file")
 
     def testTwo(self):
         self.assertIn("usr", self.machine.execute("ls -l /").strip())
+        # testOne correctly restored existing file
+        self.assertEqual("original", self.machine.execute("cat /etc/someconfig").strip())
+        # testOne correctly cleaned up nonexisting file
+        self.machine.execute("test ! -e /var/lib/cockpittest.txt")
+        # NSS/home got restored
+        self.assertNotIn("cockpittest", self.machine.execute("cat /etc/passwd"))
+        self.machine.execute("test ! -e /home/cockpittest")
+        # machine was not reset after testOne
         self.machine.execute("[ -f /root/the_file ] || exit 1")
 
 

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -272,6 +272,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Increase the iSCSI timeouts for heavy load during our testing
         self.sed_file(r"s|^\(node\..*log.*_timeout = \).*|\1 60|", "/etc/iscsi/iscsid.conf")
 
+        # make sure this gets cleaned up, to avoid reboot hangs (https://bugzilla.redhat.com/show_bug.cgi?id=1817241)
+        self.restore_dir("/var/lib/iscsi")
+
         # Setup a iSCSI target
         m.execute("""
                   targetcli /backstores/ramdisk create test 50M


### PR DESCRIPTION
Creating and deleting iSCSI nodes leaves some node information behind in
/var/lib/iscsi. This causes a subsequent boot to hang, as it waits in
vain for an IQN which does not exist any more.

Work around that by restoring the originally empty /var/lib/iscsi.

See https://bugzilla.redhat.com/show_bug.cgi?id=1817241