### PR TITLE
machines: Improve visual feedback when changing a VM's state

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -117,22 +117,6 @@
         transform: translateY(3px) rotate(var(--pf-c-table__toggle--c-button--m-expanded__toggle-icon--Rotate));
     }
 
-    // Shrink buttons down a little
-    td:not(.pf-c-table__toggle) {
-        > .pf-c-button,
-        > .pf-c-input-group > .pf-c-button,
-        > .btn-group > .pf-c-button {
-            padding: 0.25rem 0.75rem;
-        }
-
-        > .pf-m-link {
-            &:only-child {
-                width: 100%;
-                text-align: left;
-            }
-        }
-    }
-
     // Remove excess PF4 nested compact paddings
     // (as PF4 has different assumptions)
     .pf-c-table.pf-m-compact tr {

--- a/pkg/machines/components/networks/network.jsx
+++ b/pkg/machines/components/networks/network.jsx
@@ -101,7 +101,7 @@ export const getNetworkRow = ({ dispatch, network, resourceHasError, onAddErrorN
 class NetworkActions extends React.Component {
     constructor() {
         super();
-        this.state = { deleteDialogProps: undefined };
+        this.state = { deleteDialogProps: undefined, operationInProgress: false };
         this.onActivate = this.onActivate.bind(this);
         this.onDeactivate = this.onDeactivate.bind(this);
     }
@@ -115,7 +115,8 @@ class NetworkActions extends React.Component {
                         text: cockpit.format(_("Network $0 failed to get activated"), network.name),
                         detail: exc.message, resourceId: network.id,
                     });
-                });
+                })
+                .always(() => this.setState({ operationInProgress: false }));
     }
 
     onDeactivate() {
@@ -127,7 +128,8 @@ class NetworkActions extends React.Component {
                         text: cockpit.format(_("Network $0 failed to get deactivated"), network.name),
                         detail: exc.message, resourceId: network.id,
                     });
-                });
+                })
+                .always(() => this.setState({ operationInProgress: false }));
     }
 
     render() {
@@ -151,11 +153,11 @@ class NetworkActions extends React.Component {
         return (
             <>
                 { network.active &&
-                <Button id={`deactivate-${id}`} onClick={this.onDeactivate}>
+                <Button id={`deactivate-${id}`} isLoading={this.state.operationInProgress} isDisabled={this.state.operationInProgress} onClick={this.onDeactivate}>
                     {_("Deactivate")}
                 </Button> }
                 { !network.active &&
-                <Button id={`activate-${id}`} onClick={this.onActivate}>
+                <Button id={`activate-${id}`} isLoading={this.state.operationInProgress} isDisabled={this.state.operationInProgress} onClick={this.onActivate}>
                     {_("Activate")}
                 </Button>
                 }

--- a/pkg/machines/components/storagePools/storagePool.jsx
+++ b/pkg/machines/components/storagePools/storagePool.jsx
@@ -148,6 +148,7 @@ class StoragePoolActions extends React.Component {
         let deactivateButton = (
             <Button id={`deactivate-${id}`}
                 variant='secondary'
+                isLoading={this.state.operationInProgress}
                 isDisabled={this.state.operationInProgress}
                 onClick={this.onDeactivate}>
                 {_("Deactivate")}
@@ -156,6 +157,7 @@ class StoragePoolActions extends React.Component {
         let activateButton = (
             <Button id={`activate-${id}`}
                 variant='secondary'
+                isLoading={this.state.operationInProgress}
                 isDisabled={this.state.operationInProgress}
                 onClick={this.onActivate}>
                 {_("Activate")}

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -48,6 +48,13 @@ const _ = cockpit.gettext;
 const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetailsPage }) => {
     const [isActionOpen, setIsActionOpen] = useState(false);
     const [showDeleteDialog, toggleDeleteModal] = useState(false);
+    const [operationInProgress, setOperationInProgress] = useState(false);
+    const [prevVmState, setPrevVmState] = useState(vm.state);
+
+    if (vm.state !== prevVmState) {
+        setPrevVmState(vm.state);
+        setOperationInProgress(false);
+    }
 
     const id = vmId(vm.name);
     const state = vm.state;
@@ -59,6 +66,7 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
             text: cockpit.format(_("VM $0 failed to start"), vm.name),
             detail: ex.message, resourceId: vm.id,
         });
+        setOperationInProgress(false);
     });
     const onInstall = () => dispatch(installVm(vm)).catch(ex => {
         onAddErrorNotification({
@@ -83,6 +91,7 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
             text: cockpit.format(_("VM $0 failed to shutdown"), vm.name),
             detail: ex.message, resourceId: vm.id,
         });
+        setOperationInProgress(false);
     });
     const onPause = () => dispatch(pauseVm(vm)).catch(ex => {
         onAddErrorNotification({
@@ -136,8 +145,11 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
     if (LibvirtDBus.canShutdown(state)) {
         shutdown = (
             <Button key='action-shutdown'
+                    isSmall
                     variant={isDetailsPage ? 'primary' : 'secondary'}
-                    onClick={() => onShutdown()} id={`${id}-shutdown-button`}>
+                    isLoading={operationInProgress}
+                    isDisabled={operationInProgress}
+                    onClick={() => { setOperationInProgress(true); onShutdown() }} id={`${id}-shutdown-button`}>
                 {_("Shut down")}
             </Button>
         );
@@ -188,8 +200,11 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
     if (LibvirtDBus.canRun(state, hasInstallPhase)) {
         run = (
             <Button key='action-run'
+                    isSmall
                     variant={isDetailsPage ? 'primary' : 'secondary'}
-                    onClick={() => onStart()} id={`${id}-run`}>
+                    isLoading={operationInProgress}
+                    isDisabled={operationInProgress}
+                    onClick={() => { setOperationInProgress(true); onStart() }} id={`${id}-run`}>
                 {_("Run")}
             </Button>
         );

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -419,24 +419,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         # test VM error messages
         b.click("#vm-subVmTest2-run")
-        b.click("#vm-subVmTest2-run") # make use of slow processing - the button is still present; will cause error
-        # triangle by status
-        b.wait_present("tbody tr[data-row-id=vm-subVmTest2-system] td span span.pficon-warning-triangle-o.machines-status-alert")
-        # inline notification with error
-        b.wait_in_text("div.pf-c-alert.pf-m-danger .pf-c-alert__title", "VM subVmTest2 failed to start")
-
-        message = "domain is already running"
-
-        b.wait_in_text("button.alert-link.more-button", "show more") # more/less button
-        b.click("button.alert-link.more-button")
-        b.wait_in_text(".pf-c-alert__description", message)
-        b.wait_in_text("button.alert-link.more-button", "show less")
-
-        b.click("div.pf-c-alert.pf-m-danger button.pf-c-button") # close button
-        # inline notification is gone
-        b.wait_not_present("div.pf-c-alert.pf-m-danger")
-        # triangle by status is gone
-        b.wait_not_present("tbody tr[data-row-id=vm-subVmTest2-system] td span span.pficon-warning-triangle-o.machines-status-alert")
 
         b.set_input_text("#text-search", "subVmTest2")
         self.waitVmRow("subVmTest2")


### PR DESCRIPTION
Stop overriding the size of the buttons with custom CSS and do it the
PF4 way instead.

Now clicking on run button twice in order to create an error does not
work so remove the relevant test code.

Fixes #14728