### PR TITLE
machines: Unify combination of units in the usage tab

### DIFF
--- a/pkg/machines/components/vm/vmUsageTab.jsx
+++ b/pkg/machines/components/vm/vmUsageTab.jsx
@@ -28,6 +28,7 @@ import {
     toReadableNumber,
     units,
     toFixedPrecision,
+    getBestUnit,
 } from "../../helpers.js";
 
 import DonutChart from "../../c3charts.jsx";
@@ -86,12 +87,14 @@ class VmUsageTab extends React.Component {
             height,
         };
 
+        const bestUnit = getBestUnit(memTotal, units.KiB);
+
         return (
             <Flex>
                 <FlexItem className="memory-usage-chart">
                     <DonutChart data={memChartData} size={chartSize} width='8' tooltipText=' '
-                                primaryTitle={toReadableNumber(convertToUnit(rssMem, units.KiB, units.GiB))}
-                                secondaryTitle='GiB'
+                                primaryTitle={toReadableNumber(convertToUnit(rssMem, units.KiB, bestUnit))}
+                                secondaryTitle={bestUnit.name}
                                 caption={`used from ${cockpit.format_bytes(memTotal * 1024)} memory`} />
                 </FlexItem>
                 <FlexItem className="vcpu-usage-chart">

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -86,6 +86,10 @@ function getLogarithmOfBase1024(value) {
     return value > 0 ? (Math.floor(Math.log(value) / Math.log(1024))) : 0;
 }
 
+export function getBestUnit(input, inputUnit) {
+    return logUnitMap[getLogarithmOfBase1024(convertToUnitVerbose(input, inputUnit, units.B).value)];
+}
+
 export function convertToBestUnit(input, inputUnit) {
     return convertToUnitVerbose(input, inputUnit,
                                 logUnitMap[getLogarithmOfBase1024(convertToUnitVerbose(input, inputUnit, units.B).value)]);

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -305,6 +305,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.click("#vm-subVmTest1-usage")
         b.wait_in_text(".memory-usage-chart .usage-donut-caption", "256 MiB")
         b.wait_present("#chart-donut-0 .donut-title-big-pf")
+        b.wait_in_text("#chart-donut-0", "MiB")
         b.wait(lambda: get_usage("#chart-donut-0") > 0.0)
         b.wait_in_text(".vcpu-usage-chart .usage-donut-caption", "1 vCPU")
         # CPU usage cannot be nonzero with blank image, so just ensure it's a percentage


### PR DESCRIPTION
machines: Unify combination of units in the usage tab

The same unit should be used both for the graph and the helper text below.

Fixes #14503