### PR TITLE
po: Fix PO template build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,12 +143,6 @@ org.freedesktop.UDisks2.h
 /pkg/*/*.min.css.gz
 /pkg/*/*.min.html.gz
 /pkg/*/manifest.json
-/src/base1/*.min.js
-/src/base1/*.min.css
-/src/base1/*.gz
-/src/base1/fonts/*.gz
-/src/base1/po.js.gz
-/src/base1/mustache.js
 /po/po.*.js
 po*.js.gz
 /.vagrant

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -56,6 +56,7 @@ if dpkg-architecture --is amd64; then
     grep -q 'src/ws/login.html' po/cockpit.pot
     grep -q 'pkg/systemd/manifest.json.in' po/cockpit.pot
     grep -q 'src/bridge/cockpitpackages.c' po/cockpit.pot
+    ! grep -q 'test-.*.js' po/cockpit.pot
 else
     # on i386, validate that "distclean" does not remove too much
     make dist-gzip

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -46,6 +46,16 @@ fi
 if dpkg-architecture --is amd64; then
     # run distcheck on main arch
     make XZ_COMPRESS_FLAGS='-0' V=0 distcheck 2>&1
+
+    # check translation build
+    make po/cockpit.pot
+    # do some spot checks
+    grep -q 'pkg/base1/cockpit.js' po/cockpit.pot
+    grep -q 'pkg/lib/machine-dialogs.js' po/cockpit.pot
+    grep -q 'pkg/systemd/services.html' po/cockpit.pot
+    grep -q 'src/ws/login.html' po/cockpit.pot
+    grep -q 'pkg/systemd/manifest.json.in' po/cockpit.pot
+    grep -q 'src/bridge/cockpitpackages.c' po/cockpit.pot
 else
     # on i386, validate that "distclean" does not remove too much
     make dist-gzip

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -66,7 +66,7 @@ po/POTFILES.html.in:
 	( cd $(srcdir) && find $(TRANSLATE) -name '*.html' ) > $@
 po/POTFILES.js.in:
 	$(MKDIR_P) $(notdir $@)
-	( cd $(srcdir) && find src/base1/ $(TRANSLATE) -name '*.js' -o -name '*.jsx' ) > $@
+	( cd $(srcdir) && find $(TRANSLATE) -name '*.js' -o -name '*.jsx' ) > $@
 po/POTFILES.manifest.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json.in' ) > $@

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -66,7 +66,7 @@ po/POTFILES.html.in:
 	( cd $(srcdir) && find $(TRANSLATE) -name '*.html' ) > $@
 po/POTFILES.js.in:
 	$(MKDIR_P) $(notdir $@)
-	( cd $(srcdir) && find $(TRANSLATE) -name '*.js' -o -name '*.jsx' ) > $@
+	( cd $(srcdir) && find $(TRANSLATE) ! -name 'test-*' -name '*.js' -o -name '*.jsx' ) > $@
 po/POTFILES.manifest.in:
 	$(MKDIR_P) $(notdir $@)
 	( cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json.in' ) > $@


### PR DESCRIPTION
Commit 4b2f7176730 broke building cockpit.pot as src/base1/ does not
exist any more.

Let's prevent that in the future, and build the PO template during unit
tests, and do some spot-checks in it that it really catches HTML, js,
C, and manifest files.