### PR TITLE
tools: Add make build dependency for RPM

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -91,6 +91,7 @@ BuildRequires: pkgconfig(polkit-agent-1) >= 0.105
 BuildRequires: pam-devel
 
 BuildRequires: autoconf automake
+BuildRequires: make
 BuildRequires: /usr/bin/python3
 BuildRequires: gettext >= 0.19.7
 %if %{defined build_dashboard}


### PR DESCRIPTION
Recent Fedora does not pull it in automatically any more.

No need to do that for Debian, as there make is build-essential.

Part of issue #14409