### PR TITLE
test: Only disable ntp if available and active

### DIFF
--- a/test/verify/check-journal
+++ b/test/verify/check-journal
@@ -360,7 +360,10 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         # so disable them for this test, we don't test PCP here
         m.execute("systemctl disable --now pmie pmlogger || true")
 
-        m.execute("timedatectl set-ntp off")
+        m.execute("""ntp=`timedatectl show --property NTP --value`
+                     if [ $ntp == "yes" ]; then
+                         timedatectl set-ntp off
+                     fi""")
         # this is asynchronous; must wait until timesyncd stops before the time can be set
         m.execute("while systemctl is-active systemd-timesyncd; do sleep 1; done")
         m.execute("timedatectl set-time 2038-01-01")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -53,7 +53,10 @@ def topServiceValue(browser, aria_label, col_label, row):
 
 def prepareArchive(machine, name, time):
     machine.upload(["verify/files/metrics-archives/{0}".format(name)], "/tmp/")
-    machine.execute("""timedatectl set-ntp off
+    machine.execute("""ntp=`timedatectl show --property NTP --value`
+                       if [ $ntp == "yes" ]; then
+                           timedatectl set-ntp off
+                       fi
                        systemctl stop pmlogger
                        # don't let NM set transient host names from DHCP
                        systemctl stop NetworkManager
@@ -112,7 +115,10 @@ class TestHistoryMetrics(MachineCase):
         m = self.machine
 
         m.execute("systemctl stop pmlogger")
-        m.execute("timedatectl set-ntp off")
+        m.execute("""ntp=`timedatectl show --property NTP --value`
+             if [ $ntp == "yes" ]; then
+                 timedatectl set-ntp off
+             fi""")
         m.execute("while systemctl is-active systemd-timesyncd; do sleep 1; done")
         m.execute("timedatectl set-time '2020-11-24 09:24:05'")
 

--- a/test/verify/check-services
+++ b/test/verify/check-services
@@ -762,7 +762,10 @@ class TestTimers(MachineCase):
 
         # set an initial baseline date/time, to ensure that we never jump backwards in subsequent tests
         m.execute("timedatectl set-timezone UTC")
-        m.execute("timedatectl set-ntp off")
+        m.execute("""ntp=`timedatectl show --property NTP --value`
+                     if [ $ntp == "yes" ]; then
+                         timedatectl set-ntp off
+                     fi""")
         wait(lambda: "false" in m.execute(
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")


### PR DESCRIPTION
In rhel-8.4 it is not available, see https://bugzilla.redhat.com/show_bug.cgi?id=1918340

As part of https://github.com/cockpit-project/bots/pull/1551
It still will have one test failing, but that one we need to naughtify