### PR TITLE
test: Fix cleanup of override files

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1367,6 +1367,9 @@ class MachineCase(unittest.TestCase):
 
         If path does not currently exist, it will be removed again on cleanup.
         '''
+        if not self.is_nondestructive():
+            return  # skip for efficiency reasons
+
         exists = self.machine.execute("if test -e %s; then echo yes; fi" % path).strip() != ""
         if exists:
             backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -870,18 +870,18 @@ class MachineCase(unittest.TestCase):
                 machine.dhcp_server()
 
         if self.machine:
-            # Pages with debug enabled are huge and loading/executing them is heavy for browsers
-            # To make it easier for browsers and thus make tests quicker, disable packagekit and systemd preloads
-            # Only "TEST_OS_DEFAULT" has debug build enabled, see `build_and_install()` in `test/image-prepare`
-            if self.machine.image == testvm.TEST_OS_DEFAULT:
-                self.disable_preload("packagekit", "systemd")
-
             self.journal_start = self.machine.journal_cursor()
             self.browser = self.new_browser()
             # fail tests on criticals
             self.machine.write("/etc/cockpit/cockpit.conf", "[Log]\nFatal = criticals\n")
             if self.is_nondestructive():
                 self.nonDestructiveSetup()
+
+            # Pages with debug enabled are huge and loading/executing them is heavy for browsers
+            # To make it easier for browsers and thus make tests quicker, disable packagekit and systemd preloads
+            # Only "TEST_OS_DEFAULT" has debug build enabled, see `build_and_install()` in `test/image-prepare`
+            if self.machine.image == testvm.TEST_OS_DEFAULT:
+                self.disable_preload("packagekit", "systemd")
 
     def nonDestructiveSetup(self):
         '''generic setUp/tearDown for @nondestructive tests'''


### PR DESCRIPTION
Commit 962ea145f65a changed MachineCase.write_file() to use 
restore_file(). This broke TestRunTest.testExistingMachine on Fedora 32
in a subtle way: As the override files are now already existing, the 
inner test tried to restore the original version instead of just
deleting the file, but that happened *after* nonDestructiveSetup()
already removed the backup directory.

Call disable_preload() *after* nonDestructiveSetup() to fix this.