### PR TITLE
test: Skip tangd-update.service hack on rhel-7-9

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -156,7 +156,8 @@ class TestStorage(StorageCase):
         #
         #        https://github.com/latchset/tang/issues/23
 
-        m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
+        if m.image not in ["rhel-7-9"]:
+            m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
 
         m.execute("systemctl start tangd.socket")
 


### PR DESCRIPTION
Test passes without it and it only breaks the test.

(well, TBH I haven't tested it, but lets try it here)