### PR TITLE
kdump: Utilize description list instead of form for displaying data

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -21,7 +21,12 @@ import cockpit from "cockpit";
 
 import React from "react";
 import { OnOffSwitch } from "cockpit-components-onoff.jsx";
-import { Button, Tooltip, TooltipPosition, Page, PageSection, PageSectionVariants, Bullseye } from "@patternfly/react-core";
+import {
+    Button, Tooltip, TooltipPosition,
+    Page, PageSection, PageSectionVariants,
+    Bullseye,
+    DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
+} from "@patternfly/react-core";
 
 import * as Select from "cockpit-components-select.jsx";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
@@ -494,30 +499,45 @@ export class KdumpPage extends React.Component {
             <Page>
                 <PageSection variant={PageSectionVariants.light}>
                     <Bullseye>
-                        <form className="ct-form">
-                            <label className="control-label">{_("kdump status")}</label>
-                            <div role="group">
-                                <OnOffSwitch state={!!serviceRunning} onChange={this.props.onSetServiceState}
-                                    disabled={this.props.stateChanging} />
-                                {serviceWaiting}
-                                {kdumpServiceDetails}
-                            </div>
+                        <DescriptionList>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("kdump status")}</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <div role="group">
+                                        <OnOffSwitch state={!!serviceRunning} onChange={this.props.onSetServiceState}
+                                            disabled={this.props.stateChanging} />
+                                        {serviceWaiting}
+                                        {kdumpServiceDetails}
+                                    </div>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
 
-                            <label className="control-label">{_("Reserved memory")}</label>
-                            {reservedMemory}
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("Reserved memory")}</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {reservedMemory}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
 
-                            <label className="control-label">{_("Crash dump location")}</label>
-                            {settingsLink}
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>{_("Crash dump location")}</DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {settingsLink}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
 
-                            <div role="group">
-                                {testButton}
-                                <button className="popover-ct-kdump link-button">
-                                    <Tooltip id="tip-test-info" content={tooltip_info}>
-                                        <span className="fa fa-lg fa-info-circle" />
-                                    </Tooltip>
-                                </button>
-                            </div>
-                        </form>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm />
+                                <DescriptionListDescription>
+                                    {testButton}
+                                    <button className="popover-ct-kdump link-button">
+                                        <Tooltip id="tip-test-info" content={tooltip_info}>
+                                            <span className="fa fa-lg fa-info-circle" />
+                                        </Tooltip>
+                                    </button>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
                     </Bullseye>
                 </PageSection>
             </Page>

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -38,3 +38,10 @@ ul.pf-c-select__menu {
 .pf-c-breadcrumb__item-divider > svg {
     vertical-align: -0.125em;
 }
+
+// Patternfly horizontal lists should convert to vertical in small screens https://github.com/patternfly/patternfly-react/issues/4777
+@media (min-width: 640px) {
+    .pf-c-description-list {
+        --pf-c-description-list__group--GridTemplateColumns: var(--pf-c-description-list--m-horizontal__group--GridTemplateColumns);
+    }
+}


### PR DESCRIPTION
This approach should be served as an example of how to use
DescriptionList component for displaying data instead of the much used
<form> which is incorrectly used in many places.

Now: 
![Screen Shot 2020-09-04 at 10 36 15](https://user-images.githubusercontent.com/14921356/92219617-1c475580-ee9b-11ea-8472-9e7da8d0a29c.png)


Previously: 
![Screen Shot 2020-09-04 at 10 49 28](https://user-images.githubusercontent.com/14921356/92220460-56652700-ee9c-11ea-9995-48a8d8899bf5.png)


This commit improves the mobile version of the kdump page.