### PR TITLE
ssh: fix printing of non-nul-terminated stderr

### DIFF
--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -1738,7 +1738,7 @@ on_channel_data (ssh_session session,
 
   if (is_stderr || self->exit_code == NO_COCKPIT)
     {
-      g_printerr ("%s", bdata);
+      g_printerr ("%.*s", (int) len, bdata);
       ret = len;
     }
   else if (self->received_frame)


### PR DESCRIPTION
`bdata` here is passed in to our callback with a `len` parameter.
Respect it.

This prevents an obscure error where we can end up printing some extra
junk that was laying around in memory, at the end of the output.  In
particular, we were seeing a stray 'sh %s' showing up from (apparently)
nowhere in some of our tests.  The actual origin of that was the
"LESSOPEN=||/usr/bin/lesspipe.sh %s" environment variable.

This 'sh %s' (which had no trailing newline) was causing later stderr
output which should be ignored (in particular, warnings about missing
locales) to fail to match the filter for those messages.

For what it's worth, this issue probably stopped actually appearing some
time ago due to unrelated changes in cockpit-ssh.  We see the issue now
in our integration tests only as a result of installing the distro
package of cockpit from centos-7.