### PR TITLE
networking: Fix explicitly selecting a select button choice

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -80,6 +80,7 @@ function select_btn(func, spec, klass) {
     });
 
     function select(a) {
+        choice = a;
         $(btn).val(a);
     }
 

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -74,6 +74,10 @@ class TestNetworking(NetworkCase):
         b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface2)
         self.wait_onoff("#network-interface-slaves tr[data-interface='%s']" % iface2, True)
 
+        # Check that it has the expected mode
+        if m.image not in [ "rhel-8-2-distropkg" ]: #13866
+            b.wait_in_text("#network-interface-settings", "Active Backup")
+
         # Deactivate the bond and make sure it is still there after a
         # reload.
         b.wait_text_not("#network-interface-mac", "")


### PR DESCRIPTION
After calling "select_btn_select(btn, choice)", we want "select_btn_selected(btn) == choice".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1817948