### PR TITLE
tools: Don't treat webpack warnings as errors

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -73,8 +73,10 @@ function process_result(err, stats) {
     }
 
     // Failure exit code when compilation fails
-    if (stats.hasErrors() || stats.hasWarnings()) {
+    if (stats.hasErrors() || stats.hasWarnings())
         console.log(stats.toString("normal"));
+
+    if (stats.hasErrors()) {
         if (!ops.watch)
             process.exit(1);
         return;


### PR DESCRIPTION
In some versions of webpack, irrelevant warnings are resulting
in failure to build from sources