### PR TITLE
Example of plotting with Patternfly Charts 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "@patternfly/react-console": "2.0.16",
     "@patternfly/react-core": "4.75.2",
     "@patternfly/react-table": "4.19.5",
+    "@patternfly/react-charts": "",
+    "@patternfly/react-styles": "",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "@novnc/novnc": "1.1.0",
     "bootstrap": "3.4.1",

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -68,3 +68,9 @@ svg {
         }
     }
 }
+
+// Override chart numbers to be monospaced, as RedHatText does not have tabular numbers
+// Issue: https://github.com/RedHatOfficial/RedHatFont/issues/27
+.pf-c-chart text[id*=axis] {
+    --pf-chart-global--FontFamily: var(--pf-global--FontFamily--monospace);
+}

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -462,6 +462,8 @@ class Metrics_stacked_instances_series extends Metrics_series {
 
 export class Plot {
     constructor(element, x_range_seconds, x_stop_seconds) {
+        cockpit.event_target(this);
+
         this.element = element;
         this.options = { };
 
@@ -479,19 +481,23 @@ export class Plot {
         this.cur_hover_series = null;
         this.cur_hover_val = false;
 
-        $(this.element).on('plothover', null, this, this.hover_on);
-        $(this.element).on('mouseleave', null, this, this.hover_off);
-        $(this.element).on('plotselecting', null, this, this.selecting);
-        $(this.element).on('plotselected', null, this, this.selected);
+        if (this.element) {
+            $(this.element).on('plothover', null, this, this.hover_on);
+            $(this.element).on('mouseleave', null, this, this.hover_off);
+            $(this.element).on('plotselecting', null, this, this.selecting);
+            $(this.element).on('plotselected', null, this, this.selected);
 
-        // for testing
-        $(this.element).data('flot_data', this.flot_data);
+            // for testing
+            $(this.element).data('flot_data', this.flot_data);
+        }
 
         this.reset(x_range_seconds, x_stop_seconds);
     }
 
     refresh_now() {
-        if (this.element.height() === 0 || this.element.width() === 0)
+        this.dispatchEvent("plot", this.flot_data);
+
+        if (this.element == null || this.element.height() === 0 || this.element.width() === 0)
             return;
 
         if (this.flot === null)
@@ -598,12 +604,14 @@ export class Plot {
         this.series = [];
         this.flot_data = [];
         this.flot = null;
-        $(this.element).empty();
-        $(this.element).data('flot_data', null);
+        if (this.element) {
+            $(this.element).empty();
+            $(this.element).data('flot_data', null);
+        }
     }
 
     resize() {
-        if (this.element.height() === 0 || this.element.width() === 0)
+        if (this.element == null || this.element.height() === 0 || this.element.width() === 0)
             return;
         if (this.flot)
             this.flot.resize();

--- a/pkg/playground/manifest.json.in
+++ b/pkg/playground/manifest.json.in
@@ -39,6 +39,9 @@
         "plot": {
             "label": "Plots"
         },
+        "plot-pf4": {
+            "label": "Plots using PF4 graphs"
+        },
         "service": {
             "label": "Generic Service Monitor"
         },

--- a/pkg/playground/plot-pf4.html
+++ b/pkg/playground/plot-pf4.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Cockpit Plots using PF4</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="plot-pf4.css" type="text/css" rel="stylesheet">
+    <script src="../base1/jquery.js"></script>
+    <script src="../base1/cockpit.js"></script>
+    <script src="plot-pf4.js"></script>
+</head>
+<body class="pf-m-redhat-font">
+  <div class="container-fluid">
+    <div id="plots"></div>
+  </div>
+</body>
+</html>

--- a/pkg/playground/plot-pf4.js
+++ b/pkg/playground/plot-pf4.js
@@ -1,0 +1,531 @@
+import '@patternfly/patternfly/patternfly-charts.css';
+import '../lib/patternfly/patternfly-cockpit.scss';
+import './plot-pf4.css';
+
+import React, { useState, useRef } from 'react';
+import ReactDOM from "react-dom";
+import {
+    Chart, ChartArea, ChartAxis, ChartStack
+} from '@patternfly/react-charts';
+import { VictorySelectionContainer } from "victory-selection-container";
+
+import {
+    Button,
+    Dropdown,
+    DropdownToggle,
+    DropdownItem,
+    DropdownSeparator,
+    Page,
+    Card,
+    CardBody,
+    Split,
+    SplitItem,
+    Grid,
+    GridItem
+} from '@patternfly/react-core';
+
+import * as plot from "plot.js";
+import { useObject, useEvent } from "hooks.js";
+
+import cockpit from "cockpit";
+import moment from "moment";
+
+import "../lib/patternfly/patternfly-4-overrides.scss";
+
+const _ = cockpit.gettext;
+
+moment.locale(cockpit.language);
+
+function time_ticks(data) {
+    const start_ms = data[0][0].x;
+    const end_ms = data[0][data[0].length - 1].x;
+
+    // Determine size between ticks
+
+    const sizes_in_seconds = [
+        60, // minute
+        5 * 60, // 5 minutes
+        10 * 60, // 10 minutes
+        30 * 60, // half hour
+        60 * 60, // hour
+        6 * 60 * 60, // quarter day
+        12 * 60 * 60, // half day
+        24 * 60 * 60, // day
+        7 * 24 * 60 * 60, // week
+        30 * 24 * 60 * 60, // month
+        183 * 24 * 60 * 60, // half a year
+        365 * 24 * 60 * 60, // year
+        10 * 365 * 24 * 60 * 60 // 10 years
+    ];
+
+    let size;
+    for (let i = 0; i < sizes_in_seconds.length; i++) {
+        if (((end_ms - start_ms) / 1000) / sizes_in_seconds[i] < 10 || i == sizes_in_seconds.length - 1) {
+            size = sizes_in_seconds[i] * 1000;
+            break;
+        }
+    }
+
+    // Determine what to omit from the tick label.  If it's all in the
+    // current year, we don't need to include the year, for example.
+
+    var n = new Date();
+    var l = new Date(start_ms);
+
+    const year_index = 0;
+    const month_index = 1;
+    const day_index = 2;
+    const hour_minute_index = 3;
+
+    let format_begin;
+    const format_end = hour_minute_index;
+
+    format_begin = year_index;
+    if (l.getFullYear() == n.getFullYear()) {
+        format_begin = month_index;
+        if (l.getMonth() == n.getMonth()) {
+            format_begin = day_index;
+            if (l.getDate() == n.getDate())
+                format_begin = hour_minute_index;
+        }
+    }
+
+    if (format_begin == day_index)
+        format_begin = month_index;
+
+    // Compute the actual ticks
+
+    const ticks = [];
+    let t = Math.ceil(start_ms / size) * size;
+    while (t < end_ms) {
+        ticks.push(t);
+        t += size;
+    }
+
+    // Render the label
+
+    function pad(n) {
+        var str = n.toFixed();
+        if (str.length == 1)
+            str = '0' + str;
+        return str;
+    }
+
+    function format_tick(val, index, ticks) {
+        var d = new Date(val);
+        var label = ' ';
+
+        if (year_index >= format_begin && year_index <= format_end)
+            label += d.getFullYear().toFixed() + ' ';
+        if (month_index >= format_begin && month_index <= format_end)
+            label += moment(d).format('MMM') + ' ';
+        if (day_index >= format_begin && day_index <= format_end)
+            label += d.getDate().toFixed() + '\n';
+        if (hour_minute_index >= format_begin && hour_minute_index <= format_end)
+            label += pad(d.getHours()) + ':' + pad(d.getMinutes()) + ' ';
+
+        return label.substr(0, label.length - 1);
+    }
+
+    return {
+        ticks: ticks,
+        formatter: format_tick
+    };
+}
+
+function value_ticks(data) {
+    let max = 4 * 1024;
+    for (let i = 0; i < data[0].length; i++) {
+        let s = 0;
+        for (let j = 0; j < data.length; j++)
+            s += data[j][i].y;
+        if (s > max)
+            max = s;
+    }
+
+    // Pick a unit
+    let unit = 1;
+    while (max > unit * 1024)
+        unit *= 1024;
+
+    // Find the highest power of 10 that is below max.  If we use that
+    // as the distance between ticks, we get at most 10 ticks.
+    var size = Math.pow(10, Math.floor(Math.log10(max / unit))) * unit;
+
+    // Get the number of ticks to be around 4, but don't produce
+    // fractional numbers.
+    while (max / size > 7)
+        size *= 2;
+    while (max / size < 3 && size / unit >= 10)
+        size /= 2;
+
+    var ticks = [];
+    for (let t = 0; t <= max; t += size)
+        ticks.push(t);
+
+    const unit_str = cockpit.format_bytes_per_sec(unit, 1024, true)[1];
+
+    return {
+        ticks: ticks,
+        formatter: (val) => cockpit.format_bytes_per_sec(val, unit_str, true)[0],
+        unit: unit_str
+    };
+}
+
+class ZoomState {
+    constructor(plots) {
+        cockpit.event_target(this);
+        this.x_range = 5 * 60;
+        this.x_stop = undefined;
+        this.history = [];
+        this.plots = plots;
+
+        this.enable_zoom_in = false;
+        this.enable_zoom_out = true;
+        this.enable_scroll_left = true;
+        this.enable_scroll_right = false;
+    }
+
+    reset() {
+        const plot_min_x_range = 5 * 60;
+
+        if (this.x_range < plot_min_x_range) {
+            this.x_stop += (plot_min_x_range - this.x_range) / 2;
+            this.x_range = plot_min_x_range;
+        }
+        if (this.x_stop >= (new Date()).getTime() / 1000 - 10)
+            this.x_stop = undefined;
+
+        this.plots.forEach(p => {
+            p.stop_walking();
+            p.reset(this.x_range, this.x_stop);
+            p.refresh();
+            if (this.x_stop === undefined)
+                p.start_walking();
+        });
+
+        this.enable_zoom_in = (this.x_range > plot_min_x_range);
+        this.enable_scroll_right = (this.x_stop !== undefined);
+
+        this.dispatchEvent("changed");
+    }
+
+    set_range(x_range) {
+        this.history = [];
+        this.x_range = x_range;
+        this.reset();
+    }
+
+    zoom_in(x_range, x_stop) {
+        this.history.push(this.x_range);
+        this.x_range = x_range;
+        this.x_stop = x_stop;
+        this.reset();
+    }
+
+    zoom_out() {
+        const plot_zoom_steps = [
+            5 * 60,
+            60 * 60,
+            6 * 60 * 60,
+            24 * 60 * 60,
+            7 * 24 * 60 * 60,
+            30 * 24 * 60 * 60,
+            365 * 24 * 60 * 60
+        ];
+
+        var r = this.history.pop();
+        if (r === undefined) {
+            var i;
+            for (i = 0; i < plot_zoom_steps.length - 1; i++) {
+                if (plot_zoom_steps[i] > this.x_range)
+                    break;
+            }
+            r = plot_zoom_steps[i];
+        }
+        if (this.x_stop !== undefined)
+            this.x_stop += (r - this.x_range) / 2;
+        this.x_range = r;
+        this.reset();
+    }
+
+    goto_now() {
+        this.x_stop = undefined;
+        this.reset();
+    }
+
+    scroll_left() {
+        var step = this.x_range / 10;
+        if (this.x_stop === undefined)
+            this.x_stop = (new Date()).getTime() / 1000;
+        this.x_stop -= step;
+        this.reset();
+    }
+
+    scroll_right() {
+        var step = this.x_range / 10;
+        if (this.x_stop !== undefined) {
+            this.x_stop += step;
+            this.reset();
+        }
+    }
+}
+
+const ZoomControls = ({ zoom_state }) => {
+    function format_range(seconds) {
+        var n;
+        if (seconds >= 365 * 24 * 60 * 60) {
+            n = Math.ceil(seconds / (365 * 24 * 60 * 60));
+            return cockpit.format(cockpit.ngettext("$0 year", "$0 years", n), n);
+        } else if (seconds >= 30 * 24 * 60 * 60) {
+            n = Math.ceil(seconds / (30 * 24 * 60 * 60));
+            return cockpit.format(cockpit.ngettext("$0 month", "$0 months", n), n);
+        } else if (seconds >= 7 * 24 * 60 * 60) {
+            n = Math.ceil(seconds / (7 * 24 * 60 * 60));
+            return cockpit.format(cockpit.ngettext("$0 week", "$0 weeks", n), n);
+        } else if (seconds >= 24 * 60 * 60) {
+            n = Math.ceil(seconds / (24 * 60 * 60));
+            return cockpit.format(cockpit.ngettext("$0 day", "$0 days", n), n);
+        } else if (seconds >= 60 * 60) {
+            n = Math.ceil(seconds / (60 * 60));
+            return cockpit.format(cockpit.ngettext("$0 hour", "$0 hours", n), n);
+        } else {
+            n = Math.ceil(seconds / 60);
+            return cockpit.format(cockpit.ngettext("$0 minute", "$0 minutes", n), n);
+        }
+    }
+
+    const [isOpen, setIsOpen] = useState(false);
+    useEvent(zoom_state, "changed");
+
+    function range_item(seconds, title) {
+        return (
+            <DropdownItem key={title}
+                          onClick={() => {
+                              setIsOpen(false);
+                              zoom_state.set_range(seconds);
+                          }}>
+                {title}
+            </DropdownItem>);
+    }
+
+    return (
+        <div>
+            <Dropdown
+                isOpen={isOpen}
+                toggle={<DropdownToggle onToggle={setIsOpen}>{format_range(zoom_state.x_range)}</DropdownToggle>}
+                dropdownItems={[
+                    <DropdownItem key="now" onClick={() => { zoom_state.goto_now(); setIsOpen(false) }}>
+                        {_("Go to now")}
+                    </DropdownItem>,
+                    <DropdownSeparator key="sep" />,
+                    range_item(5 * 60, _("5 minutes")),
+                    range_item(60 * 60, _("1 hour")),
+                    range_item(6 * 60 * 60, _("6 hours")),
+                    range_item(24 * 60 * 60, _("1 day")),
+                    range_item(7 * 24 * 60 * 60, _("1 week"))
+                ]} />
+            { "\n" }
+            <Button variant="secondary" onClick={() => zoom_state.zoom_out()}
+                    isDisabled={!zoom_state.enable_zoom_out}>
+                <span className="glyphicon glyphicon-zoom-out" />
+            </Button>
+            { "\n" }
+            <Button variant="secondary" onClick={() => zoom_state.scroll_left()}
+                    isDisabled={!zoom_state.enable_scroll_left}>
+                <span className="fa fa-angle-left" />
+            </Button>
+            <Button variant="secondary" onClick={() => zoom_state.scroll_right()}
+                    isDisabled={!zoom_state.enable_scroll_right}>
+                <span className="fa fa-angle-right" />
+            </Button>
+        </div>
+    );
+};
+
+const StoragePlot = ({ title, plot, zoom_state, onHover }) => {
+    const container_ref = useRef(null);
+    useEvent(plot, "plot");
+    useEvent(zoom_state, "changed");
+    useEvent(window, "resize");
+
+    function conv(arr) {
+        return { x: arr[0], y: arr[1] ? arr[1] - arr[2] : null };
+    }
+
+    const chart_data = plot.flot_data.map(data => data.data.map(conv));
+    const t_ticks = time_ticks(chart_data);
+    const y_ticks = value_ticks(chart_data);
+
+    let chart = null;
+    if (container_ref.current && chart_data.length > 0) {
+        chart = (
+            <>
+                <Chart containerComponent={<VictorySelectionContainer responsive={false}
+                                                                      allowSelection={zoom_state.enable_zoom_in}
+                                                                      selectionDimension="x"
+                                                                      onSelection={(a, b, c) => {
+                                                                          zoom_state.zoom_in((b.x[1] - b.x[0]) / 1000,
+                                                                                             b.x[1] / 1000);
+                                                                      }} />}
+                       width={container_ref.current.offsetWidth} height={container_ref.current.offsetHeight}
+                       padding={{ top: 14, bottom: 50, left: 50, right: 4 }}>
+                    <ChartAxis tickValues={t_ticks.ticks} tickFormat={t_ticks.formatter} />
+                    <ChartAxis dependentAxis showGrid
+                               tickValues={y_ticks.ticks} tickFormat={y_ticks.formatter} />
+                    <ChartStack>
+                        { chart_data.map((d, i) => <ChartArea key={i} data={d}
+                                                              interpolation="monotoneX"
+                                                              events={[
+                                                                  {
+                                                                      target: "data",
+                                                                      eventHandlers: {
+                                                                          onMouseOver: () => {
+                                                                              onHover(i);
+                                                                          },
+                                                                          onMouseOut: () => {
+                                                                              onHover(-1);
+                                                                          }
+                                                                      }
+                                                                  }
+                                                              ]} />)
+                        }
+                    </ChartStack>
+                </Chart>
+            </>);
+    }
+
+    return (
+        <div>
+            <div>
+                <span className="plot-unit">{y_ticks.unit}</span>
+                <span className="plot-title">{title}</span>
+            </div>
+            <div className="storage-graph" ref={container_ref}>
+                {chart}
+            </div>
+        </div>);
+};
+
+class PlotState {
+    constructor() {
+        this.plot = new plot.Plot(null, 300);
+        this.plot.start_walking();
+    }
+
+    plot_single(metric) {
+        if (this.stacked_instances_series) {
+            this.stacked_instances_series.clear_instances();
+            this.stacked_instances_series.remove();
+            this.stacked_instances_series = null;
+        }
+        if (!this.sum_series) {
+            this.sum_series = this.plot.add_metrics_sum_series(metric, { });
+        }
+    }
+
+    plot_instances(metric, insts) {
+        if (this.sum_series) {
+            this.sum_series.remove();
+            this.sum_series = null;
+        }
+        if (!this.stacked_instances_series) {
+            this.stacked_instances_series = this.plot.add_metrics_stacked_instances_series(metric, { });
+        }
+        // XXX - Add all instances, but don't remove anything.
+        //
+        // This doesn't remove old instances, but that is mostly
+        // harmless since if the block device doesn't exist anymore, we
+        // don't get samples for it.  But it would be better to be precise here.
+        for (var i = 0; i < insts.length; i++) {
+            this.stacked_instances_series.add_instance(insts[i]);
+        }
+    }
+
+    destroy() {
+        this.plot.destroy();
+    }
+}
+
+const instances_read_metric = {
+    direct: "disk.dev.read_bytes",
+    internal: "block.device.read",
+    units: "bytes",
+    derive: "rate",
+    threshold: 1000
+};
+
+const instances_write_metric = {
+    direct: "disk.dev.write_bytes",
+    internal: "block.device.written",
+    units: "bytes",
+    derive: "rate",
+    threshold: 1000
+};
+
+const single_read_metric = {
+    direct: ["disk.all.read_bytes"],
+    internal: ["disk.all.read"],
+    units: "bytes",
+    derive: "rate",
+    threshold: 1000
+};
+
+const single_write_metric = {
+    direct: ["disk.all.write_bytes"],
+    internal: ["disk.all.written"],
+    units: "bytes",
+    derive: "rate",
+    threshold: 1000
+};
+
+const StoragePlots = () => {
+    const devs = ["vda", "sda", "sdb"];
+
+    const ps1 = useObject(() => new PlotState(), ps => ps.destroy(), []);
+    const ps2 = useObject(() => new PlotState(), ps => ps.destroy(), []);
+    const zs = useObject(() => new ZoomState([ps1.plot, ps2.plot]), () => null, []);
+
+    if (devs.length > 10) {
+        ps1.plot_single(single_read_metric);
+        ps2.plot_single(single_write_metric);
+    } else {
+        ps1.plot_instances(instances_read_metric, devs);
+        ps2.plot_instances(instances_write_metric, devs);
+    }
+
+    const [hovered, setHovered] = useState(null);
+
+    return (
+        <>
+            <Split>
+                <SplitItem isFilled />
+                <SplitItem><ZoomControls zoom_state={zs} /></SplitItem>
+            </Split>
+            <Grid sm={12} md={6} lg={6} hasGutter>
+                <GridItem>
+                    <StoragePlot title="Reading" plot={ps1.plot} zoom_state={zs} onHover={idx => setHovered(devs[idx])} />
+                </GridItem>
+                <GridItem>
+                    <StoragePlot title="Writing" plot={ps2.plot} zoom_state={zs} onHover={idx => setHovered(devs[idx])} />
+                </GridItem>
+
+            </Grid>
+            <div>{(hovered && devs.length <= 10) ? hovered : "--"}</div>
+        </>);
+};
+
+const MyPage = () => {
+    return (
+        <Page>
+            <Card>
+                <CardBody>
+                    <StoragePlots />
+                </CardBody>
+            </Card>
+        </Page>);
+};
+
+document.addEventListener("DOMContentLoaded", function() {
+    ReactDOM.render(<MyPage />, document.getElementById('plots'));
+});

--- a/pkg/storaged/plot.jsx
+++ b/pkg/storaged/plot.jsx
@@ -208,8 +208,9 @@ class StoragePlot extends React.Component {
                     self.stacked_instances_series = self.plot.add_metrics_stacked_instances_series(self.props.data, { });
                     $(self.stacked_instances_series).on('hover', hover);
                 }
-                for (var i = 0; i < self.props.devs.length; i++)
+                for (var i = 0; i < self.props.devs.length; i++) {
                     self.stacked_instances_series.add_instance(self.props.devs[i]);
+                }
             }
         }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -63,6 +63,9 @@ var info = {
         "playground/plot": [
             "playground/plot.js",
         ],
+        "playground/plot-pf4": [
+            "playground/plot-pf4.js"
+        ],
         "playground/react-patterns": [
             "playground/react-patterns",
         ],
@@ -192,6 +195,7 @@ var info = {
         "playground/metrics.html",
         "playground/pkgs.html",
         "playground/plot.html",
+        "playground/plot-pf4.html",
         "playground/react-patterns.html",
         "playground/service.html",
         "playground/speed.html",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3228183/97869445-2ad6af80-1d1a-11eb-9de6-72429f595881.png)

#### Notes

- This works and looks great, but takes significantly more CPU than flot, I think.

- This re-uses a lot of lib/plot.js to produce the actual numbers. I think we should keep doing that.

- With the current approach, we need to convert from the flot style data layout to the ChartArea style layout for each render. That can go away once we drop flot totally, of course, and let lib/plot.js produce data in the right format directly.

- Stacking graphs also works, but I haven't done a full instance plot yet.

- We need to compute all tick values explicitly (instead of letting ChartAxis choose them), but that's okay.  It's not hard and we need that level of control anyway.  The example does only minute ticks, but it should be straighforward to generalize this to our usual day, month and year ticks.

- By default, a Chart is "responsive" which means that it automatically scales with its parent DOM element. But this will scale the text labels and can't change the aspect ratio. So we need to take full control over the layout of the plot, like we did with flot.  This probably leads to some flicker while resizing, but I'd rather have some temporary ugliness during resize than permanent ugliness afterwards.

- Performance is unacceptable. :-( The Victory library doesn't seem to like large datasets, and spends unacceptable amounts of time prawling through them, sorting and converting, etc.  By large I mean 3 times 300 points in a stacked graph. We don't use any of the clever features of Victory, so all that processing is wasted for us.

- Options: d3.js, SVG, canvas, or just keep using flot.  D3 feels like a step backwards towards jQuery.  Canvas and SVG both seem reasonable; I think we have all data in a form that makes actually rendering it almost trivial. This would give us enough control to produce ultra nice graphs.

#### Todo

- [x] Resizing
- [x] Stacked instance plot
- [x] History controls
- [x] IO rate axis labels, common unit on top
- [x] Zooming in via selection
- [x] Icons for zoom controls
- [x] font-family: var(--pf-global--FontFamily--monospace) for axis labels
- [x] Nicer IO rate label, decimal multiplies of a power of 1024 unit.
- [x] Hovering
- [x] More than one plot with common controls and axis
- [x] Change metric instances without destroying the whole plot
- [x] Proper layout
- [x] Profiling
- [ ] Code untangling