### PR TITLE
systemd: Fix error message when joining AD domains

### DIFF
--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -383,6 +383,12 @@ function instance(realmd, mode, realm, state) {
         if (cockpit.transport.host !== "localhost")
             return cockpit.resolve();
 
+        const server_sw = find_detail(realm, "server-software");
+        if (server_sw !== "ipa") {
+            console.log("installing ws credentials not supported for server software", server_sw);
+            return cockpit.resolve();
+        }
+
         if (auth !== "password/administrator") {
             console.log("Installing kerberos keytab and SSL certificate not supported for auth mode", auth);
             return cockpit.resolve();


### PR DESCRIPTION
Installing cockpit-ws credentials is only supported for FreeIPA. When
joining an AD domain, trying to call the `ipa` command line client will
just thrown an error message "IPA client is not configured on this
system". This appears in the "Join Domain" dialog without further
details, but the joining works anyway, so this was rather confusing.

Only actually run install_ws_credentials() when the Server software is
"ipa".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1813136