### PR TITLE
hwinfo: Fix parsing of bios_date

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -108,7 +108,8 @@ function parseDMIFields(text) {
         const sep = line.indexOf(':');
         if (sep <= 0)
             return;
-        const key = line.slice(0, sep).slice(line.lastIndexOf('/') + 1);
+        const file = line.slice(0, sep);
+        const key = file.slice(file.lastIndexOf('/') + 1);
         const value = line.slice(sep + 1);
         info[key] = value;
 

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -91,7 +91,7 @@ class SystemInfo extends React.Component {
                         </tr>
                         <tr>
                             <th>{ _("BIOS date") }</th>
-                            <td>{ moment(info.bios_date).isValid() ? moment(info.bios_date).format('L') : info.bios_date }</td>
+                            <td>{ moment(info.bios_date, "MM/DD/YYYY").isValid() ? moment(info.bios_date, "MM/DD/YYYY").format('L') : info.bios_date }</td>
                         </tr>
                     </>
                     }

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -378,8 +378,9 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(1) tr:nth-of-type(2) td', "Standard PC")
         # BIOS
         b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(1) td', "SeaBIOS")
-        # BIOS date; just ensure it's from this century
-        b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', "/20")
+        # BIOS date
+        if m.image != "rhel-8-3-distropkg": # Fixed in #14465
+            b.wait_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', m.execute("cat /sys/class/dmi/id/bios_date").strip())
 
         pci_selector = '#hwinfo #pci-listing'
         heading_selector = ' .ct-table-heading'


### PR DESCRIPTION
We parse lines in form `/sys/class/dmi/id/key:value`, but if value
contains `/`, the parsing got all wrong. It was mainly issue with
`bios_date`, as it is in form `MM/DD/YYYY`.

Also specify exact expected format in moment, so when we fail to parse
this value, we don't show current date (since `moment(undefined)` shows
current time).

Fixes #14461