### PR TITLE
tests: attempt to stabilize further TestMachines.testDiskEdit

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2950,7 +2950,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         b = self.browser
         m = self.machine
 
-        self.createVm("subVmTest1")
+        args = self.createVm("subVmTest1")
+
+        # Wait for the machine to fully boot before performing disk changes
+        wait(lambda: "Linux version" in m.execute("cat {0}".format(args["logfile"])), delay=3)
 
         # prepare libvirt storage pools
         p1 = os.path.join(self.vm_tmpdir, "vm_one")


### PR DESCRIPTION
It often fails in the CI, seemingly not picking up the changes when the
Disk edit dialog is submitted.
Let's wait for the OS to get in a responsive state before performing any
disk related operations.