### PR TITLE
[WIP] tests: fix testDetachDisk flake

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -164,6 +164,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         self.restore_dir("/var/lib/libvirt")
         self.restore_dir("/etc/libvirt")
 
+        # Guest Log files
+        self.addCleanup(m.execute, "rm -rf /var/log/libvirt/console*")
+
         # Cleanup pools
         self.addCleanup(m.execute, "rm -rf /run/libvirt/storage/*")
 


### PR DESCRIPTION
If we skip deleting logfiles in nondestructive mode we might skip waiting
for the guest to fully boot before attempting detaching devices.

This is mostly guessing what might be wrong at this point. 