### PR TITLE
system: Strip whitespace before and after MOTD

### DIFF
--- a/pkg/systemd/overview-cards/motdCard.jsx
+++ b/pkg/systemd/overview-cards/motdCard.jsx
@@ -54,7 +54,7 @@ export class MotdCard extends React.Component {
 
         return (
             <Alert id="motd-box" isInline variant="info" className="motd-box"
-                   title={ <pre id="motd">{this.state.motdText}</pre> }
+                   title={ <pre id="motd">{this.state.motdText.trim()}</pre> }
                    action={ <AlertActionCloseButton onClose={this.hideAlert} /> } />
         );
     }


### PR DESCRIPTION
Sometimes a system's MOTD may have whitespace before or after the content.

(This happens with the default Debian MOTD, for example.)

We don't need to display the whitespace preceding and following the MOTD within Cockpit.