### PR TITLE
test: Also reload libvirtd on debian-testing

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -305,7 +305,7 @@ class TestMachinesDBus(machineslib.TestMachines):
             # HACK: Capabilities are not updated dynamically
             # https://bugzilla.redhat.com/show_bug.cgi?id=1807198
             def hack_broken_caps():
-                if m.image in ["fedora-32", "ubuntu-2004"]:
+                if m.image in ["fedora-32", "ubuntu-2004", "debian-testing"]:
                     m.execute("systemctl restart libvirtd")
                     # We don't get events for shut off VMs so reload the page
                     b.reload()


### PR DESCRIPTION
Seems that the related bug got into debian as well.

Related https://github.com/cockpit-project/bots/pull/705