### PR TITLE
containers: Add VERSION label to cockpit/ws

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:30
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
+LABEL VERSION=master
 
 ARG VERSION
 


### PR DESCRIPTION
cockpituous will replace the value on release:
https://github.com/cockpit-project/cockpituous/blob/master/release/release-dockerhub#L85

Fixes #13812