### PR TITLE
machines: Fix mobile layout for VMs by moving the actions

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -93,6 +93,11 @@
         // As the width is smaller than the contents, and this is a table,
         // the cell will stay at the correct width.
         width: 1px;
+
+        @media screen and (max-width: $pf-global--breakpoint--md) {
+            grid-column: 1 / -1;
+            align-self: center;
+        }
     }
 
     .pf-c-button.pf-m-expanded .pf-c-table__toggle-icon {

--- a/pkg/machines/hostvmslist.scss
+++ b/pkg/machines/hostvmslist.scss
@@ -16,7 +16,7 @@
 
     vertical-align: middle;
 
-    @media screen and (max-width: 428px) {
+    @media screen and (max-width: $pf-global--breakpoint--md) {
         margin-top: var(--pf-c-table--m-compact__action--responsive--MarginTop);
         margin-bottom: var(--pf-c-table--m-compact__action--responsive--MarginTop);
 

--- a/pkg/machines/hostvmslist.scss
+++ b/pkg/machines/hostvmslist.scss
@@ -20,10 +20,12 @@
         margin-top: var(--pf-c-table--m-compact__action--responsive--MarginTop);
         margin-bottom: var(--pf-c-table--m-compact__action--responsive--MarginTop);
 
-        grid-row-start: 1;
-        grid-column-start: 2;
-        text-align: right;
+        // Colum 20 is the same as the expander in PF4's breakpoint
+        grid-area: 20 / 1;
+        justify-self: start;
+        margin: var(--pf-global--spacer--xs) 0;
     }
+}
 
 // Hide the CSS generated content for the tab row's data-label
 #virtual-machines-listing .pf-c-table__expandable-row > .pf-m-no-padding[data-label]::before {

--- a/pkg/machines/hostvmslist.scss
+++ b/pkg/machines/hostvmslist.scss
@@ -24,4 +24,8 @@
         grid-column-start: 2;
         text-align: right;
     }
+
+// Hide the CSS generated content for the tab row's data-label
+#virtual-machines-listing .pf-c-table__expandable-row > .pf-m-no-padding[data-label]::before {
+    content: none;
 }


### PR DESCRIPTION
Building on top of #14434, I've fixed https://github.com/cockpit-project/cockpit/pull/14434#issuecomment-669054859 by moving the action button from the top-right to the bottom-left for mobile mode, to make sure everything has enough space.