### PR TITLE
test: Define 'default' network before trying to start it

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -98,8 +98,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Ignoring just to unbreak tests for now
         self.allow_journal_messages("Failed to get COMM: No such process")
 
-        m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml")
-
     def toggleVmRow(self, vmName, connectionName='system'):
         self.browser.click("tbody tr[data-row-id=vm-{0}-{1}] .pf-c-table__toggle button".format(vmName, connectionName)) # click on the row header
 
@@ -141,7 +139,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # Wait until we can get a list of domains
         m.execute("until virsh list; do sleep 1; done")
+
         # Wait for the network 'default' to become active
+        m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml")
         m.execute("virsh net-start default || true")
         m.execute("until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
 


### PR DESCRIPTION
`startLibvirt()` tries to start the `default` network, but if it was
removed by some previous test it fails. The line I moved was introduced
in #14404 with exactly this same intention, but it needs to happen
sooner.

Hopefully fixes https://src.fedoraproject.org/rpms/cockpit/pull-request/29