### PR TITLE
tools: Revert cockpit-system → setroubleshoot-server dependency on RHEL

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -408,8 +408,8 @@ Requires: kexec-tools
 Recommends: polkit
 Recommends: PackageKit
 Recommends: NetworkManager-team
+Recommends: setroubleshoot-server >= 3.3.3
 Provides: cockpit-selinux = %{version}-%{release}
-Requires: setroubleshoot-server >= 3.3.3
 Provides: cockpit-sosreport = %{version}-%{release}
 Requires: sos
 %endif


### PR DESCRIPTION
Commit 4b112e2c turned the recommends into a requires. But
setroubleshoot-server is in AppStream, so this is invalid. Revert this
part.

https://bugzilla.redhat.com/show_bug.cgi?id=1838003