### PR TITLE
logs: Use predefined filters rather than 'start' option

### DIFF
--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -33,14 +33,16 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <div class="content-header-extra">
       <div class="filters">
         <div class="filter">
-            <label for="journal-current-day-menu" translate>Time</label>
-            <select id="journal-current-day-menu" class="ct-select">
-              <option value="recent" translate>Recent</option>
-              <option value="boot" translate>Current boot</option>
-              <option value="previous-boot" translate>Previous boot</option>
-              <option value="last-24h" translate>Last 24 hours</option>
-              <option value="last-week" translate>Last 7 days</option>
-            </select>
+            <button id="log-filters" class="btn btn-default dropdown-toggle ct-select" type="button" data-toggle="dropdown">
+              <span translate>Time</span>
+              <div class="caret"></div>
+            </button>
+            <ul class="dropdown-menu" id="logs-predefined-filters">
+              <li><a tabindex="0" data-key="boot" data-value="0" translate>Current boot</a></li>
+              <li><a tabindex="0" data-key="boot" data-value="-1" translate>Previous boot</a></li>
+              <li><a tabindex="0" data-key="since" data-value="-24hours" translate>Last 24 hours</a></li>
+              <li><a tabindex="0" data-key="since" data-value="-7days" translate>Last 7 days</a></li>
+            </ul>
         </div>
 
         <div class="filter">

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -70,6 +70,7 @@
 }
 
 #journal .filter select,
+#journal .filter button,
 #journal .filter input {
     margin-right: var(--pf-global--spacer--md);
 }
@@ -87,8 +88,10 @@
 }
 
 .filter {
+    position: relative;
     display: flex;
     align-items: baseline;
+    align-self: end;
     flex-direction: row;
     margin: 1rem 0 0;
     text-align: right;
@@ -222,6 +225,11 @@
 .dropdown-toggle:focus,
 .dropdown.open .dropdown-toggle {
     color: var(--pf-global--link--Color) !important;
+}
+
+.dropdown-menu {
+    left: auto;
+    margin: 0;
 }
 
 #logs-help-menu {

--- a/test/selenium/selenium-navigate.py
+++ b/test/selenium/selenium-navigate.py
@@ -33,7 +33,7 @@ class NavigateTestSuite(SeleniumTest):
         # Now navigate to the logs
         self.click(self.wait_link('Logs', cond=clickable))
         self.wait_frame("logs")
-        self.wait_id("journal-current-day-menu")
+        self.wait_id("log-filters")
         self.mainframe()
 
         # Now navigate back to system page

--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -196,13 +196,13 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         wait_log123()
 
-        b.go("#/?prio=debug&start=recent&service=nonexisting.service")
+        b.go("#/?prio=debug&service=nonexisting.service")
         wait_journal_empty()
 
-        b.go("#/?prio=debug&start=recent&service=log123")
+        b.go("#/?prio=debug&service=log123")
         wait_log123()
 
-        b.go("#/?prio=debug&start=recent&service=slow10.service")
+        b.go("#/?prio=debug&service=slow10.service")
         wait_journal_empty()
 
         def wait_slow10():
@@ -225,9 +225,9 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         wait_slow10()
 
-        b.go("#/?prio=debug&start=recent&service=nonexisting.service")
+        b.go("#/?prio=debug&service=nonexisting.service")
         wait_journal_empty()
-        b.go("#/?prio=debug&start=recent&service=slow10.service")
+        b.go("#/?prio=debug&service=slow10.service")
         wait_slow10()
 
         b.go("#/?prio=debug")
@@ -322,8 +322,26 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         b.wait_present("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 6')")
         b.wait_present("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 5')")
 
-        b.go("#/?tag=logger&start=last-24h&prio=crit&grep=foo")
-        b.wait_val("#journal-grep", "start:last-24h priority:crit identifier:logger foo")
+        if m.image == "rhel-8-3-distropkg": # Introduced in #14262
+            b.go("#/?tag=logger&start=last-24h&prio=crit&grep=foo")
+            b.wait_val("#journal-grep", "start:last-24h priority:crit identifier:logger foo")
+        else:
+            # Test filters
+            b.click("#log-filters")
+            b.click("#logs-predefined-filters li:first-child a")
+            b.wait_val("#journal-grep", "priority:err identifier:logger boot:0 [5-6]")
+
+            b.click("#log-filters")
+            b.click("#logs-predefined-filters li:nth-child(2) a")
+            b.wait_val("#journal-grep", "priority:err identifier:logger boot:-1 [5-6]")
+
+            b.click("#log-filters")
+            b.click("#logs-predefined-filters li:nth-child(3) a")
+            b.wait_val("#journal-grep", "priority:err identifier:logger since:-24hours [5-6]")
+
+            b.click("#log-filters")
+            b.click("#logs-predefined-filters li:nth-child(4) a")
+            b.wait_val("#journal-grep", "priority:err identifier:logger since:-7days [5-6]")
 
     def testRebootAndTime(self):
         b = self.browser
@@ -412,7 +430,10 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         ["check-journal", "BEFORE BOOT", ""]
                         ])
 
-        b.go("#/?start=boot&tag=check-journal")
+        if m.image == "rhel-8-3-distropkg": # Changed in #14262
+            b.go("#/?start=boot&tag=check-journal")
+        else:
+            b.go("#/?boot=0&tag=check-journal")
         wait_log_lines([expected_date,
                         ["check-journal", "AFTER BOOT", ""],
                         "Load earlier entries",
@@ -427,13 +448,19 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                         ])
 
         # Check selecting of services
-        b.go("#/?start=previous-boot&tag=check-journal")
+        if m.image == "rhel-8-3-distropkg": # Changed in #14262
+            b.go("#/?start=previous-boot&tag=check-journal")
+        else:
+            b.go("#/?boot=-1&tag=check-journal")
         wait_log_lines([expected_date,
                         ["check-journal", "BEFORE BOOT", ""],
                         "Load earlier entries"
                         ])
 
-        b.go("#/?start=boot&tag=check-journal")
+        if m.image == "rhel-8-3-distropkg": # Changed in #14262
+            b.go("#/?start=boot&tag=check-journal")
+        else:
+            b.go("#/?boot=0&tag=check-journal")
         wait_log_lines([expected_date,
                         ["check-journal", "AFTER BOOT", ""],
                         "Load earlier entries"


### PR DESCRIPTION
Fixes #14104

Release note:

If this lands in time for 222, let's merge it with the "no .service suffix" feature, like this:

## Logs: More flexible text filters

The text filter gained new `since:` and `boot:` quantifiers which restrict the logs to a given time span (e.g. `since:-12hours`) or the number of a previous boot (e.g. `boot:-2`). The "Time" dropdown controls these fields, and continues to have the same standard options as before, but they can now be customized easily.

The `service:`*unitname* filter now accepts a unit name without the `.service` suffix. This mirrors the [systemctl](https://www.freedesktop.org/software/systemd/man/systemctl.html) command line behaviour.