### PR TITLE
overview: remove bottom margin under motd

### DIFF
--- a/pkg/systemd/overview-cards/motdCard.scss
+++ b/pkg/systemd/overview-cards/motdCard.scss
@@ -8,3 +8,7 @@
     padding: 0;
     white-space: pre-wrap;
 }
+
+#motd-box {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
Instead of relying on margin, content in the overview grid relies on the
grid gap for spacing.

Fixes #13884

After this commit:
![Screen Shot 2020-04-17 at 12 08 18](https://user-images.githubusercontent.com/14921356/79558326-3deaa080-80a4-11ea-902c-79b03f1484d9.png)