### PR TITLE
common: reimplement cockpit_memory_clear()

### DIFF
--- a/src/common/cockpitmemory.c
+++ b/src/common/cockpitmemory.c
@@ -28,8 +28,6 @@
 #include <string.h>
 #include <errno.h>
 
-int      cockpit_secmem_drain = 0;
-
 /**
  * cockpit_memory_clear:
  *
@@ -40,33 +38,16 @@ int      cockpit_secmem_drain = 0;
  *
  * This is very similar to memset but we take extra measures to
  * prevent the compiler from optimizing it away.
- *
- * See http://www.dwheeler.com/secure-class/Secure-Programs-HOWTO/protect-secrets.html
  */
 
 void
 cockpit_memory_clear (void * data,
                       ssize_t len)
 {
-  volatile char *vp;
-
-  if (!data)
-    return;
-
   if (len < 0)
     len = strlen (data);
 
-  /* Defeats some optimizations */
-  memset (data, 0xAA, len);
-  memset (data, 0xBB, len);
-
-  /* Defeats others */
-  vp = (volatile char *)data;
-  while (len--)
-    {
-      cockpit_secmem_drain |= *vp;
-      *(vp++) = 0xAA;
-    }
+  explicit_bzero (data, len);
 }
 
 static void

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -633,8 +633,12 @@ reply_authorize_challenge (CockpitSession *session)
 
   if (response && !cookie)
     {
-      cockpit_memory_clear (session->authorization, -1);
-      g_free (session->authorization);
+      if (session->authorization)
+        {
+          cockpit_memory_clear (session->authorization, -1);
+          g_free (session->authorization);
+        }
+
       session->authorization = g_strdup (response);
       ret = TRUE;
       goto out;

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -312,8 +312,10 @@ cockpit_certificate_create_selfsigned (GError **error)
   cert_path = NULL;
 
 out:
-  cockpit_memory_clear (key_data, -1);
-  cockpit_memory_clear (cert_data, -1);
+  if (key_data)
+    cockpit_memory_clear (key_data, -1);
+  if (cert_data)
+    cockpit_memory_clear (cert_data, -1);
   if (tmp_key)
     g_unlink (tmp_key);
   if (tmp_pem)

--- a/src/ws/test-creds.c
+++ b/src/ws/test-creds.c
@@ -25,6 +25,16 @@
 #include "common/cockpittest.h"
 
 static void
+assert_all_zeros (GBytes *bytes)
+{
+  gsize size;
+  const gchar *data = g_bytes_get_data (bytes, &size);
+
+  for (gsize i = 0; i < size; i++)
+    g_assert (data[i] == '\0');
+}
+
+static void
 test_password (void)
 {
   CockpitCreds *creds;
@@ -76,8 +86,8 @@ test_set_password (void)
   g_assert (NULL == cockpit_creds_get_password (creds));
 
   /* Still hold references to all old passwords, but they are cleared */
-  g_assert_cmpstr ("\252\252\252\252\252\252\252\252", ==, g_bytes_get_data (out, NULL));
-  g_assert_cmpstr ("\252\252\252\252\252\252", ==, g_bytes_get_data (two, NULL));
+  assert_all_zeros (out);
+  assert_all_zeros (two);
 
   cockpit_creds_unref (creds);
 }
@@ -109,7 +119,7 @@ test_poison (void)
 
   /* Even though we set a new password, still NULL */
   g_assert (NULL == cockpit_creds_get_password (creds));
-  g_assert_cmpstr ("\252\252\252\252\252\252\252\252", ==, g_bytes_get_data (out, NULL));
+  assert_all_zeros (out);
 
   cockpit_creds_unref (creds);
 }


### PR DESCRIPTION
Replace our homegrown shenanigans with a more "official" way.

cockpit_memory_clear() has an additional useful feature of clearing a
nul-terminated string if len is specified as -1, so keep it around for
this purpose alone.