### PR TITLE
base1: Fix race condition in "watch change" dbus test

### DIFF
--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -45,7 +45,10 @@ fi
 
 if dpkg-architecture --is amd64; then
     # run distcheck on main arch
-    make XZ_COMPRESS_FLAGS='-0' V=0 distcheck 2>&1
+    make XZ_COMPRESS_FLAGS='-0' V=0 distcheck 2>&1 || {
+        find -name test-suite.log | xargs cat
+        exit 1
+    }
 
     # check translation build
     make po/cockpit.pot
@@ -66,7 +69,10 @@ else
     ./configure
     make distclean
     ./configure
-    make check 2>&1
+    make check 2>&1 || {
+        find -name test-suite.log | xargs cat
+        exit 1
+    }
 fi
 
 make check-memory 2>&1 || {

--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -742,17 +742,16 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
                 });
     });
 
-    QUnit.test("watch change", function (assert) {
+    QUnit.test("watch change", assert => {
         const done = assert.async();
         assert.expect(2);
 
-        var cache = { };
+        const cache = { };
 
-        var dbus = cockpit.dbus(bus_name, channel_options);
+        const dbus = cockpit.dbus(bus_name, channel_options);
         const onnotify_cache = (event, data) => Object.assign(cache, data);
         dbus.addEventListener("notify", onnotify_cache);
 
-        dbus.watch("/otree/frobber");
         const onnotify_test = (event, data) => {
             assert.equal(typeof cache["/otree/frobber"], "object", "has path");
             assert.deepEqual(cache, {
@@ -770,9 +769,11 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
             }, "correct data");
             dbus.removeEventListener("notify", onnotify_cache);
             dbus.removeEventListener("notify", onnotify_test);
-            done();
         };
         dbus.addEventListener("notify", onnotify_test);
+
+        dbus.watch("/otree/frobber")
+                .then(() => done());
     });
 
     QUnit.test("watch barrier", function (assert) {


### PR DESCRIPTION
Install the "notify" handler before calling watch(). Before the test had
a race condition where watching finished before the onnotify_cache() was
installed, and thus `cache` was empty.

Also wait until watch() succeeds, so that the subsequent test does not
run into assertions being called after done(). watch() is guaranteed to
return after notify handlers got called [1], this ensures that this
actually happens.

[1] https://cockpit-project.org/guide/latest/cockpit-dbus.html#cockpit-dbus-watch

----

This is meant to fix [this failure](https://github.com/cockpit-project/cockpit/runs/1481034306?check_suite_focus=true#step:4:3598) ([another example](https://github.com/cockpit-project/cockpit/runs/1480864471?check_suite_focus=true#step:4:3180)), which currently haunts us like crazy, out of the blue.