### PR TITLE
examples: Add XMLHttpRequest proxying through a Cockpit channel

### DIFF
--- a/doc/urls.md
+++ b/doc/urls.md
@@ -43,6 +43,14 @@ are valid for any application, just replace ```/cockpit/``` with ```/cockpit+app
 
  * ```/cockpit/channel/csrftoken?query``` External channel URLs
 
+   These are commonly used to wrap/proxy port access for Cockpit pages, as
+   their JavaScript cannot talk to them directly due to Cockpit's strict
+   [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).
+
+   See the [xhr-proxy example](../examples/xhr-proxy) how to wrap a TCP HTTP
+   port, or the [gtk-broadway example](../examples/gtk-broadway) for a more
+   complex wrapping of a stream socket.
+
 When loading through cockpit-ws any URL that does not begin with an
 application will be handled by the shell (shell/index.html by default)
 using the default application ```cockpit```.

--- a/examples/xhr-proxy/manifest.json
+++ b/examples/xhr-proxy/manifest.json
@@ -1,0 +1,10 @@
+{
+    "version": 0,
+
+    "tools": {
+        "xhrproxy": {
+            "label": "XMLHttpRequest proxy",
+            "path": "xhrproxy.html"
+        }
+    }
+}

--- a/examples/xhr-proxy/xhrproxy.html
+++ b/examples/xhr-proxy/xhrproxy.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>XMLHttpRequest proxy</title>
+    <meta charset="utf-8">
+    <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
+    <script src="../base1/cockpit.js"></script>
+</head>
+<body>
+    <div class="container-fluid">
+        <table class="form-table-ct">
+            <tr>
+                <th><label class="control-label" for="address">URL</label></th>
+                <td><input class="form-control" id="address" value="http://localhost:12345"></td>
+            </tr>
+            <tr>
+                <th></th>
+                <td><button class="pf-c-button pf-m-primary" id="get">GET request</button></td>
+            <tr>
+                <th>Code</th>
+                <td><span id="result"></span></td>
+            </tr>
+            <tr>
+                <th>Output</th>
+                <td><pre id="output"></pre></td>
+        </table>
+
+    </div>
+
+    <script src="xhrproxy.js"></script>
+</body>
+</html>

--- a/examples/xhr-proxy/xhrproxy.js
+++ b/examples/xhr-proxy/xhrproxy.js
@@ -1,0 +1,67 @@
+/* This is an example how to monkey-patch XMLHttpRequest() for HTTP requests to a local service port.
+ * Cockpit pages cannot use the standard XMLHttpRequest() due to its strict Content-Security-Policy,
+ * so these need to be wrapped into a raw cockpit channel and be "really" done from the host where
+ * the session runs. This is useful if you are wrapping existing JavaScript code that uses
+ * XMLHttpRequest(), and you are unable to change that code to use cockpit.http().
+ *
+ * Note that non-localhost connections are still forbidden by this page's Content-Security-Policy
+ * (which can be changed in the manifest), and browsers blocking Cross-Origin requests.
+ *
+ * Documentation links:
+ * - https://cockpit-project.org/guide/latest/cockpit-channels.html
+ * - doc/protocol.md
+ * - doc/urls.md
+ */
+
+const origXHROpen = XMLHttpRequest.prototype.open;
+
+/* The following is the reusable part which sets up the redirection. It must be called *after*
+ * cockpit.transport.wait() finishes, so that cockpit.transport.csrf_token is initialized. */
+
+function setupCockpitXHR() {
+    XMLHttpRequest.prototype.open = function(method, url) {
+        console.log(`calling patched XMLHttpRequest.open("${method}", "${url}")`);
+        const u = new URL(url);
+        if (u.protocol !== 'http:')
+            throw new Error("This demo only supports http:// URLs");
+
+        const channel = {
+            payload: "http-stream2",
+            method,
+            address: u.hostname,
+            port: u.port ? parseInt(u.port) : 80,
+            path: u.pathname + u.hash,
+        };
+
+        const channel_url = "/cockpit/channel/" + cockpit.transport.csrf_token + "?" +
+                            window.btoa(JSON.stringify(channel));
+
+        origXHROpen.apply(this, ["GET", channel_url]);
+    }
+}
+
+/* Send a 'init' message. After that we have the Cockpit transport token.
+ * This also tells integration tests that we are ready to go. */
+cockpit.transport.wait(setupCockpitXHR);
+
+
+/* The following implements the example page, and represents an application that uses
+ * XMLHttpRequest() and is oblivious of running inside of Cockpit */
+
+document.getElementById("get").addEventListener("click", () => {
+    const url = document.getElementById("address").value;
+    const xhr = new XMLHttpRequest();
+
+    xhr.open("GET", address.value);
+    xhr.onreadystatechange = () => {
+        if (xhr.readyState === XMLHttpRequest.DONE) {
+            console.log("XMLHttpRequest to", address.value, "done with status", xhr.status, "text", xhr.responseText);
+            document.getElementById("result").innerHTML = xhr.status.toString();
+            const output = document.getElementById("output");
+            output.innerHTML = "";
+            output.append(document.createTextNode(xhr.responseText));
+        }
+    };
+
+    xhr.send();
+});

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -26,5 +26,48 @@ class TestPinger(MachineCase):
         b.wait_in_text("#output", "--- 127.0.0.1 ping statistics")
 
 
+@nondestructive
+class TestXHRProxy(MachineCase):
+    def setUp(self):
+        super().setUp()
+        self.restore_dir("/home/admin")
+        self.machine.execute("mkdir -p ~admin/.local/share/cockpit")
+        self.machine.upload([os.path.join(EXAMPLES_DIR, "xhr-proxy")], "~admin/.local/share/cockpit/")
+
+    @skipImage("No Python installed", "fedora-coreos")
+    def testBasic(self):
+        m = self.machine
+        b = self.browser
+
+        # set up served directory
+        httpdir = self.vm_tmpdir + "/root";
+        m.execute("mkdir {0} && echo world > {0}/hello.txt".format(httpdir))
+        # start webserver
+        pid = m.spawn("cd %s && exec python3 -m http.server 12345" % httpdir, "httpserver")
+        self.addCleanup(m.execute, "kill %i" % pid)
+        self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up
+
+        self.login_and_go("/xhr-proxy/xhrproxy")
+
+        # directory index
+        b.set_val("#address", "http://localhost:12345/")
+        b.click("#get")
+        b.wait_text("#result", "200")
+        b.wait_in_text("#output", "Directory listing")
+        b.wait_in_text("#output", "hello.txt")
+
+        # specific file
+        b.set_val("#address", "http://localhost:12345/hello.txt")
+        b.click("#get")
+        b.wait_text("#result", "200")
+        b.wait_text("#output", "world\n")
+
+        # nonexisting path
+        b.set_val("#address", "http://localhost:12345/nosuchfile")
+        b.click("#get")
+        b.wait_text("#result", "404")
+        b.wait_in_text("#output", "File not found")
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This is an example how to monkey-patch XMLHttpRequest() for HTTP
requests to a local service port.  Cockpit pages cannot use the standard
XMLHttpRequest() due to its strict Content-Security-Policy, so these
need to be wrapped into a raw cockpit channel and be done from the host
where the session runs.

At the same time this also demonstrates how to talk to a port from JS
that is only accessible locally on the cockpit session machine, i. e.
where cockpit's channel acts as a proxy.
