### PR TITLE
ws: Eliminate static cockpit.conf from cockpit-tests

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -457,7 +457,6 @@ mock-pam-conv-mod.so$(EXEEXT): $(mock_pam_conv_mod_so_SOURCES)
 
 noinst_PROGRAMS += mock-pam-conv-mod.so
 CLEANFILES += mock-pam-conv-mod.so
-EXTRA_DIST += src/ws/fatal.conf
 
 testassetsdir = $(prefix)/lib/cockpit-test-assets
 testserviceddir = $(systemdunitdir)/cockpit.service.d
@@ -465,7 +464,6 @@ testserviceddir = $(systemdunitdir)/cockpit.service.d
 install-tests::
 	$(MKDIR_P) $(DESTDIR)$(testassetsdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
 	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(testassetsdir)
-	$(INSTALL_DATA) $(srcdir)/src/ws/fatal.conf $(DESTDIR)/etc/cockpit/cockpit.conf
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d

--- a/src/ws/fatal.conf
+++ b/src/ws/fatal.conf
@@ -1,2 +1,0 @@
-[Log]
-Fatal = criticals

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -826,6 +826,8 @@ class MachineCase(unittest.TestCase):
         if self.machine:
             self.journal_start = self.machine.journal_cursor()
             self.browser = self.new_browser()
+            # fail tests on criticals
+            self.machine.write("/etc/cockpit/cockpit.conf", "[Log]\nFatal = criticals\n")
             if self.is_nondestructive():
                 self.nonDestructiveSetup()
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -244,7 +244,7 @@ for pkg in apps dashboard docker machines packagekit pcp playground storaged; do
     rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg
 done
 # files from -tests
-rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets %{buildroot}/%{_sysconfdir}/cockpit/cockpit.conf
+rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets
 # files from -pcp
 rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib/pcp/
 # files from -machines
@@ -573,7 +573,6 @@ This package contains tests and files used while testing Cockpit.
 These files are not required for running Cockpit.
 
 %files -n cockpit-tests -f tests.list
-%config(noreplace) %{_sysconfdir}/cockpit/cockpit.conf
 %{_prefix}/%{__lib}/cockpit-test-assets
 
 %package -n cockpit-machines


### PR DESCRIPTION
It is rather impractical to ship a static configuration file in
cockpit-tests. It will get in the way once we ship a default one in
cockpit-ws [1], and a lot of tests have not actually used it as
(1) nonDestructiveSetup() removes an existing cockpit.conf after each
test, and (2) a lot of tests set up their own cockpit.conf.

Instead, create it dynamically in MachineCase.setUp().

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1816044