### PR TITLE
test: Don't fail on `Failed to generate stack trace: (null)`

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -977,6 +977,9 @@ class MachineCase(unittest.TestCase):
 
         # our core dump retrieval is not entirely reliable
         "Failed to send coredump datagram:.*",
+
+        # Something crashed, but we don't have more info. Don't fail on that
+        "Failed to generate stack trace: (null)",
     ]
 
     # Whitelist of allowed console.error() messages during tests; these match substrings


### PR DESCRIPTION
This message does not provide much information. We may actually know
about the real problem and may have naughty for it. Failing on this
message does not help us in any way.