### PR TITLE
HACKING: Avoid bridge on the host when starting windows-10

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -372,7 +372,7 @@ image. This image cannot be freely distributed for licensing reasons.
 Make sure you have the ```virt-viewer``` package installed on your Linux
 machine. And then run the following from the Cockpit checkout directory:
 
-    $ bots/vm-run --network windows-10
+    $ bots/vm-run windows-10
 
 If the image is not yet downloaded, it'll take a while to download and
 you'll see progress on the command line. A screen will pop up and
@@ -382,4 +382,4 @@ started. Ignore or minimize them, before starting Edge.
 Type the following into Edge's address bar to access Cockpit running on your
 development machine:
 
-     https://10.111.112.1:9090
+     https://10.0.2.2:9090


### PR DESCRIPTION
Since we fixed vm-run to provide a reasonable default networking with
the windows-10 image, we don't need to create a bridge on the host any
more. This avoids messing up the host's networking and requiring root
privileges, and also works fine in podman.

[1] https://github.com/cockpituous/bots/commit/3287a378