### PR TITLE
machines: Implement creation of VM snapshots

### DIFF
--- a/pkg/machines/components/vmSnapshotsCreateModal.jsx
+++ b/pkg/machines/components/vmSnapshotsCreateModal.jsx
@@ -1,0 +1,156 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import cockpit from "cockpit";
+import React from "react";
+import moment from "moment";
+
+import { Modal } from "patternfly-react";
+import {
+    Button,
+    FormGroup,
+    TextArea,
+    TextInput
+} from "@patternfly/react-core";
+
+import { ModalError } from "cockpit-components-inline-notification.jsx";
+import { createSnapshot } from "../libvirt-dbus.js";
+import { getVmSnapshots } from '../actions/provider-actions.js';
+
+const _ = cockpit.gettext;
+
+const NameRow = ({ onValueChanged, dialogValues, onValidate }) => {
+    return (
+        <>
+            <label className="control-label" htmlFor="name">
+                {_("Name")}
+            </label>
+            <FormGroup validated={dialogValues.validationError.name ? "error" : "default"}
+                fieldId="name"
+                helperText={dialogValues.validationError.name}>
+                <TextInput value={dialogValues.name}
+                    id="name"
+                    type="text"
+                    onChange={(value) => onValueChanged("name", value)}
+                    aria-label={_("Name input text")}
+                />
+            </FormGroup>
+        </>
+    );
+};
+
+const DescriptionRow = ({ onValueChanged, dialogValues }) => {
+    return (
+        <>
+            <label className="control-label" htmlFor="description">
+                {_("Description")}
+            </label>
+            <TextArea value={dialogValues.description}
+                id="description"
+                onChange={(value) => onValueChanged("description", value)}
+                resizeOrientation="vertical"
+                aria-label={_("Description input text")}
+            />
+        </>
+    );
+};
+
+export class CreateSnapshotModal extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            name: props.vm.name + '_' + moment().format("YYYY-MM-DD_hh:mma"),
+            description: "",
+            validationError: {},
+        };
+
+        this.onValueChanged = this.onValueChanged.bind(this);
+        this.dialogErrorSet = this.dialogErrorSet.bind(this);
+        this.onValidate = this.onValidate.bind(this);
+        this.onCreate = this.onCreate.bind(this);
+    }
+
+    onValueChanged(key, value) {
+        this.setState({ [key]: value });
+    }
+
+    dialogErrorSet(text, detail) {
+        this.setState({ dialogError: text, dialogErrorDetail: detail });
+    }
+
+    onValidate() {
+        const { name, validationError } = this.state;
+        const { vm } = this.props;
+
+        const newValidationError = { ...validationError };
+        if (vm.snapshots.findIndex(snap => snap.name === name) > -1)
+            newValidationError.name = "Name already exists";
+        else
+            newValidationError.name = undefined;
+
+        this.setState(prevState => ({ ...prevState, validationError: newValidationError }));
+    }
+
+    onCreate() {
+        const { vm, onClose, dispatch } = this.props;
+        const { name, description, validationError } = this.state;
+
+        this.onValidate();
+        if (!validationError.name) {
+            createSnapshot({ connectionName: vm.connectionName, vmId: vm.id, name, description })
+                    .then(() => {
+                        // VM Snapshots do not trigger any events so we have to refresh them manually
+                        dispatch(getVmSnapshots({ connectionName: vm.connectionName, domainPath: vm.id }));
+                        onClose();
+                    })
+                    .catch(exc => this.dialogErrorSet(_("Snapshot failed to be created"), exc.message));
+        }
+    }
+
+    render() {
+        const { idPrefix, onClose } = this.props;
+
+        const body = (
+            <form className="ct-form">
+                <NameRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+                <DescriptionRow dialogValues={this.state} onValueChanged={this.onValueChanged} />
+            </form>
+        );
+
+        return (
+            <Modal id={`${idPrefix}-modal`} onHide={onClose} show>
+                <Modal.Header>
+                    <Modal.CloseButton onClick={onClose} />
+                    <Modal.Title>{_("Create Snapshot")} </Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    {body}
+                </Modal.Body>
+                <Modal.Footer>
+                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                    <Button variant="primary" onClick={this.onCreate}>
+                        {_("Create")}
+                    </Button>
+                    <Button variant="link" className="btn-cancel" onClick={onClose}>
+                        {_("Cancel")}
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+        );
+    }
+}

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -66,7 +66,8 @@ import {
     getIfaceXML,
     getNetworkXML,
     getPoolXML,
-    getVolumeXML
+    getVolumeXML,
+    getSnapshotXML
 } from './xmlCreator.js';
 
 import {
@@ -1467,6 +1468,12 @@ export function changeNetworkAutostart(network, autostart, dispatch) {
                 return call(network.connectionName, networkPath[0], 'org.freedesktop.DBus.Properties', 'Set', args, { timeout, type: 'ssv' });
             })
             .then(() => dispatch(getNetwork({ connectionName: network.connectionName, id: network.id, name: network.name })));
+}
+
+export function createSnapshot({ connectionName, vmId, name, description }) {
+    const xmlDesc = getSnapshotXML(name, description);
+
+    return call(connectionName, vmId, 'org.libvirt.Domain', 'SnapshotCreateXML', [xmlDesc, 0], { timeout, type: 'su' });
 }
 
 export function detachIface(mac, connectionName, id, live, persistent, dispatch) {

--- a/pkg/machines/xmlCreator.js
+++ b/pkg/machines/xmlCreator.js
@@ -222,3 +222,25 @@ export function getPoolXML({ name, type, source, target }) {
 
     return new XMLSerializer().serializeToString(doc.documentElement);
 }
+
+export function getSnapshotXML(name, description) {
+    const doc = document.implementation.createDocument('', '', null);
+
+    const snapElem = doc.createElement('domainsnapshot');
+
+    if (name) {
+        const nameElem = doc.createElement('name');
+        nameElem.appendChild(doc.createTextNode(name));
+        snapElem.appendChild(nameElem);
+    }
+
+    if (description) {
+        const descriptionElem = doc.createElement('description');
+        descriptionElem.appendChild(doc.createTextNode(description));
+        snapElem.appendChild(descriptionElem);
+    }
+
+    doc.appendChild(snapElem);
+
+    return new XMLSerializer().serializeToString(doc.documentElement);
+}

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -4720,5 +4720,128 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_not_present("#vm-subVmTest1-network-3-mac")
         b.wait_not_present(".modal-dialog")
 
+    def testSnapshotCreate(self):
+        b = self.browser
+        m = self.machine
+
+        self.startVm("subVmTest1")
+
+        snapshots_present = m.execute("gdbus introspect --xml --system --dest org.libvirt --object-path /org/libvirt/QEMU | grep snapshot || true")
+        if not snapshots_present.strip(): # libvirt-dbus doesn't have snapshot APIs
+            return
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+
+        self.toggleVmRow("subVmTest1")
+        b.click("#vm-subVmTest1-snapshots") # open the Network Interfaces subtab
+
+        # Shut off domain
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "shut off")
+
+        class SnapshotCreateDialog(object):
+            def __init__(
+                self, test_obj, name=None, description=None, state="shutoff", snap_num=0, remove=True
+            ):
+                self.test_obj = test_obj
+                self.name = name
+                self.description = description
+                self.state = state
+                self.snap_num = snap_num
+                self.remove = remove
+
+            def execute(self):
+                self.open()
+                self.fill()
+                self.create()
+                self.verify_frontend()
+                self.verify_backend()
+                if self.remove:
+                    self.cleanup()
+
+            def open(self):
+                b.click("#vm-subVmTest1-add-snapshot-button") # open the Network Interfaces subtab
+                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create Snapshot")
+
+            def fill(self):
+                if self.name:
+                    b.set_input_text("#name", self.name)
+                if self.description:
+                    b.set_input_text("#description", self.description)
+
+            def cancel(self):
+                b.click(".modal-footer button:contains(Cancel)")
+                b.wait_not_present("#vm-subVmTest1-create-snapshot-modal")
+
+            def create(self):
+                b.click(".modal-footer button:contains(Create)")
+                b.wait_not_present("#vm-subVmTest1-create-snapshot-modal")
+
+            def verify_frontend(self):
+                if self.name:
+                    b.wait_in_text("#vm-subVmTest1-snapshot-{0}-name".format(self.snap_num), self.name)
+                else:
+                    self.name = b.text("#vm-subVmTest1-snapshot-{0}-name".format(self.snap_num))
+                if self.description:
+                    b.wait_in_text("#vm-subVmTest1-snapshot-{0}-description".format(self.snap_num), self.description)
+                else:
+                    b.wait_in_text("#vm-subVmTest1-snapshot-{0}-description".format(self.snap_num), "No description")
+                if self.state:
+                    if self.state == "shutoff":
+                        state = "shut off"
+                    else:
+                        state = self.state
+                    b.wait_in_text("#vm-subVmTest1-snapshot-{0}-type".format(self.snap_num), state)
+
+            def verify_backend(self):
+                # Verify libvirt XML
+                print(self.name)
+                snap_xml = "virsh -c qemu:///system snapshot-dumpxml --domain {0} --snapshotname {1}".format("subVmTest1", self.name)
+                xmllint_element = "{0} | xmllint --xpath 'string(//domainsnapshot/{{prop}})' - 2>&1 || true".format(snap_xml)
+
+                if (self.name):
+                    self.test_obj.assertEqual(self.name, m.execute(xmllint_element.format(prop='name')).strip())
+                if (self.description):
+                    self.test_obj.assertEqual(self.description, m.execute(xmllint_element.format(prop='description')).strip())
+                if (self.state):
+                    self.test_obj.assertEqual(self.state, m.execute(xmllint_element.format(prop='state')).strip())
+
+            def cleanup(self):
+                m.execute("virsh -c qemu:///system snapshot-delete --domain {0} --snapshotname {1}".format("subVmTest1", self.name))
+                b.reload()
+                b.enter_page('/machines')
+                b.wait_in_text("body", "Virtual Machines")
+                self.test_obj.toggleVmRow("subVmTest1")
+                b.click("#vm-subVmTest1-snapshots")
+
+        # No Snapshots present
+        b.wait_present("#vm-subVmTest1-add-snapshot-button")
+
+        # Test snapshot creation with pre-generated values
+        SnapshotCreateDialog(
+            self,
+        ).execute()
+
+        # Test snapshot creation with predefined values
+        SnapshotCreateDialog(
+            self,
+            name = "test_snap_1",
+            description = "Description of test_snap_1",
+            state = "shutoff",
+        ).execute()
+
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "running")
+
+        # Test snapshot creation on running VM
+        SnapshotCreateDialog(
+            self,
+            name = "test_snap_2",
+            description = "Description of test_snap_2",
+            state = "running",
+        ).execute()
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/machinesxmls.py
+++ b/test/verify/machinesxmls.py
@@ -126,7 +126,7 @@ DOMAIN_XML = """
     <acpi/>
   </features>
   <devices>
-    <disk type='file' snapshot='external'>
+    <disk type='file'>
       <driver name='qemu' type='qcow2'/>
       <source file='{image}'/>
       <target dev='vda' bus='virtio'/>


### PR DESCRIPTION
 - [x] This PR builds on top of #13100 and can be merged only after it. Only last commit is relevant to this PR.

![Screenshot from 2020-06-22 14-57-06](https://user-images.githubusercontent.com/42733240/85290063-ab49f180-b498-11ea-9a9a-24d89f7df997.png)

So far user can only input name of snapshot and description.
Name is pre-generated from VM name + date and time, and description is optional input, so ideally user doesn't have to input anything an can straight go to clicking "Create".
![Screenshot from 2020-06-22 14-54-02](https://user-images.githubusercontent.com/42733240/85290149-d16f9180-b498-11ea-968c-d5b2caa764a2.png)

I also experimented here with how we evaluate  incorrect inputs in dialogs, and tried to us React's onBlur trigger. This means that whenever uses looses trigger of a input field (clicks outside of a input field or start typing into another input field), input field is evaluated. This is more immediate and more direct compared to evaluating inputs only after user click "Create".
![Screenshot from 2020-06-22 14-54-23](https://user-images.githubusercontent.com/42733240/85290351-23181c00-b499-11ea-8ca7-075b49dcdb8d.png)
