### PR TITLE
machines: replace usage of replaceAll with replace

### DIFF
--- a/pkg/machines/components/stateIcon.jsx
+++ b/pkg/machines/components/stateIcon.jsx
@@ -62,7 +62,7 @@ export const StateIcon = ({ state, valueId, error, dismissError }) => {
             </Label>}
             <Label color={stateMap[state] && stateMap[state].color}
                    icon={stateMap[state] && stateMap[state].icon}
-                   className={"resource-state-text resource-state--" + (state || "").toLowerCase().replaceAll(' ', '-')}
+                   className={"resource-state-text resource-state--" + (state || "").toLowerCase().replace(' ', '-')}
                    id={valueId}>
                 <>
                     {rephraseUI('resourceStates', state)}


### PR DESCRIPTION
replaceAll has been a native v8 string method only short time, therefore
it has not yet reached support in all browsers.

Fixes #14980