### PR TITLE
test: Be robust against mdraids starting themselves spontaneously

### DIFF
--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -65,10 +65,14 @@ class TestStorageMdRaid(StorageCase):
         do_click()
 
         if action == "Stop":
-            # right after assembling an array the device might be busy from
-            # udev rules probing or the mdadm monitor; retry a few times
+            # Right after assembling an array the device might be busy
+            # from udev rules probing or the mdadm monitor; retry a
+            # few times.  Also, it might come back spontaneously after
+            # having been stopped successfully; wait a bit before
+            # checking whether it is really off.
             for retry in range(3):
                 try:
+                    sleep(10)
                     self.browser.wait_in_text(info_field("State", self.machine.image), "Not running")
                     break
                 except Error as ex:


### PR DESCRIPTION
This seems to happen often right after stopping them, for unknown
reasons.