### PR TITLE
test: Adjust check-login for changed sshd config on Fedora CoreOS

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -244,8 +244,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # On OSTree this happens over ssh
         if m.ostree_image:
-            self.sed_file('s/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/', '/etc/ssh/sshd_config',
-                          '( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service')
+            self.restore_dir("/etc/ssh", '( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service')
+            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
+            m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
 
         m.execute("chage -d 0 admin")
         m.start_cockpit()
@@ -342,8 +343,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         conf = "/etc/pam.d/cockpit"
         if m.ostree_image:
             conf = "/etc/pam.d/sshd"
-            self.sed_file('s/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/', '/etc/ssh/sshd_config',
-                          '( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service')
+            self.restore_dir("/etc/ssh", '( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service')
+            m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
+            m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
 
         self.sed_file('5 a auth       required    /usr/lib/cockpit-test-assets/mock-pam-conv-mod.so', conf)
 


### PR DESCRIPTION
`ChallengeResponseAuthentication` is now also set in some sshd_config.d/
snippet, and it keeps being tossed around. So just sed it in all
matching files. This complicates the code a little, but makes it more
robust against future changes.