### PR TITLE
[r83] tests: Stop using CirrOS image - since 20/11/20 it's missing from the…

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -167,7 +167,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected Operating System has minimum memory requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.ram, units.B, vmParams.memorySizeUnit),
-                    vmParams.memorySizeUnit)
+                    vmParams.memorySizeUnit.name)
             );
         }
     }
@@ -182,7 +182,7 @@ function validateParams(vmParams) {
                 cockpit.format(
                     _("The selected Operating System has minimum storage size requirement of $0 $1"),
                     convertToUnit(vmParams.os.minimumResources.storage, units.B, vmParams.storageSizeUnit),
-                    vmParams.storageSizeUnit)
+                    vmParams.storageSizeUnit.name)
             );
         }
     }
@@ -724,11 +724,11 @@ class CreateVmModal extends React.Component {
 
             if (value && value.recommendedResources.ram) {
                 stateDelta.recommendedMemory = value.recommendedResources.ram;
-                const converted = Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, this.state.memorySizeUnit));
-                if (converted == 0)
-                    this.setState({ memorySizeUnit: units.MiB.name, memorySize: Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB)) });
+                const converted = convertToUnit(stateDelta.recommendedMemory, units.B, units.GiB);
+                if (converted == 0 || converted % 1 !== 0) // If recommended memory is not a whole number in GiB, set value in MiB
+                    this.setState({ memorySizeUnit: units.MiB }, () => this.onValueChanged("memorySize", Math.floor(convertToUnit(stateDelta.recommendedMemory, units.B, units.MiB))));
                 else
-                    this.onValueChanged('memorySize', converted);
+                    this.setState({ memorySizeUnit: units.GiB }, () => this.onValueChanged("memorySize", converted));
             } else {
                 stateDelta.recommendedMemory = undefined;
             }
@@ -738,11 +738,11 @@ class CreateVmModal extends React.Component {
 
             if (value && value.recommendedResources.storage) {
                 stateDelta.recommendedStorage = value.recommendedResources.storage;
-                const converted = Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, this.state.storageSizeUnit));
-                if (converted == 0)
-                    this.setState({ storageSizeUnit: units.MiB.name, storageSize: Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB)) });
+                const converted = convertToUnit(stateDelta.recommendedStorage, units.B, this.state.storageSizeUnit);
+                if (converted == 0 || converted % 1 !== 0) // If recommended storage is not a whole number in GiB, set value in MiB
+                    this.setState({ storageSizeUnit: units.MiB }, () => this.onValueChanged("storageSize", Math.floor(convertToUnit(stateDelta.recommendedStorage, units.B, units.MiB))));
                 else
-                    this.onValueChanged('storageSize', converted);
+                    this.setState({ storageSizeUnit: units.GiB }, () => this.onValueChanged("storageSize", converted));
             } else {
                 stateDelta.recommendedStorage = undefined;
             }

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2230,10 +2230,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             # we just need to check that the VM was spawned
             fedora_28_xml = self.machine.execute("cat /usr/share/osinfo/os/fedoraproject.org/fedora-28.xml")
             root = ET.fromstring(fedora_28_xml)
-            root.find('os').find('resources').find('minimum').find('ram').text = '134217750'
-            root.find('os').find('resources').find('minimum').find('storage').text = '134217750'
-            root.find('os').find('resources').find('recommended').find('ram').text = '268435500'
-            root.find('os').find('resources').find('recommended').find('storage').text = '268435500'
+            root.find('os').find('resources').find('minimum').find('ram').text = '134217728'
+            root.find('os').find('resources').find('minimum').find('storage').text = '134217728'
+            root.find('os').find('resources').find('recommended').find('ram').text = '268435456'
+            root.find('os').find('resources').find('recommended').find('storage').text = '268435456'
             if self.machine.image not in ["debian-stable"]:
                 root.find('os').find('eol-date').text = '9999-12-31'
             new_fedora_28_xml = ET.tostring(root)

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1585,7 +1585,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         runner.createTest(TestMachines.VmDialog(self, sourceType='pxe',
                                                 name="pxe-guest",
                                                 location="Host Device {0}: macvtap".format(iface),
-                                                storage_size=100, storage_size_unit='MiB',
+                                                storage_size=128, storage_size_unit='MiB',
                                                 start_vm=True,
                                                 delete=False))
         self.machine.execute("virsh destroy pxe-guest")
@@ -1796,7 +1796,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         runner.createTest(TestMachines.VmDialog(self, sourceType='url',
                                                 location=config.VALID_URL,
                                                 memory_size=256, memory_size_unit='MiB',
-                                                storage_size=100, storage_size_unit='MiB',
+                                                storage_size=128, storage_size_unit='MiB',
                                                 start_vm=False))
 
         # Test detection of ISO file in URL
@@ -1849,8 +1849,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         FEDORA_28 = 'Fedora 28'
         FEDORA_28_SHORTID = 'fedora28'
 
-        CIRROS = 'CirrOS'
-
         MANDRIVA_2011_FILTERED_OS = 'Mandriva Linux 2011'
 
         MAGEIA_3_FILTERED_OS = 'Mageia 3'
@@ -1864,8 +1862,8 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                      expected_memory_size=None,
                      storage_size=None, storage_size_unit='GiB',
                      expected_storage_size=None,
-                     os_name='CirrOS',
-                     os_short_id=None,
+                     os_name="Fedora 28",
+                     os_short_id="fedora28",
                      is_unattended=None,
                      profile=None,
                      root_password=None,
@@ -2061,7 +2059,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                 b.wait_val("#memory-size", self.expected_memory_size)
 
             # check minimum memory is correctly set in the slider - the following are fake data
-            if self.os_name in [TestMachines.TestCreateConfig.CIRROS, TestMachines.TestCreateConfig.FEDORA_28]:
+            if self.os_name in [TestMachines.TestCreateConfig.FEDORA_28]:
                 b.wait_attr("#memory-size-slider  div[role=slider].hide", "aria-valuemin", "128")
 
             b.wait_visible("#start-vm")
@@ -2617,16 +2615,10 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
 
     # Check various configuration changes made before VM installation persist after installation
     def testConfigureBeforeInstall(self):
+        TestMachines.CreateVmRunner(self)
+
         b = self.browser
         m = self.machine
-
-        # define default storage pool for system connection
-        cmds = [
-            "virsh pool-define-as default --type dir --target /var/lib/libvirt/images",
-            "virsh pool-start default"
-        ]
-        m.execute(" && ".join(cmds))
-        m.execute("touch {0}".format(TestMachines.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH))
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual Machines")

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -1784,13 +1784,13 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
                                                 location=config.VALID_URL,
                                                 memory_size=512, memory_size_unit='MiB',
                                                 storage_pool="No Storage",
-                                                os_name=config.MICROSOFT_SERVER_2016))
+                                                os_name=config.FEDORA_28))
 
         runner.createTest(TestMachines.VmDialog(self, sourceType='url',
                                                 location=config.VALID_URL,
                                                 memory_size=512, memory_size_unit='MiB',
                                                 storage_pool="No Storage",
-                                                os_name=config.MICROSOFT_SERVER_2016,
+                                                os_name=config.FEDORA_28,
                                                 start_vm=False))
 
         runner.createTest(TestMachines.VmDialog(self, sourceType='url',
@@ -1840,8 +1840,6 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         NOT_EXISTENT_PATH = '/tmp/not-existent.iso'
         ISO_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os/images/boot.iso'
         TREE_URL = 'https://archive.fedoraproject.org/pub/archive/fedora/linux/releases/28/Server/x86_64/os'
-
-        MICROSOFT_SERVER_2016 = 'Microsoft Windows Server 2016'
 
         # LINUX can be filtered if 3 years old
         REDHAT_RHEL_4_7_FILTERED_OS = 'Red Hat Enterprise Linux 4.9'


### PR DESCRIPTION
… dropdown

$ osinfo-query os --fields=eol-date,release-date,name | grep CirrOS
 CirrOS 0.3.0                                       | 2011-10-20   | 2013-02-08
 CirrOS 0.3.1                                       | 2013-02-08   | 2014-03-19
 CirrOS 0.3.2                                       | 2014-03-19   | 2014-09-08
 CirrOS 0.3.3                                       | 2014-09-08   | 2015-04-22
 CirrOS 0.3.4                                       | 2015-04-22   | 2017-02-14
 CirrOS 0.3.5                                       | 2017-02-14   | 2017-11-20
 CirrOS 0.4.0                                       | 2017-11-20   |

 This list above shows that already three years passed from CirrOS last
 release. Today was the last day that we showed CirrOS in the list,
 following the pattern that when no EOL date is specified we count 3
 years from the release date until we stop showing the OS.

 testCreateThenInstall needed an slight adjustment, and now it calls
 CreteVmRunner which creates the ISO file and mocks the osinfo-db, which
 is needed since we changed the used OS for CirrOS to Fedora 28.

Cherry-picked from master commit 648208bcbc1c