### PR TITLE
containers: Bump bastion and ws containers to Fedora 33

### DIFF
--- a/containers/bastion/Dockerfile
+++ b/containers/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:33
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:32
+FROM fedora:33
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=master
 


### PR DESCRIPTION
I verified that `podman build` works for both containers still. I ran both produced containers, and cockpit-ws works. I can log in through the bastion host container to my SSH.