### PR TITLE
containers: Fix unit-tests container for SELinux

### DIFF
--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -16,7 +16,7 @@ or root.
 ## Building
 
 The `build` script will build the `cockpit/unit-tests` and
-`cockpit/unit-tests:i386` containers.  It should be run as root.
+`cockpit/unit-tests:i386` containers.
 
 ## Running tests
 

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -20,7 +20,7 @@ python3 -c "import fcntl, os; assert fcntl.fcntl(0, fcntl.F_GETFL) & os.O_NONBLO
 
 # copy host's source tree to avoid changing that, and make sure we have a clean tree
 if [ ! -e /source/.git ]; then
-    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro" >&2
+    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro,Z" >&2
     exit 1
 fi
 git clone /source /tmp/source

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -23,5 +23,5 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
 fi
 
 set -ex
-exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro,Z \
        ${ccarg:+"$ccarg"} $flags -- "$image" $cmd


### PR DESCRIPTION
Add missing :Z option so that this can be run on a Fedora/RHEL host with
SELinux on.
