### PR TITLE
Migrate shell modals to PF4

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -486,7 +486,7 @@ function Router(index) {
  * As a convenience, common menu items can be setup by adding the
  * selector to be used to hook them up. The accepted selectors
  * are.
- * oops_sel, logout_sel, language_sel, about_sel
+ * oops_sel, logout_sel, language_sel
  *
  * Emits "disconnect" and "expect_restart" signals, that should be
  * handled by the caller.
@@ -856,13 +856,6 @@ function Index() {
         });
     }
 
-    /* About dialog */
-    function setup_about(id) {
-        $(cockpit.info).on("changed", function() {
-            $(id).text(cockpit.info.version);
-        });
-    }
-
     function setup_killer(id) {
         $(id).on("click", function(ev) {
             if (ev && ev.button === 0)
@@ -879,8 +872,6 @@ function Index() {
     if (self.language_sel)
         setup_language(self.language_sel);
 
-    if (self.about_sel)
-        setup_about(self.about_sel);
     if (self.killer_sel)
         setup_killer(self.killer_sel);
 }

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -23,7 +23,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { showDialog } from "./active-pages";
-import { LangModal } from "./shell-modals.jsx";
+import { LangModal, TimeoutModal } from "./shell-modals.jsx";
 
 var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
 const _ = cockpit.gettext;
@@ -515,24 +515,25 @@ function Index() {
         if (!session_final_timer && current_idle_time >= session_timeout - final_countdown) {
             title = document.title;
             sessionFinalTimeout();
-            $("#session-timeout-dialog").modal("show");
-
-            document.getElementById("keep-session-alive").addEventListener("click", e => {
-                window.clearTimeout(session_final_timer);
-                session_final_timer = null;
-                document.title = title;
-                resetTimer();
-                $("#session-timeout-dialog").modal("hide");
-                final_countdown = 30000;
-            });
         }
     }
 
     function updateFinalCountdown() {
         const remaining_secs = Math.floor(final_countdown / 1000);
         const timeout_text = cockpit.format(_("You will be logged out in $0 seconds."), remaining_secs);
-        document.getElementById("timeout-message").innerHTML = timeout_text;
         document.title = "(" + remaining_secs + ") " + title;
+        ReactDOM.render(React.createElement(TimeoutModal, {
+            onClose: () => {
+                window.clearTimeout(session_final_timer);
+                session_final_timer = null;
+                document.title = title;
+                resetTimer();
+                ReactDOM.unmountComponentAtNode(document.getElementById('session-timeout-dialog'));
+                final_countdown = 30000;
+            },
+            text: timeout_text,
+        }),
+                        document.getElementById('session-timeout-dialog'));
     }
 
     function sessionFinalTimeout() {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -23,7 +23,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import { showDialog } from "./active-pages";
-import { LangModal, TimeoutModal } from "./shell-modals.jsx";
+import { LangModal, TimeoutModal, OopsModal } from "./shell-modals.jsx";
 
 var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
 const _ = cockpit.gettext;
@@ -809,10 +809,11 @@ function Index() {
         if (!oops)
             return;
         oops.children("a").on("click", function() {
-            $("#error-popup-title").text(_("Unexpected error"));
-            var details = _("Cockpit had an unexpected internal error. <br/><br/>You can try restarting Cockpit by pressing refresh in your browser. The javascript console contains details about this error (<b>Ctrl-Shift-J</b> in most browsers).");
-            $("#error-popup-message").html(details);
-            $('#error-popup').modal('show');
+            ReactDOM.render(React.createElement(OopsModal, {
+                onClose: () =>
+                    ReactDOM.unmountComponentAtNode(document.getElementById('oops-modal'))
+            }),
+                            document.getElementById('oops-modal'));
         });
     }
 

--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -266,66 +266,69 @@ export function setup() {
     /* Popover help */
             .on("click", "[data-toggle='popover']", function() {
                 $(this).popover('toggle');
-            })
+            });
 
     /* Dialog is hidden */
-            .on("hide.bs.modal", function() {
-                if (keys) {
-                    $(keys).off();
-                    keys.close();
-                    keys = null;
-                }
-                hide_add_key();
-            })
+    $("#credentials-modal-close").on("click", function() {
+        if (keys) {
+            $(keys).off();
+            keys.close();
+            keys = null;
+        }
+        hide_add_key();
+        $("#credentials-dialog").prop('hidden', true);
+    });
 
     /* Dialog is shown */
-            .on("show.bs.modal", function() {
-                keys = credentials.keys_instance();
+    $("#credentials-item").on("click", function() {
+        $("#credentials-dialog").prop('hidden', false);
 
-                $(keys).on("changed", function() {
-                    var key, id, row;
-                    var rows = { };
-                    var table = $("#credentials-dialog table.credential-listing");
+        keys = credentials.keys_instance();
 
-                    table.find("tbody[data-id]").each(function(i, el) {
-                        row = $(el);
-                        rows[row.attr("data-id")] = row;
-                    });
+        $(keys).on("changed", function() {
+            var key, id, row;
+            var rows = { };
+            var table = $("#credentials-dialog table.credential-listing");
 
-                    var body = table.find("tbody.ssh-key-body").first();
-                    for (id in keys.items) {
-                        if (!(id in rows)) {
-                            row = rows[id] = body.clone();
-                            row.attr("data-id", id)
-                                    .removeAttr("hidden");
-                            table.append(row);
-                        }
-                    }
-
-                    function text(row, field, string) {
-                        var sel = row.find(field);
-                        string = string || "";
-                        if (sel.text() !== string)
-                            sel.text(string);
-                    }
-
-                    for (id in rows) {
-                        row = rows[id];
-                        key = keys.items[id];
-                        if (key) {
-                            text(row, ".credential-label", key.name || key.comment);
-                            text(row, ".credential-type", key.type);
-                            text(row, ".credential-fingerprint", key.fingerprint);
-                            text(row, ".credential-comment", key.comment);
-                            text(row, ".credential-data", key.data);
-                            row.attr("data-name", key.name)
-                                    .attr("data-loaded", key.loaded ? "1" : "0");
-
-                            renderKeyOnOff(id, key.loaded || row.hasClass("unlock"), !key.name, row);
-                        } else if (id !== "adding") {
-                            row.remove();
-                        }
-                    }
-                });
+            table.find("tbody[data-id]").each(function(i, el) {
+                row = $(el);
+                rows[row.attr("data-id")] = row;
             });
+
+            var body = table.find("tbody.ssh-key-body").first();
+            for (id in keys.items) {
+                if (!(id in rows)) {
+                    row = rows[id] = body.clone();
+                    row.attr("data-id", id)
+                            .removeAttr("hidden");
+                    table.append(row);
+                }
+            }
+
+            function text(row, field, string) {
+                var sel = row.find(field);
+                string = string || "";
+                if (sel.text() !== string)
+                    sel.text(string);
+            }
+
+            for (id in rows) {
+                row = rows[id];
+                key = keys.items[id];
+                if (key) {
+                    text(row, ".credential-label", key.name || key.comment);
+                    text(row, ".credential-type", key.type);
+                    text(row, ".credential-fingerprint", key.fingerprint);
+                    text(row, ".credential-comment", key.comment);
+                    text(row, ".credential-data", key.data);
+                    row.attr("data-name", key.name)
+                            .attr("data-loaded", key.loaded ? "1" : "0");
+
+                    renderKeyOnOff(id, key.loaded || row.hasClass("unlock"), !key.name, row);
+                } else if (id !== "adding") {
+                    row.remove();
+                }
+            }
+        });
+    });
 }

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -94,29 +94,7 @@
             </div>
         </div>
 
-        <div class="modal" id="about" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translate="yes">About Web Console</h4>
-              </div>
-              <div class="modal-body">
-                <div translate="yes">Cockpit is an interactive Linux server admin interface.</div>
-                <div><a rel="noopener noreferrer" target="_blank" href="https://cockpit-project.org/" translate>Project website</a></div>
-                <div>
-                  <span translate="yes">Version</span> <span id="about-version"></span>.
-                </div>
-                <div><span translate>Licensed under:</span>
-                    <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
-                      rel="noopener noreferrer" target="_blank">GNU LGPL version 2.1</a>
-                </div>
-              </div>
-              <div class="modal-footer">
-                <button class="pf-c-button pf-m-secondary" data-dismiss="modal" translate>Close</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div id="about"></div>
 
         <div class="modal" id="troubleshoot-dialog" tabindex="-1" role="dialog"
             data-backdrop="static">

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -108,21 +108,7 @@
 
         <div id="session-timeout-dialog"></div>
 
-        <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" id="error-popup-title"></h4>
-              </div>
-              <div class="modal-body">
-                <p id="error-popup-message"></p>
-              </div>
-              <div class="modal-footer">
-                <button class="pf-c-button pf-m-secondary" data-dismiss="modal" translate="yes">Close</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div id="oops-modal"></div>
 
         <div class="modal" id="credentials-dialog" tabindex="-1" role="dialog" data-backdrop="static">
             <div class="modal-dialog">

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -106,21 +106,7 @@
 
         <div id="display-language"></div>
 
-        <div class="modal" id="session-timeout-dialog" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translate="yes">Session is about to expire</h4>
-              </div>
-              <div class="modal-body">
-                  <p id="timeout-message" />
-              </div>
-              <div class="modal-footer">
-                <button class="pf-c-button pf-m-primary" id="keep-session-alive" translate="yes">Continue session</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div id="session-timeout-dialog"></div>
 
         <div class="modal" id="error-popup" tabindex="-1" role="dialog" data-backdrop="static">
           <div class="modal-dialog">

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -76,8 +76,7 @@
                 <a role="link" tabindex="0" id="active-pages" translate="yes" class="navbar-advanced">Active pages</a>
               </li>
               <li>
-                  <a role="link" tabindex="0" data-toggle="modal" data-target="#credentials-dialog"
-                      id="credentials-item" translate="yes">SSH keys</a>
+                  <a role="link" tabindex="0" id="credentials-item" translate="yes">SSH keys</a>
               </li>
               <li>
                 <a role="link" tabindex="0" id="go-logout" translate="yes">Log out</a>
@@ -110,183 +109,187 @@
 
         <div id="oops-modal"></div>
 
-        <div class="modal" id="credentials-dialog" tabindex="-1" role="dialog" data-backdrop="static">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h4 class="modal-title" translate="yes">SSH keys</h4>
-                    </div>
-                    <div class="modal-body">
-                        <table class="listing-ct">
-                            <tbody>
-                                <tr id="credential-keys">
-                                    <td colspan="2" translate>Use the following keys to authenticate against other systems</td>
-                                    <td class="listing-ct-actions">
-                                        <a role="link" tabindex="0">
-                                            <i translate class="pficon pficon-add-circle-o"></i>
-                                            <span translate>Add key</span>
-                                        </a>
-                                    </td>
-                                </tr>
-                                <tr class="load-custom-key hidden">
-                                    <td colspan="3">
-                                        <div role="group">
-                                            <div id="ssh-file-container"></div>
-                                            <button class="pf-c-button pf-m-secondary" id="ssh-file-add" translate>Add</button>
-                                        </div>
-                                        <div class="dialog-error help-block"></div>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                        <div class="table-scrollable">
-                            <table class="listing-ct credential-listing">
-                                <tbody class="ssh-add-key-body open">
-                                    <tr class="listing-ct-item listing-ct-head">
-                                        <th class="credential-label"></th>
-                                        <td></td>
-                                        <td class="listing-ct-actions"></td>
-                                    </tr>
-                                    <tr class="listing-ct-body">
-                                        <td colspan="3">
-                                            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert">
-                                              <div class="pf-c-alert__icon">
-                                                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-                                              </div>
-                                              <h4 class="pf-c-alert__title credential-alert"></h4>
-                                            </div>
-                                            <div class="credential-unlock">
-                                                <dl>
-                                                    <dt>
-                                                        <label for="add-key-password" translate>Password</label>
-                                                    </dt>
-                                                    <dd>
-                                                        <input class="form-control credential-password"
-                                                                autocomplete="new-password"
-                                                                id="add-key-password"
-                                                                value="" type="password"/>
-                                                    </dd>
-                                                    <dt></dt>
-                                                    <dd>
-                                                        <button class="pf-c-button pf-m-primary"
-                                                                translate>Unlock key</button>
-                                                    </dd>
-                                                </dl>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                                <tbody class="ssh-key-body" hidden>
-                                    <tr class="listing-ct-item listing-ct-head">
-                                        <th class="credential-label"></th>
-                                        <td></td>
-                                        <td class="listing-ct-actions"></td>
-                                    </tr>
-                                    <tr class="listing-ct-panel credential-panel">
-                                        <td colspan="3">
-                                            <ul class="nav nav-tabs nav-tabs-pf">
-                                                <li class="active"><a href="#" translate="yes">Details</a></li>
-                                                <li><a href="#" translate="yes">Public key</a></li>
-                                                <li><a href="#" translate="yes">Password</a></li>
-                                            </ul>
-                                        </td>
-                                    </tr>
-                                    <tr class="listing-ct-body">
-                                        <td colspan="3">
-                                            <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert">
-                                              <div class="pf-c-alert__icon">
-                                                <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
-                                              </div>
-                                              <h4 class="pf-c-alert__title credential-alert"></h4>
-                                            </div>
-                                            <div class="credential-unlock">
-                                                <dl>
-                                                    <dt>
-                                                        <label for="ssh-key-password" translate="yes">Password</label>
-                                                    </dt>
-                                                    <dd>
-                                                        <input class="form-control credential-password"
-                                                                autocomplete="new-password"
-                                                                id="ssh-key-password"
-                                                                value="" type="password"/>
-                                                    </dd>
-                                                    <dt></dt>
-                                                    <dd>
-                                                        <button class="pf-c-button pf-m-primary"
-                                                                translate>Unlock key</button>
-                                                    </dd>
-                                                </dl>
-                                            </div>
-                                            <div class="credential-tab credential-panel">
-                                                <dl>
-                                                    <dt>
-                                                        <label translate>Comment</label>
-                                                    </dt>
-                                                    <dd class="credential-comment"></dd>
-                                                    <dt>
-                                                        <label translate>Type</label>
-                                                    </dt>
-                                                    <dd class="credential-type"></dd>
-                                                    <dt>
-                                                        <label translate>Fingerprint</label>
-                                                    </dt>
-                                                    <dd class="credential-fingerprint"></dd>
-                                                </dl>
-                                            </div>
-                                            <div class="credential-tab credential-panel" hidden>
-                                                <textarea class="credential-data form-control" rows="4" readonly>
-                                                </textarea>
-                                            </div>
-                                            <div class="credential-tab credential-panel" hidden>
-                                                <dl>
-                                                    <dt>
-                                                        <label for="credential-old-passwd" translate="yes">Old password</label>
-                                                    </dt>
-                                                    <dd>
-                                                        <input class="form-control credential-old"
-                                                            autocomplete="new-password"
-                                                            id="credential-old-passwd"
-                                                            value="" type="password"/>
-                                                    </dd>
-                                                    <dt>
-                                                        <label for="credential-new-passwd" translate="yes">New password</label>
-                                                    </dt>
-                                                    <dd>
-                                                        <input class="form-control credential-new"
-                                                            autocomplete="new-password"
-                                                            id="credential-new-passwd"
-                                                            value="" type="password"/>
-                                                    </dd>
-                                                    <dt>
-                                                        <label for="new-passwd-confirm" translate="yes">Confirm</label>
-                                                    </dt>
-                                                    <dd>
-                                                        <input class="form-control credential-two"
-                                                            autocomplete="new-password"
-                                                            id="new-passwd-confirm"
-                                                            value="" type="password"/>
-                                                    </dd>
-                                                    <dt>
-                                                        <a tabindex="0" role="button" data-toggle="popover"
-                                                            data-trigger="focus" data-placement="top"
-                                                            data-content="Tip: Make your key password match your login password to automatically authenticate against other systems." translate="data-content">
-                                                            <span class="fa fa-lg fa-info-circle"></span>
-                                                        </a>
-                                                    </dt>
-                                                    <dd>
-                                                        <button class="credential-change pf-c-button pf-m-primary"
-                                                            translate="yes">Change password</button>
-                                                    </dd>
-                                                </dl>
-                                            </div>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
+        <div hidden aria-hidden="true" id="credentials-dialog">
+            <div class="pf-c-backdrop">
+                <div class="pf-l-bullseye">
+                    <div class="pf-c-modal-box pf-m-md pf-m-align-top" role="dialog" aria-modal="true">
+                        <header class="pf-c-modal-box__header">
+                            <h1 class="pf-c-modal-box__title" translate="yes">SSH keys</h1>
+                        </header>
+                        <div class="pf-c-modal-box__body">
+                            <div class="modal-body">
+                                <table class="listing-ct">
+                                    <tbody>
+                                        <tr id="credential-keys">
+                                            <td colspan="2" translate>Use the following keys to authenticate against other systems</td>
+                                            <td class="listing-ct-actions">
+                                                <a role="link" tabindex="0">
+                                                    <i translate class="pficon pficon-add-circle-o"></i>
+                                                    <span translate>Add key</span>
+                                                </a>
+                                            </td>
+                                        </tr>
+                                        <tr class="load-custom-key hidden">
+                                            <td colspan="3">
+                                                <div role="group">
+                                                    <div id="ssh-file-container"></div>
+                                                    <button class="pf-c-button pf-m-secondary" id="ssh-file-add" translate>Add</button>
+                                                </div>
+                                                <div class="dialog-error help-block"></div>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>
+                                <div class="table-scrollable">
+                                    <table class="listing-ct credential-listing">
+                                        <tbody class="ssh-add-key-body open">
+                                            <tr class="listing-ct-item listing-ct-head">
+                                                <th class="credential-label"></th>
+                                                <td></td>
+                                                <td class="listing-ct-actions"></td>
+                                            </tr>
+                                            <tr class="listing-ct-body">
+                                                <td colspan="3">
+                                                    <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert">
+                                                      <div class="pf-c-alert__icon">
+                                                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                                      </div>
+                                                      <h4 class="pf-c-alert__title credential-alert"></h4>
+                                                    </div>
+                                                    <div class="credential-unlock">
+                                                        <dl>
+                                                            <dt>
+                                                                <label for="add-key-password" translate>Password</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <input class="form-control credential-password"
+                                                                        autocomplete="new-password"
+                                                                        id="add-key-password"
+                                                                        value="" type="password"/>
+                                                            </dd>
+                                                            <dt></dt>
+                                                            <dd>
+                                                                <button class="pf-c-button pf-m-primary"
+                                                                        translate>Unlock key</button>
+                                                            </dd>
+                                                        </dl>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                        <tbody class="ssh-key-body" hidden>
+                                            <tr class="listing-ct-item listing-ct-head">
+                                                <th class="credential-label"></th>
+                                                <td></td>
+                                                <td class="listing-ct-actions"></td>
+                                            </tr>
+                                            <tr class="listing-ct-panel credential-panel">
+                                                <td colspan="3">
+                                                    <ul class="nav nav-tabs nav-tabs-pf">
+                                                        <li class="active"><a href="#" translate="yes">Details</a></li>
+                                                        <li><a href="#" translate="yes">Public key</a></li>
+                                                        <li><a href="#" translate="yes">Password</a></li>
+                                                    </ul>
+                                                </td>
+                                            </tr>
+                                            <tr class="listing-ct-body">
+                                                <td colspan="3">
+                                                    <div class="pf-c-alert pf-m-danger pf-m-inline dialog-error" aria-label="inline danger alert">
+                                                      <div class="pf-c-alert__icon">
+                                                        <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+                                                      </div>
+                                                      <h4 class="pf-c-alert__title credential-alert"></h4>
+                                                    </div>
+                                                    <div class="credential-unlock">
+                                                        <dl>
+                                                            <dt>
+                                                                <label for="ssh-key-password" translate="yes">Password</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <input class="form-control credential-password"
+                                                                        autocomplete="new-password"
+                                                                        id="ssh-key-password"
+                                                                        value="" type="password"/>
+                                                            </dd>
+                                                            <dt></dt>
+                                                            <dd>
+                                                                <button class="pf-c-button pf-m-primary"
+                                                                        translate>Unlock key</button>
+                                                            </dd>
+                                                        </dl>
+                                                    </div>
+                                                    <div class="credential-tab credential-panel">
+                                                        <dl>
+                                                            <dt>
+                                                                <label translate>Comment</label>
+                                                            </dt>
+                                                            <dd class="credential-comment"></dd>
+                                                            <dt>
+                                                                <label translate>Type</label>
+                                                            </dt>
+                                                            <dd class="credential-type"></dd>
+                                                            <dt>
+                                                                <label translate>Fingerprint</label>
+                                                            </dt>
+                                                            <dd class="credential-fingerprint"></dd>
+                                                        </dl>
+                                                    </div>
+                                                    <div class="credential-tab credential-panel" hidden>
+                                                        <textarea class="credential-data form-control" rows="4" readonly>
+                                                        </textarea>
+                                                    </div>
+                                                    <div class="credential-tab credential-panel" hidden>
+                                                        <dl>
+                                                            <dt>
+                                                                <label for="credential-old-passwd" translate="yes">Old password</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <input class="form-control credential-old"
+                                                                    autocomplete="new-password"
+                                                                    id="credential-old-passwd"
+                                                                    value="" type="password"/>
+                                                            </dd>
+                                                            <dt>
+                                                                <label for="credential-new-passwd" translate="yes">New password</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <input class="form-control credential-new"
+                                                                    autocomplete="new-password"
+                                                                    id="credential-new-passwd"
+                                                                    value="" type="password"/>
+                                                            </dd>
+                                                            <dt>
+                                                                <label for="new-passwd-confirm" translate="yes">Confirm</label>
+                                                            </dt>
+                                                            <dd>
+                                                                <input class="form-control credential-two"
+                                                                    autocomplete="new-password"
+                                                                    id="new-passwd-confirm"
+                                                                    value="" type="password"/>
+                                                            </dd>
+                                                            <dt>
+                                                                <a tabindex="0" role="button" data-toggle="popover"
+                                                                    data-trigger="focus" data-placement="top"
+                                                                    data-content="Tip: Make your key password match your login password to automatically authenticate against other systems." translate="data-content">
+                                                                    <span class="fa fa-lg fa-info-circle"></span>
+                                                                </a>
+                                                            </dt>
+                                                            <dd>
+                                                                <button class="credential-change pf-c-button pf-m-primary"
+                                                                    translate="yes">Change password</button>
+                                                            </dd>
+                                                        </dl>
+                                                    </div>
+                                                </td>
+                                            </tr>
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </div>
                         </div>
-                    </div>
-                    <div class="modal-footer">
-                        <button class="pf-c-button pf-m-secondary" data-dismiss="modal" translate="yes">Close</button>
+                        <footer class="pf-c-modal-box__footer">
+                            <button class="pf-c-button pf-m-secondary" id="credentials-modal-close" translate="yes">Close</button>
+                        </footer>
                     </div>
                 </div>
             </div>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -69,7 +69,7 @@
               <li id="super-user-indicator-mobile" class="mobile_v"></li>
               <li class="divider mobile_v"></li>
               <li class="display-language-menu">
-                <a role="link" tabindex="0" data-toggle="modal" data-target="#display-language" translate="yes">Display language</a>
+                <a role="link" tabindex="0" translate="yes" id="open-display-language">Display language</a>
               </li>
               <li class="divider display-language-menu"></li>
               <li>
@@ -104,24 +104,7 @@
             </div>
         </div>
 
-        <div class="modal" id="display-language" tabindex="-1" role="dialog" data-backdrop="static">
-          <div class="modal-dialog">
-            <div class="modal-content">
-              <div class="modal-header">
-                <h4 class="modal-title" translate="yes">Display language</h4>
-              </div>
-              <div class="modal-body">
-                <p translate="yes">Choose the language to be used in the application</p>
-                <select id="display-language-list" size="5" data-role="none">
-                </select>
-              </div>
-              <div class="modal-footer">
-                <button class="pf-c-button pf-m-primary" id="display-language-select-button" translate="yes">Select</button>
-                <button class="pf-c-button pf-m-link" data-dismiss="modal" translate="yes">Cancel</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <div id="display-language"></div>
 
         <div class="modal" id="session-timeout-dialog" tabindex="-1" role="dialog" data-backdrop="static">
           <div class="modal-dialog">

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -45,7 +45,6 @@ document.addEventListener("click", function(ev) {
 var options = {
     logout_sel: "#go-logout",
     oops_sel: "#navbar-oops",
-    language_sel: "#display-language",
     killer_sel: "#active-pages",
     default_title: "Cockpit",
 };

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -46,7 +46,6 @@ var options = {
     logout_sel: "#go-logout",
     oops_sel: "#navbar-oops",
     language_sel: "#display-language",
-    about_sel: "#about-version",
     killer_sel: "#active-pages",
     default_title: "Cockpit",
 };

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -25,6 +25,7 @@ import ReactDOM from "react-dom";
 import { SuperuserIndicator } from "./superuser.jsx";
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 import { CockpitHosts } from "./hosts.jsx";
+import { AboutModal } from "./shell-modals.jsx";
 
 import * as base_index from "./base_index";
 
@@ -417,8 +418,13 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         divider.className = "divider";
         const about = document.createElement("li");
         const el_a = document.createElement("a");
-        el_a.setAttribute("data-toggle", "modal");
-        el_a.setAttribute("data-target", "#about");
+        el_a.onclick = () => {
+            ReactDOM.render(React.createElement(AboutModal, {
+                onClose: () =>
+                    ReactDOM.unmountComponentAtNode(document.getElementById('about'))
+            }),
+                            document.getElementById('about'));
+        };
         el_a.appendChild(document.createTextNode(_("About Web Console")));
         about.appendChild(el_a);
 

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -1,0 +1,48 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React from "react";
+import { Button, Modal } from '@patternfly/react-core';
+
+import "form-layout.scss";
+
+const _ = cockpit.gettext;
+
+export function AboutModal(props) {
+    return (
+        <Modal isOpen position="top" variant="medium"
+               onClose={props.onClose}
+               id="about-cockpit-modal"
+               title={_("About Web Console")}
+               footer={<Button variant='secondary' onClick={props.onClose}>{_("Close")}</Button>}
+        >
+            <div>{_("Cockpit is an interactive Linux server admin interface.")}</div>
+            <div><a rel="noopener noreferrer" target="_blank" href="https://cockpit-project.org/">{_("Project website")}</a></div>
+            <div>
+                <span>{_("Version")} </span>
+                <span id="about-version">{cockpit.info.version}</span>.
+            </div>
+            <div>
+                <span>{_("Licensed under:")} </span>
+                <a href="https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html"
+              rel="noopener noreferrer" target="_blank">{_("GNU LGPL version 2.1")}</a>
+            </div>
+        </Modal>);
+}

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -108,3 +108,20 @@ export function TimeoutModal(props) {
             {props.text}
         </Modal>);
 }
+
+export function OopsModal(props) {
+    return (
+        <Modal isOpen position="top" variant="medium"
+               onClose={props.onClose}
+               title={_("Unexpected error")}
+               footer={<Button variant='secondary' onClick={props.onClose}>{_("Close")}</Button>}
+        >
+            {_("Cockpit had an unexpected internal error.")}
+            <br />
+            <br />
+            <span>{("You can try restarting Cockpit by pressing refresh in your browser. The javascript console contains details about this error") + " ("}
+                <b>{_("Ctrl-Shift-J")}</b>
+                {" " + _("in most browsers") + ")."}
+            </span>
+        </Modal>);
+}

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -46,3 +46,53 @@ export function AboutModal(props) {
             </div>
         </Modal>);
 }
+
+export class LangModal extends React.Component {
+    constructor(props) {
+        super();
+
+        let language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
+        if (!language)
+            language = "en-us";
+
+        this.state = {
+            selected: language,
+        };
+
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    onSelect() {
+        const lang = this.state.selected;
+
+        if (!lang)
+            return;
+
+        const cookie = "CockpitLang=" + encodeURIComponent(lang) + "; path=/; expires=Sun, 16 Jul 3567 06:23:41 GMT";
+        document.cookie = cookie;
+        window.localStorage.setItem("cockpit.lang", lang);
+        window.location.reload(true);
+    }
+
+    render() {
+        const manifest = cockpit.manifests.shell || { };
+
+        return (
+            <Modal isOpen position="top" variant="medium"
+                   id="display-language-modal"
+                   onClose={this.props.onClose}
+                   title={_("Display language")}
+                   footer={<>
+                       <Button variant='primary' onClick={this.onSelect}>{_("Select")}</Button>
+                       <Button variant='link' onClick={this.props.onClose}>{_("Cancel")}</Button>
+                   </>}
+            >
+                <p translate="yes">Choose the language to be used in the application</p>
+                <select id="display-language-list" size="5" data-role="none" defaultValue={this.state.selected} onChange={e => this.setState({ selected: e.target.value })}>
+                    {Object.keys(manifest.locales || { }).map(key => {
+                        return <option key={key} value={key}>{manifest.locales[key]}</option>;
+                    })}
+                </select>
+            </Modal>);
+    }
+}

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -96,3 +96,15 @@ export class LangModal extends React.Component {
             </Modal>);
     }
 }
+
+export function TimeoutModal(props) {
+    return (
+        <Modal isOpen position="top" variant="medium"
+               showClose={false}
+               title={_("Session is about to expire")}
+               id="session-timeout-modal"
+               footer={<Button variant='primary' onClick={props.onClose}>{_("Continue session")}</Button>}
+        >
+            {props.text}
+        </Modal>);
+}

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -164,9 +164,14 @@ class TestApps(PackageCase):
             b.switch_to_top()
             b.click("#navbar-dropdown")
             b.click(".display-language-menu a")
-            b.wait_popup('display-language')
-            b.set_val("#display-language select", lang)
-            b.click("#display-language-select-button")
+            if m.image == "rhel-8-3-distropkg": # Changed in #14890
+                b.wait_popup('display-language')
+                b.set_val("#display-language select", lang)
+                b.click("#display-language-select-button")
+            else:
+                b.wait_visible('#display-language-modal')
+                b.set_val("#display-language-modal select", lang)
+                b.click("#display-language-modal footer button.pf-m-primary")
             b.expect_load()
             # HACK: work around language switching in Chrome not working in current session (issue #8160)
             b.reload(ignore_cache=True)
@@ -177,7 +182,7 @@ class TestApps(PackageCase):
         b.wait_present(".app-description:contains('DESCRIPTION:de')")
         b.wait_not_present(".app-description:contains('DESCRIPTION:none')")
 
-        set_lang("ja-ja")
+        set_lang("ja-jp")
         b.wait_present(".app-description:contains('DESCRIPTION:none')")
         b.wait_not_present(".app-description:contains('DESCRIPTION:de')")
 

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -48,21 +48,21 @@ class TestMenu(MachineCase):
 
         # Test session timeout
         time.sleep(20)
-        b.wait_not_visible("#session-timeout-dialog")
+        b.wait_not_present("#session-timeout-modal")
         b.wait_visible("#nav-system")
         b.enter_page("/system")
         b.mouse("#system_information_hardware_text", "mousemove", 24, 24)
         b.switch_to_top()
         time.sleep(35)
         with b.wait_timeout(3):
-            b.wait_popup("session-timeout-dialog")
-            self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 15)
-        b.click("#keep-session-alive")
-        b.wait_popdown("session-timeout-dialog")
+            b.wait_visible("#session-timeout-modal")
+            self.assertGreater(int(b.text("#session-timeout-modal .pf-c-modal-box__body").split()[-2]), 15)
+        b.click("#session-timeout-modal footer button")
+        b.wait_not_present("#session-timeout-modal")
         time.sleep(30)
         with b.wait_timeout(8):
-            b.wait_popup("session-timeout-dialog")
-            self.assertGreater(int(b.text("#session-timeout-dialog #timeout-message").split()[-2]), 20)
+            b.wait_popup("session-timeout-modal")
+            self.assertGreater(int(b.text("#session-timeout-modal .pf-c-modal-box__body").split()[-2]), 20)
         time.sleep(30)
         b.wait_visible("#login")
         b.wait_visible("#login-info-message")
@@ -73,7 +73,7 @@ class TestMenu(MachineCase):
         self.login_and_go("/system")
         b.switch_to_top()
         time.sleep(75)
-        b.wait_not_visible("#session-timeout-dialog")
+        b.wait_not_present("#session-timeout-modal")
         b.wait_visible("#nav-system")
 
         self.check_axe("Test-navigation")

--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -41,10 +41,10 @@ class TestMenu(MachineCase):
 
         b.switch_to_top()
         b.click('#navbar-docs-dropdown')
-        b.click('a[data-target="#about"]')
-        b.wait_popup('about')
-        b.click('#about button[data-dismiss="modal"]')
-        b.wait_popdown("about")
+        b.click('a:contains("About Web Console")')
+        b.wait_visible('.pf-c-modal-box__body:contains("Cockpit is an interactive Linux server admin interface")')
+        b.click('#about-cockpit-modal .pf-c-modal-box__footer button')
+        b.wait_not_present('#about-cockpit-modal')
 
         # Test session timeout
         time.sleep(20)

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -51,7 +51,7 @@ class TestPages(MachineCase):
         self.browser.click("#navbar-dropdown")
 
         self.browser.click(".display-language-menu a")
-        self.browser.wait_popup('display-language')
+        self.browser.wait_visible('#display-language-modal')
 
 
     def testBasic(self):
@@ -166,8 +166,8 @@ OnCalendar=daily
         # Lets try changing the language
 
         self.open_lang_modal()
-        b.set_val("#display-language select", "de-de")
-        b.click("#display-language-select-button")
+        b.set_val("#display-language-modal select", "de-de")
+        b.click("#display-language-modal footer button.pf-m-primary")
         b.expect_load()
         if b.cdp.browser in ["chrome", "chromium"]:
             # HACK: work around language switching in Chrome not working in current session (issue #8160)
@@ -249,16 +249,16 @@ OnCalendar=daily
         b.wait_present('#overview')
 
         self.open_lang_modal()
-        languages = b.eval_js("ph_select('#display-language-list option').map(function(e) { return e.value })")
-        b.click("#display-language button[data-dismiss]") # Close the menu
+        languages = b.eval_js("ph_select('#display-language-modal-list option').map(function(e) { return e.value })")
+        b.click("#display-language-modal footer button.pf-m-link") # Close the menu
 
         for language in languages:
             b.go("/system")
             b.enter_page("/system")
 
             self.open_lang_modal()
-            b.set_val("#display-language select", language)
-            b.click("#display-language-select-button")
+            b.set_val("#display-language-modal select", language)
+            b.click("#display-language-modal footer button.pf-m-primary")
             b.expect_load()
             if b.cdp.browser in ["chrome", "chromium"]:
                 # HACK: work around language switching in Chrome not working in current session (issue #8160)
@@ -308,8 +308,8 @@ OnCalendar=daily
         self.login_and_go('/system')
         b.wait_present('#overview')
         self.open_lang_modal()
-        b.set_val('#display-language select', 'pt-br')
-        b.click('#display-language-select-button')
+        b.set_val('#display-language-modal select', 'pt-br')
+        b.click('#display-language-modal footer button.pf-m-primary')
         b.expect_load()
         if b.cdp.browser in ["chrome", "chromium"]:
             # HACK: work around language switching in Chrome not working in current session (issue #8160)
@@ -501,8 +501,8 @@ OnCalendar=daily
 
         # Search internationalized menu
         self.open_lang_modal()
-        b.set_val("#display-language select", "de-de")
-        b.click("#display-language-select-button")
+        b.set_val("#display-language-modal select", "de-de")
+        b.click("#display-language-modal footer button.pf-m-primary")
         b.expect_load()
         if b.cdp.browser in ["chrome", "chromium"]:
             # HACK: work around language switching in Chrome not working in current session (issue #8160)


### PR DESCRIPTION
There are still two remaining ones. Both use `pkg/lib/machine-dialogs.js` which cannot be simple converted into PF4.
@mvollmer mentioned some time ago that we shoud move all of these into dashboard (which also uses them) and implement the ones we need in host switcher in react. I think that is the approach in which we want to go.

Tests are going to be very sad, just want to get a list of failing tests that I can fix locally first.