### PR TITLE
test: Fix chcon test

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -504,7 +504,7 @@ class TestSystemInfo(MachineCase):
             m.execute('chmod +x /usr/local/bin/lscpu')
             if cmdline:
                 m.write('/run/cmdline', cmdline)
-                m.execute('if type chcon >/dev/null 2>&1; then chcon --reference /proc/cmdline /run/cmdline; fi && mount --bind /run/cmdline /proc/cmdline')
+                m.execute('if selinuxenabled 2>/dev/null; then chcon --reference /proc/cmdline /run/cmdline; fi && mount --bind /run/cmdline /proc/cmdline')
 
             b.reload()
             b.enter_page('/system/hwinfo')

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -169,7 +169,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
         cp -a /usr/sbin/dhclient {0}/dhclient.real
         printf '#!/bin/sh\\nsleep {1}\\nexec {0}/dhclient.real "$@"' > {0}/dhclient
         chmod a+x {0}/dhclient
-        if type chcon >/dev/null 2>&1; then chcon --reference /usr/sbin/dhclient {0}/dhclient; fi
+        if selinuxenabled 2>&1; then chcon --reference /usr/sbin/dhclient {0}/dhclient; fi
         mount -o bind {0}/dhclient /usr/sbin/dhclient
         """.format(self.vm_tmpdir, delay))
         self.addCleanup(self.machine.execute, "umount /usr/sbin/dhclient")


### PR DESCRIPTION
Commit 30cf873d105d880 introduced a chcon into check-system-info.
Debian/Ubuntu images do ship chcon, but don't enable SELinux, so this
failed. Use `selinuxenabled` instead like in check-connection. Also
update `slow_down_dhclient()` (where this was copied from) to
consistently use the same approach to guard chcon.