### PR TITLE
test: Don't retry on journal and browser messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1143,7 +1143,7 @@ class MachineCase(unittest.TestCase):
                 if re.search(p, log):
                     break
             else:
-                raise Error(log)
+                raise Error("FAIL: Test completed, but found unexpected browser errors:\n" + log)
 
     def check_axe(self, label=None, suffix=""):
         """Run aXe check on the currently active frame

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -62,10 +62,7 @@ class TestBastion(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.allow_journal_messages("Sorry, try again.",
-                                    "sudo: no password was provided",
-                                    "sudo: 1 incorrect password attempt",
-                                    "sudo: .* incorrect password attempts")
+        self.allow_authorize_journal_messages()
 
         m.start_cockpit(key_based=True)
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -181,6 +181,9 @@ class TestApps(PackageCase):
         b.wait_present(".app-description:contains('DESCRIPTION:none')")
         b.wait_not_present(".app-description:contains('DESCRIPTION:de')")
 
+        # like in the general whitelist, but translated
+        self.allow_journal_messages("xargs: basename: .*Signal 13.*")
+
     def testBrokenXML(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -533,7 +533,7 @@ class TestConnection(MachineCase):
         rss = int(output.split(" ")[0])
 
         # This fails when flow control is not present
-        self.assertLess(rss, 200000)
+        self.assertLess(rss, 250000)
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     def testLocalSession(self):

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -375,6 +375,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#content-user-name', 'Administrator')
 
         self.allow_restart_journal_messages()
+        self.allow_authorize_journal_messages()
 
     @skipImage("No tlog", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004",
                "rhel-8-2", "rhel-8-2-distropkg", "rhel-8-3", "centos-8-stream", "fedora-coreos")

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -48,12 +48,6 @@ def readFile(name):
             content = f.read().replace('\n', '')
     return content
 
-def createUser(machine, user_group):
-    user_name = 'test_' + user_group + '_user'
-    machine.execute(
-        'useradd -G {0} {1} && echo "{1}:foobar" | chpasswd'.format(user_group, user_name))
-    return user_name
-
 # If this test fails to run, the host machine needs:
 # echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 # rmmod kvm-intel && modprobe kvm-intel || true
@@ -254,20 +248,25 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
     def testBasic(self):
         self._testBasic()
 
+    def createUser(self, user_group):
+        user_name = 'test_' + user_group + '_user'
+        self.machine.execute(
+            'useradd -G {0} {1} && echo "{1}:foobar" | chpasswd'.format(user_group, user_name))
+        # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
+        # so make sure that there are no leftover user processes that bleed into the next test
+        self.addCleanup(self.machine.execute, "pkill -u {0}; while pgrep -u {0}; do sleep 0.5; done".format(user_name))
+        return user_name
+
     # FIXME remove this skipImage
     @skipImage('Fails with Rejected send message, 1 matched rules; type="method_call"', "rhel-8-2", "rhel-8-3", "rhel-8-2-distropkg", "ubuntu-stable", "ubuntu-2004", "debian-testing", "debian-stable", "centos-8-stream")
     def testBasicLibvirtUserUnprivileged(self):
-        m = self.machine
-        user_group = 'libvirt'
-        user = createUser(m, user_group)
+        user = self.createUser(user_group='libvirt')
         self._testBasic(user, False)
 
     def testBasicWheelUserUnprivileged(self):
-        m = self.machine
-        user_group = 'wheel'
-        user = createUser(m, user_group)
+        user = self.createUser(user_group='wheel')
         self._testBasic(user, False, True)
-        self.allow_journal_messages("{0} is not in the sudoers file.  This incident will be reported.".format(user))
+        self.allow_authorize_journal_messages()
 
     def _testBasic(self, user=None, authorized=True, expect_empty_list=False):
         b = self.browser

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -255,6 +255,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # user libvirtd instance tends to SIGABRT with "Failed to find user record for uid .." on shutdown during cleanup
         # so make sure that there are no leftover user processes that bleed into the next test
         self.addCleanup(self.machine.execute, "pkill -u {0}; while pgrep -u {0}; do sleep 0.5; done".format(user_name))
+        # HACK: ...but it still tends to crash during shutdown (without known stack trace)
+        self.allow_journal_messages('Process .*libvirtd* of user 10.* dumped core.*')
+
         return user_name
 
     # FIXME remove this skipImage

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -579,10 +579,8 @@ for s in key p12 pem; do docker cp freeipa:jane.$s .; done
 
             m.stop_cockpit()
 
-        self.allow_journal_messages("jane is not allowed to run sudo on x0.  This incident will be reported.",
-                                    "Sorry, try again.",
-                                    "sudo: no password was provided",
-                                    "sudo: 1 incorrect password attempt")
+        self.allow_journal_messages("jane is not allowed to run sudo on x0.  This incident will be reported.")
+        self.allow_authorize_journal_messages()
 
         # cert auth should not be enabled by default
         do_test(['--cert', '/var/tmp/jane.pem', '--key', '/var/tmp/jane.key'],

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -124,9 +124,7 @@ session include system-auth
     def testWrongPasswd(self):
         b = self.browser
 
-        self.allow_journal_messages("Sorry, try again.",
-                                    "sudo: 3 incorrect password attempts",
-                                    "sudo: no password was provided")
+        self.allow_authorize_journal_messages()
 
         # Log in with limited access
         self.login_and_go(superuser=False)

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -97,7 +97,8 @@ def finish_test(opts, test):
         # HACK: many tests are unstable, always retry them 3 times
         retry_reason = b"be robust against unstable tests"
 
-    if test.retries < 2:
+    unexpected_message = b"Test completed, but found unexpected" in test.output
+    if test.retries < 2 and not unexpected_message:
         test.retries += 1
         test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
         print_test(test, print_tap=opts.thorough)


### PR DESCRIPTION
These messages indicate that something is wrong and they need our
attention. Just retrying it hides it and makes it harder to notice.

Also show similar message on browser errors.

How to test:
```
--- test/common/testlib.py
+++ test/common/testlib.py
@@ -946,9 +946,6 @@ class MachineCase(unittest.TestCase):
         # pkg/packagekit/autoupdates.jsx backend check often gets interrupted by logout
         "xargs: basename: terminated by signal 13",
 
-        # SELinux messages to ignore
-        "(audit: )?type=1403 audit.*",
-        "(audit: )?type=1404 audit.*",
         # happens on Atomic (https://bugzilla.redhat.com/show_bug.cgi?id=1298157)
         "(audit: )?type=1400 audit.*: avc:  granted .*",
```
and then 
` ./test/verify/run-tests TestSelinux.testEnforcingToggle`

Without this patch it runs the test 3 times. With this patch it does not retry at all.