### PR TITLE
base1: Fix D-Bus "watch barrier" test

### DIFF
--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -2,8 +2,8 @@
 
 This container has all build dependencies and toolchains (GCC and clang) that
 we want to exercise Cockpit with, mostly for `make distcheck` and `make
-check-memory`. This container gets run in semaphore, but can be easily run
-locally too.
+check-memory`. This container runs on [GitHub](.github/workflows/unit-tests.yml),
+but can be easily run locally too.
 
 It assumes that the Cockpit source git checkout is available in `/source`. It
 will not modify that directory or take uncommitted changes into account, but it

--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -783,7 +783,7 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
         var cache = { };
 
         var dbus = cockpit.dbus(bus_name, channel_options);
-        const onnotify = (event, data) => Object.assign(cache, data);
+        const onnotify = (event, data) => deep_update(cache, data);
         dbus.addEventListener("notify", onnotify);
 
         dbus.watch({ path_namespace: "/otree" });

--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -780,33 +780,32 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
         const done = assert.async();
         assert.expect(2);
 
-        const cache = { };
+        var cache = { };
 
-        const dbus = cockpit.dbus(bus_name, channel_options);
+        var dbus = cockpit.dbus(bus_name, channel_options);
         const onnotify = (event, data) => Object.assign(cache, data);
         dbus.addEventListener("notify", onnotify);
 
-        dbus.watch({ path_namespace: "/otree" })
-                .then(() => {
-                    dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
-                              "HelloWorld", ["Browser-side JS"])
-                            .done(function(reply) {
-                                assert.deepEqual(cache["/otree/frobber"]["com.redhat.Cockpit.DBusTests.Frobber"],
-                                                 {
-                                                     FinallyNormalName: "There aint no place like home",
-                                                     ReadonlyProperty: "blah",
-                                                     aay: [], ag: [], ao: [], as: [],
-                                                     ay: "QUJDYWJjAA==",
-                                                     b: false, d: 43, g: "", i: 0, n: 0,
-                                                     o: "/", q: 0, s: "", t: 0, u: 0, x: 0,
-                                                     y: 42
-                                                 }, "correct data");
-                            })
-                            .always(function() {
-                                assert.equal(this.state(), "resolved", "finished successfully");
-                                dbus.removeEventListener("notify", onnotify);
-                                done();
-                            });
+        dbus.watch({ path_namespace: "/otree" });
+
+        dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
+                  "HelloWorld", ["Browser-side JS"])
+                .done(function(reply) {
+                    assert.deepEqual(cache["/otree/frobber"]["com.redhat.Cockpit.DBusTests.Frobber"],
+                                     {
+                                         FinallyNormalName: "There aint no place like home",
+                                         ReadonlyProperty: "blah",
+                                         aay: [], ag: [], ao: [], as: [],
+                                         ay: "QUJDYWJjAA==",
+                                         b: false, d: 43, g: "", i: 0, n: 0,
+                                         o: "/", q: 0, s: "", t: 0, u: 0, x: 0,
+                                         y: 42
+                                     }, "correct data");
+                })
+                .always(function() {
+                    assert.equal(this.state(), "resolved", "finished successfully");
+                    dbus.removeEventListener("notify", onnotify);
+                    done();
                 });
     });
 


### PR DESCRIPTION
In that test it could happen that after the first `notify` signal with
the expected properties there is a second `onnotify()` invocation with
an empty property update dict (which is unnecessary, but formally
conforming with the spec, and mostly harmless).

I broke that in commit d196498c44, which replaced a deep update of the
cache object with a shallow override: I wrongly thought that there
should/will only ever be one invocation.

Go back to a "deep update" to accomodate multiple notify signals,
similar to how the "watch interfaces" test works.

Fixes #15095