### PR TITLE
ws: Add key usage and constraints to self-signed server certificate

### DIFF
--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -149,7 +149,10 @@ openssl_make_dummy_cert (const gchar *key_file,
               "distinguished_name = req_distinguished_name\n"
               "[ req_distinguished_name ]\n"
               "[ v3_req ]\n"
-              "subjectAltName=IP:127.0.0.1,DNS:localhost\n",
+              "subjectAltName=IP:127.0.0.1,DNS:localhost\n"
+              "basicConstraints = critical, CA:TRUE\n"
+              "keyUsage = critical, digitalSignature,cRLSign,keyCertSign,keyEncipherment,keyAgreement\n"
+              "extendedKeyUsage = serverAuth\n",
               -1, error))
       goto out;
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -341,6 +341,18 @@ class TestConnection(MachineCase):
         m.message(output)
         self.assertIn("DONE", output)
 
+        # has proper keyUsage and SAN (both with sscg and with self-signed)
+        output = m.execute("openssl s_client -showcerts -connect 172.27.0.15:9090 |"
+                           "openssl x509 -in - -noout -ext keyUsage,extendedKeyUsage,subjectAltName")
+        # keyUsage
+        self.assertIn("Digital Signature", output)
+        self.assertIn("Key Encipherment", output)
+        # extendedKeyUsage
+        self.assertIn("TLS Web Server Authentication", output)
+        # SAN
+        self.assertIn("IP Address:127.0.0.1", output)
+        self.assertIn("DNS:localhost", output)
+
         # SSLv3 should not work
         output = m.execute('openssl s_client -connect 172.27.0.15:9090 -ssl3 2>&1 || true')
         self.assertNotIn("DONE", output)


### PR DESCRIPTION
According to Common Criteria:

  Server certificates presented for TLS shall have the Server Authentication
  purpose (id-kp 1 with OID 1.3.6.1.5.5.7.3.1) in the extendedKeyUsage field.

Add a `keyUsage` and `extendedKeyUsage` field, and also mark that it's a
CA as it is a self-signed certificate.

https://bugzilla.redhat.com/show_bug.cgi?id=1859812