### PR TITLE
workflows: Allow manually triggering unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,5 @@
 name: unit-tests
-on: [push, pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sometimes gihub fails to trigger this workflow so allow us to do so
manually. Also drop the `pull_request` as it is not actually needed.