### PR TITLE
system: Don't call cockpit.permissions for LoginMessages

### DIFF
--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -46,7 +46,6 @@ class LoginMessages extends React.Component {
     constructor() {
         super();
         this.state = { messages: {} };
-        this.permission = cockpit.permission({ admin: true });
 
         this.close = this.close.bind(this);
 


### PR DESCRIPTION
It is not actually used by the rest of the code.

This matters with #13482, calling cockpit.permissions would cause a reload of the page when permissions actually change.
