### PR TITLE
machines: avoid crash because of vm.metadata being undefined on deleted VM

### DIFF
--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -51,7 +51,7 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
 
     const id = vmId(vm.name);
     const state = vm.state;
-    const hasInstallPhase = vm.metadata.hasInstallPhase;
+    const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
     const dropdownItems = [];
 
     const onStart = () => dispatch(startVm(vm)).catch(ex => {

--- a/pkg/machines/components/vmOverviewTabLibvirt.jsx
+++ b/pkg/machines/components/vmOverviewTabLibvirt.jsx
@@ -199,7 +199,7 @@ class VmOverviewTabLibvirt extends React.Component {
         let firmwareLinkWrapper;
         // <os firmware=[bios/efi]' settings is available only for libvirt version >= 5.2. Before that version it silently ignores this attribute in the XML
         if (this.state.loaderElems && libvirtVersion >= 5002000) {
-            const hasInstallPhase = vm.metadata.hasInstallPhase;
+            const hasInstallPhase = vm.metadata && vm.metadata.hasInstallPhase;
             const labelForFirmware = labelForFirmwarePath(vm.loader, vm.arch);
             let currentFirmware;
             if (vm.firmware == "efi" || labelForFirmware == "efi")


### PR DESCRIPTION
should solve this issue: https://logs.cockpit-project.org/logs/pull-14819-20201027-163530-f61a5b97-rhel-8-3-distropkg/log.html#284