### PR TITLE
test: Ignore "invalid locale" messages on Debian

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1044,6 +1044,10 @@ class MachineCase(unittest.TestCase):
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:
             messages += machine.audit_messages("14", cursor=cursor) # 14xx is selinux
 
+        if self.image.startswith('debian'):
+            # Debian images don't have any non-C locales (mostly deliberate, to test this scenario somewhere)
+            self.allowed_messages.append("invalid or unusable locale: .*")
+
         if self.image in ['fedora-32', 'fedora-31', 'fedora-testing']:
             # Fedora >= 30 switched to dbus-broker
             self.allowed_messages.append("dbus-daemon didn't send us a dbus address; not installed?.*")


### PR DESCRIPTION
ssh usually tries to set the client locale into the server ssh session,
even though they don't exist there. This often causes tests to fail with

    invalid or unusable locale: en_US.UTF-8

unexpected messages. The latest cockpit/tasks container refresh seems to
have subtly changed the locale configuration, so that this now fails
every Debian test.

Not having any non-C locales on Debian images is deliberate, as we want
to test this scenario somewhere. So just ignore that error.