### PR TITLE
firewall: Fixup spacing in translation string

### DIFF
--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -103,9 +103,7 @@
         <div class="pf-l-gallery pf-m-gutter">
           <article class="pf-c-card" id="networking-firewall" hidden>
             <div class="pf-c-card__header">
-              <div class="pf-c-card__title" translate="yes">
-                Firewall
-              </div>
+              <div class="pf-c-card__title" translate="yes">Firewall</div>
               <div class="firewall-switch">
               </div>
               <div class="pf-c-card__actions">


### PR DESCRIPTION
When having the string on separate line it is then generated as:
`msgid "                Firewall              "` (damn you github, don't suppres those spaces, I am trying to prove something here :unamused: )

Noticed in #14576