### PR TITLE
tools: spec file adjustments for openSUSE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -444,6 +444,7 @@ include src/branding/debian/Makefile.am
 include src/branding/default/Makefile.am
 include src/branding/fedora/Makefile.am
 include src/branding/kubernetes/Makefile.am
+include src/branding/opensuse-tumbleweed/Makefile.am
 include src/branding/registry/Makefile.am
 include src/branding/rhel/Makefile.am
 include src/branding/scientific/Makefile.am

--- a/src/branding/opensuse-tumbleweed/Makefile.am
+++ b/src/branding/opensuse-tumbleweed/Makefile.am
@@ -1,0 +1,11 @@
+tumbleweedbrandingdir = $(datadir)/cockpit/branding/opensuse-tumbleweed
+
+tumbleweedbranding_DATA = \
+	src/branding/opensuse-tumbleweed/branding.css \
+	$(NULL)
+
+EXTRA_DIST += $(tumbleweedbranding_DATA)
+
+install-data-hook::
+	$(LN_S) -f /usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(tumbleweedbrandingdir)/default-1920x1200.jpg
+	$(LN_S) -f /usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(tumbleweedbrandingdir)/square-hicolor.svg

--- a/src/branding/opensuse-tumbleweed/branding.css
+++ b/src/branding/opensuse-tumbleweed/branding.css
@@ -1,0 +1,30 @@
+.navbar-pf {
+    border-color: #73ba25 !important;
+}
+
+body.login-pf {
+    background: url("default-1920x1200.jpg") no-repeat 50% 0;
+    background-size: cover;
+    background-color: #42474c;
+}
+
+#badge {
+    width: 5em;
+    height: 5em;
+    background-image: url("square-hicolor.svg");
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+#brand {
+    font-size: 18pt;
+    text-transform: uppercase;
+}
+
+#brand:before {
+    content: "${NAME}";
+}
+
+#index-brand:before {
+    content: "${NAME}";
+}

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -98,6 +98,8 @@ BuildRequires: pcp-devel
 BuildRequires: libpcp3
 BuildRequires: libpcp_import1
 BuildRequires: openssh
+BuildRequires: distribution-logos
+BuildRequires: wallpaper-branding
 %else
 BuildRequires: pcp-libs-devel
 BuildRequires: openssh-clients
@@ -283,7 +285,7 @@ sed -i "s|%{buildroot}||" *.list
 # remove brandings that don't match the distro as they may contain
 # stale symlinks
 pushd %{buildroot}/%{_datadir}/cockpit/branding
-ls -1 | grep -v default | xargs rm -vr
+ls -1 | (. /etc/os-release; grep -v "default\|$ID") | xargs rm -vr
 popd
 # need this in SUSE as post build checks dislike stale symlinks
 install -m 644 -D /dev/null %{buildroot}/run/cockpit/motd


### PR DESCRIPTION
I don't know if you want to litter your spec file with our stuff but worth a try I guess :)
Apart from the usual package name differences there are also some files packages twice or not owned directories caught.
The debug trick doesn't work, the macro has different content on openSUSE. Also, openSUSE doesn't like stale symlinks.