### PR TITLE
ws: Restrict our cookie to the login host only

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1594,7 +1594,7 @@ cockpit_auth_login_finish (CockpitAuth *self,
             force_secure = connection ? !G_IS_SOCKET_CONNECTION (connection) : TRUE;
           cookie_name = application_cookie_name (cockpit_creds_get_application (creds));
           cookie_b64 = g_base64_encode ((guint8 *)session->cookie, strlen (session->cookie));
-          header = g_strdup_printf ("%s=%s; Path=/; %s HttpOnly",
+          header = g_strdup_printf ("%s=%s; Path=/; SameSite=Strict;%s HttpOnly",
                                     cookie_name, cookie_b64,
                                     force_secure ? " Secure;" : "");
           g_free (cookie_b64);
@@ -1730,7 +1730,7 @@ cockpit_auth_empty_cookie_value (const gchar *path, gboolean secure)
 
   /* this is completely security irrelevant, but security scanners complain
    * about the lack of Secure (rhbz#1677767) */
-  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/;%s HttpOnly",
+  gchar *cookie_line = g_strdup_printf ("%s=deleted; PATH=/; SameSite=strict;%s HttpOnly",
                                         cookie,
                                         secure ? " Secure;" : "");
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -523,7 +523,7 @@ static const DefaultFixture fixture_shell_path_login = {
   .org_path = "/path/system/host",
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
-      "Set-Cookie: cockpit=deleted; PATH=/; HttpOnly\r*"
+      "Set-Cookie: cockpit=deleted; PATH=/; SameSite=strict; HttpOnly\r*"
       "<html>*"
       "<base href=\"/path/\">*"
       "login-button*"

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -103,6 +103,7 @@ class TestConnection(MachineCase):
         # cookie should not be marked as secure, it's not https
         cookie = b.cookie("cockpit")
         self.assertTrue(cookie["httpOnly"])
+        self.assertEqual(cookie["sameSite"], "Strict")
         self.assertFalse(cookie["secure"])
 
         # take cockpit-ws down on the server page
@@ -421,12 +422,14 @@ class TestConnection(MachineCase):
         # cookie should be marked as secure
         self.assertTrue(cookie["httpOnly"])
         self.assertTrue(cookie["secure"])
+        self.assertEqual(cookie["sameSite"], "Strict")
         # same after logout
         b.logout()
         cookie = b.cookie("cockpit")
         self.assertEqual(cookie["value"], "deleted")
         self.assertTrue(cookie["httpOnly"])
         self.assertTrue(cookie["secure"])
+        self.assertEqual(cookie["sameSite"], "Strict")
 
         # http on localhost should not redirect to https
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://127.0.0.1:9090"))


### PR DESCRIPTION
Mark our cookie as `SameSite: Strict` [1]. The current `None` default
will soon be moved to `Lax` by Firefox and Chromium, and recent versions
started to throw a warning about it.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite

https://bugzilla.redhat.com/show_bug.cgi?id=1891944