### PR TITLE
ws: Replace deprecated PermissionsStartOnly systemd option

### DIFF
--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -9,8 +9,7 @@ After=cockpit-wsinstance-http.socket cockpit-wsinstance-http-redirect.socket coc
 RuntimeDirectory=cockpit/tls
 # systemd ≥ 241 sets this automatically
 Environment=RUNTIME_DIRECTORY=/run/cockpit/tls
-ExecStartPre=@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
+ExecStartPre=+@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
 ExecStart=@libexecdir@/cockpit-tls
-PermissionsStartOnly=true
 User=@user@
 Group=@group@


### PR DESCRIPTION
systemd 231 replaced it with the `+` prefix, and 240 deprecated it. All
our supported OSes have newer systemd versions now, and our ./configure
even demands ≥ 235.