### PR TITLE
test: Adjust SSH fingerprint parsing for RHEL 8.3 OpenSSH

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -361,7 +361,7 @@ class TestMultiMachine(MachineCase):
         b.wait_in_text("#conversation-prompt", "Fingerprint")
         b.wait_in_text("#conversation-message", "Do you want to proceed this time?")
 
-        match = re.match(r'(MD5|SHA256) Fingerprint \(ssh-(.*)\):', b.text("#conversation-prompt"))
+        match = re.match(r'(MD5|SHA256) Fingerprint \((?:ssh-)?([^-]*).*\):', b.text("#conversation-prompt"))
         assert match
         (hash_fn, algo) = match.groups()
         try:


### PR DESCRIPTION
The fingerprint prompt is now "SHA256 Fingerprint (ecdsa-sha2-nistp256)"
without the "ssh-" prefix, and a more detailed algorithm. Make the ssh-
prefix optional and only take the first part of the algorithm, so that
this gets along with either format.