### PR TITLE
test: When executing js command that doesn't return any value, don't …

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -176,7 +176,7 @@ class CDP:
                     "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
                     "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"]
         elif self.browser == "firefox":
-            subprocess.Popen(["firefox", "--headless", "--no-remote", "-CreateProfile", "blank"], env=env).communicate()
+            subprocess.Popen([exe, "--headless", "--no-remote", "-CreateProfile", "blank"], env=env).communicate()
             profile = glob.glob(os.path.join(self._browser_home, ".mozilla/firefox/*.blank"))[0]
 
             with open(os.path.join(profile, "user.js"), "w") as f:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -169,6 +169,12 @@ class Browser:
             msg += "\n" + trailer
         raise Error("%s(%s): %s" % (func, arg, msg))
 
+    # Execute js code that does not return anything
+    def inject_js(self, code):
+        self.cdp.invoke("Runtime.evaluate", expression=code, trace=code,
+                        silent=False, awaitPromise=True, returnByValue=False, no_trace=True)
+
+    # Execute js code that returns something
     def eval_js(self, code, no_trace=False):
         result = self.cdp.invoke("Runtime.evaluate", expression=code, trace=code,
                                  silent=False, awaitPromise=True, returnByValue=True, no_trace=no_trace)

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -78,7 +78,7 @@ class TestJournal(MachineCase):
         m.execute("systemctl disable --now pmie pmlogger || true")
 
         def inject_extras():
-            b.eval_js("""
+            b.inject_js("""
             ph_get_log_lines = function () {
                 var lines = [ ];
                 var panels = ph_find('.cockpit-log-panel').childNodes;
@@ -148,7 +148,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         self.login_and_go("/system/logs")
         inject_extras()
 
-        b.eval_js("""
+        b.inject_js("""
             localTime = function(time) {
                 var month_names = [
                     'January',

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -46,14 +46,14 @@ class TestMetrics(MachineCase, StorageHelpers):
         b = self.browser
         m = self.machine
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plot_timestamp = function (sel) {
             var data = $(sel).data("flot_data")[0]['data'];
             return data[data.length-1][0];
           }
         """)
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plot_timestamp_is = function (sel, ts) {
             return ph_plot_timestamp(sel, 0) >= ts;
           }
@@ -69,7 +69,7 @@ class TestMetrics(MachineCase, StorageHelpers):
         # outlier will make us miss the expected plateau.  Such
         # outliers happen frequently with the CPU plot.
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plateau = function (data, min, max, duration, label) {
               var i, j;
               var sum;  // sum of data[i..j]
@@ -90,7 +90,7 @@ class TestMetrics(MachineCase, StorageHelpers):
           }
         """)
 
-        b.eval_js("""
+        b.inject_js("""
           ph_flot_data_plateau = function (sel, min, max, duration, label) {
             return ph_plateau($(sel).data("flot_data")[0]['data'], min, max, duration, label);
           }

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -50,7 +50,8 @@ class TestMultiOS(MachineCase):
     }
 
     def check_spawn(self, b, address):
-        # Firefox cannot do `cockpit.spawn` as it returns promise
+        # HACK: Firefox cannot do `cockpit.spawn` as it returns promise
+        # Firefox can wait for promise to resolve, but then cannot get value from it
         if b.cdp.browser == "firefox":
             return
         result = b.call_js_func("""(function(address) {
@@ -59,6 +60,9 @@ class TestMultiOS(MachineCase):
         self.assertEqual(result, "hi\n")
 
     def check_dbus(self, b, address):
+        # HACK: Firefox cannot do `cockpit.dbus.proxy.call` as it returns promise
+        if b.cdp.browser == "firefox":
+            return
         b.call_js_func("""(function(address) {
             return cockpit.dbus("org.freedesktop.DBus", { host: address })
                 .proxy("org.freedesktop.DBus", "/").call("GetId");

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -620,14 +620,14 @@ OnCalendar=daily
                     info[name] = int(value)
             return info
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plot_timestamp = function (sel) {
             var data = $(sel).data("flot_data")[0]['data'];
             return data[data.length-1][0];
           }
         """)
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plot_timestamp_is = function (sel, ts) {
             return ph_plot_timestamp(sel, 0) >= ts;
           }
@@ -643,7 +643,7 @@ OnCalendar=daily
         # outlier will make us miss the expected plateau.  Such
         # outliers happen frequently with the CPU plot.
 
-        b.eval_js("""
+        b.inject_js("""
           ph_plateau = function (data, min, max, duration, label) {
               var i, j;
               var sum;  // sum of data[i..j]
@@ -664,7 +664,7 @@ OnCalendar=daily
           }
         """)
 
-        b.eval_js("""
+        b.inject_js("""
           ph_flot_data_plateau = function (sel, min, max, duration, label) {
             return ph_plateau($(sel).data("flot_data")[0]['data'], min, max, duration, label);
           }

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -59,7 +59,7 @@ class TestStorageMultipath(StorageCase):
         self.login_and_go("/storage")
         b.wait_in_text("#drives", "VirtIO")
 
-        b.eval_js("""
+        b.inject_js("""
           ph_texts = function (sel) {
             return ph_select(sel).map(function (e) { return e.textContent });
           }""")

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -53,7 +53,7 @@ mkpart logical ext2 24 48"""
         m.execute("udevadm settle")
         m.execute("mke2fs -q -L TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1-part5")
 
-        b.eval_js("""
+        b.inject_js("""
           ph_texts = function (sel) {
             return ph_select(sel).map(function(e) { return e.textContent });
           }""")


### PR DESCRIPTION
…expect it

Also sosreport tests are broken, as when it tries to extract the archive, it cannot extract `/procs` due to lack of permissions. Wonder how this differ between chrome and firefox...
