### PR TITLE
tests: Robustify testConfigureBeforeInstall by avoiding triggering ra…

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2708,6 +2708,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # Install the VM
         b.click("#vm-VmNotInstalled-install")
+        # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
+        wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
         b.wait_present("li.active #vm-VmNotInstalled-consoles")
         b.click("#vm-VmNotInstalled-off-caret")
         b.click("#vm-VmNotInstalled-forceOff")


### PR DESCRIPTION
…ce in libvirt

The test was clicking 'Install' button in the UI and right when the VM
console appeared it clicked the 'Force off' button.
That created a race condition in virt-install, making the installation to fail.
What was happening in detail is explained bellow:

When we trigger the install_machine.sh script by clicking on the install
button we get the following events:

+ virsh event --loop --event lifecycle --timeout 5
event 'lifecycle' for domain VmNotInstalled: Undefined Removed
event 'lifecycle' for domain VmNotInstalled: Resumed Unpaused
event 'lifecycle' for domain VmNotInstalled: Started Booted
event 'lifecycle' for domain VmNotInstalled: Defined Added
event loop timed out
events received: 4

These are the signals generated while the install_machines.sh script is
running. We manually call `virsh undefine` to remove the existing domain
which gives us the `Undefined` signal (first).
The rest of the signals are triggered by the `virt-install` command.

When we receive the `Started` signal we update the UI and show the VM,
the test realizes it and clicks the `Force off` button.
If that operation manages to get before the virDomainDefineXML that
virt-install will attempt to do, that define call fails to get the lock
on the domain, because we quickly shut it off, and since the domain by
that point was transient, the object was on the process of being removed
from libvirt's object list. Any attempt to perform an operation at this
point will result in 'domain is aready being removed' error message,
since the lock on that domain is already acquired.

So, just wait that the domain is also defined, and not transient any
more before attempting to stop it, so that we don't chase all possible
race conditions.