### PR TITLE
test: Update run-tests to skip retry on check-image test

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -212,7 +212,11 @@ def run(opts, image):
         changed_tests = []
 
     # HACK: Running all machines or realms tests 3 times takes too long and the global timeout is reached
-    changed_tests = [test for test in changed_tests if "check-machines" not in test and "check-realms" not in test]
+    # Image building test takes too long as well
+    changed_tests = [test for test in changed_tests if
+                     "check-machines" not in test and
+                     "check-realms" not in test and
+                     "check-image" not in test]
 
     seen_classes = {}
     for filename in glob.glob(os.path.join(opts.test_dir, "check-*")):


### PR DESCRIPTION
Image building test takes too long and most of time do not spend on testing but image building
Skip test file update retry