### PR TITLE
doc: Document how to disable kerberos negotiation

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -21,8 +21,9 @@ The command is then responsible to:
  * setup an appropriate session and environment based on those credentials
  * launch a bridge that speaks the cockpit protocol on stdin and stdout.
 
-The default command is `cockpit-session` it is able to handle basic, gssapi,
-and TLS client certificate (tls-cert) authentication.
+The default command is `cockpit-session` it is able to handle Password
+(`[basic]`), Kerberos/GSSAPI (`[negotiate]`), and TLS client certificate
+(`[tls-cert]`) authentication.
 
 Authentication commands are called with a single argument which is the host that the user
 is connecting to. They communicate with their parent process using the cockpit protocol on
@@ -142,7 +143,7 @@ in cockpit.conf:
 ClientCertAuthentication = yes
 ```
 
-This uses the `tls-cert` authentication scheme.
+This uses the `[tls-cert]` authentication scheme.
 
 When enabling this mode, other authentication types commonly get disabled. See
 the next section for details.
@@ -156,11 +157,19 @@ are supported.
  * **remote-login-ssh** Use the `SSH-Login` section instead.
  * **none** Disable this auth scheme.
 
-To configure an action add the `action` option. For example to disable basic authentication.
-cockpit.conf should contain the following section.
+To configure an action add the `action` option. For example to disable basic authentication,
+cockpit.conf should contain the following section:
 
 ```
 [basic]
+action = none
+```
+
+Likewise, if the browser offers Kerberos/GSSAPI authentication, but cockpit should
+ignore it, create the following section:
+
+```
+[negotiate]
 action = none
 ```
 

--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -23,6 +23,10 @@
       card authentication</link>.
     </para>
 
+    <para>You can also <ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/authentication.md#actions">disable
+    authentication schemes</ulink> to enforce authentication policies, or to suppress
+    undesired browser GSSAPI authentication dialogs.</para>
+
     <para>The web server can also be run from the
       <ulink url="https://hub.docker.com/r/cockpit/ws/">cockpit/ws</ulink>
       container. If you are running cockpit on a container host operating system like

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -78,11 +78,12 @@ ClientCertAuthentication = yes
     <ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/authentication.md">
     other authentication types</ulink> commonly get disabled, so that *only* client certificate
     authentication will be accepted. By default, after a failed certificate authentication attempt,
-    Cockpit's normal login page will appear and permit other login types such as `basic` (passwords)
-    or `gssapi` (Kerberos).  For example, password authentication gets disabled with:</para>
+    Cockpit's normal login page will appear and permit other login types such as <code>basic</code>
+    (passwords) or <code>negotiate</code> (Kerberos).  For example, password authentication gets
+    disabled with:</para>
 
 <programlisting>
-[Basic]
+[basic]
 action = none
 </programlisting>
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -831,6 +831,13 @@ class TestKerberos(MachineCase):
         self.assertIn('"csrf-token"', output)
         self.allow_restart_journal_messages()
 
+        m.execute("printf '[Negotiate]\naction = none\n' >> /etc/cockpit/cockpit.conf")
+        m.restart_cockpit()
+        output = m.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
+                            '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
+                            'http://x0.cockpit.lan:9090/cockpit/login'])
+        self.assertIn("HTTP/1.1 401 Authentication disabled", output)
+
 
 @skipImage("Package (un)install does not work on OSTree", "fedora-coreos")
 class TestPackageInstall(packagelib.PackageCase):


### PR DESCRIPTION
authentication.md was wrong about what exactly the authentication schema
is for Kerberos/GSSAPI. Show the precise identifiers in cockpit.conf,
and give an explicit example how to disable kerberos. Fix the same error
in the certificate authentication docs.

Add a link to the primary server authentication docs to make this easier
to find.

Add a test case to make sure that this actually works.

Thanks to @H20-17 for discovering this!

Fixes #13036
Fixes #13202