### PR TITLE
storage: List entries from /etc/crypttab that are still locked

### DIFF
--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import { cellWidth, SortByDirection } from '@patternfly/react-table';
+
+import { ListingTable } from "cockpit-components-table.jsx";
+import { block_name, get_block_link_parts, go_to_block } from "./utils.js";
+import { OptionalPanel } from "./optional-panel.jsx";
+
+const _ = cockpit.gettext;
+
+export class LockedCryptoPanel extends React.Component {
+    render() {
+        var client = this.props.client;
+
+        function is_locked_crypto(path) {
+            var block = client.blocks[path];
+            var crypto = client.blocks_crypto[path];
+            var cleartext = client.blocks_cleartext[path];
+            return crypto && !cleartext && !block.HintIgnore;
+        }
+
+        function make_locked_crypto(path) {
+            var block = client.blocks[path];
+
+            const parts = get_block_link_parts(client, block.path);
+            const name = cockpit.format(parts.format, parts.link);
+
+            return {
+                props: { path, client, key: path },
+                columns: [
+                    { title:  name },
+                    { title:  block_name(block) },
+                ]
+            };
+        }
+
+        var locked_cryptos = Object.keys(client.blocks).filter(is_locked_crypto)
+                .map(make_locked_crypto);
+
+        if (locked_cryptos.length == 0)
+            return null;
+
+        function onRowClick(event, row) {
+            if (!event || event.button !== 0)
+                return;
+            go_to_block(row.props.client, row.props.path);
+        }
+
+        // table-hover class is needed till PF4 Table has proper support for clickable rows
+        // https://github.com/patternfly/patternfly-react/issues/3267
+        return (
+            <OptionalPanel id="locked-cryptos"
+                title={_("Locked devices")}>
+                <ListingTable variant='compact'
+                    sortBy={{ index: 0, direction: SortByDirection.asc }}
+                    aria-label={_("Locked devices")}
+                    className='table-hover'
+                    onRowClick={onRowClick}
+                    columns={[
+                        { title: _("Name"), transforms: [cellWidth(30)], sortable: true },
+                        { title: _("Device"), transforms: [cellWidth(30)], sortable: true },
+                    ]}
+                    rows={locked_cryptos} />
+            </OptionalPanel>
+        );
+    }
+}

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -24,6 +24,7 @@ import { Page, Grid, GridItem, Card, CardBody, Gallery } from "@patternfly/react
 import { StoragePlots } from "./plot.jsx";
 
 import { FilesystemsPanel } from "./fsys-panel.jsx";
+import { LockedCryptoPanel } from "./crypto-panel.jsx";
 import { NFSPanel } from "./nfs-panel.jsx";
 import { ThingsPanel } from "./things-panel.jsx";
 import { IscsiPanel } from "./iscsi-panel.jsx";
@@ -53,6 +54,7 @@ export class Overview extends React.Component {
                                 </CardBody>
                             </Card>
                             <FilesystemsPanel client={client} />
+                            <LockedCryptoPanel client={client} />
                             <NFSPanel client={client} />
                             <JobsPanel client={client} />
                             <StorageLogsPanel />

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -78,6 +78,12 @@ class TestStorageLuks(StorageCase):
         self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 file system")
 
+        # It should be listed on the Overview. Click it to come back
+        # here.
+        b.go("#/")
+        b.mousedown("#locked-cryptos tr:contains(MYDISK)")
+        b.wait_visible("#storage-detail")
+
         # Unlock, this uses the stored passphrase
         self.content_head_action(1, "Unlock")
         self.content_row_wait_in_col(2, 1, "ext4 file system")


### PR DESCRIPTION
People might want to find them easily in order to unlock them
manually.

Demo: https://www.youtube.com/watch?v=mmFOTQ39ZPk

Fixes #14697

## Release notes

Cockpit now lists those encrypted devices in the overview that are still locked. This makes them easy to find if you want to unlock them manually.

![image](https://user-images.githubusercontent.com/3228183/95431061-4df98380-0955-11eb-8e27-3850be6c5897.png)
