### PR TITLE
test: stop testing the VMs state after attempting shutdown during installation

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2297,7 +2297,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b.click("#vm-{0}-forceOff".format(name))
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
-            b.wait_in_text("#vm-{0}-state".format(name), "shut off")
 
             return self
 


### PR DESCRIPTION
This check was inherently racy, because of https://bugzilla.redhat.com/show_bug.cgi?id=1818089
When we performed the 'destroy' operation on the domain, virt-install
exited and restarted the guest. Thus for a fraction of a second the
state was 'shut off' allowing the test sometimes to pass.