### PR TITLE
nav: Nudge focus ring offset by a small amount

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -462,6 +462,10 @@ $desktop: $phone + 1px;
         &:focus {
             text-decoration: none;
         }
+
+        &:focus {
+            outline-offset: var(--pf-global--spacer--xs);
+        }
     }
 
     button,


### PR DESCRIPTION
Moving the focus ring a little bit away from navigation text makes it easier to read the focused element.