### PR TITLE
test: Accept more versions of "Failed to generate stack trace" messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1140,7 +1140,7 @@ class MachineCase(unittest.TestCase):
             # When coredump could not be generated, we cannot do much with info about there being a coredump
             # Ignore this message and all subsequent core dumps
             # If there is more than just one line about coredump, it will fail and show this messages
-            if m == "Failed to generate stack trace: (null)":
+            if m.startswith("Failed to generate stack trace"):
                 self.allowed_messages.append("Process .* of user .* dumped core.*")
                 continue
 


### PR DESCRIPTION
We sometimes see also "Failed to generate stack trace: invalid `Elf' handle".

Should fix https://logs.cockpit-project.org/logs/pull-14923-20201119-031817-a364e9ca-fedora-33/log.html#43