### PR TITLE
machine: Fix race condition when rendering data about disks

### DIFF
--- a/pkg/machines/components/vmDisksTab.jsx
+++ b/pkg/machines/components/vmDisksTab.jsx
@@ -137,7 +137,9 @@ export class VmDisksTabLibvirt extends React.Component {
             const pool = storagePools.filter(pool => pool.name == disk.source.pool)[0];
             const volumes = pool ? pool.volumes : [];
             const volumeName = disk.source.volume;
-            const volume = volumes.filter(vol => vol.name == volumeName)[0];
+            let volume;
+            if (volumes)
+                volume = volumes.filter(vol => vol.name == volumeName)[0];
 
             if (volume) {
                 capacity = volume.capacity;


### PR DESCRIPTION
Sometimes Ooops: TypeError would show when you try to load directly the
page with VM (e.g. .../machines#vm?name=[VM_NAME]&connection=[CONNECTION])
because there was no check to make sure that volumes, which are used to
get data about disk with volume as a source, were already fetched thru
dbus API.