### PR TITLE
tools: When filtering manifest files look for '.in'

### DIFF
--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -48,8 +48,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
               <div class="pf-c-alert__icon">
                 <span class="pficon pficon-info"></span>
               </div>
-              <h4 class="pf-c-alert__title alert-message" translate="yes">The generated archive contains data considered sensitive and its content should be reviewed by the originating organization before being passed to any third party.</span>
-              </h4>
+              <h4 class="pf-c-alert__title alert-message" translate="yes">The generated archive contains data considered sensitive and its content should be reviewed by the originating organization before being passed to any third party.</h4>
             </div>
             <div id="sos-progress" class="text-center">
               <div translate="yes">Generating report</div>

--- a/pkg/systemd/graphs.html
+++ b/pkg/systemd/graphs.html
@@ -43,8 +43,7 @@
                                         <i class="fa fa-caret-down pf-c-context-selector__toggle-icon" aria-hidden="true"></i>
                                     </button>
                                     <ul class="dropdown-menu" role="menu">
-                                        <li role="presentation"><a role="link" tabindex="0" role="menuitem" data-action="goto-now" translate>Go to
-                                                now</a></li>
+                                        <li role="presentation"><a role="link" tabindex="0" role="menuitem" data-action="goto-now" translate>Go to now</a></li>
                                         <li role="presentation" class="divider"></li>
                                         <li role="presentation"><a role="link" tabindex="0" role="menuitem" data-range="300" translate>5 minutes</a>
                                         </li>

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -187,7 +187,7 @@ function generateDeps(makefile, stats) {
 
     var filters = po_locations.map(function (l) { return "-N " + l; });
     if (prefix === "shell")
-        filters.push("$(addprefix -N ,$(shell find pkg/ -name manifest.json))");
+        filters.push("$(addprefix -N ,$(shell find pkg/ -name manifest.json.in))");
 
     lines.push(path.join(pkgdir, "%.po") + ": po/%.po");
     lines.push("\t$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \\");

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -186,6 +186,7 @@ function generateDeps(makefile, stats) {
     makeArray(prefix + "_TESTS", tests);
 
     var filters = po_locations.map(function (l) { return "-N " + l; });
+    filters.push("-N src/base1/cockpit.js"); // FIXME: See #13906
     if (prefix === "shell")
         filters.push("$(addprefix -N ,$(shell find pkg/ -name manifest.json.in))");
 


### PR DESCRIPTION
In language files (like 'de.po') we refer to manifest files like
`pkg/sosreport/manifest.json.in`. This is later on used with `msggrep`
to only include relative files. Looking for `manifest.json` did not
return any results and therefore we would not translate things in shell
like labels or help menu items. (We would translate it only if the same
string comes also from different location, which was the case for
majority of label as <title> usually has the same string.)