### PR TITLE
machines: Port storage pools and networks lists to ListingTable component

### DIFF
--- a/pkg/machines/components/networks/network.jsx
+++ b/pkg/machines/components/networks/network.jsx
@@ -17,10 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Button } from '@patternfly/react-core';
 
-import { ListingRow } from 'cockpit-components-listing.jsx';
+import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
 import {
     rephraseUI,
     networkId
@@ -37,70 +36,67 @@ import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-export class Network extends React.Component {
-    render() {
-        const { dispatch, network, resourceHasError, onAddErrorNotification } = this.props;
-        const idPrefix = `${networkId(network.name, network.connectionName)}`;
-        const name = (
-            <span id={`${idPrefix}-name`}>
-                { network.name }
-            </span>);
-        const device = (
-            <span id={`${idPrefix}-device`}>
-                { network.bridge && network.bridge.name }
-            </span>);
-        const forwarding = (
-            <span id={`${idPrefix}-forwarding`}>
-                { rephraseUI('networkForward', network.forward ? network.forward.mode : "none") }
-            </span>);
-        const state = (
-            <>
-                { resourceHasError[network.id] ? <span className='pficon-warning-triangle-o machines-status-alert' /> : null }
-                <span id={`${idPrefix}-state`}>
-                    { network.active ? _("active") : _("inactive") }
-                </span>
-            </>);
-        const cols = [
-            { name, header: true },
-            device,
-            rephraseUI('connections', network.connectionName),
-            forwarding,
-            state,
-        ];
+export const getNetworkRow = ({ dispatch, network, resourceHasError, onAddErrorNotification }) => {
+    const idPrefix = `${networkId(network.name, network.connectionName)}`;
+    const name = (
+        <span id={`${idPrefix}-name`}>
+            { network.name }
+        </span>);
+    const device = (
+        <span id={`${idPrefix}-device`}>
+            { network.bridge && network.bridge.name }
+        </span>);
+    const forwarding = (
+        <span id={`${idPrefix}-forwarding`}>
+            { rephraseUI('networkForward', network.forward ? network.forward.mode : "none") }
+        </span>);
+    const state = (
+        <>
+            { resourceHasError[network.id] ? <span className='pficon-warning-triangle-o machines-status-alert' /> : null }
+            <span id={`${idPrefix}-state`}>
+                { network.active ? _("active") : _("inactive") }
+            </span>
+        </>);
+    const cols = [
+        { title: name, header: true },
+        { title: device },
+        { title: rephraseUI('connections', network.connectionName) },
+        { title: forwarding },
+        { title: state },
+    ];
 
-        const overviewTabName = (
-            <div id={`${idPrefix}-overview`}>
-                {_("Overview")}
-            </div>
-        );
+    const overviewTabName = (
+        <div id={`${idPrefix}-overview`}>
+            {_("Overview")}
+        </div>
+    );
 
-        const tabRenderers = [
-            {
-                name: overviewTabName,
-                renderer: NetworkOverviewTab,
-                data: { network, dispatch, }
-            },
-        ];
-        const extraClasses = [];
+    const tabRenderers = [
+        {
+            name: overviewTabName,
+            renderer: NetworkOverviewTab,
+            data: { network, dispatch, }
+        },
+    ];
+    const extraClasses = [];
 
-        if (resourceHasError[network.id])
-            extraClasses.push('error');
+    if (resourceHasError[network.id])
+        extraClasses.push('error');
 
-        return (
-            <ListingRow rowId={idPrefix}
-                extraClasses={extraClasses}
-                columns={cols}
-                tabRenderers={tabRenderers}
-                listingActions={<NetworkActions onAddErrorNotification={onAddErrorNotification} network={network} />} />
-        );
-    }
-}
+    const expandedContent = (
+        <ListingPanel
+            columns={cols}
+            tabRenderers={tabRenderers}
+            listingActions={<NetworkActions onAddErrorNotification={onAddErrorNotification} network={network} />} />
+    );
 
-Network.propTypes = {
-    onAddErrorNotification: PropTypes.func.isRequired,
-    resourceHasError: PropTypes.object.isRequired,
-    dispatch: PropTypes.func.isRequired,
-    network: PropTypes.object.isRequired,
+    return {
+        extraClasses,
+        columns: cols,
+        rowId: idPrefix,
+        props: { key: idPrefix },
+        expandedContent: expandedContent,
+    };
 };
 
 class NetworkActions extends React.Component {

--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -21,9 +21,9 @@ import PropTypes from 'prop-types';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
-import { Listing } from 'cockpit-components-listing.jsx';
-import { Network } from './network.jsx';
-import { getNetworkDevices, networkId } from '../../helpers.js';
+import { ListingTable } from 'cockpit-components-table.jsx';
+import { getNetworkRow } from './network.jsx';
+import { getNetworkDevices } from '../../helpers.js';
 import { CreateNetworkAction } from './createNetworkDialog.jsx';
 
 const _ = cockpit.gettext;
@@ -51,22 +51,15 @@ export class NetworkList extends React.Component {
                     </BreadcrumbItem>
                 </Breadcrumb>
                 <div id='networks-listing' className='container-fluid'>
-                    <Listing title={_("Networks")}
-                        columnTitles={[_("Name"), _("Device"), _("Connection"), _("Forwarding mode"), _("State")]}
+                    <ListingTable title={_("Networks")}
+                        variant='compact'
+                        columns={[_("Name"), _("Device"), _("Connection"), _("Forwarding mode"), _("State")]}
                         emptyCaption={_("No network is defined on this host")}
-                        actions={actions}>
-                        {networks
+                        actions={actions}
+                        rows={networks
                                 .sort(sortFunction)
-                                .map(network => {
-                                    return (
-                                        <Network key={`${networkId(network.name, network.connectionName)}`}
-                                            dispatch={dispatch} network={network}
-                                            resourceHasError={resourceHasError}
-                                            onAddErrorNotification={onAddErrorNotification} />
-                                    );
-                                })
-                        }
-                    </Listing>
+                                .map(network => getNetworkRow({ dispatch, network, resourceHasError, onAddErrorNotification }))
+                        } />
                 </div>
             </>
         );

--- a/pkg/machines/components/storagePools/storagePoolList.jsx
+++ b/pkg/machines/components/storagePools/storagePoolList.jsx
@@ -21,9 +21,8 @@ import PropTypes from 'prop-types';
 import { Breadcrumb, BreadcrumbItem } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
-import { Listing } from 'cockpit-components-listing.jsx';
-import { StoragePool } from './storagePool.jsx';
-import { storagePoolId } from '../../helpers.js';
+import { ListingTable } from 'cockpit-components-table.jsx';
+import { getStoragePoolRow } from './storagePool.jsx';
 import { CreateStoragePoolAction } from './createStoragePoolDialog.jsx';
 
 const _ = cockpit.gettext;
@@ -50,25 +49,20 @@ export class StoragePoolList extends React.Component {
                     </BreadcrumbItem>
                 </Breadcrumb>
                 <div id='storage-pools-listing' className='container-fluid'>
-                    <Listing title={_("Storage Pools")}
-                        columnTitles={[_("Name"), _("Size"), _("Connection"), _("State")]}
+                    <ListingTable caption={_("Storage Pools")}
+                        variant='compact'
+                        columns={[_("Name"), _("Size"), _("Connection"), _("State")]}
                         emptyCaption={_("No storage pool is defined on this host")}
-                        actions={actions}>
-                        {storagePools
+                        actions={actions}
+                        rows={storagePools
                                 .sort(sortFunction)
                                 .map(storagePool => {
                                     const filterVmsByConnection = vms.filter(vm => vm.connectionName == storagePool.connectionName);
 
-                                    return (
-                                        <StoragePool key={`${storagePoolId(storagePool.id, storagePool.connectionName)}`}
-                                            storagePool={storagePool}
-                                            vms={filterVmsByConnection}
-                                            resourceHasError={resourceHasError}
-                                            onAddErrorNotification={onAddErrorNotification} />
-                                    );
+                                    return getStoragePoolRow({ storagePool, vms: filterVmsByConnection, resourceHasError, onAddErrorNotification });
                                 })
                         }
-                    </Listing>
+                    />
                 </div>
             </>
         );

--- a/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
@@ -48,7 +48,7 @@ export class StoragePoolVolumesTab extends React.Component {
 
     static getDerivedStateFromProps(props, current_state) {
         if ((props.storagePool.volumes || []).length !== current_state.rows.length) {
-            return { rows: props.storagePool.volumes };
+            return { rows: props.storagePool.volumes || [] };
         }
         return null;
     }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -116,11 +116,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b.wait_not_present(vm_row)
 
     def togglePoolRow(self, poolName, connectionName="system"):
-        self.browser.click("tbody tr[data-row-id=pool-{0}-system] th".format(poolName)) # click on the row header
+        self.browser.click("tbody tr[data-row-id=pool-{0}-{1}] .pf-c-table__toggle button".format(poolName, connectionName)) # click on the row header
 
     def waitPoolRow(self, poolName, connectionName="system", present="true"):
         b = self.browser
-        pool_row = "tbody tr[data-row-id=pool-{0}-{1}] th".format(poolName, connectionName)
+        pool_row = "tbody tr[data-row-id=pool-{0}-{1}] td".format(poolName, connectionName)
         if present:
             b.wait_present(pool_row)
         else:

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -127,11 +127,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b.wait_not_present(pool_row)
 
     def toggleNetworkRow(self, networkName, connectionName="system"):
-        self.browser.click("tbody tr[data-row-id=network-{0}-system] th".format(networkName)) # click on the row header
+        self.browser.click("tbody tr[data-row-id=network-{0}-{1}] .pf-c-table__toggle button".format(networkName, connectionName)) # click on the row header
 
     def waitNetworkRow(self, networkName, connectionName="system", present="true"):
         b = self.browser
-        network_row = "tbody tr[data-row-id=network-{0}-{1}] th".format(networkName, connectionName)
+        network_row = "tbody tr[data-row-id=network-{0}-{1}] td".format(networkName, connectionName)
         if present:
             b.wait_present(network_row)
         else:


### PR DESCRIPTION
The PF4 tables have some differences with our previous table implementation. Porting the rest of the tables in machines page to PF4 to achieve uniformity. 

(Review with --ignore-all-space to save you time, it's a lot of unavoidable whitespace changes)