### PR TITLE
machines: Enable noVNC shared access

### DIFF
--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -159,6 +159,7 @@ class Vnc extends React.Component {
                         port={window.location.port || (encrypt ? '443' : '80')}
                         path={path}
                         encrypt={encrypt}
+                        shared='true'
                         credentials={credentials}
                         vncLogging='warn'
                         onDisconnected={this.onDisconnected}


### PR DESCRIPTION
react-console will request exclusive access by default (shared=false)
When cockpit used "Graphics Console (VNC)", it will disallow other
connection to VNC.
Only way to release the connection is shutdown VM
and don't open "Graphics Console (VNC)"
Otherwise, you can't use 3rd party VNC viewer to connect.

If VNC listens 0.0.0.0 IP, no matter open "Graphics Console (VNC)" or
not
It will hold the connection and disallow other connection.

Testing with OpenMediaVault 5.x (Debian buster)
Cockpit 217-2~bpo10+1