### PR TITLE
test: Adjust clipboard browser permission

### DIFF
--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -200,7 +200,7 @@ class TestSelinux(MachineCase):
         b.click(row_selector + " button{}".format(self.danger_btn_class))
         b.wait_not_present(row_selector)
 
-        b.grant_permissions("clipboardRead", "clipboardWrite")
+        b.grant_permissions("clipboardReadWrite")
 
         b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
         b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -104,7 +104,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # Firefox does not support setting of permissions
         # and therefore we cannot test copy/paste with context menu
         if b.cdp.browser != "firefox":
-            b.grant_permissions("clipboardRead", "clipboardWrite")
+            b.grant_permissions("clipboardReadWrite")
 
             # Execute command
             wait_line(n, prompt)


### PR DESCRIPTION
The current spec only knows `clipboardReadWrite` [1], and the former
split permisisons are not recognized any more by Chromium 81.

[1] https://chromedevtools.github.io/devtools-protocol/tot/Browser#type-PermissionType