### PR TITLE
test: Make check for no failed services more robust

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -949,7 +949,8 @@ ExecStart=/usr/bin/false
             # System page should not have notification
             b.click('#host-apps a[href="/system"]')
             b.enter_page('/system')
-            b.wait_not_in_text(".system-health-events", "failed")
+            b.wait_not_in_text(".system-health-events", "service has failed")
+            b.wait_not_in_text(".system-health-events", "services have failed")
 
     def testHiddenFailure(self):
         m = self.machine


### PR DESCRIPTION
There can be a different failure on the overview page that contains the word
"failed".

Fixes #13818