### PR TITLE
networking: Avoid checkpointing in tests and use custom settle_time

### DIFF
--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -38,6 +38,7 @@ class TestNetworking(NetworkCase):
             wait(lambda: m.execute("nmcli dev con %s" % iface))
 
         self.login_and_go("/network")
+        self.nm_checkpoints_enable()
         self.wait_for_iface(iface, prefix="172.")
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")
@@ -113,6 +114,7 @@ class TestNetworking(NetworkCase):
         self.ensure_nm_uses_dhclient()
 
         self.login_and_go("/network")
+        self.nm_checkpoints_enable()
         self.wait_for_iface(iface, prefix="172.")
         b.click("#networking-interfaces tr[data-interface='%s']" % iface)
         b.wait_visible("#network-interface")

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -58,6 +58,13 @@ class NetworkHelpers:
         m.execute("nmcli con up %s ifname %s" % (iface, iface))
         self.addCleanup(m.execute, "nmcli con delete %s" % iface)
 
+    def nm_checkpoints_disable(self):
+        self.browser.eval_js("window.cockpit_tests_disable_checkpoints = true;")
+
+    def nm_checkpoints_enable(self, settle_time=3.0):
+        self.browser.eval_js("window.cockpit_tests_disable_checkpoints = false;")
+        self.browser.eval_js("window.cockpit_tests_checkpoint_settle_time = %s;" % settle_time)
+
 
 class NetworkCase(MachineCase, NetworkHelpers):
     def setUp(self):
@@ -172,3 +179,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
 
     def toggle_onoff(self, sel):
         self.browser.click(sel + " input")
+
+    def login_and_go(self, *args, **kwargs):
+        super().login_and_go(*args, **kwargs)
+        self.nm_checkpoints_disable()


### PR DESCRIPTION
A long settle_time time causes the checkpointing race to get pretty
tight, and checkpoints would be unexpectedly rolled back in our
integration tests.  On the other hand, we had to increased the
settle_time in 7b115d15f44aa and f1d06abedaee50d to make the
checkpointing tests themselves more robust.

Thus, we reset the settle_time to something that is appropriate for
manual use, switch off checkpointing entirely for most of the
integration tests, and use a long settle_time when testing checkpoints
themselves.

Fixes #13821