### PR TITLE
machines: Implement reverting and deletion of VM snapshots

### DIFF
--- a/pkg/machines/components/vmSnapshotsTab.jsx
+++ b/pkg/machines/components/vmSnapshotsTab.jsx
@@ -30,7 +30,7 @@ import { RevertSnapshotModal } from './vmSnapshotsRevertModal.jsx';
 import { deleteSnapshot } from '../libvirt-dbus.js';
 import { getVmSnapshots } from '../actions/provider-actions.js';
 
-import './vmSnapshotsTab.css';
+import './vmSnapshotsTab.scss';
 
 const _ = cockpit.gettext;
 
@@ -80,11 +80,14 @@ class VmSnapshotsTab extends React.Component {
             {
                 name: _("Creation Time"), value: (snap, snapId) => {
                     const date = prettyTime(snap.creationTime);
-                    return (
+                    return (<div className="snap-creation-time">
                         <div id={`${id}-snapshot-${snapId}-date`}>
                             {date}
                         </div>
-                    );
+                        { snap.isCurrent && <Tooltip content={_("Current")}>
+                            <i id={`${id}-snapshot-${snapId}-current`} className="pficon pficon-ok" />
+                        </Tooltip> }
+                    </div>);
                 }
             },
             {

--- a/pkg/machines/components/vmSnapshotsTab.scss
+++ b/pkg/machines/components/vmSnapshotsTab.scss
@@ -10,3 +10,7 @@
 .tooltip-circle {
     padding: .5rem
 }
+
+.snap-creation-time {
+    display: flex;
+}

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1476,6 +1476,20 @@ export function createSnapshot({ connectionName, vmId, name, description }) {
     return call(connectionName, vmId, 'org.libvirt.Domain', 'SnapshotCreateXML', [xmlDesc, 0], { timeout, type: 'su' });
 }
 
+export function deleteSnapshot({ connectionName, domainPath, snapshotName }) {
+    return call(connectionName, domainPath, 'org.libvirt.Domain', 'SnapshotLookupByName', [snapshotName, 0], { timeout, type: 'su' })
+            .then((objPath) => {
+                return call(connectionName, objPath[0], 'org.libvirt.DomainSnapshot', 'Delete', [0], { timeout, type: 'u' });
+            });
+}
+
+export function revertSnapshot({ connectionName, domainPath, snapshotName }) {
+    return call(connectionName, domainPath, 'org.libvirt.Domain', 'SnapshotLookupByName', [snapshotName, 0], { timeout, type: 'su' })
+            .then((objPath) => {
+                return call(connectionName, objPath[0], 'org.libvirt.DomainSnapshot', 'Revert', [0], { timeout, type: 'u' });
+            });
+}
+
 export function detachIface(mac, connectionName, id, live, persistent, dispatch) {
     let ifaceXML;
     let detachFlags = Enum.VIR_DOMAIN_AFFECT_CURRENT;

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -841,7 +841,7 @@ const LIBVIRT_DBUS_PROVIDER = {
                                 return dispatch(updateDomainSnapshots({
                                     connectionName,
                                     domainPath,
-                                    snaps
+                                    snaps: snaps.sort((a, b) => a.creationTime - b.creationTime)
                                 }));
                             });
                 })

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -182,7 +182,7 @@
 }
 
 #vcpus-tooltip.pficon-pending, #boot-order-tooltip.pficon-pending,
-.machines-disks .pficon-pending {
+.machines-disks .pficon-pending, .pficon-ok{
     margin-left: 0.5rem;
 }
 
@@ -191,7 +191,7 @@
     font-size: 16px;
 }
 
-.modal-footer .pficon-pending, .pficon-warning-triangle-o {
+.modal-footer .pficon-pending, .pficon-warning-triangle-o, .pficon-ok {
     line-height: inherit;
     margin-right: 0.5rem;
 }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -3467,6 +3467,42 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.click('#deactivate-network-test_network4-{0}'.format(connectionName)) # Deactivate transient network
         self.waitNetworkRow("test_network4", connectionName, False) # Check it's not present after deactivation
 
+    def testSnapshotRevert(self):
+        b = self.browser
+        m = self.machine
+
+        self.startVm("subVmTest1")
+
+        # Check snapshot for running VM
+        m.execute("virsh detach-disk --domain subVmTest1 --target vda --config") # vda is raw disk, which are not supported by internal snapshots
+        m.execute("qemu-img create -f qcow2 /var/lib/libvirt/images/foobar.qcow2 1M")
+        m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/images/foobar.qcow2 --target vdb --subdriver qcow2 --config")
+        m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshot1 --description 'Description of snapshot1'")
+        m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshot2 --description 'Description of snapshot2'")
+
+        self.login_and_go("/machines")
+        b.wait_in_text("body", "Virtual Machines")
+        self.waitVmRow("subVmTest1")
+        self.toggleVmRow("subVmTest1")
+        if m.image in distrosWithoutSnapshot:
+            b.wait_not_present("#vm-subVmTest1-snapshots")
+            return
+        b.click("#vm-subVmTest1-snapshots")
+
+        b.wait_present("#vm-subVmTest1-snapshot-0-current")
+        b.wait_not_present("#vm-subVmTest1-snapshot-1-current")
+        self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot1 | grep 'Current:' | awk '{print $2}'").strip())
+        self.assertEqual("yes", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot2 | grep 'Current:' | awk '{print $2}'").strip())
+
+        b.click("#vm-subVmTest1-snapshot-1-revert")
+        b.wait_in_text(".modal-dialog .modal-header .modal-title", "Revert to Snapshot snapshot1")
+        b.click('div.modal-footer button:contains("Revert")')
+
+        b.wait_not_present("#vm-subVmTest1-snapshot-0-current")
+        b.wait_present("#vm-subVmTest1-snapshot-1-current")
+        self.assertEqual("yes", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot1 | grep 'Current:' | awk '{print $2}'").strip())
+        self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot2 | grep 'Current:' | awk '{print $2}'").strip())
+
     def testSnapshots(self):
         # Checks if difference of @time1 and @time2 is not greater than @difference (in seconds)
         def checkTimeDiff(time1, time2, difference):
@@ -4749,14 +4785,13 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         self.startVm("subVmTest1")
 
-        snapshots_present = m.execute("gdbus introspect --xml --system --dest org.libvirt --object-path /org/libvirt/QEMU | grep snapshot || true")
-        if not snapshots_present.strip(): # libvirt-dbus doesn't have snapshot APIs
-            return
-
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")
 
         self.toggleVmRow("subVmTest1")
+        if m.image in distrosWithoutSnapshot:
+            b.wait_not_present("#vm-subVmTest1-snapshots")
+            return
         b.click("#vm-subVmTest1-snapshots") # open the Network Interfaces subtab
 
         # Shut off domain
@@ -4785,7 +4820,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     self.cleanup()
 
             def open(self):
-                b.click("#vm-subVmTest1-add-snapshot-button") # open the Network Interfaces subtab
+                b.click("#vm-subVmTest1-add-snapshot-button")
                 b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create Snapshot")
 
             def fill(self):
@@ -4832,12 +4867,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     self.test_obj.assertEqual(self.state, m.execute(xmllint_element.format(prop='state')).strip())
 
             def cleanup(self):
-                m.execute("virsh -c qemu:///system snapshot-delete --domain {0} --snapshotname {1}".format("subVmTest1", self.name))
-                b.reload()
-                b.enter_page('/machines')
-                b.wait_in_text("body", "Virtual Machines")
-                self.test_obj.toggleVmRow("subVmTest1")
-                b.click("#vm-subVmTest1-snapshots")
+                b.click("#delete-vm-subVmTest1-snapshot-{0}".format(self.snap_num))
+                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Delete Snapshot {0}".format(self.name))
+                b.click('div.modal-footer button:contains("Delete")')
+                b.wait_not_present("#vm-subVmTest1-snapshot-{0}-name:contains({1})".format(self.snap_num, self.name))
 
         # No Snapshots present
         b.wait_present("#vm-subVmTest1-add-snapshot-button")


### PR DESCRIPTION
 - [x] This PR builds on top of #13100 , so only last 3 commits are relevant to this PR.

Reverting to a snapshot means VM is restored to a state in which it was when a snapshot was taken.
![Screenshot from 2020-06-29 22-15-23](https://user-images.githubusercontent.com/42733240/86052106-bbdd0780-ba56-11ea-9502-e19a318cd87e.png)

Deleting snapshots is self explanatory.
![Screenshot from 2020-06-29 22-02-47](https://user-images.githubusercontent.com/42733240/86052118-c0a1bb80-ba56-11ea-8ef6-5f849a077ed1.png)


Also with action of reverting, it's important to distinguish which snapshot is "current". Current snapshot means that current state of VM is "closest", is succeeding "current" snapshot. So when you create several snapshots, let's say A, B, C, D in that order, at that moment D is current snapshot. But when you revert to the snapshot B, that snapshot becomes the current one.
I tried to solve this problem of distinguishing current snapshot by adding border on the right side of the row of the snapshot and changing background color to `--pf-global--BackgroundColor--200`. Although I don't know if this would be clear enough to the user.
![Screenshot from 2020-06-29 21-57-51](https://user-images.githubusercontent.com/42733240/86052127-c4cdd900-ba56-11ea-8746-55dd489d5d82.png)

