### PR TITLE
network: replace network page modals with PF4 modals

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Cockpit isn't a Node package, these are devel time deps, not needed to build tarball either",
   "private": true,
   "dependencies": {
-    "@patternfly/patternfly": "4.42.2",
+    "@patternfly/patternfly": "4.50.0",
     "@patternfly/react-console": "2.0.15",
     "@patternfly/react-core": "4.65.0",
     "@patternfly/react-table": "4.18.14",

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -493,285 +493,307 @@
     </main>
   </div>
 
-  <div class="modal" id="network-ip-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">IP settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-ip-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-ip-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+  <div hidden aria-hidden="true" id="network-ip-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-ip-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">IP settings</h4>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-ip-settings-body">
             </div>
-            <h4 class="pf-c-alert__title"></h4>
           </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-ip-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-ip-settings-cancel">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="network-bond-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Bond settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-          <button id="bond-help-popup-button" class="close pficon pficon-help" data-toggle="popover">
-        </div>
-        <div class="modal-body">
-          <div id="network-bond-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bond-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            </div>
-            <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-bond-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-bond-settings-cancel">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="network-team-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Team settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-team-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-team-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            </div>
-            <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-team-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-team-settings-cancel">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="network-teamport-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Team port settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-teamport-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-teamport-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-            </div>
-            <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-teamport-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-teamport-settings-cancel">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="network-bridge-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Bridge settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-bridge-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bridge-settings-error">
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-ip-settings-error">
               <div class="pf-c-alert__icon">
                   <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
               </div>
               <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-bridge-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-bridge-settings-cancel">Cancel</button>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-ip-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-ip-settings-cancel">Cancel</button>
+          </footer>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="network-bridgeport-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Bridge port settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-bridgeport-settings-body">
+  <div hidden aria-hidden="true" id="network-bond-settings-dialog">
+   <div class="pf-c-backdrop">
+     <div class="pf-l-bullseye">
+       <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+         <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-bond-settings-close-button" translate="aria-label">
+           <i class="fa fa-times" aria-hidden="true"></i>
+         </button>
+         <header class="pf-c-modal-box__header pf-m-help">
+           <div class="pf-c-modal-box__header-main">
+             <h1 class="pf-c-modal-box__title" translate="yes">Bond settings</h4>
+           </div>
+           <div class="pf-c-modal-box__header-help">
+             <button id="bond-help-popup-button" class="pf-c-button pf-m-plain" type="button" aria-label="Help" tranlate="aria-label">
+               <i class="pficon pficon-help" aria-hidden="true" data-toggle="popover"></i>
+             </button>
+           </div>
+         </header>
+         <div class="pf-c-modal-box__body">
+           <div id="network-bond-settings-body">
+           </div>
+         </div>
+         <footer class="pf-c-modal-box__footer">
+           <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bond-settings-error">
+             <div class="pf-c-alert__icon">
+                 <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+             </div>
+             <h4 class="pf-c-alert__title"></h4>
+           </div>
+           <button class="pf-c-button pf-m-primary" translate="yes" id="network-bond-settings-apply">Apply</button>
+           <button class="pf-c-button pf-m-link" translate="yes" id="network-bond-settings-cancel">Cancel</button>
+         </footer>
+       </div>
+     </div>
+   </div>
+  </div>
+
+  <div hidden aria-hidden="true" id="network-team-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-team-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Team settings</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-team-settings-body">
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bridgeport-settings-error">
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-team-settings-error">
               <div class="pf-c-alert__icon">
                   <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
               </div>
               <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-bridgeport-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-bridgeport-settings-cancel">Cancel</button>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-team-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-team-settings-cancel">Cancel</button>
+          </footer>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="network-vlan-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">VLAN settings</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-vlan-settings-body">
+  <div hidden aria-hidden="true" id="network-teamport-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-teamport-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Team port settings</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-teamport-settings-body">
+            </div>
           </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-vlan-settings-error">
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-teamport-settings-error">
               <div class="pf-c-alert__icon">
                   <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
               </div>
               <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-vlan-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-vlan-settings-cancel">Cancel</button>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <div class="modal" id="network-mtu-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Ethernet MTU</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-mtu-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-mtu-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             </div>
-            <h4 class="pf-c-alert__title"></h4>
-          </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-mtu-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-mtu-settings-cancel">Cancel</button>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-teamport-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-teamport-settings-cancel">Cancel</button>
+          </footer>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="network-mac-settings-dialog"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Ethernet MAC</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <div id="network-mac-settings-body">
-          </div>
-        </div>
-        <div class="modal-footer">
-          <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-mac-settings-error">
-            <div class="pf-c-alert__icon">
-                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+  <div hidden aria-hidden="true" id="network-bridge-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-bridge-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Bridge settings</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-bridge-settings-body">
             </div>
-            <h4 class="pf-c-alert__title"></h4>
           </div>
-          <button class="pf-c-button pf-m-primary" translate="yes" id="network-mac-settings-apply">Apply</button>
-          <button class="pf-c-button pf-m-link" translate="yes" id="network-mac-settings-cancel">Cancel</button>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bridge-settings-error">
+                <div class="pf-c-alert__icon">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                </div>
+                <h4 class="pf-c-alert__title"></h4>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-bridge-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-bridge-settings-cancel">Cancel</button>
+          </footer>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="error-popup"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Unexpected error</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
-        </div>
-        <div class="modal-body">
-          <p id="error-popup-message"></p>
-        </div>
-        <div class="modal-footer">
-          <button class="pf-c-button pf-m-primary" data-dismiss="modal" translate>Close</button>
+  <div hidden aria-hidden="true" id="network-bridgeport-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-bridgeport-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Bridge port settings</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-bridgeport-settings-body">
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-bridgeport-settings-error">
+                <div class="pf-c-alert__icon">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                </div>
+                <h4 class="pf-c-alert__title"></h4>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-bridgeport-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-bridgeport-settings-cancel">Cancel</button>
+          </footer>
         </div>
       </div>
     </div>
   </div>
 
-  <div class="modal" id="confirm-breaking-change-popup"
-       tabindex="-1" role="dialog"
-       data-backdrop="static">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h4 class="modal-title" translate="yes">Connection will be lost</h4>
-          <button class="close pficon pficon-close" data-dismiss="modal"></button>
+  <div hidden aria-hidden="true" id="network-vlan-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-vlan-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">VLAN settings</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-vlan-settings-body">
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-vlan-settings-error">
+                <div class="pf-c-alert__icon">
+                    <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                </div>
+                <h4 class="pf-c-alert__title"></h4>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-vlan-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-vlan-settings-cancel">Cancel</button>
+          </footer>
         </div>
-        <div class="modal-body">
-          <div class="pficon pficon-warning-triangle-o"></div>
-          <div id="confirm-breaking-change-text"></div>
+      </div>
+    </div>
+  </div>
+
+  <div hidden aria-hidden="true" id="network-mtu-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-mtu-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Ethernet MTU</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-mtu-settings-body">
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-mtu-settings-error">
+              <div class="pf-c-alert__icon">
+                  <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+              </div>
+              <h4 class="pf-c-alert__title"></h4>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-mtu-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-mtu-settings-cancel">Cancel</button>
+          </footer>
         </div>
-        <div class="modal-footer">
-          <button class="pf-c-button pf-m-danger"></button>
-          <button class="pf-c-button pf-m-primary" data-dismiss="modal" translate>Keep connection</button>
+      </div>
+    </div>
+  </div>
+
+  <div hidden aria-hidden="true" id="network-mac-settings-dialog">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <button class="pf-c-button pf-m-plain" type="button" aria-label="Close" id="network-mac-settings-close-button" translate="aria-label">
+            <i class="fa fa-times" aria-hidden="true"></i>
+          </button>
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Ethernet MAC</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div id="network-mac-settings-body">
+            </div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert" id="network-mac-settings-error">
+              <div class="pf-c-alert__icon">
+                  <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+              </div>
+              <h4 class="pf-c-alert__title"></h4>
+            </div>
+            <button class="pf-c-button pf-m-primary" translate="yes" id="network-mac-settings-apply">Apply</button>
+            <button class="pf-c-button pf-m-link" translate="yes" id="network-mac-settings-cancel">Cancel</button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div hidden aria-hidden="true" id="error-popup">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Unexpected error</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <p id="error-popup-message"></p>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <button class="pf-c-button pf-m-primary" id="error-popup-cancel" translate>Close</button>
+          </footer>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div hidden aria-hidden="true" id="confirm-breaking-change-popup">
+    <div class="pf-c-backdrop">
+      <div class="pf-l-bullseye">
+        <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+          <header class="pf-c-modal-box__header">
+            <h1 class="pf-c-modal-box__title" translate="yes">Connection will be lost</h1>
+          </header>
+          <div class="pf-c-modal-box__body">
+            <div class="pficon pficon-warning-triangle-o"></div>
+            <div id="confirm-breaking-change-text"></div>
+          </div>
+          <footer class="pf-c-modal-box__footer">
+            <button class="pf-c-button pf-m-danger"></button>
+            <button class="pf-c-button pf-m-primary" data-dismiss="modal" translate>Keep connection</button>
+          </footer>
         </div>
       </div>
     </div>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -56,8 +56,8 @@ function show_unexpected_error(error) {
     var msg = error.message || error || "???";
     console.warn(msg);
     $("#error-popup-message").text(msg);
-    $('.modal[role="dialog"]').modal('hide');
-    $('#error-popup').modal('show');
+    $('#error-popup').prop('hidden', false);
+    $('#error-popup-cancel').click(() => $('#error-popup').prop('hidden', true));
 }
 
 function select_btn(func, spec, klass) {
@@ -1839,7 +1839,7 @@ PageNetworking.prototype = {
                 }
             };
 
-        $('#network-bond-settings-dialog').modal('show');
+        $('#network-bond-settings-dialog').trigger('show');
     },
 
     add_team: function () {
@@ -1871,7 +1871,7 @@ PageNetworking.prototype = {
                 }
             };
 
-        $('#network-team-settings-dialog').modal('show');
+        $('#network-team-settings-dialog').trigger('show');
     },
 
     add_bridge: function () {
@@ -1908,7 +1908,7 @@ PageNetworking.prototype = {
                 }
             };
 
-        $('#network-bridge-settings-dialog').modal('show');
+        $('#network-bridge-settings-dialog').trigger('show');
     },
 
     add_vlan: function () {
@@ -1935,7 +1935,7 @@ PageNetworking.prototype = {
                 }
             };
 
-        $('#network-vlan-settings-dialog').modal('show');
+        $('#network-vlan-settings-dialog').trigger('show');
     }
 
 };
@@ -2168,14 +2168,14 @@ function with_checkpoint(model, modify, options) {
                                         .always(hide_curtain)
                                         .fail(function () {
                                             dialog.find('#confirm-breaking-change-text').html(options.fail_text);
-                                            dialog.find('.modal-footer button.pf-m-danger')
+                                            dialog.find('.pf-c-modal-box__footer button.pf-m-danger')
                                                     .off('click')
                                                     .text(options.anyway_text)
                                                     .syn_click(model, function () {
-                                                        dialog.modal('hide');
+                                                        dialog.prop('hidden', true);
                                                         modify();
                                                     });
-                                            dialog.modal('show');
+                                            dialog.prop('hidden', false);
                                         });
                             }, settle_time * 1000);
                         })
@@ -2393,7 +2393,7 @@ PageNetworkInterface.prototype = {
         dialog.ghost_settings = self.ghost_settings;
         dialog.apply_settings = settings_applier(self.model, self.dev, con);
         dialog.done = reactivate_connection;
-        $(id).modal('show');
+        $(id).trigger('show');
     },
 
     set_mac: function() {
@@ -3182,6 +3182,7 @@ PageNetworkIpSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-ip-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-ip-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-ip-settings-apply').click($.proxy(this, "apply"));
     },
@@ -3362,7 +3363,7 @@ PageNetworkIpSettings.prototype = {
             params.routes = [];
         }
 
-        $('#network-ip-settings-dialog .modal-title').text(
+        $('#network-ip-settings-dialog .pf-c-modal-box__title').text(
             (topic == "ipv4") ? _("IPv4 settings") : _("IPv6 settings"));
         $('#network-ip-settings-body').html(render_ip_settings());
 
@@ -3381,7 +3382,7 @@ PageNetworkIpSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-ip-settings-dialog').modal('hide');
+        $('#network-ip-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -3390,7 +3391,7 @@ PageNetworkIpSettings.prototype = {
         function modify() {
             return PageNetworkIpSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-ip-settings-dialog').modal('hide');
+                        $('#network-ip-settings-dialog').trigger('hide');
                         if (PageNetworkIpSettings.done)
                             return PageNetworkIpSettings.done();
                     })
@@ -3652,6 +3653,7 @@ PageNetworkBondSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-bond-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-bond-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-bond-settings-apply').click($.proxy(this, "apply"));
     },
@@ -3793,7 +3795,7 @@ PageNetworkBondSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-bond-settings-dialog').modal('hide');
+        $('#network-bond-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -3807,7 +3809,7 @@ PageNetworkBondSettings.prototype = {
                                       self.settings,
                                       "bond")
                     .then(function() {
-                        $('#network-bond-settings-dialog').modal('hide');
+                        $('#network-bond-settings-dialog').trigger('hide');
                         if (PageNetworkBondSettings.connection)
                             cockpit.location.go([self.settings.connection.interface_name]);
                         if (PageNetworkBondSettings.done)
@@ -3853,6 +3855,7 @@ PageNetworkTeamSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-team-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-team-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-team-settings-apply').click($.proxy(this, "apply"));
     },
@@ -3996,7 +3999,7 @@ PageNetworkTeamSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-team-settings-dialog').modal('hide');
+        $('#network-team-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -4010,7 +4013,7 @@ PageNetworkTeamSettings.prototype = {
                                       self.settings,
                                       "team")
                     .then(function() {
-                        $('#network-team-settings-dialog').modal('hide');
+                        $('#network-team-settings-dialog').trigger('hide');
                         if (PageNetworkTeamSettings.connection)
                             cockpit.location.go([self.settings.connection.interface_name]);
                         if (PageNetworkTeamSettings.done)
@@ -4056,6 +4059,7 @@ PageNetworkTeamPortSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-teamport-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-teamport-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-teamport-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4119,7 +4123,7 @@ PageNetworkTeamPortSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-teamport-settings-dialog').modal('hide');
+        $('#network-teamport-settings-dialog').prop('hidden', true);
     },
 
     apply: function() {
@@ -4129,7 +4133,7 @@ PageNetworkTeamPortSettings.prototype = {
         function modify () {
             return PageNetworkTeamPortSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-teamport-settings-dialog').modal('hide');
+                        $('#network-teamport-settings-dialog').trigger('hide');
                         if (PageNetworkTeamPortSettings.done)
                             return PageNetworkTeamPortSettings.done();
                     })
@@ -4155,6 +4159,7 @@ PageNetworkBridgeSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-bridge-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-bridge-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-bridge-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4249,7 +4254,7 @@ PageNetworkBridgeSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-bridge-settings-dialog').modal('hide');
+        $('#network-bridge-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -4263,7 +4268,7 @@ PageNetworkBridgeSettings.prototype = {
                                       self.settings,
                                       "bridge")
                     .then(function() {
-                        $('#network-bridge-settings-dialog').modal('hide');
+                        $('#network-bridge-settings-dialog').trigger('hide');
                         if (PageNetworkBridgeSettings.connection)
                             cockpit.location.go([self.settings.connection.interface_name]);
                         if (PageNetworkBridgeSettings.done)
@@ -4311,6 +4316,7 @@ PageNetworkBridgePortSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-bridgeport-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-bridgeport-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-bridgeport-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4356,7 +4362,7 @@ PageNetworkBridgePortSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-bridgeport-settings-dialog').modal('hide');
+        $('#network-bridgeport-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -4366,7 +4372,7 @@ PageNetworkBridgePortSettings.prototype = {
         function modify () {
             return PageNetworkBridgePortSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-bridgeport-settings-dialog').modal('hide');
+                        $('#network-bridgeport-settings-dialog').trigger('hide');
                         if (PageNetworkBridgePortSettings.done)
                             return PageNetworkBridgePortSettings.done();
                     })
@@ -4393,6 +4399,7 @@ PageNetworkVlanSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-vlan-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-vlan-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-vlan-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4467,7 +4474,7 @@ PageNetworkVlanSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-vlan-settings-dialog').modal('hide');
+        $('#network-vlan-settings-dialog').prop('hidden', true);
     },
 
     apply: function() {
@@ -4477,7 +4484,7 @@ PageNetworkVlanSettings.prototype = {
         function modify () {
             return PageNetworkVlanSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-vlan-settings-dialog').modal('hide');
+                        $('#network-vlan-settings-dialog').trigger('hide');
                         if (PageNetworkVlanSettings.connection)
                             cockpit.location.go([self.settings.connection.interface_name]);
                         if (PageNetworkVlanSettings.done)
@@ -4515,6 +4522,7 @@ PageNetworkMtuSettings.prototype = {
     },
 
     setup: function () {
+        $('#network-mtu-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-mtu-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-mtu-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4543,7 +4551,7 @@ PageNetworkMtuSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-mtu-settings-dialog').modal('hide');
+        $('#network-mtu-settings-dialog').trigger('hide');
     },
 
     apply: function() {
@@ -4569,7 +4577,7 @@ PageNetworkMtuSettings.prototype = {
         function modify () {
             return PageNetworkMtuSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-mtu-settings-dialog').modal('hide');
+                        $('#network-mtu-settings-dialog').trigger('hide');
                         if (PageNetworkMtuSettings.done)
                             return PageNetworkMtuSettings.done();
                     })
@@ -4594,6 +4602,7 @@ PageNetworkMacSettings.prototype = {
     },
 
     setup: function () {
+        $('#networl-mac-settings-close-button').click($.proxy(this, "cancel"));
         $('#network-mac-settings-cancel').click($.proxy(this, "cancel"));
         $('#network-mac-settings-apply').click($.proxy(this, "apply"));
     },
@@ -4623,7 +4632,7 @@ PageNetworkMacSettings.prototype = {
     },
 
     cancel: function() {
-        $('#network-mac-settings-dialog').modal('hide');
+        $('#network-mac-settings-dialog').prop('hidden', true);
     },
 
     apply: function() {
@@ -4641,7 +4650,7 @@ PageNetworkMacSettings.prototype = {
         function modify () {
             return PageNetworkMacSettings.apply_settings(self.settings)
                     .then(function () {
-                        $('#network-mac-settings-dialog').modal('hide');
+                        $('#network-mac-settings-dialog').prop('hidden', true);
                         if (PageNetworkMacSettings.done)
                             return PageNetworkMacSettings.done();
                     })
@@ -4671,9 +4680,15 @@ function PageNetworkMacSettings() {
 function dialog_setup(d) {
     d.setup();
     $('#' + d.id)
-            .on('show.bs.modal', function () { d.enter() })
-            .on('shown.bs.modal', function () { d.show() })
-            .on('hidden.bs.modal', function () { d.leave() });
+            .on('show', function () {
+                $('#' + d.id).prop('hidden', false);
+                d.enter();
+                d.show();
+            })
+            .on('hide', function () {
+                $('#' + d.id).prop('hidden', true);
+                d.leave();
+            });
 }
 
 function page_show(p, arg) {

--- a/pkg/networkmanager/networking.css
+++ b/pkg/networkmanager/networking.css
@@ -7,6 +7,11 @@
 @import "../../node_modules/@patternfly/patternfly/components/Table/table.css";
 @import "../../node_modules/@patternfly/patternfly/components/Table/table-grid.css";
 
+/* The following are needed for the Modal */
+@import "../../node_modules/@patternfly/patternfly/components/Backdrop/backdrop.css";
+@import "../../node_modules/@patternfly/patternfly/layouts/Bullseye/bullseye.css";
+@import "../../node_modules/@patternfly/patternfly/components/ModalBox/modal-box.css";
+
 #networking, #network-interface {
   .pf-l-gallery {
       --pf-l-gallery--GridTemplateColumns: 1fr;

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -45,13 +45,13 @@ class TestBonding(NetworkCase):
         # Bond them
         b.click("button:contains('Add bond')")
         b.wait_popup("network-bond-settings-dialog")
-        b.click("#network-bond-settings-dialog .close.pficon-close")
+        b.click("#network-bond-settings-dialog #network-bond-settings-close-button")
         b.wait_popdown("network-bond-settings-dialog")
         b.click("button:contains('Add bond')")
         b.wait_popup("network-bond-settings-dialog")
-        b.click("#network-bond-settings-dialog .close.pficon-help")
+        b.click("#network-bond-settings-dialog #bond-help-popup-button")
         b.wait_visible(".popover .popover-title:contains('Network bond')")
-        b.click("#network-bond-settings-dialog .close.pficon-help")
+        b.click("#network-bond-settings-dialog #bond-help-popup-button")
         b.wait_not_present(".popover .popover-title:contains('Network bond')")
 
         b.set_val("#network-bond-settings-interface-name-input", "tbond")


### PR DESCRIPTION
Upgrade @patternfly/patternfly to get support for help icon in modal
headers.
See https://github.com/patternfly/patternfly/issues/3474