### PR TITLE
machines: fix misaligned first header column in nested tables

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -137,7 +137,7 @@
 
     // Adjust the padding for nested ct-tables in ct-tables
     .ct-table {
-        td {
+        td, th {
             &:first-child {
                 --pf-c-table--nested--first-last-child--PaddingLeft: var(--pf-global--spacer--lg);
             }


### PR DESCRIPTION
Commit 8960ea incorrectly adjusted the padding of the `<td>`s but not
`<th>`s in nested tables.
Fixes #14546
