### PR TITLE
test: Add --machine/--browser options to run-tests

### DIFF
--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -57,12 +57,43 @@ class TestRunTestListing(unittest.TestCase):
         self.assertRegex(revtests.stdout, re.compile(b".*TestTerminal.*TestServices.*TestLogin.*TestFirewall.*TestAccounts.*", re.S))
 
     def testNonDestructive(self):
-        self.assertEqual(subprocess.check_output([os.path.join(dirname, "run-tests"), "--nondestructive", "-l", "TestExample"]).strip().decode(),
+        self.assertEqual(subprocess.check_output([run_tests, "--nondestructive", "-l", "TestExample"]).strip().decode(),
                          "1..1\nTestExample.testNondestructive")
 
         # with short option and substring
-        self.assertEqual(subprocess.check_output([os.path.join(dirname, "run-tests"), "-nl", "TestExamp"]).strip().decode(),
+        self.assertEqual(subprocess.check_output([run_tests, "-nl", "TestExamp"]).strip().decode(),
                          "1..1\nTestExample.testNondestructive")
+
+
+# This can't be @nondestructive, as we run our own @nondestructive test nested inside this test. This will already call the
+# cleanup handlers, and the outside cleanup would then fail to do that again.
+class TestRunTest(MachineCase):
+    def testExistingMachine(self):
+        env = os.environ.copy()
+        try:
+            del env["TEST_JOBS"]
+        except KeyError:
+            pass
+        out = subprocess.check_output([run_tests, "-vt",
+                                       "--machine", self.machine.ssh_address + ":" + self.machine.ssh_port,
+                                       "--browser", self.machine.web_address + ":" + self.machine.web_port,
+                                       "TestNondestructiveExample"], env=env)
+        self.assertRegex(out, b"\nok .* TestNondestructiveExample.testOne")
+        self.assertRegex(out, b"\nok .* TestNondestructiveExample.testTwo")
+        self.assertIn(b"TESTS PASSED", out)
+
+        # can't be called with concurrency
+        p = subprocess.Popen([run_tests, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67", "-j2"],
+                             stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+        (out, err) = p.communicate()
+        self.assertGreaterEqual(p.returncode, 1)
+        self.assertIn(b"--machine cannot be used with concurrent jobs", err)
+
+        # implies --nondestructive
+        out = subprocess.check_output([run_tests, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67",
+                                       "TestExample.testBasic"], env=env)
+        self.assertIn(b"1..0", out)
+        self.assertNotIn(b"TestExample", out)
 
 
 class TestTestlib(MachineCase):

--- a/test/verify/run-tests
+++ b/test/verify/run-tests
@@ -173,14 +173,19 @@ def run(opts, image):
     sys.stdout.flush()
 
     if serial_tests and not opts.list:
-        testlib.MachineCase.get_global_machine()
+        if opts.machine:
+            ssh_address = opts.machine
+            web_address = opts.browser
+        else:
+            ssh_address = "{0}:{1}".format(testlib.MachineCase.get_global_machine().ssh_address,
+                                           testlib.MachineCase.get_global_machine().ssh_port)
+            web_address = "{0}:{1}".format(testlib.MachineCase.get_global_machine().web_address,
+                                           testlib.MachineCase.get_global_machine().web_port)
         for test in serial_tests:
             test.command.insert(-2, "--machine")
-            test.command.insert(-2, "{0}:{1}".format(testlib.MachineCase.get_global_machine().ssh_address,
-                                                 testlib.MachineCase.get_global_machine().ssh_port))
+            test.command.insert(-2, ssh_address)
             test.command.insert(-2, "--browser")
-            test.command.insert(-2, "{0}:{1}".format(testlib.MachineCase.get_global_machine().web_address,
-                                                 testlib.MachineCase.get_global_machine().web_port))
+            test.command.insert(-2, web_address)
 
     running_tests = []
     serial_test = None
@@ -221,7 +226,7 @@ def run(opts, image):
 
                     # sometimes our global machine gets messed up; also, tests that time out don't run cleanup handlers
                     # restart it to avoid an unbounded number of test retries and follow-up errors
-                    if poll_result == 124 or (retry_reason and b"test harness" in retry_reason):
+                    if not opts.machine and (poll_result == 124 or (retry_reason and b"test harness" in retry_reason)):
                         # try hard to keep the test output consistent
                         testlib.MachineCase.kill_global_machine()
                         testlib.MachineCase.get_global_machine()
@@ -266,7 +271,16 @@ def main():
                         help='Thorough mode, no skipping known issues')
     parser.add_argument('-n', '--nondestructive', action='store_true',
                         help='Only consider @nondestructive tests')
+    parser.add_argument('--machine', metavar="hostname[:port]",
+                        default=None, help="Run tests against an already running machine;  implies --nondestructive")
+    parser.add_argument('--browser', metavar="hostname[:port]",
+                        default=None, help="When using --machine, use this cockpit web address")
     opts = parser.parse_args()
+
+    if opts.machine:
+        if opts.jobs > 1:
+            parser.error("--machine cannot be used with concurrent jobs")
+        opts.nondestructive = True
 
     image = testvm.DEFAULT_IMAGE
     revision = os.environ.get("TEST_REVISION")


### PR DESCRIPTION
This allows downstream tests to run nondestructive tests in the same
manner as upstream -- with test retries, naughties, and not having to
specify the check-* command.
