### PR TITLE
test: Adjust for /etc/ssh/sshd_config.d/ directory

### DIFF
--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -49,8 +49,8 @@ class TestLoopback(MachineCase):
         self.assertIn("no-cockpit", b.text('#login-fatal'))
 
         m.disconnect()
-        self.sed_file('s/.*PasswordAuthentication.*/PasswordAuthentication no/', '/etc/ssh/sshd_config',
-                      '( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service')
+        m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
+        m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
         m.wait_execute()
 
         b.reload()

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -101,7 +101,7 @@ class TestMultiMachineKeyAuth(MachineCase):
         self.machine2.disconnect()
         self.machine2.execute("useradd user -c 'User' || true", direct=True)
         self.machine2.execute(
-            "sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config", direct=True)
+            "sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)", direct=True)
         self.machine2.execute(
             "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
         self.machine2.wait_execute()


### PR DESCRIPTION
Recent Fedora versions now put the distro specific configuration into
/etc/ssh/sshd_config.d/50-redhat.conf, which includes
`PasswordAuthentication yes`.