### PR TITLE
po: Don't double cd when building cockpit.appstream.pot

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -87,8 +87,8 @@ po/cockpit.manifest.pot:
 		$$(cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json.in')
 
 po/cockpit.appstream.pot:
-	cd $(srcdir) && $(XGETTEXT) --output=$(abs_builddir)/$@ \
-		$$(cd $(srcdir) && find $(TRANSLATE) -name '*.appdata.xml.in')
+	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po $(XGETTEXT) --output=$(abs_builddir)/$@ \
+		$$(find $(TRANSLATE) -name '*.appdata.xml.in')
 
 po/cockpit.polkit.pot:
 	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po $(XGETTEXT) --output=$(abs_builddir)/$@ \


### PR DESCRIPTION
Then the `find` could not find the file as it was one directory up as
expected.

I tried to unify all the .pot files to use the same pattern, but that
did not work out well, as each works ever so slightly differently.