### PR TITLE
test: allow networking in testlib's global machine

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -188,10 +188,11 @@ def run(opts, image):
             ssh_address = opts.machine
             web_address = opts.browser
         else:
-            ssh_address = "{0}:{1}".format(testlib.MachineCase.get_global_machine().ssh_address,
-                                           testlib.MachineCase.get_global_machine().ssh_port)
-            web_address = "{0}:{1}".format(testlib.MachineCase.get_global_machine().web_address,
-                                           testlib.MachineCase.get_global_machine().web_port)
+            m = testlib.MachineCase.get_global_machine(restrict=not opts.enable_network)
+            ssh_address = "{0}:{1}".format(m.ssh_address,
+                                           m.ssh_port)
+            web_address = "{0}:{1}".format(m.web_address,
+                                           m.web_port)
         for test in serial_tests:
             test.command.insert(-2, "--machine")
             test.command.insert(-2, ssh_address)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1528,6 +1528,8 @@ def arg_parser(enable_sit=True):
                             help="Sit and wait after test failure")
     parser.add_argument('--nonet', dest="fetch", action="store_false",
                         help="Don't go online to download images or data")
+    parser.add_argument('--enable-network', dest='enable_network', action='store_true',
+                        help="Enable network access for tests")
     parser.add_argument('tests', nargs='*')
     parser.add_argument("-l", "--list", action="store_true", help="Print the list of tests that would be executed")
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -711,9 +711,9 @@ class MachineCase(unittest.TestCase):
     provision = None
 
     @classmethod
-    def get_global_machine(klass):
+    def get_global_machine(klass, restrict=True):
         if not klass.global_machine:
-            klass.global_machine = klass.new_machine(klass, cleanup=False)
+            klass.global_machine = klass.new_machine(klass, restrict=restrict, cleanup=False)
             if opts.trace:
                 print("Starting global machine {0}".format(klass.global_machine.label))
             klass.global_machine.start()
@@ -783,7 +783,7 @@ class MachineCase(unittest.TestCase):
         path = "/usr/share/cockpit/%s/override.json" % package
         self.write_file(path, '{ "preload": [%s]}' % ', '.join('"{0}"'.format(page) for page in pages))
 
-    def setUp(self):
+    def setUp(self, restrict=True):
         if opts.address and self.provision is not None:
             raise unittest.SkipTest("Cannot provision multiple machines if a specific machine address is specified")
 
@@ -797,7 +797,7 @@ class MachineCase(unittest.TestCase):
         if self.is_nondestructive() and not opts.address:
             if self.provision:
                 raise unittest.SkipTest("Cannot provision machines if test is marked as nondestructive")
-            self.machine = self.machines['machine1'] = MachineCase.get_global_machine()
+            self.machine = self.machines['machine1'] = MachineCase.get_global_machine(restrict=restrict)
         else:
             self.machine = None
             # First create all machines, wait for them later
@@ -809,6 +809,8 @@ class MachineCase(unittest.TestCase):
                     del options['dns']
                 if 'dhcp' in options:
                     del options['dhcp']
+                if 'restrict' not in options:
+                    options['restrict'] = restrict
                 machine = self.new_machine(**options)
                 self.machines[key] = machine
                 if not self.machine:


### PR DESCRIPTION
The global machine is created when running non-destructive tests without
passing `--machine`. It is created without networking and there is no
way for a test to override this default.

The machines we run non-destructive tests against usually have
networking enabled. Thus, enable networking for the global machine as
well.