### PR TITLE
test: Wait for firewalld service state

### DIFF
--- a/test/verify/check-networking-firewall
+++ b/test/verify/check-networking-firewall
@@ -90,10 +90,25 @@ class TestFirewall(NetworkCase):
         b.wait_in_text("#networking-firewall-summary", "0 active zones")
 
         # toggle the service from CLI, page should react
-        m.execute("systemctl start firewalld")
+        try:
+            m.execute("systemctl start firewalld")
+            wait_unit_state(m, "firewalld", "active")
+        except Error:
+            print("====== firewalld.service =======")
+            print(m.execute("systemctl status firewalld"))
+            raise
+
         self.wait_onoff("#networking-firewall-switch", True)
         b.wait_in_text("#networking-firewall-summary", "{} active zone".format(active_zones))
-        m.execute("systemctl stop firewalld")
+
+        try:
+            m.execute("systemctl stop firewalld")
+            wait_unit_state(m, "firewalld", "inactive")
+        except Error:
+            print("====== firewalld.service =======")
+            print(m.execute("systemctl status firewalld"))
+            raise
+
         self.wait_onoff("#networking-firewall-switch", False)
         b.wait_in_text("#networking-firewall-summary", "0 active zones")
 


### PR DESCRIPTION
There seems to be some issue with this part of test where it times out
waiting for the change in the UI. There are 3 possible explanations:
1. The service fails to stop/start
2. There is no event delivered (or is delivered but we process it wrongly)
3. It just takes a bit longer to propagate in the UI

This PR does not fix any of these issues (possibly the last one) but it
should point if the issue is no. 1 or no. 2. Then we can do more
debugging.

I cannot reproduce it locally while running that test in loop in 3 parallel batches...
Talking about failure like this: https://logs.cockpit-project.org/logs/pull-14602-20200911-063101-73421c5c-fedora-32/log.html