### PR TITLE
test: Clean up TestJournal.testAbrt* selectors

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -21,6 +21,8 @@ import parent
 from testlib import *
 import time
 
+sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
+
 
 class TestJournal(MachineCase):
     def setUp(self):
@@ -214,12 +216,10 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
                                ["systemd", "Started Slowly log 10 identical lines.", ""]])
 
         def wait_log_present(message):
-            sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('%s')" % message
-            b.wait_visible(sel)
+            b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('%s')" % message)
 
         def wait_log_not_present(message):
-            sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('%s')" % message
-            b.wait_not_present(sel)
+            b.wait_not_present("#journal-box .cockpit-logline .cockpit-log-message:contains('%s')" % message)
 
         m.execute("systemctl start slow10")
 
@@ -476,10 +476,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         m.execute(r"printf 'MESSAGE=Hello \01 World\nPRIORITY=3\nFOO=bar\nBIN=a\01b\02c\03\n' | logger --journald")
         self.login_and_go("/system/logs#/?tag=logger")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('[13 bytes of binary data]')"
-        b.click(sel)
-
+        b.click("#journal-box .cockpit-logline .cockpit-log-message:contains('[13 bytes of binary data]')")
         b.wait_text("#journal-entry-message", "[13 bytes of binary data]")
 
         def wait_field(name, value):
@@ -496,10 +493,7 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         m.execute(r"printf 'PRIORITY=3\nFOO=bar\n' | logger --journald")
         self.login_and_go("/system/logs#/?tag=logger")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('[no data]')"
-        b.click(sel)
-
+        b.click("#journal-box .cockpit-logline .cockpit-log-message:contains('[no data]')")
         b.wait_text("#journal-entry-message", "[no data]")
 
     @nondestructive
@@ -546,16 +540,14 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         self.login_and_go("/system/logs")
 
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-
         self.select_priority("Critical and above")
-        b.wait_visible(sel)
+        b.wait_visible(sleep_crash_list_sel)
 
         self.select_priority("Alert and above")
-        b.wait_not_present(sel)
+        b.wait_not_present(sleep_crash_list_sel)
 
         self.select_priority("Critical and above")
-        b.click(sel)
+        b.click(sleep_crash_list_sel)
 
         def wait_field(name, value):
             row_sel = "#journal-entry-fields tr:contains('" + name + "')"
@@ -566,13 +558,8 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         b.click("li:contains(Problem info)")
         wait_field("reason", "killed by SIGSEGV")
         b.click("li:contains(Problem details)")
-        sel = "#journal-entry-fields #accordion-markup .panel .panel-heading"
-        sel += " .panel-title .accordion-toggle:contains('core_backtrace')"
-        b.click(sel)
-
-        sel = "#journal-entry #accordion-markup .panel .panel-collapse"
-        sel += " .panel-body:contains('signal: 11  executable: ')"
-        b.wait_present(sel)
+        b.click("#journal-entry-fields #accordion-markup .accordion-toggle:contains('core_backtrace')")
+        b.wait_present("#journal-entry #accordion-markup .panel-body:contains('signal: 11  executable: ')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
                "ubuntu-2004", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "centos-8-stream")
@@ -594,18 +581,12 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         self.crash()
 
         self.login_and_go("/system/logs")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-        b.click(sel)
+        b.click(sleep_crash_list_sel)
 
         b.wait_in_text("#journal-entry-heading", "sleep")
-        sel = "#journal-entry-fields .nav .pf-m-danger"
-        b.click(sel)
-
+        b.click("#journal-entry-fields .nav .pf-m-danger")
         b.wait_in_text('#journal-box', "(sleep) crashed in")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-        b.click(sel)
+        b.click(sleep_crash_list_sel)
 
         b.wait_in_text("#journal-entry-heading", "sleep")
         # details view should hide log view
@@ -650,15 +631,9 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         self.crash()
 
         self.login_and_go("/system/logs")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:first-child button:contains('Report')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:first-child a[href$='/reports/bthash/123deadbeef'"
-        b.wait_present(sel)
+        b.click(sleep_crash_list_sel)
+        b.click("table.reporting-table tr:first-child button:contains('Report')")
+        b.wait_present("table.reporting-table tr:first-child a[href$='/reports/bthash/123deadbeef'")
 
         # "Unreport" the problem to test reporting unknown problem
         m.execute('find /var/spool/abrt -name "reported_to" -or -name "ureports_counter" | xargs rm')
@@ -671,28 +646,18 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         b.reload()
         b.enter_page("/system/logs")
 
-        sel = "table.reporting-table tr:contains('Report to Cockpit') button:contains('Report')"
-        b.click(sel)
+        b.click("table.reporting-table tr:contains('Report to Cockpit') button:contains('Report')")
 
         test_user = 'correcthorsebatterystaple'
 
         for purpose in ['text', 'password']:
             b.wait_visible(".modal-content input[type='%s']" % (purpose))
+            b.set_val(".modal-content input", test_user)
+            b.click(".modal-footer button:contains('Send')")
 
-            sel = ".modal-content input"
-            b.set_val(sel, test_user)
-
-            sel = ".modal-footer button:contains('Send')"
-            b.click(sel)
-
-        sel = ".modal-content p:contains('Password')"
-        b.wait_not_present(sel)
-
-        sel = ".modal-footer button:contains('No')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']"
-        b.wait_present(sel)
+        b.wait_not_present(".modal-content p:contains('Password')")
+        b.click(".modal-footer button:contains('No')")
+        b.wait_present("table.reporting-table tr:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
                "ubuntu-2004", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "centos-8-stream")
@@ -724,20 +689,11 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
 
         self.login_and_go("/system/logs")
 
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:contains('Report to Cockpit') button:contains('Report')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:contains('Report to Cockpit') td:contains('Cancel me')"
-        b.wait_visible(sel)
-
-        sel = "table.reporting-table tr:contains('Report to Cockpit') button:contains('Cancel')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:contains('Report to Cockpit') td:contains('Reporting was canceled')"
-        b.wait_present(sel)
+        b.click(sleep_crash_list_sel)
+        b.click("table.reporting-table tr:contains('Report to Cockpit') button:contains('Report')")
+        b.wait_visible("table.reporting-table tr:contains('Report to Cockpit') td:contains('Cancel me')")
+        b.click("table.reporting-table tr:contains('Report to Cockpit') button:contains('Cancel')")
+        b.wait_present("table.reporting-table tr:contains('Report to Cockpit') td:contains('Reporting was canceled')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
                "ubuntu-2004", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "centos-8-stream")
@@ -765,15 +721,9 @@ ExecStart=/bin/sh -c 'for s in $(seq 10); do echo SLOW; sleep 0.1; done; sleep 1
         self.crash()
 
         self.login_and_go("/system/logs")
-
-        sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:first-child button:contains('Report')"
-        b.click(sel)
-
-        sel = "table.reporting-table tr:first-child a[href$='/reports/bthash/123deadbeef'"
-        b.wait_present(sel)
+        b.click(sleep_crash_list_sel)
+        b.click("table.reporting-table tr:first-child button:contains('Report')")
+        b.wait_present("table.reporting-table tr:first-child a[href$='/reports/bthash/123deadbeef'")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Factor out the very common, and sometimes changing, selector for the
sleep crash in the journal list box.

Eliminate single-use selector variables.