### PR TITLE
Fix weight values for Redhat fonts

### DIFF
--- a/src/base1/_fonts.scss
+++ b/src/base1/_fonts.scss
@@ -17,16 +17,16 @@ $relative: true
 
 @include printRedHatFont(700, "Bold", $familyName: "RedHatDisplay");
 @include printRedHatFont(700, "BoldItalic", $style: "italic", $familyName: "RedHatDisplay");
-@include printRedHatFont(300, "Black", $familyName: "RedHatDisplay");
-@include printRedHatFont(300, "BlackItalic", $style: "italic", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "Black", $familyName: "RedHatDisplay");
+@include printRedHatFont(900, "BlackItalic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(300, "Italic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(400, "Medium", $familyName: "RedHatDisplay");
 @include printRedHatFont(400, "MediumItalic", $style: "italic", $familyName: "RedHatDisplay");
 @include printRedHatFont(300, "Regular", $familyName: "RedHatDisplay");
 
-@include printRedHatFont(300, "Bold");
-@include printRedHatFont(300, "BoldItalic", $style: "italic");
-@include printRedHatFont(300, "Italic");
+@include printRedHatFont(700, "Bold");
+@include printRedHatFont(700, "BoldItalic", $style: "italic");
+@include printRedHatFont(400, "Italic");
 @include printRedHatFont(700, "Medium");
 @include printRedHatFont(700, "MediumItalic", $style: "italic");
 @include printRedHatFont(400, "Regular");


### PR DESCRIPTION
Value are fetched from https://github.com/RedHatOfficial/RedHatFont/blob/master/webfonts/red-hat-font.css

There has been some confusion with fonts weights because from other
sources like https://fonts.google.com/specimen/Red+Hat+Text#standard-styles
the RedHat fonts appear to use different font wrights.
Let's just trust the official RedHat repository for this.