### PR TITLE
build: add jump-start option to build without node

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,6 +250,31 @@ uninstall-local::
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS)
 	$(V_TAR) tar -cf - $^ | tar -C $(distdir) -xf -
 
+# this makes it possible to `make check`
+JUMPSTART_EXTRAS = \
+	node_modules/chrome-remote-interface \
+	node_modules/ws \
+	$(NULL)
+
+# We extract with `tar -m` so the order of files equals the order of
+# timestamps.  Make sure the stamp files stay at the end so that they
+# are the "newest".
+JUMPSTART_CONTENTS = \
+	$(JUMPSTART_EXTRAS) \
+	$(WEBPACK_INPUTS) \
+	$(WEBPACK_OUTPUTS) \
+	$(WEBPACK_DEPS) \
+	$(WEBPACK_STAMPS)
+
+cockpit-jumpstart.tar: $(JUMPSTART_CONTENTS)
+	tar cf $@ $^
+
+cockpit-jumpstart.tar.xz: cockpit-jumpstart.tar
+	xz --extreme < $< > $@
+
+jumpstart:
+	tar xmf cockpit-jumpstart.tar.xz
+
 #
 
 ACLOCAL_AMFLAGS = -I tools ${ACLOCAL_FLAGS}

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,6 +66,10 @@ V_GZIP = $(V_GZIP_$(V))
 V_GZIP_ = $(V_GZIP_$(AM_DEFAULT_VERBOSITY))
 V_GZIP_0 = @echo "  GZIP    " $@;
 
+V_XZ = $(V_XZ_$(V))
+V_XZ_ = $(V_XZ_$(AM_DEFAULT_VERBOSITY))
+V_XZ_0 = @echo "  XZ      " $@;
+
 V_COPY = $(V_COPY_$(V))
 V_COPY_ = $(V_COPY_$(AM_DEFAULT_VERBOSITY))
 V_COPY_0 = @echo "  COPY    " $@;
@@ -113,6 +117,14 @@ CAT_RULE = \
 GZ_RULE = \
 	$(V_GZIP) $(MKDIR_P) $(dir $@) && \
 	gzip -n -c $< > $@.tmp && $(MV) $@.tmp $@
+
+XZ_RULE = \
+	$(V_XZ) $(MKDIR_P) $(dir $@) && \
+	xz $(XZ_COMPRESS_FLAGS) -c $< > $@.tmp && $(MV) $@.tmp $@
+
+TAR_RULE = \
+	$(V_TAR) $(MKDIR_P) $(dir $@) && \
+	tar c $^ > $@.tmp && $(MV) $@.tmp $@
 
 SUBST_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && sed \
@@ -267,10 +279,10 @@ JUMPSTART_CONTENTS = \
 	$(WEBPACK_STAMPS)
 
 cockpit-jumpstart.tar: $(JUMPSTART_CONTENTS)
-	tar cf $@ $^
+	$(TAR_RULE)
 
 cockpit-jumpstart.tar.xz: cockpit-jumpstart.tar
-	xz --extreme < $< > $@
+	$(XZ_RULE)
 
 jumpstart:
 	tar xmf cockpit-jumpstart.tar.xz


### PR DESCRIPTION
Add a pair of new makefile rules to support "jump-start" builds.

First, `make cockpit-jumpstart.tar.xz` can be used to create an archive
of the files needed to build the current version of cockpit without
requiring any of npm, node, or webpack.

Second, `make jumpstart` will use a `cockpit-jumpstart.tar.xz` found in
the current directory.

After a "jump-start", it's possible to build the C parts of cockpit and
run the full suite of unit tests, and prepare images for testing.