### PR TITLE
test/common/run-tests: don't fail when not run from a git checkout

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -297,14 +297,14 @@ def main():
         opts.nondestructive = True
 
     image = testvm.DEFAULT_IMAGE
-    revision = os.environ.get("TEST_REVISION")
     test_browser = os.environ.get("TEST_BROWSER", "chromium")
-    if not revision:
-        revision = subprocess.check_output(["git", "rev-parse", "HEAD"],
-                                           universal_newlines=True).strip()
+    if "TEST_REVISION" not in os.environ:
+        r = subprocess.run(["git", "rev-parse", "HEAD"],
+                           universal_newlines=True, check=False, stdout=subprocess.PIPE)
+        if r.returncode == 0:
+            os.environ["TEST_REVISION"] = r.stdout.strip()
 
     # Tell any subprocesses what we are testing
-    os.environ["TEST_REVISION"] = revision
     os.environ["TEST_BROWSER"] = test_browser
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -296,16 +296,16 @@ def main():
             parser.error("--machine cannot be used with concurrent jobs")
         opts.nondestructive = True
 
-    image = testvm.DEFAULT_IMAGE
-    test_browser = os.environ.get("TEST_BROWSER", "chromium")
+    # Tell any subprocesses what we are testing
     if "TEST_REVISION" not in os.environ:
         r = subprocess.run(["git", "rev-parse", "HEAD"],
                            universal_newlines=True, check=False, stdout=subprocess.PIPE)
         if r.returncode == 0:
             os.environ["TEST_REVISION"] = r.stdout.strip()
 
-    # Tell any subprocesses what we are testing
-    os.environ["TEST_BROWSER"] = test_browser
+    os.environ["TEST_BROWSER"] = os.environ.get("TEST_BROWSER", "chromium")
+
+    image = testvm.DEFAULT_IMAGE
     testvm.DEFAULT_IMAGE = image
     os.environ["TEST_OS"] = image
 


### PR DESCRIPTION
See commits.

I ran into this when trying to use `run-tests` from gating, where it is run from a tarball, not a git checkout