### PR TITLE
tools: Skip slow tests on hppa in Debian

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -25,7 +25,7 @@ Build-Depends: debhelper (>= 10),
                glib-networking,
                openssh-client <!nocheck>,
                python3,
-Standards-Version: 4.5.0
+Standards-Version: 4.5.1
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
 Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -5,8 +5,10 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 # only ship deprecated PatternFly API for stable releases (backports); Debian sid/testing has no VERSION_ID
 SHIP_PF_API = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),10 20.04)
 
-# this is an emulated architecture for now, and too slow to run expensive unit tests
-ifeq ($(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64)
+# riscv is an emulated architecture for now, and too slow to run expensive unit tests
+# hppa's threading is absurdly slow (#981127)
+SLOW_ARCHES = $(filter $(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64 hppa)
+ifneq ($(SLOW_ARCHES),)
 	export COCKPIT_SKIP_SLOW_TESTS=1
 endif
 


### PR DESCRIPTION
hppa needs almost an hour to run the test-tls-certfile unit test. Skip
slow tests on this architecture to avoid a build timeout.

https://bugs.debian.org/981127
