### PR TITLE
machines: show vm actions header in console page as well

### DIFF
--- a/pkg/machines/components/vm/vmExpandedContent.jsx
+++ b/pkg/machines/components/vm/vmExpandedContent.jsx
@@ -57,6 +57,21 @@ export const VmExpandedContent = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
+    const vmActionsPageSection = (
+        <PageSection variant={PageSectionVariants.light}>
+            <div className="vm-top-panel">
+                <h2 className="vm-name">{vm.name}</h2>
+                <VmActions vm={vm}
+                           config={config}
+                           dispatch={dispatch}
+                           storagePools={storagePools}
+                           onAddErrorNotification={onAddErrorNotification}
+                           isDetailsPage />
+            </div>
+            {notifications && <div className="vm-notifications">{notifications}</div>}
+        </PageSection>
+    );
+
     if (cockpit.location.path[1] == "console") {
         return (<Page breadcrumb={
             <Breadcrumb className='machines-listing-breadcrumb'>
@@ -70,6 +85,7 @@ export const VmExpandedContent = ({
                     {_("Console")}
                 </BreadcrumbItem>
             </Breadcrumb>}>
+            {vmActionsPageSection}
             <PageSection variant={PageSectionVariants.light}>
                 <Consoles vm={vm} config={config} dispatch={dispatch}
                           onAddErrorNotification={onAddErrorNotification} />
@@ -164,18 +180,7 @@ export const VmExpandedContent = ({
                     {vm.name}
                 </BreadcrumbItem>
             </Breadcrumb>}>
-            <PageSection variant={PageSectionVariants.light}>
-                <div className="vm-top-panel">
-                    <h2 className="vm-name">{vm.name}</h2>
-                    <VmActions vm={vm}
-                               config={config}
-                               dispatch={dispatch}
-                               storagePools={storagePools}
-                               onAddErrorNotification={onAddErrorNotification}
-                               isDetailsPage />
-                </div>
-                {notifications && <div className="vm-notifications">{notifications}</div>}
-            </PageSection>
+            {vmActionsPageSection}
             <PageSection>
                 <Gallery className='ct-vm-overview' hasGutter>
                     {cards}


### PR DESCRIPTION
When the VM is shut off we display a message, 'Please start the VM to
see the console'. The user should be able therefore to start it from the
same page the message is displayed at.

Fixes #14785

Previously:
![Screen Shot 2020-10-26 at 10 22 23](https://user-images.githubusercontent.com/14921356/97155120-2a1ba780-1775-11eb-93cd-d541002acb62.png)


Now:
![Screen Shot 2020-10-26 at 10 10 26](https://user-images.githubusercontent.com/14921356/97155088-1bcd8b80-1775-11eb-982a-282a54cd1873.png)
