### PR TITLE
workflows: Fix po-refresh token

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -30,6 +30,8 @@ jobs:
         with:
           # need this to also fetch tags
           fetch-depth: 0
+          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
+          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 
       - name: Run po-refresh bot
         run: |


### PR DESCRIPTION
actions/checkout always uses a token to clone the tree. This lands in
.git/config as `extraheader = AUTHORIZATION basic ...`, which overrides
our global setting in ~/.git-credentials. As a result, `git push` to the
cockpituous fork was denied.

Tell checkout to use the cockpituous token instead for consistency.