### PR TITLE
logs: Keep state in variables and don't parse it from HTML

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -140,7 +140,7 @@ $(function() {
 
         function query_error(error) {
             /* TODO: blank slate */
-            console.warn(cockpit.message(error));
+            console.error(cockpit.message(error));
         }
 
         function prepend_entries(entries) {
@@ -424,6 +424,9 @@ $(function() {
 
         full_grep += grep;
         document.getElementById("journal-grep").value = full_grep;
+
+        if (the_journal)
+            the_journal.stop();
 
         the_journal = journalbox($("#journal-box"), query_start, match, prio_level, options.tag, follow, grep);
     }

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -136,12 +136,16 @@ $(function() {
 
         var loading_services = false;
 
+        let no_logs = true;
+
         function query_error(error) {
             /* TODO: blank slate */
             console.warn(cockpit.message(error));
         }
 
         function prepend_entries(entries) {
+            if (entries.length > 0)
+                no_logs = false;
             for (var i = 0; i < entries.length; i++) {
                 renderer.prepend(entries[i]);
                 current_services.add(entries[i].SYSLOG_IDENTIFIER);
@@ -151,13 +155,14 @@ $(function() {
         }
 
         function append_entries(entries) {
+            if (entries.length > 0)
+                no_logs = false;
             for (var i = 0; i < entries.length; i++)
                 renderer.append(entries[i]);
             renderer.append_flush();
         }
 
         function didnt_reach_start(first) {
-            const no_logs = document.querySelector("#journal-box .cockpit-log-panel").innerHTML === "";
             manage_start_box(false, no_logs,
                              no_logs ? _("No Logs Found") : "",
                              no_logs ? _("You may try to load older entries.") : "",
@@ -180,7 +185,7 @@ $(function() {
                                              }
                                          })
                                          .done(function() {
-                                             if (document.querySelector("#journal-box .cockpit-log-panel").innerHTML === "")
+                                             if (no_logs)
                                                  manage_start_box(false, true, _("No Logs Found"), _("Can not find any logs using the current combination of filters."));
                                              else if (count < query_more)
                                                  ReactDOM.unmountComponentAtNode(document.getElementById("start-box"));
@@ -194,11 +199,9 @@ $(function() {
                     .stream(function(entries) {
                         if (entries[0].__CURSOR == cursor)
                             entries.shift();
-                        prepend_entries(entries);
-                        const sb_title = document.querySelector("#start-box .pf-c-title");
-                        if (sb_title && sb_title.innerHTML === "No Logs Found") {
+                        if (entries.length > 0 && no_logs)
                             ReactDOM.unmountComponentAtNode(document.getElementById("start-box"));
-                        }
+                        prepend_entries(entries);
                     }));
         }
         outer.follow = follow;
@@ -303,7 +306,7 @@ $(function() {
                     }
                 })
                 .done(function() {
-                    if (document.querySelector("#journal-box .cockpit-log-panel").innerHTML === "")
+                    if (no_logs)
                         manage_start_box(false, true, _("No Logs Found"), _("Can not find any logs using the current combination of filters."));
                     else if (count < query_count)
                         ReactDOM.unmountComponentAtNode(document.getElementById("start-box"));
@@ -317,11 +320,9 @@ $(function() {
                         })
                                 .fail(query_error)
                                 .stream(function(entries) {
-                                    prepend_entries(entries);
-                                    const sb_title = document.querySelector("#start-box .pf-c-title");
-                                    if (sb_title && sb_title.innerHTML === "No Logs Found") {
+                                    if (entries.length > 0 && no_logs)
                                         ReactDOM.unmountComponentAtNode(document.getElementById("start-box"));
-                                    }
+                                    prepend_entries(entries);
                                 }));
                     }
                     if (!all || stopped)


### PR DESCRIPTION
The old behavior had two issues:
1. It was not working when the page was translated (#13902)
2. It was prone to races (#14037)

Fixes #13902
Fixes #14037

Tested it locally and it all seems to work as expected. Also ran testBasic 10 times and succeeded every time. Let's see if CI agrees with me.