### PR TITLE
Modernize storage page - stop using bootstrap classes and use PF4 components instead

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -20,6 +20,8 @@
 import cockpit from "cockpit";
 import React from "react";
 
+import { Card, CardHeader, CardActions, CardTitle, CardBody } from '@patternfly/react-core';
+
 import { journal } from "journal";
 import "journal.css";
 import "cockpit-components-logs-panel.scss";
@@ -144,15 +146,15 @@ export class LogsPanel extends React.Component {
 
     render() {
         return (
-            <div className="panel panel-default cockpit-log-panel" role="table">
-                <div className="panel-heading">
-                    <h2 className="panel-title">{this.props.title}</h2>
-                    { this.props.goto_url && <button className="link-button" role="link" onClick={e => cockpit.jump(this.props.goto_url)}>{_("All logs")}</button> }
-                </div>
-                <div className={"panel-body " + ((!this.state.logs.length && this.props.emptyMessage.length) ? "empty-message" : "")} role="rowgroup">
+            <Card className="cockpit-log-panel">
+                <CardHeader>
+                    <CardTitle>{this.props.title}</CardTitle>
+                    { this.props.goto_url && <CardActions><button className="link-button" role="link" onClick={e => cockpit.jump(this.props.goto_url)}>{_("All logs")}</button></CardActions>}
+                </CardHeader>
+                <CardBody className={(!this.state.logs.length && this.props.emptyMessage.length) ? "empty-message" : "contains-list"}>
                     { this.state.logs.length ? this.state.logs : this.props.emptyMessage }
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
     }
 }

--- a/pkg/lib/cockpit-components-logs-panel.scss
+++ b/pkg/lib/cockpit-components-logs-panel.scss
@@ -2,3 +2,22 @@
     padding: 0.5rem 1rem;
     text-align: center;
 }
+
+.cockpit-log-panel .panel-body {
+    padding-left: 0;
+    padding-right: 0;
+}
+
+.cockpit-log-panel .pf-c-card__header,
+.cockpit-log-panel .pf-c-card__header .pf-c-card__actions {
+    flex-wrap: wrap;
+    button {
+        margin-bottom: 0.5rem;
+    }
+}
+
+.cockpit-log-panel .pf-c-card__header > .pf-c-card__title {
+  padding: 0;
+  font-weight: normal;
+  font-size: var(--pf-global--FontSize--2xl);
+}

--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -83,6 +83,11 @@
     border-top-width: 1px;
 }
 
+/* Don't show headers without content */
+.cockpit-log-panel .panel-heading:last-child {
+    display: none !important;
+}
+
 .cockpit-logmsg-reboot {
     font-style: italic;
 }

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -47,7 +47,7 @@
 .networking-page .pf-c-card__header > .pf-c-card__title {
   padding: 0;
   font-weight: normal;
-  font-size: var(--pf-global--FontSize--3xl);
+  font-size: var(--pf-global--FontSize--2xl);
 }
 
 .networking-page .cockpit-log-panel {

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -50,11 +50,6 @@
   font-size: var(--pf-global--FontSize--3xl);
 }
 
-.networking-page .pf-c-card__header > .pf-c-card__title {
-  padding: 0;
-  font-weight: normal;
-  font-size: var(--pf-global--FontSize--3xl);
-}
 .networking-page .cockpit-log-panel {
   max-width: 100vw;
 }

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -50,6 +50,11 @@
   font-size: var(--pf-global--FontSize--3xl);
 }
 
+.networking-page .pf-c-card__header > .pf-c-card__title {
+  padding: 0;
+  font-weight: normal;
+  font-size: var(--pf-global--FontSize--3xl);
+}
 .networking-page .cockpit-log-panel {
   max-width: 100vw;
 }

--- a/pkg/storaged/block-details.jsx
+++ b/pkg/storaged/block-details.jsx
@@ -19,6 +19,9 @@
 
 import cockpit from "cockpit";
 import React from "react";
+
+import { Card, CardBody, CardTitle, Text, TextVariants } from "@patternfly/react-core";
+
 import * as utils from "./utils.js";
 import { StdDetailsLayout } from "./details.jsx";
 import * as Content from "./content-views.jsx";
@@ -30,9 +33,9 @@ export class BlockDetails extends React.Component {
         var block = this.props.block;
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">{_("Block")}</div>
-                <div className="panel-body">
+            <Card>
+                <CardTitle><Text component={TextVariants.h2}>{_("Block")}</Text></CardTitle>
+                <CardBody>
                     <div className="ct-form">
                         <label className="control-label">{_("storage", "Capacity")}</label>
                         <div>{ utils.fmt_size_long(block.Size) }</div>
@@ -40,8 +43,8 @@ export class BlockDetails extends React.Component {
                         <label className="control-label">{_("storage", "Device File")}</label>
                         <div>{ utils.block_name(block) }</div>
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         var content = <Content.Block client={this.props.client} block={block} />;

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -25,6 +25,7 @@ import {
 import * as utils from "./utils.js";
 
 import React from "react";
+import { Card, CardHeader, CardTitle, CardBody, CardActions, Text, TextVariants } from "@patternfly/react-core";
 
 import { Listing, ListingRow } from "cockpit-components-listing.jsx";
 import { StorageButton, StorageLink, StorageBarMenu, StorageMenuItem } from "./storage-controls.jsx";
@@ -629,11 +630,17 @@ const BlockContent = ({ client, block, allow_partitions }) => {
             </div>);
 
     return (
-        <Listing title={_("Content")}
-                 actions={format_disk_btn}
-                 emptyCaption="">
-            { block_rows(client, block) }
-        </Listing>
+        <Card>
+            <CardHeader>
+                <CardTitle><Text component={TextVariants.h2}>{_("Content")}</Text></CardTitle>
+                <CardActions>{format_disk_btn}</CardActions>
+            </CardHeader>
+            <CardBody className="contains-list">
+                <Listing emptyCaption="">
+                    { block_rows(client, block) }
+                </Listing>
+            </CardBody>
+        </Card>
     );
 };
 
@@ -792,11 +799,17 @@ export class VGroup extends React.Component {
             </div>);
 
         return (
-            <Listing title="Logical Volumes"
-                     actions={new_volume_link}
-                     emptyCaption={_("No Logical Volumes")}>
-                { vgroup_rows(self.props.client, vgroup) }
-            </Listing>
+            <Card>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{_("Logical Volumes")}</Text></CardTitle>
+                    <CardActions>{new_volume_link}</CardActions>
+                </CardHeader>
+                <CardBody className="contains-list">
+                    <Listing emptyCaption={_("No Logical Volumes")}>
+                        { vgroup_rows(self.props.client, vgroup) }
+                    </Listing>
+                </CardBody>
+            </Card>
         );
     }
 }

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -19,6 +19,9 @@
 
 import cockpit from "cockpit";
 import React from "react";
+
+import { Card, CardBody, CardTitle, CardHeader, CardActions, Text, TextVariants } from "@patternfly/react-core";
+
 import sha1 from "js-sha1";
 import stable_stringify from "json-stable-stringify-without-jsonify";
 
@@ -582,26 +585,27 @@ export class CryptoKeyslots extends React.Component {
         const remaining = this.state.max_slots - keys.length;
 
         return (
-            <div className="panel panel-default key-slot-panel">
-                <div className="panel-heading">
-                    <div className="pull-right">
+            <Card className="key-slot-panel">
+                <CardHeader>
+                    <CardActions>
                         <span className="key-slot-panel-remaining">
                             { remaining < 6 ? (remaining ? cockpit.format(_("$0 slots remain"), remaining) : _("No available slots")) : null }
                         </span>
-                        { "\n" }
                         <StorageButton onClick={() => add_dialog(client, block)}
                                        excuse={(keys.length == this.state.max_slots)
                                            ? _("No free key slots")
                                            : null}>
                             <span className="fa fa-plus" />
                         </StorageButton>
-                    </div>
-                    {_("Keys")}
-                </div>
-                <table className="table">
-                    <tbody>{ rows }</tbody>
-                </table>
-            </div>
+                    </CardActions>
+                    <CardTitle><Text component={TextVariants.h2}>{_("Keys")}</Text></CardTitle>
+                </CardHeader>
+                <CardBody className="contains-list">
+                    <table className="table">
+                        <tbody>{ rows }</tbody>
+                    </table>
+                </CardBody>
+            </Card>
         );
     }
 }

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -20,6 +20,8 @@
 import cockpit from "cockpit";
 import React from "react";
 
+import { Page, PageSection, PageSectionVariants, Grid, GridItem, Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
+
 import * as utils from "./utils.js";
 import { BlockDetails } from "./block-details.jsx";
 import { DriveDetails } from "./drive-details.jsx";
@@ -35,36 +37,36 @@ export class StdDetailsLayout extends React.Component {
     render() {
         if (this.props.sidebar) {
             return (
-                <div>
-                    <div id="detail-header" className="col-md-12">
+                <>
+                    <GridItem id="detail-header" span={12}>
                         { this.props.alert }
                         { this.props.header }
-                    </div>
-                    <div id="detail-sidebar" className="col-md-4 col-lg-3 col-md-push-8 col-lg-push-9">
-                        { this.props.sidebar }
-                    </div>
-                    <div className="col-md-8 col-lg-9 col-md-pull-4 col-lg-pull-3">
+                    </GridItem>
+                    <GridItem md={8} lg={9}>
                         <div id="detail-content">
                             { this.props.content }
                         </div>
                         <JobsPanel client={this.props.client} />
-                    </div>
-                </div>
+                    </GridItem>
+                    <GridItem id="detail-sidebar" md={4} lg={3}>
+                        { this.props.sidebar }
+                    </GridItem>
+                </>
             );
         } else {
             return (
-                <div>
-                    <div id="detail-header" className="col-md-12">
+                <>
+                    <GridItem id="detail-header" md={12}>
                         { this.props.alert }
                         { this.props.header }
-                    </div>
-                    <div className="col-md-12">
-                        <div id="detail-content">
+                    </GridItem>
+                    <GridItem md={12}>
+                        <GridItem id="detail-content">
                             { this.props.content }
-                        </div>
+                        </GridItem>
                         <JobsPanel client={this.props.client} />
-                    </div>
-                </div>
+                    </GridItem>
+                </>
             );
         }
     }
@@ -118,18 +120,22 @@ export class Details extends React.Component {
         }
 
         if (!body)
-            body = <div className="col-md-12">{_("Not found")}</div>;
+            body = <GridItem span={12}>{_("Not found")}</GridItem>;
 
         return (
-            <div id="storage-detail">
-                <div className="col-md-12">
-                    <ol className="breadcrumb">
-                        <li><button role="link" className="link-button" onClick={go_up}>{_("Storage")}</button></li>
-                        <li className="active">{name}</li>
-                    </ol>
-                </div>
-                {body}
-            </div>
+            <Page id="storage-detail">
+                <PageSection variant={PageSectionVariants.light} type='nav'>
+                    <Breadcrumb>
+                        <BreadcrumbItem onClick={go_up} to="#">{_("Storage")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{name}</BreadcrumbItem>
+                    </Breadcrumb>
+                </PageSection>
+                <PageSection>
+                    <Grid hasGutter>
+                        {body}
+                    </Grid>
+                </PageSection>
+            </Page>
         );
     }
 }

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -88,7 +88,7 @@ class StoragePage extends React.Component {
             // we can throw this hack out.
             <>
                 <MultipathAlert client={client} />
-                <div hidden={!!detail}><Overview client={client} /></div>
+                {!detail && <Overview client={client} />}
                 {detail}
             </>
         );

--- a/pkg/storaged/drive-details.jsx
+++ b/pkg/storaged/drive-details.jsx
@@ -19,6 +19,9 @@
 
 import cockpit from "cockpit";
 import React from "react";
+
+import { Card, CardBody, CardTitle, Text, TextVariants } from "@patternfly/react-core";
+
 import * as utils from "./utils.js";
 import { StdDetailsLayout } from "./details.jsx";
 import { Block } from "./content-views.jsx";
@@ -64,9 +67,9 @@ export class DriveDetails extends React.Component {
         }
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">{_("Drive")}</div>
-                <div className="panel-body">
+            <Card>
+                <CardTitle><Text component={TextVariants.h2}>{_("Drive")}</Text></CardTitle>
+                <CardBody>
                     <div className="ct-form">
                         <DriveDetailsRow title={_("storage", "Model")} value={drive.Model} />
                         <DriveDetailsRow title={_("storage", "Firmware Version")} value={drive.Revision} />
@@ -79,8 +82,8 @@ export class DriveDetails extends React.Component {
                             <DriveDetailsRow title={_("storage", "Multipathed Devices")} value={multipath_blocks.map(utils.block_name).join(" ")} />
                         )}
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         var content = <Block client={this.props.client} block={drive_block} />;

--- a/pkg/storaged/drive-details.jsx
+++ b/pkg/storaged/drive-details.jsx
@@ -70,7 +70,7 @@ export class DriveDetails extends React.Component {
             <Card>
                 <CardTitle><Text component={TextVariants.h2}>{_("Drive")}</Text></CardTitle>
                 <CardBody>
-                    <div className="ct-form">
+                    <div className="ct-form ct-form-info">
                         <DriveDetailsRow title={_("storage", "Model")} value={drive.Model} />
                         <DriveDetailsRow title={_("storage", "Firmware Version")} value={drive.Revision} />
                         <DriveDetailsRow title={_("storage", "Serial Number")} value={drive.Serial} />

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -30,10 +30,5 @@
     <script src="../*/po.js"></script>
     <script src="storage.js"></script>
 </head>
-<body class="pf-m-redhat-font" hidden>
-
-  <div id="storage">
-  </div>
-
-</body>
+<body class="pf-m-redhat-font" id="storage" hidden></body>
 </html>

--- a/pkg/storaged/jobs-panel.jsx
+++ b/pkg/storaged/jobs-panel.jsx
@@ -19,6 +19,9 @@
 
 import cockpit from "cockpit";
 import React from "react";
+
+import { Card, CardBody, CardTitle, Text, TextVariants } from "@patternfly/react-core";
+
 import { StorageButton } from "./storage-controls.jsx";
 import { block_name, mdraid_name, lvol_name, format_delay } from "./utils.js";
 
@@ -182,14 +185,16 @@ export class JobsPanel extends React.Component {
         jobs = jobs.sort(cmp_job);
 
         return (
-            <div className="detail-jobs panel panel-default">
-                <div className="panel-heading">{_("Jobs")}</div>
-                <table className="table">
-                    <tbody>
-                        { jobs.map((p) => <JobRow key={p} client={client} job={client.jobs[p]} now={server_now} />) }
-                    </tbody>
-                </table>
-            </div>
+            <Card className="detail-jobs">
+                <CardTitle><Text component={TextVariants.h2}>{_("Jobs")}</Text></CardTitle>
+                <CardBody className="contains-list">
+                    <table className="table">
+                        <tbody>
+                            { jobs.map((p) => <JobRow key={p} client={client} job={client.jobs[p]} now={server_now} />) }
+                        </tbody>
+                    </table>
+                </CardBody>
+            </Card>
         );
     }
 }

--- a/pkg/storaged/logs-panel.jsx
+++ b/pkg/storaged/logs-panel.jsx
@@ -36,6 +36,6 @@ export class StorageLogsPanel extends React.Component {
 
         const search_options = { prio: "debug", _SYSTEMD_UNIT: "storaged.service,udisks2.service,dm-event.service,smartd.service,multipathd.service" };
         const url = "/system/logs/#/?prio=debug&_SYSTEMD_UNIT=storaged.service,udisks2.service,dm-event.service,smartd.service,multipathd.service";
-        return <LogsPanel title={_("Storage Logs")} match={match} max={10} search_options={search_options} goto_url={url} />;
+        return <LogsPanel title={_("Storage Logs")} match={match} max={10} search_options={search_options} goto_url={url} className="contains-list" />;
     }
 }

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { Alert } from "@patternfly/react-core";
+import { Alert, Card, CardTitle, CardHeader, CardActions, CardBody, Text, TextVariants } from "@patternfly/react-core";
 import * as utils from "./utils.js";
 import { StdDetailsLayout } from "./details.jsx";
 import { SidePanel, SidePanelBlockRow } from "./side-panel.jsx";
@@ -296,19 +296,19 @@ export class MDRaidDetails extends React.Component {
         }
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">
-                    { cockpit.format(_("RAID Device $0"), utils.mdraid_name(mdraid)) }
-                    <span className="pull-right">
+            <Card>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{ cockpit.format(_("RAID Device $0"), utils.mdraid_name(mdraid)) }</Text></CardTitle>
+                    <CardActions>
                         { running
                             ? <StorageButton onClick={stop}>{_("Stop")}</StorageButton>
                             : <StorageButton onClick={start}>{_("Start")}</StorageButton>
                         }
                         { "\n" }
                         <StorageButton kind="danger" onClick={delete_dialog}>{_("Delete")}</StorageButton>
-                    </span>
-                </div>
-                <div className="panel-body">
+                    </CardActions>
+                </CardHeader>
+                <CardBody>
                     <div className="ct-form">
                         <label className="control-label">{_("storage", "Device")}</label>
                         <div>{ block ? utils.decode_filename(block.PreferredDevice) : "-" }</div>
@@ -327,8 +327,8 @@ export class MDRaidDetails extends React.Component {
                         <label className="control-label">{_("storage", "State")}</label>
                         <div>{ running ? _("Running") : _("Not running") }</div>
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         var sidebar = <MDRaidSidebar client={this.props.client} mdraid={mdraid} />;

--- a/pkg/storaged/nfs-details.jsx
+++ b/pkg/storaged/nfs-details.jsx
@@ -20,7 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import moment from "moment";
-import { Alert } from "@patternfly/react-core";
+import { Alert, Card, CardTitle, CardBody, Text, TextVariants } from "@patternfly/react-core";
 
 import { dialog_open, TeardownMessage, TextInput, ComboBox, CheckBoxes } from "./dialog.jsx";
 import * as format from "./format-dialog.jsx";
@@ -291,9 +291,9 @@ export class NFSDetails extends React.Component {
         }
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">
-                    {entry.fields[0]}
+            <Card>
+                <CardTitle>
+                    <Text component={TextVariants.h2}>{entry.fields[0]}</Text>
                     <span className="pull-right">
                         { entry.mounted
                             ? <StorageButton onClick={unmount}>{_("Unmount")}</StorageButton>
@@ -308,8 +308,8 @@ export class NFSDetails extends React.Component {
                             ] : null
                         }
                     </span>
-                </div>
-                <div className="panel-body">
+                </CardTitle>
+                <CardBody>
                     <div className="ct-form">
                         <label className="control-label">{_("Server")}</label>
                         <div>{entry.fields[0]}</div>
@@ -323,8 +323,8 @@ export class NFSDetails extends React.Component {
                             : _("--")
                         }
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         return <StdDetailsLayout client={client} header={header} />;

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -113,7 +113,7 @@ export class OptionalPanel extends React.Component {
                         { heading_right }
                     </CardActions>
                 </CardHeader>
-                <CardBody>
+                <CardBody className="contains-list">
                     { feature_enabled
                         ? this.props.children
                         : <div className="empty-panel-text">{not_installed_text}</div>

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -20,6 +20,8 @@
 import cockpit from "cockpit";
 import React from "react";
 
+import { Card, CardHeader, CardTitle, CardActions, CardBody, Text, TextVariants } from "@patternfly/react-core";
+
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import { StorageButton } from "./storage-controls.jsx";
 
@@ -104,18 +106,20 @@ export class OptionalPanel extends React.Component {
         }
 
         return (
-            <div className={"panel panel-default " + className} id={id}>
-                <div className="panel-heading">
-                    <h2 className="panel-title">{title}</h2>
-                    <div className="panel-actions">
+            <Card className={className} id={id}>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{title}</Text></CardTitle>
+                    <CardActions>
                         { heading_right }
-                    </div>
-                </div>
-                { feature_enabled
-                    ? this.props.children
-                    : <div className="empty-panel-text">{not_installed_text}</div>
-                }
-            </div>
+                    </CardActions>
+                </CardHeader>
+                <CardBody>
+                    { feature_enabled
+                        ? this.props.children
+                        : <div className="empty-panel-text">{not_installed_text}</div>
+                    }
+                </CardBody>
+            </Card>
         );
     }
 }

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -43,7 +43,7 @@ export class Overview extends React.Component {
         var client = this.props.client;
 
         return (
-            <Page>
+            <Page id="main-storage">
                 <Grid hasGutter>
                     <GridItem md={8} lg={9}>
                         <Gallery hasGutter>

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -19,6 +19,8 @@
 
 import React from "react";
 
+import { Page, PageSection, Grid, GridItem } from "@patternfly/react-core";
+
 import { StoragePlots } from "./plot.jsx";
 
 import { FilesystemsPanel } from "./fsys-panel.jsx";
@@ -41,22 +43,29 @@ export class Overview extends React.Component {
         var client = this.props.client;
 
         return (
-            <div className="container-fluid">
-                <div className="col-md-8 col-lg-9">
-                    <StoragePlots client={client} onHover={(dev) => this.setState({ highlight: dev })} />
-                    <br />
-                    <FilesystemsPanel client={client} />
-                    <NFSPanel client={client} />
-                    <JobsPanel client={client} />
-                    <StorageLogsPanel />
-                </div>
-                <div className="col-md-4 col-lg-3 storage-sidebar">
-                    <ThingsPanel client={client} />
-                    <DrivesPanel client={client} highlight={this.state.highlight} />
-                    <IscsiPanel client={client} />
-                    <OthersPanel client={client} />
-                </div>
-            </div>
+            <Page>
+                <Grid>
+                    <GridItem md={8} lg={9}>
+                        <PageSection>
+                            <StoragePlots client={client} onHover={(dev) => this.setState({ highlight: dev })} />
+                        </PageSection>
+                        <PageSection>
+                            <FilesystemsPanel client={client} />
+                            <NFSPanel client={client} />
+                            <JobsPanel client={client} />
+                            <StorageLogsPanel />
+                        </PageSection>
+                    </GridItem>
+                    <GridItem md={4} lg={3} className="storage-sidebar">
+                        <PageSection>
+                            <ThingsPanel client={client} />
+                            <DrivesPanel client={client} highlight={this.state.highlight} />
+                            <IscsiPanel client={client} />
+                            <OthersPanel client={client} />
+                        </PageSection>
+                    </GridItem>
+                </Grid>
+            </Page>
         );
     }
 }

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -19,7 +19,7 @@
 
 import React from "react";
 
-import { Page, PageSection, Grid, GridItem } from "@patternfly/react-core";
+import { Page, Grid, GridItem, Card, CardBody, Gallery } from "@patternfly/react-core";
 
 import { StoragePlots } from "./plot.jsx";
 
@@ -44,25 +44,27 @@ export class Overview extends React.Component {
 
         return (
             <Page>
-                <Grid>
+                <Grid hasGutter>
                     <GridItem md={8} lg={9}>
-                        <PageSection>
-                            <StoragePlots client={client} onHover={(dev) => this.setState({ highlight: dev })} />
-                        </PageSection>
-                        <PageSection>
+                        <Gallery hasGutter>
+                            <Card>
+                                <CardBody>
+                                    <StoragePlots client={client} onHover={(dev) => this.setState({ highlight: dev })} />
+                                </CardBody>
+                            </Card>
                             <FilesystemsPanel client={client} />
                             <NFSPanel client={client} />
                             <JobsPanel client={client} />
                             <StorageLogsPanel />
-                        </PageSection>
+                        </Gallery>
                     </GridItem>
                     <GridItem md={4} lg={3} className="storage-sidebar">
-                        <PageSection>
+                        <Gallery hasGutter>
                             <ThingsPanel client={client} />
                             <DrivesPanel client={client} highlight={this.state.highlight} />
                             <IscsiPanel client={client} />
                             <OthersPanel client={client} />
-                        </PageSection>
+                        </Gallery>
                     </GridItem>
                 </Grid>
             </Page>

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -16,6 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
+@import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 
 #storage {
     padding-left: 5px;

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -19,25 +19,62 @@
 @import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 @import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 
-/* Reply on the margin from the Card for spacing */
-#storage .pf-c-card .table {
-    margin-bottom: 0;
+#storage {
+    overflow: auto;
 }
 
-#storage .pf-c-page {
-    padding: var(--pf-global--gutter);
+.pf-c-page__main {
+    overflow: visible;
+}
+
+/* Rely on the margin from the Card for spacing */
+#storage .pf-c-card .table {
+    margin-bottom: 0;
 }
 
 #storage .pf-l-gallery {
     --pf-l-gallery--GridTemplateColumns: 1fr;
 }
 
+#storage .pf-c-card__body.contains-list {
+    padding-left: 0;
+    padding-right: 0;
+    padding-bottom: var(--pf-global--spacer--xs);
+}
+
+#storage .pf-c-card__body.contains-list > .pf-c-table > :last-child > tr:last-child {
+    border-bottom: none;
+}
+
+#main-storage.pf-c-page,
+#storage-detail .pf-c-page__main-section,
+#storage-detail .pf-c-page__main-nav {
+    padding: var(--pf-global--gutter);
+    overflow: auto;
+}
+
+#main-storage > .pf-c-page__main {
+    padding-bottom: var(--pf-global--spacer--md);
+}
+
+#detail-content, #detail-content .pf-c-card {
+    height: 100%;
+}
+
 #storage .pf-c-card__header > .pf-c-card__title {
   padding: 0;
+}
+
+#storage .pf-c-card__title {
   font-weight: normal;
 }
 
-#storage .empty-panel-text {
+#storage .pf-c-card__header {
+  padding: var(--pf-global--spacer--md) var(--pf-global--spacer--md) var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
+}
+
+#storage .empty-panel-text,
+#storage .ct-table-empty td {
     text-align: center;
     margin: 5px;
     color: var(--color-gray-9);

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -17,10 +17,24 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 @import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
+@import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 
-#storage {
-    padding-left: 5px;
-    padding-right: 5px;
+/* Reply on the margin from the Card for spacing */
+#storage .pf-c-card .table {
+    margin-bottom: 0;
+}
+
+#storage .pf-c-page {
+    padding: var(--pf-global--gutter);
+}
+
+#storage .pf-l-gallery {
+    --pf-l-gallery--GridTemplateColumns: 1fr;
+}
+
+#storage .pf-c-card__header > .pf-c-card__title {
+  padding: 0;
+  font-weight: normal;
 }
 
 #storage .empty-panel-text {

--- a/pkg/storaged/storage.css
+++ b/pkg/storaged/storage.css
@@ -69,6 +69,10 @@
   font-weight: normal;
 }
 
+#storage .pf-c-card__title > h2 {
+  font-size: var(--pf-global--FontSize--2xl);
+}
+
 #storage .pf-c-card__header {
   padding: var(--pf-global--spacer--md) var(--pf-global--spacer--md) var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
 }

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { Alert } from "@patternfly/react-core";
+import { Alert, Card, CardHeader, CardActions, CardTitle, CardBody, Text, TextVariants } from "@patternfly/react-core";
 import { get_active_usage, teardown_active_usage, fmt_size, decode_filename } from "./utils.js";
 import { dialog_open, SizeSlider, BlockingMessage, TeardownMessage } from "./dialog.jsx";
 import { StdDetailsLayout } from "./details.jsx";
@@ -249,19 +249,19 @@ export class VDODetails extends React.Component {
         var stats = this.state.stats;
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">
-                    {cockpit.format(_("VDO Device $0"), vdo.name)}
-                    <span className="pull-right">
+            <Card>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{cockpit.format(_("VDO Device $0"), vdo.name)}</Text></CardTitle>
+                    <CardActions>
                         { block
                             ? <StorageButton onClick={stop}>{_("Stop")}</StorageButton>
                             : <StorageButton onClick={vdo.start}>{_("Start")}</StorageButton>
                         }
                         { "\n" }
                         <StorageButton kind="danger" onClick={delete_}>{_("Delete")}</StorageButton>
-                    </span>
-                </div>
-                <div className="panel-body">
+                    </CardActions>
+                </CardHeader>
+                <CardBody>
                     <div className="ct-form">
                         <label className="control-label">{_("Device File")}</label>
                         <div>{vdo.dev}</div>
@@ -312,8 +312,8 @@ export class VDODetails extends React.Component {
                                            onChange={() => vdo.set_deduplication(!vdo.deduplication)} />
                         </div>
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         var content = <Block client={client} block={block} allow_partitions={false} />;

--- a/pkg/storaged/vgroup-details.jsx
+++ b/pkg/storaged/vgroup-details.jsx
@@ -19,6 +19,9 @@
 
 import cockpit from "cockpit";
 import React from "react";
+
+import { Card, CardBody, CardTitle, CardHeader, CardActions, Text, TextVariants } from "@patternfly/react-core";
+
 import * as utils from "./utils.js";
 import { fmt_to_fragments } from "./utilsx.jsx";
 import { StdDetailsLayout } from "./details.jsx";
@@ -206,16 +209,16 @@ export class VGroupDetails extends React.Component {
         }
 
         var header = (
-            <div className="panel panel-default">
-                <div className="panel-heading">
-                    <span>{fmt_to_fragments(_("Volume Group $0"), <b>{vgroup.Name}</b>)}</span>
-                    <span className="pull-right">
+            <Card>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{fmt_to_fragments(_("Volume Group $0"), <b>{vgroup.Name}</b>)}</Text></CardTitle>
+                    <CardActions>
                         <StorageButton onClick={rename}>{_("Rename")}</StorageButton>
                         { "\n" }
                         <StorageButton kind="danger" onClick={delete_}>{_("Delete")}</StorageButton>
-                    </span>
-                </div>
-                <div className="panel-body">
+                    </CardActions>
+                </CardHeader>
+                <CardBody>
                     <div className="ct-form">
                         <label className="control-label">{_("storage", "UUID")}</label>
                         <div>{ vgroup.UUID }</div>
@@ -223,8 +226,8 @@ export class VGroupDetails extends React.Component {
                         <label className="control-label">{_("storage", "Capacity")}</label>
                         <div>{ utils.fmt_size_long(vgroup.Size) }</div>
                     </div>
-                </div>
-            </div>
+                </CardBody>
+            </Card>
         );
 
         var sidebar = <VGroupSidebar client={this.props.client} vgroup={vgroup} />;

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -256,10 +256,15 @@ Unit=test.service
         self.check_service_details(["Not running", "Automatically starts"], ["Start", "Disallow running (mask)"], True)
         self.do_action("Start")
         self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
-        b.wait_in_text('.cockpit-log-panel .panel-body', "START")
-        b.wait_in_text('.cockpit-log-panel .panel-body', "WORKING")
+        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14513
+            b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "START")
+            b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "WORKING")
+            b.click(".cockpit-log-panel .pf-c-card__header button")
+        else:
+            b.wait_in_text('.cockpit-log-panel .panel-body', "START")
+            b.wait_in_text('.cockpit-log-panel .panel-body', "WORKING")
+            b.click(".cockpit-log-panel .panel-heading button")
 
-        b.click(".cockpit-log-panel .panel-heading button")
         b.enter_page("/system/logs")
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(3)", "START")
@@ -394,7 +399,10 @@ Unit=test.service
 
         # Check that journalbox shows empty state
         b.click(self.svc_sel("systemd-halt.service"))
-        b.wait_text('.cockpit-log-panel .panel-body', "No log entries")
+        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14513
+            b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
+        else:
+            b.wait_text('.cockpit-log-panel .panel-body', "No log entries")
 
     def testApi(self):
         m = self.machine

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -89,7 +89,7 @@ class TestStorageHidden(StorageCase):
         wait(lambda: "my-crypto-tag" in m.execute("%s dump | grep ChildConfiguration" % self.storagectl_cmd))
 
         # Deleting the volume group should still remove the fstab entry
-        b.click('.panel-heading:contains("Volume Group") button:contains("Delete")')
+        b.click('.pf-c-card__header:contains("Volume Group") button:contains("Delete")')
         self.confirm()
         b.wait_visible("#storage")
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_1), "")
@@ -130,7 +130,7 @@ class TestStorageHidden(StorageCase):
         # we need to wait for mdadm --monitor to stop using the device before delete
         m.execute("while fuser -s /dev/md127; do sleep 0.2; done", timeout=20)
 
-        self.browser.click('.panel-heading:contains("RAID Device") button:contains("Delete")')
+        self.browser.click('.pf-c-card__header:contains("RAID Device") button:contains("Delete")')
         self.confirm()
         b.wait_visible("#storage")
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_2), "")

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -107,7 +107,7 @@ class TestStorageISCSI(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Mount Point", "_netdev")
 
         # Add the target a second time, just to check that the sorting function works
-        b.click('#storage-detail .breadcrumb button')
+        b.click('#storage-detail a.pf-c-breadcrumb__link')
         b.wait_visible('#storage')
         b.click('#add-iscsi-portal')
         self.dialog_wait_open()

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -183,7 +183,7 @@ class TestStorageLuks(StorageCase):
 
         self.content_tab_wait_in_info(1, 1, "Options", "(none)")
         tab = self.content_tab_expand(1, 1)
-        panel = tab + " .panel:contains(Keys) "
+        panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_present(panel)
         b.wait_in_text(panel + ".table tr:nth-child(1)", "Passphrase")
 
@@ -259,7 +259,7 @@ class TestStorageLuks(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Options", "(none)")
         # add one more passphrase
         tab = self.content_tab_expand(1, 1)
-        panel = tab + " .panel:contains(Keys) "
+        panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_present(panel)
         b.click(panel + ".fa-plus")
         self.dialog_wait_open()
@@ -315,11 +315,11 @@ class TestStorageLuks(StorageCase):
             # check if add button is inactive
             b.wait_present(panel + ":disabled")
             # check if edit button is inactive
-            slots_table = tab + " .panel table "
+            slots_table = tab + " .pf-c-card table "
             b.wait_present(slots_table + ":disabled")
 
         # remove one slot
-        slots_table = tab + " .panel table "
+        slots_table = tab + " .pf-c-card table "
         b.wait_present(slots_table + "tbody tr:last-child .fa-minus")
         b.click(slots_table + "tbody tr:last-child .fa-minus")
         b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-7")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -186,7 +186,7 @@ class TestStorageLvm2(StorageCase):
         self.content_row_wait_in_col(2, 2, "/dev/vgroup0/thin")
 
         # add a disk and resize the pool
-        b.click('#detail-sidebar .panel-heading button')
+        b.click('#detail-sidebar .pf-c-card__header button')
         self.dialog_wait_open()
         self.dialog_set_val('disks', {dev_2: True})
         self.dialog_apply()
@@ -212,7 +212,7 @@ class TestStorageLvm2(StorageCase):
         self.wait_in_storaged_configuration(mount_point_thin)
 
         # remove volume group
-        b.click('.panel-heading:contains("Volume Group") button:contains("Delete")')
+        b.click('.pf-c-card__header:contains("Volume Group") button:contains("Delete")')
         self.confirm()
         b.wait_visible("#storage")
         self.assertEqual(m.execute("grep %s /etc/fstab || true" % mount_point_thin), "")
@@ -247,7 +247,7 @@ class TestStorageLvm2(StorageCase):
         b.wait_in_text("#detail-sidebar", "Partition of Linux scsi_debug")
 
         # Add the unused space of disk2
-        self.dialog_with_retry(trigger=lambda: b.click('#detail-sidebar .panel-heading button'),
+        self.dialog_with_retry(trigger=lambda: b.click('#detail-sidebar .pf-c-card__header button'),
                                expect=lambda: self.dialog_is_present(
                                    'disks', "unpartitioned space on " + disk2),
                                values={"disks": {disk2: True}})

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -46,7 +46,7 @@ class TestStorageMdRaid(StorageCase):
         })""", states)
 
     def raid_add_disk(self, name):
-        self.dialog_open_with_retry(trigger=lambda: self.browser.click('#detail-sidebar .panel-heading button'),
+        self.dialog_open_with_retry(trigger=lambda: self.browser.click('#detail-sidebar .pf-c-card__header button'),
                                     expect=lambda: self.dialog_is_present('disks', name))
         self.dialog_set_val("disks", { name: True })
         self.dialog_apply_with_retry()
@@ -55,12 +55,12 @@ class TestStorageMdRaid(StorageCase):
         self.browser.click('#detail-sidebar tr:contains("%s") button.pf-m-secondary' % name)
 
     def raid_action(self, action):
-        self.browser.click('.panel-heading:contains("RAID Device") button:contains(%s)' % action)
+        self.browser.click('.pf-c-card__header:contains("RAID Device") button:contains(%s)' % action)
 
     def raid_default_action(self, action):
         def do_click():
-            self.browser.wait_present('.panel-heading:contains("RAID Device") button:contains(%s)' % action)
-            self.browser.click('.panel-heading:contains("RAID Device") button:contains(%s)' % action)
+            self.browser.wait_present('.pf-c-card__header:contains("RAID Device") button:contains(%s)' % action)
+            self.browser.click('.pf-c-card__header:contains("RAID Device") button:contains(%s)' % action)
 
         do_click()
 
@@ -276,7 +276,7 @@ class TestStorageMdRaid(StorageCase):
         self.raid_default_action("Stop")
         b.wait_in_text(info_field("State"), "Not running")
 
-        b.wait_present('#detail-sidebar .panel-heading button:disabled')
+        b.wait_present('#detail-sidebar .pf-c-card__header button:disabled')
         b.wait_present('#detail-sidebar tr:contains(DISK1) button:disabled')
         b.wait_present('#detail-sidebar tr:contains(DISK2) button:disabled')
 
@@ -284,7 +284,7 @@ class TestStorageMdRaid(StorageCase):
         b.wait_in_text(info_field("State"), "Running")
 
         # With a running array, we can add spares, but not remove "in-sync" disks
-        b.wait_not_present('#detail-sidebar .panel-heading button:disabled')
+        b.wait_not_present('#detail-sidebar .pf-c-card__header button:disabled')
         b.wait_present('#detail-sidebar tr:contains(DISK1) button:disabled')
         b.wait_present('#detail-sidebar tr:contains(DISK2) button:disabled')
 

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -127,6 +127,7 @@ class TestStorageNfs(StorageCase):
 
         # Remove /home/foo
         b.click("#detail-header button:contains(Remove)")
+        b.wait_not_present('#storage-detail')
         b.wait_visible("#storage")
         b.wait_not_present("#nfs-mounts td:contains(/home/foo)")
         m.execute("! test -e /mnt")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -103,7 +103,7 @@ class TestStorageVDO(StorageCase):
         # Stop
 
         b.wait_present('#detail-content table')
-        b.click('.panel-heading:contains("VDO") button:contains("Stop")')
+        b.click('.pf-c-card__header:contains("VDO") button:contains("Stop")')
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "Proceeding will unmount all filesystems on it.")
         self.dialog_apply()
@@ -112,7 +112,7 @@ class TestStorageVDO(StorageCase):
 
         # Delete
 
-        b.click('.panel-heading:contains("VDO") button:contains("Delete")')
+        b.click('.pf-c-card__header:contains("VDO") button:contains("Delete")')
         self.confirm()
         b.wait_visible("#storage")
         b.wait_not_in_text("#devices", "vdo0")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -89,7 +89,7 @@ class StorageHelpers:
     # Content
 
     def content_row_tbody(self, index):
-        return "#detail-content > section > table > tbody:nth-of-type(%d)" % index
+        return "#detail-content section > table > tbody:nth-of-type(%d)" % index
 
     def content_row_expand(self, index):
         b = self.browser


### PR DESCRIPTION
Since we have the cards design in many pages already, I felt that the storage page felt somehow awkward.
I feel now it's more consistent with the rest of the pages.

Now:
![Screen Shot 2020-08-26 at 23 46 44](https://user-images.githubusercontent.com/14921356/91363592-3fb83380-e7fd-11ea-80b2-c6fc0eb9ebdc.png)

Before:
![Screen Shot 2020-08-27 at 00 35 56](https://user-images.githubusercontent.com/14921356/91363629-51014000-e7fd-11ea-97bb-2279c21cf727.png)
