### PR TITLE
WIP: machines, lib: Use SelectableListing for VM boot order

### DIFF
--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -20,6 +20,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import './listing.scss';
+import '../../node_modules/@patternfly/patternfly/components/Select/select.scss';
+import '../../node_modules/@patternfly/patternfly/components/Check/check.scss';
 
 /* entry for an alert in the listing, can be expanded (with details) or standard
  * rowId optional: an identifier for the row which will be set as "data-row-id" attribute on the <tr>
@@ -402,4 +404,36 @@ Listing.propTypes = {
         ])),
     columnTitleClick: PropTypes.func,
     actions: PropTypes.node
+};
+
+/* Implements PF4-compatible listing with clickable rows
+ * Intended for use in modal dialogs
+ *
+ * - rows {object}: with properties: name
+ * - onRowToggle {function}: toggle handler which takes row name as an arguement
+ * - idPrefix {string}
+ */
+export const SelectableListing = ({ rows, onRowToggle, idPrefix }) => {
+    return (
+        <fieldset className="list-group dialog-list-ct pf-c-select" id={idPrefix + "-selectable-listing"}>
+            {rows.map(row => {
+                return (
+                    <label className="pf-c-check pf-c-select__menu-item" htmlFor={idPrefix + "-" + row.id} key={row.id}>
+                        <input className="pf-c-check__input"
+                            name="select-checkbox-expanded-active"
+                            onChange={() => onRowToggle(row.id)}
+                            type="checkbox"
+                            id={idPrefix + "-" + row.id + "-checkbox"}
+                            checked={row.selected} />
+                        <span className="pf-c-check__label">{row.name}</span>
+                    </label>);
+            })}
+        </fieldset>
+    );
+};
+
+SelectableListing.propTypes = {
+    rows: PropTypes.array,
+    idPrefix: PropTypes.string,
+    onRowToggle: PropTypes.func,
 };

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -19,6 +19,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
+import { Flex, FlexItem, FlexModifiers } from '@patternfly/react-core';
 import './listing.scss';
 import '../../node_modules/@patternfly/patternfly/components/Select/select.scss';
 import '../../node_modules/@patternfly/patternfly/components/Check/check.scss';
@@ -418,14 +419,32 @@ export const SelectableListing = ({ rows, onRowToggle, idPrefix }) => {
         <fieldset className="list-group dialog-list-ct pf-c-select" id={idPrefix + "-selectable-listing"}>
             {rows.map(row => {
                 return (
-                    <label className="pf-c-check pf-c-select__menu-item" htmlFor={idPrefix + "-" + row.id} key={row.id}>
-                        <input className="pf-c-check__input"
-                            name="select-checkbox-expanded-active"
-                            onChange={() => onRowToggle(row.id)}
-                            type="checkbox"
-                            id={idPrefix + "-" + row.id + "-checkbox"}
-                            checked={row.selected} />
-                        <span className="pf-c-check__label">{row.name}</span>
+                    <label className="pf-c-select__menu-item" htmlFor={idPrefix + "-" + row.id} key={row.id}>
+                        <Flex>
+                            <Flex>
+                                <FlexItem>
+                                    <input className="pf-c-check__input"
+                                        name="select-checkbox-expanded-active"
+                                        onChange={() => onRowToggle(row.id)}
+                                        type="checkbox"
+                                        id={idPrefix + "-" + row.id + "-checkbox"}
+                                        checked={row.selected} />
+                                </FlexItem>
+                                <FlexItem>
+                                    <span id={idPrefix + "-" + row.id + "-name"} className="pf-c-check__label">{row.name}</span>
+                                </FlexItem>
+                            </Flex>
+                            <Flex breakpointMods={[{ modifier: FlexModifiers["flex-1"] }]}>
+                                <FlexItem>
+                                    <span id={idPrefix + "-" + row.id + "-additionalinfo"}>{row.additionalInfo && row.additionalInfo.map(info => info)}</span>
+                                </FlexItem>
+                            </Flex>
+                            <Flex>
+                                <FlexItem breakpointMods={ [{ modifier: FlexModifiers["justify-content-flex-end"] }] }>
+                                    <span id={idPrefix + "-" + row.id + "-actions"}>{row.actions}</span>
+                                </FlexItem>
+                            </Flex>
+                        </Flex>
                     </label>);
             })}
         </fieldset>

--- a/pkg/machines/components/vm/bootOrderModal.css
+++ b/pkg/machines/components/vm/bootOrderModal.css
@@ -50,10 +50,6 @@
     display: none;
 }
 
-.boot-order .ct-form + .ct-form {
-    margin-left: 1rem;
-}
-
 @media screen and (min-width: 769px) {
     /* Adjust the spacing offset */
     .boot-order .list-group {

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -160,10 +160,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b.wait_present("#vm-subVmTest1-order-modal-window")
         # Make sure the footer warning does not appear
         b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
-        # Move first device down and check whetever succeeded
-        row = b.text("#vm-subVmTest1-order-modal-device-row-1 .list-view-pf-additional-info")
-        b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down")
-        b.wait_in_text("#vm-subVmTest1-order-modal-device-row-0 .list-view-pf-additional-info", row)
+        # Move first device down
+        b.click("#vm-subVmTest1-order-modal-0-actions #vm-subVmTest1-order-modal-down")
         # Make sure the footer warning does appear
         b.wait_present("#vm-subVmTest1-order-modal-min-message")
 
@@ -190,7 +188,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         # Make sure the footer warning does not appear
         b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
         # Unselect second device
-        b.click("#vm-subVmTest1-order-modal-device-row-1 input")
+        b.click("#vm-subVmTest1-order-modal-1-checkbox")
         # Make sure the footer warning still does not appear, since machine is shut down
         b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
 
@@ -270,8 +268,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         bootOrder = b.text("#vm-VmNotInstalled-boot-order")
         b.click("#vm-VmNotInstalled-boot-order")
         b.wait_present(".modal-body")
-        b.set_checked("#vm-VmNotInstalled-order-modal-device-row-1-checkbox", True)
-        b.click("#vm-VmNotInstalled-order-modal-device-row-0 #vm-VmNotInstalled-order-modal-down")
+        b.set_checked("#vm-VmNotInstalled-order-modal-1-checkbox", True)
+        b.click("#vm-VmNotInstalled-order-modal-0-actions #vm-VmNotInstalled-order-modal-down")
         b.click("#vm-VmNotInstalled-order-modal-save")
         b.wait_not_present(".modal-body")
 
@@ -647,7 +645,7 @@ class TestMachinesDBus(machineslib.TestMachines):
         bootOrder = b.text("#vm-subVmTest1-boot-order")
         b.click("#vm-subVmTest1-boot-order") # Open dialog
         b.wait_present(".modal-body")
-        b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down") # Change order
+        b.click("#vm-subVmTest1-order-modal-0-actions #vm-subVmTest1-order-modal-down") # Change order
         b.click("#vm-subVmTest1-order-modal-save") # Save
         b.wait_not_present(".modal-body")
 


### PR DESCRIPTION
**Work in Progress.**

Use cockpit custom PF4-based listing with clickable rows for VM boot order.

Currently will try to figure out here with @garrett  how to organize row content if checkbox, name, description and actions are needed in a row.
![Screenshot from 2020-03-26 15-23-54](https://user-images.githubusercontent.com/42733240/77657579-cbd7dd80-6f75-11ea-8bf6-aa1b6fac9e2e.png)
