### PR TITLE
test: Fix preferences for new Firefox

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -182,6 +182,8 @@ class CDP:
             with open(os.path.join(profile, "user.js"), "w") as f:
                 f.write("""
                     user_pref("remote.enabled", true);
+                    user_pref("remote.frames.enabled", true);
+                    user_pref("app.update.auto", false);
                     user_pref("datareporting.policy.dataSubmissionEnabled", false);
                     user_pref("toolkit.telemetry.reportingpolicy.firstRun", false);
                     user_pref("dom.disable_beforeunload", true);


### PR DESCRIPTION
We need to use firefox nightly since shipped versions don't include
`--remote-debugging-port` option. For this we want to disable automatic
updates.

Also we need `remote.frames.enabled` due to https://bugzilla.mozilla.org/show_bug.cgi?id=1593226