### PR TITLE
shell: Move 'About Cockpit' into 'Help' and rename it

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -61,12 +61,8 @@
                   </li>
                   <li class="divider display-language-menu"></li>
                   <li>
-                    <a role="link" tabindex="0" data-toggle="modal" data-target="#about" translate="yes">About Cockpit</a>
-                  </li>
-                  <li>
                     <a role="link" tabindex="0" id="active-pages" translate="yes" class="navbar-advanced">Active Pages</a>
                   </li>
-                  <li class="divider"></li>
                   <li id="go-account" hidden>
                     <a role="link" tabindex="0" translate="yes">Account Settings</a>
                   </li>
@@ -87,7 +83,7 @@
           <div class="modal-dialog">
             <div class="modal-content">
               <div class="modal-header">
-                <h4 class="modal-title" translate="yes">About Cockpit</h4>
+                <h4 class="modal-title" translate="yes">About Web Console</h4>
               </div>
               <div class="modal-body">
                 <div translate="yes">Cockpit is an interactive Linux server admin interface.</div>

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -614,6 +614,19 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
         if (item && item.docs && item.docs.length > 0)
             item.docs.forEach(e => create_item(_(e.label), e.url));
+
+        // Add 'About Web Console' item
+        const divider = document.createElement("li");
+        divider.className = "divider";
+        const about = document.createElement("li");
+        const el_a = document.createElement("a");
+        el_a.setAttribute("data-toggle", "modal");
+        el_a.setAttribute("data-target", "#about");
+        el_a.appendChild(document.createTextNode(_("About Web Console")));
+        about.appendChild(el_a);
+
+        docs_items.appendChild(divider);
+        docs_items.appendChild(about);
     }
 
     function update_navbar(machine, state, compiled) {

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -80,7 +80,7 @@ html.index-page body {
 
 /* navbar documentation */
 
-#navbar-docs-items a {
+#navbar-docs-items a:not([data-toggle]) {
     color: var(--color-link)
 }
 

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -39,11 +39,12 @@ class TestMenu(MachineCase):
         self.login_and_go("/system")
 
         b.switch_to_top()
-        b.click('#navbar-dropdown')
-        b.click('a[data-target="#about"]')
-        b.wait_popup('about')
-        b.click('#about button[data-dismiss="modal"]')
-        b.wait_popdown("about")
+        if m.image != "rhel-8-2-distropkg": # Changed in #13836
+            b.click('#navbar-docs-dropdown')
+            b.click('a[data-target="#about"]')
+            b.wait_popup('about')
+            b.click('#about button[data-dismiss="modal"]')
+            b.wait_popdown("about")
 
         # Test session timeout
         time.sleep(20)

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -33,6 +33,7 @@ class TestPages(MachineCase):
         b.wait_visible("#navbar-docs-items")
         expected = "Web Console"
         expected += "".join(items)
+        expected += "About Web Console"
         # DOCUMENTATION_URL is only in Fedora
         # RHEL is tracked in rhbz#1789984
         if "fedora" in m.image:


### PR DESCRIPTION
Rename 'Cockpit' to 'Web Console'.
Move 'About Cockpit' into 'Help' as it makes more sense there as in
account settings.

Inspired by the designs for the new navigation where this item was moved into Help section.
@garrett agree with this change?

![movedabout](https://user-images.githubusercontent.com/12330670/78228792-7056a400-74cf-11ea-9683-69c8c96061c9.png)

![withoutabout](https://user-images.githubusercontent.com/12330670/78228807-7482c180-74cf-11ea-8b7d-aeb4e1d53c97.png)
