### PR TITLE
updates: Redesign available and up-to-date pages and autoupdates

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -20,9 +20,8 @@
 import cockpit from "cockpit";
 import React from "react";
 import PropTypes from 'prop-types';
-import { debounce } from "throttle-debounce";
+import { Alert, Button, Form, FormGroup, Modal, Radio, Text, TextVariants } from '@patternfly/react-core';
 
-import { OnOffSwitch } from "cockpit-components-onoff.jsx";
 import * as Select from "cockpit-components-select.jsx";
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 
@@ -249,67 +248,128 @@ function getBackend(forceReinit) {
  * Properties:
  * onInitialized(enabled): (optional): callback once backend knowsn whether automatic updates are enabled
  */
-export default class AutoUpdates extends React.Component {
+export const AutoUpdatesBody = (props) => {
+    const { enabled, type, day, time } = props;
+    const days = {
+        "": "everyday",
+        mon: "every Monday",
+        tue: "every Tuesday",
+        wed: "every Wednesday",
+        thu: "every Thursday",
+        fri: "every Friday",
+        sat: "every Saturday",
+        sun: "every Sunday"
+    };
+
+    let str;
+    if (enabled) {
+        str = type == "security" ? _("Security updates ") : _("Updates ");
+        str += cockpit.format(_("will be applied $0 at $1"), days[day], time);
+    } else {
+        str = _("Automatic updates are not set up");
+    }
+
+    return (<Text component={TextVariants.p}>{str}</Text>);
+};
+
+/**
+ * Main React component
+ *
+ * Properties:
+ * onInitialized(enabled): (optional): callback once backend knowsn whether automatic updates are enabled
+ */
+export class AutoUpdates extends React.Component {
     constructor() {
         super();
-        this.state = { backend: null, pending: false, pendingEnable: null };
+        this.state = {
+            pending: false,
+            showModal: false,
+            supported: undefined,
+            enabled: undefined,
+            type: undefined,
+            day: undefined,
+            time: undefined,
+        };
+        this.handleChange = this.handleChange.bind(this);
         this.initializeBackend();
-        this.debouncedSetConfig = debounce(300, false, (enabled, type, day, time) => {
-            this.state.backend.setConfig(enabled, type, day, time)
-                    .always(() => {
-                        this.debugBackendState("handleChange: setConfig finished");
-                        this.setState({ pending: false, pendingEnable: null });
-                    });
-        });
     }
 
     initializeBackend(forceReinit) {
         return getBackend(forceReinit).then(b => {
-            const promise = this.setState({ backend: b }, () => {
+            const promise = this.setState({ backend: b, enabled: b.enabled, type: b.type, day: b.day, time: b.time }, () => {
                 this.debugBackendState("AutoUpdates: backend initialized");
                 return null;
             });
-            if (this.props.onInitialized)
-                this.props.onInitialized(b ? b.enabled : null);
+            if (this.props.onInitialized) {
+                this.props.onInitialized({
+                    autoUpdatesEnabled: b ? b.enabled : null,
+                    autoUpdatesType: b ? b.type : null,
+                    autoUpdatesDay: b ? b.day : null,
+                    autoUpdatesTime: b ? b.time : null,
+                });
+            }
             return promise;
         });
     }
 
     debugBackendState(prefix) {
         if (this.state.backend)
-            debug(`${prefix}: state is (${this.state.backend.enabled}, ${this.state.backend.type}, ${this.state.backend.day}, ${this.state.backend.time})`);
+            debug(`${prefix}: state is (${this.state.enabled}, ${this.state.type}, ${this.state.day}, ${this.state.time})`);
     }
 
-    handleChange(enabled, type, day, time) {
+    handleChange() {
+        const { backend, enabled, type, day, time } = this.state;
+
         this.debugBackendState(`handleChange(${enabled}, ${type}, ${day}, ${time})`);
-        this.setState({ pending: true, pendingEnable: enabled });
-        this.debouncedSetConfig(enabled, type, day, time);
+        this.setState({ pending: true });
+        backend.setConfig(enabled, type, day, time)
+                .always((b) => {
+                    this.debugBackendState("handleChange: setConfig finished");
+                    if (this.props.onInitialized) {
+                        this.props.onInitialized({
+                            autoUpdatesEnabled: enabled,
+                            autoUpdatesType: type,
+                            autoUpdatesDay: day,
+                            autoUpdatesTime: time,
+                        });
+                    }
+                    this.setState({ pending: false, showModal: false });
+                });
     }
 
     render() {
-        const backend = this.state.backend;
-        if (!backend)
+        if (!this.state.backend)
             return null;
 
-        let autoConfig;
         const enabled = !this.state.pending && this.props.privileged;
+        const hours = Array.from(Array(24).keys());
+        const body = (
+            <Form isHorizontal>
+                <FormGroup fieldId="type" label={_("Type")}>
+                    <Radio isChecked={!this.state.enabled}
+                           onChange={e => this.setState({ enabled: false, type: null })}
+                           enabled={enabled}
+                           label={_("No updates")}
+                           id="no-updates"
+                           name="type" />
+                    <Radio isChecked={this.state.enabled && this.state.type === "security"}
+                           onChange={e => this.setState({ enabled: true, type: "security" })}
+                           enabled={enabled}
+                           label={_("Security updates only")}
+                           id="security-updates"
+                           name="type" />
+                    <Radio isChecked={this.state.enabled && this.state.type === "all"}
+                           onChange={e => this.setState({ enabled: true, type: "all" })}
+                           enabled={enabled}
+                           label={_("All updates")}
+                           id="all-updates"
+                           name="type" />
+                </FormGroup>
 
-        if (backend.enabled && backend.installed) {
-            const hours = Array.from(Array(24).keys());
-
-            autoConfig = (
-                <div className="auto-conf">
-                    <span className="auto-conf-group">
-                        <Select.Select id="auto-update-type" enabled={enabled} initial={backend.type}
-                                       onChange={ t => this.handleChange(null, t, null, null) }>
-                            <Select.SelectEntry data="all">{_("Apply all updates")}</Select.SelectEntry>
-                            <Select.SelectEntry data="security">{_("Apply security updates")}</Select.SelectEntry>
-                        </Select.Select>
-                    </span>
-
-                    <span className="auto-conf-group">
-                        <Select.Select id="auto-update-day" enabled={enabled} initial={backend.day}
-                                       onChange={ d => this.handleChange(null, null, d, null) }>
+                {this.state.enabled && <>
+                    <FormGroup fieldId="when" label={_("When")}>
+                        <Select.Select id="auto-update-day" enabled={enabled} initial={this.state.day}
+                                       onChange={d => this.setState({ day: d })}>
                             <Select.SelectEntry data="">{_("every day")}</Select.SelectEntry>
                             <Select.SelectDivider />
                             <Select.SelectEntry data="mon">{_("Mondays")}</Select.SelectEntry>
@@ -320,41 +380,57 @@ export default class AutoUpdates extends React.Component {
                             <Select.SelectEntry data="sat">{_("Saturdays")}</Select.SelectEntry>
                             <Select.SelectEntry data="sun">{_("Sundays")}</Select.SelectEntry>
                         </Select.Select>
-                    </span>
 
-                    <span className="auto-conf-group">
                         <span className="auto-conf-text">{_("at")}</span>
 
-                        <Select.Select id="auto-update-time" enabled={enabled} initial={backend.time}
-                                       onChange={ t => this.handleChange(null, null, null, t) }>
-                            { hours.map(h => <Select.SelectEntry key={h} data={h + ":00"}>{('0' + h).slice(-2) + ":00"}</Select.SelectEntry>)}
+                        <Select.Select id="auto-update-time" enabled={enabled} initial={this.state.time}
+                                       onChange={t => this.setState({ time: t })}>
+                            {hours.map(h => <Select.SelectEntry key={h} data={h + ":00"}>{('0' + h).slice(-2) + ":00"}</Select.SelectEntry>)}
                         </Select.Select>
-                    </span>
+                    </FormGroup>
 
-                    <span className="auto-conf-group auto-conf-text">{_("and restart the machine automatically.")}</span>
-                </div>
-            );
-        }
+                    <Alert variant="info" title={_("This host will reboot after updates are installed.")} isInline />
+                </>}
+            </Form>
+        );
 
-        // we want the button to already show the target state while being disabled
-        const onOffState = this.state.pendingEnable == null ? backend.enabled : this.state.pendingEnable;
-
-        return (
-            <div className="header-buttons pk-updates--header pk-updates--header--auto" id="automatic">
-                <h2 className="pk-updates--header--heading">{_("Automatic updates")}</h2>
-                <div className="pk-updates--header--actions">
-                    <OnOffSwitch state={onOffState} disabled={!enabled}
-                                 onChange={e => {
-                                     if (!this.state.backend.installed) {
-                                         install_dialog(this.state.backend.packageName)
-                                                 .then(() => { this.initializeBackend(true).then(() => { this.handleChange(e, null, null, null) }) }, () => null);
-                                     } else {
-                                         this.handleChange(e, null, null, null);
-                                     }
-                                 }} />
-                </div>
-                {autoConfig}
-            </div>);
+        return (<>
+            <Button variant="secondary"
+                    isDisabled={!enabled}
+                    onClick={() => {
+                        if (!this.state.backend) {
+                            install_dialog(this.state.backend.packageName)
+                                    .then(() => {
+                                        this.initializeBackend(true);
+                                        this.setState({ showModal: true });
+                                    }, () => null);
+                        } else {
+                            this.setState({ showModal: true });
+                        }
+                    }}>
+                {_("Edit")}
+            </Button>
+            <Modal position="top" variant="small" id="automatic-updates-dialog" isOpen={this.state.showModal}
+                   title={_("Automatic updates")}
+                   footer={
+                       <>
+                           <Button variant="primary"
+                                   isLoading={ this.state.pending }
+                                   isDisabled={ this.state.pending }
+                                   onClick={ this.handleChange }>
+                               {_("Save changes")}
+                           </Button>
+                           <Button variant="link"
+                                   isDisabled={ this.state.pending }
+                                   isLoading={ this.state.pending }
+                                   onClick={() => this.setState({ showModal: false })}>
+                               {_("Cancel")}
+                           </Button>
+                       </>
+                   }>
+                {body}
+            </Modal>
+        </>);
     }
 }
 

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -296,7 +296,7 @@ export class AutoUpdates extends React.Component {
 
     initializeBackend(forceReinit) {
         return getBackend(forceReinit).then(b => {
-            const promise = this.setState({ backend: b, enabled: b.enabled, type: b.type, day: b.day, time: b.time }, () => {
+            const promise = this.setState({ backend: b, enabled: b && b.enabled, type: b && b.type, day: b && b.day, time: b && b.time }, () => {
                 this.debugBackendState("AutoUpdates: backend initialized");
                 return null;
             });
@@ -398,7 +398,7 @@ export class AutoUpdates extends React.Component {
             <Button variant="secondary"
                     isDisabled={!enabled}
                     onClick={() => {
-                        if (!this.state.backend) {
+                        if (!this.state.backend.installed) {
                             install_dialog(this.state.backend.packageName)
                                     .then(() => {
                                         this.initializeBackend(true);

--- a/pkg/packagekit/history.jsx
+++ b/pkg/packagekit/history.jsx
@@ -102,8 +102,7 @@ export class History extends React.Component {
         });
 
         return (
-            <ListingTable caption={_("Update history")}
-                          aria-label={_("Updates history")}
+            <ListingTable aria-label={_("Updates history")}
                           showHeader={false}
                           className="updates-history"
                           columns={[_("Time"), _("History package count")]}

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -389,6 +389,7 @@ const UpdatesList = ({ updates }) => {
     return (
         <ListingTable className="available"
                 aria-label={_("Available updates")}
+                gridBreakPoint='grid-lg'
                 columns={[
                     { title: _("Name") },
                     { title: _("Version") },

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -387,8 +387,7 @@ const UpdatesList = ({ updates }) => {
     });
 
     return (
-        <ListingTable className="available"
-                aria-label={_("Available updates")}
+        <ListingTable aria-label={_("Available updates")}
                 gridBreakPoint='grid-lg'
                 columns={[
                     { title: _("Name") },
@@ -616,7 +615,7 @@ class CardsPage extends React.Component {
                         <CardTitle><h2>{card.title}</h2></CardTitle>
                         {card.actions && <CardActions>{card.actions}</CardActions>}
                     </CardHeader>
-                    <CardBody>
+                    <CardBody className="contains-list">
                         {card.body}
                     </CardBody>
                 </Card>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -546,8 +546,8 @@ const StatusCard = ({ updates, highestSeverity, timeSinceRefresh }) => {
         </Flex>
         <Flex flex={{ default: 'flex_1' }}>
             <FlexItem>
-                <Text component={TextVariants.p}>{stateStr}</Text>
-                <Text component={TextVariants.small}>{lastChecked}</Text>
+                <Text id="state" component={TextVariants.p}>{stateStr}</Text>
+                <Text id="last-checked" component={TextVariants.small}>{lastChecked}</Text>
             </FlexItem>
         </Flex>
     </Flex>);
@@ -581,7 +581,7 @@ class CardsPage extends React.Component {
                 id: "automatic-updates",
                 className: "pk-card-info",
                 title: _("Automatic updates"),
-                actions: (<AutoUpdates onInitialized={newState => this.setState(newState)} privileged={this.state.privileged} />),
+                actions: (<AutoUpdates onInitialized={newState => this.setState(newState)} privileged={this.props.privileged} />),
                 body: (<AutoUpdatesBody enabled={this.state.autoUpdatesEnabled}
                                         type={this.state.autoUpdatesType}
                                         day={this.state.autoUpdatesDay}
@@ -954,14 +954,14 @@ class OsUpdates extends React.Component {
             let text;
 
             applyAll = (
-                <Button variant="primary" onClick={ () => this.applyUpdates(false) }>
+                <Button id={num_updates == num_security_updates ? "install-security" : "install-all"} variant="primary" onClick={ () => this.applyUpdates(false) }>
                     { num_updates == num_security_updates
                         ? _("Install security updates") : _("Install all updates") }
                 </Button>);
 
             if (num_security_updates > 0 && num_updates > num_security_updates) {
                 applySecurity = (
-                    <Button variant="secondary" onClick={ () => this.applyUpdates(true) }>
+                    <Button id="install-security" variant="secondary" onClick={ () => this.applyUpdates(true) }>
                         {_("Install security updates")}
                     </Button>);
             }

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -25,8 +25,8 @@ import ReactDOM from 'react-dom';
 
 import moment from "moment";
 import {
-    Button, Grid, GridItem, Tooltip,
-    Card, CardTitle, CardActions, CardHeader, CardBody, CardFooter,
+    Button, Gallery, Tooltip,
+    Card, CardTitle, CardActions, CardHeader, CardBody,
     DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     Flex, FlexItem,
     Page, PageSection, PageSectionVariants,
@@ -567,8 +567,8 @@ class CardsPage extends React.Component {
         const cardContents = [
             {
                 id: "status",
-                span: 6,
                 title: _("Status"),
+                className: "pk-card-info",
                 actions: (<Tooltip content={_("Check for updates")}>
                     <Button variant="secondary" onClick={this.props.handleRefresh}><RedoIcon /></Button>
                 </Tooltip>),
@@ -577,8 +577,8 @@ class CardsPage extends React.Component {
                                   timeSinceRefresh={this.props.timeSinceRefresh} />
             },
             {
-                span: 6,
                 id: "automatic-updates",
+                className: "pk-card-info",
                 title: _("Automatic updates"),
                 actions: (<AutoUpdates onInitialized={newState => this.setState(newState)} privileged={this.state.privileged} />),
                 body: (<AutoUpdatesBody enabled={this.state.autoUpdatesEnabled}
@@ -610,19 +610,15 @@ class CardsPage extends React.Component {
 
         return cardContents.map(card => {
             return (
-                <GridItem key={card.id} span={card.span}>
-                    <Card className={card.className}
-                          id={card.id}>
-                        <CardHeader>
-                            <CardTitle><h2>{card.title}</h2></CardTitle>
-                            {card.actions && <CardActions>{card.actions}</CardActions>}
-                        </CardHeader>
-                        <CardBody>
-                            {card.body}
-                        </CardBody>
-                        <CardFooter />
-                    </Card>
-                </GridItem>
+                <Card key={card.id} className={card.className} id={card.id}>
+                    <CardHeader>
+                        <CardTitle><h2>{card.title}</h2></CardTitle>
+                        {card.actions && <CardActions>{card.actions}</CardActions>}
+                    </CardHeader>
+                    <CardBody>
+                        {card.body}
+                    </CardBody>
+                </Card>
             );
         });
     }
@@ -992,13 +988,13 @@ class OsUpdates extends React.Component {
                         <h2 id="page-title">{_("Software updates")}</h2>
                     </PageSection>
                     <PageSection>
-                        <Grid hasGutter>
+                        <Gallery className='pk-overview' hasGutter>
                             <CardsPage handleRefresh={this.handleRefresh}
                                        applySecurity={applySecurity}
                                        applyAll={applyAll}
                                        highestSeverity={highest_severity}
                                        {...this.state} />
-                        </Grid>
+                        </Gallery>
                     </PageSection>
                 </>
             );
@@ -1048,9 +1044,9 @@ class OsUpdates extends React.Component {
                         <h2 id="page-title">{_("Software updates")}</h2>
                     </PageSection>
                     <PageSection>
-                        <Grid hasGutter>
+                        <Gallery className='pk-overview' hasGutter>
                             <CardsPage handleRefresh={this.handleRefresh} {...this.state} />
-                        </Grid>
+                        </Gallery>
                     </PageSection>
                 </>
             );

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -274,9 +274,8 @@ function updateItem(info, pkgNames, key) {
         type = (
             <>
                 <Tooltip id="tip-severity" content={ secSeverity || _("security") }>
-                    <span className={iconClasses}>
-                        { (info.cve_urls && info.cve_urls.length > 0) ? info.cve_urls.length : "" }
-                    </span>
+                    <span className={iconClasses} />
+                    { (info.cve_urls && info.cve_urls.length > 0) ? info.cve_urls.length : "" }
                 </Tooltip>
             </>);
     } else {
@@ -284,9 +283,8 @@ function updateItem(info, pkgNames, key) {
         type = (
             <>
                 <Tooltip id="tip-severity" content={tip}>
-                    <span className={iconClasses}>
-                        { bugs ? info.bug_urls.length : "" }
-                    </span>
+                    <span className={iconClasses} />
+                    { bugs ? info.bug_urls.length : "" }
                 </Tooltip>
             </>);
     }

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -35,7 +35,7 @@ import {
 import { RebootingIcon, CheckIcon, ExclamationCircleIcon, RedoIcon } from "@patternfly/react-icons";
 import { Remarkable } from "remarkable";
 
-import AutoUpdates from "./autoupdates.jsx";
+import { AutoUpdates, AutoUpdatesBody } from "./autoupdates.jsx";
 import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -580,7 +580,11 @@ class CardsPage extends React.Component {
                 span: 6,
                 id: "automatic-updates",
                 title: _("Automatic updates"),
-                body: (<AutoUpdates onInitialized={newState => this.setState(newState)} privileged={this.state.privileged} />),
+                actions: (<AutoUpdates onInitialized={newState => this.setState(newState)} privileged={this.state.privileged} />),
+                body: (<AutoUpdatesBody enabled={this.state.autoUpdatesEnabled}
+                                        type={this.state.autoUpdatesType}
+                                        day={this.state.autoUpdatesDay}
+                                        time={this.state.autoUpdatesTime} />),
             },
         ];
 
@@ -596,11 +600,11 @@ class CardsPage extends React.Component {
             });
         }
 
-        if (!this.state.autoUpdatesEnabled) { // automatic updates are not tracked by PackageKit, hide history when they are enabled
+        if (!this.state.autoUpdatesEnabled && this.props.history.length > 0) { // automatic updates are not tracked by PackageKit, hide history when they are enabled
             cardContents.push({
                 id: "update-history",
                 title: _("Update history"),
-                body: <History packagekit={this.state.autoUpdatesEnabled ? [] : this.props.history} />
+                body: <History packagekit={this.props.history} />
             });
         }
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -596,6 +596,7 @@ class CardsPage extends React.Component {
                     {this.props.applySecurity}
                     {this.props.applyAll}
                 </div>),
+                containsList: true,
                 body: <UpdatesList updates={this.props.updates} />
             });
         }
@@ -604,6 +605,7 @@ class CardsPage extends React.Component {
             cardContents.push({
                 id: "update-history",
                 title: _("Update history"),
+                containsList: true,
                 body: <History packagekit={this.props.history} />
             });
         }
@@ -615,7 +617,7 @@ class CardsPage extends React.Component {
                         <CardTitle><h2>{card.title}</h2></CardTitle>
                         {card.actions && <CardActions>{card.actions}</CardActions>}
                     </CardHeader>
-                    <CardBody className="contains-list">
+                    <CardBody className={card.containsList ? "contains-list" : null}>
                         {card.body}
                     </CardBody>
                 </Card>

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -358,3 +358,11 @@ table.header-buttons {
 table.available {
     margin-bottom: var(--pf-global--spacer--3xl);
 }
+
+.pk-overview {
+    --pf-l-gallery--GridTemplateColumns: repeat(auto-fit,minmax(0.5fr,1fr));
+
+    > article:not(.pk-card-info) {
+        grid-column: span 2;
+    }
+}

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -1,4 +1,11 @@
 @import "@patternfly/patternfly/components/Page/page.scss";
+@import "~@patternfly/patternfly/components/Page/page.scss";
+@import "../lib/ct-card.scss";
+
+/* Style the list cards as ct-cards */
+.pf-c-page__main-section .pf-c-card {
+    @extend .ct-card;
+}
 
 .pf-c-table tr:nth-child(1) {
     > td, th {

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -251,14 +251,12 @@ div.changelog {
 }
 
 .flow-list-blank-slate {
-    padding-top: 8em;
     margin: 0 auto;
     max-width: 69rem;
     text-align: center;
 }
 
 .flow-list {
-    margin: 1em 1em 3em;
     padding: 0;
     max-width: 110rem;
     text-align: left;
@@ -278,7 +276,6 @@ div.changelog {
 }
 
 .update-log {
-    padding-top: 8em;
     margin: 0 auto;
     max-width: 69rem;
     text-align: center;
@@ -353,10 +350,6 @@ table.header-buttons {
 
 .pk-updates .pf-c-description-list + div {
     padding-top: var(--pf-global--spacer--md);
-}
-
-table.available {
-    margin-bottom: var(--pf-global--spacer--3xl);
 }
 
 .pk-overview {

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -100,6 +100,7 @@ table.listing-ct thead th {
     td.type {
         white-space: nowrap;
     }
+
     td.changelog {
         vertical-align: top;
 
@@ -154,6 +155,14 @@ table.listing-ct thead th {
 .pficon-enhancement:before {
     content: "\e93a";
     font-family: pf-symbols;
+}
+
+td.type {
+    > .pficon,
+    > .fa {
+        margin: calc(-0.5 * var(--pf-global--spacer--xs)) var(--pf-global--spacer--xs) 0 0;
+        vertical-align: middle;
+    }
 }
 
 div.changelog {

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -360,9 +360,17 @@ table.available {
 }
 
 .pk-overview {
-    --pf-l-gallery--GridTemplateColumns: repeat(auto-fit,minmax(0.5fr,1fr));
+    --pk-columns: 2;
+    --pf-l-gallery--GridTemplateColumns: repeat(var(--pk-columns), 1fr);
 
-    > article:not(.pk-card-info) {
-        grid-column: span 2;
+    > .pf-c-card:not(.pk-card-info) {
+        // Extend all non-info cards to be full width;
+        // let pk-card-info fit 1 column of the grid
+        grid-column: 1 / -1;
+    }
+
+    @media screen and (max-width: $pf-global--breakpoint--lg) {
+        // Shrink to 1 column when space is constrained
+        --pk-columns: 1;
     }
 }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -79,7 +79,7 @@ class TestUpdates(NoSubManCase):
         b = self.browser
         if arch is None:
             arch = self.primary_arch
-        row = ".pk-updates .available.ct-table > tbody:nth-of-type(%i) " % index
+        row = "#available-updates table[aria-label='Available updates'] > tbody:nth-of-type(%i) " % index
         severity_to_icon = {"bug": "fa-bug", "enhancement": "pficon-enhancement", "security": "pficon-security"}
 
         if isinstance(pkgname, list):
@@ -144,12 +144,10 @@ class TestUpdates(NoSubManCase):
         # no updates on the Software Updates page
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_present(".content-header-extra button")
-        b.wait_in_text("#state", "No updates pending")
+        b.wait_not_present("#automatic-updates")
+        b.wait_in_text("#status #state", "System is up to date")
         # PK starts from a blank state, thus should force refresh and set the "time since" to 0
-        b.wait_text(".content-header-extra--updated", "Last checked: a few seconds ago")
-        # empty state visible in main area
-        b.wait_present("#updates .pf-c-empty-state")
+        b.wait_in_text("#status #last-checked", "Last checked: a few seconds ago")
 
         install_lockfile = "/tmp/finish-pk"
         # create two updates; force installing chocolate before vanilla
@@ -161,15 +159,14 @@ class TestUpdates(NoSubManCase):
         self.enableRepo()
 
         # check again
-        b.wait_in_text(".content-header-extra button", "Check for updates")
-        b.click(".content-header-extra button")
+        b.click("#status button")
 
-        b.wait_text(".content-header-extra--updated", "Last checked: a few seconds ago")
+        b.wait_in_text("#status #last-checked", "Last checked: a few seconds ago")
 
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_present("#available-updates")
         self.assertEqual(b.text("#state"), "2 updates")
 
-        b.wait_in_text("table.available", "vanilla")
+        b.wait_in_text("table[aria-label='Available updates']", "vanilla")
         self.check_nth_update(1, "chocolate", "2.0-2", arch=self.secondary_arch)
         self.check_nth_update(2, "vanilla", "1.0-2")
 
@@ -190,8 +187,8 @@ class TestUpdates(NoSubManCase):
         self.assertFalse(b.is_present("table.updates-history"))
 
         # should only have one button (no security updates)
-        self.assertEqual(b.text(".pk-updates--header--actions button"), "Install all updates")
-        b.click(".pk-updates--header--actions button")
+        self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
+        b.click("#available-updates button#install-all")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
@@ -214,16 +211,13 @@ class TestUpdates(NoSubManCase):
         m.execute("touch {0}".format(install_lockfile))
 
         # update should succeed and show restart page; cancel
-        b.wait_in_text("#app #updates h1", "Restart recommended")
-        self.assertEqual(b.text("#app #updates button.pf-m-primary"), "Restart now")
-        b.click("#app #updates button.pf-m-link:contains('Ignore')")
+        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
+        self.assertEqual(b.text("#app .pf-c-empty-state button.pf-m-primary"), "Restart now")
+        b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
 
-        # should go back to updates overview, nothing pending any more
-        b.wait_in_text("#state", "No updates pending")
-        b.wait_in_text(".content-header-extra--updated", "Last checked")
-
-        # empty state visible in main area
-        b.wait_present("#updates .pf-c-empty-state")
+        # TODO make Packagekit GetUpdates work for tests properly
+        b.wait_not_present("#available-updates")
+        b.wait_in_text("#status #last-checked", "Last checked")
 
         # new versions are now installed
         m.execute("test -f /stamp-vanilla-1.0-2 && test -f /stamp-chocolate-2.0-2")
@@ -272,10 +266,10 @@ class TestUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_present("#available-updates")
         self.assertEqual(b.text("#state"), "6 updates, including 3 security fixes")
 
-        b.wait_in_text("table.available", "sevcritical")
+        b.wait_in_text("table[aria-label='Available updates']", "sevcritical")
 
         # security updates should get sorted on top and then alphabetically, so start with "secdeclare"
         sel = self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
@@ -342,14 +336,14 @@ class TestUpdates(NoSubManCase):
         b.enter_page("/updates")
 
         # install only security updates
-        self.assertEqual(b.text("#app #updates button.pf-m-secondary"), "Install security updates")
-        b.click("#app #updates button.pf-m-secondary")
+        self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
+        b.click("#available-updates button#install-security")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
         # should have succeeded and show restart page
-        b.wait_in_text("#app #updates h1", "Restart recommended")
+        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
 
         def assertHistory(path, updates):
             selector = path + " li:nth-child({0})"
@@ -363,15 +357,15 @@ class TestUpdates(NoSubManCase):
         assertHistory("ul", ["secdeclare", "secparse", "sevcritical"])
 
         # ignore restarting
-        b.click("#app #updates button.pf-m-link:contains('Ignore')")
+        b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
 
         # should have succeeded; 3 non-security updates left
         b.wait_in_text("#state", "3 updates")
-        b.wait_in_text("#updates #available h3", "Available updates")
-        b.wait_in_text("table.available", "norefs-doc")
-        self.assertIn("buggy", b.text("table.available"))
-        self.assertNotIn("secdeclare", b.text("table.available"))
-        self.assertNotIn("secparse", b.text("table.available"))
+        b.wait_present("#available-updates")
+        b.wait_in_text("table[aria-label='Available updates']", "norefs-doc")
+        self.assertIn("buggy", b.text("table[aria-label='Available updates']"))
+        self.assertNotIn("secdeclare", b.text("table[aria-label='Available updates']"))
+        self.assertNotIn("secparse", b.text("table[aria-label='Available updates']"))
 
         # history should show the security updates
         assertHistory("table.updates-history ul", ["secdeclare", "secparse", "sevcritical"])
@@ -385,15 +379,15 @@ class TestUpdates(NoSubManCase):
         m.execute("test -f /stamp-buggy-2-1 && test -f /stamp-norefs-bin-1-1 && test -f /stamp-norefs-doc-1-1")
 
         # should now only have one button (no security updates left)
-        self.assertEqual(b.text(".pk-updates--header--actions button"), "Install all updates")
-        b.click(".pk-updates--header--actions button")
+        self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
+        b.click("#available-updates button#install-all")
 
         b.wait_in_text("#state", "Applying updates")
         b.wait_present("#app div.progress-bar")
 
         # should have succeeded and show restart
-        b.wait_in_text("#app #updates h1", "Restart recommended")
-        b.wait_present("#app #updates button.pf-m-link:Contains('Ignore')")
+        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
+        b.wait_present("#app .pf-c-empty-state button.pf-m-link:Contains('Ignore')")
 
         # new versions are now installed
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
@@ -403,7 +397,7 @@ class TestUpdates(NoSubManCase):
         assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
         # do the reboot; this will disconnect the web UI
-        b.click("#app #updates button.pf-m-primary")
+        b.click("#app .pf-c-empty-state button.pf-m-primary")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
@@ -414,9 +408,7 @@ class TestUpdates(NoSubManCase):
         b.login_and_go("/updates")
 
         # no further updates
-        b.wait_in_text("#state", "No updates pending")
-        # empty state visible in main area
-        b.wait_present("#updates .pf-c-empty-state")
+        b.wait_in_text("#state", "System is up to date")
 
         # history on "up to date" page should show the recent update (expanded by default)
         assertHistory("table.updates-history tbody.pf-m-expanded ul", ["buggy", "norefs-bin", "norefs-doc"])
@@ -439,11 +431,12 @@ class TestUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_present("#available-updates")
         self.assertEqual(b.text("#state"), "1 security fix")
 
         # should only have one button (only security updates)
-        self.assertEqual(b.text(".pk-updates--header--actions button"), "Install security updates")
+        b.wait_not_present("#available-updates button#install-all")
+        self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
 
         # security fix without CVE URLs
         # PackageKit's dnf backend does not recognize this (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
@@ -453,12 +446,12 @@ class TestUpdates(NoSubManCase):
             self.createPackage("secnocve", "1", "2", severity="security", changes="Fix leak")
             self.enableRepo()
             # check for updates
-            b.wait_in_text(".content-header-extra button", "Check for updates")
-            b.click(".content-header-extra button")
-            b.wait_in_text("#available h3", "Available updates")
+            b.wait_in_text("#status button")
+            b.click("#status button")
+            b.wait_present("#available-updates")
             b.wait_in_text("#state", "2")
 
-            b.wait_in_text("table.available", "secnocve")
+            b.wait_in_text("table[aria-label='Available updates']", "secnocve")
 
             # secnocve should be displayed properly
             self.check_nth_update(2, "secnocve", "1-2", "security", desc_matches=["Fix leak"])
@@ -489,7 +482,7 @@ class TestUpdates(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_in_text("table.available", "Things change")
+        b.wait_in_text("table[aria-label='Available updates']", "Things change")
 
         # "coarse" package list should be complete
         t = b.text("#app .ct-table tbody:nth-of-type(1) tr:first-child [data-label=Name]")
@@ -531,14 +524,14 @@ class TestUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_in_text("#updates h3", "Available updates")
+        b.wait_present("#available-updates")
         self.assertEqual(b.text("#state"), "1 update")
 
-        b.click(".pk-updates--header--actions button")
+        b.click("#available-updates button#install-all")
 
         b.wait_in_text("#state", "Applying updates failed")
 
-        self.assertRegex(b.text("#app #updates pre:first-of-type"),
+        self.assertRegex(b.text("#app .pf-c-page pre:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory")
 
         # not expecting any buttons
@@ -562,14 +555,14 @@ class TestUpdates(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.click(".pk-updates--header--actions button")
+        b.click("#available-updates button#install-all")
 
         # let updates start and zap PackageKit
         b.wait_present("#app div.progress-bar")
         m.execute("systemctl kill --signal=SEGV packagekit.service")
 
         b.wait_in_text("#state", "Applying updates failed")
-        b.wait_in_text("#app #updates", "PackageKit crashed")
+        b.wait_in_text("#app .pf-c-page", "PackageKit crashed")
 
         self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
         self.allow_journal_messages("Process .* dumped core.*")
@@ -593,7 +586,7 @@ class TestUpdates(NoSubManCase):
         b.login_and_go("/updates")
 
         b.wait_in_text("#state", "Loading available updates failed")
-        b.wait_in_text("#app pre", "PackageKit is not installed")
+        b.wait_in_text(".pf-c-page__main-section pre", "PackageKit is not installed")
 
         # update status on front page should be invisible
         b.go("/system")
@@ -613,12 +606,12 @@ class TestUpdates(NoSubManCase):
         # getting update info is allowed to all users
         self.login_and_go("/updates", superuser=False)
         b.wait_text("#state", "1 update")
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_present("#available-updates")
 
         # but applying updates is not; FIXME: this is a crappy UX
-        b.click(".pk-updates--header--actions button")
+        b.click("#available-updates button#install-all")
         b.wait_text("#state", "Applying updates failed")
-        b.wait_in_text("#updates pre", "authentication")
+        b.wait_in_text("#app pre", "authentication")
 
         # become superuser
         b.switch_to_top()
@@ -639,17 +632,18 @@ class TestUpdates(NoSubManCase):
         # page adjusts automatically to privilege change
         b.switch_to_frame("cockpit1:localhost/updates")
         b.wait_text("#state", "1 update")
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_present("#available-updates")
 
         # applying updates works now
-        b.click(".pk-updates--header--actions button")
+        b.click("#available-updates button#install-all")
 
-        b.wait_in_text("#app #updates h1", "Restart recommended")
-        self.assertEqual(b.text("#app #updates button.pf-m-primary"), "Restart now")
-        b.click("#app #updates button.pf-m-link:contains('Ignore')")
+        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
+        self.assertEqual(b.text("#app .pf-c-empty-state button.pf-m-primary"), "Restart now")
+        b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
 
         # should go back to updates overview, nothing pending any more
-        b.wait_in_text("#state", "No updates pending")
+        # TODO make Packagekit GetUpdates work for tests properly
+        b.wait_not_present("#available-updates")
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 class TestWsUpdate(NoSubManCase):
@@ -675,7 +669,7 @@ class TestWsUpdate(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.click(".pk-updates--header--actions button")
+        b.click("#available-updates button#install-all")
         b.wait_in_text("#state", "Applying updates")
         b.wait_in_text("#app div.progress-description", "slow")
 
@@ -689,9 +683,9 @@ class TestWsUpdate(NoSubManCase):
         m.execute("touch {0}".format(install_lockfile))
 
         # should have succeeded and show restart page; cancel
-        b.wait_in_text("#app #updates h1", "Restart recommended")
-        b.click("#app #updates button.pf-m-link:contains('Ignore')")
-        b.wait_in_text("#state", "No updates pending")
+        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
+        b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
+        b.wait_in_text("#state", "System is up to date")
 
         # now pretend that there is a newer cockpit-ws available, warn about disconnect
         self.createPackage("cockpit-ws", "999", "1")
@@ -699,13 +693,15 @@ class TestWsUpdate(NoSubManCase):
         self.createPackage("cockpit", "999", "1")
         m.execute("if type apt; then dpkg -P cockpit-ws-dbgsym; fi")
         self.enableRepo()
-        b.wait_in_text(".content-header-extra button", "Check for updates")
-        b.click(".content-header-extra button")
+        b.wait_present("#status button")
+        b.click("#status button")
 
-        b.wait_in_text("#updates #available h3", "Available updates")
+        b.wait_present("#available-updates")
         self.assertEqual(b.text("#state"), "2 updates")
-        b.wait_in_text("table.available", "cockpit-ws")
-        b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
+        b.wait_in_text("table[aria-label='Available updates']", "cockpit-ws")
+
+        #TODO redesign this functionality in a new design
+        #b.wait_in_text("#app div.alert-warning", "This web console will be updated.")
 
         self.allow_restart_journal_messages()
 
@@ -768,13 +764,13 @@ class TestUpdatesSubscriptions(PackageCase):
         b.go("/updates")
         b.enter_page("/updates")
         # empty state visible in main area
-        b.wait_present("#updates .pf-c-empty-state button")
-        b.wait_in_text("#updates .pf-c-empty-state", "This system is not registered")
+        b.wait_present(".pf-c-empty-state button")
+        b.wait_in_text(".pf-c-empty-state", "This system is not registered")
         # no header bar
         b.wait_not_present(".content-header-extra")
 
         # test the button to switch to Subscriptions
-        b.click("#updates .pf-c-empty-state button")
+        b.click(".pf-c-empty-state button")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname === "/subscriptions"')
 
@@ -782,9 +778,9 @@ class TestUpdatesSubscriptions(PackageCase):
         self.register()
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_present(".content-header-extra button")
-        b.wait_in_text("#state", "No updates pending")
-        b.wait_in_text("#updates .pf-c-empty-state", "up to date")
+        # check updates
+        b.wait_present("#status button")
+        b.wait_in_text("#state", "System is up to date")
 
         # same on system page
         b.go("/system")
@@ -816,25 +812,21 @@ class TestUpdatesSubscriptions(PackageCase):
         b.enter_page("/updates")
 
         # empty state visible in main area
-        b.wait_present("#updates .pf-c-empty-state button")
-        b.wait_in_text("#updates .pf-c-empty-state", "This system is not registered")
-
-        # should show header bar
-        b.wait_text("#state", "1 update")
-        b.wait_text(".content-header-extra--updated", "Last checked: a few seconds ago")
+        b.wait_present(".pf-c-empty-state button")
+        b.wait_in_text(".pf-c-empty-state", "This system is not registered")
 
         # after registration it should show available updates
         self.register()
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_not_present("#updates .pf-c-empty-state")
-        b.wait_in_text("#available h3", "Available updates")
+        b.wait_not_present(".pf-c-empty-state")
+        b.wait_present("#available-updates")
         # no update history yet
         self.assertFalse(b.is_present("table.updates-history"))
 
         # has action buttons
-        b.wait_present(".content-header-extra button")
-        self.assertEqual(b.text(".pk-updates--header--actions button"), "Install all updates")
+        b.wait_present("#status button")
+        self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
 
         # show available updates on system page too
         b.go("/system")
@@ -864,12 +856,6 @@ class TestAutoUpdates(NoSubManCase):
             self.assertFalse(b.is_present("#automatic"))
             self.assertFalse(b.is_present("#auto-update-type"))
             return
-
-        def wait_pending():
-            # the controls get disabled while applying the config changes is in progress; wait for both transitions
-            b.wait_present("#automatic input:disabled")
-            b.wait_not_present("#automatic input:disabled")
-            b.wait_not_present("#automatic .disabled")
 
         def assertTimerDnf(hour, dow):
             out = m.execute("systemctl --no-legend list-timers dnf-automatic-install.timer")
@@ -917,107 +903,116 @@ class TestAutoUpdates(NoSubManCase):
                 raise NotImplementedError(self.backend)
 
         # automatic updates are supported, but off
-        b.wait_present("#automatic h2")
-        b.wait_present("#automatic .onoff-ct input:not(:checked)")
+        b.wait_present("#automatic-updates")
+        b.wait_in_text("#automatic-updates p", "Automatic updates are not set up")
         self.assertFalse(b.is_present("#auto-update-type"))
         assertTimer(None)
 
         # enable
-        b.click("#automatic .onoff-ct input")
-        wait_pending()
-        b.wait_present("#automatic .onoff-ct input:checked")
-        assertTimer("06")
-        assertType("all")
-        b.wait_in_text("#auto-update-type", "Apply all updates")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#all-updates")
         b.wait_in_text("#auto-update-time", "06:00")
         b.wait_in_text("#auto-update-day", "every day")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates p", "Updates will be applied")
+        assertTimer("06")
+        assertType("all")
 
         # change type to security
-        b.set_val("#auto-update-type", "security")
-        wait_pending()
-        b.wait_in_text("#auto-update-type", "Apply security updates")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#security-updates")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Security updates will be applied")
         assertType("security")
         assertTimer("06")
 
         # change it back
-        b.set_val("#auto-update-type", "all")
-        wait_pending()
-        b.wait_in_text("#auto-update-type", "Apply all updates")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#all-updates")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Updates will be applied")
         assertType("all")
         assertTimer("06")
 
         # change day
-        b.set_val("#auto-update-day", "thu")
-        wait_pending()
-        b.wait_in_text("#auto-update-day", "Thursday")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.set_val("#auto-update-day", "Thursdays")
+        b.select_from_dropdown("#auto-update-day", "Thursdays")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Updates will be applied every Thursday")
         assertType("all")
         assertTimer("06", "Thu")
 
         # change time
-        b.set_val("#auto-update-time", "21:00")
-        wait_pending()
-        b.wait_in_text("#auto-update-time", "21:00")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.select_from_dropdown("#auto-update-time", "21:00")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Updates will be applied every Thursday at 21:00")
         assertType("all")
         assertTimer("21", "Thu")
 
         # page should parse it correctly from the timer
         b.logout()
         b.login_and_go("/updates")
-        b.wait_present("#automatic .onoff-ct input:checked")
-        b.wait_in_text("#auto-update-day", "Thursday")
-        b.wait_in_text("#auto-update-time", "21:00")
+        b.wait_in_text("#automatic-updates p", "Updates will be applied every Thursday at 21:00")
 
         # change back to daily
-        b.set_val("#auto-update-day", "")
-        wait_pending()
-        b.wait_in_text("#auto-update-day", "every day")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.select_from_dropdown("#auto-update-day", "every day")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Updates will be applied everyday at 21:00")
         assertType("all")
         assertTimer("21")
 
         # disable
-        b.click("#automatic .onoff-ct input")
-        wait_pending()
-        b.wait_present("#automatic .onoff-ct input:not(:checked)")
-        self.assertFalse(b.is_present("#auto-update-type"))
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#no-updates")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates p", "Automatic updates are not set up")
         assertTimer(None)
 
         if self.backend == "dnf":
+            b.click("#automatic-updates button")
+            b.wait_present("#automatic-updates-dialog")
+            b.click("#all-updates")
+            b.click("#automatic-updates-dialog button:contains('Save changes')")
+            b.wait_not_present("#automatic-updates-dialog")
             # OnCalendar= parsing: only time
             m.execute("mkdir -p /etc/systemd/system/dnf-automatic.timer.d")
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=08:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
-            b.click("#automatic .onoff-ct input")
-            b.wait_present("#automatic .onoff-ct input:checked")
-            b.wait_in_text("#auto-update-time", "08:00")
-            b.wait_in_text("#auto-update-day", "every day")
+            b.wait_in_text("#automatic-updates", "Updates will be applied everyday at 8:00")
 
             # OnCalendar= parsing: weekday and time
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=Tue 20:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
-            b.wait_present("#automatic .onoff-ct input:checked")
-            b.wait_in_text("#auto-update-time", "20:00")
-            b.wait_in_text("#auto-update-day", "Tuesday")
+            b.wait_in_text("#automatic-updates", "Updates will be applied every Tuesday at 20:00")
 
             # OnCalendar= parsing: "every day" calendar and time
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-*-* 07:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
-            b.wait_present("#automatic .onoff-ct input:checked")
-            b.wait_in_text("#auto-update-time", "07:00")
-            b.wait_in_text("#auto-update-day", "every day")
+            b.wait_in_text("#automatic-updates", "Updates will be applied everyday at 7:00")
 
             # OnCalendar= parsing: unsupported
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=*-02-* 11:00\n" > '
-                      r'/etc/systemd/system/dnf-automatic.timer.d/cal.conf; systemctl daemon-reload')
+                      r'/etc/systemd/system/dnf-automatic-install.timer.d/time.conf; systemctl daemon-reload')
             b.reload()
             b.enter_page("/updates")
-            b.wait_in_text("#updates .pf-c-empty-state", "up to date")
-            b.wait_not_present("#automatic")
+            b.wait_in_text("#status #state", "System is up to date")
+            b.wait_in_text("#automatic-updates", "Automatic updates are not set up")
 
     def testWithAvailableUpdates(self):
         b = self.browser
@@ -1029,20 +1024,20 @@ class TestAutoUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_present("#available")
+        b.wait_present("#available-updates")
 
         if not self.supported_backend:
-            self.assertFalse(b.is_present("#automatic"))
-            self.assertFalse(b.is_present("#auto-update-type"))
+            b.wait_in_text("#automatic-updates", "Automatic updates are not set up")
             return
 
-        b.wait_present("#automatic .onoff-ct input:not(:checked)")
-        self.assertFalse(b.is_present("#auto-update-type"))
+        b.wait_in_text("#automatic-updates", "Automatic updates are not set up")
 
         # enable
-        b.click("#automatic .onoff-ct input")
-        b.wait_present("#automatic .onoff-ct input:checked")
-        b.wait_present("#auto-update-type")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#all-updates")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates p", "Updates will be applied")
 
         if self.backend == 'dnf':
             self.checkUpgradeRebootDnf()
@@ -1058,12 +1053,11 @@ class TestAutoUpdates(NoSubManCase):
         self.login_and_go("/updates", superuser=False)
 
         if not self.supported_backend:
-            self.assertFalse(b.is_present("#automatic"))
-            self.assertFalse(b.is_present("#auto-update-type"))
+            self.assertFalse(b.is_present("#automatic-updates"))
             return
 
         # detecting auto updates configuration works unprivileged, but changing does not
-        b.wait_present("#automatic .onoff-ct input:disabled:not(:checked)")
+        b.wait_present("#automatic-updates button:disabled")
 
         # become superuser
         b.switch_to_top()
@@ -1082,11 +1076,13 @@ class TestAutoUpdates(NoSubManCase):
         b.switch_to_frame("cockpit1:localhost/updates")
 
         # enable auto-updates
-        b.wait_present("#automatic .onoff-ct input:not(:checked)")
-        b.wait_not_present("#auto-update-type")
-        b.click("#automatic .onoff-ct input")
-        b.wait_present("#automatic .onoff-ct input:checked")
-        b.wait_present("#auto-update-type:not(:disabled)")
+        b.wait_in_text("#automatic-updates", "Automatic updates are not set up")
+        b.click("#automatic-updates button")
+        b.wait_present("#automatic-updates-dialog")
+        b.click("#all-updates")
+        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        b.wait_in_text("#automatic-updates", "Updates will be applied")
+
 
         # Drop privileges
         b.switch_to_top()
@@ -1102,9 +1098,8 @@ class TestAutoUpdates(NoSubManCase):
         b.switch_to_frame("cockpit1:localhost/updates")
 
         # auto-update status still visible, but disabled
-        b.wait_present("#automatic .onoff-ct input:checked")
-        b.wait_present("#automatic .onoff-ct input:disabled")
-        b.wait_present("#auto-update-type:disabled")
+        b.wait_in_text("#automatic-updates p", "will be applied")
+        b.wait_present("#automatic-updates button:disabled")
 
     def checkUpgradeRebootDnf(self):
         """part of testWithAvailableUpdates() for dnf backend"""
@@ -1151,24 +1146,23 @@ class TestAutoUpdatesInstall(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_present("#available")
+        b.wait_present("#available-updates")
         if self.backend == 'dnf':
-            b.wait_present("#automatic .onoff-ct input:not(:checked)")
+            b.wait_in_text("#automatic-updates p", "Automatic updates are not set up")
         else:
             # on-demand installation isn't supported, switch to enable it isn't visible
-            self.assertFalse(b.is_present("#automatic"))
+            b.wait_in_text("#automatic-updates", "Automatic updates are not set up")
 
         # apply updates
-        b.click("#app #updates button.pk-update--all")
+        b.click("#available-updates button#install-all")
+        b.click(".pf-c-empty-state button.pf-m-link")
 
-        # empty state visible in main area
-        b.click('#updates .pf-c-empty-state button.pf-m-link')
-        self.assertFalse(b.is_present("#available"))
+        self.assertFalse(b.is_present("#available-updates"))
         if self.backend == 'dnf':
-            b.is_present('#automatic')
+            b.is_present('#automatic-updates')
         else:
             # on-demand installation isn't supported
-            self.assertFalse(b.is_present('#automatic'))
+            self.assertFalse(b.is_present('#automatic-updates'))
 
     @skipImage("No supported auto update backend", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")
     def testInstall(self):
@@ -1203,7 +1197,7 @@ WantedBy=basic.target
         b.login_and_go('/updates')
 
         # click through install dialog
-        b.click("#automatic .onoff-ct input")
+        b.click("#automatic-updates button")
         b.wait_popup('dialog')
         b.wait_visible('#dialog button.apply')
         b.wait_not_attr('#dialog button.apply', 'disabled', '')
@@ -1211,8 +1205,7 @@ WantedBy=basic.target
 
         # as dnf-automatic isn't actually installed DnfImpl.setConfig will fail,
         # but we can check that the backend is now enabled
-        b.wait_present("#automatic .onoff-ct input:checked")
-
+        b.wait_present("#automatic-updates-dialog")
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Fixes: #14749
Fixes: #14723

Use PF4 cards for updates page. Redesign and refactor autoupdates.

### Autoupdates
![Screenshot from 2020-11-20 11-04-30](https://user-images.githubusercontent.com/42733240/99790264-2422a780-2b24-11eb-9b67-59217867dd5a.png)
![Screenshot from 2020-11-20 11-04-44](https://user-images.githubusercontent.com/42733240/99790273-271d9800-2b24-11eb-9ee1-299d5a45d904.png)


### Available
![Screenshot from 2020-11-20 11-03-47](https://user-images.githubusercontent.com/42733240/99790005-c2fad400-2b23-11eb-9e0d-59c875ad44d7.png)
.
.
.
![Screenshot from 2020-11-20 11-04-01](https://user-images.githubusercontent.com/42733240/99790017-c8581e80-2b23-11eb-9c33-84f566afff5d.png)


### Up to date
![Screenshot from 2020-11-20 11-37-19](https://user-images.githubusercontent.com/42733240/99790708-c93d8000-2b24-11eb-9f46-3370d8e13d08.png)
