### PR TITLE
Fix breadcrumbs in graphs page and every page that uses React Breadcrumb component

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -31,3 +31,10 @@ ul.pf-c-select__menu {
     max-height: 20rem;
     overflow-y: auto;
 }
+
+/* Breadcrumb dividers have some inline style to align them
+ * https://github.com/patternfly/patternfly-react/issues/4767
+ */
+.pf-c-breadcrumb__item-divider > svg {
+    vertical-align: -0.125em;
+}

--- a/pkg/systemd/graphs.html
+++ b/pkg/systemd/graphs.html
@@ -21,11 +21,11 @@
                             <ol class="pf-c-breadcrumb__list">
                                 <li class="pf-c-breadcrumb__item">
                                     <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link system-link">Overview</a>
+                                </li>
+                                <li class="pf-c-breadcrumb__item">
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>
-                                </li>
-                                <li class="pf-c-breadcrumb__item">
                                     <a translate='yes' href="#" class="pf-c-breadcrumb__link pf-m-current" aria-current="page">Usage Graphs</a>
                                 </li>
                             </ol>
@@ -104,17 +104,17 @@
                             <ol class="pf-c-breadcrumb__list">
                                 <li class="pf-c-breadcrumb__item">
                                     <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link system-link">Overview</a>
+                               </li>
+                                <li class="pf-c-breadcrumb__item">
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>
-                                </li>
-                                <li class="pf-c-breadcrumb__item">
                                     <a role="link" tabindex="0" translate='yes' class="pf-c-breadcrumb__link graphs-link">Usage Graphs</a>
+                                </li>
+                                <li class="pf-c-breadcrumb__item">
                                     <span class="pf-c-breadcrumb__item-divider">
                                         <i class="fa fa-angle-right" aria-hidden="true"></i>
                                     </span>
-                                </li>
-                                <li class="pf-c-breadcrumb__item">
                                     <a translate='yes' href="#" class="pf-c-breadcrumb__link pf-m-current" id="complicated_graph_current_breadcrumb" aria-current="page"></a>
                                 </li>
                             </ol>


### PR DESCRIPTION
Now:
![Screen Shot 2020-09-02 at 12 35 14](https://user-images.githubusercontent.com/14921356/91970989-cea2df80-ed18-11ea-97d4-553a8d711e03.png)

Previously:
![Screen Shot 2020-09-02 at 12 35 01](https://user-images.githubusercontent.com/14921356/91971009-d2cefd00-ed18-11ea-957a-d33cd87550cd.png)

And the alignment issue:

Now:
![Screen Shot 2020-09-02 at 12 37 36](https://user-images.githubusercontent.com/14921356/91971196-188bc580-ed19-11ea-899d-b727f93fca8f.png)

Previously:
![Screen Shot 2020-09-02 at 12 36 21](https://user-images.githubusercontent.com/14921356/91971147-04e05f00-ed19-11ea-9c5e-bc1f5b12a89e.png)

