### PR TITLE
machines: Fix memory race condition in testConfigureBeforeInstall

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2736,6 +2736,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.click("#vm-VmNotInstalled-action-kebab button")
         b.click("#vm-VmNotInstalled-forceOff")
         b.wait_in_text("#vm-VmNotInstalled-state", "shut off")
+        wait(lambda: "307200" in m.execute("virsh dominfo VmNotInstalled | grep 'Used memory'"), delay=1) # Wait until memory parameters get adjusted after shutting the VM
 
         # Check configuration changes survived installation
         b.click("#vm-VmNotInstalled-overview")


### PR DESCRIPTION
The "used memory" parameter differs between running and shut off VM. In
this test, a dialog with memory parameters would be opened immediately
after shutting off a VM, which would lead to a race condition where an
the old value would be rendered because there was not enough time to update
a VM config.

Fix this by waiting until the memory parameters of VM are updated.

This race condition was causing a failure: https://logs.cockpit-project.org/logs/pull-14471-20200812-073912-3ad9266e-rhel-8-3/log.html#97-2