### PR TITLE
machines: Drop unnecessary aria-label

### DIFF
--- a/pkg/machines/components/vmSnapshotsCreateModal.jsx
+++ b/pkg/machines/components/vmSnapshotsCreateModal.jsx
@@ -44,8 +44,7 @@ const NameRow = ({ onValueChanged, dialogValues, onValidate }) => {
                 validated={dialogValues.validationError.name ? "error" : "default"}
                 id="name"
                 type="text"
-                onChange={(value) => onValueChanged("name", value)}
-                aria-label={_("Name input text")} />
+                onChange={(value) => onValueChanged("name", value)} />
         </FormGroup>
     );
 };
@@ -57,7 +56,6 @@ const DescriptionRow = ({ onValueChanged, dialogValues }) => {
                 id="description"
                 onChange={(value) => onValueChanged("description", value)}
                 resizeOrientation="vertical"
-                aria-label={_("Description input text")}
             />
         </FormGroup>
     );


### PR DESCRIPTION
When `fieldId` and `id` is used together, this label is unnecessary. But
mainly the `input text` part makes it more confusing then helping and
also tricky to translate. Screen readers know it is input and also that
it expects text, and thanks to fieldId it knows it is named Name or
Description.