### PR TITLE
test: Accept firefox reported error

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -90,6 +90,10 @@ function setupLogging(client) {
         if (details.exception && details.exception.className === "PhWaitCondTimeout")
             return;
 
+        // HACK: https://github.com/cockpit-project/cockpit/issues/14871
+        if (details.description && details.description.indexOf("Rendering components directly into document.body is discouraged") > -1)
+            return
+
         process.stderr.write(details.description || JSON.stringify(details) + "\n");
 
         unhandledExceptions.push(details.exception.message ||


### PR DESCRIPTION
Also if `text` is present, show rather that then the whole exception.

This error is super noisy and makes the log file too big.
See for example [this one](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-14860-20201105-101029-336f7f16-fedora-32-firefox/log)
