### PR TITLE
PF: drop override (font & alignment changed in PF)

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -7,21 +7,6 @@
     overflow-wrap: break-word;
 }
 
-/* WORKAROUND:  Dropdown (PF4): Caret is not properly aligned bug */
-/* See: https://github.com/patternfly/patternfly/issues/2715 */
-/* Align the icons inside of all dropdown toggles. */
-/* Part 1 of 2 */
-.pf-c-dropdown__toggle-button {
-  display: flex;
-  align-items: center;
-}
-
-/* Make split button dropdowns the same height as their sibling. */
-/* Part 2 of 2 */
-.pf-m-split-button {
-  align-items: stretch;
-}
-
 /* WORKAROUND: Navigation problems with Tertiary Nav widget on mobile */
 /* See: https://github.com/patternfly/patternfly-design/issues/840 */
 /* Helper mod to wrap pf-c-nav__tertiary */


### PR DESCRIPTION
PF4 changed to using Red Hat Text as the default and fixed the alignment issues. Therefore, we no longer need an override for the dropdown to properly align the dropmarker in split buttons.

Screenshot from the split button on the Overview page in Cockpit without the override:

![Screen Shot 2020-08-31 at 13 58 51](https://user-images.githubusercontent.com/10246/91717609-206d2d80-eb92-11ea-8567-078f58aaecaf.png)

Closes https://github.com/patternfly/patternfly/issues/2715