### PR TITLE
test: More thoroughly backup/restore journal

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -26,8 +26,14 @@ class TestJournal(MachineCase):
     def setUp(self):
         super().setUp()
 
-        self.restore_dir("/var/log/journal", post_restore_action="systemctl try-restart systemd-journald")
-        self.machine.execute("systemctl try-restart systemd-journald")
+        if self.is_nondestructive():
+            # we need persistent journal for the rebooting tests
+            self.restore_dir("/run/log/journal", post_restore_action="systemctl try-restart systemd-journald")
+            self.restore_dir("/var/log/journal", post_restore_action="systemctl try-restart systemd-journald")
+            self.machine.execute("systemctl stop systemd-journald")
+            self.machine.execute("rm -rf /run/log/journal/* /var/log/journal/*")
+            self.machine.execute("systemctl start systemd-journald")
+            self.allow_journal_messages("Specifying boot ID or boot offset has no effect, no persistent journal was found.*")
 
     def injectExtras(self):
         self.browser.inject_js("""


### PR DESCRIPTION
Clean the complete journal for test runs, and also cover
/run/log/journal/. That way, messages from previous tests don't cause
duplicate log entries and thus duplicate selectors.

----

This hopefully fixes [this failure](https://logs.cockpit-project.org/logs/pull-1030-20200701-055444-0331ee8a-fedora-testing-cockpit-project-cockpit/log.html) spotted in https://github.com/cockpit-project/bots/pull/1030 . I cannot reproduce that locally, but it's a good enough theory to test it :)