### PR TITLE
storage: Include stderr of fsadm in dialog

### DIFF
--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -233,7 +233,7 @@ export class VDODetails extends React.Component {
                                           if (block && block.IdUsage == "filesystem")
                                               return cockpit.spawn([ "fsadm", "resize",
                                                   decode_filename(block.Device) ],
-                                                                   { superuser: true });
+                                                                   { superuser: true, err: "message" });
                                       });
                               }
                           }


### PR DESCRIPTION
This allows naughty patterns to match it, and is generally the right thing to do.