### PR TITLE
base1: Document and fix up javascript debugging

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -309,6 +309,32 @@ To revert the above logging changes:
     $ sudo systemctl daemon-reload
     $ sudo systemctl restart cockpit
 
+## Debug logging in Javascript console
+
+Various javascript methods in Cockpit can show debug messages. You
+can turn them on by setting a `window.debugging` global, or setting
+up a `debugging` property in the browser storage. To do this
+run the following in your javascript console:
+
+    >> sessionStorage.debugging = "all"
+
+You'll notice that there's a ton of messages that get shown. If you
+want to be more specific, instead of "all" use one of the following
+specific types:
+
+    "all"      // All available debug messages
+    "channel"  // All channel messages sent to server
+    "dbus"     // DBus related debug messages
+    "http"     // HTTP (via the server) related debug messages
+    "spawn"    // Debug messages related to executing processes
+
+There are other strings related to the code you may be working on.
+
+In addition, if you want your debug setting to survive a browser refresh
+or Cockpit log out, use something like:
+
+    >> localStorage.debugging = "spawn"
+
 ## Running Cockpit processes under a debugger
 
 You may want to run cockpit-ws under a debugger such as valgrind or gdb.

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -33,11 +33,22 @@ var mock = mock || { }; // eslint-disable-line no-use-before-define
 var cockpit = { };
 event_mixin(cockpit, { });
 
+/*
+ * The debugging property is a global that is used
+ * by various parts of the code to show/hide debug
+ * messages in the javascript console.
+ *
+ * We supprot using storage to get/set that property
+ * so that it carries across the various frames or
+ * alternatively persists across refreshes.
+ */
 if (typeof window.debugging === "undefined") {
     try {
         // Sometimes this throws a SecurityError such as during testing
-        window.debugging = window.sessionStorage.debugging ||
-                           window.localStorage.debugging;
+        Object.defineProperty(window, "debugging", {
+            get: function() { return window.sessionStorage.debugging || window.localStorage.debugging },
+            set: function(x) { window.sessionStorage.debugging = x }
+        });
     } catch (e) { }
 }
 


### PR DESCRIPTION
The window.debugging = "all" command can be used in the
javascript console to produce lots of debug output. However
the more specific messages such as "spawn" were hard to use
since one had to set that global in the relevant frame,
or use localStorage and refresh.

We now set things up to automatically reflect the storage
debugging variables in each frame, via a getter/setter.

The sessionStorage overrides localStorage if both are set.

In addition we add documentation for this mechanism.