### PR TITLE
machines: ensure that 'state' is a String before applying string functions

### DIFF
--- a/pkg/machines/components/stateIcon.jsx
+++ b/pkg/machines/components/stateIcon.jsx
@@ -62,7 +62,7 @@ export const StateIcon = ({ state, valueId, error, dismissError }) => {
             </Label>}
             <Label color={stateMap[state] && stateMap[state].color}
                    icon={stateMap[state] && stateMap[state].icon}
-                   className={"resource-state-text resource-state--" + state.toLowerCase().replaceAll(' ', '-')}
+                   className={"resource-state-text resource-state--" + (state || "").toLowerCase().replaceAll(' ', '-')}
                    id={valueId}>
                 <>
                     {rephraseUI('resourceStates', state)}


### PR DESCRIPTION
'state' should always be a string as we fetch it from the libvirt API, but
seems that users have encountered crashes because of 'state' being
undefined there.

Fixes #14959