### PR TITLE
lib: Make sure that flex items work correctly on chrome as well

### DIFF
--- a/pkg/lib/cockpit-components-listing-panel.scss
+++ b/pkg/lib/cockpit-components-listing-panel.scss
@@ -7,7 +7,6 @@
     );
     display: flex;
     align-items: flex-end;
-    justify-content: space-between;
 
     .pf-c-nav {
       margin-left: var(--pf-global--spacer--xs);
@@ -50,7 +49,8 @@
   // Support action buttons on the right
   &-actions {
     display: flex;
-    justify-content: end;
+    flex: auto;
+    justify-content: flex-end;
     margin: var(--pf-global--spacer--sm) var(--pf-global--spacer--sm);
   }
 

--- a/pkg/lib/cockpit-components-listing-panel.scss
+++ b/pkg/lib/cockpit-components-listing-panel.scss
@@ -6,7 +6,8 @@
       transparent 1px
     );
     display: flex;
-    align-items: end;
+    align-items: flex-end;
+    justify-content: space-between;
 
     .pf-c-nav {
       margin-left: var(--pf-global--spacer--xs);
@@ -49,7 +50,6 @@
   // Support action buttons on the right
   &-actions {
     display: flex;
-    flex: auto;
     justify-content: end;
     margin: var(--pf-global--spacer--sm) var(--pf-global--spacer--sm);
   }


### PR DESCRIPTION
See https://github.com/cockpit-project/cockpit-podman/issues/410

- `align-items: end` does not seem to work in chrome but it needs `flex-end`
- Items cannot be positioned to the end of container in chrome.
  Therefore I just dropped `flex: auto` to stop the container from
  taking all remaining space and just put space between those two
  elements.

Before (firefox and chrome):
![firefoxbefore](https://user-images.githubusercontent.com/12330670/87539918-0c7f7200-c69f-11ea-87aa-f70d7946c492.png)
![chromebefore](https://user-images.githubusercontent.com/12330670/87539931-0f7a6280-c69f-11ea-9cf9-051759d4ce23.png)

After (firefox and chrome):
![newfirefox](https://user-images.githubusercontent.com/12330670/87539955-173a0700-c69f-11ea-9957-2c10b030a71d.png)
![newchrome](https://user-images.githubusercontent.com/12330670/87539962-199c6100-c69f-11ea-8c34-5d860b51a56f.png)
