### PR TITLE
doc: Use standard Promise API and ES6 arrow handlers

### DIFF
--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -249,7 +249,7 @@ cockpit.transport.close([problem])
   <refsection id="cockpit-transport-filter">
     <title>cockpit.transport.filter()</title>
 <programlisting>
-cockpit.transport.filter(function(message, channelid, control) { ... }, [out])
+cockpit.transport.filter((message, channelid, control) =>  { ... }, [out])
 </programlisting>
     <para>Add a filter to the underlying channel transport. All incoming messages will be
       passed to each of the filter callbacks that are registered. If the <code>out</code>

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -174,7 +174,7 @@ client.close([problem])
   <refsection id="cockpit-dbus-onclose">
     <title>client.onclose</title>
 <programlisting>
-client.addEventListener("close", function(options) { ... })
+client.addEventListener("close", options => { ... })
 </programlisting>
     <para>An event triggered when the DBus client closes. This can happen either because
       <link linkend="cockpit-dbus-close">client.close()</link> function was called,
@@ -187,7 +187,7 @@ client.addEventListener("close", function(options) { ... })
   <refsection id="cockpit-dbus-onowned">
     <title>client.onowner</title>
 <programlisting>
-client.addEventListener("owner", function(event, owner) { ... })
+client.addEventListener("owner", (event, owner) => { ... })
 </programlisting>
     <para>An event triggered when the owner of the DBus name changes. The owner
       value will be the id of the name owner on the bus or null if the name
@@ -263,26 +263,26 @@ proxy.WritableProp = value
 
 <programlisting>
 proxy.Method(arg1, arg2)
-    .done(function(retval1, retval2) {
+    .then((retval1, retval2) => {
         ...
     })
-    .fail(function(ex) {
+    .catch(ex => {
         ...
     });
 </programlisting>
     <para>All DBus methods on the <code>interface</code> that start with an upper case
       letter (as is convention) will be automatically defined on this proxy. These
       methods are called with arguments as normal javascript arguments. A
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete successfully when the method returns, or fail if an error occurs.
-      The return values from the DBus method will be passed to the <code>done</code> handler
+      The return values from the DBus method will be passed to the <code>then</code> handler
       function directly.</para>
 
     <para>Methods that do not start with an upper case letter can be invoked by using
       the usual <link linkend="cockpit-dbus-proxy-call"><code>proxy.call()</code></link> directly.</para>
 
 <programlisting>
-proxy.addEventListener("Signal", function(event, arg1, arg2) {
+proxy.addEventListener("Signal", (event, arg1, arg2) => {
     ...
 });
 </programlisting>
@@ -363,7 +363,7 @@ invocation = proxy.call(method, args, [options])
 
     <para>The returned value is identical to the one returned from
       <link linkend="cockpit-dbus-call">client.call()</link>. It is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete successfully when the method returns, or fail if an error occurs.</para>
   </refsection>
 
@@ -371,7 +371,7 @@ invocation = proxy.call(method, args, [options])
     <title>proxy.wait()</title>
 <programlisting>
 promise = proxy.wait()
-proxy.wait(function() {
+proxy.wait(() => {
     ...
 });
 </programlisting>
@@ -385,7 +385,7 @@ proxy.wait(function() {
   <refsection id="cockpit-dbus-proxy-onchanged">
     <title>proxy.onchanged</title>
 <programlisting>
-proxy.addEventListener("changed", function(event, data) {
+proxy.addEventListener("changed", (event, data) => {
     ...
 });
 </programlisting>
@@ -405,7 +405,7 @@ proxy.addEventListener("changed", function(event, data) {
   <refsection id="cockpit-dbus-proxy-signal">
     <title>proxy.onsignal</title>
 <programlisting>
-proxy.addEventListener("signal", function(event, name, args) {
+proxy.addEventListener("signal", (event, name, args) => {
     ...
 });
 </programlisting>
@@ -468,7 +468,7 @@ for (proxy in proxies) {
     <title>proxies.wait()</title>
 <programlisting>
 promise = proxies.wait()
-proxies.wait(function() {
+proxies.wait(() => {
     ...
 });
 </programlisting>
@@ -499,7 +499,7 @@ proxies.wait(function() {
   <refsection id="cockpit-dbus-proxies-onadded">
     <title>proxies.onadded</title>
 <programlisting>
-proxies.addEventListener("added", function(event, proxy) {
+proxies.addEventListener("added", (event, proxy) => {
     ...
 })
 </programlisting>
@@ -510,7 +510,7 @@ proxies.addEventListener("added", function(event, proxy) {
   <refsection id="cockpit-dbus-proxies-onchanged">
     <title>proxies.onchanged</title>
 <programlisting>
-proxies.addEventListener("changed", function(event, proxy) {
+proxies.addEventListener("changed", (event, proxy) => {
     ...
 })
 </programlisting>
@@ -521,7 +521,7 @@ proxies.addEventListener("changed", function(event, proxy) {
   <refsection id="cockpit-dbus-proxies-onremoved">
     <title>proxies.onremoved</title>
 <programlisting>
-proxies.addEventListener("removed", function(event, proxy) {
+proxies.addEventListener("removed", (event, proxy) => {
     ...
 })
 </programlisting>
@@ -544,7 +544,7 @@ invocation = client.call(path, interface, method, args, [options])
       <code>args</code> may be <code>null</code> if no arguments are to be sent.</para>
 
     <para>The returned value is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete successfully when the method returns, or fail if an error occurs.</para>
 
     <para>If <code>options</code> is specified it should be a plain javascript object,
@@ -573,13 +573,13 @@ invocation = client.call(path, interface, method, args, [options])
     </variablelist>
   </refsection>
 
-  <refsection id="cockpit-dbus-done">
-    <title>invocation.done()</title>
+  <refsection id="cockpit-dbus-then">
+    <title>invocation.then()</title>
 <programlisting>
-invocation.done(function(args, options) { ... })
+invocation.then((args, options) => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       method. It sets up a handler to be called when the DBus method call finishes
       successfully.</para>
     <para>The <code>args</code> argument is an array of return values from the DBus method.
@@ -605,13 +605,13 @@ invocation.done(function(args, options) { ... })
 
   </refsection>
 
-  <refsection id="cockpit-dbus-fail">
-    <title>invocation.fail()</title>
+  <refsection id="cockpit-dbus-catch">
+    <title>invocation.catch()</title>
 <programlisting>
-invocation.fail(function(exception) { ... })
+invocation.catch(exception => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink> method.
       It sets up a handler to be called when the DBus method call fails.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -637,21 +637,10 @@ invocation.fail(function(exception) { ... })
     </variablelist>
   </refsection>
 
-  <refsection id="cockpit-dbus-always">
-    <title>invocation.always()</title>
-<programlisting>
-invocation.always(function() { ... })
-</programlisting>
-    <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
-      It sets up a handler to be called when the DBus method call finishes whether successfully,
-      or fails.</para>
-  </refsection>
-
   <refsection id="cockpit-dbus-subscribe">
     <title>client.subscribe()</title>
 <programlisting>
-subscription = client.subscribe(match, function(path, interface, signal, args) { ... })
+subscription = client.subscribe(match, (path, interface, signal, args) => { ... })
 </programlisting>
     <para>Subscribe to signals. The <code>match</code> argument is a javascript plain object which
       defines what signals to subscribe to. Each property in the <code>match</code> argument restricts
@@ -757,7 +746,7 @@ watch = client.watch({ "path_namespace": path_namespace, "interface": interface 
     </variablelist>
 
     <para>The returned value is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete successfully when the watch has populated its initial set of properties
       and interfaces, and these have been notified via
       <link linkend="cockpit-dbus-onnotify"><code>client.onnotify</code></link>.</para>
@@ -768,39 +757,28 @@ watch = client.watch({ "path_namespace": path_namespace, "interface": interface 
       also be removed the same number of times before the removal takes effect.</para>
   </refsection>
 
-  <refsection id="cockpit-dbus-watch-done">
-    <title>watch.done()</title>
+  <refsection id="cockpit-dbus-watch-then">
+    <title>watch.then()</title>
 <programlisting>
-watch.done(function() { ... })
+watch.then(() => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       method. It sets up a handler to be called when the watch has populated its initial
       properties and interfaces.</para>
   </refsection>
 
-  <refsection id="cockpit-dbus-watch-fail">
-    <title>watch.fail()</title>
+  <refsection id="cockpit-dbus-watch-catch">
+    <title>watch.catch()</title>
 <programlisting>
-watch.fail(function() { ... })
+watch.catch(ex => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       method. It sets up a handler to be called if the watch fails to populate its initial
       properties and interfaces. Note that a watch will only fail if the DBus client
       closes or is somehow disconnected. It does not fail in the case of missing
       interfaces or properties.</para>
-  </refsection>
-
-  <refsection id="cockpit-dbus-watch-always">
-    <title>watch.always()</title>
-<programlisting>
-watch.always(function() { ... })
-</programlisting>
-    <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink>
-      method. It sets up a handler to be called when the watch has populated its initial
-      properties and interfaces or has failed to do so.</para>
   </refsection>
 
   <refsection id="cockpit-dbus-watch-remove">
@@ -816,7 +794,7 @@ watch.remove()
   <refsection id="cockpit-dbus-onnotify">
     <title>client.onnotify</title>
 <programlisting>
-client.addEventListener("notify", function(data) { ... })
+client.addEventListener("notify", data => { ... })
 </programlisting>
     <para>An event triggered when
       <link linkend="cockpit-dbus-watch">watched</link> properties or interfaces change.</para>
@@ -861,7 +839,7 @@ client.notify(data)
   <refsection id="cockpit-dbus-onmeta">
     <title>client.onmeta</title>
 <programlisting>
-client.onmeta = function(ev, data) { ... }
+client.onmeta = (ev, data) => { ... }
 </programlisting>
     <para>An event triggered when the meta data about
       <link linkend="cockpit-dbus-watch">watched</link> interfaces is loaded.</para>

--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -23,20 +23,20 @@ file = cockpit.file(path,
 
 promise = file.read()
 promise
-    .done(function (content, tag) { ... })
-    .fail(function (error) { ... })
+    .then((content, tag) => { ... })
+    .catch(error => { ... })
 
 promise = file.replace(content, [ expected_tag ])
 promise
-    .done(function (new_tag) { ... })
-    .fail(function (error) { ... })
+    .then(new_tag => { ... })
+    .catch(error => { ... })
 
 promise = file.modify(callback, [ initial_content, initial_tag ]
 promise
-    .done(function (new_content, new_tag) { ... })
-    .fail(function (error) { ... })
+    .then((new_content, new_tag) => { ... })
+    .catch(error => { ... })
 
-file.watch(function (content, tag, [error]) { })
+file.watch((content, tag, [error]) => { })
 
 file.close()
 </programlisting>
@@ -48,24 +48,24 @@ file.close()
     <para>You can read a file with code like this:</para>
 <programlisting>
 cockpit.file("/path/to/file").read()
-    .done(function (content, tag) {
+    .then((content, tag) => {
         ...
     })
-    .fail(function (error) {
+    .catch(error => {
         ...
     });
 </programlisting>
     <para>The <code>read()</code> method returns a
-      <ulink url="https://www.promisejs.org/">promise</ulink>.</para>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>.</para>
     <para>When successful, the promise will be resolved with the content of the
       file. Unless you specify options to change this (see below), the file
       is assumed to be text in the UTF-8 encoding, and <code>content</code>
       will be a string.</para>
-    <para>The tag that is passed to the <code>done()</code> callback is a short
+    <para>The tag that is passed to the <code>then()</code> callback is a short
       string that is associated with the file and changes whenever the
       content of the file changes.  It is meant to be used with <code>replace()</code>.</para>
     <para>It is not an error when the file does not exist. In this case, the
-      <code>done()</code> callback will be called with a <code>null</code>
+      <code>then()</code> callback will be called with a <code>null</code>
       value for <code>content</code> and <code>tag</code> is <code>"-"</code>.</para>
       <para>The <code>superuser</code> and <code>host</code> options can be used the same way
       as described in the <link linkend="cockpit-channels-channel">cockpit.channel()</link>
@@ -77,16 +77,16 @@ cockpit.file("/path/to/file").read()
     <para>To write to a file, use code like this:
 <programlisting>
 cockpit.file("/path/to/file").replace("my new content\n")
-    .done(function (tag) {
+    .then(tag => {
         ...
     })
-    .fail(function (error) {
+    .catch(error => {
         ...
     });
 </programlisting>
     </para>
     <para>The <code>replace()</code> method returns a
-      <ulink url="https://www.promisejs.org/">promise</ulink>.</para>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>.</para>
     <para>When the promise is resolved, the file has been atomically replaced
       (via the <code>rename()</code> syscall) with the new content. As with
       <code>read()</code>, by default the new content is a string and will
@@ -171,7 +171,7 @@ new_content = callback (old_content)
       callbacks. Returning <code>undefined</code> from the proxy is the
       same as returning <code>old_content</code>.</para>
     <para>The <code>modify()</code> method returns a
-      <ulink url="https://www.promisejs.org/">promise</ulink>.</para>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>.</para>
     <para>The promise will be resolved with the new content and its tag, like so
 <programlisting>
 function shout(old_content) {
@@ -179,10 +179,10 @@ function shout(old_content) {
 }
 
 cockpit.file("/path/to/file").modify(shout)
-    .done(function (content, tag) {
+    .then((content, tag) => {
         ...
     })
-    .fail(function (error) {
+    .catch(error => {
         ...
     });
 </programlisting>

--- a/doc/guide/cockpit-http.xml
+++ b/doc/guide/cockpit-http.xml
@@ -128,7 +128,7 @@ request = http.get(path, [params, [headers]])
     <para>Optionally a plain javascript object containing headers can be included in the
       <code>headers</code> argument.</para>
     <para>The return value is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete if the request happens successfully, or fail if there's a problem.</para>
   </refsection>
 
@@ -144,7 +144,7 @@ request = http.post(path, body, [headers])
     <para>Optionally a plain javascript object containing headers can be included in the
       <code>headers</code> argument.</para>
     <para>The return value is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete if the request happens successfully, or fail if there's a problem.</para>
   </refsection>
 
@@ -181,17 +181,17 @@ request = http.request(options)
     </variablelist>
 
     <para>The return value is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       that will complete if the request happens successfully, or fail if there's a problem.</para>
   </refsection>
 
-  <refsection id="cockpit-http-done">
-    <title>request.done()</title>
+  <refsection id="cockpit-http-then">
+    <title>request.then()</title>
 <programlisting>
-request.done(function(data) { ... })
+request.then(data => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink>
       method. It sets up a handler to be called when the request finishes successfully.</para>
     <para>The <code>data</code> argument contains the body result of the request.
       If it a string, unless the process was opened in binary mode, in which case the
@@ -201,13 +201,13 @@ request.done(function(data) { ... })
       be included in the <code>data</code> argument.</para>
   </refsection>
 
-  <refsection id="cockpit-http-fail">
-    <title>request.fail()</title>
+  <refsection id="cockpit-http-catch">
+    <title>request.catch()</title>
 <programlisting>
-request.fail(function(exception[, data]) { ... })
+request.catch((exception[, data]) => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink> method.
       It sets up a handler to be called when the request fails, or returns an error code.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -241,21 +241,10 @@ request.fail(function(exception[, data]) { ... })
       the <code>data</code> argument. Otherwise this argument will be <code>undefined</code>.</para>
   </refsection>
 
-  <refsection id="cockpit-http-always">
-    <title>request.always()</title>
-<programlisting>
-request.always(function() { ... })
-</programlisting>
-    <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
-      It sets up a handler to be called when the process completes, whether it exits successfully,
-      fails, terminates, or exits with a failure.</para>
-  </refsection>
-
   <refsection id="cockpit-http-response">
     <title>request.response()</title>
 <programlisting>
-request.response(function(status, headers) { ... })
+request.response((status, headers) => { ... })
 </programlisting>
     <para>This sets up a handler to be called when the HTTP request gets the initial response
       from the server. The <code>status</code> argument is the HTTP status integer, and the
@@ -266,7 +255,7 @@ request.response(function(status, headers) { ... })
   <refsection id="cockpit-http-stream">
     <title>request.stream()</title>
 <programlisting>
-request.stream(function(data) { ... })
+request.stream(data => { ... })
 </programlisting>
     <para>This sets up a handler to be called when the request returns output data. The
       handler will be called multiple times.</para>
@@ -276,7 +265,7 @@ request.stream(function(data) { ... })
       indicates the number of characters or bytes consumed from <code>data</code>. Any data
       not consumed will be included again the next time the handler is called.</para>
     <para>If a <code>request.stream()</code> handler is set up, then the
-      <code><link linkend="cockpit-http-done">request.done()</link></code> handlers will
+      <code><link linkend="cockpit-http-then">request.then()</link></code> handlers will
       only get any remaining data not consumed by the stream handler.</para>
   </refsection>
 

--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -20,7 +20,7 @@ cockpit.logout([reload])
     <title>cockpit.user()</title>
 <programlisting>
 var promise = cockpit.user();
-promise.done(function (user) { ... });
+promise.then(user => { ... });
 </programlisting>
     <para>This object contains information about the user that's currently logged into cockpit.
       The following fields are defined:</para>

--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -88,7 +88,7 @@ process = cockpit.spawn(args, [options])
     </variablelist>
 
     <para>The spawned process is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</ulink>
       that will complete if the process exits successfully, or fail if there's a problem.
       Some additional methods besides the standard promise methods are documented
       below.</para>
@@ -118,7 +118,7 @@ process = cockpit.script(script, [args], [options])
       <link linkend="cockpit-spawn-spawn"><code>cockpit.spawn()</code></link> function.</para>
 
     <para>The spawned process is a
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</ulink>
       that will complete if the script exits successfully, or fail if there's a problem.
       Some additional methods besides the standard promise methods are documented
       below.</para>
@@ -129,13 +129,13 @@ process = cockpit.script(script, [args], [options])
       The standard error is logged to the journal by default.</para>
   </refsection>
 
-  <refsection id="cockpit-spawn-done">
-    <title>process.done()</title>
+  <refsection id="cockpit-spawn-then">
+    <title>process.then()</title>
 <programlisting>
-process.done(function(data[, message]) { ... })
+process.then((data[, message]) => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://www.promisejs.org/">promise</ulink>
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</ulink>
       method. It sets up a handler to be called when the process finishes successfully.</para>
     <para>The <code>data</code> argument contains the standard output of the process.
       If it a string, unless the process was opened in binary mode, in which case the
@@ -148,13 +148,13 @@ process.done(function(data[, message]) { ... })
       output of the process.</para>
   </refsection>
 
-  <refsection id="cockpit-spawn-fail">
-    <title>process.fail()</title>
+  <refsection id="cockpit-spawn-catch">
+    <title>process.catch()</title>
 <programlisting>
-process.fail(function(exception[, data]) { ... })
+process.catch((exception[, data]) => { ... })
 </programlisting>
     <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
+      <ulink url="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">Promise</ulink> method.
       It sets up a handler to be called when the process fails, terminates or exits.</para>
 
     <para>The <code>exception</code> object passed to the handler can have the
@@ -189,21 +189,10 @@ process.fail(function(exception[, data]) { ... })
       the <code>data</code> argument. Otherwise this argument will be <code>undefined</code>.</para>
   </refsection>
 
-  <refsection id="cockpit-spawn-always">
-    <title>process.always()</title>
-<programlisting>
-process.always(function() { ... })
-</programlisting>
-    <para>This is a standard
-      <ulink url="https://api.jquery.com/category/deferred-object/">jQuery promise</ulink> method.
-      It sets up a handler to be called when the process completes, whether it exits successfully,
-      fails, terminates, or exits with a failure.</para>
-  </refsection>
-
   <refsection id="cockpit-spawn-stream">
     <title>process.stream()</title>
 <programlisting>
-process.stream(function(data) { ... })
+process.stream(data => { ... })
 </programlisting>
     <para>This sets up a handler to be called when the process has standard output. The
       handler will be called multiple times. The handler will be called regardless of
@@ -214,7 +203,7 @@ process.stream(function(data) { ... })
       indicates the number of characters or bytes consumed from <code>data</code>. Any data
       not consumed will be included again the next time the handler is called.</para>
     <para>If a <code>process.stream()</code> handler is set up, then the
-      <code><link linkend="cockpit-spawn-done">process.done()</link></code> handlers will
+      <code><link linkend="cockpit-spawn-then">process.then()</link></code> handlers will
       only get any remaining data not consumed by the stream handler.</para>
   </refsection>
 


### PR DESCRIPTION
We have deprecated the old jQuery .done()/.fail() API a long time ago,
no new code should be written with it any more. Also, these days
promise callbacks are usually written with arrows, to get sane `this`
behaviour. All browser engines have supported arrows for many years now.

This will better reflect real code and make the Cockpit API easier to
relate to standard JS.