### PR TITLE
test: Clean up obsolete rhel-8-3-distropkg special cases

### DIFF
--- a/test/verify/check-accounts
+++ b/test/verify/check-accounts
@@ -103,10 +103,7 @@ class TestAccounts(MachineCase):
         b.wait(lambda: m.execute("passwd -S root").split()[1] in ["L", "LK"])
 
         # go back to accounts overview, check pf-c-breadcrumb
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.click("#account .pf-c-breadcrumb a")
-        else:
-            b.click("#account .breadcrumb button")
+        b.click("#account .pf-c-breadcrumb a")
         b.wait_present("#accounts-create")
 
         # Create a user from the UI
@@ -116,8 +113,7 @@ class TestAccounts(MachineCase):
         b.set_input_text('#accounts-create-user-name', "berta")
         b.set_input_text('#accounts-create-real-name', "Berta Bestimmt")
         b.set_input_text('#accounts-create-pw1', "foo")
-        if m.image != "rhel-8-3-distropkg": # Fixed in #14559
-            b.wait_visible("#accounts-create-password-meter.weak")
+        b.wait_visible("#accounts-create-password-meter.weak")
         b.set_input_text('#accounts-create-pw1', good_password)
         b.wait_visible("#accounts-create-password-meter.excellent")
 
@@ -159,8 +155,7 @@ class TestAccounts(MachineCase):
 
         # Password is weak, lets change it to another weak - this should still not accept
         b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Password quality check failed:")
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
-            b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
+        b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
         b.set_input_text('#accounts-create-pw1', "bar")
         b.set_input_text('#accounts-create-pw2', "bar")
         b.wait_not_present("#accounts-create-dialog .dialog-error.help-block")
@@ -168,11 +163,7 @@ class TestAccounts(MachineCase):
 
         # Lets confirm the weak password now
         b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Password quality check failed:")
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
-            b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
-        else: # On distropkg we need to use a good password to create account
-            b.set_input_text('#accounts-create-pw1', good_password)
-            b.set_input_text('#accounts-create-pw2', good_password)
+        b.wait_in_text("#accounts-create-dialog .dialog-error.help-block", "Click Create again to use the password anyway.")
 
         b.click('#accounts-create-dialog button.apply')
 
@@ -207,7 +198,7 @@ class TestAccounts(MachineCase):
 
         # Login as jussi and change role admin for itself
         b.logout()
-        b.login_and_go("/users", user="jussi", password="bar" if m.image != "rhel-8-3-distropkg" else good_password)
+        b.login_and_go("/users", user="jussi", password="bar")
 
         # There is only one badge and it is for jussi
         b.wait_text('.cockpit-account-badge', 'Your account')
@@ -244,8 +235,7 @@ class TestAccounts(MachineCase):
         b.wait_visible("#account-set-password-meter.weak")
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .dialog-error.help-block", "Password quality check failed:")
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14557
-            b.wait_in_text("#account-set-password-dialog .dialog-error.help-block", "Click Set again to use the password anyway.")
+        b.wait_in_text("#account-set-password-dialog .dialog-error.help-block", "Click Set again to use the password anyway.")
 
         # password mismatch
         b.set_input_text("#account-set-password-pw1", good_password + 'a')

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -674,24 +674,23 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
                 # should clean up processes
                 self.assertEqual(m.execute("! pgrep -a cockpit-ws && ! pgrep -a cockpit-bridge"), "")
 
-        if m.image != "rhel-8-3-distropkg":  # fixed in PR #14324
-            # cockpit-desktop can start a privileged bridge through polkit
-            # we don't have an agent, so just allow the privilege without interactive authentication
-            m.write("/etc/polkit-1/localauthority/50-local.d/test.pkla", r"""
+        # cockpit-desktop can start a privileged bridge through polkit
+        # we don't have an agent, so just allow the privilege without interactive authentication
+        m.write("/etc/polkit-1/localauthority/50-local.d/test.pkla", r"""
 [Testing without an agent]
 Identity=unix-user:admin
 Action=org.cockpit-project.cockpit.root-bridge
 ResultAny=yes
 ResultInactive=yes
 ResultActive=yes""")
-            m.write(r"/tmp/browser.sh", """#!/bin/sh -e
+        m.write(r"/tmp/browser.sh", """#!/bin/sh -e
 curl --silent --compressed -o /tmp/out.html "$@"
 # wait until privileged bridge starts
 until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
 """)
-            m.execute("chmod 755 /tmp/browser.sh")
-            m.execute("su - -c 'BROWSER=/tmp/browser.sh %s system' admin" % cockpit_desktop)
-            self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
+        m.execute("chmod 755 /tmp/browser.sh")
+        m.execute("su - -c 'BROWSER=/tmp/browser.sh %s system' admin" % cockpit_desktop)
+        self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
 
         self.allow_authorize_journal_messages()
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
@@ -735,11 +734,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
             return False
         wait(check_wss_log)
 
-        # our logging changed, but the distropkg still behaves the old way
-        if m.image in ['rhel-8-3-distropkg']:
-            wait(lambda: "received request from bad Origin" in m.execute("journalctl -b -t cockpit-ws"))
-        else:
-            wait(lambda: m.execute("grep 'received request from bad Origin' /var/log/ws-notls.log"))
+        wait(lambda: m.execute("grep 'received request from bad Origin' /var/log/ws-notls.log"))
 
         # sanity check: unencrypted http through SSL proxy does not work
         m.execute("! curl http://localhost:9090")

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -264,8 +264,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_js_cond('window.location.pathname.indexOf("/@10.111.113.3") === 0')
 
         # remote hosts should not have the dashboard, since #14590
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14567
-            b.wait_not_in_text("#nav-system", "Dashboard")
+        b.wait_not_in_text("#nav-system", "Dashboard")
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
@@ -275,14 +274,13 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.enter_page("/network", "10.111.113.3")
 
         # Remove host underneath ourselves
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14567
-            b.switch_to_top()
-            b.click("#hosts-sel button")
-            b.click("button:contains('Edit hosts')")
-            b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-danger")
-            b.wait_not_present("iframe.container-frame[name='cockpit1:10.111.113.3/network']")
-            b.wait_js_cond('window.location.pathname == "/system"')
-            b.enter_page("/system", "localhost")
+        b.switch_to_top()
+        b.click("#hosts-sel button")
+        b.click("button:contains('Edit hosts')")
+        b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-danger")
+        b.wait_not_present("iframe.container-frame[name='cockpit1:10.111.113.3/network']")
+        b.wait_js_cond('window.location.pathname == "/system"')
+        b.enter_page("/system", "localhost")
 
         # removing machines interrupts channels
         self.allow_restart_journal_messages()

--- a/test/verify/check-keys
+++ b/test/verify/check-keys
@@ -71,12 +71,8 @@ class TestKeys(MachineCase):
 
         # no keys
         login("user", "foobar", "User")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
-        else:
-            b.wait_in_text("#account-authorized-keys-list div.list-group-item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 1)
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
         # add bad
         b.click('#authorized-key-add')
@@ -96,14 +92,9 @@ class TestKeys(MachineCase):
 
         # Not allowed, except on Ubuntu, where we can find out that ~/.ssh doesn't exist, which is shown as "no keys".
         if "ubuntu" not in m.image and "debian" not in m.image:
-            if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-                b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child",
-                               "You do not have permission")
-                b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
-            else:
-                b.wait_in_text("#account-authorized-keys-list div.list-group-item:first-child",
-                                "You do not have permission")
-                b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 1)
+            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child",
+                           "You do not have permission")
+            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
         b.logout()
 
@@ -114,12 +105,8 @@ class TestKeys(MachineCase):
         # Log in as admin
         login("admin", "foobar", "Administrator")
         b.go("#/user")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
-        else:
-            b.wait_in_text("#account-authorized-keys-list div.list-group-item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 1)
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
         # Adding keys sets permissions properly
         b.wait_text("#account-user-name", "user")
@@ -135,41 +122,24 @@ class TestKeys(MachineCase):
 
         # Add invalid key directly
         m.execute("(echo '' && echo 'bad') >> /home/user/.ssh/authorized_keys")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:last-child", "Invalid key")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 2)
-        else:
-            b.wait_in_text("#account-authorized-keys-list div.list-group-item:last-child", "Invalid key")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 2)
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:last-child", "Invalid key")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 2)
 
         # Removing the key
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.click("#account-authorized-keys-list li.pf-c-data-list__item:last-child button")
-            b.wait_not_in_text("#account-authorized-keys-list li.pf-c-data-list__item:last-child", "Invalid key")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
-        else:
-            b.click("#account-authorized-keys-list div.list-group-item:last-child button")
-            b.wait_not_in_text("#account-authorized-keys-list div.list-group-item:last-child", "Invalid key")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 1)
+        b.click("#account-authorized-keys-list li.pf-c-data-list__item:last-child button")
+        b.wait_not_in_text("#account-authorized-keys-list li.pf-c-data-list__item:last-child", "Invalid key")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
         data = m.execute("cat /home/user/.ssh/authorized_keys")
         self.assertEqual(data, KEY + '\n')
         b.logout()
 
         # User can still see their keys
         login("user", "foobar", "User")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "test-name")
-        else:
-            b.wait_in_text("#account-authorized-keys-list div.list-group-item:first-child", "test-name")
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "test-name")
 
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14517
-            b.click("#account-authorized-keys-list li.pf-c-data-list__item:first-child button")
-            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
-        else:
-            b.click("#account-authorized-keys-list div.list-group-item:first-child button")
-            b.wait_in_text("#account-authorized-keys-list div.list-group-item:first-child", "no authorized public keys")
-            b.wait_js_func("ph_count_check", "#account-authorized-keys-list div.list-group-item", 1)
+        b.click("#account-authorized-keys-list li.pf-c-data-list__item:first-child button")
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
+        b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
         self.allow_restart_journal_messages()
         self.allow_authorize_journal_messages()

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -88,9 +88,8 @@ class TestMenu(MachineCase):
         b.go("/playground/exception")
 
         # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
-        if m.image != "rhel-8-3-distropkg": # Introduced in #14325
-            b.wait_visible("#host-apps .pf-m-current")
-            b.wait_visible("#host-apps .pf-m-current:contains('Development')")
+        b.wait_visible("#host-apps .pf-m-current")
+        b.wait_visible("#host-apps .pf-m-current:contains('Development')")
 
         b.enter_page("/playground/exception")
         b.wait_visible("button")

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -244,7 +244,6 @@ class TestMultiMachineAdd(MachineCase):
         b.wait_attr("#dashboard-hosts a[data-address='m3'] img", 'src', '../shell/images/server-small.png')
 
 
-@skipImage("Changed in #14344", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestMultiMachine(MachineCase):
     provision = {

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -120,7 +120,6 @@ class TestMultiMachineKeyAuth(MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
-    @skipImage("Changed in #14344", "rhel-8-3-distropkg")
     def testBasic(self):
         b = self.browser
         m1 = self.machine
@@ -274,7 +273,6 @@ Host 10.111.113.2
         b.wait_present("#dashboard-hosts .list-group-item[data-address='10.111.113.2']")
         self.allow_hostkey_messages()
 
-    @skipImage("Fixed in #14551", "rhel-8-3-distropkg")
     def testLockedDefaultIdentity(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-multi-os
+++ b/test/verify/check-multi-os
@@ -47,7 +47,6 @@ def add_machine(b, address, password):
     b.wait_popdown('dashboard_setup_server_dialog')
 
 
-@skipImage("Changed in #14344", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestMultiOS(MachineCase):
     provision = {
@@ -144,7 +143,6 @@ class TestMultiOS(MachineCase):
         # Messages from previous versions of cockpit
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
 
-@skipImage("Changed in #14344", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestMultiOSDirect(MachineCase):
     provision = {

--- a/test/verify/check-networking-basic
+++ b/test/verify/check-networking-basic
@@ -57,11 +57,10 @@ class TestNetworkingBasic(NetworkCase):
         b.click("tr:contains('IPv4') a")
         b.wait_popup("network-ip-settings-dialog")
         b.select_from_dropdown("#network-ip-settings-dialog select", "Manual")
-        # Manual mode  disables automatic switches (fixed in PR #14291)
-        if m.image not in ["rhel-8-3-distropkg"]:
-            b.wait_present("#network-ip-settings-dialog [data-field='dns'] .onoff-ct :disabled")
-            b.wait_present("#network-ip-settings-dialog [data-field='dns_search'] .onoff-ct :disabled")
-            b.wait_present("#network-ip-settings-dialog [data-field='routes'] .onoff-ct :disabled")
+        # Manual mode  disables automatic switches
+        b.wait_present("#network-ip-settings-dialog [data-field='dns'] .onoff-ct :disabled")
+        b.wait_present("#network-ip-settings-dialog [data-field='dns_search'] .onoff-ct :disabled")
+        b.wait_present("#network-ip-settings-dialog [data-field='routes'] .onoff-ct :disabled")
 
         b.set_val('#network-ip-settings-dialog input[placeholder="Address"]', "1.2.3.4")
         b.set_val('#network-ip-settings-dialog input[placeholder*="netmask"]', "255.255.0.8")
@@ -70,20 +69,13 @@ class TestNetworkingBasic(NetworkCase):
         b.set_val('#network-ip-settings-dialog input[placeholder*="netmask"]', "255.255.192.0")
         b.click("#network-ip-settings-dialog button:contains('Apply')")
         b.wait_popdown("network-ip-settings-dialog")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('%s')" % iface, "1.2.3.4/18")
-        else:
-            b.wait_in_text("#network-interface .panel:contains('%s')" % iface, "1.2.3.4/18")
+        b.wait_in_text("#network-interface .pf-c-card:contains('%s')" % iface, "1.2.3.4/18")
 
         con_id = wait(lambda: self.iface_con_id(iface))
 
         # Disconnect
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
-            self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        else:
-            self.wait_onoff(".panel-heading:contains('%s')" % iface, True)
-            self.toggle_onoff(".panel-heading:contains('%s')" % iface)
+        self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
         b.wait_in_text("tr:contains('Status')", "Inactive")
 
         # Switch it back to "auto" from the command line and bring it
@@ -155,12 +147,8 @@ class TestNetworkingBasic(NetworkCase):
         b.click("#networking-nm-crashed a")
         b.enter_page("/system/services")
         b.wait_text(".service-name", "Network Manager")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14459
-            b.click(".service-top-panel .pf-c-dropdown button")
-            b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
-        else:
-            b.click(".service-top-panel .dropdown-kebab-pf button")
-            b.click(".service-top-panel .dropdown-menu a:contains('Start')")
+        b.click(".service-top-panel .pf-c-dropdown button")
+        b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")
 
         # networking page should notice start from Services page

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -25,7 +25,6 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 
 @nondestructive
-@skipImage("Changed in #14322", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestBonding(NetworkCase):
     def testBasic(self):
@@ -85,16 +84,10 @@ class TestBonding(NetworkCase):
 
         # Deactivate the bond and make sure it is still there after a
         # reload.
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff(".pf-c-card__header:contains('tbond')", True)
-            self.toggle_onoff(".pf-c-card__header:contains('tbond')")
-            b.wait_in_text("tr:contains('Status')", "Inactive")
-            b.wait_not_present(".pf-c-card__header:contains('tbond') .onoff-ct input:disabled")
-        else:
-            self.wait_onoff(".panel-heading:contains('tbond')", True)
-            self.toggle_onoff(".panel-heading:contains('tbond')")
-            b.wait_in_text("tr:contains('Status')", "Inactive")
-            b.wait_not_present(".panel-heading:contains('tbond') .onoff-ct input:disabled")
+        self.wait_onoff(".pf-c-card__header:contains('tbond')", True)
+        self.toggle_onoff(".pf-c-card__header:contains('tbond')")
+        b.wait_in_text("tr:contains('Status')", "Inactive")
+        b.wait_not_present(".pf-c-card__header:contains('tbond') .onoff-ct input:disabled")
 
         b.reload()
         b.enter_page("/network")
@@ -180,22 +173,15 @@ class TestBonding(NetworkCase):
         self.addCleanup(m.execute, "nmcli dev delete tbond3000 2>/dev/null || true")
 
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff("#network-interface .pf-c-card__header", True)
-        else:
-            self.wait_onoff("#network-interface .panel-heading", True)
+        self.wait_onoff("#network-interface .pf-c-card__header", True)
         b.wait_in_text("tr:contains('Status')", "Configuring")
 
         b.click("tr:contains('Bond') a")
         b.wait_popup("network-bond-settings-dialog")
 
         # Check that link monitoring is correctly set up
-        if m.image != "rhel-8-3-distropkg": # Fixed in #14555
-            b.wait_val("#network-bond-settings-link-monitoring-select", "arp")
-            b.wait_val("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
-        else:
-            b.wait_val("#network-bond-settings-link-monitoring-select", "mii")
-            b.wait_val("#network-bond-settings-monitoring-targets-input", "")
+        b.wait_val("#network-bond-settings-link-monitoring-select", "arp")
+        b.wait_val("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
 
         b.set_val("#network-bond-settings-interface-name-input", "tbond3000")
         b.click("#network-bond-settings-dialog button:contains('Apply')")
@@ -204,7 +190,6 @@ class TestBonding(NetworkCase):
 
     def testActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 
@@ -230,10 +215,7 @@ class TestBonding(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", ip)
-        else:
-            b.wait_in_text("#network-interface .panel:contains('tbond')", ip)
+        b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", ip)
 
     def testAmbiguousMember(self):
         b = self.browser
@@ -270,7 +252,6 @@ class TestBonding(NetworkCase):
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
 
 
-@skipImage("Changed in #14322", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestBondingVirt(NetworkCase):
     provision = {
@@ -300,10 +281,7 @@ class TestBondingVirt(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", "10.111.113.1")
-        else:
-            b.wait_in_text("#network-interface .panel:contains('tbond')", "10.111.113.1")
+        b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", "10.111.113.1")
 
         # Delete the bond
         b.click("#network-interface button:contains('Delete')")
@@ -341,10 +319,7 @@ class TestBondingVirt(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tbond'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", "10.111.113.1")
-        else:
-            b.wait_in_text("#network-interface .panel:contains('tbond')", "10.111.113.1")
+        b.wait_in_text("#network-interface .pf-c-card:contains('tbond')", "10.111.113.1")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -23,7 +23,6 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Changed in #14322", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestBridge(NetworkCase):
     def testBasic(self):
@@ -70,7 +69,6 @@ class TestBridge(NetworkCase):
 
     def testActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 
@@ -93,10 +91,7 @@ class TestBridge(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tbridge'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('tbridge')", "10.111")
-        else:
-            b.wait_in_text("#network-interface .panel:contains('tbridge')", "10.111")
+        b.wait_in_text("#network-interface .pf-c-card:contains('tbridge')", "10.111")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-networking-checkpoints
+++ b/test/verify/check-networking-checkpoints
@@ -45,12 +45,8 @@ class TestNetworkingCheckpoints(NetworkCase):
         b.wait_visible("#network-interface")
 
         # Disconnect
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
-            self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        else:
-            self.wait_onoff(".panel-heading:contains('%s')" % iface, True)
-            self.toggle_onoff(".panel-heading:contains('%s')" % iface)
+        self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
 
         # Wait for dialog to appear and dismiss it
         b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
@@ -130,12 +126,8 @@ class TestNetworkingCheckpoints(NetworkCase):
         self.slow_down_dhclient(dhcp_delay)
 
         # Disconnect and trigger a slow rollback
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
-            self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        else:
-            self.wait_onoff(".panel-heading:contains('%s')" % iface, True)
-            self.toggle_onoff(".panel-heading:contains('%s')" % iface)
+        self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
         with b.wait_timeout(120):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
 

--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -100,10 +100,7 @@ class TestFirewall(NetworkCase):
         b.click("#networking-firewall-link")
         b.enter_page("/network/firewall")
 
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14537
-            b.click(".pf-c-breadcrumb li:first a")
-        else:
-            b.click(".breadcrumb li:first button")
+        b.click(".pf-c-breadcrumb li:first a")
 
         b.enter_page("/network")
 

--- a/test/verify/check-networking-settings
+++ b/test/verify/check-networking-settings
@@ -66,10 +66,7 @@ class TestNetworkingSettings(NetworkCase):
 
         # The interface will be activated. Deactivate it.
         b.wait_in_text("tr:contains('Status')", "1.2.3.4/24")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        else:
-            self.toggle_onoff(".panel-heading:contains('%s')" % iface)
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
         b.wait_in_text("tr:contains('Status')", "Inactive")
 
         # Delete the connection settings again and wait for the ghost
@@ -78,10 +75,7 @@ class TestNetworkingSettings(NetworkCase):
         b.wait_in_text("tr:contains('IPv4')", "Automatic")
 
         # Activate with ghost settings
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        else:
-            self.toggle_onoff(".panel-heading:contains('%s')" % iface)
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
         b.wait_in_text("tr:contains('Status')", "10.111.")
 
         # Check again that we now have connection settings

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -23,9 +23,8 @@ from testlib import *
 
 
 @skipImage("NetworkManager-team not installed", "fedora-coreos")
-@skipImage("Changed in #14322", "rhel-8-3-distropkg")
-@nondestructive
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
+@nondestructive
 class TestTeam(NetworkCase):
     def testBasic(self):
         b = self.browser
@@ -68,12 +67,8 @@ class TestTeam(NetworkCase):
         # Deactivate the team and make sure it is still there after a
         # reload.
         b.wait_text_not("#network-interface-mac", "")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            self.wait_onoff(".pf-c-card__header:contains('tteam')", True)
-            self.toggle_onoff(".pf-c-card__header:contains('tteam')")
-        else:
-            self.wait_onoff(".panel-heading:contains('tteam')", True)
-            self.toggle_onoff(".panel-heading:contains('tteam')")
+        self.wait_onoff(".pf-c-card__header:contains('tteam')", True)
+        self.toggle_onoff(".pf-c-card__header:contains('tteam')")
         b.wait_in_text("tr:contains('Status')", "Inactive")
         b.reload()
         b.enter_page("/network")
@@ -97,7 +92,6 @@ class TestTeam(NetworkCase):
 
     def testActive(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 
@@ -120,10 +114,7 @@ class TestTeam(NetworkCase):
         b.click("#networking-interfaces tr[data-interface='tteam'] td:first-child")
         b.wait_visible("#network-interface")
         b.wait_present("#network-interface-members tr[data-interface='%s']" % iface)
-        if m.image != "rhel-8-3-distropkg": # Changed in #14454
-            b.wait_in_text("#network-interface .pf-c-card:contains('tteam')", "10.111")
-        else:
-            b.wait_in_text("#network-interface .panel:contains('tteam')", "10.111")
+        b.wait_in_text("#network-interface .pf-c-card:contains('tteam')", "10.111")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -127,12 +127,8 @@ class CommonTests:
         # log in as domain admin and check that we can do privileged operations
         b.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user='%s@cockpit.lan' % self.admin_user, password=self.admin_password)
         b.wait_in_text("#statuses", "Running")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14459
-            b.click(".service-top-panel .pf-c-dropdown button")
-            b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
-        else:
-            b.click(".service-top-panel .dropdown-kebab-pf button")
-            b.click(".service-top-panel .dropdown-menu a:contains('Stop')")
+        b.click(".service-top-panel .pf-c-dropdown button")
+        b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
         # stopping the unit may interrupt the D-Bus proxy inspection of that unit
         self.allow_journal_messages(".*systemd1:.*systemd_2dtmpfiles_2dclean_2etimer: Timeout was reached")
@@ -144,12 +140,8 @@ class CommonTests:
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
         b.wait_in_text("#statuses", "Not running")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14459
-            b.click(".service-top-panel .pf-c-dropdown button")
-            b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
-        else:
-            b.click(".service-top-panel .dropdown-kebab-pf button")
-            b.click(".service-top-panel .dropdown-menu a:contains('Start')")
+        b.click(".service-top-panel .pf-c-dropdown button")
+        b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")
         b.logout()
 
@@ -292,12 +284,8 @@ class CommonTests:
         b.enter_page('/system/services')
 
         b.wait_in_text("#statuses", "Running")
-        if m.image != "rhel-8-3-distropkg": # Changed in #14459
-            b.click(".service-top-panel .pf-c-dropdown button")
-            b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
-        else:
-            b.click(".service-top-panel .dropdown-kebab-pf button")
-            b.click(".service-top-panel .dropdown-menu a:contains('Stop')")
+        b.click(".service-top-panel .pf-c-dropdown button")
+        b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
 
         b.go('/system')

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -49,12 +49,8 @@ class TestServices(MachineCase):
         self.browser.click(".service-top-panel .onoff-ct input")
 
     def do_action(self, action):
-        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14459
-            self.browser.click(".service-top-panel .pf-c-dropdown button")
-            self.browser.click(".service-top-panel .pf-c-dropdown__menu a:contains('{0}')".format(action))
-        else:
-            self.browser.click(".service-top-panel .dropdown-kebab-pf button")
-            self.browser.click(".service-top-panel .dropdown-menu a:contains('{0}')".format(action))
+        self.browser.click(".service-top-panel .pf-c-dropdown button")
+        self.browser.click(".service-top-panel .pf-c-dropdown__menu a:contains('{0}')".format(action))
 
     def check_service_details(self, statuses, actions, enabled, onoff=True, kebab=True):
         self.browser.wait_collected_text("#statuses .status", "".join(statuses))
@@ -63,22 +59,13 @@ class TestServices(MachineCase):
         else:
             self.browser.wait_not_present(".service-top-panel .onoff-ct")
 
-        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14459
-            if kebab:
-                self.browser.click(".service-top-panel .pf-c-dropdown button")
-                self.browser.wait_text(".service-top-panel .pf-c-dropdown__menu", "".join(actions))
-                # Click away to close the pf-c-dropdown__menu
-                self.browser.click(".service-top-panel .pf-c-dropdown button")
-            else:
-                self.browser.wait_not_present(".service-top-panel .pf-c-dropdown")
+        if kebab:
+            self.browser.click(".service-top-panel .pf-c-dropdown button")
+            self.browser.wait_text(".service-top-panel .pf-c-dropdown__menu", "".join(actions))
+            # Click away to close the pf-c-dropdown__menu
+            self.browser.click(".service-top-panel .pf-c-dropdown button")
         else:
-            if kebab:
-                self.browser.click(".service-top-panel .dropdown-kebab-pf button")
-                self.browser.wait_text(".service-top-panel .dropdown-menu", "".join(actions))
-                # Click away to close the dropdown-menu
-                self.browser.click(".service-top-panel .dropdown-kebab-pf button")
-            else:
-                self.browser.wait_not_present(".service-top-panel .dropdown-kebab-pf")
+            self.browser.wait_not_present(".service-top-panel .pf-c-dropdown")
 
     def svc_sel(self, service):
         return 'li[data-goto-unit="%s"]' % service
@@ -249,14 +236,9 @@ Unit=test.service
         self.check_service_details(["Not running", "Automatically starts"], ["Start", "Disallow running (mask)"], True)
         self.do_action("Start")
         self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
-        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14513
-            b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "START")
-            b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "WORKING")
-            b.click(".cockpit-log-panel .pf-c-card__header button")
-        else:
-            b.wait_in_text('.cockpit-log-panel .panel-body', "START")
-            b.wait_in_text('.cockpit-log-panel .panel-body', "WORKING")
-            b.click(".cockpit-log-panel .panel-heading button")
+        b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "START")
+        b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "WORKING")
+        b.click(".cockpit-log-panel .pf-c-card__header button")
 
         b.enter_page("/system/logs")
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
@@ -378,10 +360,7 @@ Unit=test.service
 
         # Check that journalbox shows empty state
         b.click(self.svc_sel("systemd-halt.service"))
-        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14513
-            b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
-        else:
-            b.wait_text('.cockpit-log-panel .panel-body', "No log entries")
+        b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
 
     def testApi(self):
         m = self.machine

--- a/test/verify/check-shutdown-restart
+++ b/test/verify/check-shutdown-restart
@@ -70,7 +70,6 @@ class TestShutdownRestart(MachineCase):
 
         m.wait_reboot()
 
-    @skipImage("Changed in #14344", "rhel-8-3-distropkg")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -323,7 +323,6 @@ class TestSuperuserOldWebserver(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
-@skipImage("Changed in #14344", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestSuperuserDashboard(MachineCase):
     provision = {
@@ -446,7 +445,6 @@ class TestSuperuserOldDashboard(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
-@skipImage("Changed in #14344", "rhel-8-3-distropkg")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestSuperuserDashboardOldMachine(MachineCase):
     provision = {

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -380,8 +380,7 @@ class TestSystemInfo(MachineCase):
         # BIOS
         b.wait_in_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(1) td', "SeaBIOS")
         # BIOS date
-        if m.image != "rhel-8-3-distropkg": # Fixed in #14465
-            b.wait_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', m.execute("cat /sys/class/dmi/id/bios_date").strip())
+        b.wait_text('#hwinfo .info-table-ct tbody:nth-of-type(2) tr:nth-of-type(3) td', m.execute("cat /sys/class/dmi/id/bios_date").strip())
 
         pci_selector = '#hwinfo #pci-listing'
         heading_selector = ' .ct-table-heading'
@@ -401,10 +400,7 @@ class TestSystemInfo(MachineCase):
         b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
 
         # go back to system page
-        if self.machine.image != "rhel-8-3-distropkg": # Changed in #14537
-            b.click('.pf-c-breadcrumb li:first a')
-        else:
-            b.click('.breadcrumb button')
+        b.click('.pf-c-breadcrumb li:first a')
 
         b.enter_page("/system")
 


### PR DESCRIPTION
Commit 2d50f4bcad skips entire test classes for the basic packages, so
they don't need individual -distropkg special cases any more.