### PR TITLE
Machines color selector

### DIFF
--- a/pkg/lib/machine-color-picker.html
+++ b/pkg/lib/machine-color-picker.html
@@ -1,14 +1,11 @@
-<div>
-    <div id="host-edit-color" data-toggle="dropdown"></div>
+<div id="host-edit-color" data-toggle="dropdown" tabindex="0">
     <div id="host-edit-color-popover" class="popover in" tabindex="-1">
-        <div class="arrow"></div>
+        <div class="ct-popover-arrow"></div>
         <div class="popover-content">
             {{#colors}}
-            <div>
                 {{#list}}
-                <div class="color-cell"></div>
+                    <div class="color-cell" tabindex="0"></div>
                 {{/list}}
-            </div>
             {{/colors}}
         </div>
         <div class="arrow"></div>

--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -317,26 +317,7 @@ function MachineColorPicker(machines_ins) {
 
         $("#host-edit-color", selector).parent()
                 .on('show.bs.dropdown', function () {
-                    var $div = $('#host-edit-color', selector);
-                    var $pop = $('#host-edit-color-popover', selector);
-                    var div_pos = $div.position();
-                    var div_width = $div.width();
-                    var div_height = $div.height();
-                    var pop_width = $pop.width();
-                    var pop_height = $pop.height();
-
-                    var top = div_pos.top - pop_height + 10;
-                    if (top < 0) {
-                        top = div_pos.top + div_height + 10;
-                        $pop.addClass("bottom");
-                        $pop.removeClass("top");
-                    } else {
-                        $pop.addClass("top");
-                        $pop.removeClass("bottom");
-                    }
-                    $pop.css('left', div_pos.left + (div_width - pop_width) / 2);
-                    $pop.css('top', top);
-                    $pop.show();
+                    $('#host-edit-color-popover', selector).show();
                 })
                 .on('hide.bs.dropdown', function () {
                     $('#host-edit-color-popover', selector).hide();

--- a/pkg/lib/machine-dialogs.scss
+++ b/pkg/lib/machine-dialogs.scss
@@ -1,26 +1,77 @@
 #host-edit-color {
-    width:100px;
-    height:26px;
+    position: relative;
+    width: 7rem;
+    height: 1.5rem;
+    border-radius: var(--pf-global--BorderRadius--sm);
+
+    &:not(:hover):not(:focus) {
+        box-shadow: inset 0 0 0 1px var(--pf-global--BorderColor--100);
+    }
+
+    &:hover,
+    &:focus,
+    &-popover .color-cell:hover,
+    &-popover .color-cell:focus {
+        cursor: pointer;
+        box-shadow: inset 0 0 0 3px #3337;
+    }
+    &-popover .color-cell:not(:hover):not(:focus) {
+        box-shadow: inset 0 0 0 3px #fff;
+    }
 }
 
-#host-edit-color-popover .popover-content {
-    text-align: center;
-    padding: 0.5rem;
-}
+#host-edit-color-popover {
+    --border-color: var(--pf-global--BorderColor--200);
+    border-color: var(--border-color);
+    box-shadow: var(--pf-global--BoxShadow--sm) !important;
+    top: calc(100% + var(--pf-global--spacer--sm));
+    right: auto;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 0.5rem;
+    // PF3 defines a max width; we unset it to allow the dialog to size itself
+    max-width: auto;
 
-#host-edit-color-popover .popover-content > div {
-    display: flex;
-}
+    .ct-popover-arrow {
+        --arrow-size: 11px;
+        --arrow-color: var(--border-color);
+        position: absolute;
+        transform: translateX(-50%);
+        top: calc(var(--arrow-size) * -1);
+        width: 0;
+        height: 0;
+        left: 50%;
 
-#host-edit-color-popover .color-cell {
-    display: inline-block;
-    width: 2rem;
-    height: 2rem;
-    margin: 1px;
-}
+        &, &::after {
+            border: 0 solid transparent;
+            border-width: var(--arrow-size);
+            border-top-width: 0;
+            border-bottom-color: var(--arrow-color);
+        }
 
-#host-edit-color:hover,
-#host-edit-color-popover .color-cell:hover {
-    cursor: pointer;
-    box-shadow: inset 0px 0px 0px 1px #7BB2DD;
+        &::after {
+            --arrow-color: white;
+            content: '';
+            position: absolute;
+            top: 1px;
+            left: calc(var(--arrow-size) * -1);
+        }
+    }
+
+    .popover-content {
+        --patch-size: 2rem;
+        --row-count: 6;
+        --padding: 0.5rem;
+        text-align: center;
+        padding: 0.5rem;
+        display: flex;
+        flex-flow: row wrap;
+        width: calc(var(--row-count) * var(--patch-size) + (var(--padding) * 2));
+    }
+
+    .color-cell {
+        width: var(--patch-size);
+        height: var(--patch-size);
+        margin: 0;
+    }
 }

--- a/pkg/lib/machine-dialogs.scss
+++ b/pkg/lib/machine-dialogs.scss
@@ -23,12 +23,11 @@
 #host-edit-color-popover {
     --border-color: var(--pf-global--BorderColor--200);
     border-color: var(--border-color);
-    box-shadow: var(--pf-global--BoxShadow--sm) !important;
-    top: calc(100% + var(--pf-global--spacer--sm));
-    right: auto;
-    left: 50%;
-    transform: translateX(-50%);
-    margin-top: 0.5rem;
+    box-shadow: var(--pf-global--BoxShadow--md);
+    top: 50%;
+    left: calc(100% + var(--pf-global--spacer--sm));
+    transform: translateY(-50%);
+    margin-left: 0.5rem;
     // PF3 defines a max width; we unset it to allow the dialog to size itself
     max-width: auto;
 
@@ -36,25 +35,25 @@
         --arrow-size: 11px;
         --arrow-color: var(--border-color);
         position: absolute;
-        transform: translateX(-50%);
-        top: calc(var(--arrow-size) * -1);
+        transform: translateY(-50%);
+        top: 50%;
         width: 0;
         height: 0;
-        left: 50%;
+        left: calc(var(--arrow-size) * -1);
 
         &, &::after {
             border: 0 solid transparent;
             border-width: var(--arrow-size);
-            border-top-width: 0;
-            border-bottom-color: var(--arrow-color);
+            border-left-width: 0;
+            border-right-color: var(--arrow-color);
         }
 
         &::after {
             --arrow-color: white;
             content: '';
             position: absolute;
-            top: 1px;
-            left: calc(var(--arrow-size) * -1);
+            left: 1px;
+            top: calc(var(--arrow-size) * -1);
         }
     }
 

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -339,7 +339,7 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
         b.click('#host-edit-color')
         b.wait_visible('#host-edit-color-popover')
         b.wait_visible('#host-edit-user[disabled]')
-        b.click('#host-edit-color-popover div.popover-content > div:first-child > div:nth-child(3)')
+        b.click('#host-edit-color-popover div.popover-content > div:nth-child(3)')
         b.wait_not_visible('#host-edit-color-popover')
         b.click('#host-edit-apply')
         b.wait_popdown('host-edit-dialog')


### PR DESCRIPTION
Originally from changes in #13663's host switcher. I split out the commits so they can be independent from that huge PR.

I reworked the way the color selector acts and functions. The positioning is now 100% CSS with no JS changes, so it is more resilient.

I've also added a commit to move the location to the right side instead of below. (This is optional; we could back out the commit before squashing, if others aren't fans. I like it though.)

Additionally, I added preliminary keyboard support (for tabbing around). However, you cannot activate colors by the keyboard (yet). That would probably require changing click handlers.