### PR TITLE
networkmanager: add firewalld keyword

### DIFF
--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -24,7 +24,7 @@
                     "matches": ["network", "interface", "bridge", "vlan", "bond", "team", "port", "mac", "ipv4", "ipv6"]
                 },
                 {
-                    "matches": ["firewall", "zone", "tcp", "udp"],
+                    "matches": ["firewall", "firewalld", "zone", "tcp", "udp"],
                     "goto": "/network/firewall"
                 }
             ]


### PR DESCRIPTION
During our usability testing in June, one participant tried to
search for firewalld, without success, so adding that as a keyword