### PR TITLE
Reorganize check-metrics, fix "current memory" metric flake

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -36,6 +36,21 @@ def getCompressedMinuteValue(browser, g_type, saturation, hour, minute):
     return float(m.group(1))
 
 
+def progressValue(browser, progress_bar_sel):
+    sel = progress_bar_sel + " .pf-c-progress__indicator"
+    browser.wait_visible(sel)
+    browser.wait_attr_contains(sel, "style", "width:")
+    style = browser.attr(sel, "style")
+    m = re.search("width: (\d+)%;", style)
+    return int(m.group(1))
+
+
+def topServiceValue(browser, aria_label, col_label, row):
+    sel = "table[aria-label='%s'] tbody tr:nth-of-type(%d) td[data-label='%s']" % (aria_label, row, col_label)
+    # split off unit, like "12 MB"
+    return float(browser.text(sel).split(' ')[0])
+
+
 def prepareArchive(machine, name, time):
     machine.upload(["verify/files/metrics-archives/{0}".format(name)], "/tmp/")
     machine.execute("""timedatectl set-ntp off
@@ -74,9 +89,9 @@ def login(self):
     else:
         self.login_and_go("/metrics")
 
-@skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
-class TestMetrics(MachineCase):
 
+@skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
+class TestHistoryMetrics(MachineCase):
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty
         valid_start = self.browser.call_js_func("ph_count", ".metrics-data-cpu.valid-data")
@@ -307,41 +322,30 @@ class TestMetrics(MachineCase):
         b.enter_page("/system/services")
         b.wait_in_text("#service-details", "pmlogger.service")
 
-    @nondestructive
-    def testCurrentMetrics(self):
+
+@skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
+@nondestructive
+class TestCurrentMetrics(MachineCase):
+    def setUp(self):
+        super().setUp()
+        # packagekit/dnf often eats a lot of CPU; silence it to have better control over CPU usage
+        self.machine.execute("systemctl mask packagekit && killall -9 /usr/libexec/packagekitd && killall -9 dnf || true")
+        self.addCleanup(self.machine.execute, "systemctl unmask packagekit")
+        # make sure to clean up our test resource consumers on failures
+        self.addCleanup(self.machine.execute, "systemctl stop cockpittest.slice 2>/dev/null || true")
+        login(self)
+
+    def testCPU(self):
         b = self.browser
         m = self.machine
 
-        # packagekit/dnf often eats a lot of CPU; silence it to have better control over CPU usage
-        m.execute("systemctl mask packagekit && killall -9 /usr/libexec/packagekitd && killall -9 dnf || true")
-        self.addCleanup(m.execute, "systemctl unmask packagekit")
-
-        login(self)
-
-        def progressValue(progress_bar_sel):
-            sel = progress_bar_sel + " .pf-c-progress__indicator"
-            b.wait_visible(sel)
-            b.wait_attr_contains(sel, "style", "width:")
-            style = b.attr(sel, "style")
-            m = re.search("width: (\d+)%;", style)
-            return int(m.group(1))
-
-        def topServiceValue(aria_label, col_label, row):
-            sel = "table[aria-label='%s'] tbody tr:nth-of-type(%d) td[data-label='%s']" % (aria_label, row, col_label)
-            # split off unit, like "12 MB"
-            return float(b.text(sel).split(' ')[0])
-
-        # CPU
-
         nproc = m.execute("nproc").strip()
         b.wait_in_text("#current-cpu-usage", nproc + " CPU")
-        # make sure to clean up our test resource consumers on failures
-        self.addCleanup(m.execute, "systemctl stop cockpittest.slice 2>/dev/null || true")
         # wait until system settles down
-        b.wait(lambda: progressValue("#current-cpu-usage") < 20)
+        b.wait(lambda: progressValue(b, "#current-cpu-usage") < 20)
         m.execute("systemd-run --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
         m.execute("systemd-run --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
-        b.wait(lambda: progressValue("#current-cpu-usage") > 75)
+        b.wait(lambda: progressValue(b, "#current-cpu-usage") > 75)
         # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
         b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
         b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(2) td[data-label='Service']", "cpu-piglet")
@@ -349,17 +353,17 @@ class TestMetrics(MachineCase):
         # There might be some other processes which take more resources
         # Keep this logging so we can easily debug which ones we might need to cleanup
         try:
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) > 50)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 1) < 70)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) > 20)
-            b.wait(lambda: topServiceValue("Top 5 CPU services", "%", 2) < 40)
+            b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 1) > 50)
+            b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 1) < 70)
+            b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 2) > 20)
+            b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 2) < 40)
         except:
             print(m.execute("top -b -n 1"))
             raise
 
         m.execute("systemctl stop cpu-hog cpu-piglet")
         # should go back to idle usage
-        b.wait(lambda: progressValue("#current-cpu-usage") < 20)
+        b.wait(lambda: progressValue(b, "#current-cpu-usage") < 20)
         # it could be that the table disappears completely if no service has a noticeable CPU usage;
         # so don't assume the table exists
         b.wait_not_in_text("#current-metrics-card-cpu", "cpu-hog")
@@ -383,11 +387,15 @@ class TestMetrics(MachineCase):
         with b.wait_timeout(180):
             b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) < 10)
 
-        # Memory
+    def testMemory(self):
+        b = self.browser
+        m = self.machine
+        # wait until RAM usage is initialized
+        b.wait(lambda: progressValue(b, "#current-memory-usage") > 10)
 
         # our test machines have ~ 1 GiB of memory, a reasonable chunk of it should be used
         b.wait_in_text("#current-memory-usage", " GiB")
-        initial_usage = progressValue("#current-memory-usage")
+        initial_usage = progressValue(b, "#current-memory-usage")
         self.assertGreater(initial_usage, 10)
         self.assertLess(initial_usage, 80)
         # allocate an extra 300 MB; this may cause other stuff to get unmapped,
@@ -396,12 +404,12 @@ class TestMetrics(MachineCase):
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 3s
         time.sleep(8)
-        hog_usage = progressValue("#current-memory-usage")
+        hog_usage = progressValue(b, "#current-memory-usage")
         self.assertGreater(hog_usage, initial_usage + 8)
 
         b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
-        b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) > 300)
-        b.wait(lambda: topServiceValue("Top 5 memory services", "Used", 1) < 350)
+        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) > 300)
+        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) < 350)
 
         # total memory is shown as tooltip
         b.mouse("#current-memory-usage", "mouseenter")
@@ -422,13 +430,13 @@ class TestMetrics(MachineCase):
         if m.execute("swapon --show").strip():
             # use even more memory to trigger swap
             m.execute("systemd-run --slice cockpittest --unit mem-hog2 sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
-            b.wait(lambda: progressValue("#current-swap-usage") > 0)
+            b.wait(lambda: progressValue(b, "#current-swap-usage") > 0)
 
             m.execute("systemctl stop mem-hog mem-hog2")
 
             # should go back to initial_usage; often below, due to paged out stuff
-            b.wait(lambda: progressValue("#current-memory-usage") <= initial_usage)
-            self.assertGreater(progressValue("#current-memory-usage"), 10)
+            b.wait(lambda: progressValue(b, "#current-memory-usage") <= initial_usage)
+            self.assertGreater(progressValue(b, "#current-memory-usage"), 10)
             b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
 
             # total swap is shown as tooltip
@@ -436,7 +444,10 @@ class TestMetrics(MachineCase):
             b.wait_in_text(".pf-c-tooltip", "GiB total")
             b.mouse("#current-swap-usage", "mouseleave")
 
-        # Disk I/O
+    def testDiskIO(self):
+        b = self.browser
+        m = self.machine
+        login(self)
 
         # test env should be quiet enough to not transmit MB/s
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-read")))
@@ -450,7 +461,7 @@ class TestMetrics(MachineCase):
         # writing lots of data
         m.execute("systemd-run --slice cockpittest --unit disk-write-hog sh -ec "
                   " 'while true; do dd if=/dev/zero of=/var/tmp/blob bs=1M count=100; done'")
-        self.addCleanup(self.machine.execute, "rm -f /var/tmp/blob")
+        self.addCleanup(m.execute, "rm -f /var/tmp/blob")
         b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-write")))
         b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))  # this should stay calm
         m.execute("systemctl stop disk-write-hog")
@@ -467,8 +478,8 @@ class TestMetrics(MachineCase):
                   mount -o loop $F /var/cockpittest
                   rm $F
                   """)
-        self.addCleanup(self.machine.execute, "umount /var/cockpittest")
-        self.assertLess(progressValue(".pf-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
+        self.addCleanup(m.execute, "umount /var/cockpittest")
+        self.assertLess(progressValue(b, ".pf-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
         progress_sel = ".pf-c-progress[data-disk-usage-target='/var/cockpittest'] .pf-c-progress__status"
         # free size is anything between 40 and 50 MB
         self.assertRegex(b.text(progress_sel), "^4\d\.\d MB free$")
@@ -480,7 +491,7 @@ class TestMetrics(MachineCase):
         b.mouse(progress_sel, "mouseleave")
 
         m.execute("dd if=/dev/zero of=/var/cockpittest/blob bs=1M count=40")
-        b.wait(lambda: progressValue(".pf-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
+        b.wait(lambda: progressValue(b, ".pf-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
 
         # clicking on progress leads to the storage page
         if m.image != "fedora-coreos":
@@ -504,7 +515,9 @@ class TestMetrics(MachineCase):
         b.wait_visible(progress_sel)
         self.assertFalse(b.is_present("#current-disks-usage button"))
 
-        # Network usage
+    def testNetwork(self):
+        b = self.browser
+        m = self.machine
 
         # add synthetic veth which is guaranteed quiet
         m.execute("ip link add name cockpittest1 type veth peer name vcockpittest1")
@@ -531,6 +544,7 @@ class TestMetrics(MachineCase):
         # nothing happens on cockpittest1
         b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='In']", "0")
         b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='Out']", "0")
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestCockpitPcp(packagelib.PackageCase):
@@ -574,6 +588,7 @@ class TestCockpitPcp(packagelib.PackageCase):
         b.expect_load()
         b.enter_page("/metrics")
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestMultiCPU(MachineCase):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -390,6 +390,8 @@ class TestCurrentMetrics(MachineCase):
     def testMemory(self):
         b = self.browser
         m = self.machine
+        # only some images have swap
+        have_swap = m.execute("swapon --show").strip()
         # wait until RAM usage is initialized
         b.wait(lambda: progressValue(b, "#current-memory-usage") > 10)
 
@@ -398,9 +400,11 @@ class TestCurrentMetrics(MachineCase):
         initial_usage = progressValue(b, "#current-memory-usage")
         self.assertGreater(initial_usage, 10)
         self.assertLess(initial_usage, 80)
-        # allocate an extra 300 MB; this may cause other stuff to get unmapped,
+        # allocate a chunk of memory; this may cause other stuff to get unmapped,
         # thus not exact addition, but usage should go up
-        m.execute("systemd-run --collect --slice cockpittest --unit mem-hog sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); touch /tmp/hogged; sleep infinity'")
+        size = 300 if have_swap else 200
+        m.execute("systemd-run --collect --slice cockpittest --unit mem-hog sh -ec "
+                  f"'MEMBLOB=$(yes | dd bs=1M count={size} iflag=fullblock); touch /tmp/hogged; sleep infinity'")
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 3s
         time.sleep(8)
@@ -408,8 +412,8 @@ class TestCurrentMetrics(MachineCase):
         self.assertGreater(hog_usage, initial_usage + 8)
 
         b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
-        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) > 300)
-        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) < 350)
+        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) > size)
+        b.wait(lambda: topServiceValue(b, "Top 5 memory services", "Used", 1) < size + 50)
 
         # total memory is shown as tooltip
         b.mouse("#current-memory-usage", "mouseenter")
@@ -426,8 +430,7 @@ class TestCurrentMetrics(MachineCase):
         b.enter_page("/metrics")
         b.wait_visible("table[aria-label='Top 5 memory services']")
 
-        # only some images have swap
-        if m.execute("swapon --show").strip():
+        if have_swap:
             # use even more memory to trigger swap
             m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
             b.wait(lambda: progressValue(b, "#current-swap-usage") > 0)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -539,7 +539,7 @@ class TestCurrentMetrics(MachineCase):
         b.wait(lambda: rateMatches("Out", r'^(0|[0-9.]+ (KiB|B)/s)$'))
         # pipe lots of data through lo
         m.execute("systemd-run --collect --slice cockpittest --unit lo-hog sh -ec "
-                  " 'nc -l 2000 > /dev/null & nc localhost 2000 </dev/zero'")
+                  " 'nc -n -vv -l 2000 > /dev/null & sleep 1; nc -vv localhost 2000 </dev/zero'")
         b.wait(lambda: rateMatches("In", r'^[0-9.]+ (MiB|GiB)/s$'))
         b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (MiB|GiB)/s$'))
         m.execute("systemctl stop lo-hog")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -343,8 +343,8 @@ class TestCurrentMetrics(MachineCase):
         b.wait_in_text("#current-cpu-usage", nproc + " CPU")
         # wait until system settles down
         b.wait(lambda: progressValue(b, "#current-cpu-usage") < 20)
-        m.execute("systemd-run --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
-        m.execute("systemd-run --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
         b.wait(lambda: progressValue(b, "#current-cpu-usage") > 75)
         # no other process in the test VM should take > 30% CPU, by the "settles down" assertion above
         b.wait_text("table[aria-label='Top 5 CPU services'] tbody tr:nth-of-type(1) td[data-label='Service']", "cpu-hog")
@@ -374,7 +374,7 @@ class TestCurrentMetrics(MachineCase):
 
         # HACK: debian-stable does not update load when done though systemd-run
         if m.image != "debian-stable":
-            m.execute("systemd-run --slice cockpittest --unit load-hog sh -ec "
+            m.execute("systemd-run --collect --slice cockpittest --unit load-hog sh -ec "
                       "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=10K count=500 status=none & done'")
             b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) > 15)
             m.execute("systemctl stop load-hog 2>/dev/null || true") # ok to fail, as the command exits by itself
@@ -400,7 +400,7 @@ class TestCurrentMetrics(MachineCase):
         self.assertLess(initial_usage, 80)
         # allocate an extra 300 MB; this may cause other stuff to get unmapped,
         # thus not exact addition, but usage should go up
-        m.execute("systemd-run --slice cockpittest --unit mem-hog sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); touch /tmp/hogged; sleep infinity'")
+        m.execute("systemd-run --collect --slice cockpittest --unit mem-hog sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); touch /tmp/hogged; sleep infinity'")
         m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
         # bars update every 3s
         time.sleep(8)
@@ -429,7 +429,7 @@ class TestCurrentMetrics(MachineCase):
         # only some images have swap
         if m.execute("swapon --show").strip():
             # use even more memory to trigger swap
-            m.execute("systemd-run --slice cockpittest --unit mem-hog2 sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
+            m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 sh -ec 'MEMBLOB=$(yes | dd bs=1M count=300 iflag=fullblock); sleep infinity'")
             b.wait(lambda: progressValue(b, "#current-swap-usage") > 0)
 
             m.execute("systemctl stop mem-hog mem-hog2")
@@ -453,13 +453,13 @@ class TestCurrentMetrics(MachineCase):
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-read")))
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-write")))
         # reading lots of data
-        m.execute("systemd-run --slice cockpittest --unit disk-read-hog sh -ec 'while true; do echo 3 > /proc/sys/vm/drop_caches; grep -r . /usr >/dev/null; done'")
+        m.execute("systemd-run --collect --slice cockpittest --unit disk-read-hog sh -ec 'while true; do echo 3 > /proc/sys/vm/drop_caches; grep -r . /usr >/dev/null; done'")
         b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-read")))
         b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-write")))  # this should stay calm
         m.execute("systemctl stop disk-read-hog")
         b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))  # back to quiet
         # writing lots of data
-        m.execute("systemd-run --slice cockpittest --unit disk-write-hog sh -ec "
+        m.execute("systemd-run --collect --slice cockpittest --unit disk-write-hog sh -ec "
                   " 'while true; do dd if=/dev/zero of=/var/tmp/blob bs=1M count=100; done'")
         self.addCleanup(m.execute, "rm -f /var/tmp/blob")
         b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-write")))
@@ -535,7 +535,7 @@ class TestCurrentMetrics(MachineCase):
         b.wait(lambda: rateMatches("In", r'^(0|[0-9.]+ (KiB|B)/s)$'))
         b.wait(lambda: rateMatches("Out", r'^(0|[0-9.]+ (KiB|B)/s)$'))
         # pipe lots of data through lo
-        m.execute("systemd-run --slice cockpittest --unit lo-hog sh -ec "
+        m.execute("systemd-run --collect --slice cockpittest --unit lo-hog sh -ec "
                   " 'nc -l 2000 > /dev/null & nc localhost 2000 </dev/zero'")
         b.wait(lambda: rateMatches("In", r'^[0-9.]+ (MiB|GiB)/s$'))
         b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (MiB|GiB)/s$'))


### PR DESCRIPTION
Fixes our #2 top flake on https://images-frontdoor.apps.ocp.ci.centos.org/failure-stats.html