### PR TITLE
pf3: Align dialogs to the center, like PF4

### DIFF
--- a/src/base1/patternfly-overrides.scss
+++ b/src/base1/patternfly-overrides.scss
@@ -405,6 +405,13 @@ select.form-control {
 
 // Restyle modals
 .modal {
+  &.in {
+    // Align to the center, like PF4
+    // !important is needed as PF3 adds an inline "display: block" style
+    display: grid !important;
+    align-items: center;
+  }
+
   &-header {
     background: var(--pf-global--BackgroundColor--100);
     padding: 0 0 1.5rem;


### PR DESCRIPTION
As PF4 decided to align dialogs to the center, let's override PF3 to do the same. This should help when we have a mix of PF3 & PF4 dialogs.