### PR TITLE
workflows: Fix npm-update

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
+          # need this to be able to push to the cockpituous fork
+          fetch-depth: 0
           # the default GITHUB_TOKEN would override our ~/.git-credentials from above
           token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 


### PR DESCRIPTION
Pushing to the cockpituous fork failed due to

   ! [remote rejected] HEAD -> npm-update-qunit-20201201-144141 (shallow update not allowed)

Fetch the full history to fix that.

-----

I [ran this fix on my fork](https://github.com/cockpit-project/cockpit/actions/runs/394071621), it succeeded and produced PR #14991, and unit tests got triggered as expected. We can't/shouldn't actually land that as it includes the fix from this PR, but it proves that this works.