### PR TITLE
package.json: Revert to terser 4.6.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "stdio": "^2.1.1",
     "strict-loader": "^1.2.0",
     "style-loader": "^1.1.3",
+    "terser": "4.6.7",
     "uglify-js": "^3.8.0",
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11"


### PR DESCRIPTION
4.6.8 breaks the world:
https://github.com/terser/terser/issues/624
https://github.com/terser/terser/issues/625