### PR TITLE
storage: Cleaner exit for luksmeta-monitor-hack

### DIFF
--- a/pkg/storaged/luksmeta-monitor-hack.py
+++ b/pkg/storaged/luksmeta-monitor-hack.py
@@ -10,6 +10,7 @@ import re
 import base64
 import signal
 import atexit
+import os
 
 def b64_decode(data):
     # The data we get doesn't seem to have any padding, but the base64
@@ -111,12 +112,13 @@ def monitor(dev):
     # will be closed when we exit, but that will only happen when it
     # actually writes something.
 
-    def sigexit(signo, stack):
-        sys.exit(0)
-
     def killmon():
         if mon:
             mon.terminate()
+
+    def sigexit(signo, stack):
+        killmon()
+        os._exit(0)
 
     atexit.register(killmon)
     signal.signal(signal.SIGTERM, sigexit)


### PR DESCRIPTION
Calling sys.exit will throw an exception to get its job done, and if
that happens at the wrong moment, we get a backtrace like this:

    Exception ignored in: <bound method Popen.__del__ of <subprocess.Popen object at 0x7fb30d260048>>
    Traceback (most recent call last):
    File "/usr/lib64/python3.6/subprocess.py", line 785, in __del__
    File "<stdin>", line 115, in sigexit
    SystemExit: 0

In order to avoid this, let's just do everything directly in the
signal handlers and exit cleanly via os._exit().

Fixes #14011