### PR TITLE
specfile: Fix up requires for cockpit-system

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -408,9 +408,10 @@ Requires: kexec-tools
 Recommends: polkit
 Recommends: PackageKit
 Recommends: NetworkManager-team
-Recommends: setroubleshoot-server >= 3.3.3
 Provides: cockpit-selinux = %{version}-%{release}
+Requires: setroubleshoot-server >= 3.3.3
 Provides: cockpit-sosreport = %{version}-%{release}
+Requires: sos
 %endif
 %if 0%{?fedora} >= 29
 # 0.7.0 (actually) supports task cancellation.


### PR DESCRIPTION
`cockpit-system` on rhel bundles some other packages, like c-selinux and
c-sosreport. Make sure that this package has the same `Requires` as its
standalone counterparts.

`cockpit-sosreport` requires `sos` and `cockpit-selinux` requires, not
recommends, setroubleshoot-server.