### PR TITLE
networking: Disable automatic switches in IP settings dialogs

### DIFF
--- a/pkg/lib/cockpit-components-onoff.jsx
+++ b/pkg/lib/cockpit-components-onoff.jsx
@@ -24,7 +24,7 @@ import "./cockpit-components-onoff.scss";
 /* Component to show an on/off switch
  * state      boolean value (off or on)
  * onChange   triggered when the switch is flipped, parameter: new state
- * enabled    whether the component is enabled or not, defaults to true
+ * disabled   whether the component is disabled or not, defaults to false
  * id         optional string, ID of the top-level HTML tag (only necessary
  *            when embedding this into a non-React page)
  * text       optional string that appears to the right of the button

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -3135,18 +3135,18 @@ function PageNetworkInterface(model) {
 
 function switchbox(val, callback) {
     var onoff = $('<span>');
-    var enabled = true;
+    var disabled = false;
     function render () {
         ReactDOM.render(
             React.createElement(OnOffSwitch, {
                 state: val,
-                enabled: enabled,
+                disabled: disabled,
                 onChange: callback
             }),
             onoff[0]);
     }
     onoff.enable = function (val) {
-        enabled = val;
+        disabled = !val;
         render();
     };
     render();

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -56,6 +56,11 @@ class TestNetworkingBasic(NetworkCase):
         b.click("tr:contains('IPv4') a")
         b.wait_popup("network-ip-settings-dialog")
         b.select_from_dropdown("#network-ip-settings-dialog select", "Manual")
+        # Manual mode  disables automatic switches (fixed in PR #14291)
+        if m.image not in ["rhel-8-3-distropkg"]:
+            b.wait_present("#network-ip-settings-dialog [data-field='dns'] .onoff-ct :disabled")
+            b.wait_present("#network-ip-settings-dialog [data-field='dns_search'] .onoff-ct :disabled")
+            b.wait_present("#network-ip-settings-dialog [data-field='routes'] .onoff-ct :disabled")
 
         b.set_val('#network-ip-settings-dialog input[placeholder="Address"]', "1.2.3.4")
         b.set_val('#network-ip-settings-dialog input[placeholder*="Netmask"]', "255.255.0.8")


### PR DESCRIPTION
The direction of this state flag was reversed a while back but this one
was missed which caused the Automatic switches for the DNS, DNS Search
Domains, and Routes settings weren't getting disabled correctly.

Fixes #14290