### PR TITLE
storage: Support "noauto" crypto backing devices better

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -377,5 +377,59 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(1, 1, "Encrypted data")
         self.content_row_wait_in_col(2, 1, "Unrecognized Data")
 
+    def testNoauto(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk and format it with luks and a filesystem, but without "Unlock at boot"
+
+        m.add_disk("50M", serial="MYDISK")
+        b.wait_in_text("#drives", "MYDISK")
+        b.click('tr:contains("MYDISK")')
+        b.wait_visible("#storage-detail")
+
+        self.content_head_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "crypto.on": True,
+                     "crypto_options.auto": False,
+                     "passphrase": "vainu-reku-toma-rolle-kaja",
+                     "passphrase2": "vainu-reku-toma-rolle-kaja",
+                     "mount_options.auto": True,
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 1, "Encrypted data")
+        self.content_tab_wait_in_info(1, 1, "Options", "noauto")
+        self.content_row_wait_in_col(2, 1, "ext4 File System")
+
+        # The filesystem should be mounted but have the "noauto" option
+        self.wait_mounted(2,1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+
+        # Unmounting should keep the noauto option, as always
+        self.content_dropdown_action(2, "Unmount")
+        self.content_tab_wait_in_info(2, 1, "Mount Point", "The filesystem is not mounted")
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+
+        # Mounting should also keep the "noauto", but it should not show up in the extra options
+        self.content_head_action(2, "Mount")
+        self.dialog_check({ "mount_options.extra": False })
+        self.dialog_apply()
+        self.wait_mounted(2,1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+
+        # As should updating the mount information
+        self.content_tab_info_action(2, 1, "Mount Point", wrapped=True)
+        self.dialog_check({ "mount_options.extra": False })
+        self.dialog_apply()
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+
+        # Removing "noauto" externally should show a warning
+        m.execute("sed -i -e 's/noauto//' /etc/fstab")
+        fsys_tab = self.content_tab_expand(2, 1)
+        b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
+        b.click(fsys_tab + " button:contains(Do not mount automatically)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -145,17 +145,9 @@ class TestStorageMounting(StorageCase):
         wait_not_checked("crypto_options.ro")
         wait_not_checked("mount_options.ro")
 
-        # Uncheck crypto auto.  This gets propagated to mount auto.
-        self.dialog_set_val("crypto_options.auto", False)
-        wait_not_checked("mount_options.auto")
-
         # Check crypto ro.  This gets propagated to mount ro.
         self.dialog_set_val("crypto_options.ro", True)
         wait_checked("mount_options.ro")
-
-        # Check mount auto.  This gets propagated to crypto auto.
-        self.dialog_set_val("mount_options.auto", True)
-        wait_checked("crypto_options.auto")
 
         # Uncheck mount ro.  This gets propagated to crypto ro.
         self.dialog_set_val("mount_options.ro", False)
@@ -167,8 +159,8 @@ class TestStorageMounting(StorageCase):
         self.dialog_set_val("crypto_options.ro", True)
 
         # Set extra options.
-        self.dialog_set_val("crypto_options.extra", "foo")
-        self.dialog_set_val("mount_options.extra", "foo")
+        self.dialog_set_val("crypto_options.extra", "x-foo")
+        self.dialog_set_val("mount_options.extra", "x-foo")
 
         # Fill in the erst and do the format
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
@@ -180,8 +172,10 @@ class TestStorageMounting(StorageCase):
         self.content_row_wait_in_col(1, 1, "Encrypted data")
         self.content_row_wait_in_col(2, 1, "ext4 File System")
         self.wait_in_storaged_configuration("/data")
-        m.execute("grep 'noauto,readonly,foo' /etc/crypttab")
-        m.execute("grep 'noauto,ro,foo' /etc/fstab")
+        self.wait_mounted(2, 1)
+
+        m.execute("grep 'noauto,readonly,x-foo' /etc/crypttab")
+        m.execute("grep 'noauto,ro,x-foo' /etc/fstab")
 
 
     def testMountingHelp(self):
@@ -292,6 +286,26 @@ class TestStorageMounting(StorageCase):
                      "mount_point": "/run/data"})
         self.content_row_wait_in_col(1, 1, "ext4 File System")
         self.content_tab_wait_in_info(1, 2, "Mount Point", "/run/data")
+
+    def testFirstMount(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        m.add_disk("50M", serial="MYDISK")
+        b.click("#drives tr:contains(MYDISK)")
+        b.wait_visible("#storage-detail")
+
+        m.execute("mkfs.ext4 /dev/sda")
+        self.content_row_wait_in_col(1, 1, "ext4 File System")
+
+        m.execute("! grep /run/data /etc/fstab")
+        self.content_head_action(1, "Mount")
+        self.dialog({ "mount_point": "/run/data",
+                      "mount_options.extra": "x-foo" })
+        m.execute("grep /run/data /etc/fstab")
+        m.execute("grep 'x-foo' /etc/fstab")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
 A filesystem that has a crypto backing device with the "noauto" option
will now always have the "noauto" mount option, even when mounted.
    
If such a filesystem doesn't have the "noauto" option, Cockpit will
warn about it and offer to add it.

Fixes #14467

### Release notes

#### Storage: Better support for "noauto" LUKS devices

Cockpit now behaves more sensible with encrypted filesystems that have "noauto" in their LUKS options. Such a filesystem will now also always have "noauto" in their mounting options even when mounted.