### PR TITLE
test: Fix race condition in TestPages.testFrameReload()

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -389,6 +389,7 @@ OnCalendar=daily
         b.switch_to_top()
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
+        b.expect_load_frame("cockpit1:localhost/playground/test")
         b.wait_present("iframe.container-frame[name='%s'][data-ready]" % frame)
 
         b.enter_page("/playground/test")


### PR DESCRIPTION
After tickling the frame to reload, wait for that to happen. Otherwise,
if that happens a bit more slowly, the subsequent `data-ready` wait is a no-op, and
`#file-content` never gets visible as the test still looks into the old
(and now destroyed) page context.

----

Example: https://logs.cockpit-project.org/logs/pull-14098-20200517-193551-1a756276-fedora-coreos/log.html#180-2
