### PR TITLE
workflows: Fix po-refresh

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -23,6 +23,9 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
 
       - name: Run po-refresh bot
         run: |


### PR DESCRIPTION
We need this to fetch tags and history, as it builds the project.