### PR TITLE
tools: Clean up cockpit-ws system user creation

### DIFF
--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home /nonexisting --no-create-home cockpit-ws
-adduser --system --group --home /nonexisting --no-create-home cockpit-wsinstance
+adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
+adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
 
 # change group of cockpit-session on upgrades (changed in version 203)
 if OUT=$(dpkg-statoverride --list /usr/lib/cockpit/cockpit-session) && [ "$OUT#root cockpit-ws 4750}" != "$OUT" ]; then


### PR DESCRIPTION
Use `/nonexistent` instead of `/nonexisting` home directory to be
consistent with other Debian system users.

Use `--quiet` to avoid confusing warnings on package installation.

https://bugs.debian.org/968400