### PR TITLE
storage: Correctly use plural forms

### DIFF
--- a/pkg/storaged/drives-panel.jsx
+++ b/pkg/storaged/drives-panel.jsx
@@ -101,7 +101,7 @@ export class DrivesPanel extends React.Component {
                        className="storage-drives-list"
                        title={_("Drives")}
                        empty_text={_("No drives attached")}
-                       show_all_text={cockpit.format(_("Show all $0 drives"), drives.length)}>
+                       show_all_text={cockpit.format(cockpit.ngettext("Show $0 drive", "Show all $0 drives", drives.length), drives.length)}>
                 { drives }
             </SidePanel>
         );

--- a/pkg/storaged/things-panel.jsx
+++ b/pkg/storaged/things-panel.jsx
@@ -79,7 +79,7 @@ export class ThingsPanel extends React.Component {
                        title={_("Devices")}
                        actions={actions}
                        empty_text={_("No devices")}
-                       show_all_text={cockpit.format(_("Show all $0 devices"), devices.length)}
+                       show_all_text={cockpit.format(cockpit.ngettext("Show $0 device", "Show all $0 devices", devices.length), devices.length)}
                        client={client}>
                 { devices }
             </SidePanel>


### PR DESCRIPTION
Admittedly this is shown just when `$0 > 20` which would work fine for
majority of languages, but some languages use modulo when picking the
correct plural form where this would not work out.