### PR TITLE
test: Fix TestLogin.testTally to not fail on existing tally log

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -622,9 +622,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             # https://bugzilla.redhat.com/show_bug.cgi?id=1836182
             self.allow_journal_messages('.*type=1400.*avc:  denied  { chown }.*comm="cockpit-session".*')
 
-        if module == 'pam_tally2':
-            # at first, we should have no log file
-            m.execute("! test -f {}".format(logfile('admin')))
+        # start from a clean slate
+        self.restore_file(logfile('admin'))
+        m.execute("rm -f " + logfile('admin'))
 
         # make sure we can still login
         b.login_and_go("/system")


### PR DESCRIPTION
Running testTally more than once in a row (as it happens when a PR
touches check-login) causes the second run to fail on an existing tally
log. Instead of assuming that it does not exist (which isn't a good
assumption for already existing testbeds), just make sure to delete it,
and restore it at the end.