### PR TITLE
test: Bump up location change rate limiter in Firefox

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -190,6 +190,7 @@ class CDP:
                     user_pref("browser.download.dir", "{0}");
                     user_pref("browser.download.folderList", 2);
                     user_pref("signon.rememberSignons", false);
+                    user_pref("dom.navigation.locationChangeRateLimit.count", 9999);
                     """.format(self.download_dir))
 
             with open(os.path.join(profile, "handlers.json"), "w") as f:


### PR DESCRIPTION
There are 200 allowed changes in 10 seconds by default. Bump it up to
9999 otherwise tests can hit this and then fail with:
```
Too many calls to Location or History APIs within a short timeframe.
SecurityError: The operation is insecure.
```

Fixes #14720