### PR TITLE
machines: Fix no IP configuraiton for virtual networks

### DIFF
--- a/pkg/machines/components/networks/createNetworkDialog.jsx
+++ b/pkg/machines/components/networks/createNetworkDialog.jsx
@@ -412,8 +412,8 @@ class CreateNetworkModal extends React.Component {
                 name, forwardMode, ip, prefix, device,
                 ipv4DhcpRangeStart, ipv4DhcpRangeEnd, ipv6DhcpRangeStart, ipv6DhcpRangeEnd
             } = this.state;
-            const ipv6 = ip === "IPv4 only" ? undefined : this.state.ipv6;
-            const ipv4 = ip === "IPv6 only" ? undefined : this.state.ipv4;
+            const ipv6 = ["IPv4 only", "None"].includes(ip) ? undefined : this.state.ipv6;
+            const ipv4 = ["IPv6 only", "None"].includes(ip) ? undefined : this.state.ipv4;
             const netmask = utils.netmaskConvert(this.state.netmask);
 
             this.setState({ createInProgress: true });

--- a/test/verify/check-machines-dbus
+++ b/test/verify/check-machines-dbus
@@ -1428,6 +1428,9 @@ class TestMachinesDBus(machineslib.TestMachines):
                         b.wait_not_present("#network-{0}-{1}-ipv4-address".format(self.name, connectionName))
                     if not "6" in self.ip_conf:
                         b.wait_not_present("#network-{0}-{1}-ipv6-address".format(self.name, connectionName))
+                else:
+                    b.wait_not_present("#network-{0}-{1}-ipv4-address".format(self.name, connectionName))
+                    b.wait_not_present("#network-{0}-{1}-ipv6-address".format(self.name, connectionName))
 
             def cleanup(self):
                 m.execute("virsh net-undefine {0}".format(self.name))


### PR DESCRIPTION
When user selected "None" IP configuration, virtual networks would
still have defualt IP configuration.

Fixes: #13893