### PR TITLE
machines: Fix test for different time formats

### DIFF
--- a/test/verify/check-machines
+++ b/test/verify/check-machines
@@ -3692,7 +3692,7 @@ class TestMachines(MachineCase, StorageHelpers, NetworkHelpers):
             if not tmp[1].startswith('00:') and not tmp[0] == "Today":
                 return False
 
-            diff = datetime.strptime(time1, '%H:%M:%S') - datetime.strptime(tmp[1] + tmp[2], '%I:%M%p')
+            diff = datetime.strptime(time1, '%H:%M:%S') - datetime.strptime("".join(tmp[-2:]), '%I:%M%p')
             return -difference < diff.total_seconds() < difference
 
         b = self.browser


### PR DESCRIPTION
This would fix a failing test in case of different moment js formats
(e.g. "Today 11:11 PM" vs "Today at 11:11 PM")

Fixes a test fail at https://github.com/cockpit-project/cockpit/pull/15120