### PR TITLE
test: Fix Machines testNICAdd permanent attachment

### DIFF
--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -2178,6 +2178,8 @@ class TestMachinesDBus(machineslib.TestMachines):
         # Test permanent attachment to running VM
         NICAddDialog(
             self,
+            source_type="Virtual network",
+            source="test_network",
             permanent=True,
         ).execute()
 


### PR DESCRIPTION
Specify a type and source in the "permanent attachment to running VM"
check. Otherwise it's going to default to "Direct attachment" and try to
use whichever real interface happens to be first. This is almost
certainly going to fail, as e. g. "lo" can't be attached (resulting in
"invalid argument") and vnet0 or most other interfaces are already busy.