### PR TITLE
common: reimplement cockpit_frame_read()

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -35,6 +35,7 @@ sent through the channel 'a5', that might look like:
 When a message is sent over a stream transport that does not have distinct
 messages (such as SSH or stdio), the message is also prefixed with a base 10
 integer and new line, which represents the length of the following message.
+The length must be a positive number (ie: strictly greater than zero).
 
 An example. When going over a stream transport with a payload of the 3 byte
 string 'abc', and a channel of 'a5', would have a message length of 6: 3 bytes of

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -35,7 +35,8 @@ sent through the channel 'a5', that might look like:
 When a message is sent over a stream transport that does not have distinct
 messages (such as SSH or stdio), the message is also prefixed with a base 10
 integer and new line, which represents the length of the following message.
-The length must be a positive number (ie: strictly greater than zero).
+The length must be a positive number in canonical form (ie: strictly greater
+than zero, with no leading zeros).
 
 An example. When going over a stream transport with a payload of the 3 byte
 string 'abc', and a channel of 'a5', would have a message length of 6: 3 bytes of

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -123,6 +123,7 @@ libcockpit_common_a_LIBS = \
 # TESTS
 
 COCKPIT_CHECKS = \
+	test-frame \
 	test-hash \
 	test-hex \
 	test-json \
@@ -158,6 +159,10 @@ test_channel_SOURCES = \
 	src/common/mock-transport.c src/common/mock-transport.h
 test_channel_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_channel_LDADD = $(libcockpit_common_a_LIBS)
+
+test_frame_CFLAGS = $(libcockpit_common_a_CFLAGS)
+test_frame_SOURCES = src/common/test-frame.c
+test_frame_LDADD = $(libcockpit_common_a_LIBS)
 
 test_hash_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_hash_SOURCES = src/common/test-hash.c

--- a/src/common/cockpitframe.c
+++ b/src/common/cockpitframe.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <unistd.h>
 
-#define MAX_FRAME_SIZE_BYTES 7
+#define MAX_FRAME_SIZE_BYTES 8
 
 /**
  * cockpit_frame_parse:
@@ -56,7 +56,7 @@ cockpit_frame_parse (unsigned char *input,
   for (i = 0; i < length; i++)
     {
       /* Check invalid characters, prevent integer overflow, limit max length */
-      if (i > MAX_FRAME_SIZE_BYTES || (char)(input[i]) < '0' || (char)(input[i]) > '9')
+      if (i >= MAX_FRAME_SIZE_BYTES || (char)(input[i]) < '0' || (char)(input[i]) > '9')
         break;
       size *= 10;
       size += (char)(input[i]) - '0';

--- a/src/common/cockpitframe.c
+++ b/src/common/cockpitframe.c
@@ -66,8 +66,12 @@ cockpit_frame_parse (unsigned char *input,
   if (i == length)
     return 0;
 
-  /* A failure */
-  if (size == 0 || input[i] != '\n')
+  /* Improperly formatted if any of the following cases:
+   *   - no digits read
+   *   - digits not followed by newline
+   *   - size had a leading zero
+   */
+  if (size == 0 || input[i] != '\n' || input[0] == '0')
     return -1;
 
   if (consumed)

--- a/src/common/test-frame.c
+++ b/src/common/test-frame.c
@@ -1,0 +1,201 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "common/cockpitframe.h"
+#include "common/cockpittest.h"
+
+#include <glib.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <unistd.h>
+
+typedef struct
+{
+  FILE *write_fp;
+  int read_fd;
+} Fixture;
+
+typedef struct
+{
+  const char *input;
+  int expect_errno;
+} TestCase;
+
+static void
+fixture_setup (Fixture        *self,
+               const TestCase *tc)
+{
+  int pipefd[2];
+
+  int r = pipe (pipefd);
+  g_assert_cmpint (r, ==, 0);
+
+  self->write_fp = fdopen (pipefd[1], "w");
+  self->read_fd = pipefd[0];
+
+  if (tc->input)
+    {
+      fprintf (self->write_fp, "%s", tc->input);
+      fflush (self->write_fp);
+    }
+}
+
+static void
+fixture_close_write (Fixture *self)
+{
+  if (self->write_fp)
+    {
+      fclose (self->write_fp);
+      self->write_fp = NULL;
+    }
+}
+
+static void
+fixture_close_read (Fixture *self)
+{
+  if (self->read_fd != -1)
+    {
+      close (self->read_fd);
+      self->read_fd = -1;
+    }
+}
+
+static void
+fixture_teardown (Fixture *self,
+                  const TestCase *tc)
+{
+  if (tc->expect_errno)
+    {
+      alarm (10);
+
+      g_autofree unsigned char *output = NULL;
+      ssize_t size = cockpit_frame_read (self->read_fd, &output);
+
+      g_assert_cmpint (size, ==, -1);
+      g_assert_cmpint (errno, ==, tc->expect_errno);
+      g_assert (output == NULL);
+
+      alarm (0);
+    }
+
+  fixture_close_write (self);
+  fixture_close_read (self);
+}
+
+static void
+test_valid (Fixture *pipe, const TestCase *tc)
+{
+  /* Try sending valid frames of various sizes */
+  for (gint i = 1; i < 1000; i++)
+    {
+      /* Write a frame consisting of `i` spaces.  After the frame, write
+       * a pattern that we can use to detect that only the correct
+       * amount of bytes were read.
+       */
+      fprintf (pipe->write_fp, "%u\n%*sTHEEND", i, i, "");
+      fflush (pipe->write_fp);
+
+      /* Read it back and see what happens */
+      g_autofree unsigned char *output = NULL;
+      ssize_t size = cockpit_frame_read (pipe->read_fd, &output);
+
+      g_assert_cmpint (size, ==, i);
+      for (gint j = 0; j < size; j++)
+        g_assert (output[j] == ' ');
+
+      /* Make sure our pattern is there */
+      char buffer[7];
+      size = read (pipe->read_fd, buffer, sizeof buffer);
+      g_assert_cmpint (size, ==, 6);
+      g_assert (memcmp (buffer, "THEEND", 6) == 0);
+    }
+}
+
+static void
+test_fail_badfd (Fixture *fixture, const TestCase *tc)
+{
+  /* cause cockpit_frame_read() to read from -1 */
+  fixture_close_read (fixture);
+}
+
+static void
+test_fail_short (Fixture *fixture, const TestCase *tc)
+{
+  /* cause cockpit_frame_read() to read the message, then EOF */
+  fixture_close_write (fixture);
+}
+
+static void
+test_fail_nonblocking (Fixture *pipe, const TestCase *tc)
+{
+  /* cause cockpit_frame_read() to read the message, then EAGAIN */
+  (void) fcntl (pipe->read_fd, F_SETFL, O_NONBLOCK);
+}
+
+/* many of the testcases are driven entirely by the fixture setup/teardown */
+static void nil (void) { }
+
+int
+main (int argc,
+      char *argv[])
+{
+  cockpit_test_init (&argc, &argv);
+
+  /* kwargs hack, plus avoid casting gconstpointer */
+#define PIPE_TEST(name,func,...) g_test_add_vtable(name, sizeof(Fixture), \
+                                            &(TestCase) { __VA_ARGS__ }, \
+                                            (GTestFixtureFunc) fixture_setup, \
+                                            (GTestFixtureFunc) func, \
+                                            (GTestFixtureFunc) fixture_teardown)
+
+  PIPE_TEST("/frame/read-frame/valid", test_valid);
+
+  PIPE_TEST("/frame/read-frame/fail/badfd", test_fail_badfd,
+            .expect_errno=EBADF);
+
+  PIPE_TEST("/frame/read-frame/fail/short", test_fail_short,
+            .input="10\nabc", .expect_errno=EBADMSG);
+
+  PIPE_TEST("/frame/read-frame/fail/nonblocking", test_fail_nonblocking,
+            .input="10\nabc", .expect_errno=EAGAIN);
+
+  /* This valid message should fail because we get EAGAIN while trying to read it... */
+  PIPE_TEST("/frame/read-frame/fail/nonblocking-big", test_fail_nonblocking,
+            .input="99999999\nabc", .expect_errno=EAGAIN);
+  /* ...but add one byte more, and it's now an invalid message. */
+  PIPE_TEST("/frame/read-frame/fail/nonblocking-toobig", test_fail_nonblocking,
+            .input="100000000\nabc", .expect_errno=EBADMSG);
+
+  /* Some generic failures due to broken messages */
+  PIPE_TEST("/frame/read-frame/fail/non-numeric", nil,
+            .input="abc\nabc", .expect_errno=EBADMSG);
+  PIPE_TEST("/frame/read-frame/fail/semi-numeric", nil,
+            .input="1000abc\nabc", .expect_errno=EBADMSG);
+  PIPE_TEST("/frame/read-frame/fail/toobig", nil,
+            .input="100000000\nabc", .expect_errno=EBADMSG);
+  PIPE_TEST("/frame/read-frame/fail/toobig-nonnumeric", nil,
+            .input="10000000a\nabc", .expect_errno=EBADMSG);
+  PIPE_TEST("/frame/read-frame/fail/leading-zero", nil,
+            .input="03\nabc", .expect_errno=EBADMSG);
+  PIPE_TEST("/frame/read-frame/fail/empty-header", nil,
+            .input="\nabc", .expect_errno=EBADMSG);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
- doc: document that cockpit frames are non-empty
- common: add a restriction to the protocol format
- common: reimplement cockpit_frame_read()
