### PR TITLE
test: Disable preloads for multimachine tests

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -23,6 +23,7 @@ import time
 
 import parent
 from testlib import *
+from machine_core.constants import TEST_OS_DEFAULT
 
 
 def break_hostkey(m, address, filename=None):
@@ -140,6 +141,15 @@ class TestMultiMachineAdd(MachineCase):
         self.machine3 = self.machines['machine3']
         self.machine3.execute("hostnamectl set-hostname machine3")
 
+        # Disable preloading on all machines ("machine1" is done in testlib.py)
+        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+        # In these tests we actually switch between machines in quick succession which can make things even worse
+        if self.machine.image == TEST_OS_DEFAULT:
+            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+
     def testBasic(self):
         b = self.browser
         m2 = self.machine2
@@ -232,6 +242,15 @@ class TestMultiMachine(MachineCase):
         self.machine2.execute("hostnamectl set-hostname machine2")
         self.machines['machine3'].execute("hostnamectl set-hostname machine3")
         self.allow_journal_messages("sudo: unable to resolve host machine1: .*")
+
+        # Disable preloading on all machines ("machine1" is done in testlib.py)
+        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+        # In these tests we actually switch between machines in quick succession which can make things even worse
+        if self.machine.image == TEST_OS_DEFAULT:
+            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
 
     def checkDirectLogin(self, root='/'):
         b = self.browser

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -22,6 +22,7 @@ import subprocess
 
 import parent
 from testlib import *
+from machine_core.constants import TEST_OS_DEFAULT
 
 
 def kill_user_admin(machine):
@@ -104,6 +105,13 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.execute(
             "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
         self.machine2.wait_execute()
+
+        # Disable preloading on all machines ("machine1" is done in testlib.py)
+        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+        # In these tests we actually switch between machines in quick succession which can make things even worse
+        if self.machine.image == TEST_OS_DEFAULT:
+            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
+            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")


### PR DESCRIPTION
These tests seem to be very slow on Fedora 31 so lets try disabling
preloading.