### PR TITLE
test: Adjust to changed clipboard permissions in current Chromium

### DIFF
--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -162,7 +162,11 @@ class TestSelinux(MachineCase):
         b.click(row_selector + " button.pficon-delete")
         b.wait_not_present(row_selector)
 
-        b.grant_permissions("clipboardRead", "clipboardWrite")
+        try:
+            b.grant_permissions("clipboardReadWrite", "clipboardSanitizedWrite")
+        except RuntimeError:
+            # fallback for older Chrome releases
+            b.grant_permissions("clipboardRead", "clipboardWrite")
 
         b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
         b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -103,7 +103,11 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # Firefox does not support setting of permissions
         # and therefore we cannot test copy/paste with context menu
         if b.cdp.browser != "firefox":
-            b.grant_permissions("clipboardRead", "clipboardWrite")
+            try:
+                b.grant_permissions("clipboardReadWrite", "clipboardSanitizedWrite")
+            except RuntimeError:
+                # fallback for older Chrome releases
+                b.grant_permissions("clipboardRead", "clipboardWrite")
 
             # Execute command
             wait_line(n, prompt)


### PR DESCRIPTION
A few months ago, Chromium changed the clipboard related permissions
(it's an experimental API). Use the new ones, and fall back to the old
ones until we update our cockpit/tasks container [2].

[1] https://chromedevtools.github.io/devtools-protocol/tot/Browser/#type-PermissionType
[2] https://github.com/cockpit-project/cockpituous/pull/327

Cherry-picked from master commit 3179fa2f0