### PR TITLE
login: Use show() and hide() instead of display: block/none

### DIFF
--- a/src/ws/login.js
+++ b/src/ws/login.js
@@ -479,7 +479,7 @@
     function login_note(msg) {
         var el = id("login-note");
         if (msg) {
-            el.style.display = 'block';
+            show(el);
             el.textContent = msg;
         } else {
             el.innerHTML = '&nbsp;';
@@ -598,9 +598,9 @@
         var msg = prompt_data.error || prompt_data.message;
         if (msg) {
             em.textContent = msg;
-            em.style.display = "block";
+            show(em);
         } else {
-            em.style.display = "none";
+            hide(em);
         }
 
         var ei = id("conversation-input");


### PR DESCRIPTION
Super-simple patch that swaps out style display for show/hide (which takes elements in addition to strings for this exact case).