### PR TITLE
machines: Fix shared proptype introduced in commit f5b0630

### DIFF
--- a/pkg/machines/components/vnc.jsx
+++ b/pkg/machines/components/vnc.jsx
@@ -159,7 +159,7 @@ class Vnc extends React.Component {
                         port={window.location.port || (encrypt ? '443' : '80')}
                         path={path}
                         encrypt={encrypt}
-                        shared='true'
+                        shared
                         credentials={credentials}
                         vncLogging='warn'
                         onDisconnected={this.onDisconnected}


### PR DESCRIPTION
Not sure why tests found it before, but now it's broken on master. 