### PR TITLE
check-login: use faillock on debian-testing

### DIFF
--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -564,14 +564,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
 
-        if m.image.startswith('debian') or m.image.startswith('ubuntu'):
+        if m.image == 'debian-stable' or m.image.startswith('ubuntu'):
             module = 'pam_tally2'
             logfile = lambda user: '/var/log/tallylog'
-        elif m.image.startswith('rhel') or m.image.startswith('fedora') or m.image.startswith('cent'):
+        else:
             module = 'faillock'
             logfile = lambda user: '/var/run/faillock/' + user
-        else:
-            raise ValueError('unexpected image name', m.image)
 
         def expect_fail_count(expected, user="admin", must_exist=True):
             if must_exist:
@@ -609,6 +607,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # add it to the pam config
         if module == 'pam_tally2':
             self.sed_file("/common-auth/ { iauth required pam_tally2.so deny=4\n }", "/etc/pam.d/cockpit")
+        elif m.image == 'debian-testing':
+            # enable pam_faillock.  see example in pam_faillock(8), adopted for sss
+            self.sed_file("""s/re.*pam_deny.so/[default=die] pam_faillock.so authfail/;
+                             s/re.*pam_permit.so/sufficient pam_faillock.so authsucc/;
+                          """, "/etc/pam.d/common-auth")
         else:
             # see https://access.redhat.com/solutions/62949
             self.sed_file("""/pam_unix/ {


### PR DESCRIPTION
As of pam 1.4.0-1 in debian-testing, tally2 is gone and has been
replaced with faillock.  Unfortunately, the tests are currently failing
due to the /sbin/faillock command not currently being properly packaged.
For now, we're introducing a naughty in bots#1569 to deal with that, but
let's make sure that this test starts working again properly once the
issue has been resolved.