### PR TITLE
apps: Use flex instead of table in caption

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -58,7 +58,7 @@ class ApplicationRow extends React.Component {
         if (comp.installed) {
             name = <Button variant="link" onClick={left_click(() => launch(comp))}>{comp.name}</Button>;
         } else {
-            name = comp.name;
+            name = <span className="noninstalled">{comp.name}</span>;
         }
 
         if (state.progress) {

--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -146,16 +146,14 @@ export class ApplicationList extends React.Component {
 
         return (
             <table className={table_classes}>
-                <caption>
-                    <table>
-                        <tbody>
-                            <tr>
-                                <td><h2>{_("Applications")}</h2></td>
-                                <td>{refresh_progress}</td>
-                                <td>{refresh_button}</td>
-                            </tr>
-                        </tbody>
-                    </table>
+                <caption className="caption-with-actions">
+                    <span>
+                        <h2>{_("Applications")}</h2>
+                        <div className="right-menu">
+                            {refresh_progress}
+                            {refresh_button}
+                        </div>
+                    </span>
                 </caption>
                 <tbody>
                     { tbody }

--- a/pkg/apps/application.css
+++ b/pkg/apps/application.css
@@ -69,7 +69,6 @@
 }
 
 .app-list .progress-title {
-    float: left;
     margin-right: 10px;
 }
 
@@ -124,4 +123,17 @@
 
 .app-screenshot {
     margin: 10px;
+}
+
+.caption-with-actions {
+    width: 100%;
+}
+
+.caption-with-actions span {
+    display: flex;
+    justify-content: space-between;
+}
+
+.right-menu * {
+    display: inline-block;
 }

--- a/pkg/apps/application.css
+++ b/pkg/apps/application.css
@@ -137,3 +137,8 @@
 .right-menu * {
     display: inline-block;
 }
+
+/* Give it the same padding as button have */
+.noninstalled {
+    margin-left: var(--pf-global--spacer--md);
+}


### PR DESCRIPTION
It was misbehaving in some locales, like Japanese otherwise.
Also style that installed and non-installed apps align.

Before:
![jabfore](https://user-images.githubusercontent.com/12330670/79211640-c79d3280-7e46-11ea-9750-8cb3e0c1387f.png)
Now:
![sfterjan](https://user-images.githubusercontent.com/12330670/79212575-21522c80-7e48-11ea-98d6-104c59cd216b.png)

