### PR TITLE
login: Always show the "Other options" header

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -564,7 +564,7 @@ if (window.NodeList && !NodeList.prototype.forEach)
         id("login-password-input").value = '';
 
         if (need_host()) {
-            hide("#option-group");
+            toggle_options(null, true);
             expanded = true;
         } else {
             hideToggle("#option-group", !connectable || form != "login");

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -66,7 +66,6 @@ class TestBastion(MachineCase):
 
         b.open("/")
         b.wait_visible("#login")
-        b.wait_not_visible("#option-group")
         b.wait_visible("#server-field")
         b.wait_text("#server-name", "Cockpit Bastion")
 
@@ -81,7 +80,6 @@ class TestBastion(MachineCase):
         # With a url, host is already there
         b.open("/=10.111.113.1")
         b.wait_visible("#login")
-        b.wait_visible("#option-group")
         b.wait_visible("#server-field")
         b.wait_val("#server-field", "10.111.113.1")
         b.wait_text("#server-name", "10.111.113.1")
@@ -123,7 +121,6 @@ class TestBastion(MachineCase):
 
         b.open("/")
         b.wait_visible("#login")
-        b.wait_not_visible("#option-group")
         b.wait_visible("#server-field")
         b.wait_text("#server-name", "Cockpit Bastion")
 


### PR DESCRIPTION
Previously it would turn off when RequireHost was set to true in
cockpit.conf, but only when there wasn't any "/=HOST" element in the
URL already.

Let's just show it always, which should be less confusing and also
avoid a recently introduced layout bug.

Fixes #15255