### PR TITLE
nav: Underline hostname on hover

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -611,6 +611,10 @@ $desktop: $phone + 1px;
         text-decoration: none;
         // approximate --pf-global--BackgroundColor--dark-400, but with opacity
         background: rgba(249, 252, 255, 0.32);
+
+        .hostname {
+            text-decoration: underline;
+        }
     }
 
     &:focus {


### PR DESCRIPTION
Simple adjustment to fix #14304.

This makes the host switcher have an underline when hovered, like all the rest of the items in the top bar. I'm not sure if it'll fix the issue 100%, but this should help a lot.