### PR TITLE
test: Possibility to add allowed messages from ENV

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -982,12 +982,16 @@ class MachineCase(unittest.TestCase):
         "Failed to generate stack trace: (null)",
     ]
 
+    allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")
+
     # Whitelist of allowed console.error() messages during tests; these match substrings
     allowed_console_errors = [
         # HACK: These should be fixed, but debugging these is not trivial, and the impact is very low
         "Warning: .* setState.*on an unmounted component",
         "Warning: Can't perform a React state update on an unmounted component."
     ]
+
+    allowed_console_errors += os.environ.get("TEST_ALLOW_BROWSER_ERRORS", "").split(",")
 
     def allow_journal_messages(self, *patterns):
         """Don't fail if the journal contains a entry completely matching the given regexp"""


### PR DESCRIPTION
How to test:
```
--- test/common/testlib.py
+++ test/common/testlib.py
@@ -946,9 +946,6 @@ class MachineCase(unittest.TestCase):
         # pkg/packagekit/autoupdates.jsx backend check often gets interrupted by logout
         "xargs: basename: terminated by signal 13",
 
-        # SELinux messages to ignore
-        "(audit: )?type=1403 audit.*",
-        "(audit: )?type=1404 audit.*",
         # happens on Atomic (https://bugzilla.redhat.com/show_bug.cgi?id=1298157)
         "(audit: )?type=1400 audit.*: avc:  granted .*",
```

`./test/verify/check-setroubleshoot TestSelinux.testEnforcingToggle` fails with:
```
testlib.Error: FAIL: Test completed, but found unexpected journal messages:
audit: type=1404 audit(1588661472.381:367): enforcing=0 old_enforcing=1 auid=1000 ses=4 enabled=1 old-enabled=1 lsm=selinux res=1
```

then running ` TEST_ALLOW_JOURNAL_MESSAGES="(audit: )?type=1403 audit.*,(audit: )?type=1404 audit.*" ./test/verify/check-setroubleshoot TestSelinux.testEnforcingToggle` works again.