### PR TITLE
systemd: Strip leading empty lines in motd

### DIFF
--- a/pkg/systemd/overview-cards/motdCard.jsx
+++ b/pkg/systemd/overview-cards/motdCard.jsx
@@ -38,8 +38,9 @@ export class MotdCard extends React.Component {
 
     componentDidMount() {
         cockpit.file("/etc/motd").watch(content => {
+            /* trim initial empty lines and trailing space, but keep initial spaces to not break ASCII art */
             if (content)
-                content = content.trimRight();
+                content = content.trimRight().replace(/^\s*\n/, '');
             if (content && content != cockpit.localStorage.getItem('dismissed-motd')) {
                 this.setState({ motdText: content, motdVisible: true });
             } else {

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -362,9 +362,13 @@ class TestSystemInfo(MachineCase):
         self.login_and_go("/system")
         b.wait_not_present('#motd-box')
 
-        m.execute(r"printf '  Hello\n  World\n\n' >/etc/motd")
+        m.execute(r"printf '\n  \n  Hello\n  World\n\n' >/etc/motd")
         b.wait_visible('#motd-box')
-        b.wait_text('#motd', "  Hello\n  World")
+        # strips empty lines, but not leading spaces; fixed in PR #13951
+        if m.image in ["rhel-8-2-distropkg"]:
+            b.wait_text('#motd', "\n  \n  Hello\n  World")
+        else:
+            b.wait_text('#motd', "  Hello\n  World")
 
         b.click('#motd-box button')
         b.wait_not_present('#motd-box')


### PR DESCRIPTION
Initial empty lines are commonly used to separate multiple motd.d/
entries from one another, but we don't show these. They look bad in the
Alert box, so strip them. But still retain leading spaces, as they are
commonly being used for ASCII art.