### PR TITLE
containers/ws: Adjust install instructions for image download

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -24,12 +24,12 @@ Cockpit packages.
 
 4. Run the Cockpit web service with this privileged container (as root):
    ```
-   podman container runlabel --name cockpit-ws RUN cockpit/ws
+   podman container runlabel --name cockpit-ws RUN docker.io/cockpit/ws
    ```
 
 5. Make Cockpit start on boot:
    ```
-   podman container runlabel INSTALL cockpit/ws
+   podman container runlabel INSTALL docker.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 


### PR DESCRIPTION
Apparently podman on Fedora CoreOS has stopped looking into the
docker.io registry by default, so that a bare "cockpit/ws" would just
check registry.fedoraproject.org.

See https://github.com/cockpit-project/cockpit-container/issues/20

-----

This can be tested on e. g. our fedora-coreos image, after `podman rmi --all`. I can reproduce the original reporter's problem and validated that with the prefix it works well.