### PR TITLE
common: Set strict Cross-Origin-Resource-Policy

### DIFF
--- a/src/base1/test-http.js
+++ b/src/base1/test-http.js
@@ -212,6 +212,7 @@ QUnit.test("headers", function (assert) {
                     "Referrer-Policy": "no-referrer",
                     "X-DNS-Prefetch-Control": "off",
                     "X-Content-Type-Options": "nosniff",
+                    "Cross-Origin-Resource-Policy": "same-origin",
                 }, "got back headers");
             })
             .always(function() {
@@ -253,6 +254,7 @@ QUnit.test("connection headers", function (assert) {
                     "Referrer-Policy": "no-referrer",
                     "X-DNS-Prefetch-Control": "off",
                     "X-Content-Type-Options": "nosniff",
+                    "Cross-Origin-Resource-Policy": "same-origin",
                 }, "got back combined headers");
             })
             .always(function() {

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -34,7 +34,7 @@
 extern gboolean cockpit_webserver_want_certificate;
 
 /* JSON dict snippet for headers that are present in every request */
-#define STATIC_HEADERS "\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"X-Content-Type-Options\":\"nosniff\""
+#define STATIC_HEADERS "\"Cross-Origin-Resource-Policy\":\"same-origin\",\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"X-Content-Type-Options\":\"nosniff\""
 
 static void
 on_closed_set_flag (CockpitChannel *channel,

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -46,7 +46,7 @@
 #define CHECKSUM_CSP            "80921dc3cde9ff9f2acd2a5851f9b2a3b25ea7b4577128461d9e32fbdd671e16"
 
 /* JSON dict snippet for headers that are present in every request */
-#define STATIC_HEADERS "\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"X-Content-Type-Options\":\"nosniff\""
+#define STATIC_HEADERS "\"X-DNS-Prefetch-Control\":\"off\",\"Referrer-Policy\":\"no-referrer\",\"X-Content-Type-Options\":\"nosniff\",\"Cross-Origin-Resource-Policy\": \"same-origin\""
 #define STATIC_HEADERS_CACHECONTROL STATIC_HEADERS ",\"Cache-Control\":\"no-cache, no-store\""
 
 extern const gchar **cockpit_bridge_data_dirs;

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -746,6 +746,7 @@ enum {
     HEADER_DNS_PREFETCH_CONTROL = 1 << 4,
     HEADER_REFERRER_POLICY = 1 << 5,
     HEADER_CONTENT_TYPE_OPTIONS = 1 << 6,
+    HEADER_CROSS_ORIGIN_RESOURCE_POLICY = 1 << 7,
 };
 
 static GString *
@@ -786,6 +787,8 @@ append_header (GString *string,
     return HEADER_REFERRER_POLICY;
   if (g_ascii_strcasecmp ("X-Content-Type-Options", name) == 0)
     return HEADER_CONTENT_TYPE_OPTIONS;
+  if (g_ascii_strcasecmp ("Cross-Origin-Resource-Policy", name) == 0)
+    return HEADER_CROSS_ORIGIN_RESOURCE_POLICY;
   if (g_ascii_strcasecmp ("Content-Length", name) == 0 ||
       g_ascii_strcasecmp ("Transfer-Encoding", name) == 0 ||
       g_ascii_strcasecmp ("Connection", name) == 0)
@@ -893,6 +896,10 @@ finish_headers (CockpitWebResponse *self,
     g_string_append (string, "Referrer-Policy: no-referrer\r\n");
   if ((seen & HEADER_CONTENT_TYPE_OPTIONS) == 0)
     g_string_append (string, "X-Content-Type-Options: nosniff\r\n");
+  /* Be very strict here -- there is no reason that external web sites should
+   * be able to read any resource. This does *not* affect embedding with <iframe> */
+  if ((seen & HEADER_CROSS_ORIGIN_RESOURCE_POLICY) == 0)
+    g_string_append (string, "Cross-Origin-Resource-Policy: same-origin\r\n");
 
   g_string_append (string, "\r\n");
   return g_string_free_to_bytes (string);

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -35,7 +35,7 @@
 #include <string.h>
 
 /* headers that are present in every request */
-#define STATIC_HEADERS "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\nX-Content-Type-Options: nosniff\r\n\r\n"
+#define STATIC_HEADERS "X-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\nX-Content-Type-Options: nosniff\r\nCross-Origin-Resource-Policy: same-origin\r\n\r\n"
 static gchar *srcdir;
 
 typedef struct {

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -53,7 +53,7 @@
 #define PASSWORD "this is the password"
 
 /* headers that are present in every request */
-#define STATIC_HEADERS "X-Content-Type-Options: nosniff\r\nX-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\n"
+#define STATIC_HEADERS "X-Content-Type-Options: nosniff\r\nX-DNS-Prefetch-Control: off\r\nReferrer-Policy: no-referrer\r\nCross-Origin-Resource-Policy: same-origin\r\n"
 
 typedef struct {
   CockpitWebService *service;

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -387,6 +387,9 @@ class TestConnection(MachineCase):
         self.assertIn(
             "default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 wss://127.0.0.1:9090", headers)
         self.assertIn("Access-Control-Allow-Origin: https://127.0.0.1:9090", headers)
+        # CORP is also set for dynamic paths
+        if m.image not in ["rhel-8-3-distropkg"]:  # added in PR #14215
+            self.assertIn("Cross-Origin-Resource-Policy: same-origin", headers)
 
         self.allow_journal_messages(
             ".*Peer failed to perform TLS handshake",
@@ -520,6 +523,8 @@ class TestConnection(MachineCase):
         headers = m.execute("curl -s --head http://172.27.0.15:9090/cockpit/static/login.min.html")
         self.assertIn("HTTP/1.1 200 OK\r\n", headers)
         self.assertIn("Content-Type: text/html\r\n", headers)
+        if m.image not in ["rhel-8-3-distropkg"]:  # added in PR #14215
+            self.assertIn("Cross-Origin-Resource-Policy: same-origin\r\n", headers)
         # login.html is not always accessible as a file (e. g. in Atomic), so just assert a reasonable content length
         self.assertIn("Content-Length: ", headers)
         length = int(headers.split('Content-Length: ', 1)[1].split()[0])

--- a/test/verify/files/embed-cockpit.html
+++ b/test/verify/files/embed-cockpit.html
@@ -5,8 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="shortcut icon" href="../dist/img/favicon.ico">
-    <link href="../../../dist/base1/patternfly.min.css" rel="stylesheet" media="screen, print">
-    <link href="../../../dist/base1/patternfly-additions.css" rel="stylesheet" media="screen, print">
+    <link href="../../../dist/base1/patternfly.css" rel="stylesheet" media="screen, print">
     <style>
         #embed-links .card-pf-body {
             opacity: 0.3;


### PR DESCRIPTION
There is no good use case for including parts of Cockpit's resources
into websites of a different origin. Cockpit does not expose any images
or scripts which would work or make sense there. Thus set the
`Cross-Origin-Resource-Policy` header [1] to `same-origin` for both
static and authenticated paths.

Do this even for "ping", as this doesn't matter for that API -- CORP
leaves the complete response intact, it just instructs the browser to
discard the response contents.

The only cross-origin use case that we have is to embed Cockpit frames
into other websites. The CORP header does not affect `<iframe>`, so this
continues to work fine.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)

## Release note
Cockpit's web server now sets the [Cross-Origin-Resource-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cross-Origin_Resource_Policy_(CORP)) header to `same-origin`. Web browsers use this header to prevent other web sites from loading individual HTML, JavaScript, or image resources from cockpit via `<img>`, `<script>`, or similar tags. This is mostly a precaution -- currently there are no known vulnerabilities with including resources that way, but as this is not a legitimate use case, there is no reason to allow it.
