### PR TITLE
bridge: remove log handler remover code

### DIFF
--- a/src/bridge/cockpitpolkitagent.c
+++ b/src/bridge/cockpitpolkitagent.c
@@ -462,7 +462,6 @@ void
 cockpit_polkit_agent_unregister (gpointer data)
 {
   CockpitPolkitRegistered *registered = data;
-  guint handler = 0;
 
   if (!registered)
     return;
@@ -473,8 +472,6 @@ cockpit_polkit_agent_unregister (gpointer data)
 
   /* Now unregister with polkit */
   polkit_agent_listener_unregister (registered->registration_handle);
-
-  g_log_remove_handler (NULL, handler);
 
   g_free (registered);
 }


### PR DESCRIPTION
This code doesn't do anything anymore, since we never install a log
handler anymore.  It should have been removed earlier.