### PR TITLE
test: Fix race condition in TestLogin.testBasic

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -150,6 +150,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             if not m.image.startswith("rhel") and not m.image.startswith("centos"):  # no tcsh in RHEL
                 m.execute("sed -r -i.bak '/^admin:/ s_:[^:]+$_:/bin/tcsh_' /etc/passwd")
                 b.login_and_go()
+                b.enter_page('/system')
+                b.wait_visible('.system-information')
                 b.logout()
                 m.execute("mv /etc/passwd.bak /etc/passwd")
 


### PR DESCRIPTION
Wait until the /system page has loaded, instead of immediately logging
out after logging in. It may otherwise happen that the
JavaScript/websocket parts haven't initialized yet, and the `cockpit`
object isn't available yet.