### PR TITLE
machines: Fix D-Bus error messages

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -452,7 +452,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                     .then(objPaths => {
                         return Promise.all(objPaths[0].map((path) => dispatch(getNetwork({ connectionName, id:path }))));
                     })
-                    .fail(ex => console.warn('GET_ALL_NETWORKS action failed:', JSON.stringify(ex)));
+                    .catch(ex => console.warn('GET_ALL_NETWORKS action failed:', ex.toString()));
         };
     },
 
@@ -462,7 +462,7 @@ const LIBVIRT_DBUS_PROVIDER = {
         return dispatch => {
             call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'ListNodeDevices', [0], { timeout, type: 'u' })
                     .then(objPaths => Promise.all(objPaths[0].map(path => dispatch(getNodeDevice({ connectionName, id:path })))))
-                    .fail(ex => console.warn('GET_ALL_NODE_DEVICES action failed:', JSON.stringify(ex)));
+                    .catch(ex => console.warn('GET_ALL_NODE_DEVICES action failed:', ex.toString()));
         };
     },
 
@@ -482,7 +482,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                                     });
                         }));
                     })
-                    .fail(ex => console.warn('GET_ALL_STORAGE_POOLS action failed:', JSON.stringify(ex)));
+                    .catch(ex => console.warn('GET_ALL_STORAGE_POOLS action failed:', ex.toString()));
         };
     },
 
@@ -493,7 +493,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         dispatch(deleteUnlistedVMs(connectionName, [], objPaths[0]));
                         return Promise.all(objPaths[0].map((path) => dispatch(getVm({ connectionName, id:path }))));
                     })
-                    .fail(ex => console.warn('GET_ALL_VMS action failed:', JSON.stringify(ex)));
+                    .catch(ex => console.warn('GET_ALL_VMS action failed:', ex.toString()));
         };
     },
 
@@ -536,7 +536,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         const count = getDomainMaxVCPU(capsXML[0]);
                         dispatch(setHypervisorMaxVCPU({ count, connectionName }));
                     })
-                    .fail(ex => console.warn("GetDomainCapabilities failed: %s", ex));
+                    .catch(ex => console.warn("GetDomainCapabilities failed: %s", ex.toString()));
         }
 
         return unknownConnectionName(setHypervisorMaxVCPU);
@@ -577,7 +577,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         const network = parseNetDumpxml(xml);
                         dispatch(updateOrAddNetwork(Object.assign({}, props, network), updateOnly));
                     })
-                    .catch(ex => console.warn('GET_NETWORK action failed failed for path', objPath, ex));
+                    .catch(ex => console.warn('GET_NETWORK action failed for path', objPath, ex.toString()));
         };
     },
 
@@ -614,7 +614,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         const iface = parseIfaceDumpxml(xml);
                         dispatch(updateOrAddInterface(Object.assign({}, props, iface)));
                     })
-                    .catch(ex => console.log('listInactiveInterfaces action failed for path', objPath, ex));
+                    .catch(ex => console.log('listInactiveInterfaces action for path', objPath, ex.toString()));
         };
     },
 
@@ -635,7 +635,7 @@ const LIBVIRT_DBUS_PROVIDER = {
 
                         dispatch(updateOrAddNodeDevice(deviceXmlObject));
                     })
-                    .catch(ex => console.warn('GET_NODE_DEVICE action failed failed for path', objPath, ex));
+                    .catch(ex => console.warn('GET_NODE_DEVICE action failed for path', objPath, ex.toString()));
         };
     },
 
@@ -689,7 +689,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         else
                             dispatch(updateStorageVolumes({ connectionName, poolName: dumpxmlParams.name, volumes: [] }));
                     })
-                    .catch(ex => console.warn('GET_STORAGE_POOL action failed failed for path', objPath, ex));
+                    .catch(ex => console.warn('GET_STORAGE_POOL action failed for path', objPath, ex.toString()));
         };
     },
 
@@ -733,7 +733,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         }));
                     });
                 })
-                .fail(ex => console.warn("GET_STORAGE_VOLUMES action failed for pool %s: %s", poolName, JSON.stringify(ex)));
+                .catch(ex => console.warn("GET_STORAGE_VOLUMES action failed for pool %s: %s", poolName, ex.toString()));
     },
 
     /*
@@ -804,7 +804,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                         else
                             dispatch(updateOrAddVm(Object.assign({}, props, dumpxmlParams)));
                     })
-                    .catch(function(ex) { console.warn("GET_VM action failed failed for path", objPath, ex); return cockpit.reject(ex) });
+                    .catch(function(ex) { console.warn("GET_VM action failed for path", objPath, ex.toString()); return cockpit.reject(ex) });
         };
     },
 
@@ -1020,7 +1020,7 @@ function doUsagePolling(name, connectionName, objPath) {
                         dispatch(updateVm(props));
                     }
                 })
-                .fail(ex => console.warn(`GetStats(${name}, ${connectionName}) failed: ${JSON.stringify(ex)}`))
+                .catch(ex => console.warn(`GetStats(${name}, ${connectionName}) failed: ${ex.toString()}`))
                 .always(() => dispatch(delayPolling(doUsagePolling(name, connectionName, objPath), null, name, connectionName)));
     };
 }
@@ -1160,7 +1160,7 @@ function domainEventUndefined(connectionName, domPath, dispatch) {
                 else
                     dispatch(getVm({ connectionName, id:domPath, updateOnly: true }));
             })
-            .fail(ex => console.warn('ListDomains action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('ListDomains action failed:', ex.toString()));
 }
 
 function domainUpdateOrDelete(connectionName, domPath, dispatch) {
@@ -1172,7 +1172,7 @@ function domainUpdateOrDelete(connectionName, domPath, dispatch) {
                 else // Transient vm will get undefined when stopped
                     dispatch(undefineVm({ connectionName, id:domPath, transientOnly: true }));
             })
-            .fail(ex => console.warn('GET_ALL_NETWORKS action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('GET_ALL_NETWORKS action failed:', ex.toString()));
 }
 
 function storagePoolUpdateOrDelete(connectionName, poolPath, dispatch) {
@@ -1183,7 +1183,7 @@ function storagePoolUpdateOrDelete(connectionName, poolPath, dispatch) {
                 else // Transient pool which got undefined when stopped
                     dispatch(undefineStoragePool({ connectionName, id:poolPath }));
             })
-            .fail(ex => console.warn('GET_ALL_NETWORKS action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('GET_ALL_NETWORKS action failed:', ex.toString()));
 }
 
 function networkUpdateOrDelete(connectionName, netPath, dispatch) {
@@ -1194,7 +1194,7 @@ function networkUpdateOrDelete(connectionName, netPath, dispatch) {
                 else // Transient network which got undefined when stopped
                     dispatch(undefineNetwork({ connectionName, id:netPath }));
             })
-            .fail(ex => console.warn('GET_ALL_NETWORKS action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('GET_ALL_NETWORKS action failed:', ex.toString()));
 }
 
 function startEventMonitorNetworks(connectionName, dispatch) {
@@ -1460,7 +1460,7 @@ export function getAllInterfaces(dispatch, connectionName) {
             .then((ifaces) => {
                 return Promise.all(ifaces[0].map(path => dispatch(getInterface({ connectionName, id:path }))));
             })
-            .fail(ex => console.warn('getAllInterfaces action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('getAllInterfaces action failed:', ex.toString()));
 }
 
 export function getDomainCapabilities(connectionName) {
@@ -1472,7 +1472,7 @@ function initResource(connectionName, method, updateOrAddMethod, flags) {
             .then(objPaths => {
                 return Promise.all(objPaths[0].map(() => updateOrAddMethod({})));
             })
-            .fail(ex => console.warn('initResource action failed:', JSON.stringify(ex)));
+            .catch(ex => console.warn('initResource action failed:', ex.toString()));
 }
 
 export function networkActivate(connectionName, objPath) {


### PR DESCRIPTION
`ex` is an object and thus not directly printable. Consistently turn it
into a string so that the warning becomes useful. Other places already
used `JSON.stringify()`, which works, but is a bit harder to read.

Also use catch() consistently.