### PR TITLE
doc: Clarify GSSAPI authentication

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -165,8 +165,8 @@ cockpit.conf should contain the following section:
 action = none
 ```
 
-Likewise, if the browser offers Kerberos/GSSAPI authentication, but cockpit should
-ignore it, create the following section:
+Likewise, if the machine is part of a Kerberos domain, but that should not be used to
+authenticate to cockpit, create the following section:
 
 ```
 [negotiate]


### PR DESCRIPTION
Commit 1faa25851 added some documentation how to disable Kerberos
authentication. But its not the browser which initiates it, it's the
server (if GSSAPI is available).

Thanks to @H20-17 for spotting!