### PR TITLE
packagekit: Reload Software Updates page on superuser changes, some code cleanup

### DIFF
--- a/pkg/lib/superuser.jsx
+++ b/pkg/lib/superuser.jsx
@@ -38,18 +38,18 @@ import cockpit from "cockpit";
  * and it should also re-initialize itself by opening all "superuser"
  * channels again that are currently open.
  *
- * - superuser.reload_on_change()
+ * - superuser.reload_page_on_change()
  *
  * Calling this function instructs the "superuser" object to reload
  * the page whenever "superuser.allowed" changes. This is a (bad)
  * alternative to re-initializing the page and intended to be used
  * only to help with the transition.
  *
- * Even if you are using "superuser.reload_on_change" to avoid having
+ * Even if you are using "superuser.reload_page_on_change" to avoid having
  * to re-initialize your page dynamically, you should still use the
  * "changed" event to update the page appearance since
  * "superuser.allowed" might still change a couple of times right
- * after page.
+ * after page reload.
  */
 
 function Superuser() {

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -19,6 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
+import PropTypes from 'prop-types';
 import { debounce } from "throttle-debounce";
 
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
@@ -355,3 +356,7 @@ export default class AutoUpdates extends React.Component {
             </div>);
     }
 }
+
+AutoUpdates.propTypes = {
+    onInitialized: PropTypes.func,
+};

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -115,7 +115,7 @@ function cleanupChangelogLine(text) {
     return text.trim();
 }
 
-function Expander({ title, onExpand, children }) {
+const Expander = ({ title, onExpand, children }) => {
     const [expanded, setExpanded] = useState(false);
 
     useEffect(() => {
@@ -135,7 +135,7 @@ function Expander({ title, onExpand, children }) {
             </div>
             {expanded ? children : null}
         </>);
-}
+};
 
 function count_security_updates(updates) {
     var num_security = 0;
@@ -153,51 +153,51 @@ function find_highest_severity(updates) {
     return max;
 }
 
-function HeaderBar(props) {
-    var num_updates = Object.keys(props.updates).length;
-    var num_security = 0;
-    var state;
+const HeaderBar = ({ state, updates, timeSinceRefresh, onRefresh, unregistered, allowCancel, onCancel }) => {
+    const num_updates = Object.keys(updates).length;
+    let num_security = 0;
+    let state_str;
 
     // unregistered & no available updates → blank slate, no header bar
-    if (props.unregistered && props.state == "uptodate")
+    if (unregistered && state == "uptodate")
         return null;
 
-    if (props.state == "available") {
-        num_security = count_security_updates(props.updates);
+    if (state == "available") {
+        num_security = count_security_updates(updates);
         if (num_updates == num_security)
-            state = cockpit.ngettext("$1 security fix", "$1 security fixes", num_security);
+            state_str = cockpit.ngettext("$1 security fix", "$1 security fixes", num_security);
         else {
-            state = cockpit.ngettext("$0 update", "$0 updates", num_updates);
+            state_str = cockpit.ngettext("$0 update", "$0 updates", num_updates);
             if (num_security > 0)
-                state += cockpit.ngettext(", including $1 security fix", ", including $1 security fixes", num_security);
+                state_str += cockpit.ngettext(", including $1 security fix", ", including $1 security fixes", num_security);
         }
-        state = cockpit.format(state, num_updates, num_security);
+        state_str = cockpit.format(state_str, num_updates, num_security);
     } else {
-        state = STATE_HEADINGS[props.state];
+        state_str = STATE_HEADINGS[state];
     }
 
-    if (!state)
+    if (!state_str)
         return null;
 
-    var lastChecked;
-    var actionButton;
-    if (props.state == "uptodate" || props.state == "available") {
-        if (!props.unregistered)
-            actionButton = <Button variant="secondary" onClick={props.onRefresh}>{_("Check for Updates")}</Button>;
-        if (props.timeSinceRefresh !== null)
-            lastChecked = cockpit.format(_("Last checked: $0"), moment(moment().valueOf() - props.timeSinceRefresh * 1000).fromNow());
-    } else if (props.state == "applying") {
-        actionButton = <Button variant="link" onClick={props.onCancel} isDisabled={!props.allowCancel}>{_("Cancel")}</Button>;
+    let lastChecked;
+    let actionButton;
+    if (state == "uptodate" || state == "available") {
+        if (!unregistered)
+            actionButton = <Button variant="secondary" onClick={onRefresh}>{_("Check for Updates")}</Button>;
+        if (timeSinceRefresh !== null)
+            lastChecked = cockpit.format(_("Last checked: $0"), moment(moment().valueOf() - timeSinceRefresh * 1000).fromNow());
+    } else if (state == "applying") {
+        actionButton = <Button variant="link" onClick={onCancel} isDisabled={!allowCancel}>{_("Cancel")}</Button>;
     }
 
     return (
         <div className="content-header-extra">
-            <div id="state" className="content-header-extra--state">{state}</div>
+            <div id="state" className="content-header-extra--state">{state_str}</div>
             <div className="content-header-extra--updated">{lastChecked}</div>
             <div className="content-header-extra--action">{actionButton}</div>
         </div>
     );
-}
+};
 
 function getSeverityURL(urls) {
     if (!urls)
@@ -231,7 +231,7 @@ class UpdateItem extends React.Component {
     render() {
         const info = this.props.info;
 
-        var bugs = null;
+        let bugs = null;
         if (info.bug_urls && info.bug_urls.length) {
             // we assume a bug URL ends with a number; if not, show the complete URL
             bugs = insertCommas(info.bug_urls.map(url => (
@@ -241,7 +241,7 @@ class UpdateItem extends React.Component {
             ));
         }
 
-        var cves = null;
+        let cves = null;
         if (info.cve_urls && info.cve_urls.length) {
             cves = insertCommas(info.cve_urls.map(url => (
                 <a key={url} href={url} rel="noopener noreferrer" target="_blank">
@@ -250,7 +250,7 @@ class UpdateItem extends React.Component {
             ));
         }
 
-        var errata = null;
+        let errata = null;
         if (info.vendor_urls) {
             errata = insertCommas(info.vendor_urls.filter(url => url.indexOf("/errata/") > 0).map(url => (
                 <a key={url} href={url} rel="noopener noreferrer" target="_blank">
@@ -261,10 +261,10 @@ class UpdateItem extends React.Component {
                 errata = null; // simpler testing below
         }
 
-        var secSeverityURL = getSeverityURL(info.vendor_urls);
-        var secSeverity = secSeverityURL ? secSeverityURL.slice(secSeverityURL.indexOf("#") + 1) : null;
-        var iconClasses = PK.getSeverityIcon(info.severity, secSeverity);
-        var type;
+        let secSeverityURL = getSeverityURL(info.vendor_urls);
+        const secSeverity = secSeverityURL ? secSeverityURL.slice(secSeverityURL.indexOf("#") + 1) : null;
+        const iconClasses = PK.getSeverityIcon(info.severity, secSeverity);
+        let type;
         if (info.severity === PK.Enum.INFO_SECURITY) {
             if (secSeverityURL)
                 secSeverityURL = <a rel="noopener noreferrer" target="_blank" href={secSeverityURL}>{secSeverity}</a>;
@@ -286,21 +286,21 @@ class UpdateItem extends React.Component {
                 </>);
         }
 
-        var pkgList = this.props.pkgNames.map(n => (
+        const pkgList = this.props.pkgNames.map(n => (
             <OverlayTrigger key={n.name + n.arch} overlay={ <Tooltip id="tip-summary">{packageSummaries[n.name] + " (" + n.arch + ")"}</Tooltip> } placement="top">
                 <span>{n.name}</span>
             </OverlayTrigger>)
         );
-        var pkgs = insertCommas(pkgList);
-        var pkgsTruncated = pkgs;
+        const pkgs = insertCommas(pkgList);
+        let pkgsTruncated = pkgs;
         if (pkgList.length > 4)
             pkgsTruncated = insertCommas(pkgList.slice(0, 4).concat("…"));
 
-        var descriptionFirstLine = (info.description || "").trim();
+        let descriptionFirstLine = (info.description || "").trim();
         if (descriptionFirstLine.indexOf("\n") >= 0)
             descriptionFirstLine = descriptionFirstLine.slice(0, descriptionFirstLine.indexOf("\n"));
         descriptionFirstLine = cleanupChangelogLine(descriptionFirstLine);
-        var description;
+        let description;
         if (info.markdown) {
             descriptionFirstLine = <span dangerouslySetInnerHTML={{ __html: this.remarkable.render(descriptionFirstLine) }} />;
             description = <div dangerouslySetInnerHTML={{ __html: this.remarkable.render(info.description) }} />;
@@ -308,7 +308,7 @@ class UpdateItem extends React.Component {
             description = <div className="changelog">{info.description}</div>;
         }
 
-        var details = null;
+        let details = null;
         if (this.state.expanded) {
             details = (
                 <tr className="listing-ct-panel">
@@ -353,15 +353,15 @@ class UpdateItem extends React.Component {
     }
 }
 
-function UpdatesList(props) {
-    var updates = [];
+const UpdatesList = ({ updates }) => {
+    const update_ids = [];
 
     // PackageKit doesn"t expose source package names, so group packages with the same version and changelog
     // create a reverse version+changes → [id] map on iteration
-    var sameUpdate = {};
-    var packageNames = {};
-    Object.keys(props.updates).forEach(id => {
-        const u = props.updates[id];
+    const sameUpdate = {};
+    const packageNames = {};
+    Object.keys(updates).forEach(id => {
+        const u = updates[id];
         // did we already see the same version and description? then merge
         const hash = u.version + u.description;
         const seenId = sameUpdate[hash];
@@ -371,15 +371,15 @@ function UpdatesList(props) {
             // this is a new update
             sameUpdate[hash] = id;
             packageNames[id] = [{ name: u.name, arch: u.arch }];
-            updates.push(id);
+            update_ids.push(id);
         }
     });
 
     // sort security first
-    updates.sort((a, b) => {
-        if (props.updates[a].severity === PK.Enum.INFO_SECURITY && props.updates[b].severity !== PK.Enum.INFO_SECURITY)
+    update_ids.sort((a, b) => {
+        if (updates[a].severity === PK.Enum.INFO_SECURITY && updates[b].severity !== PK.Enum.INFO_SECURITY)
             return -1;
-        if (props.updates[a].severity !== PK.Enum.INFO_SECURITY && props.updates[b].severity === PK.Enum.INFO_SECURITY)
+        if (updates[a].severity !== PK.Enum.INFO_SECURITY && updates[b].severity === PK.Enum.INFO_SECURITY)
             return 1;
         return a.localeCompare(b);
     });
@@ -395,10 +395,10 @@ function UpdatesList(props) {
                     <th scope="col">{_("Details")}</th>
                 </tr>
             </thead>
-            { updates.map(id => <UpdateItem key={id} pkgNames={packageNames[id].sort((a, b) => a.name > b.name)} info={props.updates[id]} />) }
+            { update_ids.map(id => <UpdateItem key={id} pkgNames={packageNames[id].sort((a, b) => a.name > b.name)} info={updates[id]} />) }
         </table>
     );
-}
+};
 
 class ApplyUpdates extends React.Component {
     constructor() {

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -27,11 +27,13 @@ import { OverlayTrigger, Tooltip } from "patternfly-react";
 import { Button } from '@patternfly/react-core';
 import { RebootingIcon, CheckIcon, ExclamationCircleIcon } from "@patternfly/react-icons";
 import { Remarkable } from "remarkable";
+
 import AutoUpdates from "./autoupdates.jsx";
 import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
+import { superuser } from 'superuser.jsx';
 import * as PK from "packagekit.js";
 
 import "listing.scss";
@@ -71,6 +73,8 @@ function init() {
         [PK.Enum.STATUS_CLEANUP]: _("Set up"),
         [PK.Enum.STATUS_SIGCHECK]: _("Verified"),
     };
+
+    superuser.reload_page_on_change();
 }
 
 // parse CVEs from an arbitrary text (changelog) and return URL array

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -600,6 +600,49 @@ class TestUpdates(NoSubManCase):
         b.wait_text(self.update_text, "Loading available updates failed")
         self.assertIn("exclamation", b.attr(self.update_icon, "class"))
 
+    @skipImage("superuser changing added in PR #13482", "rhel-8-2-distropkg")
+    def testUnprivileged(self):
+        b = self.browser
+        m = self.machine
+
+        self.createPackage("vanilla", "1.0", "1", install=True)
+        self.createPackage("vanilla", "2.0", "2")
+        self.enableRepo()
+        m.execute("pkcon refresh")
+
+        # getting update info is allowed to all users
+        self.login_and_go("/updates", superuser=False)
+        b.wait_text("#state", "1 update")
+        b.wait_in_text("#available h2", "Available Updates")
+
+        # but applying updates is not; FIXME: this is a crappy UX
+        b.click("#app .container-fluid button")
+        b.wait_text("#state", "Applying updates failed")
+        b.wait_in_text(".container-fluid pre", "authentication")
+
+        # become superuser
+        b.switch_to_top()
+        b.click("#super-user-indicator button")
+        b.wait_in_text(".modal-dialog:contains('Administrative access')", "Please authenticate")
+        b.set_input_text(".modal-dialog:contains('Administrative access') input", "foobar")
+        b.click(".modal-dialog button:contains('Authenticate')")
+        b.wait_not_present(".modal-dialog:contains('Administrative access')")
+        b.wait_text("#super-user-indicator", "Administrative access")
+
+        # page reloads automatically
+        b.switch_to_frame("cockpit1:localhost/updates")
+        b.wait_text("#state", "1 update")
+        b.wait_in_text("#available h2", "Available Updates")
+
+        # applying updates works now
+        b.click("#app .container-fluid button")
+
+        b.wait_in_text("#app .container-fluid h1", "Restart Recommended")
+        self.assertEqual(b.text("#app .container-fluid button.pf-m-primary"), "Restart Now")
+        b.click("#app .container-fluid button.pf-m-link:contains('Ignore')")
+
+        # should go back to updates overview, nothing pending any more
+        b.wait_in_text("#state", "No updates pending")
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 class TestWsUpdate(NoSubManCase):


### PR DESCRIPTION
The page currently relies entirely on polkit permissions for PackageKit
calls. Make sure that everything gets reinitialized when superuser
status changes. This is a blunt and simple fix for now, this will be
refined later.
