### PR TITLE
cockpituous: Release to Fedora 33

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -26,6 +26,7 @@ job release-srpm
 job release-koji -k master
 job release-koji f31
 job release-koji f32
+job release-koji f33
 
 # Upload release to github, using tarball
 job release-github
@@ -39,6 +40,7 @@ job release-dockerhub cockpit-project/cockpit-container
 # Push out a Bodhi update
 job release-bodhi F31
 job release-bodhi F32
+job release-bodhi F33
 
 # Upload documentation
 job tools/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Bodhi activation point is the [next Tuesday](https://fedorapeople.org/groups/schedule/f-33/f-33-key-tasks.html). We won't have another release in the meantime so lets not forget about it. I'll start preparing F33 image now so we can also test it.