### PR TITLE
machines: Disable boot order editing for running guests

### DIFF
--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -279,14 +279,9 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       delete=False))
         self.machine.execute("virsh destroy pxe-guest")
 
-        # Verify that the newly created disk is first in the boot order and the network used for the PXE boot is marked as non bootable
-        b.click("#vm-pxe-guest-overview")
-        b.click("#vm-pxe-guest-boot-order button")
-        b.wait_visible("#vm-pxe-guest-order-modal-window")
-        b.wait_visible("#vm-pxe-guest-order-modal-device-row-0 input:checked")
-        b.wait_in_text("#vm-pxe-guest-order-modal-device-row-0 .list-group-item-heading", "disk")
-        b.wait_visible("#vm-pxe-guest-order-modal-device-row-1 input:not(checked)")
-        b.wait_in_text("#vm-pxe-guest-order-modal-device-row-1 .list-group-item-heading", "network")
+        # Verify that the newly created disk is first in the boot order and the network used for the PXE boot is not on the bootable devices list
+        b.wait_in_text("#vm-pxe-guest-boot-order", "disk")
+        b.wait_not_in_text("#vm-pxe-guest-boot-order", "network")
 
     def testCreateThenInstall(self):
         runner = TestMachinesCreate.CreateVmRunner(self)

--- a/test/verify/check-machines-settings
+++ b/test/verify/check-machines-settings
@@ -251,7 +251,6 @@ class TestMachinesSettings(VirtualMachinesCase):
 
     def testBootOrder(self):
         b = self.browser
-        m = self.machine
 
         self.createVm("subVmTest1")
         self.machine.execute("touch /var/lib/libvirt/images/phonycdrom; virsh attach-disk subVmTest1 /var/lib/libvirt/images/phonycdrom sdb --type cdrom --config")
@@ -266,11 +265,15 @@ class TestMachinesSettings(VirtualMachinesCase):
         # Wait for the edit button
         bootOrder = b.text("#vm-subVmTest1-boot-order")
 
+        # Ensure that it's disabled for running VMs
+        b.wait_visible("#vm-subVmTest1-boot-order button[aria-disabled=true]")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
+
         # Open dialog
         b.click("#vm-subVmTest1-boot-order button")
         b.wait_visible("#vm-subVmTest1-order-modal-window")
-        # Make sure the footer warning does not appear
-        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
         # Check a cdrom attributes are shown correctly
         cdrom_row = b.text("#vm-subVmTest1-order-modal-device-row-2 .list-view-pf-additional-info")
         self.assertTrue("cdrom" and "/var/lib/libvirt/images/phonycdrom" in cdrom_row)
@@ -278,35 +281,21 @@ class TestMachinesSettings(VirtualMachinesCase):
         row = b.text("#vm-subVmTest1-order-modal-device-row-1 .list-view-pf-additional-info")
         b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down")
         b.wait_in_text("#vm-subVmTest1-order-modal-device-row-0 .list-view-pf-additional-info", row)
-        # Make sure the footer warning does appear
-        b.wait_visible("#vm-subVmTest1-order-modal-min-message")
 
         # Save
         b.click("#vm-subVmTest1-order-modal-save")
         b.wait_not_present("#vm-subVmTest1-order-modal-window")
-        # Make sure warning next to boot order appears
-        b.wait_visible("#boot-order-tooltip")
-
-        # Shut off domain and check changes are applied
-        b.click("#vm-subVmTest1-action-kebab button")
-        b.click("#vm-subVmTest1-forceOff")
-        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
 
         # Check boot order has changed and no warning is shown
         b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
-        b.wait_not_present("#boot-order-tooltip")
 
         bootOrder = b.text("#vm-subVmTest1-boot-order")
 
         # Open dialog
         b.click("#vm-subVmTest1-boot-order button")
         b.wait_visible("#vm-subVmTest1-order-modal-window")
-        # Make sure the footer warning does not appear
-        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
         # Unselect second device
         b.click("#vm-subVmTest1-order-modal-device-row-1 input")
-        # Make sure the footer warning still does not appear, since machine is shut down
-        b.wait_not_present("#vm-subVmTest1-order-modal-min-message")
 
         # Save
         b.click("#vm-subVmTest1-order-modal-save")
@@ -314,14 +303,6 @@ class TestMachinesSettings(VirtualMachinesCase):
 
         # Check boot order has changed and no warning is shown
         b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
-        b.wait_not_present("#boot-order-tooltip")
-
-        # Run VM
-        b.click("#vm-subVmTest1-run")
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
-        # Non-persistent VM doesn't have configurable boot order
-        m.execute("virsh undefine subVmTest1")
-        b.wait_visible("#vm-subVmTest1-boot-order button:disabled")
 
     def testDomainMemorySettings(self):
         b = self.browser
@@ -405,17 +386,14 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-state", "Running")
         self.goToVmPage("subVmTest1")
 
-        # Change Boot Order setting
-        bootOrder = b.text("#vm-subVmTest1-boot-order")
-        b.click("#vm-subVmTest1-boot-order button") # Open dialog
-        b.wait_visible(".pf-c-modal-box__body")
-        b.click("#vm-subVmTest1-order-modal-device-row-0 #vm-subVmTest1-order-modal-down") # Change order
-        b.click("#vm-subVmTest1-order-modal-save") # Save
-        b.wait_not_present(".pf-c-modal-box__body")
+        # Change CPU model setting
+        b.wait_visible("#vm-subVmTest1-cpu-model button[aria-disabled=false]")
+        b.click("#vm-subVmTest1-cpu-model button")
+        b.select_from_dropdown("#cpu-model-select-group select", "host-passthrough")
+        b.click("#cpu-config-dialog-apply")
 
         # Change vCPUs setting
         b.click("#vm-subVmTest1-vcpus-count button") # Open dialog
-        b.wait_visible(".pf-c-modal-box__body")
         b.set_input_text("#machines-vcpu-max-field", "3") # Change values
         b.set_input_text("#machines-vcpu-count-field", "3")
         b.click("#machines-vcpu-modal-dialog-apply") # Save
@@ -427,7 +405,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-state", "Shut off")
 
         # Check both changes have been applied
-        b.wait_not_in_text("#vm-subVmTest1-boot-order", bootOrder)
+        b.wait_in_text("#vm-subVmTest1-cpu-model", "host passthrough")
         b.wait_in_text("#vm-subVmTest1-vcpus-count", "3")
 
 


### PR DESCRIPTION
It was implemented previously quite naively, resulting in wrong warnings
being shown in the UI when there was a mismatch between the active and
inactive XML bootable devices.

For example:
* The user would attach a transient disk/NIC to the running guest.
* That would cause a mismatch between the enumerated bootable devices
  between the active and the inactive XML configuration,
* The UI would show a warning, but there would be no way for the user to
  find out that the transient device they just added was the reason
  for the warning.

Doing a 1-1 comparison of the bootable devices between the active and
inactive XML is a real pain, since these devices don't have some unique
common identifier.

So let's remove this functionality of allowing the users to edit boot
order on running VMs to avoid more issues in the future.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1915765