### PR TITLE
tests: Accept more IPs in login tests

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -104,7 +104,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#current-username', 'admin')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*172.27.0.2")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         # reload, which should log us in with the cookie
         b.reload()
@@ -112,7 +112,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text('#current-username', 'admin')
 
         if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
-            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*172.27.0.2")
+            self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         b.go("/users#/admin")
         b.enter_page("/users")
@@ -183,11 +183,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 b.wait_present('#login-messages')
                 b.wait_present('#last-login')
                 b.wait_in_text('#last-login', "Last login")
-                b.wait_in_text('#last-login', "172.27.0.2")
+                b.wait_in_text('#last-login', "from") # only present if IP was logged
 
                 if n_fail:
                     b.wait_present('#last-failed-login')
-                    b.wait_in_text('#last-failed-login', "172.27.0.2")
+                    b.wait_in_text('#last-failed-login', "from")
                     b.wait_in_text('#login-messages', 'There were {} failed'.format(n_fail))
                 else:
                     self.assertFalse(b.is_present('#last-failed-login'))


### PR DESCRIPTION
We run the login tests not only on our own test VMs but also as part of
distro package validation testing.  Stop hardcoding the IP we use in our
test framework.

Fixes #14874