### PR TITLE
tools: Prevent co-installation of newer bridge with older cockpit-docker

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -374,6 +374,7 @@ Conflicts: cockpit-networkmanager < 233
 Conflicts: cockpit-storaged < 233
 Conflicts: cockpit-system < 233
 Conflicts: cockpit-tests < 233
+Conflicts: cockpit-docker < 233
 
 %description bridge
 The Cockpit bridge component installed server side and runs commands on the

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -66,6 +66,7 @@ Breaks: cockpit-dashboard (<< 170.x),
  cockpit-storaged (<< 233),
  cockpit-system (<< 233),
  cockpit-tests (<< 233),
+ cockpit-docker (<< 233),
 Replaces: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on


### PR DESCRIPTION
cockpit-docker has not been supported/built for a while, but apparently
some users still have it installed. Clean it up on upgrades as well (or
let them keep an older cockpit-bridge), but prevent broken partial
upgrades.

This extends commit 23fadbd9b25e4f3.

Fixes #14979