### PR TITLE
build: Reduce tar verbosity

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,11 @@ V_COPY = $(V_COPY_$(V))
 V_COPY_ = $(V_COPY_$(AM_DEFAULT_VERBOSITY))
 V_COPY_0 = @echo "  COPY    " $@;
 
+V_TAR = $(V_TAR_$(V))
+V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
+V_TAR_0 = @echo "  TAR     " $@;
+
+
 MV = mv -f
 
 COPY_RULE = \
@@ -226,17 +231,17 @@ maintainer-clean-local::
 
 install-data-local:: $(WEBPACK_INSTALL)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+	$(V_TAR) tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 install-data-local:: $(WEBPACK_DEBUG)
 	$(MKDIR_P) $(DESTDIR)$(debugdir)$(pkgdatadir)
-	tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
+	$(V_TAR) tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(debugdir)$(pkgdatadir) --strip-components=1 -xvf -
 uninstall-local::
 	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \;
 	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
 	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete
 	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_PO)
-	tar -cf - $^ | tar -C $(distdir) -xf -
+	$(V_TAR) tar -cf - $^ | tar -C $(distdir) -xf -
 
 #
 

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -41,7 +41,7 @@ cd /tmp/source
 
 ./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
 
-make V=1 all
+make all
 
 if [ -n "${BUILD_ONLY:-}" ]; then
   exit 0


### PR DESCRIPTION
Avoid the ginormous (> 64 KiB!) tar invocation lines with all our built
webpack inputs in silent mode. These made the build output hard to read
(finding warnings or errors), and unnecessarily blew up build logs.

Also reduce verbosity in unit test container runs -- there is no
surprise what's going on there, as it is a static container image, and
it's very easy to reproduce the run locally.