### PR TITLE
github: Run unit tests as an Actions workflow

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,41 @@
+name: unit-tests
+on: [push, pull_request]
+jobs:
+  gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      #- name: interactive SSH debug session
+      #  uses: mxschmitt/action-tmate@v3
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start
+
+  clang:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start CC=clang
+
+  i386:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start :i386

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -48,7 +48,7 @@ Some examples:
 
 For interactive debugging, run a shell in the container:
 
-    $ ./start shell     # start an interactive shell on i386
+    $ ./start shell     # start an interactive shell in default container
 
 You will find the cockpit source tree (from the host) mounted at `/source` in
 the container.

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 top_srcdir=$(realpath -m "$0"/../../..)
-image=cockpit/unit-tests:latest
+image=docker.io/cockpit/unit-tests:latest
 flags=''
 cmd=''
 


### PR DESCRIPTION
This allows us to test a new unit-tests container in a pull request by
(temporarily) specifying a staging tag, without breaking all other PRs,
and also keep all the configuration inside our repository.

Semaphore 2.0 has these advantages as well, but does not offer enough
(free plan) capacity to sustain the volume of Cockpit PRs. We even run
into bottlenecks with Semaphore 1.

Add a commented out step for an interactive debug shell, to provide an
equivalent for Semaphore's "Launch SSH session".
