### PR TITLE
test: Look for and prefer "firefox-nightly" executable

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -25,7 +25,7 @@ def browser_path(browser, show_browser):
 
 def browser_path_firefox():
     """ Return path to Firefox browser """
-    p = subprocess.check_output("which firefox || true",
+    p = subprocess.check_output("which firefox-nightly || which firefox || true",
                                 shell=True, universal_newlines=True).strip()
     if p:
         return p


### PR DESCRIPTION
So that people can easily have both the regular Firefox for their
normal use and Firefox Nightly for the tests.