### PR TITLE
bridge: Add internal metric to get the current load

### DIFF
--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -22,6 +22,8 @@ libcockpit_bridge_METRICS = \
 	src/bridge/cockpitmountsamples.h \
 	src/bridge/cockpitnetworksamples.c \
 	src/bridge/cockpitnetworksamples.h \
+	src/bridge/cockpitschedsamples.c \
+	src/bridge/cockpitschedsamples.h \
 	src/bridge/cockpitsamples.c \
 	src/bridge/cockpitsamples.h \
 	$(NULL)

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -32,6 +32,7 @@
 #include "cockpitmountsamples.h"
 #include "cockpitcgroupsamples.h"
 #include "cockpitdisksamples.h"
+#include "cockpitschedsamples.h"
 
 #include "common/cockpitjson.h"
 
@@ -53,7 +54,8 @@ typedef enum {
   NETWORK_SAMPLER = 1 << 3,
   MOUNT_SAMPLER = 1 << 4,
   CGROUP_SAMPLER = 1 << 5,
-  DISK_SAMPLER = 1 << 6
+  DISK_SAMPLER = 1 << 6,
+  SCHED_SAMPLER = 1 << 7,
 } SamplerSet;
 
 typedef struct {
@@ -95,6 +97,8 @@ static MetricDescription metric_descriptions[] = {
   { "cgroup.memory.sw-limit", "bytes",    "instant", TRUE, CGROUP_SAMPLER },
   { "cgroup.cpu.usage",       "millisec", "counter", TRUE, CGROUP_SAMPLER },
   { "cgroup.cpu.shares",      "count",    "instant", TRUE, CGROUP_SAMPLER },
+
+  { "sched.loadavg",             "count",    "instant", TRUE, SCHED_SAMPLER },
 
   { NULL }
 };
@@ -331,6 +335,8 @@ cockpit_internal_metrics_tick (CockpitMetrics *metrics,
     cockpit_cgroup_samples (COCKPIT_SAMPLES (self));
   if (self->samplers & DISK_SAMPLER)
     cockpit_disk_samples (COCKPIT_SAMPLES (self));
+  if (self->samplers & SCHED_SAMPLER)
+    cockpit_sched_samples (COCKPIT_SAMPLES (self));
 
   /* Check for disappeared instances
    */

--- a/src/bridge/cockpitschedsamples.c
+++ b/src/bridge/cockpitschedsamples.c
@@ -1,0 +1,49 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "cockpitschedsamples.h"
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+void
+cockpit_sched_samples (CockpitSamples *samples)
+{
+  /* exactly like pcp's kernel.load.all metric */
+  const char * const instances[] = { "1min", "5min", "15min" };
+  double loadavg[3];
+  int count;
+  static bool logged_failure = false;
+
+  count = getloadavg(loadavg, 3);
+  if (count < 0) {
+      /* only log this once, chance is that it fails every time */
+      if (!logged_failure)
+        {
+          g_message ("getloadavg() failed: %m");
+          logged_failure = true;
+        }
+      return;
+    }
+
+  /* samples are guint64, so multiply by 100 to get two fractional digits */
+  for (int i = 0; i < count; ++i)
+    cockpit_samples_sample (samples, "sched.loadavg", instances[i], (gint64) (loadavg[i] * 100 + 0.5));
+}

--- a/src/bridge/cockpitschedsamples.h
+++ b/src/bridge/cockpitschedsamples.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "cockpitsamples.h"
+
+G_BEGIN_DECLS
+
+void            cockpit_sched_samples         (CockpitSamples *samples);
+
+
+G_END_DECLS


### PR DESCRIPTION
Add a new `sched.loadavg` metric with three instances "1min", "5min", and
"15min", similar to PCP's `kernel.all.load`. This is more efficient than
polling /proc/loadavg and integrates better with the whole metrics
channel flow.

----

This will be used in  https://github.com/martinpitt/performance-graphs/tree/current-metrics
