### PR TITLE
storage: Some Card layout and render fixes

### DIFF
--- a/pkg/lib/ct-card.scss
+++ b/pkg/lib/ct-card.scss
@@ -6,7 +6,7 @@
 .ct-card.pf-c-card .pf-c-card__body.contains-list {
     padding-left: 0;
     padding-right: 0;
-    padding-bottom: var(--pf-global--spacer--xs);
+    padding-bottom: 0;
 }
 
 .ct-card.pf-c-card .pf-c-card__body.contains-list > .pf-c-table > :last-child > tr:last-child {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -47,10 +47,6 @@
     padding-bottom: var(--pf-global--spacer--md);
 }
 
-#detail-content, #detail-content .pf-c-card {
-    height: 100%;
-}
-
 #storage .empty-panel-text,
 #storage .ct-table-empty td {
     text-align: center;


### PR DESCRIPTION
Don't make the content fill its grid cell and don't put a border on
the last row.

Before:
![image](https://user-images.githubusercontent.com/3228183/92593365-ad5a6a00-f2a9-11ea-96cf-1d63bbe20f5c.png)

After:
![image](https://user-images.githubusercontent.com/3228183/92593307-8f8d0500-f2a9-11ea-94a2-a6e31baca2de.png)
