### PR TITLE
machines: pf-c-page should not be wrapped by a div

### DIFF
--- a/pkg/machines/components/vm/vmExpandedContent.scss
+++ b/pkg/machines/components/vm/vmExpandedContent.scss
@@ -1,9 +1,5 @@
 @import "../../../lib/ct-card.scss";
 
-#app {
-  height: 100%;
-}
-
 #app .pf-c-card {
     @extend .ct-card;
 }

--- a/pkg/machines/index.html
+++ b/pkg/machines/index.html
@@ -13,8 +13,7 @@
   <script type="text/javascript" src="machines.js"></script>
 </head>
 
-<body class="pf-m-redhat-font">
-  <div id="app"></div>
+<body class="pf-m-redhat-font" id="app">
 </body>
 </html>
 


### PR DESCRIPTION
The custom rule to stretch the page vertically is not needed any more.