### PR TITLE
terminal: Protect against invalid resizes

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -255,10 +255,11 @@ export class Terminal extends React.Component {
 
         var realHeight = this.state.terminal._core.renderer.dimensions.actualCellHeight;
         var realWidth = this.state.terminal._core.renderer.dimensions.actualCellWidth;
-        this.setState({
-            rows: Math.floor((node.parentElement.clientHeight - padding) / realHeight),
-            cols: Math.floor((node.parentElement.clientWidth - padding) / realWidth)
-        });
+        if (realHeight && realWidth && realWidth !== 0 && realHeight !== 0)
+            this.setState({
+                rows: Math.floor((node.parentElement.clientHeight - padding) / realHeight),
+                cols: Math.floor((node.parentElement.clientWidth - padding) / realWidth)
+            });
     }
 
     setTerminalTheme(theme) {


### PR DESCRIPTION
This is a backport of part of 6341cf173473417e35dd88fbf049fa767c87fdcc
and prevents check-embed from flaking.