### PR TITLE
machines: Fix network device detection

### DIFF
--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -56,13 +56,13 @@ class VmNetworkTab extends React.Component {
     }
 
     componentDidMount() {
-        cockpit.spawn(["ls", "/sys/class/net"])
-                .fail(e => console.log(e))
-                .done(output => {
-                    const devs = output.split('\n');
-                    devs.pop();
+        // only consider symlinks -- there might be other stuff like "bonding_masters" which we don't want
+        cockpit.spawn(["find", "/sys/class/net", "-type", "l", "-printf", '%f\n'], { err: "message" })
+                .then(output => {
+                    const devs = output.trim().split('\n');
                     this.setState({ networkDevices: devs });
-                });
+                })
+                .catch(e => console.warn("could not read /sys/class/net:", e.toString()));
 
         if (this.props.vm.state != 'running' && this.props.vm.state != 'paused')
             return;


### PR DESCRIPTION
 * /sys/class/net can contain other things than symlinks to interfaces,
   e. g. `bonding_masters` (after `modprobe bonding`). Use find instead
   of ls to only pick the symlinks.

 * Fix showing the error message; previous code only showed
   `<unavailable>` in the console, as the error message from spawn is an
   object.

 * It was not obvious what the pop() was doing; replace with trim(), as
   the purpose is to avoid getting an empty element after the final \n.

 * Use standard JS promise API.

Fixes commit fc3dbd91de