### PR TITLE
machines: support iface type 'ethernet' when detecting NICs before VM installation

### DIFF
--- a/pkg/machines/libvirtUtils.js
+++ b/pkg/machines/libvirtUtils.js
@@ -67,7 +67,7 @@ export function prepareNICParam(nics) {
             user: nic.type === "user",
             bridge: nic.source.bridge,
             network: nic.source.network,
-            type: nic.type === "direct" ? "direct" : null,
+            type: (nic.type === "direct" || nic.type === "ethernet") ? nic.type : null,
             source: nic.source.dev,
             mac: nic.mac,
             model: nic.model,


### PR DESCRIPTION
When performing VM Creation/Installation in two steps we need to pass to
the 'virt-install' script the complete VM configuration. We already do
that but interfaces of type 'ethernet' were not parsed.
This commit add support for these.

Fixes #14316