### PR TITLE
test: fix an m.execute() invocation in check-realms

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -810,7 +810,7 @@ ExecStart=/bin/true
         # Make sure negotiate auth is not offered first
         m.start_cockpit()
 
-        output = m.execute(['/usr/bin/curl -v -s',
+        output = m.execute(['/usr/bin/curl', '-v', '-s',
                             '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
                             'http://x0.cockpit.lan:9090/cockpit/login', '2>&1'])
         self.assertIn("HTTP/1.1 401", output)


### PR DESCRIPTION
TestKerberos.testNegotiate() is using an undocumented feature of
m.execute() by passing the individual arguments of curl as a list rather
than a string.  This feature has long been broken: ssh just concatenates
the arguments back together anyway.  This is plainly illustrated by the
fact that this test has been calling m.execute() with

  '/usr/bin/curl -v -s'

as the first argument, and it's been working.

Split that out properly in preparation for an upcoming change to the
bots to make this function properly.