### PR TITLE
logs: Also support "service:<name>" without ".service" suffix

### DIFF
--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -415,7 +415,10 @@ $(function() {
         }
 
         if (options.service) {
-            match.push(...['_SYSTEMD_UNIT=' + options.service, "+", "COREDUMP_UNIT=" + options.service, "+", "UNIT=" + options.service]);
+            let s = options.service;
+            if (!s.endsWith(".service"))
+                s = s + ".service";
+            match.push(...['_SYSTEMD_UNIT=' + s, "+", "COREDUMP_UNIT=" + s, "+", "UNIT=" + s]);
             full_grep += "service:" + options.service + " ";
         }
 

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -233,7 +233,11 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         b.go("#/?prio=debug&start=recent&service=nonexisting.service")
         wait_journal_empty()
-        b.go("#/?prio=debug&start=recent&service=log123.service")
+
+        if m.image == "rhel-8-3-distropkg": # Changed in #14221
+            b.go("#/?prio=debug&start=recent&service=log123.service")
+        else:
+            b.go("#/?prio=debug&start=recent&service=log123")
         wait_log123()
 
         b.go("#/?prio=debug&start=recent&service=slow10.service")


### PR DESCRIPTION
Seems that users expect it to work without the suffix.
It is also more aligned to what systemctl does and also our service page.