### PR TITLE
tools: Build all binary packages for EPEL

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -68,7 +68,8 @@ Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{v
 
 # in RHEL the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
 # and cockpit-appstream (building optional packages like cockpit-{machines,pcp})
-%if 0%{?rhel}
+# This split does not apply to EPEL/COPR.
+%if 0%{?rhel} && 0%{?epel} == 0
 
 %if "%{name}" == "cockpit"
 %define build_basic 1


### PR DESCRIPTION
Commit cc34ffcab caused our COPR EPEL-8 builds to only build the basic
packages. This is not intended: Neither do COPR or EPEL repositories
have the BaseOS/AppStream split (so it doesn't make sense to split the
source package), nor do we ever release a cockpit-appstream.srpm to
them.

So make EPEL behave like Fedora and build all packages again.

Fixes #14974

 - [x] Fix centos-8-stream image refresh: https://github.com/cockpit-project/bots
 - [x] Fix centos-8-stream image mock to use `centos-stream-x86_64` mock config instead of `epel-8-x86_64` (which default.cfg points to): https://github.com/cockpit-project/bots/pull/1441