### PR TITLE
compat (Chrome, WebKit): Use flex-start/end in flex

### DIFF
--- a/pkg/lib/listing.scss
+++ b/pkg/lib/listing.scss
@@ -11,7 +11,7 @@
     > header {
         display: flex;
         align-items: center;
-        justify-content: start;
+        justify-content: flex-start;
         flex-flow: wrap;
 
         > :only-child {
@@ -122,7 +122,7 @@ tbody.open > tr.listing-ct-item th {
 
 tbody.open td div.listing-ct-head {
     background-color: $color-pf-white;
-    align-items: end;
+    align-items: flex-end;
 }
 
 tbody.open > .listing-ct-panel > td > .listing-ct-body {

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -156,7 +156,7 @@
 
 .machines-listing-actions {
     display: flex;
-    justify-content: end;
+    justify-content: flex-end;
     flex-flow: wrap;
     margin: -0.25rem 0;
 }

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -27,7 +27,7 @@
 
 @media screen and (min-width: 640px) {
     .pk-updates--header--auto {
-        justify-content: start;
+        justify-content: flex-start;
     }
 }
 

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -251,7 +251,7 @@ $desktop: $phone + 1px;
     }
 
     .area-ct-subnav {
-        align-self: end;
+        align-self: flex-end;
         z-index: 2;
 
         &:not(.interact) {

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -91,7 +91,7 @@
     position: relative;
     display: flex;
     align-items: baseline;
-    align-self: end;
+    align-self: flex-end;
     flex-direction: row;
     margin: 1rem 0 0;
     text-align: right;
@@ -151,7 +151,7 @@
 
 .content-header-extra {
     display: flex;
-    align-items: end;
+    align-items: flex-end;
     padding: 0 var(--pf-global--spacer--lg) var(--pf-global--spacer--md);
 }
 

--- a/pkg/systemd/overview-cards/healthCard.scss
+++ b/pkg/systemd/overview-cards/healthCard.scss
@@ -5,7 +5,7 @@
       display: flex;
       // Align icons vertically to text
       align-items: center;
-      justify-content: start;
+      justify-content: flex-start;
 
       + li {
         margin-top: 0.5rem;

--- a/src/ws/login.css
+++ b/src/ws/login.css
@@ -237,7 +237,7 @@ form .control-label {
 .checkbox-row > input[type=checkbox] {
   width: 16px;
   height: 16px;
-  align-self: start;
+  align-self: flex-start;
   margin-top: calc((1.5rem - 16px) / 2);
   margin-right: 0.5rem;
 }


### PR DESCRIPTION
Chrome and WebKit do not yet properly support justify-content and
align-items set to start or end for flex.

https://caniuse.com/#feat=mdn-css_properties_align-items_flex_context_start_end

Both do support start/end for grid, however.

(Do note that flex-start/flex-end are not appropriate for grid, so we
have to be aware if the element is using a display of flex or grid.)

https://caniuse.com/#feat=mdn-css_properties_align-items_grid_context_start_end

Therefore, for the time being, we need to ensure all display: flex
elements are using flex-start & flex-end instead of start & end, for
Chrome and WebKit support.

This is a follow-up to #14360 and applies to more of Cockpit.