### PR TITLE
test: Run LUKS tests with more VM memory

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -24,6 +24,11 @@ from testlib import *
 
 class TestStorageLuks(StorageCase):
 
+    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    provision = {
+        "0": {"memory_mb": 1536}
+    }
+
     def testLuks(self):
         self.allow_journal_messages("Device is not initialized.*", ".*could not be opened.")
         m = self.machine


### PR DESCRIPTION
In recent versions, cryptsetup uses memory-hard PBKDF, which overflows
our default 1 GiB of RAM. Run the tests with 1.5 GiB to avoid that,
which is the minimum requirement for CentOS 8 [1]. See [2] for details.

[1] https://wiki.centos.org/About/Product
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1881829