### PR TITLE
shell: Also log dialog field errors to console

### DIFF
--- a/pkg/lib/patterns.js
+++ b/pkg/lib/patterns.js
@@ -35,8 +35,10 @@ function field_error(target, error) {
     }
 
     var message;
-    if (error.message)
+    if (error.message) {
+        console.warn(error.message);
         message = $("<div class='dialog-error help-block'>").text(error.message);
+    }
     wrapper.addClass("has-error").append(message);
 
     if (!wrapper.hasClass("error-keep")) {


### PR DESCRIPTION
This will hopefully help with flaky Firefox tests which are not able
to produce screenshots.

Example: https://logs.cockpit-project.org/logs/pull-14913-20201216-093850-252cf626-fedora-32-firefox/log.html#49-2