### PR TITLE
test: Allow authorize messages in TestConnection.testCockpitDesktop

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -680,6 +680,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
             m.execute("su - -c 'BROWSER=/tmp/browser.sh %s system' admin" % cockpit_desktop)
             self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
 
+        self.allow_authorize_journal_messages()
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
         self.allow_journal_messages("Refusing to render service to dead parents.")
         self.allow_journal_messages(".*No authentication agent found.*")


### PR DESCRIPTION
I've seen this test fail quite a lot recently, like [here](https://logs-https-cockpit.apps.ci.centos.org/logs/pull-14328-20200708-135108-83a12c32-ubuntu-2004/log.html#276) or [here](https://logs-https-cockpit.apps.ci.centos.org/logs/pull-14338-20200709-061131-c1c5d7d9-ubuntu-2004/log.html#19). This should fix it.