### PR TITLE
[rhel-8.3] test: Replace deprecated `time.clock()` with `time.process_time()`

### DIFF
--- a/test/selenium/testlib_avocado/seleniumlib.py
+++ b/test/selenium/testlib_avocado/seleniumlib.py
@@ -149,7 +149,7 @@ class SeleniumTest(Test):
         if len(args) > 0:
             suffix = sep.join(args)
         else:
-            datesuffix = str(time.clock())[2:]
+            datesuffix = str(time.process_time())[2:]
             if inspect and inspect.stack() and len(inspect.stack()) > 0:
                 stackinfo = [x[3] for x in inspect.stack() if x[3].startswith("test") or x[3] in ["tearDown", "setUp"]]
             else:


### PR DESCRIPTION
This method is deprecated since Python version 3.3 and is removed in Python version 3.8.
Fedora 32 ships by default Python 3.8

Cherry-picked from master commit e0badff