### PR TITLE
rhel-8.3: test: Fix check-embed to work with chromium>=85

### DIFF
--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -28,21 +28,32 @@ class TestEmbed(MachineCase):
         b = self.browser
         m = self.machine
 
-        m.start_cockpit()
+        m.execute("mkdir -p /home/admin/.local/share/cockpit/embed-cockpit")
+        m.upload(["verify/files/embed-cockpit/index.html",
+                  "verify/files/embed-cockpit/embed.js",
+                  "verify/files/embed-cockpit/manifest.json"],
+                 "/home/admin/.local/share/cockpit/embed-cockpit/")
 
-        b.open("file://%s/verify/files/embed-cockpit.html" % TEST_DIR)
+        # replace the shell with our embedded page, this way we can avoid
+        # cross-origin errors when executing js in the iframe
+        m.write("/etc/cockpit/cockpit.conf","""
+[WebService]
+Shell=/embed-cockpit/index.html
+""")
+        m.start_cockpit()
+        self.login_and_go()
+
         b.wait_present("#embed-loaded")
+        b.wait_present("#embed-address")
+        m.write("/etc/cockpit/cockpit.conf","""
+[WebService]
+Shell=/shell/index.html
+""")
         b.set_val("#embed-address", "http://{0}:{1}".format(m.web_address, m.web_port))
         b.click("#embed-full")
         b.wait_present("iframe[name='embed-full'][loaded]")
         b.switch_to_frame("embed-full")
-        b.wait_visible("#login")
-        b.set_val('#login-user-input', "admin")
-        b.set_val('#login-password-input', "foobar")
-        b.set_checked('#authorized-input', True)
-        b.click('#login-button')
-        # don't use expect_load() here as the outside page doesn't reload, just the iframe
-        b.expect_load_frame("cockpit1:localhost/system")
+        b.wait_present("#system_information_os_text")
 
         # Page should show automatically now that other frame logged in
         b.switch_to_top()

--- a/test/verify/files/embed-cockpit/embed.js
+++ b/test/verify/files/embed-cockpit/embed.js
@@ -1,0 +1,35 @@
+var frames = { };
+
+function click(ev) {
+  var href = ev.target.getAttribute("href");
+  ev.preventDefault();
+
+  var address = document.getElementById("embed-address").value;
+  if (address.indexOf(":") === -1)
+    address += ":9090";
+  var url = address + href;
+
+  var frame = frames[url];
+  if (!frame) {
+    frame = frames[url] = document.createElement("iframe");
+    frame.setAttribute("src", url)
+    frame.setAttribute("name", ev.target.getAttribute("id"));
+    document.getElementById("embed-here").appendChild(frame);
+    frame.addEventListener("load", function(ev) {
+      ev.target.setAttribute("loaded", "1");
+    });
+  }
+
+  var i, iframes = document.querySelectorAll("iframe");
+  for (i = 0; i < iframes.length; i++)
+    iframes[i].setAttribute("hidden", "hidden");
+  frame.removeAttribute("hidden");
+  document.getElementById("embed-title").innerText = ev.target.innerText;
+  return false;
+}
+
+document.addEventListener("DOMContentLoaded", function() {
+  var x, links = document.querySelectorAll("#embed-links a[href]");
+  for (x = 0; x < links.length; x++)
+    links[x].addEventListener("click", click);
+});

--- a/test/verify/files/embed-cockpit/index.html
+++ b/test/verify/files/embed-cockpit/index.html
@@ -4,14 +4,15 @@
     <title>Embed Example</title>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="shortcut icon" href="../dist/img/favicon.ico">
-    <link href="../../../dist/base1/patternfly.css" rel="stylesheet" media="screen, print">
+    <script type="text/javascript" src="embed.js"></script>
     <style>
         #embed-links .card-pf-body {
             opacity: 0.3;
         }
         #embed-here {
-            height: 550px;
+            display: block;
+            width: 1024px;
+            height: 768px;
         }
         #embed-address {
             display: block;
@@ -23,25 +24,12 @@
         iframe {
             display: block;
             width: 100%;
-            height: 500px;
+            height: 100%;
             border: 1px solid #ddd;
         }
     </style>
 </head>
-<body class="cards-pf">
-
-    <!-- BOILERPLATE: Makes this look like another app -->
-    <nav class="navbar navbar-default navbar-pf" role="navigation">
-        <div class="navbar-header"><a class="navbar-brand"><img src="../dist/img/brand.svg"/></a></div>
-        <ul class="nav navbar-nav navbar-utility">
-            <li class="dropdown">
-                <a href="#" class="dropdown-toggle" data-toggle="dropdown">
-                    <span class="pficon pficon-user"></span> Brian Johnson <b class="caret"></b></a>
-                <ul class="dropdown-menu"><li><a href="#">Link</a></li></ul>
-            </li>
-        </ul>
-      </div>
-    </nav>
+<body id="content" class="cards-pf">
 
     <!-- BOILERPLATE: Makes this look like another app -->
     <div class="container-fluid container-cards-pf">
@@ -52,7 +40,7 @@
                 </div>
                 <div class="card-pf card-pf-accented card-pf-aggregate-status">
                     <h2 class="card-pf-title">
-                        <a id="embed-full" href="/cockpit/@localhost/shell/index.html">
+                        <a id="embed-full" href="/cockpit/@localhost/system/index.html">
                             <span class="fa fa-server"></span>Full Server
                         </a>
                     </h2>
@@ -128,41 +116,6 @@
             </div>
         </div><!-- /row -->
     </div><!-- /container -->
-    <script>
-        var frames = { };
-
-        function click(ev) {
-            var href = ev.target.getAttribute("href");
-            ev.preventDefault();
-
-            var address = document.getElementById("embed-address").value;
-            if (address.indexOf(":") === -1)
-                address += ":9090";
-            var url = address + href;
-
-            var frame = frames[url];
-            if (!frame) {
-                frame = frames[url] = document.createElement("iframe");
-                frame.setAttribute("src", url)
-                frame.setAttribute("name", ev.target.getAttribute("id"));
-                document.getElementById("embed-here").appendChild(frame);
-                frame.addEventListener("load", function(ev) {
-                    ev.target.setAttribute("loaded", "1");
-                });
-            }
-
-            var i, iframes = document.querySelectorAll("iframe");
-            for (i = 0; i < iframes.length; i++)
-                iframes[i].setAttribute("hidden", "hidden");
-            frame.removeAttribute("hidden");
-            document.getElementById("embed-title").innerText = ev.target.innerText;
-            return false;
-        }
-
-        var x, links = document.querySelectorAll("#embed-links a[href]");
-        for (x = 0; x < links.length; x++)
-            links[x].addEventListener("click", click);
-    </script>
     <div id="embed-loaded">
     </div>
 </body>

--- a/test/verify/files/embed-cockpit/manifest.json
+++ b/test/verify/files/embed-cockpit/manifest.json
@@ -1,0 +1,12 @@
+{
+    "version": "999",
+    "requires": {
+        "cockpit": "122"
+    },
+
+    "tools": {
+        "index": {
+            "label": "Embed Cockpit"
+        }
+    }
+}


### PR DESCRIPTION
The default "Referrer-Policy" for chromium is now
strict-origin-when-cross-origin, which caused the previous version of
the test to fail as js from the local embed-cockpit.html file to the
iframe was considered cross-origin.

By making the embed file the default shell, it is no longer
cross-origin.

Fixes #14718
Closes #