### PR TITLE
Bridge: Add channel redirection

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -110,6 +110,8 @@ The following fields are defined:
  * "capabilities": Optional, array of capability strings required from the bridge
  * "session": Optional, set to "private" or "shared". Defaults to "shared"
  * "flow-control": Optional boolean whether the channel should throttle itself via flow control.
+ * "redirect": Optional, id of channel to whose input the channel's output will
+   be redirected to (like a Unix pipe).
 
 If "binary" is set to "raw" then this channel transfers binary messages.
 

--- a/src/bridge/cockpitpeer.h
+++ b/src/bridge/cockpitpeer.h
@@ -21,6 +21,7 @@
 #define __COCKPIT_PEER_H__
 
 #include "common/cockpittransport.h"
+#include "common/cockpitredirect.h"
 
 G_BEGIN_DECLS
 
@@ -56,6 +57,7 @@ CockpitTransport *  cockpit_peer_ensure_with_done                (CockpitPeer *p
 gboolean            cockpit_peer_handle                          (CockpitPeer *peer,
                                                                   const gchar *channel,
                                                                   JsonObject *options,
+                                                                  CockpitRedirect *redirect_target,
                                                                   GBytes *data);
 
 void                cockpit_peer_reset                           (CockpitPeer *peer);

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -418,8 +418,8 @@ process_init (CockpitRouter *self,
 
 static gboolean
 handle_redirect (CockpitRouter *self,
-		 JsonObject *options,
-		 CockpitRedirect **redirect)
+                 JsonObject *options,
+                 CockpitRedirect **redirect)
 {
   const gchar *channel_name;
   CockpitChannel *target_channel;
@@ -446,7 +446,7 @@ handle_redirect (CockpitRouter *self,
     {
       CockpitTransport *target_transport = cockpit_peer_ensure (target_peer);
       *redirect = g_object_new (COCKPIT_TYPE_PEER_REDIRECT,
-		                "channel", channel_name,
+		                            "channel", channel_name,
                                 "transport", target_transport,
                                 NULL);
       return TRUE;

--- a/src/bridge/test-peer.c
+++ b/src/bridge/test-peer.c
@@ -138,7 +138,7 @@ on_transport_control (CockpitTransport *transport,
 
   if (channel && g_str_equal (command, "open"))
     {
-      if (tc->peer && cockpit_peer_handle (tc->peer, channel, options, message))
+      if (tc->peer && cockpit_peer_handle (tc->peer, channel, options, NULL, message))
         {
           return TRUE;
         }

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -72,6 +72,8 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitpipe.h \
 	src/common/cockpitpipetransport.c \
 	src/common/cockpitpipetransport.h \
+	src/common/cockpitredirect.c \
+	src/common/cockpitredirect.h \
 	src/common/cockpitsystem.c \
 	src/common/cockpitsystem.h \
 	src/common/cockpittemplate.c \

--- a/src/common/cockpitchannel.h
+++ b/src/common/cockpitchannel.h
@@ -81,6 +81,9 @@ void                cockpit_channel_send              (CockpitChannel *self,
                                                        GBytes *payload,
                                                        gboolean valid_utf8);
 
+void                cockpit_channel_internal_recv     (CockpitChannel *self,
+                                                       GBytes *payload);
+
 JsonObject *        cockpit_channel_get_options       (CockpitChannel *self);
 
 JsonObject *        cockpit_channel_close_options     (CockpitChannel *self);

--- a/src/common/cockpitredirect.c
+++ b/src/common/cockpitredirect.c
@@ -1,0 +1,315 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "cockpitredirect.h"
+
+#include "cockpitchannel.h"
+#include "cockpittransport.h"
+
+/**
+ * CockpitRedirect:
+ * Interface used to represent a channel redirection.
+ */
+
+G_DEFINE_INTERFACE (CockpitRedirect, cockpit_redirect, G_TYPE_OBJECT)
+
+static void
+cockpit_redirect_default_init (CockpitRedirectInterface *iface)
+{
+  /* No default signals or properties */
+}
+
+/**
+ * cockpit_redirect_send:
+ * @self: a channel redirect
+ * @payload: data to be sent through
+ *
+ * Send a message through a channel redirect.
+ *
+ * Returns: whether data has been sent successfully
+ */
+gboolean
+cockpit_redirect_send (CockpitRedirect *self,
+                       GBytes *payload)
+{
+  CockpitRedirectInterface *iface;
+
+  g_return_val_if_fail (COCKPIT_IS_REDIRECT (self), FALSE);
+
+  iface = COCKPIT_REDIRECT_GET_IFACE (self);
+  g_return_val_if_fail (iface->send != NULL, FALSE);
+  return iface->send (self, payload);
+}
+
+/**
+ * CockpitChannelRedirect:
+ * Represents redirection to a local channel.
+ */
+
+struct _CockpitChannelRedirect {
+  GObject parent_instance;
+
+  CockpitChannel *channel;
+  gboolean channel_open;
+
+  gulong channel_closed_sig;
+};
+
+static void
+cockpit_channel_redirect_interface_init (CockpitRedirectInterface *iface)
+{
+  iface->send = (gboolean (*)(CockpitRedirect *, GBytes *)) cockpit_channel_redirect_send;
+}
+
+G_DEFINE_TYPE_WITH_CODE (CockpitChannelRedirect, cockpit_channel_redirect, G_TYPE_OBJECT,
+                         G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_REDIRECT,
+                                                cockpit_channel_redirect_interface_init))
+enum {
+  CHANNEL_PROP_0,
+  CHANNEL_PROP_CHANNEL
+};
+
+static void
+on_channel_closed (CockpitChannel *channel,
+                   const gchar *problem,
+                   gpointer user_data)
+{
+  CockpitChannelRedirect *self = COCKPIT_CHANNEL_REDIRECT (user_data);
+  self->channel_open = FALSE;
+}
+
+static void
+cockpit_channel_redirect_init (CockpitChannelRedirect *self)
+{
+  self->channel_open = TRUE;
+}
+
+static void
+cockpit_channel_redirect_dispose (GObject *gobject)
+{
+  CockpitChannelRedirect *self = COCKPIT_CHANNEL_REDIRECT (gobject);
+
+  if (self->channel_closed_sig)
+    g_signal_handler_disconnect (self->channel, self->channel_closed_sig);
+  self->channel_closed_sig = 0;
+
+  g_clear_object (&self->channel);
+
+  G_OBJECT_CLASS (cockpit_channel_redirect_parent_class)->dispose (gobject);
+}
+
+static void
+cockpit_channel_redirect_set_property (GObject *obj,
+                                       guint prop_id,
+                                       const GValue *value,
+                                       GParamSpec *pspec)
+{
+  CockpitChannelRedirect *self = COCKPIT_CHANNEL_REDIRECT (obj);
+
+  switch (prop_id)
+    {
+    case CHANNEL_PROP_CHANNEL:
+      self->channel = g_value_dup_object (value);
+      self->channel_closed_sig = g_signal_connect (self->channel, "closed", G_CALLBACK (on_channel_closed), self);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, prop_id, pspec);
+      break;
+    }
+}
+
+static void
+cockpit_channel_redirect_class_init (CockpitChannelRedirectClass *class)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+  object_class->set_property = cockpit_channel_redirect_set_property;
+  object_class->dispose = cockpit_channel_redirect_dispose;
+
+  g_object_class_install_property (object_class, CHANNEL_PROP_CHANNEL,
+                                   g_param_spec_object ("channel", "channel", "channel",
+                                                        COCKPIT_TYPE_CHANNEL,
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY));
+}
+
+gboolean
+cockpit_channel_redirect_send (CockpitChannelRedirect *self,
+                               GBytes *payload)
+{
+  if (!self->channel_open)
+    return FALSE;
+
+  CockpitTransport *inbound_transport = cockpit_channel_get_transport (self->channel);
+  const gchar *channel_id = cockpit_channel_get_id (self->channel);
+
+  cockpit_transport_emit_recv (inbound_transport, channel_id, payload);
+  return TRUE;
+}
+
+/**
+ * CockpitPeerRedirect:
+ * Represents redirection to a transport with another bridge at the other end.
+ */
+
+struct _CockpitPeerRedirect {
+  GObject parent_instance;
+
+  const gchar *channel;
+  CockpitTransport *transport;
+  gboolean target_open;
+
+  guint transport_closed_sig;
+  guint transport_control_sig;
+};
+
+static void
+cockpit_peer_redirect_interface_init (CockpitRedirectInterface *iface)
+{
+  iface->send = (gboolean (*)(CockpitRedirect *, GBytes *)) cockpit_peer_redirect_send;
+}
+
+G_DEFINE_TYPE_WITH_CODE (CockpitPeerRedirect, cockpit_peer_redirect, G_TYPE_OBJECT,
+G_IMPLEMENT_INTERFACE (COCKPIT_TYPE_REDIRECT,
+                       cockpit_peer_redirect_interface_init))
+enum {
+  PEER_PROP_0,
+  PEER_PROP_CHANNEL,
+  PEER_PROP_TRANSPORT
+};
+
+static void
+on_transport_closed (CockpitTransport *transport,
+                     const gchar *problem,
+                     gpointer user_data)
+{
+  /* Target transport closed */
+  CockpitPeerRedirect *self = COCKPIT_PEER_REDIRECT (user_data);
+
+  self->target_open = FALSE;
+}
+
+static gboolean
+on_transport_control (CockpitTransport *transport,
+                      const char *command,
+                      const gchar *channel_id,
+                      JsonObject *options,
+                      GBytes *payload,
+                      gpointer user_data)
+{
+  /* Control message on target transport - check if the target channel is closing */
+  CockpitPeerRedirect *self = COCKPIT_PEER_REDIRECT (user_data);
+
+  if (g_strcmp0 (command, "close"))
+    return FALSE;
+
+  if (!self->channel || g_strcmp0 (channel_id, self->channel))
+    return FALSE;
+
+  self->target_open = FALSE;
+  return FALSE;
+}
+
+static void
+cockpit_peer_redirect_init (CockpitPeerRedirect *self)
+{
+  self->channel = NULL;
+  self->target_open = TRUE;
+}
+
+static void
+cockpit_peer_redirect_dispose (GObject *gobject)
+{
+  CockpitPeerRedirect *self = COCKPIT_PEER_REDIRECT (gobject);
+
+  if (self->transport_closed_sig)
+    g_signal_handler_disconnect (self->transport, self->transport_closed_sig);
+  self->transport_closed_sig = 0;
+
+  if (self->transport_control_sig)
+    g_signal_handler_disconnect (self->transport, self->transport_control_sig);
+  self->transport_control_sig = 0;
+
+  g_clear_object (&self->transport);
+
+  g_free ((gpointer) self->channel);
+  self->channel = NULL;
+
+  G_OBJECT_CLASS (cockpit_peer_redirect_parent_class)->dispose (gobject);
+}
+
+static void
+cockpit_peer_redirect_set_property (GObject *obj,
+                                    guint prop_id,
+                                    const GValue *value,
+                                    GParamSpec *pspec)
+{
+  CockpitPeerRedirect *self = COCKPIT_PEER_REDIRECT (obj);
+
+  switch (prop_id)
+  {
+    case PEER_PROP_CHANNEL:
+      self->channel = g_value_dup_string (value);
+      break;
+    case PEER_PROP_TRANSPORT:
+      self->transport = g_value_dup_object (value);
+      self->transport_closed_sig = g_signal_connect (self->transport,
+                                                     "closed",
+                                                     G_CALLBACK (on_transport_closed),
+                                                     self);
+      self->transport_control_sig = g_signal_connect (self->transport,
+                                                      "control",
+                                                      G_CALLBACK (on_transport_control),
+                                                      self);
+      break;
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (obj, prop_id, pspec);
+      break;
+  }
+}
+
+static void
+cockpit_peer_redirect_class_init (CockpitPeerRedirectClass *class)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+  object_class->set_property = cockpit_peer_redirect_set_property;
+  object_class->dispose = cockpit_peer_redirect_dispose;
+
+  g_object_class_install_property (object_class, PEER_PROP_CHANNEL,
+                                   g_param_spec_string ("channel", "channel", "channel",
+                                                        NULL,
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY));
+
+  g_object_class_install_property (object_class, PEER_PROP_TRANSPORT,
+                                   g_param_spec_object ("transport", "transport", "transport",
+                                                        COCKPIT_TYPE_TRANSPORT,
+                                                        G_PARAM_WRITABLE |
+                                                        G_PARAM_CONSTRUCT_ONLY));
+}
+
+gboolean
+cockpit_peer_redirect_send (CockpitPeerRedirect *self,
+                            GBytes *payload)
+{
+  if (!self->target_open)
+    return FALSE;
+
+  cockpit_transport_send (self->transport, self->channel, payload);
+  return TRUE;
+}

--- a/src/common/cockpitredirect.h
+++ b/src/common/cockpitredirect.h
@@ -1,0 +1,63 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __COCKPITREDIRECT_H__
+#define __COCKPITREDIRECT_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/* CockpitRedirect interface */
+
+#define COCKPIT_TYPE_REDIRECT cockpit_redirect_get_type ()
+G_DECLARE_INTERFACE (CockpitRedirect, cockpit_redirect, COCKPIT, REDIRECT, GObject)
+
+struct _CockpitRedirectInterface
+{
+  GTypeInterface parent_iface;
+
+  gboolean (*send) (CockpitRedirect *self,
+                    GBytes *payload);
+};
+
+gboolean cockpit_redirect_send (CockpitRedirect *self,
+                                GBytes *payload);
+
+/* CockpitChannelRedirect class */
+
+#define COCKPIT_TYPE_CHANNEL_REDIRECT cockpit_channel_redirect_get_type ()
+G_DECLARE_FINAL_TYPE (CockpitChannelRedirect, cockpit_channel_redirect, COCKPIT, CHANNEL_REDIRECT,
+                      GObject)
+
+gboolean
+cockpit_channel_redirect_send (CockpitChannelRedirect *self, GBytes *payload);
+
+/* CockpitPeerRedirect class */
+
+#define COCKPIT_TYPE_PEER_REDIRECT cockpit_peer_redirect_get_type ()
+G_DECLARE_FINAL_TYPE (CockpitPeerRedirect, cockpit_peer_redirect, COCKPIT, PEER_REDIRECT,
+                      GObject)
+
+gboolean
+cockpit_peer_redirect_send (CockpitPeerRedirect *self, GBytes *payload);
+
+G_END_DECLS
+
+#endif


### PR DESCRIPTION
This adds a "redirect" option to the open command, which takes the name
of the channel the output of the new one will be redirected to. The
redirect is effectively applied as close to the channels as possible.

Closes #14560

---

There are two cases in which the output is redirected from a channel:
- The output is redirected from a local channel. This is handled in `CockpitRouter` by setting the `redirect_target` property of `CockpitChannel`, which uses it to send data to the redirect target instead of the transport in `cockpit_channel_actual_send`.
- The output is redirected from a peer. This is handled in `cockpit_peer_handle` by passing the redirect target as an argument and then by putting the redirect into a hash table with the (source) channel name as a key. `on_other_recv` then looks up the channel name in the table, again sending it to the redirect target instead of the transport if a corresponding entry is present.

Similarly there are two redirect target types: a local channel and a peer. These are handled by different implementations of the `CockpitRedirect` interface - `CockpitChannelRedirect` for local channels (holding a reference to the corresponding `CockpitChannel` object) and `CockpitPeerRedirect` for peers (holding a reference to the transport and the channel name).

Redirection of a channel is attempted on all bridges - the shortest path then takes precedence (e.g. if there is a redirect between two channels on the same peer, it happens on both the parent bridge and the peer, but effectively the data is redirected on the peer and nothing arrives on the parent). This also means it is compatible with older versions of cockpit-bridge - they simply ignore the redirect option and the redirect is done on the parent bridge (this can obviously be slower, but it will work).

I hope this makes sense - it seems like a small, but useful feature to me. (For potential uses see the linked issue.)

