### PR TITLE
users: Allow weak passwords

### DIFF
--- a/pkg/users/users.scss
+++ b/pkg/users/users.scss
@@ -183,3 +183,7 @@
     position: relative;
     top: -5px;
 }
+
+.help-block {
+    white-space: pre-wrap;
+}

--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -135,16 +135,36 @@ class TestAccounts(MachineCase):
         m.execute("userdel berta")
         b.wait_not_in_text('#accounts-list', "Berta Bestimmt")
 
-        # Create a locked user
+        # Create a locked user with weak password
         m.execute("sed -i 's/^SHELL=.*$/SHELL=/' /etc/default/useradd")
         b.click('#accounts-create')
         b.wait_visible('#accounts-create-dialog')
         b.set_input_text('#accounts-create-user-name', "jussi")
         b.set_input_text('#accounts-create-real-name', "Jussi Junior")
-        b.set_input_text('#accounts-create-pw1', good_password)
-        b.set_input_text('#accounts-create-pw2', good_password)
+        b.set_input_text('#accounts-create-pw1', "foo")
+        b.set_input_text('#accounts-create-pw2', "foo")
         b.set_checked('#accounts-create-locked', True)
         b.click('#accounts-create-dialog button.apply')
+
+        # Password is weak, lets change it to another weak - this should still not accept
+        b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Password quality check failed:")
+        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
+            b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
+        b.set_input_text('#accounts-create-pw1', "bar")
+        b.set_input_text('#accounts-create-pw2', "bar")
+        b.wait_not_present("#accounts-create-dialog .dialog-error.help-block")
+        b.click('#accounts-create-dialog button.apply')
+
+        # Lets confirm the weak password now
+        b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Password quality check failed:")
+        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
+            b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
+        else: # On distropkg we need to use a good password to create account
+            b.set_input_text('#accounts-create-pw1', good_password)
+            b.set_input_text('#accounts-create-pw2', good_password)
+
+        b.click('#accounts-create-dialog button.apply')
+
         b.wait_not_present('#accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Jussi Junior")
 
@@ -176,7 +196,7 @@ class TestAccounts(MachineCase):
 
         # Login as jussi and change role admin for itself
         b.logout()
-        b.login_and_go("/users", user="jussi", password=good_password)
+        b.login_and_go("/users", user="jussi", password="bar" if m.image != "rhel-8-3-distropkg" else good_password)
 
         # There is only one badge and it is for jussi
         b.wait_text('.cockpit-account-badge', 'Your account')
@@ -212,6 +232,8 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw2", 'a')
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .dialog-error.help-block", "Password quality check failed:")
+        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
+            b.wait_in_text("#account-set-password-dialog .dialog-error.help-block", "Click Set again to use the password anyway.")
 
         # password mismatch
         b.set_input_text("#account-set-password-pw1", good_password + 'a')


### PR DESCRIPTION
Modeled after anaconda where you can use a weak password if you click
the button two times.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1652390
Fixes #14478

@andreasn WDYT? Also the wording is not ideal, maybe I should spin up one fedora VM to see what exactly anaconda says.

<hr> 
Release note draft:

**Accounts: Allow setting up weak passwords**

Cockpit now allows users to set up a weak passwords. User is firstly notified that such password is weak but if user wishes to continue then clicking the submit button again will use the selected password anyway.

![cretejose](https://user-images.githubusercontent.com/12330670/92237578-e19fe600-eeb7-11ea-8e57-d53320a8dea1.png)


