### PR TITLE
bridge: drop some debugging output

### DIFF
--- a/src/bridge/cockpithttpstream.c
+++ b/src/bridge/cockpithttpstream.c
@@ -205,7 +205,6 @@ typedef struct _CockpitHttpStream {
   CockpitStream *stream;
   gulong sig_open;
   gulong sig_read;
-  gulong sig_rejected_cert;
   gulong sig_close;
 
   gint state;
@@ -642,22 +641,6 @@ on_stream_read (CockpitStream *stream,
 }
 
 static void
-on_rejected_cert (CockpitStream *stream,
-                  const gchar *pem_data,
-                  gpointer user_data)
-{
-  CockpitHttpStream *self = user_data;
-  CockpitChannel *channel = user_data;
-  JsonObject *close_options = NULL; // owned by channel
-
-  if (self->state != FINISHED)
-    {
-      close_options = cockpit_channel_close_options (channel);
-      json_object_set_string_member (close_options, "rejected-certificate", pem_data);
-    }
-}
-
-static void
 on_stream_close (CockpitStream *stream,
                  const gchar *problem,
                  gpointer user_data)
@@ -955,7 +938,6 @@ cockpit_http_stream_close (CockpitChannel *channel,
             g_signal_handler_disconnect (self->stream, self->sig_open);
           g_signal_handler_disconnect (self->stream, self->sig_read);
           g_signal_handler_disconnect (self->stream, self->sig_close);
-          g_signal_handler_disconnect (self->stream, self->sig_rejected_cert);
           cockpit_http_client_checkin (self->client, self->stream);
           cockpit_flow_throttle (COCKPIT_FLOW (self->stream), NULL);
           cockpit_flow_throttle (COCKPIT_FLOW (channel), NULL);
@@ -1056,8 +1038,6 @@ cockpit_http_stream_prepare (CockpitChannel *channel)
 
   self->sig_read = g_signal_connect (self->stream, "read", G_CALLBACK (on_stream_read), self);
   self->sig_close = g_signal_connect (self->stream, "close", G_CALLBACK (on_stream_close), self);
-  self->sig_rejected_cert = g_signal_connect (self->stream, "rejected-cert",
-                                              G_CALLBACK (on_rejected_cert), self);
 
   /* Let the channel throttle the stream's input flow*/
   cockpit_flow_throttle (COCKPIT_FLOW (self->stream), COCKPIT_FLOW (self));
@@ -1085,7 +1065,6 @@ cockpit_http_stream_dispose (GObject *object)
         g_signal_handler_disconnect (self->stream, self->sig_open);
       g_signal_handler_disconnect (self->stream, self->sig_read);
       g_signal_handler_disconnect (self->stream, self->sig_close);
-      g_signal_handler_disconnect (self->stream, self->sig_rejected_cert);
       cockpit_stream_close (self->stream, NULL);
       g_object_unref (self->stream);
     }

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -56,7 +56,6 @@ typedef struct _CockpitWebSocketStream {
   gulong sig_closing;
   gulong sig_close;
   gulong sig_error;
-  gulong sig_accept_cert;
 
   gboolean binary;
   gboolean closed;
@@ -128,25 +127,6 @@ static void
 cockpit_web_socket_stream_init (CockpitWebSocketStream *self)
 {
 
-}
-
-static gboolean
-on_rejected_certificate (GTlsConnection *conn,
-                         GTlsCertificate *peer_cert,
-                         GTlsCertificateFlags errors,
-                         gpointer user_data)
-{
-  CockpitChannel *channel = user_data;
-  JsonObject *close_options = NULL; // owned by channel
-  gchar *pem_data = NULL;
-
-  g_return_val_if_fail (peer_cert != NULL, FALSE);
-  g_object_get (peer_cert, "certificate-pem", &pem_data, NULL);
-  close_options = cockpit_channel_close_options (channel);
-  json_object_set_string_member (close_options, "rejected-certificate", pem_data);
-
-  g_free (pem_data);
-  return FALSE;
 }
 
 static void
@@ -291,18 +271,6 @@ on_socket_connect (GObject *object,
       goto out;
     }
 
-  if (G_IS_TLS_CONNECTION (io))
-    {
-      self->sig_accept_cert =  g_signal_connect (G_TLS_CONNECTION (io),
-                                                 "accept-certificate",
-                                                 G_CALLBACK (on_rejected_certificate),
-                                                 self);
-    }
-  else
-    {
-      self->sig_accept_cert = 0;
-    }
-
   self->client = web_socket_client_new_for_stream (self->url, self->origin, (const gchar **)protocols, io);
 
   node = json_object_get_member (options, "headers");
@@ -404,7 +372,6 @@ static void
 cockpit_web_socket_stream_dispose (GObject *object)
 {
   CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (object);
-  GIOStream *io = NULL; // Owned by self->client;
 
   if (self->client)
     {
@@ -415,10 +382,6 @@ cockpit_web_socket_stream_dispose (GObject *object)
       g_signal_handler_disconnect (self->client, self->sig_closing);
       g_signal_handler_disconnect (self->client, self->sig_close);
       g_signal_handler_disconnect (self->client, self->sig_error);
-
-      io = web_socket_connection_get_io_stream (self->client);
-      if (io != NULL && self->sig_accept_cert)
-        g_signal_handler_disconnect (io, self->sig_accept_cert);
 
       g_object_unref (self->client);
       self->client = NULL;

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -324,11 +324,6 @@ test_tls_authority_bad (TestTls *test,
 
   GBytes *bytes;
   JsonObject *resp;
-  gchar *expected_pem = NULL;
-  gchar *expected_json = NULL;
-
-  g_object_get (test->certificate, "certificate-pem", &expected_pem, NULL);
-  g_assert_true (expected_pem != NULL);
 
   tls = cockpit_json_parse_object (json, -1, &error);
   g_assert_no_error (error);
@@ -354,13 +349,10 @@ test_tls_authority_bad (TestTls *test,
     g_main_context_iteration (NULL, TRUE);
 
   resp = mock_transport_pop_control (test->transport);
-  expected_json = g_strdup_printf ("{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\", "
-                                   " \"rejected-certificate\":\"%s\"}", expected_pem);
-  cockpit_assert_json_eq (resp, expected_json);
+  json_object_remove_member (resp, "message");
+  cockpit_assert_json_eq (resp, "{\"command\":\"close\",\"channel\":\"444\",\"problem\":\"unknown-hostkey\"}");
 
   g_object_unref (channel);
-  g_free (expected_pem);
-  g_free (expected_json);
 }
 
 int


### PR DESCRIPTION
Cockpit used to report some extra error data on TLS certificate errors
from CockpitStream connections, but this is now dead code (as a result
of the TLS handshake being performed inside of GSocketClient). Nothing
appears to be using this data, outside of the tests.

----

Split out from PR #13865, which got stalled for months already. This by itself is not that useful yet, but it paves the way for further simplification of the bridge code. Let's test and land that separately.