### PR TITLE
test: Fix restarting of global machines

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -156,6 +156,28 @@ def build_command(filename, test, opts):
     cmd.append(test)
     return cmd
 
+class GlobalMachine:
+    def __init__(self, restrict=True):
+        self.image = testvm.DEFAULT_IMAGE
+        self.network = testvm.VirtNetwork(image=self.image)
+        self.networking = self.network.host(restrict=restrict)
+        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image)
+        if not os.path.exists(self.machine.image_file):
+            self.machine.pull(self.machine.image_file)
+        self.machine.start()
+
+    def reset(self):
+        # It is important to re-use self.networking here, so that the
+        # machine keeps its browser and control port.
+        self.machine.kill()
+        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image)
+        self.machine.start()
+
+    def kill(self):
+        self.machine.kill()
+        self.network.kill()
+
+
 def run(opts, image):
     # Build the list of tests we'll parallelize and the ones we'll run serially
     test_loader = unittest.TestLoader()
@@ -170,6 +192,7 @@ def run(opts, image):
     # - "working" - None if the machine is idle
     # - "tests"   - Array of tests to run
     # - "time"    - Combined time all tests took
+    # - "machine" - A GlobalMachine instance for running the tests
     batch_tests = {}
 
     # Make sure tests can make relative imports
@@ -258,12 +281,12 @@ def run(opts, image):
             batch_size = len(serial_tests) // opts.batches
 
             for i in range(opts.batches):
-                batch_tests[i] = {"working": None, "tests": [], "time": 0}
-                m = testlib.MachineCase.get_global_machine(restrict=not opts.enable_network, id=i)
-                ssh_address = "{0}:{1}".format(m.ssh_address,
-                                               m.ssh_port)
-                web_address = "{0}:{1}".format(m.web_address,
-                                               m.web_port)
+                m = GlobalMachine(restrict=not opts.enable_network)
+                batch_tests[i] = { "working": None, "tests": [], "time": 0, "machine": m }
+                ssh_address = "{0}:{1}".format(m.machine.ssh_address,
+                                               m.machine.ssh_port)
+                web_address = "{0}:{1}".format(m.machine.web_address,
+                                               m.machine.web_port)
 
                 if i == opts.batches - 1: # Last machine needs to resolve the rest
                     batch = serial_tests[batch_size * i : ]
@@ -325,9 +348,9 @@ def run(opts, image):
                     # restart it to avoid an unbounded number of test retries and follow-up errors
                     if not opts.machine and (poll_result == 124 or (retry_reason and b"test harness" in retry_reason)):
                         # try hard to keep the test output consistent
-                        testlib.MachineCase.kill_global_machine(test.serial_machine)
-                        # FIXME: May change the ports when a parallel run-tests is running
-                        testlib.MachineCase.get_global_machine(restrict=not opts.enable_network, id=test.serial_machine)
+                        sys.stderr.write("Restarting global machine %s\n" % test.serial_machine)
+                        sys.stderr.flush()
+                        batch_tests[test.serial_machine]["machine"].reset()
 
                 # run again if needed
                 if retry_reason:
@@ -347,7 +370,9 @@ def run(opts, image):
             time.sleep(0.5)
 
     if not opts.list:
-        testlib.MachineCase.kill_global_machines()
+        for b in batch_tests.values():
+            if "machine" in b:
+                b["machine"].kill()
 
         duration = int(time.time() - start_time)
         hostname = socket.gethostname().split(".")[0]


### PR DESCRIPTION
When restarting a global machine, we want it to keep its ports because
they are already hard coded into the command lines for running the
nondestructive tests.

Also, and more importantly, we used to release all the networking port
locks for all global machines when restarting a single one. This
resulted in allocating a control port for the restarted machine that
was still in use by other global machines.

The error message for that was:

    libvirt domain already exists: operation failed: domain
    'fedora-33-127.0.0.2-2201' already exists with uuid ...

since the control port is included in the domain name for virtual
machines.

Fixes #14657