### PR TITLE
PF4 Selects in modals are not espaping outside of the modals by default

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -178,7 +178,8 @@ export class FileAutoComplete extends React.Component {
                 }}
                 onToggle={this.onToggle}
                 onClear={this.clearSelection}
-                isOpen={this.state.isOpen}>
+                isOpen={this.state.isOpen}
+                menuAppendTo="parent">
                 {this.state.displayFiles.map((option, index) => (
                     <SelectOption key={option.path}
                                   className={option.type}

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -393,7 +393,8 @@ class OSRow extends React.Component {
                             onValueChanged('os', null);
                         }}
                         onToggle={isOpen => this.setState({ isOpen })}
-                        isOpen={this.state.isOpen}>
+                        isOpen={this.state.isOpen}
+                        menuAppendTo="parent">
                         {this.state.osEntries.map(os => <SelectOption key={os.shortId}
                                                                       value={this.createValue(os)} />)}
                     </PFSelect>

--- a/pkg/systemd/overview-cards/serverTime.js
+++ b/pkg/systemd/overview-cards/serverTime.js
@@ -508,20 +508,22 @@ function ChangeSystimeBody({ state, errors, change }) {
         </table>);
 
     return (
-        <div className="modal-body ct-form">
+        <div className="ct-form">
             <label htmlFor="systime-timezones" className="control-label">{_("Time zone")}</label>
             <Validated errors={errors} error_key="time_zone">
                 <Select id="systime-timezones" variant={SelectVariant.typeahead}
                         isOpen={zonesOpen} onToggle={setZonesOpen}
                         selections={time_zone}
-                        onSelect={(event, value) => { setZonesOpen(false); change("time_zone", value) }}>
+                        onSelect={(event, value) => { setZonesOpen(false); change("time_zone", value) }}
+                        menuAppendTo="parent">
                     { time_zones.map(tz => <SelectOption key={tz} value={tz}>{tz.replace(/_/g, " ")}</SelectOption>) }
                 </Select>
             </Validated>
             <label className="control-label" htmlFor="change_systime">{_("Set time")}</label>
             <Select id="change_systime"
                     isOpen={modeOpen} onToggle={setModeOpen}
-                    selections={mode} onSelect={(event, value) => { setModeOpen(false); change("mode", value) }}>
+                    selections={mode} onSelect={(event, value) => { setModeOpen(false); change("mode", value) }}
+                    menuAppendTo="parent">
                 <SelectOption value="manual_time">{_("Manually")}</SelectOption>
                 <SelectOption isDisabled={!ntp_supported} value="ntp_time">{_("Automatically using NTP")}</SelectOption>
                 <SelectOption isDisabled={!ntp_supported || !custom_ntp.supported} value="ntp_time_custom">{_("Automatically using specific NTP servers")}</SelectOption>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -221,7 +221,7 @@ class TestSystemInfo(MachineCase):
     def set_change_time_dialog_mode(self, mode):
         b = self.browser
         b.click("#system_information_change_systime label:contains('Set time') + div button")
-        b.click("#system_information_change_systime label:contains('Set time') + div ul button:contains('%s')" % mode)
+        b.click("#change_systime button:contains('%s')" % mode)
         b.wait_in_text("#system_information_change_systime label:contains('Set time') + div button", mode)
 
     def testTime(self):


### PR DESCRIPTION
menuAppendTo="parent" should be used in this case.

Also remove redundant 'modal-body' class from the content of the PF4
Modal.

Fixes #14857 , please add it when merging - I forgot.