### PR TITLE
shell: Only show superuser indicator when a machine is connected

### DIFF
--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -416,10 +416,15 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function update_superuser(machine, state, compiled) {
-        ReactDOM.render(React.createElement(SuperuserIndicator, { host: machine.connection_string }),
-                        document.getElementById('super-user-indicator'));
-        ReactDOM.render(React.createElement(SuperuserIndicator, { host: machine.connection_string }),
-                        document.getElementById('super-user-indicator-mobile'));
+        if (machine.state == "connected") {
+            ReactDOM.render(React.createElement(SuperuserIndicator, { host: machine.connection_string }),
+                            document.getElementById('super-user-indicator'));
+            ReactDOM.render(React.createElement(SuperuserIndicator, { host: machine.connection_string }),
+                            document.getElementById('super-user-indicator-mobile'));
+        } else {
+            ReactDOM.unmountComponentAtNode(document.getElementById('super-user-indicator'));
+            ReactDOM.unmountComponentAtNode(document.getElementById('super-user-indicator-mobile'));
+        }
     }
 
     function update_title(label, machine) {


### PR DESCRIPTION
Showing it for a disconnected machine does 'work' in the sense that
the SuperuserIndicator stays invisible, but it wouldn't try to
reconnect once the machine changes its state from "failed" to
"connected".

By only rendering the SuperuserIndicator for connected machines, we
make sure that the indicator correctly follows the connectedness state
of the machine.