### PR TITLE
test: Skip tangd hack on centos-8

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -145,7 +145,7 @@ class TestStorage(StorageCase):
         #        background, and it's not reliable either.
         #
         #        https://github.com/latchset/tang/issues/23
-        if m.image not in ["rhel-8-2", "rhel-8-2-distropkg", "rhel-8-3"]:
+        if m.image not in ["rhel-8-2", "rhel-8-2-distropkg", "rhel-8-3", "centos-8-stream"]:
             m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
 
         m.execute("systemctl start tangd.socket")


### PR DESCRIPTION
Fails with:
```
Failed to reset failed state of unit tangd-update.service: Unit tangd-update.service not loaded.
Failed to restart tangd-update.service: Unit tangd-update.service not found.
```

As found in https://github.com/cockpit-project/bots/pull/762