### PR TITLE
updates: Redesign updates followup

### DIFF
--- a/pkg/apps/utils.jsx
+++ b/pkg/apps/utils.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { Button, Split, SplitItem, Spinner } from "@patternfly/react-core";
+import { Button, Progress, Split, SplitItem, Spinner } from "@patternfly/react-core";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 
 const _ = cockpit.gettext;
@@ -66,16 +66,7 @@ export const ProgressBar = ({ title, data }) => {
             </SplitItem>
         </Split>);
     } else {
-        return (
-            <div>
-                <div className="progress-title">
-                    {title}
-                </div>
-                <div className="progress">
-                    <div className="progress-bar" style={{ width: data.percentage + "%" }} />
-                </div>
-            </div>
-        );
+        return <Progress value={data.percentage} title={title} />;
     }
 };
 

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -411,22 +411,23 @@ export class AutoUpdates extends React.Component {
                 {_("Edit")}
             </Button>
             <Modal position="top" variant="small" id="automatic-updates-dialog" isOpen={this.state.showModal}
-                   title={_("Automatic updates")}
-                   footer={
-                       <>
-                           <Button variant="primary"
-                                   isLoading={ this.state.pending }
-                                   isDisabled={ this.state.pending }
-                                   onClick={ this.handleChange }>
-                               {_("Save changes")}
-                           </Button>
-                           <Button variant="link"
-                                   isDisabled={ this.state.pending }
-                                   onClick={() => this.setState({ showModal: false })}>
-                               {_("Cancel")}
-                           </Button>
-                       </>
-                   }>
+                title={_("Automatic updates")}
+                onClose={() => this.setState({ showModal: false })}
+                footer={
+                    <>
+                        <Button variant="primary"
+                                isLoading={ this.state.pending }
+                                isDisabled={ this.state.pending }
+                                onClick={ this.handleChange }>
+                            {_("Save changes")}
+                        </Button>
+                        <Button variant="link"
+                                isDisabled={ this.state.pending }
+                                onClick={() => this.setState({ showModal: false })}>
+                            {_("Cancel")}
+                        </Button>
+                    </>
+                }>
                 {body}
             </Modal>
         </>);

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -25,7 +25,7 @@ import ReactDOM from 'react-dom';
 
 import moment from "moment";
 import {
-    Button, Gallery, Tooltip,
+    Button, Gallery, Progress, Tooltip,
     Card, CardTitle, CardActions, CardHeader, CardBody,
     DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     Flex, FlexItem,
@@ -470,11 +470,7 @@ class ApplyUpdates extends React.Component {
                         <div className="spinner spinner-xs spinner-inline" />
                         {actionHTML}
                     </div>
-                    <div className="progress progress-label-top-right">
-                        <div className="progress-bar" role="progressbar" style={ { width: this.state.percentage + "%" } }>
-                            { this.state.timeRemaining !== null ? <span>{moment.duration(this.state.timeRemaining * 1000).humanize()}</span> : null }
-                        </div>
-                    </div>
+                    <Progress title={this.state.timeRemaining && moment.duration(this.state.timeRemaining * 1000).humanize()} value={this.state.percentage} />
                 </div>
 
                 <div className="update-log">
@@ -935,13 +931,7 @@ class OsUpdates extends React.Component {
             });
 
             if (this.state.loadPercent)
-                return (
-                    <div className="progress-main-view">
-                        <div className="progress">
-                            <div className="progress-bar" role="progressbar" style={ { width: this.state.loadPercent + "%" } } />
-                        </div>
-                    </div>
-                );
+                return <Progress value={this.state.loadPercent} title={STATE_HEADINGS[state]} />;
             else
                 return <EmptyStatePanel loading />;
 

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -203,6 +203,12 @@ div.changelog {
     margin: 10ex auto 0;
 }
 
+/* don't let the install progress bar get too wide */
+.progress-cancel {
+    display: flex;
+    margin: 1em auto;
+}
+
 /* stolen from pkg/systemd/overview.scss */
 .content-header-extra {
     background: #f5f5f5;

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -190,15 +190,12 @@ class TestUpdates(NoSubManCase):
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
         b.click("#available-updates button#install-all")
 
-        b.wait_in_text("#state", "Applying updates")
+        # applying updates panel present
         b.wait_visible("#app div.pf-c-progress__bar")
 
-        # no refresh button or "last checked", but Cancel button
-        b.wait_text(".content-header-extra--updated", "")
-        b.wait_in_text(".content-header-extra button", "Cancel")
-
+        b.wait_in_text(".progress-main-view button.progress-cancel", "Cancel")
         # Cancel button should eventually get disabled
-        b.wait_visible(".content-header-extra button:disabled")
+        b.wait_visible(".progress-main-view button.progress-cancel:disabled")
 
         # update log only exists in the expander, collapsed by default
         self.assertFalse(b.is_present("#update-log"))
@@ -339,7 +336,7 @@ class TestUpdates(NoSubManCase):
         self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
         b.click("#available-updates button#install-security")
 
-        b.wait_in_text("#state", "Applying updates")
+        # applying updates panel present
         b.wait_visible("#app div.pf-c-progress__bar")
 
         # should have succeeded and show restart page
@@ -382,7 +379,7 @@ class TestUpdates(NoSubManCase):
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
         b.click("#available-updates button#install-all")
 
-        b.wait_in_text("#state", "Applying updates")
+        # applying updates panel present
         b.wait_visible("#app div.pf-c-progress__bar")
 
         # should have succeeded and show restart
@@ -529,7 +526,8 @@ class TestUpdates(NoSubManCase):
 
         b.click("#available-updates button#install-all")
 
-        b.wait_in_text("#state", "Applying updates failed")
+        # error message visible
+        b.wait_visible("#app .pf-c-page pre")
 
         self.assertRegex(b.text("#app .pf-c-page pre:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory")
@@ -561,8 +559,8 @@ class TestUpdates(NoSubManCase):
         b.wait_visible("#app div.pf-c-progress__bar")
         m.execute("systemctl kill --signal=SEGV packagekit.service")
 
-        b.wait_in_text("#state", "Applying updates failed")
-        b.wait_in_text("#app .pf-c-page", "PackageKit crashed")
+        # error message visible
+        b.wait_in_text("#app .pf-c-page pre", "PackageKit crashed")
 
         self.allow_journal_messages(".*org.freedesktop.PackageKit.*Error.NoReply.*")
         self.allow_journal_messages("Process .* dumped core.*")
@@ -585,7 +583,7 @@ class TestUpdates(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_in_text("#state", "Loading available updates failed")
+        # error message present
         b.wait_in_text(".pf-c-page__main-section pre", "PackageKit is not installed")
 
         # update status on front page should be invisible
@@ -610,7 +608,7 @@ class TestUpdates(NoSubManCase):
 
         # but applying updates is not; FIXME: this is a crappy UX
         b.click("#available-updates button#install-all")
-        b.wait_text("#state", "Applying updates failed")
+        # error message visible
         b.wait_in_text("#app pre", "authentication")
 
         # become superuser
@@ -637,9 +635,11 @@ class TestUpdates(NoSubManCase):
         # applying updates works now
         b.click("#available-updates button#install-all")
 
-        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
-        self.assertEqual(b.text("#app .pf-c-empty-state button.pf-m-primary"), "Restart now")
-        b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
+        # wait until installation is finished
+        m.execute("while [ ! -e /stamp-vanilla-2.0-2 ]; do sleep 1; done")
+        # reboot panel is visible
+        b.wait_visible("#app .pf-c-empty-state")
+        b.click("#app .pf-c-empty-state button:contains('Ignore')")
 
         # should go back to updates overview, nothing pending any more
         # TODO make Packagekit GetUpdates work for tests properly
@@ -670,20 +670,21 @@ class TestWsUpdate(NoSubManCase):
         b.login_and_go("/updates")
 
         b.click("#available-updates button#install-all")
-        b.wait_in_text("#state", "Applying updates")
+
+        # applying updates panel present
         b.wait_in_text("#app div.progress-description", "slow")
 
         # restarting should pick up that install progress
         m.restart_cockpit()
         b.login_and_go("/updates")
-        b.wait_in_text("#state", "Applying updates")
-        b.wait_visible("#app div.pf-c-progress__bar")
+
+        b.wait_in_text(".pf-c-empty-state h1", "Initializing")
 
         # finish the package installation
         m.execute("touch {0}".format(install_lockfile))
 
         # should have succeeded and show restart page; cancel
-        b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
+        b.wait_visible("#app .pf-c-empty-state")
         b.click("#app .pf-c-empty-state button.pf-m-link:contains('Ignore')")
         b.wait_in_text("#state", "System is up to date")
 
@@ -766,8 +767,6 @@ class TestUpdatesSubscriptions(PackageCase):
         # empty state visible in main area
         b.wait_visible(".pf-c-empty-state button")
         b.wait_in_text(".pf-c-empty-state", "This system is not registered")
-        # no header bar
-        b.wait_not_present(".content-header-extra")
 
         # test the button to switch to Subscriptions
         b.click(".pf-c-empty-state button")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -191,7 +191,7 @@ class TestUpdates(NoSubManCase):
         b.click("#available-updates button#install-all")
 
         b.wait_in_text("#state", "Applying updates")
-        b.wait_visible("#app div.progress-bar")
+        b.wait_visible("#app div.pf-c-progress__bar")
 
         # no refresh button or "last checked", but Cancel button
         b.wait_text(".content-header-extra--updated", "")
@@ -340,7 +340,7 @@ class TestUpdates(NoSubManCase):
         b.click("#available-updates button#install-security")
 
         b.wait_in_text("#state", "Applying updates")
-        b.wait_visible("#app div.progress-bar")
+        b.wait_visible("#app div.pf-c-progress__bar")
 
         # should have succeeded and show restart page
         b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
@@ -383,7 +383,7 @@ class TestUpdates(NoSubManCase):
         b.click("#available-updates button#install-all")
 
         b.wait_in_text("#state", "Applying updates")
-        b.wait_visible("#app div.progress-bar")
+        b.wait_visible("#app div.pf-c-progress__bar")
 
         # should have succeeded and show restart
         b.wait_in_text("#app .pf-c-empty-state h1", "Restart recommended")
@@ -558,7 +558,7 @@ class TestUpdates(NoSubManCase):
         b.click("#available-updates button#install-all")
 
         # let updates start and zap PackageKit
-        b.wait_visible("#app div.progress-bar")
+        b.wait_visible("#app div.pf-c-progress__bar")
         m.execute("systemctl kill --signal=SEGV packagekit.service")
 
         b.wait_in_text("#state", "Applying updates failed")
@@ -677,7 +677,7 @@ class TestWsUpdate(NoSubManCase):
         m.restart_cockpit()
         b.login_and_go("/updates")
         b.wait_in_text("#state", "Applying updates")
-        b.wait_visible("#app div.progress-bar")
+        b.wait_visible("#app div.pf-c-progress__bar")
 
         # finish the package installation
         m.execute("touch {0}".format(install_lockfile))

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1157,7 +1157,6 @@ class TestAutoUpdatesInstall(NoSubManCase):
         b.click("#available-updates button#install-all")
         b.click(".pf-c-empty-state button.pf-m-link")
 
-        self.assertFalse(b.is_present("#available-updates"))
         if self.backend == 'dnf':
             b.is_present('#automatic-updates')
         else:


### PR DESCRIPTION
A followup of a previous redesign. It mainly changes:

- Fix a autoupdates modal not closing
- Use PF4 progress bar instead of a custom one
- And most importantly, get rid of the Header bar, which was almost always present on top of the updates page. After a previous redesign, the Header bar was only used to show a status of what's happening in updates page and a Cancel button in case an update is in progress. Both of this can be shown in an empty state panel:

![Screenshot from 2021-01-04 13-27-54](https://user-images.githubusercontent.com/42733240/103535584-46cd0d80-4e91-11eb-93e9-17f0c72bf926.png)
![Screenshot from 2021-01-04 13-27-23](https://user-images.githubusercontent.com/42733240/103535587-492f6780-4e91-11eb-9315-4f84048c7dc4.png)
![Screenshot from 2021-01-04 13-09-14](https://user-images.githubusercontent.com/42733240/103535580-446ab380-4e91-11eb-879e-e0bfc893b9e1.png)
