### PR TITLE
[r82] test: Adjust Machines tests for test VMs with > 1 GiB RAM

### DIFF
--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -1927,9 +1927,6 @@ class TestMachines(NetworkCase):
             if self.connection:
                 self.connectionText = TestMachines.TestCreateConfig.LIBVIRT_CONNECTION[connection]
 
-        def getMemoryText(self):
-            return "{0} {1}".format(self.memory_size, self.memory_size_unit)
-
         def open(self):
             b = self.browser
 
@@ -2304,7 +2301,13 @@ class TestMachines(NetworkCase):
 
             # check memory
             b.click("#vm-{0}-usage".format(name))
-            b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", dialog.getMemoryText())
+            # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
+            # the host has (less or more than 1 GiB), and thus needs to be dynamic
+            if dialog.memory_size >= 1024 and dialog.memory_size_unit == "MiB":
+                memory_text = "%.2f GiB" % (dialog.memory_size / 1024)
+            else:
+                memory_text = "{0} {1}".format(dialog.memory_size, dialog.memory_size_unit)
+            b.wait_in_text("tbody.open .listing-ct-body td:nth-child(1) .usage-donut-caption", memory_text)
 
             # check disks
             b.click("#vm-{0}-disks".format(name)) # open the "Disks" subtab


### PR DESCRIPTION
Some Machines tests check adjusting the guest RAM size to the maximum of
what the host has available. The formatting of the usage donut then
depends on whether that results in a size < 1 GiB (in which case the
usage will be formatted in MiB) or > 1 GiB (then it will be GiB). Thus
replicate the cockpit_format_bytes() logic in the test to work with
testbeds that have more RAM.

This doesn't affect the creation dialog itself, just the donut check; so
move the text computation logic out of the VmDialog class.

Cherry-picked from master commit 3ceac9489d2f0