### PR TITLE
test: Add run-tests --exclude option

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -40,6 +40,15 @@ def test_name(test):
     return "{0} {1} {2}{3}".format(test.test_id, test.command[0], test.command[-1], " [ND]" if test.nondestructive else "")
 
 
+def flush_stdout():
+    while True:
+        try:
+            sys.stdout.flush()
+            break
+        except BlockingIOError:
+            time.sleep(0.1)
+
+
 def print_test(test, print_tap=True):
     for line in test.output.splitlines(keepends=True):
         while line:
@@ -49,7 +58,7 @@ def print_test(test, print_tap=True):
             except BlockingIOError as e:
                 line = line[e.characters_written:]
                 time.sleep(0.1)
-    sys.stdout.flush()
+    flush_stdout()
 
     if not print_tap:
         return
@@ -63,7 +72,7 @@ def print_test(test, print_tap=True):
                                   test.output.splitlines()[-1].strip().decode() if test.process.returncode == 77 else ""))
     else:
         print("not ok " + test_name(test))
-    sys.stdout.flush()
+    flush_stdout()
 
 def finish_test(opts, test):
     """Returns if a test should retry or not
@@ -189,7 +198,7 @@ def run(opts, image):
     serial_tests.sort(key=lambda t: t.command[-1], reverse=bool(binascii.crc32(image.encode()) & 1))
 
     print("1..{0}".format(len(parallel_tests) + len(serial_tests)))
-    sys.stdout.flush()
+    flush_stdout()
 
     if serial_tests and not opts.list:
         if opts.machine:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -282,7 +282,6 @@ def run(opts, image):
 
 def main():
     parser = testlib.arg_parser(enable_sit=False)
-    parser.add_argument('--publish', action='store', help="Unused")
     parser.add_argument('-j', '--jobs', type=int,
                         default=os.environ.get("TEST_JOBS", 1), help="Number of concurrent jobs")
     parser.add_argument('--thorough', action='store_true',

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -172,6 +172,8 @@ def run(opts, image):
                 test_timeout = getattr(test_method, "__timeout", getattr(test, "__timeout", 600))
                 if opts.tests and not any([t in test_str for t in opts.tests]):
                     continue
+                if test_str in opts.exclude:
+                    continue
                 nd = getattr(test_method, "_testlib__non_destructive", False)
                 test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd)
                 if nd:
@@ -294,6 +296,8 @@ def main():
                         default=None, help="When using --machine, use this cockpit web address")
     parser.add_argument('--test-dir', default=testvm.TEST_DIR,
                         help="Directory in which to glob check-* files")
+    parser.add_argument('--exclude', action="append", default=[], metavar="TestClass.testName",
+                        help="Exclude test (exact match only); can be specified multiple times")
     opts = parser.parse_args()
 
     if opts.machine:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1527,8 +1527,8 @@ def arg_parser(enable_sit=True):
                         help="Don't go online to download images or data")
     parser.add_argument('--enable-network', dest='enable_network', action='store_true',
                         help="Enable network access for tests")
-    parser.add_argument('tests', nargs='*')
     parser.add_argument("-l", "--list", action="store_true", help="Print the list of tests that would be executed")
+    parser.add_argument('tests', nargs='*')
 
     parser.set_defaults(verbosity=1, fetch=True)
     return parser

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -45,6 +45,11 @@ class TestRunTestListing(unittest.TestCase):
         # Filter a specific test
         self.assertIn("1..1\nTestNondestructiveExample.testOne",
                       subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "-l", "TestNondestructiveExample.testOne"]).strip().decode())
+        # Exclude test patterns
+        self.assertIn("1..1\nTestNondestructiveExample.testOne",
+                      subprocess.check_output([run_tests, "--test-dir", VERIFY_DIR, "-l",
+                                               "--exclude", "bogus", "--exclude", "TestNondestructiveExample.testTwo",
+                                               "TestNondestructiveExample"]).strip().decode())
 
         ndtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"], env=forward_sort_env, check=True, capture_output=True)
         self.assertIn(b"TestExample.testNondestructive\n", ndtests.stdout)


### PR DESCRIPTION
This is useful for skipping one or two specific tests in downstream
gating without having to explicitly enumerate all the others.