### PR TITLE
cockpituous: Run release in a GitHub workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release
+on:
+  push:
+    tags:
+      # this is a glob, not a regexp
+      - '[0-9]*'
+jobs:
+  cockpituous:
+    runs-on: ubuntu-latest
+    container:
+      image: docker.io/cockpit/release
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+
+          # This uses the shared cockpit-project organization secrets:
+          # https://github.com/organizations/cockpit-project/settings/secrets
+          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/.ssh/known_hosts
+          echo '${{ secrets.FEDPKG_SSH_PUBLIC }}' > ~/.ssh/id_rsa.pub
+          echo '${{ secrets.FEDPKG_SSH_PRIVATE }}' > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          echo 'cockpit' > ~/.config/bodhi-user
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+          echo '${{ secrets.COPR_TOKEN }}' > ~/.config/copr
+          echo '${{ secrets.COCKPIT_FEDORA_PASSWORD }}' > ~/.fedora-password
+
+      - name: Run cockpituous
+        run: |
+          # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
+          export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
+          cd /build
+          release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) tools/cockpituous-release

--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -1,7 +1,11 @@
 # This is a script run to release Cockpit
 #
-# This script is run in the cockpit/release container
+# This script is run in a cockpit/release container:
 # https://github.com/cockpit-project/cockpituous/tree/master/release
+#
+# This gets triggered on pushing a signed release tag, through a GitHub action:
+#
+#   .github/workflows/release.yml
 #
 # Anything that start with 'job' may run in a way that it SIGSTOP's
 # itself when preliminary preparition and then gets a SIGCONT in


### PR DESCRIPTION
Enter the new world of GitHub actions [1]/GitLab pipelines [2]. This
simplifies our end of the infrastructure considerably:

* No need any more to set up webhooks, all the relevant configuration
  is right in the workflow file.

* Does not need any infrastructure on our side any more.

* GitHub automatically provides a temporary `GITHUB_TOKEN` with
  sufficient write access to the project to publish a release, so we
  don't need to carry around that secret.

[1] https://github.com/features/actions
[2] https://docs.gitlab.com/ee/ci/pipelines/

 - [x] When landing, disable the "repo/tag creation" webhook