### PR TITLE
workflows: Fix unit tests with podman

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: unit-tests
 on: [pull_request, workflow_dispatch]
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         startarg: [':latest', ':i386', 'CC=clang']


### PR DESCRIPTION
The recent podman version on the OSBS repo which GitHub workflows use
now fails as unprivileged user on Ubuntu 18.04 (which is still what
`ubuntu-latest` points to):

    ERRO[0063] could not find slirp4netns, the network namespace won't be configured: exec: "slirp4netns": executable file not found in $PATH

This package does not yet exist in 18.04, so move the workflow to 20.04
instead.

Note: We could also run it with sudo or with docker, but let's keep
close to what developers do on their machines.