### PR TITLE
base1: fix style for Red Hat italic font

### DIFF
--- a/src/base1/_fonts.scss
+++ b/src/base1/_fonts.scss
@@ -26,7 +26,7 @@ $relative: true
 
 @include printRedHatFont(700, "Bold");
 @include printRedHatFont(700, "BoldItalic", $style: "italic");
-@include printRedHatFont(400, "Italic");
+@include printRedHatFont(400, "Italic", $style: "italic");
 @include printRedHatFont(700, "Medium");
 @include printRedHatFont(700, "MediumItalic", $style: "italic");
 @include printRedHatFont(400, "Regular");


### PR DESCRIPTION
The RedHatText Italic font family now has a font-style of italic. This follows the style used for the other italic red hat fonts.