### PR TITLE
tests: Increase timeout in check-sosreport

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -58,7 +58,7 @@ threads=1
         b.click('[data-target="#sos"]')
         b.wait_visible("#sos")
 
-        with b.wait_timeout(360):
+        with b.wait_timeout(540):
             b.wait(lambda: b.eval_js('ph_find(".progress-bar").offsetWidth') > 0)
             b.wait_visible("#sos-download")
 


### PR DESCRIPTION
This test keeps running into the timeout on rhel-atomic.

See cockpit-project/bots#1271