### PR TITLE
bridge: fix a leak on connect in websocketstream

### DIFF
--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -64,10 +64,6 @@ typedef struct _CockpitWebSocketStream {
 
 } CockpitWebSocketStream;
 
-typedef struct {
-  CockpitChannelClass parent_class;
-} CockpitWebSocketStreamClass;
-
 G_DEFINE_TYPE (CockpitWebSocketStream, cockpit_web_socket_stream, COCKPIT_TYPE_CHANNEL);
 
 static void

--- a/src/bridge/cockpitwebsocketstream.c
+++ b/src/bridge/cockpitwebsocketstream.c
@@ -257,7 +257,7 @@ on_socket_connect (GObject *object,
                    GAsyncResult *result,
                    gpointer user_data)
 {
-  CockpitWebSocketStream *self = COCKPIT_WEB_SOCKET_STREAM (user_data);
+  g_autoptr(CockpitWebSocketStream) self = user_data; /* capture the ref passed to the async op */
   CockpitChannel *channel = COCKPIT_CHANNEL (self);
   const gchar *problem = "protocol-error";
   g_autofree const gchar **protocols = NULL;

--- a/src/bridge/cockpitwebsocketstream.h
+++ b/src/bridge/cockpitwebsocketstream.h
@@ -17,15 +17,10 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef COCKPIT_WEB_SOCKET_STREAM_H__
-#define COCKPIT_WEB_SOCKET_STREAM_H__
+#pragma once
 
-#include <gio/gio.h>
+#include "common/cockpitchannel.h"
 
-G_BEGIN_DECLS
-
-#define COCKPIT_TYPE_WEB_SOCKET_STREAM         (cockpit_web_socket_stream_get_type ())
-
-GType              cockpit_web_socket_stream_get_type     (void) G_GNUC_CONST;
-
-#endif /* COCKPIT_WEB_SOCKET_STREAM_H__ */
+#define COCKPIT_TYPE_WEB_SOCKET_STREAM (cockpit_web_socket_stream_get_type ())
+G_DECLARE_FINAL_TYPE (CockpitWebSocketStream, cockpit_web_socket_stream,
+                      COCKPIT, WEB_SOCKET_STREAM, CockpitChannel)

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -169,7 +169,6 @@ test_basic (TestCase *test,
 
   recv = mock_transport_pop_channel (test->transport, "444");
   cockpit_assert_bytes_eq (recv, "MESSAGE", 7);
-  g_bytes_unref (recv);
 
   cockpit_channel_close (channel, "ending");
 
@@ -300,7 +299,6 @@ test_tls_authority_good (TestTls *test,
 
   recv = mock_transport_pop_channel (test->transport, "444");
   cockpit_assert_bytes_eq (recv, "MESSAGE", 7);
-  g_bytes_unref (recv);
 
   cockpit_channel_close (channel, "ending");
 


### PR DESCRIPTION
We add a ref to the object when making the async call, but we don't free
it from the completion handler.  Use an autoptr to make sure we get this
right.

Also, modernise the header a bit to make sure autoptr works with this
type.

Add a testcase which detected a leak before this change.


I've spent a couple of days being confused about why valgrind is only flagging this leak in a small number of cases.  It was reliably triggered from the branch porting the cockpit connection code to GSocketClient (due to an earlier error being flagged, which I've replicated here in another test).  This fix seems logical and correct to me, but I'm a bit nervous that there's an outstanding reference somewhere...

Let's see what the bots think.