### PR TITLE
docker: Fix image table headings

### DIFF
--- a/pkg/docker/containers-view.jsx
+++ b/pkg/docker/containers-view.jsx
@@ -570,7 +570,7 @@ export class ImageList extends React.Component {
             </button>
         </div>;
 
-        var columnTitles = [_("Name"), '', _("Created"), _("Size"), ''];
+        var columnTitles = [_("Name"), _("Created"), _("Size"), ''];
 
         var pendingRows = this.state.pulling.map(function (job) {
             if (job.error)


### PR DESCRIPTION
Drop the extra column title, it pushed "Created" and "Size" to the wrong
column.

Fixes #14278