### PR TITLE
tools: Fix duplicated -debuginfo files

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -254,6 +254,7 @@ find %{buildroot}%{_datadir}/cockpit/playground -type f >> tests.list
 %if 0%{?build_basic} == 0
 for pkg in base1 branding motd kdump networkmanager selinux shell sosreport ssh static systemd tuned users; do
     rm -r %{buildroot}/%{_datadir}/cockpit/$pkg
+    rm -rf %{buildroot}/usr/src/debug/%{_datadir}/cockpit/$pkg
     rm -f %{buildroot}/%{_datadir}/metainfo/org.cockpit-project.cockpit-${pkg}.metainfo.xml
 done
 for data in doc locale man pixmaps polkit-1; do
@@ -274,7 +275,7 @@ rm -f %{buildroot}%{_datadir}/metainfo/cockpit.appdata.xml
 # when not building optional packages, remove their files
 %if 0%{?build_optional} == 0
 for pkg in apps dashboard machines packagekit pcp playground storaged; do
-    rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg
+    rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg %{buildroot}/usr/src/debug/%{_datadir}/cockpit/$pkg
 done
 # files from -tests
 rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -28,7 +28,7 @@ usage()
 quiet="--quiet"
 check=""
 
-args=$(getopt -o "h,v" -l "help,quick,verbose" -- "$@")
+args=$(getopt -o "h,q,v" -l "help,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
 	case $1 in


### PR DESCRIPTION
When not building basic/optional packages, also remove the corresponding
source map files. This fixes cockpit-debuginfo and 
cockpit-appstream-debuginfo both shipping the same files.

https://bugzilla.redhat.com/show_bug.cgi?id=1870521