### PR TITLE
common: Fix deadlock in channel pressure handling

### DIFF
--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -88,16 +88,17 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # The '@' sign is in the default prompt
         b.wait_in_text(".terminal-title", '@')
 
+        # output flooding
+        if m.image != 'rhel-8-2-distropkg':  # fixed in PR #14079
+            b.key_press("seq 1000000\r")
+            b.wait_in_text(".terminal .xterm-accessibility-tree", "9999989999991000000admin@")
+
         # now reset terminal
         b.click('button:contains("Reset")')
 
         # assert that the output from earlier is gone
         wait_line(n + 1, blank_state)
         self.assertNotIn('admin', b.text(line_sel(n + 1)))
-
-        # output flooding; FIXME: issue #12580
-        # b.key_press("seq 1000000\r")
-        # b.wait_in_text(".terminal .xterm-accessibility-tree", "9999989999991000000admin@")
 
         def select_line(sel, width):
             # Select line by dragging mouse


### PR DESCRIPTION
When a channel applies back-pressure to its input because its output
queue is getting too large, it relies on the consumer to acknowledge the
reads by ponging to the pings that the channel sent out.

However, it can happen that the last ping was sent for a sequence number
*before* the one that the channel expects for lifting the pressure. Then
the receiver could drain the output queue and dutifully respond to all
pings, but the last sequence number would still be smaller than the
treshold for lifting the pressure. But the channel isn't sending
anything else either and thus never generates new pings.

Fix this by sending an additional ping when going into pressure mode, to
ensure that the last pong sequence number is within the out_window
again.

This can also be reproduced/investigated with this test-spawn-proc unit
test:
```js
QUnit.only("stream large output - find", function (assert) {
    const done = assert.async();
    assert.expect(2);

    cockpit.spawn(["find", "/"], { err: "ignore" })
            .stream(function(resp) {
                console.log("got block", resp.length);
            })
            .then(function(resp) {
                assert.equal(resp, "", "no done data");
            })
            .always(function() {
                assert.equal(this.state(), "resolved", "didn't fail");
                done();
            });
});
```
But this is not appropriate for actually committing -- the find often
fails at the end, and takes too many IO resources for a unit test. The
integration test confirms the fix, though.

Fixes #12580
https://bugzilla.redhat.com/show_bug.cgi?id=1751783

 - [x] Builds on top of various unit test fixes: PR #14075 
 - [x] Update PR reference in integration test
 - [x] Revert the order again and beautify the code