### PR TITLE
depencency: set version for novnc.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@patternfly/react-core": "3.158.1",
     "@patternfly/react-table": "2.28.50",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
+    "@novnc/novnc": "1.1.0",
     "bootstrap": "3.4.1",
     "bootstrap-datepicker": "1.9.0",
     "c3": "0.4.24",


### PR DESCRIPTION
Latest update of novnc breaks, so set it to version 1.1.0