### PR TITLE
tools: Don't run unit tests on RHEL 8 i686

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -165,7 +165,13 @@ exec 2>&1
 %define testsuite_fail || true
 %endif
 %endif
-make -j4 check %{?testsuite_fail}
+# HACK: RHEL i686 builders hang after running all tests; not a supported architecture, so don't bother
+%if 0%{?rhel} >= 8
+%ifarch i686
+%define testsuite_skip #
+%endif
+%endif
+%{?testsuite_skip} make -j4 check %{?testsuite_fail}
 
 %install
 make install DESTDIR=%{buildroot}


### PR DESCRIPTION
The RHEL  i686 builders hang more often than not *after* running the
unit tests. This is not a supported architecture in RHEL 8, so don't
bother.