### PR TITLE
machines: Fix description (not group)

### DIFF
--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -269,9 +269,9 @@ class VmOverviewTabLibvirt extends React.Component {
 
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{_("State")}</DescriptionListTerm>
-                                <DescriptionListGroup>
+                                <DescriptionListDescription>
                                     <StateIcon state={vm.state} valueId={`${idPrefix}-state`} showIcon />
-                                </DescriptionListGroup>
+                                </DescriptionListDescription>
                             </DescriptionListGroup>
 
                             <DescriptionListGroup>


### PR DESCRIPTION
That was cherry-picked from https://github.com/cockpit-project/cockpit/pull/14756/commits because it's actually fixing a bug (machines details page not wrapping properly) and should go inside this release.