### PR TITLE
test: Stop creating core dump artifacts

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1288,7 +1288,8 @@ class MachineCase(unittest.TestCase):
                 except OSError as ex:
                     if ex.errno == errno.ENOTEMPTY:
                         print("Core dumps downloaded to %s" % (dest))
-                        attach(dest)
+                        # Enable this to temporarily(!) create artifacts for core dumps, if a crash is hard to reproduce
+                        # attach(dest)
 
     def settle_cpu(self):
         '''Wait until CPU usage in the VM settles down


### PR DESCRIPTION
They take a *lot* of space and upload bandwidth, and we use them so
rarely that it is not generally worth the trouble. We can re-enable them
on demand if we every run into crashes which can't easily be reproduced.