### PR TITLE
tools: Drop obsolete second release-dockerhub invocation

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -35,7 +35,6 @@ job release-copr @cockpit/cockpit-preview
 
 # Update the Github repo that Docker Hub is tracking
 job release-dockerhub cockpit-project/cockpit-container
-job release-dockerhub cockpituous/cockpit cockpit-project/cockpit
 
 # Push out a Bodhi update
 job release-bodhi F31


### PR DESCRIPTION
This committed an "Update to VERSION" change to our Dockerfiles to
cockpituous' cockpit repo fork's master branch. This is totally useless.
    
Our official cockpit/ws containers are built from the
cockpit-project/cockpit-container github repo.
