### PR TITLE
test: rhel-8-4 supports firmware configuration

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2825,7 +2825,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
 
         # Change the os boot firmware configuration
-        supports_firmware_config = m.image in ['fedora-32', 'fedora-33', 'fedora-testing', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
+        supports_firmware_config = m.image in ['fedora-32', 'fedora-33', 'fedora-testing', 'rhel-8-3', 'rhel-8-3-distropkg', 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
         if supports_firmware_config:
             b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
             b.click("#vm-VmNotInstalled-firmware")


### PR DESCRIPTION
Downstream sees this already. We don't see it due to https://github.com/cockpit-project/bots/pull/1394

Blocked until we get new refresh.