### PR TITLE
test: Dynamically recognize distropkg affected versions

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -29,6 +29,7 @@ import shutil
 import socket
 import sys
 import traceback
+import subprocess
 import re
 import json
 import tempfile
@@ -804,6 +805,16 @@ class MachineCase(unittest.TestCase):
         path = "/usr/share/cockpit/%s" % package
         if self.machine.execute("if test -e %s; then echo yes; fi" % path):
             self.write_file(path + '/override.json', '{ "preload": [%s]}' % ', '.join('"{0}"'.format(page) for page in pages))
+
+    def system_before(self, version, release=1):
+        try:
+            v = self.machine.execute("rpm -q --qf '%{V}\\n' cockpit-system").split(".")
+        except subprocess.CalledProcessError:
+            return False
+
+        if int(v[0]) == version:
+            return int(v[1]) < release
+        return int(v[0]) < version
 
     def setUp(self, restrict=True):
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -164,7 +164,7 @@ class TestApps(PackageCase):
             b.switch_to_top()
             b.click("#navbar-dropdown")
             b.click(".display-language-menu a")
-            if m.image == "rhel-8-3-distropkg": # Changed in #14890
+            if self.system_before(233): # Changed in #14890
                 b.wait_popup('display-language')
                 b.set_val("#display-language select", lang)
                 b.click("#display-language-select-button")

--- a/test/verify/check-dashboard
+++ b/test/verify/check-dashboard
@@ -222,7 +222,7 @@ class TestBasicDashboard(MachineCase, DashBoardHelpers):
 
         b.enter_page("/system", "10.111.113.3")
         b.wait_text_not("#system_information_systime_button", "")
-        if m.image != "rhel-8-3-distropkg":
+        if not self.system_before(231):
             b.click(".system-information a")  # View hardware details
             b.enter_page("/system/hwinfo", "10.111.113.3")
             b.click(".pf-c-breadcrumb li:first-child a")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -623,7 +623,7 @@ class TestUpdates(NoSubManCase):
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14740
+        if not self.system_before(231): # Changed in #14740
             b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
             b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
             b.click(".pf-c-modal-box button:contains('Authenticate')")
@@ -1070,7 +1070,7 @@ class TestAutoUpdates(NoSubManCase):
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14740
+        if not self.system_before(231): # Changed in #14740
             b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
             b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
             b.click(".pf-c-modal-box button:contains('Authenticate')")
@@ -1093,7 +1093,7 @@ class TestAutoUpdates(NoSubManCase):
         # Drop privileges
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if m.image not in ["rhel-8-3-distropkg"]: # Changed in #14740
+        if not self.system_before(231): # Changed in #14740
             b.click(".pf-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
             b.wait_not_present(".pf-c-modal-box:contains('Switch to limited access')")
         else:


### PR DESCRIPTION
Checking against image name has two disadvantages:
1. In RHEL downstream the "distropkg situation" can happen on base system as
   well since we split into cockpit and cockpit-appstream and when we
   update both on the same time, we are actually testing
   cockpit-appstream against distro version.
2. When actively delivering to RHEL it is rather common that we need to
   update tests on image refresh.

This approach solves both of these problems. Of course, it has potential
to leave old dead branches in the code, but I think it still provides us
with more advantages. Also it is easy to recognize if we can cleanup
these branches if we know what version of cockpit-system we have in our
oldest distropkg and what we have already released into rhel.