### PR TITLE
lib/page: Re-add space between paragraphs

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -2,6 +2,12 @@ a {
     cursor: pointer;
 }
 
+p + p {
+    // The mix of PF3 and PF4 removes margin from paragraphs.
+    // We want successive paragraphs to have spaces between each other.
+    margin-top: var(--pf-global--spacer--md);
+}
+
 .disabled {
     pointer-events: auto;
 }


### PR DESCRIPTION
For some reason, paragraphs have lost margins between PF3 and PF4. And subsequent paragraphs do not have spacing between themselves, so I'm re-adding this to all of Cockpit.

We usually don't use paragraphs next to each other, but sometimes we do.