### PR TITLE
test: remove tangd-update workaround

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -156,7 +156,7 @@ class TestStorage(StorageCase):
         #
         #        https://github.com/latchset/tang/issues/23
 
-        if m.image not in ["rhel-7-9"]:
+        if m.image not in ["rhel-7-9", "centos-7"]:
             m.execute("systemctl reset-failed tangd-update; systemctl restart tangd-update")
 
         m.execute("systemctl start tangd.socket")


### PR DESCRIPTION
The latest tang release in centos-7 (version 6-2) now contains a fix for
https://bugzilla.redhat.com/show_bug.cgi?id=1703445.

There are now no more OS images left using this branch which require
this workaround, so let's remove it entirely.