### PR TITLE
pf: Override description list; condense & subgridify 

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -39,11 +39,31 @@ svg {
     }
 }
 
-// When using horizontal ruler inside description list it's just for the spacing - don't show it
+// Override the description list to use smaller spacing and subgrid (where available)
 .pf-c-description-list {
-    // The default gap between the rows is too large
-    --pf-c-description-list--RowGap: 1rem;
+    // Decrease the vertical spacing between lines
+    --pf-c-description-list--RowGap: var(--pf-global--spacer--sm);
 
+    // In browsers that support subgrid, shrink labels to longest
+    // This should be considered for upstreaming to PF4's description list
+    // or at least consider applying across Cockpit (opt-in or by default)
+    @supports (grid-template-columns: subgrid) {
+        grid-template-columns: auto 1fr;
+
+        > * {
+            grid-column: 1 / -1;
+        }
+
+        &__group {
+            grid-template-columns: subgrid;
+        }
+
+        &__term {
+            max-width: var(--pf-c-description-list--m-horizontal__term--width);
+        }
+    }
+
+    // When using horizontal ruler inside description list it's just for the spacing - don't show it
     > hr {
         border-top: none;
     }


### PR DESCRIPTION
1. Allow actions to wrap in constrained space (at the card level)
2. Fix too-much-space between definition list items
3. Use subgrid to fix alignment of definition list labels to the longest one 