### PR TITLE
test: Adjust check-kdump for unit with precondition

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -81,8 +81,15 @@ class TestKdump(MachineCase):
             b.mouse("#app span.popover-ct-kdump", "mouseenter")
             b.wait_in_text(".pf-c-tooltip", "No memory reserved.")
             b.mouse("#app span.popover-ct-kdump", "mouseleave")
-            # service should indicate an error and the button should be off
-            b.wait_in_text("#app", "Service has an error")
+            # newer kdump.service have `ConditionKernelCommandLine=crashkernel` which fails gracefully
+            unit = m.execute("systemctl cat kdump.service")
+            if 'ConditionKernelCommandLine=crashkernel' in unit:
+                # service should indicate that the unit is stopped
+                b.wait_in_text("#app", "Service is stopped")
+            else:
+                # service should indicate an error
+                b.wait_in_text("#app", "Service has an error")
+            # ... and the button should be off
             assertActive(False)
 
         # there shouldn't be any crash reports in the target directory


### PR DESCRIPTION
Current kdump unit gained a `ConditionKernelCommandLine=crashkernel`
which makes the unit behave more gracefully in the default state -- it
stays stopped instead of failing. Adjust the test to get along with both
cases.