### PR TITLE
lib: fix keyboard natigation in the NavItems of expandable table rows

### DIFF
--- a/pkg/lib/cockpit-components-listing-panel.jsx
+++ b/pkg/lib/cockpit-components-listing-panel.jsx
@@ -82,8 +82,8 @@ export class ListingPanel extends React.Component {
     render() {
         const links = this.props.tabRenderers.map((itm, idx) => {
             return (
-                <NavItem key={idx} id={itm.id} itemId={idx} isActive={idx === this.state.activeTab}>
-                    {itm.name}
+                <NavItem key={idx} itemId={idx} isActive={idx === this.state.activeTab}>
+                    <a id={itm.id} href="#">{itm.name}</a>
                 </NavItem>
             );
         });

--- a/pkg/machines/components/vm/vmExpandedContent.jsx
+++ b/pkg/machines/components/vm/vmExpandedContent.jsx
@@ -37,23 +37,17 @@ export const VmExpandedContent = ({
     vm, vms, config, libvirtVersion, hostDevices, storagePools,
     onUsageStartPolling, onUsageStopPolling, dispatch, networks, interfaces, nodeDevices, resourceHasError, onAddErrorNotification
 }) => {
-    const overviewTabName = (<a href="#" id={`${vmId(vm.name)}-overview`}>{_("Overview")}</a>);
-    const usageTabName = (<a href="#" id={`${vmId(vm.name)}-usage`}>{_("Usage")}</a>);
-    const disksTabName = (<a href="#" id={`${vmId(vm.name)}-disks`}>{_("Disks")}</a>);
-    const networkTabName = (<a href="#" id={`${vmId(vm.name)}-networks`}>{_("Network Interfaces")}</a>);
-    const consolesTabName = (<a href="#" id={`${vmId(vm.name)}-consoles`}>{_("Consoles")}</a>);
-
     const tabRenderers = [
-        { name: overviewTabName, id: cockpit.format("$0-overview", vmId(vm.name)), renderer: VmOverviewTab, data: { vm, config, dispatch, nodeDevices, libvirtVersion } },
-        { name: usageTabName, id: cockpit.format("$0-usage", vmId(vm.name)), renderer: VmUsageTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive' },
-        { name: disksTabName, id: cockpit.format("$0-disks", vmId(vm.name)), renderer: VmDisksTab, data: { vm, vms, config, storagePools, onUsageStartPolling, onUsageStopPolling, dispatch, onAddErrorNotification }, presence: 'onlyActive' },
-        { name: networkTabName, id: cockpit.format("$0-networks", vmId(vm.name)), renderer: VmNetworkTab, presence: 'onlyActive', data: { vm, dispatch, config, hostDevices, interfaces, networks, nodeDevices, onAddErrorNotification } },
-        { name: consolesTabName, id: cockpit.format("$0-consoles", vmId(vm.name)), renderer: Consoles, data: { vm, config, dispatch, onAddErrorNotification } },
+        { name: _("Overview"), id: cockpit.format("$0-overview", vmId(vm.name)), renderer: VmOverviewTab, data: { vm, config, dispatch, nodeDevices, libvirtVersion } },
+        { name: _("Usage"), id: cockpit.format("$0-usage", vmId(vm.name)), renderer: VmUsageTab, data: { vm, onUsageStartPolling, onUsageStopPolling }, presence: 'onlyActive' },
+        { name: _("Disks"), id: cockpit.format("$0-disks", vmId(vm.name)), renderer: VmDisksTab, data: { vm, vms, config, storagePools, onUsageStartPolling, onUsageStopPolling, dispatch, onAddErrorNotification }, presence: 'onlyActive' },
+        { name: _("Network Interfaces"), id: cockpit.format("$0-networks", vmId(vm.name)), renderer: VmNetworkTab, presence: 'onlyActive', data: { vm, dispatch, config, hostDevices, interfaces, networks, nodeDevices, onAddErrorNotification } },
+        { name: _("Consoles"), id: cockpit.format("$0-consoles", vmId(vm.name)), renderer: Consoles, data: { vm, config, dispatch, onAddErrorNotification } },
     ];
 
     let initiallyActiveTab = null;
     if (vm.ui && vm.ui.initiallyOpenedConsoleTab) {
-        initiallyActiveTab = tabRenderers.map((o) => o.name).indexOf(consolesTabName);
+        initiallyActiveTab = tabRenderers.map((o) => o.name).indexOf(_("Consoles"));
     }
 
     return (<ListingPanel

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -90,7 +90,7 @@ function create_tabs(client, target, is_partition) {
         if (associated_warnings)
             tab_warnings = warnings.filter(w => associated_warnings.indexOf(w.warning) >= 0);
         if (tab_warnings.length > 0)
-            name = <a><span className="pficon pficon-warning-triangle-o" /> {name}</a>;
+            name = <><span className="pficon pficon-warning-triangle-o" /> {name}</>;
         tabs.push(
             {
                 name: name,


### PR DESCRIPTION
The <a> element had missing href.

!Note:
This affected Storage Page and VMs page.
The file needs to be synced with cockpit-podman since there exists the same problem.