### PR TITLE
test: Adjust expected systemd message for scheduled reboot

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1106,7 +1106,8 @@ class TestAutoUpdates(NoSubManCase):
         out = m.execute(
             "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
         self.assertIn("vanilla", out)
-        self.assertIn("Shutdown scheduled", out)
+        # systemd 245.7 correctly says "reboot", older version say "shutdown"
+        self.assertRegex(out, "(Shutdown|Reboot) scheduled")
 
         # run it again, now there are no available updates → no reboot
         m.execute("systemctl start dnf-automatic-install.service")

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -192,7 +192,7 @@ rm -rf ~/rpmbuild
         if install:
             cmd += "rpm -i {0}/{1}-{2}-{3}.*.rpm"
         self.machine.execute(cmd.format(self.repo_dir, name, version, release, arch))
-        self.addCleanup(self.machine.execute, "rpm -e %s 2>/dev/null || true" % name)
+        self.addCleanup(self.machine.execute, "rpm -e --nodeps %s 2>/dev/null || true" % name)
 
     def createAptChangelogs(self):
         # apt metadata has no formal field for bugs/CVEs, they are parsed from the changelog


### PR DESCRIPTION
Latest systemd fixes the message for a scheduled reboot to actually say
"Reboot" instead of "Shutdown". Accept either.