### PR TITLE
tests: When allowing coredumps, don't save them

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1214,6 +1214,8 @@ class MachineCase(unittest.TestCase):
                     attach(log)
 
     def copy_cores(self, title, label=None):
+        if self.allow_core_dumps:
+            return
         for name, m in self.machines.items():
             if m.ssh_reachable:
                 directory = "%s-%s-%s.core" % (label or self.label(), m.label, title)

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -38,6 +38,8 @@ class TestJournal(MachineCase):
                 browser.click(button_text_selector)
 
     def crash(self):
+        self.allow_core_dumps = True
+
         m = self.machine
 
         m.execute("ulimit -c unlimited")
@@ -373,7 +375,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                "ubuntu-2004", "fedora-coreos", "rhel-8-2", "rhel-8-2-distropkg",
                "rhel-8-3", "centos-8-stream")
     def testAbrtSegv(self):
-        self.allow_core_dumps = True
         b = self.browser
 
         self.crash()
@@ -412,7 +413,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                "ubuntu-2004", "fedora-coreos", "rhel-8-2", "rhel-8-2-distropkg",
                "rhel-8-3", "centos-8-stream")
     def testAbrtDelete(self):
-        self.allow_core_dumps = True
         b = self.browser
 
         # A bit of a race might happen if you delete the journal entry whilst
@@ -446,7 +446,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                "ubuntu-2004", "fedora-coreos", "rhel-8-2", "rhel-8-2-distropkg",
                "rhel-8-3", "centos-8-stream")
     def testAbrtReport(self):
-        self.allow_core_dumps = True
         # The testing server is located at verify/files/mock-faf-server.py
         # Adjust Handler.known for for the expected succession of known/unknown problems
         b = self.browser
@@ -521,8 +520,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                "ubuntu-2004", "fedora-coreos", "rhel-8-2", "rhel-8-2-distropkg",
                "rhel-8-3", "centos-8-stream")
     def testAbrtReportCancel(self):
-        self.allow_core_dumps = True
-
         b = self.browser
         m = self.machine
 
@@ -561,8 +558,6 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                "ubuntu-2004", "fedora-coreos", "rhel-8-2", "rhel-8-2-distropkg",
                "rhel-8-3", "centos-8-stream")
     def testAbrtReportNoReportd(self):
-        self.allow_core_dumps = True
-
         b = self.browser
         m = self.machine
 


### PR DESCRIPTION
By setting `allow_core_dumps` to `True` we say that we should not check
for coredumps in journal. Lets also not save them.

While on it, I moved this setting to `crash()` in test-journal, as it
makes more sense there.

Part of #13854