### PR TITLE
ws: Don't allow "localhost" as a remote host

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -810,6 +810,8 @@ if (window.NodeList && !NodeList.prototype.forEach)
                         host_failure(_("Refusing to connect. Host is unknown"));
                     } else if (xhr.statusText.indexOf("invalid-hostkey") > -1) {
                         host_failure(_("Refusing to connect. Hostkey does not match"));
+                    } else if (xhr.statusText.indexOf("remote-host-required") > -1) {
+                        login_failure(_("Remote host required"));
                     } else if (is_conversation) {
                         login_failure(_("Authentication failed"));
                     } else {

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1075,39 +1075,22 @@ cockpit_session_create (CockpitAuth *self,
 }
 
 static gboolean
-inet_addr_in_list (GInetAddress *addr, GList *list)
-{
-  for (GList *l = list; l; l = l->next)
-    if (g_inet_address_equal (addr, l->data))
-      return TRUE;
-  return FALSE;
-}
-
-static gboolean
 is_localhost (const char *host)
 {
-  gchar *hostname = g_malloc0 (HOST_NAME_MAX + 1);
   GResolver *resolver = g_resolver_get_default ();
-  GList *target_addrs = g_resolver_lookup_by_name (resolver, host, NULL, NULL);
-  gethostname (hostname, HOST_NAME_MAX);
-  hostname[HOST_NAME_MAX] = '\0';
-  GList *local_addrs = g_resolver_lookup_by_name (resolver, hostname, NULL, NULL);
+  GList *addrs = g_resolver_lookup_by_name (resolver, host, NULL, NULL);
   gboolean local = FALSE;
 
-  for (GList *t = target_addrs; t; t = t->next)
+  for (GList *t = addrs; t; t = t->next)
     {
-      if (g_inet_address_get_is_loopback (t->data)
-          || inet_addr_in_list (t->data, local_addrs))
+      if (g_inet_address_get_is_loopback (t->data))
         {
           local = TRUE;
           break;
         }
     }
 
-  g_resolver_free_addresses (target_addrs);
-  g_resolver_free_addresses (local_addrs);
-  g_free (hostname);
-
+  g_resolver_free_addresses (addrs);
   return local;
 }
 


### PR DESCRIPTION
Fixes #15077

- [ ] Define what exactly counts as local.
- [ ] Decide the name of the "AllowLocalHost" option.
- [ ] Documentation
- [ ] Tests

------
Release notes

### When acting as a bastion host, Cockpit now denies connections to the bastion host itself.

When configured as a pure bastion host by setting `RequireHost` to true in `cockpit.conf`, Cockpit would indeed require the user to specify a host to connect to during login, but one could simply say "localhost" to cause Cockpit to try to connect to the bastion host itself via SSH.  This will now be denied, unless the new `XXX` config option is also set to true.

[ For the DNS based check: ]
Cockpit decides which address is local or not based on data returned by the Internet name resolver. Make sure that the output of `getent ahosts $(hostname)` includes all IP addresses that should be blocked.