### PR TITLE
test: Restore utmp in check-login to pacify libvirt

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -215,6 +215,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m.start_cockpit()
 
         # Clean out the relevant logfiles
+        self.restore_file("/var/run/utmp")  # https://bugzilla.redhat.com/show_bug.cgi?id=1783715
         m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
 
         # First login should have no messages


### PR DESCRIPTION
If check-login ran before the Machines tests, the latter failed with

    internal error: child reported (status=125): Unable to get host boot time: No such process'

Libvirt looks at the boot time in /run/utmp to determine that, and
apparently fails to fall back to /proc/uptime in some versions
(https://bugzilla.redhat.com/show_bug.cgi?id=1783715)

Avoid that by restoring the file.