### PR TITLE
machines: fix check of cpu configuration between active/inactive XML

### DIFF
--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -162,6 +162,14 @@ export function getDomainCapCPUCustomModels(capsXML) {
     return customModeElem && Array.prototype.map.call(customModeElem.getElementsByTagName("model"), modelElem => modelElem.textContent);
 }
 
+export function getDomainCapCPUHostModel(capsXML) {
+    const domainCapsElem = getElem(capsXML);
+    const cpuElem = domainCapsElem.getElementsByTagName("cpu") && domainCapsElem.getElementsByTagName("cpu")[0];
+    const modeElems = cpuElem && cpuElem.getElementsByTagName("mode");
+    const hostModelModeElem = modeElems && Array.prototype.find.call(modeElems, modeElem => modeElem.getAttribute("name") == "host-model");
+    return hostModelModeElem && Array.prototype.map.call(hostModelModeElem.getElementsByTagName("model"), modelElem => modelElem.textContent)[0];
+}
+
 export function getSingleOptionalElem(parent, name) {
     const subElems = parent.getElementsByTagName(name);
     return subElems.length > 0 ? subElems[0] : undefined; // optional

--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -2731,6 +2731,18 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
         xmllint_element = "{0} | xmllint --xpath 'string(//domain/{{prop}})' - 2>&1 || true".format(dom_xml)
         self.assertEqual("coreduo", m.execute(xmllint_element.format(prop='cpu/model')).strip())
 
+        # Host-model gets expanded  to custom mode when the VM is running
+        b.click("#vm-subVmTest1-cpu-model button")
+        b.select_from_dropdown("#cpu-model-select-group select", "host-model")
+        b.click("#cpu-config-dialog-apply")
+        b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "host")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-run")
+        b.wait_in_text("#vm-subVmTest1-state", "Running")
+        b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "custom")
+        # In the test ENV libvirt does not properly set the CPU model so we see a tooltip https://bugzilla.redhat.com/show_bug.cgi?id=1913337
+        # b.wait_not_present("#cpu-tooltip")
+
     def testBootOrder(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The default VM CPU mode is to host-model mode. The XML in this case looks like:

    <cpu mode='host-model' check='partial'/>

When the Vm starts, the live xml adapts and shows the host-model expanded.
This is expected and important since the expansion varies depending on
the host and so needs to be tracked across migration.

Therefore, when performing the check between inactive and active XML CPU
configuration, we need to have a special case for the host-model mode.

Related to: rhbz#1913205