### PR TITLE
workflows: Fix unit tests with podman for container refreshes

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   # we do both builds and all tests in a single run, so that we only upload the containers on success
+  # run as root, as podman is missing slirp4netns in Ubuntu 18.04, and does not have overlayfs by default
   refresh:
     runs-on: ubuntu-latest
     timeout-minutes: 180
@@ -18,21 +19,21 @@ jobs:
           fetch-depth: 0
 
       - name: Build fresh containers
-        run: containers/unit-tests/build
+        run: sudo containers/unit-tests/build
 
       - name: Run amd64 gcc test
-        run: containers/unit-tests/start
+        run: sudo containers/unit-tests/start
 
       - name: Run amd64 clang test
-        run: containers/unit-tests/start CC=clang
+        run: sudo containers/unit-tests/start CC=clang
 
       - name: Run i386 test
-        run: containers/unit-tests/start :i386
+        run: sudo containers/unit-tests/start :i386
 
       - name: Log into container registry
-        run: podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
+        run: sudo podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
 
       - name: Push containers to registry
         run: |
-          podman push ghcr.io/cockpit-project/unit-tests:latest
-          podman push ghcr.io/cockpit-project/unit-tests:i386
+          sudo podman push ghcr.io/cockpit-project/unit-tests:latest
+          sudo podman push ghcr.io/cockpit-project/unit-tests:i386


### PR DESCRIPTION
Similar as in commit 881b3343b90f, the unit-tests-refresh workflow now
fails in Ubuntu 18.04 due to missing slirp4netns. But for building
containers we also want overlayfs, which is also not available by
default. So run the builds and runs in system podman to avoid both
issues.

--- 

See the [recent nightly failure](https://github.com/cockpit-project/cockpit/actions/runs/404572813) for the now-familiar failure to talk to npmjs.com. I [triggered this manually](https://github.com/cockpit-project/cockpit/runs/1508679926?check_suite_focus=true), and it gets much further again, and just fails on the dreaded "watch change" test.