### PR TITLE
test: Robustify TestHostSwitching.testBasic

### DIFF
--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -20,7 +20,6 @@
 import json
 import subprocess
 
-import time
 import parent
 from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
@@ -163,6 +162,10 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.wait_dashboard_addresses(b, ["localhost"])
         self.wait_dashboard_addresses(b2, ["localhost"])
 
+        # HACK: wait until session processes go away, see #14088
+        for machine in [m2, m3]:
+            machine.execute("while loginctl show-user admin >/dev/null 2>&1; do sleep 1; done")
+
         # Check that the two removed machines are listed in "Add Host"
         # on both browsers
         self.check_discovered_addresses(b, ["10.111.113.2", "10.111.113.3"])
@@ -194,7 +197,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         key = m.execute("grep '10.111.113.2' /etc/ssh/ssh_known_hosts && sed -i '/10.111.113.2/d' /etc/ssh/ssh_known_hosts")
         m.execute(
             "mkdir -p ~admin/.ssh && echo '{0}' > ~admin/.ssh/known_hosts && chown -R admin:admin ~admin/.ssh""".format(key))
-        time.sleep(5) # HACK - with devel builds things are too slow, likely related to #14088
         self.add_machine(b, "10.111.113.2", True)
         self.wait_dashboard_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"])
         self.wait_connected(b, "10.111.113.2")
@@ -252,6 +254,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
+        # removing machines interrupts channels
+        self.allow_restart_journal_messages()
 
     def testSetup(self):
         b = self.browser


### PR DESCRIPTION
Replace the sleep(5) hack with a proper waiting loop that directly
addresses #14088.

Allow channel disconnect errors, as we interrupt sessions.
