### PR TITLE
systemd: Fix showing the "More" diagnostics in realm join dialog

### DIFF
--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -33,8 +33,7 @@ function instance(realmd, mode, realm, state) {
     var kerberos_membership = null;
     var kerberos = null;
 
-    // Hidden attribute does not work because .pf-c-class has diplay: grid
-    $(".realms-op-error").hide();
+    $(".realms-op-error").prop("hidden", true);
 
     /* If in an operation first time cancel is clicked, cancel operation */
     $(".realms-op-cancel").on("click", function() {
@@ -56,8 +55,8 @@ function instance(realmd, mode, realm, state) {
             });
 
     $(dialog).on("click", ".realms-op-more-diagnostics", function() {
-        $(".realms-op-error").hide();
-        $(".realms-op-diagnostics").show();
+        $(".realms-op-error").prop("hidden", true);
+        $(".realms-op-diagnostics").prop("hidden", false);
     });
 
     var timeout = null;
@@ -474,7 +473,7 @@ function instance(realmd, mode, realm, state) {
         var id = "cockpit-" + unique;
         unique += 1;
         busy(id);
-        $(".realms-op-error").hide();
+        $(".realms-op-error").prop("hidden", true);
 
         ensure()
                 .fail(function() {
@@ -485,7 +484,7 @@ function instance(realmd, mode, realm, state) {
 
                     $(".realms-op-message").empty();
                     $(".realms-op-diagnostics").empty()
-                            .hide();
+                            .prop("hidden", true);
 
                     var diagnostics = "";
                     var sub = realmd.subscribe({ member: "Diagnostics" }, function(path, iface, signal, args) {
@@ -505,7 +504,7 @@ function instance(realmd, mode, realm, state) {
                             busy(null);
                             $(".realms-op-message").empty()
                                     .text(_("Joining this domain is not supported"));
-                            $(".realms-op-error").show();
+                            $(".realms-op-error").prop("hidden", false);
                         }
                     } else if (mode == 'leave') {
                         call = cleanup_ws_credentials().then(function() { realm.Deconfigure(options) });
@@ -525,7 +524,7 @@ function instance(realmd, mode, realm, state) {
                                     console.log("Failed to " + mode + " domain: " + realm.Name + ": " + ex);
                                     $(".realms-op-message").empty()
                                             .text(ex + " ");
-                                    $(".realms-op-error").show();
+                                    $(".realms-op-error").prop("hidden", false);
                                     if (diagnostics) {
                                         $(".realms-op-message")
                                                 .append('<a tabindex="0" class="realms-op-more-diagnostics">' + _("More") + '</a>');

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -261,6 +261,23 @@ class TestRealms(MachineCase):
             b.wait_text_not(".realms-op-message", "")
             error = b.text(".realms-op-message")
             b.wait_not_visible(".realms-op-leave-only-row")
+            if not "Already running another action" in error:
+                # More link is part of the message component, so this looks a little funny here
+                # also, older releases have a less useful error message
+                if m.image in ["ubuntu-1804", "debian-stable"]:
+                    self.assertEqual(error, "Running ipa-client-install failed More")
+                else:
+                    self.assertEqual(error, "Password is incorrect More")
+                # "More" should be visible, and diagnostics not shown by default
+                b.wait_not_visible(".realms-op-diagnostics")
+                b.click(".realms-op-more-diagnostics")
+                # that hides the initial message and the More link
+                b.wait_not_visible(".realms-op-message")
+                b.wait_not_visible(".realms-op-more-diagnostics")
+                # and shows the raw log; fixed in PR #13802
+                if m.image not in ["rhel-8-2-distropkg"]:
+                    b.wait_visible(".realms-op-diagnostics")
+                    b.wait_in_text(".realms-op-diagnostics", "ipa-client-install command failed")
             b.click(".realms-op-cancel")
             b.wait_popdown("realms-op")
             if not "Already running another action" in error:


### PR DESCRIPTION
Commit 0a760b705ce was missing the realms-op-diagnostics field, which
also uses "hidden", and thus never appeared when calling .show(). The
effect was that clicking on the "More" link to get the verbose
diagnostics just made the whole error message go away.

Change the "hidden" instead of the "display" attribute to fix that. Do
the same for realms-op-error for consistency.

Add a test for the error handling: Initially we just want to show the
error message and the "More" link, and when clicking we want both go to
away and show the verbose "diagnostics" log.

Part of https://bugzilla.redhat.com/show_bug.cgi?id=1813136