### PR TITLE
web_socket_util_parse_headers: Move Insert after check

### DIFF
--- a/src/websocket/test-websocket.c
+++ b/src/websocket/test-websocket.c
@@ -316,6 +316,25 @@ test_parse_headers (void)
 }
 
 static void
+test_parse_duplicate_headers (void)
+{
+  GHashTable *headers;
+  gssize ret;
+
+  const gchar *input =
+      "header1: value2\r\n"
+      "Header1: value3\r\n"
+      "\r\n"
+      "BODY  ";
+
+  ret = web_socket_util_parse_headers (input, strlen (input), &headers);
+  g_assert_cmpint (ret, ==, strlen (input) - 6);
+  g_assert_cmpstr (g_hash_table_lookup (headers, "header1"), ==, "value3");
+  g_assert (g_hash_table_lookup (headers, "Something else") == NULL);
+  g_hash_table_unref (headers);
+}
+
+static void
 test_parse_headers_no_out (void)
 {
   const gchar *input =
@@ -1314,6 +1333,7 @@ main (int argc,
   g_test_add_func ("/web-socket/parse-version-1-0", test_parse_version_1_0);
   g_test_add_func ("/web-socket/parse-version-1-1", test_parse_version_1_1);
   g_test_add_func ("/web-socket/parse-headers", test_parse_headers);
+  g_test_add_func ("/web-socket/parse-duplicate-headers", test_parse_duplicate_headers);
   g_test_add_func ("/web-socket/parse-headers-no-out", test_parse_headers_no_out);
   g_test_add_func ("/web-socket/parse-headers-bad", test_parse_headers_bad);
   g_test_add_func ("/web-socket/parse-headers-not-enough", test_parse_headers_not_enough);

--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -324,8 +324,6 @@ web_socket_util_parse_headers (const gchar *data,
   gsize consumed = 0;
   gboolean end = FALSE;
   gsize line_len;
-  gchar *name;
-  gchar *value;
 
   parsed_headers = web_socket_util_new_headers ();
 
@@ -360,9 +358,9 @@ web_socket_util_parse_headers (const gchar *data,
               break;
             }
 
-          name = g_strndup (data, colon - data);
+          g_autofree gchar *name = g_strndup (data, colon - data);
           g_strstrip (name);
-          value = g_strndup (colon + 1, line - (colon + 1));
+          g_autofree gchar *value = g_strndup (colon + 1, line - (colon + 1));
           g_strstrip (value);
 
           if (!is_valid_line (name, -1) || !g_utf8_validate (value, -1, NULL))
@@ -371,7 +369,7 @@ web_socket_util_parse_headers (const gchar *data,
               consumed = -1;
               break;
             }
-          g_hash_table_insert (parsed_headers, name, value);
+          g_hash_table_insert (parsed_headers, g_steal_pointer(&name), g_steal_pointer(&value));
         }
 
       consumed += line_len;

--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -369,7 +369,7 @@ web_socket_util_parse_headers (const gchar *data,
               consumed = -1;
               break;
             }
-          g_hash_table_insert (parsed_headers, g_steal_pointer(&name), g_steal_pointer(&value));
+          g_hash_table_insert (parsed_headers, g_steal_pointer (&name), g_steal_pointer (&value));
         }
 
       consumed += line_len;

--- a/src/websocket/websocket.c
+++ b/src/websocket/websocket.c
@@ -364,7 +364,6 @@ web_socket_util_parse_headers (const gchar *data,
           g_strstrip (name);
           value = g_strndup (colon + 1, line - (colon + 1));
           g_strstrip (value);
-          g_hash_table_insert (parsed_headers, name, value);
 
           if (!is_valid_line (name, -1) || !g_utf8_validate (value, -1, NULL))
             {
@@ -372,6 +371,7 @@ web_socket_util_parse_headers (const gchar *data,
               consumed = -1;
               break;
             }
+          g_hash_table_insert (parsed_headers, name, value);
         }
 
       consumed += line_len;


### PR DESCRIPTION
It is possible for g_hash_table_insert to invalidate the strings. Move the ownership transfer to after the check to ensure we don't touch the name and value again after insert.