### PR TITLE
machines: Fix condition for disabling 'Create' button

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -1003,13 +1003,10 @@ export class CreateVmAction extends React.Component {
             testdata = "disabledOsInfo";
         else if (!this.state.virtInstallAvailable)
             testdata = "disabledVirtInstall";
-        else if (this.state.downloadOSSupported === undefined)
-            testdata = "disabledDownloadOS";
+        else if (this.state.downloadOSSupported === undefined || this.state.unattendedSupported === undefined)
+            testdata = "disabledCheckingFeatures";
         let createButton = (
-            <Button isDisabled={!(this.props.systemInfo.osInfoList &&
-                               (this.state.virtInstallAvailable !== undefined ||
-                                   (this.state.virtInstallAvailable &&
-                                       (this.state.downloadOSSupported === undefined || this.state.unattendedSupported === undefined))))}
+            <Button isDisabled={testdata !== undefined}
                     testdata={testdata}
                     id={this.props.mode == 'create' ? 'create-new-vm' : 'import-vm-disk'}
                     variant='secondary'

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1932,6 +1932,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         self.login_and_go("/machines")
         self.browser.wait_in_text("body", "Virtual Machines")
         self.browser.wait_visible("#create-new-vm:not(:disabled)")
+        self.browser.wait_attr("#create-new-vm", "testdata", None)
 
         virt_install_bin = self.machine.execute("which virt-install").strip()
         self.machine.execute('mount -o bind /dev/null {0}'.format(virt_install_bin))


### PR DESCRIPTION
Previously when `virt-install` was not available the condition
evaluated to 'true' since `this.state.virtInstallAvailable !==
undefined` is truthy.

The test was also not properly checking the disabled button
functionality since when freshly loading the page the button is always
disabled for a fraction of a second. This commit fixes the test as well
to perform a more robust check.

This fixes the testDisabledCreate flake test - with failures such as 
https://logs.cockpit-project.org/logs/pull-13695-20200416-160442-23b1ea4b-rhel-8-2-distropkg/log.html#192-2
or 
https://logs.cockpit-project.org/logs/pull-13695-20200416-160442-23b1ea4b-ubuntu-2004/log.html#192-2