### PR TITLE
package.json: Lock @patternfly/react-styles version

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@patternfly/patternfly": "4.70.2",
     "@patternfly/react-console": "4.2.7",
     "@patternfly/react-core": "4.84.4",
+    "@patternfly/react-styles": "4.7.24",
     "@patternfly/react-table": "4.19.45",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "@novnc/novnc": "1.2.0",


### PR DESCRIPTION
It's part of patternfly-react, so we should update it in a controlled
fashion. Yesterday's 4.7.25 release does not work with the older react-*
releases that we already pinned.

Let's update all these in lockstep after today's release.