### PR TITLE
tools: Add watch mode to webpack-make

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -160,9 +160,14 @@ just run `make` to update everything that has changed; for iterating faster,
 you can run webpack in "watch" mode on the particular page that you are working
 on, which reduces the build time to less than a third. E. g.
 
-    $ ESLINT=0 tools/webpack-make -d dist/systemd/Makefile.deps -w
+    $ tools/webpack-watch systemd
 
-Then reload cockpit in your browser.
+Note that this disables eslint by default -- if you want to enable it, run it
+as
+
+    $ ESLINT=1 tools/webpack-watch systemd
+
+Then reload cockpit in your browser after building the page.
 
 To make Cockpit again use the installed code, rather than that from your
 git checkout directory, run the following, and log into Cockpit again:

--- a/HACKING.md
+++ b/HACKING.md
@@ -12,26 +12,18 @@ Cockpit git repository checkout.
 
 Cockpit uses Node.js during development. Node.js is not used at runtime.
 To make changes on Cockpit you'll want to install Node.js, NPM and
-various development dependencies like Webpack.
+various development dependencies.
 
-On Debian and Ubuntu, the available versions of nodejs and npm are old
-and/or incompatible with each other.  You should not try to use them to
-build cockpit.  You can use the helpful "n" utility to get a more
-reasonable environment to work with.
+On Debian and recent Ubuntu ≥ 19.04:
 
     $ sudo apt-get install nodejs npm
-    $ sudo npm install -g n
-    $ sudo apt-get remove nodejs npm
-    $ sudo n lts
 
-On Fedora, the distribution versions are sufficient:
+On Fedora:
 
     $ sudo dnf install nodejs npm
 
-And lastly get Webpack and the development dependencies:
-
-    $ sudo npm install -g webpack
-    $ npm install
+On older OS releases you can use the [n utility](https://github.com/tj/n) to
+get a current version of npm and nodejs.
 
 When relying on CI to run the test suite, this is all that is
 necessary to work on the JavaScript components of Cockpit.

--- a/HACKING.md
+++ b/HACKING.md
@@ -128,6 +128,12 @@ Violations of some rules can be fixed automatically by:
 
 Rules configuration can be found in the `.eslintrc.json` file.
 
+During fast iterative development, you can also choose to not run eslint. This
+speeds up the build and avoids build failures due to e. g.  ill-formatted
+comments or unused identifiers:
+
+    $ make ESLINT=0
+
 ## Working on your local machine: Cockpit's session pages
 
 It's easy to set up your local Linux machine for rapid development of Cockpit's

--- a/HACKING.md
+++ b/HACKING.md
@@ -155,8 +155,14 @@ Use the same user and password that you used to log into your Linux desktop.
 
 http://localhost:9090
 
-After every change to your sources, run `make` to update all the webpacks, and
-reload cockpit in your browser.
+After every change to your sources the webpacks need to be rebuilt: You can
+just run `make` to update everything that has changed; for iterating faster,
+you can run webpack in "watch" mode on the particular page that you are working
+on, which reduces the build time to less than a third. E. g.
+
+    $ ESLINT=0 tools/webpack-make -d dist/systemd/Makefile.deps -w
+
+Then reload cockpit in your browser.
 
 To make Cockpit again use the installed code, rather than that from your
 git checkout directory, run the following, and log into Cockpit again:

--- a/Makefile.am
+++ b/Makefile.am
@@ -209,7 +209,7 @@ dist/%/Makefile.deps:
 # have a manifest, no actual webpack, so don't call webpack-make for these
 dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make
 	$(V_WEBPACK) $(MKDIR_P) dist/$* && \
-	(if ls $(srcdir)/pkg/$*/*.html >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
+	(if ls $(srcdir)/pkg/$*/*.html >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
 	  touch $@
 
 dist/%/manifest.json: pkg/%/manifest.json

--- a/tools/README.dist
+++ b/tools/README.dist
@@ -1,10 +1,8 @@
 Webpack build output
 ====================
 
-This directory is populated with the built Cockpit packages when
-you run Webpack:
-
-    $ webpack
+This directory is populated with the built Cockpit packages from webpack (see
+HACKING.md).
 
 You can link this directory into your home directory and have
 Cockpit on your local machine use the built packages:
@@ -14,8 +12,3 @@ Cockpit on your local machine use the built packages:
 
 Make sure to log into Cockpit as the same user on the same local
 machine as you are running the commands above.
-
-If you want to setup automatic syncing as you edit javascript files
-you can:
-
-    $ webpack --progress --colors --watch

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -23,7 +23,8 @@ try {
 
 var ops = stdio.getopt({
     config: { key: "c", args: 1, description: "Path to webpack.config.js", default: "webpack.config.js" },
-    deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" }
+    deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" },
+    watch: { key: "w", args: 0, description: "Enable webpack watch mode" },
 });
 
 var srcdir = process.env.SRCDIR || ".";
@@ -44,7 +45,19 @@ var config = require(config_path);
 // The latest input file time updated and used below
 var latest = fs.statSync(config_path).mtime;
 
-webpack(config, function(err, stats) {
+compiler = webpack(config);
+
+if (ops.watch) {
+    compiler.hooks.watchRun.tap("WebpackInfo", compilation => {
+        const time = new Date().toTimeString().split(' ')[0];
+        process.stdout.write(`${ time  } Build started\n`);
+    });
+    compiler.watch({}, process_result);
+} else {
+    compiler.run(process_result);
+}
+
+function process_result(err, stats) {
     // process.stdout.write(stats.toString({colors: true}) + "\n");
 
     if (err) {
@@ -53,16 +66,23 @@ webpack(config, function(err, stats) {
         return;
     }
 
+    if (ops.watch) {
+        const info = stats.toJson();
+        const time = new Date().toTimeString().split(' ')[0];
+        process.stdout.write(`${ time  } Build succeeded, took ${ info.time/1000 }s\n`);
+    }
+
     // Failure exit code when compilation fails
     if (stats.hasErrors() || stats.hasWarnings()) {
         console.log(stats.toString("normal"));
-        process.exit(1);
+        if (!ops.watch)
+            process.exit(1);
         return;
     }
 
     if (makefile)
         generateDeps(makefile, stats);
-});
+}
 
 function generateDeps(makefile, stats) {
 

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -22,13 +22,9 @@ try {
 }
 
 var ops = stdio.getopt({
+    config: { key: "c", args: 1, description: "Path to webpack.config.js", default: "webpack.config.js" },
     deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" }
 });
-
-if (!ops.args || ops.args.length < 1 || ops.args.length > 2) {
-    console.log("usage: webpack-make config [section]");
-    process.exit(2);
-}
 
 var srcdir = process.env.SRCDIR;
 var makefile = ops.deps;
@@ -42,7 +38,7 @@ if (makefile) {
 }
 
 var cwd = process.cwd();
-var config_path = path.resolve(cwd, ops.args[0]);
+var config_path = path.resolve(cwd, ops.config);
 var config = require(config_path);
 
 // The latest input file time updated and used below

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -26,7 +26,7 @@ var ops = stdio.getopt({
     deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" }
 });
 
-var srcdir = process.env.SRCDIR;
+var srcdir = process.env.SRCDIR || ".";
 var makefile = ops.deps;
 var prefix = "packages";
 var npm = { "dependencies": { } };

--- a/tools/webpack-watch
+++ b/tools/webpack-watch
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Calls webpack-make in watch mode for the given pkg/<page>
+
+set -eu
+mydir=$(dirname $0)
+
+if [ -z "${1:-}" ] || [ -n "${2:-}" ]; then
+    echo "Usage: $0 <page in pkg/>" >&2
+    exit 1
+fi
+
+# disable eslint by default, unless explicitly enabled
+export ESLINT=${ESLINT:-0}
+
+"$mydir/webpack-make" -d "$mydir/../dist/$1/Makefile.deps" -w

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -401,7 +401,7 @@ module.exports = {
         rules: [
             {
                 enforce: 'pre',
-                test: /\.(js|es6|jsx)$/,
+                test: /\.(js|jsx)$/,
                 exclude: /\/node_modules\/.*\//, // exclude external dependencies
                 loader: "eslint-loader"
             },
@@ -416,7 +416,7 @@ module.exports = {
                 use: babel_loader
             },
             {
-                test: /\.(js|jsx|es6)$/,
+                test: /\.(js|jsx)$/,
                 // exclude external dependencies; it's too slow, and they are already plain JS except the above
                 exclude: /\/node_modules\/.*\//,
                 use: babel_loader

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -252,6 +252,9 @@ var section = process.env.ONLYDIR || null;
 /* A standard nodejs and webpack pattern */
 var production = process.env.NODE_ENV === 'production';
 
+/* development options for faster iteration */
+var eslint = process.env.ESLINT !== '0';
+
 /*
  * Note that we're avoiding the use of path.join as webpack and nodejs
  * want relative paths that start with ./ explicitly.
@@ -401,7 +404,7 @@ module.exports = {
         rules: [
             {
                 enforce: 'pre',
-                test: /\.(js|jsx)$/,
+                test: eslint ? /\.(js|jsx)$/ : /dont.match.me/,
                 exclude: /\/node_modules\/.*\//, // exclude external dependencies
                 loader: "eslint-loader"
             },


### PR DESCRIPTION
Watch mode makes fast iterations much faster. Compared to plain `make`,
watch mode and disabling eslint reduces e. g. tuned from 19s to 3s, or
systemd from 48s to 17s on the first rebuild, and 5s (!) on the second.