### PR TITLE
tests: Intruduce hack for libvirt-dbus on system connection on ubuntu

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -68,6 +68,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         self.restore_dir("/var/lib/libvirt")
         self.restore_dir("/etc/libvirt")
 
+        if m.image in ["ubuntu-2004", "ubuntu-stable"]:
+            # https://bugs.launchpad.net/ubuntu/+source/libvirt-dbus/+bug/1892757
+            m.execute("usermod -a -G libvirt libvirtdbus")
+
         # Cleanup pools
         self.addCleanup(m.execute, "rm -rf /run/libvirt/storage/*")
 


### PR DESCRIPTION
Recently a security issue was fixed by setting libvirt's socket
permissions to 0660 from 0666.
See https://people.canonical.com/~ubuntu-security/cve/2020/CVE-2020-15708.html

This completely breaks libvirt-dbus system connection.

root@ubuntu:~# gdbus call --system --dest org.libvirt --object-path /org/libvirt/QEMU --method org.libvirt.Connect.ListDomains 0
Error: GDBus.Error:org.libvirt.Error: Failed to connect socket to '/var/run/libvirt/libvirt-sock': Permission denied

That is because libvirt-sock by default allows rw access to users that are in the libvirt group.

root@ubuntu:~# ls -la /var/run/libvirt/libvirt-sock
srw-rw---- 1 root libvirt 0 Aug 24 15:33 /var/run/libvirt/libvirt-sock

However libvirt-dbus system process is running as libvirtdbus/libvirtdbus user/group.

root@ubuntu:~# ps aux | grep libvirt-dbus
\libvirt+ 6813 0.0 1.6 363436 18892 ? Sl 15:33 0:00 /usr/sbin/libvirt-dbus --system
root 7207 0.0 0.0 8164 672 pts/0 S+ 15:35 0:00 grep --color=auto libvirt-dbus

root@ubuntu:~# cat /proc/6813/status | grep Uid
Uid: 996 996 996 996

root@ubuntu:~# cat /proc/6813/status | grep Gid
Gid: 996 996 996 996

root@ubuntu:~# cat /etc/group | grep 996
libvirtdbus:x:996:

root@ubuntu:~# id libvirtdbus
uid=996(libvirtdbus) gid=996(libvirtdbus) groups=996(libvirtdbus)

Add a HACK for allowing tests to run while waiting for the official
resolution.
Upstream bug https://bugs.launchpad.net/ubuntu/+source/libvirt-dbus/+bug/1892757