### PR TITLE
overview: start using <h2> in CardTitles and stop overriding the default CSS

### DIFF
--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Card, CardBody, Button, CardTitle } from '@patternfly/react-core';
+import { Card, CardBody, Button, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import * as service from "service.js";
@@ -269,7 +269,7 @@ export class ConfigurationCard extends React.Component {
 
         return (
             <Card className="system-configuration">
-                <CardTitle>{_("Configuration")}</CardTitle>
+                <CardTitle><Text component={TextVariants.h2}>{_("Configuration")}</Text></CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -18,7 +18,7 @@
  */
 
 import React from 'react';
-import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 
 import cockpit from "cockpit";
 import { PageStatusNotifications } from "../page-status.jsx";
@@ -32,7 +32,7 @@ export class HealthCard extends React.Component {
     render() {
         return (
             <Card className="system-health">
-                <CardTitle>{_("Health")}</CardTitle>
+                <CardTitle><Text component={TextVariants.h2}>{_("Health")}</Text></CardTitle>
                 <CardBody>
                     <ul className="system-health-events">
                         <PageStatusNotifications />

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle, Text, TextVariants } from '@patternfly/react-core';
 import moment from 'moment';
 
 import cockpit from "cockpit";
@@ -102,7 +102,7 @@ export class SystemInfomationCard extends React.Component {
     render() {
         return (
             <Card className="system-information">
-                <CardTitle>{_("System information")}</CardTitle>
+                <CardTitle><Text component={TextVariants.h2}>{_("System information")}</Text></CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -20,6 +20,7 @@ import React from 'react';
 import {
     Card, CardBody, CardFooter,
     Progress, ProgressMeasureLocation, ProgressVariant, CardTitle,
+    Text, TextVariants,
 } from '@patternfly/react-core';
 
 import * as machine_info from "machine-info.js";
@@ -113,7 +114,7 @@ export class UsageCard extends React.Component {
 
         return (
             <Card className="system-usage">
-                <CardTitle>{_("Usage")}</CardTitle>
+                <CardTitle><Text component={TextVariants.h2}>{_("Usage")}</Text></CardTitle>
                 <CardBody>
                     <table className="pf-c-table pf-m-grid-md pf-m-compact">
                         <tbody>

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -110,11 +110,6 @@
   }
 
   .pf-c-card {
-    &__title {
-      font-size: var(--pf-global--FontSize--xl);
-      font-weight: var(--pf-global--FontWeight--normal);
-    }
-
     &__body {
       .fa,
       .pficon {
@@ -252,10 +247,6 @@
 
 @media (min-width: 780px) {
   /* Embiggen subheading & card headings when there's space */
-
-  .ct-system-overview .pf-c-card__title {
-    font-size: var(--pf-global--FontSize--2xl);
-  }
 
   .ct-overview-header-subheading {
     font-size: var(--pf-global--FontSize--lg);


### PR DESCRIPTION
This came up in the review of https://github.com/cockpit-project/cockpit/pull/14513

Dont merge yet!!! This might need h3