### PR TITLE
workflows: Reduce unit-test timeout to 1 hour

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 jobs:
   gcc:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -17,6 +18,7 @@ jobs:
         run: containers/unit-tests/start
 
   clang:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
@@ -29,6 +31,7 @@ jobs:
         run: containers/unit-tests/start CC=clang
 
   i386:
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
The default is 6 hours, which causes too long hangs.