### PR TITLE
tools: Don't run slow unit tests on RISC-V architectures in Debian/Ubuntu

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -8,6 +8,11 @@ ifeq ($(BUILD_DOCKER),)
        export DH_OPTIONS = -Ncockpit-docker
 endif
 
+# this is an emulated architecture for now, and too slow to run expensive unit tests
+ifeq ($(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64)
+	export COCKPIT_SKIP_SLOW_TESTS=1
+endif
+
 %:
 	dh $@
 


### PR DESCRIPTION
Currently all available buildds are emulated, and thus very slow. It
takes way more than 10 minutes to run test-tls-certfile, so skip that
and other slow unit tests on this architecture.