### PR TITLE
machines: fix disabled OS input in case OS autodetection returned empty dict

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -623,18 +623,13 @@ class CreateVmModal extends React.Component {
                                 const osEntry = this.props.osInfoList.filter(osEntry => osEntry.id == res.os);
 
                                 if (osEntry && osEntry[0]) {
-                                    this.setState({
-                                        autodetectOSInProgress: false,
-                                    });
                                     this.onValueChanged('os', osEntry[0]);
                                     this.onValueChanged('sourceMediaID', res.media);
                                 }
                             }, ex => {
                                 console.log("osinfo-detect command failed: ", ex.message);
-                                this.setState({
-                                    autodetectOSInProgress: false,
-                                });
-                            });
+                            })
+                            .always(() => this.setState({ autodetectOSInProgress: false }));
                 };
                 this.typingTimeout = setTimeout(() => onOsAutodetect(value), 250);
             }


### PR DESCRIPTION
There are cases where the OS autodetection script returns successfully,
but the result in an empty dict.
Always re-enable the OS input after the script returned.

Fixes #14501