### PR TITLE
tests: Don't start VMs when installing with `Download an OS` option

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1512,25 +1512,22 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # name already used from a VM that is currently being created
         # https://bugzilla.redhat.com/show_bug.cgi?id=1780451
-        # downloadOS option exists only in virt-install >= 2.2.1 which is the reason we have the condition for the OSes list below
-        if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'centos-8-stream']:
-            self.browser.wait_not_present('select option[data-value="Download an OS"]')
-        else:
-            createDownloadAnOSTest(TestMachines.VmDialog(self, name='existing-name', sourceType='downloadOS',
-                                                         expected_memory_size=256,
-                                                         expected_storage_size=256,
-                                                         os_name=config.FEDORA_28,
-                                                         os_short_id=config.FEDORA_28_SHORTID,
-                                                         start_vm=True, delete=False))
+        createTest(TestMachines.VmDialog(self, name='existing-name', sourceType='file',
+                                         location=config.NOVELL_MOCKUP_ISO_PATH,
+                                         storage_pool="No Storage",
+                                         os_name=config.FEDORA_28,
+                                         start_vm=True, delete=False))
 
-            checkDialogFormValidationTest(TestMachines.VmDialog(self, "existing-name", storage_size=1,
-                                                                check_script_finished=False, env_is_empty=False), {"Name": "already exists"})
+        checkDialogFormValidationTest(TestMachines.VmDialog(self, "existing-name", storage_size=1,
+                                                            check_script_finished=False, env_is_empty=False), {"Name": "already exists"})
 
-            self.machine.execute("killall -9 virt-install")
+        mock_dialog = type('', (), {})
+        mock_dialog.name = 'existing-name'
+        runner.deleteVm(mock_dialog)
 
-            # Close the notificaton which will appear for the failed installation
-            self.browser.click(".toast-notifications-list-pf div.pf-c-alert button.pf-c-button")
-            self.browser.wait_not_present(".toast-notifications-list-pf div.pf-c-alert")
+        # Close the notificaton which will appear for the failed installation
+        self.browser.click(".toast-notifications-list-pf div.pf-c-alert button.pf-c-button")
+        self.browser.wait_not_present(".toast-notifications-list-pf div.pf-c-alert")
 
         # location
         checkDialogFormValidationTest(TestMachines.VmDialog(self, sourceType='url',
@@ -1555,6 +1552,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                                       {"Operating System": "You need to select the most closely matching Operating System"})
 
         # try to CREATE few machines
+        # downloadOS option exists only in virt-install >= 2.2.1 which is the reason we have the condition for the OSes list below
         if self.machine.image in ['debian-stable', 'debian-testing', 'ubuntu-stable', 'ubuntu-1804', 'centos-8-stream']:
             self.browser.wait_not_present('select option[data-value="Download an OS"]')
         else:


### PR DESCRIPTION
When `Download an OS` option is used `virt-install` will fetch the
minimal files necessary to kick off the installation process from a
distro tree URL as specified by osinfo-db.

The test VMs don't have access to external network so virt-install will
fail on a timeout to download these files at some point, causing the
installation to fail.

Stop relying on these timeouts being long enough to be able to parse the
`virt-install` args before the timeout makes `virt-install` to exit.

Fixes #13834