### PR TITLE
pcp: Fix cast

### DIFF
--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -513,7 +513,8 @@ convert_metric_description (CockpitPcpMetrics *self,
       return FALSE;
     }
 
-  rc = pmLookupName (1, (char **)&info->name, &info->id);
+  // HACK: cast to `void *` as pcp-5.2.3 changed it from `char **` to `const char **`
+  rc = pmLookupName (1, (void *)&info->name, &info->id);
   if (rc < 0)
     {
       if (not_found)


### PR DESCRIPTION
I cannot build the source due to this error:
```
src/bridge/cockpitpcpmetrics.c: In function ‘convert_metric_description’:
src/bridge/cockpitpcpmetrics.c:516:25: error: passing argument 2 of ‘pmLookupName’ from incompatible pointer type [-Werror=incompatible-pointer-types]
  516 |   rc = pmLookupName (1, (char **)&info->name, &info->id);
      |                         ^~~~~~~~~~~~~~~~~~~~
      |                         |
      |                         char **
In file included from src/bridge/cockpitpcpmetrics.c:29:
/usr/include/pcp/pmapi.h:266:39: note: expected ‘const char **’ but argument is of type ‘char **’
  266 | PCP_CALL extern int pmLookupName(int, const char **, pmID *);
      |                                       ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Not sure why CI nor anyone else does not get this error.