### PR TITLE
systemd: Disallow cancelling a running domain join

### DIFF
--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -480,6 +480,7 @@ function instance(realmd, mode, realm, state) {
         unique += 1;
         busy(id);
         $(".realms-op-error").prop("hidden", true);
+        $(".realms-op-cancel").prop('disabled', true);
 
         ensure()
                 .fail(function() {
@@ -544,6 +545,7 @@ function instance(realmd, mode, realm, state) {
                             })
                             .always(function() {
                                 sub.remove();
+                                $(".realms-op-cancel").prop('disabled', false);
                             });
                 });
     }

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -8,13 +8,13 @@ import operation_html from "raw-loader!./realmd-operation.html";
 
 const _ = cockpit.gettext;
 
-var MANAGER = "/org/freedesktop/realmd";
+const MANAGER = "/org/freedesktop/realmd";
 
-var SERVICE = "org.freedesktop.realmd.Service";
-var PROVIDER = "org.freedesktop.realmd.Provider";
-var KERBEROS = "org.freedesktop.realmd.Kerberos";
-var KERBEROS_MEMBERSHIP = "org.freedesktop.realmd.KerberosMembership";
-var REALM = "org.freedesktop.realmd.Realm";
+const SERVICE = "org.freedesktop.realmd.Service";
+const PROVIDER = "org.freedesktop.realmd.Provider";
+const KERBEROS = "org.freedesktop.realmd.Kerberos";
+const KERBEROS_MEMBERSHIP = "org.freedesktop.realmd.KerberosMembership";
+const REALM = "org.freedesktop.realmd.Realm";
 
 function instance(realmd, mode, realm, state) {
     var dialog = jQuery.parseHTML(operation_html)[0];

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -188,8 +188,8 @@ def run(opts, image):
     if len(changed_tests) > 3:
         changed_tests = []
 
-    # HACK: Running all machines tests 3 times takes too long and the global timeout is reached
-    changed_tests = [test for test in changed_tests if "check-machines" not in test]
+    # HACK: Running all machines or realms tests 3 times takes too long and the global timeout is reached
+    changed_tests = [test for test in changed_tests if "check-machines" not in test and "check-realms" not in test]
 
     seen_classes = {}
     for filename in glob.glob(os.path.join(opts.test_dir, "check-*")):

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -103,6 +103,8 @@ class CommonTests:
         b.set_val(self.op_admin_password, self.admin_password)
         b.wait_not_visible(".realms-op-leave-only-row")
         b.click(".realms-op-apply")
+        # running operation cannot be cancelled any more
+        b.wait_visible(".realms-op-cancel:disabled")
         with b.wait_timeout(300):
             b.wait_popdown("realms-op")
 
@@ -235,18 +237,6 @@ class CommonTests:
         b.set_val(self.op_address, "NOPE")
         b.wait_text(".realms-op-address-error", "Domain NOPE could not be contacted")
         b.wait_not_visible(".realms-op-address-spinner")
-        b.click(".realms-op-cancel")
-        b.wait_popdown("realms-op")
-
-        # Cancel a join
-        b.click(self.domain_sel)
-        b.wait_popup("realms-op")
-        b.set_val(self.op_address, "cockpit.lan")
-        b.wait_attr(self.op_admin, "placeholder", 'e.g. "%s"' % self.admin_user)
-        b.set_val(self.op_admin, self.admin_user)
-        b.set_val(self.op_admin_password, self.admin_password)
-        b.click(".realms-op-apply")
-        b.wait_visible(".realms-op-spinner")
         b.click(".realms-op-cancel")
         b.wait_popdown("realms-op")
 


### PR DESCRIPTION
If the join process is cancelled later than just a tiny amount of time
after starting the installation process, the system is in a half-joined
state, ipa-client-install fails with random exceptions, realm list
claims you are joined, but you are not fully, and realm
leave/ipa-client-uninstall also failsbecause of the inconsistent system
state.

Let's not allow that any more. If the join fails due to invalid
credentials etc, the dialog will come back with a proper error message,
and if it succeeds you can always immediately leave again.