### PR TITLE
test: Configure the real Candlepin CA certificate on the client

### DIFF
--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -54,7 +54,7 @@ from testlib import *
 WAIT_SCRIPT = """
 set -ex
 for x in $(seq 1 200); do
-    if curl --insecure -s https://%(addr)s:8443/candlepin; then
+    if curl -s https://%(addr)s:8443/candlepin; then
         break
     else
         sleep 1
@@ -103,8 +103,15 @@ class SubscriptionsCase(MachineCase):
         m = self.machine
         m.upload([product_file_one, product_file_two], "/etc/pki/product")
 
-        # make sure that rhsm skips certificate checks for the server
-        m.execute("sed -i -e 's/insecure = 0/insecure = 1/g' /etc/rhsm/rhsm.conf")
+        # Install Candlepin CA cert to where curl,
+        # subscription-manager, and insights-client can find it.
+        candlepin_ca_cert = self.candlepin.execute("cat /etc/candlepin/certs/candlepin-ca.crt")
+        m.write("/tmp/candlepin-ca.crt", candlepin_ca_cert)
+        m.execute("cat /tmp/candlepin-ca.crt >>/etc/rhsm/ca/redhat-uep.pem")
+        m.execute("cat /tmp/candlepin-ca.crt >>/etc/pki/tls/certs/ca-bundle.crt")
+
+        # We also need to use the right hostname to match the certificate.
+        m.execute("echo '10.111.112.100 services.cockpit.lan' >>/etc/hosts")
 
         # Apply some extra cleanups on rhel-atomic.  These cleanups
         # are necessary because all changes to /etc after a "atomic
@@ -113,7 +120,7 @@ class SubscriptionsCase(MachineCase):
             m.execute("rm -f /etc/pki/consumer/* /etc/pki/entitlement/*")
 
         # Wait for the web service to be accessible
-        args = {"addr": "10.111.112.100"}
+        args = {"addr": "services.cockpit.lan"}
         m.execute(script=WAIT_SCRIPT % args)
 
         if m.image != "rhel-atomic":  # insights-client not installed there
@@ -160,7 +167,7 @@ class TestSubscriptions(SubscriptionsCase):
             b.set_val("#subscription-register-url", "custom")
 
         # enter server and incorrect login data
-        b.set_input_text("#subscription-register-url-custom", "10.111.112.100:8443/candlepin")
+        b.set_input_text("#subscription-register-url-custom", "services.cockpit.lan:8443/candlepin")
         b.set_input_text("#subscription-register-username", "doc")
         b.set_input_text("#subscription-register-password", "wrongpass")
 
@@ -243,7 +250,7 @@ class TestSubscriptions(SubscriptionsCase):
             b.set_val("#subscription-register-url", "custom")
 
         # enter server data
-        b.set_input_text("#subscription-register-url-custom", "10.111.112.100:8443/candlepin")
+        b.set_input_text("#subscription-register-url-custom", "services.cockpit.lan:8443/candlepin")
 
         # make sure we have an activation key on the target machine
         self.candlepin.execute("curl -s --insecure --request POST --user admin:admin {url}".format(url=key_url))
@@ -283,7 +290,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
-        b.set_input_text("#subscription-register-url-custom", "10.111.112.100:8443/candlepin")
+        b.set_input_text("#subscription-register-url-custom", "services.cockpit.lan:8443/candlepin")
         b.set_input_text("#subscription-register-username", "admin")
         b.set_input_text("#subscription-register-password", "admin")
         b.set_input_text("#subscription-register-org", "admin")
@@ -339,7 +346,7 @@ class TestSubscriptions(SubscriptionsCase):
         b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
-        b.set_input_text("#subscription-register-url-custom", "10.111.112.100:8443/candlepin")
+        b.set_input_text("#subscription-register-url-custom", "services.cockpit.lan:8443/candlepin")
         b.set_input_text("#subscription-register-username", "admin")
         b.set_input_text("#subscription-register-password", "admin")
         b.set_input_text("#subscription-register-org", "admin")
@@ -395,7 +402,7 @@ class TestSubscriptionsPackages(SubscriptionsCase, PackageCase):
         b.wait_visible("#subscription-register-url")
 
         b.set_val("#subscription-register-url", "custom")
-        b.set_input_text("#subscription-register-url-custom", "10.111.112.100:8443/candlepin")
+        b.set_input_text("#subscription-register-url-custom", "services.cockpit.lan:8443/candlepin")
         b.set_input_text("#subscription-register-username", "admin")
         b.set_input_text("#subscription-register-password", "admin")
         b.set_input_text("#subscription-register-org", "admin")


### PR DESCRIPTION
This allows us to remove the various --insecure and insecure=0 options
when contacting Candlepin.

More importantly, it allows insights-client to perform its performance
metric upload to Candlepin, something that can't be configured to be
done insecurely.