### PR TITLE
tools: Drop cockpit-dashboard recommendation from cockpit metapackage

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -131,7 +131,6 @@ Recommends: (cockpit-docker if /usr/bin/docker)
 %endif
 
 %if 0%{?rhel} == 0
-Recommends: cockpit-dashboard
 Recommends: (cockpit-networkmanager if NetworkManager)
 Suggests: cockpit-selinux
 %endif
@@ -676,14 +675,13 @@ Cockpit support for reading PCP metrics and loading PCP archives.
 
 %if %{defined build_dashboard}
 %package -n cockpit-dashboard
-Summary: Cockpit remote servers and dashboard
+Summary: Cockpit remote server dashboard
 BuildArch: noarch
 Requires: cockpit-ssh >= 135
 Conflicts: cockpit-ws < 135
 
 %description -n cockpit-dashboard
-Cockpit support for connecting to remote servers (through ssh),
-bastion hosts, and a basic dashboard.
+Cockpit page for showing performance graphs for up to 20 remote servers.
 
 %files -n cockpit-dashboard -f dashboard.list
 

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -39,7 +39,6 @@ Depends: ${misc:Depends},
          cockpit-system (>= ${source:Version}),
 Recommends: cockpit-storaged (>= ${source:Version}),
             cockpit-networkmanager (>= ${source:Version}),
-            cockpit-dashboard (>= ${source:Version}),
             cockpit-packagekit (>= ${source:Version}),
 Suggests: cockpit-doc (>= ${source:Version}),
           cockpit-pcp (>= ${source:Version}),
@@ -74,9 +73,8 @@ Depends: ${misc:Depends},
          cockpit-ws (>= ${source:Version}),
          cockpit-ws (<< ${source:Version}.1~),
 Replaces: cockpit-system (<< 128), cockpit-ws (<< 128)
-Description: Cockpit remote servers and dashboard
- Cockpit support for connecting to remote servers (through ssh)
- bastion hosts, and a basic dashboard.
+Description: Cockpit remote server dashboard
+ Cockpit page for showing performance graphs for up to 20 remote servers.
 
 Package: cockpit-doc
 Section: doc


### PR DESCRIPTION
The new integrated host switching obsoletes most of the dashboard use
cases, and we don't want to promote the "remote server graphs" feature
much as it's really not very good.

Also adjust the package description, as cockpit-ssh moved into
cockpit-bridge a long time ago already.
