### PR TITLE
machines: Show cdrom details in bootorder dialog

### DIFF
--- a/pkg/machines/components/vm/bootOrderModal.jsx
+++ b/pkg/machines/components/vm/bootOrderModal.jsx
@@ -95,6 +95,10 @@ const DeviceRow = ({ idPrefix, device, index, onToggle, upDisabled, downDisabled
         addOptional(additionalInfo, device.device.source.volume, _("Volume"));
         addOptional(additionalInfo, device.device.source.host.name, _("Host"));
         addOptional(additionalInfo, device.device.source.host.port, _("Port"));
+        if (device.device.device === "cdrom") {
+            addOptional(additionalInfo, device.device.device, _("Device"));
+            addOptional(additionalInfo, device.device.bus, _("Bus"));
+        }
         break;
     }
     case "network": {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2706,6 +2706,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m = self.machine
 
         self.createVm("subVmTest1")
+        self.machine.execute("touch /var/lib/libvirt/images/phonycdrom; virsh attach-disk subVmTest1 /var/lib/libvirt/images/phonycdrom sdb --type cdrom --config")
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
@@ -2722,6 +2723,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_present("#vm-subVmTest1-order-modal-window")
         # Make sure the footer warning does not appear
         b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
+        # Check a cdrom attributes are shown correctly
+        cdrom_row = b.text("#vm-subVmTest1-order-modal-device-row-2 .list-view-pf-additional-info")
+        self.assertTrue("cdrom" and "/var/lib/libvirt/images/phonycdrom" in cdrom_row)
         # Move first device down and check whetever succeeded
         row = b.text("#vm-subVmTest1-order-modal-device-row-1 .list-view-pf-additional-info")
         b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1880175

### Before:
![Screenshot from 2020-09-29 13-07-18](https://user-images.githubusercontent.com/42733240/94551830-43086a00-0256-11eb-9eb5-7dc67a869e51.png)


### After
![Screenshot from 2020-09-29 13-07-25](https://user-images.githubusercontent.com/42733240/94551856-4b60a500-0256-11eb-9ea3-53b1e570c54a.png)
