### PR TITLE
unit-tests: copy source into container explicitly

### DIFF
--- a/containers/unit-tests/Dockerfile
+++ b/containers/unit-tests/Dockerfile
@@ -13,7 +13,7 @@ WORKDIR /home/builder
 
 ENV LANG=C.UTF-8
 
-VOLUME /source
+VOLUME /pack.tar
 
 COPY entrypoint /
 ENTRYPOINT ["/entrypoint"]

--- a/containers/unit-tests/README.md
+++ b/containers/unit-tests/README.md
@@ -5,9 +5,11 @@ we want to exercise Cockpit with, mostly for `make distcheck` and `make
 check-memory`. This container runs on [GitHub](.github/workflows/unit-tests.yml),
 but can be easily run locally too.
 
-It assumes that the Cockpit source git checkout is available in `/source`. It
-will not modify that directory or take uncommitted changes into account, but it
-will re-use an already existing `node_modules/` directory.
+On startup, it will look for `/pack.tar`, extract it into the home directory,
+and run the contained unpack.sh.
+
+We use this mechanism to inject what we want to test.  See the create-pack
+script in this directory for details on how that works.
 
 The scripts can use either podman (preferred) or docker. If you use docker, you
 need to run all commands as root. With podman the containers work as either user
@@ -20,11 +22,6 @@ The `build` script will build the `cockpit/unit-tests` and
 build one variant, e.g. `build i386`.
 
 ## Running tests
-
-You need to disable SELinux with `sudo setenforce 0` for this. There is no
-other way for the container to access the files in your build tree (do *not*
-use the `--volume` `:Z` option, as that will destroy the file labels on the
-host).
 
 Tests in that container get started with the `start` script.  By default, this
 script runs the unit tests on amd64.  The script accepts a number of arguments
@@ -56,14 +53,11 @@ For interactive debugging, run a shell in the container:
 
     $ ./start shell     # start an interactive shell in default container
 
-You will find the cockpit source tree (from the host) mounted at `/source` in
-the container.
+You will find the cockpit source tree (from the host) unpacked in the home
+directory (~/cockpit) inside the container.
 
-`/source/containers/unit-tests/run.sh` will start the builds and test run, then
-you can investigate in the build tree at `/tmp/source/`.
-
-`/source/containers/unit-tests/run.sh` also includes a `build` mode which
-will checkout and build the source, but not run any tests.
+`containers/unit-tests/run.sh` will start the builds and test run, then
+you can investigate in the build tree.
 
 You can also attach to another container using the provided `exec` script.  For example:
 

--- a/containers/unit-tests/create-pack
+++ b/containers/unit-tests/create-pack
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+set -eu
+cd "$(realpath -m "$0"/../../..)"
+
+message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
+
+# bundle the current state of HEAD
+(
+    head_sha="$(git rev-parse HEAD)"
+    head_pack="tmp/${head_sha}.pack"
+    if [ ! -f "${head_pack}" ]; then
+        message 'BUNDLE' "${head_pack}  [HEAD]"
+        # include the latest tag so that git-describe works
+        latest_tag="$(git describe --abbrev=0 HEAD)"
+        git bundle create --quiet "${head_pack}" HEAD ${latest_tag}
+    fi
+    echo "# ${head_pack}"
+    echo "echo '=== Unpacking cockpit'"
+    echo "git -c advice.detachedHead=false clone ${head_pack} cockpit"
+)
+
+# bundle the node_modules from our cache so the container doesn't need
+# to download them
+(
+    GITHUB_REPO='node-cache'
+    SUBDIR='node_modules'
+    V=0
+    . tools/git-utils.sh
+    node_sha="$(get_index_gitlink node_modules)"
+    node_pack="tmp/${node_sha}.pack"
+    if [ ! -f "${node_pack}" ]; then
+        fetch_sha_to_cache "${node_sha}"
+        message 'BUNDLE' "${node_pack}  [node_modules]"
+        git_cache bundle create --quiet "${node_pack}" "sha-${node_sha}"
+    fi
+    echo "# ${node_pack}"
+    echo "echo '=== Unpacking node_modules'"
+    echo "git -c advice.detachedHead=false clone -b sha-${node_sha} ${node_pack} cockpit/node_modules"
+    echo "echo '=== Copying package-lock.json'"
+    echo "make -C cockpit -f pkg/build package-lock.json"
+)
+
+echo "rm -rf tmp"

--- a/containers/unit-tests/create-pack
+++ b/containers/unit-tests/create-pack
@@ -21,7 +21,7 @@ message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
 )
 
 # bundle the node_modules from our cache so the container doesn't need
-# to download them
+# to download them (since it has no network access)
 (
     GITHUB_REPO='node-cache'
     SUBDIR='node_modules'

--- a/containers/unit-tests/create-pack
+++ b/containers/unit-tests/create-pack
@@ -65,4 +65,16 @@ message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
     fi
 )
 
+# if dist/ is up to date, then include it
+(
+    if pkg/build -q -o package-lock.json; then
+        dist_tar="tmp/dist.tar"
+        message 'TAR' "${dist_tar}"
+        tar cf "${dist_tar}" dist
+        echo "# ${dist_tar}"
+        echo "echo '=== Unpacking dist/'"
+        echo "tar xm -C cockpit dist < ${dist_tar}"
+    fi
+)
+
 echo "rm -rf tmp"

--- a/containers/unit-tests/create-pack
+++ b/containers/unit-tests/create-pack
@@ -41,4 +41,28 @@ message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
     echo "make -C cockpit -f pkg/build package-lock.json"
 )
 
+# if the tree isn't clean, make a stash and send it in, too.  we do this
+# separately from HEAD, because we can send the stash as a thin pack.
+(
+    # `git stash create -u` doesn't work properly, so check for untracked files
+    # and warn.  This can be removed (and -u added below) when that's supported.
+    untracked="$(git ls-files -o --exclude-standard)"
+    if [ -n "${untracked}" ]; then
+        printf '\nThe following untracked files will be excluded:\n%s\n\n' "${untracked}" >&2
+    fi
+    stash_sha="$(git stash create)"
+    if [ -n "${stash_sha}" ]; then
+        stash_pack="tmp/${stash_sha}.pack"
+        message 'BUNDLE' "${stash_pack}  [stash]"
+        # we can't include raw commits, so use a temporary tag
+        git tag "stash-${stash_sha}" "${stash_sha}" >/dev/null
+        git bundle create --quiet "${stash_pack}" "stash-${stash_sha}" "^HEAD"
+        git tag --delete "stash-${stash_sha}" >/dev/null
+        echo "# ${stash_pack}"
+        echo "echo '=== Unpacking stash'"
+        echo "git -C cockpit bundle unbundle ../${stash_pack}"
+        echo "git -C cockpit stash apply --quiet ${stash_sha}"
+    fi
+)
+
 echo "rm -rf tmp"

--- a/containers/unit-tests/entrypoint
+++ b/containers/unit-tests/entrypoint
@@ -8,5 +8,16 @@ echo -n "Host: " && uname -srvm
 echo -n "Container: \${NAME} \${VERSION} / " && ${personality} uname -nrvm
 echo
 
+# extract our pack, if we haven't yet
+if [ -s /pack.tar -a ! -f ~/.unpacked ]; then
+    (
+        cd
+        tar xf /pack.tar
+        sh -e unpack.sh
+        rm unpack.sh
+        touch .unpacked
+    )
+fi
+
 set -ex
 exec ${personality} -- "$@"

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+cd "$(realpath -m "$0"/../../..)"
+
 set -o pipefail
 set -eux
 
@@ -20,17 +22,6 @@ export MAKEFLAGS="-j $(nproc)"
   top -b -n1
   echo ===== 28 mins ====================
 )&
-
-# copy host's source tree to avoid changing that, and make sure we have a clean tree
-if [ ! -e /source/.git ]; then
-    echo "This container must be run with --volume <host cockpit source checkout>:/source:ro" >&2
-    exit 1
-fi
-git clone /source /tmp/source
-if [ -d /source/node_modules ]; then
-    cp -r /source/node_modules /tmp/source/
-fi
-cd /tmp/source
 
 for scenario in "$@"; do
     containers/unit-tests/scenario/${scenario}

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -4,7 +4,7 @@ set -eu
 cd "$(realpath -m "$0"/../../..)"
 
 image='ghcr.io/cockpit-project/unit-tests:latest'
-flags=''
+flags='--network=none' # disabled for 'shell'
 
 while test $# -gt 0; do
   case "$1" in

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,8 +1,9 @@
 #!/bin/sh
 set -eu
 
-top_srcdir=$(realpath -m "$0"/../../..)
-image=ghcr.io/cockpit-project/unit-tests:latest
+cd "$(realpath -m "$0"/../../..)"
+
+image='ghcr.io/cockpit-project/unit-tests:latest'
 flags=''
 
 while test $# -gt 0; do
@@ -10,9 +11,9 @@ while test $# -gt 0; do
     --docker) docker="docker";;
     --podman) docker="podman";;
     CC=*) ccarg="--env=$1";;
-    shell) flags=-it; cmd=/bin/bash;;
     :*) image=ghcr.io/cockpit-project/unit-tests"$1";;
-    build|dist|distcheck|check-memory) cmd="/source/containers/unit-tests/run.sh $1";;
+    shell) flags='-it'; cmd="/bin/bash";;
+    build|dist|distcheck|check-memory) cmd="cockpit/containers/unit-tests/run.sh $1";;
     *) echo "Unknown option '$1'"; exit 1;;
   esac
   shift
@@ -28,6 +29,14 @@ if test -z "${docker:=$(which podman || which docker || true)}"; then
   exit 1
 fi
 
-set -ex
-exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
-       ${ccarg:+"$ccarg"} $flags -- "$image" $cmd
+mkdir -p tmp
+containers/unit-tests/create-pack > tmp/unpack.sh
+sed -ne 's/^# //p' tmp/unpack.sh | tar c -T - -C tmp unpack.sh > tmp/pack.tar
+
+${docker} run \
+    --rm \
+    ${flags} \
+    --shm-size=512M \
+    -v "$(pwd)/tmp/pack.tar":/pack.tar:ro,z \
+    ${ccarg:+"$ccarg"} \
+    -- "$image" $cmd


### PR DESCRIPTION
Our current approach to mounting the source directory as a volume inside of the container is problematic for two main reasons:                         
    
 - it doesn't work with selinux, due to incorrect labels 
    
 - it doesn't work with git worktrees, due to the .git file referring to a directory which doesn't get mounted into the container
    
We can fix both of these problems by being more explicit about injecting the source that we want to test into the container.                         
    
Replace our /source volume with a new /pack.tar file.  If it's present, /entrypoint will unpack it into the home directory and run an unpack.sh script from inside of it.  This is our mechanism for getting information into the container.                            
                       
Add a create-pack script on the outside for creating this archive.  It creates a git bundle for both the current HEAD, and for the node_modules in use by that HEAD.  It writes the script for unpacking those to its own stdout.  Each additional file which needs to be included in the .tar is written on a comment line.  Some sed/tar trickery in the start script makes sure everything gets packed up nicely.                                                
                                                                            
Moving the extraction steps to the entrypoint has a couple of nice effects: it means that when using a shell, you end up in an environment with everything already unpacked and ready to build.  It also means that the run.sh script is now "pure": you can run it directly on a source directory, outside of the container, and it will do the same things it does on the inside.
                                                                            
The source ends up in ~/cockpit now, instead of /tmp/source.            
