### PR TITLE
tests: don't rely on a VirtIO disk to exist in storage tests

### DIFF
--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -39,8 +39,7 @@ class TestStorageBasic(StorageCase):
 
         self.browser.wait_present("#devices [data-toggle=dropdown]")
 
-        b.wait_in_text("#drives", "VirtIO")
-        b.wait_not_in_text("#drives", "Show all")
+        b.wait_present("#mounts tbody tr")
 
         # Add a disk, partition it, format it, and finally remove it.
         disk = self.add_ram_disk()

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -29,7 +29,7 @@ class TestStorageFormat(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         # Try to format a disk that is too small for XFS.
 
@@ -52,7 +52,7 @@ class TestStorageFormat(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         m.add_disk("50M", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -32,7 +32,7 @@ class TestStorageLvm2(StorageCase):
         mount_point_thin = "/run/thin"
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         dev_1 = self.add_ram_disk()
         dev_2 = self.add_loopback_disk()
@@ -222,7 +222,7 @@ class TestStorageLvm2(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         disk1 = self.add_ram_disk()
         disk2 = self.add_loopback_disk()
@@ -258,7 +258,7 @@ class TestStorageLvm2(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         disk = self.add_ram_disk(100)
         b.wait_in_text("#drives", disk)

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -91,7 +91,7 @@ class TestStorageMdRaid(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         # Add four disks and make a RAID out of three of them
         m.add_disk("50M", serial="DISK1")
@@ -247,7 +247,7 @@ class TestStorageMdRaid(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         m.add_disk("50M", serial="DISK1")
         m.add_disk("50M", serial="DISK2")

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -57,7 +57,7 @@ class TestStorageMultipath(StorageCase):
         m.execute("udevadm trigger")
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         b.inject_js("""
           ph_texts = function (sel) {

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -30,7 +30,7 @@ class TestStorageNfs(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         m.execute("mkdir /home/foo /home/bar")
         m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
@@ -153,7 +153,7 @@ class TestStorageNfs(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         m.execute("mkdir /home/foo /home/bar")
         m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
@@ -177,7 +177,7 @@ class TestStorageNfs(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         m.execute("mkdir /home/foo /home/bar")
         m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -30,7 +30,7 @@ class TestStoragePartitions(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         # A loopback device ends with a digit and partitions have
         # names like "/dev/loop0p1".  Check that the storage stack has
@@ -70,7 +70,7 @@ class TestStoragePartitions(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         disk = self.add_ram_disk()
         b.click('#drives tr:contains("%s")' % disk)

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -29,7 +29,7 @@ class TestStorageRaid1(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         # Add four two and make a RAID out of them
         m.add_disk("50M", serial="DISK1")

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -29,7 +29,7 @@ class TestStorageUnused(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         # The following block devices should not be offered for creating a
         # raid

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -30,7 +30,7 @@ class TestStorageUsed(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-        b.wait_in_text("#drives", "VirtIO")
+        b.wait_present("#mounts tbody tr")
 
         disk = self.add_ram_disk()
         b.wait_in_text("#drives", disk)


### PR DESCRIPTION
Our test VMs indeed prepare a qemu VM with a VirtIO disk present. However, in
fedora CI, we don't have control of the test environment provided, in
matters of what disks are present.
They currently use XEN virtual machines for testing, and the root
partition appears to be on /dev/xvd*, which is simply the Xen disk
storage device.

Let's make the check for when the storage page is loaded a bit more
relaxed. With this commit we wait for mount point == '/' in the
"filesystems" table.