### PR TITLE
machines: Remove the option for user account creation for unattended installations

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -183,8 +183,8 @@ function validateParams(vmParams) {
             );
         }
     }
-    if (vmParams.unattendedInstallation && !vmParams.rootPassword && (permission.user.name == 'root' || !vmParams.userPassword))
-        validationFailed.password = _("Please set a root or a user password");
+    if (vmParams.unattendedInstallation && !vmParams.rootPassword)
+        validationFailed.password = _("Please set a root password");
 
     return validationFailed;
 }
@@ -445,18 +445,6 @@ const UnattendedRow = ({ validationFailed, unattendedDisabled, unattendedInstall
                         {profile == 'desktop' && <p className="text-info">{_("Leave the password blank if you do not wish to have a root account created")}</p>}
                     </HelpBlock>
                 </FormGroup>
-                {permission.user.name != 'root' && profile == 'desktop' && <>
-                    <label htmlFor='user-password' className='control-label'>
-                        {cockpit.format(_("Password for $0"), permission.user.name)}
-                    </label>
-                    <FormGroup validationState={validationStatePassword} bsClass='form-group ct-validation-wrapper' controlId='user-password'>
-                        <Password id='user-password' onValueChanged={(value) => onValueChanged('userPassword', value)} />
-                        <HelpBlock>
-                            <p className="text-danger">{validationFailed.password}</p>
-                            <p className="text-info">{_("Leave the password blank if you do not wish to have a user account created")}</p>
-                        </HelpBlock>
-                    </FormGroup>
-                </>}
                 <hr />
             </> : <span />}
         </>
@@ -596,7 +584,6 @@ class CreateVmModal extends React.Component {
             minimumMemory: 0,
             recommendedStorage: undefined,
             minimumStorage: 0,
-            userPassword: '',
             rootPassword: '',
         };
         this.onCreateClicked = this.onCreateClicked.bind(this);
@@ -785,7 +772,6 @@ class CreateVmModal extends React.Component {
                 storageVolume: this.state.storageVolume,
                 startVm: this.state.startVm,
                 unattended: this.state.unattendedInstallation,
-                userPassword: this.state.userPassword,
                 rootPassword: this.state.rootPassword,
             };
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1446,7 +1446,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             runner.createDownloadAnOSTest(TestMachines.VmDialog(self, sourceType='downloadOS',
                                                                 is_unattended=True, profile="Workstation",
-                                                                user_password="catsaremybestfr13nds", root_password="dogsaremybestfr13nds",
+                                                                root_password="dogsaremybestfr13nds",
                                                                 storage_size=246, storage_size_unit='MiB',
                                                                 os_name=config.FEDORA_28,
                                                                 os_short_id=config.FEDORA_28_SHORTID))
@@ -1458,15 +1458,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                                                                 storage_size=256, storage_size_unit='MiB',
                                                                 os_name=config.FEDORA_28,
                                                                 os_short_id=config.FEDORA_28_SHORTID))
-
-            # Don't create root account
-            runner.createDownloadAnOSTest(TestMachines.VmDialog(self, sourceType='downloadOS',
-                                                                is_unattended=True, profile="Workstation",
-                                                                user_password="catsaremybestfr13nds",
-                                                                storage_size=256, storage_size_unit='MiB',
-                                                                os_name=config.FEDORA_28,
-                                                                os_short_id=config.FEDORA_28_SHORTID))
-
 
             # name already used from a VM that is currently being created
             # https://bugzilla.redhat.com/show_bug.cgi?id=1780451
@@ -1956,9 +1947,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 if self.root_password:
                     root_password_file = virt_install_cmd_out.split("admin-password-file=", 1)[1].split(",")[0]
                     self.assertIn(self.machine.execute("cat {0}".format(root_password_file)).rstrip(), self.root_password)
-                if self.user_password:
-                    user_password_file = virt_install_cmd_out.split("user-password-file=", 1)[1].split(",")[0]
-                    self.assertIn(self.machine.execute("cat {0}".format(user_password_file)).rstrip(), self.user_password)
 
         def fill(self):
             def getSourceTypeLabel(sourceType):
@@ -2056,8 +2044,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 b.click("#unattended-installation")
                 if self.profile:
                     b.select_from_dropdown("#profile-select", self.profile)
-                if self.user_password:
-                    b.set_input_text("#user-password", self.user_password)
                 if self.root_password:
                     b.set_input_text("#root-password", self.root_password)
 


### PR DESCRIPTION
This feature was inherently broken.
virt-install is using the username of the user that ran the script to
create the same user inside the VM if the 'User password' was passed.
However, since we run the script to create the VM with 'superuser:
true', it always runs as root, when the cockpit user has privileges
to do so, resulting in virt-install always creating the root user of the
VM and no user account.

Untill we will be able to pass to the virt-install script the user name
of the new user we need to disable this feature.

https://bugzilla.redhat.com/show_bug.cgi?id=1853918

virt-install Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1855020