### PR TITLE
Fix manifest ownership on install

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -226,10 +226,10 @@ maintainer-clean-local::
 
 install-data-local:: $(WEBPACK_INSTALL)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	tar -cf - $^ | tar -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+	tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 install-data-local:: $(WEBPACK_DEBUG)
 	$(MKDIR_P) $(DESTDIR)$(debugdir)$(pkgdatadir)
-	tar -cf - $^ | tar -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
+	tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
 uninstall-local::
 	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \;
 	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete


### PR DESCRIPTION
After an install from source, the builder's uid leaks on the manifest.json file.
Specifying the `--no-same-owner` prevents it from occurring.

Before:
```
[archie@d47f818d4c65 cockpit-218]$ sudo make install -j 4
[...]
[archie@d47f818d4c65 cockpit-218]$ ls -al /usr/local/share/cockpit/users
total 224
drwxr-xr-x  2 root   root     4096 May  5 19:04 .
drwxr-xr-x 23 root   root     4096 May  5 19:04 ..
-rw-r--r--  1 root   root     3222 May  5 19:04 index.html.gz
-rw-rw-r--  1 archie archie    751 May  5 18:58 manifest.json
-rw-r--r--  1 root   root     2605 May  5 19:04 po.ca.js.gz
```
After:
```
[archie@9b3ee741a9ad cockpit-218]$ ls -al /usr/local/share/cockpit/users
total 224
drwxr-xr-x  2 root root   4096 May  5 19:32 .
drwxr-xr-x 23 root root   4096 May  5 19:32 ..
-rw-r--r--  1 root root   3222 May  5 19:30 index.html.gz
-rw-r--r--  1 root root    751 May  5 19:29 manifest.json
-rw-r--r--  1 root root   2605 May  5 19:30 po.ca.js.gz
-rw-r--r--  1 root root   2844 May  5 19:30 po.cs.js.gz
-rw-r--r--  1 root root   2744 May  5 19:30 po.de.js.gz
```