### PR TITLE
bridge: Only gather info from the first channel for peer bridges

### DIFF
--- a/src/bridge/cockpitpeer.c
+++ b/src/bridge/cockpitpeer.c
@@ -57,6 +57,7 @@ struct _CockpitPeer {
   guint authorize_values_timeout;
 
   /* first_host */
+  gboolean first_channel_done;
   gchar *init_host;
   gchar *init_superuser;
 
@@ -263,7 +264,7 @@ on_other_control (CockpitTransport *transport,
       if (cockpit_json_get_object (options, "capabilities", NULL, &capabilities) && capabilities)
         {
           if (!cockpit_json_get_bool (capabilities, "explicit-superuser", FALSE, &explicit_superuser_capability))
-            g_warning ("invalued 'explicit-superuser' value in init message");
+            g_warning ("invalid 'explicit-superuser' value in init message");
         }
 
       // Authorization for SSH is over now, but we still need the
@@ -946,8 +947,10 @@ cockpit_peer_handle (CockpitPeer *self,
     }
 
   /* If this is the first channel, we can cache data from it */
-  if (!self->inited)
+  if (!self->first_channel_done)
     {
+      self->first_channel_done = TRUE;
+
       if (!self->init_host && cockpit_json_get_string (options, "host", NULL, &host))
         self->init_host = g_strdup (host);
 
@@ -1121,4 +1124,5 @@ cockpit_peer_reset (CockpitPeer *self)
   self->problem = NULL;
   self->closed = FALSE;
   self->inited = FALSE;
+  self->first_channel_done = FALSE;
 }


### PR DESCRIPTION
This was always the intention, but the code would potentially treat
many of the early "open" requests as being first, until the peer
bridge would send its "init" message.

This was mostly harmless since the code would combine properties from
all these "open" requests, and none would be lost.  Except for
"init-superuser", where later requests would overwrite earlier ones.

It is not useful to have properties like" user" and "password" on
anything but the first request.  Thus, we make it so that we only ever
look at the first "open" request.