### PR TITLE
test: Make sure that default libvirt network is defined in Machines tests

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -107,6 +107,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             m.execute("until test -e /run/libvirt/libvirt-sock; do sleep 1; done")
             m.execute("chmod o+rwx /run/libvirt/libvirt-sock")
 
+        m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml")
+
     def toggleVmRow(self, vmName, connectionName='system'):
         self.browser.click("tbody tr[data-row-id=vm-{0}-{1}] .pf-c-table__toggle button".format(vmName, connectionName)) # click on the row header
 


### PR DESCRIPTION
Solves tests failures like https://logs.cockpit-project.org/logs/pull-14365-20200717-113454-6764db97-debian-testing/log.html#91-2

I was not able to find in the libvirt documentation what is exactly that defines the default network.
In any case, re-definining it won't hurt, and it will prevent some tests failures.