### PR TITLE
Revert "tools: Require shadow-utils also on Fedora/RHEL"

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -394,7 +394,9 @@ embed or extend Cockpit.
 Summary: Cockpit admin interface package for configuring and troubleshooting a system
 BuildArch: noarch
 Requires: cockpit-bridge >= %{version}-%{release}
+%if !0%{?suse_version}
 Requires: shadow-utils
+%endif
 Requires: grep
 Requires: /usr/bin/pwscore
 Requires: /usr/bin/date


### PR DESCRIPTION
This reverts commit 5eb6af26402d059b0d2f23ace45c8e1ee7b1524f.