### PR TITLE
ws: Drop "build" date field from websocket info

### DIFF
--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -13,7 +13,6 @@ libcockpit_ssh_a_SOURCES = \
 libcockpit_ssh_a_CFLAGS = \
 	-fPIC \
 	-I$(top_srcdir)/src/ssh \
-	-DCOCKPIT_BUILD_INFO=\"$(COCKPIT_BUILD_INFO)\"	\
 	-DG_LOG_DOMAIN=\"cockpit-ssh\" \
 	$(COCKPIT_SSH_SESSION_CFLAGS) \
 	$(NULL)

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -1,6 +1,3 @@
-
-COCKPIT_BUILD_INFO = "Built on $(shell date)"
-
 LOGIN_PO_FILES = $(patsubst %,dist/static/login.po.%.html,$(LINGUAS))
 
 staticdir = $(datadir)/cockpit/static
@@ -90,7 +87,6 @@ libcockpit_ws_a_SOURCES = \
 
 libcockpit_ws_a_CFLAGS = \
 	-I$(top_srcdir)/src/ws \
-	-DCOCKPIT_BUILD_INFO=\"$(COCKPIT_BUILD_INFO)\"	\
 	-DG_LOG_DOMAIN=\"cockpit-ws\" \
 	$(COCKPIT_WS_CFLAGS) \
 	$(NULL)

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1129,7 +1129,6 @@ on_web_socket_open (WebSocketConnection *connection,
 
   info = json_object_new ();
   json_object_set_string_member (info, "version", PACKAGE_VERSION);
-  json_object_set_string_member (info, "build", COCKPIT_BUILD_INFO);
   json_object_set_object_member (object, "system", info);
 
   command = cockpit_json_write_bytes (object);


### PR DESCRIPTION
Nothing uses that field, and it causes the build to not be reproducible.

Thanks to Bernhard Wiedemann for finding this!