### PR TITLE
test: Make check for no failed services more robust, take #2

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -982,7 +982,8 @@ Where=/fail
             # System page should not have notification
             b.click('#host-apps a[href="/system"]')
             b.enter_page('/system')
-            b.wait_not_in_text(".system-health-events", "failed")
+            b.wait_not_in_text(".system-health-events", "service has failed")
+            b.wait_not_in_text(".system-health-events", "services have failed")
 
         self.allow_journal_messages(".*type=1400 audit(.*): avc:  denied  { create } .* comm=\"systemd\" name=\"fail\".*")
 


### PR DESCRIPTION
Commit e93698e6a fixed testNotifyFailed(). Fix testHiddenFailure() in
the same way, so that a failure to load available updates does not get
in the way.