### PR TITLE
machines: Remove --noreboot parameter to virt-install for VM installation

### DIFF
--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -106,7 +106,7 @@ if [ "$START_VM" = "true" ]; then
     HAS_INSTALL_PHASE="false"
     # Wait for the installer to complete in case we don't use existing image or we don't boot with PXE
     if [ "$SOURCE_TYPE" != "pxe" ] && [ "$SOURCE_TYPE" != "disk_image" ]; then
-        STARTUP_PARAMS="$STARTUP_PARAMS --wait -1 --noreboot"
+        STARTUP_PARAMS="$STARTUP_PARAMS --wait -1"
     fi
 else
     # 2 = last phase only

--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -112,7 +112,6 @@ virt-install \
     --quiet \
     --wait -1 \
     --noautoconsole \
-    --noreboot \
     --check path_in_use=off \
     $MEMORY_PARAM \
     $DISKS_PARAM \

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2308,6 +2308,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             # unfinished install script runs indefinitelly, so we need to force it off
             b.click("#vm-{0}-off-caret".format(name))
             b.click("#vm-{0}-forceOff".format(name))
+            # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
+            # After shutting it off virt-install will restart the domain and exit because of the above bug
             b.wait_in_text("#vm-{0}-state".format(name), "shut off")
 
             return self
@@ -2721,6 +2723,13 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
         wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
         b.wait_present("li.active #vm-VmNotInstalled-consoles")
+        b.click("#vm-VmNotInstalled-off-caret")
+        b.click("#vm-VmNotInstalled-forceOff")
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
+        # After shutting it off virt-install will restart the domain and exit because of the above bug
+        # We need to wait till it's restarted and shut if off again in order to edit the offline VM configuration
+        logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
+        wait(lambda: self.machine.execute("cat {0}".format(logfile)).count('starting up libvirt') == 2, delay=3)
         b.click("#vm-VmNotInstalled-off-caret")
         b.click("#vm-VmNotInstalled-forceOff")
         b.wait_in_text("#vm-VmNotInstalled-state", "shut off")


### PR DESCRIPTION
We were passing this parameter so that when the VM installation finishes
it won't automatically reboot. It will stay alive and if the user tries
to reboot it, it will just shut off, because the installation VM config is
always set up with <on_reboot>destroy</on_reboot>.

Some more info for understanding the virt-install logic here:

When creating a new VM through virt-install we have two steps:
1) the install phase, where the guest is set to boot off the fetched/supplied kernel/initrd
2) the post-install phase, where the guest is set to boot off <disk>

In order for the post-install config to actually take effect, the VM needs to be
fully powered off, after which libvirt will replace the 'install phase'
config with the 'post-install config'.

So, virt-install will force on_reboot=destroy, so that if anaconda
(or other installation program) requests a reboot, libvirt will instead
fully power off the VM, so the post-install config can take effect.

This patch allows virt-install to have this default behavior, so
hopefully users won't notice that trying to issue a 'restart' after
installation finish won't result in the expected behavior.

Relevant to: https://bugzilla.redhat.com/show_bug.cgi?id=1750637