### PR TITLE
shell: Drop already bundled nav.css

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="index.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
-    <link href="../shell/nav.css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="../*/po.js"></script>


### PR DESCRIPTION
webpack builds shell.scss, which in turn imports nav.scss.
So, the requirement 'shell/index.css' is enough.

Fixes: #15057