### PR TITLE
packagekit: Better reaction to superuser changes

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -18,6 +18,7 @@
  */
 
 import cockpit from "cockpit";
+import { superuser } from 'superuser.jsx';
 
 const _ = cockpit.gettext;
 
@@ -78,6 +79,9 @@ function dbus_client() {
 
     return _dbus_client;
 }
+
+// Reconnect when privileges change
+superuser.addEventListener("changed", () => { _dbus_client = null });
 
 /**
  * Call a PackageKit method

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -287,11 +287,12 @@ export default class AutoUpdates extends React.Component {
     }
 
     render() {
-        var backend = this.state.backend;
+        const backend = this.state.backend;
         if (!backend)
             return null;
 
-        var autoConfig;
+        let autoConfig;
+        const enabled = !this.state.pending && this.props.privileged;
 
         if (backend.enabled && backend.installed) {
             const hours = Array.from(Array(24).keys());
@@ -299,7 +300,7 @@ export default class AutoUpdates extends React.Component {
             autoConfig = (
                 <div className="auto-conf">
                     <span className="auto-conf-group">
-                        <Select.Select id="auto-update-type" enabled={!this.state.pending} initial={backend.type}
+                        <Select.Select id="auto-update-type" enabled={enabled} initial={backend.type}
                                        onChange={ t => this.handleChange(null, t, null, null) }>
                             <Select.SelectEntry data="all">{_("Apply all updates")}</Select.SelectEntry>
                             <Select.SelectEntry data="security">{_("Apply security updates")}</Select.SelectEntry>
@@ -307,7 +308,7 @@ export default class AutoUpdates extends React.Component {
                     </span>
 
                     <span className="auto-conf-group">
-                        <Select.Select id="auto-update-day" initial={backend.day}
+                        <Select.Select id="auto-update-day" enabled={enabled} initial={backend.day}
                                        onChange={ d => this.handleChange(null, null, d, null) }>
                             <Select.SelectEntry data="">{_("every day")}</Select.SelectEntry>
                             <Select.SelectDivider />
@@ -324,7 +325,7 @@ export default class AutoUpdates extends React.Component {
                     <span className="auto-conf-group">
                         <span className="auto-conf-text">{_("at")}</span>
 
-                        <Select.Select id="auto-update-time" initial={backend.time}
+                        <Select.Select id="auto-update-time" enabled={enabled} initial={backend.time}
                                        onChange={ t => this.handleChange(null, null, null, t) }>
                             { hours.map(h => <Select.SelectEntry key={h} data={h + ":00"}>{('0' + h).slice(-2) + ":00"}</Select.SelectEntry>)}
                         </Select.Select>
@@ -342,7 +343,7 @@ export default class AutoUpdates extends React.Component {
             <div className="header-buttons pk-updates--header pk-updates--header--auto" id="automatic">
                 <h2 className="pk-updates--header--heading">{_("Automatic Updates")}</h2>
                 <div className="pk-updates--header--actions">
-                    <OnOffSwitch state={onOffState} disabled={this.state.pending}
+                    <OnOffSwitch state={onOffState} disabled={!enabled}
                                  onChange={e => {
                                      if (!this.state.backend.installed) {
                                          install_dialog(this.state.backend.packageName)
@@ -358,5 +359,6 @@ export default class AutoUpdates extends React.Component {
 }
 
 AutoUpdates.propTypes = {
+    privileged: PropTypes.bool.isRequired,
     onInitialized: PropTypes.func,
 };

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -530,6 +530,7 @@ class OsUpdates extends React.Component {
             allowCancel: null,
             history: [],
             unregistered: false,
+            privileged: false,
             autoUpdatesEnabled: undefined
         };
         this.handleLoadError = this.handleLoadError.bind(this);
@@ -537,8 +538,9 @@ class OsUpdates extends React.Component {
         this.handleRestart = this.handleRestart.bind(this);
         this.loadUpdates = this.loadUpdates.bind(this);
 
-        // get out of error state when switching from unprivileged to privileged
         superuser.addEventListener("changed", () => {
+            this.setState({ privileged: superuser.allowed });
+            // get out of error state when switching from unprivileged to privileged
             if (superuser.allowed && this.state.state.indexOf("Error") >= 0)
                 this.loadUpdates();
         });
@@ -878,7 +880,7 @@ class OsUpdates extends React.Component {
             return (
                 <div className="pk-updates">
                     {unregisteredWarning}
-                    <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } />
+                    <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } privileged={this.state.privileged} />
                     <div id="available" className="pk-updates--header">
                         <h2 className="pk-updates--header--heading">{_("Available Updates")}</h2>
                         <div className="pk-updates--header--actions">
@@ -945,7 +947,7 @@ class OsUpdates extends React.Component {
 
             return (
                 <>
-                    <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } />
+                    <AutoUpdates onInitialized={ enabled => this.setState({ autoUpdatesEnabled: enabled }) } privileged={this.state.privileged} />
                     <EmptyStatePanel icon={CheckIcon} title={ _("System is up to date") } />
 
                     { // automatic updates are not tracked by PackageKit, hide history when they are enabled

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -73,8 +73,6 @@ function init() {
         [PK.Enum.STATUS_CLEANUP]: _("Set up"),
         [PK.Enum.STATUS_SIGCHECK]: _("Verified"),
     };
-
-    superuser.reload_page_on_change();
 }
 
 // parse CVEs from an arbitrary text (changelog) and return URL array
@@ -538,6 +536,12 @@ class OsUpdates extends React.Component {
         this.handleRefresh = this.handleRefresh.bind(this);
         this.handleRestart = this.handleRestart.bind(this);
         this.loadUpdates = this.loadUpdates.bind(this);
+
+        // get out of error state when switching from unprivileged to privileged
+        superuser.addEventListener("changed", () => {
+            if (superuser.allowed && this.state.state.indexOf("Error") >= 0)
+                this.loadUpdates();
+        });
     }
 
     componentDidMount() {

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -629,7 +629,7 @@ class TestUpdates(NoSubManCase):
         b.wait_not_present(".modal-dialog:contains('Administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
 
-        # page reloads automatically
+        # page adjusts automatically to privilege change
         b.switch_to_frame("cockpit1:localhost/updates")
         b.wait_text("#state", "1 update")
         b.wait_in_text("#available h2", "Available Updates")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1045,6 +1045,53 @@ class TestAutoUpdates(NoSubManCase):
         else:
             raise NotImplementedError(self.backend)
 
+    @skipImage("superuser changing added in PR #13482", "rhel-8-2-distropkg")
+    def testPrivilegeChange(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("pkcon refresh")
+
+        self.login_and_go("/updates", superuser=False)
+
+        if not self.supported_backend:
+            self.assertFalse(b.is_present("#automatic"))
+            self.assertFalse(b.is_present("#auto-update-type"))
+            return
+
+        # detecting auto updates configuration works unprivileged, but changing does not
+        b.wait_present("#automatic .onoff-ct input:disabled:not(:checked)")
+
+        # become superuser
+        b.switch_to_top()
+        b.click("#super-user-indicator button")
+        b.wait_in_text(".modal-dialog:contains('Administrative access')", "Please authenticate")
+        b.set_input_text(".modal-dialog:contains('Administrative access') input", "foobar")
+        b.click(".modal-dialog button:contains('Authenticate')")
+        b.wait_not_present(".modal-dialog:contains('Administrative access')")
+        b.wait_text("#super-user-indicator", "Administrative access")
+        b.switch_to_frame("cockpit1:localhost/updates")
+
+        # enable auto-updates
+        b.wait_present("#automatic .onoff-ct input:not(:checked)")
+        b.wait_not_present("#auto-update-type")
+        b.click("#automatic .onoff-ct input")
+        b.wait_present("#automatic .onoff-ct input:checked")
+        b.wait_present("#auto-update-type:not(:disabled)")
+
+        # Drop privileges
+        b.switch_to_top()
+        b.click("#super-user-indicator button")
+        b.click(".modal-dialog:contains('Switch to limited access') button:contains('Limit access')")
+        b.wait_not_present(".modal-dialog:contains('Switch to limited access')")
+        b.wait_text("#super-user-indicator", "Limited access")
+        b.switch_to_frame("cockpit1:localhost/updates")
+
+        # auto-update status still visible, but disabled
+        b.wait_present("#automatic .onoff-ct input:checked")
+        b.wait_present("#automatic .onoff-ct input:disabled")
+        b.wait_present("#auto-update-type:disabled")
+
     def checkUpgradeRebootDnf(self):
         """part of testWithAvailableUpdates() for dnf backend"""
 


### PR DESCRIPTION
This properly reacts to superuser changes instead of reloading the page, and also disables auto-updates when unprivileged.

 - [x] Builds on top of #14053 

@mvollmer, of course we can also directly land this instead of #14053 if you prefer.