### PR TITLE
storage: Don't leave udevadm processes behind on page reload

### DIFF
--- a/pkg/storaged/luksmeta-monitor-hack.py
+++ b/pkg/storaged/luksmeta-monitor-hack.py
@@ -104,7 +104,7 @@ def info(dev):
 def monitor(dev):
     path = subprocess.check_output([ "udevadm", "info", "-q", "path", dev ]).rstrip(b"\n")
     mon = subprocess.Popen([ "stdbuf", "-o", "L", "udevadm", "monitor", "-u", "-s", "block"],
-                           bufsize=1, stdout=subprocess.PIPE)
+                           stdout=subprocess.PIPE)
 
     old_infos = info(dev)
     sys.stdout.write(json.dumps(old_infos) + "\n")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -121,6 +121,13 @@ class TestStorage(StorageCase):
         assert m.execute("grep -v ^# /etc/crypttab || true").strip() == ""
         assert m.execute("grep %s /etc/fstab || true" % mount_point_secret) == ""
 
+        # luksmeta-monitor-hack.py might leave a udevadm process
+        # behind, so let's check that the session goes away cleanly
+        # after a logout.
+
+        b.logout()
+        wait(lambda: m.execute("(loginctl list-users | grep admin) || true") == "")
+
     @skipImage("No clevis/tang", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")
     def testClevisTang(self):
         m = self.machine


### PR DESCRIPTION
When reloading a page, Cockpit correctly closes all channels, which
will correctly kill all processes spawned via cockpit.spawn.  Child
processes of those processes will usually also exit on their own
because they get their stdin/stdout closed.

The "udevadm monitor" process spawned by luksmeta-monitor-hack would
not get killed on a page reload however, since it doesn't immediately
react to having its pipes closed, since it doesn't read from stdin and
doesn't write to stdout frequently enough.

Thus we make sure it is killed explicitly.