### PR TITLE
pkg: Import polyfills on all pages that use finally()

### DIFF
--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -17,6 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'polyfills'; // once per application
+
 import cockpit from "cockpit";
 
 import React from "react";

--- a/pkg/machines/index.js
+++ b/pkg/machines/index.js
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import '../lib/polyfills.js'; // once per application
+import 'polyfills'; // once per application
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -16,9 +16,9 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+import 'polyfills'; // once per application
 
 import cockpit from "cockpit";
-import '../lib/polyfills.js'; // once per application
 import React, { useState, useEffect } from "react";
 import ReactDOM from 'react-dom';
 

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+import 'polyfills'; // once per application
 
 import cockpit from "cockpit";
 import React from "react";

--- a/pkg/storaged/nfs-details.jsx
+++ b/pkg/storaged/nfs-details.jsx
@@ -17,8 +17,6 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import "polyfills";
-
 import cockpit from "cockpit";
 import React from "react";
 import moment from "moment";

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -17,9 +17,10 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'polyfills'; // once per application
+
 import cockpit from "cockpit";
 import moment from 'moment';
-import '../lib/polyfills.js'; // once per application
 import React from "react";
 import ReactDOM from 'react-dom';
 

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import 'polyfills.js';
+import 'polyfills';
 import cockpit from "cockpit";
 import moment from "moment";
 

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -17,6 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'polyfills'; // once per application
+
 import React from "react";
 import ReactDOM from 'react-dom';
 import {

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -17,6 +17,8 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'polyfills'; // once per application
+
 import $ from 'jquery';
 import cockpit from 'cockpit';
 import moment from "moment";


### PR DESCRIPTION
Edge 11 still doesn't know about Promise.finally(), which caused the
Services page to crash since the React rewrite.

Also change all other pages to do the import in the same style.