### PR TITLE
ws: Stop setting G_TLS_GNUTLS_PRIORITY

### DIFF
--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -143,8 +143,6 @@ main (int argc,
   /* Any interaction with a krb5 ccache should be explicit */
   g_setenv ("KRB5CCNAME", "FILE:/dev/null", TRUE);
 
-  g_setenv ("G_TLS_GNUTLS_PRIORITY", "SECURE128:%LATEST_RECORD_VERSION:-VERS-SSL3.0:-VERS-TLS1.0", FALSE);
-
   memset (&data, 0, sizeof (data));
 
   context = g_option_context_new (NULL);


### PR DESCRIPTION
This was done 5 years ago in commit 0750a1024586d23 to disable SSL3.
This is the default these days, and that setting is now invalid with
recent GnuTLS/glib versions:

    G_TLS_GNUTLS_PRIORITY is invalid; ignoring

Drop it and rely on the OS defaults. Our integration test will still
make sure that SSL3 and other old ciphers won't work.