### PR TITLE
README.md: remove link to semaphore build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![semaphore ci build status](https://semaphoreci.com/api/v1/cockpit-project/cockpit/branches/master/badge.svg)](https://semaphoreci.com/cockpit-project/cockpit) <br />
-
 # Cockpit
 **A sysadmin login session in a web browser**
 


### PR DESCRIPTION
We stopped using semaphore a while ago...