### PR TITLE
machines: add extra field validation for storage volume creation dialog

### DIFF
--- a/pkg/machines/components/storagePools/storageVolumeCreateBody.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreateBody.jsx
@@ -22,27 +22,34 @@ import PropTypes from 'prop-types';
 import { FormGroup, FormSection, InputGroup, TextInput } from "@patternfly/react-core";
 
 import * as Select from "cockpit-components-select.jsx";
-import { units, digitFilter } from '../../helpers.js';
+import { convertToUnit, units, digitFilter } from '../../helpers.js';
 import cockpit from 'cockpit';
 
 const _ = cockpit.gettext;
 
-const VolumeName = ({ idPrefix, volumeName, onValueChanged }) => {
+const VolumeName = ({ idPrefix, volumeName, validationFailed, onValueChanged }) => {
+    const validationStateName = validationFailed.volumeName ? 'error' : 'default';
     return (
         <FormGroup fieldId={`${idPrefix}-name`}
+                   validated={validationStateName}
+                   helperTextInvalid={validationFailed.volumeName}
                    label={_("Name")}>
             <TextInput id={`${idPrefix}-name`}
                         minLength={1}
                         placeholder={_("New volume name")}
                         value={volumeName || ""}
+                        validated={validationStateName}
                         onChange={value => onValueChanged('volumeName', value)} />
         </FormGroup>
     );
 };
 
-const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolType, onValueChanged }) => {
+const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolCapacity, storagePoolType, validationFailed, onValueChanged }) => {
+    // TODO: Use slider
     let formatRow;
     let validVolumeFormats;
+    const volumeMaxSize = parseFloat(convertToUnit(storagePoolCapacity, units.B, unit).toFixed(2));
+    const validationStateSize = validationFailed.size ? 'error' : 'default';
 
     // For the valid volume format types for different pool types see https://libvirt.org/storage.html
     if (['disk'].indexOf(storagePoolType) > -1) {
@@ -70,6 +77,9 @@ const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolType, onValueC
     return (
         <FormSection className="ct-form-split">
             <FormGroup fieldId={`${idPrefix}-size`}
+                       id={`${idPrefix}-size-group`}
+                       validated={validationStateSize}
+                       helperTextInvalid={validationFailed.size}
                        label={_("Size")}>
                 <InputGroup>
                     <TextInput id={`${idPrefix}-size`}
@@ -78,6 +88,8 @@ const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolType, onValueC
                                onKeyPress={digitFilter}
                                step={1}
                                min={0}
+                               max={volumeMaxSize}
+                               validated={validationStateSize}
                                onChange={value => onValueChanged('size', value)} />
                     <Select.Select id={`${idPrefix}-unit`}
                                    initial={unit}
@@ -96,17 +108,20 @@ const VolumeDetails = ({ idPrefix, size, unit, format, storagePoolType, onValueC
     );
 };
 
-export const VolumeCreateBody = ({ idPrefix, storagePool, onValueChanged, dialogValues }) => {
+export const VolumeCreateBody = ({ idPrefix, storagePool, validationFailed, onValueChanged, dialogValues }) => {
     return (
         <>
             <VolumeName idPrefix={idPrefix}
                         volumeName={dialogValues.volumeName}
+                        validationFailed={validationFailed}
                         onValueChanged={onValueChanged} />
             <VolumeDetails idPrefix={idPrefix}
                            size={dialogValues.size}
                            unit={dialogValues.unit}
                            format={dialogValues.format}
+                           storagePoolCapacity={storagePool.capacity}
                            storagePoolType={storagePool.type}
+                           validationFailed={validationFailed}
                            onValueChanged={onValueChanged} />
         </>
     );

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -4547,7 +4547,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         class StorageVolumeCreateDialog(object):
             def __init__(
                 self, test_obj, pool_name, vol_name, size="128", unit="MiB", format='qcow2',
-                pool_type = "dir", xfail=False, xfail_error=None, remove=True,
+                pool_type = "dir", xfail=False, xfail_object=None, xfail_error=None, remove=True,
             ):
                 self.test_obj = test_obj
                 self.pool_name = pool_name
@@ -4557,6 +4557,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 self.unit = unit
                 self.format = format
                 self.xfail = xfail
+                self.xfail_object = xfail_object
                 self.xfail_error = xfail_error
                 self.remove = remove
 
@@ -4597,12 +4598,15 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             def create(self):
                 b.click(".pf-c-modal-box__footer button:contains(Create)")
 
-                if (not self.xfail):
+                if not self.xfail:
                     # Creation of volumes might take longer for some pool types
                     if self.pool_type  in ["disk", "netfs"]:
                         b.wait_present(".pf-c-modal-box__footer button.pf-m-in-progress")
                         b.wait_present(".pf-c-modal-box__footer button:contains(Create):disabled")
                     b.wait_not_present("#create-volume-dialog-modal")
+                else:
+                    if "size" == self.xfail_object:
+                        b.wait_in_text("#create-volume-dialog-size-group .pf-c-form__helper-text.pf-m-error", self.xfail_error)
 
             def verify(self):
                 # Check that the defined volume is now visible
@@ -4631,6 +4635,20 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 b.click("#pool-{0}-system-overview".format(self.pool_name)) # open the "Storage volumes" subtab
 
                 self.test_obj.togglePoolRow(self.pool_name)
+
+        # Check size validation
+        StorageVolumeCreateDialog(
+            self,
+            pool_name="dir-pool",
+            vol_name="volume_of_dir_pool",
+            size="1000",
+            unit="GiB",
+            format="qcow2",
+            remove=True,
+            xfail=True,
+            xfail_object='size',
+            xfail_error = "exceed the storage pool",
+        ).execute()
 
         # Check volume creation for various pool types
         StorageVolumeCreateDialog(


### PR DESCRIPTION
Firstly, add an max size allowance when creating new storage volumes.
The new max value is the total capacity of the pool.
This is a very generous max limit, but anything stricter like setting
the pool capacity cancels the whole idea of thin-provisioning.
It's perfectly fine that the combined capacity of all volumes exceeds
capacity of the storage pool as long as the volumes are actually not using it
all.
Secondly, validate that the storage volume name is not empty.

This change affects two dialig, the Volume Creation and the Add Disk
dialog.

Fixes #13120
Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1777685