### PR TITLE
tests: Robustify TestMachines.testCreateThenInstall

### DIFF
--- a/pkg/machines/scripts/install_machine.sh
+++ b/pkg/machines/scripts/install_machine.sh
@@ -128,6 +128,7 @@ virsh -c "$CONNECTION_URI"  -q dumpxml --inactive "$VM_NAME" > "$DOMAIN_FILE"
 METADATA_LINE=`grep -n '</metadata>' "$DOMAIN_FILE" | sed 's/[^0-9]//g'`
 METADATA='    <cockpit_machines:data xmlns:cockpit_machines="https://github.com/cockpit-project/cockpit/tree/master/pkg/machines"> \
   <cockpit_machines:has_install_phase>false</cockpit_machines:has_install_phase> \
+  <cockpit_machines:install_source_type>'"$SOURCE_TYPE"'</cockpit_machines:install_source_type> \
   <cockpit_machines:install_source>'"$SOURCE"'</cockpit_machines:install_source> \
   <cockpit_machines:os_variant>'"$OS"'</cockpit_machines:os_variant> \
 </cockpit_machines:data>'

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2315,6 +2315,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             self._assertCorrectConfiguration(dialog)
 
+            # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
+            wait(lambda: dialog.name in self.machine.execute("virsh list --persistent"), delay=3)
+
             # unfinished install script runs indefinitelly, so we need to force it off
             b.click("#vm-{0}-action-kebab button".format(name))
             b.click("#vm-{0}-forceOff".format(name))
@@ -2401,13 +2404,13 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def _assertDomainDefined(self, name, connection):
             listCmd = ""
             if connection == "session":
-                listCmd = "runuser -l admin -c 'virsh -c qemu:///session list --persistent --all'"
+                listCmd = "runuser -l admin -c 'virsh -c qemu:///session dumpxml --inactive {0} | grep cockpit_machines | wc -l'".format(name)
             else:
                 # When creating VMs from the UI default connection is the system
                 # In this case don't use runuser -l admin because we get errors 'authentication unavailable'
-                listCmd = "virsh -c qemu:///system list --persistent --all"
+                listCmd = "virsh -c qemu:///system dumpxml --inactive {0} | grep cockpit_machines | wc -l".format(name)
 
-            wait(lambda: name in self.machine.execute(listCmd))
+            wait(lambda: "6" in self.machine.execute(listCmd))
 
             return self
 


### PR DESCRIPTION
This test suffers from the following race condition:

* A VM installation is running
  (virt-install is running through pkg/machines/scripts/install_machine.sh script)
* The test clicks 'Force Off' button from the UI which makes virt-install
  command exit and install_machines.sh script should continue to try to
  re-define the domain in order to inject the metadata.
* Then the test tries to delete the VM and expects to see an empty list after
  the delete operation

-- Race condition --
Sometimes the deletion was processed before the install_machine.sh
script redefined the domain, resulting in non empty list after the
delete operation.

There is nothing really to be fixed in the source code, this test just
asks for problems.
Robustify it by waiting for the metadata of the VM to get set, which
ensures that install_machines.sh script has finished.


### note

Fixes the test failure as seen here: https://logs.cockpit-project.org/logs/pull-13100-20200722-134409-36534d27-centos-8-stream/log.html#281

This could all be avoided if we did not try to redefine the VM in the install_machine.sh script, in order to inject custom metadsta.
I am considering to stop doing so, but let's just robustify the test first without source code changes.