### PR TITLE
networking: Avoid checkpointing in tests and use custom settle_time

### DIFF
--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -27,7 +27,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = 'cockpit1'
         self.add_veth(iface, dhcp_cidr="10.111.113.2/20")
@@ -121,7 +121,7 @@ class TestNetworking(NetworkCase):
                 b.wait_not_visible("#networking-nm-crashed")
                 b.wait_visible("#networking-nm-disabled")
 
-        self.login_and_go("/network")
+        self.nm_login()
         assert_running()
 
         # stop/start NM on CLI, page should notice

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -30,7 +30,7 @@ class TestBonding(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface1 = "cockpit1"
         self.add_veth(iface1, dhcp_cidr="10.111.113.1/24", dhcp_range=['10.111.113.2', '10.111.113.254'])
@@ -122,7 +122,7 @@ class TestBonding(NetworkCase):
         m.execute("nmcli con add type ethernet ifname %s con-name TEST2" % iface2)
         m.execute("nmcli con mod TEST1 ipv4.method link-local")
 
-        self.login_and_go("/network")
+        self.nm_login()
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
@@ -148,7 +148,7 @@ class TestBonding(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         # Wait until the page is really ready by waiting for some ethernet interface
         # to show up in some row.
@@ -181,7 +181,7 @@ class TestBonding(NetworkCase):
     def testActive(self):
         b = self.browser
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = "cockpit1"
         self.add_veth(iface, dhcp_cidr="10.111.112.2/20")
@@ -211,7 +211,7 @@ class TestBonding(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = "cockpit1"
         self.add_veth(iface, dhcp_cidr="10.111.113.2/20")
@@ -255,7 +255,7 @@ class TestBondingVirt(NetworkCase):
 
         iface = self.get_iface(m, m.networking["mac"])
 
-        self.login_and_go("/network")
+        self.nm_login()
         self.wait_for_iface(iface)
 
         # Put the main interface into a bond.  Everything should keep working.
@@ -287,7 +287,7 @@ class TestBondingVirt(NetworkCase):
         iface = self.get_iface(m, m.networking["mac"])
         self.ensure_nm_uses_dhclient()
 
-        self.login_and_go("/network")
+        self.nm_login()
         self.wait_for_iface(iface)
 
         # Slow down DHCP enough that it would trigger a rollback.

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -28,7 +28,7 @@ class TestBridge(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         # These are two independent networks. Thus there is no loop between the
         # bridge that all VMs are connected to, and the bridge we are creating here.
@@ -69,7 +69,7 @@ class TestBridge(NetworkCase):
     def testActive(self):
         b = self.browser
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = "cockpit1"
         self.add_veth(iface, dhcp_cidr="10.111.112.2/20")

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -37,7 +37,7 @@ class TestNetworking(NetworkCase):
             # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1400525
             wait(lambda: m.execute("nmcli dev con %s" % iface))
 
-        self.login_and_go("/network")
+        self.nm_login(disable_checkpoints=False, checkpoint_settle_time=3.0)
         self.wait_for_iface(iface, prefix="172.")
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")
@@ -112,7 +112,7 @@ class TestNetworking(NetworkCase):
 
         self.ensure_nm_uses_dhclient()
 
-        self.login_and_go("/network")
+        self.nm_login(disable_checkpoints=False, checkpoint_settle_time=3.0)
         self.wait_for_iface(iface, prefix="172.")
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -83,7 +83,7 @@ class TestFirewall(NetworkCase):
             b.relogin("/network", authorized=True)
         else:
             m.execute("systemctl stop firewalld")
-            self.login_and_go("/network")
+            self.nm_login()
 
         self.wait_onoff("#networking-firewall-switch", False)
         self.toggle_onoff("#networking-firewall-switch")

--- a/test/verify/check-networking-mac
+++ b/test/verify/check-networking-mac
@@ -34,7 +34,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = self.add_iface()
         self.wait_for_iface(iface)
@@ -62,7 +62,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface1 = self.add_iface()
         iface2 = self.add_iface()

--- a/test/verify/check-networking-mtu
+++ b/test/verify/check-networking-mtu
@@ -34,7 +34,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = self.add_iface()
         self.wait_for_iface(iface)

--- a/test/verify/check-networking-other
+++ b/test/verify/check-networking-other
@@ -35,7 +35,7 @@ class TestNetworking(NetworkCase):
         wait(lambda: m.execute('nmcli device | grep %s | grep -v unavailable' % iface))
         m.execute("nmcli dev set %s managed yes" % iface)
 
-        self.login_and_go("/network")
+        self.nm_login()
         self.wait_for_iface(iface, active=False)
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")

--- a/test/verify/check-networking-settings
+++ b/test/verify/check-networking-settings
@@ -34,7 +34,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = self.add_iface(activate=False)
         self.wait_for_iface(iface, active=False)
@@ -90,7 +90,7 @@ class TestNetworking(NetworkCase):
         con_id = self.iface_con_id(iface)
         m.execute("nmcli con mod '%s' connection.gateway-ping-timeout 12" % con_id)
 
-        self.login_and_go("/network")
+        self.nm_login()
         self.wait_for_iface(iface)
 
         # IPv4 address sharing

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -29,7 +29,7 @@ class TestTeam(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         b.wait_attr("#networking-add-team", "data-test-stable", "yes")
 
@@ -92,7 +92,7 @@ class TestTeam(NetworkCase):
     def testActive(self):
         b = self.browser
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = "cockpit1"
         self.add_veth(iface, dhcp_cidr="10.111.112.2/20")

--- a/test/verify/check-networking-unmanaged
+++ b/test/verify/check-networking-unmanaged
@@ -40,7 +40,7 @@ class TestNetworking(NetworkCase):
         m.execute(r"printf '[keyfile]\nunmanaged-devices=%s\n' > /etc/NetworkManager/conf.d/unmanaged.conf" % iface)
         m.execute("systemctl restart NetworkManager")
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         b.wait_present("#networking-unmanaged-interfaces tr[data-interface='" + iface + "']")
 

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -28,7 +28,7 @@ class TestNetworking(NetworkCase):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/network")
+        self.nm_login()
 
         iface = 'cockpit1'
         self.add_veth(iface, dhcp_cidr="10.111.113.2/20")

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -55,6 +55,13 @@ class NetworkHelpers:
         m.execute("nmcli con up %s ifname %s" % (iface, iface))
         self.addCleanup(m.execute, "nmcli con delete %s" % iface)
 
+    def nm_login(self, disable_checkpoints=True, checkpoint_settle_time=None):
+        self.login_and_go("/network")
+        if disable_checkpoints:
+            self.browser.eval_js("window.cockpit_tests_disable_checkpoints = true;")
+        if checkpoint_settle_time is not None:
+            self.browser.eval_js("window.cockpit_tests_checkpoint_settle_time = %s;" % checkpoint_settle_time)
+
 
 class NetworkCase(MachineCase, NetworkHelpers):
     def setUp(self):


### PR DESCRIPTION
A long settle_time time causes the checkpointing race to get pretty
tight, and checkpoints would be unexpectedly rolled back in our
integration tests.  On the other hand, we had to increased the
settle_time in 7b115d15f44aa and f1d06abedaee50d to make the
checkpointing tests themselves more robust.

Thus, we reset the settle_time that is appropriate for manual use,
switch off checkpointing entirely for most of the integration tests,
and use a long settle_time when testing checkpoints themselves.

Fixes #13821