### PR TITLE
cockpituous: Drop release-dsc

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -46,6 +46,3 @@ job release-bodhi F33
 
 # Upload documentation
 job tools/release-guide dist/guide cockpit-project/cockpit-project.github.io
-
-# Create and publish a Debian repository
-job release-dsc


### PR DESCRIPTION
The built dsc doesn't go anywhere, so that just happens in vain. It's
also the only thing that requires a GPG key, so let's just drop that.