### PR TITLE
Revert "containers: Fix unit-tests container for SELinux"

### DIFF
--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -20,6 +20,11 @@ The `build` script will build the `cockpit/unit-tests` and
 
 ## Running tests
 
+You need to disable SELinux with `sudo setenforce 0` for this. There is no
+other way for the container to access the files in your build tree (do *not*
+use the `--volume` `:Z` option, as that will destroy the file labels on the
+host).
+
 Tests in that container get started with the `start` script.  By default, this
 script runs the unit tests on amd64.  The script accepts a number of arguments
 to modify its behaviour:

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -20,7 +20,7 @@ python3 -c "import fcntl, os; assert fcntl.fcntl(0, fcntl.F_GETFL) & os.O_NONBLO
 
 # copy host's source tree to avoid changing that, and make sure we have a clean tree
 if [ ! -e /source/.git ]; then
-    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro,Z" >&2
+    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro" >&2
     exit 1
 fi
 git clone /source /tmp/source

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -23,5 +23,5 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
 fi
 
 set -ex
-exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro,Z \
+exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
        ${ccarg:+"$ccarg"} $flags -- "$image" $cmd


### PR DESCRIPTION
Turns out :Z destroys the labels on the host, so let's not do that.
Instead, document that you need to setenforce 0.

Better solutions appreciated!

This reverts commit d82cda29177294d795a2879d4484f272c37f3bc0.