### PR TITLE
tests: fix testCreateFileSource flake

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2328,6 +2328,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             vm_delete_button = "#vm-{0}-delete".format(dialog.name)
 
             b.click("#vm-{0}-action-kebab button".format(dialog.name))
+            b.wait_present(vm_delete_button + " a[aria-disabled=false]")
             b.click(vm_delete_button)
             b.wait_present("#vm-{0}-delete-modal-dialog".format(dialog.name))
             b.click("#vm-{0}-delete-modal-dialog button:contains(Delete)".format(dialog.name))


### PR DESCRIPTION
This test was often failing to delete the VMs because it was clicking on
practically disabled selectors without event listeners for click.
Normally 'click' function from testlib, checks for the 'disabled'
attribute on the selector before clicking it, but in this case the
selector won't have a 'disabled' attribute, rather it's child (the 'a' element)
will have an 'aria-disabled' attribute.

Related failure: https://logs.cockpit-project.org/logs/pull-14373-20200724-054736-89df2b19-centos-8-stream/log.html