### PR TITLE
unit-tests: Introduce unit-test "scenarios"

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -21,14 +21,17 @@ jobs:
       - name: Build fresh containers
         run: sudo containers/unit-tests/build
 
-      - name: Run amd64 gcc test
-        run: sudo containers/unit-tests/start
+      - name: Run amd64 gcc check-memory test
+        run: sudo containers/unit-tests/start check-memory
 
-      - name: Run amd64 clang test
-        run: sudo containers/unit-tests/start CC=clang
+      - name: Run i386 clang check-memory test
+        run: sudo containers/unit-tests/start :i386 CC=clang check-memory
 
-      - name: Run i386 test
-        run: sudo containers/unit-tests/start :i386
+      - name: Run amd64 clang distcheck test
+        run: sudo containers/unit-tests/start CC=clang distcheck
+
+      - name: Run i386 gcc distcheck test
+        run: sudo containers/unit-tests/start :i386 distcheck
 
       - name: Log into container registry
         run: sudo podman login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,7 +5,11 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        startarg: [':latest', ':i386', 'CC=clang']
+        startarg:
+         - check-memory
+         - CC=clang :i386 check-memory
+         - CC=clang distcheck
+         - :i386 distcheck
       fail-fast: false
     timeout-minutes: 60
     steps:
@@ -18,8 +22,13 @@ jobs:
       - name: Build unit test container if it changed
         run: |
           changes=$(git diff --name-only origin/master..HEAD -- containers/unit-tests/)
-          [ '${{ matrix.startarg }}' = ':i386' ] && arch=i386 || arch=amd64
-          [ -z "$changes" ] || containers/unit-tests/build $arch
+          if [ -n "${changes}" ]; then
+            case '${{ matrix.startarg }}' in
+              *:i386*) arch=i386;;
+              *) arch=amd64;;
+            esac
+            containers/unit-tests/build $arch
+          fi
 
       - name: Run unit-tests container
         run: 'containers/unit-tests/start ${{ matrix.startarg }}'

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -34,16 +34,21 @@ to modify its behaviour:
    to build with a different compiler)
  - `:tag` to specify a different tag to use for the `cockpit/unit-tests` image
    (eg: `i386`)
- - `shell` to specify that an interactive shell should be launched instead of
-   running the unit tests
+
+Additionally, a testing scenario must be provided.  Supported options are:
+
+ - `check-memory`: runs 'make check-memory' (ie: run the unit tests under valgrind)
+ - `distcheck`: runs 'make distcheck' and some related checks
+ - `shell`: specify that an interactive shell should be launched instead of
+   building and testing
 
 Some examples:
 
-    $ ./start           # run the unit tests on amd64
+    $ ./start check-memory             # run the valgrind tests on amd64
 
-    $ ./start CC=clang  # run the unit tests on amd64, compiled with clang
+    $ ./start CC=clang check-memory    # run the valgrind tests, compiled with clang
 
-    $ ./start :i386     # run the unit tests on i386
+    $ ./start :i386 distcheck          # run the distcheck tests on i386
 
 ## Debugging tests
 

--- a/containers/unit-tests/build.sh
+++ b/containers/unit-tests/build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -eux
+
+./autogen.sh --prefix=/usr --enable-strict --with-systemdunitdir=/tmp
+
+make all
+

--- a/containers/unit-tests/scenario-check-memory.sh
+++ b/containers/unit-tests/scenario-check-memory.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+make check-memory 2>&1 || {
+    cat test-suite.log
+    exit 1
+}

--- a/containers/unit-tests/scenario-distcheck.sh
+++ b/containers/unit-tests/scenario-distcheck.sh
@@ -1,0 +1,29 @@
+#!/bin/sh -eux
+
+make XZ_COMPRESS_FLAGS='-0' V=0 distcheck 2>&1 || {
+  find -name test-suite.log | xargs cat
+  exit 1
+}
+
+# check translation build
+make po/cockpit.pot
+# do some spot checks
+grep -q 'pkg/base1/cockpit.js' po/cockpit.pot
+grep -q 'pkg/lib/machine-dialogs.js' po/cockpit.pot
+grep -q 'pkg/systemd/services.html' po/cockpit.pot
+grep -q 'pkg/static/login.html' po/cockpit.pot
+grep -q 'pkg/systemd/manifest.json.in' po/cockpit.pot
+grep -q 'src/bridge/cockpitpackages.c' po/cockpit.pot
+! grep -q 'test-.*.js' po/cockpit.pot
+
+# validate that "distclean" does not remove too much
+mkdir _distcleancheck
+tar -C _distcleancheck -xf cockpit-[0-9]*.tar.xz
+cd _distcleancheck/cockpit-*
+./configure
+make distclean
+./configure
+make check 2>&1 || {
+    find -name test-suite.log | xargs cat
+    exit 1
+}

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -2,6 +2,7 @@
 
 top_srcdir=$(realpath -m "$0"/../../..)
 image=ghcr.io/cockpit-project/unit-tests:latest
+scenario=''
 flags=''
 cmd=''
 
@@ -12,10 +13,16 @@ while test $# -gt 0; do
     CC=*) ccarg="--env=$1";;
     shell) flags=-it; cmd=/bin/bash;;
     :*) image=ghcr.io/cockpit-project/unit-tests"$1";;
+    distcheck|check-memory) scenario="--env=TEST_SCENARIO=$1";;
     *) echo "Unknown option '$1'"; exit 1;;
   esac
   shift
 done
+
+if test -z "$scenario" -a -z "$cmd"; then
+  echo 'Must specify a scenario or `shell`'
+  exit 1
+fi
 
 if test -z "${docker:=$(which podman || which docker || true)}"; then
   echo 'Neither podman nor docker are installed'
@@ -24,4 +31,4 @@ fi
 
 set -ex
 exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
-       ${ccarg:+"$ccarg"} $flags -- "$image" $cmd
+       ${ccarg:+"$ccarg"} $scenario $flags -- "$image" $cmd

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -3,7 +3,8 @@
 # Check for mistakes in tarball distribution
 
 # Make sure we don't distribute gz files
-find $1/dist -name '*.gz' -print | tee /dev/stderr | sort | while read file; do
+find $1/dist -name '*.gz' -print | sort | while read file; do
+        find $1/dist -name '*.gz' -print >&2
         echo "Refusing to distribute gzip files" >&2
         exit 1
 done


### PR DESCRIPTION
    Split the actions performed while unit testing into separate files:
    
     - build.sh: configure and build on a checked out tree
     - scenario-check-memory.sh: run `make check-memory`
     - scenario-distcheck.sh: run various `make distcheck` type tests
    
    This allows a human user to run the various test scenarios on a checked
    out tree, including building it with the correct arguments, without
    spinning up a container.
    
    Modify run.sh to always call build.sh, and call a scenario script
    according to the value of the SCENARIO environment variable.  Modify the
    start script to set this variable according to a now-mandatory
    commandline argument.
    
    Adjust the github workflows so that we do four testcases now:
    
     - amd64 gcc check-memory
     - i386 clang check-memory
     - amd64 clang distcheck
     - i386 gcc distcheck
    
    This gets us a full build with `make check` run in every arch/compiler
    combination, plus makes sure we're running each of check-memory and
    distcheck for each arch and each compiler.
