### PR TITLE
containers: Move unit-tests container to GitHub registry

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Run i386 test
         run: containers/unit-tests/start :i386
 
-      - name: Log into Dockerhub
-        run: podman login -u cockpituous -p ${{ secrets.DOCKER_TOKEN }} docker.io
+      - name: Log into container registry
+        run: podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
 
       - name: Push containers to registry
         run: |
-          podman push docker.io/cockpit/unit-tests:latest
-          podman push docker.io/cockpit/unit-tests:i386
+          podman push ghcr.io/cockpit-project/unit-tests:latest
+          podman push ghcr.io/cockpit-project/unit-tests:i386

--- a/containers/unit-tests/build
+++ b/containers/unit-tests/build
@@ -9,9 +9,9 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
 fi
 
 if [ -z "${1:-}" ] || [ "${1:-}" = amd64 ]; then
-    $docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t docker.io/cockpit/unit-tests ${dir}
+    $docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t ghcr.io/cockpit-project/unit-tests ${dir}
 fi
 
 if [ -z "${1:-}" ] || [ "${1:-}" = i386 ]; then
-    $docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t docker.io/cockpit/unit-tests:i386 ${dir}
+    $docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t ghcr.io/cockpit-project/unit-tests:i386 ${dir}
 fi

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,7 +1,7 @@
 #!/bin/sh -e
 
 top_srcdir=$(realpath -m "$0"/../../..)
-image=docker.io/cockpit/unit-tests:latest
+image=ghcr.io/cockpit-project/unit-tests:latest
 flags=''
 cmd=''
 
@@ -11,7 +11,7 @@ while test $# -gt 0; do
     --podman) docker="podman";;
     CC=*) ccarg="--env=$1";;
     shell) flags=-it; cmd=/bin/bash;;
-    :*) image=docker.io/cockpit/unit-tests"$1";;
+    :*) image=ghcr.io/cockpit-project/unit-tests"$1";;
     *) echo "Unknown option '$1'"; exit 1;;
   esac
   shift


### PR DESCRIPTION
We build and use the container on GitHub, so it makes most sense to also
keep the container image there, instead of downloading it from docker.io
dozens of times each day. The latter is not only wasteful, but also
prone to run into pull limits now.

 - [x] Fix dbus unit test race: PR #14985
 - [x] Wait for successful [refresh workflow run](https://github.com/cockpit-project/cockpit/actions/runs/391701631)
 - [x] Make container image public, and connect it to the repo