### PR TITLE
test: treat fedora-testing similarly to fedora-33 

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -620,7 +620,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # pam_faillock tries to chown the file to be owned by the user itself,
         # which is currently an selinux fail on the following distros:
-        if m.image in ['centos-8-stream', 'fedora-32', 'fedora-33', 'rhel-8-3', 'rhel-8-4']:
+        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-32', 'fedora-33', 'rhel-8-3', 'rhel-8-4']:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1836182
             self.allow_journal_messages('.*type=1400.*avc:  denied  { chown }.*comm="cockpit-session".*')
 

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -30,7 +30,7 @@ from storagelib import StorageHelpers
 from machinesxmls import *
 from datetime import datetime
 
-distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "fedora-32", "fedora-coreos", "fedora-testing", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "ubuntu-2004", "ubuntu-stable"]
+distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "fedora-32", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "ubuntu-2004", "ubuntu-stable"]
 
 def getNetworkDevice(m):
     net_devices_str = m.execute("virsh iface-list")
@@ -1623,7 +1623,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
-        if self.machine.image not in [ "fedora-33" ]:
+        if self.machine.image not in ["fedora-33", "fedora-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             self.machine.execute("virsh destroy pxe-guest")
@@ -2880,7 +2880,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m.execute("> {0}".format(logfile)) # clear logfile
         b.click("#vm-VmNotInstalled-action-kebab button")
         b.click("#vm-VmNotInstalled-forceOff")
-        if m.image not in [ "fedora-33" ]:
+        if m.image not in ["fedora-33", "fedora-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             # We need to wait till it's restarted and shut if off again in order to edit the offline VM configuration

--- a/test/verify/check-networking-bond
+++ b/test/verify/check-networking-bond
@@ -63,7 +63,7 @@ class TestBonding(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-33"]:
+        if m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed and both On

--- a/test/verify/check-networking-bridge
+++ b/test/verify/check-networking-bridge
@@ -54,7 +54,7 @@ class TestBridge(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-33"]:
+        if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Check that the members are displayed and both On

--- a/test/verify/check-networking-team
+++ b/test/verify/check-networking-team
@@ -55,7 +55,7 @@ class TestTeam(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-33"]:
+        if m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed


### PR DESCRIPTION
fedora-testing is now based on fedora-33, so remove it from the list.