### PR TITLE
maint: bump up @patternfly/patternfly, @patternfly/react-core and @patternfly/react-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@patternfly/patternfly": "2.70.0",
+    "@patternfly/patternfly": "4.6.4",
     "@patternfly/react-console": "2.0.14",
-    "@patternfly/react-core": "3.134.2",
-    "@patternfly/react-table": "2.28.29",
+    "@patternfly/react-core": "4.2.7",
+    "@patternfly/react-table": "4.0.22",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "bootstrap": "3.4.1",
     "bootstrap-datepicker": "1.9.0",


### PR DESCRIPTION
The above modules were upgraded to prerelease-v4 tag instead of the
latest.