### PR TITLE
test: Avoid libvirtd crash in TestMachines.testLibvirt, some more test fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -994,6 +994,7 @@ class MachineCase(unittest.TestCase):
 
         # Something crashed, but we don't have more info. Don't fail on that
         "Failed to generate stack trace: \(null\)",
+        "Failed to get (COMM|EXE).*: No such process",
 
         # The usual sudo finger wagging
         "We trust you have received the usual lecture from the local System",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -993,7 +993,7 @@ class MachineCase(unittest.TestCase):
         "Failed to send coredump datagram:.*",
 
         # Something crashed, but we don't have more info. Don't fail on that
-        "Failed to generate stack trace: (null)",
+        "Failed to generate stack trace: \(null\)",
 
         # The usual sudo finger wagging
         "We trust you have received the usual lecture from the local System",

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -400,7 +400,12 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             m.execute("systemctl stop libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
             self.addCleanup(m.execute, "systemctl start libvirtd-ro.socket libvirtd.socket libvirtd-admin.socket")
 
+        def hack_libvirtd_crash():
+            # work around libvirtd crashing when stopped too quickly; https://bugzilla.redhat.com/show_bug.cgi?id=1828207
+            m.execute("virsh domifaddr 1")
+
         m.execute("systemctl disable {0}".format(libvirtServiceName))
+        hack_libvirtd_crash()
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
         b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
@@ -413,8 +418,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
         b.wait_in_text("body", "Virtual Machines")
         with b.wait_timeout(15):
+            b.wait_not_present(".pf-c-empty-state")
             b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
+        hack_libvirtd_crash()
         m.execute("systemctl stop {0}".format(libvirtServiceName))
         b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")
         b.wait_present("#enable-libvirt:checked")
@@ -427,9 +434,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
         b.wait_in_text("body", "Virtual Machines")
         with b.wait_timeout(15):
+            b.wait_not_present(".pf-c-empty-state")
             b.wait_in_text("tbody tr[data-row-id=vm-subVmTest1] th", "subVmTest1")
 
         m.execute("systemctl enable {0}".format(libvirtServiceName))
+        hack_libvirtd_crash()
         m.execute("systemctl stop {0}".format(libvirtServiceName))
 
         b.wait_in_text(".pf-c-empty-state", "Virtualization Service (libvirt) is Not Active")

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -132,6 +132,8 @@ class CommonTests:
         b.click(".service-top-panel .dropdown-kebab-pf button")
         b.click(".service-top-panel .dropdown-menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
+        # stopping the unit may interrupt the D-Bus proxy inspection of that unit
+        self.allow_journal_messages(".*systemd1:.*systemd_2dtmpfiles_2dclean_2etimer: Timeout was reached")
         b.logout()
 
         # should also work with capitalized domain and lower-case user (fixed in PR #13934)

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -30,6 +30,8 @@ class TestTerminal(MachineCase):
         m = self.machine
         b.default_user = "admin"
 
+        self.allow_journal_messages(".*external channel failed: terminated")
+
         # Make sure we get what we expect
         m.write("/tmp/bashrc-extra", """
 PS1="\\u@\\h \\W]\$ "


### PR DESCRIPTION
libvirtd often crashes when stopping it right after starting [1]. As a
workaround, be a little less demanding, and wait for domain interfaces
to have initialized before stopping the service again.

Also make sure that the page recognized that the service started up
again and the empty state goes away.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1828207

Fixes #12978