### PR TITLE
Add OpenSUSE Tumbleweed favicon

### DIFF
--- a/src/branding/opensuse/Makefile.am
+++ b/src/branding/opensuse/Makefile.am
@@ -9,3 +9,4 @@ EXTRA_DIST += $(opensusebranding_DATA)
 install-data-hook::
 	$(LN_S) -f /usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
 	$(LN_S) -f /usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
+	$(LN_S) -f /usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico


### PR DESCRIPTION
Just installed cockpit on a tumbleweed system and was sad to see it had the default favicon so I found `/usr/share/pixmaps/distribution-logos/square-hicolor.svg` and converted it to a 48x48 favicon.ico.