### PR TITLE
Fix check-metrics tests that use prepareArchive()

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -55,6 +55,8 @@ def prepareArchive(machine, name, time):
     machine.upload(["verify/files/metrics-archives/{0}".format(name)], "/tmp/")
     machine.execute("""timedatectl set-ntp off
                        systemctl stop pmlogger
+                       # don't let NM set transient host names from DHCP
+                       systemctl stop NetworkManager
                        hostnamectl set-hostname localhost.localdomain
                        rm -rf /var/log/pcp/pmlogger/*
                        tar -C / -xzvf /tmp/{0}

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -58,6 +58,8 @@ def prepareArchive(machine, name, time):
                        hostnamectl set-hostname localhost.localdomain
                        rm -rf /var/log/pcp/pmlogger/*
                        tar -C / -xzvf /tmp/{0}
+                       # set-ntp off is asynchronous; wait until timesyncd stops before the time can be set
+                       while systemctl is-active systemd-timesyncd; do sleep 1; done
                        timedatectl set-time @{1}""".format(name, time))
 
 def login(self):


### PR DESCRIPTION
This fixes the 7th [top flake](https://images-frontdoor.apps.ocp.ci.centos.org/failure-stats.html) ([example](https://logs.cockpit-project.org/logs/pull-15123-20210115-073403-44eb2a33-ubuntu-2004/log.html#81-2)), and another one that I saw during my local runs. I'm not 100% sure about the third commit yet, I'll either squash it or take it out. Locally tests work for me with debian-testing and ubuntu-2004, but let's get them a crunching through our bots.