### PR TITLE
hwinfo: replace ListView with DataList from PF4 in security mitigations modal

### DIFF
--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -25,10 +25,16 @@ import moment from 'moment';
 import React from "react";
 import ReactDOM from 'react-dom';
 
-import { ListView } from 'patternfly-react';
 import {
     Alert, AlertActionCloseButton, Button,
+    DataList,
+    DataListItem,
+    DataListCell,
+    DataListItemRow,
+    DataListItemCells,
+    DataListAction,
     Page, PageSection, PageSectionVariants,
+    Text, TextVariants,
     Breadcrumb, BreadcrumbItem,
     Modal,
 } from '@patternfly/react-core';
@@ -198,16 +204,31 @@ class CPUSecurityMitigationsDialog extends React.Component {
     render() {
         const rows = [];
         if (this.state.nosmt !== undefined)
-            rows.push((
-                <ListView.Item key="nosmt" heading={ <span>{ _("Disable simultaneous multithreading") } (nosmt)<small>
-                    <a href="https://access.redhat.com/security/vulnerabilities/L1TF" target="_blank" rel="noopener noreferrer">
-                        <i className="fa fa-external-link" aria-hidden="true" /> { _("Read more...") }
-                    </a>
-                </small></span> }
-                               actions={ <div id="nosmt-switch">
-                                   <OnOffSwitch disabled={this.state.rebooting} onChange={ value => this.setState({ nosmt: value }) } state={ this.state.nosmt } />
-                               </div> } />
-            ));
+            rows.push(
+                <DataListItem key="nosmt">
+                    <DataListItemRow>
+                        <DataListItemCells
+                            dataListCells={[
+                                <DataListCell key="primary content">
+                                    <span>
+                                        <div className='nosmt-heading'>{ _("Disable simultaneous multithreading") } (nosmt)</div>
+                                        <small className='nosmt-read-more-link'>
+                                            <a href="https://access.redhat.com/security/vulnerabilities/L1TF" target="_blank" rel="noopener noreferrer">
+                                                <i className="fa fa-external-link" aria-hidden="true" /> { _("Read more...") }
+                                            </a>
+                                        </small>
+                                    </span>
+                                </DataListCell>,
+                            ]}
+                        />
+                        <DataListAction>
+                            <div id="nosmt-switch">
+                                <OnOffSwitch disabled={this.state.rebooting} onChange={ value => this.setState({ nosmt: value }) } state={ this.state.nosmt } />
+                            </div>
+                        </DataListAction>
+                    </DataListItemRow>
+                </DataListItem>
+            );
 
         const footer = (
             <>
@@ -227,10 +248,12 @@ class CPUSecurityMitigationsDialog extends React.Component {
                    onClose={this.props.onClose}
                    title={ _("CPU security toggles") }>
                 <>
-                    { _("Software-based workarounds help prevent CPU security issues. These mitigations have the side effect of reducing performance. Change these settings at your own risk.") }
-                    <ListView>
+                    <Text className='cpu-mitigations-dialog-info' component={TextVariants.p}>
+                        { _("Software-based workarounds help prevent CPU security issues. These mitigations have the side effect of reducing performance. Change these settings at your own risk.") }
+                    </Text>
+                    <DataList>
                         { rows }
-                    </ListView>
+                    </DataList>
                     { this.state.alert !== undefined &&
                     <Alert variant="danger"
                         actionClose={<AlertActionCloseButton onClose={() => this.setState({ alert: undefined })} />}

--- a/pkg/systemd/hwinfo.scss
+++ b/pkg/systemd/hwinfo.scss
@@ -25,3 +25,13 @@ tr.listing-ct-item td:last-child {
 section.pf-c-page__main-breadcrumb {
     padding-bottom: var(--pf-global--spacer--xl);
 }
+
+.nosmt-read-more-link {
+    display: block;
+}
+.nosmt-heading {
+    font-weight: var(--pf-global--FontWeight--bold);
+}
+.cpu-mitigations-dialog-info {
+    margin-bottom: var(--pf-global--spacer--md);
+}


### PR DESCRIPTION
That's a trivial PF3->PF4 conversion, no UI changes are expected.
Screenshot before and after here:
![Screen Shot 2020-10-23 at 11 27 57](https://user-images.githubusercontent.com/14921356/96987702-a5861a80-1523-11eb-9199-e687d2d956e6.png)
![Screen Shot 2020-10-23 at 11 27 41](https://user-images.githubusercontent.com/14921356/96987706-a61eb100-1523-11eb-93ff-9db4ccc81cff.png)
