### PR TITLE
session: reopen memfd ro to avoid SELinux trouble

### DIFF
--- a/src/ws/session-utils.h
+++ b/src/ws/session-utils.h
@@ -91,6 +91,6 @@ int open_session (pam_handle_t *pamh);
 int fork_session (char **env, int (*session)(char**));
 
 FILE *open_memfd (const char *name);
-bool seal_memfd (FILE *memfd);
+int seal_memfd (FILE **memfd);
 
 void fd_remap (const int *remap_fds, int n_remap_fds);

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -448,8 +448,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # not an admin
         b.wait_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
-        # with current SELinux policy, user_u and staff_u are not allowed to read cockpit_tmpfs_t memfd: https://bugzilla.redhat.com/show_bug.cgi?id=1814052
-        if m.image in ["fedora-31", "fedora-32", "fedora-testing", "rhel-8-3", "rhel-8-3-distropkg", "centos-8-stream"]:
+        # RHEL 8.3 cockpit-session doesn't reopen the memfd correctly, so it
+        # still hits the selinux fail.
+        if m.image in ['rhel-8-3-distropkg']:
+            self.allow_journal_messages('.*type=1400.*avc:  denied  { write }.*comm="bash".*')
             self.allow_journal_messages('Could not query seals on fd .*: not memfd.*')
             self.assertFalse(b.is_present('#last-login'))
         else:
@@ -464,7 +466,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*/var/lib/cockpit/machines.json.*Permission denied")
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
-        self.allow_journal_messages('.*type=1400.*avc:  denied  { write }.*comm="bash".*')
         if m.image in ["centos-8-stream"]:
             # older releases have more noise
             self.allow_journal_messages("sudo: .*setresuid.*: Operation not permitted")


### PR DESCRIPTION
SELinux is somewhat understandably upset that we're passing an
unexpected readwrite fd across a privilege barrier.  From our side, it
seems reasonable, since we've just applied seals to make it immutable,
but SELinux doesn't understand that.

Avoid the problem by reopening the file descriptor readonly using the
usual /proc/self/fd trick.