### PR TITLE
machines: port to PF4 modals

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -19,8 +19,9 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, HelpBlock, Modal } from 'patternfly-react';
+import { FormGroup, HelpBlock } from 'patternfly-react';
 import {
+    Modal,
     Select as PFSelect, SelectOption, SelectVariant,
     Button, Tooltip, TooltipPosition
 } from '@patternfly/react-core';
@@ -927,25 +928,23 @@ class CreateVmModal extends React.Component {
         );
 
         return (
-            <Modal id='create-vm-dialog' show onHide={ this.props.close }>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={ this.props.close } />
-                    <Modal.Title> {this.props.mode == 'create' ? _("Create new virtual machine") : _("Import a virtual machine")} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {dialogBody}
-                </Modal.Body>
-                <Modal.Footer>
+            <Modal position="top" variant="medium" id='create-vm-dialog' isOpen onClose={ this.props.close }
+                title={this.props.mode == 'create' ? _("Create new virtual machine") : _("Import a virtual machine")}
+                actions={[
                     <Button variant="primary"
-                            isDisabled={Object.getOwnPropertyNames(validationFailed).length > 0}
+                            key="primary-button"
+                            isLoading={this.state.inProgress}
+                            isDisabled={this.state.inProgress || Object.getOwnPropertyNames(validationFailed).length > 0}
                             onClick={this.onCreateClicked}>
                         {this.props.mode == 'create' ? _("Create") : _("Import")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
+                    </Button>,
+                    <Button variant='link'
+                            key="cancel-button"
+                            className='btn-cancel' onClick={ this.props.close }>
                         {_("Cancel")}
                     </Button>
-                    {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+                ]}>
+                {dialogBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/deleteDialog.jsx
+++ b/pkg/machines/components/deleteDialog.jsx
@@ -19,8 +19,7 @@
 
 import cockpit from 'cockpit';
 import React from 'react';
-import { Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { vmId } from '../helpers.js';
 import { deleteVm } from '../actions/provider-actions.js';
@@ -129,22 +128,20 @@ export class DeleteDialog extends React.Component {
     render() {
         const id = vmId(this.props.vm.name);
         return (
-            <Modal id={`${id}-delete-modal-dialog`} show onHide={this.props.toggleModal}>
-                <Modal.Header>
-                    <Modal.Title> {`Confirm deletion of ${this.props.vm.name}`} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    <DeleteDialogBody disks={this.state.disks} destroy={this.state.destroy} onChange={this.onDiskCheckedChanged} />
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='danger' onClick={this.delete}>
-                        {_("Delete")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={this.props.toggleModal}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id={`${id}-delete-modal-dialog`} isOpen onClose={this.props.toggleModal}
+                title={`Confirm deletion of ${this.props.vm.name}`}
+                footer={
+                    <>
+                        {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                        <Button variant='danger' onClick={this.delete}>
+                            {_("Delete")}
+                        </Button>
+                        <Button variant='link' className='btn-cancel' onClick={this.props.toggleModal}>
+                            {_("Cancel")}
+                        </Button>
+                    </>
+                }>
+                <DeleteDialogBody disks={this.state.disks} destroy={this.state.destroy} onChange={this.onDiskCheckedChanged} />
             </Modal>
         );
     }

--- a/pkg/machines/components/deleteResource.jsx
+++ b/pkg/machines/components/deleteResource.jsx
@@ -19,8 +19,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, Modal, Tooltip } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
@@ -57,24 +56,20 @@ export class DeleteResourceModal extends React.Component {
         const { objectName, objectType, actionName, actionDescription, onClose } = this.props;
 
         return (
-            <Modal show onHide={onClose}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={onClose} />
-                    <Modal.Title>{ (actionName || _("Delete")) + cockpit.format((" $0 $1"), objectType, objectName) }</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    { actionDescription || cockpit.format(_("Confirm this action")) }
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='danger' isDisabled={this.state.inProgress} onClick={this.delete}>
-                        {actionName || _("Delete")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={onClose}>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+            <Modal position="top" variant="medium" isOpen onClose={onClose}
+                   title={ (actionName || _("Delete")) + cockpit.format((" $0 $1"), objectType, objectName) }
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='danger' isLoading={this.state.inProgress} isDisabled={this.state.inProgress} onClick={this.delete}>
+                               {actionName || _("Delete")}
+                           </Button>
+                           <Button variant='link' className='btn-cancel' onClick={onClose}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                { actionDescription || cockpit.format(_("Confirm this action")) }
             </Modal>
         );
     }

--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -17,8 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react';
-import { Modal } from 'patternfly-react';
-import { Button, Alert, Spinner } from '@patternfly/react-core';
+import { Button, Alert, Modal, Spinner } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 
 import * as Select from "cockpit-components-select.jsx";
@@ -547,24 +546,20 @@ export class AddDiskModalBody extends React.Component {
         }
 
         return (
-            <Modal id={`${idPrefix}-dialog-modal-window`} show onHide={this.props.close}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.props.close} />
-                    <Modal.Title>{_("Add disk")}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button id={`${idPrefix}-dialog-add`} variant='primary' isDisabled={this.state.addDiskInProgress || storagePools.length == 0 || this.state.dialogLoading} onClick={this.onAddClicked}>
-                        {_("Add")}
-                    </Button>
-                    <Button id={`${idPrefix}-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.addDiskInProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id={`${idPrefix}-dialog-modal-window`} isOpen onClose={this.props.close}
+                   title={_("Add disk")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button id={`${idPrefix}-dialog-add`} variant='primary' isLoading={this.state.addDiskInProgress} isDisabled={this.state.addDiskInProgress || storagePools.length == 0} onClick={this.onAddClicked}>
+                               {_("Add")}
+                           </Button>
+                           <Button id={`${idPrefix}-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {defaultBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/diskEdit.jsx
+++ b/pkg/machines/components/diskEdit.jsx
@@ -18,9 +18,8 @@
  */
 
 import React from 'react';
-import { Modal } from 'patternfly-react';
 import cockpit from 'cockpit';
-import { Button, Tooltip, Alert, Radio } from '@patternfly/react-core';
+import { Button, Tooltip, Alert, Modal, Radio } from '@patternfly/react-core';
 import { InfoAltIcon } from '@patternfly/react-icons';
 
 import * as Select from 'cockpit-components-select.jsx';
@@ -185,24 +184,23 @@ class EditDiskModalBody extends React.Component {
         };
 
         return (
-            <Modal id={`${idPrefix}-dialog`} show onHide={this.props.close}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.props.close} />
-                    <Modal.Title>{cockpit.format(_("Edit $0 attributes"), getDiskPrettyName(vm.disks[disk.target]))} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" id={`${idPrefix}-dialog`} isOpen onClose={this.props.close}
+                   title={cockpit.format(_("Edit $0 attributes"), getDiskPrettyName(vm.disks[disk.target]))}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button id={`${idPrefix}-dialog-save`} variant='primary' onClick={this.onSaveClicked}>
+                               {_("Save")}
+                           </Button>
+                           <Button id={`${idPrefix}-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     { showWarning() }
                     {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button id={`${idPrefix}-dialog-save`} variant='primary' onClick={this.onSaveClicked}>
-                        {_("Save")}
-                    </Button>
-                    <Button id={`${idPrefix}-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/components/networks/createNetworkDialog.jsx
+++ b/pkg/machines/components/networks/createNetworkDialog.jsx
@@ -20,8 +20,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, HelpBlock, Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { FormGroup, HelpBlock } from 'patternfly-react';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { networkCreate } from '../../libvirt-dbus.js';
@@ -473,26 +473,23 @@ class CreateNetworkModal extends React.Component {
         );
 
         return (
-            <Modal id='create-network-dialog' className='network-create' show onHide={ this.props.close }>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={ this.props.close } />
-                    <Modal.Title> {_("Create virtual network")} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {body}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='primary'
-                        isDisabled={ this.state.createInProgress || Object.getOwnPropertyNames(validationFailed).length > 0 }
-                        onClick={ this.onCreate }>
-                        {_("Create")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.createInProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id='create-network-dialog' className='network-create' isOpen onClose={ this.props.close }
+                   title={_("Create virtual network")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='primary'
+                                   isLoading={ this.state.createInProgress }
+                                   isDisabled={ this.state.createInProgress || Object.getOwnPropertyNames(validationFailed).length > 0 }
+                                   onClick={ this.onCreate }>
+                               {_("Create")}
+                           </Button>
+                           <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {body}
             </Modal>
         );
     }

--- a/pkg/machines/components/nicAdd.jsx
+++ b/pkg/machines/components/nicAdd.jsx
@@ -19,8 +19,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { NetworkTypeAndSourceRow, NetworkModelRow } from './nicBody.jsx';
@@ -186,26 +185,23 @@ export class AddNIC extends React.Component {
         );
 
         return (
-            <Modal id={`${idPrefix}-dialog`} onHide={this.props.close} className='nic-add' show>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.props.close} />
-                    <Modal.Title>{_("Add virtual network interface")}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button isDisabled={["network", "direct", "bridge"].includes(this.state.networkType) && this.state.networkSource === undefined}
-                            id={`${idPrefix}-add`}
-                            variant='primary'
-                            onClick={this.add}>
-                        {_("Add")}
-                    </Button>
-                    <Button id={`${idPrefix}-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id={`${idPrefix}-dialog`} isOpen onClose={this.props.close} className='nic-add'
+                title={_("Add virtual network interface")}
+                footer={
+                    <>
+                        {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                        <Button isDisabled={["network", "direct", "bridge"].includes(this.state.networkType) && this.state.networkSource === undefined}
+                                id={`${idPrefix}-add`}
+                                variant='primary'
+                                onClick={this.add}>
+                            {_("Add")}
+                        </Button>
+                        <Button id={`${idPrefix}-cancel`} variant='link' className='btn-cancel' onClick={this.props.close}>
+                            {_("Cancel")}
+                        </Button>
+                    </>
+                }>
+                {defaultBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/nicEdit.jsx
+++ b/pkg/machines/components/nicEdit.jsx
@@ -19,8 +19,7 @@
 import React from 'react';
 import cockpit from 'cockpit';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button, Alert } from '@patternfly/react-core';
+import { Button, Alert, Modal } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { NetworkTypeAndSourceRow, NetworkModelRow } from './nicBody.jsx';
@@ -156,24 +155,23 @@ export class EditNICModal extends React.Component {
         };
 
         return (
-            <Modal id={`${idPrefix}-edit-dialog-modal-window`} onHide={this.props.onClose} className='nic-edit' show>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.props.onClose} />
-                    <Modal.Title>{cockpit.format(_("$0 virtual network interface settings"), network.mac)}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" id={`${idPrefix}-edit-dialog-modal-window`} isOpen onClose={this.props.onClose} className='nic-edit'
+                   title={cockpit.format(_("$0 virtual network interface settings"), network.mac)}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button isDisabled={this.state.saveDisabled} id={`${idPrefix}-edit-dialog-save`} variant='primary' onClick={this.save}>
+                               {_("Save")}
+                           </Button>
+                           <Button id={`${idPrefix}-edit-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.onClose}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     { showWarning() }
                     {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button isDisabled={this.state.saveDisabled} id={`${idPrefix}-edit-dialog-save`} variant='primary' onClick={this.save}>
-                        {_("Save")}
-                    </Button>
-                    <Button id={`${idPrefix}-edit-dialog-cancel`} variant='link' className='btn-cancel' onClick={this.props.onClose}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
+++ b/pkg/machines/components/storagePools/createStoragePoolDialog.jsx
@@ -19,8 +19,8 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormGroup, HelpBlock, Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { FormGroup, HelpBlock } from 'patternfly-react';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { LIBVIRT_SYSTEM_CONNECTION } from '../../helpers.js';
 import { MachinesConnectionSelector } from '../machinesConnectionSelector.jsx';
@@ -497,24 +497,20 @@ class CreateStoragePoolModal extends React.Component {
         );
 
         return (
-            <Modal id='create-storage-pool-dialog' className='pool-create' show onHide={ this.props.close }>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={ this.props.close } />
-                    <Modal.Title>{_("Create storage pool")}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='primary' isDisabled={this.state.createInProgress} onClick={this.onCreateClicked}>
-                        {_("Create")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.createInProgress && <div className="spinner spinner-sm pull-left" />}
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id='create-storage-pool-dialog' className='pool-create' isOpen onClose={ this.props.close }
+                   title={_("Create storage pool")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='primary' isLoading={this.state.createInProgress} isDisabled={this.state.createInProgress} onClick={this.onCreateClicked}>
+                               {_("Create")}
+                           </Button>
+                           <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {defaultBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/storagePools/storagePoolDelete.jsx
+++ b/pkg/machines/components/storagePools/storagePoolDelete.jsx
@@ -18,8 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, Modal, Tooltip } from '@patternfly/react-core';
 
 import { getStorageVolumesUsage, storagePoolId } from '../../helpers.js';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
@@ -218,25 +217,22 @@ export class StoragePoolDelete extends React.Component {
             <>
                 {deleteButton()}
 
-                <Modal show={this.state.showModal} onHide={this.close}>
-                    <Modal.Header>
-                        <Modal.CloseButton onClick={this.close} />
-                        <Modal.Title> {cockpit.format(_("Delete storage pool $0"), storagePool.name)} </Modal.Title>
-                    </Modal.Header>
-                    <Modal.Body>
-                        {defaultBody}
-                    </Modal.Body>
-                    <Modal.Footer>
-                        {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                        <Button variant='danger'
-                            onClick={this.delete}
-                            isDisabled={canDeleteOnlyWithoutVolumes(storagePool, vms) && this.state.deleteVolumes}>
-                            {_("Delete")}
-                        </Button>
-                        <Button variant='link' className='btn-cancel' onClick={this.close}>
-                            {_("Cancel")}
-                        </Button>
-                    </Modal.Footer>
+                <Modal position="top" variant="medium" isOpen={this.state.showModal} onClose={this.close}
+                       title={cockpit.format(_("Delete storage pool $0"), storagePool.name)}
+                       footer={
+                           <>
+                               {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                               <Button variant='danger'
+                                   onClick={this.delete}
+                                   isDisabled={canDeleteOnlyWithoutVolumes(storagePool, vms) && this.state.deleteVolumes}>
+                                   {_("Delete")}
+                               </Button>
+                               <Button variant='link' className='btn-cancel' onClick={this.close}>
+                                   {_("Cancel")}
+                               </Button>
+                           </>
+                       }>
+                    {defaultBody}
                 </Modal>
             </>
         );

--- a/pkg/machines/components/storagePools/storageVolumeCreate.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreate.jsx
@@ -19,8 +19,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button, Tooltip } from '@patternfly/react-core';
+import { Button, Modal, Tooltip } from '@patternfly/react-core';
 import cockpit from 'cockpit';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
@@ -74,29 +73,25 @@ class CreateStorageVolumeModal extends React.Component {
         const idPrefix = `${this.props.idPrefix}-dialog`;
 
         return (
-            <Modal id={`${idPrefix}-modal`} className='volume-create' show onHide={ this.props.close }>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={ this.props.close } />
-                    <Modal.Title>{_("Create storage volume")}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    <div className='ct-form'>
-                        <VolumeCreateBody idPrefix={idPrefix}
-                                          storagePool={this.props.storagePool}
-                                          dialogValues={this.state}
-                                          onValueChanged={this.onValueChanged} />
-                    </div>
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant="primary" onClick={this.onCreateClicked} isDisabled={this.state.createInProgress}>
-                        {_("Create")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.createInProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id={`${idPrefix}-modal`} className='volume-create' isOpen onClose={this.props.close}
+                   title={_("Create storage volume")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant="primary" onClick={this.onCreateClicked} isLoading={this.state.createInProgress} isDisabled={this.state.createInProgress}>
+                               {_("Create")}
+                           </Button>
+                           <Button variant='link' className='btn-cancel' onClick={ this.props.close }>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <div className='ct-form'>
+                    <VolumeCreateBody idPrefix={idPrefix}
+                                      storagePool={this.props.storagePool}
+                                      dialogValues={this.state}
+                                      onValueChanged={this.onValueChanged} />
+                </div>
             </Modal>
         );
     }

--- a/pkg/machines/components/vcpuModal.jsx
+++ b/pkg/machines/components/vcpuModal.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
 import cockpit from 'cockpit';
-import { Alert, Button, Tooltip } from '@patternfly/react-core';
+import { Alert, Button, Modal, Tooltip } from '@patternfly/react-core';
 import { InfoAltIcon } from '@patternfly/react-icons';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
@@ -239,24 +238,23 @@ export class VCPUModal extends React.Component {
         );
 
         return (
-            <Modal id='machines-vcpu-modal-dialog' show onHide={this.props.close}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.props.close} />
-                    <Modal.Title>{cockpit.format(_("$0 vCPU details"), vm.name)}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" id='machines-vcpu-modal-dialog' isOpen onClose={this.props.close}
+                   title={cockpit.format(_("$0 vCPU details"), vm.name)}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button id='machines-vcpu-modal-dialog-apply' variant='primary' onClick={this.save}>
+                               {_("Apply")}
+                           </Button>
+                           <Button id='machines-vcpu-modal-dialog-cancel' variant='link' className='btn-cancel' onClick={this.props.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     { caution }
                     { defaultBody }
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button id='machines-vcpu-modal-dialog-apply' variant='primary' onClick={this.save}>
-                        {_("Apply")}
-                    </Button>
-                    <Button id='machines-vcpu-modal-dialog-cancel' variant='link' className='btn-cancel' onClick={this.props.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/components/vm/bootOrderModal.jsx
+++ b/pkg/machines/components/vm/bootOrderModal.jsx
@@ -24,9 +24,8 @@ import {
     Icon,
     ListView,
     ListViewItem,
-    Modal
 } from 'patternfly-react';
-import { Button, Alert } from '@patternfly/react-core';
+import { Button, Alert, Modal } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import {
@@ -307,24 +306,23 @@ export class BootOrderModal extends React.Component {
         const title = _("Boot order");
 
         return (
-            <Modal id={`${idPrefix}-window`} show onHide={this.close} className='boot-order'>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.close} />
-                    <Modal.Title> {`${vm.name} ${title}`} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" id={`${idPrefix}-window`} isOpen onClose={this.close} className='boot-order'
+                   title={`${vm.name} ${title}`}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button id={`${idPrefix}-save`} variant='primary' onClick={this.save}>
+                               {_("Save")}
+                           </Button>
+                           <Button id={`${idPrefix}-cancel`} variant='link' onClick={this.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     {showWarning()}
                     {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button id={`${idPrefix}-save`} variant='primary' onClick={this.save}>
-                        {_("Save")}
-                    </Button>
-                    <Button id={`${idPrefix}-cancel`} variant='link' onClick={this.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/components/vm/firmwareModal.jsx
+++ b/pkg/machines/components/vm/firmwareModal.jsx
@@ -19,8 +19,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cockpit from 'cockpit';
-import { Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import * as Select from "cockpit-components-select.jsx";
@@ -51,12 +50,20 @@ export class FirmwareModal extends React.Component {
 
     render() {
         return (
-            <Modal show onHide={this.close}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.close} />
-                    <Modal.Title> {_("Change firmware")} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" isOpen onClose={this.close}
+                   title={_("Change firmware")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='primary' id="firmware-dialog-apply" onClick={this.save}>
+                               {_("Save")}
+                           </Button>
+                           <Button variant='link' onClick={this.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     <Select.Select
                                    onChange={value => this.setState({ firmware: value })}
                                    initial={this.props.firmware == 'efi' ? this.props.firmware : 'bios' }
@@ -68,16 +75,7 @@ export class FirmwareModal extends React.Component {
                             UEFI
                         </Select.SelectEntry>
                     </Select.Select>
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='primary' id="firmware-dialog-apply" onClick={this.save}>
-                        {_("Save")}
-                    </Button>
-                    <Button variant='link' onClick={this.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/components/vm/memoryModal.jsx
+++ b/pkg/machines/components/vm/memoryModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { HelpBlock, Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { HelpBlock } from 'patternfly-react';
+import { Button, Modal } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
 import cockpit from 'cockpit';
@@ -138,23 +138,20 @@ export class MemoryModal extends React.Component {
         );
 
         return (
-            <Modal id='vm-memory-modal' show onHide={this.close}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={this.close} />
-                    <Modal.Title>{cockpit.format(_("$0 memory adjustment"), vm.name)}</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {defaultBody}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button id={`${idPrefix}-save`} variant='primary' onClick={this.save}>
-                        {_("Save")}
-                    </Button>
-                    <Button id={`${idPrefix}-cancel`} variant='link' onClick={this.close}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id='vm-memory-modal' isOpen onClose={this.close}
+                   title={cockpit.format(_("$0 memory adjustment"), vm.name)}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button id={`${idPrefix}-save`} variant='primary' onClick={this.save}>
+                               {_("Save")}
+                           </Button>
+                           <Button id={`${idPrefix}-cancel`} variant='link' onClick={this.close}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {defaultBody}
             </Modal>
         );
     }

--- a/pkg/machines/components/vmSnapshotsCreateModal.jsx
+++ b/pkg/machines/components/vmSnapshotsCreateModal.jsx
@@ -20,10 +20,10 @@ import cockpit from "cockpit";
 import React from "react";
 import moment from "moment";
 
-import { Modal } from "patternfly-react";
 import {
     Button,
     FormGroup,
+    Modal,
     TextArea,
     TextInput
 } from "@patternfly/react-core";
@@ -133,23 +133,20 @@ export class CreateSnapshotModal extends React.Component {
         );
 
         return (
-            <Modal id={`${idPrefix}-modal`} onHide={onClose} show>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={onClose} />
-                    <Modal.Title>{_("Create snapshot")} </Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
-                    {body}
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant="primary" onClick={this.onCreate}>
-                        {_("Create")}
-                    </Button>
-                    <Button variant="link" className="btn-cancel" onClick={onClose}>
-                        {_("Cancel")}
-                    </Button>
-                </Modal.Footer>
+            <Modal position="top" variant="medium" id={`${idPrefix}-modal`} isOpen onClose={onClose}
+                   title={_("Create snapshot")}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant="primary" onClick={this.onCreate}>
+                               {_("Create")}
+                           </Button>
+                           <Button variant="link" className="btn-cancel" onClick={onClose}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {body}
             </Modal>
         );
     }

--- a/pkg/machines/components/vmSnapshotsRevertModal.jsx
+++ b/pkg/machines/components/vmSnapshotsRevertModal.jsx
@@ -19,8 +19,7 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Modal } from 'patternfly-react';
-import { Button } from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
@@ -60,24 +59,22 @@ export class RevertSnapshotModal extends React.Component {
         const { idPrefix, snap, onClose } = this.props;
 
         return (
-            <Modal id={`${idPrefix}-snapshot-${snap.name}-modal`} show onHide={onClose}>
-                <Modal.Header>
-                    <Modal.CloseButton onClick={onClose} />
-                    <Modal.Title>{ cockpit.format(_("Revert to snapshot $0"), snap.name) }</Modal.Title>
-                </Modal.Header>
-                <Modal.Body>
+            <Modal position="top" variant="medium" id={`${idPrefix}-snapshot-${snap.name}-modal`} isOpen onClose={onClose}
+                   title={cockpit.format(_("Revert to snapshot $0"), snap.name)}
+                   footer={
+                       <>
+                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                           <Button variant='primary' isLoading={this.state.inProgress} isDisabled={this.state.inProgress} onClick={this.revert}>
+                               {_("Revert")}
+                           </Button>
+                           <Button variant='link' className='btn-cancel' onClick={onClose}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                <>
                     { cockpit.format(_("Reverting to this snapshot will take the VM back to the time of the snapshot and the current state will be lost, along with any data not captured in a snapshot")) }
-                </Modal.Body>
-                <Modal.Footer>
-                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
-                    <Button variant='primary' isDisabled={this.state.inProgress} onClick={this.revert}>
-                        {_("Revert")}
-                    </Button>
-                    <Button variant='link' className='btn-cancel' onClick={onClose}>
-                        {_("Cancel")}
-                    </Button>
-                    {this.state.inProgress && <div className="spinner spinner-sm pull-right" />}
-                </Modal.Footer>
+                </>
             </Modal>
         );
     }

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -171,10 +171,6 @@
     padding-right: 5px;
 }
 
-#create-vm-dialog .spinner {
-    display: inline-block;
-}
-
 #vcpus-tooltip.pficon-pending, #boot-order-tooltip.pficon-pending,
 .machines-disks .pficon-pending, .pficon-ok{
     margin-left: 0.5rem;
@@ -185,7 +181,7 @@
     font-size: 16px;
 }
 
-.modal-footer .pficon-pending, .pficon-warning-triangle-o, .pficon-ok {
+.pf-c-modal-box__footer .pficon-pending, .pficon-warning-triangle-o, .pficon-ok {
     line-height: inherit;
     margin-right: 0.5rem;
 }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -659,7 +659,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def open(self):
             b = self.test_obj.browser
             b.click("#vm-{0}-disks-adddisk".format(self.vm_name)) # button
-            b.wait_in_text(".modal-dialog .modal-header .modal-title", "Add disk")
+            b.wait_in_text(".pf-c-modal-box__title", "Add disk")
 
             b.wait_present("label:contains(Create new)")
             if self.use_existing_volume:
@@ -675,7 +675,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.select_from_dropdown("#vm-{0}-disks-adddisk-new-select-pool".format(self.vm_name), self.pool_name)
                 else:
                     b.click("#vm-{0}-disks-adddisk-new-select-pool".format(self.vm_name))
-                    b.wait_present(".modal-dialog option[data-value={0}]:disabled".format(self.pool_name))
+                    b.wait_present(".pf-c-modal-box option[data-value={0}]:disabled".format(self.pool_name))
                     return self
 
                 # Insert name for the new volume
@@ -706,25 +706,25 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             # Configure performance options
             if self.cache_mode:
-                b.click("div.modal-dialog button:contains(Show additional options)")
-                b.select_from_dropdown("div.modal-dialog #cache-mode", self.cache_mode)
-                b.click("div.modal-dialog button:contains(Hide additional options)")
+                b.click("div.pf-c-modal-box button:contains(Show additional options)")
+                b.select_from_dropdown("div.pf-c-modal-box #cache-mode", self.cache_mode)
+                b.click("div.pf-c-modal-box button:contains(Hide additional options)")
             else:
-                b.wait_not_present("#div.modal-dialog #cache-mode")
+                b.wait_not_present("#div.pf-c-modal-box #cache-mode")
 
             # Configure bus type
             if self.bus_type != "virtio":
-                b.click("div.modal-dialog button:contains(Show additional options)")
-                b.select_from_dropdown("div.modal-dialog #bus-type", self.bus_type)
-                b.click("div.modal-dialog button:contains(Hide additional options)")
+                b.click("div.pf-c-modal-box button:contains(Show additional options)")
+                b.select_from_dropdown("div.pf-c-modal-box #bus-type", self.bus_type)
+                b.click("div.pf-c-modal-box button:contains(Hide additional options)")
             else:
-                b.wait_not_present("#div.modal-dialog #cache-mode")
+                b.wait_not_present("#div.pf-c-modal-box #cache-mode")
 
             return self
 
         def add_disk(self):
             b = self.test_obj.browser
-            b.click(".modal-footer button:contains(Add)")
+            b.click(".pf-c-modal-box__footer button:contains(Add)")
             b.wait_not_present("#vm-{0}-disks-adddisk-dialog-modal-window".format(self.vm_name))
 
             return self
@@ -1083,7 +1083,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_present("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
         b.click("label:contains(Use existing)")
         b.wait_present("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
-        b.click(".modal-footer button:contains(Cancel)")
+        b.click(".pf-c-modal-box__footer button:contains(Cancel)")
 
         # Make sure that trying to inspect the Disks tab will just show the fields that are available when a pool is inactive
         b.reload()
@@ -1149,7 +1149,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         b.click("#vm-subVmTest1-vcpus-count") # open VCPU modal detail window
 
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
 
         # Test basic vCPU properties
         b.wait_val("#machines-vcpu-count-field", "1")
@@ -1167,7 +1167,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # Save
         b.click("#machines-vcpu-modal-dialog-apply")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Make sure warning next to vcpus appears
         b.wait_present("#vcpus-tooltip")
@@ -1193,7 +1193,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # Open dialog window
         b.click("#vm-subVmTest1-vcpus-count")
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
 
         # Check basic values
         b.wait_val("#machines-vcpu-count-field", "3")
@@ -1215,7 +1215,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Open dialog
         b.click("#vm-subVmTest1-vcpus-count")
 
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
 
         b.set_input_text("#machines-vcpu-count-field", "2")
 
@@ -1243,7 +1243,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Open dialog
         b.click("#vm-subVmTest1-vcpus-count")
 
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
 
         # Set new socket value
         b.wait_val("#coresSelect", "2")
@@ -2036,9 +2036,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             b.wait_present("#create-vm-dialog")
             if self.sourceType == 'disk_image':
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Import a virtual machine")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Import a virtual machine")
             else:
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create new virtual machine")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create new virtual machine")
 
             if self.os_name is not None:
                 # check if there is os present in osinfo-query because it can be filtered out in the UI
@@ -2097,7 +2097,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             return self
 
         def createAndVerifyVirtInstallArgs(self):
-            self.browser.click(".modal-footer button:contains(Create)")
+            self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
             self.browser.wait_not_present("#create-vm-dialog")
 
             virt_install_cmd = "ps aux | grep 'virt\-install\ \-\-connect'"
@@ -2223,7 +2223,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def cancel(self, force=False):
             b = self.browser
             if b.is_present("#create-vm-dialog"):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-vm-dialog")
             elif force:
                 raise Exception("There is no dialog to cancel")
@@ -2233,20 +2233,20 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             b = self.browser
 
             if self.sourceType == 'disk_image':
-                b.click(".modal-footer button:contains(Import)")
+                b.click(".pf-c-modal-box__footer button:contains(Import)")
             else:
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
 
             for error, error_msg in errors.items():
-                error_location = ".modal-body label:contains('{0}') + div.form-group.has-error span.help-block".format(error)
+                error_location = ".pf-c-modal-box__body label:contains('{0}') + div.form-group.has-error span.help-block".format(error)
                 b.wait_visible(error_location)
                 if (error_msg):
                     b.wait_in_text(error_location, error_msg)
 
             if self.sourceType == 'disk_image':
-                b.wait_present(".modal-footer button:contains(Import):disabled")
+                b.wait_present(".pf-c-modal-box__footer button:contains(Import):disabled")
             else:
-                b.wait_present(".modal-footer button:contains(Create):disabled")
+                b.wait_present(".pf-c-modal-box__footer button:contains(Create):disabled")
 
             return self
 
@@ -2263,12 +2263,12 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     raise Error("Retry limit exceeded: None of [%s] is part of the error message '%s'" % (
                         ', '.join(errors), b.text(error_location)))
 
-            b.click(".modal-footer button:contains(Create)")
+            b.click(".pf-c-modal-box__footer button:contains(Create)")
 
-            error_location = ".modal-footer div.pf-c-alert"
+            error_location = ".pf-c-modal-box__footer div.pf-c-alert"
 
-            b.wait_present(".modal-footer .spinner")
-            b.wait_not_present(".modal-footer .spinner")
+            b.wait_present(".pf-c-modal-box__footer button.pf-m-in-progress")
+            b.wait_not_present(".pf-c-modal-box__footer button.pf-m-in-progress")
             try:
                 with b.wait_timeout(10):
                     b.wait_present(error_location)
@@ -2416,9 +2416,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         def _create(self, dialog):
             b = self.browser
             if dialog.sourceType == 'disk_image':
-                b.click(".modal-footer button:contains(Import)")
+                b.click(".pf-c-modal-box__footer button:contains(Import)")
             else:
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
             init_state = "Creating VM installation" if dialog.start_vm else "Creating VM"
             second_state = "Running" if dialog.start_vm else "Shut off"
 
@@ -2774,7 +2774,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         dialog.open() \
                 .fill() \
 
-        b.click(".modal-footer button:contains(Create)")
+        b.click(".pf-c-modal-box__footer button:contains(Create)")
         b.wait_not_present("#create-vm-dialog")
 
         self.waitVmRow("VmNotInstalled")
@@ -2792,11 +2792,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.set_input_text("#vm-VmNotInstalled-memory-modal-memory", "300")
         b.blur("#vm-VmNotInstalled-memory-modal-memory")
         b.click("#vm-VmNotInstalled-memory-modal-save")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Change vCPUs setting
         b.click("#vm-VmNotInstalled-vcpus-count")
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
         b.set_input_text("#machines-vcpu-max-field", "8")
         b.blur("#machines-vcpu-max-field")
         b.set_input_text("#machines-vcpu-count-field", "2")
@@ -2805,16 +2805,16 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.select_from_dropdown("#coresSelect", "2")
         b.select_from_dropdown("#threadsSelect", "2")
         b.click("#machines-vcpu-modal-dialog-apply")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Change Boot Order setting
         bootOrder = b.text("#vm-VmNotInstalled-boot-order")
         b.click("#vm-VmNotInstalled-boot-order")
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
         b.set_checked("#vm-VmNotInstalled-order-modal-device-row-1-checkbox", True)
         b.click("#vm-VmNotInstalled-order-modal-device-row-0 #vm-VmNotInstalled-order-modal-down")
         b.click("#vm-VmNotInstalled-order-modal-save")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Attach some interface
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
@@ -2824,10 +2824,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         if supports_firmware_config:
             b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
             b.click("#vm-VmNotInstalled-firmware")
-            b.wait_present(".modal-body")
+            b.wait_present(".pf-c-modal-box__body")
             b.select_from_dropdown("select", "UEFI")
             b.click("#firmware-dialog-apply")
-            b.wait_not_present(".modal-body")
+            b.wait_not_present(".pf-c-modal-box__body")
             b.wait_in_text("#vm-VmNotInstalled-firmware", "UEFI")
 
             # Temporarily delete the OVMF binary and check the firmware options again
@@ -2892,18 +2892,18 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_val("#vm-VmNotInstalled-memory-modal-max-memory", "400")
         b.wait_val("#vm-VmNotInstalled-memory-modal-memory", "300")
         b.click("#vm-VmNotInstalled-memory-modal-cancel")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Check vCPU settings have persisted
         b.click("#vm-VmNotInstalled-vcpus-count")
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
         b.wait_val("#machines-vcpu-max-field", "8")
         b.wait_val("#machines-vcpu-count-field", "2")
         b.wait_val("#socketsSelect", "2")
         b.wait_val("#coresSelect", "2")
         b.wait_val("#threadsSelect", "2")
         b.click("#machines-vcpu-modal-dialog-cancel")
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Check changed boot order have persisted
         b.wait_text_not("#vm-VmNotInstalled-boot-order", bootOrder)
@@ -3133,16 +3133,16 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         b.wait_present("#vm-subVmTest1-disks-vdc-device")
         b.click("#delete-subVmTest1-disk-vdc")
-        b.wait_present(".modal-dialog")
-        b.click(".modal-footer button:contains(Remove)")
-        b.wait_present(".modal-footer .spinner")
+        b.wait_present(".pf-c-modal-box")
+        b.click(".pf-c-modal-box__footer button:contains(Remove)")
+        b.wait_present(".pf-c-modal-box__footer button.pf-m-in-progress")
         # When live-detaching disks the guest OS needs to cooperate so that we can
         # see the disk getting detached in the UI.
         # Wait until we see the login prompt before attempting operation that need
         # the OS for fully respond
         with b.wait_timeout(180):
             b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
-        b.wait_not_present(".modal-dialog")
+        b.wait_not_present(".pf-c-modal-box")
 
         # Test that detaching disk of a running domain will affect the
         # inactive configuration as well
@@ -3154,10 +3154,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Test detaching permanent disk of a stopped domain
         b.wait_present("#vm-subVmTest1-disks-vdd-device")
         b.click("#delete-subVmTest1-disk-vdd")
-        b.wait_present(".modal-dialog")
-        b.click(".modal-footer button:contains(Remove)")
+        b.wait_present(".pf-c-modal-box")
+        b.click(".pf-c-modal-box__footer button:contains(Remove)")
         b.wait_not_present("#vm-subVmTest1-disks-vdd-device")
-        b.wait_not_present(".modal-dialog")
+        b.wait_not_present(".pf-c-modal-box")
 
         # Test detaching disk of a paused domain
         m.execute("> {0}".format(args["logfile"])) # clear logfile
@@ -3175,10 +3175,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m.execute("virsh attach-disk --domain subVmTest1 --source {0}/mydiskofpoolone_1 --target vdc --targetbus virtio".format(p1))
         b.wait_present("#vm-subVmTest1-disks-vdc-device")
         b.click("#delete-subVmTest1-disk-vdc")
-        b.wait_present(".modal-dialog")
-        b.click(".modal-footer button:contains(Remove)")
+        b.wait_present(".pf-c-modal-box")
+        b.click(".pf-c-modal-box__footer button:contains(Remove)")
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
-        b.wait_not_present(".modal-dialog")
+        b.wait_not_present(".pf-c-modal-box")
 
     def testMultipleSettings(self):
         b = self.browser
@@ -3195,18 +3195,18 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Change Boot Order setting
         bootOrder = b.text("#vm-subVmTest1-boot-order")
         b.click("#vm-subVmTest1-boot-order") # Open dialog
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
         b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down") # Change order
         b.click("#vm-subVmTest1-order-modal-save") # Save
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Change vCPUs setting
         b.click("#vm-subVmTest1-vcpus-count") # Open dialog
-        b.wait_present(".modal-body")
+        b.wait_present(".pf-c-modal-box__body")
         b.set_input_text("#machines-vcpu-max-field", "3") # Change values
         b.set_input_text("#machines-vcpu-count-field", "3")
         b.click("#machines-vcpu-modal-dialog-apply") # Save
-        b.wait_not_present(".modal-body")
+        b.wait_not_present(".pf-c-modal-box__body")
 
         # Shut off domain
         b.click("#vm-subVmTest1-action-kebab button")
@@ -3387,7 +3387,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_in_text("#vm-subVmTest1-network-1-select-type", "Bridge to LAN")
         b.select_from_dropdown("#vm-subVmTest1-network-1-select-type", "Virtual network")
         b.wait_present("#vm-subVmTest1-network-1-edit-dialog-save:disabled")
-        b.click(".modal-footer button:contains(Cancel)")
+        b.click(".pf-c-modal-box__footer button:contains(Cancel)")
 
         # Ensure that when the source of a NIC was removed we can still change it
 
@@ -3497,7 +3497,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # Delete an inactive network
         b.click('#delete-network-test_network2-{0}'.format(connectionName))
-        b.click(".modal-footer button:contains(Delete)")
+        b.click(".pf-c-modal-box__footer button:contains(Delete)")
         self.waitNetworkRow("test_network2", connectionName, False)
 
         # Delete an active network
@@ -3505,7 +3505,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b.wait_in_text("#network-test_network2-{0}-state".format(connectionName), "active")
         self.toggleNetworkRow("test_network2", connectionName)
         b.click('#delete-network-test_network2-{0}'.format(connectionName))
-        b.click(".modal-footer button:contains(Delete)")
+        b.click(".pf-c-modal-box__footer button:contains(Delete)")
         self.waitNetworkRow("test_network2", connectionName, False)
 
     def testNetworks(self):
@@ -3614,8 +3614,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         self.assertEqual("no", m.execute("virsh snapshot-info --domain subVmTest1 --snapshotname snapshot1 | grep 'Current:' | awk '{print $2}'").strip())
 
         b.click("#vm-subVmTest1-snapshot-1-revert")
-        b.wait_in_text(".modal-dialog .modal-header .modal-title", "Revert to snapshot snapshot1")
-        b.click('div.modal-footer button:contains("Revert")')
+        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Revert to snapshot snapshot1")
+        b.click('.pf-c-modal-box__footer button:contains("Revert")')
 
         b.wait_not_present("#vm-subVmTest1-snapshot-0-current")
         b.wait_present("#vm-subVmTest1-snapshot-1-current")
@@ -3812,9 +3812,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Delete an inactive Pool. It's volumes won't be deleted
         b.wait_present("#delete-pool-myPoolTwo-{0}".format(connectionName))
         b.click("#delete-pool-myPoolTwo-{0}".format(connectionName))
-        b.wait_in_text("div.modal-dialog div.modal-body div.ct-form", "Its content will not be deleted.")
-        b.click('div.modal-footer button:contains("Delete")')
-        b.wait_not_present("div.modal-dialog")
+        b.wait_in_text("div.pf-c-modal-box div.pf-c-modal-box__body div.ct-form", "Its content will not be deleted.")
+        b.click('.pf-c-modal-box__footer button:contains("Delete")')
+        b.wait_not_present("div.pf-c-modal-box")
         b.wait_not_present("#pool-myPoolTwo-{0}-storage-volumes-list".format(connectionName))
         self.assertNotEqual(m.execute("ls -A {0}".format(p2)), "")
 
@@ -3829,10 +3829,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Delete and active Pool and also its volumes
         b.wait_present("#delete-pool-myPoolTwo-{0}".format(connectionName))
         b.click("#delete-pool-myPoolTwo-{0}".format(connectionName))
-        b.wait_present("div.modal-dialog")
+        b.wait_present("div.pf-c-modal-box")
         b.set_checked("input#storage-pool-delete-volumes", True)
-        b.click('div.modal-footer button:contains("Delete")')
-        b.wait_not_present("div.modal-dialog")
+        b.click('.pf-c-modal-box__footer button:contains("Delete")')
+        b.wait_not_present("div.pf-c-modal-box")
         b.wait_not_present("#pool-myPoolTwo-{0}-storage-volumes-list".format(connectionName))
         self.assertEqual(m.execute("ls -A {0}".format(p2)), "")
         self.waitPoolRow("myPoolTwo", connectionName, False)
@@ -3928,7 +3928,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             def open(self):
                 b.click("#create-network")
                 b.wait_present("#create-network-dialog")
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create virtual network")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create virtual network")
 
             def fill(self):
                 b.set_input_text("#create-network-name", self.name)
@@ -3959,34 +3959,34 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                             b.set_input_text("#network-ipv6-dhcp-range-end", self.ipv6_dhcp_end)
 
             def cancel(self):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-network-dialog")
 
             def create(self):
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
 
                 if (self.xfail):
                     # Check incomplete dialog
                     if "name" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #create-network-name + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #create-network-name + span p", self.xfail_error)
                     if "ipv4_address" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv4-address + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv4-address + span p", self.xfail_error)
                     if "ipv4_netmask" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv4-netmask + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv4-netmask + span p", self.xfail_error)
                     if "ipv4_dhcp_start" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv4-dhcp-range-start + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv4-dhcp-range-start + span p", self.xfail_error)
                     if "ipv4_dhcp_end" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv4-dhcp-range-end + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv4-dhcp-range-end + span p", self.xfail_error)
                     if "ipv6_address" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv6-address + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv6-address + span p", self.xfail_error)
                     if "ipv6_prefix" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv6-prefix + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv6-prefix + span p", self.xfail_error)
                     if "ipv6_dhcp_start" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv6-dhcp-range-start + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv6-dhcp-range-start + span p", self.xfail_error)
                     if "ipv6_dhcp_end" in self.xfail_objects:
-                        b.wait_in_text("#create-network-dialog .modal-body form div.has-error #network-ipv6-dhcp-range-end + span p", self.xfail_error)
+                        b.wait_in_text("#create-network-dialog .pf-c-modal-box__body form div.has-error #network-ipv6-dhcp-range-end + span p", self.xfail_error)
                     if "footer" in self.xfail_objects:
-                        error_location = "#create-network-dialog .modal-footer .pf-m-danger"
+                        error_location = "#create-network-dialog .pf-c-modal-box__footer .pf-m-danger"
                         b.wait_present(error_location)
                         error_message = b.text(error_location)
                         self.test_obj.assertIn(self.xfail_error, error_message)
@@ -4280,7 +4280,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             def open(self):
                 b.click("#create-storage-pool")
                 b.wait_present("#create-storage-pool-dialog")
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create storage pool")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create storage pool")
 
             def fill(self):
                 b.set_input_text("#storage-pool-dialog-name", self.name)
@@ -4310,24 +4310,24 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.click("storage-pool-dialog-autostart")
 
             def cancel(self):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-storage-pool-dialog")
 
             def create(self):
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
 
                 if not self.xfail:
                     b.wait_not_present("#create-storage-pool-dialog")
                 else:
                     # Check incomplete dialog
                     if (not self.name):
-                        b.wait_present("#create-storage-pool-dialog .modal-body form div.has-error #storage-pool-dialog-name")
+                        b.wait_present("#create-storage-pool-dialog .pf-c-modal-box__body form div.has-error #storage-pool-dialog-name")
 
                     if (not self.target):
-                        b.wait_present("#create-storage-pool-dialog .modal-body label:contains(Target) + div.has-error")
+                        b.wait_present("#create-storage-pool-dialog .pf-c-modal-box__body label:contains(Target) + div.has-error")
                     # Check errors from backend
                     if self.xfail_error:
-                        error_location = "#create-storage-pool-dialog .modal-footer .pf-m-danger"
+                        error_location = "#create-storage-pool-dialog .pf-c-modal-box__footer .pf-m-danger"
                         b.wait_present(error_location)
                         error_message = b.text(error_location)
                         self.test_obj.assertIn(self.xfail_error, error_message)
@@ -4485,10 +4485,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 # Ensure that iscsi-direct is absent from the types dropdown
                 b.click("#create-storage-pool")
                 b.wait_present("#create-storage-pool-dialog")
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create storage pool")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create storage pool")
                 b.click("#storage-pool-dialog-type")
                 b.wait_not_present("#storage-pool-dialog-type option[value*='isci-direct']")
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-storage-pool-dialog")
 
         # Prepare a Volume Group to be used as source for the LVM pool
@@ -4569,7 +4569,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 b.click("#{0}-system-create-volume-button".format(self.pool_name)) # open the "Storage volumes" subtab
 
                 b.wait_present("#create-volume-dialog-modal")
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create storage volume")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create storage volume")
 
             def fill(self):
                 b.set_input_text("#create-volume-dialog-name", self.vol_name)
@@ -4584,17 +4584,17 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.select_from_dropdown("#create-volume-dialog-format", self.format)
 
             def cancel(self):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#create-storage-pool-dialog")
 
             def create(self):
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
 
                 if (not self.xfail):
                     # Creation of volumes might take longer for some pool types
                     if self.pool_type  in ["disk", "netfs"]:
-                        b.wait_present(".modal-footer div.spinner")
-                        b.wait_present(".modal-footer button:contains(Create):disabled")
+                        b.wait_present(".pf-c-modal-box__footer button.pf-m-in-progress")
+                        b.wait_present(".pf-c-modal-box__footer button:contains(Create):disabled")
                     b.wait_not_present("#create-volume-dialog-modal")
 
             def verify(self):
@@ -4725,7 +4725,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             def open(self):
                 b.click("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Add virtual network interface")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Add virtual network interface")
 
             def fill(self):
                 b.select_from_dropdown("#vm-subVmTest1-add-iface-select-type", self.source_type)
@@ -4745,11 +4745,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.wait_not_present("#vm-subVmTest1-add-iface-permanent")
 
             def cancel(self):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
 
             def create(self):
-                b.click(".modal-footer button:contains(Add)")
+                b.click(".pf-c-modal-box__footer button:contains(Add)")
 
                 b.wait_not_present("#vm-subVmTest1-add-iface-dialog")
 
@@ -4800,16 +4800,16 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 else:
                     b.click("#delete-vm-subVmTest1-iface-{0}".format(self.nic_num))
                     # Confirm in confirmation window
-                    b.wait_in_text(".modal-dialog .modal-header .modal-title", "Delete Network Interface")
+                    b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Network Interface")
                     vm_state = b.text("#vm-subVmTest1-state")
-                    b.click(".modal-footer button:contains(Delete)")
+                    b.click(".pf-c-modal-box__footer button:contains(Delete)")
                     # On a running VM detaching NIC takes longer and we can see the spinner
                     if vm_state == "Running":
-                        b.wait_present(".modal-footer .spinner")
+                        b.wait_present(".pf-c-modal-box__footer button.pf-m-in-progress")
 
                     # Check NIC is no longer in list
                     b.wait_not_present("#vm-subVmTest1-network-{0}-mac".format(self.nic_num))
-                    b.wait_not_present(".modal-dialog")
+                    b.wait_not_present(".pf-c-modal-box")
 
         # No NICs present
         b.wait_present("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
@@ -4882,11 +4882,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # Now there are three NICs present - try to delete the second one and make sure that it's deleted and the dialog is not present anymore
         b.wait_present("#vm-subVmTest1-network-3-mac")
         b.click("#delete-vm-subVmTest1-iface-2")
-        b.wait_in_text(".modal-dialog .modal-header .modal-title", "Delete Network Interface")
-        b.click(".modal-footer button:contains(Delete)")
+        b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Network Interface")
+        b.click(".pf-c-modal-box__footer button:contains(Delete)")
         # Check NIC is no longer in list
         b.wait_not_present("#vm-subVmTest1-network-3-mac")
-        b.wait_not_present(".modal-dialog")
+        b.wait_not_present(".pf-c-modal-box")
 
     def testSnapshotCreate(self):
         b = self.browser
@@ -4930,7 +4930,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             def open(self):
                 b.click("#vm-subVmTest1-add-snapshot-button")
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Create snapshot")
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create snapshot")
 
             def fill(self):
                 if self.name:
@@ -4939,11 +4939,11 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                     b.set_input_text("#description", self.description)
 
             def cancel(self):
-                b.click(".modal-footer button:contains(Cancel)")
+                b.click(".pf-c-modal-box__footer button:contains(Cancel)")
                 b.wait_not_present("#vm-subVmTest1-create-snapshot-modal")
 
             def create(self):
-                b.click(".modal-footer button:contains(Create)")
+                b.click(".pf-c-modal-box__footer button:contains(Create)")
                 b.wait_not_present("#vm-subVmTest1-create-snapshot-modal")
 
             def verify_frontend(self):
@@ -4977,8 +4977,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
             def cleanup(self):
                 b.click("#delete-vm-subVmTest1-snapshot-{0}".format(self.snap_num))
-                b.wait_in_text(".modal-dialog .modal-header .modal-title", "Delete Snapshot {0}".format(self.name))
-                b.click('div.modal-footer button:contains("Delete")')
+                b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Delete Snapshot {0}".format(self.name))
+                b.click('.pf-c-modal-box__footer button:contains("Delete")')
                 b.wait_not_present("#vm-subVmTest1-snapshot-{0}-name:contains({1})".format(self.snap_num, self.name))
 
         # No Snapshots present


### PR DESCRIPTION
For showing in progress in modals start using the isLoading variant of buttons
instead of showing spinner in the footer which is the suggested way from
PF4 to show in progress dialogs.

It will have one trivial merge conflict with https://github.com/cockpit-project/cockpit/pull/14740 but I want to see the tests since it will be probably a massacre.