### PR TITLE
Split basic/optional package build on RHEL

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -101,6 +101,7 @@ def main():
 def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
     machine.upload([os.path.join(testvm.SCRIPTS_DIR, "lib")], "/var/lib/testvm")
+    machine.upload([os.path.join(BASE, "tools", "make-srpm")], "/var/lib/testvm")
     machine.upload([os.path.join(testvm.SCRIPTS_DIR, "%s.install" % machine.image)], "/var/tmp")
     machine.upload([os.path.join(BASE, "containers")], "/var/tmp")
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -247,7 +247,7 @@ done
 for data in doc locale man pixmaps polkit-1; do
     rm -r %{buildroot}/%{_datadir}/$data
 done
-for lib in systemd tmpfiles.d firewalld; do
+for lib in systemd tmpfiles.d; do
     rm -r %{buildroot}/%{_prefix}/%{__lib}/$lib
 done
 for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-desktop; do

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -39,11 +39,6 @@
 
 %define _hardened_build 1
 
-# build basic packages like cockpit-bridge
-%define build_basic 1
-# build optional extensions like cockpit-machines
-%define build_optional 1
-
 %define __lib lib
 
 %if 0%{?rhel}
@@ -69,6 +64,23 @@ Source0:        cockpit-%{version}.tar.gz
 %else
 Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
+%endif
+
+# in RHEL the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
+# and cockpit-appstream (building optional packages like cockpit-{machines,pcp})
+%if 0%{?rhel}
+
+%if "%{name}" == "cockpit"
+%define build_basic 1
+%define build_optional 0
+%else
+%define build_basic 0
+%define build_optional 1
+%endif
+
+%else
+%define build_basic 1
+%define build_optional 1
 %endif
 
 BuildRequires: gcc

--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -53,15 +53,27 @@ sed -e "/^Version:.*/d" -e "1i\
 tmpdir=$(mktemp -d $PWD/srpm-build.XXXXXX)
 tar xaf "$source" -O cockpit-$version/tools/cockpit.spec | modify_spec > $tmpdir/cockpit.spec
 
-rpmbuild -bs \
-         --quiet \
-         --define "_sourcedir $(dirname $source)" \
-         --define "_specdir $tmpdir" \
-         --define "_builddir $tmpdir" \
-         --define "_srcrpmdir `pwd`" \
-         --define "_rpmdir $tmpdir" \
-         --define "_buildrootdir $tmpdir/.build" \
-         $tmpdir/cockpit.spec
+# on RHEL/CentOS, cockpit is delivered as two mostly identical source packages.
+# "cockpit" with build_basic=1, and "cockpit-appstream" with build_optional=1
+# the spec has proper build_* defaults depending on the Name:
+if grep -qE '^ID=.*(rhel|centos)' /etc/os-release; then
+    sed '/^Name:/ s/$/-appstream/' < $tmpdir/cockpit.spec > $tmpdir/cockpit-appstream.spec
+fi
 
-rpm --qf '%{Name}-%{Version}-%{Release}.src.rpm\n' -q --specfile $tmpdir/cockpit.spec | head -n1
+RPMNAMES=""
+
+for spec in $tmpdir/*.spec; do
+    rpmbuild -bs \
+             --quiet \
+             --define "_sourcedir $(dirname $source)" \
+             --define "_specdir $tmpdir" \
+             --define "_builddir $tmpdir" \
+             --define "_srcrpmdir `pwd`" \
+             --define "_rpmdir $tmpdir" \
+             --define "_buildrootdir $tmpdir/.build" \
+             $spec
+     RPMNAMES="$RPMNAMES $(rpm --qf '%{Name}-%{Version}-%{Release}.src.rpm\n' -q --specfile $spec | head -n1)"
+done
+
 rm -rf $tmpdir
+echo "$RPMNAMES"

--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -38,4 +38,30 @@ else
     source="$1"
 fi
 
-exec "$base/bots/images/scripts/lib/make-srpm" "$source"
+version=$(echo "$source" | sed -n 's|.*cockpit-\([^ /-]\+\)\.tar\..*|\1|p')
+if [ -z "$version" ]; then
+    echo "make-srpm: couldn't parse version from tarball: $source"
+    exit 2
+fi
+
+# We actually modify the spec so that the srpm is standalone buildable
+modify_spec() {
+sed -e "/^Version:.*/d" -e "1i\
+%define wip wip\nVersion: $version\n"
+}
+
+tmpdir=$(mktemp -d $PWD/srpm-build.XXXXXX)
+tar xaf "$source" -O cockpit-$version/tools/cockpit.spec | modify_spec > $tmpdir/cockpit.spec
+
+rpmbuild -bs \
+         --quiet \
+         --define "_sourcedir $(dirname $source)" \
+         --define "_specdir $tmpdir" \
+         --define "_builddir $tmpdir" \
+         --define "_srcrpmdir `pwd`" \
+         --define "_rpmdir $tmpdir" \
+         --define "_buildrootdir $tmpdir/.build" \
+         $tmpdir/cockpit.spec
+
+rpm --qf '%{Name}-%{Version}-%{Release}.src.rpm\n' -q --specfile $tmpdir/cockpit.spec | head -n1
+rm -rf $tmpdir


### PR DESCRIPTION
On RHEL/CentOS, cockpit is delivered as two mostly identical source
packages.  "cockpit" with build_basic=1, and "cockpit-appstream" with
build_optional=1.

Do that split upstream, so that upstream testing better reflects what
actually happens downstream in RHEL. This will also finally exercise the 
`build_*=0` code paths, so that we stop breaking them:

 - Check the OS and source package name in the spec to provide the 
   correct values for build_*. This minimizes the downstream delta to
   just Name: and %changelog.

 - Adjust make-srpm to build a separate cockpit-appstream.spec on
   RHEL/CentOS, and build srpms for all generated specs.
