### PR TITLE
build: change the generation of manifest.json

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -151,8 +151,6 @@ SUBST_RULE = \
 	$(GZ_RULE)
 .js.js.gz:
 	$(GZ_RULE)
-.json.in.json:
-	$(SUBST_RULE)
 .map.map.gz:
 	$(GZ_RULE)
 .service.in.service:
@@ -232,8 +230,8 @@ dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/node_modu
 	(if ls $(srcdir)/pkg/$*/*.js >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
 	  touch $@
 
-dist/%/manifest.json: pkg/%/manifest.json
-	$(COPY_RULE)
+dist/%/manifest.json: pkg/%/manifest.json.in
+	$(SUBST_RULE)
 
 -include $(WEBPACK_DEPS)
 


### PR DESCRIPTION
Instead of our substitution rule being used to transform

  pkg/*/manifest.json.in

into

  pkg/*/manifest.json

and then a separate copy rule being used to copy the file into

  dist/*/manifest.json

just do the substitution directly.

This solves two minor issues:

  - the pkg/*/manifest.json files were being treated by make as
    non-precious intermediates, which means that you'd often see them
    being deleted as part of a large `rm` at the end of a fresh build

  - for some reason, webpack-make is writing the manifest.json file for
    networkmanager (and only networkmanager) to its Makefile.deps,
    resulting in make *not* deleting the file as a non-precious
    intermediate.  This had the effect that we'd see spurious copies of
    the file sometimes.