### PR TITLE
test: Also cleanup selinux modules

### DIFF
--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -268,7 +268,7 @@ class TestSelinux(MachineCase):
         b.wait_in_text(".xterm-accessibility-tree", "boolean -m -0 zebra_write_config")
         b.wait_in_text(".xterm-accessibility-tree", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
 
-        m.execute("semanage boolean -D && semanage fcontext -D")
+        m.execute("semanage boolean -D && semanage fcontext -D && semanage module -D")
         b.go("/selinux/setroubleshoot")
         b.enter_page("/selinux/setroubleshoot")
         b.reload()


### PR DESCRIPTION
Fedora seems to have a new local modification, that is preventing tests
from seeing 'No System Modifications'.

Log: https://logs.cockpit-project.org/logs/pull-700-20200331-143900-468782d5-fedora-testing-cockpit-project-cockpit/log.html#202-2

Related https://github.com/cockpit-project/bots/pull/700
Related https://github.com/cockpit-project/bots/pull/699