### PR TITLE
test: Adjust Machines tests for test VMs with 1 GiB RAM

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2013,7 +2013,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                         b.wait_not_present("#storage-size")
                     else:
                         b.select_from_dropdown("#storage-size-unit-select", self.storage_size_unit)
-                        if self.storage_size:
+                        if self.storage_size is not None:
                             b.set_input_text("#storage-size", str(self.storage_size), value_check=False)
                             b.blur("#storage-size")
                             # helpblock will be missing if available storage size could not be calculated (no default storage pool found)

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1897,9 +1897,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             if self.connection:
                 self.connectionText = connection.capitalize()
 
-        def getMemoryText(self):
-            return "{0} {1}".format(self.memory_size, self.memory_size_unit)
-
         def open(self):
             b = self.browser
 
@@ -2335,7 +2332,13 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             # check memory
             b.click("#vm-{0}-usage".format(name))
-            b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", dialog.getMemoryText())
+            # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
+            # the host has (less or more than 1 GiB), and thus needs to be dynamic
+            if dialog.memory_size >= 1024 and dialog.memory_size_unit == "MiB":
+                memory_text = "%.2f GiB" % (dialog.memory_size/1024)
+            else:
+                memory_text = "{0} {1}".format(dialog.memory_size, dialog.memory_size_unit)
+            b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", memory_text)
 
             # check disks
             b.click("#vm-{0}-disks".format(name)) # open the "Disks" subtab


### PR DESCRIPTION
Some Machines tests check adjusting the guest RAM size to the maximum of
what the host has available. The formatting of the usage donut then
depends on whether that results in a size < 1 GiB (in which case the
usage will be formatted in MiB) or > 1 GiB (then it will be GiB). Thus
replicate the cockpit_format_bytes() logic in the test to work with
testbeds that have more RAM.

This doesn't affect the creation dialog itself, just the donut check; so
move the text computation logic out of the VmDialog class.

--- 

I locally tested this against our current 1 GiB test VMs as well as an 1.1 GiB one from https://github.com/cockpit-project/bots/pull/890