### PR TITLE
Make team and bridge tests nondestructive

### DIFF
--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -21,16 +21,10 @@ import parent
 from netlib import *
 from testlib import *
 
-from machine_core.constants import TEST_OS_DEFAULT
 
-
-class TestNetworking(NetworkCase):
-    provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
-    }
-
-    def testBridge(self):
+@nondestructive
+class TestBridge(NetworkCase):
+    def testBasic(self):
         b = self.browser
         m = self.machine
 
@@ -38,10 +32,14 @@ class TestNetworking(NetworkCase):
 
         # These are two independent networks. Thus there is no loop between the
         # bridge that all VMs are connected to, and the bridge we are creating here.
-        iface1 = self.add_iface()
-        iface2 = self.add_iface(activate=False)
+        iface1 = "cockpit1"
+        self.add_veth(iface1, dhcp_cidr="10.111.113.1/24", dhcp_range=['10.111.113.2', '10.111.113.254'])
+        self.nm_activate_eth(iface1)
+        iface2 = "cockpit2"
+        self.add_veth(iface2, dhcp_cidr="10.111.114.1/24", dhcp_range=['10.111.114.2', '10.111.114.254'])
+        self.nm_activate_eth(iface2)
         self.wait_for_iface(iface1)
-        self.wait_for_iface(iface2, active=False)
+        self.wait_for_iface(iface2)
 
         # Bridge them
         b.click("button:contains('Add Bridge')")
@@ -68,17 +66,18 @@ class TestNetworking(NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
-    def testBridgeActive(self):
+    def testActive(self):
         b = self.browser
 
         self.login_and_go("/network")
 
-        iface = self.add_iface()
+        iface = "cockpit1"
+        self.add_veth(iface, dhcp_cidr="10.111.112.2/20")
+        self.nm_activate_eth(iface)
         self.wait_for_iface(iface)
-        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
 
-        # Put an active interface into a bridge.  The bridge should
-        # get the same IP as the active interface.
+        # Put an active interface into a bridge. We can't select/copy the MAC, so we can't expect to
+        # get the same IP as the active interface, but it should get a valid DHCP IP.
 
         b.click("button:contains('Add Bridge')")
         b.wait_popup("network-bridge-settings-dialog")
@@ -91,7 +90,7 @@ class TestNetworking(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tbridge'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
-        b.wait_in_text("#network-interface .panel:contains('tbridge')", ip)
+        b.wait_in_text("#network-interface .panel:contains('tbridge')", "10.111")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -21,17 +21,11 @@ import parent
 from netlib import *
 from testlib import *
 
-from machine_core.constants import TEST_OS_DEFAULT
-
 
 @skipImage("NetworkManager-team not installed", "fedora-coreos")
-class TestNetworking(NetworkCase):
-    provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
-    }
-
-    def testTeam(self):
+@nondestructive
+class TestTeam(NetworkCase):
+    def testBasic(self):
         b = self.browser
         m = self.machine
 
@@ -39,8 +33,12 @@ class TestNetworking(NetworkCase):
 
         b.wait_attr("#networking-add-team", "data-test-stable", "yes")
 
-        iface1 = self.add_iface()
-        iface2 = self.add_iface()
+        iface1 = "cockpit1"
+        self.add_veth(iface1, dhcp_cidr="10.111.113.1/24", dhcp_range=['10.111.113.2', '10.111.113.254'])
+        self.nm_activate_eth(iface1)
+        iface2 = "cockpit2"
+        self.add_veth(iface2, dhcp_cidr="10.111.114.1/24", dhcp_range=['10.111.114.2', '10.111.114.254'])
+        self.nm_activate_eth(iface2)
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
@@ -91,17 +89,18 @@ class TestNetworking(NetworkCase):
         self.allow_journal_messages(".*Connection reset by peer.*",
                                     "connection unexpectedly closed by peer")
 
-    def testTeamActive(self):
+    def testActive(self):
         b = self.browser
 
         self.login_and_go("/network")
 
-        iface = self.add_iface()
+        iface = "cockpit1"
+        self.add_veth(iface, dhcp_cidr="10.111.112.2/20")
+        self.nm_activate_eth(iface)
         self.wait_for_iface(iface)
-        ip = b.text("#networking-interfaces tr[data-interface='%s'] td:nth-child(2)" % iface)
 
-        # Put an active interface into a team.  The team should
-        # get the same IP as the active interface.
+        # Put an active interface into a team. We can't select/copy the MAC, so we can't expect to
+        # get the same IP as the active interface, but it should get a valid DHCP IP.
 
         b.click("button:contains('Add Team')")
         b.wait_popup("network-team-settings-dialog")
@@ -114,7 +113,7 @@ class TestNetworking(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-slaves tr[data-interface='%s']" % iface)
-        b.wait_in_text("#network-interface .panel:contains('tteam')", ip)
+        b.wait_in_text("#network-interface .panel:contains('tteam')", "10.111")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 - [x] Builds on top of PR #13879 

This is relatively straightforward now, except for the different behaviour of "same IP", that @mvollmer and I discussed in the above PR.

With that we have parity with Selenium tests in the networking area. For now I'd like to keep the other tests destructive with `provision`, so that we have a few tests that exercise "real" (well, QEMU) network interfaces.