### PR TITLE
bastion: Install systemd into the image

### DIFF
--- a/containers/bastion/install.sh
+++ b/containers/bastion/install.sh
@@ -8,7 +8,7 @@ fi
 
 if [ -z "$OFFLINE" ]; then
     "$INSTALLER" -y update
-    "$INSTALLER" install -y python3 openssl
+    "$INSTALLER" install -y python3 openssl systemd
 fi
 
 /container/scripts/install-rpms.sh cockpit-ws


### PR DESCRIPTION
`systemd` has been present for `fedora` images up to version 31. In
version 32 it has been dropped. `cockpit-ws` requires this package.

See https://github.com/cockpit-project/bots/pull/1184

Will need to be backported to 7.9 and 8.3 stable branches.