### PR TITLE
test: Move run-tests to test/common

### DIFF
--- a/test/common/parent.py
+++ b/test/common/parent.py
@@ -1,0 +1,7 @@
+import os
+import sys
+
+TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+BOTS_DIR = os.path.join(os.path.dirname(TEST_DIR), "bots")
+sys.path.append(os.path.join(BOTS_DIR, "machine"))
+sys.path.append(os.path.join(TEST_DIR, "common"))

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -138,7 +138,10 @@ def run(opts, image):
     start_time = time.time()
     serial_tests_duration = 0
 
-    for filename in glob.glob(os.path.join(os.path.dirname(__file__), "check-*")):
+    # Make sure tests can make relative imports
+    sys.path.append(os.path.realpath(opts.test_dir))
+
+    for filename in glob.glob(os.path.join(opts.test_dir, "check-*")):
         name = check_valid(filename)
         if not name or not os.path.isfile(filename):
             continue
@@ -275,6 +278,8 @@ def main():
                         default=None, help="Run tests against an already running machine;  implies --nondestructive")
     parser.add_argument('--browser', metavar="hostname[:port]",
                         default=None, help="When using --machine, use this cockpit web address")
+    parser.add_argument('--test-dir', default=testvm.TEST_DIR,
+                        help="Directory in which to glob check-* files")
     opts = parser.parse_args()
 
     if opts.machine:

--- a/test/run
+++ b/test/run
@@ -11,11 +11,11 @@ TEST_SCENARIO=${TEST_SCENARIO:-verify}
 case $TEST_SCENARIO in
     verify)
         test/image-prepare --verbose $TEST_OS
-        test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;
     firefox)
         test/image-prepare --verbose $TEST_OS
-        TEST_BROWSER=firefox test/verify/run-tests --jobs ${TEST_JOBS:-1}
+        TEST_BROWSER=firefox test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;
     selenium-*)
         test/image-prepare --verbose $TEST_OS

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -26,7 +26,8 @@ import parent
 from testlib import *
 
 dirname = os.path.dirname(__file__)
-run_tests = os.path.join(dirname, "run-tests")
+run_tests = os.path.join(TEST_DIR, "common", "run-tests")
+VERIFY_DIR = os.path.join(TEST_DIR, "verify")
 
 class TestRunTestListing(unittest.TestCase):
 
@@ -39,13 +40,13 @@ class TestRunTestListing(unittest.TestCase):
         self.assertEqual(subprocess.check_output([os.path.join(dirname, "check-example"), "-l", "TestNondestructiveExample"]).strip().decode(),
                          "TestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo")
         # Filter on class
-        p = subprocess.run([run_tests, "-l", "TestNondestructiveExample"], env=forward_sort_env, capture_output=True, check=True)
+        p = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-l", "TestNondestructiveExample"], env=forward_sort_env, capture_output=True, check=True)
         self.assertIn(b"1..2\nTestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo", p.stdout.strip())
         # Filter a specific test
         self.assertIn("1..1\nTestNondestructiveExample.testOne",
-                      subprocess.check_output([run_tests, "-l", "TestNondestructiveExample.testOne"]).strip().decode())
+                      subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "-l", "TestNondestructiveExample.testOne"]).strip().decode())
 
-        ndtests = subprocess.run([run_tests, "-n", "-l"], env=forward_sort_env, check=True, capture_output=True)
+        ndtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"], env=forward_sort_env, check=True, capture_output=True)
         self.assertIn(b"TestExample.testNondestructive\n", ndtests.stdout)
         self.assertIn(b"TestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo", ndtests.stdout)
 
@@ -53,15 +54,15 @@ class TestRunTestListing(unittest.TestCase):
         self.assertRegex(ndtests.stdout, re.compile(b".*TestAccounts.*TestFirewall.*TestLogin.*TestServices.*TestTerminal.*", re.S))
 
         # reverse direction
-        revtests = subprocess.run([run_tests, "-n", "-l"], env=rev_sort_env, check=True, capture_output=True)
+        revtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"], env=rev_sort_env, check=True, capture_output=True)
         self.assertRegex(revtests.stdout, re.compile(b".*TestTerminal.*TestServices.*TestLogin.*TestFirewall.*TestAccounts.*", re.S))
 
     def testNonDestructive(self):
-        self.assertEqual(subprocess.check_output([run_tests, "--nondestructive", "-l", "TestExample"]).strip().decode(),
+        self.assertEqual(subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "--nondestructive", "-l", "TestExample"]).strip().decode(),
                          "1..1\nTestExample.testNondestructive")
 
         # with short option and substring
-        self.assertEqual(subprocess.check_output([run_tests, "-nl", "TestExamp"]).strip().decode(),
+        self.assertEqual(subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "-nl", "TestExamp"]).strip().decode(),
                          "1..1\nTestExample.testNondestructive")
 
 
@@ -74,7 +75,7 @@ class TestRunTest(MachineCase):
             del env["TEST_JOBS"]
         except KeyError:
             pass
-        out = subprocess.check_output([run_tests, "-vt",
+        out = subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "-vt",
                                        "--machine", self.machine.ssh_address + ":" + self.machine.ssh_port,
                                        "--browser", self.machine.web_address + ":" + self.machine.web_port,
                                        "TestNondestructiveExample"], env=env)
@@ -83,14 +84,14 @@ class TestRunTest(MachineCase):
         self.assertIn(b"TESTS PASSED", out)
 
         # can't be called with concurrency
-        p = subprocess.Popen([run_tests, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67", "-j2"],
+        p = subprocess.Popen([run_tests, "--test-dir", VERIFY_DIR, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67", "-j2"],
                              stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
         (out, err) = p.communicate()
         self.assertGreaterEqual(p.returncode, 1)
         self.assertIn(b"--machine cannot be used with concurrent jobs", err)
 
         # implies --nondestructive
-        out = subprocess.check_output([run_tests, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67",
+        out = subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "--machine", "1.2.3.4:56", "--browser", "1.2.3.4:67",
                                        "TestExample.testBasic"], env=env)
         self.assertIn(b"1..0", out)
         self.assertNotIn(b"TestExample", out)

--- a/test/verify/parent.py
+++ b/test/verify/parent.py
@@ -1,7 +1,1 @@
-import os
-import sys
-
-TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-BOTS_DIR = os.path.join(os.path.dirname(TEST_DIR), "bots")
-sys.path.append(os.path.join(TEST_DIR, "common"))
-sys.path.append(os.path.join(BOTS_DIR, "machine"))
+../common/parent.py


### PR DESCRIPTION
This should fix TAP output for external projects using the cockpit test
infrastructure.