### PR TITLE
[rhel-8.3] test: More cryptsetup PBKDF adjustments

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -27,6 +27,11 @@ from testlib import *
 
 class TestStorageResize(StorageCase):
 
+    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    provision = {
+        "0": {"memory_mb": 1536}
+    }
+
     def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None,
                     need_passphrase=False):
         m = self.machine

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -37,7 +37,7 @@ class TestStorageUsed(StorageCase):
         m.execute("parted -s %s mktable msdos" % disk)
         m.execute("parted -s %s mkpart primary ext2 1M 25" % disk)
         m.execute("udevadm settle")
-        m.execute("echo einszweidrei | cryptsetup luksFormat %s1" % disk)
+        m.execute("echo einszweidrei | cryptsetup luksFormat --pbkdf-memory 32768 %s1" % disk)
         m.execute("echo einszweidrei | cryptsetup luksOpen %s1 dm-test" % disk)
         m.execute("udevadm settle")
         m.execute("mke2fs -q -L TEST /dev/mapper/dm-test")


### PR DESCRIPTION
Commit 0c067822b3 forgot two places that also call `cryptsetup luksFormat`:

  - Use a bigger VM in TestStorageResize, as Cockpit itself creates the
    LUKS device there.

  - check-storage-used is a @nondestructive test (no `provision`), but
    there the test itself calls `cryptsetup luksFormat`, so just use the
    option to tell it to use less RAM.

Cherry-picked from master commit 883f1d036dd0