### PR TITLE
tools: Recommend sudo over polkit

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -416,7 +416,7 @@ Obsoletes: cockpit-networkmanager
 Requires: NetworkManager >= 1.6
 Provides: cockpit-kdump = %{version}-%{release}
 Requires: kexec-tools
-Recommends: polkit
+Recommends: (sudo or polkit)
 Recommends: PackageKit
 Recommends: NetworkManager-team
 Recommends: setroubleshoot-server >= 3.3.3

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -141,7 +141,7 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${bridge:minversion}),
          libpwquality-tools,
          openssl,
-Recommends: policykit-1
+Recommends: sudo | policykit-1
 Provides: cockpit-shell,
           cockpit-systemd,
           cockpit-tuned,


### PR DESCRIPTION
cockpit's primary way to get a privileged bridge is through sudo now. If
it is not available, the shell just shows "Something went wrong / Spawn
failed". So recommend sudo to avoid this.

Demote polkit to a fallback dependency, to correspond to the shell manifest.

https://bugs.debian.org/978135