### PR TITLE
test: Cleanup modules on ansible machine

### DIFF
--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -225,6 +225,7 @@ class TestSelinux(MachineCase):
         b.wait_in_text(ansible_script_sel, "- name: Allow zebra to write config")
 
         ansible_m = self.machines["ansible_machine"]
+        ansible_m.execute("semanage module -D")
         ansible_m.execute("mkdir -p roles/selinux/tasks/")
         ansible_m.write("tests.yml",
 """


### PR DESCRIPTION
Fedora 31 contains `ipa_custodia` rule, which is not on rhel/centos
machines. That means that when we generate script on these machines and apply
it to the f-31 one, they are not the same, as we don't remove all rules
and don't do anything specific about modules.

Just remove this rules from the ansible machines as rhel/centos don't
modify it and fedora contains it, so it will set it back up.