### PR TITLE
machines: move nicEdit modal dialog out of the Table rows

### DIFF
--- a/pkg/machines/components/nicEdit.jsx
+++ b/pkg/machines/components/nicEdit.jsx
@@ -47,7 +47,7 @@ const NetworkMacRow = ({ network }) => {
     );
 };
 
-class EditNICModal extends React.Component {
+export class EditNICModal extends React.Component {
     constructor(props) {
         super(props);
 
@@ -120,7 +120,7 @@ class EditNICModal extends React.Component {
                 })
                 .then(() => {
                     dispatch(getVm({ connectionName: vm.connectionName, id: vm.id }));
-                    this.props.close();
+                    this.props.onClose();
                 });
     }
 
@@ -156,7 +156,7 @@ class EditNICModal extends React.Component {
         };
 
         return (
-            <Modal id={`${idPrefix}-edit-dialog-modal-window`} onHide={this.props.close} className='nic-edit' show>
+            <Modal id={`${idPrefix}-edit-dialog-modal-window`} onHide={this.props.onClose} className='nic-edit' show>
                 <Modal.Header>
                     <Modal.CloseButton onClick={this.props.close} />
                     <Modal.Title> {`${network.mac} Virtual Network Interface Settings`} </Modal.Title>
@@ -170,7 +170,7 @@ class EditNICModal extends React.Component {
                     <Button isDisabled={this.state.saveDisabled} id={`${idPrefix}-edit-dialog-save`} variant='primary' onClick={this.save}>
                         {_("Save")}
                     </Button>
-                    <Button id={`${idPrefix}-edit-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
+                    <Button id={`${idPrefix}-edit-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.onClose}>
                         {_("Cancel")}
                     </Button>
                 </Modal.Footer>
@@ -178,49 +178,7 @@ class EditNICModal extends React.Component {
         );
     }
 }
-
-export class EditNICAction extends React.Component {
-    constructor(props) {
-        super(props);
-
-        this.state = {
-            showModal: false,
-        };
-        this.open = this.open.bind(this);
-        this.close = this.close.bind(this);
-    }
-
-    close() {
-        this.setState({ showModal: false });
-    }
-
-    open() {
-        this.setState({ showModal: true });
-    }
-
-    render() {
-        const { idPrefix, dispatch, vm, network, nodeDevices, interfaces, availableSources } = this.props;
-
-        return (
-            <div id={`${idPrefix}-edit-dialog-full`}>
-                <Button id={`${idPrefix}-edit-dialog`} variant='secondary' onClick={this.open}>
-                    {_("Edit")}
-                </Button>
-
-                {this.state.showModal && <EditNICModal idPrefix={idPrefix}
-                                             dispatch={dispatch}
-                                             vm={vm}
-                                             network={network}
-                                             nodeDevices={nodeDevices}
-                                             interfaces={interfaces}
-                                             availableSources={availableSources}
-                                             close={this.close} />}
-            </div>
-        );
-    }
-}
-
-EditNICAction.propTypes = {
+EditNICModal.propTypes = {
     availableSources: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired,
     idPrefix: PropTypes.string.isRequired,
@@ -228,6 +186,5 @@ EditNICAction.propTypes = {
     network: PropTypes.object.isRequired,
     interfaces: PropTypes.array.isRequired,
     nodeDevices: PropTypes.array.isRequired,
+    onClose: PropTypes.func.isRequired,
 };
-
-export default EditNICAction;

--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -65,14 +65,14 @@ class VmDisksTab extends React.Component {
         super(props);
 
         this.state = {
-            showModal: false,
+            showAddDiskModal: false,
         };
         this.open = this.open.bind(this);
         this.close = this.close.bind(this);
     }
 
     close() {
-        this.setState({ showModal: false });
+        this.setState({ showAddDiskModal: false });
     }
 
     open() {
@@ -81,7 +81,7 @@ class VmDisksTab extends React.Component {
         // https://bugzilla.redhat.com/show_bug.cgi?id=1578836
         this.props.dispatch(getAllStoragePools(this.props.vm.connectionName))
                 .then(() => {
-                    this.setState({ showModal: true });
+                    this.setState({ showAddDiskModal: true });
                 });
     }
 
@@ -92,7 +92,7 @@ class VmDisksTab extends React.Component {
                 <Button id={`${idPrefix}-adddisk`} variant='primary' onClick={this.open} className='pull-right'>
                     {_("Add Disk")}
                 </Button>
-                {this.state.showModal && <AddDiskModalBody close={this.close} dispatch={dispatch} idPrefix={idPrefix} vm={vm} vms={vms} storagePools={storagePools.filter(pool => pool && pool.active)} />}
+                {this.state.showAddDiskModal && <AddDiskModalBody close={this.close} dispatch={dispatch} idPrefix={idPrefix} vm={vm} vms={vms} storagePools={storagePools.filter(pool => pool && pool.active)} />}
             </>
         );
         let renderCapacityUsed, renderAccess, renderAdditional;

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -38,7 +38,7 @@ class VmNetworkTab extends React.Component {
         super(props);
 
         this.state = {
-            showModal: false,
+            showAddNICModal: false,
             interfaceAddress: [],
             networkDevices: undefined,
         };
@@ -48,11 +48,11 @@ class VmNetworkTab extends React.Component {
     }
 
     close() {
-        this.setState({ showModal: false });
+        this.setState({ showAddNICModal: false });
     }
 
     open() {
-        this.setState({ showModal: true });
+        this.setState({ showAddNICModal: true });
     }
 
     componentDidMount() {
@@ -282,7 +282,7 @@ class VmNetworkTab extends React.Component {
                     {_("Add Network Interface")}
                 </Button>
 
-                {this.state.showModal && this.state.networkDevices !== undefined &&
+                {this.state.showAddNICModal && this.state.networkDevices !== undefined &&
                     <AddNIC dispatch={dispatch}
                         idPrefix={`${id}-add-iface`}
                         vm={vm}

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -24,7 +24,7 @@ import cockpit from 'cockpit';
 import { changeNetworkState, getVm } from "../actions/provider-actions.js";
 import { rephraseUI, vmId } from "../helpers.js";
 import AddNIC from './nicAdd.jsx';
-import EditNICAction from './nicEdit.jsx';
+import { EditNICModal } from './nicEdit.jsx';
 import WarningInactive from './warningInactive.jsx';
 import './nic.css';
 import { detachIface, vmInterfaceAddresses } from '../libvirt-dbus.js';
@@ -207,14 +207,24 @@ class VmNetworkTab extends React.Component {
                 name: "", value: (network, networkId) => {
                     const isUp = network.state === 'up';
                     const editNICAction = () => {
-                        if (vm.persistent && this.state.networkDevices !== undefined)
-                            return <EditNICAction dispatch={dispatch}
-                                       idPrefix={`${id}-network-${networkId}`}
-                                       vm={vm}
-                                       network={network}
-                                       nodeDevices={nodeDevices}
-                                       availableSources={availableSources}
-                                       interfaces={interfaces} />;
+                        const editNICDialogProps = {
+                            dispatch,
+                            idPrefix: `${id}-network-${networkId}`,
+                            vm,
+                            network,
+                            nodeDevices,
+                            availableSources,
+                            interfaces,
+                            onClose: () => this.setState({ editNICDialogProps: undefined }),
+                        };
+                        if (vm.persistent && this.state.networkDevices !== undefined) {
+                            return (
+                                <Button id={`${editNICDialogProps.idPrefix}-edit-dialog`} variant='secondary'
+                                        onClick={() => this.setState({ editNICDialogProps })}>
+                                    {_("Edit")}
+                                </Button>
+                            );
+                        }
                     };
 
                     const deleteDialogProps = {
@@ -267,6 +277,7 @@ class VmNetworkTab extends React.Component {
         return (
             <div className="machines-network-list">
                 {this.state.deleteDialogProps && <DeleteResourceModal {...this.state.deleteDialogProps} />}
+                {this.state.editNICDialogProps && <EditNICModal {...this.state.editNICDialogProps } />}
                 <Button id={`${id}-add-iface-button`} variant='secondary' className='pull-right' onClick={this.open}>
                     {_("Add Network Interface")}
                 </Button>


### PR DESCRIPTION
(should robustify [testNetworkSettings](https://jenkins-continuous-infra.apps.ci.centos.org/job/fedora-rawhide-pr-pipeline/3295/artifact/package-tests/logs/FAIL-str_verify.log)) flake test