### PR TITLE
shell: Add popover to explain empty "User" field to "Add host" dialog

### DIFF
--- a/pkg/lib/machine-add.html
+++ b/pkg/lib/machine-add.html
@@ -10,17 +10,11 @@
 </div>
 
 <div class="modal-body">
-    {{^editing}}
-    <p>
-      <span translate="yes">Specify the host and the login user account for the host that you want to add.</span><br/>
-      <span translate="yes">For the host, either specify the hostname, IP address, an alias name or a unique resource identifier for the SSH destination.</span><br/>
-      <span translate="yes">Leave the user name blank to connect to this machine as the currently logged in user. If you enter a different user name, that user will always be used when connecting to this machine.</span>
-    </p><br/>
-    {{/editing}}
     <form class="ct-form">
-      <label translate="yes" class="control-label">Host</label>
+      <label translate="yes" class="control-label" for="add-machine-address">Host</label>
       <div class="dialog-wrapper error-keep">
         <input class="form-control" id="add-machine-address"
+               aria-describedby="add-machine-address-helper"
                type="text" value="{{ host_address }}" {{connection_change_disabled}}
                list="options"
                placeholder="{{ placeholder }}"/>
@@ -29,11 +23,16 @@
           <option value="{{.}}">
             {{/options}}
         </datalist>
+        <div class="pf-c-form__helper-text" id="add-machine-address-helper" translate="yes">Can be a hostname, IP address, alias name, or unique SSH resource</div>
       </div>
 
-      <label translate="yes" class="control-label">User name</label>
-      <input class="form-control" id="add-machine-user"
-             type="text" value="{{ host_user }}" {{connection_change_disabled}}/>
+      <label translate="yes" class="control-label" for="add-machine-user">User name</label>
+      <div>
+        <input class="form-control" id="add-machine-user" type="text"
+               aria-describedby="add-machine-user-helper"
+               value="{{ host_user }}" {{connection_change_disabled}} />
+        <div class="pf-c-form__helper-text" id="add-machine-user-helper" translate="yes">When empty, connect with the current user</div>
+      </div>
 
       <label translate="yes" class="control-label">Color</label>
       <div id="add-machine-color-picker"/>

--- a/pkg/lib/machine-add.html
+++ b/pkg/lib/machine-add.html
@@ -13,7 +13,8 @@
     {{^editing}}
     <p>
       <span translate="yes">Specify the host and the login user account for the host that you want to add.</span><br/>
-      <span translate="yes">For the host, either specify the hostname, IP address, an alias name or a unique resource identifier for the SSH destination.</span>
+      <span translate="yes">For the host, either specify the hostname, IP address, an alias name or a unique resource identifier for the SSH destination.</span><br/>
+      <span translate="yes">Leave the user name blank to connect to this machine as the currently logged in user. If you enter a different user name, that user will always be used when connecting to this machine.</span>
     </p><br/>
     {{/editing}}
     <form class="ct-form">

--- a/pkg/lib/machine-dialogs.scss
+++ b/pkg/lib/machine-dialogs.scss
@@ -90,3 +90,11 @@
     visibility: hidden;
     height: 0px;
 }
+
+// When the dialog is ported to PF4, we can remove these lines.
+// (The element isn't currently imported, so its CSS variables aren't either. So we're defining what PF4 currently defines them as.)
+.pf-c-form__helper-text {
+    --pf-c-form__helper-text--MarginTop: var(--pf-global--spacer--xs);
+    --pf-c-form__helper-text--FontSize: var(--pf-global--FontSize--sm);
+    --pf-c-form__helper-text--Color: var(--pf-global--Color--100);
+}


### PR DESCRIPTION
Fixes #14734