### PR TITLE
test: Skip dhclient-modifying tests on Fedora CoreOS

### DIFF
--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -226,6 +226,7 @@ class TestNetworking(NetworkCase):
         b.wait_present("#networking-interfaces tr[data-interface='%s']" % iface)
 
     @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-1804", "ubuntu-2004", "ubuntu-stable")
+    @skipImage("not using dhclient", "fedora-coreos")
     def testBondingMainSlowly(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -60,6 +60,7 @@ class TestNetworking(NetworkCase):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
 
     @skipImage("Main interface settings are read-only", "debian-stable", "debian-testing")
+    @skipImage("not using dhclient", "fedora-coreos")
     def testCheckpointSlowRollback(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Recent versions don't install dhclient by default any more, and NM uses
its internal DHCP client. So this test does not work any more.