### PR TITLE
machines: Port remaining PF3 Tooltip

### DIFF
--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -19,10 +19,10 @@
 import cockpit from 'cockpit';
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Tooltip } from 'patternfly-react';
 import {
     Button,
     Dropdown, DropdownItem, DropdownSeparator, KebabToggle,
+    Tooltip,
 } from '@patternfly/react-core';
 
 import {
@@ -132,15 +132,14 @@ const VmActions = ({ vm, dispatch, storagePools, onStart, onInstall, onReboot, o
     if (state !== undefined && LibvirtDBus.canDelete && LibvirtDBus.canDelete(state, vm.id)) {
         if (!vm.persistent) {
             dropdownItems.push(
-                <DropdownItem key={`${id}-delete`}
-                              id={`${id}-delete`}
-                              className='pf-m-danger'
-                              tooltip={<Tooltip id={`${id}-delete-tooltip`}>
-                                  {_("This VM is transient. Shut it down if you wish to delete it.")}
-                              </Tooltip>}
-                              isDisabled>
-                    {_("Delete")}
-                </DropdownItem>
+                <Tooltip id={`${id}-delete-tooltip`} content={_("This VM is transient. Shut it down if you wish to delete it.")}>
+                    <DropdownItem key={`${id}-delete`}
+                                  id={`${id}-delete`}
+                                  className='pf-m-danger'
+                                  isDisabled>
+                        {_("Delete")}
+                    </DropdownItem>
+                </Tooltip>
             );
         } else {
             dropdownItems.push(


### PR DESCRIPTION
This was forgotten in PR #14195

Don't use  DropdownItem's `tooltip=` property as that does not work [1].
Wrap it in a Tooltip instead.

[1] https://github.com/patternfly/patternfly-react/issues/4581



 - [x] builds on top of #14358