### PR TITLE
webpack: Drop sass-resources-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "raw-loader": "^4.0.0",
     "sass": "^1.26.5",
     "sass-loader": "^8.0.2",
-    "sass-resources-loader": "^2.0.1",
     "sizzle": "^2.3.5",
     "stdio": "^2.1.1",
     "strict-loader": "^1.2.0",

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -22,8 +22,8 @@
  * Newer code should not include cockpit.css, but our examples still do
  */
 import "../lib/patternfly/patternfly-cockpit.scss";
-import "@patternfly/patternfly/components/_all.scss";
 import "../lib/page.scss";
+import "@patternfly/patternfly/components/Button/button.css";
 import "../lib/listing.scss";
 
 /* eslint-disable indent,no-empty */

--- a/pkg/lib/_global-variables.scss
+++ b/pkg/lib/_global-variables.scss
@@ -1,3 +1,5 @@
+@import "@patternfly/patternfly/base/patternfly-variables.scss";
+
 /* Bootstrap scss compilation will complain if these are not set
  * https://github.com/twbs/bootstrap/issues/23982
  */

--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -1,3 +1,4 @@
+@import "@patternfly/patternfly/base/patternfly-variables.scss";
 @import "@patternfly/patternfly/components/Table/table.scss";
 @import "@patternfly/patternfly/components/Table/table-grid.scss";
 

--- a/pkg/lib/listing.scss
+++ b/pkg/lib/listing.scss
@@ -1,5 +1,6 @@
 /* Listing pattern */
 
+@import "@patternfly/patternfly/sass-utilities/colors.scss";
 @import "./variables.scss";
 
 .ct-listing {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -1,3 +1,5 @@
+@import "./_global-variables.scss";
+@import "@patternfly/patternfly/base/patternfly-themes.scss";
 @import "./patternfly/patternfly-4-overrides.scss";
 @import "@patternfly/patternfly/components/Page/page.scss";
 

--- a/pkg/machines/components/vm/vmDetailsPage.scss
+++ b/pkg/machines/components/vm/vmDetailsPage.scss
@@ -1,3 +1,4 @@
+@import "_global-variables.scss";
 @import "../../../lib/ct-card.scss";
 
 .vm-details .pf-c-card {

--- a/pkg/machines/components/vms/hostvmslist.scss
+++ b/pkg/machines/components/vms/hostvmslist.scss
@@ -1,3 +1,4 @@
+@import "@patternfly/patternfly/base/patternfly-variables.scss";
 @import "@patternfly/patternfly/components/Table/table.scss";
 @import "@patternfly/patternfly/components/Table/table-grid.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -1,7 +1,6 @@
 @import "../lib/page.scss";
 @import "../lib/table.css";
 
-@import "@patternfly/patternfly/components/Page/page.scss";
 @import "@patternfly/patternfly/components/Alert/alert.scss";
 @import "../lib/ct-card.scss";
 

--- a/pkg/playground/jquery-patterns.js
+++ b/pkg/playground/jquery-patterns.js
@@ -6,7 +6,7 @@ import "page.scss";
 import "listing.scss";
 import "timeline.css";
 import "table.css";
-import "../../node_modules/@patternfly/patternfly/components/Button/button.scss";
+import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 
 $(function() {

--- a/pkg/playground/plot.js
+++ b/pkg/playground/plot.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import * as plot from "plot.js";
 
 import '../lib/patternfly/patternfly-cockpit.scss';
-import "../../node_modules/@patternfly/patternfly/components/Button/button.scss";
+import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 import "plot.css";
 

--- a/pkg/playground/speed.js
+++ b/pkg/playground/speed.js
@@ -1,7 +1,7 @@
 import cockpit from "cockpit";
 
 import '../lib/patternfly/patternfly-cockpit.scss';
-import "../../node_modules/@patternfly/patternfly/components/Button/button.scss";
+import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 
 var channel = null;

--- a/pkg/playground/test.js
+++ b/pkg/playground/test.js
@@ -2,7 +2,7 @@ import $ from "jquery";
 import cockpit from "cockpit";
 
 import '../lib/patternfly/patternfly-cockpit.scss';
-import "../../node_modules/@patternfly/patternfly/components/Button/button.scss";
+import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
 
 $(function() {

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -12,7 +12,7 @@ import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 
 import { new_machine_dialog_manager } from "machine-dialogs";
 
-import "../../node_modules/@patternfly/patternfly/components/Select/select.scss";
+import "../../node_modules/@patternfly/patternfly/components/Select/select.css";
 
 const _ = cockpit.gettext;
 const hosts_sel = document.getElementById("nav-hosts");

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -33,7 +33,6 @@ import { Details } from "./details.jsx";
 
 import "bootstrap/dist/js/bootstrap";
 
-import "page.scss";
 import "table.css";
 import "plot.css";
 import "journal.css";

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-@import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
+@import "../lib/page.scss";
 @import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 @import "../lib/ct-card.scss";
 

--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -1,3 +1,4 @@
+@import "_global-variables.scss";
 @import '../../lib/journal.css';
 @import '../../lib/ct-card.scss';
 

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -1,3 +1,4 @@
+@import "_global-variables.scss";
 @import "../system-global.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 @import "./timer.scss";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -587,18 +587,6 @@ module.exports = {
                             }
                         }
                     },
-                    {
-                        loader: 'sass-resources-loader',
-                            // Make PF3 and PF4 variables globably accessible to be used by the components scss
-                            options: {
-                                resources: [
-                                    path.resolve(libdir, './_global-variables.scss'),
-                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-themes.scss'),
-                                    path.resolve(nodedir, './@patternfly/patternfly/base/patternfly-variables.scss'),
-                                    path.resolve(nodedir, './patternfly/dist/sass/patternfly/_variables.scss')
-                                ],
-                            },
-                    },
                 ]
             },
             {


### PR DESCRIPTION
Explicitly include the required PF variables definitions into components
instead. This makes separate compilation and lib component reuse easier,
and paves the way for using sassc (which doesn't support global
resources). Finally it makes it explicit where we still use PF3, instead
of adding it to each and every built CSS file.

-----

This by and large works, but fails test-static code as the generated dist/base1/cockpit.css contains wrong font paths. I somehow feel between a rock and a hard place here: our webpack rule which applies the string-replace-loader stuff *only* applies to *.js files at the top level; I originally tried to build this from a separate pkg/base1/cockpit.scss, but this fails miserably. At the same time, when building it from cockpit.js it does not apply the string-replace even when I include `base1\/cockpit.scss` into the rule. @KKoukiou , do you have a brilliant idea here?

Submitting this PR anyway to not forget about it, and I want to see what the integration tests do. Visually it seems all fine to me.

 - [x] Fix wrong font paths in base1/cockpit.scss