### PR TITLE
test: Stop cockpit.service quietly

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -863,7 +863,7 @@ class MachineCase(unittest.TestCase):
             self.restore_file("/etc/crypttab")
 
             # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
-            self.addCleanup(m.execute, "systemctl stop cockpit")
+            self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
 
         # The sssd daemon seems to get confused when we restore
         # backups of /etc/group etc and stops following updates to it.


### PR DESCRIPTION
This avoids

    Warning: Stopping cockpit.service, but it can still be activated by:
    cockpit.socket

between all nondestructive tests.