### PR TITLE
test: Fix check-realms curl invocation harder

### DIFF
--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -810,9 +810,9 @@ ExecStart=/bin/true
         # Make sure negotiate auth is not offered first
         m.start_cockpit()
 
-        output = m.execute(['/usr/bin/curl', '-v', '-s',
-                            '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
-                            'http://x0.cockpit.lan:9090/cockpit/login', '2>&1'])
+        output = m.execute('/usr/bin/curl -v -s '
+                           '--resolve x0.cockpit.lan:9090:10.111.113.1 '
+                           'http://x0.cockpit.lan:9090/cockpit/login 2>&1')
         self.assertIn("HTTP/1.1 401", output)
         self.assertNotIn("WWW-Authenticate: Negotiate", output)
 


### PR DESCRIPTION
Commit 426bd42b31a1f was incompatible with
https://github.com/cockpit-project/bots/commit/13eff0d5743b
and also did not really make sense: `2>&1` is shell syntax, not an argv,
so instead run the whole command as a single shell string.