### PR TITLE
machines: Split DeleteResourceSource component to avoid nesting statefull modals inside table rows

### DIFF
--- a/pkg/machines/components/deleteResource.jsx
+++ b/pkg/machines/components/deleteResource.jsx
@@ -27,37 +27,26 @@ import { ModalError } from 'cockpit-components-inline-notification.jsx';
 
 const _ = cockpit.gettext;
 
-export class DeleteResource extends React.Component {
+export class DeleteResourceModal extends React.Component {
     constructor(props) {
         super(props);
 
         this.state = {
-            showModal: false,
             dialogError: undefined,
             inProgress: false,
         };
 
         this.delete = this.delete.bind(this);
-        this.close = this.close.bind(this);
-        this.open = this.open.bind(this);
         this.dialogErrorSet = this.dialogErrorSet.bind(this);
     }
 
     delete() {
         this.setState({ inProgress: true });
         this.props.deleteHandler()
-                .fail(exc => {
+                .then(this.props.onClose, exc => {
                     this.setState({ inProgress: false });
                     this.dialogErrorSet(cockpit.format(_("The $0 could not be deleted"), this.props.objectType.toLowerCase()), exc.message);
                 });
-    }
-
-    open() {
-        this.setState({ showModal: true });
-    }
-
-    close() {
-        this.setState({ showModal: false, dialogError: undefined });
     }
 
     dialogErrorSet(text, detail) {
@@ -65,70 +54,70 @@ export class DeleteResource extends React.Component {
     }
 
     render() {
-        const { objectName, objectType, objectId, disabled, overlayText, actionName } = this.props;
-
-        const deleteButton = () => {
-            if (disabled) {
-                return (
-                    <OverlayTrigger overlay={
-                        <Tooltip id={`delete-${objectId}-tooltip`}>
-                            { overlayText }
-                        </Tooltip> } placement='top'>
-                        <span>
-                            <Button id={`delete-${objectId}`}
-                                variant='danger'
-                                style={{ pointerEvents: 'none' }}
-                                isDisabled>
-                                {actionName || _("Delete")}
-                            </Button>
-                        </span>
-                    </OverlayTrigger>
-                );
-            } else {
-                return (
-                    <Button id={`delete-${objectId}`}
-                        variant='danger'
-                        onClick={this.open}>
-                        {actionName || _("Delete")}
-                    </Button>
-                );
-            }
-        };
+        const { objectName, objectType, actionName, onClose } = this.props;
 
         return (
-            <>
-                { deleteButton() }
-
-                <Modal show={this.state.showModal} onHide={this.close}>
-                    <Modal.Header>
-                        <Modal.CloseButton onClick={this.close} />
-                        <Modal.Title>{ (actionName || _("Delete")) + cockpit.format((" $0 $1"), objectType, objectName) }</Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                        { cockpit.format(_("Confirm this action")) }
-                    </Modal.Body>
-                    <Modal.Footer>
-                        {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                        <Button variant='danger' isDisabled={this.state.inProgress} onClick={this.delete}>
-                            {actionName || _("Delete")}
-                        </Button>
-                        <Button variant='link' className='btn-cancel' onClick={this.close}>
-                            {_("Cancel")}
-                        </Button>
-                        {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
-                    </Modal.Footer>
-                </Modal>
-            </>
+            <Modal show onHide={onClose}>
+                <Modal.Header>
+                    <Modal.CloseButton onClick={onClose} />
+                    <Modal.Title>{ (actionName || _("Delete")) + cockpit.format((" $0 $1"), objectType, objectName) }</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    { cockpit.format(_("Confirm this action")) }
+                </Modal.Body>
+                <Modal.Footer>
+                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                    <Button variant='danger' isDisabled={this.state.inProgress} onClick={this.delete}>
+                        {actionName || _("Delete")}
+                    </Button>
+                    <Button variant='link' className='btn-cancel' onClick={onClose}>
+                        {_("Cancel")}
+                    </Button>
+                    {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
+                </Modal.Footer>
+            </Modal>
         );
     }
 }
 
-DeleteResource.propTypes = {
+DeleteResourceModal.propTypes = {
     objectType: PropTypes.string.isRequired,
     objectName: PropTypes.string.isRequired,
-    objectId: PropTypes.string.isRequired,
     deleteHandler: PropTypes.func.isRequired,
+    onClose: PropTypes.func.isRequired,
+};
+
+export const DeleteResourceButton = ({ objectId, disabled, overlayText, actionName, showDialog }) => {
+    if (disabled) {
+        return (
+            <OverlayTrigger overlay={
+                <Tooltip id={`delete-${objectId}-tooltip`}>
+                    { overlayText }
+                </Tooltip> } placement='top'>
+                <span>
+                    <Button id={`delete-${objectId}`}
+                        variant='danger'
+                        style={{ pointerEvents: 'none' }}
+                        isDisabled>
+                        {actionName || _("Delete")}
+                    </Button>
+                </span>
+            </OverlayTrigger>
+        );
+    } else {
+        return (
+            <Button id={`delete-${objectId}`}
+                variant='danger'
+                onClick={showDialog}>
+                {actionName || _("Delete")}
+            </Button>
+        );
+    }
+};
+DeleteResourceButton.propTypes = {
+    objectId: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
     overlayText: PropTypes.string,
     actionName: PropTypes.string,
+    showDialog: PropTypes.func.isRequired,
 };

--- a/pkg/machines/components/networks/network.jsx
+++ b/pkg/machines/components/networks/network.jsx
@@ -26,7 +26,7 @@ import {
     networkId
 } from '../../helpers.js';
 import { NetworkOverviewTab } from './networkOverviewTab.jsx';
-import { DeleteResource } from '../deleteResource.jsx';
+import { DeleteResourceModal, DeleteResourceButton } from '../deleteResource.jsx';
 import {
     networkActivate,
     networkDeactivate,
@@ -106,6 +106,7 @@ Network.propTypes = {
 class NetworkActions extends React.Component {
     constructor() {
         super();
+        this.state = { deleteDialogProps: undefined };
         this.onActivate = this.onActivate.bind(this);
         this.onDeactivate = this.onDeactivate.bind(this);
     }
@@ -145,6 +146,12 @@ class NetworkActions extends React.Component {
                 return networkUndefine(network.connectionName, network.id);
             }
         };
+        const deleteDialogProps = {
+            objectType: "Network",
+            objectName: network.name,
+            onClose: () => this.setState({ deleteDialogProps: undefined }),
+            deleteHandler: () => deleteHandler(network),
+        };
 
         return (
             <>
@@ -157,12 +164,11 @@ class NetworkActions extends React.Component {
                     {_("Activate")}
                 </Button>
                 }
-                <DeleteResource objectType="Network"
-                    objectId={id}
-                    objectName={network.name}
-                    deleteHandler={() => deleteHandler(network)}
-                    overlayText={_("Non-persistent network cannot be deleted. It ceases to exists when it's deactivated.")}
-                    disabled={!network.persistent} />
+                {this.state.deleteDialogProps && <DeleteResourceModal {...this.state.deleteDialogProps} />}
+                <DeleteResourceButton objectId={id}
+                                      showDialog={() => this.setState({ deleteDialogProps })}
+                                      overlayText={_("Non-persistent network cannot be deleted. It ceases to exists when it's deactivated.")}
+                                      disabled={!network.persistent} />
             </>
         );
     }

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -29,7 +29,7 @@ import WarningInactive from './warningInactive.jsx';
 import './nic.css';
 import { detachIface, vmInterfaceAddresses } from '../libvirt-dbus.js';
 import { ListingTable } from "cockpit-components-table.jsx";
-import { DeleteResource } from './deleteResource.jsx';
+import { DeleteResourceButton, DeleteResourceModal } from './deleteResource.jsx';
 
 const _ = cockpit.gettext;
 
@@ -217,13 +217,17 @@ class VmNetworkTab extends React.Component {
                                        interfaces={interfaces} />;
                     };
 
+                    const deleteDialogProps = {
+                        objectType: "Network Interface",
+                        objectName: network.mac,
+                        onClose: () => this.setState({ deleteDialogProps: undefined }),
+                        deleteHandler: () => detachIface(network.mac, vm.connectionName, vm.id, vm.state === 'running', vm.persistent, dispatch),
+                    };
                     const deleteNICAction = (
-                        <DeleteResource objectType="Network Interface"
-                                        objectName={network.mac}
-                                        objectId={`${id}-iface-${networkId}`}
-                                        disabled={vm.state != 'shut off' && vm.state != 'running'}
-                                        overlayText={_("The VM needs to be running or shut off to detach this device")}
-                                        deleteHandler={() => detachIface(network.mac, vm.connectionName, vm.id, vm.state === "running", vm.persistent, dispatch)} />
+                        <DeleteResourceButton objectId={`${id}-iface-${networkId}`}
+                                              disabled={vm.state != 'shut off' && vm.state != 'running'}
+                                              showDialog={() => this.setState({ deleteDialogProps })}
+                                              overlayText={_("The VM needs to be running or shut off to detach this device")} />
                     );
 
                     return (
@@ -262,6 +266,7 @@ class VmNetworkTab extends React.Component {
 
         return (
             <div className="machines-network-list">
+                {this.state.deleteDialogProps && <DeleteResourceModal {...this.state.deleteDialogProps} />}
                 <Button id={`${id}-add-iface-button`} variant='secondary' className='pull-right' onClick={this.open}>
                     {_("Add Network Interface")}
                 </Button>


### PR DESCRIPTION
PF4 React Table component sometimes recreates the components inside Table rows,
and then showModal will revert to false, causing the dialog to close.

By keeping the state outside of the Table components we can rely
on the dialog staying open.

Note: Commit 20963cb addressed a similar issue with different approach.
In our case that approach is not adequate because we need to keep
information about more state properties than just the visibility of the
modal.

Fixes #13860