### PR TITLE
test: Quiesce Chromium logorhea

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -174,7 +174,7 @@ class CDP:
             return [exe, "--headless" if not self.show_browser else "", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
                     "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
                     "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
-                    "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"]
+                    "--v=0", "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"]
         elif self.browser == "firefox":
             subprocess.Popen([exe, "--headless", "--no-remote", "-CreateProfile", "blank"], env=env).communicate()
             profile = glob.glob(os.path.join(self._browser_home, ".mozilla/firefox/*.blank"))[0]


### PR DESCRIPTION
Recent chromium versions (seen with 85.0.4183.121) have become
ridiculously chatty, spewing thousands of messages like

    ERROR:paint_controller.cc(646)] PaintController::FinishCycle() completed
    VERBOSE2:thread_state.cc(429)] [state:0x560d0d8fefc0] ScheduleGCIfNeeded

Explicitly set verbosity 0. This was, and is supposed to be, the
default, but apparently not any more.