### PR TITLE
feat: prioritizing the tarball version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -16,7 +16,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 AC_INIT([Cockpit],
-        [m4_esyscmd_s([if [ -e .git ]; then echo $(git describe | tr - . ); else cat .tarball; fi])],
+        [m4_esyscmd_s([if [ -f .tarball ]; then cat .tarball; else echo $(git describe | tr - . ); fi])],
         [devel@lists.cockpit-project.org],
         [cockpit],
         [https://cockpit-project.org/])


### PR DESCRIPTION
By prioritizing the tarball version, a git overlay has no effect
on the readout version. With this modification the version detection
works in Yocto 3.x.