### PR TITLE
Change empty state secondary buttons to use link-styled buttons

### DIFF
--- a/pkg/machines/components/libvirtSlate.jsx
+++ b/pkg/machines/components/libvirtSlate.jsx
@@ -97,7 +97,7 @@ class LibvirtSlate extends React.Component {
         );
 
         const troubleshoot_btn = (
-            <Button variant="secondary" onClick={ mouseClick(this.goToServicePage) }>
+            <Button variant="link" onClick={ mouseClick(this.goToServicePage) }>
                 { _("Troubleshoot") }
             </Button>);
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -502,7 +502,7 @@ const AskRestart = ({ onIgnore, onRestart, history }) => <>
                      paragraph={ _("Updated packages may require a restart to take effect.") }
                      action={ _("Restart Now") }
                      onAction={ onRestart}
-                     secondary={ <Button variant="secondary" onClick={onIgnore}>{_("Ignore")}</Button> } />
+                     secondary={ <Button variant="link" onClick={onIgnore}>{_("Ignore")}</Button> } />
 
     <div className="flow-list-blank-slate">
         <Expander title={_("Package information")}>

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -213,8 +213,7 @@ class TestUpdates(NoSubManCase):
         # update should succeed and show restart page; cancel
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
         self.assertEqual(b.text("#app .container-fluid button.pf-m-primary"), "Restart Now")
-        self.assertEqual(b.text("#app .container-fluid button.pf-m-secondary"), "Ignore")
-        b.click("#app .container-fluid button.pf-m-secondary")
+        b.click("#app .container-fluid button.pf-m-link:contains('Ignore')")
 
         # should go back to updates overview, nothing pending any more
         b.wait_in_text("#state", "No updates pending")
@@ -361,7 +360,7 @@ class TestUpdates(NoSubManCase):
         assertHistory("ul", ["secdeclare", "secparse", "sevcritical"])
 
         # ignore restarting
-        b.click("#app .container-fluid button.pf-m-secondary")
+        b.click("#app .container-fluid button.pf-m-link:contains('Ignore')")
 
         # should have succeeded; 3 non-security updates left
         b.wait_in_text("#state", "3 updates")
@@ -391,7 +390,7 @@ class TestUpdates(NoSubManCase):
 
         # should have succeeded and show restart
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
-        b.wait_present("#app .container-fluid button.pf-m-secondary")
+        b.wait_present("#app .container-fluid button.pf-m-link:Contains('Ignore')")
 
         # new versions are now installed
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
@@ -639,7 +638,7 @@ class TestWsUpdate(NoSubManCase):
 
         # should have succeeded and show restart page; cancel
         b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
-        b.click("#app .container-fluid button.pf-m-secondary")
+        b.click("#app .container-fluid button.pf-m-link:contains('Ignore')")
         b.wait_in_text("#state", "No updates pending")
 
         # now pretend that there is a newer cockpit-ws available, warn about disconnect
@@ -1047,7 +1046,7 @@ class TestAutoUpdatesInstall(NoSubManCase):
         b.click("#app .container-fluid button.pk-update--all")
 
         # empty state visible in main area
-        b.click('.container-fluid .pf-c-empty-state button.pf-m-secondary')
+        b.click('.container-fluid .pf-c-empty-state button.pf-m-link')
         self.assertFalse(b.is_present("#available"))
         if self.backend == 'dnf':
             b.is_present('#automatic')

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -534,7 +534,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
 
-        b.click(".pf-c-empty-state button.pf-m-secondary")  # Troubleshoot
+        b.click(".pf-c-empty-state button.pf-m-link")  # Troubleshoot
         b.leave_page()
         url_location = "/system/services#/{0}".format(libvirtServiceName)
         b.wait(lambda: url_location in b.eval_js("window.location.href"))


### PR DESCRIPTION
Fixes #13895

I could find only these two places where we use also secondary options.
There may be some places I missed? (if you can find some, please let me know). But they most likely don't use this empty state component so they should be migrated as well.

@garrett 

Now looks like:
![Screenshot from 2020-04-14 12-23-16](https://user-images.githubusercontent.com/12330670/79214724-39777b00-7e4b-11ea-9b13-9780e31fb5f6.png)
