### PR TITLE
bridge: Add extra parameters on fslist

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -872,9 +872,10 @@ The following options can be specified in the "open" control message:
 The channel will send a number of JSON messages that list the current
 content of the directory.  These messages have a "event" field with
 value "present", a "path" field that holds the (relative) name of
-the file and a type field. Type will be one of: file, directory, link,
-special or unknown. After all files have been listed the "ready"
-control message will be sent.
+the file, "owner", "group", "size" and "modified" (timestamp) fields with
+some basic file information, and a "type" field. Type will be one of:
+file, directory, link, special or unknown. After all files have been listed the
+"ready" control message will be sent.
 
 Other messages on the stream signal changes to the directory, in the
 same format as used by the "fswatch1" payload type.

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -133,6 +133,14 @@ on_files_listed (GObject *source_object,
         (msg, "path", g_file_info_get_attribute_byte_string (info, G_FILE_ATTRIBUTE_STANDARD_NAME));
       json_object_set_string_member
         (msg, "type", cockpit_file_type_to_string (g_file_info_get_file_type (info)));
+      json_object_set_string_member
+        (msg, "owner", g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_OWNER_USER));
+      json_object_set_string_member
+        (msg, "group", g_file_info_get_attribute_string (info, G_FILE_ATTRIBUTE_OWNER_GROUP));
+      json_object_set_int_member
+        (msg, "size", g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_STANDARD_SIZE));
+      json_object_set_int_member
+        (msg, "modified", g_file_info_get_attribute_uint64 (info, G_FILE_ATTRIBUTE_TIME_MODIFIED));
       msg_bytes = cockpit_json_write_bytes (msg);
       json_object_unref (msg);
       cockpit_channel_send (COCKPIT_CHANNEL(self), msg_bytes, FALSE);
@@ -250,7 +258,9 @@ cockpit_fslist_prepare (CockpitChannel *channel)
     }
 
   g_file_enumerate_children_async (file,
-                                   G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE,
+                                   G_FILE_ATTRIBUTE_STANDARD_NAME "," G_FILE_ATTRIBUTE_STANDARD_TYPE ","
+                                   G_FILE_ATTRIBUTE_OWNER_USER "," G_FILE_ATTRIBUTE_OWNER_GROUP ","
+                                   G_FILE_ATTRIBUTE_STANDARD_SIZE "," G_FILE_ATTRIBUTE_TIME_MODIFIED,
                                    G_FILE_QUERY_INFO_NONE,
                                    G_PRIORITY_DEFAULT,
                                    self->cancellable,

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -834,6 +834,10 @@ test_dir_simple (TestCase *tc,
   g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present");
   g_assert_cmpstr (json_object_get_string_member (event, "path"), ==, base);
   g_assert_cmpstr (json_object_get_string_member (event, "type"), ==, "file");
+  g_assert_cmpstr (json_object_get_string_member (event, "owner"), ==, g_get_user_name());
+  g_assert_cmpstr (json_object_get_string_member (event, "group"), !=, NULL);
+  g_assert_cmpint (json_object_get_int_member (event, "size"), ==, 6);
+  g_assert_cmpint (json_object_get_int_member (event, "modified"), >, 1610000000);
   json_object_unref (event);
 
   control = recv_control (tc);
@@ -863,6 +867,10 @@ test_dir_simple_no_watch (TestCase *tc,
   g_assert_cmpstr (json_object_get_string_member (event, "event"), ==, "present");
   g_assert_cmpstr (json_object_get_string_member (event, "path"), ==, base);
   g_assert_cmpstr (json_object_get_string_member (event, "type"), ==, "file");
+  g_assert_cmpstr (json_object_get_string_member (event, "owner"), ==, g_get_user_name());
+  g_assert_cmpstr (json_object_get_string_member (event, "group"), !=, NULL);
+  g_assert_cmpint (json_object_get_int_member (event, "size"), ==, 6);
+  g_assert_cmpint (json_object_get_int_member (event, "modified"), >, 1610000000);
   json_object_unref (event);
 
   control = recv_control (tc);


### PR DESCRIPTION
For #14170, This is just the starting point for running strace, I added a few basic attributes that are usually available for ls. 

This PR also does not do anything regarding the watch on fslist, I'd be happy to have any guidance how to handle it.