### PR TITLE
Fix CSS rule specificity when overwriting PF4 rules

### DIFF
--- a/pkg/machines/components/stateIcon.scss
+++ b/pkg/machines/components/stateIcon.scss
@@ -16,6 +16,6 @@
   }
 }
 
-.resource-state--shut-off, .resource-state--inactive {
+.pf-c-label.resource-state--shut-off, .pf-c-label.resource-state--inactive {
   background: transparent;
 }

--- a/pkg/machines/components/vm/vmExpandedContent.scss
+++ b/pkg/machines/components/vm/vmExpandedContent.scss
@@ -31,7 +31,7 @@
     margin-top: 2rem;
 }
 
-.ct-vm-overview {
+.pf-l-gallery.ct-vm-overview {
   $ctVmBreakpoint: 1000px;
 
   @media screen and (max-width: $ctVmBreakpoint) {


### PR DESCRIPTION
PF4 imports come first, then we import the custom CSS. In SCSS the most
rule should take effect, when there is not difference in the specificity.
I noticed on my system the opposite however.
When being certain about overwriting default value, increase the
specificity, so that we don't rely on the order of the imported CSS.