### PR TITLE
workflows: Fix npm-update token

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -18,6 +18,9 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v2
+        with:
+          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
+          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 
       - name: Run npm-update bot
         run: |


### PR DESCRIPTION
actions/checkout always uses a token to clone the tree. This lands in
.git/config as `extraheader = AUTHORIZATION basic ...`, which overrides
our global setting in ~/.git-credentials. As a result, `git push` to the
cockpituous fork was denied.

Tell checkout to use the cockpituous token instead for consistency.

See also d65d4c3789f5