### PR TITLE
bridge: use GSocketClient in cockpit_connect_stream()

### DIFF
--- a/src/bridge/cockpitconnect.c
+++ b/src/bridge/cockpitconnect.c
@@ -78,153 +78,65 @@ cockpit_connectable_unref (gpointer data)
     }
 }
 
-typedef struct {
-  CockpitConnectable *connectable;
-  GSocketAddressEnumerator *enumerator;
-  GCancellable *cancellable;
-  GIOStream *io;
-  GError *error;
-} ConnectStream;
-
 static void
-connect_stream_free (gpointer data)
+socket_client_event (GSocketClient      *client,
+                     GSocketClientEvent  event,
+                     GSocketConnectable *gconnectable,
+                     GIOStream          *connection,
+                     gpointer            user_data)
 {
-  ConnectStream *cs = data;
-  if (cs->connectable)
-    cockpit_connectable_unref (cs->connectable);
-  if (cs->cancellable)
-    g_object_unref (cs->cancellable);
-  g_object_unref (cs->enumerator);
-  g_clear_error (&cs->error);
-  if (cs->io)
-    g_object_unref (cs->io);
-  g_free (cs);
+  CockpitConnectable *connectable = user_data;
+
+  switch (event)
+    {
+    case G_SOCKET_CLIENT_TLS_HANDSHAKING:
+      {
+        GTlsClientConnection *tls_client = G_TLS_CLIENT_CONNECTION (connection);
+
+        g_tls_client_connection_set_validation_flags (tls_client, connectable->tls_flags);
+
+        if (connectable->tls_cert)
+          g_tls_connection_set_certificate (G_TLS_CONNECTION (tls_client), connectable->tls_cert);
+
+        if (connectable->tls_database)
+          g_tls_connection_set_database (G_TLS_CONNECTION (tls_client), connectable->tls_database);
+
+        g_tls_connection_set_require_close_notify (G_TLS_CONNECTION (tls_client), FALSE);
+
+        return;
+      }
+
+    default:
+      return;
+  }
 }
 
 static void
-on_address_next (GObject *object,
-                 GAsyncResult *result,
-                 gpointer user_data);
-
-static void
-on_socket_connect (GObject *object,
-                   GAsyncResult *result,
-                   gpointer user_data)
+socket_client_connect_done (GObject      *object,
+                            GAsyncResult *result,
+                            gpointer      user_data)
 {
-  GSimpleAsyncResult *simple = G_SIMPLE_ASYNC_RESULT (user_data);
-  ConnectStream *cs = g_simple_async_result_get_op_res_gpointer (simple);
-  CockpitConnectable *connectable = cs->connectable;
-  GError *error = NULL;
+  g_autoptr(GSocketConnection) connection;
+  g_autoptr(GTask) task = user_data;
+  g_autoptr(GError) error = NULL;
 
-  g_socket_connection_connect_finish (G_SOCKET_CONNECTION (object), result, &error);
-
-  g_debug ("%s: connected", connectable->name);
-
-  if (error)
+  connection = g_socket_client_connect_finish (G_SOCKET_CLIENT (object), result, &error);
+  if (connection != NULL)
     {
-      g_debug ("%s: couldn't connect: %s", connectable->name, error->message);
-      g_clear_error (&cs->error);
-      cs->error = error;
+      GIOStream *stream; /* weak */
 
-      g_socket_address_enumerator_next_async (cs->enumerator, cs->cancellable,
-                                              on_address_next, g_object_ref (simple));
-    }
-  else
-    {
-      g_debug ("%s: connected", connectable->name);
-
-      if (connectable->tls)
+      if (G_IS_TCP_WRAPPER_CONNECTION (connection))
         {
-          cs->io = g_tls_client_connection_new (G_IO_STREAM (object), connectable->address, &error);
-          if (cs->io)
-            {
-              g_debug ("%s: tls handshake", connectable->name);
-
-              g_tls_client_connection_set_validation_flags (G_TLS_CLIENT_CONNECTION (cs->io),
-                                                            connectable->tls_flags);
-
-              if (connectable->tls_cert)
-                g_tls_connection_set_certificate (G_TLS_CONNECTION (cs->io), connectable->tls_cert);
-              if (connectable->tls_database)
-                g_tls_connection_set_database (G_TLS_CONNECTION (cs->io), connectable->tls_database);
-
-              /* We track data end the same way we do for HTTP */
-              g_tls_connection_set_require_close_notify (G_TLS_CONNECTION (cs->io), FALSE);
-            }
-
-          else if (error)
-            {
-              g_debug ("%s: couldn't open tls connection: %s", connectable->name, error->message);
-              g_clear_error (&cs->error);
-              cs->error = error;
-            }
+          stream = g_tcp_wrapper_connection_get_base_io_stream (G_TCP_WRAPPER_CONNECTION (connection));
+          g_assert (G_IS_TLS_CONNECTION (stream));
         }
       else
-        {
-          cs->io = g_object_ref (object);
-        }
+        stream = G_IO_STREAM (connection);
 
-      g_simple_async_result_complete (simple);
-    }
-
-  g_object_unref (object);
-  g_object_unref (simple);
-}
-
-static void
-on_address_next (GObject *object,
-                 GAsyncResult *result,
-                 gpointer user_data)
-{
-  GSimpleAsyncResult *simple = G_SIMPLE_ASYNC_RESULT (user_data);
-  ConnectStream *cs = g_simple_async_result_get_op_res_gpointer (simple);
-  CockpitConnectable *connectable = cs->connectable;
-  GSocketConnection *connection;
-  GSocketAddress *address;
-  GError *error = NULL;
-  GSocket *sock;
-
-  address = g_socket_address_enumerator_next_finish (G_SOCKET_ADDRESS_ENUMERATOR (object),
-                                                     result, &error);
-
-  if (error)
-    {
-      g_debug ("%s: couldn't resolve: %s", connectable->name, error->message);
-      g_clear_error (&cs->error);
-      cs->error = error;
-      g_simple_async_result_complete (simple);
-    }
-  else if (address)
-    {
-      sock = g_socket_new (g_socket_address_get_family (address), G_SOCKET_TYPE_STREAM, 0, &error);
-      if (sock)
-        {
-          g_socket_set_blocking (sock, FALSE);
-
-          connection = g_socket_connection_factory_create_connection (sock);
-          g_object_unref (sock);
-
-          g_socket_connection_connect_async (connection, address, cs->cancellable,
-                                             on_socket_connect, g_object_ref (simple));
-        }
-
-      if (error)
-        {
-          g_debug ("%s: couldn't open socket: %s", connectable->name, error->message);
-          g_clear_error (&cs->error);
-          cs->error = error;
-          g_simple_async_result_complete (simple);
-        }
-      g_object_unref (address);
+      g_task_return_pointer (task, g_object_ref (stream), g_object_unref);
     }
   else
-    {
-      if (!cs->error)
-          g_message ("%s: no addresses found", connectable->name);
-      g_simple_async_result_complete (simple);
-    }
-
-  g_object_unref (simple);
+    g_task_return_error (task, g_steal_pointer (&error));
 }
 
 void
@@ -247,53 +159,35 @@ cockpit_connect_stream_full (CockpitConnectable *connectable,
                              GAsyncReadyCallback callback,
                              gpointer user_data)
 {
-  GSimpleAsyncResult *simple;
-  ConnectStream *cs;
-
   g_return_if_fail (connectable != NULL);
   g_return_if_fail (G_IS_SOCKET_CONNECTABLE (connectable->address));
   g_return_if_fail (!cancellable || G_IS_CANCELLABLE (cancellable));
 
-  simple = g_simple_async_result_new (NULL, callback, user_data, cockpit_connect_stream);
-  cs = g_new0 (ConnectStream, 1);
-  cs->connectable = cockpit_connectable_ref (connectable);
-  cs->cancellable = cancellable ? g_object_ref (cancellable) : NULL;
-  cs->enumerator = g_socket_connectable_enumerate (connectable->address);
-  g_simple_async_result_set_op_res_gpointer (simple, cs, connect_stream_free);
+  g_autoptr(GSocketClient) client = g_socket_client_new ();
 
-  g_socket_address_enumerator_next_async (cs->enumerator, NULL,
-                                          on_address_next, g_object_ref (simple));
+  /* otherwise, we'll go fishing around in GSettings... */
+  g_socket_client_set_enable_proxy (client, FALSE);
 
-  g_object_unref (simple);
+  if (connectable->tls)
+    {
+      g_signal_connect_data (client, "event", G_CALLBACK (socket_client_event),
+                             cockpit_connectable_ref (connectable),
+                             (GClosureNotify) cockpit_connectable_unref, 0);
+
+      g_socket_client_set_tls (client, TRUE);
+    }
+
+  g_socket_client_connect_async (client, connectable->address, cancellable, socket_client_connect_done,
+                                 g_task_new (NULL, cancellable, callback, user_data));
 }
 
 GIOStream *
 cockpit_connect_stream_finish (GAsyncResult *result,
                                GError **error)
 {
-  GSimpleAsyncResult *simple;
-  ConnectStream *cs;
+  g_return_val_if_fail (g_task_is_valid (result, NULL), NULL);
 
-  g_return_val_if_fail (g_simple_async_result_is_valid (result, NULL, cockpit_connect_stream), NULL);
-
-  simple = G_SIMPLE_ASYNC_RESULT (result);
-  cs = g_simple_async_result_get_op_res_gpointer (simple);
-
-  if (cs->io)
-    {
-      return g_object_ref (cs->io);
-    }
-  else if (cs->error)
-    {
-      g_propagate_error (error, cs->error);
-      cs->error = NULL;
-      return NULL;
-    }
-  else
-    {
-      g_set_error (error, G_IO_ERROR, G_IO_ERROR_HOST_NOT_FOUND, "No addresses found");
-      return NULL;
-    }
+  return g_task_propagate_pointer (G_TASK (result), error);
 }
 
 static void

--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -205,7 +205,6 @@ typedef struct _CockpitHttpStream {
   CockpitStream *stream;
   gulong sig_open;
   gulong sig_read;
-  gulong sig_rejected_cert;
   gulong sig_close;
 
   gint state;
@@ -632,22 +631,6 @@ on_stream_read (CockpitStream *stream,
 }
 
 static void
-on_rejected_cert (CockpitStream *stream,
-                  const gchar *pem_data,
-                  gpointer user_data)
-{
-  CockpitHttpStream *self = user_data;
-  CockpitChannel *channel = user_data;
-  JsonObject *close_options = NULL; // owned by channel
-
-  if (self->state != FINISHED)
-    {
-      close_options = cockpit_channel_close_options (channel);
-      json_object_set_string_member (close_options, "rejected-certificate", pem_data);
-    }
-}
-
-static void
 on_stream_close (CockpitStream *stream,
                  const gchar *problem,
                  gpointer user_data)
@@ -945,7 +928,6 @@ cockpit_http_stream_close (CockpitChannel *channel,
             g_signal_handler_disconnect (self->stream, self->sig_open);
           g_signal_handler_disconnect (self->stream, self->sig_read);
           g_signal_handler_disconnect (self->stream, self->sig_close);
-          g_signal_handler_disconnect (self->stream, self->sig_rejected_cert);
           cockpit_http_client_checkin (self->client, self->stream);
           cockpit_flow_throttle (COCKPIT_FLOW (self->stream), NULL);
           cockpit_flow_throttle (COCKPIT_FLOW (channel), NULL);
@@ -1046,8 +1028,6 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
 
   self->sig_read = g_signal_connect (self->stream, "read", G_CALLBACK (on_stream_read), self);
   self->sig_close = g_signal_connect (self->stream, "close", G_CALLBACK (on_stream_close), self);
-  self->sig_rejected_cert = g_signal_connect (self->stream, "rejected-cert",
-                                              G_CALLBACK (on_rejected_cert), self);
 
   /* Let the channel throttle the stream's input flow*/
   cockpit_flow_throttle (COCKPIT_FLOW (self->stream), COCKPIT_FLOW (self));
@@ -1075,7 +1055,6 @@ cockpit_http_stream_dispose (GObject *object)
         g_signal_handler_disconnect (self->stream, self->sig_open);
       g_signal_handler_disconnect (self->stream, self->sig_read);
       g_signal_handler_disconnect (self->stream, self->sig_close);
-      g_signal_handler_disconnect (self->stream, self->sig_rejected_cert);
       cockpit_stream_close (self->stream, NULL);
       g_object_unref (self->stream);
     }

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -56,7 +56,6 @@ typedef struct _CockpitWebSocketStream {
   gulong sig_closing;
   gulong sig_close;
   gulong sig_error;
-  gulong sig_accept_cert;
 
   gboolean binary;
   gboolean closed;
@@ -124,25 +123,6 @@ static void
 cockpit_web_socket_stream_init (CockpitWebSocketStream *self)
 {
 
-}
-
-static gboolean
-on_rejected_certificate (GTlsConnection *conn,
-                         GTlsCertificate *peer_cert,
-                         GTlsCertificateFlags errors,
-                         gpointer user_data)
-{
-  CockpitChannel *channel = user_data;
-  JsonObject *close_options = NULL; // owned by channel
-  gchar *pem_data = NULL;
-
-  g_return_val_if_fail (peer_cert != NULL, FALSE);
-  g_object_get (peer_cert, "certificate-pem", &pem_data, NULL);
-  close_options = cockpit_channel_close_options (channel);
-  json_object_set_string_member (close_options, "rejected-certificate", pem_data);
-
-  g_free (pem_data);
-  return FALSE;
 }
 
 static void
@@ -287,18 +267,6 @@ on_socket_connect (GObject *object,
       return;
     }
 
-  if (G_IS_TLS_CONNECTION (io))
-    {
-      self->sig_accept_cert =  g_signal_connect (G_TLS_CONNECTION (io),
-                                                 "accept-certificate",
-                                                 G_CALLBACK (on_rejected_certificate),
-                                                 self);
-    }
-  else
-    {
-      self->sig_accept_cert = 0;
-    }
-
   self->client = web_socket_client_new_for_stream (self->url, self->origin, protocols, io);
 
   node = json_object_get_member (options, "headers");
@@ -391,7 +359,6 @@ static void
 cockpit_web_socket_stream_dispose (GObject *object)
 {
   CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (object);
-  GIOStream *io = NULL; // Owned by self->client;
 
   if (self->client)
     {
@@ -402,10 +369,6 @@ cockpit_web_socket_stream_dispose (GObject *object)
       g_signal_handler_disconnect (self->client, self->sig_closing);
       g_signal_handler_disconnect (self->client, self->sig_close);
       g_signal_handler_disconnect (self->client, self->sig_error);
-
-      io = web_socket_connection_get_io_stream (self->client);
-      if (io != NULL && self->sig_accept_cert)
-        g_signal_handler_disconnect (io, self->sig_accept_cert);
 
       g_object_unref (self->client);
       self->client = NULL;

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -348,11 +348,6 @@ test_tls_authority_bad (TestTls *test,
 
   GBytes *bytes;
   JsonObject *resp;
-  gchar *expected_pem = NULL;
-  gchar *expected_json = NULL;
-
-  g_object_get (test->certificate, "certificate-pem", &expected_pem, NULL);
-  g_assert_true (expected_pem != NULL);
 
   tls = cockpit_json_parse_object (json, -1, &error);
   g_assert_no_error (error);
@@ -378,13 +373,10 @@ test_tls_authority_bad (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   resp = mock_transport_pop_control (test->transport);
-  expected_json = g_strdup_printf ("{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", "
-                                   " \"rejected-certificate\":\"%s\"}", expected_pem);
-  cockpit_assert_json_eq (resp, expected_json);
+  json_object_remove_member (resp, "message");
+  cockpit_assert_json_eq (resp, "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\"}");
 
   g_object_unref (channel);
-  g_free (expected_pem);
-  g_free (expected_json);
 }
 
 int

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -987,7 +987,8 @@ static gboolean
 should_suppress_request_error (GError *error,
                                gsize received)
 {
-  if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF))
+  if (g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_EOF) ||
+      g_error_matches (error, G_TLS_ERROR, G_TLS_ERROR_NOT_TLS))
     {
       g_debug ("request error: %s", error->message);
       return TRUE;


### PR DESCRIPTION
Replace our home-grown iterator/connect logic with GSocketClient: it's more than powerful enough to do everything we need.
    
Take the opportunity to port to GTask.


Right now I want to see what the bots say about this.  The second commit needs to be discussed.