### PR TITLE
test: Drop obsolete chronyd hacks from check-realms

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -426,19 +426,6 @@ class TestIPA(TestRealms, CommonTests):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
         wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
 
-        # HACK: ipa-client-install fails on restarting absent chronyd.service: https://launchpad.net/bugs/1890786
-        if self.machine.image in ["ubuntu-2004", "ubuntu-stable"]:
-            self.write_file("/run/systemd/system/chronyd.service", """
-[Service]
-Type=oneshot
-ExecStart=/bin/true
-""")
-            self.machine.execute("ln -s /bin/true /usr/bin/chronyc")
-
-            # HACK: It now expects chrony.service and not chronyd.service: https://bugs.debian.org/968428
-            # Not to be attached to a specific version of a testing image, support both for now
-            self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
-
         # wait until FreeIPA started up
         self.machines['services'].execute("""docker exec -i freeipa sh -ec '
             while ! echo %s | kinit -f %s; do sleep 5; done
@@ -758,21 +745,6 @@ class TestKerberos(MachineCase):
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
         "services": {"image": "services", "memory_mb": 2048}
     }
-
-    def setUp(self):
-        super().setUp()
-        # HACK: ipa-client-install fails on restarting absent chronyd.service: https://launchpad.net/bugs/1890786
-        if self.machine.image in ["ubuntu-2004", "ubuntu-stable"]:
-            self.write_file("/run/systemd/system/chronyd.service", """
-[Service]
-Type=oneshot
-ExecStart=/bin/true
-""")
-            self.machine.execute("ln -s /bin/true /usr/bin/chronyc")
-
-            # HACK: It now expects chrony.service and not chronyd.service: https://bugs.debian.org/968428
-            # Not to be attached to a specific version of a testing image, support both for now
-            self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
 
     def configure_kerberos(self, keytab):
         self.machines["services"].execute("/run-freeipa")


### PR DESCRIPTION
Both related bugs got fixed a while ago.