### PR TITLE
storaged: fix sidepanel warning/actions overflowing on some screen sizes

### DIFF
--- a/pkg/storaged/side-panel.jsx
+++ b/pkg/storaged/side-panel.jsx
@@ -115,17 +115,17 @@ export class SidePanelRow extends React.Component {
                 role="link" tabIndex="0"
                 onKeyPress={this.props.go ? go : null}
                 onClick={this.props.go ? go : null} className={this.props.highlight ? "highlight-ct" : ""}>
-                <td className={"sidepanel-row " + (this.props.highlight ? "highlight-ct" : "")}>
-                    <div className="sidepanel-row-body">
-                        <div className="sidepanel-row-name">{this.props.name}</div>
-                        <div className="sidepanel-row-info">
-                            <div className="sidepanel-row-detail">{this.props.detail}</div>
-                            <div className="sidepanel-row-devname">{this.props.devname}</div>
+                <td className={this.props.highlight ? "highlight-ct" : ""}>
+                    <div className="sidepanel-row">
+                        <div className="sidepanel-row-body">
+                            <div className="sidepanel-row-name">{this.props.name}</div>
+                            <div className="sidepanel-row-info">
+                                <div className="sidepanel-row-detail">{this.props.detail}</div>
+                                <div className="sidepanel-row-devname">{this.props.devname}</div>
+                            </div>
                         </div>
+                        {decoration}
                     </div>
-                </td>
-                <td className="sidepanel-row-decoration">
-                    {decoration}
                 </td>
             </tr>
         );

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -655,6 +655,8 @@ td.storage-action {
 .sidepanel-row {
     display: flex;
     flex-direction: row;
+    justify-content: space-between;
+    gap: var(--pf-global--spacer--sm);
 }
 
 .sidepanel-row-detail {
@@ -670,11 +672,6 @@ td.storage-action {
     display: flex;
     flex-flow: row wrap;
     justify-content: space-between;
-}
-
-.pf-c-table tbody > tr > td.sidepanel-row-decoration {
-    --pf-c-table--cell--Width: 10%;
-    width: var(--pf-c-table--cell--Width);
 }
 
 .sidepanel-row .spinner {


### PR DESCRIPTION
Just place the two elements using flex instead of arranging them using
two table columns.

Fixes #14973