### PR TITLE
machines: add support for cloning VMs

### DIFF
--- a/pkg/machines/components/vmCloneDialog.jsx
+++ b/pkg/machines/components/vmCloneDialog.jsx
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { useState } from 'react';
+import { Button, Form, FormGroup, Modal, TextInput } from '@patternfly/react-core';
+
+import { isEmpty, isObjectEmpty } from '../helpers.js';
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+
+import "./vmCloneDialog.scss";
+const _ = cockpit.gettext;
+
+export const CloneDialog = ({ name, connectionName, toggleModal }) => {
+    const [newVmName, setNewVmName] = useState(name + '-clone');
+    const [inProgress, setInProgress] = useState(false);
+    const [virtCloneOutput, setVirtCloneOutput] = useState('');
+    const [error, dialogErrorSet] = useState({});
+
+    function validateParams() {
+        const validation = {};
+        if (isEmpty(newVmName.trim()))
+            validation.name = _("Name must not be empty");
+
+        return validation;
+    }
+
+    function onClone() {
+        const validation = validateParams();
+        if (!isObjectEmpty(validation)) {
+            setInProgress(false);
+            return;
+        }
+
+        setInProgress(true);
+        return cockpit.spawn(["virt-clone", "--connect", "qemu:///" + connectionName, "--original", name, "--name", newVmName, "--auto-clone"], { superuser: "try", pty: true })
+                .stream(setVirtCloneOutput)
+                .then(toggleModal, exc => {
+                    setInProgress(false);
+                    dialogErrorSet({ dialogError: cockpit.format(_("Failed to clone VM $0"), name) });
+                });
+    }
+
+    const validationFailed = validateParams();
+    return (
+        <Modal position="top" variant="small" isOpen onClose={toggleModal}
+           title={cockpit.format(_("Create a clone VM based on $0"), name)}
+           footer={
+               <>
+                   {!isObjectEmpty(error) && <ModalError dialogError={error.dialogError} dialogErrorDetail={virtCloneOutput} />}
+                   {isObjectEmpty(error) && virtCloneOutput && <code className="vm-clone-virt-clone-output">{virtCloneOutput}</code>}
+                   <Button variant='primary'
+                           isDisabled={!isObjectEmpty(validationFailed)}
+                           isLoading={inProgress}
+                           onClick={onClone}>
+                       {_("Clone")}
+                   </Button>
+                   <Button variant='link' onClick={toggleModal}>
+                       {_("Cancel")}
+                   </Button>
+               </>
+           }>
+            <Form isHorizontal>
+                <FormGroup label={_("Name")} fieldId="vm-name"
+                           id="vm-name-group"
+                           helperTextInvalid={validationFailed.name}
+                           validated={validationFailed.name ? "error" : "default"}>
+                    <TextInput id='vm-name'
+                               validated={validationFailed.name ? "error" : "default"}
+                               value={newVmName}
+                               onChange={setNewVmName} />
+                </FormGroup>
+            </Form>
+        </Modal>
+    );
+};

--- a/pkg/machines/components/vmCloneDialog.scss
+++ b/pkg/machines/components/vmCloneDialog.scss
@@ -1,0 +1,3 @@
+.vm-clone-virt-clone-output {
+    flex: 0 0 100%;
+}

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -394,6 +394,15 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
         self.goToMainPage()
 
+        # clone
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-clone a[aria-disabled=false]")
+
+        b.wait_text(".pf-c-modal-box__title-text", "Create a clone VM based on subVmTest1")
+        b.click("footer button.pf-m-primary")
+        b.wait_not_present(".pf-c-modal-box")
+        self.waitVmRow("subVmTest1-clone")
+
         # start another one, should appear automatically
         self.createVm("subVmTest2")
         b.wait_in_text("#vm-subVmTest2-state", "Running")


### PR DESCRIPTION
Relevant to https://bugzilla.redhat.com/show_bug.cgi?id=1683391
Fixes #14523

For release notes:
![Screen Shot 2020-11-24 at 12 52 13](https://user-images.githubusercontent.com/14921356/100107521-04fc8080-2e6a-11eb-9572-66564013c7aa.png)

### Machines: add support for cloning virtual machines

Cloning creates a new VM that uses its own disk image for storage, but most of the clone’s configuration and stored data is identical to the source VM. This makes it possible to prepare a number of VMs optimized for a certain task without the need to optimize each VM individually. 