### PR TITLE
Enable going from embedded logs panel to specific log entries

### DIFF
--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -60,15 +60,15 @@
     width: 2.5rem;
 }
 
-.cockpit-log-panel > .cockpit-logline:hover {
+.cockpit-log-panel .cockpit-logline:hover {
     background-color: var(--color-ct-list-hover-bg);
 }
 
-.cockpit-log-panel > .cockpit-logline:hover .cockpit-log-message {
+.cockpit-log-panel .cockpit-logline:hover .cockpit-log-message {
     color: var(--color-ct-list-hover-text);
 }
 
-.cockpit-log-panel > .cockpit-logline:hover {
+.cockpit-log-panel .cockpit-logline:hover {
     cursor: pointer;
 }
 

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -534,9 +534,25 @@ journal.renderer = function renderer(funcs_or_box) {
     };
 };
 
-journal.logbox = function logbox(match, max_entries) {
+journal.logbox = function logbox(match, max_entries, search_options) {
     var entries = [];
     var box = document.createElement("div");
+    box.addEventListener("click", goto_log);
+    box.addEventListener("keypress", goto_log);
+
+    function goto_log(ev) {
+        // only consider primary mouse button for clicks
+        if (ev.type === 'click' && ev.button !== 0)
+            return;
+
+        // only consider enter button for keyboard events
+        if (ev.type === 'keypress' && ev.key !== "Enter")
+            return;
+
+        const cursor = ev.target.closest(".cockpit-logline").getAttribute("data-cursor");
+        if (cursor)
+            cockpit.jump("system/logs#/" + cursor + "?parent_options=" + JSON.stringify(search_options || {}));
+    }
 
     function render() {
         var renderer = journal.renderer(box);

--- a/pkg/lib/journal_line.mustache
+++ b/pkg/lib/journal_line.mustache
@@ -1,4 +1,4 @@
-<div class="cockpit-logline" data-cursor="{{cursor}}" role="row">
+<div class="cockpit-logline" data-cursor="{{cursor}}" role="row" tabindex="0">
   <div class="cockpit-log-warning" role="cell">{{#warning}}
     <i class="fa fa-exclamation-triangle"></i>
   {{/warning}}{{#problem}}

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1729,7 +1729,8 @@ PageNetworking.prototype = {
 
     enter: function () {
         this.log_box = journal.logbox(["_SYSTEMD_UNIT=NetworkManager.service",
-            "_SYSTEMD_UNIT=firewalld.service"], 10);
+            "_SYSTEMD_UNIT=firewalld.service"], 10,
+                                      { prio: "debug", _SYSTEMD_UNIT: "NetworkManager.service,firewalld.service" });
         $('#networking-log').empty()
                 .append(this.log_box);
 

--- a/pkg/storaged/logs-panel.jsx
+++ b/pkg/storaged/logs-panel.jsx
@@ -34,8 +34,8 @@ export class StorageLogsPanel extends React.Component {
             "_SYSTEMD_UNIT=multipathd.service"
         ];
 
+        const search_options = { prio: "debug", _SYSTEMD_UNIT: "storaged.service,udisks2.service,dm-event.service,smartd.service,multipathd.service" };
         const url = "/system/logs/#/?prio=debug&_SYSTEMD_UNIT=storaged.service,udisks2.service,dm-event.service,smartd.service,multipathd.service";
-
-        return <LogsPanel title={_("Storage Logs")} match={match} max={10} goto_url={url} />;
+        return <LogsPanel title={_("Storage Logs")} match={match} max={10} search_options={search_options} goto_url={url} />;
     }
 }

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -976,6 +976,15 @@ $(function() {
             cockpit.location.go([cursor], { parent_options: JSON.stringify(cockpit.location.options) });
     });
 
+    $('#journal-box').on('keypress', '.cockpit-logline', function(ev) {
+        if (ev.key !== "Enter")
+            return;
+
+        var cursor = $(this).attr('data-cursor');
+        if (cursor)
+            cockpit.location.go([cursor], { parent_options: JSON.stringify(cockpit.location.options) });
+    });
+
     $('#journal-current-day-menu').on('change', function() {
         const options = parse_search(document.getElementById("journal-grep").value);
         update_services_list = true;

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -110,7 +110,7 @@ export class Service extends React.Component {
                 </PageSection>
                 {!this.cur_unit_is_template && (this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") &&
                 <PageSection variant={PageSectionVariants.light}>
-                    <LogsPanel title={_("Service Logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} />
+                    <LogsPanel title={_("Service Logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", service: cur_unit_id }} />
                 </PageSection>}
             </Page>
         );

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -274,6 +274,19 @@ Unit=test.service
             b.enter_page("/system/logs")
             b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
             b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(3)", "START")
+            # Debian supports grep only from 19.10, see https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1751006
+            if m.image != "debian-stable":
+                b.wait_val("#journal-grep", "priority:debug service:test.service ")
+            b.go("/system/services#test.service")
+            b.enter_page("/system/services")
+
+            b.click(".cockpit-logline:contains('WORKING')")
+            b.enter_page("/system/logs")
+            b.wait_text("#journal-entry-message", "WORKING")
+            b.click("#journal-navigate-home")
+            # Debian supports grep only from 19.10, see https://bugs.launchpad.net/ubuntu/+source/systemd/+bug/1751006
+            if m.image != "debian-stable":
+                b.wait_val("#journal-grep", "priority:debug service:test.service ")
             b.go("/system/services#test.service")
             b.enter_page("/system/services")
 


### PR DESCRIPTION
Also making sure that 'Logs' breadcrumb on logs page correctly shows
filters that were applied in the box.

Keyboard navigation and activation is also supported. Both in embedded
logs as well as on the logs page.

Fixes #1113