### PR TITLE
base1: Drop jQuery usage from test-chan

### DIFF
--- a/src/base1/Makefile.am
+++ b/src/base1/Makefile.am
@@ -128,13 +128,6 @@ $(base_TESTS): dist/base1/test-%.html: src/base1/test-%.js $(base_DEPS)
 	cp -L $< $@.tmp.js && $(MV) $@.tmp.js $(dir $@)/$(notdir $<) && \
 	$(SED_TEST_TEMPLATE) $(srcdir)/src/base1/qunit-template.html > $@.tmp && $(MV) $@.tmp $@
 
-# HACK: last user of jquery is test-chan; port that away and drop this special-case rule
-dist/base1/test-chan.html: src/base1/test-chan.js $(base_QUNIT_DEPS)
-	$(ESLINT_RULE)
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cat $(srcdir)/node_modules/jquery/dist/jquery.slim.min.js $< > $@.tmp.js && $(MV) $@.tmp.js $(dir $@)/$(notdir $<) && \
-	$(SED_TEST_TEMPLATE) $(srcdir)/src/base1/qunit-template.html > $@.tmp && $(MV) $@.tmp $@
-
 # Simple tests run without QUnit
 
 dist/base1/test-%.js: dist/base1/test-%.html

--- a/src/base1/test-spawn.js
+++ b/src/base1/test-spawn.js
@@ -1,13 +1,5 @@
 /* global cockpit, QUnit */
 
-/* Seems like something jQuery should provide */
-if (!console.assert) {
-    console.assert = function(cond, msg) {
-        if (!cond)
-            throw msg || "assertion failed";
-    };
-}
-
 function MockPeer() {
     /*
      * Events triggered here:


### PR DESCRIPTION
This test previously failed with the standard JS EventListener API, as
with that the registered listeners get called asynchronously, while with
jQuery they got called synchronously. This caused send() to _first_ call
the fallback MockPeer.onrecv() echo implementation, and _then_ the
registered "real" recv handler. Thus the former sent wrong and
unexpected replies. To fix that, postpone onrecv()'s own reply sending,
so that the event listeners have a chance to run first.

Adjust the number of expected messages in "filter message in" for that,
as this now does not see MockPeer.onrecv()'s standard reply any more.

This was the last jQuery consumer in the unit tests (and all of base1),
so drop the jquery bundling hack as well.
