### PR TITLE
maint: bump up version of @patternfly/* npm modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@patternfly/patternfly": "2.71.7",
+    "@patternfly/patternfly": "4.23.3",
     "@patternfly/react-console": "2.0.15",
-    "@patternfly/react-core": "3.158.1",
-    "@patternfly/react-table": "2.28.50",
+    "@patternfly/react-core": "4.32.1",
+    "@patternfly/react-table": "4.12.1",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "@novnc/novnc": "1.1.0",
     "bootstrap": "3.4.1",

--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -70,7 +70,7 @@ class ApplicationRow extends React.Component {
                     <div>
                         {comp.summary}
                         <Alert isInline variant='danger'
-                            action={<AlertActionCloseButton onClose={left_click(() => { this.setState({ error: null }) })} />}
+                            actionClose={<AlertActionCloseButton onClose={left_click(() => { this.setState({ error: null }) })} />}
                             title={state.error} />
                     </div>
                 );

--- a/pkg/lib/cockpit-components-empty-state.jsx
+++ b/pkg/lib/cockpit-components-empty-state.jsx
@@ -27,8 +27,8 @@ import {
     EmptyStateIcon,
     EmptyStateBody,
     EmptyStateSecondaryActions,
+    Spinner,
 } from '@patternfly/react-core';
-import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import "./cockpit-components-empty-state.css";
 
 export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAction, secondary }) => {
@@ -37,7 +37,7 @@ export const EmptyStatePanel = ({ title, paragraph, loading, icon, action, onAct
         <EmptyState variant={EmptyStateVariant.full}>
             { loading && <Spinner size="xl" /> }
             { icon && <EmptyStateIcon icon={icon} /> }
-            <Title size="lg">
+            <Title headingLevel="h1" size="lg">
                 {title}
             </Title>
             <EmptyStateBody>

--- a/pkg/lib/cockpit-components-inline-notification.jsx
+++ b/pkg/lib/cockpit-components-inline-notification.jsx
@@ -65,7 +65,7 @@ export class InlineNotification extends React.Component {
         }
         const extraProps = {};
         if (onDismiss)
-            extraProps.action = <AlertActionCloseButton onClose={onDismiss} />;
+            extraProps.actionClose = <AlertActionCloseButton onClose={onDismiss} />;
 
         return (
             <Alert variant={type || 'danger'}

--- a/pkg/lib/cockpit-components-listing-panel.jsx
+++ b/pkg/lib/cockpit-components-listing-panel.jsx
@@ -19,7 +19,7 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Nav, NavItem, NavList, NavVariants } from '@patternfly/react-core';
+import { Nav, NavItem, NavList } from '@patternfly/react-core';
 import './cockpit-components-listing-panel.scss';
 
 /* tabRenderers optional: list of tab renderers for inline expansion, array of objects with
@@ -129,8 +129,8 @@ export class ListingPanel extends React.Component {
                 </div>;
         } else {
             heading = (<div className="ct-listing-panel-head">
-                {links.length && <Nav onSelect={this.handleTabClick}>
-                    <NavList variant={NavVariants.tertiary}>
+                {links.length && <Nav variant="tertiary" onSelect={this.handleTabClick}>
+                    <NavList>
                         {links}
                     </NavList>
                 </Nav>}

--- a/pkg/lib/cockpit-components-listing-panel.scss
+++ b/pkg/lib/cockpit-components-listing-panel.scss
@@ -1,6 +1,6 @@
 .ct-listing-panel {
   &-head {
-    background: linear-gradient(to top, 
+    background: linear-gradient(to top,
       var(--pf-global--BorderColor--100) 0,
       var(--pf-global--BorderColor--100) 1px,
       transparent 1px
@@ -13,7 +13,7 @@
     }
 
     .pf-c-nav__item {
-      --pf-c-nav__tertiary-list-item--MarginRight: 0;
+      --pf-c-nav__list-item--MarginRight: 0;
       cursor: pointer;
     }
 
@@ -21,21 +21,21 @@
     // meanwhile, let's force restyle the tertiary to look like the upcoming tabs.
     // See https://patternfly-next-pr-2757.surge.sh/documentation/core/components/tabs
     // Setting padding height to be 1/2, however for being embedded in the list.
-    .pf-c-nav__tertiary-list {
+    .pf-c-nav .pf-c-nav__list {
       flex-wrap: wrap;
 
       .pf-c-nav__link {
-        --pf-c-nav__tertiary-list-link--PaddingTop: var(--pf-global--spacer--sm);
-        --pf-c-nav__tertiary-list-link--PaddingBottom: var(--pf-global--spacer--sm);
-        --pf-c-nav__tertiary-list-link--PaddingLeft: var(--pf-global--spacer--md);
-        --pf-c-nav__tertiary-list-link--PaddingRight: var(--pf-global--spacer--md);
+        --pf-c-nav__link--PaddingTop: var(--pf-global--spacer--sm);
+        --pf-c-nav__link--PaddingBottom: var(--pf-global--spacer--sm);
+        --pf-c-nav__link--PaddingLeft: var(--pf-global--spacer--md);
+        --pf-c-nav__link--PaddingRight: var(--pf-global--spacer--md);
         padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
 
         &:hover {
-          --pf-c-nav__tertiary-list-link--Color: inherit;
+          --pf-c-nav__link--Color: inherit;
 
           &::after {
-            --pf-c-nav__tertiary-list-link--hover--after--BackgroundColor: var(--pf-global--BorderColor--light-100);
+            --pf-c-nav__link--hover--after--BackgroundColor: var(--pf-global--BorderColor--light-100);
           }
         }
       }
@@ -61,6 +61,11 @@
   }
 
   &-body {
+    // Don't let PF4 automatically add a border in tables inside the body
+    --pf-c-table__expandable-row--after--BorderLeftWidth: 0;
+    --pf-c-table--border-width--base: 0;
+
+    // Add some sizing to the body
     padding: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
     width: 100%;
 

--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -127,13 +127,6 @@
         font-size: var(--pf-global--FontSize--sm);
         font-weight: var(--pf-global--FontWeight--semi-bold);
     }
-
-    .pf-m-expanded {
-        // PF4 dropped the shadow of expanded tables
-        box-shadow: none !important;
-        // Re-add bottom line
-        border-bottom: var(--pf-c-table--BorderWidth) solid var(--pf-c-table--BorderColor)
-    }
 }
 
 // Special handling for rows with errors

--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -80,14 +80,12 @@
         // As the width is smaller than the contents, and this is a table,
         // the cell will stay at the correct width.
         width: 1px;
+    }
 
-        > .pf-c-button {
-            padding-top: var(--pf-global--spacer--sm);
-            padding-bottom: var(--pf-global--spacer--sm);
-            vertical-align: top;
-            // Not every browser supports text-top, so define top (above) as a fallback
-            vertical-align: text-top;
-        }
+    .pf-c-button.pf-m-expanded .pf-c-table__toggle-icon {
+        // Similar to PF4, but with a translate to bump the expanded icon down 3 pixels,
+        // to better align the expanded form
+        transform: translateY(3px) rotate(var(--pf-c-table__toggle--c-button--m-expanded__toggle-icon--Rotate));
     }
 
     // Shrink buttons down a little

--- a/pkg/lib/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly-4-overrides.scss
@@ -26,7 +26,9 @@
 /* See: https://github.com/patternfly/patternfly-design/issues/840 */
 /* Helper mod to wrap pf-c-nav__tertiary */
 .ct-m-nav__tertiary-wrap {
-    flex-wrap: wrap;
+    .pf-c-nav__list {
+        flex-wrap: wrap;
+    }
 
     .pf-c-nav__scroll-button {
         display: none;
@@ -35,5 +37,12 @@
 
 /* Helper mod to center pf-c-nav__tertiary when it wraps */
 .ct-m-nav__tertiary-center {
-    justify-content: center;
+    .pf-c-nav__list {
+        justify-content: center;
+    }
+}
+
+ul.pf-c-select__menu {
+    max-height: 20rem;
+    overflow-y: scroll;
 }

--- a/pkg/playground/react-demo-cards.jsx
+++ b/pkg/playground/react-demo-cards.jsx
@@ -22,7 +22,7 @@ import ReactDOM from "react-dom";
 
 import {
     Button, Card, CardHeader, CardBody, CardFooter,
-    CardHead, CardActions, Gallery, GalleryItem
+    CardTitle, CardActions, Gallery, GalleryItem
 } from '@patternfly/react-core';
 
 const CardsDemo = () => {
@@ -38,17 +38,17 @@ const CardsDemo = () => {
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
         <Card isCompact key="card4">
-            <CardHeader>I have a header too</CardHeader>
+            <CardTitle>I have a header too</CardTitle>
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
         <Card key="card5">
-            <CardHead>
+            <CardHeader>
                 <CardActions>
                     <input type="checkbox" />
                     <Button className="btn">click</Button>
                 </CardActions>
-                <CardHeader>This is a card header</CardHeader>
-            </CardHead>
+            </CardHeader>
+            <CardTitle>This is a card header</CardTitle>
             <CardBody>I'm a card in a gallery</CardBody>
         </Card>,
         <GalleryItem key="card6">
@@ -58,7 +58,7 @@ const CardsDemo = () => {
     return (
         <>
             <h4>PF4 cards arranged using a PF4 Gallery</h4>
-            <Gallery gutter="md">
+            <Gallery hasGutter>
                 { cards }
             </Gallery>
         </>

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -238,7 +238,7 @@ class DismissableError extends React.Component {
         return (
             <Alert isInline
                 variant='danger' title={this.props.children}
-                action={<AlertActionCloseButton onClose={this.handleDismissError} />} />
+                actionClose={<AlertActionCloseButton onClose={this.handleDismissError} />} />
         );
     }
 }
@@ -464,7 +464,7 @@ export class SETroubleshootPage extends React.Component {
             errorMessage = (
                 <Alert isInline
                     variant='danger' title={this.props.error}
-                    action={<AlertActionCloseButton onClose={this.handleDismissError} />} />
+                    actionClose={<AlertActionCloseButton onClose={this.handleDismissError} />} />
             );
         }
 

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -63,7 +63,7 @@ $desktop: $phone + 1px;
         width: 100%;
         font-size: var(--pf-global--FontSize--sm);
         font-weight: var(--pf-global--FontWeight--normal);
-        color: var(--pf-c-nav--m-dark__list-link--Color);
+        color: var(--pf-c-nav--m-dark__link--Color);
         display: inline-block;
         opacity: 0.8;
     }
@@ -73,7 +73,7 @@ $desktop: $phone + 1px;
     }
 
     .non-menu-item {
-        color: var(--pf-c-nav__list-link--Color);
+        color: var(--pf-c-nav__link--Color);
         display: flex;
         justify-content: center;
     }
@@ -435,6 +435,10 @@ $desktop: $phone + 1px;
     display: flex;
     justify-content: space-between;
 
+    > .pf-c-nav__section-title:not(a) {
+        flex: auto;
+    }
+
     a {
         color: var(--pf-global--link--Color--light);
         font-weight: normal;
@@ -688,20 +692,6 @@ $desktop: $phone + 1px;
     .pf-c-page__sidebar .pf-c-nav {
         width: unset;
     }
-}
-
-// TODO - this should come from PF, just overwrite until new version is available
-.pf-c-nav__list > .pf-c-nav__item > .pf-c-nav__link::after {
-    left: 0;
-    top: 0;
-    bottom: 0;
-    height: 100%; // We may actually need this even with the new PF version (when item has 'Contains:...'
-    width: var(--pf-c-nav__list-link--after--Height);
-}
-
-// TODO - this should come from PF, just overwrite until new version is available
-.pf-c-nav__list .pf-c-nav__link {
-    padding-bottom: var(--pf-c-nav__list-link--PaddingTop);
 }
 
 /* Navigation animation */

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -213,9 +213,8 @@
 
 import cockpit from "cockpit";
 
-import React from "react";
-import { TypeAheadSelect } from "patternfly-react";
-import { Alert, Tooltip, TooltipPosition } from "@patternfly/react-core";
+import React, { useState } from "react";
+import { Alert, Tooltip, TooltipPosition, Select as TypeAheadSelect, SelectOption, SelectVariant } from "@patternfly/react-core";
 
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { StatelessSelect, SelectEntry } from "cockpit-components-select.jsx";
@@ -492,6 +491,25 @@ export const PassInput = (tag, title, options) => {
     };
 };
 
+const TypeAheadSelectElement = ({ options, change }) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [value, setValue] = useState(null);
+
+    return (
+        <TypeAheadSelect
+            variant={SelectVariant.typeahead}
+            id="nfs-path-on-server"
+            isOpen={isOpen}
+            selections={value}
+            onToggle={isOpen => setIsOpen(isOpen)}
+            onSelect={(event, value) => { setValue(value); change(value) }}
+            onClear={() => setValue(false)}
+            isDisabled={options.disabled}>
+            {options.choices.map(entry => <SelectOption key={entry} value={entry} />)}
+        </TypeAheadSelect>
+    );
+};
+
 export const ComboBox = (tag, title, options) => {
     return {
         tag: tag,
@@ -501,30 +519,7 @@ export const ComboBox = (tag, title, options) => {
 
         render: (val, change) =>
             <div data-field={tag} data-field-type="combobox">
-                <TypeAheadSelect
-                    id="nfs-path-on-server"
-                    labelKey="path"
-                    placeholder=""
-                    paginate={false}
-                    onChange={value => change(value[0])}
-                    onInputChange={change}
-                    options={options.choices}
-                    disabled={options.disabled}
-                    onKeyDown={ev => { // Capture ESC event
-                        if (ev.keyCode == 27) {
-                            ev.persist();
-                            ev.nativeEvent.stopImmediatePropagation();
-                            ev.stopPropagation();
-                        }
-                    }}
-                    renderMenu={(results, menuProps) => {
-                        // Hide the menu when there are no results.
-                        if (!results.length) {
-                            return null;
-                        }
-                        return <TypeAheadSelect.TypeaheadMenu {...menuProps} labelKey='path' options={results} />;
-                    }}
-                />
+                <TypeAheadSelectElement options={options} change={change} />
             </div>
     };
 };

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -216,7 +216,7 @@ class CPUSecurityMitigationsDialog extends React.Component {
                     </ListView>
                     { this.state.alert !== undefined &&
                     <Alert variant="danger"
-                        action={<AlertActionCloseButton onClose={() => this.setState({ alert: undefined })} />}
+                        actionClose={<AlertActionCloseButton onClose={() => this.setState({ alert: undefined })} />}
                         title={this.state.alert} />}
                 </Modal.Body>
                 <Modal.Footer>

--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Card, CardHeader, CardBody, Button } from '@patternfly/react-core';
+import { Card, CardBody, Button, CardTitle } from '@patternfly/react-core';
 
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import * as service from "service.js";
@@ -270,7 +270,7 @@ export class ConfigurationCard extends React.Component {
 
         return (
             <Card className="system-configuration">
-                <CardHeader>{_("Configuration")}</CardHeader>
+                <CardTitle>{_("Configuration")}</CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 
 import cockpit from "cockpit";
 import { PageStatusNotifications } from "../page-status.jsx";
@@ -32,7 +32,7 @@ export class HealthCard extends React.Component {
     render() {
         return (
             <Card className="system-health">
-                <CardHeader>{_("Health")}</CardHeader>
+                <CardTitle>{_("Health")}</CardTitle>
                 <CardBody>
                     <ul className="system-health-events">
                         <PageStatusNotifications />

--- a/pkg/systemd/overview-cards/motdCard.jsx
+++ b/pkg/systemd/overview-cards/motdCard.jsx
@@ -54,9 +54,9 @@ export class MotdCard extends React.Component {
             return null;
 
         return (
-            <Alert id="motd-box" isInline variant="info" className="motd-box"
+            <Alert id="motd-box" isInline variant="default" className="motd-box"
                    title={ <pre id="motd">{this.state.motdText}</pre> }
-                   action={ <AlertActionCloseButton onClose={this.hideAlert} /> } />
+                   actionClose={ <AlertActionCloseButton onClose={this.hideAlert} /> } />
         );
     }
 }

--- a/pkg/systemd/overview-cards/serverTime.js
+++ b/pkg/systemd/overview-cards/serverTime.js
@@ -512,7 +512,7 @@ function ChangeSystimeBody({ state, errors, change }) {
             <label htmlFor="systime-timezones" className="control-label">{_("Time Zone")}</label>
             <Validated errors={errors} error_key="time_zone">
                 <Select id="systime-timezones" variant={SelectVariant.typeahead}
-                        isExpanded={zonesOpen} onToggle={setZonesOpen}
+                        isOpen={zonesOpen} onToggle={setZonesOpen}
                         selections={time_zone}
                         onSelect={(event, value) => { setZonesOpen(false); change("time_zone", value) }}>
                     { time_zones.map(tz => <SelectOption key={tz} value={tz}>{tz.replace(/_/g, " ")}</SelectOption>) }
@@ -520,7 +520,7 @@ function ChangeSystimeBody({ state, errors, change }) {
             </Validated>
             <label className="control-label" htmlFor="change_systime">{_("Set Time")}</label>
             <Select id="change_systime"
-                    isExpanded={modeOpen} onToggle={setModeOpen}
+                    isOpen={modeOpen} onToggle={setModeOpen}
                     selections={mode} onSelect={(event, value) => { setModeOpen(false); change("mode", value) }}>
                 <SelectOption value="manual_time">{_("Manually")}</SelectOption>
                 <SelectOption isDisabled={!ntp_supported} value="ntp_time">{_("Automatically using NTP")}</SelectOption>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Card, CardHeader, CardBody, CardFooter } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import moment from 'moment';
 
 import cockpit from "cockpit";
@@ -102,7 +102,7 @@ export class SystemInfomationCard extends React.Component {
     render() {
         return (
             <Card className="system-information">
-                <CardHeader>{_("System information")}</CardHeader>
+                <CardTitle>{_("System information")}</CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -18,8 +18,8 @@
  */
 import React from 'react';
 import {
-    Card, CardHeader, CardBody, CardFooter,
-    Progress, ProgressMeasureLocation, ProgressVariant,
+    Card, CardBody, CardFooter,
+    Progress, ProgressMeasureLocation, ProgressVariant, CardTitle,
 } from '@patternfly/react-core';
 
 import * as machine_info from "machine-info.js";
@@ -113,7 +113,7 @@ export class UsageCard extends React.Component {
 
         return (
             <Card className="system-usage">
-                <CardHeader>{_("Usage")}</CardHeader>
+                <CardTitle>{_("Usage")}</CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -140,7 +140,7 @@ class LoginMessages extends React.Component {
                    variant={this.state.messages.type}
                    isInline={!fail_count_message}
                    className={!fail_count_message ? "no-title" : ""}
-                   action={<AlertActionCloseButton onClose={this.close} />}
+                   actionClose={<AlertActionCloseButton onClose={this.close} />}
                    title={fail_count_message || last_log_item}
             >
                 {last_login_message && fail_count_message && last_log_item}
@@ -260,7 +260,7 @@ class OverviewPage extends React.Component {
                 </PageSection>
                 <PageSection variant={PageSectionVariants.default}>
                     <LoginMessages />
-                    <Gallery className='ct-system-overview' gutter="lg">
+                    <Gallery className='ct-system-overview' hasGutter>
                         <MotdCard />
                         <HealthCard />
                         <UsageCard />

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -110,7 +110,7 @@
   }
 
   .pf-c-card {
-    &__header {
+    &__title {
       font-size: var(--pf-global--FontSize--xl);
       font-weight: var(--pf-global--FontWeight--normal);
     }
@@ -246,14 +246,14 @@
     --pf-c-card--child--PaddingRight: var(--pf-global--spacer--md);
     --pf-c-card--child--PaddingBottom: var(--pf-global--spacer--md);
     --pf-c-card--child--PaddingLeft: var(--pf-global--spacer--md);
-    --pf-c-card__header--not-last-child--PaddingBottom: var(--pf-global--spacer--sm);
+    --pf-c-card__title--not-last-child--PaddingBottom: var(--pf-global--spacer--sm);
   }
 }
 
 @media (min-width: 780px) {
   /* Embiggen subheading & card headings when there's space */
 
-  .ct-system-overview .pf-c-card__header {
+  .ct-system-overview .pf-c-card__title {
     font-size: var(--pf-global--FontSize--2xl);
   }
 
@@ -367,6 +367,21 @@
 
 .pf-c-button.no-left-padding {
     padding-left: 0;
+}
+
+/* Add a subtle dropshadow to the alerts, to separate them from the background, similar to the cards on the page */
+.pf-c-page__main-section:not(.ct-overview-header),
+.pf-l-gallery {
+  > .pf-c-alert {
+    box-shadow: var(--pf-global--BoxShadow--sm);
+
+    // Default PF4 blue and background grey are too close in shade
+    // So: Lighten up the blue to provide a touch more contrast
+    // (Based on default's light green, but in a blue shade)
+    &.pf-m-info {
+      --pf-c-alert--BackgroundColor: #f1f8fe;
+    }
+  }
 }
 
 #motd-box > .pf-c-alert {

--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -44,7 +44,6 @@ export function ServiceTabs({ onChange, activeTab, tabErrors }) {
 
     return (
         <Nav variant="tertiary" id="services-filter"
-             className="ct-m-nav__tertiary-wrap ct-m-nav__tertiary-center"
              onSelect={result => { setActiveItem(result.itemId); onChange(result.itemId) }}>
             <NavList>
                 {Object.keys(service_tabs_suffixes).map(key => {

--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -19,7 +19,7 @@
 
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-import { Nav, NavList, NavItem, NavVariants } from '@patternfly/react-core';
+import { Nav, NavList, NavItem } from '@patternfly/react-core';
 
 import cockpit from "cockpit";
 
@@ -43,9 +43,10 @@ export function ServiceTabs({ onChange, activeTab, tabErrors }) {
     const [activeItem, setActiveItem] = useState(activeTab);
 
     return (
-        <Nav id="services-filter"
-            onSelect={result => { setActiveItem(result.itemId); onChange(result.itemId) }}>
-            <NavList variant={NavVariants.tertiary} className="ct-m-nav__tertiary-wrap ct-m-nav__tertiary-center">
+        <Nav variant="tertiary" id="services-filter"
+             className="ct-m-nav__tertiary-wrap ct-m-nav__tertiary-center"
+             onSelect={result => { setActiveItem(result.itemId); onChange(result.itemId) }}>
+            <NavList>
                 {Object.keys(service_tabs_suffixes).map(key => {
                     return (
                         <NavItem itemId={key}

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -28,13 +28,11 @@ import {
     Page, PageSection, PageSectionVariants,
     TextInput,
     Card,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+    ToolbarGroup,
 } from '@patternfly/react-core';
-import {
-    DataToolbar,
-    DataToolbarItem,
-    DataToolbarGroup,
-    DataToolbarContent,
-} from '@patternfly/react-core/dist/esm/experimental';
 import { SearchIcon } from '@patternfly/react-icons';
 
 import * as Select from "cockpit-components-select.jsx";
@@ -729,9 +727,9 @@ class ServicesPage extends React.Component {
                 .sort(this.compareUnits);
 
         const toolbarItems = <>
-            <DataToolbarGroup>
-                <DataToolbarItem variant="label" id="services-text-filter-label">{_("Filter")}</DataToolbarItem>
-                <DataToolbarItem variant="search-filter">
+            <ToolbarGroup>
+                <ToolbarItem variant="label" id="services-text-filter-label">{_("Filter")}</ToolbarItem>
+                <ToolbarItem variant="search-filter">
                     <TextInput name="services-text-filter"
                             id="services-text-filter"
                             type="search"
@@ -739,8 +737,8 @@ class ServicesPage extends React.Component {
                             onChange={this.onInputChange}
                             aria-labelledby="services-text-filter-label"
                             placeholder={_("Filter by name or description")} />
-                </DataToolbarItem>
-                <DataToolbarItem variant="search-filter">
+                </ToolbarItem>
+                <ToolbarItem variant="search-filter">
                     <Select.StatelessSelect id="services-dropdown"
                             selected={currentTypeFilter.key}
                             onChange={value => this.onTypeDropdownSelect(typeDropdownOptions.find(option => option.key == value))}>
@@ -750,17 +748,17 @@ class ServicesPage extends React.Component {
                             </Select.SelectEntry>
                         ))}
                     </Select.StatelessSelect>
-                </DataToolbarItem>
-            </DataToolbarGroup>
+                </ToolbarItem>
+            </ToolbarGroup>
             {activeTab == "timer" &&
             <>
-                <DataToolbarItem variant="separator" />
-                <DataToolbarItem>
+                <ToolbarItem variant="separator" />
+                <ToolbarItem>
                     { this.state.privileged && <Button key='create-timer-action' variant="secondary"
                                                        id="create-timer"
                                                        onClick={onCreateTimer}>{_("Create Timer")}</Button>
                     }
-                </DataToolbarItem>
+                </ToolbarItem>
             </>}
         </>;
 
@@ -775,10 +773,10 @@ class ServicesPage extends React.Component {
                 </PageSection>
                 <PageSection>
                     <Card isCompact>
-                        <DataToolbar data-loading={this.state.loadingUnits}
+                        <Toolbar data-loading={this.state.loadingUnits}
                                      id="services-toolbar">
-                            <DataToolbarContent>{toolbarItems}</DataToolbarContent>
-                        </DataToolbar>
+                            <ToolbarContent>{toolbarItems}</ToolbarContent>
+                        </Toolbar>
                         <ServicesList key={cockpit.format("$0-list", activeTab)}
                             isTimer={activeTab == 'timer'}
                             units={units} />

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -57,6 +57,9 @@
 .pf-c-nav__link > .fa {
     margin-left: 0.5rem;
 }
+.pf-c-page__main-nav {
+    padding-bottom: 1rem;
+}
 
 // Add some spacing between the icon and the status string in the list
 .service-unit-status-failed > .fa {

--- a/pkg/systemd/superuser-alert.jsx
+++ b/pkg/systemd/superuser-alert.jsx
@@ -56,7 +56,7 @@ export class SuperuserAlert extends React.Component {
                 <Alert className="ct-limited-access-alert"
                        hidden={this.superuser.Current != "none"}
                        variant="info" isInline
-                       action={actions}
+                       actionClose={actions}
                        title={_("Web console is running in limited access mode.")} />
             </>);
     }

--- a/src/base1/patternfly-overrides.scss
+++ b/src/base1/patternfly-overrides.scss
@@ -152,33 +152,6 @@ select.form-control {
   padding-right: 2.5em !important;
 }
 
-// Adjust typeahead find style
-.rbt {
-  &-input {
-    // Support typehead hints
-    &-hint {
-      // Stretch the hint and its input child 100% tall
-      &,
-      > input {
-        height: 100%;
-      }
-
-      // Shave off the border and padding, as these misalign the element
-      // (as this widget uses inline styles (ugh!), we _have to_ use !important)
-      > input {
-        border-width: 0 1px !important;
-        padding-top: 0 !important;
-        padding-bottom: 0 !important;
-      }
-    }
-  }
-
-  // Adjust spinner position
-  &-aux {
-    right: 2rem !important;
-  }
-}
-
 // Adjust dropdown menus
 .dropdown-menu {
   > li {

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -324,14 +324,15 @@ class Browser:
             self.wait_val(selector, val)
 
     def set_file_autocomplete_val(self, identifier, location):
-        file_item_selector_template = "#{0} li a:contains({1})"
+        file_item_selector_template = "#{0} li button:contains({1})"
 
         path = ''
         index = 0
+        self.click("label[for={0}] + div button".format(identifier))
+        self.wait_present("#" + identifier)
         for path_part in filter(None, location.split('/')):
             path += '/' + path_part
-            file_item_selector = file_item_selector_template.format(identifier, path_part)
-            self.click("label[for={0}] + div input[type=text]".format(identifier))
+            file_item_selector = file_item_selector_template.format(identifier, path)
             self.click(file_item_selector)
             if index != len(list(filter(None, location.split('/')))) - 1 or location[-1] == '/':
                 self.wait_val("label[for={0}] + div input[type=text]".format(identifier), path + '/')

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -300,17 +300,17 @@ class TestKeys(MachineCase):
 
         b.wait_visible("#credential-keys")
         b.wait_present("#credential-keys a")
-        b.wait_not_visible("tr.load-custom-key")
+        b.wait_not_visible("#ssh-file-add")
         b.click("#credential-keys a")
         b.wait_visible("tr.load-custom-key")
-        b.wait_visible("tr.load-custom-key button")
+        b.wait_visible("#ssh-file-add")
         b.wait_visible("#ssh-file-container")
         b.set_val("#ssh-file-container input[type=text]", "/bad")
-        b.click("tr.load-custom-key button")
+        b.click("#ssh-file-add")
         b.wait_text("tr.load-custom-key div.dialog-error", "Not a valid private key")
 
         b.set_val("#ssh-file-container input[type=text]", "/tmp/new.rsa")
-        b.click("tr.load-custom-key button")
+        b.click("#ssh-file-add")
         b.wait_not_visible("tr.load-custom-key")
         # OpenSSH 7.8 and up has a new default key format where
         # keys are marked as "agent_only", thereby limiting functionality
@@ -353,12 +353,12 @@ class TestKeys(MachineCase):
             b.wait_not_visible("tr.load-custom-key")
             b.click("#credential-keys a")
             b.wait_visible("tr.load-custom-key")
-            b.wait_visible("tr.load-custom-key button")
+            b.wait_visible("#ssh-file-add")
             b.set_val("#ssh-file-container input[type=text]", "/bad")
-            b.click("tr.load-custom-key button")
+            b.click("#ssh-file-add")
 
             b.set_val("#ssh-file-container input[type=text]", "/tmp/new.rsa")
-            b.click("tr.load-custom-key button")
+            b.click("#ssh-file-add")
             b.wait_not_visible("tr.load-custom-key")
             b.wait_present("tbody.ssh-add-key-body[data-name='/tmp/new.rsa']")
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1919,11 +1919,12 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def checkOsFiltered(self):
             b = self.browser
 
-            b.focus("label[for=os-select] + div > div > div > input")
+            b.focus("label[for=os-select] + div input")
             b.key_press(self.os_name)
+
             try:
                 with b.wait_timeout(5):
-                    b.wait_in_text("#os-select li a", "No matches found")
+                    b.wait_in_text("#os-select li button", "No results found")
                 return self
             except AssertionError:
                 # os found which is not ok
@@ -1983,9 +1984,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 b.select_from_dropdown("#source-type", getSourceTypeLabel(self.sourceTypeSecondChoice))
 
             if self.os_name:
-                b.focus("label:contains('Operating System') + div > div > div > input")
-                b.key_press(self.os_name)
-                b.key_press("\t")
+                b.click("label:contains('Operating System') + div button")
+                b.click("#os-select li:contains('{0}') button".format(self.os_name))
 
             if self.sourceType != 'disk_image':
                 if not self.expected_storage_size:

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -552,20 +552,18 @@ OnCalendar=daily
         b.focus("#demo-file-ac input[type=text]")
         b.key_press(stuff + "/")
         # need to wait for the widget's "fast typing" inhibition delay to trigger the completion popup
-        b.wait_text("#file-autocomplete-widget.dropdown-menu li:nth-of-type(1) a span span", "dir1/")
-        b.wait_text("#file-autocomplete-widget.dropdown-menu li:nth-of-type(2) a span span", "file1.txt")
-        b.blur("#demo-file-ac input[type=text]")
-        b.wait_not_present("#file-autocomplete-widget")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", "dir1/")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "file1.txt")
+        b.key_press(["\r"])
+        b.wait_not_present("#file-autocomplete-widget li")
 
         # now update file1, check robustness with dynamic events
         m.execute("touch %s/file1.txt" % stuff)
         b.focus("#demo-file-ac input[type=text]")
         time.sleep(1)
-        b.key_press([" ", "\b"])
+        b.key_press(["\b"]*5)
         # this should still be unique
-        b.wait_text("#file-autocomplete-widget.dropdown-menu li:nth-of-type(2) a span span", "file1.txt")
-        b.blur("#demo-file-ac input[type=text]")
-        b.wait_not_present("#file-autocomplete-widget")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "file1.txt")
 
         # add new file
         m.execute("touch %s/other" % stuff)
@@ -574,7 +572,7 @@ OnCalendar=daily
         b.key_press(["\b"])
         time.sleep(1)
         b.key_press("/")
-        b.wait_text("#file-autocomplete-widget.dropdown-menu li:nth-of-type(3) a span span", "other")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "other")
 
     @skipImage("No PCP available", "fedora-coreos")
     def testPlots(self):

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -168,7 +168,7 @@ class TestStorageNfs(StorageCase):
                 return len(choices) == 2 and "/home/foo" in choices and "/home/bar" in choices
             self.retry(None, check, None)
 
-        b.click('#dialog [data-field="remote"] input.rbt-input-main')
+        b.click('#dialog [data-field="remote"] button.pf-c-select__toggle-button')
         wait_for_exports()
 
     def testNfsBusy(self):

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -255,7 +255,8 @@ class StorageHelpers:
                 self.browser.set_checked(sel + " input[type=checkbox]", True)
                 self.browser.set_input_text(sel + "+ input[type=text]", val)
         elif ftype == "combobox":
-            self.browser.set_input_text(sel + " input[type=text]", val)
+            self.browser.click(sel + " button.pf-c-select__toggle-button")
+            self.browser.click(sel + " .pf-c-select__menu li:contains('{0}') button".format(val))
         else:
             self.browser.set_val(sel, val)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -509,7 +509,8 @@ module.exports = {
                             options: {
                                 resources: [
                                     path.resolve(libdir, './_global-variables.scss'),
-                                    path.resolve(nodedir, './@patternfly/patternfly/patternfly-variables.scss'),
+                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-themes.scss'),
+                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-variables.scss'),
                                     path.resolve(nodedir, './patternfly/dist/sass/patternfly/_variables.scss')
                                 ],
                             },


### PR DESCRIPTION
This was a breaking release which changed:

* directory structure in the @patternfly/patternfly repository thus
includes to patternfly-variables has to be adjusted
* Renamed/Removed components from @patternfly/react-core
* @patternfly/react-core now depends on react-popper:2.2.3 which is
already brought as dependency of patternfly-react npm module (PF3)
thus we pin it here in the packag.json to avoid it being pulled in the
old version