### PR TITLE
shell: Always show active menu item

### DIFF
--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -238,6 +238,15 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             document.getElementById("main").style.removeProperty('--ct-color-host-accent');
         }
 
+        let component_manifest = state.component;
+        // If `state.component` is not known to any manifest, find where it comes from
+        if (compiled.items[state.component] == undefined) {
+            let s = state.component;
+            while (s && compiled.items[s] == undefined)
+                s = s.substring(0, s.lastIndexOf("/"));
+            component_manifest = s;
+        }
+
         // Filtering of navigation by term
         function keyword_filter(item, term) {
             function keyword_relevance(current_best, item) {
@@ -286,7 +295,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
         // Rendering of separate navigation menu items
         function nav_item(component, term) {
-            const active = state.component === component.path;
+            const active = component_manifest === component.path;
 
             // Parse path
             let path = component.path;

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -85,6 +85,12 @@ class TestMenu(MachineCase):
         # Ensure that our tests pick up unhandled JS exceptions
         b.switch_to_top()
         b.go("/playground/exception")
+
+        # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
+        if m.image != "rhel-8-3-distropkg": # Introduced in #14325
+            b.wait_visible("#host-apps .pf-m-current")
+            b.wait_visible("#host-apps .pf-m-current:contains('Development')")
+
         b.enter_page("/playground/exception")
         b.wait_visible("button")
         with self.assertRaisesRegex(RuntimeError, "TypeError:.*undefined"):


### PR DESCRIPTION
For example visiting firewall of HW details page did not show any active
item in the main menu.

Fixes: #10545
Closes: #14325