### PR TITLE
containers: Bump bastion and ws containers to Fedora 31

### DIFF
--- a/containers/bastion/Dockerfile
+++ b/containers/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:30
+FROM fedora:31
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=master
 


### PR DESCRIPTION
Our copr does not build Fedora 30 packages any more, so building the
official cockpit/ws currently fails on Dockerhub.

[DockerHub failure log](https://hub.docker.com/repository/registry-1.docker.io/cockpit/ws/builds/021b2e2a-dd8e-4ba9-9ec2-36b213af6d3d)