### PR TITLE
test: fix TestMachines.testSnapshotRevert flake

### DIFF
--- a/pkg/machines/components/vmSnapshotsTab.jsx
+++ b/pkg/machines/components/vmSnapshotsTab.jsx
@@ -204,7 +204,7 @@ class VmSnapshotsTab extends React.Component {
         const columnTitles = detailMap.map(target => target.name);
         let rows = [];
         if (vm.snapshots) {
-            rows = vm.snapshots.sort((a, b) => b.creationTime - a.creationTime).map((target, snapId) => {
+            rows = vm.snapshots.sort((a, b) => ((b.creationTime - a.creationTime) || (a.name.localeCompare(b.name)))).map((target, snapId) => {
                 const columns = detailMap.map(d => {
                     let column = null;
                     if (typeof d.value === 'string') {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -3506,8 +3506,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m.execute("virsh detach-disk --domain subVmTest1 --target vda --config") # vda is raw disk, which are not supported by internal snapshots
         m.execute("qemu-img create -f qcow2 /var/lib/libvirt/images/foobar.qcow2 1M")
         m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/images/foobar.qcow2 --target vdb --subdriver qcow2 --config")
+        m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshot0 --description 'Description of snapshot0'")
         m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshot1 --description 'Description of snapshot1'")
-        m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshot2 --description 'Description of snapshot2'")
+        # snapshot1 is the current snapshot
+        m.execute("virsh snapshot-current --domain subVmTest1 --snapshotname snapshot0")
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
@@ -3520,8 +3522,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         b.wait_present("#vm-subVmTest1-snapshot-0-current")
         b.wait_not_present("#vm-subVmTest1-snapshot-1-current")
+        self.assertEqual("yes", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot0 | grep 'Current:' | awk '{print $2}'").strip())
         self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot1 | grep 'Current:' | awk '{print $2}'").strip())
-        self.assertEqual("yes", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot2 | grep 'Current:' | awk '{print $2}'").strip())
 
         b.click("#vm-subVmTest1-snapshot-1-revert")
         b.wait_in_text(".modal-dialog .modal-header .modal-title", "Revert to snapshot snapshot1")
@@ -3529,8 +3531,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         b.wait_not_present("#vm-subVmTest1-snapshot-0-current")
         b.wait_present("#vm-subVmTest1-snapshot-1-current")
+        self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot0 | grep 'Current:' | awk '{print $2}'").strip())
         self.assertEqual("yes", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot1 | grep 'Current:' | awk '{print $2}'").strip())
-        self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot2 | grep 'Current:' | awk '{print $2}'").strip())
 
     def testSnapshots(self):
         # Checks if difference of @time1 and @time2 is not greater than @difference (in seconds)


### PR DESCRIPTION
The creation time of two two snapshots is the same within the test, so they appear in
random order in the list which confuses the test.

The test itself had some wrong logic as well, which was addressed within
this commit. For consistency use snapshot names following the rows
indexes because it get confusing otherwise.