### PR TITLE
shell: Rename "Authentication" to "SSH Keys"

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -61,7 +61,7 @@
                   </li>
                   <li>
                       <a role="link" tabindex="0" data-toggle="modal" data-target="#credentials-dialog"
-                          id="credentials-item" translate="yes">Authentication</a>
+                          id="credentials-item" translate="yes">SSH Keys</a>
                   </li>
                   <li>
                     <a role="link" tabindex="0" id="go-logout" translate="yes">Log Out</a>
@@ -159,7 +159,7 @@
             <div class="modal-dialog">
                 <div class="modal-content">
                     <div class="modal-header">
-                        <h4 class="modal-title" translate="yes">Authentication</h4>
+                        <h4 class="modal-title" translate="yes">SSH Keys</h4>
                     </div>
                     <div class="modal-body">
                         <table class="listing-ct">


### PR DESCRIPTION
The dialog does nothing else now.