### PR TITLE
tools: Prevent co-installation of newer bridge with older packages

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -368,6 +368,12 @@ Provides: cockpit-ssh = %{version}-%{release}
 Conflicts: cockpit-dashboard < 170.x
 # PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
 Conflicts: cockpit-ws < 181.x
+# 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)
+Conflicts: cockpit-dashboard < 233
+Conflicts: cockpit-networkmanager < 233
+Conflicts: cockpit-storaged < 233
+Conflicts: cockpit-system < 233
+Conflicts: cockpit-tests < 233
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -58,7 +58,14 @@ Depends: ${misc:Depends},
          ${shlibs:Depends},
          glib-networking
 Provides: cockpit-ssh
-Breaks: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
+Breaks: cockpit-dashboard (<< 170.x),
+ cockpit-ws (<< 181.x),
+# 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)
+ cockpit-dashboard (<< 233),
+ cockpit-networkmanager (<< 233),
+ cockpit-storaged (<< 233),
+ cockpit-system (<< 233),
+ cockpit-tests (<< 233),
 Replaces: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on


### PR DESCRIPTION
Cockpit 233 stopped shipping base1/jquery.js in cockpit-bridge, see
commit 049e8b8dce. The pages which still require jQuery started to
bundle it in their own webpacks. Thus users must not try a partial
upgrade with e.g. upgrading cockpit-bridge to ≥ 233, but leaving e.g.
cockpit-storaged at an older version.

Add Breaks/Conflicts to the cockpit-bridge package dependencies to
prevent that.

Fixes #14974