### PR TITLE
machines: Fix Desktop Viewer Console tab CSS issues

### DIFF
--- a/pkg/machines/components/desktopConsole.jsx
+++ b/pkg/machines/components/desktopConsole.jsx
@@ -20,6 +20,8 @@ import React from "react";
 import cockpit from 'cockpit';
 import { vmId } from '../helpers.js';
 
+import { Button } from '@patternfly/react-core';
+
 import './consoles.css';
 
 const _ = cockpit.gettext;
@@ -122,16 +124,14 @@ const ConnectWithRemoteViewer = ({ vm, config, onDesktopConsole }) => {
     const onLaunch = () => onDesktopConsole(display);
 
     return (
-        <td className='machines-desktop-main-col'>
-            <p className='machines-desktop-viewer-block'>
-                <button onClick={onLaunch} id={`${vmId(vm.name)}-consoles-launch`}>
-                    {_("Launch Remote Viewer")}
-                </button>
-            </p>
+        <div className='machines-desktop-main-col'>
+            <Button variant="secondary" onClick={onLaunch} id={`${vmId(vm.name)}-consoles-launch`}>
+                {_("Launch Remote Viewer")}
+            </Button>
             <div className='machines-desktop-viewer-block'>
                 <MoreInformation vm={vm} config={config} />
             </div>
-        </td>
+        </div>
     );
 };
 
@@ -189,13 +189,13 @@ const ManualConnection = ({ displays, idPrefix }) => {
     }
 
     return (
-        <td className='machines-desktop-main-col'>
+        <div className='machines-desktop-main-col'>
             <h2>{_("Manual Connection")}</h2>
             <div className='machines-desktop-manual-block'>{msg}</div>
             <div className='machines-desktop-manual-block'>
                 <ManualConnectionDetails displays={displays} idPrefix={idPrefix} />
             </div>
-        </td>
+        </div>
     );
 };
 
@@ -203,14 +203,10 @@ const DesktopConsoleDownload = ({ children, vm, onDesktopConsole, config }) => {
     return (
         <div className="manual-connection">
             {children}
-            <table className='machines-desktop-main'>
-                <tbody>
-                    <tr>
-                        <ConnectWithRemoteViewer config={config} vm={vm} onDesktopConsole={onDesktopConsole} />
-                        <ManualConnection displays={vm.displays} idPrefix={`${vmId(vm.name)}-consoles-manual`} />
-                    </tr>
-                </tbody>
-            </table>
+            <div className='machines-desktop-main'>
+                <ConnectWithRemoteViewer config={config} vm={vm} onDesktopConsole={onDesktopConsole} />
+                <ManualConnection displays={vm.displays} idPrefix={`${vmId(vm.name)}-consoles-manual`} />
+            </div>
         </div>
     );
 };

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -70,29 +70,19 @@
     color: var(--color-link);
 }
 
-.machines-desktop {
-    display: flex;
-    flex-wrap: wrap;
-}
-
 .machines-desktop-main {
-    width: 100%;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+    margin-top: var(--pf-global--spacer--md);
 }
 
 .machines-desktop-main-col {
-    width: 50%;
     text-align: center;
     vertical-align: top;
-}
 
-.machines-desktop-manual-block {
-    margin-top: 1.5em;
-    margin-bottom: 1.5em;
-}
-
-.machines-desktop-viewer-block {
-    margin-top: 3em;
-    margin-bottom: 2.5em;
+    > button.pf-m-secondary {
+        margin-bottom: var(--pf-global--spacer--sm);
+    }
 }
 
 .machines-desktop-manual-con-details {


### PR DESCRIPTION
This table incorrectly inherited CSS from PF4 tables, because it's
nested in the PF4 table, and some rules from the imported PF4 were
applied.
Let's make this a simple grid and avoid using nested tables.

In addition the 'Launch Remote Viewer' button was ported to PF4 Button.

Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1868584