### PR TITLE
test: Drop chrony purging from debian-testing

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -97,10 +97,10 @@ class TestSystemInfo(MachineCase):
     def setUp(self):
         super().setUp()
 
-        # Debian will not allow timesyncd to start if any other NTP packge is installed
-        # We only support timesyncd for NTP configuration, so make sure chrony
-        # is not installed in the debian test images
-        if self.machine.image in ["debian-stable", "debian-testing", "ubuntu-stable"]:
+        # Debian will not allow timesyncd to start if any other NTP packge is installed We only
+        # support timesyncd for NTP configuration, so make sure chrony is not installed in the older
+        # debian/ubuntu images which don't yet have systemd-timesyncd
+        if self.machine.image in ["debian-stable", "ubuntu-stable"]:
             self.machine.execute("dpkg --remove chrony");
 
     @enableAxe


### PR DESCRIPTION
systemd-timesyncd got split out recently into a separate package,
conflicting with chrony, see
https://github.com/cockpit-project/bots/pull/757