### PR TITLE
machines: fix testAddDiskSCSI

### DIFF
--- a/pkg/machines/components/diskAdd.jsx
+++ b/pkg/machines/components/diskAdd.jsx
@@ -116,7 +116,7 @@ const PoolRow = ({ idPrefix, onValueChanged, storagePoolName, vmStoragePools }) 
                 {_("Pool")}
             </label>
             <Select.Select id={`${idPrefix}-select-pool`}
-                           enabled={vmStoragePools.length > 0}
+                           enabled={vmStoragePools.length > 0 && vmStoragePools.every(pool => pool.volumes !== undefined)}
                            onChange={value => onValueChanged('storagePoolName', value)}
                            initial={storagePoolName || _("No storage pools available")}
                            extraClass="form-control">

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -688,6 +688,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             if not self.use_existing_volume:
                 # Choose storage pool
                 if not self.pool_type or self.pool_type not in ['iscsi', 'iscsi-direct']:
+                    b.wait_present("#vm-{0}-disks-adddisk-new-select-pool:enabled".format(self.vm_name))
                     b.select_from_dropdown("#vm-{0}-disks-adddisk-new-select-pool".format(self.vm_name), self.pool_name)
                 else:
                     b.click("#vm-{0}-disks-adddisk-new-select-pool".format(self.vm_name))
@@ -707,6 +708,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 if self.permanent:
                     b.click("#vm-{0}-disks-adddisk-permanent".format(self.vm_name))
             else:
+                b.wait_present("#vm-{0}-disks-adddisk-existing-select-pool:enabled".format(self.vm_name))
                 # Choose storage pool
                 b.select_from_dropdown("#vm-{0}-disks-adddisk-existing-select-pool".format(self.vm_name), self.pool_name)
                 # Select from the available volumes


### PR DESCRIPTION
Allow the selection of storage pool only after all of the volumes of
storage pools are fetched. This prevents a race condition which causes a
flaky test.

<details>
  <summary>Example of such flaky test</summary>
  ```
# testAddDiskSCSI (__main__.TestMachines)
error: failed to connect to the hypervisor
error: Failed to connect socket to '/var/run/libvirt/libvirt-sock': No such file or directory
error: failed to connect to the hypervisor
error: Failed to connect socket to '/var/run/libvirt/libvirt-sock': No such file or directory
error: Failed to start network default
error: Requested operation is not valid: network is already active
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))

DevTools listening on ws://127.0.0.1:10003/devtools/browser/ab8373a8-b182-45be-ad84-c680f7cc9c39
[1027/140633.176825:ERROR:egl_util.cc(70)] Failed to load GLES library: /usr/lib64/chromium-browser/swiftshader/libGLESv2.so: /usr/lib64/chromium-browser/swiftshader/libGLESv2.so: cannot open shared object file: No such file or directory
[1027/140633.179002:ERROR:viz_main_impl.cc(150)] Exiting GPU process due to errors during initialization
CDP: {"source":"security","level":"error","text":"Refused to apply style from 'http://127.0.0.2:9091/cockpit/@localhost/shell/nav.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.","timestamp":1603807594645.566,"url":"http://127.0.0.2:9091/machines"}
> warning: initResource action failed: No such method 'ListInterfaces'
> warning: getAllInterfaces action failed: No such method 'ListInterfaces'
> warning: grep: /sys/class/dmi/id/power/autosuspend_delay_ms: Input/output error

> warning: initResource action failed: No such method 'ListInterfaces'
> warning: getAllInterfaces action failed: No such method 'ListInterfaces'
> warning: LIST_DOMAIN_SNAPSHOTS action failed for domain %s: %s /org/libvirt/QEMU/domain/_a80b24aa_3811_4d55_a512_e67f21873bbe {"problem":null,"name":"org.freedesktop.DBus.Error.UnknownMethod","message":"No such method 'ListDomainSnapshots'"}
iscsi-pool None
iscsi-pool unit:0:0:0
> error: 
> error: 
{"exceptionId":1,"text":"Uncaught","lineNumber":356,"columnNumber":370295,"url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","stackTrace":{"callFrames":[{"functionName":"_p","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":356,"columnNumber":370295},{"functionName":"Ga","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":57929},{"functionName":"Yo","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":66790},{"functionName":"_s","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":105387},{"functionName":"cl","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":96716},{"functionName":"sl","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":96641},{"functionName":"Zs","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":93671},{"functionName":"","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":45313},{"functionName":"t.unstable_runWithPriority","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":348,"columnNumber":3843},{"functionName":"Ui","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":45022},{"functionName":"qi","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":45258},{"functionName":"zi","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":45193},{"functionName":"","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":114459},{"functionName":"Y","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":114465},{"functionName":"F","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":2092},{"functionName":"B","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":2176},{"functionName":"Jt","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":23690},{"functionName":"Xt","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":22907},{"functionName":"t.unstable_runWithPriority","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":348,"columnNumber":3843},{"functionName":"Ui","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":45022},{"functionName":"j","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":114294},{"functionName":"$t","scriptId":"34","url":"http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js","lineNumber":340,"columnNumber":22723},{"functionName":"ph_set_val","scriptId":"3","url":"","lineNumber":52,"columnNumber":7},{"functionName":"","scriptId":"72","url":"","lineNumber":0,"columnNumber":0}]},"exception":{"type":"object","subtype":"error","className":"TypeError","description":"TypeError: Cannot read property 'find' of undefined\n    at _p (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:357:370296)\n    at Ga (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:57930)\n    at Yo (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:66791)\n    at _s (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:105388)\n    at cl (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:96717)\n    at sl (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:96642)\n    at Zs (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:93672)\n    at http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:45314\n    at t.unstable_runWithPriority (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:349:3844)\n    at Ui (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:45023)","objectId":"{\"injectedScriptId\":8,\"id\":3}","preview":{"type":"object","subtype":"error","description":"TypeError: Cannot read property 'find' of undefined\n    at _p (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:357:370296)\n    at Ga (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:57930)\n    at Yo (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:66791)\n    at _s (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:105388)\n    at cl (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:96717)\n    at sl (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:96642)\n    at Zs (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:93672)\n    at http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:45314\n    at t.unstable_runWithPriority (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:349:3844)\n    at Ui (http://127.0.0.2:9091/cockpit/@localhost/machines/machines.js:341:45023)","overflow":false,"properties":[{"name":"stack","type":"string","value":"TypeError: Cannot read property 'find' of undefineockpit/@localhost/machines/machines.js:341:45023)"},{"name":"message","type":"string","value":"Cannot read property 'find' of undefined"}]}},"executionContextId":8}
Traceback (most recent call last):
  File "/usr/lib64/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "test/verify/check-machines", line 832, in testAddDiskSCSI
    self.VMAddDiskDialog(
  File "test/verify/check-machines", line 670, in execute
    self.fill()
  File "test/verify/check-machines", line 711, in fill
    b.select_from_dropdown("#vm-{0}-disks-adddisk-existing-select-pool".format(self.vm_name), self.pool_name)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 312, in select_from_dropdown
    self.set_val(selector, value_id)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 227, in set_val
    self.call_js_func('ph_set_val', selector, val)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 197, in call_js_func
    return self.eval_js("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 180, in eval_js
    result = self.cdp.invoke("Runtime.evaluate", expression=code, trace=code,
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 109, in invoke
    res = self.command(cmd)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 136, in command
    raise RuntimeError(res["error"])
RuntimeError: TypeError: Cannot read property 'find' of undefined
Wrote screenshot to TestMachines-testAddDiskSCSI-centos-8-stream-127.0.0.2-2201-FAIL.png
Wrote HTML dump to TestMachines-testAddDiskSCSI-centos-8-stream-127.0.0.2-2201-FAIL.html
Wrote JS log to TestMachines-testAddDiskSCSI-centos-8-stream-127.0.0.2-2201-FAIL.js.log
Journal extracted to TestMachines-testAddDiskSCSI-centos-8-stream-127.0.0.2-2201-FAIL.log.gz
error: Failed to delete pool iscsi-pool
error: this function is not supported by the connection driver: pool does not support pool deletion
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))
/usr/lib/python3.6/site-packages/rtslib_fb/root.py:175: UserWarning: Cannot set dbroot to /var/target. Target drivers have already been registered.
  .format(self._default_dbroot))
> warning: LIST_DOMAIN_SNAPSHOTS action failed for domain %s: %s /org/libvirt/QEMU/domain/_a80b24aa_3811_4d55_a512_e67f21873bbe {"problem":null,"name":"org.freedesktop.DBus.Error.UnknownMethod","message":"No such method 'ListDomainSnapshots'"}
> warning: loading available updates failed: {"detail":"cannot update repo 'appstream': Cannot prepare internal mirrorlist: Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=genclo [Could not resolve host: mirrorlist.centos.org]; Last error: Curl error (6): Couldn't resolve host name for http://mirrorlist.centos.org/?release=8-stream&arch=x86_64&repo=AppStream&infra=genclo [Could not resolve host: mirrorlist.centos.org]","code":64}
> warning: transport closed: disconnected
Traceback (most recent call last):
  File "test/verify/check-machines", line 832, in testAddDiskSCSI
    self.VMAddDiskDialog(
  File "test/verify/check-machines", line 670, in execute
    self.fill()
  File "test/verify/check-machines", line 711, in fill
    b.select_from_dropdown("#vm-{0}-disks-adddisk-existing-select-pool".format(self.vm_name), self.pool_name)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 312, in select_from_dropdown
    self.set_val(selector, value_id)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 227, in set_val
    self.call_js_func('ph_set_val', selector, val)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 197, in call_js_func
    return self.eval_js("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 180, in eval_js
    result = self.cdp.invoke("Runtime.evaluate", expression=code, trace=code,
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 109, in invoke
    res = self.command(cmd)
  File "/home/user/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 136, in command
    raise RuntimeError(res["error"])
RuntimeError: TypeError: Cannot read property 'find' of undefined

# Result testAddDiskSCSI (__main__.TestMachines) failed
# 1 TEST FAILED [54s on 2-ci-srv-03]
not ok 240 test/verify/check-machines TestMachines.testAddDiskSCSI [ND]
```
</details>