### PR TITLE
commen: Fix NULL dereference in cockpit_channel_control()

### DIFF
--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -1073,7 +1073,7 @@ cockpit_channel_control (CockpitChannel *self,
   CockpitChannelPrivate *priv = cockpit_channel_get_instance_private (self);
   JsonObject *object;
   GBytes *message;
-  const gchar *problem;
+  const gchar *problem = NULL;
   gchar *problem_copy = NULL;
 
   g_return_if_fail (COCKPIT_IS_CHANNEL (self));
@@ -1089,14 +1089,17 @@ cockpit_channel_control (CockpitChannel *self,
    * and let close send the message */
   else if (g_str_equal (command, "close"))
     {
-      if (!priv->close_options)
+      if (options)
         {
-          /* Ref for close_options, freed in parent */
-          priv->close_options = json_object_ref (options);
-        }
+          if (!priv->close_options)
+            {
+              /* Ref for close_options, freed in parent */
+              priv->close_options = json_object_ref (options);
+            }
 
-      if (!cockpit_json_get_string (options, "problem", NULL, &problem))
-        problem = NULL;
+          if (!cockpit_json_get_string (options, "problem", NULL, &problem))
+            problem = NULL;
+        }
 
       /* Use a problem copy so it out lasts the value in close_options */
       problem_copy = g_strdup (problem);

--- a/src/common/test-channel.c
+++ b/src/common/test-channel.c
@@ -494,6 +494,26 @@ test_capable (void)
 }
 
 static void
+test_null_close_control (void)
+{
+  MockTransport *transport;
+  CockpitChannel *channel;
+
+  transport = g_object_new (mock_transport_get_type (), NULL);
+
+  channel = g_object_new (mock_echo_channel_get_type (),
+                          "transport", transport,
+                          "id", "55",
+                          NULL);
+
+  /* Make sure the NULL here works */
+  cockpit_channel_control (channel, "close", NULL);
+
+  g_object_unref (channel);
+  g_object_unref (transport);
+}
+
+static void
 test_ping_channel (void)
 {
   JsonObject *reply = NULL;
@@ -754,6 +774,7 @@ main (int argc,
 
   g_test_add_func ("/channel/get-option", test_get_option);
   g_test_add_func ("/channel/properties", test_properties);
+  g_test_add_func ("/channel/test-null-close-control", test_null_close_control);
   g_test_add_func ("/channel/test_close_not_capable",
                    test_close_not_capable);
   g_test_add_func ("/channel/test_capable",


### PR DESCRIPTION
The cockpit_channel_control() function can be called with
a NULL options argument. In the case of a "close" message
this would have resulted in a NULL pointer being used.