### PR TITLE
test: Use more robust checks for storage test

### DIFF
--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -54,8 +54,9 @@ class TestStorageBasic(StorageCase):
 
         m.execute('parted -s %s mktable gpt' % disk)
         m.execute('parted -s %s mkpart primary ext2 1M 8M' % disk)
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
-        self.content_tab_wait_in_info(1, 1, "Name", "primary")
+        b.wait_in_text(".contains-list", "7 MiB Unrecognized data")
+        b.wait_in_text(".contains-list", "42 MiB Free space")
+        b.wait_in_text(".contains-list", "Nameprimary")
 
         # create file system on the first partition
         # HACK - the block device might disappear briefly when udevd does its BLKRRPART.


### PR DESCRIPTION
There is a somewhat weird behavior happening on the page.
We start with one item "50M on unrecognized data". Then those `parted`
commands create two records of 7M and 42M. The weird part is, that for a
short second, it is shown back as one item of 50M, and then pack to
those two items. This happens in a very quick succession, I had to
record my screen and step it frame by frame.

Problem with those original checks was, that it first checked if element
is present and then tried to read string of this element. But that
element disappeared in the meantime, so the check failed. When we always
just check the parent element, we know it will be always present.

This is not in our top 10 flakes, but would be in around 12th or so. Also it is in top 10 for 3 OSes.
I am not super convinced, if this is expected behaviour, e.g. that is how parted works, or it is bug either in the API we use or even on our side how we handle and render items. I just thought I would post this, maybe @mvollmer has some insights.