### PR TITLE
test: Introduce @no_retry_when_changed

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -27,16 +27,16 @@ os.environ['PYTHONUNBUFFERED'] = '1'
 class Test:
     process = None
     retries = 0
-    max_retries = 2
+    retry_when_affected = True
     output = b""
 
-    def __init__(self, test_id, command, timeout, nondestructive, max_retries):
+    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected):
         self.test_id = test_id
         self.command = command
         self.timeout = timeout
         self.nondestructive = nondestructive
         self.serial_machine = None
-        self.max_retries = max_retries
+        self.retry_when_affected = retry_when_affected
 
 
 def test_name(test):
@@ -88,7 +88,7 @@ def finish_test(opts, test, affected_tests):
     affected = test.command[0] in affected_tests
 
     # Try affected tests 3 times
-    if test.process.returncode == 0 and affected and test.retries < test.max_retries:
+    if test.process.returncode == 0 and affected and test.retry_when_affected:
         retry_reason = b"test affected tests 3 times"
         test.retries += 1
         test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
@@ -125,11 +125,11 @@ def finish_test(opts, test, affected_tests):
     elif affected: # Don't retry affected failed tests
         retry_reason = None
     else:
-        # HACK: many tests are unstable, always retry them 3 times, unless marked with @noretry
+        # HACK: many tests are unstable, always retry them 3 times
         retry_reason = b"be robust against unstable tests"
 
     unexpected_message = b"Test completed, but found unexpected" in test.output
-    if test.retries < test.max_retries and not unexpected_message and retry_reason:
+    if test.retries < 2 and not unexpected_message and retry_reason:
         test.retries += 1
         test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
         print_test(test, print_tap=opts.thorough)
@@ -240,8 +240,8 @@ def run(opts, image):
                 if test_str in opts.exclude:
                     continue
                 nd = getattr(test_method, "_testlib__non_destructive", False)
-                mr = getattr(test_method, "_testlib__max_retries", 2)
-                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, mr)
+                rwa = getattr(test_method, "_testlib__retry_when_affected", True)
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa)
                 if nd:
                     serial_tests.append(test)
                 else:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -52,7 +52,7 @@ __all__ = (
     'Browser',
     'MachineCase',
     'nondestructive',
-    'noretry',
+    'no_retry_when_changed',
     'skipImage',
     'skipBrowser',
     'skipPackage',
@@ -1444,19 +1444,21 @@ def nondestructive(testEntity):
     return testEntity
 
 
-def noretry(testEntity):
-    """Tests decorated with noretry will only run once
+def no_retry_when_changed(testEntity):
+    """Tests decorated with no_retry_when_changed will only run once if they've been changed
 
-    Can be used on test classes and individual methods.
+    Tests that have been changed are expected to succeed 3 times, if the test
+    takes a long time, this prevents timeouts. Can be used on test classes and
+    individual methods.
     """
 
     if inspect.isclass(testEntity) and issubclass(testEntity, unittest.TestCase):
         for test_function in inspect.getmembers(testEntity, is_test_function):
-            test_function[1]._testlib__max_retries = 0
+            test_function[1]._testlib__retry_when_affected = False
     elif is_test_function(testEntity):
-        testEntity._testlib__max_retries = 0
+        testEntity._testlib__retry_when_affected = False
     else:
-        raise Error("The noretry decorator can only be used on test classes and test methods")
+        raise Error("The no_retry_when_changed decorator can only be used on test classes and test methods")
     return testEntity
 
 

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -82,7 +82,7 @@ class DashBoardHelpers:
             self.machines[m].write("/home/admin/.ssh/authorized_keys", pubkey)
             self.machines[m].execute("chown admin:admin /home/admin/.ssh/authorized_keys")
 
-@noretry
+@no_retry_when_changed
 @skipBrowser("Firefox looses track of contexts", "firefox")
 class TestBasicDashboard(MachineCase, DashBoardHelpers):
     provision = {

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -96,7 +96,7 @@ class HostSwitcherHelpers:
         for m in self.machines:
             self.authorize_pubkey(self.machines[m], "admin", pubkey)
 
-@noretry
+@no_retry_when_changed
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
 class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     provision = {

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -68,7 +68,7 @@ def release_target(used_targets, target):
 # rmmod kvm-intel && modprobe kvm-intel || true
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
-@noretry
+@no_retry_when_changed
 class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
     created_pool = False
 

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -391,7 +391,7 @@ class CommonTests:
 
 @skipImage("No realmd available", "fedora-coreos")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
-@noretry
+@no_retry_when_changed
 class TestRealms(MachineCase):
     '''Common variables and tests for all supported domain backends'''
 
@@ -411,7 +411,7 @@ class TestRealms(MachineCase):
 
 @skipImage("freeipa not currently available", "debian-testing")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
-@noretry
+@no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()
@@ -605,7 +605,7 @@ ipa user-add-cert alice --certificate="%(cert)s"
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
-@noretry
+@no_retry_when_changed
 class TestAD(TestRealms, CommonTests):
     def setUp(self):
         super().setUp()
@@ -744,7 +744,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 @skipImage("No realmd available", "fedora-coreos")
 @skipImage("freeipa not currently available", "debian-testing")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg")
-@noretry
+@no_retry_when_changed
 class TestKerberos(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},


### PR DESCRIPTION
This partially reverts the work done in 47dc4d28 (#14680). The goal of
the decorator should have been to not run decorated affected tests 3
times to make sure they're stable.