### PR TITLE
machines: Check if 'ui' is defined before accessing it

### DIFF
--- a/pkg/machines/components/vm/vmExpandedContent.jsx
+++ b/pkg/machines/components/vm/vmExpandedContent.jsx
@@ -52,7 +52,7 @@ export const VmExpandedContent = ({
     ];
 
     let initiallyActiveTab = null;
-    if (vm.ui.initiallyOpenedConsoleTab) {
+    if (vm.ui && vm.ui.initiallyOpenedConsoleTab) {
         initiallyActiveTab = tabRenderers.map((o) => o.name).indexOf(consolesTabName);
     }
 


### PR DESCRIPTION
Otherwise oops can happen:
`TypeError: Cannot read property 'initiallyOpenedConsoleTab' of undefined`.

From what I can see this must be a timing related issue so just don't try
to access the object if not ready yet.