### PR TITLE
tests: Robustify testNICAdd by creating the test Virtual Network before page load

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -2011,6 +2011,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         b = self.browser
         m = self.machine
 
+        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network".format(TEST_NETWORK_XML))
+
         args = self.startVm("subVmTest1")
 
         self.login_and_go("/machines")
@@ -2141,8 +2143,6 @@ class TestMachinesDBus(machineslib.TestMachines):
 
         # No NICs present
         b.wait_present("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
-        # Test network type source
-        m.execute("echo \"{0}\" > /tmp/xml && virsh net-define /tmp/xml && virsh net-start test_network".format(TEST_NETWORK_XML))
 
         NICAddDialog(
             self,


### PR DESCRIPTION
It's also possible to create the test network after the page was loaded
(how we used to do it) and just wait for the the internal state to get updated,
before opening the dialog which uses the newly added resource, but this is
prompt to be more unstable than just creating the necessary resources
before page load.

Fixes #13861