### PR TITLE
[rhel-8.3] test: Fix TestLogin.testExpired for pam_pwquality with retry=1

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -244,6 +244,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             m.execute("sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config /etc/ssh/sshd_config.d/*")
             m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
 
+        # test steps below assume a pam_pwquality config with retry > 1; on some images authselect drops that setting
+        if not m.image.startswith('debian') and not m.image.startswith('ubuntu'):
+            self.sed_file("/password.*requisite.*pam_pwquality/ s/$/ retry=3/", "/etc/pam.d/password-auth")
+
         m.execute("chage -d 0 admin")
         m.start_cockpit()
         b.open("/system")


### PR DESCRIPTION
This test is written with the assumption that trying to change the PAM
password to a bad one will have more than one retry. This isn't the case
on some images that use authselect, such as our centos-8-stream or
rhel-8-* images.

This was previously hacked around in the image *.install scripts [1],
but also hits us in Fedora/RHEL downstream gating tests, which is why
that test is currently skipped [2]. Adjust the PAM config in the test
itself, so that it can run in any testbed, and we can re-enable the test
downstream.

[1] https://github.com/cockpit-project/bots/pull/1555
[2] https://src.fedoraproject.org/rpms/cockpit/blob/917966b/f/tests/run-test.sh#_75

Cherry-picked from master commit 83e1ec6c9504f.