### PR TITLE
machines: Show proper source for vNIC Bridge to LAN option

### DIFF
--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -215,10 +215,7 @@ class App extends React.Component {
                 <NetworkList networks={networks}
                     dispatch={dispatch}
                     resourceHasError={this.state.resourceHasError}
-                    onAddErrorNotification={this.onAddErrorNotification}
-                    vms={vms}
-                    nodeDevices={nodeDevices}
-                    interfaces={interfaces} />
+                    onAddErrorNotification={this.onAddErrorNotification} />
                 }
             </>
         );

--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -54,7 +54,7 @@ export class NetworkList extends React.Component {
     }
 
     render() {
-        const { dispatch, networks, resourceHasError, onAddErrorNotification, vms, nodeDevices, interfaces } = this.props;
+        const { dispatch, networks, resourceHasError, onAddErrorNotification } = this.props;
         const sortFunction = (networkA, networkB) => networkA.name.localeCompare(networkB.name);
         const actions = (<CreateNetworkAction devices={this.state.networkDevices} dispatch={dispatch} />);
 
@@ -105,7 +105,4 @@ NetworkList.propTypes = {
     networks: PropTypes.array.isRequired,
     onAddErrorNotification: PropTypes.func.isRequired,
     resourceHasError: PropTypes.object.isRequired,
-    vms: PropTypes.array.isRequired,
-    nodeDevices: PropTypes.array.isRequired,
-    interfaces: PropTypes.array.isRequired,
 };

--- a/pkg/machines/components/networks/networkList.jsx
+++ b/pkg/machines/components/networks/networkList.jsx
@@ -37,6 +37,17 @@ import './networkList.scss';
 const _ = cockpit.gettext;
 
 export class NetworkList extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            networkDevices: undefined,
+        };
+    }
+
+    componentDidMount() {
+        getNetworkDevices(devs => this.setState({ networkDevices: devs }));
+    }
+
     shouldComponentUpdate(nextProps, _) {
         const networks = nextProps.networks;
         return !networks.find(network => !network.name);
@@ -45,8 +56,7 @@ export class NetworkList extends React.Component {
     render() {
         const { dispatch, networks, resourceHasError, onAddErrorNotification, vms, nodeDevices, interfaces } = this.props;
         const sortFunction = (networkA, networkB) => networkA.name.localeCompare(networkB.name);
-        const devices = getNetworkDevices(vms, nodeDevices, interfaces);
-        const actions = (<CreateNetworkAction devices={devices} dispatch={dispatch} />);
+        const actions = (<CreateNetworkAction devices={this.state.networkDevices} dispatch={dispatch} />);
 
         return (
             <Page breadcrumb={

--- a/pkg/machines/components/vm/nics/nicAdd.jsx
+++ b/pkg/machines/components/vm/nics/nicAdd.jsx
@@ -25,7 +25,6 @@ import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { NetworkTypeAndSourceRow, NetworkModelRow } from './nicBody.jsx';
 import { getVm } from '../../../actions/provider-actions.js';
 import LibvirtDBus, { attachIface } from '../../../libvirt-dbus.js';
-import { getNetworkDevices } from '../../../helpers.js';
 
 import './nic.css';
 
@@ -130,15 +129,13 @@ export class AddNIC extends React.Component {
     }
 
     render() {
-        const { idPrefix, vm, nodeDevices, interfaces } = this.props;
-        const networkDevices = getNetworkDevices(vm.connectionName, nodeDevices, interfaces);
+        const { idPrefix, vm } = this.props;
 
         const defaultBody = (
             <Form isHorizontal>
                 <NetworkTypeAndSourceRow idPrefix={idPrefix}
                                          dialogValues={this.state}
                                          onValueChanged={this.onValueChanged}
-                                         networkDevices={networkDevices}
                                          connectionName={vm.connectionName} />
 
                 <NetworkModelRow idPrefix={idPrefix}
@@ -186,8 +183,7 @@ AddNIC.propTypes = {
     dispatch: PropTypes.func.isRequired,
     idPrefix: PropTypes.string.isRequired,
     vm: PropTypes.object.isRequired,
-    interfaces: PropTypes.array.isRequired,
-    nodeDevices: PropTypes.array.isRequired,
+    availableSources: PropTypes.array.isRequired,
 };
 
 export default AddNIC;

--- a/pkg/machines/components/vm/nics/nicAdd.jsx
+++ b/pkg/machines/components/vm/nics/nicAdd.jsx
@@ -92,6 +92,8 @@ export class AddNIC extends React.Component {
             let sources;
             if (value === "network")
                 sources = this.state.availableSources.network;
+            else if (value === "bridge")
+                sources = this.state.availableSources.bridge;
             else
                 sources = this.state.availableSources.device;
 

--- a/pkg/machines/components/vm/nics/nicBody.jsx
+++ b/pkg/machines/components/vm/nics/nicBody.jsx
@@ -66,7 +66,7 @@ NetworkModelRow.propTypes = {
     dialogValues: PropTypes.object.isRequired,
 };
 
-export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues, connectionName, networkDevices }) => {
+export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues, connectionName }) => {
     const defaultNetworkType = dialogValues.networkType;
     let availableNetworkTypes = [];
     let defaultNetworkSource = dialogValues.networkSource;
@@ -154,6 +154,5 @@ NetworkTypeAndSourceRow.propTypes = {
     idPrefix: PropTypes.string.isRequired,
     connectionName: PropTypes.string.isRequired,
     onValueChanged: PropTypes.func.isRequired,
-    networkDevices: PropTypes.array.isRequired,
     dialogValues: PropTypes.object.isRequired,
 };

--- a/pkg/machines/components/vm/nics/nicBody.jsx
+++ b/pkg/machines/components/vm/nics/nicBody.jsx
@@ -94,6 +94,8 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
         let sources;
         if (dialogValues.networkType === "network")
             sources = dialogValues.availableSources.network;
+        else if (dialogValues.networkType === "bridge")
+            sources = dialogValues.availableSources.bridge;
         else
             sources = dialogValues.availableSources.device;
 
@@ -108,6 +110,8 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
         } else {
             if (dialogValues.networkType === "network")
                 defaultNetworkSource = _("No virtual networks");
+            else if (dialogValues.networkType === "bridge")
+                defaultNetworkSource = _("No network bridges");
             else
                 defaultNetworkSource = _("No network devices");
 
@@ -136,7 +140,7 @@ export const NetworkTypeAndSourceRow = ({ idPrefix, onValueChanged, dialogValues
                         })}
             </Select.Select>
             {["network", "direct", "bridge"].includes(dialogValues.networkType) && (
-                <FormGroup fieldId={`${idPrefix}-select-source`} label={_("Source")}>
+                <FormGroup fieldId={`${idPrefix}-select-source`} label={dialogValues.networkType === "bridge" ? _("Bridge") : _("Source")}>
                     <Select.Select id={`${idPrefix}-select-source`}
                                    onChange={value => onValueChanged('networkSource', value)}
                                    enabled={networkSourceEnabled}

--- a/pkg/machines/components/vm/nics/nicEdit.jsx
+++ b/pkg/machines/components/vm/nics/nicEdit.jsx
@@ -27,7 +27,6 @@ import {
     changeNetworkSettings,
     getVm
 } from '../../../actions/provider-actions.js';
-import { getNetworkDevices } from '../../../helpers.js';
 
 import 'form-layout.scss';
 
@@ -121,15 +120,13 @@ export class EditNICModal extends React.Component {
     }
 
     render() {
-        const { idPrefix, vm, network, nodeDevices, interfaces } = this.props;
-        const networkDevices = getNetworkDevices(vm.connectionName, nodeDevices, interfaces);
+        const { idPrefix, vm, network } = this.props;
 
         const defaultBody = (
             <Form>
                 <NetworkTypeAndSourceRow idPrefix={idPrefix}
                                          dialogValues={this.state}
                                          onValueChanged={this.onValueChanged}
-                                         networkDevices={networkDevices}
                                          connectionName={vm.connectionName} />
                 <NetworkModelRow idPrefix={idPrefix}
                                  dialogValues={this.state}
@@ -177,7 +174,5 @@ EditNICModal.propTypes = {
     idPrefix: PropTypes.string.isRequired,
     vm: PropTypes.object.isRequired,
     network: PropTypes.object.isRequired,
-    interfaces: PropTypes.array.isRequired,
-    nodeDevices: PropTypes.array.isRequired,
     onClose: PropTypes.func.isRequired,
 };

--- a/pkg/machines/components/vm/nics/nicEdit.jsx
+++ b/pkg/machines/components/vm/nics/nicEdit.jsx
@@ -58,7 +58,7 @@ export class EditNICModal extends React.Component {
             availableSources = props.availableSources.device;
         } else if (props.network.type === "bridge") {
             currentSource = props.network.source.bridge;
-            availableSources = props.availableSources.device;
+            availableSources = props.availableSources.bridge;
         }
         if (availableSources.includes(currentSource))
             defaultNetworkSource = currentSource;
@@ -87,6 +87,8 @@ export class EditNICModal extends React.Component {
             let sources;
             if (value === "network")
                 sources = this.state.availableSources.network;
+            else if (value === "bridge")
+                sources = this.state.availableSources.bridge;
             else
                 sources = this.state.availableSources.device;
 

--- a/pkg/machines/components/vm/nics/vmNicsCard.jsx
+++ b/pkg/machines/components/vm/nics/vmNicsCard.jsx
@@ -60,7 +60,7 @@ export class VmNetworkActions extends React.Component {
     }
 
     render() {
-        const { vm, dispatch, networks, nodeDevices, interfaces } = this.props;
+        const { vm, dispatch, networks } = this.props;
         const id = vmId(vm.name);
         const availableSources = {
             network: networks.map(network => network.name),
@@ -71,9 +71,7 @@ export class VmNetworkActions extends React.Component {
                 <AddNIC dispatch={dispatch}
                     idPrefix={`${id}-add-iface`}
                     vm={vm}
-                    nodeDevices={nodeDevices}
                     availableSources={availableSources}
-                    interfaces={interfaces}
                     close={this.close} />}
             <Button id={`${id}-add-iface-button`} variant="secondary" onClick={this.open}>
                 {_("Add network interface")}
@@ -86,7 +84,6 @@ VmNetworkActions.propTypes = {
     vm: PropTypes.object.isRequired,
     networks: PropTypes.array.isRequired,
     interfaces: PropTypes.array.isRequired,
-    nodeDevices: PropTypes.array.isRequired,
     dispatch: PropTypes.func.isRequired,
 };
 
@@ -134,7 +131,7 @@ export class VmNetworkTab extends React.Component {
     }
 
     render() {
-        const { vm, dispatch, networks, nodeDevices, interfaces, onAddErrorNotification } = this.props;
+        const { vm, dispatch, networks, interfaces, onAddErrorNotification } = this.props;
         const id = vmId(vm.name);
         const availableSources = {
             network: networks.map(network => network.name),
@@ -266,7 +263,6 @@ export class VmNetworkTab extends React.Component {
                             idPrefix: `${id}-network-${networkId}`,
                             vm,
                             network,
-                            nodeDevices,
                             availableSources,
                             interfaces,
                             onClose: () => this.setState({ editNICDialogProps: undefined }),

--- a/pkg/machines/components/vm/nics/vmNicsCard.jsx
+++ b/pkg/machines/components/vm/nics/vmNicsCard.jsx
@@ -22,7 +22,7 @@ import { Button } from '@patternfly/react-core';
 
 import cockpit from 'cockpit';
 import { changeNetworkState, getVm } from "../../../actions/provider-actions.js";
-import { rephraseUI, vmId } from "../../../helpers.js";
+import { rephraseUI, vmId, getNetworkBridges, getNetworkDevices } from "../../../helpers.js";
 import AddNIC from './nicAdd.jsx';
 import { EditNICModal } from './nicEdit.jsx';
 import WarningInactive from '../../common/warningInactive.jsx';
@@ -32,15 +32,6 @@ import { ListingTable } from "cockpit-components-table.jsx";
 import { DeleteResourceButton, DeleteResourceModal } from '../../common/deleteResource.jsx';
 
 const _ = cockpit.gettext;
-
-const getNetworkDevices = (updateState) => {
-    cockpit.spawn(["find", "/sys/class/net", "-type", "l", "-printf", '%f\n'], { err: "message" })
-            .then(output => {
-                const devs = output.trim().split('\n');
-                updateState(devs);
-            })
-            .catch(e => console.warn("could not read /sys/class/net:", e.toString()));
-};
 
 export class VmNetworkActions extends React.Component {
     constructor(props) {

--- a/pkg/machines/components/vm/nics/vmNicsCard.jsx
+++ b/pkg/machines/components/vm/nics/vmNicsCard.jsx
@@ -40,6 +40,7 @@ export class VmNetworkActions extends React.Component {
         this.state = {
             showAddNICModal: false,
             networkDevices: undefined,
+            networkBridges: undefined,
         };
 
         this.open = this.open.bind(this);
@@ -57,6 +58,7 @@ export class VmNetworkActions extends React.Component {
     componentDidMount() {
         // only consider symlinks -- there might be other stuff like "bonding_masters" which we don't want
         getNetworkDevices(devs => this.setState({ networkDevices: devs }));
+        this.setState({ networkBridges: getNetworkBridges(this.props.interfaces) });
     }
 
     render() {
@@ -65,6 +67,7 @@ export class VmNetworkActions extends React.Component {
         const availableSources = {
             network: networks.map(network => network.name),
             device: this.state.networkDevices,
+            bridge: this.state.networkBridges,
         };
         return (<>
             {this.state.showAddNICModal && this.state.networkDevices !== undefined &&
@@ -94,6 +97,7 @@ export class VmNetworkTab extends React.Component {
         this.state = {
             interfaceAddress: [],
             networkDevices: undefined,
+            networkBridges: undefined,
         };
 
         this.deviceProxyHandler = this.deviceProxyHandler.bind(this);
@@ -110,6 +114,7 @@ export class VmNetworkTab extends React.Component {
     componentDidMount() {
         // only consider symlinks -- there might be other stuff like "bonding_masters" which we don't want
         getNetworkDevices(devs => this.setState({ networkDevices: devs }));
+        this.setState({ networkBridges: getNetworkBridges(this.props.interfaces) });
 
         if (this.props.vm.state != 'running' && this.props.vm.state != 'paused')
             return;
@@ -136,6 +141,7 @@ export class VmNetworkTab extends React.Component {
         const availableSources = {
             network: networks.map(network => network.name),
             device: this.state.networkDevices,
+            bridge: this.state.networkBridges,
         };
 
         const nicLookupByMAC = (interfacesList, mac) => {

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -674,29 +674,15 @@ export function getStorageVolumesUsage(vms, storagePool) {
 
 /**
  * Returns a list of potential physical devices suitable as network devices
- * by merging all network node devices and interfaces.
- *
- * @param {array} vms
- * @param {array} nodeDevices
- * @param {array} interfaces
  * @returns {array}
  */
-export function getNetworkDevices(vms, nodeDevices, interfaces) {
-    const devs = [];
-
-    nodeDevices.forEach(dev => {
-        if (dev.capability.type === "net")
-            devs.push(dev.capability.interface);
-    });
-
-    interfaces.forEach(iface => {
-        devs.push(iface.name);
-    });
-
-    const uniq = [...new Set(devs)];
-    uniq.sort();
-
-    return uniq;
+export function getNetworkDevices(updateState) {
+    cockpit.spawn(["find", "/sys/class/net", "-type", "l", "-printf", '%f\n'], { err: "message" })
+            .then(output => {
+                const devs = output.trim().split('\n');
+                updateState(devs);
+            })
+            .catch(e => console.warn("could not read /sys/class/net:", e.toString()));
 }
 
 export function getDefaultVolumeFormat(pool) {

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -673,6 +673,15 @@ export function getStorageVolumesUsage(vms, storagePool) {
 }
 
 /**
+ * Filters only network bridges out of all network devices
+ * @param {array} interfaces
+ * @returns {array}
+ */
+export function getNetworkBridges(interfaces) {
+    return interfaces.filter(iface => iface.type === "bridge");
+}
+
+/**
  * Returns a list of potential physical devices suitable as network devices
  * @returns {array}
  */


### PR DESCRIPTION
When adding a virtual network interface of type "Bridge to LAN" to a VM, the list of possible sources would include all network devices, including even a physical one. Correct way is to show only network bridges. 

This PR will be followed by another PR implementing the ability to add bridges through machines vNIC UI (or creating them automatically for the user)