### PR TITLE
test: Fix test-webserver port address formatting for IPv6

### DIFF
--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -93,7 +93,7 @@ setup (TestCase *tc,
   /* HACK: this should be "localhost", but this fails on COPR; https://github.com/cockpit-project/cockpit/issues/12423 */
   tc->localport = g_strdup_printf ("127.0.0.1:%d", port);
   if (str)
-    tc->hostport = g_strdup_printf ("%s:%d", str, port);
+    tc->hostport = g_strdup_printf ("[%s]:%d", str, port);
   if (inet)
     g_object_unref (inet);
   g_free (str);


### PR DESCRIPTION
If cockpit_test_find_non_loopback_address() finds an IPv6 address, then
we can't just concatenate `:port`, but need to enclose the address in
`[]`. g_network_address_parse() supports that syntax for IPv4 as well.

Many thanks to Aurelien Jarno for the fix!

https://bugs.debian.org/960752