### PR TITLE
[WIP] machines: Port some of the modal dialogs to PF4 Modal component

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -562,3 +562,21 @@ input[type=number] {
     line-height: 1.5;
     border-radius: .2rem;
 }
+
+/* PF4 modals have a max height and scroll on overflow - unset the maximum height to avoid getting a scrollbar */
+.pf-c-modal-box {
+    max-height: calc(100vh - var(--pf-global--spacer--2xl));
+
+    /* PF4 modals are missing pf-m-md class for medium size modals */
+    &.pf-m-md {
+        max-width: 50rem;
+        margin: var(--pf-global--spacer--lg);
+
+        @media screen and (max-width: 50rem) {
+            max-width: calc(100% - var(--pf-global--spacer--lg)); // Ensure modal has gutters at full width
+        }
+    }
+}
+.pf-c-backdrop > .pf-l-bullseye {
+    align-items: start;
+}

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -19,8 +19,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, HelpBlock, Modal, OverlayTrigger, Tooltip, TypeAheadSelect } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { FormGroup, HelpBlock, OverlayTrigger, Tooltip, TypeAheadSelect } from 'patternfly-react';
+import { Button, Modal } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
 import { MachinesConnectionSelector } from '../machinesConnectionSelector.jsx';
@@ -929,25 +929,26 @@ class CreateVmModal extends React.Component {
         );
 
         return (
-            <Modal id='create-vm-dialog' show onHide={ this.props.close }>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={ this.props.close } />
-                    <Modal.Title> {this.props.mode == 'create' ? _("Create New Virtual Machine") : _("Import A Virtual Machine")} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {dialogBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    <Button variant="primary"
-                            isDisabled={Object.getOwnPropertyNames(validationFailed).length > 0}
-                            onClick={this.onCreateClicked}>
-                        {this.props.mode == 'create' ? _("Create") : _("Import")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+            <Modal id='create-vm-dialog' appendTo={document.body} isOpen onClose={ this.props.close }
+                   className='pf-m-md'
+                   title={this.props.mode == 'create' ? _("Create New Virtual Machine") : _("Import A Virtual Machine")}
+                   footer={<>
+                       <Button variant="primary"
+                               key="btn-create"
+                               isDisabled={Object.getOwnPropertyNames(validationFailed).length > 0}
+                               onClick={this.onCreateClicked}>
+                           {this.props.mode == 'create' ? _("Create") : _("Import")}
+                       </Button>
+                       <Button variant='link'
+                               key="btn-cancel"
+                               className='btn-cancel'
+                               onClick={ this.props.close }>
+                           {_("Cancel")}
+                       </Button>
+                       {this.state.inProgress && <div key="spiner" className="spinner spinner-sm pull-right" />}
+                   </>}
+                   isFooterLeftAligned>
+                {dialogBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -19,8 +19,8 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { Modal, OverlayTrigger, Tooltip } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { OverlayTrigger, Tooltip } from 'patternfly-react';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { vmId } from '../helpers.js';
 import { deleteVm } from '../actions/provider-actions.js';
@@ -78,10 +78,10 @@ const DeleteDialogBody = ({ disks, destroy, onChange }) => {
         );
 
     return (
-        <div className="modal-body">
+        <>
             {alert}
             {disksBody}
-        </div>
+        </>
     );
 };
 
@@ -169,22 +169,21 @@ export class DeleteDialog extends React.Component {
             <span>
                 { deleteButton }
 
-                <Modal id={`${id}-delete-modal-dialog`} show={this.state.showModal} onHide={this.close}>
-                    <Modal.Header>
-                        <Modal.Title> {`Confirm deletion of ${this.props.vm.name}`} </Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                        <DeleteDialogBody disks={this.state.disks} destroy={this.state.destroy} onChange={this.onDiskCheckedChanged} />
-                    </Modal.Body>
-                    <Modal.Footer>
-                        {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                        <Button variant='danger' onClick={this.delete}>
-                            {_("Delete")}
-                        </Button>
-                        <Button variant='link' className='btn-cancel' onClick={this.close}>
-                            {_("Cancel")}
-                        </Button>
-                    </Modal.Footer>
+                <Modal id={`${id}-delete-modal-dialog`} isOpen={this.state.showModal} onClose={this.close}
+                       className="pf-m-md"
+                       appendTo={document.body}
+                       title={`Confirm deletion of ${this.props.vm.name}`}
+                       footer={<>
+                           {this.state.dialogError && <ModalError key="error" dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='danger' key="btn-delete" onClick={this.delete}>
+                               {_("Delete")}
+                           </Button>
+                           <Button variant='link' key="btn-cancel" className='btn-cancel' onClick={this.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>}
+                       isFooterLeftAligned>
+                    <DeleteDialogBody disks={this.state.disks} destroy={this.state.destroy} onChange={this.onDiskCheckedChanged} />
                 </Modal>
             </span>
         );

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -2030,9 +2030,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             b.wait_present("#create-vm-dialog")
             if self.sourceType == 'disk_image':
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Import A Virtual Machine")
+                b.wait_in_text(".pf-c-modal-box .pf-c-title", "Import A Virtual Machine")
             else:
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create New Virtual Machine")
+                b.wait_in_text(".pf-c-modal-box .pf-c-title", "Create New Virtual Machine")
 
             if self.os_name is not None:
                 # check if there is os present in osinfo-query because it can be filtered out in the UI
@@ -2063,7 +2063,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             return self
 
         def createAndVerifyVirtInstallArgs(self):
-            self.browser.click(".modal-footer button:contains(Create)")
+            self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
             self.browser.wait_not_present("#create-vm-dialog")
 
             virt_install_cmd = "ps aux | grep 'virt\-install\ \-\-connect'"
@@ -2185,7 +2185,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def cancel(self, force=False):
             b = self.browser
             if b.is_present("#create-vm-dialog"):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-vm-dialog")
             elif force:
                 raise Exception("There is no dialog to cancel")
@@ -2194,9 +2194,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def create(self):
             b = self.browser
             if self.sourceType == 'disk_image':
-                b.click(".modal-footer button:contains(Import)")
+                b.click(".pf-c-modal-box__footer button:contains(Import)")
             else:
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
             init_state = "creating VM installation" if self.start_vm else "creating VM"
             second_state = "running" if self.start_vm else "shut off"
 
@@ -2208,20 +2208,20 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b = self.browser
 
             if self.sourceType == 'disk_image':
-                b.click(".modal-footer button:contains(Import)")
+                b.click(".pf-c-modal-box__footer button:contains(Import)")
             else:
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
 
             for error, error_msg in errors.items():
-                error_location = ".modal-body label:contains('{0}') + div.form-group.has-error span.help-block".format(error)
+                error_location = ".pf-c-modal-box__body label:contains('{0}') + div.form-group.has-error span.help-block".format(error)
                 b.wait_visible(error_location)
                 if (error_msg):
                     b.wait_in_text(error_location, error_msg)
 
             if self.sourceType == 'disk_image':
-                b.wait_present(".modal-footer button:contains(Import):disabled")
+                b.wait_present(".pf-c-modal-box__footer button:contains(Import):disabled")
             else:
-                b.wait_present(".modal-footer button:contains(Create):disabled")
+                b.wait_present(".pf-c-modal-box__footer button:contains(Create):disabled")
 
             return self
 
@@ -2238,12 +2238,12 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     raise Error("Retry limit exceeded: None of [%s] is part of the error message '%s'" % (
                         ', '.join(errors), b.text(error_location)))
 
-            b.click(".modal-footer button:contains(Create)")
+            b.click(".pf-c-modal-box__footer button:contains(Create)")
 
-            error_location = ".modal-footer div.pf-c-alert"
+            error_location = ".pf-c-modal-box__footer div.pf-c-alert"
 
-            b.wait_present(".modal-footer .spinner")
-            b.wait_not_present(".modal-footer .spinner")
+            b.wait_present(".pf-c-modal-box__footer .spinner")
+            b.wait_not_present(".pf-c-modal-box__footer .spinner")
             try:
                 with b.wait_timeout(10):
                     b.wait_present(error_location)


### PR DESCRIPTION
Two modals were ported within this commit:
* Create VM dialog
* Delete VM dialog

PF4 modals need some overrides in page.scss.
**
DO NOT MERGE ME before creating PF4 issues for the overrides.
**

Related PF issues:
https://github.com/patternfly/patternfly/issues/2980
https://github.com/patternfly/patternfly-react/issues/4093
https://github.com/patternfly/patternfly/issues/2979