### PR TITLE
session: don't spawn cockpit-bridge with the shell

### DIFF
--- a/src/ws/session-utils.c
+++ b/src/ws/session-utils.c
@@ -1001,3 +1001,18 @@ spawn_and_wait (const char **argv, const char **envp,
       return wstatus;
     }
 }
+
+bool
+user_has_valid_login_shell (const char **envp)
+{
+  /* <lis> >>> random.randint(0,127)
+   * <lis> 71
+   * <pitti> https://xkcd.com/221/
+   */
+  const char *argv[] = { pwd->pw_shell, "-c", "exit 71;", NULL };
+  const int remap_fds[] = { -1, 2, -1 }; /* send stdout to stderr */
+  int wstatus;
+
+  wstatus = spawn_and_wait (argv, envp, remap_fds, 3, pwd->pw_uid, pwd->pw_gid);
+  return WIFEXITED(wstatus) && WEXITSTATUS(wstatus) == 71;
+}

--- a/src/ws/session-utils.h
+++ b/src/ws/session-utils.h
@@ -100,3 +100,6 @@ spawn_and_wait (const char **argv,
                 int n_remap_fds,
                 uid_t uid,
                 gid_t gid);
+
+bool
+user_has_valid_login_shell (const char **envp);

--- a/src/ws/session-utils.h
+++ b/src/ws/session-utils.h
@@ -25,6 +25,7 @@
 #include <err.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdnoreturn.h>
 #include <string.h>
 #include <pwd.h>
 #include <grp.h>
@@ -88,9 +89,14 @@ GNUC_NORETURN void exit_init_problem (int result_code);
 #endif
 
 int open_session (pam_handle_t *pamh);
-int fork_session (char **env, int (*session)(char**));
 
 FILE *open_memfd (const char *name);
 int seal_memfd (FILE **memfd);
 
-void fd_remap (const int *remap_fds, int n_remap_fds);
+int
+spawn_and_wait (const char **argv,
+                const char **envp,
+                const int *remap_fds,
+                int n_remap_fds,
+                uid_t uid,
+                gid_t gid);

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -145,6 +145,13 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.open("/system")
             b.wait_not_visible("#option-group")
 
+            # test login with tcsh
+            if not m.image.startswith("rhel") and not m.image.startswith("centos"):  # no tcsh in RHEL
+                m.execute("sed -r -i.bak '/^admin:/ s_:[^:]+$_:/bin/tcsh_' /etc/passwd")
+                b.login_and_go()
+                b.logout()
+                m.execute("mv /etc/passwd.bak /etc/passwd")
+
             # login with user shell that prints some stdout/err noise
             # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
             m.execute("set -e; cd ~admin; cp -a .bashrc .bashrc.bak; [ ! -e .profile ] || cp -a .profile .profile.bak; "


### PR DESCRIPTION
Spawning cockpit-bridge under the shell has caused quite a lot of
annoying problems over time, mostly to do with file descriptors:

 - the user's shell rc scripts can write messages to stdout, which would
   be interpreted as cockpit frames

 - some shells (csh) don't support the redirection syntax we've been
   trying to use to solve the above problem

 - some shells (tcsh) seem to close all fds >= 3

 - some shells (tlog-rec-session) open a new pseudoterminal, running the
   session command with stdin/out/err attached to it, and writing the
   results to stdout, regardless of which fds they were written on

The above problems make it pretty difficult to come up with a mechanism
to get a clean fd through to cockpit-bridge which we can reliably speak
cockpit protocol on.  Let's give up on trying.

Instead, we use our fancy new spawn helper to spawn the user's shell
with a simple command: 'exit 71'.  We use this randomly-chosen number to
check if the given shell is a valid login shell or not.  If the shell
exits with the expected status, we allow the login to continue, spawning
cockpit-bridge directly.  Otherwise, we give a permissions error.

 - [x] builds on top of #14372
 - [x] builds on top of #14374
