### PR TITLE
workflows: Add automatic weekly unit-test container refresh

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -1,0 +1,38 @@
+name: unit-test-refresh
+on:
+  schedule:
+    # auto-refresh every Sunday evening
+    - cron: '0 22 * * 0'
+  # can be run manually on https://github.com/cockpit-project/cockpit/actions
+  workflow_dispatch:
+jobs:
+  # we do both builds and all tests in a single run, so that we only upload the containers on success
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Build fresh containers
+        run: containers/unit-tests/build
+
+      - name: Run amd64 gcc test
+        run: containers/unit-tests/start
+
+      - name: Run amd64 clang test
+        run: containers/unit-tests/start CC=clang
+
+      - name: Run i386 test
+        run: containers/unit-tests/start :i386
+
+      - name: Log into Dockerhub
+        run: podman login -u cockpituous -p ${{ secrets.DOCKER_TOKEN }} docker.io
+
+      - name: Push containers to registry
+        run: |
+          podman push docker.io/cockpit/unit-tests:latest
+          podman push docker.io/cockpit/unit-tests:i386


### PR DESCRIPTION
This will make sure that we don't keep a  broken and un-upgradeable
unit-tests container around, like in the last year.

----

This is a single large job (will take over an hour), but I don't really know otherwise how to parallelize it effectively with keeping the atomicity. I.e. I wouldn't want to e.g. upload a new amd64 container if the i386 refresh fails. But nobody will actually watch this and wait for it, so I think it's bearable.

I temporarily copied the dockerhub cockpituous token secret to my fork, and [manually started a run](https://github.com/martinpitt/cockpit/actions/runs/361589834). Let's wait until this is successful before reviewing/landing.

 - [x] Let the job succeed on my fork, and verify that it updates the [dockerhub image](https://hub.docker.com/r/cockpit/unit-tests/tags/)