### PR TITLE
tests: make testDiskEdit more stable by checking radio buttons value …

### DIFF
--- a/pkg/machines/components/vm/disks/diskEdit.jsx
+++ b/pkg/machines/components/vm/disks/diskEdit.jsx
@@ -82,7 +82,7 @@ const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
 
 const AccessRow = ({ onValueChanged, dialogValues, driverType, idPrefix }) => {
     return (
-        <FormGroup fieldId={`${idPrefix}-access`} label={_("Access")} isInline>
+        <FormGroup id={`${idPrefix}-access`} label={_("Access")} isInline data-access={dialogValues.access}>
             <Radio id={`${idPrefix}-readonly`}
                    name="access"
                    value="readonly"

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -98,6 +98,7 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         # Changing readonly with running VM
         b.set_checked("#vm-subVmTest1-disks-vde-edit-readonly", True)
+        b.wait_attr("#vm-subVmTest1-disks-vde-edit-access", "data-access", "readonly")
 
         # Tooltip in dialog should show
         b.wait_visible("#vm-subVmTest1-disks-vde-edit-idle-message")
@@ -123,6 +124,7 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         # Changing readonly
         b.set_checked("#vm-subVmTest1-disks-vde-edit-writable-shareable", True)
+        b.wait_attr("#vm-subVmTest1-disks-vde-edit-access", "data-access", "shareable")
         # Tooltip in dialog should not be present
         b.wait_not_present("#vm-subVmTest1-disks-vde-edit-idle-message")
 


### PR DESCRIPTION
…before closing the modal

Radio buttons don't seem to expose a 'checked' attribute, therefore this
commits add the selected radio button value as an attribute of the
FormGroup.

Cherry-picked from https://github.com/cockpit-project/cockpit/pull/15208, if it really works in can be merged independently.