### PR TITLE
ws: Clean up unsupported krb5 enctypes from mock KDC

### DIFF
--- a/src/ws/mock-kdc.conf.in
+++ b/src/ws/mock-kdc.conf.in
@@ -13,6 +13,6 @@
   key_stash_file = @dir@/key_stash
   acl_file = @dir@/kadm5.acl
   admin_keytab = @dir@/kadm5.keytab
-  supported_enctypes = aes256-cts:normal aes128-cts:normal arcfour-hmac:normal camellia256-cts:normal camellia128-cts:normal des-cbc-md5:normal des-cbc-crc:normal
+  supported_enctypes = DEFAULT
   database_name = @dir@/database
  }


### PR DESCRIPTION
Recently krb5 started to be stricter about unrecognized enctypes [1],
and that commit is now in Fedora Rawhide. This broke test-kerberos with

    cockpit-ws:ERROR:src/ws/test-kerberos.c:301:test_authenticate:
    assertion failed (GSS_S_CONTINUE_NEEDED == status): (1 == 851968): Unspecified GSS failure.
    Minor code may provide more information (Decrypt integrity check failed)

Between Fedora 33 and CentOS 8 there is no set of encryption types that
is supported everywhere; also, we don't particularly care about the 
encryption type for this unit test, so just use whatever kerberos
considers a good default [2].

[1] https://github.com/krb5/krb5/commit/be5396ada0e8dab
[2] https://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/kdc_conf.html#encryption-types
