### PR TITLE
test: Fix TestMachines.testConfigureBeforeInstall on fedora-testing

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2678,7 +2678,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             # HACK: Capabilities are not updated dynamically
             # https://bugzilla.redhat.com/show_bug.cgi?id=1807198
             def hack_broken_caps():
-                if m.image in ["fedora-32", "rhel-8-3", "rhel-8-3-distropkg", "ubuntu-2004", "debian-testing"]:
+                if m.image in ["fedora-32", "fedora-testing", "rhel-8-3", "rhel-8-3-distropkg", "ubuntu-2004", "debian-testing"]:
                     m.execute("systemctl restart libvirtd")
                     # We don't get events for shut off VMs so reload the page
                     b.reload()


### PR DESCRIPTION
fedora-testing has been Fedora 32 for a while now, so hack_broken_caps()
needs to be applied to it as well.