### PR TITLE
lib: Fix cockpit-po-plugin instantiation without options

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -9,6 +9,8 @@ const srcdir = process.env.SRCDIR || path.resolve(__dirname, '..', '..');
 
 module.exports = class {
     constructor(options) {
+        if (!options)
+            options = {};
         this.subdir = options.subdir || '';
         this.msggrep_options = options.msggrep_options;
         this.wrapper = options.wrapper || 'cockpit.locale(PO_DATA);';


### PR DESCRIPTION
starter-kit and other projects that just have one webpack have no need
to specify any option. The plugin previously crashed with

    TypeError: Cannot read property 'subdir' of undefined

 in that case. Default to an empty object if options are undefined.