### PR TITLE
test: Fix SELinux context of fake /proc/cmdline

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -504,7 +504,7 @@ class TestSystemInfo(MachineCase):
             m.execute('chmod +x /usr/local/bin/lscpu')
             if cmdline:
                 m.write('/run/cmdline', cmdline)
-                m.execute('mount --bind /run/cmdline /proc/cmdline')
+                m.execute('if type chcon >/dev/null 2>&1; then chcon --reference /proc/cmdline /run/cmdline; fi && mount --bind /run/cmdline /proc/cmdline')
 
             b.reload()
             b.enter_page('/system/hwinfo')


### PR DESCRIPTION
This avoids violations of systemd-gpt-generator and possibly other
things that try to parse it.