### PR TITLE
bridge: Pass connectable to TLS client connection

### DIFF
--- a/src/bridge/cockpitconnect.c
+++ b/src/bridge/cockpitconnect.c
@@ -135,7 +135,7 @@ on_socket_connect (GObject *object,
 
       if (connectable->tls)
         {
-          cs->io = g_tls_client_connection_new (G_IO_STREAM (object), NULL, &error);
+          cs->io = g_tls_client_connection_new (G_IO_STREAM (object), connectable->address, &error);
           if (cs->io)
             {
               g_debug ("%s: tls handshake", connectable->name);


### PR DESCRIPTION
This is being used for SNI and better error messages for TLS
connections [1]. Recent glib versions started to warn about this, which
makes our tests fail:

    (test-httpstream:172365): GLib-Net-WARNING **: 02:19:07.627: GTlsClientConnection certificate verification will fail because its server-identity property is NULL. Fix your application!
    (test-websocketstream:172431): GLib-Net-WARNING **: 02:19:08.201: GTlsClientConnection certificate verification will fail because its server-identity property is NULL. Fix your application!

[1] https://developer.gnome.org/gio/stable/GTlsClientConnection.html#GTlsClientConnection--server-identity