### PR TITLE
tests: fix some pyflakes .format() gripes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1495,7 +1495,7 @@ class TapRunner:
 
         # Return 77 if all tests were skipped
         if len(skips) == test_count:
-            sys.stdout.write("# SKIP {1}\n".format(failures, ", ".join(["{0} {1}".format(str(s[0]), s[1]) for s in skips])))
+            sys.stdout.write("# SKIP {0}\n".format(", ".join(["{0} {1}".format(str(s[0]), s[1]) for s in skips])))
             return 77
         if failures:
             sys.stdout.write("# {0} TEST{1} FAILED {2}\n".format(failures, "S" if failures > 1 else "", details))

--- a/test/selenium/testlib_avocado/libnetwork.py
+++ b/test/selenium/testlib_avocado/libnetwork.py
@@ -174,7 +174,7 @@ class BaseNetworkClass:
 
     def set_ipv4(self, ip, gw):
         self._nmcli_con_cmd("mod", self.name, "ipv4.method manual ipv4.addresses {ip}  ipv4.gateway {gw}".
-                            format(type=type, ip=ip, gw=gw))
+                            format(ip=ip, gw=gw))
         self.con_up()
 
     @staticmethod

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -3614,7 +3614,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_present("#pool-myPoolTwo-{0}-volume-VolumeOne-usedby".format(connectionName))
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeOne-usedby".format(connectionName), "subVmTest1")
 
-        m.execute("virsh detach-disk --config --target vdd subVmTest1".format(diskXML))
+        m.execute("virsh detach-disk --config --target vdd subVmTest1")
         b.wait_in_text("#pool-myPoolTwo-{0}-volume-VolumeOne-usedby".format(connectionName), "")
 
         # Check activate button when pool activation is pending

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -417,9 +417,9 @@ class TestFirewall(NetworkCase):
 
             b.wait_not_present("#add-zone-dialog")
             for source in sources.split(",") if sources else []:
-                b.wait_present("#zones-listing .zone-section[data-id='{}']".format(zone, source))
+                b.wait_in_text("#zones-listing .zone-section[data-id='{}'] .zone-section-targets".format(zone), source)
             for i in interfaces:
-                b.wait_present("#zones-listing .zone-section[data-id='{}']".format(zone, i))
+                b.wait_in_text("#zones-listing .zone-section[data-id='{}'] .zone-section-targets".format(zone), i)
             b.wait_present("#zones-listing .zone-section[data-id='{}']".format(zone))
             b.wait_present("#zones-listing .zone-section[data-id='{}'] tr[data-row-id='cockpit']".format(zone))
 


### PR DESCRIPTION
New versions of pyflakes seem to be catching some errors in our use of
str.format() in the tests.  Fix those up.

I've made the changes, in each case, that preseve the existing
functionality, but in some cases (particularly, firewall) it's not clear
what the correct intent was.  Someone should look over those.

```
test/verify/check-networking-firewall:420:32 '...'.format(...) has unused arguments at position(s): 1
test/verify/check-networking-firewall:422:32 '...'.format(...) has unused arguments at position(s): 1
test/verify/check-machines:3617:19 '...'.format(...) has unused arguments at position(s): 0
test/common/testlib.py:1498:30 '...'.format(...) has unused arguments at position(s): 0
test/selenium/testlib_avocado/libnetwork.py:176:47 '...'.format(...) has unused named argument(s): type
```