### PR TITLE
a11y, ux: Change input[type=number] to inputmode

### DIFF
--- a/pkg/docker/index.html
+++ b/pkg/docker/index.html
@@ -514,7 +514,7 @@
                     </div>
                     <div id="restart-policy-retries-container" class="hidden">
                       <label class="control-label" for="restart-policy-retries" translate="yes">Retries:</label>
-                      <input id="restart-policy-retries" class="form-control" type="number" value="0" min="0" name="restart-policy-retries">
+                      <input id="restart-policy-retries" class="form-control" type="text" inputmode="numeric" pattern="[0-9]*" value="0" min="0" name="restart-policy-retries">
                     </div>
                   </div>
                 </td>

--- a/pkg/machines/components/memorySelectRow.css
+++ b/pkg/machines/components/memorySelectRow.css
@@ -25,6 +25,7 @@
 }
 
 /* Constrain number width */
+.slider-input-group input[inputmode=numeric],
 .slider-input-group input[type=number] {
     max-width: 5rem;
 }

--- a/pkg/machines/components/memorySelectRow.jsx
+++ b/pkg/machines/components/memorySelectRow.jsx
@@ -63,7 +63,7 @@ class MemorySelectRow extends React.Component {
                     onSlide={onValueChange} /> : null}
                 <div role="group" className="form-group">
                     <input id={id} className="form-control"
-                        type="number"
+                        type="text" inputMode="numeric" pattern="[0-9]*"
                         min={minValue}
                         max={maxValue}
                         value={toFixedPrecision(this.state.memory)}

--- a/pkg/machines/components/storagePools/storageVolumeCreateBody.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreateBody.jsx
@@ -81,7 +81,7 @@ const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolType, onValueC
             <div role="group" className="ct-form-split">
                 <input id={`${idPrefix}-size`}
                        className="form-control add-disk-size"
-                       type="number"
+                       type="text" inputMode="numeric" pattern="[0-9]*"
                        value={toFixedPrecision(size)}
                        onKeyPress={digitFilter}
                        step={1}

--- a/pkg/machines/components/vcpuModal.css
+++ b/pkg/machines/components/vcpuModal.css
@@ -4,6 +4,7 @@
   grid-row-gap: 1em;
 }
 
+.vcpu-modal-grid input[inputmode=numeric],
 .vcpu-modal-grid input[type=number] {
     max-width: 7rem;
 }

--- a/pkg/machines/components/vcpuModal.jsx
+++ b/pkg/machines/components/vcpuModal.jsx
@@ -188,7 +188,7 @@ export class VCPUModal extends React.Component {
                         {_("vCPU Count")}
                     </label>
                     <div controlid="vcpu-count" role="group">
-                        <input id="machines-vcpu-count-field" type="number" className="form-control ct-form-stretch" value={this.state.count} onChange={this.onCountSelect} />
+                        <input id="machines-vcpu-count-field" type="text" inputMode="numeric" pattern="[0-9]*" className="form-control ct-form-stretch" value={this.state.count} onChange={this.onCountSelect} />
                         <div className="info-circle">
                             <Tooltip entryDelay={0} content={_("Fewer than the maximum number of virtual CPUs should be enabled.")}>
                                 <InfoAltIcon />
@@ -200,7 +200,7 @@ export class VCPUModal extends React.Component {
                         {_("vCPU Maximum")}
                     </label>
                     <div controlid="vcpu-maximum" role="group">
-                        <input id="machines-vcpu-max-field" type="number" className="form-control ct-form-stretch" onChange={this.onMaxChange} value={this.state.max} />
+                        <input id="machines-vcpu-max-field" type="text" inputMode="numeric" pattern="[0-9]*" className="form-control ct-form-stretch" onChange={this.onMaxChange} value={this.state.max} />
                         <div className="info-circle">
                             <Tooltip entryDelay={0} content={cockpit.format(
                                 _("Maximum number of virtual CPUs allocated for the guest OS, which must be between 1 and $0"),

--- a/src/base1/cockpit.css
+++ b/src/base1/cockpit.css
@@ -980,6 +980,7 @@ div.timeline-ct.timeline-ct-end .timeline-ct-md {
 }
 
 /* HACK: https://github.com/patternfly/patternfly/issues/255 */
+input[inputmode=numeric],
 input[type=number] {
   padding: 0 0 0 5px;
 }


### PR DESCRIPTION
Fixes #14309

Details:
https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/