### PR TITLE
tests: fix TestSystemInfo.testCPUSecurityMitigationsEnable

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -481,7 +481,7 @@ class TestSystemInfo(MachineCase):
         self.restore_dir("/usr/local/bin")
 
         self.login_and_go('/system/hwinfo')
-        b.wait_visible('#hwinfo th:contains(CPU)')
+        b.wait_in_text("#hwinfo", "CPU")
 
         def spoof_threads(threads_per_core, expect_link_present, expect_smt_state=None, cmdline=None):
             m.write('/usr/local/bin/lscpu', lscpu.format(threads_per_core))
@@ -612,7 +612,6 @@ fi
 
         # Behaviour for non-admins
         self.login_and_go('/system/hwinfo', superuser=False)
-        b.wait_visible('#hwinfo th:contains(CPU)')
         b.wait_visible('#cpu_mitigations[disabled]')
         b.mouse('#tip-cpu-security', 'mouseenter')
         b.wait_text('.pf-c-tooltip', 'The user admin is not permitted to change cpu security mitigations')


### PR DESCRIPTION
This started failing with:
 #hwinfo th:contains(CPU) is ambiguous

Indeed there are two elements starting containing 'CPU' string in the
description. Let's keep using the old wait_present method.

See failure https://logs.cockpit-project.org/logs/pull-15130-20210113-101552-dd028da8-fedora-33/log.html#298-2