### PR TITLE
test: Allow more sudo related messages in testSELinuxRestrictedUser

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -450,14 +450,13 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.logout()
         self.allow_authorize_journal_messages()
         # not allowed to restricted users
-        self.allow_journal_messages("sudo: setrlimit.*: Operation not permitted")
-        self.allow_journal_messages("sudo: unable to open /var/db/sudo: Permission denied")
+        self.allow_journal_messages("sudo:.* Operation not permitted")
+        self.allow_journal_messages("sudo:.* Permission denied")
         self.allow_journal_messages(".*/var/lib/cockpit/machines.json.*Permission denied")
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
         if m.image in ["centos-8-stream"]:
             # older releases have more noise
-            self.allow_journal_messages("sudo: .*setresuid.*: Operation not permitted")
             self.allow_journal_messages("sudo: no valid sudoers.*")
             self.allow_journal_messages("sudo: unable to initialize policy plugin")
             self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="pkexec".* scontext=user_u.*')


### PR DESCRIPTION
In current rawhide, there is now a message

    sudo: unable to open /sudo/ts/unpriv: Permission denied

Just allow any kind of permission message for sudo in that test, it's
not useful to pin them down so carefully.