### PR TITLE
tools: Drop cockpit-appstream split for RHEL/ELN ≥ 9

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -66,10 +66,11 @@ Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 %endif
 
-# in RHEL the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
+# in RHEL 8 the source package is duplicated: cockpit (building basic packages like cockpit-{bridge,system})
 # and cockpit-appstream (building optional packages like cockpit-{machines,pcp})
 # This split does not apply to EPEL/COPR.
-%if 0%{?rhel} && 0%{?epel} == 0
+# In Fedora ELN/RHEL 9+ there is just one source package, which ships rpms in both BaseOS and AppStream
+%if 0%{?rhel} == 8 && 0%{?epel} == 0
 
 %if "%{name}" == "cockpit"
 %define build_basic 1

--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -53,10 +53,10 @@ sed -e "/^Version:.*/d" -e "1i\
 tmpdir=$(mktemp -d $PWD/srpm-build.XXXXXX)
 tar xaf "$source" -O cockpit-$version/tools/cockpit.spec | modify_spec > $tmpdir/cockpit.spec
 
-# on RHEL/CentOS, cockpit is delivered as two mostly identical source packages.
+# on RHEL/CentOS 8 (only), cockpit is delivered as two mostly identical source packages.
 # "cockpit" with build_basic=1, and "cockpit-appstream" with build_optional=1
 # the spec has proper build_* defaults depending on the Name:
-if grep -qE '^ID=.*(rhel|centos)' /etc/os-release; then
+if grep -qE '^ID=.*(rhel|centos)' /etc/os-release && grep -qE '^VERSION_ID="8' /etc/os-release; then
     sed '/^Name:/ s/$/-appstream/' < $tmpdir/cockpit.spec > $tmpdir/cockpit-appstream.spec
 fi
 


### PR DESCRIPTION
Turns out that sources in BaseOS *can* ship binary RPMs in AppStream as
well. This got an explicit blessing, and will significantly simplify our
downstream packaging.

We may eventually reunite them for RHEL 8 as well, but for now let's fix
RHEL 9 and ELN.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1916251