### PR TITLE
workflows: Fix po-refresh harder

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -8,10 +8,14 @@ on:
   workflow_dispatch:
 jobs:
   po-refresh:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
-        run: sudo apt-get install -y --no-install-recommends npm make gettext
+        run: |
+          sudo apt-get install -y --no-install-recommends npm make gettext pkg-config \
+              libpolkit-agent-1-dev libpolkit-gobject-1-dev libsystemd-dev libjson-glib-dev \
+              libgnutls28-dev libkrb5-dev libssh-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev \
+              xsltproc xmlto
 
       - name: Set up configuration and secrets
         run: |


### PR DESCRIPTION
This does a full package build at the moment, and thus requires build
dependencies.

Move to Ubuntu 20.04, as 18.04's libssh is too old.

----

My previous PR #14824 was not sufficient, it [failed on missing build deps](https://github.com/cockpit-project/cockpit/runs/1319197992?check_suite_focus=true). Now I properly tested this [on my repo](https://github.com/martinpitt/cockpit/runs/1319861003?check_suite_focus=true), with missing credentials -- so the actual po-refresh went alright, and it just (expectedly) failed to push it to the weblate git repo.