### PR TITLE
Redefine PF4 breakpoints global variables to avoid premature wrapping

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "less-loader": "^5.0.0",
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.1",
+    "null-loader": "^3.0.0",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^4.0.0",
     "sass-loader": "^8.0.2",

--- a/pkg/lib/_global-variables.scss
+++ b/pkg/lib/_global-variables.scss
@@ -3,3 +3,16 @@
  */
 $grid-gutter-width: 30px;
 $font-size-base: 1;
+
+/*
+ * PatternFly 4 adapting the lists too early.
+ * When PF4 has a breakpoint of 768px width, it's actually 1108 for us, as the sidebar is 340px.
+ * (This does use the intended content area, but there's a mismatch between content and browser width as we use iframes.)
+ * So redefine grid breakpoints
+ */
+$pf-global--breakpoint--xs: 0 !default;
+$pf-global--breakpoint--sm: 236px !default;
+$pf-global--breakpoint--md: 428px !default;
+$pf-global--breakpoint--lg: 652px !default;
+$pf-global--breakpoint--xl: 860px !default;
+$pf-global--breakpoint--2xl: 1110px !default;

--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -1,3 +1,6 @@
+@import "~@patternfly/patternfly/components/Table/table.scss";
+@import "~@patternfly/patternfly/components/Table/table-grid.scss";
+
 // Display the actions next to the header inline
 header {
     display: flex;

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -1,4 +1,5 @@
-@import "../../node_modules/@patternfly/patternfly/components/Table/table.scss";
+@import "~@patternfly/patternfly/components/Table/table.scss";
+@import "~@patternfly/patternfly/components/Page/page.scss";
 @import "./system-global.scss";
 
 /* System Time Modal dialog needs table.css */

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -444,6 +444,20 @@ module.exports = {
                     },
                 ]
             },
+            {
+                // See https://github.com/patternfly/patternfly-react/issues/3815 and
+                // [Redefine grid breakpoints] section in pkg/lib/_global-variables.scss for more details
+                // Components which are using the pf-global--breakpoint-* variables should import scss manually
+                // instead off the automatically imported CSS stylesheets
+                test: /\.css$/,
+                include: stylesheet => {
+                    return (
+                        stylesheet.includes('@patternfly/react-styles/css/components/Page/') ||
+                        stylesheet.includes('@patternfly/react-styles/css/components/Table/')
+                    );
+                },
+                use: ["null-loader"]
+            }
         ],
     }
 };


### PR DESCRIPTION
* This was split out of https://github.com/cockpit-project/cockpit/pull/13695 to allow quicker merging 

When PF4 has a breakpoint of 768px width, it's actually 1108 for us,
as the sidebar is 340px. This does use the intended content area, but there's a
mismatch between content and browser width as we use iframes.

So redefine grid breakpoints in _gloabal-variables.scss file which is
configured to be visible by all scss files.
In order that these variables take effect we should make sure that the
components that are using these variables are also using scss and not css.

See https://github.com/patternfly/patternfly-react/issues/3815 for more
info.

In order to achieve that utilize null-loader, which allows us to filter
out CSS stylesheets from specific directories.