### PR TITLE
Fix stylesheet

### DIFF
--- a/examples/pinger/ping.html
+++ b/examples/pinger/ping.html
@@ -3,7 +3,7 @@
 <head>
     <title>Pinger</title>
     <meta charset="utf-8">
-    <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
+    <link href="../apps/apps.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
 </head>
 <body>


### PR DESCRIPTION
The cockpit stylesheet in the pinger example cannot be loaded. Seems like its failing to import patternfly.css. I'm pretty sure my fix is not the correct way to do it - but it works.