### PR TITLE
test: In check-metrics, check if image has swap

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -187,14 +187,14 @@ class TestMetrics(MachineCase, StorageHelpers):
         b.wait_visible(".ct-graph-memory")
         b.wait_visible(".ct-graph-cpu")
 
-        # memory graph page
-        if m.image in ["fedora-coreos", "ubuntu-2004", "ubuntu-stable", "debian-stable", "debian-testing"]:
+        # memory graph page; not all images have swap
+        if m.execute("swapon --show").strip():
+            b.wait_not_visible("#link-memory")
+            b.click("#link-memory-and-swap")
+        else:
             # no swap on these
             b.wait_not_visible("#link-memory-and-swap")
             b.click("#link-memory")
-        else:
-            b.wait_not_visible("#link-memory")
-            b.click("#link-memory-and-swap")
         b.wait_not_visible(".ct-graph-cpu")
         b.wait_visible("#memory_status_title")
         b.wait_visible("#memory_status_graph")


### PR DESCRIPTION
When building the centos-8-stream image from the cloud image instead of
the DVD [1], it ends up having no swap.
    
As this keeps changing between images, determining if the image has swap
is very robust, and as the test handles both cases, replace the static
list with a dynamic check.

[1] https://github.com/cockpit-project/bots/pull/1250