### PR TITLE
shell: Disable idle timeout by default

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -217,10 +217,10 @@ ProtocolHeader = X-Forwarded-Proto
           <informalexample>
 <programlisting language="js">
 [Session]
-IdleTimeout=0
+IdleTimeout=15
 </programlisting>
-          </informalexample>		
-          <para>When not specified, the default is <literal>15</literal> minutes.</para>
+          </informalexample>
+          <para>When not specified, there is no idle timeout by default.</para>
         </listitem>
       </varlistentry>
     </variablelist>

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -67,7 +67,7 @@ class TestMenu(MachineCase):
         b.wait_visible("#login")
         b.wait_visible("#login-info-message")
         b.wait_text("#login-info-message", "You have been logged out due to inactivity.")
-        m.execute("sed -i 's/IdleTimeout = 1/IdleTimeout = 0/' /etc/cockpit/cockpit.conf")
+        m.execute("sed -i '/IdleTimeout/d' /etc/cockpit/cockpit.conf")
         m.restart_cockpit()
         b.reload()
         self.login_and_go("/system")


### PR DESCRIPTION
Common Criteria [1] only require the availability of an idle auto-lock,
not that it's enabled by default. As Cockpit is never the primary
session on a device, it makes more sense to let the login/window manager
(desktop) or screen lock (mobile devices) take care of protecting the
session.

Instead, let's rather implement an automatic timeout of sudo privileges,
once that rework is in place. That will mimic the behavior of the
command line (ssh + sudo).

Also add some code cleanups:

 * Only set up the idle timers in the shell if the timeout is non-zero.
   This isn't as easy to do in the frames, as we currently don't block
   frames construction on the GetUInt(IdleTimeout), but it helps a bit.

 * Rename setupTimers() to a more specific setupIdleResetTimers().

 * Fix listening to scroll events.

 * In setupIdleResetTimers(), rename the `document` argument (which is a
   public global variable with well-defined purpose) to `win`, to avoid
   confusion.

[1] https://www.niap-ccevs.org/MMO/PP/-442-/#FMT_SMF_EXT.1.1