### PR TITLE
machines: Fix TypeError for OSRow in VM creation dialog

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -353,7 +353,7 @@ class OSRow extends React.Component {
             return ({
                 toString: function() { return this.displayName },
                 compareTo: function(value) {
-                    return value.os.shortId.toLowerCase().includes(this.os.shortId) || value.displayName.toLowerCase().includes(this.displayName);
+                    return value.shortId.toLowerCase().includes(this.shortId) || value.displayName.toLowerCase().includes(this.displayName);
                 },
                 ...os,
                 displayName: getOSStringRepresentation(os),


### PR DESCRIPTION
When user selects an OS in VM creation dialog and then selects another
OS, they are greeted by TypeError "value.os is undefined".

Fixes #14394