### PR TITLE
workflows: Fix apt installation

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up dependencies
-        run: sudo apt-get install -y npm make
+        run: |
+          sudo apt update
+          sudo apt install -y npm make
 
       - name: Set up configuration and secrets
         run: |

--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -12,7 +12,8 @@ jobs:
     steps:
       - name: Set up dependencies
         run: |
-          sudo apt-get install -y --no-install-recommends npm make gettext pkg-config \
+          sudo apt update
+          sudo apt install -y --no-install-recommends npm make gettext pkg-config \
               libpolkit-agent-1-dev libpolkit-gobject-1-dev libsystemd-dev libjson-glib-dev \
               libgnutls28-dev libkrb5-dev libssh-dev libpam0g-dev libpcp3-dev libpcp-import1-dev libpcp-pmda3-dev \
               xsltproc xmlto


### PR DESCRIPTION
GitHub's base VMs don't automatically refresh package indexes, so it can
happen that one of the package dependencies get out of date and are not
available on the mirrors any more.

Run `apt update` first to ensure that the workflow installs the latest
packages.

Ported from starter-kit commit 8771907002e2.