### PR TITLE
test: Disable preloading of machines in dashboard

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -22,6 +22,7 @@ import subprocess
 
 import parent
 from testlib import *
+from machine_core.constants import TEST_OS_DEFAULT
 
 
 class DashBoardHelpers:
@@ -79,6 +80,18 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
         'machine2': {"address": "10.111.113.2/20"},
         'machine3': {"address": "10.111.113.3/20"}
     }
+
+    def setUp(self):
+        super().setUp()
+
+        # Disable preloading on all machines ("machine1" is done in testlib.py)
+        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+        # In these tests we actually switch between machines in quick succession which can make things even worse
+        if self.machine.image == TEST_OS_DEFAULT:
+            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
 
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
Commit 313ee7ac replaced previously used "hacklib" with disabling
preloading on just the default machine. However in this test we actually
switcher between three machines quickly, which makes the issue even
worse.

Example failure: https://logs.cockpit-project.org/logs/pull-13905-20200424-092742-2c601399-fedora-31/log.html#214-2
I noticed that since yesterday we got quite a few of these failures. I haven't seen them before, so I assume it must be it.