### PR TITLE
shell: Implement navigation and host switching in more sensible way

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -580,28 +580,6 @@ function Index() {
         $(self).triggerHandler("disconnect", watchdog_problem);
     });
 
-    /* Handle navigation */
-    $(document).on("click", ".nav-item", function(ev) {
-        if (ev.target.nodeName === "BUTTON") // Buttons in navigation have their own handlers
-            return;
-
-        let target_class = ev.target.className;
-        if (typeof target_class !== "string")
-            target_class = "";
-
-        if (target_class.indexOf("event-eater") > -1) // Special case for stopping propagation on disabled buttons
-            return;
-
-        let a = this;
-        if (ev.target.nodeName !== "A")
-            a = this.querySelector("a");
-
-        if (!a.host || window.location.host === a.host) {
-            self.jump(a.getAttribute('href'));
-            ev.preventDefault();
-        }
-    });
-
     /* Handles an href link as seen below */
     $(document).on("click", "a[href]", function(ev) {
         var a = this;

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -113,6 +113,7 @@ export class CockpitHosts extends React.Component {
     }
 
     onHostEdit(event, machine) {
+        event.preventDefault();
         const dlg = $("#edit-host-dialog");
 
         const can_change_user = machine.address != "localhost";
@@ -205,6 +206,7 @@ export class CockpitHosts extends React.Component {
                 header={(m.user ? m.user : this.state.current_user) + " @"}
                 status={m.state === "failed" ? { type: "error", title: _("Connection error") } : null}
                 className={m.state}
+                jump={this.props.jump}
                 actions={[
                     <Button isDisabled={m.address === "localhost"} className="nav-action" hidden={!editing} onClick={e => this.onHostEdit(e, m)} key={m.label + "edit"} variant="secondary"><EditIcon /></Button>,
                     <Button isDisabled={m.address === "localhost"} onClick={e => this.onRemove(e, m)} className="nav-action" hidden={!editing} key={m.label + "remove"} variant="danger"><MinusIcon /></Button>

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -328,6 +328,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 keyword: component.keyword.keyword,
                 term: term,
                 to: index.href({ host: machine.address, component: path, hash: hash }),
+                jump: index.jump,
             });
         }
 
@@ -355,6 +356,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 filtering: keyword_filter,
                 sorting: (a, b) => { return b.keyword.score - a.keyword.score },
                 current: state.component,
+                jump: index.jump,
             }),
             document.getElementById("host-apps"));
 

--- a/pkg/shell/nav.jsx
+++ b/pkg/shell/nav.jsx
@@ -114,7 +114,10 @@ export class CockpitNav extends React.Component {
                             <div className="nav-group-heading">
                                 <h2 className="pf-c-nav__section-title" id={"section-title-" + g.name}>{g.name}</h2>
                                 { g.action &&
-                                    <a className="pf-c-nav__section-title nav-item" href={g.action.path}>{g.action.label}</a>
+                                    <a className="pf-c-nav__section-title nav-item" href={g.action.path} onClick={ ev => {
+                                        this.props.jump(g.action.path);
+                                        ev.preventDefault();
+                                    }}>{g.action.label}</a>
                                 }
                             </div>
                             <ul className="pf-c-nav__list">
@@ -137,6 +140,7 @@ CockpitNav.propTypes = {
     current: PropTypes.string.isRequired,
     filtering: PropTypes.func.isRequired,
     sorting: PropTypes.func.isRequired,
+    jump: PropTypes.func.isRequired,
 };
 
 function PageStatus({ status, name }) {
@@ -177,33 +181,24 @@ export function CockpitNavItem(props) {
     if (props.header)
         header_matches = props.keyword === props.header.toLowerCase();
 
-    // Buttons when disabled don't get any events, but the events go to their parents
-    // This is problematic when there are disabled buttons over elements that have event listeners
-    // In our case it is navigation item with possible actions (like editing of host)
-    function event_eater(ev) {
-        if (ev) {
-            ev.stopPropagation();
-            ev.preventDefault();
-        }
-    }
-
     const classes = props.className ? [props.className] : [];
     classes.push("pf-c-nav__item", "nav-item");
 
     return (
         <li className={classes.join(" ")}>
             <span className={"pf-c-nav__link" + (props.active ? " pf-m-current" : "")} data-for={props.to}>
-                <a href={props.to}>
+                <a href={props.to} onClick={ev => {
+                    props.jump(props.to);
+                    ev.preventDefault();
+                }}>
                     { props.header && <span className="hint">{header_matches ? <FormattedText keyword={props.header} term={props.term} /> : props.header}</span> }
                     { name_matches ? <FormattedText keyword={props.name} term={props.term} /> : props.name }
                     { !name_matches && !header_matches && props.keyword && <span className="hint">{_("Contains:")} <FormattedText keyword={props.keyword} term={props.term} /></span> }
                 </a>
                 {s && s.type && <PageStatus status={s} name={props.name} />}
-                { props.actions &&
-                    <div role="presentation" className="nav-host-action-buttons event-eater" onClick={event_eater} onKeyPress={event_eater}>
-                        {props.actions}
-                    </div>
-                }
+                <div role="presentation" className="nav-host-action-buttons">
+                    {props.actions}
+                </div>
             </span>
         </li>
     );
@@ -212,6 +207,7 @@ export function CockpitNavItem(props) {
 CockpitNavItem.propTypes = {
     name: PropTypes.string.isRequired,
     to: PropTypes.string.isRequired,
+    jump: PropTypes.func.isRequired,
     status: PropTypes.object,
     active: PropTypes.bool,
     keyword: PropTypes.string,


### PR DESCRIPTION
There was this weird event listener in `pkg/shell/base_index.js` that
was listening on events from react components created in a completely
different place. It was very hard for other maintainers to find where
this is being handled.

Also this function had a bunch of hacks like ignoring `button`s clicks
or we had to have `event-eater` hack.

Also it was not working ideally as the hack with `button` did not work
out as expected when we clicked on the icon in that button.

This patch just does it "the right way" where we handle events on
appropriate elements when we create them. This does not need any of
those hacks and works more reliably not mentioning it is much better
readable.

Seems to work nicely for me, lets see if tests see some place I forgot to check out.