### PR TITLE
[rhel-8.3] test: Increase timeout for fips-mode-setup

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -466,7 +466,7 @@ class TestMultiMachine(MachineCase):
                 grubby --update-kernel=$(grubby --default-kernel) --args=fips=1
                 uuid=$(findmnt -no uuid /boot)
                 [ -n "$uuid" ] && grubby --update-kernel=$(grubby --default-kernel) --args=boot=UUID=${uuid}
-            fi''')
+            fi''', timeout=300)
         self.machine.spawn('sync && sync && sync && sleep 0.1 && reboot', 'reboot')
         self.machine.wait_reboot()
         # ensure it's really enabled


### PR DESCRIPTION
It legitimately takes about a minute on a quiet system, so it often ran
into the default 1min timeout.

Cherry-picked from master branch commit 25407ad

For https://github.com/cockpit-project/bots/pull/1311