### PR TITLE
Remove duplicated words on updates tab

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3739,7 +3739,7 @@ msgstr "Les 7 derniers jours"
 
 #: pkg/packagekit/updates.jsx:194
 msgid "Last checked: $0"
-msgstr "Dernière vérification : il y a $0"
+msgstr "Dernière vérification : $0"
 
 #: pkg/systemd/overview.jsx:136
 msgid "Last failed login:"


### PR DESCRIPTION
Remove "il y a" to avoid sentences like :
Dernière vérification : il y a il y a 11 minutes