### PR TITLE
test: Allow restart messages in TestLogin.testTally

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -678,5 +678,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 expect_failed_login("root", "bad", n)
             expect_successful_login("root", "foobar")
 
+        self.allow_restart_journal_messages()
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
The test restarts cockpit a lot, so occasionally runs into disconnect
messages.