### PR TITLE
test: Rename test classes to be unique

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -6,7 +6,6 @@ import string
 import subprocess
 import sys
 import unittest
-import dataclasses
 import errno
 import time
 import re
@@ -25,15 +24,17 @@ sys.dont_write_bytecode = True
 os.environ['PYTHONUNBUFFERED'] = '1'
 
 
-@dataclasses.dataclass
 class Test:
-    test_id: int
-    command: list
-    timeout: int
-    nondestructive: bool = False
-    process: subprocess.Popen = None
-    retries: int = 0
-    output: bytes = b""
+    process = None
+    retries = 0
+    output = b""
+
+    def __init__(self, test_id, command, timeout, nondestructive):
+        self.test_id = test_id
+        self.command = command
+        self.timeout = timeout
+        self.nondestructive = nondestructive
+
 
 def test_name(test):
     return "{0} {1} {2}{3}".format(test.test_id, test.command[0], test.command[-1], " [ND]" if test.nondestructive else "")

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -142,6 +142,7 @@ def run(opts, image):
     # Make sure tests can make relative imports
     sys.path.append(os.path.realpath(opts.test_dir))
 
+    seen_classes = {}
     for filename in glob.glob(os.path.join(opts.test_dir, "check-*")):
         name = check_valid(filename)
         if not name or not os.path.isfile(filename):
@@ -151,8 +152,14 @@ def run(opts, image):
         loader.exec_module(module)
         for test_suite in test_loader.loadTestsFromModule(module):
             for test in test_suite:
+                # ensure that test classes are unique, so that they can be selected properly
+                cls = test.__class__.__name__
+                if seen_classes.get(cls) not in [None, filename]:
+                    raise ValueError("test class %s in %s already defined in %s" % (cls, filename, seen_classes[cls]))
+                seen_classes[cls] = filename
+
                 test_method = getattr(test.__class__, test._testMethodName)
-                test_str = "{0}.{1}".format(test.__class__.__name__, test._testMethodName)
+                test_str = "{0}.{1}".format(cls, test._testMethodName)
                 # most tests should take much less than 10mins, so default to that;
                 # longer tests can be annotated with @timeout(seconds)
                 # check the test function first, fall back to the class'es timeout

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -22,7 +22,7 @@ from netlib import *
 from testlib import *
 
 @nondestructive
-class TestNetworking(NetworkCase):
+class TestNetworkingBasic(NetworkCase):
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @skipImage("No network checkpoint support", "ubuntu-2004", "ubuntu-stable")
-class TestNetworking(NetworkCase):
+class TestNetworkingCheckpoints(NetworkCase):
 
     def testCheckpoint(self):
         b = self.browser

--- a/test/verify/check-networking-mac
+++ b/test/verify/check-networking-mac
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-class TestNetworking(NetworkCase):
+class TestNetworkingMAC(NetworkCase):
     provision = {
         "machine1": {},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}

--- a/test/verify/check-networking-mtu
+++ b/test/verify/check-networking-mtu
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-class TestNetworking(NetworkCase):
+class TestNetworkingMTU(NetworkCase):
     provision = {
         "machine1": {},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}

--- a/test/verify/check-networking-other
+++ b/test/verify/check-networking-other
@@ -22,7 +22,7 @@ from netlib import *
 from testlib import *
 
 
-class TestNetworking(NetworkCase):
+class TestNetworkingOther(NetworkCase):
 
     def testOther(self):
         b = self.browser

--- a/test/verify/check-networking-settings
+++ b/test/verify/check-networking-settings
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-class TestNetworking(NetworkCase):
+class TestNetworkingSettings(NetworkCase):
     provision = {
         "machine1": {},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}

--- a/test/verify/check-networking-unmanaged
+++ b/test/verify/check-networking-unmanaged
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-class TestNetworking(NetworkCase):
+class TestNetworkingUnmanaged(NetworkCase):
     provision = {
         "machine1": {},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}

--- a/test/verify/check-networking-vlan
+++ b/test/verify/check-networking-vlan
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-class TestNetworking(NetworkCase):
+class TestNetworkingVLAN(NetworkCase):
     def testVlan(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-class TestStorage(StorageCase):
+class TestStorageBasic(StorageCase):
 
     def testBasic(self):
         m = self.machine

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageFormat(StorageCase):
 
     def testFormatTooSmall(self):
         m = self.machine

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageHidden(StorageCase):
 
     def testHiddenLuks(self):
         m = self.machine

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-class TestStorage(StorageCase):
+class TestStorageIgnored(StorageCase):
 
     def testIgnored(self):
         m = self.machine

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -24,7 +24,7 @@ from testlib import *
 
 @skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "debian-testing",
            "ubuntu-2004", "ubuntu-stable")
-class TestStorage(StorageCase):
+class TestStorageISCSI(StorageCase):
 
     def testISCSI(self):
         m = self.machine

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageLuks(StorageCase):
 
     def testLuks(self):
         self.allow_journal_messages("Device is not initialized.*", ".*could not be opened.")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 @nondestructive
-class TestStorage(StorageCase):
+class TestStorageLvm2(StorageCase):
 
     def testLvm(self):
         m = self.machine

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -27,7 +27,7 @@ def info_field(name, image_name):
     return '#detail-header label:contains("%s") + div' % name
 
 
-class TestStorage(StorageCase):
+class TestStorageMdRaid(StorageCase):
 
     def wait_states(self, states):
         self.browser.wait_js_func("""(function(states) {

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -34,7 +34,7 @@ ExecStart=/usr/lib/storaged/storaged
 """
 
 
-class TestStorage(StorageCase):
+class TestStorageMounting(StorageCase):
 
     def testMounting(self):
         m = self.machine

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageMsDOS(StorageCase):
 
     def testDosParts(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @skipImage("UDisks doesn't have support for multipath", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")
-class TestStorage(StorageCase):
+class TestStorageMultipath(StorageCase):
 
     def testBasic(self):
         m = self.machine

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -23,7 +23,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageNfs(StorageCase):
 
     def testNfsClient(self):
         m = self.machine
@@ -225,7 +225,7 @@ class TestStorage(StorageCase):
 
 @skipImage("No udisks/cockpit-storaged on OSTree images", "fedora-coreos")
 @nondestructive
-class TestStoragePackages(PackageCase, StorageHelpers):
+class TestStoragePackagesNFS(PackageCase, StorageHelpers):
 
     def testNfsMissingPackages(self):
         m = self.machine

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-class TestStorage(StorageCase):
+class TestStoragePartitions(StorageCase):
 
     def testPartitions(self):
         m = self.machine

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageRaid1(StorageCase):
 
     def testRaidLevelOne(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -25,7 +25,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageResize(StorageCase):
 
     def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None,
                     need_passphrase=False):

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -21,7 +21,7 @@ import parent
 from storagelib import *
 from testlib import *
 
-class TestStorage(StorageCase):
+class TestStorageScaling(StorageCase):
 
     def testScaling(self):
         m = self.machine

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -22,7 +22,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageUnused(StorageCase):
 
     def testUnused(self):
         m = self.machine

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-class TestStorage(StorageCase):
+class TestStorageUsed(StorageCase):
 
     def testUsed(self):
         m = self.machine

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -23,7 +23,7 @@ from storagelib import *
 from testlib import *
 
 
-class TestStorage(StorageCase):
+class TestStorageVDO(StorageCase):
 
     def testVdo(self):
         m = self.machine
@@ -270,7 +270,7 @@ config: !Configuration
         b.wait_in_text("#devices", "vdo1")
 
 
-class TestStoragePackages(PackageCase, StorageHelpers):
+class TestStoragePackagesVDO(PackageCase, StorageHelpers):
 
     def testVdoMissingPackages(self):
         m = self.machine


### PR DESCRIPTION
So that we can select them properly with run-tests. Otherwise classes
with the same name hide each other.

Also eliminate `dataclass` from  run-test, it's still too new for RHEL 8.