### PR TITLE
cockpit-desktop: Open links with target=_blank

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -38,6 +38,7 @@ set -eu
 
 # minimalistic WebKit browser
 PYWEBKIT='
+import subprocess
 import sys
 import gi
 
@@ -57,12 +58,16 @@ class Browser(Gtk.Window):
         self.add(self.webview)
         self.webview.show()
         self.webview.connect("load-changed", self._title_changed)
+        self.webview.connect("create", self._open_external)
 
         self.connect("destroy", Gtk.main_quit)
         self.connect("key-press-event", self._key_pressed)
 
         self.show()
         self.webview.load_uri(uri)
+
+    def _open_external(self, widget, event):
+        subprocess.run(["xdg-open", event.get_request().get_uri()])
 
     def _title_changed(self, widget, event):
         self.set_title(self.webview.get_title() or "")


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1882677

HOWEVER - since the browser is spawn in a separate network, those links cannot be loaded. The same issue exists with chrome/firefox. I am thinking if we want to run browser separately, but then it would not see cockpit... Any ideas?

Then we could enhance chrome/firefox as well so they don't show url and tab bars and would open these link in separate windows (or reusing your current session) but it still needs to deal with that network problem.