### PR TITLE
services: Port service details info to PF4 description list

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -45,3 +45,13 @@ ul.pf-c-select__menu {
         --pf-c-description-list__group--GridTemplateColumns: var(--pf-c-description-list--m-horizontal__group--GridTemplateColumns);
     }
 }
+
+// When using horizontal ruler inside description list it's just for the spacing - don't show it
+.pf-c-description-list {
+    // The default gap between the rows is too large
+    --pf-c-description-list--RowGap: 1rem;
+
+    > hr {
+        border-top: none;
+    }
+}

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -22,6 +22,7 @@ import moment from "moment";
 import PropTypes from "prop-types";
 import {
     Alert, Button,
+    DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     Dropdown, DropdownItem, DropdownSeparator, KebabToggle,
     Tooltip, TooltipPosition,
     Card, CardBody, CardTitle, Text, TextVariants,
@@ -438,34 +439,38 @@ export class ServiceDetails extends React.Component {
                             }
                         </CardTitle>
                         <CardBody>
-                            <form className="ct-form">
-                                <label className="control-label" htmlFor="statuses">{ _("Status") }</label>
-                                <div id="statuses" className="ct-validation-wrapper">
-                                    { status }
-                                </div>
+                            <DescriptionList>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>{ _("Status") }</DescriptionListTerm>
+                                    <DescriptionListDescription id="statuses">
+                                        { status }
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
                                 <hr />
-                                <label className="control-label" htmlFor="path">{ _("Path") }</label>
-                                <span id="path">{this.props.unit.FragmentPath}</span>
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>{ _("Path") }</DescriptionListTerm>
+                                    <DescriptionListDescription id="path">{this.props.unit.FragmentPath}</DescriptionListDescription>
+                                </DescriptionListGroup>
                                 <hr />
                                 { notMetConditions.length > 0 &&
-                                    <>
-                                        <label className="control-label failed" htmlFor="condition">{ _("Condition failed") }</label>
-                                        <div id="condition" className="ct-validation-wrapper">
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm className="failed">{ _("Condition failed") }</DescriptionListTerm>
+                                        <DescriptionListDescription id="condition">
                                             {notMetConditions.map(cond => <div key={cond.split(' ').join('')}>{cond}</div>)}
-                                        </div>
-                                    </>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
                                 }
                                 <hr />
                                 {relationships.map(rel =>
                                     rel.Units && rel.Units.length > 0 &&
-                                        <React.Fragment key={rel.Name.split().join("")}>
-                                            <label className="control-label closer-lines" htmlFor={rel.Name}>{rel.Name}</label>
-                                            <ul id={rel.Name.split(" ").join("")} className="comma-list closer-lines">
+                                        <DescriptionListGroup key={rel.Name.split().join("")}>
+                                            <DescriptionListTerm className="closer-lines">{rel.Name}</DescriptionListTerm>
+                                            <DescriptionListDescription id={rel.Name.split(" ").join("")} className="comma-list closer-lines">
                                                 {rel.Units.map(unit => <li key={unit}><a href={"#/" + unit} className={this.props.isValid(unit) ? "" : "disabled"}>{unit}</a></li>)}
-                                            </ul>
-                                        </React.Fragment>
+                                            </DescriptionListDescription>
+                                        </DescriptionListGroup>
                                 )}
-                            </form>
+                            </DescriptionList>
                         </CardBody>
                     </>
                 }

--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -19,11 +19,11 @@
   padding-left: 0;
 }
 
-.comma-list > li {
+.comma-list li {
   display: inline-block;
 }
 
-.comma-list > li:not(:last-child):after {
+.comma-list li:not(:last-child):after {
   content: ",";
   margin-right: 0.5em;
 }


### PR DESCRIPTION
Reduce the description list row spacing globally to 1.5rem.

Not a big difference here:
![Screen Shot 2020-10-15 at 13 35 02](https://user-images.githubusercontent.com/14921356/96118063-499c1000-0eeb-11eb-95f0-9b323440cd5b.png)
