### PR TITLE
test: adapt to new virt-install in debian-testing

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1622,7 +1622,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
-        if self.machine.image not in ["fedora-33", "fedora-testing"]:
+        if self.machine.image not in ["fedora-33", "fedora-testing", "debian-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             self.machine.execute("virsh destroy pxe-guest")
@@ -2870,7 +2870,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         m.execute("> {0}".format(logfile)) # clear logfile
         b.click("#vm-VmNotInstalled-action-kebab button")
         b.click("#vm-VmNotInstalled-forceOff")
-        if m.image not in ["fedora-33", "fedora-testing"]:
+        if m.image not in ["fedora-33", "fedora-testing", "debian-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             # We need to wait till it's restarted and shut if off again in order to edit the offline VM configuration


### PR DESCRIPTION
debian-testing just got virt-install 3.2.0, which includes a fix to
prevent rebooting of a newly-created VM if it was manually stopped.

We therefore don't need this workaround on debian-testing anymore.

See also https://bugzilla.redhat.com/show_bug.cgi?id=1818089
See also https://github.com/virt-manager/virt-manager/commit/1b48772bc1fc8aa7fd390c7b42d675395e5d7969