### PR TITLE
systemd: Display uptime on overview page

### DIFF
--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -96,9 +96,7 @@ export class SystemInfomationCard extends React.Component {
                     const uptime = parseFloat(content.split(' ')[0]);
                     this.setState({ systemUptime: moment.duration(uptime * 1000).humanize() });
                 })
-                .fail(ex => {
-                    console.error("Error reading system uptime", ex);
-                });
+                .fail(ex => console.error("Error reading system uptime", ex));
     }
 
     render() {

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -85,15 +85,14 @@ export class SystemInfomationCard extends React.Component {
     }
 
     getSystemUptime() {
-        var self = this;
-
         cockpit.spawn(["cat", "/proc/uptime"])
-                .done(function(text) {
-                    var uptime_days = 0;
-                    var uptime_hours = 0;
-                    var uptime_minutes = 0;
-                    var match = text.match(/[0-9]*\.[0-9]{2}/);
-                    var uptime_raw = match && parseFloat(match[0]);
+                .then(text => {
+                    let uptime_days = 0;
+                    let uptime_hours = 0;
+                    let uptime_minutes = 0;
+
+                    const match = text.match(/[0-9]*\.[0-9]{2}/);
+                    let uptime_raw = match && parseFloat(match[0]);
 
                     uptime_days = Math.floor(uptime_raw / 86400);
                     uptime_raw = uptime_raw - (uptime_days * 86400);
@@ -105,19 +104,19 @@ export class SystemInfomationCard extends React.Component {
 
                     if (uptime_days == 0) {
                         if (uptime_hours == 0) {
-                            self.system_uptime = (<> <div id="system_uptime">{uptime_minutes} {_("Minutes")} </div> </>);
+                            this.system_uptime = (<div id="system_uptime">{uptime_minutes} {_("Minutes")} </div>);
                         } else {
-                            self.system_uptime = (<> <div id="system_uptime">{uptime_hours} {_("Hours")} {uptime_minutes} {_("Minutes")} </div> </>);
+                            this.system_uptime = (<div id="system_uptime">{uptime_hours} {_("Hours")} {uptime_minutes} {_("Minutes")} </div>);
                         }
                     } else {
                         if (uptime_hours == 0) {
-                            self.system_uptime = (<> <div id="system_uptime">{uptime_days} {_("Days")} {uptime_minutes} {_("Minutes")} </div> </>);
+                            this.system_uptime = (<div id="system_uptime">{uptime_days} {_("Days")} {uptime_minutes} {_("Minutes")} </div>);
                         } else {
-                            self.system_uptime = (<> <div id="system_uptime">{uptime_days} {_("Days")} {uptime_hours} {_("Hours")} </div> </>);
+                            this.system_uptime = (<div id="system_uptime">{uptime_days} {_("Days")} {uptime_hours} {_("Hours")} </div>);
                         }
                     }
                 })
-                .fail(function(ex) {
+                .catch(function(ex) {
                     console.error("Error reading system uptime", ex);
                 });
     }

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -127,7 +127,7 @@ export class SystemInfomationCard extends React.Component {
                                 </td>
                             </tr>
                             <tr>
-                                <th scope="row" className="system-information-uptime">{_("System uptime")}</th>
+                                <th scope="row" className="system-information-uptime">{_("Uptime")}</th>
                                 <td>
                                     <div id="system_uptime">{this.state.systemUptime}</div>
                                 </td>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -31,7 +31,6 @@ export class SystemInfomationCard extends React.Component {
         super(props);
 
         this.state = {};
-        this.system_uptime = null;
         this.getDMIInfo = this.getDMIInfo.bind(this);
         this.getMachineId = this.getMachineId.bind(this);
         this.getSystemUptime = this.getSystemUptime.bind(this);
@@ -41,6 +40,15 @@ export class SystemInfomationCard extends React.Component {
         this.getDMIInfo();
         this.getMachineId();
         this.getSystemUptime();
+
+        this.uptimeTimer = setInterval(
+            () => this.getSystemUptime(),
+            60000
+        );
+    }
+
+    componentWillUnmount() {
+        clearInterval(this.uptimeTimer);
     }
 
     getMachineId() {
@@ -104,15 +112,15 @@ export class SystemInfomationCard extends React.Component {
 
                     if (uptime_days == 0) {
                         if (uptime_hours == 0) {
-                            this.system_uptime = (<div id="system_uptime">{uptime_minutes} {_("Minutes")} </div>);
+                            this.setState({ systemUptime: uptime_minutes + " " + _("Minutes") });
                         } else {
-                            this.system_uptime = (<div id="system_uptime">{uptime_hours} {_("Hours")} {uptime_minutes} {_("Minutes")} </div>);
+                            this.setState({ systemUptime: uptime_hours + " " + _("Hours") + " " + uptime_minutes + " " + ("Minutes") });
                         }
                     } else {
                         if (uptime_hours == 0) {
-                            this.system_uptime = (<div id="system_uptime">{uptime_days} {_("Days")} {uptime_minutes} {_("Minutes")} </div>);
+                            this.setState({ system_uptime: uptime_days + " " + _("Days") + " " + uptime_minutes + " " + _("Minutes") });
                         } else {
-                            this.system_uptime = (<div id="system_uptime">{uptime_days} {_("Days")} {uptime_hours} {_("Hours")} </div>);
+                            this.setState({ system_uptime: uptime_days + " " + _("Days") + " " + uptime_hours + " " + _("Hours") });
                         }
                     }
                 })
@@ -149,7 +157,7 @@ export class SystemInfomationCard extends React.Component {
                             <tr>
                                 <th scope="row" className="system-information-uptime">{_("System uptime")}</th>
                                 <td>
-                                    {this.system_uptime}
+                                    <div id="system_uptime">{this.state.systemUptime}</div>
                                 </td>
                             </tr>
                         </tbody>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -31,13 +31,16 @@ export class SystemInfomationCard extends React.Component {
         super(props);
 
         this.state = {};
+        this.system_uptime = null;
         this.getDMIInfo = this.getDMIInfo.bind(this);
         this.getMachineId = this.getMachineId.bind(this);
+        this.getSystemUptime = this.getSystemUptime.bind(this);
     }
 
     componentDidMount() {
         this.getDMIInfo();
         this.getMachineId();
+        this.getSystemUptime();
     }
 
     getMachineId() {
@@ -81,6 +84,44 @@ export class SystemInfomationCard extends React.Component {
                 });
     }
 
+    getSystemUptime() {
+        var self = this;
+
+        cockpit.spawn(["cat", "/proc/uptime"])
+                .done(function(text) {
+                    var uptime_days = 0;
+                    var uptime_hours = 0;
+                    var uptime_minutes = 0;
+                    var match = text.match(/[0-9]*\.[0-9]{2}/);
+                    var uptime_raw = match && parseFloat(match[0]);
+
+                    uptime_days = Math.floor(uptime_raw / 86400);
+                    uptime_raw = uptime_raw - (uptime_days * 86400);
+
+                    uptime_hours = Math.floor(uptime_raw / 3600);
+                    uptime_raw = uptime_raw - (uptime_hours * 3600);
+
+                    uptime_minutes = Math.floor(uptime_raw / 60);
+
+                    if (uptime_days == 0) {
+                        if (uptime_hours == 0) {
+                            self.system_uptime = (<> <div id="system_uptime">{uptime_minutes} {_("Minutes")} </div> </>);
+                        } else {
+                            self.system_uptime = (<> <div id="system_uptime">{uptime_hours} {_("Hours")} {uptime_minutes} {_("Minutes")} </div> </>);
+                        }
+                    } else {
+                        if (uptime_hours == 0) {
+                            self.system_uptime = (<> <div id="system_uptime">{uptime_days} {_("Days")} {uptime_minutes} {_("Minutes")} </div> </>);
+                        } else {
+                            self.system_uptime = (<> <div id="system_uptime">{uptime_days} {_("Days")} {uptime_hours} {_("Hours")} </div> </>);
+                        }
+                    }
+                })
+                .fail(function(ex) {
+                    console.error("Error reading system uptime", ex);
+                });
+    }
+
     render() {
         return (
             <Card className="system-information">
@@ -104,6 +145,12 @@ export class SystemInfomationCard extends React.Component {
                                 <th scope="row" className="system-information-machine-id">{_("Machine ID")}</th>
                                 <td>
                                     <div id="system_machine_id">{this.state.machineID}</div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <th scope="row" className="system-information-uptime">{_("System uptime")}</th>
+                                <td>
+                                    {this.system_uptime}
                                 </td>
                             </tr>
                         </tbody>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -222,6 +222,10 @@ class TestSystemInfo(MachineCase):
             self.addCleanup(m.execute, "umount /proc/uptime")
             with b.wait_timeout(70):
                 b.wait_text("#system_uptime", "33 minutes")
+            # 4 months and a bit, moment humanize() rounds quite aggressively; also, test a slightly different format
+            m.write("/tmp/fake_uptime", "10370000 12345.30\n")
+            with b.wait_timeout(70):
+                b.wait_text("#system_uptime", "4 months")
 
         self.allow_journal_messages("error loading contents of os-release: .*")
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -213,6 +213,16 @@ class TestSystemInfo(MachineCase):
         self.login_and_go("/system")
         b.wait_text('#system_machine_id', mid)
 
+        # uptime (introduced in PR #13885)
+        if m.image not in ["rhel-8-2-distropkg"]:
+            b.wait_text_not("#system_uptime", "")
+            # replace it with a known value, it should automatically update every minute
+            m.write("/tmp/fake_uptime", "2000.12 12345.30\n")
+            m.execute("mount -o bind /tmp/fake_uptime /proc/uptime")
+            self.addCleanup(m.execute, "umount /proc/uptime")
+            with b.wait_timeout(70):
+                b.wait_text("#system_uptime", "33 minutes")
+
         self.allow_journal_messages("error loading contents of os-release: .*")
 
     def testTime(self):


### PR DESCRIPTION
Implementing issue #13541  for displaying the system uptime in the System Information card on the Overview page.

![image](https://user-images.githubusercontent.com/200109/79829991-c1f2a000-83a4-11ea-8321-a6de42d64a0f.png)

