### PR TITLE
test: Show which serial machine was used

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -40,7 +40,12 @@ class Test:
 
 
 def test_name(test):
-    return "{0} {1} {2}{3}".format(test.test_id, test.command[0], test.command[-1], " [ND]" if test.nondestructive else "")
+    return "{0} {1} {2}{3}".format(
+            test.test_id,
+            test.command[0],
+            test.command[-1],
+            " [ND@{0}]".format(test.serial_machine) if test.nondestructive else "",
+            )
 
 
 def flush_stdout():


### PR DESCRIPTION
With this patch we can see in log which tests were ran on the same VM.
That is useful when we suspect something broke the VM but with 4
parallel nond machines running we cannot easily know which test ran
right before the test we investigate.

Would look something like this: (both zero as I ran them on one VM)
```
> warning: Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
> warning: transport closed: disconnected
# Result testNetworkingPage (__main__.TestFirewall) succeeded
# 1 TEST PASSED [28s on vypocetnik]
ok 2 test/verify/check-networking-firewall TestFirewall.testNetworkingPage [ND] (0)
# ----------------------------------------------------------------------
# testMultipleZones (__main__.TestFirewall)

DevTools listening on ws://127.0.0.1:9378/devtools/browser/b4131698-953a-46b8-959c-bd2f79956fb8
CDP: {"source":"security","level":"error","text":"Refused to apply style from 'http://127.0.0.2:9091/cockpit/$17e2996f148dcd664d55fb04176681e3ac2beee6c3a0099f7d407d2bc0a1ec2e/shell/nav.css' because its MIME type ('text/html') is not a supported stylesheet MIME type, and strict MIME checking is enabled.","timestamp":1606389320319.8398,"url":"http://127.0.0.2:9091/network/firewall"}
> info: %cDownload the React DevTools for a better development experience: https://fb.me/react-devtools font-weight:bold
> warning: Warning: React.createFactory() is deprecated and will be removed in a future major release. Consider using JSX or use React.createElement() directly instead.
> warning: grep: /sys/class/dmi/id/power/autosuspend_delay_ms: Input/output error

> warning: transport closed: disconnected
# Result testMultipleZones (__main__.TestFirewall) succeeded
# 1 TEST PASSED [15s on vypocetnik]
ok 1 test/verify/check-networking-firewall TestFirewall.testMultipleZones [ND] (0)
```