### PR TITLE
hosts: Enable to remove the current host

### DIFF
--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -165,6 +165,13 @@ export class CockpitHosts extends React.Component {
 
     onRemove(event, machine) {
         event.preventDefault();
+
+        if (this.props.machine === machine) {
+            // Removing machine underneath ourself - jump to localhost
+            const addr = this.props.hostAddr({ host: "localhost" }, true);
+            this.props.jump(addr);
+        }
+
         if (this.props.machines.list.length <= 2)
             this.setState({ editing: false });
         this.props.machines.change(machine.key, { visible: false });
@@ -210,7 +217,7 @@ export class CockpitHosts extends React.Component {
                 className={m.state}
                 actions={[
                     <Button isDisabled={m.address === "localhost"} className="nav-action" hidden={!editing} onClick={e => this.onHostEdit(e, m)} key={m.label + "edit"} variant="secondary"><EditIcon /></Button>,
-                    <Button isDisabled={m === this.props.machine || m.address === "localhost"} onClick={e => this.onRemove(e, m)} className="nav-action" hidden={!editing} key={m.label + "remove"} variant="danger"><MinusIcon /></Button>
+                    <Button isDisabled={m.address === "localhost"} onClick={e => this.onRemove(e, m)} className="nav-action" hidden={!editing} key={m.label + "remove"} variant="danger"><MinusIcon /></Button>
                 ]}
         />;
         const label = this.props.machine.label || "";
@@ -257,4 +264,5 @@ CockpitHosts.propTypes = {
     machines: PropTypes.object.isRequired,
     selector: PropTypes.string.isRequired,
     hostAddr: PropTypes.func.isRequired,
+    jump: PropTypes.func.isRequired,
 };

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -366,6 +366,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 machines: machines,
                 selector: "nav-hosts",
                 hostAddr: index.href,
+                jump: index.jump,
             }),
             document.getElementById("hosts-sel"));
     }

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -249,6 +249,16 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("#link-network a")
         b.enter_page("/network", "10.111.113.3")
 
+        # Remove host underneath ourselves
+        if m.image != "rhel-8-3-distropkg": # Introduced in #14567
+            b.switch_to_top()
+            b.click("#hosts-sel button")
+            b.click("button:contains('Edit hosts')")
+            b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-danger")
+            b.wait_not_present("iframe.container-frame[name='cockpit1:10.111.113.3/network']")
+            b.wait_js_cond('window.location.pathname == "/system"')
+            b.enter_page("/system", "localhost")
+
         # removing machines interrupts channels
         self.allow_restart_journal_messages()
         self.allow_hostkey_messages()


### PR DESCRIPTION
We were disabling to remove host on which we are currently at. We had at
last two reports about this, so lets not enforce it.
When user removes such host, will be switched to the `localhost`.

Fixes #14150