### PR TITLE
test: Use proper config for sos 4

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -35,20 +35,27 @@ class TestSOS(MachineCase):
         b = self.browser
         m = self.machine
 
-        # TODO - Sos 4 has moved config to /etc/sos/sos.conf and uses a different format.
-        # But we can't use that because of https://bugzilla.redhat.com/show_bug.cgi?id=1882015
-        self.restore_file("/etc/sos.conf")
-        m.write("/etc/sos.conf",
-                """
+        if m.image in ["centos-8-stream", "debian-stable"]: # Still has sos in version 3.x
+            self.restore_file("/etc/sos.conf")
+            m.write("/etc/sos.conf",
+                    """
 [general]
 only-plugins=release,date,host,cgroups,networking
 threads=1
 """)
+        else:
+            # HACK: sos ships wrong sos.conf, we need to mkdir it, see https://bugzilla.redhat.com/show_bug.cgi?id=1903281
+            m.execute("mkdir -p /etc/sos")
 
-        # Sos 4 is very slow to start without Internet, but killing
-        # the repos fixes that.
-        self.restore_dir("/etc/yum.repos.d", reboot_safe=True)
-        self.machine.execute("rm -rf /etc/yum.repos.d/*")
+            self.restore_file("/etc/sos/sos.conf")
+            m.write("/etc/sos/sos.conf",
+                    """
+[global]
+threads=1
+
+[report]
+only-plugins=release,date,host,cgroups,networking
+""")
 
         if urlroot != "":
             m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot=%s" > /etc/cockpit/cockpit.conf' % urlroot)


### PR DESCRIPTION
The mentioned issue was fixed, seems to work locally. Lets see what CI thinks.
This is driven as gating for 8.3 is broken on sos and if this works, we can just locally hack around it without delivering new version into BaseOs.