### PR TITLE
tuned: Show which profile is active

### DIFF
--- a/pkg/tuned/change-profile.jsx
+++ b/pkg/tuned/change-profile.jsx
@@ -21,6 +21,8 @@ import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
 
+import { Label, Split, SplitItem } from '@patternfly/react-core';
+
 const _ = cockpit.gettext;
 
 /* Performance profile entry
@@ -34,17 +36,27 @@ const _ = cockpit.gettext;
  */
 class TunedDialogProfile extends React.Component {
     render() {
-        var classes = "list-group-item";
-        if (this.props.selected)
+        let classes = "list-group-item";
+        let variant = "filled";
+
+        if (this.props.selected) {
             classes += " active";
-        var recommended;
-        if (this.props.recommended)
-            recommended = <span className="badge pull-right">{ _("recommended") }</span>;
+            variant = "outline";
+        }
+
         return (
             <button className={ classes } key={ this.props.name } onClick={ this.props.click }>
-                {recommended}
-                <p>{ this.props.title }</p>
-                <small>{ this.props.description }</small>
+                <Split>
+                    <SplitItem isFilled>
+                        <p>{ this.props.title }</p>
+                        <small>{ this.props.description }</small>
+                    </SplitItem>
+                    <SplitItem>
+                        {this.props.recommended && <Label color="blue" variant={variant}>{_("recommended")}</Label>}
+                        {" "}
+                        {this.props.active && <Label color="blue" variant={variant}>{_("active")}</Label>}
+                    </SplitItem>
+                </Split>
             </button>
         );
     }
@@ -87,7 +99,7 @@ export class TunedDialogBody extends React.Component {
     render() {
         var self = this;
         var profiles = this.props.profiles.map(function(itm) {
-            itm.active = (self.props.active_profile == itm.profile);
+            itm.active = (self.props.active_profile == itm.name);
             itm.selected = (self.state.selected_profile == itm.name);
             itm.click = self.handleProfileClick.bind(self, itm.name);
             return <TunedDialogProfile key={itm.name} { ...itm } />;

--- a/test/verify/check-tuned
+++ b/test/verify/check-tuned
@@ -73,9 +73,10 @@ class TestTuned(MachineCase):
         body_selector = ".pf-c-modal-box:contains('Change performance profile')"
         b.wait_present("{0} .list-group-item.active p".format(body_selector))
 
-        # Make sure we see the recommended profile and its badge
+        # Make sure we see the recommended profile and its badges
         b.wait_in_text("{0} .list-group-item.active p".format(body_selector), recommended_profile)
-        b.wait_present("{0} .list-group-item.active span.badge:contains('recommended')".format(body_selector))
+        b.wait_present("{0} .list-group-item.active .pf-c-label:contains('recommended')".format(body_selector))
+        b.wait_present("{0} .list-group-item.active .pf-c-label:contains('active')".format(body_selector))
 
         b.click("{0} .list-group-item p:contains('balanced')".format(body_selector))
         b.wait_present("{0} .list-group-item.active p:contains('balanced')".format(body_selector))


### PR DESCRIPTION
Also use PF4 components for labels and layout.

Fixes #3607

Now looks like this:
![activeisrecomemndededefwerfwe](https://user-images.githubusercontent.com/12330670/101135974-e71ee080-360c-11eb-982c-276b9d55d6af.png)
![activenone](https://user-images.githubusercontent.com/12330670/101135977-e9813a80-360c-11eb-9f38-cf3e2f3648fc.png)
