### PR TITLE
[rhel-7.9] package.json: Fix version for novnc

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@babel/polyfill": "7.4.4",
+    "@novnc/novnc": "1.1.0",
     "@patternfly/react-console": "1.10.46",
     "angular": "1.3.20",
     "angular-bootstrap-npm": "0.13.4",


### PR DESCRIPTION
Latest 1.2 update of novnc breaks current version of @patternfly/react-console, so set it to version 1.1.0.

Cherry-picked from master commit 76f4802