### PR TITLE
test: Drop get_temp_dir() usage from image-prepare

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -70,8 +70,7 @@ def main():
         sys.stderr.write("image-prepare: use of --install-only with --build-only is incompatible\n")
         return 2
 
-    # Default to putting build output in the tmp/build-results directory
-    results = os.path.join(testvm.get_temp_dir(), "build-results")
+    results = os.path.abspath("tmp/build-results")
 
     # Make sure any images are downloaded
     try:


### PR DESCRIPTION
We are going to eliminate `$TEST_DATA`, it currently influences too many
things which really don't belong together. There is little reason to put
the built rpms into some user-controlled path -- in particular, we
*don't* want to put them into some persistent and possibly remote
storage if `$TEST_DATA` points to a container volume.

get_temp_dir() is too unspecific to be used as public API, so let's
eliminate it. This is the only consumer outside of bots itself.