### PR TITLE
ws: Fix login with (t)csh

### DIFF
--- a/doc/man/cockpit-bridge.xml
+++ b/doc/man/cockpit-bridge.xml
@@ -82,6 +82,14 @@
             available to the user running this command.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>--output-fd</option> <replaceable>NUMBER</replaceable></term>
+        <listitem>
+          <para>Send protocol responses to given file descriptor number instead of stdout.
+            This is useful when stdout is already being used for something else, such as
+            debug logs or messages printed by shell profiles.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -147,6 +147,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.open("/system")
             b.wait_not_visible("#option-group")
 
+            # test login with tcsh
+            if not m.image.startswith("rhel") and not m.image.startswith("centos"):  # no tcsh in RHEL
+                m.execute("sed -r -i.bak '/^admin:/ s_:[^:]+$_:/bin/tcsh_' /etc/passwd")
+                b.login_and_go()
+                b.logout()
+                m.execute("mv /etc/passwd.bak /etc/passwd")
+                self.allow_journal_messages('Could not query seals on fd .*: not memfd.*')
+
             # login with user shell that prints some stdout/err noise
             # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
             m.execute("set -e; cd ~admin; cp -a .bashrc .bashrc.bak; [ ! -e .profile ] || cp -a .profile .profile.bak; "
@@ -154,9 +162,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                       "echo 'echo noise-profile-out; echo noise-profile-err >&2' >> .profile")
             self.addCleanup(m.execute, "set -e; cd ~admin; mv .bashrc.bak .bashrc; "
                                        "if [ -e .profile.bak ]; then mv .profile.bak .profile; else rm .profile; fi")
-            b.try_login("admin", "foobar")
-            b.expect_load()
-            b.wait_present("#content")
+            b.login_and_go()
+            b.logout()
 
         self.allow_journal_messages("Returning error-response ... with reason .*",
                                     "pam_unix\(cockpit:auth\): authentication failure; .*",

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -457,6 +457,7 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.37.4
+Conflicts: cockpit-bridge < 222.1
 Conflicts: firewalld < 0.6.0-1
 Recommends: sscg >= 2.3
 Recommends: system-logos

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -189,7 +189,8 @@ Depends: ${misc:Depends},
          adduser,
          openssl,
          systemd (>= 235),
-Conflicts: firewalld (<< 0.6.0)
+Conflicts: firewalld (<< 0.6.0),
+           cockpit-bridge (<< 222.1),
 Suggests: sssd-dbus
 Description: Cockpit Web Service
  The Cockpit Web Service listens on the network, and authenticates


### PR DESCRIPTION
csh does not support redirecting arbitrary fds with e. g. `>&3`. Thus
cockpit-session cannot use that to connect its stdout to
cockpit-bridge's stdin; trying that tried to create a literal file "3",
which caused a login failure.

Add a `--output-fd` option to cockpit-bridge and use that instead of the 
redirection. This drops the shell syntax assumption and thus makes this
work with csh and tcsh.

Adjust package dependencies to ensure that this cockpit-ws version does
not try to talk to an old bridge.

Also simplify TestLogin.testBasic() a bit, there is no need to use 
`try_login()` as it's expected to be successful.

Fixes #14060
https://bugzilla.redhat.com/show_bug.cgi?id=1848616

 - [x] Add tcsh to Fedora test images: cockpit-project/bots#1037
 - [x] Add tcsh to Debian/Ubuntu test images: cockpit-project/bots#1038 