### PR TITLE
test: Fix race condition in TestSOS.testCancel

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -95,8 +95,8 @@ threads=1
 
         b.click("#sos-cancel")
         b.wait_not_visible("#sos")
-        # cleans up properly
-        m.execute("! pgrep -a sosreport")
+        # cleans up properly; unfortunately closing the process is async, so need to retry a few times
+        m.execute("while pgrep -a sosreport; do sleep 1; done", timeout=10)
         self.assertEqual(m.execute("ls /var/tmp/sosreport* 2>/dev/null || true"), "")
 
     def testAppStream(self):


### PR DESCRIPTION
Clicking the Cancel button merely .close()s the sosreport process, it
does not synchronously wait for its termination. So  it is often still
around right after that. Give it 10s to terminate.

sosreport with the full configuration takes about two minutes, so the
chances of this catching the regular (non-cancel) end is negligible.