### PR TITLE
lib: Rename superuser.jsx to superuser.js

### DIFF
--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -27,7 +27,7 @@ import ReactDOM from "react-dom";
 
 import { KdumpPage } from "./kdump-view.jsx";
 import * as kdumpClient from "./kdump-client.js";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 superuser.reload_page_on_change();
 

--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -18,7 +18,7 @@
  */
 
 import cockpit from "cockpit";
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 const _ = cockpit.gettext;
 

--- a/pkg/lib/superuser.js
+++ b/pkg/lib/superuser.js
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 
-/* import { superuser } from "superuser.jsx";
+/* import { superuser } from "superuser";
  *
  * The "superuser" object indicates whether or not the current page
  * can open superuser channels.

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -34,7 +34,7 @@ import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import { ModalError } from "cockpit-components-inline-notification.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import "page.scss";
 import "table.css";

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -23,7 +23,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import cockpit from 'cockpit';
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 import firewall from './firewall-client.js';
 import * as utils from './utils';

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -33,7 +33,7 @@ import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 import * as PK from "packagekit.js";
 
 import "listing.scss";

--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -27,7 +27,7 @@ import '../../src/base1/patternfly-cockpit.scss';
 import * as troubleshootClient from "./setroubleshoot-client";
 import * as selinuxClient from "./selinux-client.js";
 import { SETroubleshootPage } from "./setroubleshoot-view.jsx";
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 const _ = cockpit.gettext;
 

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -7,7 +7,7 @@ import { PageSidebar, Button } from '@patternfly/react-core';
 import { EditIcon, MinusIcon } from '@patternfly/react-icons';
 
 import 'polyfills';
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 
 import { machines } from "machines";

--- a/pkg/sosreport/index.js
+++ b/pkg/sosreport/index.js
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import $ from "jquery";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import '../../src/base1/patternfly-cockpit.scss';
 

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 import * as PK from 'packagekit.js';
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 import * as utils from './utils';
 

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -24,7 +24,7 @@ import cockpit from "cockpit";
 import { journal } from "journal";
 import moment from "moment";
 import { init_reporting } from "./reporting.jsx";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import ReactDOM from 'react-dom';
 import React from 'react';

--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -30,7 +30,7 @@ import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import { Privileged } from "cockpit-components-privileged.jsx";
 import { ServerTime } from './serverTime.js';
 import * as realmd from "./realmd-operation.js";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 /* These add themselves to jQuery so just including is enough */
 import "patterns";

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -32,7 +32,7 @@ import {
 } from '@patternfly/react-core';
 
 import { shutdown, shutdown_modal_setup } from "./shutdown.js";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { SystemInfomationCard } from './overview-cards/systemInformationCard.jsx';
 import { ConfigurationCard } from './overview-cards/configurationCard.jsx';

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -25,7 +25,7 @@ import {
 
 import { ServiceDetails, ServiceTemplate } from "./service-details.jsx";
 import { LogsPanel } from "cockpit-components-logs-panel.jsx";
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 import cockpit from "cockpit";
 

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -46,7 +46,7 @@ import { onCreateTimer, timerDialogSetup } from "./timer-dialog.js";
 import moment from "moment";
 import { page_status } from "notifications";
 import cockpit from "cockpit";
-import { superuser } from 'superuser.jsx';
+import { superuser } from 'superuser';
 
 moment.locale(cockpit.language);
 

--- a/pkg/tuned/dialog.js
+++ b/pkg/tuned/dialog.js
@@ -22,7 +22,7 @@ import cockpit from "cockpit";
 
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 import * as service from "service";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 import React from "react";
 
 import { TunedDialogBody } from "./change-profile.jsx";

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { useState, useEffect } from 'react';
 import moment from "moment";
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { Button } from '@patternfly/react-core';
 import { show_unexpected_error } from "./dialog-utils.js";

--- a/pkg/users/account-roles.js
+++ b/pkg/users/account-roles.js
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React, { useState } from 'react';
 import { Tooltip, TooltipPosition } from '@patternfly/react-core';
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { show_unexpected_error } from "./dialog-utils.js";
 

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { Button, Badge } from '@patternfly/react-core';
 import { account_create_dialog } from "./account-create-dialog.js";

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -23,7 +23,7 @@ import cockpit from 'cockpit';
 import moment from "moment";
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { usePageLocation, useLoggedInUser, useFile } from "hooks.js";
 import { etc_passwd_syntax, etc_group_syntax } from "./parsers.js";

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -19,7 +19,7 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { superuser } from "superuser.jsx";
+import { superuser } from "superuser";
 
 import { Modal } from 'patternfly-react';
 import { Validated, has_errors } from "./dialog-utils.js";


### PR DESCRIPTION
There is no JSX in that file, and there shouldn't be -- that file should
be usable from non-React/JSX code as well.

This is mostly just cosmetical, but as this file is expected to be
copied to external projects, let's not raise wrong expectations.

This also disambiguates it from pkg/shell/superuser.jsx, which *is*
React/JSX.