### PR TITLE
shell: Never connect to remote machines automatically

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -793,7 +793,7 @@ function Index() {
             self.navigate(ev.state, true);
         });
 
-        self.navigate();
+        self.navigate(null, true);
         cockpit.translate();
         $("body").prop("hidden", false);
     };

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -231,6 +231,11 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         if (!machine)
             machine = machines.lookup(state.host);
 
+        if (!machine || machine.state != "connected") {
+            ReactDOM.unmountComponentAtNode(document.getElementById("host-apps"));
+            return;
+        }
+
         if (!compiled)
             compiled = compile(machine);
 

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -198,7 +198,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         } else if (!machine.visible) {
             machine.state = "failed";
             machine.problem = "not-found";
-        } else if (reconnect && machine.state !== "connected") {
+        } else if (reconnect) {
             loader.connect(state.host);
         }
 

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -483,13 +483,14 @@ function Loader(machines, session_only) {
         if (!$.isEmptyObject(overlay))
             machines.overlay(host, overlay);
 
-        /* Don't automatically reconnect failed machines */
+        /* Don't automatically reconnect failed machines, and don't
+         * automatically connect to new machines.  The navigation will
+         * explicitly connect as necessary.
+         */
         if (machine.visible) {
             if (old_conns && machine.connection_string != old_conns) {
                 cockpit.kill(old_conns);
                 self.disconnect(host);
-                self.connect(host);
-            } else if (!machine.problem) {
                 self.connect(host);
             }
         } else {

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -307,9 +307,10 @@ function Machines() {
     };
 
     self.overlay = function overlay(host, values) {
+        var address = self.split_connection_string(host).address;
         var changes = { };
-        changes[host] = $.extend({ }, last.overlay[host] || { });
-        merge(changes[host], values);
+        changes[address] = $.extend({ }, last.overlay[address] || { });
+        merge(changes[address], values);
         refresh({
             content: last.content,
             overlay: $.extend({ }, last.overlay, changes)

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -210,11 +210,14 @@ function Machines() {
 
         // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
         var bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
-        var mod = bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
-                .catch(function(error) {
-                    console.error("failed to call cockpit.Machines.Update(): ", error);
-                    self.overlay(host, values);
-                });
+        var mod =
+            bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
+                    .catch(function(error) {
+                        console.error("failed to call cockpit.Machines.Update(): ", error);
+                    })
+                    .then(() => {
+                        self.overlay(host, values);
+                    });
 
         return mod;
     }

--- a/test/verify/check-host-switching
+++ b/test/verify/check-host-switching
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import json
+import time
 
 import parent
 from testlib import *
@@ -77,8 +78,13 @@ class HostSwitcherHelpers:
             b.click('#hosts_setup_server_dialog .pf-m-primary')
         b.wait_popdown('hosts_setup_server_dialog')
 
-    def wait_connected(self, b, address):
+    def connect_and_wait(self, b, address):
+        b.click("a[href='/@{0}']".format(address))
+        b.click("#hosts-sel button")
         b.wait_visible(".connected a[href='/@{0}']".format(address))
+        # Switch back to localhost, since the rest of the test expects that
+        b.click("a[href='/@localhost']")
+        b.click("#hosts-sel button")
 
     def get_pubkey(self, machine, account):
         return machine.execute("cat /home/%s/.ssh/id_rsa.pub" % account)
@@ -143,7 +149,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
         self.add_machine(b, "10.111.113.2")
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.2")
+        self.connect_and_wait(b, "10.111.113.2")
 
         # Main host should have both buttons disabled, the second both enabled
         b.click("button:contains('Edit hosts')")
@@ -159,7 +165,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
         self.add_machine(b, "10.111.113.3")
         self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.3")
+        self.connect_and_wait(b, "10.111.113.3")
 
         # Remove two
         self.machine_remove(b, "10.111.113.2", m2)
@@ -174,7 +180,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         # Add one back, check addresses on both browsers
         self.add_machine(b, "10.111.113.2", True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.2")
+        self.connect_and_wait(b, "10.111.113.2")
         self.check_discovered_addresses(b, ["10.111.113.3"])
 
         b.wait_not_present(".nav-item span[data-for='/@10.111.113.2'] .nav-status")
@@ -182,7 +188,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         # And the second one, check addresses
         self.add_machine(b, "10.111.113.3", True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"])
-        self.wait_connected(b, "10.111.113.3")
+        self.connect_and_wait(b, "10.111.113.3")
         self.check_discovered_addresses(b, [])
 
         # Test change user, not doing in edit to reuse machines
@@ -264,8 +270,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.add_machine(b, "10.111.113.2")
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.2")
-        self.wait_connected(b2, "10.111.113.2")
+        self.connect_and_wait(b, "10.111.113.2")
+        self.connect_and_wait(b2, "10.111.113.2")
 
         # Main host should have both buttons disabled, the second both enabled
         b.click("button:contains('Edit hosts')")
@@ -282,8 +288,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.add_machine(b, "10.111.113.3")
         self.wait_host_addresses(b, ["localhost", "10.111.113.3", "10.111.113.2"])
         self.wait_host_addresses(b2, ["localhost", "10.111.113.3", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.3")
-        self.wait_connected(b2, "10.111.113.3")
+        self.connect_and_wait(b, "10.111.113.3")
+        self.connect_and_wait(b2, "10.111.113.3")
 
         # Remove two
         self.machine_remove(b, "10.111.113.2", m2)
@@ -303,7 +309,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.add_machine(b, "10.111.113.2", True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2"])
-        self.wait_connected(b, "10.111.113.2")
+        self.connect_and_wait(b, "10.111.113.2")
         self.check_discovered_addresses(b, ["10.111.113.3"])
         self.check_discovered_addresses(b2, ["10.111.113.3"])
 
@@ -313,7 +319,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.add_machine(b, "10.111.113.3", True)
         self.wait_host_addresses(b, ["localhost", "10.111.113.2", "10.111.113.3"])
         self.wait_host_addresses(b2, ["localhost", "10.111.113.2", "10.111.113.3"])
-        self.wait_connected(b, "10.111.113.3")
+        self.connect_and_wait(b, "10.111.113.3")
         self.check_discovered_addresses(b, [])
         self.check_discovered_addresses(b2, [])
 
@@ -339,7 +345,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("#hosts-sel button")
         self.add_machine(b, "10.111.113.3")
         self.wait_host_addresses(b, ["localhost", "10.111.113.3"])
-        self.wait_connected(b, "10.111.113.3")
+        self.connect_and_wait(b, "10.111.113.3")
 
         b.click("button:contains('Edit hosts')")
         b.click("#nav-hosts .nav-item span[data-for='/@10.111.113.3'] button.nav-action.pf-m-secondary")
@@ -389,6 +395,23 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_not_present(".nav-item span[data-for='/@10.111.113.3']")
         b.wait_text(".nav-item span[data-for='/@10.111.113.2']", "admin @machine2")
 
+    def testNoAutoconnect(self):
+        b = self.browser
+        m2 = self.machines["machine2"]
+
+        self.login_and_go(None)
+
+        # And and connect to a second machine
+        b.click("#hosts-sel button")
+        self.add_machine(b, "10.111.113.2")
+        b.click("a[href='/@10.111.113.2']")
+        b.wait_visible("iframe.container-frame[name='cockpit1:10.111.113.2/system']")
+        self.assertIn("admin", m2.execute("loginctl"))
+        b.click("#hosts-sel button")
+        b.click("a[href='/@localhost']")
+        b.relogin()
+        time.sleep(60)
+        self.assertNotIn(m2.execute("loginctl"), "admin")
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestHostEditing(MachineCase, HostSwitcherHelpers):


### PR DESCRIPTION
Release note:
----
### Shell: SSH connections to remote machines are only opened when necessary

Cockpit remembers all remote hosts of a session and used to immediately connect to all of them when starting the next session.  Now a SSH connection is only opened when navigating to the remote machine for the first time.