### PR TITLE
lib: Include current directory in FileAutoComplete option listing

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -106,6 +106,14 @@ export class FileAutoComplete extends React.Component {
             path: (this.state.directory == '' ? '/' : this.state.directory) + file.path
         }));
 
+        const currentDir = this.state.value && this.state.directory === this.state.value.path;
+        if (this.state.directory && !error && !currentDir) {
+            listItems.unshift({
+                type: "directory",
+                path: this.state.directory
+            });
+        }
+
         this.setState({
             displayFiles: listItems,
             error: error,

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -555,9 +555,10 @@ OnCalendar=daily
         b.focus("#demo-file-ac input[type=text]")
         b.key_press(stuff + "/")
         # need to wait for the widget's "fast typing" inhibition delay to trigger the completion popup
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", "dir1/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "file1.txt")
-        b.key_press(["\r"])
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", stuff + "/")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "dir1/")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
+        b.click("#file-autocomplete-widget li:nth-of-type(2) button")
         b.wait_not_present("#file-autocomplete-widget li")
 
         # now update file1, check robustness with dynamic events
@@ -566,7 +567,7 @@ OnCalendar=daily
         time.sleep(1)
         b.key_press(["\b"]*5)
         # this should still be unique
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "file1.txt")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
 
         # add new file
         m.execute("touch %s/other" % stuff)
@@ -575,7 +576,7 @@ OnCalendar=daily
         b.key_press(["\b"])
         time.sleep(1)
         b.key_press("/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "other")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "other")
 
     @skipImage("No PCP available", "fedora-coreos")
     def testPlots(self):


### PR DESCRIPTION
When a directory path is specified, a listing of options wouldn't contain a
current directory, only its children. This would lead to bugs where:
1. The user could not change a path to the parent directory of the previously
   specified directory
2. The user could not just type a full path to some directory and then press
   Enter. They would have to use autocomplete shortcut or choose from a
   list of options offered in a dropdown.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1866995

### Before:
![Screenshot from 2020-08-13 14-28-49](https://user-images.githubusercontent.com/42733240/90134353-54aeb480-dd71-11ea-9635-9d5c504fa1b0.png)

### After
![Screenshot from 2020-08-13 14-25-14](https://user-images.githubusercontent.com/42733240/90134156-05688400-dd71-11ea-8744-374797bc4977.png)