### PR TITLE
base1: Stop building and shipping jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "eslint-plugin-react": "^7.19.0",
     "eslint-plugin-react-hooks": "^2.5.1",
     "eslint-plugin-standard": "^4.0.1",
+    "expose-loader": "^1.0.1",
     "file-selector": "^0.2.2",
     "html-webpack-plugin": "^4.0.1",
     "htmlparser": "^1.7.7",

--- a/pkg/dashboard/index.html
+++ b/pkg/dashboard/index.html
@@ -24,7 +24,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="dashboard.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../*/po.js"></script>
     <script src="../manifests.js"></script>

--- a/pkg/dashboard/list.js
+++ b/pkg/dashboard/list.js
@@ -19,6 +19,7 @@
 
 import '../lib/patternfly/patternfly-cockpit.scss';
 import $ from "jquery";
+import "bootstrap/dist/js/bootstrap";
 import { mustache } from "mustache";
 
 import cockpit from "cockpit";

--- a/pkg/lib/plot.js
+++ b/pkg/lib/plot.js
@@ -20,6 +20,7 @@
 import $ from 'jquery';
 import cockpit from 'cockpit';
 
+import 'bootstrap/dist/js/bootstrap';
 import 'jquery-flot/jquery.flot';
 import 'jquery-flot/jquery.flot.selection';
 import 'jquery-flot/jquery.flot.time';

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -24,7 +24,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="network.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="../*/po.js"></script>

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -36,6 +36,7 @@ import { journal } from 'journal';
 
 /* jQuery extensions */
 import 'patterns';
+import 'bootstrap/dist/js/bootstrap';
 
 import "page.scss";
 import "table.css";

--- a/pkg/playground/jquery-patterns.html
+++ b/pkg/playground/jquery-patterns.html
@@ -5,7 +5,6 @@
     <title>Cockpit Pattern Usage</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="jquery-patterns.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="jquery-patterns.js"></script>
 </head>

--- a/pkg/playground/metrics.html
+++ b/pkg/playground/metrics.html
@@ -5,7 +5,6 @@
     <title>Cockpit Monitoring</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="metrics.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="metrics.js"></script>
 </head>

--- a/pkg/playground/pkgs.html
+++ b/pkg/playground/pkgs.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Cockpit Packages</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="pkgs.js"></script>
 </head>

--- a/pkg/playground/plot.html
+++ b/pkg/playground/plot.html
@@ -5,7 +5,6 @@
     <title>Cockpit Plots</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="plot.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="plot.js"></script>
 </head>

--- a/pkg/playground/service.html
+++ b/pkg/playground/service.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Cockpit Generic Service Monitor</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="service.js"></script>
 </head>

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -5,7 +5,6 @@
     <title>Cockpit playground</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="test.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="test.js"></script>
 </head>

--- a/pkg/playground/translate.html
+++ b/pkg/playground/translate.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Cockpit playground</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
 </head>
 <body class="pf-m-redhat-font" hidden>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -7,7 +7,6 @@
     <link href="index.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
     <link href="../shell/nav.css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="../*/po.js"></script>

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -18,6 +18,8 @@
  */
 
 import $ from "jquery";
+import "bootstrap/dist/js/bootstrap";
+
 import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -22,7 +22,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <title translate="yes">Diagnostic reports</title>
     <meta charset="utf-8">
     <link href="sosreport.css" rel="stylesheet">
-    <script type="text/javascript" src="../base1/jquery.js"></script>
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../*/po.js"></script>
     <script type="text/javascript" src="sosreport.js"></script>

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -31,6 +31,8 @@ import { MultipathAlert } from "./multipath.jsx";
 import { Overview } from "./overview.jsx";
 import { Details } from "./details.jsx";
 
+import "bootstrap/dist/js/bootstrap";
+
 import "page.scss";
 import "table.css";
 import "plot.css";

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -24,7 +24,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="storage.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="../*/po.js"></script>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -9,7 +9,6 @@
   <link rel="stylesheet" href="overview.css">
 
   <script type="text/javascript" src="../base1/cockpit.js"></script>
-  <script type="text/javascript" src="../base1/jquery.js"></script>
   <script type="text/javascript" src="overview.js"></script>
   <script type="text/javascript" src="../*/po.js"></script>
   <script src="../manifests.js"></script>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -23,7 +23,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <title translate>Journal</title>
   <meta charset="utf-8">
   <link href="logs.css" rel="stylesheet">
-  <script type="text/javascript" src="../base1/jquery.js"></script>
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script src="../*/po.js"></script>
 </head>

--- a/pkg/systemd/logs.js
+++ b/pkg/systemd/logs.js
@@ -20,6 +20,8 @@
 import '../lib/patternfly/patternfly-cockpit.scss';
 
 import $ from "jquery";
+import "bootstrap/js/dropdown";
+
 import cockpit from "cockpit";
 import { journal } from "journal";
 import moment from "moment";

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -5,7 +5,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="services.css" type="text/css" rel="stylesheet">
-    <script src="../base1/jquery.js"></script>
     <script src="../base1/cockpit.js"></script>
     <script src="services.js"></script>
     <script src="../*/po.js"></script>

--- a/pkg/systemd/services/timer-dialog.js
+++ b/pkg/systemd/services/timer-dialog.js
@@ -18,9 +18,11 @@
  */
 
 import $ from "jquery";
+
 import cockpit from "cockpit";
 import { mustache } from "mustache";
 import { systemd_client, SD_OBJ, SD_MANAGER, clock_realtime_now, updateTime } from "./services.jsx";
+import "bootstrap/dist/js/bootstrap";
 import "bootstrap-datepicker/dist/js/bootstrap-datepicker";
 
 import moment from "moment";

--- a/pkg/systemd/shutdown.js
+++ b/pkg/systemd/shutdown.js
@@ -22,6 +22,7 @@ import cockpit from "cockpit";
 
 /* These add themselves to jQuery so just including is enough */
 import "patterns";
+import "bootstrap/dist/js/bootstrap";
 import "bootstrap-datepicker/dist/js/bootstrap-datepicker";
 
 import "./shutdown.scss";

--- a/pkg/tuned/dialog.js
+++ b/pkg/tuned/dialog.js
@@ -28,6 +28,8 @@ import React from "react";
 import { TunedDialogBody } from "./change-profile.jsx";
 import link_html from "raw-loader!./link.html";
 
+import 'bootstrap/js/tooltip';
+
 const _ = cockpit.gettext;
 
 function setup() {

--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -4,7 +4,6 @@ basedir = $(pkgdatadir)/base1
 nodist_base_DATA = \
 	dist/base1/cockpit.min.css.gz \
 	dist/base1/patternfly.css \
-	dist/base1/jquery.min.js.gz \
 	dist/base1/cockpit.min.js.gz \
 	$(NULL)
 base_DATA = \
@@ -15,7 +14,6 @@ basedebugdir = $(debugdir)$(basedir)
 basedebug_DATA = \
 	dist/base1/cockpit.min.css.map \
 	dist/base1/patternfly.css.map \
-	dist/base1/jquery.min.js.map \
 	dist/base1/cockpit.min.js.map \
 	$(NULL)
 
@@ -34,11 +32,6 @@ PATTERNFLY_CSS_RULE = \
 
 dist/base1/cockpit.min.css: src/base1/cockpit.scss
 	$(PATTERNFLY_CSS_RULE)
-dist/base1/jquery.js:
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $(srcdir)/node_modules/jquery/dist/jquery.js $(srcdir)/node_modules/bootstrap/dist/js/bootstrap.js $(srcdir)/node_modules/patternfly/dist/js/patternfly.js > $@.tmp && $(MV) $@.tmp $@
-dist/base1/jquery.min.js: dist/base1/jquery.js
-	$(MIN_JS_RULE)
 dist/base1/cockpit.js: src/base1/cockpit.js
 	$(ESLINT_RULE)
 	$(COPY_RULE)
@@ -49,8 +42,6 @@ dist/base1/manifest.json: src/base1/manifest.json
 
 
 dist/base1/cockpit.min.js.map: dist/base1/cockpit.min.js
-
-dist/base1/jquery.min.js.map: dist/base1/jquery.min.js
 
 dist/base1/cockpit.min.css.map: dist/base1/cockpit.min.css
 
@@ -182,9 +173,6 @@ EXTRA_DIST += \
 	dist/base1/cockpit.min.css.map \
 	dist/base1/cockpit.min.js \
 	dist/base1/cockpit.min.js.map \
-	dist/base1/jquery.js \
-	dist/base1/jquery.min.js \
-	dist/base1/jquery.min.js.map \
 	dist/base1/patternfly.css \
 	dist/base1/patternfly.css.map \
 	dist/base1/simple-tap.js \
@@ -212,10 +200,6 @@ MAINTAINERCLEANFILES += \
 	dist/base1/fonts/fontawesome.woff \
 	dist/base1/fonts/glyphicons.woff \
 	dist/base1/fonts/patternfly.woff \
-	dist/base1/jquery.js \
-	dist/base1/jquery.min.js \
-	dist/base1/jquery.min.js.gz \
-	dist/base1/jquery.min.js.map \
 	dist/base1/manifest.json \
 	dist/base1/patternfly.css \
 	dist/base1/patternfly.css.map \

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -659,7 +659,7 @@ OnCalendar=daily
 
         b.inject_js("""
           ph_flot_data_plateau = function (sel, min, max, duration, label) {
-            return ph_plateau($(sel).data("flot_data")[0]['data'], min, max, duration, label);
+            return ph_plateau(jQuery(sel).data("flot_data")[0]['data'], min, max, duration, label);
           }
         """)
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -228,7 +228,6 @@ var info = {
 
 var externals = {
     "cockpit": "cockpit",
-    "jquery": "jQuery",
 };
 
 /* ---------------------------------------------------------------------
@@ -415,6 +414,28 @@ module.exports = {
                 test: eslint ? /\.(js|jsx)$/ : /dont.match.me/,
                 exclude: /\/node_modules\/.*\//, // exclude external dependencies
                 loader: "eslint-loader"
+            },
+            // flot and bootstrap UI require jQuery to be in the global namespace
+            // only expose that to pages which need it, as we want to port to React and get rid of jQuery
+            {
+                issuer: /shell|networkmanager|dashboard|storaged|playground\/plot|systemd\/(logs|services|shutdown)/,
+                test: require.resolve('jquery'),
+                loader: 'expose-loader',
+                options: {
+                    exposes: 'jQuery'
+                }
+            },
+            // tuned is embedded into overview, but both require global jQuery; overriding is ok
+            {
+                issuer: /tuned/,
+                test: require.resolve('jquery'),
+                loader: 'expose-loader',
+                options: {
+                    exposes: {
+                        globalName: 'jQuery',
+                        override: true,
+                    }
+                }
             },
             {
                 test: /\.js$/,


### PR DESCRIPTION
base1's jquery API was deprecated 2½ years ago [1], and all external consumers got moved away from it in [2].

This requires some cleanup in our own webpacks (separate commit).
 
[1] https://cockpit-project.org/blog/cockpit-163.html
[2] https://github.com/cockpit-project/cockpit/pull/8505

 - [x] Builds on top of PR #14888 (due to collision on base1/Makefile.am)