### PR TITLE
Bump optimize-css-assets-webpack-plugin to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "mini-css-extract-plugin": "^0.9.0",
     "node-sass": "^4.13.1",
     "null-loader": "^3.0.0",
-    "optimize-css-assets-webpack-plugin": "^3.2.1",
+    "optimize-css-assets-webpack-plugin": "^5.0.4",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^4.0.0",
     "sass": "^1.26.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -233,6 +233,8 @@ var externals = {
  * Implementation
  */
 
+process.traceDeprecation = true;
+
 var webpack = require("webpack");
 var copy = require("copy-webpack-plugin");
 var html = require('html-webpack-plugin');


### PR DESCRIPTION
This gets rid of these warnings:

   DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead

Enable deprecation tracing in webpack config, so that it's easier for us
in the future to track down the root causes. See

See https://github.com/webpack/webpack/issues/6568#issuecomment-377491754 for details.