### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH - superseded by #14284

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -1,5 +1,5 @@
 
-COCKPIT_BUILD_INFO = "Built on $(shell date)"
+COCKPIT_BUILD_INFO = "Built on $(shell date -u -d @$${SOURCE_DATE_EPOCH:-$$(date +%s)})"
 
 LOGIN_PO_FILES = $(patsubst %,dist/static/login.po.%.html,$(LINGUAS))
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This date call only works with GNU `date`.
Also use UTC to be independent of timezone.