### PR TITLE
all: remove "outfd" workaround

### DIFF
--- a/src/common/cockpithacks-glib.h
+++ b/src/common/cockpithacks-glib.h
@@ -29,3 +29,27 @@
 
 #include "cockpithacks.h"
 #include <glib.h>
+
+/* g_debug() defaults to writing its output to stdout, which doesn't
+ * really work for us.  GLib 2.67.0 introduced an API to change this
+ * behaviour, and we want to use this API if it's available.
+ *
+ * Otherwise, we know that earlier versions of GLib use the `stdout`
+ * `FILE *` to do its write, while we write directly to fd 1, so we can
+ * replace the value of `stdout` to cause GLib to write elsewhere.  This
+ * is specifically not allowed by POSIX, but works on Linux.
+ */
+#include <stdio.h>
+
+static void
+cockpit_hacks_redirect_gdebug_to_stderr (void)
+{
+#if GLIB_CHECK_VERSION(2,67,0)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  g_log_writer_default_set_use_stderr (TRUE);
+#pragma GCC diagnostic pop
+#else
+  stdout = stderr;
+#endif
+}

--- a/src/ssh/cockpitsshrelay.h
+++ b/src/ssh/cockpitsshrelay.h
@@ -39,8 +39,7 @@ typedef struct _CockpitSshRelay                  CockpitSshRelayClass;
 
 GType                   cockpit_ssh_relay_get_type     (void) G_GNUC_CONST;
 
-CockpitSshRelay *       cockpit_ssh_relay_new          (const gchar *connection_string,
-                                                        gint out_fd);
+CockpitSshRelay *       cockpit_ssh_relay_new          (const gchar *connection_string);
 
 gint                    cockpit_ssh_relay_result       (CockpitSshRelay* self);
 

--- a/src/ssh/ssh.c
+++ b/src/ssh/ssh.c
@@ -21,6 +21,7 @@
 
 #include <gio/gio.h>
 
+#include "common/cockpithacks-glib.h"
 #include "common/cockpittest.h"
 
 #include "cockpitsshrelay.h"
@@ -31,25 +32,12 @@ main (int argc,
       char *argv[])
 {
   gint ret = 1;
-  gint outfd;
   CockpitSshRelay *relay;
   GOptionContext *context;
   GError *error = NULL;
   GMainLoop *loop = NULL;
 
-  /*
-   * This process talks on stdin/stdout. However lots of stuff wants to write
-   * to stdout, such as g_debug, and uses fd 1 to do that. Reroute fd 1 so that
-   * it goes to stderr, and use another fd for stdout.
-   */
-  outfd = dup (1);
-  if (outfd < 0 || dup2 (2, 1) < 1)
-    {
-      g_printerr ("cockpit-ssh: bridge couldn't redirect stdout to stderr");
-      if (outfd > -1)
-        close (outfd);
-      outfd = 1;
-    }
+  cockpit_hacks_redirect_gdebug_to_stderr ();
 
   signal (SIGALRM, SIG_DFL);
   signal (SIGQUIT, SIG_DFL);
@@ -84,7 +72,7 @@ main (int argc,
 
   loop = g_main_loop_new (NULL, FALSE);
 
-  relay = cockpit_ssh_relay_new (argv[1], outfd);
+  relay = cockpit_ssh_relay_new (argv[1]);
   g_signal_connect_swapped (relay, "disconnect", G_CALLBACK (g_main_loop_quit), loop);
 
   g_main_loop_run (loop);


### PR DESCRIPTION
~~Add a new log writer function (this is post-2.50 GLib language for a log
handler) which ensures that g_debug() lands on stderr instead of stdout.~~

~~This will allow us to drop our stdout→stderr redirections everywhere.~~

~~This is really really preliminary.  I have no idea if it will work.~~

~~It's also built on top of #14390 because there would be minor rebase issues otherwise, and I'm in a hurry :)~~

~~See https://gitlab.gnome.org/GNOME/glib/-/issues/2087 for an upstream discussion about this issue.~~

GLib 2.68 is gaining g_log_writer_default_set_use_stderr() to allow us to direct all logging output toward stderr.  Use that when it's available.

Because it's not widely available yet, move our dup2()-based "outfd" workarounds to a much simpler approach: assign the value of the stderr FILE* to stdout as well.  This is evil, but it will cause all logging to go to stderr, and is vastly simpler than what we have now.
    

 - [x] land #14390 and rebase this
 - [x] consider new API from https://gitlab.gnome.org/GNOME/glib/-/issues/2087
 - [x] consider `stdout = stderr` trickery
 - [x] test against GLib 2.67