### PR TITLE
testlib: don't remove /var/lib/systemd/coredump

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -885,7 +885,7 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(m.execute, "logger -p user.info 'COCKPITTEST: end %s'" % name)
 
         # core dumps get copied per-test, don't clobber subsequent tests with them
-        self.addCleanup(m.execute, "rm -rf /var/lib/systemd/coredump")
+        self.addCleanup(m.execute, "find /var/lib/systemd/coredump -type f -delete")
 
         # temporary directory in the VM
         self.addCleanup(m.execute, "if [ -d {0} ]; then findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount && rm -r {0}; fi".format(self.vm_tmpdir))


### PR DESCRIPTION
We see a lot of messages like:

  Failed to create temporary file for coredump /var/lib/systemd/coredump/core.libvirtd.1001.746601e77b394c91b233abce203cf0ca.18835.1597175105000000.lz4: No such file or directory

while running machines tests.  This is caused by the fact that we blow
away the /var/lib/systemd/coredump directory between testcases.
Instead, let's delete the contents of the directory, but leave the
directory itself in place.