### PR TITLE
machines: Robustify VM delete operation in case it was performed during installation

### DIFF
--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -391,7 +391,7 @@ const LIBVIRT_DBUS_PROVIDER = {
         }
 
         if (options.destroy) {
-            return destroy().then(undefine());
+            return undefine().then(destroy());
         } else {
             return undefine()
                     .catch(ex => {


### PR DESCRIPTION
Before this commit, when a user clicked 'Delete' for a VM while it was
being created, the following racy scenario happened:

1: Delete operation first calls 'Destroy' API for the domain (See DELETE_VM function)

2: virt-install script would exit but the VM would still exist (not
   `Undefine` call processed yet, and
   pkg/machines/scripts/create_machines.sh continue by trying to
   redefine the VM in order to inject the metadata.
3: The `Delete` operation in not yet done, it will also try to call 'Undefine'
   API for the domain

The Undefine/Define API calls (steps 2,3) sometimes did not run in the expected order
resulting in the domain to not get removed in the end.

So by swapping the order of destroy/undefine in the 'Delete' operation
we make sure that when virt-install script exits (that happens when the domain get's destroyed)
the domain is not defined any more and the script won't try then to
redefine it either.

Also de-flakes TestMachines.testCreateFileSource.

Related logs for the previous failure:
 https://logs.cockpit-project.org/logs/pull-14372-20200720-182117-87f7a11c-debian-testing/log.html#87-2