### PR TITLE
test: Eliminate writing to /usr

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -544,10 +544,10 @@ class TestMultiMachine(MachineCase):
         m2 = self.machine2
 
         # Modify the terminals to be different on the two machines.
-        m1.needs_writable_usr()
-        m1.execute("gunzip -c /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m1-token</body>|' > /usr/share/cockpit/systemd/terminal.html")
-        m2.needs_writable_usr()
-        m2.execute("gunzip -c /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m2-token</body>|' > /usr/share/cockpit/systemd/terminal.html")
+        m1.execute("zcat /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m1-token</body>|' | gzip"
+                   " > /tmp/terminal.html.gz && mount -o bind /tmp/terminal.html.gz /usr/share/cockpit/systemd/terminal.html.gz")
+        m2.execute("zcat /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m2-token</body>|' | gzip"
+                   " > /tmp/terminal.html.gz && mount -o bind /tmp/terminal.html.gz /usr/share/cockpit/systemd/terminal.html.gz")
 
         self.login_and_go("/dashboard")
         add_machine(b, "10.111.113.2")

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -49,13 +49,14 @@ test_html = """
 """
 
 
+@nondestructive
 class TestPackages(MachineCase):
 
     def testBasic(self):
         m = self.machine
         b = self.browser
 
-        m.needs_writable_usr()
+        self.restore_dir("/usr/share/cockpit")
 
         self.login_and_go("/playground/pkgs")
 


### PR DESCRIPTION
This is generally error prone, and specifically bad on OSTree. Use bind
mounts instead to fake things.

Make check-packages @nondestructive, so that restore_dir() will do the
temporary bind mount for us. That test is also super-quick (boot time
dominated the test time).

Make netlib.py helpers nondestructive as well, which will help with
making bond and vlan tests fully nondestructive.