### PR TITLE
test: Always start NetworkManager for NetworkCase tests

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -86,6 +86,8 @@ class NetworkCase(MachineCase, NetworkHelpers):
             self.restore_dir("/etc/NetworkManager", post_restore_action="systemctl try-restart NetworkManager")
             self.restore_dir("/etc/sysconfig/network-scripts")
 
+        m.execute("systemctl start NetworkManager")
+
         # Ensure a clean and consistent state.  We remove rogue
         # connections that might still be here from the time of
         # creating the image and we prevent NM from automatically


### PR DESCRIPTION
Every now and then NetworkManager is not running and then bunch of tests fail.

Fixes #14877 - I could not find any reason why NetworkManager would not be running. Seems just like some rare race happening. Lets just start it back up. If I see the same issue again as I reported in #14877 I'll reopen the issue.

Fixes failures like these: https://logs.cockpit-project.org/logs/pull-14927-20201119-104043-0eba091a-ubuntu-stable/log.html#153-2 