### PR TITLE
Use json-memfd to pass "origin-ip" from -tls to -ws (enabling remote IP logging)

### DIFF
--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -54,6 +54,8 @@ noinst_LIBRARIES += libcockpit-common.a
 libcockpit_common_a_SOURCES = \
 	src/common/cockpitchannel.c \
 	src/common/cockpitchannel.h \
+	src/common/cockpitcontrolmessages.c \
+	src/common/cockpitcontrolmessages.h \
 	src/common/cockpiterror.h src/common/cockpiterror.c \
 	src/common/cockpitflow.c \
 	src/common/cockpitflow.h \

--- a/src/common/cockpitcontrolmessages.c
+++ b/src/common/cockpitcontrolmessages.c
@@ -1,0 +1,96 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cockpitcontrolmessages.h"
+
+#include <gio/gunixfdmessage.h>
+
+void
+cockpit_control_messages_clear (CockpitControlMessages *ccm)
+{
+  for (gint i = 0; i < ccm->n_messages; i++)
+    g_object_unref (ccm->messages[i]);
+  g_free (ccm->messages);
+
+  ccm->messages = NULL;
+  ccm->n_messages = 0;
+}
+
+gboolean
+cockpit_control_messages_empty (CockpitControlMessages *ccm)
+{
+  return ccm->n_messages == 0;
+}
+
+gpointer
+cockpit_control_messages_get_single_message (CockpitControlMessages  *ccm,
+                                             GType                    message_type,
+                                             GError                 **error)
+{
+  if (ccm->n_messages != 1)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                   "Unexpectedly received %d control messages (one message of type %s expected)",
+                   ccm->n_messages, g_type_name (message_type));
+      return NULL;
+    }
+
+  if (!G_TYPE_CHECK_INSTANCE_TYPE (ccm->messages[0], message_type))
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                   "Unexpectedly received control message of type %s (type %s expected)",
+                   G_OBJECT_TYPE_NAME (ccm->messages[0]), g_type_name (message_type));
+      return NULL;
+    }
+
+  return ccm->messages[0];
+}
+
+const gint *
+cockpit_control_messages_peek_fd_list (CockpitControlMessages  *ccm,
+                                       gint                    *n_fds,
+                                       GError                 **error)
+{
+  GUnixFDMessage *message = cockpit_control_messages_get_single_message (ccm, G_TYPE_UNIX_FD_MESSAGE, error);
+
+  if (message == NULL)
+    return NULL;
+
+  return g_unix_fd_list_peek_fds (g_unix_fd_message_get_fd_list (message), n_fds);
+}
+
+gint
+cockpit_control_messages_peek_single_fd (CockpitControlMessages  *ccm,
+                                         GError                **error)
+{
+  int n_fds;
+  const gint *fds = cockpit_control_messages_peek_fd_list (ccm, &n_fds, error);
+
+  if (fds == NULL)
+    return -1;
+
+  if (n_fds != 1)
+    {
+      g_set_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                   "Unexpectedly received %d file descriptors (1 expected)", n_fds);
+      return -1;
+    }
+
+  return fds[0];
+}

--- a/src/common/cockpitcontrolmessages.h
+++ b/src/common/cockpitcontrolmessages.h
@@ -1,0 +1,52 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+typedef struct
+{
+  GSocketControlMessage **messages;
+  int                     n_messages;
+} CockpitControlMessages;
+
+#define COCKPIT_CONTROL_MESSAGES_INIT {}
+
+void
+cockpit_control_messages_clear (CockpitControlMessages *ccm);
+
+gboolean
+cockpit_control_messages_empty (CockpitControlMessages *ccm);
+
+gpointer
+cockpit_control_messages_get_single_message (CockpitControlMessages *ccm,
+                                             GType message_type,
+                                             GError **error);
+
+const gint *
+cockpit_control_messages_peek_fd_list (CockpitControlMessages *ccm,
+                                       gint *n_fds,
+                                       GError **error);
+
+gint
+cockpit_control_messages_peek_single_fd (CockpitControlMessages *ccm,
+                                         GError **error);
+
+G_DEFINE_AUTO_CLEANUP_CLEAR_FUNC(CockpitControlMessages, cockpit_control_messages_clear)

--- a/src/common/cockpitmemfdread.c
+++ b/src/common/cockpitmemfdread.c
@@ -158,3 +158,18 @@ cockpit_memfd_read_json (gint fd,
 
   return cockpit_json_parse_object (content, -1, error);
 }
+
+JsonObject *
+cockpit_memfd_read_json_from_control_messages (CockpitControlMessages  *ccm,
+                                               GError                 **error)
+{
+  if (ccm->n_messages == 0)
+    return NULL;
+
+  gint peeked_fd = cockpit_control_messages_peek_single_fd (ccm, error);
+
+  if (peeked_fd == -1)
+    return NULL;
+
+  return cockpit_memfd_read_json (peeked_fd, error);
+}

--- a/src/common/cockpitmemfdread.h
+++ b/src/common/cockpitmemfdread.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "cockpitcontrolmessages.h"
+
 #include <json-glib/json-glib.h>
 #include <glib.h>
 
@@ -35,3 +37,7 @@ cockpit_memfd_read_from_envvar (gchar **result,
 JsonObject *
 cockpit_memfd_read_json (gint fd,
                          GError **error);
+
+JsonObject *
+cockpit_memfd_read_json_from_control_messages (CockpitControlMessages *ccm,
+                                               GError **error);

--- a/src/common/test-jsonfds.c
+++ b/src/common/test-jsonfds.c
@@ -19,6 +19,7 @@
 
 #include "config.h"
 
+#include "cockpitcontrolmessages.h"
 #include "cockpitjsonprint.h"
 #include "cockpitmemfdread.h"
 #include "cockpittest.h"
@@ -553,6 +554,367 @@ test_memfd_json_error_cases (void)
 
 }
 
+/* --- unix socket testing --- */
+
+static GSList *live_control_messages;
+
+static void
+assert_live_control_messages (gint expected)
+{
+  g_assert_cmpint (g_slist_length (live_control_messages), ==, expected);
+}
+
+static void
+remove_message_from_list (gpointer data,
+                          GObject *where_the_object_was)
+{
+  for (GSList **n = &live_control_messages; *n; n = &(*n)->next)
+    if ((*n)->data == where_the_object_was)
+      {
+        *n = g_slist_delete_link (*n, *n);
+        return;
+      }
+
+  g_error ("Couldn't find control message %p in list", where_the_object_was);
+
+}
+
+static void
+make_socketpair (GSocket **one,
+                 GSocket **two)
+{
+  int fds[2];
+
+  int r = socketpair (AF_UNIX, SOCK_STREAM, 0, fds);
+  g_assert_cmpint (r, ==, 0);
+
+  GError *error = NULL;
+  *one = g_socket_new_from_fd (fds[0], &error);
+  g_assert_no_error (error);
+  *two = g_socket_new_from_fd (fds[1], &error);
+  g_assert_no_error (error);
+}
+
+static void
+receive_cmsgs (GSocket                 *socket,
+               CockpitControlMessages  *ccm)
+{
+  gchar buffer[1];
+  GInputVector vector = { buffer, sizeof buffer };
+  GError *error = NULL;
+  g_socket_receive_message (socket,
+                            NULL, /* address */
+                            &vector, 1,
+                            &ccm->messages, &ccm->n_messages,
+                            NULL, NULL,
+                            &error);
+
+  /* Use this to make sure all messages are getting properly freed */
+  for (gint i = 0; i < ccm->n_messages; i++)
+    {
+      live_control_messages = g_slist_prepend (live_control_messages, ccm->messages[i]);
+      g_object_weak_ref (G_OBJECT (ccm->messages[i]), remove_message_from_list, NULL);
+    }
+
+  g_assert_no_error (error);
+}
+
+static void
+receive_nothing (GSocket *socket)
+{
+  g_auto(CockpitControlMessages) ccm = COCKPIT_CONTROL_MESSAGES_INIT;
+
+  receive_cmsgs (socket, &ccm);
+
+  g_assert (cockpit_control_messages_empty (&ccm));
+}
+
+static gint *
+receive_fds (GSocket  *socket,
+             gint     *out_nfds,
+             GError  **error)
+{
+  g_auto(CockpitControlMessages) ccm = COCKPIT_CONTROL_MESSAGES_INIT;
+
+  receive_cmsgs (socket, &ccm);
+
+  int n_fds;
+  const gint *fds = cockpit_control_messages_peek_fd_list (&ccm, &n_fds, error);
+
+  if (fds == NULL)
+    return NULL;
+
+  gint *result = g_new (int, n_fds + 1);
+  for (gint i = 0; i < n_fds; i++)
+    result[i] = dup (fds[i]);
+  result[n_fds] = -1;
+  *out_nfds = n_fds;
+  return result;
+}
+
+static void
+free_fds (gint **inout_fds,
+          gint  *inout_nfds)
+{
+  gint *fds = *inout_fds;
+  gint nfds = *inout_nfds;
+
+  for (gint i = 0; i < nfds; i++)
+    {
+      g_assert (fds[i] != -1);
+      int r = close (fds[i]);
+      g_assert (r == 0);
+    }
+  g_assert (fds[nfds] == -1);
+
+  g_free (fds);
+
+  *inout_fds = NULL;
+  *inout_nfds = 0;
+}
+
+static gint
+receive_fd (GSocket  *socket,
+            GError  **error)
+{
+  g_auto(CockpitControlMessages) ccm = COCKPIT_CONTROL_MESSAGES_INIT;
+
+  receive_cmsgs (socket, &ccm);
+
+  int fd = cockpit_control_messages_peek_single_fd (&ccm, error);
+
+  if (fd == -1)
+    return -1;
+
+  return dup (fd);
+}
+
+static void
+send_cmsgs (GSocket                *socket,
+            GSocketControlMessage **messages,
+            gint                   n_messages,
+            gint                   n_bytes)
+{
+  const gchar buffer[100] = "";
+  g_assert_cmpint(n_bytes, <=, sizeof buffer);
+  GOutputVector vector = { buffer, n_bytes };
+  GError *error = NULL;
+  g_socket_send_message (socket,
+                         NULL, /* address */
+                         &vector, 1,
+                         messages, n_messages,
+                         0, NULL, &error);
+  g_assert_no_error (error);
+}
+
+static void
+send_nothing (GSocket *socket,
+              gint n_bytes)
+{
+  send_cmsgs (socket, NULL, 0, n_bytes);
+}
+
+static GSocketControlMessage *
+make_fd_message (const gint *fds,
+                 gint        n_fds)
+{
+  g_autoptr(GUnixFDList) fdl = g_unix_fd_list_new ();
+
+  for (gint i = 0; i < n_fds; i++)
+    {
+      GError *error = NULL;
+      g_unix_fd_list_append (fdl, fds[i], &error);
+      g_assert_no_error (error);
+    }
+
+  return g_unix_fd_message_new_with_fd_list (fdl);
+}
+
+static void
+send_fds (GSocket    *socket,
+          const gint *fds,
+          gint        n_fds)
+{
+  g_autoptr(GSocketControlMessage) fdm = make_fd_message (fds, n_fds);
+  send_cmsgs (socket, &fdm, 1, 1);
+}
+
+static void
+send_fd (GSocket *socket,
+         gint     fd)
+{
+  send_fds (socket, &fd, 1);
+}
+
+static void
+assert_base_state (GSocket *one,
+                   GSocket *two)
+{
+  assert_live_control_messages (0);
+  g_assert (g_socket_condition_check (one, G_IO_IN | G_IO_OUT) == G_IO_OUT);
+  g_assert (g_socket_condition_check (two, G_IO_IN | G_IO_OUT) == G_IO_OUT);
+}
+
+static void
+test_unix_socket_simple (void)
+{
+  g_autoptr(GSocket) one, two;
+
+  make_socketpair (&one, &two);
+  assert_base_state (one, two);
+
+  /* boring */
+  send_nothing (one, 1);
+  receive_nothing (two);
+  assert_base_state (one, two);
+
+  send_nothing (two, 1);
+  receive_nothing (one);
+  assert_base_state (one, two);
+
+  /* try a single fd */
+  send_fd (one, 1);
+  GError *error = NULL;
+  gint fd = receive_fd (two, &error);
+  g_assert_no_error (error);
+  g_assert (fd != -1);
+  close (fd);
+  assert_base_state (one, two);
+
+  /* try multiple fds */
+  send_fds (one, (gint []){ 0, 1, 2}, 3);
+  gint n_fds;
+  gint *fds = receive_fds (two, &n_fds, &error);
+  g_assert_no_error (error);
+  g_assert (fds != NULL);
+  g_assert_cmpint (n_fds, ==, 3);
+  free_fds (&fds, &n_fds);
+  assert_base_state (one, two);
+}
+
+static void
+test_unix_socket_partial_read (void)
+{
+  g_autoptr(GSocket) one, two;
+
+  make_socketpair (&one, &two);
+  assert_base_state (one, two);
+
+  /* test unspecified behaviour, which we rely on: the cmsg should be
+   * read with the first byte of the message with which it was sent.
+   *
+   * we depend on this because we start on the cockpit-ws side by
+   * reading a single byte, but we will send the json blob as part of
+   * the first full packet from cockpit-tls.
+   */
+  send_nothing (one, 10);
+  int fd1 = 1;
+  g_autoptr(GSocketControlMessage) fdm = make_fd_message (&fd1, 1);
+  send_cmsgs (one, &fdm, 1, 10);
+
+  for (gint i = 0; i < 20; i++)
+    {
+      g_autoptr(GError) error = NULL;
+      gint fd = receive_fd (two, &error);
+
+      if (fd != -1)
+        {
+          /* we expect to get this at the 11th try */
+          g_assert_cmpint (i, ==, 10);
+          close (fd);
+        }
+      else
+        {
+          cockpit_assert_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_INVAL, "*0 control message*");
+        }
+    }
+}
+
+static void
+test_unix_socket_error_cases (void)
+{
+  g_autoptr(GSocket) one, two;
+
+  make_socketpair (&one, &two);
+  assert_base_state (one, two);
+
+  /* try receiving an fd when nothing was sent */
+  send_nothing (one, 1);
+  GError *error = NULL;
+  int fd = receive_fd (two, &error);
+  g_assert (fd == -1);
+  cockpit_assert_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_INVAL, "*0 control message*");
+  g_clear_error (&error);
+  assert_base_state (one, two);
+
+  /* see what happens if we send more fds than expected */
+  send_fds (one, (const gint []){ 0, 1, 2}, 3);
+  fd = receive_fd (two, &error);
+  g_assert (fd == -1);
+  cockpit_assert_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_INVAL, "*received 3*1 expected*");
+  g_clear_error (&error);
+  assert_base_state (one, two);
+
+  /* The remaining tests rely on receiving SCM_CREDENTIALS.  We need to
+   * enable SO_PASSCRED for that.
+   */
+  int truth = 1;
+  int r = setsockopt (g_socket_get_fd (two), SOL_SOCKET, SO_PASSCRED, &truth, sizeof truth);
+  g_assert (r == 0);
+
+  /* see what happens if we send the wrong message type */
+  g_autoptr(GSocketControlMessage) creds = g_unix_credentials_message_new ();
+  send_cmsgs (one, &creds, 1, 1);
+  fd = receive_fd (two, &error);
+  g_assert (fd == -1);
+  cockpit_assert_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_INVAL,
+                                "*GUnixCredentialsMessage*GUnixFDMessage expected*");
+  g_clear_error (&error);
+  assert_base_state (one, two);
+
+  /* see what happens if we send too many messages */
+  g_autoptr(GUnixFDList) fdl = g_unix_fd_list_new ();
+  g_unix_fd_list_append (fdl, 1, &error);
+  g_assert_no_error (error);
+  g_autoptr(GSocketControlMessage) fdm = g_unix_fd_message_new_with_fd_list (fdl);
+  GSocketControlMessage *messages[] = { creds, fdm };
+  send_cmsgs (one, messages, G_N_ELEMENTS (messages), 1);
+  fd = receive_fd (two, &error);
+  g_assert (fd == -1);
+  g_assert_error (error, G_FILE_ERROR, G_FILE_ERROR_INVAL);
+  g_assert (strstr (error->message, "2 control messages (one message"));
+  g_clear_error (&error);
+  assert_base_state (one, two);
+}
+
+/* --- putting it all together (unix sockets) --- */
+
+static void
+test_unix_socket_combined (void)
+{
+  g_autoptr(GSocket) one, two;
+
+  make_socketpair (&one, &two);
+  assert_base_state (one, two);
+
+  FILE *stream = cockpit_json_print_open_memfd ("xyz", 1);
+  cockpit_json_print_string_property (stream, "test", "it worked!", -1);
+  gint fd = cockpit_json_print_finish_memfd (&stream);
+
+  send_fd (one, fd);
+  close (fd);
+
+  g_auto(CockpitControlMessages) ccm = COCKPIT_CONTROL_MESSAGES_INIT;
+  receive_cmsgs (two, &ccm);
+
+  g_autoptr(GError) error = NULL;
+  g_autoptr(JsonObject) json = cockpit_memfd_read_json_from_control_messages (&ccm, &error);
+  g_assert_no_error (error);
+
+  g_assert_cmpint (json_object_get_int_member (json, "version"), ==, 1);
+  g_assert_cmpstr (json_object_get_string_member (json, "test"), ==, "it worked!");
+}
+
 int
 main (int    argc,
       char **argv)
@@ -572,6 +934,10 @@ main (int    argc,
   g_test_add_func ("/json/fd/memfd/error-cases", test_memfd_error_cases);
   g_test_add_func ("/json/fd/memfd/json", test_memfd_json);
   g_test_add_func ("/json/fd/memfd/json/error-cases", test_memfd_json_error_cases);
+  g_test_add_func ("/json/fd/unix-socket/simple", test_unix_socket_simple);
+  g_test_add_func ("/json/fd/unix-socket/partial-read", test_unix_socket_partial_read);
+  g_test_add_func ("/json/fd/unix-socket/error-cases", test_unix_socket_error_cases);
+  g_test_add_func ("/json/fd/unix-socket/combined", test_unix_socket_combined);
 
   return g_test_run ();
 }

--- a/src/ws/session.c
+++ b/src/ws/session.c
@@ -295,7 +295,7 @@ perform_basic (const char *rhost,
   if (res == PAM_SUCCESS)
     res = open_session (pamh);
   else
-    btmp_log (user, "");
+    btmp_log (user, rhost);
 
   free (user);
   if (password)
@@ -501,7 +501,7 @@ perform_gssapi (const char *rhost,
   res = open_session (pamh);
   if (res != PAM_SUCCESS)
     {
-      btmp_log (str, "");
+      btmp_log (str, rhost);
       goto out;
     }
 

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -104,7 +104,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#current-username', 'admin')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*172.27.0.2")
 
         # reload, which should log us in with the cookie
         b.reload()
@@ -112,7 +112,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#current-username', 'admin')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*172.27.0.2")
 
         b.go("/users#/admin")
         b.enter_page("/users")
@@ -183,9 +183,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 b.wait_present('#login-messages')
                 b.wait_present('#last-login')
                 b.wait_in_text('#last-login', "Last login")
+                b.wait_in_text('#last-login', "172.27.0.2")
 
                 if n_fail:
                     b.wait_present('#last-failed-login')
+                    b.wait_in_text('#last-failed-login', "172.27.0.2")
                     b.wait_in_text('#login-messages', 'There were {} failed'.format(n_fail))
                 else:
                     self.assertFalse(b.is_present('#last-failed-login'))


### PR DESCRIPTION
For a long time (since `cockpit-tls` landed) we've been unable to log the IP address of remote connections.   Use our already-existing memfd-json utilities to add a metadata blob passed from `cockpit-tls` to `cockpit-ws` as a way of getting the connection metadata (specifically, the remote IP) into `-ws`.