### PR TITLE
ws: Automatically renew auto-created expired certificates

### DIFF
--- a/doc/man/cockpit-tls.xml
+++ b/doc/man/cockpit-tls.xml
@@ -79,7 +79,8 @@
       and a second one containing a <literal>BEGIN PRIVATE KEY</literal> or similar.
       The key must not be encrypted.</para>
     <para>If there is no TLS certificate, a self-signed certificate is
-      automatically generated using <command>openssl</command> and stored in
+      automatically generated using <command>sscg</command> (if available) or
+      <command>openssl</command> and stored in
       the <filename>0-self-signed.cert</filename> file.</para>
     <para>When enrolling into a FreeIPA domain, an SSL certificate is requested from
       the IPA server and stored in <filename>10-ipa.cert</filename>.</para>

--- a/doc/man/remotectl.xml
+++ b/doc/man/remotectl.xml
@@ -58,7 +58,10 @@
         <listitem><para>Manage Cockpit's SSL certificate. If used without options will check if cockpit has a valid certificate without making any changes.</para>
 
         <para>
-          <option>--ensure</option> Ensure that a certificate exists and can be loaded. Certificate will be created if it does not already exist.
+          <option>--ensure</option> Ensure that a certificate exists and can be loaded. If none exists, create a <code>0-self-signed.cert</code>
+            certificate, using <ulink url="https://github.com/sgallagher/sscg">sscg</ulink> (if available) or
+            <ulink url="https://linux.die.net/man/1/openssl">openssl</ulink>. That self-signed default certificate will be automatically
+            renewed when it expires.
         </para>
 
         <para>

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -133,10 +133,10 @@ openssl_make_dummy_cert (const gchar *key_file,
 {
   gboolean ret = FALSE;
   gint exit_status;
-  gchar *stderr_str = NULL;
-  gchar *command_line = NULL;
-  gchar *ssl_config = NULL;
-  gchar *subject = generate_subject ();
+  g_autofree gchar *stderr_str = NULL;
+  g_autofree gchar *command_line = NULL;
+  g_autofree gchar *ssl_config = NULL;
+  g_autofree gchar *subject = generate_subject ();
 
   /* make config file with subjectAltName for localhost and our tests */
   ssl_config = create_temp_file (g_get_tmp_dir (), "ssl.conf.XXXXXX", error);
@@ -186,10 +186,6 @@ openssl_make_dummy_cert (const gchar *key_file,
 out:
   if (ssl_config)
     g_unlink (ssl_config);
-  g_free (ssl_config);
-  g_free (stderr_str);
-  g_free (command_line);
-  g_free (subject);
   return ret;
 }
 

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -156,7 +156,7 @@ openssl_make_dummy_cert (const gchar *key_file,
   const gchar *argv[] = {
     "openssl",
     "req", "-x509",
-    "-days", "36500",
+    "-days", "365",
     "-newkey", "rsa:2048",
     "-keyout", key_file,
     "-keyform", "PEM",
@@ -210,7 +210,7 @@ sscg_make_dummy_cert (const gchar *key_file,
 
   const gchar *argv[] = {
     "sscg", "--quiet",
-    "--lifetime", "3650",
+    "--lifetime", "365",
     "--key-strength", "2048",
     "--cert-key-file", key_file,
     "--cert-file", cert_file,

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -176,7 +176,8 @@ openssl_make_dummy_cert (const gchar *key_file,
                      NULL, &stderr_str, &exit_status, error) ||
       !g_spawn_check_exit_status (exit_status, error))
     {
-      g_warning ("%s", stderr_str);
+      if (stderr_str)
+        g_warning ("%s", stderr_str);
       g_prefix_error (error, "Error generating temporary self-signed dummy cert using openssl: ");
       goto out;
     }

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -141,7 +141,7 @@ openssl_make_dummy_cert (const gchar *key_file,
   /* make config file with subjectAltName for localhost and our tests */
   ssl_config = create_temp_file (g_get_tmp_dir (), "ssl.conf.XXXXXX", error);
   if (!ssl_config)
-      return FALSE;
+      goto out;
   if (!g_file_set_contents (ssl_config,
               "[ req ]\n"
               "req_extensions = v3_req\n"
@@ -151,7 +151,7 @@ openssl_make_dummy_cert (const gchar *key_file,
               "[ v3_req ]\n"
               "subjectAltName=IP:127.0.0.1,DNS:localhost\n",
               -1, error))
-      return FALSE;
+      goto out;
 
   const gchar *argv[] = {
     "openssl",

--- a/src/ws/remotectl.c
+++ b/src/ws/remotectl.c
@@ -48,17 +48,6 @@ message_handler (const gchar *log_domain,
   g_printerr ("%s: %s\n", g_get_prgname (), message);
 }
 
-gboolean
-cockpit_remotectl_no_arguments (const gchar *option_value,
-                                const gchar *value,
-                                gpointer data,
-                                GError **error)
-{
-  g_set_error_literal (error, G_OPTION_ERROR, G_OPTION_ERROR_FAILED,
-                       "Too many arguments specified");
-  return FALSE;
-}
-
 int
 main (int argc,
       char **argv)

--- a/src/ws/remotectl.h
+++ b/src/ws/remotectl.h
@@ -25,9 +25,4 @@
 int             cockpit_remotectl_certificate       (int argc,
                                                      char *argv[]);
 
-gboolean        cockpit_remotectl_no_arguments      (const gchar *option_value,
-                                                     const gchar *value,
-                                                     gpointer data,
-                                                     GError **error);
-
 #endif /* COCKPIT_REMOTECTL_H_ */

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -156,17 +156,15 @@ teardown (TestCase *tc,
 
 
 static void
-test_combine_good (TestCase *test,
-                   gconstpointer data)
+test_success (TestCase *test,
+              gconstpointer data)
 {
-
   g_assert_cmpint (test->ret, ==, 0);
-
 }
 
 static void
-test_combine_bad (TestCase *test,
-                  gconstpointer data)
+test_failure (TestCase *test,
+              gconstpointer data)
 {
   GDir *dir = NULL;
   GError *error = NULL;
@@ -254,24 +252,24 @@ main (int argc,
   cockpit_test_init (&argc, &argv);
 
   g_test_add ("/remotectl-certificate/combine-good-rsa", TestCase, &fixture_good_rsa_file,
-              setup, test_combine_good, teardown);
+              setup, test_success, teardown);
   g_test_add ("/remotectl-certificate/combine-good-ecc", TestCase, &fixture_good_ecc_file,
-              setup, test_combine_good, teardown);
+              setup, test_success, teardown);
   g_test_add ("/remotectl-certificate/combine-bad-file", TestCase, &fixture_bad_file,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/combine-bad-file2", TestCase, &fixture_bad_file2,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/combine-not-valid", TestCase, &fixture_invalid1,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/combine-no-key", TestCase, &fixture_invalid2,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/combine-no-cert", TestCase, &fixture_invalid3,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/create-no-permission", TestCase, &fixture_create_no_permission,
-              setup, test_combine_bad, teardown);
+              setup, test_failure, teardown);
   g_test_add ("/remotectl-certificate/load-combined-key-first", TestCase, &fixture_preinstall_combined_key_first,
-              setup, test_combine_good, teardown);
+              setup, test_success, teardown);
   g_test_add ("/remotectl-certificate/load-combined-key-last", TestCase, &fixture_preinstall_combined_key_last,
-              setup, test_combine_good, teardown);
+              setup, test_success, teardown);
   return g_test_run ();
 }


### PR DESCRIPTION
TLS certificates should not be valid for longer than two years [1], and
some browsers (in particular, Safari) are being really picky about it.

So reduce the lifetime for our self-signed (previously 100 years) or
sscg (previously 10 years) certificates to 1 year, and automatically
renew them when they are expired.

[1] https://www.globalsign.com/en/blog/ssl-certificate-validity-capped-at-maximum-two-years

Fixes #14121