### PR TITLE
test: Fake EOL date of Fedora 28

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2229,6 +2229,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             root.find('os').find('resources').find('minimum').find('storage').text = '134217750'
             root.find('os').find('resources').find('recommended').find('ram').text = '268435500'
             root.find('os').find('resources').find('recommended').find('storage').text = '268435500'
+            if self.machine.image not in ["debian-stable"]:
+                root.find('os').find('eol-date').text = '9999-12-31'
             new_fedora_28_xml = ET.tostring(root)
             self.machine.execute("echo \'{0}\' > {1}/fedora-28.xml".format(str(new_fedora_28_xml, 'utf-8'), self.test_obj.vm_tmpdir))
             self.machine.execute("mount -o bind  {0}/fedora-28.xml /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml".format(self.test_obj.vm_tmpdir))


### PR DESCRIPTION
We write the year 2020. Forgotten by the masses, and shadowed by the
turmoils of the COVID-19 pandemic, a little gray Linux distribution took
its last breath and withered away. The big Lib Virt forgot about its
once loved child, and refused to ever look at it again.

But a small group of intrepid developers put on their red helmets^Whats,
mounted their cockpit, and went out to salvage it. Never shall the world
forget "Fedora 28" again, and it will still stand strong long after
every other penguin in the world ate their last fish.

---

Boring technical epilogue: libvirt only allows installing a distribution
up to a year after its EOL. Make sure that we don't run into that trap
anytime soon again.