### PR TITLE
motd: show the motd only to admin users

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,7 @@ SUBST_RULE = \
 	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
 	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \
 	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
+	-e 's,[@]admin_group[@],$(admin_group),g' \
 	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
 	-e 's,[@]with_networkmanager_needs_root[@],$(with_networkmanager_needs_root),g' \
 	-e 's,[@]with_storaged_iscsi_sessions[@],$(with_storaged_iscsi_sessions),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -462,6 +462,25 @@ fi
 AC_SUBST(COCKPIT_WSINSTANCE_USER)
 AC_SUBST(COCKPIT_WSINSTANCE_GROUP)
 
+# admin users group
+AC_ARG_WITH([admin-group],
+            [AC_HELP_STRING([--with-admin-group=GROUP],
+                            [system group to which admin users belong])],
+            [admin_group=$withval],
+            [
+              AC_MSG_CHECKING([for system group to which admin users belong])
+              CANDIDATE_GROUPS="wheel sudo root"
+              admin_group="$(getent group ${CANDIDATE_GROUPS} | head -n1 | cut -f1 -d:)"
+              if test -n "$admin_group"; then
+                AC_MSG_RESULT([$admin_group])
+              else
+                AC_MSG_RESULT([unable to detect])
+                AC_MSG_ERROR([none of '${CANDIDATE_GROUPS}' exist: please specify a group with --with-admin-group=])
+              fi
+            ])
+AC_SUBST(admin_group)
+
+
 AC_ARG_WITH(selinux_config_type,
 	    AS_HELP_STRING([--with-selinux-config-type=<type>],
 			   [SELinux context type for cockpit config files]
@@ -613,6 +632,7 @@ echo "
         cockpit-ws group:           ${COCKPIT_GROUP}
         cockpit-ws instance user:   ${COCKPIT_WSINSTANCE_USER}
         cockpit-ws instance group:  ${COCKPIT_WSINSTANCE_GROUP}
+        admin group:                ${admin_group}
         selinux config type:        ${COCKPIT_SELINUX_CONFIG_TYPE}
 
         Maintainer mode:            ${USE_MAINTAINER_MODE}

--- a/src/ws/cockpit-tempfiles.conf.in
+++ b/src/ws/cockpit-tempfiles.conf.in
@@ -1,2 +1,3 @@
-d /run/cockpit 0755 - - -
-L+ /run/cockpit/motd - - - - @datadir@/@PACKAGE@/motd/inactive.motd
+C /run/cockpit/inactive.motd 0640 root @admin_group@ - @datadir@/@PACKAGE@/motd/inactive.motd
+f /run/cockpit/active.motd   0640 root @admin_group@ -
+L+ /run/cockpit/motd - - - - inactive.motd

--- a/src/ws/cockpit.socket.in
+++ b/src/ws/cockpit.socket.in
@@ -7,7 +7,7 @@ Wants=cockpit-motd.service
 ListenStream=9090
 ExecStartPost=-@datadir@/@PACKAGE@/motd/update-motd '' localhost
 ExecStartPost=-/bin/ln -snf active.motd /run/cockpit/motd
-ExecStopPost=-/bin/ln -snf @datadir@/@PACKAGE@/motd/inactive.motd /run/cockpit/motd
+ExecStopPost=-/bin/ln -snf inactive.motd /run/cockpit/motd
 
 [Install]
 WantedBy=sockets.target

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -459,15 +459,48 @@ class TestConnection(MachineCase):
     def testSocket(self):
         m = self.machine
 
-        self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit.issue"))
-        self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
+        # non-admin user
+        m.execute("useradd user")
+
+        # enable no-password login for 'admin' and 'user'
+        m.execute("passwd -d admin")
+        m.execute("passwd -d user")
+
+        # debian-stable only allows passwordless logins from /etc/securetty, which excludes ssh
+        if m.image in ['debian-stable']:
+            self.sed_file('s/nullok_secure/nullok/', '/etc/pam.d/common-auth')
+
+        self.sed_file('$ a\\\nPermitEmptyPasswords yes', '/etc/ssh/sshd_config',
+                      'systemctl restart sshd.service')
+
+        def assertInOrNot(string, result, expected):
+            if expected:
+                self.assertIn(string, result)
+            else:
+                self.assertNotIn(string, result)
+
+        def checkMotdForUser(string, user, expected):
+            result = m.execute(f"ssh -o StrictHostKeyChecking=no -n {user}@localhost")
+            assertInOrNot(string, result, expected)
+
+        def checkMotdContent(string, expected=True):
+            # Needs https://github.com/linux-pam/linux-pam/pull/292 (or PAM 1.5.0)
+            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'debian-testing', 'ubuntu-2004', 'ubuntu-stable', 'rhel-8-3', 'rhel-8-4'])
+
+            # check issue (should be exactly the same as motd)
+            assertInOrNot(string, m.execute("cat /etc/issue.d/cockpit.issue"), expected)
+
+            # check motd as 'root' (via cat) and 'admin' and 'user' (via ssh)
+            assertInOrNot(string, m.execute("cat /etc/motd.d/cockpit"), expected)
+            checkMotdForUser(string, expected=expected, user='admin')
+            checkMotdForUser(string, expected=old_pam and expected or False, user='user')
+
+        checkMotdContent('systemctl')
+        checkMotdContent(':9090/', expected=False)
         m.start_cockpit()
 
-        self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertIn("9090", m.execute("cat /etc/issue.d/cockpit.issue"))
-        self.assertIn("9090", m.execute("cat /etc/motd.d/cockpit"))
-
+        checkMotdContent(':9090/')
+        checkMotdContent('systemctl', expected=False)
         m.execute("systemctl stop cockpit.socket")
 
         # Change port according to documentation: https://cockpit-project.org/guide/latest/listen.html
@@ -475,16 +508,14 @@ class TestConnection(MachineCase):
         m.execute(
             'mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=/run/cockpit/sock\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
 
-        self.assertIn("systemctl", m.execute("cat /etc/issue.d/cockpit.issue"))
-        self.assertIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertNotIn("443", m.execute("cat /etc/motd.d/cockpit"))
+        checkMotdContent('systemctl')
+        checkMotdContent(':9090/', expected=False)
+        checkMotdContent(':443/', expected=False)
         m.start_cockpit(tls=True)
 
-        self.assertNotIn("systemctl", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertNotIn("9090", m.execute("cat /etc/motd.d/cockpit"))
-        self.assertIn("443", m.execute("cat /etc/issue.d/cockpit.issue"))
-        self.assertIn("443", m.execute("cat /etc/motd.d/cockpit"))
+        checkMotdContent('systemctl', expected=False)
+        checkMotdContent(':9090/', expected=False)
+        checkMotdContent(':443/')
 
         output = m.execute('curl -k https://localhost 2>&1 || true')
         self.assertIn('Loading...', output)


### PR DESCRIPTION
Prevent non-admin users from seeing useless messages about how to enable
the web console.  They can't do that anyway.

This adds a new configure option, --with-admin-user=, to define which
group is considered to be the admin users group.  The default is a check
for the following groups, in order: wheel, sudo, root.

Open question: should non-admins see the message about how to login?

 * [x] wait for resolution on linux-pam/linux-pam#292
 * [x] get PAM fix vendor-patched into F33: https://bugzilla.redhat.com/show_bug.cgi?id=1896452
 * [x] rebuild `fedora-33` image https://github.com/cockpit-project/bots/pull/1403