### PR TITLE
Use autocomplete='new-password' to prevent browsers autofilling passw…

### DIFF
--- a/pkg/lib/machine-change-auth.html
+++ b/pkg/lib/machine-change-auth.html
@@ -77,7 +77,7 @@
                 <td class="top key-locked form-group">
                     <div class="locked-identity"></div>
                     <div translate="yes">Enter passphrase to add identity to ssh-agent</div>
-                    <input class="locked-identity-password" type="password" autocomplete="off"></input>
+                    <input class="locked-identity-password" type="password" autocomplete="new-password"></input>
                     <button class="pf-c-button pf-m-primary" translate="yes">Unlock</button>
                 </td>
             </tr>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -276,7 +276,7 @@
                                                     </dt>
                                                     <dd>
                                                         <input class="form-control credential-password"
-                                                                autocomplete="off"
+                                                                autocomplete="new-password"
                                                                 id="add-key-password"
                                                                 value="" type="password"/>
                                                     </dd>
@@ -320,7 +320,7 @@
                                                     </dt>
                                                     <dd>
                                                         <input class="form-control credential-password"
-                                                                autocomplete="off"
+                                                                autocomplete="new-password"
                                                                 id="ssh-key-password"
                                                                 value="" type="password"/>
                                                     </dd>
@@ -358,7 +358,7 @@
                                                     </dt>
                                                     <dd>
                                                         <input class="form-control credential-old"
-                                                            autocomplete="off"
+                                                            autocomplete="new-password"
                                                             id="credential-old-passwd"
                                                             value="" type="password"/>
                                                     </dd>
@@ -367,7 +367,7 @@
                                                     </dt>
                                                     <dd>
                                                         <input class="form-control credential-new"
-                                                            autocomplete="off"
+                                                            autocomplete="new-password"
                                                             id="credential-new-passwd"
                                                             value="" type="password"/>
                                                     </dd>
@@ -376,7 +376,7 @@
                                                     </dt>
                                                     <dd>
                                                         <input class="form-control credential-two"
-                                                            autocomplete="off"
+                                                            autocomplete="new-password"
                                                             id="new-passwd-confirm"
                                                             value="" type="password"/>
                                                     </dd>


### PR DESCRIPTION
…ord and username

In chrome a bug is visible when after loading the page nav search bar
would get autofilled with username out of browser's saved usernames and
password.
In other parts of UI the browser would fill wrong field with username.
We normally use autocomplete="off" property, but according to
https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields
many browsers already ignore autocomplete="off" property and recommend
using autocomplete="new-password" instead.

After loading the page on my Chromium 83.0.4103.116, it seach nav bar gets autofilled
![Screenshot from 2020-07-08 15-03-45](https://user-images.githubusercontent.com/42733240/86924954-78f2f200-c130-11ea-8471-248fe4d84e57.png)

This bug is even more visible in SSH keys dialog
![Screenshot from 2020-07-08 15-05-43](https://user-images.githubusercontent.com/42733240/86925070-a344af80-c130-11ea-833d-04039a90105c.png)
![Screenshot from 2020-07-08 15-05-53](https://user-images.githubusercontent.com/42733240/86925074-a50e7300-c130-11ea-976a-58d5ecf17d5c.png)
