### PR TITLE
Reduce size of css files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "clean-css-cli": "^4.3.0",
     "copy-webpack-plugin": "^5.1.1",
     "css-loader": "^3.4.2",
+    "optimize-css-assets-webpack-plugin": "^3.2.1",
     "eslint": "^6.8.0",
     "eslint-config-standard": "^14.1.1",
     "eslint-config-standard-react": "^9.2.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -235,6 +235,7 @@ var html = require('html-webpack-plugin');
 var miniCssExtractPlugin = require('mini-css-extract-plugin');
 var path = require("path");
 var fs = require("fs");
+const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 
 /* These can be overridden, typically from the Makefile.am */
 var srcdir = process.env.SRCDIR || __dirname;
@@ -313,6 +314,7 @@ var plugins = [
     new copy(info.files),
     new miniCssExtractPlugin("[name].css"),
     new CleanUpStatsPlugin(),
+    new OptimizeCSSAssetsPlugin({cssProcessorOptions: {map: {inline: false} } }),
 ];
 
 var output = {


### PR DESCRIPTION
Some rules may be imported more times or they might be overwritten in
the same file. Removing such rules reduces the size of css files.

Related #12910

Fixes at least my comment from #12910, possibly the whole issue? I am still not sure what @garrett meant there so cannot verify it.

Some stats:

File name | Size before | Size after | Proportion
--- | --- | --- | ---
/usr/share/cockpit/apps/apps.css.gz| 11K|9.4K | 85%                             
/usr/share/cockpit/users/users.css.gz| 14K|11K | 78%                            
/usr/share/cockpit/tuned/performance.css.gz| 8.4K|8.1K | 96%                    
/usr/share/cockpit/dashboard/dashboard.css.gz| 9.8K|8.7K | 88%                  
/usr/share/cockpit/kdump/kdump.css.gz| 16K|10K |62%                             
/usr/share/cockpit/docker/docker.css.gz| 19K|14K|73%                            
/usr/share/cockpit/selinux/selinux.css.gz| 17K|14K|82%                          
/usr/share/cockpit/packagekit/updates.css.gz| 19K|16K|84%                       
/usr/share/cockpit/playground/index.css.gz| 5.2K|5.2K|100%                      
/usr/share/cockpit/playground/speed.css.gz| 4.0K|4.0K|100%                      
/usr/share/cockpit/playground/plot.css.gz| 4.6K|4.3K|93%                        
/usr/share/cockpit/playground/react-patterns.css.gz| 18K|14K|78%                
/usr/share/cockpit/playground/metrics.css.gz| 635|491|77%                       
/usr/share/cockpit/playground/jquery-patterns.css.gz| 12K|11K|91%               
/usr/share/cockpit/playground/test.css.gz| 4.0K|4.0K|100%                       
/usr/share/cockpit/shell/index.css.gz| 26K|17K|65%                              
/usr/share/cockpit/sosreport/sosreport.css.gz| 11K|9.1K|82%                     
/usr/share/cockpit/base1/patternfly.min.css.gz| 69K|69K|100%                    
/usr/share/cockpit/base1/cockpit.min.css.gz| 3.2K|3.2K|100%                     
/usr/share/cockpit/ocserv/ocserv.css| 1.3K|1.3K|100%                            
/usr/share/cockpit/networkmanager/firewall.css.gz| 22K|16K|72%                  
/usr/share/cockpit/networkmanager/network.css.gz| 18K|13K|72%                   
/usr/share/cockpit/machines/machines.css.gz| 40K|27K|67%                        
/usr/share/cockpit/branding/rhel/branding.css| 556|556|100%                     
/usr/share/cockpit/branding/default/branding.css| 534|534|100%                  
/usr/share/cockpit/branding/ubuntu/branding.css| 486|486|100%                   
/usr/share/cockpit/branding/centos/branding.css| 437|437|100%                   
/usr/share/cockpit/branding/registry/branding.css| 478|478|100%                  
/usr/share/cockpit/branding/scientific/branding.css| 384|384|100%               
/usr/share/cockpit/branding/fedora/branding.css| 473|473|100%                   
/usr/share/cockpit/branding/debian/branding.css| 436|436|100%                   
/usr/share/cockpit/branding/kubernetes/branding.css| 478|478|100%               
/usr/share/cockpit/systemd/services.css.gz| 17K|13K|76%                         
/usr/share/cockpit/systemd/overview.css.gz| 33K|23K|69%                         
/usr/share/cockpit/systemd/terminal.css.gz| 12K|8.0K|66%                        
/usr/share/cockpit/systemd/logs.css.gz| 19K|13K|68%                             
/usr/share/cockpit/systemd/hwinfo.css.gz| 27K|23K|85%                           
/usr/share/cockpit/systemd/graphs.css.gz| 6.8K|6.6K|97%                         
/usr/share/cockpit/storaged/storage.css.gz| 33K|27K|81%

I havn't noticed any visual regression, but second pair of eyes would be great.
Should this also be used only in production mode?