### PR TITLE
all: Add { superuser: "try" } for things that might need Polkit

### DIFF
--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -264,7 +264,7 @@ function Machines() {
                 conn_to = machine.connection_string;
 
             if (!machine || machine.label !== values.label) {
-                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to });
+                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to, superuser: "try" });
                 call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
                                       "SetPrettyHostname", [ values.label, true ])
                         .always(function() {

--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -234,7 +234,7 @@ function fetchZoneInfos(zones) {
 
 initFirewalldDbus();
 
-cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'])
+cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'], { superuser: "try" })
         .done(() => {
             firewall.readonly = false;
             firewall.dispatchEvent('changed');

--- a/pkg/realmd/operation.js
+++ b/pkg/realmd/operation.js
@@ -606,7 +606,7 @@ function setup() {
 
     function setup_realms_proxy() {
         // HACK: need to reinitialize after installing realmd (https://github.com/cockpit-project/cockpit/pull/9125)
-        realmd = cockpit.dbus("org.freedesktop.realmd");
+        realmd = cockpit.dbus("org.freedesktop.realmd", { superuser: "try" });
         realmd.watch(MANAGER);
 
         $(realmd).on("close", function(ev, options) {

--- a/pkg/selinux/setroubleshoot-client.js
+++ b/pkg/selinux/setroubleshoot-client.js
@@ -35,10 +35,10 @@ var dbusPathFixit = "/org/fedoraproject/SetroubleshootFixit/object";
 
 client.init = function(capabilitiesChangedCallback) {
     client.connected = false;
-    var dbusClientSeTroubleshoot = cockpit.dbus(busName);
+    var dbusClientSeTroubleshoot = cockpit.dbus(busName, { superuser: "try" });
     client.proxy = dbusClientSeTroubleshoot.proxy(dbusInterface, dbusPath);
 
-    client.proxyFixit = cockpit.dbus(busNameFixit).proxy(dbusInterfaceFixit, dbusPathFixit);
+    client.proxyFixit = cockpit.dbus(busNameFixit, { superuser: "try" }).proxy(dbusInterfaceFixit, dbusPathFixit);
 
     var dfd = cockpit.defer();
 


### PR DESCRIPTION
Cockpit should always use the maximum privileges it has.  Otherwise
actions might be rejected that are actually allowed.

Cherry-picked from master commit 168f819ebd, restricted to a safe and
non-intrusive subset.

https://bugzilla.redhat.com/show_bug.cgi?id=1841559