### PR TITLE
examples: How to launch and reattach to a long-running process

### DIFF
--- a/examples/long-running-process/README.md
+++ b/examples/long-running-process/README.md
@@ -1,0 +1,28 @@
+## Launch and reattach to a long-running process
+
+Cockpit pages should never spawn long-running precious processes, as a Cockpit
+session is not reliably connected for a long time:  Network interfaces go down
+or  roam, TCP timeouts happen, browsers crash, tabs get closed accidentally,
+batteries drain, people close/suspend their laptops, and so on.
+
+Most services that Cockpit talks to manage their own runtime state and jobs,
+such as udisks, libvirt, or podman. But this is not the case for e.g. running
+Ansible playbooks or installer scripts. These should be wrapped into a
+transient service unit, so that systemd takes over the role of the job manager.
+
+This example demonstrates how to do that. It runs an arbitary shell command in
+a transient cockpit-longrunning.service, shows the live log output, and
+reattaches to it on page load. I.e. you can start the process, log out, log
+back in, and the service is recognized as "already running" with the complete
+output.
+
+For your own use case, the most important design question is the choice of the
+service name, especially if the page can manage more than one process (such as
+launching parallel playbooks with different environment variables). It must
+contain exactly all the identifying properties in the name, so that it is
+predictable.
+
+If your page does manage multiple processes in parallel, it needs to enumerate
+running units with [ListUnits()](https://www.freedesktop.org/wiki/Software/systemd/dbus/).
+This example page only manages one at a time, and thus just uses a `GetUnit()` call
+with a known name.

--- a/examples/long-running-process/index.html
+++ b/examples/long-running-process/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Launch and reattach to long-running process</title>
+    <meta charset="utf-8">
+    <link href="../base1/cockpit.css" type="text/css" rel="stylesheet">
+    <link href="long-running.css" type="text/css" rel="stylesheet">
+    <script src="../base1/cockpit.js"></script>
+    <script src="long-running.js"></script>
+</head>
+
+<body>
+    <div class="container-fluid">
+        <p><label>State:</label> <span id="state"></span></p>
+        <p><input id="command" type="text" /> <button id="run" disabled>Start process</button></p>
+        <pre id="output"></pre>
+    </div>
+</body>
+</html>
+

--- a/examples/long-running-process/long-running.css
+++ b/examples/long-running-process/long-running.css
@@ -1,0 +1,10 @@
+pre {
+    background-color: #EEEEEE;
+    min-height: 5em;
+    max-height: 50em;
+    overflow-y: scroll;
+}
+
+#command {
+    min-width: 50ex;
+}

--- a/examples/long-running-process/long-running.js
+++ b/examples/long-running-process/long-running.js
@@ -1,0 +1,124 @@
+/* global cockpit */
+
+// DOM objects
+let state, command, run_button, output;
+
+// systemd D-Bus API names
+const O_SD_OBJ = "/org/freedesktop/systemd1";
+const I_SD_MGR = "org.freedesktop.systemd1.Manager";
+const I_SD_UNIT = "org.freedesktop.systemd1.Unit";
+const I_DBUS_PROP = "org.freedesktop.DBus.Properties";
+
+// default shell command for the long-running process to run
+const default_command = "date; for i in `seq 30`; do echo $i; sleep 1; done";
+
+// don't require superuser; this is only for reading the current state
+const systemd_client = cockpit.dbus("org.freedesktop.systemd1");
+
+function error(ex) {
+    state.innerHTML = "Error: " + ex.toString();
+    run_button.setAttribute("disabled", "");
+}
+
+// follow live output of the given unit, put into "output" <pre> area
+function showJournal(unitName, filter_arg) {
+    // run at most one instance of journal tailing
+    if (this.journalctl)
+        return;
+
+    // reset previous output
+    output.innerHTML = "";
+
+    const argv = ["journalctl", "--output=cat", "--unit", unitName, "--follow", "--lines=all", filter_arg];
+    this.journalctl = cockpit.spawn(argv, { superuser: "require", err: "message" })
+            .stream(data => output.append(document.createTextNode(data)))
+            .catch(ex => { output.innerHTML = JSON.stringify(ex) });
+}
+
+// check if the transient unit for our command is running
+function checkState(unit) {
+    systemd_client.call(O_SD_OBJ, I_SD_MGR, "GetUnit", [unit], { type: "s" })
+            .then(([unitObj]) => {
+                /* Some time may pass between getting JobNew and the unit actually getting activated;
+                 * we may get an inactive unit here; watch for state changes. This will also update
+                 * the UI if the unit stops. */
+                this.subscription = systemd_client.subscribe(
+                    { interface: I_DBUS_PROP, member: "PropertiesChanged" },
+                    (path, iface, signal, args) => {
+                        if (path === unitObj && args[1].ActiveState)
+                            checkState(unit);
+                    });
+
+                systemd_client.call(unitObj, I_DBUS_PROP, "GetAll", [I_SD_UNIT], { type: "s" })
+                        .then(([props]) => {
+                            if (props.ActiveState.v === 'activating') {
+                                state.innerHTML = cockpit.format("$0 is running", unit);
+                                run_button.setAttribute("disabled", "");
+                                // StateChangeTimestamp property is in µs since epoch, but journalctl expects seconds
+                                showJournal(unit, "--since=@" + Math.floor(props.StateChangeTimestamp.v / 1000000));
+                            } else if (props.ActiveState.v === 'failed') {
+                                state.innerHTML = cockpit.format("$0 is not running and failed", unit);
+                                run_button.setAttribute("disabled", "");
+                                // Show the whole journal of this boot; this may be refined a bit with props.InvocationID
+                                showJournal(unit, "--boot");
+                            } else {
+                                /* Type=oneshot transient units only have state "activating" or "failed",
+                                 * or don't exist at all (handled below in NoSuchUnit case).
+                                 * If you don't care about "failed", call systemd-run with --collect */
+                                state.innerHTML = cockpit.format("Error: unexpected state of $0: $1", unit, props.ActiveState.v);
+                            }
+                        })
+                        .catch(error);
+            })
+            .catch(ex => {
+                if (ex.name === "org.freedesktop.systemd1.NoSuchUnit") {
+                    if (this.subscription) {
+                        this.subscription.remove();
+                        this.subscription = null;
+                    }
+                    state.innerHTML = cockpit.format("$0 is not running", unit);
+                    run_button.removeAttribute("disabled");
+                } else {
+                    error(ex);
+                }
+            });
+}
+
+/* Start long-running process, called on clicking the "Start Process" button.
+ * This runs as root, thus will be shared with all privileged Cockpit sessions.
+ */
+function run(unit) {
+    const argv = ["systemd-run", "--unit", unit, "--service-type=oneshot", "--no-block", "--", "/bin/sh", "-ec", command.value];
+    cockpit.spawn(argv, { superuser: "require", err: "message" })
+            .catch(error);
+}
+
+// called once after page initializes
+function setup() {
+    state = document.getElementById("state");
+    command = document.getElementById("command");
+    run_button = document.getElementById("run");
+    output = document.getElementById("output");
+
+    state.innerHTML = "initializing";
+    command.value = default_command;
+
+    /* Build a service name which contains exactly the identifying properties for the
+     * command to re-attach to. For a single static command this is just the page name,
+     * but it could also include the command name or path, arguments, or a playbook name,
+     * etc.  if the page is dealing with multiple commands. */
+    const serviceName = "cockpit-longrunning.service";
+
+    run_button.addEventListener("click", () => run(serviceName));
+
+    // Watch for start event of the service
+    systemd_client.subscribe({ interface: I_SD_MGR, member: "JobNew" }, (path, iface, signal, args) => {
+        if (args[2] == serviceName)
+            checkState(serviceName);
+    });
+    // Check if it is already running
+    checkState(serviceName);
+}
+
+// Wait until page is loaded
+cockpit.transport.wait(setup);

--- a/examples/long-running-process/manifest.json
+++ b/examples/long-running-process/manifest.json
@@ -1,0 +1,10 @@
+{
+    "version": 0,
+
+    "tools": {
+        "index": {
+            "label": "Long-running Process",
+            "path": "index.html"
+        }
+    }
+}

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -69,5 +69,81 @@ class TestXHRProxy(MachineCase):
         b.wait_in_text("#output", "File not found")
 
 
+@nondestructive
+class TestLongRunning(MachineCase):
+
+    def setUp(self):
+        super().setUp()
+        m = self.machine
+        m.execute("mkdir -p ~admin/.local/share/cockpit")
+        m.upload([os.path.join(EXAMPLES_DIR, "long-running-process")], "~admin/.local/share/cockpit/")
+        # clean up after test failures
+        self.addCleanup(m.execute, "systemctl stop cockpit-longrunning.service 2>/dev/null && systemctl reset-failed cockpit-longrunning.service || true")
+
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/long-running-process")
+
+        self.assertEqual(m.execute("systemctl is-active cockpit-longrunning.service || true").strip(), "inactive")
+        b.wait_text("#state", "cockpit-longrunning.service is not running")
+        b.wait_text("#output", "")
+
+        # run a command that the test can control synchronously
+        ack_file = self.vm_tmpdir + "/ack_a";
+        b.set_val("#command", "date; echo STEP_A; until [ -e %s ]; do sleep 1; done; echo STEP_B; sleep 1; echo DONE" % ack_file)
+        b.click("button#run")
+
+        b.wait_text("#state", "cockpit-longrunning.service is running")
+        b.wait_in_text("#output", "\nSTEP_A\n")
+        self.assertNotIn("\nSTEP_B", b.text("#output"))
+        self.assertEqual(m.execute("systemctl is-active cockpit-longrunning.service || true").strip(), "activating")
+
+        # reattaches in new session
+        b.logout()
+        b.login_and_go("/long-running-process")
+        b.wait_text("#state", "cockpit-longrunning.service is running")
+        b.wait_in_text("#output", "\nSTEP_A\n")
+        self.assertEqual(m.execute("systemctl is-active cockpit-longrunning.service || true").strip(), "activating")
+
+        # resume process
+        m.execute("mkdir -p %s && touch %s" % (self.vm_tmpdir, ack_file))
+        b.wait_in_text("#output", "\nSTEP_B\n")
+        # wait for completion
+        b.wait_in_text("#output", "\nDONE\n")
+        b.wait_text("#state", "cockpit-longrunning.service is not running")
+        self.assertEqual(m.execute("systemctl is-active cockpit-longrunning.service || true").strip(), "inactive")
+
+        # in next session it is back at "not running"
+        b.logout()
+        b.login_and_go("/long-running-process")
+        b.wait_text("#state", "cockpit-longrunning.service is not running")
+        b.wait_text("#output", "")
+
+        # failing process
+        m.execute("rm -f " + ack_file)
+        b.set_val("#command", "date; echo BREAK_A; until [ -e %s ]; do sleep 1; done; false; echo NOTME" % ack_file)
+        b.click("button#run")
+        b.wait_text("#state", "cockpit-longrunning.service is running")
+        b.wait_in_text("#output", "\nBREAK_A\n")
+        m.execute("touch " + ack_file)
+        b.wait_text("#state", "cockpit-longrunning.service is not running and failed")
+        b.wait_in_text("#output", "cockpit-longrunning.service: Main process exited, code=exited, status=1/FAILURE")
+        out = b.text("#output")
+        self.assertNotIn("\nNOTME", out)
+        # does not contain previous logs
+        self.assertNotIn("STEP_B", out)
+
+        # failing state gets picked up on page reconnect
+        b.logout()
+        b.login_and_go("/long-running-process")
+        b.wait_text("#state", "cockpit-longrunning.service is not running and failed")
+        b.wait_in_text("#output", "cockpit-longrunning.service: Main process exited, code=exited, status=1/FAILURE")
+        out = b.text("#output")
+        self.assertIn("\nBREAK_A\n", out)
+        self.assertNotIn("\nNOTME", out)
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Cockpit pages should never spawn long-running precious processes, as a
cockpit session is not reliably connected for a long time:  Network
interfaces go down or  roam, TCP timeouts happen, browsers crash, tabs
get closed accidentally, batteries drain, people close/suspend their
laptops, and so on. 

Most services that Cockpit talks to manage their own runtime state and
jobs, such as udisks, libvirt, or podman. But this is not the case for
e.g. running Ansible playbooks or launching installer scripts. These
should be wrapped into a transient service unit, so that systemd takes
over the role of the job manager.

Add a "long-running-process" example which demonstrates this. It runs an
arbitary shell command in a transient cockpit-longrunning-$USER.service,
shows the live log output, and reattaches to it on page load.

The most important design question is the choice of the service name,
especially if the page can manage more than one process (such as
launching parallel playbooks with different environment variables). It
must contain exactly all the identifying properties in the name, so that
it is predictable.