### PR TITLE
test: Add stress test to Services page

### DIFF
--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -267,6 +267,15 @@ Unit=test.service
         self.toggle_onoff()
         self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
 
+        # Survives a burst of events
+        b.go("#/")
+        self.wait_service_present("test.service")
+        m.execute("udevadm trigger; udevadm settle")
+        b.click(self.svc_sel("test.service"))
+        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
+        self.toggle_onoff()
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+
         # Check without permissions
         self.allow_authorize_journal_messages()
         b.relogin('/system/services#/test.service', authorized=False)


### PR DESCRIPTION
This reproduces the browser spinning at 100% CPU and making the page
stuck for a long time when a lot of systemd events happen at the same
time in a batch. daemon-reload has a similar, but less dramatic effect.

Can be used to validate the fix for PR #13956