### PR TITLE
machines: When creating a storage pool don't try to activate it

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -323,9 +323,6 @@ const LIBVIRT_DBUS_PROVIDER = {
         return (dispatch) => call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'StoragePoolDefineXML', [poolXmlDesc, 0], { timeout, type: 'su' })
                 .then(poolPath => {
                     storagePoolPath = poolPath[0];
-                    return call(connectionName, storagePoolPath, 'org.libvirt.StoragePool', 'Create', [Enum.VIR_STORAGE_POOL_CREATE_NORMAL], { timeout, type: 'u' });
-                })
-                .then(() => {
                     const args = ['org.libvirt.StoragePool', 'Autostart', cockpit.variant('b', autostart)];
 
                     return call(connectionName, storagePoolPath, 'org.freedesktop.DBus.Properties', 'Set', args, { timeout, type: 'ssv' });

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -224,7 +224,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                   targetcli /iscsi/%(tgt)s/tpg1/acls create %(ini)s
                   """ % {"tgt": target_iqn, "ini": orig_iqn})
 
-        self.addCleanup(m.execute, "targetcli /backstores/ramdisk delete test && targetcli /iscsi delete %s && iscsiadm -m node -o delete" % target_iqn)
+        self.addCleanup(m.execute, "targetcli /backstores/ramdisk delete test && targetcli /iscsi delete %s && (iscsiadm -m node -o delete || true)" % target_iqn)
         return orig_iqn
 
     def testState(self):
@@ -4055,13 +4055,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             def create(self):
                 b.click(".modal-footer button:contains(Create)")
 
-                if (not self.xfail):
-                    # For the pool types that take some seconds to get created check that the spinner appears.
-                    # Other pool types have the spinner as well, but let's not check this in the tests to avoid race conditions,
-                    # where the spinner disappears very fast
-                    if self.pool_type  in ["netfs", "iscsi", "iscsi-direct"]:
-                        b.wait_present(".modal-footer div.spinner")
-                        b.wait_present(".modal-footer button:contains(Create):disabled")
+                if not self.xfail:
                     b.wait_not_present("#create-storage-pool-dialog")
                 else:
                     # Check incomplete dialog
@@ -4149,7 +4143,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.wait_present('#create-volume-button:enabled')
 
             def cleanup(self):
-                m.execute("virsh pool-destroy {0} && virsh pool-undefine {0}".format(self.name))
+                m.execute("virsh pool-undefine {0}".format(self.name))
 
         StoragePoolCreateDialog(
             self,
@@ -4170,7 +4164,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         ).execute()
 
         # Manually remove the created pool
-        m.execute("virsh pool-destroy my_dir_pool_one && virsh pool-undefine my_dir_pool_one")
+        m.execute("virsh pool-undefine my_dir_pool_one")
 
         # XFAIL: Try to create a pool with incomplete modal dialog
         StoragePoolCreateDialog(


### PR DESCRIPTION
Starting a pool might fail for multiple reasons, aka target host unreachable,
and it takes some time until the operation times out. Until then we are seeing
the dialog spinner and a frozen dialog and we need to wait even a mibute
untill the API call times out and we get an error message.

Furthermore a user might want to just define resource and activate it later
on when the target storage is available.

Closes #14114