### PR TITLE
containers: Bump unit-tests to Ubuntu 20.04 LTS

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,41 @@
+name: unit-tests
+on: [push, pull_request]
+jobs:
+  gcc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      #- name: interactive SSH debug session
+      #  uses: mxschmitt/action-tmate@v3
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start
+
+  clang:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start CC=clang
+
+  i386:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start :i386

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -14,7 +14,7 @@ jobs:
       #  uses: mxschmitt/action-tmate@v3
 
       - name: Run unit-tests container
-        run: containers/unit-tests/start
+        run: containers/unit-tests/start :staging
 
   clang:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Run unit-tests container
-        run: containers/unit-tests/start CC=clang
+        run: containers/unit-tests/start :staging CC=clang
 
   i386:
     runs-on: ubuntu-latest
@@ -38,4 +38,4 @@ jobs:
           fetch-depth: 0
 
       - name: Run unit-tests container
-        run: containers/unit-tests/start :i386
+        run: containers/unit-tests/start :staging-i386

--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -1,12 +1,12 @@
 ARG debian_arch=amd64
-FROM ${debian_arch}/ubuntu:19.04
+FROM ${debian_arch}/ubuntu:20.04
 
 ARG personality=linux64
 COPY setup.sh /
 RUN ${personality} /setup.sh ${personality} && rm -rf /setup.sh
 
 # HACK: Working around Node.js screwing around with stdio
-ENV NODE_PATH /usr/local/bin/node.lts
+ENV NODE_PATH /usr/bin/node
 COPY turd-polish /usr/local/bin/node
 
 # 'builder' user created in setup.sh

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -48,7 +48,7 @@ Some examples:
 
 For interactive debugging, run a shell in the container:
 
-    $ ./start shell     # start an interactive shell on i386
+    $ ./start shell     # start an interactive shell in default container
 
 You will find the cockpit source tree (from the host) mounted at `/source` in
 the container.

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -7,9 +7,9 @@ dependencies="\
     autoconf \
     automake \
     build-essential \
-    chromium-browser \
-    clang python3 \
+    clang \
     curl \
+    debian-archive-keyring \
     dbus \
     gcc-multilib \
     gdb \
@@ -23,14 +23,10 @@ dependencies="\
     libglib2.0-0-dbgsym \
     libglib2.0-dev \
     libgnutls28-dev \
-    libgudev-1.0-dev \
     libjavascript-minifier-xs-perl \
     libjson-glib-dev \
     libjson-perl \
-    libkeyutils-dev \
     libkrb5-dev \
-    liblvm2-dev \
-    libnm-glib-dev \
     libpam0g-dev \
     libpcp-import1-dev \
     libpcp-pmda3-dev \
@@ -40,8 +36,11 @@ dependencies="\
     libssh-4-dbgsym \
     libssh-dev \
     libsystemd-dev \
+    nodejs \
+    npm \
     pkg-config \
     pyflakes3 \
+    python3 \
     python3-pep8 \
     ssh \
     strace \
@@ -67,24 +66,22 @@ chmod +x /entrypoint
 apt-get update
 apt-get install -y --no-install-recommends gnupg2 eatmydata
 
-echo "deb http://ddebs.ubuntu.com disco main universe" > /etc/apt/sources.list.d/ddebs.list
-echo "deb http://ddebs.ubuntu.com disco-updates main universe" >> /etc/apt/sources.list.d/ddebs.list
+echo "deb http://ddebs.ubuntu.com focal main universe" > /etc/apt/sources.list.d/ddebs.list
+echo "deb http://ddebs.ubuntu.com focal-updates main universe" >> /etc/apt/sources.list.d/ddebs.list
 apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F2EDC64DC5AEE1F6B9C621F0C8CAB6595FDFF622
 apt-get update
 
-eatmydata apt-get install -y --no-install-recommends ${dependencies}
+DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recommends ${dependencies}
 
-# install the npm package for just long enough to install npm from upstream
-eatmydata apt-get install -y npm
-npm install -g n
-n -a x64 lts    # no more 32bit builds, but libc6:amd64 is always installed
-rm /usr/local/bin/node
-ln -s "`n bin lts`" /usr/local/bin/node.lts
-NODE_PATH="$(n bin lts)"
-eatmydata apt-get remove -y npm nodejs
-
+# install chromium from Debian, it's not available as deb from Ubuntu any more (only snap)
+printf 'deb http://ftp.debian.org/debian buster main\ndeb http://security.debian.org/debian-security buster/updates main\n' > /etc/apt/sources.list.d/buster.list
+ln -s /usr/share/keyrings/debian-archive-buster-security-automatic.gpg /etc/apt/trusted.gpg.d/
+ln -s /usr/share/keyrings/debian-archive-buster-automatic.gpg /etc/apt/trusted.gpg.d/
+apt-get update
+apt-get install -y --no-install-recommends chromium
 apt-get clean
 
-
-
 adduser --system --gecos "Builder" builder
+
+# minimize image
+rm -rf /var/cache/apt /var/lib/apt /var/log/*

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 top_srcdir=$(realpath -m "$0"/../../..)
-image=cockpit/unit-tests:latest
+image=docker.io/cockpit/unit-tests:latest
 flags=''
 cmd=''
 

--- a/containers/unit-tests/turd-polish
+++ b/containers/unit-tests/turd-polish
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 
 # Copyright (C) 2013 Red Hat, Inc.
 #


### PR DESCRIPTION
Ubuntu 19.04 has been EOL for a while. This also allows us to go back to
the distro packages for npm and node, they are slightly newer (but same
major version) as what we installed with `n` so far.

Unfortunately chromium is not available as deb in Ubuntu any more [1],
so get it from Debian buster.

Move turd-polish to python3.

Drop a few build dependencies which have not been used in ages.

[1] https://ubuntu.com/blog/chromium-in-ubuntu-deb-to-snap-transition

 - [x] Builds on top of PR #14763
 - [ ] Discuss fate of :i386 -- keep it, useful for finding type bugs in C; move to Debian
 - [ ] Switch staging to latest