### PR TITLE
base1: Adjust test-http for recent playground change

### DIFF
--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -72,6 +72,9 @@ QUnit.test("simple request", function (assert) {
                         speed: {
                             label: "Speed Tests"
                         },
+                        journal: {
+                            label: "Logs Box"
+                        },
                         test: {
                             label: "Playground"
                         }


### PR DESCRIPTION
Commit 9afcaabd5c65 introduced a new playground page, which broke
test-http.html.