### PR TITLE
tests: fix cleaning up alerts in TestMachines.testCreate*

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2555,8 +2555,9 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             self.machine.execute("until test -z $(virsh list --all --name); do sleep 1; done")
             self.machine.execute("until test -z $(ls /home/admin/.local/share/libvirt/images/ 2>/dev/null); do sleep 1; done")
 
-            if b.is_present(".pf-c-alert-group li .pf-c-alert .pf-c-button"):
-                b.click(".pf-c-alert-group li .pf-c-alert .pf-c-button")
+            alerts = self.browser.call_js_func("ph_count", ".pf-c-alert-group li")
+            for i  in range(alerts):
+                    b.click(".pf-c-alert-group li:first-of-type .pf-c-alert .pf-c-button")
 
             b.wait_not_present(".pf-c-alert-group li .pf-c-alert")
 


### PR DESCRIPTION
When killing the VMs  which are getting installed in the tests we always expect one
alert coming from virt-install, which we clear for the next Vm creation
to get tested. Sometimes more alerts are present and we should count with it,
instead of failing the test if more than one alert appeared.

Fixes failures like testCreateFileSource here https://logs.cockpit-project.org/logs/pull-14899-20201116-133548-02d8420b-rhel-8-3-distropkg/log.html