### PR TITLE
Fix TestSystemInfo.testCPUSecurityMitigationsDetect flake

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -479,9 +479,7 @@ class TestSystemInfo(MachineCase):
         m = self.machine
 
         self.restore_dir("/usr/local/bin")
-
-        self.login_and_go('/system/hwinfo')
-        b.wait_in_text("#hwinfo", "CPU")
+        m.start_cockpit()
 
         def spoof_threads(threads_per_core, expect_link_present, expect_smt_state=None, cmdline=None):
             m.write('/usr/local/bin/lscpu', lscpu.format(threads_per_core))
@@ -492,8 +490,7 @@ class TestSystemInfo(MachineCase):
                 m.execute('mount --bind /run/cmdline /proc/cmdline && rm /run/cmdline')
 
             try:
-                b.reload()
-                b.enter_page('/system/hwinfo')
+                b.login_and_go('/system/hwinfo')
 
                 if not expect_link_present:
                     b.wait_visible('#hwinfo th:contains(CPU)')
@@ -505,6 +502,8 @@ class TestSystemInfo(MachineCase):
                     b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
                     b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
                                 (expect_smt_state and ":checked" or ":not(:checked)"))
+
+                b.logout()
             finally:
                 if cmdline:
                     m.execute('while ! umount /proc/cmdline; do sleep 1; done')

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -488,25 +488,26 @@ class TestSystemInfo(MachineCase):
             m.execute('chmod +x /usr/local/bin/lscpu')
             if cmdline:
                 m.write('/run/cmdline', cmdline)
-                m.execute('if selinuxenabled 2>/dev/null; then chcon --reference /proc/cmdline /run/cmdline; fi && mount --bind /run/cmdline /proc/cmdline')
+                m.execute('if selinuxenabled 2>/dev/null; then chcon --reference /proc/cmdline /run/cmdline; fi')
+                m.execute('mount --bind /run/cmdline /proc/cmdline && rm /run/cmdline')
 
-            b.reload()
-            b.enter_page('/system/hwinfo')
+            try:
+                b.reload()
+                b.enter_page('/system/hwinfo')
 
-            if not expect_link_present:
-                b.wait_visible('#hwinfo th:contains(CPU)')
-                b.wait_not_present('#hwinfo th:contains(CPU security)')
-            else:
-                b.click('#hwinfo button:contains(Mitigations)')
+                if not expect_link_present:
+                    b.wait_visible('#hwinfo th:contains(CPU)')
+                    b.wait_not_present('#hwinfo th:contains(CPU security)')
+                else:
+                    b.click('#hwinfo button:contains(Mitigations)')
 
-            if expect_smt_state is not None:
-                b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
-                b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
-                               (expect_smt_state and ":checked" or ":not(:checked)"))
-
-            if cmdline:
-                m.execute('while ! umount /proc/cmdline; do sleep 1; done')
-                m.execute('rm /run/cmdline')
+                if expect_smt_state is not None:
+                    b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
+                    b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
+                                (expect_smt_state and ":checked" or ":not(:checked)"))
+            finally:
+                if cmdline:
+                    m.execute('while ! umount /proc/cmdline; do sleep 1; done')
 
         spoof_threads(1, False)
         spoof_threads(2, True, True, 'param1 param2 nosmt param3=value3')


### PR DESCRIPTION
The first commit is good, and will fix the follow-up errors that we see often:
```
subprocess.CalledProcessError: Command 'if selinuxenabled 2>/dev/null; then chcon --reference /proc/cmdline /run/cmdline; fi && mount --bind /run/cmdline /proc/cmdline' returned non-zero exit status 32.
```

But the initial failure is in b.reload():
```
{"exceptionId":1,"text":"Uncaught (in promise)","lineNumber":0,"columnNumber":0,"scriptId":"1","url":"http://127.0.0.2:9191/cockpit/$91dd94251495964ea7683d4428bfbe9207ff1951456cd17b1642ef718eb9f1c5/system/hwinfo.html#/","exception":{"type":"object","className":"te","description":"te","objectId":"{\"injectedScriptId\":14,\"id\":1}","preview":{"type":"object","description":"te","overflow":false,"properties":[{"name":"problem","type":"string","value":"internal-error"},{"name":"exit_status","type":"number","value":"-1"},{"name":"exit_signal","type":"object","value":"null","subtype":"null"},{"name":"message","type":"string","value":"Internal error"},{"name":"toString","type":"function","value":""}]}},"executionContextId":14}
Traceback (most recent call last):
  File "/usr/lib64/python3.9/unittest/case.py", line 550, in _callTestMethod
    method()
  File "/work/cockpit-project/bots/make-checkout-workdir/test/verify/check-system-info", line 512, in testCPUSecurityMitigationsDetect
    spoof_threads(2, True, True, 'param1 param2 nosmt param3=value3')
  File "/work/cockpit-project/bots/make-checkout-workdir/test/verify/check-system-info", line 493, in spoof_threads
    b.reload()
  File "/work/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 139, in reload
    self.wait_js_cond("ph_select('iframe.container-frame').every(function (e) { return e.getAttribute('data-loaded'); })")
  File "/work/cockpit-project/bots/make-checkout-workdir/test/common/testlib.py", line 382, in wait_js_cond
    result = self.cdp.invoke("Runtime.evaluate",
  File "/work/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 109, in invoke
    res = self.command(cmd)
  File "/work/cockpit-project/bots/make-checkout-workdir/test/common/cdp.py", line 136, in command
    raise RuntimeError(res["error"])
RuntimeError: te
```

This is absolutely useless. I temporarily enabled debug builds for all OSes, and want to catch it in the act, to hopefully get a better exception. Running all the check-system-info tests three times here should certainly help. It only happens on centos-8-stream and rhel-8-4, apparently not anywhere else according to our flake stats.