### PR TITLE
shell: Allow only the color of a host to be edited

### DIFF
--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -142,26 +142,6 @@
                         <input data-role="none" type="file" id="host-edit-file-input" hidden/>
                         <table class="form-table-ct">
                             <tr>
-                                <td class="top" translate="yes">Host name</td>
-                                <td>
-                                    <input class="form-control" id="host-edit-name"/>
-                                </td>
-                                <td></td>
-                            </tr>
-                            <tr id="host-edit-user-row">
-                                <td class="top" translate="yes">User</td>
-                                <td>
-                                    <input class="form-control" id="host-edit-user"/>
-                                </td>
-                                <td>
-                                    <a tabindex="0" role="button" data-toggle="popover"
-                                        data-trigger="focus" data-placement="bottom" translate="data-content"
-                                        data-content="Leave blank to connect to this machine as the currently logged in user. If you enter a different username, that user will always be used when connecting to this machine.">
-                                        <span class="fa fa-lg fa-info-circle"></span>
-                                    </a>
-                                </td>
-                            </tr>
-                            <tr>
                                 <td translate="yes">Color</td>
                                 <td id="host-edit-colorpicker">
                                 </td>

--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -159,29 +159,13 @@ function host_edit_dialog(machine_manager, machine_dialogs, host) {
     if (!machine)
         return;
 
-    var can_change_user = machine.address != "localhost";
     var dlg = $("#host-edit-dialog");
     $('#host-edit-fail')
             .text("")
             .hide();
-    $('#host-edit-name').val(machine.label);
-    $('#host-edit-name').prop('disabled', machine.state == "failed");
-
-    cockpit.user().done(function (user) {
-        $('#host-edit-user').attr('placeholder', user.name);
-    });
-    $('#host-edit-user').prop('disabled', !can_change_user);
-    $('#host-edit-user').val(machine.user);
     $("#host-edit-dialog a[data-content]").popover();
 
     machine_dialogs.render_color_picker("#host-edit-colorpicker", machine.address);
-    $('#host-edit-sync-users').off('click');
-    $("#host-edit-sync-users").on('click', function () {
-        $("#host-edit-dialog").modal('hide');
-        machine_dialogs.render_dialog("sync-users",
-                                      "dashboard_setup_server_dialog",
-                                      machine.address);
-    });
 
     $('#host-edit-apply').off('click');
     $('#host-edit-apply').on('click', function () {
@@ -189,11 +173,7 @@ function host_edit_dialog(machine_manager, machine_dialogs, host) {
         var values = {
             avatar: avatar_editor.changed ? avatar_editor.get_data(128, 128, "image/png") : null,
             color: machines.colors.parse($('#host-edit-colorpicker #host-edit-color').css('background-color')),
-            label: $('#host-edit-name').val(),
         };
-
-        if (can_change_user)
-            values.user = $('#host-edit-user').val();
 
         var promise = machine_manager.change(machine.key, values);
         dlg.dialog('promise', promise);

--- a/pkg/lib/machines.js
+++ b/pkg/lib/machines.js
@@ -278,38 +278,13 @@ function Machines() {
     }
 
     self.change = function change(host, values) {
-        var mod, hostnamed, call;
+        var mod;
         var machine = self.lookup(host);
-
-        if (values.label) {
-            var conn_to = host;
-            if (machine)
-                conn_to = machine.connection_string;
-
-            if (!machine || machine.label !== values.label) {
-                hostnamed = cockpit.dbus("org.freedesktop.hostname1", { host: conn_to, superuser: "try" });
-                call = hostnamed.call("/org/freedesktop/hostname1", "org.freedesktop.hostname1",
-                                      "SetPrettyHostname", [values.label, true])
-                        .always(function() {
-                            hostnamed.close();
-                        })
-                        .fail(function(ex) {
-                            console.warn("couldn't set pretty host name: " + ex);
-                        });
-            }
-        }
 
         if (machine && !machine.on_disk)
             mod = update_session_machine(machine, host, values);
         else
             mod = update_saved_machine(host, values);
-
-        if (call)
-            // Can't use Promise.all() here, because this promise is sometimes
-            // passed to the dialog() function from pkg/lib/patterns.js, which
-            // expects a promise with a progress() method
-            // eslint-disable-next-line cockpit/no-cockpit-all
-            return cockpit.all([call, mod]);
 
         return mod;
     };

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -115,17 +115,6 @@ export class CockpitHosts extends React.Component {
     onHostEdit(event, machine) {
         const dlg = $("#edit-host-dialog");
 
-        const can_change_user = machine.address != "localhost";
-        const name = document.getElementById("edit-host-name");
-        name.disabled = machine.state == "failed";
-        name.value = machine.label;
-
-        const user = document.getElementById("edit-host-user");
-        user.placeholder = this.state.current_user;
-        user.disabled = !can_change_user;
-        user.value = machine.user || "";
-        $("#edit-host-dialog a[data-content]").popover();
-
         this.mdialogs.render_color_picker("#edit-host-colorpicker", machine.address);
 
         // Remove all existing listeners so we don't change it multiple times
@@ -137,11 +126,7 @@ export class CockpitHosts extends React.Component {
             dlg.dialog('failure', null);
             const values = {
                 color: machines.colors.parse(document.querySelector('#edit-host-colorpicker #host-edit-color').style["background-color"]),
-                label: name.value,
             };
-
-            if (can_change_user)
-                values.user = user.value;
 
             const promise = this.props.machines.change(machine.key, values);
             dlg.dialog('promise', promise);

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -104,26 +104,6 @@
                         <div>
                             <table class="form-table-ct">
                                 <tr>
-                                    <td class="top" translate="yes">Host name</td>
-                                    <td>
-                                        <input class="form-control" id="edit-host-name"/>
-                                    </td>
-                                    <td></td>
-                                </tr>
-                                <tr id="edit-host-user-row">
-                                    <td class="top" translate="yes">User</td>
-                                    <td>
-                                        <input class="form-control" id="edit-host-user"/>
-                                    </td>
-                                    <td>
-                                        <a tabindex="0" role="button" data-toggle="popover"
-                                            data-trigger="focus" data-placement="bottom" translate="data-content"
-                                            data-content="Leave blank to connect to this machine as the currently logged in user. If you enter a different username, that user will always be used when connecting to this machine.">
-                                            <span class="fa fa-lg fa-info-circle"></span>
-                                        </a>
-                                    </td>
-                                </tr>
-                                <tr>
                                     <td translate="yes">Color</td>
                                     <td id="edit-host-colorpicker"></td>
                                     <td></td>

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -244,7 +244,6 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
 
     def testEdit(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/dashboard")
         self.wait_dashboard_addresses(b, ["localhost"])
@@ -257,7 +256,6 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
         b.wait_not_visible('#dashboard-hosts a:first-child button.edit-button')
 
         b.wait_popup('host-edit-dialog')
-        b.set_val('#host-edit-name', "Horst")
         b.click('#host-edit-color')
         b.wait_visible('#host-edit-color-popover')
         b.wait_visible('#host-edit-user[disabled]')
@@ -266,9 +264,7 @@ class TestDashboardEditLimits(MachineCase, DashBoardHelpers):
         b.click('#host-edit-apply')
         b.wait_popdown('host-edit-dialog')
 
-        b.wait_in_text('#dashboard-hosts a:first-child span.host-label', "Horst")
         b.wait_not_attr("#dashboard-hosts .list-group-item[data-address='localhost']", "style", old_style)
-        self.assertEqual(m.execute("hostnamectl --pretty"), "Horst\n")
 
     def testLimits(self):
         b = self.browser

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -222,32 +222,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
         b.wait_present("iframe.container-frame[name='cockpit1:10.111.113.3/system']")
 
-        b.click("#hosts-sel button")
-        b.click("button:contains('Edit hosts')")
-
-        b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-secondary")
-
-        b.wait_popup('edit-host-dialog')
-        b.set_val('#edit-host-user', 'bad-user')
-
-        b.click('#edit-host-apply')
-        b.wait_popdown('edit-host-dialog')
-        b.wait_not_present("iframe.container-frame[name='cockpit1:10.111.113.3/system']")
-        b.wait_visible(".nav-item span[data-for='/@10.111.113.3'] .nav-status")
-        b.wait_visible(".nav-item span[data-for='/@10.111.113.3'] #localhost-error")
-        b.mouse("#localhost-error", "mouseenter")
-        b.wait_in_text(".pf-c-tooltip", "Connection error")
-        b.mouse("#localhost-error", "mouseleave")
-        b.wait_not_present("div.pf-c-tooltip")
-
-        b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-secondary")
-        b.wait_popup('edit-host-dialog')
-        b.set_val('#edit-host-user', '')
-        b.click('#edit-host-apply')
-        b.wait_popdown('edit-host-dialog')
-        b.wait_not_present(".nav-item span[data-for='/@10.111.113.3'] .nav-status")
-
         # Test switching
+        b.click("#hosts-sel button")
         b.wait_js_cond('ph_select("#nav-hosts .nav-item a").length == 3')
 
         b.click("#nav-hosts .nav-item a[href='/@localhost']")
@@ -290,22 +266,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
     def testEdit(self):
         b = self.browser
-        m1 = self.machines['machine1']
-        m3 = self.machines['machine3']
-
-        self.allow_journal_messages("Could not chdir to home directory /home/franz: No such file or directory")
-        m1.execute("useradd franz")
-        m1.execute("echo franz:foobar | chpasswd")
-        m3.execute("useradd franz")
-        m3.execute("echo franz:foobar | chpasswd")
-        self.authorize_pubkey(m3, "franz", self.get_pubkey(m1, "admin"))
-
-        # We need to have admin access on machine3 in order to change
-        # the host name.  Let's just allow sudo without a password for
-        # that.
-        #
-        m3.write("/etc/sudoers.d/admin", "admin ALL=(ALL) NOPASSWD:ALL\n")
-        m3.write("/etc/sudoers.d/franz", "admin ALL=(ALL) NOPASSWD:ALL\n")
 
         self.login_and_go()
 
@@ -319,51 +279,23 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
         b.wait_popup('edit-host-dialog')
         old_color = b.attr("#host-edit-color", "style")
-        b.set_val('#edit-host-user', 'franz')
-        b.set_val('#edit-host-name', "MesMer")
         b.click('#host-edit-color')
         b.wait_visible('#host-edit-color-popover')
         b.click('#host-edit-color-popover div.popover-content > div:nth-child(3)')
         b.wait_not_visible('#host-edit-color-popover')
-
-        b.click('#edit-host-apply')
-        b.wait_popdown('edit-host-dialog')
-
-        b.wait_text(".nav-item span[data-for='/@10.111.113.3']", "franz @MesMer")
-        self.assertEqual(m3.execute("hostnamectl --pretty"), "MesMer\n")
-
-        # Go to the updated machine and try to change whilst on it
-        b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
-        b.wait_present("iframe.container-frame[name='cockpit1:franz@10.111.113.3/system']")
-
-        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "franz@MesMer")
-        b.click("#hosts-sel button")
-        b.wait_text(".nav-item span[data-for='/@10.111.113.3']", "franz @MesMer")
-        b.click("button:contains('Edit hosts')")
-        b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-secondary")
-
-        b.wait_val('#edit-host-user', 'franz')
-        b.wait_val('#edit-host-name', "MesMer")
-        b.set_val('#edit-host-user', 'admin')
         new_color = b.attr("#host-edit-color", "style")
         self.assertNotEqual(old_color, new_color)
-
         b.click('#edit-host-apply')
         b.wait_popdown('edit-host-dialog')
-
-        b.wait_text(".nav-item span[data-for='/@10.111.113.3']", "admin @MesMer")
-        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@MesMer")
 
         # Test that unprivileged user cannot edit or add hosts
         b.logout()
-        self.login_and_go("/system", user="franz", superuser=False)
+        self.login_and_go("/system", superuser=False)
         b.switch_to_top()
         b.click("#hosts-sel button")
         b.wait_visible("#nav-hosts .nav-item span[data-for='/@10.111.113.3']")
         b.wait_not_present("button:contains('Edit hosts')")
         b.wait_not_present("button:contains('Add new host')")
-
-
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestHostEditing(MachineCase, HostSwitcherHelpers):


### PR DESCRIPTION
Previously, the dialog allowed setting the pretty name of the remote
machine, on the remote machine. This is an unexpected thing to be able
to do from such a place, and people might think that they can change
the address of the SSH connection here.

Moreover, changing connection parameters like address and user require
a new login process which might prompt for a password, etc.  It is
better to let people launch into that workflow from the "Add host"
dialog instead of via the "not connected" curtain.