### PR TITLE
networking: interface-details: stop using container-fluid bootstrap class for page layout

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -398,84 +398,101 @@
     </form>
   </script>
 
-  <div id="network-interface" class="container-fluid" hidden>
-    <ol class="breadcrumb">
-      <li><a role="link" tabindex="0" translate="yes">Networking</a></li>
-      <li class="active"></li>
-    </ol>
-    <div class="row">
-      <div id="network-interface-graph-toolbar" class="zoom-controls standard-zoom-controls">
-        <div class="dropdown">
-          <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
-            <span></span>
-            <div class="caret"></div>
+  <div id="network-interface" class="pf-c-page" hidden>
+    <main  class="pf-c-page__main" tabIndex="-1">
+      <section class="pf-c-page__main-breadcrumb pf-m-light">
+          <nav class="pf-c-breadcrumb" aria-label="breadcrumb">
+              <ol class="pf-c-breadcrumb__list">
+                <li class="pf-c-breadcrumb__item"><a class="pf-c-breadcrumb__link" role="link" tabindex="0" translate="yes">Networking</a></li>
+                <li class="pf-c-breadcrumb__item">
+                    <span class="pf-c-breadcrumb__item-divider">
+                        <i class="fa fa-angle-right" aria-hidden="true"></i>
+                    </span>
+                    <a class="pf-c-breadcrumb__link pf-m-current"></a>
+                </li>
+              </ol>
+          </nav>
+      </section>
+      <section class="pf-c-page__main-section pf-m-light">
+        <div id="network-interface-graph-toolbar" class="zoom-controls standard-zoom-controls">
+          <div class="dropdown">
+            <button class="btn btn-default dropdown-toggle" data-toggle="dropdown">
+              <span></span>
+              <div class="caret"></div>
+            </button>
+            <ul class="dropdown-menu" role="menu">
+              <li role="presentation"><a tabindex="0" role="menuitem" data-action="goto-now" translate="yes">Go to now</a></li>
+              <li role="presentation" class="divider"></li>
+              <li role="presentation"><a tabindex="0" role="menuitem" data-range="300" translate="yes">5 minutes</a></li>
+              <li role="presentation"><a tabindex="0" role="menuitem" data-range="3600" translate="yes">1 hour</a></li>
+              <li role="presentation"><a tabindex="0" role="menuitem" data-range="21600" translate="yes">6 hours</a></li>
+              <li role="presentation"><a tabindex="0" role="menuitem" data-range="86400" translate="yes">1 day</a></li>
+              <li role="presentation"><a tabindex="0" role="menuitem" data-range="604800" translate="yes">1 week</a></li>
+            </ul>
+          </div>
+          <button class="pf-c-button pf-m-secondary" data-action="zoom-out">
+            <span class="glyphicon glyphicon-zoom-out"></span>
           </button>
-          <ul class="dropdown-menu" role="menu">
-            <li role="presentation"><a tabindex="0" role="menuitem" data-action="goto-now" translate="yes">Go to now</a></li>
-            <li role="presentation" class="divider"></li>
-            <li role="presentation"><a tabindex="0" role="menuitem" data-range="300" translate="yes">5 minutes</a></li>
-            <li role="presentation"><a tabindex="0" role="menuitem" data-range="3600" translate="yes">1 hour</a></li>
-            <li role="presentation"><a tabindex="0" role="menuitem" data-range="21600" translate="yes">6 hours</a></li>
-            <li role="presentation"><a tabindex="0" role="menuitem" data-range="86400" translate="yes">1 day</a></li>
-            <li role="presentation"><a tabindex="0" role="menuitem" data-range="604800" translate="yes">1 week</a></li>
-          </ul>
+          <div class="btn-group">
+            <button class="pf-c-button pf-m-secondary" data-action="scroll-left">
+                <span class="fa fa-angle-left" />
+            </button>
+            <button class="pf-c-button pf-m-secondary" data-action="scroll-right">
+                <span class="fa fa-angle-right" />
+            </button>
+          </div>
         </div>
-        <button class="pf-c-button pf-m-secondary" data-action="zoom-out">
-          <span class="glyphicon glyphicon-zoom-out"></span>
-        </button>
-        <div class="btn-group">
-          <button class="pf-c-button pf-m-secondary" data-action="scroll-left">
-              <span class="fa fa-angle-left" />
-          </button>
-          <button class="pf-c-button pf-m-secondary" data-action="scroll-right">
-              <span class="fa fa-angle-right" />
-          </button>
+        <div class="col-sm-6">
+          <div>
+            <span class="plot-unit" id="network-interface-tx-unit"></span><span class="plot-title" translate="yes">Sending</span>
+          </div>
+          <div id="network-interface-tx-graph"></div>
         </div>
-      </div>
-      <div class="col-sm-6">
-        <div>
-          <span class="plot-unit" id="network-interface-tx-unit"></span><span class="plot-title" translate="yes">Sending</span>
+        <div class="col-sm-6">
+          <div>
+            <span class="plot-unit" id="network-interface-rx-unit"></span><span class="plot-title" translate="yes">Receiving</span>
+          </div>
+          <div id="network-interface-rx-graph"></div>
         </div>
-        <div id="network-interface-tx-graph"></div>
-      </div>
-      <div class="col-sm-6">
-        <div>
-          <span class="plot-unit" id="network-interface-rx-unit"></span><span class="plot-title" translate="yes">Receiving</span>
-        </div>
-        <div id="network-interface-rx-graph"></div>
-      </div>
-    </div>
-    <div class="pf-c-card">
-      <div class="pf-c-card__header">
-        <div class="pf-c-card__title" id="network-interface-name"></div>
-        <span id="network-interface-hw"></span>
-        <span id="network-interface-mac"></span>
-        <div class="pf-c-card__actions">
-          <button class="pf-c-button pf-m-danger network-privileged" id="network-interface-delete" translate="yes">Delete</button>
-          <span id="network-interface-delete-switch" class="network-privileged">
-          </span>
-        </div>
-      </div>
-      <div class="pf-c-card__body">
-        <table class="form-table-ct" id="network-interface-settings">
-        </table>
-      </div>
-    </div>
-    <div class="pf-c-card" id="network-interface-members">
-      <table class="table table-hover">
-        <thead>
-          <tr>
-            <th></th>
-            <th translate="yes" class="networking-speed">Sending</th>
-            <th translate="yes" class="networking-speed">Receiving</th>
-            <th class="networking-spacer"></th>
-            <th class="networking-action"></th>
-          </tr>
-        </thead>
-        <tbody>
-        </tbody>
-      </table>
-    </div>
+      </section>
+      <section class="pf-c-page__main-section">
+        <div class="pf-l-gallery pf-m-gutter">
+            <div class="pf-c-card">
+              <div class="pf-c-card__header">
+                <div class="pf-c-card__title">
+                  <span id="network-interface-name"></span>
+                  <span id="network-interface-hw"></span>
+                  <span id="network-interface-mac"></span>
+                </div>
+                <div class="pf-c-card__actions">
+                  <button class="pf-c-button pf-m-danger network-privileged" id="network-interface-delete" translate="yes">Delete</button>
+                  <span id="network-interface-delete-switch" class="network-privileged">
+                  </span>
+                </div>
+              </div>
+              <div class="pf-c-card__body">
+                <table class="form-table-ct" id="network-interface-settings">
+                </table>
+              </div>
+            </div>
+            <div class="pf-c-card" id="network-interface-members">
+              <table class="table table-hover">
+                <thead>
+                  <tr>
+                    <th></th>
+                    <th translate="yes" class="networking-speed">Sending</th>
+                    <th translate="yes" class="networking-speed">Receiving</th>
+                    <th class="networking-spacer"></th>
+                    <th class="networking-action"></th>
+                  </tr>
+                </thead>
+                <tbody>
+                </tbody>
+              </table>
+            </div>
+          </div>
+      </section>
+    </main>
   </div>
 
   <div class="modal" id="network-ip-settings-dialog"

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -2220,7 +2220,7 @@ PageNetworkInterface.prototype = {
     setup: function () {
         var self = this;
 
-        $('#network-interface .breadcrumb a').on("click", function() {
+        $('#network-interface .pf-c-breadcrumb  li:first a').on("click", function() {
             cockpit.location.go('/');
         });
 
@@ -2357,7 +2357,7 @@ PageNetworkInterface.prototype = {
 
         self.dev_name = dev_name;
 
-        $('#network-interface .breadcrumb .active').text(self.dev_name);
+        $('#network-interface .pf-c-breadcrumb__item .pf-c-breadcrumb__link.pf-m-current').text(self.dev_name);
 
         self.rx_series.clear_instances();
         self.tx_series.clear_instances();

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -1,13 +1,16 @@
 @import "../../node_modules/@patternfly/react-styles/css/components/Alert/alert.css";
 @import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 @import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
+@import "../../node_modules/@patternfly/patternfly/components/Breadcrumb/breadcrumb.css";
 @import "../../node_modules/@patternfly/patternfly/layouts/Gallery/gallery.css";
 @import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 @import "../../node_modules/@patternfly/patternfly/components/Table/table.css";
 @import "../../node_modules/@patternfly/patternfly/components/Table/table-grid.css";
 
-#networking .pf-l-gallery {
-    --pf-l-gallery--GridTemplateColumns: 1fr;
+#networking, #network-interface {
+  .pf-l-gallery {
+      --pf-l-gallery--GridTemplateColumns: 1fr;
+  }
 }
 
 .networking-page .firewall-switch {
@@ -19,6 +22,25 @@
     flex-wrap: wrap;
     button {
         margin-bottom: 0.5rem;
+    }
+}
+
+#network-interface {
+    section.pf-c-page__main-breadcrumb {
+        padding-bottom: var(--pf-global--spacer--xl);
+    }
+
+    .pf-c-card__header > .pf-c-card__title {
+        padding: 0;
+    }
+
+    .pf-c-card {
+        overflow-x: auto;
+    }
+
+    #network-interface-hw, #network-interface-mac {
+      font-size: var(--pf-global--FontSize--md);
+      font-weight: var(--pf-global--FontWeight--normal);
     }
 }
 
@@ -520,4 +542,8 @@ form.horizontal fieldset {
     td[data-label=Name] {
         font-weight: var(--pf-global--FontWeight--bold);
     }
+}
+
+#network-interface-members table {
+    margin-bottom: 0;
 }


### PR DESCRIPTION
Utilize Page PF4 component instead.
Also replace usage of bootstrap .breadcrumb class with the PF4 React
component.

This fixes regression in network details page introduced by:

commit 60571e3c599f5bc98a7a034204be965634427a45
Author: Katerina Koukiou <kkoukiou@redhat.com>
Date:   Thu Aug 6 17:13:34 2020 +0200

    network: Utilize cards and PF4 tables for showing the interfaces lists

Previously:
![Screen Shot 2020-08-31 at 14 32 37](https://user-images.githubusercontent.com/14921356/91722611-cb81e500-eb9a-11ea-802b-e574c6c92d32.png)

Now:

![Screen Shot 2020-08-31 at 15 01 29](https://user-images.githubusercontent.com/14921356/91722654-dd638800-eb9a-11ea-96f4-7264ecad3cd7.png)    

![Screen Shot 2020-08-31 at 15 07 24](https://user-images.githubusercontent.com/14921356/91723361-ed2f9c00-eb9b-11ea-82ba-92c9e31af3fe.png)
