### PR TITLE
machines: Fix incorrect unit shown in memory row

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -170,7 +170,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected operating system has minimum memory requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.ram, units.B, vmParams.memorySizeUnit),
-                    vmParams.memorySizeUnit.name)
+                    vmParams.memorySizeUnit)
             );
         }
     }
@@ -185,7 +185,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected operating system has minimum storage size requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.storage, units.B, vmParams.storageSizeUnit),
-                    vmParams.storageSizeUnit.name)
+                    vmParams.storageSizeUnit)
             );
         }
     }
@@ -724,9 +724,9 @@ class CreateVmModal extends React.Component {
                 stateDelta.recommendedMemory = value.recommendedResources.ram;
                 const converted = convertToUnit(stateDelta.recommendedMemory, units.B, units.GiB);
                 if (converted == 0 || converted % 1 !== 0) // If recommended memory is not a whole number in GiB, set value in MiB
-                    this.setState({ memorySizeUnit: units.MiB }, () => this.onValueChanged("memorySize", Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB))));
+                    this.setState({ memorySizeUnit: units.MiB.name }, () => this.onValueChanged("memorySize", Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB))));
                 else
-                    this.setState({ memorySizeUnit: units.GiB }, () => this.onValueChanged("memorySize", converted));
+                    this.setState({ memorySizeUnit: units.GiB.name }, () => this.onValueChanged("memorySize", converted));
             } else {
                 stateDelta.recommendedMemory = undefined;
             }
@@ -738,9 +738,9 @@ class CreateVmModal extends React.Component {
                 stateDelta.recommendedStorage = value.recommendedResources.storage;
                 const converted = convertToUnit(stateDelta.recommendedStorage, units.B, this.state.storageSizeUnit);
                 if (converted == 0 || converted % 1 !== 0) // If recommended storage is not a whole number in GiB, set value in MiB
-                    this.setState({ storageSizeUnit: units.MiB }, () => this.onValueChanged("storageSize", Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB))));
+                    this.setState({ storageSizeUnit: units.MiB.name }, () => this.onValueChanged("storageSize", Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB))));
                 else
-                    this.setState({ storageSizeUnit: units.GiB }, () => this.onValueChanged("storageSize", converted));
+                    this.setState({ storageSizeUnit: units.GiB.name }, () => this.onValueChanged("storageSize", converted));
             } else {
                 stateDelta.recommendedStorage = undefined;
             }


### PR DESCRIPTION
If value is passed as unit object, then selector would choose the first
value since it expects only strings. The desired string can be found
under unit.name.