### PR TITLE
base1: Ship base1/patternfly.css again

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -3,6 +3,7 @@
 basedir = $(pkgdatadir)/base1
 nodist_base_DATA = \
 	dist/base1/cockpit.min.css.gz \
+	dist/base1/patternfly.css \
 	dist/base1/mustache.min.js.gz \
 	dist/base1/jquery.min.js.gz \
 	dist/base1/cockpit.min.js.gz \


### PR DESCRIPTION
Commit 46db248 dropped it, so that it fell out of cockpit-bridge. This
broke every third-party Cockpit package. We didn't mean to obsolete it
*that* fast!

Fixes #14229