### PR TITLE
tools: Fix building without libssh-devel

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -93,7 +93,7 @@ BuildRequires: autoconf automake
 BuildRequires: make
 BuildRequires: /usr/bin/python3
 BuildRequires: gettext >= 0.19.7
-%if 0%{?build_optional}
+%if 0%{?build_basic}
 BuildRequires: libssh-devel >= 0.8.5
 %endif
 BuildRequires: openssl-devel
@@ -163,6 +163,9 @@ exec 2>&1
     --docdir=%_defaultdocdir/%{name} \
 %endif
     --with-pamdir='%{pamdir}' \
+%if 0%{?build_basic} == 0
+    --disable-ssh \
+%endif
     %{?vdo_on_demand:--with-vdo-package='"vdo"'}
 make -j4 %{?extra_flags} all
 


### PR DESCRIPTION
cockpit-ssh has been shipped by cockpit-bridge for a long time, so fix
the conditional BuildRequires for libssh-devel to apply to build_basic.

When building without `build_basic`, then the conditional BuildRequires:
libssh-devel does not get installed, and the package build fails with

    checking build with cockpit-ssh... yes
    checking for LIBSSH... no
    configure: error: Package requirements (libssh >= 0.8.5) were not met:

Disable the ssh feature in this case.