### PR TITLE
tools: Ignore node_modules when watching.

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -52,7 +52,7 @@ if (ops.watch) {
         const time = new Date().toTimeString().split(' ')[0];
         process.stdout.write(`${ time  } Build started\n`);
     });
-    compiler.watch({}, process_result);
+    compiler.watch(config.watchOptions, process_result);
 } else {
     compiler.run(process_result);
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -401,6 +401,10 @@ module.exports = {
         maxEntrypointSize: 20000000,
     },
 
+    watchOptions: {
+        ignored: /node_modules/
+    },
+
     module: {
         rules: [
             {


### PR DESCRIPTION
Something has changed and now node_modules seems to be too large to watch.