### PR TITLE
Document and test certificate authentication against AD

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -148,6 +148,9 @@ This uses the `[tls-cert]` authentication scheme.
 When enabling this mode, other authentication types commonly get disabled. See
 the next section for details.
 
+See the [Certificate/smart card authentication guide](https://cockpit-project.org/guide/latest/cert-authentication.html)
+for details how to set this up.
+
 Actions
 -------
 

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -17,20 +17,16 @@
     which can associate certificates to users.
   </para>
 
+  <para>To authenticate users from a Identity Management domain, the server that
+    Cockpit is running on must be joined to that domain. See the
+    <link linkend="sso-server">SSO server requirements</link> for details.</para>
 
-  <section id="certauth-server-idm">
-    <title>Identity Management setup</title>
-
-    <para>To authenticate users from a Identity Management domain, the server that
-      Cockpit is running on must be joined to that domain. See the
-      <link linkend="sso-server">SSO server requirements</link> for details.</para>
-
-    <para>The domain's users also need to get associated to certificates, usually with
-    the <command>ipa user-add-cert</command> command. See the
-    <ulink url="https://www.freeipa.org/page/V4/User_Certificates#Feature_Management">
-    FreeIPA User Certificates documentation</ulink>
-    for details. As a simple example, these commands will generate a new certificate/key
-    pair and associate it to the user <code>alice</code>:</para>
+  <section id="certauth-server-cert-generation">
+    <title>User certificate generation</title>
+    <para>Generating the certificates for users is usually done with a certificate management system like
+      <ulink url="https://pagure.io/certmonger">certmonger</ulink> or
+      <ulink url="https://www.freeipa.org/page/PKI">FreeIPA</ulink>, which are not documented here.
+      For testing purposes, these commands will generate a self-signed certificate/key for the "alice" user:</para>
 
 <programlisting>
 # create self-signed certificate and key
@@ -41,16 +37,10 @@ printf '[req]\ndistinguished_name=dn\nextensions=v3_req\n[dn]\n
 openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout alice.key \
     -out alice.pem -subj "/CN=alice" -config /tmp/openssl.cnf -extensions v3_req
 
-# FreeIPA only accepts DER format, convert it
-openssl x509 -outform der -in alice.pem -out alice.der
-
 # browsers and smart cart utilities accept PKCS#12 format, convert it
 # this needs to set a transfer/import password
 openssl pkcs12 -export -password pass:somepassword \
     -in alice.pem -inkey alice.key -out alice.p12
-
-# assign it to the IdM user alice
-ipa user-add-cert alice --certificate="$(base64 alice.der)"
 </programlisting>
 
   <para>You can now import <code>alice.p12</code> directly into your browser,
@@ -59,6 +49,81 @@ ipa user-add-cert alice --certificate="$(base64 alice.der)"
 
 <programlisting>
 pkcs15-init --store-private-key alice.p12 --format pkcs12 --auth-id 01
+</programlisting>
+
+  </section>
+
+  <section id="certauth-server-ipa">
+    <title>Certificate mapping with FreeIPA</title>
+
+    <para>The domain's users get associated to certificates with
+      the <command>ipa user-add-cert</command> command. This expects PEM format, but without the
+      <code>-----BEGIN</code>/<code>-----END</code> markers.  See the
+      <ulink url="https://www.freeipa.org/page/V4/User_Certificates#Feature_Management">
+      FreeIPA User Certificates documentation</ulink>:</para>
+
+<programlisting>
+ipa user-add-cert alice --certificate="$(grep -v ^---- alice.pem)"
+</programlisting>
+
+  </section>
+
+  <section id="certauth-server-ms-ad">
+    <title>Certificate mapping with Microsoft Active Directory</title>
+
+    <para>The domain user certificates get imported into the <code>userCertificate;binary</code>
+      LDAP attribute. The following commands convert the PEM certificate into binary DER form, create an
+      <ulink url="https://ldap.com/ldif-the-ldap-data-interchange-format/">LDIF</ulink>
+      file and apply it to the LDAP server running on the domain contoller
+      "dc.example.com":</para>
+
+<programlisting>
+openssl x509 -outform der -in alice.pem -out alice.der
+
+cat &lt;&lt;EOF &gt; alice.ldif
+version: 1
+dn: cn=alice,ou=users,ou=YOUR_NETBIOS_NAME,dc=example,dc=com
+changetype: modify
+add: userCertificate;binary
+userCertificate;binary:&lt; file://$(pwd)/alice.der
+EOF
+
+ldapmodify -H ldap://dc.example.com -f alice.ldif
+</programlisting>
+
+  </section>
+
+  <section id="certauth-server-samba-ad">
+    <title>Certificate mapping with Samba Active Directory</title>
+
+    <para>At least some versions of <ulink url="https://www.samba.org/">Samba</ulink>
+      do not support the <code>userCertificate;binary</code> LDAP attribute, so the
+      import has to happen in base64 PEM form into the textual
+      <code>userCertificate</code> attribute instead. Also, Samba uses a slightly
+      different user hierarchy:</para>
+
+<programlisting>
+cat &lt;&lt;EOF &gt; alice.ldif
+version: 1
+dn: cn=alice,cn=users,dc=example,dc=com
+changetype: modify
+add: userCertificate
+userCertificate: $(grep -v ^---- alice.pem | tr -d '\n')
+EOF
+
+ldapmodify -H ldap://dc.example.com  -f alice.ldif
+</programlisting>
+
+    <para>As <code>userCertificate</code> is a text instead of binary field, you need to set up a
+      <ulink url="https://www.mankier.com/5/sssd.conf#Certificate_Mapping_Section">certificate mapping rule</ulink>
+      in <citerefentry><refentrytitle>sssd.conf</refentrytitle><manvolnum>5</manvolnum></citerefentry>
+      in a <code>[certmap/domain/rulename]</code> section, for example:</para>
+
+<programlisting>
+[certmap/example.com/adcerts]
+# we match full certificates, so it is not important to check anything here
+matchrule = &lt;KU&gt;digitalSignature
+maprule = LDAP:(userCertificate={cert!base64})
 </programlisting>
 
   </section>

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -74,6 +74,17 @@ pkcs15-init --store-private-key alice.p12 --format pkcs12 --auth-id 01
 ClientCertAuthentication = yes
 </programlisting>
 
+  <warning>
+    <para>Any client can generate certificates with arbitrary information, thus
+      the client certificates must be checked for validity. Cockpit currently
+      accepts any client certificate and relies on sssd to verify their validity.
+      This is secure only when the entire certificate gets matched, i.e. when
+      importing the complete certificates into Identity Management as shown above.
+      <emphasis>Do not use this with local sssd <code>certmap</code> rules</emphasis>
+      which only match on Subject/Issuer properties!
+  </para>
+ </warning>
+
   <para>When enabling this mode,
     <ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/authentication.md">
     other authentication types</ulink> commonly get disabled, so that <emphasis>only</emphasis>

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1340,13 +1340,17 @@ class MachineCase(unittest.TestCase):
         else:
             self.addCleanup(self.machine.execute, "rm -rf %s" % path)
 
-    def write_file(self, path, content):
+    def write_file(self, path, content, append=False, owner=None, perm=None):
         '''Write a new file on primary machine
 
         This is safe for @nondestructive tests, the file will be removed during cleanup.
+
+        If @append is True, append to existing file instead of replacing it.
+        @owner is the desired file owner as chown shell string (e.g. "admin:nogroup")
+        @perm is the desired file permission as chmod shell string (e.g. "0600")
         '''
         m = self.machine
-        m.write(path, content)
+        m.write(path, content, append=append, owner=owner, perm=perm)
 
         if self.is_nondestructive():
             self.addCleanup(m.execute, "rm -f {0}".format(path))

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -20,6 +20,7 @@
 import base64
 import subprocess
 import time
+import re
 
 import parent
 from testlib import *
@@ -679,6 +680,133 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             expect_successful_login("root", "foobar")
 
         self.allow_restart_journal_messages()
+
+    @skipImage("sssd not available", "fedora-coreos")
+    @skipImage("sssd can't do cert mapping yet", "debian-stable")
+    def testClientCertAuthentication(self):
+        # This only tests the cockpit ←→ sssd API, but this is completely unsafe!
+        # Nothing currently checks whether the client certificate is signed by
+        # a trusted CA, or is in a revocation list. But it is convenient as a downstream
+        # gating test and as a basis to properly supporting certmap rules in the future.
+        m = self.machine
+
+        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+            # on Debian/Ubuntu, an unconfigured sssd fails to start, so only restart it at the end if it was running before
+            # also, sssd is split into several services
+            self.restore_dir("/etc/sssd", post_restore_action="systemctl stop 'sssd*'")
+        else:
+            self.restore_dir("/etc/sssd", post_restore_action="systemctl try-restart sssd")
+
+        m.execute("useradd alice && echo alice:foobar123 | chpasswd")
+        m.upload(["alice.pem", "alice.key", "alice-expired.pem", "bob.pem", "bob.key"], self.vm_tmpdir,
+                 relative_dir="src/tls/ca/")
+        alice_cert = self.vm_tmpdir + "/alice.pem"
+        alice_cert_expired = self.vm_tmpdir + "/alice-expired.pem"
+        alice_key = self.vm_tmpdir + "/alice.key"
+        alice_cert_key = ['--cert', alice_cert, '--key', alice_key]
+
+        # set up local (NIS) sssd provider and certificate mapping
+        m.write("/etc/sssd/sssd.conf", """
+[sssd]
+domains = local
+
+[domain/local]
+id_provider = files
+
+[certmap/local/alice]
+# WARNING: interface testing only, this is insecure! Nothing validates the cert signer
+matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
+""", perm="0600")
+        m.execute("systemctl restart sssd")
+
+        # ensure sssd certificate lookup works
+        user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                             'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
+                             '''"$(cat %s)" | sed 's/^o "//; s/"$//' ''' % alice_cert)
+        self.assertEqual(m.execute('busctl get-property org.freedesktop.sssd.infopipe ' + user_obj.strip() +
+                                   ' org.freedesktop.sssd.infopipe.Users.User name').strip(),
+                         's "alice"')
+
+        # These tests have to be run with curl, as chromium-headless does not support selecting/handling client-side
+        # certificates; it just rejects cert requests. For interactive tests, grab src/tls/ca/alice.p12 and import
+        # it into the browser.
+
+        def do_test(authopts, expected, not_expected=[], session_leader=None):
+            m.start_cockpit(tls=True)
+            output = m.execute(['curl', '-ksS', '-D-'] + authopts + ['https://localhost:9090/cockpit/login'])
+            for s in expected:
+                self.assertIn(s, output)
+            for s in not_expected:
+                self.assertNotIn(s, output)
+            # sessions/users often hang around in State=closing for a long time, ignore these
+            if session_leader:
+                m.execute('until [ "$(loginctl show-user --property=State --value alice)" = "active" ]; do sleep 1; done')
+                sessions = m.execute('loginctl show-user --property=Sessions --value alice').strip().split()
+                self.assertGreaterEqual(len(sessions), 1)
+                for session in sessions:
+                    out = m.execute('loginctl session-status ' + session)
+                    if "State: active" in out:  # skip closing sessions
+                        self.assertIn(session_leader, out)
+                        self.assertIn('cockpit-bridge', out)
+                        self.assertIn('cockpit; type web', out)
+                        break
+                else:
+                    self.fail("no active session for active user")
+
+                # sessions time out after 10s, but let's not wait for that
+                m.execute('loginctl terminate-session ' + sessions[0])
+                # wait until the session is gone
+                m.execute("while loginctl show-user alice | grep -q 'State=active'; do sleep 1; done")
+
+            m.stop_cockpit()
+
+        self.allow_journal_messages("alice is not allowed to run sudo.*")
+        self.allow_authorize_journal_messages()
+
+        # cert auth should not be enabled by default
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed"])
+        # password auth should work
+        do_test(['-u', 'alice:foobar123'],
+                ['HTTP/1.1 200 OK', '"csrf-token"'],
+                session_leader='cockpit-session')
+
+        # enable cert based auth
+        m.write("/etc/cockpit/cockpit.conf", '[WebService]\nClientCertAuthentication = true\n', append=True)
+        # cert auth should work now
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        # password auth, too
+        do_test(['-u', 'alice:foobar123'],
+                ['HTTP/1.1 200 OK', '"csrf-token"'],
+                session_leader='cockpit-session')
+
+        # another certificate gets rejected
+        do_test(["--cert", self.vm_tmpdir + "/bob.pem", "--key", self.vm_tmpdir + "/bob.key"],
+                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+                not_expected=["crsf-token"])
+
+        # check expired certificate
+        m.start_cockpit(tls=True)
+        journal_cursor = self.machine.journal_cursor()
+        m.execute('! curl -ksS --cert %s --key %s https://localhost:9090/cockpit/login' % (alice_cert_expired, alice_key))
+        m.stop_cockpit()
+        wait(lambda: re.search(r'.*Invalid TLS peer certificate.* expired',
+                m.execute("journalctl -ocat --cursor '%s' SYSLOG_IDENTIFIER=cockpit-tls" % journal_cursor)),
+            tries=10)
+        self.allow_journal_messages('.*Invalid TLS peer certificate.* expired')
+        self.allow_journal_messages('.*TLS handshake failed: Error in the certificate verification.*')
+
+        # disallow password auth
+        m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        do_test(['-u', 'alice:foobar123'],
+                ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
+                not_expected=["crsf-token"])
+
+        # sssd-dbus not available
+        m.execute("systemctl mask sssd-ifp && systemctl stop sssd-ifp")
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+                not_expected=["crsf-token"])
+        m.execute("systemctl unmask sssd-ifp")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -338,6 +338,12 @@ class TestIPA(TestRealms, CommonTests):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
         wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
 
+        # wait until FreeIPA started up
+        self.machines['services'].execute("""docker exec -i freeipa sh -ec '
+            while ! echo %s | kinit -f %s; do sleep 5; done
+            while ! ipa user-find >/dev/null; do sleep 5; done'
+            """ % (self.admin_password, self.admin_user), timeout=300)
+
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''
 
@@ -409,12 +415,6 @@ class TestIPA(TestRealms, CommonTests):
 
         m = self.machine
         b = self.browser
-
-        # wait until FreeIPA started up
-        out = self.machines['services'].execute("""docker exec -i freeipa sh -ec '
-            while ! echo %s | kinit -f %s; do sleep 5; done
-            while ! ipa user-find >/dev/null; do sleep 5; done'
-            """ % (self.admin_password, self.admin_user), timeout=300)
 
         # set up "alice" user with HOTP; that won't affect existing users (admin)
         # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/otp
@@ -489,11 +489,6 @@ class TestIPA(TestRealms, CommonTests):
         m = self.machine
 
         ipa_machine = self.machines['services']
-        # need to wait for IPA to start up
-        ipa_machine.execute("""docker exec -i freeipa sh -ec '
-            while ! echo %s | kinit -f %s; do sleep 5; done
-            export LC_ALL=C.UTF-8 && while ! ipa user-find >/dev/null; do sleep 5; done'
-            """ % (self.admin_password, self.admin_user), timeout=300)
         with open("src/tls/ca/alice.pem") as f:
             alice_cert = f.read().strip()
         # IPA does not like the ---BEGIN/END lines

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -626,8 +626,22 @@ class TestAD(TestRealms, CommonTests):
 
         pass
 
-    def testQualifiedUsers(self):
-        super().testQualifiedUsers()
+    def testUnqualifiedUsers(self):
+        '''Extend the test to check a new AD user'''
+
+        super().testUnqualifiedUsers()
+
+        m = self.machine
+        b = self.browser
+
+        m.start_cockpit()
+        # create another AD user
+        self.machines['services'].execute("docker exec -i samba samba-tool user add alice %s" % self.alice_password)
+        # ensure it works
+        m.execute('id alice')
+        b.login_and_go('/system', user='alice', password=self.alice_password)
+        b.wait_visible("#overview")
+        b.logout()
 
 
 JOIN_SCRIPT = """

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -505,12 +505,11 @@ yes foobar | ipa user-mod --password alice
 ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
 ipa user-add-cert alice --certificate="%s"
 ' """ % alice_cert)
-        m.upload(["alice.pem", "alice.key", "alice-expired.pem", "bob.pem", "bob.key"], "/var/tmp",
+        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
                  relative_dir="src/tls/ca/")
 
         # On Debian 9, D-Bus activation of ifp is disabled, enable it manually; see https://bugs.debian.org/925026
-        static_ifp_conf = m.image in ["debian-stable"]
-        if static_ifp_conf:
+        if m.image in ["debian-stable"]:
             m.write("/etc/sssd/conf.d/ifp.conf", "[sssd]\nservices = nss, sudo, pam, ssh, ifp\n", perm="0600")
 
         # join domain, wait until it works
@@ -591,13 +590,6 @@ ipa user-add-cert alice --certificate="%s"
                 ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
                 not_expected=["crsf-token"])
 
-        # check expired certificate
-        m.start_cockpit(tls=True)
-        m.execute('! curl -ksS --cert /var/tmp/alice-expired.pem --key /var/tmp/alice.key https://localhost:9090/cockpit/login')
-        m.stop_cockpit()
-        self.allow_journal_messages('.*Invalid TLS peer certificate.* expired')
-        self.allow_journal_messages('.*TLS handshake failed: Error in the certificate verification.*')
-
         # disallow password auth
         m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
         do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
@@ -605,19 +597,6 @@ ipa user-add-cert alice --certificate="%s"
         do_test(['-u', 'alice:foobar'],
                 ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
-
-        # sssd-dbus not available
-        if static_ifp_conf:
-            m.execute("mv /etc/sssd/conf.d/ifp.conf /etc/sssd/conf.d/ifp.conf.disabled && systemctl restart sssd")
-        else:
-            m.execute("systemctl mask sssd-ifp && systemctl stop sssd-ifp")
-        do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
-                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
-                not_expected=["crsf-token"])
-        if static_ifp_conf:
-            m.execute("mv /etc/sssd/conf.d/ifp.conf.disabled /etc/sssd/conf.d/ifp.conf && systemctl restart sssd")
-        else:
-            m.execute("systemctl unmask sssd-ifp")
 
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -332,6 +332,7 @@ class TestIPA(TestRealms, CommonTests):
         super().setUp()
         self.admin_user = "admin"
         self.admin_password = "foobarfoo"
+        self.alice_password = 'WonderLand123'
         self.expected_server_software = "ipa"
         self.machines['services'].execute("/run-freeipa")
         # Wait for FreeIPA to come up and DNS to work as expected
@@ -496,12 +497,10 @@ class TestIPA(TestRealms, CommonTests):
         # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
         ipa_machine.execute(r"""docker exec -i freeipa sh -exc '
 ipa user-add --first=Alice --last="Developer" alice
-yes foobar | ipa user-mod --password alice
+yes "%(password)s" | ipa user-mod --password alice
 ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
-ipa user-add-cert alice --certificate="%s"
-' """ % alice_cert)
-        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
-                 relative_dir="src/tls/ca/")
+ipa user-add-cert alice --certificate="%(cert)s"
+' """ % {"cert": alice_cert, "password": self.alice_password})
 
         # On Debian 9, D-Bus activation of ifp is disabled, enable it manually; see https://bugs.debian.org/925026
         if m.image in ["debian-stable"]:
@@ -511,6 +510,13 @@ ipa user-add-cert alice --certificate="%s"
         m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
         m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
         m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
+
+        # upload certificates to client machine
+        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
+                 relative_dir="src/tls/ca/")
+        alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]
+        alice_user_pass = ['-u', 'alice:' + self.alice_password]
+        bob_cert_key = ['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"]
 
         # ensure sssd certificate lookup works
         user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
@@ -557,40 +563,30 @@ ipa user-add-cert alice --certificate="%s"
         self.allow_authorize_journal_messages()
 
         # cert auth should not be enabled by default
-        do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
-                ["HTTP/1.1 401 Authentication required", '"authorize"'])
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication required", '"authorize"'])
         # password auth should work
-        do_test(['-u', 'alice:foobar'],
-                ['HTTP/1.1 200 OK', '"csrf-token"'],
-                session_leader='cockpit-session')
+        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
 
         # enable cert based auth
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nClientCertAuthentication = true\n", append=True)
         # cert auth should work now
-        do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
-                ['HTTP/1.1 200 OK', '"csrf-token"'])
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
         # password auth, too
-        do_test(['-u', 'alice:foobar'],
-                ['HTTP/1.1 200 OK', '"csrf-token"'],
-                session_leader='cockpit-session')
+        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
         # cert auth should go through PAM stack and re-create home dir
         home_dir = m.execute("getent passwd alice | cut -d: -f6").strip()
         m.execute("rm -r " + home_dir)
-        do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
-                ['HTTP/1.1 200 OK', '"csrf-token"'])
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
         m.execute('test -f %s/.bashrc' % home_dir)
 
         # another certificate gets rejected
-        do_test(['--cert', '/var/tmp/bob.pem', '--key', '/var/tmp/bob.key'],
-                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+        do_test(bob_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
                 not_expected=["crsf-token"])
 
         # disallow password auth
         m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
-        do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
-                ['HTTP/1.1 200 OK', '"csrf-token"'])
-        do_test(['-u', 'alice:foobar'],
-                ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
 
 
@@ -600,6 +596,7 @@ class TestAD(TestRealms, CommonTests):
         super().setUp()
         self.admin_user = "Administrator"
         self.admin_password = "foobarFoo123"
+        self.alice_password = 'WonderLand123'
         self.expected_server_software = "active-directory"
         self.machines['services'].execute("/run-samba-domain")
         # Wait for AD to come up and DNS to work as expected

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -599,16 +599,22 @@ class TestAD(TestRealms, CommonTests):
         self.alice_password = 'WonderLand123'
         self.expected_server_software = "active-directory"
         self.machines['services'].execute("/run-samba-domain")
+
+        m = self.machine
+
         # Wait for AD to come up and DNS to work as expected
-        wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
+        wait(lambda: m.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
         # DNS is not sufficient yet, needs to start LDAP server as well
-        self.machine.execute("until nc -z f0.cockpit.lan 389; do sleep 1; done")
+        m.execute("until nc -z f0.cockpit.lan 389; do sleep 1; done")
         # also wait for Kerberos
-        self.machine.execute("set -e; until echo %s | kinit %s@COCKPIT.LAN; do sleep 1; done; kdestroy" % (self.admin_password, self.admin_user))
+        m.execute("set -e; until echo %s | kinit %s@COCKPIT.LAN; do sleep 1; done; kdestroy" % (self.admin_password, self.admin_user))
 
         # allow sudo access to domain admins; FIXME: Is there a server-side setting for this,
         # similar to "ipa-advise enable-admins-sudo"?
-        self.machine.write("/etc/sudoers.d/domain-admins", r"%domain\ admins@COCKPIT.LAN ALL=(ALL) ALL")
+        m.write("/etc/sudoers.d/domain-admins", r"%domain\ admins@COCKPIT.LAN ALL=(ALL) ALL")
+
+        # HACK: work around https://bugzilla.redhat.com/show_bug.cgi?id=1839805
+        m.write("/etc/sssd/conf.d/rhbz1839805.conf", "[domain/cockpit.lan]\nad_gpo_access_control=disabled\n", perm="0600")
 
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -307,6 +307,96 @@ class CommonTests:
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
+    def checkClientCertAuthentication(self):
+        '''Common tests for certificate authentication
+
+        This assumes that IdM and sssd are all set up correctly already.
+        '''
+        m = self.machine
+
+        # join domain, wait until it works
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
+        m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
+        m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
+
+        # upload certificates to client machine
+        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
+                 relative_dir="src/tls/ca/")
+        alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]
+        alice_user_pass = ['-u', 'alice:' + self.alice_password]
+        bob_cert_key = ['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"]
+
+        # ensure sssd certificate lookup works
+        user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                             'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
+                             '''"$(cat /var/tmp/alice.pem)" | sed 's/^o "//; s/"$//' ''')
+        self.assertEqual(m.execute('busctl get-property org.freedesktop.sssd.infopipe ' + user_obj.strip() +
+                                   ' org.freedesktop.sssd.infopipe.Users.User name').strip(),
+                         's "alice"')
+
+        # These tests have to be run with curl, as chromium-headless does not support selecting/handling client-side
+        # certificates; it just rejects cert requests. For interactive tests, grab src/tls/ca/alice.p12 and import
+        # it into the browser.
+
+        def do_test(authopts, expected, not_expected=[], session_leader=None):
+            m.start_cockpit(tls=True)
+            output = m.execute(['curl', '-ksS', '-D-'] + authopts + ['https://localhost:9090/cockpit/login'])
+            for s in expected:
+                self.assertIn(s, output)
+            for s in not_expected:
+                self.assertNotIn(s, output)
+
+            # sessions/users often hang around in State=closing for a long time, ignore these
+            if session_leader:
+                m.execute('until [ "$(loginctl show-user --property=State --value alice)" = "active" ]; do sleep 1; done')
+                sessions = m.execute('loginctl show-user --property=Sessions --value alice').strip().split()
+                self.assertGreaterEqual(len(sessions), 1)
+                for session in sessions:
+                    out = m.execute('loginctl session-status ' + session)
+                    if "State: active" in out:  # skip closing sessions
+                        self.assertIn(session_leader, out)
+                        self.assertIn('cockpit-bridge', out)
+                        self.assertIn('cockpit; type web', out)
+                        break
+                else:
+                    self.fail("no active session for active user")
+
+                # sessions time out after 10s, but let's not wait for that
+                m.execute('loginctl terminate-session ' + sessions[0])
+                # wait until the session is gone
+                m.execute("while loginctl show-user alice | grep -q 'State=active'; do sleep 1; done")
+
+            m.stop_cockpit()
+
+        self.allow_journal_messages("alice is not allowed to run sudo on x0.  This incident will be reported.")
+        self.allow_authorize_journal_messages()
+
+        # cert auth should not be enabled by default
+        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication required", '"authorize"'])
+        # password auth should work
+        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
+
+        # enable cert based auth
+        m.write("/etc/cockpit/cockpit.conf", '[WebService]\nClientCertAuthentication = true\n', append=True)
+        # cert auth should work now
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        # password auth, too
+        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
+        # cert auth should go through PAM stack and re-create home dir
+        m.execute("rm -r ~alice")
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        m.execute("test -f ~alice/.bashrc")
+
+        # another certificate gets rejected
+        do_test(bob_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+                not_expected=["crsf-token"])
+
+        # disallow password auth
+        m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
+        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
+                not_expected=["crsf-token"])
+
 
 @skipImage("No realmd available", "fedora-coreos")
 class TestRealms(MachineCase):
@@ -506,88 +596,7 @@ ipa user-add-cert alice --certificate="%(cert)s"
         if m.image in ["debian-stable"]:
             m.write("/etc/sssd/conf.d/ifp.conf", "[sssd]\nservices = nss, sudo, pam, ssh, ifp\n", perm="0600")
 
-        # join domain, wait until it works
-        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
-        m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
-        m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
-
-        # upload certificates to client machine
-        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
-                 relative_dir="src/tls/ca/")
-        alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]
-        alice_user_pass = ['-u', 'alice:' + self.alice_password]
-        bob_cert_key = ['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"]
-
-        # ensure sssd certificate lookup works
-        user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
-                             'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
-                             '''"$(cat /var/tmp/alice.pem)" | sed 's/^o "//; s/"$//' ''')
-        self.assertEqual(m.execute('busctl get-property org.freedesktop.sssd.infopipe ' + user_obj.strip() +
-                                   ' org.freedesktop.sssd.infopipe.Users.User name').strip(),
-                         's "alice"')
-
-        # These tests have to be run with curl, as chromium-headless does not support selecting/handling client-side
-        # certificates; it just rejects cert requests. For interactive tests, grab src/tls/ca/alice.p12 and import
-        # it into the browser.
-
-        def do_test(authopts, expected, not_expected=[], session_leader=None):
-            m.start_cockpit(tls=True)
-            output = m.execute(['curl', '-ksS', '-D-'] + authopts + ['https://localhost:9090/cockpit/login'])
-            for s in expected:
-                self.assertIn(s, output)
-            for s in not_expected:
-                self.assertNotIn(s, output)
-
-            if session_leader:
-                tries = 0
-                while tries < 10:
-                    out = m.execute('loginctl show-user --property=Sessions alice')
-                    sessions = out.split('=')[1].split()
-                    if len(sessions) == 1:
-                        break
-                    time.sleep(5)
-                    tries += 1
-                self.assertEqual(len(sessions), 1)
-                out = m.execute('loginctl session-status ' + sessions[0])
-                self.assertIn(session_leader, out)
-                self.assertIn('cockpit-bridge', out)
-                self.assertIn('cockpit; type web', out)
-                # sessions time out after 10s, but let's not wait for that
-                m.execute('loginctl terminate-session ' + sessions[0])
-                # wait until the session is gone
-                m.execute("while loginctl show-user alice; do sleep 1; done")
-
-            m.stop_cockpit()
-
-        self.allow_journal_messages("alice is not allowed to run sudo on x0.  This incident will be reported.")
-        self.allow_authorize_journal_messages()
-
-        # cert auth should not be enabled by default
-        do_test(alice_cert_key, ["HTTP/1.1 401 Authentication required", '"authorize"'])
-        # password auth should work
-        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
-
-        # enable cert based auth
-        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nClientCertAuthentication = true\n", append=True)
-        # cert auth should work now
-        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
-        # password auth, too
-        do_test(alice_user_pass, ['HTTP/1.1 200 OK', '"csrf-token"'], session_leader='cockpit-session')
-        # cert auth should go through PAM stack and re-create home dir
-        home_dir = m.execute("getent passwd alice | cut -d: -f6").strip()
-        m.execute("rm -r " + home_dir)
-        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
-        m.execute('test -f %s/.bashrc' % home_dir)
-
-        # another certificate gets rejected
-        do_test(bob_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
-                not_expected=["crsf-token"])
-
-        # disallow password auth
-        m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
-        do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
-        do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
-                not_expected=["crsf-token"])
+        self.checkClientCertAuthentication()
 
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")
@@ -598,6 +607,8 @@ class TestAD(TestRealms, CommonTests):
         self.admin_password = "foobarFoo123"
         self.alice_password = 'WonderLand123'
         self.expected_server_software = "active-directory"
+        # necessary to run ldapmodify; FIXME: change this on the services image itself
+        self.machines['services'].execute("sed -i 's/-e/-e INSECURELDAP=true &/' /run-samba-domain")
         self.machines['services'].execute("/run-samba-domain")
 
         m = self.machine
@@ -642,6 +653,41 @@ class TestAD(TestRealms, CommonTests):
         b.login_and_go('/system', user='alice', password=self.alice_password)
         b.wait_visible("#overview")
         b.logout()
+
+    def testClientCertAuthentication(self):
+        m = self.machine
+
+        services_machine = self.machines['services']
+        with open("src/tls/ca/alice.pem") as f:
+            alice_cert = f.read().strip()
+        # mangle into form palatable for LDAP
+        alice_cert = ''.join([l for l in alice_cert.splitlines() if not l.startswith("----")])
+        # set up an AD user and import their TLS certificate; avoid using the common "userCertificate;binary",
+        # as that does not work with Samba
+        services_machine.execute(r"""docker exec -i samba sh -exc '
+samba-tool user add alice %(alice_pass)s
+printf "version: 1\ndn: cn=alice,cn=users,dc=cockpit,dc=lan\nchangetype: modify\nadd: userCertificate\nuserCertificate: %(alice_cert)s\n" | \
+        ldapmodify -v -U Administrator -w '%(admin_pass)s'
+# for debugging:
+ldapsearch -v -U Administrator -w '%(admin_pass)s' -b 'cn=alice,cn=users,dc=cockpit,dc=lan'
+' """ % { "alice_pass": self.alice_password, "admin_pass": self.admin_password, "alice_cert": alice_cert })
+
+        # set up sssd for certificate mapping to AD
+        # see sssd.conf(5) "CERTIFICATE MAPPING SECTION" and sss-certmap(5)
+        m.write("/etc/sssd/conf.d/certmap.conf", """
+[certmap/cockpit.lan/certs]
+# our test certificates don't have EKU, and as we match full certificates it is not important to check anything here
+matchrule = <KU>digitalSignature
+# default rule; doesn't work because samba's LDAP doesn't understand ";binary"
+# maprule = LDAP:(userCertificate;binary={cert!bin})
+# match verbatim base64 certificate
+maprule = LDAP:(userCertificate={cert!base64})
+# match cert properties only; this looks at SubjectAlternativeName, which our test certs don't have
+# this also requires CA validation in cockpit-tls or sssd, which we don't have yet
+# maprule = (|(userPrincipalName={subject_principal})(sAMAccountName={subject_principal.short_name}))
+""", perm="0600")
+
+        self.checkClientCertAuthentication()
 
 
 JOIN_SCRIPT = """

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -78,7 +78,7 @@ class CommonTests:
         b = self.browser
 
         # Tell realmd to enable domain-qualified logins; unqualified ones are covered in testUnqualifiedUsers
-        m.execute("printf '[cockpit.lan]\\nfully-qualified-names = yes\\n'  >> /etc/realmd.conf")
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = yes\n", append=True)
 
         self.login_and_go("/system")
 
@@ -256,7 +256,7 @@ class CommonTests:
 
         # Tell realmd to not enable domain-qualified logins
         # (https://bugzilla.redhat.com/show_bug.cgi?id=1575538)
-        m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
         m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
 
         # wait until domain user works
@@ -508,14 +508,13 @@ ipa user-add-cert alice --certificate="%s"
         m.upload(["alice.pem", "alice.key", "alice-expired.pem", "bob.pem", "bob.key"], "/var/tmp",
                  relative_dir="src/tls/ca/")
 
-        # On older Debian/Ubuntu D-Bus activation of ifp is disabled, enable it manually; see https://bugs.debian.org/925026
+        # On Debian 9, D-Bus activation of ifp is disabled, enable it manually; see https://bugs.debian.org/925026
         static_ifp_conf = m.image in ["debian-stable"]
         if static_ifp_conf:
-            m.write("/etc/sssd/conf.d/ifp.conf", "[sssd]\nservices = nss, sudo, pam, ssh, ifp\n")
-            m.execute("chmod 600 /etc/sssd/conf.d/ifp.conf")
+            m.write("/etc/sssd/conf.d/ifp.conf", "[sssd]\nservices = nss, sudo, pam, ssh, ifp\n", perm="0600")
 
         # join domain, wait until it works
-        m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
         m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
         m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
 
@@ -572,7 +571,7 @@ ipa user-add-cert alice --certificate="%s"
                 session_leader='cockpit-session')
 
         # enable cert based auth
-        m.execute("printf '[WebService]\nClientCertAuthentication = true\n' >> /etc/cockpit/cockpit.conf")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nClientCertAuthentication = true\n", append=True)
         # cert auth should work now
         do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
                 ['HTTP/1.1 200 OK', '"csrf-token"'])
@@ -600,7 +599,7 @@ ipa user-add-cert alice --certificate="%s"
         self.allow_journal_messages('.*TLS handshake failed: Error in the certificate verification.*')
 
         # disallow password auth
-        m.execute("printf '[Basic]\naction = none\n' >> /etc/cockpit/cockpit.conf")
+        m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
         do_test(['--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key'],
                 ['HTTP/1.1 200 OK', '"csrf-token"'])
         do_test(['-u', 'alice:foobar'],
@@ -728,7 +727,7 @@ class TestKerberos(MachineCase):
 
         # Tell realmd to not enable domain-qualified logins
         # (https://bugzilla.redhat.com/show_bug.cgi?id=1575538)
-        m.execute("printf '[cockpit.lan]\\nfully-qualified-names = no\\n'  >> /etc/realmd.conf")
+        m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
 
         # delete the local admin user, going to use the IPA one instead
         m.execute("userdel admin")
@@ -819,7 +818,7 @@ class TestKerberos(MachineCase):
         self.assertIn('"csrf-token"', output)
         self.allow_restart_journal_messages()
 
-        m.execute("printf '[Negotiate]\naction = none\n' >> /etc/cockpit/cockpit.conf")
+        m.write("/etc/cockpit/cockpit.conf", "[Negotiate]\naction = none\n", append=True)
         m.restart_cockpit()
         output = m.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
                             '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',


### PR DESCRIPTION
Structurally this is similar to authentication against FreeIPA: The full user certificate is imported into LDAP.

Lousy preview of guide page: https://piware.de/tmp/cert-authentication.html (all CSS is missing,  but it's readable enough)

 - [x] builds on top of #14265
 - [x] Add AD specific documentation
 - [x] Test this against MS AD, in particular for `userCertificate` vs. `userCertificate;binary`
 - [x] Document both text and binary field
 - [x] Add append and mode parameters to m.write(): https://github.com/cockpit-project/bots/pull/1018