### PR TITLE
storage: Show spinner inside the buttons when operation is in progress

### DIFF
--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -167,12 +167,12 @@ export class DialogFooter extends React.Component {
             actions_disabled = true;
             if (!(this.state.action_in_progress_promise && this.state.action_in_progress_promise.cancel) && !this.state.action_progress_cancel)
                 cancel_disabled = true;
-            wait_element = <div className="dialog-wait-ct pull-right">
+            wait_element = <div className="dialog-wait-ct">
                 <span>{ this.state.action_progress_message }</span>
                 <div className="spinner spinner-sm" />
             </div>;
         } else if (this.props.idle_message) {
-            wait_element = <div className="dialog-wait-ct pull-right">
+            wait_element = <div className="dialog-wait-ct">
                 { this.props.idle_message }
             </div>;
         }

--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -87,10 +87,10 @@ export function install_dialog(pkg, options) {
 
         if (progress_message)
             footer_message = (
-                <div>
-                    <div className="spinner spinner-sm" />
+                <>
                     <span>{ progress_message }</span>
-                </div>
+                    <div className="spinner spinner-sm" />
+                </>
             );
         else if (data && data.download_size) {
             footer_message = (

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -155,10 +155,14 @@ a.disabled:hover {
 
 .dialog-wait-ct {
     margin-top: 3px;
+    /* Right align footer idle messages after the buttons */
+    margin-left: auto;
 }
 
 .dialog-wait-ct .spinner {
     display: inline-block;
+    /* Add spacing betweem possible messages and the spinner */
+    margin-left: var(--pf-global--spacer--md);
 }
 
 .dialog-wait-ct span {

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -63,7 +63,7 @@ svg {
         flex-wrap: wrap;
         gap: var(--pf-global--spacer--sm);
 
-        div:not(.pf-c-button), .pf-c-alert {
+        > div:not(.pf-c-button):not(.dialog-wait-ct) {
             flex: 0 0 100%;
         }
     }

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -391,7 +391,8 @@ export const dialog_open = (def) => {
         return {
             idle_message: (running_promise
                 ? <>
-                    <div className="spinner spinner-sm" /><span>{running_title}</span>
+                    <span>{running_title}</span>
+                    <div className="spinner spinner-sm" />
                 </>
                 : null),
             extra_element: extra,


### PR DESCRIPTION
When an 'idle message' is presented show it in the same row with the
action buttons in the footer.

Before:

After: 
![Screen Shot 2020-10-27 at 10 47 05](https://user-images.githubusercontent.com/14921356/97284892-e478e080-1841-11eb-938e-72efc0920440.png)

Before:
![marius](https://user-images.githubusercontent.com/14921356/97285020-05413600-1842-11eb-961b-99886a3fdcd2.png)

