### PR TITLE
bridge: Fix warning about uninitialized value

### DIFF
--- a/src/bridge/cockpitdbusinternal.c
+++ b/src/bridge/cockpitdbusinternal.c
@@ -63,9 +63,7 @@ static GIOStream *
 create_io_stream_for_unix_socket (gint fd)
 {
   g_autoptr(GError) error = NULL;
-  g_autoptr(GSocket) socket;
-
-  socket = g_socket_new_from_fd (fd, &error);
+  g_autoptr(GSocket) socket = g_socket_new_from_fd (fd, &error);
   g_assert_no_error (error);
 
   return G_IO_STREAM (g_socket_connection_factory_create_connection (socket));


### PR DESCRIPTION
Initialize the socket auto pointer right away. This fixes this warning:

```
src/bridge/cockpitdbusinternal.c: In function 'create_io_stream_for_unix_socket':
/usr/include/glib-2.0/glib/gmacros.h:1049:17: warning: 'socket' may be used uninitialized in this function [-Wmaybe-uninitialized]
 1049 |     { if (_ptr) (cleanup) ((ParentName *) _ptr); }                                                              \
      |                 ^
src/bridge/cockpitdbusinternal.c:66:22: note: 'socket' was declared here
   66 |   g_autoptr(GSocket) socket;
      |                      ^~~~~~
```