### PR TITLE
test: Increase timeout for terminal flooding test

### DIFF
--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -88,7 +88,8 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
 
         # output flooding
         b.key_press("seq 1000000\r")
-        b.wait_in_text(".terminal .xterm-accessibility-tree", "9999989999991000000admin@")
+        with b.wait_timeout(300):
+            b.wait_in_text(".terminal .xterm-accessibility-tree", "9999989999991000000admin@")
 
         # now reset terminal
         b.click('button:contains("Reset")')


### PR DESCRIPTION
In Fedora dist-git testing it only got to ~ 600000 after a minute, so
give it five minutes instead of one.