### PR TITLE
machines: Use MiB for memory/storage if recommended value is not a whole number

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -170,7 +170,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected operating system has minimum memory requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.ram, units.B, vmParams.memorySizeUnit),
-                    vmParams.memorySizeUnit)
+                    vmParams.memorySizeUnit.name)
             );
         }
     }
@@ -185,7 +185,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected operating system has minimum storage size requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.storage, units.B, vmParams.storageSizeUnit),
-                    vmParams.storageSizeUnit)
+                    vmParams.storageSizeUnit.name)
             );
         }
     }
@@ -722,11 +722,11 @@ class CreateVmModal extends React.Component {
 
             if (value && value.recommendedResources.ram) {
                 stateDelta.recommendedMemory = value.recommendedResources.ram;
-                const converted = Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, this.state.memorySizeUnit));
-                if (converted == 0)
-                    this.setState({ memorySizeUnit: units.MiB.name, memorySize: Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB)) });
+                const converted = convertToUnit(stateDelta.recommendedMemory, units.B, units.GiB);
+                if (converted == 0 || converted % 1 !== 0) // If recommended memory is not a whole number in GiB, set value in MiB
+                    this.setState({ memorySizeUnit: units.MiB }, () => this.onValueChanged("memorySize", Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB))));
                 else
-                    this.onValueChanged('memorySize', converted);
+                    this.setState({ memorySizeUnit: units.GiB }, () => this.onValueChanged("memorySize", converted));
             } else {
                 stateDelta.recommendedMemory = undefined;
             }
@@ -736,11 +736,11 @@ class CreateVmModal extends React.Component {
 
             if (value && value.recommendedResources.storage) {
                 stateDelta.recommendedStorage = value.recommendedResources.storage;
-                const converted = Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, this.state.storageSizeUnit));
-                if (converted == 0)
-                    this.setState({ storageSizeUnit: units.MiB.name, storageSize: Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB)) });
+                const converted = convertToUnit(stateDelta.recommendedStorage, units.B, this.state.storageSizeUnit);
+                if (converted == 0 || converted % 1 !== 0) // If recommended storage is not a whole number in GiB, set value in MiB
+                    this.setState({ storageSizeUnit: units.MiB }, () => this.onValueChanged("storageSize", Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB))));
                 else
-                    this.onValueChanged('storageSize', converted);
+                    this.setState({ storageSizeUnit: units.GiB }, () => this.onValueChanged("storageSize", converted));
             } else {
                 stateDelta.recommendedStorage = undefined;
             }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2389,10 +2389,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             # we just need to check that the VM was spawned
             fedora_28_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
             root = ET.fromstring(fedora_28_xml)
-            root.find('os').find('resources').find('minimum').find('ram').text = '134217750'
-            root.find('os').find('resources').find('minimum').find('storage').text = '134217750'
-            root.find('os').find('resources').find('recommended').find('ram').text = '268435500'
-            root.find('os').find('resources').find('recommended').find('storage').text = '268435500'
+            root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
+            root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
+            root.find('os').find('resources').find('recommended').find('ram').text = '268435456'
+            root.find('os').find('resources').find('recommended').find('storage').text = '268435456'
             if self.machine.image not in ["debian-stable"]:
                 root.find('os').find('eol-date').text = '9999-12-31'
             new_fedora_28_xml = ET.tostring(root)


### PR DESCRIPTION
By default GiB are used as a unit for memory. However if recommended memory is
something like 1.5GiB, it's floored to 1GiB which then results to error
and user having to fix it manually. Prevent this from happening.
Fix it also for storage.
