### PR TITLE
tools: Force a "make" run after incremental webpacking

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -80,8 +80,20 @@ function process_result(err, stats) {
         return;
     }
 
-    if (makefile)
-        generateDeps(makefile, stats);
+    if (makefile) {
+        if (!ops.watch)
+            generateDeps(makefile, stats);
+        else {
+            // Force "make" to re-create everything.  The results of
+            // incremental building are not good enough for building
+            // RPMs, for example.
+            var stamp = makefile.split("/").slice(0, -1).concat(["stamp"]).join("/");
+            if (fs.existsSync(makefile))
+                fs.unlinkSync(makefile);
+            if (fs.existsSync(stamp))
+                fs.unlinkSync(stamp);
+        }
+    }
 }
 
 function generateDeps(makefile, stats) {


### PR DESCRIPTION
The results of incremental runs of webpack are not really good enough
for 'official' things like creating images for CI.  For example, the
_OUTPUT and _INSTALL variables in Makefile.deps are not always
correct.