### PR TITLE
pf4: Allow card headers to wrap

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -68,3 +68,10 @@ svg {
         }
     }
 }
+
+.pf-c-card__header {
+  // Allow actions to wrap if there's not enough space
+  // issue: https://github.com/patternfly/patternfly/issues/3713
+  // upstream fix (pending): https://github.com/patternfly/patternfly/pull/3714
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
Add an override to let card headers wrap. This is also being addressed upstream.

Meanwhile, we have an override that fixes long content in headers, such as buttons in the action area on card headers.