### PR TITLE
test: Use different /system subpage in page switching tests

### DIFF
--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -82,6 +82,7 @@ class DashBoardHelpers:
             self.machines[m].write("/home/admin/.ssh/authorized_keys", pubkey)
             self.machines[m].execute("chown admin:admin /home/admin/.ssh/authorized_keys")
 
+@noretry
 @skipBrowser("Firefox looses track of contexts", "firefox")
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     provision = {

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -315,6 +315,7 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
 @nondestructive
 class TestLocalDashboard(MachineCase, DashBoardHelpers):
     def testDashboard(self):
+        self.restore_file("/etc/ssh/ssh_known_hosts")
         b = self.browser
 
         self.setup_ssh_auth()

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -230,10 +230,11 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
-        b.click(".system-usage a")  # View graphs
-        b.enter_page("/system/graphs", "10.111.113.3")
-        b.click("#link-network a")
-        b.enter_page("/network", "10.111.113.3")
+        if m.image != "rhel-8-3-distropkg":
+            b.click(".system-information a")  # View hardware details
+            b.enter_page("/system/hwinfo", "10.111.113.3")
+            b.click(".pf-c-breadcrumb li:first-child a")
+            b.enter_page("/system", "10.111.113.3")
 
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -96,6 +96,7 @@ class HostSwitcherHelpers:
         for m in self.machines:
             self.authorize_pubkey(self.machines[m], "admin", pubkey)
 
+@noretry
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     provision = {

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -269,10 +269,10 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
-        b.click(".system-usage a")  # View graphs
-        b.enter_page("/system/graphs", "10.111.113.3")
-        b.click("#link-network a")
-        b.enter_page("/network", "10.111.113.3")
+        b.click(".system-information a")  # View hardware details
+        b.enter_page("/system/hwinfo", "10.111.113.3")
+        b.click(".pf-c-breadcrumb li:first-child a")
+        b.enter_page("/system", "10.111.113.3")
 
         # Remove host underneath ourselves
         b.switch_to_top()


### PR DESCRIPTION
Adjust check-{dashboard,host-switching} to switch to the hardware info
subpage instead of the graphs subpage, as we will soon replace the
latter with a standalone webpack.

 - [x] add `@noretry`: PR #14680 
 - [x] mark these tests as noretry