### PR TITLE
machines: fix distance between the chart elements in VM Usage tab

### DIFF
--- a/pkg/machines/c3charts.jsx
+++ b/pkg/machines/c3charts.jsx
@@ -89,10 +89,10 @@ class DonutChart extends React.Component {
     render() {
         this._renderChart();
 
-        return (<div>
+        return (<>
             <div id={this.domId} />
             <div className='usage-donut-caption'>{this.props.caption}</div>
-        </div>);
+        </>);
     }
 }
 

--- a/pkg/machines/components/vm/vmUsageTab.jsx
+++ b/pkg/machines/components/vm/vmUsageTab.jsx
@@ -20,6 +20,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
 
+import { Flex, FlexItem } from '@patternfly/react-core';
+
 import {
     logDebug,
     convertToUnit,
@@ -85,24 +87,20 @@ class VmUsageTab extends React.Component {
         };
 
         return (
-            <table>
-                <tbody>
-                    <tr>
-                        <td>
-                            <DonutChart data={memChartData} size={chartSize} width='8' tooltipText=' '
-                                    primaryTitle={toReadableNumber(convertToUnit(rssMem, units.KiB, units.GiB))}
-                                    secondaryTitle='GiB'
-                                    caption={`used from ${cockpit.format_bytes(memTotal * 1024)} memory`} />
-                        </td>
-
-                        <td>
-                            <DonutChart data={cpuChartData} size={chartSize} width='8' tooltipText=' '
-                                    primaryTitle={cpuUsage} secondaryTitle='%'
-                                    caption={`used from ${totalCpus} vCPUs`} />
-                        </td>
-                    </tr>
-                </tbody>
-            </table>);
+            <Flex>
+                <FlexItem className="memory-usage-chart">
+                    <DonutChart data={memChartData} size={chartSize} width='8' tooltipText=' '
+                                primaryTitle={toReadableNumber(convertToUnit(rssMem, units.KiB, units.GiB))}
+                                secondaryTitle='GiB'
+                                caption={`used from ${cockpit.format_bytes(memTotal * 1024)} memory`} />
+                </FlexItem>
+                <FlexItem className="vcpu-usage-chart">
+                    <DonutChart data={cpuChartData} size={chartSize} width='8' tooltipText=' '
+                                primaryTitle={cpuUsage} secondaryTitle='%'
+                                caption={`used from ${totalCpus} vCPUs`} />
+                </FlexItem>
+            </Flex>
+        );
     }
 }
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -303,10 +303,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # switch to and check Usage
         b.click("#vm-subVmTest1-usage")
-        b.wait_in_text("tbody.pf-m-expanded .ct-listing-panel-body td:nth-child(1) .usage-donut-caption", "256 MiB")
+        b.wait_in_text(".memory-usage-chart .usage-donut-caption", "256 MiB")
         b.wait_present("#chart-donut-0 .donut-title-big-pf")
         b.wait(lambda: get_usage("#chart-donut-0") > 0.0)
-        b.wait_in_text("tbody.pf-m-expanded .ct-listing-panel-body td:nth-child(2) .usage-donut-caption", "1 vCPU")
+        b.wait_in_text(".vcpu-usage-chart .usage-donut-caption", "1 vCPU")
         # CPU usage cannot be nonzero with blank image, so just ensure it's a percentage
         b.wait_present("#chart-donut-1 .donut-title-big-pf")
         self.assertLessEqual(get_usage("#chart-donut-1"), 100.0)
@@ -2378,7 +2378,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 memory_text = "%.2f GiB" % (dialog.memory_size/1024)
             else:
                 memory_text = "{0} {1}".format(dialog.memory_size, dialog.memory_size_unit)
-            b.wait_in_text("tbody.pf-m-expanded .ct-listing-panel-body td:nth-child(1) .usage-donut-caption", memory_text)
+            b.wait_in_text(".memory-usage-chart .usage-donut-caption", memory_text)
 
             # check disks
             b.click("#vm-{0}-disks".format(name)) # open the "Disks" subtab


### PR DESCRIPTION
Nested PF4 tables have issues, we should not follow this pattern.
Replace tables with flex for creating the layout of this component.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1873931