### PR TITLE
codespell first-pass (2020-06-29)

### DIFF
--- a/containers/bastion/cockpit-auth-ssh-key
+++ b/containers/bastion/cockpit-auth-ssh-key
@@ -31,7 +31,7 @@ COCKPIT_SSH_COMMAND = "/usr/libexec/cockpit-ssh"
 # we will try to decrypt the key with the given password. If successful
 # we send the decrypted key to cockpit-ws for use with cockpit-ssh.
 # Once finished we exec cockpit-ssh to actually establish the ssh connection.
-# All comunication with cockpit-ws happens on stdin and stdout using the
+# All communication with cockpit-ws happens on stdin and stdout using the
 # cockpit protocol
 # (https://github.com/cockpit-project/cockpit/blob/master/doc/protocol.md)
 

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -29,7 +29,7 @@ Authentication commands are called with a single argument which is the host that
 is connecting to. They communicate with their parent process using the cockpit protocol on
 stdin and stdout.
 
-Credentials can then be retrived by issuing a authorize command with a challenge. The challenge
+Credentials can then be retrieved by issuing a authorize command with a challenge. The challenge
 should correspond to the authorization type in header (ei: Basic or Bearer). For example:
 
 

--- a/doc/guide/feature-virtualmachines.xml
+++ b/doc/guide/feature-virtualmachines.xml
@@ -30,7 +30,7 @@
     <para>
         In order to manipulate as unprivileged user VMs on system connection through
         <emphasis>cockpit-machines</emphasis> plugin using libvirt D-Bus provider you need to follow
-        the intructions specified <ulink url="https://libvirt.org/dbus.html#usage">here</ulink>.
+        the instructions specified <ulink url="https://libvirt.org/dbus.html#usage">here</ulink>.
     </para>
     </section>
 

--- a/doc/guide/gtk-doc.xsl
+++ b/doc/guide/gtk-doc.xsl
@@ -68,7 +68,7 @@
   <!-- ========================================================= -->
 
   <!-- l10n is slow, we don't ue it, so we'd like to turn it off
-       this atleast avoid the re-evaluation -->
+       this at least avoid the re-evaluation -->
   <xsl:template name="l10n.language">en</xsl:template>
 
   <xsl:param name="gtkdoc.l10n.xml" select="document('http://docbook.sourceforge.net/release/xsl/current/common/en.xml')"/>
@@ -657,7 +657,7 @@ Get a newer version at http://docbook.sourceforge.net/projects/xsl/
           </xsl:when>
           <!-- this is not yet very nice, as it requires all glossdic/indexdiv
           elements having a anchor element. maybe we can customize the xsl
-          to automaticaly create local anchors
+          to automatically create local anchors
           -->
           <xsl:when test="count($glssections) > 0">
             <tr>

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -90,8 +90,8 @@ $ cockpit-bridge --packages
           <para>By default Cockpit serves packages using a strict
             <ulink url="https://en.wikipedia.org/wiki/Content_Security_Policy">Content Security Policy</ulink>,
             which among other things does not allow inline styles or scripts. This can
-            be overriden on a per-package basis, with this setting.</para>
-          <para>If the overriden content security policy does not contain a <code>default-src</code>,
+            be overridden on a per-package basis, with this setting.</para>
+          <para>If the overridden content security policy does not contain a <code>default-src</code>,
             <code>connect-src</code>, <code>base-uri</code>, <code>form-action</code>, <code>object-src</code>,
             or <code>block-all-mixed-content</code> then these will be added to the policy from the manifest.</para>
         </listitem>

--- a/doc/man/pam_ssh_add.xml
+++ b/doc/man/pam_ssh_add.xml
@@ -50,7 +50,7 @@
   <para>
     By default the session module will start a new ssh-agent and run
     ssh-add, loading any keys that exist in the default path for the
-    newly logged in user. If any keys prompt for a password, and a authenication
+    newly logged in user. If any keys prompt for a password, and a authentication
     token was successfully stored, that token will be provided as the password.
   </para>
 

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -223,7 +223,7 @@ by adding a "auth-method-results" object to the close object. This is mainly
 useful to provide helpful error messages and suggestions to users.
 
 The "auth-method-results" object contains a key for each method that cockpit-ws
-is able to atempt authentication with as well as the result of the atempt.
+is able to attempt authentication with as well as the result of the attempt.
 For example:
 
     {

--- a/doc/routing.md
+++ b/doc/routing.md
@@ -5,7 +5,7 @@ Flow Control
 
 Cockpit's protocol passes messages on reliable, ordered underlying
 transports (eg: WebSockets, HTTP responses, stdio) between multiple
-peers, aranged in in a non-rooted tree graph.
+peers, arranged in in a non-rooted tree graph.
 
 Cockpit's flow control is not about replaying messages, but avoiding
 flooding any peer by sending messages along any link in the graph
@@ -19,7 +19,7 @@ down a certain channel which is flooding communication.
 Therefore we use a windowing flow control protocol. It is based around
 per-channel "ping" control messages. In the Cockpit protocol "ping"
 messages in a channel are responded to by specific leaves of the graph.
-They are replied to with a "pong" contaning otherwise identical content.
+They are replied to with a "pong" containing otherwise identical content.
 Other "ping" messages are used as keep alives, but these are beyond the
 scope of this description.
 

--- a/examples/poc-cim/test.html
+++ b/examples/poc-cim/test.html
@@ -60,7 +60,7 @@
 
             /* Wheee */
             $("table").show();
-            message("Done! " + instances.length + " processes, " + data.length + " bytes transfered from CIM ");
+            message("Done! " + instances.length + " processes, " + data.length + " bytes transferred from CIM ");
 
             $(response).find("INSTANCE").each(function() {
                 tbody.append(

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -62,8 +62,8 @@ div.spinner {
 }
 
 /*
- * Used to make a table cell that contains buttons have less padding
- * HACK: Because CSS has no parant selector.
+ * Reduce padding on table cells that contain buttons
+ * HACK: Because CSS has no parent selector.
  */
 .cell-buttons,
 .table > tbody > tr > .cell-buttons {

--- a/pkg/docker/docker.css
+++ b/pkg/docker/docker.css
@@ -62,7 +62,7 @@ div.spinner {
 }
 
 /*
- * Used to make a table cell that containts buttons have less padding
+ * Used to make a table cell that contains buttons have less padding
  * HACK: Because CSS has no parant selector.
  */
 .cell-buttons,

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -368,7 +368,7 @@ docker.console = function console_(container_id, command, options) {
     function prepare() {
         self.connected = false;
 
-        /* Nothing to prepare? Connect diretly to container? */
+        /* Nothing to prepare? Connect directly to container? */
         if (!exec) {
             if (tty === false) {
                 return attach("GET /v1.15/containers/" + encodeURIComponent(container_id) +
@@ -508,7 +508,7 @@ docker.console = function console_(container_id, command, options) {
         }
     };
 
-    /* Allows the curser to restart the attach request */
+    /* Allows the cursor to restart the attach request */
     self.connect = function connect() {
         self.close("disconnected");
         prepare();

--- a/pkg/docker/docker.js
+++ b/pkg/docker/docker.js
@@ -368,7 +368,7 @@ docker.console = function console_(container_id, command, options) {
     function prepare() {
         self.connected = false;
 
-        /* Nothing to prepare? Connect directly to container? */
+        /* Nothing to prepare? Connect directly to container. */
         if (!exec) {
             if (tty === false) {
                 return attach("GET /v1.15/containers/" + encodeURIComponent(container_id) +

--- a/pkg/kdump/kdump-client.js
+++ b/pkg/kdump/kdump-client.js
@@ -25,7 +25,7 @@ import crashKernelScript from 'raw-loader!./crashkernel.sh';
 import testWritableScript from 'raw-loader!./testwritable.sh';
 const _ = cockpit.gettext;
 
-const deprecatedKeys = ["net", "options", "link_delay", "disk_timeout", "debug_mem_level", "blacklist"];
+const deprecatedKeys = ["net", "options", "link_delay", "disk_timeout", "debug_mem_level", "blocklist"];
 const knownKeys = [
     "raw", "nfs", "ssh", "sshkey", "path", "core_collector", "kdump_post", "kdump_pre", "extra_bins", "extra_modules",
     "default", "force_rebuild", "override_resettable", "dracut_args", "fence_kdump_args", "fence_kdump_nodes"
@@ -114,7 +114,7 @@ export class KdumpClient {
             return dfd.promise();
         } else if (target.target === "nfs") {
             if (!target.nfs.value.match("\\S+:/.+"))
-                dfd.reject(_("nfs dump target isn't formated as server:path"));
+                dfd.reject(_("nfs dump target isn't formatted as server:path"));
         } else if (target.target === "ssh") {
             if (!target.ssh.value.trim())
                 dfd.reject(_("ssh server is empty"));

--- a/pkg/kdump/kdump-client.js
+++ b/pkg/kdump/kdump-client.js
@@ -25,7 +25,7 @@ import crashKernelScript from 'raw-loader!./crashkernel.sh';
 import testWritableScript from 'raw-loader!./testwritable.sh';
 const _ = cockpit.gettext;
 
-const deprecatedKeys = ["net", "options", "link_delay", "disk_timeout", "debug_mem_level", "blocklist"];
+const deprecatedKeys = ["net", "options", "link_delay", "disk_timeout", "debug_mem_level", "blacklist"];
 const knownKeys = [
     "raw", "nfs", "ssh", "sshkey", "path", "core_collector", "kdump_post", "kdump_pre", "extra_bins", "extra_modules",
     "default", "force_rebuild", "override_resettable", "dracut_args", "fence_kdump_args", "fence_kdump_nodes"

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -65,7 +65,7 @@ export var journal = { };
  *  .done(function(entries) { }): Called when done, @entries is
  *         an array of all journal entries loaded. If .stream()
  *         has been invoked then @entries will be empty.
- *  .fail(funciton(ex) { }): called if the operation fails
+ *  .fail(function(ex) { }): called if the operation fails
  *  .stream(function(entries) { }): called when we receive entries
  *         entries. Called once per batch of journal @entries,
  *         whether following or not.

--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -149,7 +149,7 @@ function Dialog(selector, address, machines_ins, codes) {
 
         var machine = self.machines_ins.lookup(address);
         if (machine && machine.host_key && !machine.on_disk) {
-            conn_options['temp-session'] = false; /* Compatiblity option */
+            conn_options['temp-session'] = false; /* Compatibility option */
             conn_options.session = 'shared';
             conn_options['host-key'] = machine.host_key;
         }
@@ -901,7 +901,7 @@ function SyncUsers(dialog) {
 
         dialog.run(promise);
 
-        /* A successfull sync should close the dialog */
+        /* A successful sync should close the dialog */
         dialog.set_on_success(null);
 
         promise.always(function () {

--- a/pkg/lib/machine-dialogs.js
+++ b/pkg/lib/machine-dialogs.js
@@ -965,7 +965,7 @@ function SyncUsers(dialog) {
     }
 
     function render() {
-        function formated_groups() {
+        function formatted_groups() {
             if (this.groups)
                 return this.groups.join(", ");
         }
@@ -986,7 +986,7 @@ function SyncUsers(dialog) {
             users : user_list,
             perm_failed : perm_failed ? cockpit.message(perm_failed) : null,
             allows_password : allows_password,
-            formated_groups: formated_groups,
+            formatted_groups: formatted_groups,
         });
 
         dialog.get_sel(".modal-content").html(text);

--- a/pkg/lib/machine-sync-users.html
+++ b/pkg/lib/machine-sync-users.html
@@ -36,7 +36,7 @@
                   <td>{{username}}</td>
                   <td>{{name}}</td>
                   <td>&#8226;&#8226;&#8226;&#8226;&#8226;</td>
-                  <td>{{formated_groups}}</td>
+                  <td>{{formatted_groups}}</td>
               </tr>
         {{/users}}
         </tbody>

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -202,7 +202,7 @@ input[type=number] {
 }
 
 @-moz-document url-prefix() {
-    /* Accomodate Firefox styling selects with slightly different padding. */
+    /* Accommodate Firefox styling selects with slightly different padding. */
     .ct-select {
         padding-left: 0.25em;
     }

--- a/pkg/lib/patterns.js
+++ b/pkg/lib/patterns.js
@@ -237,7 +237,7 @@ window.addEventListener("hashchange", function() {
  *
  * The following div.slider-bar if present is resized to fill the remainder
  * of the slider if not given a specific size. You can put more div.slider-bar
- * inside it to reflect squashing other prevous allocations.
+ * inside it to reflect squashing other previous allocations.
  *
  * If the following div.slider-bar have a width specified, then the
  * slider supports the concept of overflowing. If the slider overflows

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -41,7 +41,7 @@ import cockpit from "cockpit";
  * Either 'undefined' when the value can't be retrieved, or a
  * boolean that tells whether the service is started 'enabled'.
  * What it means exactly for a service to be enabled depends on
- * the service, but a enabled service is usually started on boot,
+ * the service, but an enabled service is usually started on boot,
  * no matter whether other services need it or not.  A disabled
  * service is usually only started when it is needed by some other
  * service.

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -42,7 +42,7 @@ import cockpit from "cockpit";
  * boolean that tells whether the service is started 'enabled'.
  * What it means exactly for a service to be enabled depends on
  * the service, but a enabled service is usually started on boot,
- * no matter wether other services need it or not.  A disabled
+ * no matter whether other services need it or not.  A disabled
  * service is usually only started when it is needed by some other
  * service.
  *

--- a/pkg/machines/components/networks/utils.js
+++ b/pkg/machines/components/networks/utils.js
@@ -40,7 +40,7 @@ export function validateIpv4(address) {
 }
 
 /**
- * validates correctnes of ipv4 prefix length or mask
+ * validates correctness of ipv4 prefix length or mask
  *
  * @param {string} prefixOrNetmask
  * @returns {boolean}
@@ -167,7 +167,7 @@ export function validateIpv6(address) {
 }
 
 /**
- * validates correctnes of ipv6 prefix length
+ * validates correctness of ipv6 prefix length
  *
  * @param {string} prefixOrNetmask
  * @returns {boolean}

--- a/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
+++ b/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
@@ -71,7 +71,7 @@ const StoragePoolTypeRow = ({ onValueChanged, dialogValues, libvirtVersion }) =>
         poolTypes.push({ type: 'iscsi-direct', detail: _("iSCSI direct Target") });
 
     /* TODO
-        { type: 'fs', detail _("Pre-formated Block Device") },
+        { type: 'fs', detail _("Pre-formatted Block Device") },
         { type: 'gluster', detail _("Gluster Filesystem") },
         { type: 'mpath', detail _("Multipath Device Enumerator") },
         { type: 'rbd', detail _("RADOS Block Device/Ceph") },

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -233,7 +233,7 @@ class VmOverviewTabLibvirt extends React.Component {
                         );
                     } else {
                         firmwareLinkWrapper = (
-                            <Tooltip id='firmware-edit-disabled-on-transient' content={_("Transient VMs don't support editting firmware configuration")}>
+                            <Tooltip id='firmware-edit-disabled-on-transient' content={_("Transient VMs don't support editing firmware configuration")}>
                                 {firmwareLink(true)}
                             </Tooltip>
                         );

--- a/pkg/machines/components/vmnetworktab.jsx
+++ b/pkg/machines/components/vmnetworktab.jsx
@@ -161,7 +161,7 @@ class VmNetworkTab extends React.Component {
                     const ips = (iface && iface[2]) ? iface[2] : undefined;
 
                     if (!ips) {
-                    // There is not IP address assosiated with this NIC
+                    // There is not IP address associated with this NIC
                         return _("Unknown");
                     } else {
                         return (

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -512,7 +512,7 @@ export function getBootOrderDevices(vm) {
     }
 
     // if boot order was defined in os->boot (old way), array contains only devices without boot order
-    // in case of boot order devined in devices->boot (new way), array contains all devices
+    // in case of boot order defined in devices->boot (new way), array contains all devices
     for (let i = 0; i < disks.length; i++) {
         const disk = disks[i];
 
@@ -524,7 +524,7 @@ export function getBootOrderDevices(vm) {
     }
 
     // if boot order was defined in os->boot (old way), array contains only devices without boot order
-    // in case of boot order devined in devices->boot (new way), array contains all devices
+    // in case of boot order defined in devices->boot (new way), array contains all devices
     for (let i = 0; i < ifaces.length; i++) {
         const iface = ifaces[i];
 

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1023,7 +1023,7 @@ function doUsagePolling(name, connectionName, objPath) {
 }
 
 /**
- * Subscribe to D-Bus signals and defines the handlers to be invoked in each occassion.
+ * Subscribe to D-Bus signals and defines the handlers to be invoked in each occasion.
  * @param  {String} connectionName D-Bus connection type; one of session/system.
  * @param  {String} libvirtServiceName
  */

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -191,7 +191,7 @@ function NetworkManagerModel() {
      * structure.  This has the advantage of avoiding wasting
      * resources for maintaining the unused proxies, avoids some code
      * complexity, and allows to do the right thing with the
-     * pecularities of the NetworkManager API.
+     * peculiarities of the NetworkManager API.
      *
      * However, we do use a fake object manager since that allows us
      * to avoid a lot of 'GetAll' round trips during initialization
@@ -2021,7 +2021,7 @@ function choice_title(choices, choice, def) {
  * 2) Make the change
  * 3) Destroy the checkpoint
  *
- * If step 2 breaks the connection, step 3 wont happen and the
+ * If step 2 breaks the connection, step 3 won't happen and the
  * checkpoint will roll back after some time.  This is supposed to
  * restore connectivity, so steps 2 and 3 will complete at that time,
  * and step 3 will fail because the checkpoint doesn't exist anymore.
@@ -2068,7 +2068,7 @@ function choice_title(choices, choice, def) {
  * changes, and it is thus important to show it if at all possible.
  */
 
-/* Considerations for chosing the times below
+/* Considerations for choosing the times below
  *
  * curtain_time too short:  Curtain comes up too often for good changes.
  *
@@ -3548,7 +3548,7 @@ function set_slave(model, master_connection, master_settings, slave_type,
         }
 
         return settings_applier(model, iface.Device, main_connection)(slave_settings).then(function () {
-            // If the master already exists, activate or deactivate the slave immediatly so that
+            // If the master already exists, activate or deactivate the slave immediately so that
             // the settings actually apply and the interface becomes a slave.  Otherwise we
             // activate it later when the master is created.
             if (master_connection) {
@@ -4667,7 +4667,7 @@ function PageNetworkMacSettings() {
  * pages and dialogs, and expects page.setup, page.enter, page.show,
  * and page.leave to be called at the right times.
  *
- * We cater to this with a little compatability shim consisting of
+ * We cater to this with a little compatibility shim consisting of
  * 'dialog_setup', 'page_show', and 'page_hide'.
  */
 

--- a/pkg/playground/jquery-patterns.js
+++ b/pkg/playground/jquery-patterns.js
@@ -22,7 +22,7 @@ $(function() {
     });
 
     /*
-     * These are failures targetted at specific fields. Note that we set
+     * These are failures targeted at specific fields. Note that we set
      * selectors on the target property of the exception. Also note how
      * the .dialog('failure') accepts multiple exceptions as arguments.
      */

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -17,7 +17,7 @@
         <br/>
         <br/>
         <div class="cockpit-internal-reauthorize">
-            <button class="pf-c-button pf-m-secondary">Priveleged Action</button>
+            <button class="pf-c-button pf-m-secondary">Privileged Action</button>
             <span></span>
         </div>
         <div class="super-channel">

--- a/pkg/playground/translate.html
+++ b/pkg/playground/translate.html
@@ -64,7 +64,7 @@
         <p>Note that we do <b>not support</b>:<p>
         <ul>
             <li>Interpolation of variables.</li>
-            <li>Tranlatable attributes.</li>
+            <li>Translatable attributes.</li>
             <li>Pluralization</li>
             <li>The <code>&lt;translate&gt;</code> element</li>
         </ul>

--- a/pkg/shell/nav.jsx
+++ b/pkg/shell/nav.jsx
@@ -157,7 +157,7 @@ function PageStatus({ status, name }) {
     );
 }
 
-function FormatedText({ keyword, term }) {
+function FormattedText({ keyword, term }) {
     function split_text(text, term) {
         const b = text.toLowerCase().indexOf(term);
         const e = b + term.length;
@@ -194,9 +194,9 @@ export function CockpitNavItem(props) {
         <li className={classes.join(" ")}>
             <span className={"pf-c-nav__link" + (props.active ? " pf-m-current" : "")} data-for={props.to}>
                 <a href={props.to}>
-                    { props.header && <span className="hint">{header_matches ? <FormatedText keyword={props.header} term={props.term} /> : props.header}</span> }
-                    { name_matches ? <FormatedText keyword={props.name} term={props.term} /> : props.name }
-                    { !name_matches && !header_matches && props.keyword && <span className="hint">{_("Contains:")} <FormatedText keyword={props.keyword} term={props.term} /></span> }
+                    { props.header && <span className="hint">{header_matches ? <FormattedText keyword={props.header} term={props.term} /> : props.header}</span> }
+                    { name_matches ? <FormattedText keyword={props.name} term={props.term} /> : props.name }
+                    { !name_matches && !header_matches && props.keyword && <span className="hint">{_("Contains:")} <FormattedText keyword={props.keyword} term={props.term} /></span> }
                 </a>
                 {s && s.type && <PageStatus status={s} name={props.name} />}
                 { props.actions &&

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -436,7 +436,7 @@ function init_model(callback) {
     }
 
     function enable_nfs_features() {
-        // mount.nfs might be in */sbin but that ins't always in
+        // mount.nfs might be in */sbin but that isn't always in
         // $PATH, such as when connecting from CentOS to another
         // machine via SSH as non-root.
         const std_path = "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin";

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -55,7 +55,7 @@
 
    ACTION FUNCTIONS
 
-   The action funtion is called like this:
+   The action function is called like this:
 
       action(values, progress_callback)
 
@@ -323,10 +323,10 @@ export const dialog_open = (def) => {
 
     fields.forEach(f => { values[f.tag] = f.initial_value });
 
-    // We reconstruct the body everytime the values change so that it
+    // We reconstruct the body every time the values change so that it
     // will be re-rendered.  This could be done with some state in the
     // Body component maybe, but we also want the values up here so
-    // that we can pass them to validate and the action functon.
+    // that we can pass them to validate and the action function.
 
     const update = (errors, trigger) => {
         if (def.update)

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -46,7 +46,7 @@ const _ = cockpit.gettext;
    - is_enabled:  A function that should return whether the feature is enabled.  This
                   function is called during rendering and thus needs to be fast and synchronous.
 
-   - package:     The name of tha package to install.  If omitted or false, the feature
+   - package:     The name of the package to install.  If omitted or false, the feature
                   can not be enabled at run-time and the panel will be fully invisible
                   if not already enabled.
 

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -102,9 +102,9 @@ export function fmt_rate(bytes_per_sec) {
 }
 
 export function format_temperature(kelvin) {
-    var celcius = kelvin - 273.15;
-    var fahrenheit = 9.0 * celcius / 5.0 + 32.0;
-    return celcius.toFixed(1) + "° C / " + fahrenheit.toFixed(1) + "° F";
+    var celsius = kelvin - 273.15;
+    var fahrenheit = 9.0 * celsius / 5.0 + 32.0;
+    return celsius.toFixed(1) + "° C / " + fahrenheit.toFixed(1) + "° F";
 }
 
 export function format_fsys_usage(used, total) {

--- a/pkg/systemd/README-realmd.md
+++ b/pkg/systemd/README-realmd.md
@@ -69,7 +69,7 @@ the domain name. If it does not, then rename the computer Cockpit is running on:
 
     $ sudo hostnamectl set-hostname my-server.domain.com
 
-**BUG:** If your domain is an IPA domain, then you need to explictly add a service
+**BUG:** If your domain is an IPA domain, then you need to explicitly add a service
 before Cockpit can be used with Single Sign on. The following must be done on
 the computer running Cockpit.
 [realmd bug](https://bugzilla.redhat.com/show_bug.cgi?id=1144292)

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -47,7 +47,7 @@ export class PageStatusNotifications extends React.Component {
     }
 
     render() {
-        // Explicit whitelist for now, until we can get a dynamic list
+        // Explicit allowlist for now, until we can get a dynamic list
         return ["system/services", "updates"].map(page => {
             const status = page_status.get(page);
             if (status && (status.type || status.details) && status.title) {

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -272,7 +272,7 @@ class ServiceActions extends React.Component {
             <>
                 { this.state.dialogMaskedOpened &&
                     <ServiceConfirmDialog id="mask-service" title={ _("Mask Service") }
-                                          message={ _("Masking service prevents all dependant units from running. This can have bigger impact than anticipated. Please confirm that you want to mask this unit.")}
+                                          message={ _("Masking service prevents all dependent units from running. This can have bigger impact than anticipated. Please confirm that you want to mask this unit.")}
                                           close={() => this.setState({ dialogMaskedOpened: false }) }
                                           confirmText={ _("Mask Service") }
                                           confirmAction={() => {
@@ -301,7 +301,7 @@ ServiceActions.propTypes = {
 
 /*
  * React template for a service details
- * Shows current status and informations about the service.
+ * Shows current status and information about the service.
  * Enables user to control this unit like starting, enabling, etc. the service.
  * Required props:
  *  -  unit

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -40,7 +40,7 @@ export class Service extends React.Component {
         this.state = {
             error: undefined,
             /* The initial load of the Services page will not call GetAll for units Properties
-             * since ListUnits API call allready has provided us with a subset of the Properties.
+             * since ListUnits API call already has provided us with a subset of the Properties.
              * As a result, properties like the 'Requires' are not present in the state at this point.
              * If it's the first time to open this service's details page we need to fetch
              * the unit properties by calling getUnitByPath.

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -210,7 +210,7 @@ class ServicesPage extends React.Component {
         });
 
         /* Start listening to signals for updates - when in the middle of reload mute all signals
-         * - We don't need to listen to 'UnitFilesChanged' signal since everytime we
+         * - We don't need to listen to 'UnitFilesChanged' signal since every time we
          *   perform some file operation we do call Reload which issues 'Reload' signal
          * - JobNew is also useless, JobRemoved is enough since it comes in pair with JobNew
          *   but we are interested to update the state when the operation finished

--- a/pkg/users/authorized-keys.js
+++ b/pkg/users/authorized-keys.js
@@ -26,7 +26,7 @@ function AuthorizedKeys (user_name, home_dir) {
             self.state = "ready";
         } else {
             self.state = "failed";
-            console.warn("Error proccessing authentication keys: " + ex);
+            console.warn("Error processing authentication keys: " + ex);
         }
         self.dispatchEvent("changed");
     }

--- a/po/ca.po
+++ b/po/ca.po
@@ -9080,7 +9080,7 @@ msgid "nfs"
 msgstr ""
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr ""
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/ca.po
+++ b/po/ca.po
@@ -7784,7 +7784,7 @@ msgid "Tower"
 msgstr "Torre"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/ca.po
+++ b/po/ca.po
@@ -4265,7 +4265,7 @@ msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -8207,7 +8207,7 @@ msgid "Tower"
 msgstr "Věž"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr "U přechodných virt. strojů nelze upravovat nastavení firmware"
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/cs.po
+++ b/po/cs.po
@@ -9564,7 +9564,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "cíl výpisu nfs nemá podobu server:umisteni"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/cs.po
+++ b/po/cs.po
@@ -4490,7 +4490,7 @@ msgstr "Maskováno"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -9256,7 +9256,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "Das NFS-Speicherauszugsziel ist nicht als Serverpfad formatiert"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/de.po
+++ b/po/de.po
@@ -4339,7 +4339,7 @@ msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7953,7 +7953,7 @@ msgid "Tower"
 msgstr "Turm"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/es.po
+++ b/po/es.po
@@ -4347,7 +4347,7 @@ msgstr "Enmascarado"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -9306,7 +9306,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs dump target no está declarado como servidor:ruta"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/es.po
+++ b/po/es.po
@@ -7991,7 +7991,7 @@ msgid "Tower"
 msgstr "Torre"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 "Las MVs que son temporales no tienen soporte para editar la configuración "
 "del firmware"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4296,7 +4296,7 @@ msgstr "Masqué"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7893,7 +7893,7 @@ msgid "Tower"
 msgstr "Tower"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 "Les machines virtuelles temporaires ne permettent pas de modifier la "
 "configuration du micrologiciel"

--- a/po/fr.po
+++ b/po/fr.po
@@ -9183,7 +9183,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "la cible nfs dump n’a pas été formatée sous la forme server : path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/he.po
+++ b/po/he.po
@@ -4271,7 +4271,7 @@ msgstr "ממוסך"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/he.po
+++ b/po/he.po
@@ -7779,7 +7779,7 @@ msgid "Tower"
 msgstr "מארז גבוה"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr "מכונות וירטואליות זמניות לא תומכות בעריכת הגדרות קושחה"
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/he.po
+++ b/po/he.po
@@ -9056,7 +9056,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "יעד היטל ה־nfs אינו כתוב בצורה server:path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/it.po
+++ b/po/it.po
@@ -7997,7 +7997,7 @@ msgid "Tower"
 msgstr "Tower"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/it.po
+++ b/po/it.po
@@ -9319,7 +9319,7 @@ msgid "nfs"
 msgstr ""
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs dump target non è formattato come server:path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/it.po
+++ b/po/it.po
@@ -4386,7 +4386,7 @@ msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -9116,7 +9116,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs ダンプターゲットは server:path の形式になっていません"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/ja.po
+++ b/po/ja.po
@@ -4258,7 +4258,7 @@ msgstr "マスク"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7828,7 +7828,7 @@ msgid "Tower"
 msgstr "タワー"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr "transient VMはファームウェア設定の編集をサポートしていません"
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/ko.po
+++ b/po/ko.po
@@ -4324,7 +4324,7 @@ msgstr "마스크 설정됨"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/ko.po
+++ b/po/ko.po
@@ -9236,7 +9236,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs 덤프 대상이 server:path 형식으로 되어 있지 않습니다"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/ko.po
+++ b/po/ko.po
@@ -7928,7 +7928,7 @@ msgid "Tower"
 msgstr "타워"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/nl.po
+++ b/po/nl.po
@@ -4274,7 +4274,7 @@ msgstr "Gemaskeerd"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -9157,7 +9157,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs dump target is niet geformatteerd als server:pad"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/nl.po
+++ b/po/nl.po
@@ -7864,7 +7864,7 @@ msgid "Tower"
 msgstr "Toren"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 "Tijdelijke VM's bieden geen ondersteuning voor het bewerken van "
 "firmwareconfiguratie"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7883,7 +7883,7 @@ msgid "Tower"
 msgstr "Tower"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 "Tymczasowe maszyny wirtualne nie obsługują modyfikowania konfiguracji "
 "oprogramowania sprzętowego"

--- a/po/pl.po
+++ b/po/pl.po
@@ -4295,7 +4295,7 @@ msgstr "Zamaskowana"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -9169,7 +9169,7 @@ msgid "nfs"
 msgstr "NFS"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "cel zrzutu NFS nie jest sformatowany jako serwer:ścieżka"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -9197,7 +9197,7 @@ msgid "nfs"
 msgstr ""
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "destino de despejo nfs não é formatado como servidor: caminho"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7896,7 +7896,7 @@ msgid "Tower"
 msgstr "Torre"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -4331,7 +4331,7 @@ msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -4358,7 +4358,7 @@ msgstr "Скрыто"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -8003,7 +8003,7 @@ msgid "Tower"
 msgstr "Компьютер в корпусе «башня»"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr "Временные ВМ не поддерживают редактирование конфигурации микропрограмм"
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/ru.po
+++ b/po/ru.po
@@ -9322,7 +9322,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "Формат цели дампа NFS отличается от вида сервер:путь"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/sv.po
+++ b/po/sv.po
@@ -4259,7 +4259,7 @@ msgstr "Gömd"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7811,7 +7811,7 @@ msgid "Tower"
 msgstr "Torn"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/sv.po
+++ b/po/sv.po
@@ -9110,7 +9110,7 @@ msgid "nfs"
 msgstr ""
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs-dumpmålet är inte formaterat som server:sökväg"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/uk.po
+++ b/po/uk.po
@@ -9188,7 +9188,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr ""
 "форматування місця для дампів у nfs не збігається із потрібним: сервер:шлях"
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -4303,7 +4303,7 @@ msgstr "Замасковано"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7897,7 +7897,7 @@ msgid "Tower"
 msgstr "Башточка"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 "Для тимчасових віртуальних машин не передбачено підтримки редагування "
 "налаштувань мікропрограми"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -7781,7 +7781,7 @@ msgid "Tower"
 msgstr "Tower"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -9076,7 +9076,7 @@ msgid "nfs"
 msgstr "nfs"
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs dump 目标的格式不是 server:path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -4265,7 +4265,7 @@ msgstr "掩盖的"
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -7807,7 +7807,7 @@ msgid "Tower"
 msgstr "塔"
 
 #: pkg/machines/components/vmOverviewTabLibvirt.jsx:236
-msgid "Transient VMs don't support editting firmware configuration"
+msgid "Transient VMs don't support editing firmware configuration"
 msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:515

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -4274,7 +4274,7 @@ msgstr ""
 
 #: pkg/systemd/services/service-details.jsx:275
 msgid ""
-"Masking service prevents all dependant units from running. This can have "
+"Masking service prevents all dependent units from running. This can have "
 "bigger impact than anticipated. Please confirm that you want to mask this "
 "unit."
 msgstr ""

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -9114,7 +9114,7 @@ msgid "nfs"
 msgstr ""
 
 #: pkg/kdump/kdump-client.js:117
-msgid "nfs dump target isn't formated as server:path"
+msgid "nfs dump target isn't formatted as server:path"
 msgstr "nfs dump target未格式化為server：path"
 
 #: pkg/machines/components/networks/networkOverviewTab.jsx:84

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -4184,7 +4184,7 @@ function factory() {
 
             /* Callbacks that want to stream or get headers */
             var streamer = null;
-            var responders = null;
+            var responsers = null;
 
             var resp = null;
 
@@ -4199,9 +4199,9 @@ function factory() {
                 /* Anyone looking for response details? */
                 if (options.command == "response") {
                     resp = options;
-                    if (responders) {
+                    if (responsers) {
                         resp.headers = resp.headers || { };
-                        invoke_functions(responders, ret, [resp.status, resp.headers]);
+                        invoke_functions(responsers, ret, [resp.status, resp.headers]);
                     }
                 }
             }
@@ -4245,9 +4245,9 @@ function factory() {
                 return ret;
             };
             ret.response = function(callback) {
-                if (responders === null)
-                    responders = [];
-                responders.push(callback);
+                if (responsers === null)
+                    responsers = [];
+                responsers.push(callback);
                 return ret;
             };
             ret.input = function(message, stream) {

--- a/src/base1/cockpit.js
+++ b/src/base1/cockpit.js
@@ -38,7 +38,7 @@ event_mixin(cockpit, { });
  * by various parts of the code to show/hide debug
  * messages in the javascript console.
  *
- * We supprot using storage to get/set that property
+ * We support using storage to get/set that property
  * so that it carries across the various frames or
  * alternatively persists across refreshes.
  */
@@ -1512,7 +1512,7 @@ function factory() {
     };
 
     cockpit.format_number = function format_number(number) {
-        /* We show 3 digits of precison but avoid scientific notation.
+        /* We show 3 digits of precision but avoid scientific notation.
          * We also show integers without digits after the comma.
          *
          * We want to localise the decimal place, but we never want to
@@ -2132,7 +2132,7 @@ function factory() {
                             path = gdata.links[k][0];
                             row = gdata.links[k][1];
 
-                            /* Calulate the data field to fill in */
+                            /* Calculate the data field to fill in */
                             data = items[f + i];
                             map = mapping;
                             jlen = path.length;
@@ -3594,7 +3594,7 @@ function factory() {
         };
     }
 
-    /* Well known busses */
+    /* Well known buses */
     var shared_dbus = {
         internal: null,
         session: null,
@@ -4184,7 +4184,7 @@ function factory() {
 
             /* Callbacks that want to stream or get headers */
             var streamer = null;
-            var responsers = null;
+            var responders = null;
 
             var resp = null;
 
@@ -4199,9 +4199,9 @@ function factory() {
                 /* Anyone looking for response details? */
                 if (options.command == "response") {
                     resp = options;
-                    if (responsers) {
+                    if (responders) {
                         resp.headers = resp.headers || { };
-                        invoke_functions(responsers, ret, [resp.status, resp.headers]);
+                        invoke_functions(responders, ret, [resp.status, resp.headers]);
                     }
                 }
             }
@@ -4245,9 +4245,9 @@ function factory() {
                 return ret;
             };
             ret.response = function(callback) {
-                if (responsers === null)
-                    responsers = [];
-                responsers.push(callback);
+                if (responders === null)
+                    responders = [];
+                responders.push(callback);
                 return ret;
             };
             ret.input = function(message, stream) {

--- a/src/base1/patternfly-4-cockpit.scss
+++ b/src/base1/patternfly-4-cockpit.scss
@@ -1,4 +1,4 @@
-/* Set fake font and icon path variables - we are going to indentify these through
+/* Set fake font and icon path variables - we are going to identify these through
  * patternfly.sed and remove the relevant font-face declarations
  */
 $pf-global--font-path: 'patternfly-fonts-fake-path';

--- a/src/base1/patternfly-overrides.scss
+++ b/src/base1/patternfly-overrides.scss
@@ -163,7 +163,7 @@ select.form-control {
         height: 100%;
       }
 
-      // Shave off the border and padding, as these misalign the elemnt
+      // Shave off the border and padding, as these misalign the element
       // (as this widget uses inline styles (ugh!), we _have to_ use !important)
       > input {
         border-width: 0 1px !important;

--- a/src/base1/test-dbus-common.js
+++ b/src/base1/test-dbus-common.js
@@ -32,7 +32,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.deepEqual(reply, ["Word! You said `Browser-side JS'. I'm Skeleton, btw!"], "reply");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -124,7 +124,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     ], "round trip");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -197,7 +197,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     ], "round trip");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -221,7 +221,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     ], "round trip");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -303,7 +303,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     }], "reply");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -383,7 +383,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
 
         dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber", "RequestSignalEmission", [0])
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "emmision requested");
+                    assert.equal(this.state(), "resolved", "emission requested");
                     assert.equal(received, true, "signal received");
                     done();
                 });
@@ -407,7 +407,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
 
         dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber", "RequestSignalEmission", [0])
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "emmision requested");
+                    assert.equal(this.state(), "resolved", "emission requested");
                     assert.equal(received, true, "signal received");
                 })
                 .then(function() {
@@ -416,7 +416,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
 
                     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber", "RequestSignalEmission", [0])
                             .always(function() {
-                                assert.equal(this.state(), "resolved", "second emmision requested");
+                                assert.equal(this.state(), "resolved", "second emission requested");
                                 assert.equal(received, false, "signal not received");
                                 done();
                             });
@@ -436,7 +436,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(options.type, "a{ss}uit", "got back type");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -489,7 +489,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.equal(options.type, "ay", "got back type");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -650,7 +650,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.ok(options.flags.indexOf(">") !== -1 || options.flags.indexOf("<") !== -1, "has byte order");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -665,7 +665,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                     assert.deepEqual(reply, [], "round trip");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     done();
                 });
     });
@@ -791,7 +791,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
                                      }, "correct data");
                 })
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "finished successfuly");
+                    assert.equal(this.state(), "resolved", "finished successfully");
                     $(dbus).off();
                     done();
                 });
@@ -1023,7 +1023,7 @@ function common_dbus_tests(channel_options, bus_name) { // eslint-disable-line n
 
         proxy.call("RequestSignalEmission", [0])
                 .always(function() {
-                    assert.equal(this.state(), "resolved", "emmision requested");
+                    assert.equal(this.state(), "resolved", "emission requested");
                     assert.equal(received, true, "signal received");
                     $(dbus).off();
                     $(proxy).off();

--- a/src/base1/test-dbus-framed.js
+++ b/src/base1/test-dbus-framed.js
@@ -68,7 +68,7 @@ function child_frame() {
                 dbus.close();
             })
             .always(function() {
-                test.equal(this.state(), "resolved", "finished successfuly");
+                test.equal(this.state(), "resolved", "finished successfully");
             });
     dbus.addEventListener("close", function(ev, options) {
         test.assert(!options.problem, "close cleanly");

--- a/src/base1/test-dbus.js
+++ b/src/base1/test-dbus.js
@@ -82,8 +82,8 @@ QUnit.test("owned messages", function (assert) {
     var org_owner = null;
     function on_owner (event, owner) {
         if (times_changed === 0) {
-            assert.strictEqual(typeof owner, "string", "intial owner string");
-            assert.ok(owner.length > 1, "intial owner not empty");
+            assert.strictEqual(typeof owner, "string", "initial owner string");
+            assert.ok(owner.length > 1, "initial owner not empty");
             org_owner = owner;
         } else if (times_changed === 1) {
             assert.strictEqual(owner, null, "no owner");

--- a/src/base1/test-series.js
+++ b/src/base1/test-series.js
@@ -48,13 +48,13 @@ QUnit.test("calculated order", function (assert) {
     });
 
     /* Callbacks must be called in the right order for this to work */
-    var dependant = grid.add(function(row, x, n) {
+    var dependent = grid.add(function(row, x, n) {
         for (var i = 0; i < n; i++)
             row[i + x] = calculated[i + x] + 10;
     });
 
     grid.notify(1, 4);
-    assert.deepEqual(dependant, [undefined, 10, 11, 12, 13], "dependant array contents");
+    assert.deepEqual(dependent, [undefined, 10, 11, 12, 13], "dependent array contents");
 });
 
 QUnit.test("calculated early", function (assert) {
@@ -63,7 +63,7 @@ QUnit.test("calculated early", function (assert) {
     var calculated;
 
     /* Callbacks must be called in the right order for this to work */
-    var dependant = grid.add(function(row, x, n) {
+    var dependent = grid.add(function(row, x, n) {
         for (var i = 0; i < n; i++)
             row[i + x] = calculated[i + x] + 10;
     });
@@ -75,7 +75,7 @@ QUnit.test("calculated early", function (assert) {
     }, true);
 
     grid.notify(1, 4);
-    assert.deepEqual(dependant, [undefined, 10, 11, 12, 13], "dependant array contents");
+    assert.deepEqual(dependent, [undefined, 10, 11, 12, 13], "dependent array contents");
 });
 
 QUnit.test("notify limit", function (assert) {

--- a/src/base1/test-user.js
+++ b/src/base1/test-user.js
@@ -20,7 +20,7 @@ QUnit.test("load user info", function (assert) {
                 assert.equal(user.Groups.t, "as", "type Groups");
             })
             .always(function() {
-                assert.equal(this.state(), "resolved", "finished successfuly");
+                assert.equal(this.state(), "resolved", "finished successfully");
                 done();
             });
 });

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -460,7 +460,7 @@ run_bridge (const gchar *interactive,
   CockpitTransport *transport;
   CockpitRouter *router;
   gboolean terminated = FALSE;
-  gboolean interupted = FALSE;
+  gboolean interrupted = FALSE;
   gboolean closed = FALSE;
   const gchar *directory;
   struct passwd *pwd;
@@ -532,7 +532,7 @@ run_bridge (const gchar *interactive,
     }
 
   sig_term = g_unix_signal_add (SIGTERM, on_signal_done, &terminated);
-  sig_int = g_unix_signal_add (SIGINT, on_signal_done, &interupted);
+  sig_int = g_unix_signal_add (SIGINT, on_signal_done, &interrupted);
 
   cockpit_dbus_internal_startup (interactive != NULL);
 
@@ -579,7 +579,7 @@ run_bridge (const gchar *interactive,
   g_signal_connect (transport, "closed", G_CALLBACK (on_closed_set_flag), &closed);
   send_init_command (transport, interactive ? TRUE : FALSE);
 
-  while (!terminated && !closed && !interupted)
+  while (!terminated && !closed && !interrupted)
     g_main_context_iteration (NULL, TRUE);
 
 #ifdef WITH_POLKIT

--- a/src/bridge/cockpitdbussetup.c
+++ b/src/bridge/cockpitdbussetup.c
@@ -600,7 +600,7 @@ setup_commit_passwd1 (GVariant *parameters,
   GString *string;
   gboolean user_exists;
 
-  /* We are getting encrypted passwords so we need to use
+  /* We are getting crypt()-ed passwords so we need to use
    * --crypt-method=NONE with newusers and chpasswd so that the string
    * is installed unchanged.  Unfortunately, newusers might or might
    * not support the --crypt-method option, depending on whether it

--- a/src/bridge/cockpitdbussetup.c
+++ b/src/bridge/cockpitdbussetup.c
@@ -600,7 +600,7 @@ setup_commit_passwd1 (GVariant *parameters,
   GString *string;
   gboolean user_exists;
 
-  /* We are getting crypted passwords so we need to use
+  /* We are getting encrypted passwords so we need to use
    * --crypt-method=NONE with newusers and chpasswd so that the string
    * is installed unchanged.  Unfortunately, newusers might or might
    * not support the --crypt-method option, depending on whether it

--- a/src/bridge/cockpitfslist.c
+++ b/src/bridge/cockpitfslist.c
@@ -314,7 +314,7 @@ cockpit_fslist_class_init (CockpitFslistClass *klass)
  * @transport: the transport to send/receive messages on
  * @channel_id: the channel id
  * @path: the path name of the file to read
- * @watch: boolean, watch the directoy as well?
+ * @watch: boolean, watch the directory as well?
  *
  * This function is mainly used by tests. The usual way
  * to get a #CockpitFslist is via cockpit_channel_open()

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -486,17 +486,17 @@ is_empty (const gchar *s)
 static void
 cockpit_router_normalize_host_params (JsonObject *options)
 {
-  const gchar *sharable = NULL;
+  const gchar *shareable = NULL;
   const gchar *user = NULL;
   gboolean needs_private = FALSE;
 
-  if (!cockpit_json_get_string (options, "session", NULL, &sharable))
-    sharable = NULL;
+  if (!cockpit_json_get_string (options, "session", NULL, &shareable))
+    shareable = NULL;
 
   if (!cockpit_json_get_string (options, "user", NULL, &user))
     user = NULL;
 
-  if (!sharable)
+  if (!shareable)
     {
       /* Fallback to older ways of indicating this */
       if (user || json_object_has_member (options, "host-key"))

--- a/src/bridge/mock-bridge.c
+++ b/src/bridge/mock-bridge.c
@@ -284,7 +284,7 @@ main (int argc,
 {
   CockpitTransport *transport;
   gboolean terminated = FALSE;
-  gboolean interupted = FALSE;
+  gboolean interrupted = FALSE;
   gboolean closed = FALSE;
   GOptionContext *context;
   GError *error = NULL;
@@ -328,7 +328,7 @@ main (int argc,
     }
 
   sig_term = g_unix_signal_add (SIGTERM, on_signal_done, &terminated);
-  sig_int = g_unix_signal_add (SIGINT, on_signal_done, &interupted);
+  sig_int = g_unix_signal_add (SIGINT, on_signal_done, &interrupted);
 
   transport = cockpit_pipe_transport_new_fds ("stdio", 0, outfd);
 
@@ -339,7 +339,7 @@ main (int argc,
   /* Owns the channels */
   channels = g_hash_table_new_full (g_str_hash, g_str_equal, g_free, g_object_unref);
 
-  while (!terminated && !closed && !interupted)
+  while (!terminated && !closed && !interrupted)
     g_main_context_iteration (NULL, TRUE);
 
   g_object_unref (transport);

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -744,7 +744,7 @@ test_watch_simple (TestCase *tc,
 
   /*
    * HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1259594
-   * Some versions of glib2 erroneously emit spurios "delete" events.
+   * Some versions of glib2 erroneously emit spurious "delete" events.
    */
   if (g_str_equal (json_object_get_string_member (event, "event"), "deleted"))
     {

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -36,7 +36,7 @@
 
 /*
  * To recalculate the checksums found in this file, do something like:
- * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/glob/ XDG_DATA_HOME=/nonexistant ./cockpit-bridge --packages
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/glob/ XDG_DATA_HOME=/nonexistent ./cockpit-bridge --packages
  */
 #define CHECKSUM_GLOB           "f5d1bfe84c378dee517cea3e0f0380ad2c9201f6be021fbae877a89d4cb51859"
 #define CHECKSUM_BADPACKAGE     "86ae6170eb6245c5c80dbcbcc0ba12beddee2e1d807cfdb705440e944b177fbc"

--- a/src/bridge/test-peer.c
+++ b/src/bridge/test-peer.c
@@ -242,11 +242,11 @@ mock_peer_fail_new (MockTransport *transport,
 
   if (problem)
     {
-      bridge = g_strdup_printf ("{ \"match\": { \"payload\": \"%s\" }, \"spawn\": [ \"/non-existant\" ], \"problem\": \"%s\" }", payload, problem);
+      bridge = g_strdup_printf ("{ \"match\": { \"payload\": \"%s\" }, \"spawn\": [ \"/non-existent\" ], \"problem\": \"%s\" }", payload, problem);
     }
   else
     {
-      bridge = g_strdup_printf ("{ \"match\": { \"payload\": \"%s\" }, \"spawn\": [ \"/non-existant\" ] }", payload);
+      bridge = g_strdup_printf ("{ \"match\": { \"payload\": \"%s\" }, \"spawn\": [ \"/non-existent\" ] }", payload);
     }
 
   peer = peer_new (transport, bridge);
@@ -422,7 +422,7 @@ test_fallback (TestCase *tc,
 {
   GBytes *sent;
 
-  /* The "upper" channel has a local implementaiton to fallback to */
+  /* The "upper" channel has a local implementation to fallback to */
   tc->peer = mock_peer_fail_new (tc->transport, "upper", NULL);
 
   emit_string (tc, NULL, "{\"command\": \"open\", \"channel\": \"a\", \"payload\": \"upper\"}");

--- a/src/bridge/test-router.c
+++ b/src/bridge/test-router.c
@@ -536,7 +536,7 @@ test_sharable_processing (TestCase *tc,
   cockpit_assert_json_eq (control, "{\"command\": \"open\", \"channel\": \"a\", \"payload\": \"host\", \"user\": \"user\"}");
   control = NULL;
 
-  /* Test user with sharable is not touched */
+  /* Test user with shareable is not touched */
   emit_string (tc, NULL, "{\"command\": \"open\", \"channel\": \"a\", \"payload\": \"host\", \"host\":\"localhost\", \"user\": \"user\", \"session\": \"other\"}");
   while ((control = mock_transport_pop_control (tc->transport)) == NULL)
     g_main_context_iteration (NULL, TRUE);

--- a/src/bridge/test-setup.c
+++ b/src/bridge/test-setup.c
@@ -160,7 +160,7 @@ test_prepare_fail (TestCase *tc,
   GVariant *retval;
   GError *error = NULL;
 
-  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existant";
+  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existent";
 
   cockpit_expect_message ("unable to open*");
 
@@ -275,7 +275,7 @@ test_transfer_fail (TestCase *tc,
 
   const gchar *empty[] = { NULL };
 
-  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existant";
+  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existent";
 
   cockpit_expect_message ("unable to open*");
 
@@ -561,7 +561,7 @@ test_commit_fail_passwd (TestCase *tc,
 
   const gchar *empty[] = { NULL };
 
-  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existant";
+  cockpit_bridge_path_passwd = SRCDIR "/src/bridge/mock-setup/non-existent";
 
   cockpit_expect_message ("unable to open*");
 

--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -756,7 +756,7 @@ cockpit_channel_class_init (CockpitChannelClass *klass)
                                                          /**
    * CockpitChannel:capabilities:
    *
-   * The capabilties that this channel supports.
+   * The capabilities that this channel supports.
    */
   g_object_class_install_property (gobject_class, PROP_CAPABILITIES,
                                    g_param_spec_boxed ("capabilities",
@@ -783,7 +783,7 @@ cockpit_channel_class_init (CockpitChannelClass *klass)
  * @self: a channel
  * @problem: the problem or NULL
  *
- * Close the channel. This can be called mulitple times.
+ * Close the channel. This can be called multiple times.
  *
  * It may be that the channel doesn't close immediately.
  * The channel will emit the CockpitChannel::closed signal when the
@@ -829,7 +829,7 @@ cockpit_channel_close (CockpitChannel *self,
  * @problem: the problem
  *
  * Close the channel with a @problem. In addition a "message" field
- * will be set on the channel, using the @format argument to bulid
+ * will be set on the channel, using the @format argument to build
  * the message. The message will also be logged.
  *
  * See cockpit_channel_close() for further info.

--- a/src/common/cockpitlog.c
+++ b/src/common/cockpitlog.c
@@ -58,7 +58,7 @@ cockpit_journal_log_handler (const gchar *log_domain,
   const gchar *prefix;
 
   /*
-   * Note: we should not call GLib fucntions here.
+   * Note: we should not call GLib functions here.
    *
    * Mapping glib log levels to syslog priorities
    * is not at all obvious.

--- a/src/common/cockpittransport.c
+++ b/src/common/cockpittransport.c
@@ -415,7 +415,7 @@ cockpit_transport_maybe_frame (GBytes *message,
  * @options: location to return the options
  *
  * Parse a command and return various values from the
- * command. The @options value is transfered with ownership,
+ * command. The @options value is transferred with ownership,
  * so you should free it after done. @command and @channel are owned by
  * @options. @channel will be NULL for a missing channel.
  *
@@ -437,7 +437,7 @@ cockpit_transport_parse_command (GBytes *payload,
   object = cockpit_json_parse_bytes (payload, &error);
   if (!object)
     {
-      g_warning ("Received unparseable control message: %s", error->message);
+      g_warning ("Received unparsable control message: %s", error->message);
       g_error_free (error);
       goto out;
     }

--- a/src/common/cockpittransport.h
+++ b/src/common/cockpittransport.h
@@ -35,7 +35,7 @@ struct _CockpitTransportClass
   /* signals */
 
   /*
-   * Fired when the transport recieves a new message.
+   * Fired when the transport receives a new message.
    */
   gboolean    (* recv)        (CockpitTransport *transport,
                                const gchar *channel,

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -908,7 +908,7 @@ finish_headers (CockpitWebResponse *self,
 /**
  * cockpit_web_response_set_cache_type:
  * @self: the response
- * @cache_type: Ensures the apropriate cache headers are returned for
+ * @cache_type: Ensures the appropriate cache headers are returned for
    the given cache type.
  */
 void

--- a/src/common/test-locale.c
+++ b/src/common/test-locale.c
@@ -132,7 +132,7 @@ test_set_language (const gconstpointer data)
       g_assert_cmpstr (dgettext ("test", "Unavailable"), ==, fixture->string);
     }
 
-  /* A second time, excercise cache code */
+  /* A second time, exercise cache code */
   cockpit_locale_set_language (fixture->language);
 
   /* Was supposed to fail */

--- a/src/common/test-pipe.c
+++ b/src/common/test-pipe.c
@@ -838,7 +838,7 @@ test_spawn_and_fail (void)
   gchar *problem = NULL;
   CockpitPipe *pipe;
 
-  const gchar *argv[] = { "/non-existant", NULL };
+  const gchar *argv[] = { "/non-existent", NULL };
 
   pipe = cockpit_pipe_spawn (argv, NULL, NULL, COCKPIT_PIPE_FLAGS_NONE);
   g_assert (pipe != NULL);

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -862,7 +862,7 @@ test_web_filter_split (TestCase *tc,
                    "4\r\ne</t\r\n"
                    "4\r\nitle\r\n"
                    "4\r\n></h\r\n"
-                   "4\r\need>\r\n"
+                   "4\r\nead>\r\n"
                    "11\r\n<body>Body</body>\r\n"
                    "4\r\n</ht\r\n"
                    "3\r\nml>\r\n"

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -239,7 +239,7 @@ test_return_error_resource (TestCase *tc,
 {
   const gchar *roots[] = { srcdir, NULL };
   cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
-  cockpit_web_response_file (tc->response, "/non-existant", roots);
+  cockpit_web_response_file (tc->response, "/non-existent", roots);
   cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404 Not Found*<img*Not Found*");
   cockpit_web_failure_resource = NULL;
 }
@@ -249,7 +249,7 @@ test_file_not_found (TestCase *tc,
                      gconstpointer user_data)
 {
   const gchar *roots[] = { srcdir, NULL };
-  cockpit_web_response_file (tc->response, "/non-existant", roots);
+  cockpit_web_response_file (tc->response, "/non-existent", roots);
   cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404 Not Found*");
 }
 
@@ -332,7 +332,7 @@ test_file_breakout_non_existant (TestCase *tc,
 {
   gchar *root = realpath ( SRCDIR "/src", NULL);
   const gchar *roots[] = { root, NULL };
-  const gchar *breakout = "/../non-existant";
+  const gchar *breakout = "/../non-existent";
   gchar *check = g_build_filename (roots[0], breakout, NULL);
   g_assert (root);
   g_assert (!g_file_test (check, G_FILE_TEST_EXISTS));
@@ -862,7 +862,7 @@ test_web_filter_split (TestCase *tc,
                    "4\r\ne</t\r\n"
                    "4\r\nitle\r\n"
                    "4\r\n></h\r\n"
-                   "4\r\nead>\r\n"
+                   "4\r\need>\r\n"
                    "11\r\n<body>Body</body>\r\n"
                    "4\r\n</ht\r\n"
                    "3\r\nml>\r\n"
@@ -1415,7 +1415,7 @@ test_negotiation_notfound (void)
   GError *error = NULL;
   GBytes *bytes;
 
-  bytes = cockpit_web_response_negotiation (SRCDIR "/src/common/mock-content/non-existant",
+  bytes = cockpit_web_response_negotiation (SRCDIR "/src/common/mock-content/non-existent",
                                             NULL, NULL, &chosen, &error);
 
   g_assert_no_error (error);

--- a/src/pam-ssh-add/pam-ssh-add.c
+++ b/src/pam-ssh-add/pam-ssh-add.c
@@ -369,10 +369,10 @@ log_problem (char *line,
 
 static const char *
 get_optional_env (const char *name,
-                  const char *overide)
+                  const char *override)
 {
-  if (overide)
-    return overide;
+  if (override)
+    return override;
 
   return getenv (name);
 }
@@ -543,7 +543,7 @@ get_environ_vars_from_agent (char *line,
                              void *arg)
 {
   /*
-  * ssh-agent outputs commands for exporting it's envirnment
+  * ssh-agent outputs commands for exporting it's environment
   * variables. We want to return these variables so parse
   * them out and store them.
   */
@@ -922,7 +922,7 @@ start_agent (pam_handle_t *pamh,
                                      &auth_socket,
                                      &auth_pid);
 
-  /* Store pid and socket enviroment vars */
+  /* Store pid and socket environment vars */
   if (!success || !auth_socket || !auth_pid)
     {
       res = PAM_SERVICE_ERR;

--- a/src/pam-ssh-add/test-ssh-add.c
+++ b/src/pam-ssh-add/test-ssh-add.c
@@ -36,7 +36,7 @@
 
 static int unexpected_message;
 
-/* Enviroment variables we set */
+/* Environment variables we set */
 static const char *env_names[] = {
   "XDG_RUNTIME_DIR",
   "HOME",

--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -1439,7 +1439,7 @@ cockpit_ssh_connect (CockpitSshData *data,
       g_warn_if_fail (ssh_options_set (data->session, SSH_OPTIONS_USER, data->username) == 0);
     }
 
-  /* If the user specifies a port explicitely, overwrite the config */
+  /* If the user specifies a port explicitly, overwrite the config */
   if (port != 0)
     g_warn_if_fail (ssh_options_set (data->session, SSH_OPTIONS_PORT, &port) == 0);
 
@@ -2115,7 +2115,7 @@ cockpit_ssh_source_dispatch (GSource *source,
   g_return_val_if_fail ((cond & G_IO_NVAL) == 0, FALSE);
 
   /*
-   * HACK: Yes this is anohter poll() call. The async support in
+   * HACK: Yes this is another poll() call. The async support in
    * libssh is quite hacky right now.
    *
    * https://red.libssh.org/issues/155

--- a/src/ssh/test-sshbridge.c
+++ b/src/ssh/test-sshbridge.c
@@ -486,7 +486,7 @@ do_auth_response (CockpitTransport *transport,
 
 static void
 do_basic_auth (CockpitTransport *transport,
-               const gchar *challange,
+               const gchar *challenge,
                const gchar *user,
                const gchar *password)
 {
@@ -498,7 +498,7 @@ do_basic_auth (CockpitTransport *transport,
   encoded = g_base64_encode ((guchar *)userpass, strlen (userpass));
   response = g_strdup_printf ("Basic %s", encoded);
 
-  do_auth_response (transport, challange, response);
+  do_auth_response (transport, challenge, response);
 
   g_free (userpass);
   g_free (response);
@@ -1050,7 +1050,7 @@ test_hostkey_conversation_invalid (TestCase *tc,
 
 /* The output from this will go to stderr */
 static const TestFixture fixture_bad_command = {
-  .ssh_command = "/nonexistant",
+  .ssh_command = "/nonexistent",
   .problem = "no-cockpit"
 };
 

--- a/src/tls/wsinstance-factory.c
+++ b/src/tls/wsinstance-factory.c
@@ -93,7 +93,7 @@ main (void)
    *    back to NULL.  that's how we know when to stop waiting.
    *
    * In effect, the duration of job_path being set to non-NULL is more
-   * or less equal to the duration of the existance of a job object at
+   * or less equal to the duration of the existence of a job object at
    * that path.
    */
   r = sd_bus_match_signal_async (bus, NULL,

--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -341,7 +341,7 @@ test_parse_headers_not_enough (void)
   const gchar *input =
       "Header1: value3\r\n"
       "Header2:  field\r\n"
-      "Head3:  Anothe";
+      "Head3:  Another";
 
   gssize ret;
 

--- a/src/websocket/websocketconnection.c
+++ b/src/websocket/websocketconnection.c
@@ -733,11 +733,11 @@ process_contents_rfc6455 (WebSocketConnection *self,
         {
           if (pv->message_data)
             {
-              g_message ("received out of order inital message fragment");
+              g_message ("received out of order initial message fragment");
               protocol_error_and_close (self);
               return;
             }
-          g_debug ("received inital fragment frame %d with %d payload", (int)opcode, (int)payload_len);
+          g_debug ("received initial fragment frame %d with %d payload", (int)opcode, (int)payload_len);
         }
 
       /* Middle fragment of a message */
@@ -1451,7 +1451,7 @@ web_socket_connection_class_init (WebSocketConnectionClass *klass)
    *
    * The underlying IO stream the WebSocket is communicating over. For servers
    * this must be specified as a construct property. For clients, this may be
-   * specified, if you have a stream that you've alrady connected to.
+   * specified, if you have a stream that you've already connected to.
    *
    * The input and output streams must be pollable streams.
    */
@@ -1497,7 +1497,7 @@ web_socket_connection_class_init (WebSocketConnectionClass *klass)
   /**
    * WebSocketConnection::error:
    * @self: the WebSocket
-   * @error: the error that occured
+   * @error: the error that occurred
    *
    * Emitted when an error occurred on the WebSocket. This may be fired
    * multiple times. Fatal errors will be followed by the #WebSocketConnection::close

--- a/src/ws/cockpitwsinstancecert.c
+++ b/src/ws/cockpitwsinstancecert.c
@@ -116,7 +116,7 @@ get_ws_https_instance (void)
  * (which will be added).  If @contents is %NULL then no attempt will be
  * made to read the file contents, but the other checks are performed.
  *
- * On sucess, the size of the certificate file (excluding nul
+ * On success, the size of the certificate file (excluding nul
  * terminator) is returned.  This value is never 0.  On error, -1 is
  * returned with errno not guaranteed to be set (but a message will be
  * logged).

--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -791,7 +791,7 @@
              * session ends login-data should be too.
              */
             localStorage.setItem(application + 'login-data', str);
-            /* Backwards compatbility for packages that aren't application prefixed */
+            /* Backwards compatibility for packages that aren't application prefixed */
             localStorage.setItem('login-data', str);
         }
 

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -329,7 +329,7 @@ map_gssapi_to_local (gss_name_t name,
         }
       else
         {
-          debug ("ignoring non-existant gssapi local user '%s'", str);
+          debug ("ignoring non-existent gssapi local user '%s'", str);
 
           /* If the local user doesn't exist, pretend gss_localname() failed */
           free (str);
@@ -360,7 +360,7 @@ map_gssapi_to_local (gss_name_t name,
                 }
               else
                 {
-                  warnx ("non-existant local user '%s'", str);
+                  warnx ("non-existent local user '%s'", str);
                   free (str);
                   str = NULL;
                 }
@@ -470,7 +470,7 @@ perform_gssapi (const char *authorization)
       free (challenge);
 
       /*
-       * The GSSAPI mechanism can require multiple chanllenge response
+       * The GSSAPI mechanism can require multiple challenge response
        * iterations ... so do that here.
        */
       free (input.value);

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -46,7 +46,7 @@
 
 /*
  * To recalculate the checksums found in this file, do something like:
- * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant ./cockpit-bridge --packages
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistent ./cockpit-bridge --packages
  */
 #define CHECKSUM "$6d675909f0b33b83a48e67e29cea9797012ded09394546634b9cd967bbe3fbf5"
 
@@ -556,7 +556,7 @@ test_resource_failure (TestResourceCase *tc,
 }
 
 static const TestResourceFixture checksum_fixture = {
-  .xdg_data_home = "/nonexistant"
+  .xdg_data_home = "/nonexistent"
 };
 
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -40,7 +40,7 @@
 
 /*
  * To recalculate the checksums found in this file, do something like:
- * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistant ./cockpit-bridge --packages
+ * $ XDG_DATA_DIRS=$PWD/src/bridge/mock-resource/system/ XDG_DATA_HOME=/nonexistent ./cockpit-bridge --packages
  */
 #define CHECKSUM "$6d675909f0b33b83a48e67e29cea9797012ded09394546634b9cd967bbe3fbf5"
 
@@ -381,7 +381,7 @@ setup_default (Test *test,
   if (fixture->with_home)
     g_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
   else
-    g_setenv ("XDG_DATA_HOME", "/nonexistant", TRUE);
+    g_setenv ("XDG_DATA_HOME", "/nonexistent", TRUE);
 
   base_setup (test);
   test->response = cockpit_web_response_new (test->io,

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -16,7 +16,7 @@ function ph_only(els, sel)
     if (els.length === 0)
         throw sel + " not found";
     if (els.length > 1)
-        throw sel + " is ambigous";
+        throw sel + " is ambiguous";
     return els[0];
 }
 

--- a/test/selenium/run-tests
+++ b/test/selenium/run-tests
@@ -186,7 +186,7 @@ class AvocadoTestSuite:
     def _run_one_avocado_test(self, test):
         status = True
         start_time = datetime.datetime.now()
-        # wrap command to timeout to see also partial run result, to see whats happen
+        # wrap command to timeout to see also partial run result, to see what happens
         # instead of empty output and just timeout
         self.avocado_command = ["timeout {}".format(self.timeout - round(self.timeout/100)),
                      self.base_cmd, "run",
@@ -359,7 +359,7 @@ class SeleniumOwnHub(SeleniumTestSuite):
         self.env["HUB"] = hub_address
         self.env["GUEST"] = guest_adress
         self.env["PORT"] = cockpit_port
-        # avocado and cockpit machine is in same network so use internal adress
+        # avocado and cockpit machine is in same network so use internal address
         self.env["SSH_PORT"] = "22"
         self.env["SSH_GUEST"] = self.ipaddr_cockpit
         self.env["BROWSER"] = browser
@@ -383,7 +383,7 @@ def main():
                         dest="hub",
                         action="store",
                         help="Use own Selenium hub (it is important to ensure that hub can see cockpit machine)"
-                             " You can use adress formats:"
+                             " You can use address formats:"
                              " yourHubIP"
                              " or yourHubIP:CockpitIP"
                              " or yourHubIP:CockpitIP:CockpitPort"

--- a/test/selenium/testlib_avocado/seleniumlib.py
+++ b/test/selenium/testlib_avocado/seleniumlib.py
@@ -179,7 +179,7 @@ class SeleniumTest(Test):
                 self.log.info(msg)
 
     def tearDown(self):
-        # take screenshot everytime to ensure that if test fails there will be debugging info
+        # take screenshot every time to ensure that if test fails there will be debugging info
         # in case it assert in some condition, not directly inside elements
         # and logic of when transfer images is up to scheduler
         self.take_screenshot(phase="{}-tearDown".format(self.id()), fatal=False)
@@ -312,7 +312,7 @@ parameters:
     overridetry - change value of repeats
     fatal - boolean if search is fatal or notice
     cond - use selenium conditions (aliases are defined above class)
-    wait_data_loaded - use javascipt to wait for element has attribute-data loaded; ONLY applies to cockpit page <iframe>s
+    wait_data_loaded - use javascript to wait for element has attribute-data loaded; ONLY applies to cockpit page <iframe>s
     text_ - text to be present in element
         """
         if not baseelement:

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -221,7 +221,7 @@ class TestApps(PackageCase):
         # First lay down some good XML so that we can later detect the reaction to broken XML.
         reset()
 
-        # Unparseable
+        # Unparsable
         m.write("/usr/share/app-info/xmls/test.xml", """
 This <is <not XML.
 """)

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -119,7 +119,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text("#account-user-name", "admin")
         try:
             m.execute("journalctl -p 7 SYSLOG_IDENTIFIER=cockpit-ws | grep 'cockpit-session: opening pam session'")
-            assert False, "cockpit-session debug messsages found"
+            assert False, "cockpit-session debug messages found"
         except subprocess.CalledProcessError:
             pass
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1532,7 +1532,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                                                 storage_pool="No Storage",
                                                 start_vm=True, delete=False))
 
-        # We don't want to use start_vm == False because if we get a seperate install phase
+        # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
         self.machine.execute("virsh destroy pxe-guest")
 
@@ -2132,7 +2132,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                         b.click("button.alert-link.more-button")
                         waitForError(errors, error_location)
 
-            # Close the notificaton
+            # Close the notification
             b.click(".toast-notifications-list-pf div.pf-c-alert button.pf-c-button")
             b.wait_not_present(".toast-notifications-list-pf div.pf-c-alert")
 
@@ -2245,7 +2245,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b.wait_in_text(selector, before)
 
             # Make sure that the initial state goes away and then try to check what the new state is
-            # because we might end up checking the text for the new state the momment it dissapears
+            # because we might end up checking the text for the new state the momment it disappears
             def waitStateWentAway(selector, state):
                 try:
                     b.wait_text_not(selector, state)
@@ -2974,7 +2974,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_in_text("body", "Virtual Machines")
         self.waitVmRow("subVmTest1")
 
-        # Wait for the login promt before we try detaching disks - we need the OS to be fully responsive
+        # Wait for the login prompt before we try detaching disks - we need the OS to be fully responsive
         wait(lambda: "login as 'cirros' user" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
 
         # Test detaching non permanent disk of a running domain
@@ -3954,7 +3954,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             xfail_error = "Invalid",
         ).execute()
 
-        # Check "Address not withing subnet"
+        # Check "Address not within subnet"
         NetworkCreateDialog(
             self,
             name="test_network",
@@ -4405,7 +4405,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             pool_name="disk-pool",
             pool_type="disk",
             vol_name="sda1", # Partition names must follow pattern of sda1, sda2...
-            size="10", # Only 50MiB availabl on disk-pool
+            size="10", # Only 50MiB available on disk-pool
             unit="MiB",
             format="none",
             remove=True,

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -150,7 +150,7 @@ class TestMetrics(MachineCase, StorageHelpers):
 
         net_pid = m.spawn("socat TCP-LISTEN:2000 PIPE", "load-net.log")
 
-        # might take several attemps until server-side is listening
+        # might take several attempts until server-side is listening
         (host, port) = m.forward["2000"].split(":")
         client = subprocess.Popen(
             "for retry in `seq 10`; do nc {0} {1} </dev/zero >/dev/null; sleep 1; done".format(host, port), shell=True)

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -134,7 +134,7 @@ class TestStorageResize(StorageCase):
                          need_passphrase=(self.machine.image in ["rhel-8-3", "rhel-8-3-distropkg", "centos-8-stream"]))
 
     def wait_not_present_with_udev_trigger(self, selector):
-        # This is fundamentally the same as Brower.wait, but uses a
+        # This is fundamentally the same as Browser.wait, but uses a
         # longer delay between checks to avoid spamming the machine
         # with udev triggers, which would bring it to its knees.  (And
         # a waiting loop is simple eough to repeat the code here.)

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -93,7 +93,7 @@ class TestSuperuser(MachineCase):
         self.login_and_go(superuser=False)
         b.wait_text("#super-user-indicator", "Limited access")
 
-        # Configure the sudo PAM stack to make two propmts
+        # Configure the sudo PAM stack to make two prompts
         if "debian" in m.image or "ubuntu" in m.image:
             m.write("/etc/pam.d/sudo", """
 auth required pam_unix.so

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -96,7 +96,7 @@ class TestSystemInfo(MachineCase):
     def setUp(self):
         super().setUp()
 
-        # Debian will not allow timesyncd to start if any other NTP packge is installed We only
+        # Debian will not allow timesyncd to start if any other NTP package is installed We only
         # support timesyncd for NTP configuration, so make sure chrony is not installed in the older
         # debian/ubuntu images which don't yet have systemd-timesyncd
         if self.machine.image in ["debian-stable", "ubuntu-stable"]:

--- a/test/verify/files/mock-range-server.py
+++ b/test/verify/files/mock-range-server.py
@@ -4,7 +4,7 @@
 # https://lists.gnu.org/archive/html/qemu-devel/2013-06/msg02661.html
 # https://github.com/qemu/qemu/blob/master/block/curl.c
 #
-# Standart python http server doesn't support range option, so we need to implement it manually.
+# Standard python http server doesn't support range option, so we need to implement it manually.
 #
 # QEMU also doesn't accept http driver for certain distributions (block-drv-ro-whitelist option in qemu-kvm.spec).
 # So server needs to be HTTPS.


### PR DESCRIPTION
This is a huge bunch of changes that [codespell](https://github.com/codespell-project/codespell) picked up across our codebase.

I was going to include changes of master/slave and whitelist/blacklist, but there were way too many to feel confident with those, as other system code we integrate with does expose some of those terms as part of their API. When possible, Cockpit should use terms like primary/secondary and allowlist/blocklist. We don't yet, and wouldn't really be able to everywhere until other software changes. (This is _mainly_ an issue with the Storage page, but also problematic in parts of Cockpit that touch networking and also in our tests.) So fixing this where we can would be a good idea for a follow-up.

Also, I tried to commit a lot of related things together, for easier reviewing (so it's possible to look at the diff of a commit) and consideration of splitting it out to a separate PR (as this changeset is rather huge as-is).

I did review everything myself and dropped a bunch of changes (especially those mentioned above), so it should be good. However, I did touch tests and C code and there's a lot so I might've goofed somewhere. (Again, we can split things out too.)