### PR TITLE
Fix keyboard navigation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,10 +51,8 @@
         "standard/no-callback-literal": "off",
 
         "jsx-a11y/no-static-element-interactions": "off",
-        "jsx-a11y/click-events-have-key-events": "off",
         "jsx-a11y/anchor-is-valid": "off",
         "jsx-a11y/no-autofocus": "off",
-        "jsx-a11y/no-noninteractive-element-interactions": "off",
         "jsx-a11y/no-interactive-element-to-noninteractive-role": "off",
         "jsx-a11y/no-onchange": "off",
 

--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -42,6 +42,8 @@ class Dropdown extends React.Component {
     }
 
     handleClick(event) {
+        event.preventDefault();
+
         if (event.button !== 0)
             return;
 
@@ -64,7 +66,7 @@ class Dropdown extends React.Component {
                         this.props.actions.map(function (action, index) {
                             return (
                                 <li key={index} className={ action.disabled ? 'disabled' : '' }>
-                                    <a data-value={index} role="link" tabIndex="0" onClick={this.handleClick}>{action.label}</a>
+                                    <a data-value={index} href="#" onClick={this.handleClick}>{action.label}</a>
                                 </li>
                             );
                         }.bind(this))
@@ -146,6 +148,7 @@ class ContainerProblems extends React.Component {
     }
 
     onItemClick(event) {
+        event.preventDefault();
         cockpit.jump(event.currentTarget.dataset.url, cockpit.transport.host);
     }
 
@@ -153,7 +156,7 @@ class ContainerProblems extends React.Component {
         var problem = this.props.problem;
         var problem_cursors = [];
         for (var i = 0; i < problem.length; i++) {
-            problem_cursors.push(<a key={i} data-url={problem[i][0]} className='list-group-item' role="link" tabIndex="0" onClick={this.onItemClick}>
+            problem_cursors.push(<a key={i} data-url={problem[i][0]} className='list-group-item' href="#" onClick={this.onItemClick}>
                 <span className="pficon pficon-warning-triangle-o fa-lg" />
                 {problem[i][1]}
             </a>);

--- a/pkg/lib/cockpit-components-listing.jsx
+++ b/pkg/lib/cockpit-components-listing.jsx
@@ -170,8 +170,8 @@ export class ListingRow extends React.Component {
         const allowExpand = (this.props.tabRenderers.length > 0 || this.props.simpleBody);
         let expandToggle;
         if (allowExpand) {
-            expandToggle = <td key="expandToggle" className="listing-ct-toggle" onClick={ allowNavigate ? this.handleExpandClick : undefined }>
-                <button className="pf-c-button pf-m-plain" type="button" aria-label="expand row"><i className="fa fa-fw" /></button>
+            expandToggle = <td key="expandToggle" className="listing-ct-toggle">
+                <button className="pf-c-button pf-m-plain" type="button" aria-label="expand row" onClick={ allowNavigate ? this.handleExpandClick : undefined }><i className="fa fa-fw" /></button>
             </td>;
         } else {
             expandToggle = <td key="expandToggle-empty" className="listing-ct-toggle" />;

--- a/pkg/machines/components/diskEdit.jsx
+++ b/pkg/machines/components/diskEdit.jsx
@@ -93,7 +93,7 @@ const AccessRow = ({ onValueChanged, dialogValues, driverType, idPrefix }) => {
             <label className='control-label' htmlFor={`${idPrefix}-access`}>
                 {_("Access")}
             </label>
-            <label className="radio" onClick={e => e.stopPropagation()}>
+            <label className="radio">
                 <input id={`${idPrefix}-readonly`}
                        type="radio"
                        name="readonly"
@@ -105,7 +105,7 @@ const AccessRow = ({ onValueChanged, dialogValues, driverType, idPrefix }) => {
                        className={dialogValues.readonly ? "active" : ''} />
                 {_("Read-only")}
             </label>
-            <label className="radio" onClick={e => e.stopPropagation()}>
+            <label className="radio">
                 <input id={`${idPrefix}-writable`}
                        type="radio"
                        name="writable"
@@ -118,7 +118,7 @@ const AccessRow = ({ onValueChanged, dialogValues, driverType, idPrefix }) => {
                 {_("Writeable")}
             </label>
             {(driverType === "raw") &&
-            <label className="radio" onClick={e => e.stopPropagation()}>
+            <label className="radio">
                 <input id={`${idPrefix}-writable-shareable`}
                        type="radio"
                        name="writable-shareable"

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -247,7 +247,7 @@ export function mounting_dialog(client, block, mode) {
     let footer = null;
     const show_clear_button = false;
     if (old_dir && mode == "update" && show_clear_button)
-        footer = <div className="modal-footer-teardown"><a onClick={remove}>{_("Clear mount point configuration")}</a></div>;
+        footer = <div className="modal-footer-teardown"><button className="pf-c-button pf-m-link" onClick={remove}>{_("Clear mount point configuration")}</button></div>;
     if (!is_filesystem_mounted && block_fsys.MountPoints.length > 0)
         footer = (
             <>

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -47,8 +47,10 @@ export class OverviewSidePanel extends React.Component {
 
         if (this.state.collapsed && children.length > 20) {
             show_all_button = (
-                <tr>
-                    <td onClick={() => { this.setState({ collapsed: false }) }}>
+                <tr role="button" tabIndex="0"
+                    onKeyPress={ev => ev.key === "Enter" && this.setState({ collapsed: false })}
+                    onClick={() => { this.setState({ collapsed: false }) }}>
+                    <td>
                         {this.props.show_all_text || _("Show all")}
                     </td>
                 </tr>);
@@ -82,8 +84,17 @@ export class OverviewSidePanelRow extends React.Component {
         const { client, job_path } = this.props;
 
         const go = (event) => {
-            if (!event || event.button !== 0)
+            if (!event)
                 return;
+
+            // only consider primary mouse button for clicks
+            if (event.type === 'click' && event.button !== 0)
+                return;
+
+            // only consider enter button for keyboard events
+            if (event.type === 'keypress' && event.key !== "Enter")
+                return;
+
             return this.props.go();
         };
 
@@ -97,6 +108,8 @@ export class OverviewSidePanelRow extends React.Component {
 
         return (
             <tr data-testkey={this.props.testkey}
+                role="link" tabIndex="0"
+                onKeyPress={this.props.go ? go : null}
                 onClick={this.props.go ? go : null} className={this.props.highlight ? "highlight-ct" : ""}>
                 <td className={"sidepanel-row " + (this.props.highlight ? "highlight-ct" : "")}>
                     <div className="sidepanel-row-body">

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -74,9 +74,17 @@ class StorageControl extends React.Component {
 
 function checked(callback) {
     return function (event) {
-        // only consider primary mouse button
-        if (!event || event.button !== 0)
+        if (!event)
             return;
+
+        // only consider primary mouse button for clicks
+        if (event.type === 'click' && event.button !== 0)
+            return;
+
+        // only consider enter button for keyboard events
+        if (event.type === 'keypress' && event.key !== "Enter")
+            return;
+
         var promise = client.run(callback);
         if (promise)
             promise.fail(function (error) {
@@ -203,7 +211,7 @@ export const StorageUsageBar = ({ stats, critical }) => {
 };
 
 export const StorageMenuItem = ({ onClick, children }) => (
-    <li><a onClick={checked(onClick)}>{children}</a></li>
+    <li><a role="link" tabIndex="0" onKeyPress={checked(onClick)} onClick={checked(onClick)}>{children}</a></li>
 );
 
 export const StorageBarMenu = ({ label, children }) => {

--- a/pkg/systemd/overview-cards/insights.jsx
+++ b/pkg/systemd/overview-cards/insights.jsx
@@ -120,8 +120,8 @@ export class InsightsStatus extends React.Component {
                 return (
                     <li className="system-health-insights">
                         <span className="fa fa-exclamation-triangle" />
-                        <a tabIndex='0' role="button"
-                    onClick={() => cockpit.jump("/subscriptions")}>
+                        <a href="#"
+                    onClick={ev => { ev.preventDefault(); cockpit.jump("/subscriptions") }}>
                             {_("Not connected to Insights")}
                         </a>
                     </li>);

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -134,7 +134,7 @@ export class SystemInfomationCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a role="link" tabIndex="0" className="no-left-padding" onClick={() => cockpit.jump("/system/hwinfo", cockpit.transport.host)}>
+                    <a href="#" className="no-left-padding" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
                         {_("View hardware details")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -143,7 +143,7 @@ export class UsageCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a role="link" tabIndex="0" className="no-left-padding" onClick={() => cockpit.jump("/system/graphs", cockpit.transport.host)}>
+                    <a href="#" className="no-left-padding" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/graphs", cockpit.transport.host) }}>
                         {_("View graphs")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -54,13 +54,13 @@ export class PageStatusNotifications extends React.Component {
                 let action;
                 if (status.details && status.details.link !== undefined) {
                     if (status.details.link)
-                        action = <a role="button" tabIndex="0"
-                                    onClick={ () => cockpit.jump("/" + status.details.link) }>{status.title}</a>;
+                        action = <a href="#"
+                                    onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + status.details.link) } }>{status.title}</a>;
                     else
                         action = <span>{status.title}</span>; // no link
                 } else {
-                    action = <a role="button" tabIndex="0"
-                                onClick={ () => cockpit.jump("/" + page) }>{status.title}</a>;
+                    action = <a href="#"
+                                onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + page) } }>{status.title}</a>;
                 }
 
                 let icon = status.details && status.details.icon;

--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -50,8 +50,9 @@ export function ServiceTabs({ onChange, activeTab, tabErrors }) {
                     return (
                         <NavItem itemId={key}
                                  key={key}
+                                 preventDefault
                                  isActive={activeItem == key}>
-                            <a>
+                            <a href="#">
                                 {service_tabs_suffixes[key]}
                                 {tabErrors[key] ? <span className="fa fa-exclamation-circle" /> : null}
                             </a>

--- a/test/verify/check-docker
+++ b/test/verify/check-docker
@@ -154,7 +154,7 @@ class TestDocker(MachineCase):
         b.click("#container-details .content-filter a")
         b.wait_visible("#containers-containers")
         b.wait_in_text('#containers-containers', "PROBE2")
-        b.click('#containers-containers tbody tr:contains("PROBE2") td.listing-ct-toggle')
+        b.click('#containers-containers tbody tr:contains("PROBE2") td.listing-ct-toggle button')
         b.click('#containers-containers tbody tr:contains("PROBE2") + tr button.btn-delete')
         with b.wait_timeout(20):
             try:
@@ -203,13 +203,13 @@ class TestDocker(MachineCase):
         b.wait_in_text("#containers-images", "busybox:latest")
 
         # Deleting an image without depending containers has no container list
-        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle')
+        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle button')
         b.click('#containers-images tr:contains("busybox:latest") + tr .btn-delete')
         b.wait_popup('delete-image-confirmation-dialog')
         self.assertFalse(b.is_visible('#delete-image-confirmation-dialog-containers'))
         b.click('#delete-image-confirmation-dialog-cancel')
         b.wait_popdown('delete-image-confirmation-dialog')
-        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle')
+        b.click('#containers-images tr:contains("busybox:latest") td.listing-ct-toggle button')
 
         # Create some containers
         b.click('#containers-images tr:contains("busybox:latest") button.play-button')
@@ -564,7 +564,7 @@ CMD ["/bin/sh"]
         # login and go to docker page (Docker Containers)
         self.login_and_go("/docker")
 
-        sel = "#containers-containers .listing-ct-item .listing-ct-toggle"
+        sel = "#containers-containers .listing-ct-item .listing-ct-toggle button"
         b.click(sel)
 
         # wait for the Problems tab then click it


### PR DESCRIPTION
This rule is actually very useful, as it points to things, that are not
keyboard navigable. We were introducing new breakages since we disabled
this rule (like services and overview pages).

Here is list of things that did not work before, but do now:

- service-tabs.jsx: The whole navigation (targets, sockets...) was not
reachable by keyboard.

- page-status.jsx: Items in 'Health' card were reachable by keyboard,
but could not be activated by keyboard.

- usageCard.jsx: Text 'View graphs' on 'Usage' card was reachable by
keyboard, but could not be activated by keyboard.

- systemInformationCard.jsx: Text 'View hardware details' on 'System information'
card was reachable by keyboard, but could not be activated by keyboard.

- insights.jsx: Text 'Not connected to Insights' on 'Health' card was reachable
by keyboard, but could not be activated by keyboard.

- storage-controls.jsx: The 'things' menu on storage page could be
opened by keyboard, but the elements inside were not reachable by keyboard.

- overview.jsx: On storage page non of 'Devices', Drives'... and any
other devices were not reachable by keyboard. Now they are reachable and
also it is possible to activate them by keyboard. (This includes also
'Show all' buttons)

- diskEdit.jsx: These prevents were pointless so I dropped them.
Otherwise we would need to do the same for keyboard events.

- containers-view.jsx: Items could not be activated with keyboard.

- cockpit-components-listing.jsx: Give the event listener to appropriate element.

- fsys-tab.jsx: This is actually unused but making it link-styled button
seems like a correct approach to make ti accessible.

Part of #12954

Note: There are some wrong usages still (like using anchor what should really be button), that that is more intrusive and would require a much more changes. This is to make it actually usable with keyboard.