### PR TITLE
Stop importing PF3 in terminal and hwinfo pages - and some tiny cleanups

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -3,6 +3,28 @@
 @import "./patternfly/patternfly-4-overrides.scss";
 @import "@patternfly/patternfly/components/Page/page.scss";
 
+/* Globaly resize headings */
+h1 {
+  font-size: var(--pf-global--FontSize--4xl);
+}
+
+h2 {
+  font-size: var(--pf-global--FontSize--3xl);
+}
+
+h3 {
+  font-size: var(--pf-global--FontSize--2xl);
+}
+
+h4 {
+  font-size: var(--pf-global--FontSize--xl);
+}
+
+h4 {
+  font-size: var(--pf-global--FontSize--lg);
+}
+/* End of headings resize */
+
 a {
     cursor: pointer;
 }

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -15,26 +15,6 @@ h1, h2, h3, h4, h5, h6 {
   }
 }
 
-h1 {
-  font-size: var(--pf-global--FontSize--4xl);
-}
-
-h2 {
-  font-size: var(--pf-global--FontSize--3xl);
-}
-
-h3 {
-  font-size: var(--pf-global--FontSize--2xl);
-}
-
-h4 {
-  font-size: var(--pf-global--FontSize--xl);
-}
-
-h4 {
-  font-size: var(--pf-global--FontSize--lg);
-}
-
 // Restyle inputs & dropdowns
 .input-group-addon,
 .bootstrap-select.btn-group .btn,

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import '../lib/patternfly/patternfly-cockpit.scss';
+import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 
 import cockpit from "cockpit";

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -2,8 +2,11 @@ import cockpit from "cockpit";
 
 import React from "react";
 import ReactDOM from "react-dom";
+import {
+    Toolbar, ToolbarContent, ToolbarItem
+} from "@patternfly/react-core";
 
-import '../lib/patternfly/patternfly-cockpit.scss';
+import '../lib/patternfly/patternfly-4-cockpit.scss';
 import { Terminal } from "cockpit-components-terminal.jsx";
 import { Select, SelectEntry } from "cockpit-components-select.jsx";
 
@@ -89,23 +92,32 @@ const _ = cockpit.gettext;
 
             return (
                 <div className="console-ct-container">
-                    <div className="panel-heading terminal-group">
+                    <div className="terminal-group">
                         <tt className="terminal-title">{this.state.title}</tt>
-                        <label className="control-label" htmlFor="theme-select">{_("Appearance:")}</label>
-                        <Select onChange={this.onThemeChanged}
-                            id="theme-select"
-                            className="theme-select"
-                            initial={this.state.theme}>
-                            <SelectEntry data='black-theme'>{_("Black")}</SelectEntry>
-                            <SelectEntry data='dark-theme'>{_("Dark")}</SelectEntry>
-                            <SelectEntry data='light-theme'>{_("Light")}</SelectEntry>
-                            <SelectEntry data='white-theme'>{_("White")}</SelectEntry>
-                        </Select>
-                        <button ref="resetButton"
-                            className="pf-c-button pf-m-secondary terminal-reset"
-                            onClick={this.onResetClick}>{_("Reset")}</button>
+                        <Toolbar id="toolbar">
+                            <ToolbarContent>
+                                <ToolbarItem variant="label" id="theme-select">
+                                    {_("Appearance")}
+                                </ToolbarItem>
+                                <ToolbarItem>
+                                    <Select onChange={this.onThemeChanged}
+                                        ariaLabelledBy="theme-select"
+                                        initial={this.state.theme}>
+                                        <SelectEntry data='black-theme'>{_("Black")}</SelectEntry>
+                                        <SelectEntry data='dark-theme'>{_("Dark")}</SelectEntry>
+                                        <SelectEntry data='light-theme'>{_("Light")}</SelectEntry>
+                                        <SelectEntry data='white-theme'>{_("White")}</SelectEntry>
+                                    </Select>
+                                </ToolbarItem>
+                                <ToolbarItem>
+                                    <button ref="resetButton"
+                                            className="pf-c-button pf-m-secondary terminal-reset"
+                                            onClick={this.onResetClick}>{_("Reset")}</button>
+                                </ToolbarItem>
+                            </ToolbarContent>
+                        </Toolbar>
                     </div>
-                    <div className={"panel-body " + this.state.theme} id="the-terminal">
+                    <div className={"terminal-body " + this.state.theme} id="the-terminal">
                         {terminal}
                     </div>
                 </div>

--- a/pkg/systemd/terminal.scss
+++ b/pkg/systemd/terminal.scss
@@ -1,5 +1,7 @@
 @import "../lib/console.css";
+@import "_global-variables.scss";
 @import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
+@import "../../node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 html, body {
         height: 100%;
@@ -12,7 +14,7 @@ html, body {
     overflow: hidden;
 }
 
-.console-ct-container .panel-body,
+.console-ct-container .terminal-body,
 .console-ct-container .console-ct {
     top: 0;
     right: 0;
@@ -20,7 +22,7 @@ html, body {
     left: 0;
 }
 
-.console-ct-container .panel-heading {
+.console-ct-container .terminal-group {
     border-bottom: 1px solid var(--color-border);
 }
 
@@ -30,7 +32,7 @@ html, body {
     right: 18px !important;
 }
 
-.console-ct-container .panel-body {
+.console-ct-container .terminal-body {
     padding: 0;
     position: relative;
 }
@@ -60,26 +62,21 @@ html, body {
 }
 
 .terminal-group {
-    display: grid;
-    grid-gap: 0.5rem;
-    grid-template-columns: 1fr repeat(3, auto);
+    display: flex;
+    row-gap: 0.5rem;
+    justify-content: space-between;
     align-content: center;
     align-items: baseline;
-}
+    flex-wrap: wrap;
 
-@media (min-width: 640px) {
-    .terminal-group {
-        min-height: 4rem;
+    /* Move the padding handling to the container element outside of the toolbar */
+    padding: var(--pf-global--spacer--md);
+
+    > .pf-c-toolbar {
+        padding: 0;
+        > .pf-c-toolbar__content {
+            padding: 0;
+        }
+        padding: 0;
     }
-}
-
-.terminal-group > .pf-c-button {
-    align-self: stretch;
-}
-
-.theme-select {
-    margin-left: 5px;
-    margin-right: 5px;
-    width: auto;
-    min-width: 10rem;
 }

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -180,7 +180,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         self.assertNotIn(":/.local", path)  # would happen with empty $HOME
 
         def check_theme_select(name, style):
-            b.select_from_dropdown("#theme-select", name)
+            b.select_from_dropdown("#theme-select + div select", name)
             b.wait_attr(".xterm-viewport", "style", style)
 
         # Check that color theme changes


### PR DESCRIPTION
In the meantime terminal page was fixed for mobile devices:


Previously:
![Screen Shot 2021-01-14 at 12 49 10](https://user-images.githubusercontent.com/14921356/104589937-e5fcbc80-566a-11eb-987c-10706339b19d.png)


Now:
![Screen Shot 2021-01-14 at 13 09 33](https://user-images.githubusercontent.com/14921356/104589954-eac17080-566a-11eb-88c3-67b5c1598a31.png)

