### PR TITLE
shell: Simplify machines database

### DIFF
--- a/pkg/lib/machines-old.js
+++ b/pkg/lib/machines-old.js
@@ -1,0 +1,817 @@
+import $ from "jquery";
+import cockpit from "cockpit";
+
+var mod = { };
+
+var known_hosts_path = "/etc/ssh/ssh_known_hosts";
+/*
+ * We share the Machines state between multiple frames. Only
+ * one frame has the job of loading the state, usually index.js
+ * The Loader code below does all the loading.
+ *
+ * The data is stored in sessionStorage in a JSON object, like this
+ * {
+ *    content: name → info dict from bridge's /machines Machines property
+ *    overlay: extra data to augment and override on top of content
+ * }
+ *
+ * This uses sessionStorage rather than cockpit.sessionStorage
+ * because we don't ever want to write unprefixed keys.
+ */
+
+var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
+var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
+
+function generate_session_key(host) {
+    return session_prefix + "/" + host;
+}
+
+export function host_superuser_storage_key(host) {
+    if (!host)
+        host = cockpit.transport.host;
+
+    const local_key = window.localStorage.getItem("superuser-key");
+    if (host == "localhost")
+        return local_key;
+    else if (host.indexOf("@") >= 0)
+        return "superuser:" + host;
+    else if (local_key)
+        return local_key + "@" + host;
+    else
+        return null;
+}
+
+export function get_host_superuser_value(host) {
+    const key = host_superuser_storage_key(host);
+    if (key)
+        return window.localStorage.getItem(key);
+    else
+        return null;
+}
+
+function Machines() {
+    var self = this;
+
+    var flat = null;
+    self.ready = false;
+
+    /* parsed machine data */
+    var machines = { };
+
+    /* Data shared between Machines() instances */
+    var last = {
+        content: null,
+        overlay: {
+            localhost: {
+                visible: true,
+                manifests: cockpit.manifests
+            }
+        }
+    };
+
+    function storage(ev) {
+        if (ev.key === key && ev.storageArea === window.sessionStorage)
+            refresh(JSON.parse(ev.newValue || "null"));
+    }
+
+    window.addEventListener("storage", storage);
+
+    window.setTimeout(function() {
+        var value = window.sessionStorage.getItem(key);
+        console.log("ST", value);
+        if (!self.ready && value)
+            refresh(JSON.parse(value));
+    });
+
+    var timeout = null;
+
+    function sync(machine, values, overlay) {
+        var desired = $.extend({ }, values || { }, overlay || { });
+        var prop;
+        for (prop in desired) {
+            if (machine[prop] !== desired[prop])
+                machine[prop] = desired[prop];
+        }
+        for (prop in machine) {
+            if (machine[prop] !== desired[prop])
+                delete machine[prop];
+        }
+        return machine;
+    }
+
+    function refresh(shared, push) {
+        if (!shared)
+            return;
+
+        var emit_ready = !self.ready;
+
+        self.ready = true;
+        last = shared;
+        flat = null;
+
+        if (push && !timeout) {
+            timeout = window.setTimeout(function() {
+                timeout = null;
+                window.sessionStorage.setItem(key, JSON.stringify(last));
+            }, 10);
+        }
+
+        var host;
+        var hosts = { };
+        var content = shared.content || { };
+        var overlay = shared.overlay || { };
+        for (host in content)
+            hosts[host] = true;
+        for (host in overlay)
+            hosts[host] = true;
+
+        var events = [];
+
+        var machine, application;
+        for (host in hosts) {
+            var old_machine = machines[host] || { };
+            var old_conns = old_machine.connection_string;
+
+            /* Invert logic for color, always respect what's on disk */
+            if (content[host] && content[host].color && overlay[host])
+                delete overlay[host].color;
+
+            machine = sync(old_machine, content[host], overlay[host]);
+
+            /* Fill in defaults */
+            machine.key = host;
+            if (!machine.address)
+                machine.address = host;
+
+            machine.connection_string = self.generate_connection_string(machine.user,
+                                                                        machine.port,
+                                                                        machine.address);
+
+            if (!machine.label) {
+                if (host == "localhost" || host == "localhost.localdomain") {
+                    application = cockpit.transport.application();
+                    if (application.indexOf('cockpit+=') === 0)
+                        machine.label = application.replace('cockpit+=', '');
+                    else
+                        machine.label = window.location.hostname;
+                } else {
+                    machine.label = host;
+                }
+            }
+            if (!machine.avatar)
+                machine.avatar = "../shell/images/server-small.png";
+
+            events.push([host in machines ? "updated" : "added",
+                [machine, host, old_conns]]);
+            machines[host] = machine;
+        }
+
+        /* Remove any lost hosts */
+        for (host in machines) {
+            if (!(host in hosts)) {
+                machine = machines[host];
+                delete machines[host];
+                delete overlay[host];
+                events.push(["removed", [machine, host]]);
+            }
+        }
+
+        /* Fire off all events */
+        var i;
+        var sel = $(self);
+        var len = events.length;
+        for (i = 0; i < len; i++)
+            sel.triggerHandler(events[i][0], events[i][1]);
+        if (emit_ready)
+            $(self).triggerHandler("ready");
+    }
+
+    function update_session_machine(machine, host, values) {
+        /* We don't save the whole machine object */
+        var skey = generate_session_key(host);
+        var data = $.extend({}, machine, values);
+        window.sessionStorage.setItem(skey, JSON.stringify(data));
+        self.overlay(host, values);
+        return cockpit.when([]);
+    }
+
+    function update_saved_machine(host, values) {
+        // wrap values in variants for D-Bus call; at least values.port can
+        // be int or string, so stringify everything but the "visible" boolean
+        var values_variant = {};
+        for (var prop in values) {
+            if (values[prop] !== null) {
+                if (prop == "visible")
+                    values_variant[prop] = cockpit.variant('b', values[prop]);
+                else
+                    values_variant[prop] = cockpit.variant('s', values[prop].toString());
+            }
+        }
+
+        // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
+        var bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
+        var mod = bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
+                .fail(function(error) {
+                    console.error("failed to call cockpit.Machines.Update(): ", error);
+                });
+
+        return mod;
+    }
+
+    self.add_key = function(host_key) {
+        var known_hosts = cockpit.file(known_hosts_path, { superuser: "try" });
+        return known_hosts
+                .modify(function(data) {
+                    if (!data)
+                        data = "";
+
+                    return data + "\n" + host_key;
+                })
+                .always(function() {
+                    known_hosts.close();
+                });
+    };
+
+    self.add = function add(connection_string, color) {
+        var values = self.split_connection_string(connection_string);
+        var host = values.address;
+
+        values = $.extend({
+            visible: true,
+            color: color || self.unused_color(),
+        }, values);
+
+        var machine = self.lookup(host);
+        if (machine)
+            machine.on_disk = true;
+
+        return self.change(values.address, values);
+    };
+
+    self.unused_color = function unused_color() {
+        var i;
+        var len = mod.colors.length;
+        for (i = 0; i < len; i++) {
+            if (!color_in_use(mod.colors[i]))
+                return mod.colors[i];
+        }
+        return "gray";
+    };
+
+    function color_in_use(color) {
+        var key, machine;
+        var norm = mod.colors.parse(color);
+        for (key in machines) {
+            machine = machines[key];
+            if (machine.color && mod.colors.parse(machine.color) == norm)
+                return true;
+        }
+        return false;
+    }
+
+    function merge(item, values) {
+        for (var prop in values) {
+            if (values[prop] === null)
+                delete item[prop];
+            else
+                item[prop] = values[prop];
+        }
+    }
+
+    self.change = function change(host, values) {
+        var mod, hostnamed, call;
+        var machine = self.lookup(host);
+
+        if (values.label) {
+            var conn_to = host;
+            if (machine)
+                conn_to = machine.connection_string;
+
+            if (!machine || machine.label !== values.label) {
+                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to, superuser: "try" });
+                call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
+                                      "SetPrettyHostname", [values.label, true])
+                        .always(function() {
+                            hostnamed.close();
+                        })
+                        .fail(function(ex) {
+                            console.warn("couldn't set pretty host name: " + ex);
+                        });
+            }
+        }
+
+        if (machine && !machine.on_disk)
+            mod = update_session_machine(machine, host, values);
+        else
+            mod = update_saved_machine(host, values);
+
+        if (call)
+            // Can't use Promise.all() here, because this promise is sometimes
+            // passed to the dialog() function from pkg/lib/patterns.js, which
+            // expects a promise with a progress() method
+            // eslint-disable-next-line cockpit/no-cockpit-all
+            return cockpit.all([call, mod]);
+
+        return mod;
+    };
+
+    self.data = function data(content) {
+        var host;
+        var changes = {};
+
+        for (host in content) {
+            changes[host] = $.extend({ }, last.overlay[host] || { });
+            merge(changes[host], { on_disk: true });
+        }
+
+        /* It's a full reload, so data not
+         * present is no longer from disk
+         */
+        for (host in machines) {
+            if (content && !content[host]) {
+                changes[host] = $.extend({ }, last.overlay[host] || { });
+                merge(changes[host], { on_disk: null });
+            }
+        }
+
+        refresh({
+            content: content,
+            overlay: $.extend({ }, last.overlay, changes)
+        }, true);
+    };
+
+    self.overlay = function overlay(host, values) {
+        var changes = { };
+        changes[host] = $.extend({ }, last.overlay[host] || { });
+        merge(changes[host], values);
+        refresh({
+            content: last.content,
+            overlay: $.extend({ }, last.overlay, changes)
+        }, true);
+    };
+
+    Object.defineProperty(self, "list", {
+        enumerable: true,
+        get: function get() {
+            var key;
+            if (!flat) {
+                flat = [];
+                for (key in machines) {
+                    if (machines[key].visible)
+                        flat.push(machines[key]);
+                }
+                flat.sort(function(m1, m2) {
+                    return m1.label.localeCompare(m2.label);
+                });
+            }
+            return flat;
+        }
+    });
+
+    Object.defineProperty(self, "addresses", {
+        enumerable: true,
+        get: function get() {
+            return Object.keys(machines);
+        }
+    });
+
+    self.lookup = function lookup(address) {
+        var parts = self.split_connection_string(address);
+        return machines[parts.address || "localhost"] || null;
+    };
+
+    self.generate_connection_string = function (user, port, addr) {
+        var address = addr;
+        if (user)
+            address = user + "@" + address;
+
+        if (port)
+            address = address + ":" + port;
+
+        return address;
+    };
+
+    self.split_connection_string = function(conn_to) {
+        var parts = {};
+        var user_spot = -1;
+        var port_spot = -1;
+
+        if (conn_to) {
+            user_spot = conn_to.lastIndexOf('@');
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (user_spot > 0) {
+            parts.user = conn_to.substring(0, user_spot);
+            conn_to = conn_to.substring(user_spot + 1);
+            port_spot = conn_to.lastIndexOf(':');
+        }
+
+        if (port_spot > -1) {
+            var port = parseInt(conn_to.substring(port_spot + 1), 10);
+            if (!isNaN(port)) {
+                parts.port = port;
+                conn_to = conn_to.substring(0, port_spot);
+            }
+        }
+
+        parts.address = conn_to;
+        return parts;
+    };
+
+    self.close = function close() {
+        window.removeEventListener("storage", storage);
+    };
+}
+
+function Loader(machines, session_only) {
+    var self = this;
+
+    /* Have we loaded from cockpit session */
+    var session_loaded = false;
+
+    /* echo channels to each machine */
+    var channels = { };
+
+    /* hostnamed proxies to each machine, if hostnamed available */
+    var proxies = { };
+
+    /* clients for the bridge D-Bus API */
+    var bridge_dbus = { };
+
+    function process_session_key(key, value) {
+        var host, values, machine;
+        var parts = key.split("/");
+        if (parts[0] == session_prefix &&
+            parts.length === 2) {
+            host = parts[1];
+            if (value) {
+                values = JSON.parse(value);
+                machine = machines.lookup(host);
+                if (!machine || !machine.on_disk)
+                    machines.overlay(host, values);
+                else if (!machine.visible)
+                    machines.change(host, { visible: true });
+                self.connect(host);
+            }
+        }
+    }
+
+    function load_from_session_storage() {
+        var i;
+        session_loaded = true;
+        for (i = 0; i < window.sessionStorage.length; i++) {
+            var k = window.sessionStorage.key(i);
+            process_session_key(k, window.sessionStorage.getItem(k));
+        }
+    }
+
+    function process_session_machines(ev) {
+        if (ev.storageArea === window.sessionStorage)
+            process_session_key(ev.key || "", ev.newValue);
+    }
+    window.addEventListener("storage", process_session_machines);
+
+    function state(host, value, problem) {
+        var values = { state: value, problem: problem };
+        if (value == "connected") {
+            values.restarting = false;
+        } else if (problem) {
+            values.manifests = null;
+            values.checksum = null;
+            if (problem == "authentication-failed" || problem == "authentication-not-supported")
+                values.restarting = false;
+        }
+        machines.overlay(host, values);
+    }
+
+    $(machines).on("added", updated);
+    $(machines).on("updated", updated);
+    $(machines).on("removed", removed);
+
+    function updated(ev, machine, host, old_conns) {
+        if (!machine) {
+            machine = machines.lookup(host);
+            if (!machine)
+                return;
+        }
+
+        var props = proxies[host];
+        if (!props || !props.valid)
+            props = { };
+
+        var overlay = { };
+
+        if (!machine.color)
+            overlay.color = machines.unused_color();
+
+        var label = props.PrettyHostname || props.StaticHostname;
+        if (label && label !== machine.label)
+            overlay.label = label;
+
+        var os = props.OperatingSystemPrettyName;
+        if (os && os != machine.os)
+            overlay.os = props.OperatingSystemPrettyName;
+
+        if (!$.isEmptyObject(overlay))
+            machines.overlay(host, overlay);
+
+        /* Don't automatically reconnect failed machines */
+        if (machine.visible) {
+            if (old_conns && machine.connection_string != old_conns) {
+                cockpit.kill(old_conns);
+                self.disconnect(host);
+                self.connect(host);
+            } else if (!machine.problem) {
+                self.connect(host);
+            }
+        } else {
+            self.disconnect(host);
+        }
+    }
+
+    function removed(ev, machine, host) {
+        self.disconnect(host);
+    }
+
+    self.connect = function connect(host) {
+        var machine = machines.lookup(host);
+        if (!machine)
+            return;
+
+        var channel = channels[host];
+        if (channel)
+            return;
+
+        var options = {
+            host: machine.connection_string,
+            payload: "echo",
+            "init-superuser": get_host_superuser_value(machine.connection_string)
+        };
+
+        if (!machine.on_disk && machine.host_key) {
+            options['temp-session'] = false; /* Compatibility option */
+            options.session = 'shared';
+            options['host-key'] = machine.host_key;
+        }
+
+        channel = cockpit.channel(options);
+        channels[host] = channel;
+
+        var local = host === "localhost";
+
+        /* Request is null, and message is true when connected */
+        var request = null;
+        var open = local;
+        var problem = null;
+
+        var url;
+        if (!machine.manifests) {
+            if (machine.checksum)
+                url = "../../" + machine.checksum + "/manifests.json";
+            else
+                url = "../../@" + encodeURI(machine.connection_string) + "/manifests.json";
+        }
+
+        function whirl() {
+            if (!request && open)
+                state(host, "connected", null);
+            else if (!problem)
+                state(host, "connecting", null);
+        }
+
+        /* Here we load the machine manifests, and expect them before going to "connected" */
+        function request_manifest() {
+            request = $.ajax({ url: url, dataType: "json", cache: true })
+                    .done(function(manifests) {
+                        var overlay = { manifests: manifests };
+                        var etag = request.getResponseHeader("ETag");
+                        if (etag) /* and remove quotes */
+                            overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
+                        machines.overlay(host, overlay);
+                    })
+                    .fail(function(ex) {
+                        console.warn("failed to load manifests from " + machine.connection_string + ": " + ex);
+                    })
+                    .always(function() {
+                        request = null;
+                        whirl();
+                    });
+        }
+
+        /* Try to get change notifications via the internal
+           /packages D-Bus interface of the bridge.  Not all
+           bridges support this API, so we still get the first
+           version of the manifests via HTTP in request_manifest.
+        */
+
+        function watch_manifests() {
+            var dbus = cockpit.dbus(null, {
+                bus: "internal",
+                host: machine.connection_string
+            });
+            bridge_dbus[host] = dbus;
+            dbus.subscribe({
+                path: "/packages",
+                interface: "org.freedesktop.DBus.Properties",
+                member: "PropertiesChanged"
+            },
+                           function (path, iface, mamber, args) {
+                               if (args[0] == "cockpit.Packages") {
+                                   if (args[1].Manifests) {
+                                       var manifests = JSON.parse(args[1].Manifests.v);
+                                       machines.overlay(host, { manifests: manifests });
+                                   }
+                               }
+                           });
+
+            /* Tell the bridge to reload the packages, but only if
+               it hasn't just started.  Thus, nothing happens on
+               the first login, but if you reload the shell, we
+               will also reload the packages.
+            */
+            dbus.call("/packages", "cockpit.Packages", "ReloadHint", []);
+        }
+
+        function request_hostname() {
+            if (!machine.static_hostname) {
+                var proxy = cockpit.dbus("org.freedesktop.hostname1",
+                                         { host: machine.connection_string }).proxy();
+                proxies[host] = proxy;
+                proxy.wait(function() {
+                    $(proxy).on("changed", function() {
+                        updated(null, null, host);
+                    });
+                    updated(null, null, host);
+                });
+            }
+        }
+
+        /* Send a message to the server and get back a message once connected */
+        if (!local) {
+            channel.send("x");
+
+            $(channel)
+                    .on("message", function() {
+                        open = true;
+                        if (url)
+                            request_manifest();
+                        watch_manifests();
+                        request_hostname();
+                        whirl();
+                    })
+                    .on("close", function(ev, options) {
+                        var m = machines.lookup(host);
+                        open = false;
+                        // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
+                        if (!options.problem && m && !m.visible)
+                            state(host, null, null);
+                        else
+                            state(host, "failed", options.problem || "disconnected");
+                        if (m && m.restarting) {
+                            window.setTimeout(function() {
+                                self.connect(host);
+                            }, 10000);
+                        }
+                        self.disconnect(host);
+                    });
+        } else {
+            if (url)
+                request_manifest();
+            watch_manifests();
+            request_hostname();
+        }
+
+        /* In case already ready, for example when local */
+        whirl();
+    };
+
+    self.disconnect = function disconnect(host) {
+        if (host === "localhost")
+            return;
+
+        var channel = channels[host];
+        delete channels[host];
+        if (channel) {
+            channel.close();
+            $(channel).off();
+        }
+
+        var proxy = proxies[host];
+        delete proxies[host];
+        if (proxy) {
+            proxy.client.close();
+            $(proxy).off();
+        }
+
+        var dbus = bridge_dbus[host];
+        delete bridge_dbus[host];
+        if (dbus) {
+            dbus.close();
+        }
+    };
+
+    self.expect_restart = function expect_restart(host) {
+        var parts = machines.split_connection_string(host);
+        machines.overlay(parts.address, {
+            restarting: true,
+            problem: null
+        });
+    };
+
+    self.close = function close() {
+        $(machines).off("added", updated);
+        $(machines).off("changed", updated);
+        $(machines).off("removed", removed);
+        machines = null;
+
+        window.removeEventListener("storage", process_session_machines);
+        var hosts = Object.keys(channels);
+        hosts.forEach(self.disconnect);
+    };
+
+    if (!session_only) {
+        var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
+        $(proxy).on("changed", function(data) {
+            // unwrap variants from D-Bus call
+            var wrapped = proxy.Machines;
+            var data_unwrap = {};
+            var host_props;
+            for (var host in wrapped) {
+                host_props = {};
+                for (var prop in wrapped[host])
+                    host_props[prop] = wrapped[host][prop].v;
+                data_unwrap[host] = host_props;
+            }
+
+            machines.data(data_unwrap);
+            if (!session_loaded)
+                load_from_session_storage();
+        });
+    } else {
+        load_from_session_storage();
+        machines.data({});
+    }
+}
+
+mod.instance = function instance(loader) {
+    return new Machines();
+};
+
+mod.loader = function loader(machines, session_only) {
+    return new Loader(machines, session_only);
+};
+
+mod.colors = [
+    "#0099d3",
+    "#67d300",
+    "#d39e00",
+    "#d3007c",
+    "#00d39f",
+    "#00d1d3",
+    "#00618a",
+    "#4c8a00",
+    "#8a6600",
+    "#9b005b",
+    "#008a55",
+    "#008a8a",
+    "#00b9ff",
+    "#7dff00",
+    "#ffbe00",
+    "#ff0096",
+    "#00ffc0",
+    "#00fdff",
+    "#023448",
+    "#264802",
+    "#483602",
+    "#590034",
+    "#024830",
+    "#024848"
+];
+
+mod.colors.parse = function parse_color(input) {
+    var div = document.createElement('div');
+    div.style.color = input;
+    var style = window.getComputedStyle(div, null);
+    return style.getPropertyValue("color") || div.style.color;
+};
+
+mod.known_hosts_path = known_hosts_path;
+
+cockpit.transport.wait(function() {
+    var caps = cockpit.transport.options.capabilities || [];
+    /* If cockpit-ws is handling ssh, check for each capability. Otherwise
+     * the version is new enough that is has them all */
+    if ($.inArray("ssh", caps) > -1) {
+        mod.allow_connection_string = $.inArray("connection-string", caps) != -1;
+        mod.has_auth_results = $.inArray("auth-method-results", caps) != -1;
+        known_hosts_path = "/var/lib/cockpit/known_hosts";
+        mod.known_hosts_path = known_hosts_path;
+        console.debug("Running against legacy ws with ssh, using legacy file", known_hosts_path);
+    } else {
+        mod.allow_connection_string = true;
+        mod.has_auth_results = true;
+    }
+});
+
+export const machines = mod;

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -1,30 +1,54 @@
 import $ from "jquery";
 import cockpit from "cockpit";
 
-var mod = { };
+/* Machines
 
-var known_hosts_path = "/etc/ssh/ssh_known_hosts";
-/*
- * We share the Machines state between multiple frames. Only
- * one frame has the job of loading the state, usually index.js
- * The Loader code below does all the loading.
- *
- * The data is stored in sessionStorage in a JSON object, like this
- * {
- *    content: name → info dict from bridge's /machines Machines property
- *    overlay: extra data to augment and override on top of content
- * }
- *
- * This uses sessionStorage rather than cockpit.sessionStorage
- * because we don't ever want to write unprefixed keys.
- */
+   [ user, port, host ] = parse_address(str)
+   str = unparse_address(user, port, host)
 
-var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
-var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
+   parse_color(color)
 
-function generate_session_key(host) {
-    return session_prefix + "/" + host;
-}
+   machines = new Machines()
+
+   machines.close()
+
+   machines.entries
+   machines.set(address, values)
+   m = machines.get(address)
+   machines.addEventListener("changed", ...)
+
+   color = machines.unused_color()
+   list = machines.complete(address_prefix)
+
+   A "machine" is identified by its "address".  The address is what is
+   used with SSH to make the connection, such as "user@host:1234".
+   Use parse_address and unparse_address to work with those.
+
+   The value for a machine is a arbitrary JSON object. The following
+   fields are in use:
+
+   - address (string, readonly): The address for the machine.
+   - visible (boolean): Whether the machine should be shown in the navigation.
+   - color (string): The color to use for this machine in the UI.
+   - last_used (number): Time of last use.
+
+   The "machines.list" is a list of all visible machines in a nice,
+   stable order.
+
+   Calling "machines.set" will update the entry for the given address.
+   The new values will be merged with the old values.  To remove a
+   field, set it to "undefined".
+
+   To add a new machine, just call "machine.set" for it with the first
+   values.
+
+   Entries are not really removed from the database.  When removing a
+   machine from the UI, set its "visible" field to false.
+
+   The database will forget some old entries in order to prevent
+   growing too large.
+*/
+
 
 export function host_superuser_storage_key(host) {
     if (!host)
@@ -49,719 +73,7 @@ export function get_host_superuser_value(host) {
         return null;
 }
 
-function Machines() {
-    var self = this;
-
-    var flat = null;
-    self.ready = false;
-
-    /* parsed machine data */
-    var machines = { };
-
-    /* Data shared between Machines() instances */
-    var last = {
-        content: null,
-        overlay: {
-            localhost: {
-                visible: true,
-                manifests: cockpit.manifests
-            }
-        }
-    };
-
-    function storage(ev) {
-        if (ev.key === key && ev.storageArea === window.sessionStorage)
-            refresh(JSON.parse(ev.newValue || "null"));
-    }
-
-    window.addEventListener("storage", storage);
-
-    window.setTimeout(function() {
-        var value = window.sessionStorage.getItem(key);
-        if (!self.ready && value)
-            refresh(JSON.parse(value));
-    });
-
-    var timeout = null;
-
-    function sync(machine, values, overlay) {
-        var desired = $.extend({ }, values || { }, overlay || { });
-        var prop;
-        for (prop in desired) {
-            if (machine[prop] !== desired[prop])
-                machine[prop] = desired[prop];
-        }
-        for (prop in machine) {
-            if (machine[prop] !== desired[prop])
-                delete machine[prop];
-        }
-        return machine;
-    }
-
-    function refresh(shared, push) {
-        if (!shared)
-            return;
-
-        var emit_ready = !self.ready;
-
-        self.ready = true;
-        last = shared;
-        flat = null;
-
-        if (push && !timeout) {
-            timeout = window.setTimeout(function() {
-                timeout = null;
-                window.sessionStorage.setItem(key, JSON.stringify(last));
-            }, 10);
-        }
-
-        var host;
-        var hosts = { };
-        var content = shared.content || { };
-        var overlay = shared.overlay || { };
-        for (host in content)
-            hosts[host] = true;
-        for (host in overlay)
-            hosts[host] = true;
-
-        var events = [];
-
-        var machine, application;
-        for (host in hosts) {
-            var old_machine = machines[host] || { };
-            var old_conns = old_machine.connection_string;
-
-            /* Invert logic for color, always respect what's on disk */
-            if (content[host] && content[host].color && overlay[host])
-                delete overlay[host].color;
-
-            machine = sync(old_machine, content[host], overlay[host]);
-
-            /* Fill in defaults */
-            machine.key = host;
-            if (!machine.address)
-                machine.address = host;
-
-            machine.connection_string = self.generate_connection_string(machine.user,
-                                                                        machine.port,
-                                                                        machine.address);
-
-            if (!machine.label) {
-                if (host == "localhost" || host == "localhost.localdomain") {
-                    application = cockpit.transport.application();
-                    if (application.indexOf('cockpit+=') === 0)
-                        machine.label = application.replace('cockpit+=', '');
-                    else
-                        machine.label = window.location.hostname;
-                } else {
-                    machine.label = host;
-                }
-            }
-            if (!machine.avatar)
-                machine.avatar = "../shell/images/server-small.png";
-
-            events.push([host in machines ? "updated" : "added",
-                [machine, host, old_conns]]);
-            machines[host] = machine;
-        }
-
-        /* Remove any lost hosts */
-        for (host in machines) {
-            if (!(host in hosts)) {
-                machine = machines[host];
-                delete machines[host];
-                delete overlay[host];
-                events.push(["removed", [machine, host]]);
-            }
-        }
-
-        /* Fire off all events */
-        var i;
-        var sel = $(self);
-        var len = events.length;
-        for (i = 0; i < len; i++)
-            sel.triggerHandler(events[i][0], events[i][1]);
-        if (emit_ready)
-            $(self).triggerHandler("ready");
-    }
-
-    function update_session_machine(machine, host, values) {
-        /* We don't save the whole machine object */
-        var skey = generate_session_key(host);
-        var data = $.extend({}, machine, values);
-        window.sessionStorage.setItem(skey, JSON.stringify(data));
-        self.overlay(host, values);
-        return cockpit.when([]);
-    }
-
-    function update_saved_machine(host, values) {
-        // wrap values in variants for D-Bus call; at least values.port can
-        // be int or string, so stringify everything but the "visible" boolean
-        var values_variant = {};
-        for (var prop in values) {
-            if (values[prop] !== null) {
-                if (prop == "visible")
-                    values_variant[prop] = cockpit.variant('b', values[prop]);
-                else
-                    values_variant[prop] = cockpit.variant('s', values[prop].toString());
-            }
-        }
-
-        // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
-        var bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
-        var mod = bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
-                .fail(function(error) {
-                    console.error("failed to call cockpit.Machines.Update(): ", error);
-                });
-
-        return mod;
-    }
-
-    self.add_key = function(host_key) {
-        var known_hosts = cockpit.file(known_hosts_path, { superuser: "try" });
-        return known_hosts
-                .modify(function(data) {
-                    if (!data)
-                        data = "";
-
-                    return data + "\n" + host_key;
-                })
-                .always(function() {
-                    known_hosts.close();
-                });
-    };
-
-    self.add = function add(connection_string, color) {
-        var values = self.split_connection_string(connection_string);
-        var host = values.address;
-
-        values = $.extend({
-            visible: true,
-            color: color || self.unused_color(),
-        }, values);
-
-        var machine = self.lookup(host);
-        if (machine)
-            machine.on_disk = true;
-
-        return self.change(values.address, values);
-    };
-
-    self.unused_color = function unused_color() {
-        var i;
-        var len = mod.colors.length;
-        for (i = 0; i < len; i++) {
-            if (!color_in_use(mod.colors[i]))
-                return mod.colors[i];
-        }
-        return "gray";
-    };
-
-    function color_in_use(color) {
-        var key, machine;
-        var norm = mod.colors.parse(color);
-        for (key in machines) {
-            machine = machines[key];
-            if (machine.color && mod.colors.parse(machine.color) == norm)
-                return true;
-        }
-        return false;
-    }
-
-    function merge(item, values) {
-        for (var prop in values) {
-            if (values[prop] === null)
-                delete item[prop];
-            else
-                item[prop] = values[prop];
-        }
-    }
-
-    self.change = function change(host, values) {
-        var mod, hostnamed, call;
-        var machine = self.lookup(host);
-
-        if (values.label) {
-            var conn_to = host;
-            if (machine)
-                conn_to = machine.connection_string;
-
-            if (!machine || machine.label !== values.label) {
-                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to, superuser: "try" });
-                call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
-                                      "SetPrettyHostname", [values.label, true])
-                        .always(function() {
-                            hostnamed.close();
-                        })
-                        .fail(function(ex) {
-                            console.warn("couldn't set pretty host name: " + ex);
-                        });
-            }
-        }
-
-        if (machine && !machine.on_disk)
-            mod = update_session_machine(machine, host, values);
-        else
-            mod = update_saved_machine(host, values);
-
-        if (call)
-            // Can't use Promise.all() here, because this promise is sometimes
-            // passed to the dialog() function from pkg/lib/patterns.js, which
-            // expects a promise with a progress() method
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all([call, mod]);
-
-        return mod;
-    };
-
-    self.data = function data(content) {
-        var host;
-        var changes = {};
-
-        for (host in content) {
-            changes[host] = $.extend({ }, last.overlay[host] || { });
-            merge(changes[host], { on_disk: true });
-        }
-
-        /* It's a full reload, so data not
-         * present is no longer from disk
-         */
-        for (host in machines) {
-            if (content && !content[host]) {
-                changes[host] = $.extend({ }, last.overlay[host] || { });
-                merge(changes[host], { on_disk: null });
-            }
-        }
-
-        refresh({
-            content: content,
-            overlay: $.extend({ }, last.overlay, changes)
-        }, true);
-    };
-
-    self.overlay = function overlay(host, values) {
-        var changes = { };
-        changes[host] = $.extend({ }, last.overlay[host] || { });
-        merge(changes[host], values);
-        refresh({
-            content: last.content,
-            overlay: $.extend({ }, last.overlay, changes)
-        }, true);
-    };
-
-    Object.defineProperty(self, "list", {
-        enumerable: true,
-        get: function get() {
-            var key;
-            if (!flat) {
-                flat = [];
-                for (key in machines) {
-                    if (machines[key].visible)
-                        flat.push(machines[key]);
-                }
-                flat.sort(function(m1, m2) {
-                    return m1.label.localeCompare(m2.label);
-                });
-            }
-            return flat;
-        }
-    });
-
-    Object.defineProperty(self, "addresses", {
-        enumerable: true,
-        get: function get() {
-            return Object.keys(machines);
-        }
-    });
-
-    self.lookup = function lookup(address) {
-        var parts = self.split_connection_string(address);
-        return machines[parts.address || "localhost"] || null;
-    };
-
-    self.generate_connection_string = function (user, port, addr) {
-        var address = addr;
-        if (user)
-            address = user + "@" + address;
-
-        if (port)
-            address = address + ":" + port;
-
-        return address;
-    };
-
-    self.split_connection_string = function(conn_to) {
-        var parts = {};
-        var user_spot = -1;
-        var port_spot = -1;
-
-        if (conn_to) {
-            user_spot = conn_to.lastIndexOf('@');
-            port_spot = conn_to.lastIndexOf(':');
-        }
-
-        if (user_spot > 0) {
-            parts.user = conn_to.substring(0, user_spot);
-            conn_to = conn_to.substring(user_spot + 1);
-            port_spot = conn_to.lastIndexOf(':');
-        }
-
-        if (port_spot > -1) {
-            var port = parseInt(conn_to.substring(port_spot + 1), 10);
-            if (!isNaN(port)) {
-                parts.port = port;
-                conn_to = conn_to.substring(0, port_spot);
-            }
-        }
-
-        parts.address = conn_to;
-        return parts;
-    };
-
-    self.close = function close() {
-        window.removeEventListener("storage", storage);
-    };
-}
-
-function Loader(machines, session_only) {
-    var self = this;
-
-    /* Have we loaded from cockpit session */
-    var session_loaded = false;
-
-    /* echo channels to each machine */
-    var channels = { };
-
-    /* hostnamed proxies to each machine, if hostnamed available */
-    var proxies = { };
-
-    /* clients for the bridge D-Bus API */
-    var bridge_dbus = { };
-
-    function process_session_key(key, value) {
-        var host, values, machine;
-        var parts = key.split("/");
-        if (parts[0] == session_prefix &&
-            parts.length === 2) {
-            host = parts[1];
-            if (value) {
-                values = JSON.parse(value);
-                machine = machines.lookup(host);
-                if (!machine || !machine.on_disk)
-                    machines.overlay(host, values);
-                else if (!machine.visible)
-                    machines.change(host, { visible: true });
-                self.connect(host);
-            }
-        }
-    }
-
-    function load_from_session_storage() {
-        var i;
-        session_loaded = true;
-        for (i = 0; i < window.sessionStorage.length; i++) {
-            var k = window.sessionStorage.key(i);
-            process_session_key(k, window.sessionStorage.getItem(k));
-        }
-    }
-
-    function process_session_machines(ev) {
-        if (ev.storageArea === window.sessionStorage)
-            process_session_key(ev.key || "", ev.newValue);
-    }
-    window.addEventListener("storage", process_session_machines);
-
-    function state(host, value, problem) {
-        var values = { state: value, problem: problem };
-        if (value == "connected") {
-            values.restarting = false;
-        } else if (problem) {
-            values.manifests = null;
-            values.checksum = null;
-            if (problem == "authentication-failed" || problem == "authentication-not-supported")
-                values.restarting = false;
-        }
-        machines.overlay(host, values);
-    }
-
-    $(machines).on("added", updated);
-    $(machines).on("updated", updated);
-    $(machines).on("removed", removed);
-
-    function updated(ev, machine, host, old_conns) {
-        if (!machine) {
-            machine = machines.lookup(host);
-            if (!machine)
-                return;
-        }
-
-        var props = proxies[host];
-        if (!props || !props.valid)
-            props = { };
-
-        var overlay = { };
-
-        if (!machine.color)
-            overlay.color = machines.unused_color();
-
-        var label = props.PrettyHostname || props.StaticHostname;
-        if (label && label !== machine.label)
-            overlay.label = label;
-
-        var os = props.OperatingSystemPrettyName;
-        if (os && os != machine.os)
-            overlay.os = props.OperatingSystemPrettyName;
-
-        if (!$.isEmptyObject(overlay))
-            machines.overlay(host, overlay);
-
-        /* Don't automatically reconnect failed machines */
-        if (machine.visible) {
-            if (old_conns && machine.connection_string != old_conns) {
-                cockpit.kill(old_conns);
-                self.disconnect(host);
-                self.connect(host);
-            } else if (!machine.problem) {
-                self.connect(host);
-            }
-        } else {
-            self.disconnect(host);
-        }
-    }
-
-    function removed(ev, machine, host) {
-        self.disconnect(host);
-    }
-
-    self.connect = function connect(host) {
-        var machine = machines.lookup(host);
-        if (!machine)
-            return;
-
-        var channel = channels[host];
-        if (channel)
-            return;
-
-        var options = {
-            host: machine.connection_string,
-            payload: "echo",
-            "init-superuser": get_host_superuser_value(machine.connection_string)
-        };
-
-        if (!machine.on_disk && machine.host_key) {
-            options['temp-session'] = false; /* Compatibility option */
-            options.session = 'shared';
-            options['host-key'] = machine.host_key;
-        }
-
-        channel = cockpit.channel(options);
-        channels[host] = channel;
-
-        var local = host === "localhost";
-
-        /* Request is null, and message is true when connected */
-        var request = null;
-        var open = local;
-        var problem = null;
-
-        var url;
-        if (!machine.manifests) {
-            if (machine.checksum)
-                url = "../../" + machine.checksum + "/manifests.json";
-            else
-                url = "../../@" + encodeURI(machine.connection_string) + "/manifests.json";
-        }
-
-        function whirl() {
-            if (!request && open)
-                state(host, "connected", null);
-            else if (!problem)
-                state(host, "connecting", null);
-        }
-
-        /* Here we load the machine manifests, and expect them before going to "connected" */
-        function request_manifest() {
-            request = $.ajax({ url: url, dataType: "json", cache: true })
-                    .done(function(manifests) {
-                        var overlay = { manifests: manifests };
-                        var etag = request.getResponseHeader("ETag");
-                        if (etag) /* and remove quotes */
-                            overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
-                        machines.overlay(host, overlay);
-                    })
-                    .fail(function(ex) {
-                        console.warn("failed to load manifests from " + machine.connection_string + ": " + ex);
-                    })
-                    .always(function() {
-                        request = null;
-                        whirl();
-                    });
-        }
-
-        /* Try to get change notifications via the internal
-           /packages D-Bus interface of the bridge.  Not all
-           bridges support this API, so we still get the first
-           version of the manifests via HTTP in request_manifest.
-        */
-
-        function watch_manifests() {
-            var dbus = cockpit.dbus(null, {
-                bus: "internal",
-                host: machine.connection_string
-            });
-            bridge_dbus[host] = dbus;
-            dbus.subscribe({
-                path: "/packages",
-                interface: "org.freedesktop.DBus.Properties",
-                member: "PropertiesChanged"
-            },
-                           function (path, iface, mamber, args) {
-                               if (args[0] == "cockpit.Packages") {
-                                   if (args[1].Manifests) {
-                                       var manifests = JSON.parse(args[1].Manifests.v);
-                                       machines.overlay(host, { manifests: manifests });
-                                   }
-                               }
-                           });
-
-            /* Tell the bridge to reload the packages, but only if
-               it hasn't just started.  Thus, nothing happens on
-               the first login, but if you reload the shell, we
-               will also reload the packages.
-            */
-            dbus.call("/packages", "cockpit.Packages", "ReloadHint", []);
-        }
-
-        function request_hostname() {
-            if (!machine.static_hostname) {
-                var proxy = cockpit.dbus("org.freedesktop.hostname1",
-                                         { host: machine.connection_string }).proxy();
-                proxies[host] = proxy;
-                proxy.wait(function() {
-                    $(proxy).on("changed", function() {
-                        updated(null, null, host);
-                    });
-                    updated(null, null, host);
-                });
-            }
-        }
-
-        /* Send a message to the server and get back a message once connected */
-        if (!local) {
-            channel.send("x");
-
-            $(channel)
-                    .on("message", function() {
-                        open = true;
-                        if (url)
-                            request_manifest();
-                        watch_manifests();
-                        request_hostname();
-                        whirl();
-                    })
-                    .on("close", function(ev, options) {
-                        var m = machines.lookup(host);
-                        open = false;
-                        // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
-                        if (!options.problem && m && !m.visible)
-                            state(host, null, null);
-                        else
-                            state(host, "failed", options.problem || "disconnected");
-                        if (m && m.restarting) {
-                            window.setTimeout(function() {
-                                self.connect(host);
-                            }, 10000);
-                        }
-                        self.disconnect(host);
-                    });
-        } else {
-            if (url)
-                request_manifest();
-            watch_manifests();
-            request_hostname();
-        }
-
-        /* In case already ready, for example when local */
-        whirl();
-    };
-
-    self.disconnect = function disconnect(host) {
-        if (host === "localhost")
-            return;
-
-        var channel = channels[host];
-        delete channels[host];
-        if (channel) {
-            channel.close();
-            $(channel).off();
-        }
-
-        var proxy = proxies[host];
-        delete proxies[host];
-        if (proxy) {
-            proxy.client.close();
-            $(proxy).off();
-        }
-
-        var dbus = bridge_dbus[host];
-        delete bridge_dbus[host];
-        if (dbus) {
-            dbus.close();
-        }
-    };
-
-    self.expect_restart = function expect_restart(host) {
-        var parts = machines.split_connection_string(host);
-        machines.overlay(parts.address, {
-            restarting: true,
-            problem: null
-        });
-    };
-
-    self.close = function close() {
-        $(machines).off("added", updated);
-        $(machines).off("changed", updated);
-        $(machines).off("removed", removed);
-        machines = null;
-
-        window.removeEventListener("storage", process_session_machines);
-        var hosts = Object.keys(channels);
-        hosts.forEach(self.disconnect);
-    };
-
-    if (!session_only) {
-        var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
-        $(proxy).on("changed", function(data) {
-            // unwrap variants from D-Bus call
-            var wrapped = proxy.Machines;
-            var data_unwrap = {};
-            var host_props;
-            for (var host in wrapped) {
-                host_props = {};
-                for (var prop in wrapped[host])
-                    host_props[prop] = wrapped[host][prop].v;
-                data_unwrap[host] = host_props;
-            }
-
-            machines.data(data_unwrap);
-            if (!session_loaded)
-                load_from_session_storage();
-        });
-    } else {
-        load_from_session_storage();
-        machines.data({});
-    }
-}
-
-mod.instance = function instance(loader) {
-    return new Machines();
-};
-
-mod.loader = function loader(machines, session_only) {
-    return new Loader(machines, session_only);
-};
-
-mod.colors = [
+export const machine_colors = [
     "#0099d3",
     "#67d300",
     "#d39e00",
@@ -788,29 +100,124 @@ mod.colors = [
     "#024848"
 ];
 
-mod.colors.parse = function parse_color(input) {
+export function parse_color(input) {
     var div = document.createElement('div');
     div.style.color = input;
     var style = window.getComputedStyle(div, null);
     return style.getPropertyValue("color") || div.style.color;
-};
+}
 
-mod.known_hosts_path = known_hosts_path;
+export function unparse_address(user, port, host) {
+    var address = host;
+    if (user)
+        address = user + "@" + address;
 
-cockpit.transport.wait(function() {
-    var caps = cockpit.transport.options.capabilities || [];
-    /* If cockpit-ws is handling ssh, check for each capability. Otherwise
-     * the version is new enough that is has them all */
-    if ($.inArray("ssh", caps) > -1) {
-        mod.allow_connection_string = $.inArray("connection-string", caps) != -1;
-        mod.has_auth_results = $.inArray("auth-method-results", caps) != -1;
-        known_hosts_path = "/var/lib/cockpit/known_hosts";
-        mod.known_hosts_path = known_hosts_path;
-        console.debug("Running against legacy ws with ssh, using legacy file", known_hosts_path);
-    } else {
-        mod.allow_connection_string = true;
-        mod.has_auth_results = true;
+    if (port)
+        address = address + ":" + port;
+
+    return address;
+}
+
+export function parse_address(address) {
+    var user = null;
+    var port = null;
+    var host = null;
+
+    var user_spot = -1;
+    var port_spot = -1;
+
+    if (conn_address) {
+        user_spot = address.lastIndexOf('@');
+        port_spot = address.lastIndexOf(':');
     }
-});
 
-export const machines = mod;
+    if (user_spot > 0) {
+        user = address.substring(0, user_spot);
+        address = address.substring(user_spot + 1);
+        port_spot = address.lastIndexOf(':');
+    }
+
+    if (port_spot > -1) {
+        var port = parseInt(address.substring(port_spot + 1), 10);
+        if (!isNaN(port))
+            address = address.substring(0, port_spot);
+        else
+            port = null;
+    }
+
+    return [ user, port, address ];
+}
+
+const database_key = cockpit.localStorage.prefixedKey("machines.v3.json");
+
+export class Machines {
+    constructor() {
+        cockpit.event_target(this);
+        window.addEventListener("storage", ev => {
+            if (ev.storageArea === window.localStorage && ev.key == database_key)
+                this.refresh();
+        });
+        this.refresh();
+    }
+
+    refresh() {
+        let entries = { };
+        try {
+            const db = window.localStorage.getItem(database_key);
+            if (db)
+                entries = JSON.parse(db);
+        }
+        catch (ex) {
+            console.warn("Can't parse machines database", ex.toString());
+        }
+
+        entries.localhost = { address: "localhost", visible: true, color: "" };
+
+        console.log("DB", entries);
+
+        this.entries = entries;
+        this.dispatchEvent("changed");
+    }
+
+    set(address, values) {
+        this.entries[address] = Object.assign(this.entries[address] || { }, values);
+        this.entries[address].address = address;
+        window.localStorage.setItem(database_key, JSON.stringify(this.entries));
+        this.dispatchEvent("changed");
+    }
+
+    touch(address) {
+    }
+
+    get(address) {
+        return this.entries[address];
+    }
+
+    unused_color() {
+        function color_in_use(color) {
+            var key, machine;
+            var norm = parse_color(color);
+            for (key in this.entries) {
+                machine = this.entries[key];
+                if (machine.color && parse_color(machine.color) == norm)
+                    return true;
+            }
+            return false;
+        }
+
+        var i;
+        var len = machine_colors.length;
+        for (i = 0; i < len; i++) {
+            if (!color_in_use(machine_colors[i]))
+                return machine_colors[i];
+        }
+        return "gray";
+    }
+
+    complete(partial_address) {
+        return [ ];
+    }
+}
+
+export const allow_connection_string = true;
+export const has_auth_results = true;

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -45,12 +45,7 @@ function Frames(index, setupIdleResetTimers) {
         $(frame).remove();
     }
 
-    self.remove = function remove(machine, component) {
-        var address;
-        if (typeof machine == "string")
-            address = machine;
-        else if (machine)
-            address = machine.address;
+    self.remove = function remove(address, component) {
         if (!address)
             address = "localhost";
         var list = self.iframes[address] || { };
@@ -100,28 +95,14 @@ function Frames(index, setupIdleResetTimers) {
         }
     }
 
-    self.lookup = function lookup(machine, component, hash) {
-        var host;
-        var address;
+    self.lookup = function lookup(address, component, hash) {
         var new_frame = false;
-
-        if (typeof machine == "string") {
-            address = host = machine;
-        } else if (machine) {
-            host = machine.connection_string;
-            address = machine.address;
-        }
-
-        if (!host)
-            host = "localhost";
-        if (!address)
-            address = host;
 
         var list = self.iframes[address];
         if (!list)
             self.iframes[address] = list = { };
 
-        var name = "cockpit1:" + host + "/" + component;
+        var name = "cockpit1:" + address + "/" + component;
         var frame = list[component];
         if (frame && frame.getAttribute("name") != name) {
             remove_frame(frame);
@@ -148,7 +129,7 @@ function Frames(index, setupIdleResetTimers) {
             frame = document.createElement("iframe");
             frame.setAttribute("class", "container-frame");
             frame.setAttribute("name", name);
-            frame.setAttribute("data-host", host);
+            frame.setAttribute("data-host", address);
             frame.style.display = "none";
 
             var base, checksum;
@@ -159,8 +140,8 @@ function Frames(index, setupIdleResetTimers) {
                     checksum = machine.checksum;
             }
 
-            if (checksum && checksum == component_checksum(machine, component)) {
-                if (host === "localhost")
+            if (checksum && checksum == component_checksum(machine, component)) { // XXX
+                if (address === "localhost")
                     base = "..";
                 else
                     base = "../../" + checksum;
@@ -175,7 +156,7 @@ function Frames(index, setupIdleResetTimers) {
 
                    TODO - make it possible to use $<component-checksum>.
                 */
-                base = "../../@" + host;
+                base = "../../@" + address;
             }
 
             frame.url = base + "/" + component;
@@ -260,7 +241,7 @@ function Router(index) {
     function perform_track(child) {
         var hash;
         var current_frame = index.current_frame();
-        /* Note that we ignore tracknig for old shell code */
+        /* Note that we ignore tracking for old shell code */
         if (current_frame && current_frame.contentWindow === child &&
             child.name && child.name.indexOf("/shell/shell") === -1) {
             hash = child.location.hash;

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -10,8 +10,7 @@ import 'polyfills';
 import { superuser } from "superuser";
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 
-import { machines } from "machines";
-import { new_machine_dialog_manager } from "machine-dialogs";
+import { allow_connection_string } from "machines";
 
 import "../../node_modules/@patternfly/patternfly/components/Select/select.scss";
 
@@ -69,8 +68,6 @@ export class CockpitHosts extends React.Component {
         this.onEditHosts = this.onEditHosts.bind(this);
         this.onHostEdit = this.onHostEdit.bind(this);
         this.onRemove = this.onRemove.bind(this);
-
-        this.mdialogs = new_machine_dialog_manager(this.props.machines);
     }
 
     componentDidMount() {
@@ -109,7 +106,7 @@ export class CockpitHosts extends React.Component {
     }
 
     onAddNewHost() {
-        this.mdialogs.render_dialog("add-machine", "hosts_setup_server_dialog");
+        this.props.mdialogs.render_dialog("add-machine", "hosts_setup_server_dialog");
     }
 
     onHostEdit(event, machine) {
@@ -129,7 +126,7 @@ export class CockpitHosts extends React.Component {
             $("#edit-host-dialog a[data-content]").popover();
         }
 
-        this.mdialogs.render_color_picker("#edit-host-colorpicker", machine.address);
+        this.props.mdialogs.render_color_picker("#edit-host-colorpicker", machine.address);
 
         // Remove all existing listeners so we don't change it multiple times
         const orig = document.getElementById("edit-host-apply");
@@ -143,10 +140,10 @@ export class CockpitHosts extends React.Component {
                 label: name.value,
             };
 
-            if (can_change_user && machines.allow_connection_string)
+            if (can_change_user && allow_connection_string)
                 values.user = user.value;
 
-            const promise = this.props.machines.change(machine.key, values);
+            const promise = this.props.machines_db.set(machine.address, values);
             dlg.dialog('promise', promise);
         });
         dlg.modal('show');

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -19,13 +19,12 @@
 
 import '../lib/patternfly/patternfly-cockpit.scss';
 
-import { machines } from "machines";
+import { Machines } from "machines";
 import { new_machine_dialog_manager } from "machine-dialogs";
 import * as credentials from "./credentials";
 import * as indexes from "./indexes";
 
-var machines_inst = machines.instance();
-var loader = machines.loader(machines_inst);
+var machines_inst = new Machines();
 var dialogs = new_machine_dialog_manager(machines_inst);
 
 credentials.setup();
@@ -51,4 +50,4 @@ var options = {
     default_title: "Cockpit",
 };
 
-indexes.machines_index(options, machines_inst, loader, dialogs);
+indexes.machines_index(options, machines_inst, null, dialogs);


### PR DESCRIPTION
The idea is to tear it all down and build it up again, with these goals:

- Be able to connect to remote machine as non-admin
- No auto connect to all remote machines at session start
- No editing of remote pretty names from the shell
- Allow multiple connections to same machine (maybe not in the UI yet)
- Maybe move superuser state into machines database
- Don't screw people that are happily using the current dashboard as a poor version of Foreman.
- Indeed, send the dashboard on its own journey by removing its dependency on the shell

Rough approach:

- Dashboard keeps using /etc/cockpit/machines.d/, shell gets a new database in localStorage.
- The databases will diverge, but offer each other entries for auto complete
- Drop the Loader
- Don't share state (except via the primary db in localStorage)
- Don't handle manifests in lib/machines.js, do that in the shell
- Don't handle host keys in lib/machines.js, do that is the machine dialogs
- Don't handle session state (like connection errors) in lib/machines.js, do that in the shell and dashboard, individually.

This might all just turn out to be a therapeutic excersize for @mvollmer, with nothing actually landing. Or some cleanups might land, without actual change on the surface. But I feel I have to at least get started in a serious manner to figure it all out for me. 