### PR TITLE
storage: use only PF4 components and stop including PF3 stylesheets

### DIFF
--- a/pkg/lib/cockpit-components-dialog.css
+++ b/pkg/lib/cockpit-components-dialog.css
@@ -2,3 +2,7 @@
     max-height: calc(75vh - 10rem);
     overflow: auto;
 }
+
+.dialog-wait-ct-spinner {
+    margin-left: var(--pf-global--spacer--sm);
+}

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import { Alert, Button, Modal, Popover } from "@patternfly/react-core";
+import { Alert, Button, Modal, Popover, Spinner } from "@patternfly/react-core";
 import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import "page.scss";
@@ -160,7 +160,7 @@ export class DialogFooter extends React.Component {
                 cancel_disabled = true;
             wait_element = <div className="dialog-wait-ct">
                 <span>{ this.state.action_progress_message }</span>
-                <div className="spinner spinner-sm" />
+                <Spinner isSVG className="dialog-wait-ct-spinner" size="md" />
             </div>;
         } else if (this.props.idle_message) {
             wait_element = <div className="dialog-wait-ct">

--- a/pkg/lib/cockpit-components-listing-panel.scss
+++ b/pkg/lib/cockpit-components-listing-panel.scss
@@ -52,6 +52,8 @@
     flex: auto;
     justify-content: flex-end;
     margin: var(--pf-global--spacer--sm) var(--pf-global--spacer--sm);
+    row-gap: var(--pf-global--spacer--sm);
+    column-gap: var(--pf-global--spacer--sm);
   }
 
   // Tabless mode, with just action buttons

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -553,3 +553,20 @@ html:not(.index-page) body {
     height: 100% !important;
   }
 }
+
+/* Add some spacing to nested form groups - PF4 does not support them */
+/* https://github.com/patternfly/patternfly-react/issues/5023 */
+.pf-c-form__group-control {
+    > .pf-c-form__group, .pf-c-form__section {
+        padding-top: var(--pf-global--spacer--md);
+    }
+}
+
+// When there is an Alert above the Form add some spacing
+.pf-c-modal-box .pf-c-alert + .pf-c-form {
+    padding-top: var(--pf-global--FontSize--sm);
+}
+
+.ct-icon-exclamation-triangle {
+    color: var(--pf-global--warning-color--100);
+}

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -71,7 +71,7 @@ svg {
 
   > .pf-c-card__actions {
       flex-wrap: wrap;
-      button {
+      button:not(.pf-c-dropdown__toggle) {
           margin-bottom: 0.5rem;
       }
   }

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -839,7 +839,7 @@ class CardsPage extends React.Component {
                     {this.props.cockpitUpdate &&
                         <Flex flex={{ default: 'inlineFlex' }} className="cockpit-update-warning">
                             <FlexItem>
-                                <ExclamationTriangleIcon size="ms" color="#f0ab00" className="cockpit-update-warning-icon" />
+                                <ExclamationTriangleIcon className="ct-icon-exclamation-triangle cockpit-update-warning-icon" size="sm" />
                                 <strong className="cockpit-update-warning-text">
                                     <span className="pf-screen-reader">{_("Danger alert:")}</span>
                                     {_("Web Console will restart")}

--- a/pkg/shell/nav.jsx
+++ b/pkg/shell/nav.jsx
@@ -154,7 +154,7 @@ function PageStatus({ status, name }) {
                  position={TooltipPosition.right}>
             <span id={desc} className="nav-status">
                 {status.type == "error" ? <ExclamationCircleIcon color="#f54f42" />
-                    : status.type == "warning" ? <ExclamationTriangleIcon color="#f0ab00" />
+                    : status.type == "warning" ? <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" color="#f0ab00" />
                         : <InfoCircleIcon color="#73bcf7" />}
             </span>
         </Tooltip>

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -25,7 +25,8 @@ import {
 import * as utils from "./utils.js";
 
 import React from "react";
-import { Card, CardHeader, CardTitle, CardBody, CardActions, Text, TextVariants } from "@patternfly/react-core";
+import { Card, CardHeader, CardTitle, CardBody, CardActions, Spinner, Text, TextVariants } from "@patternfly/react-core";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
@@ -93,7 +94,7 @@ function create_tabs(client, target, is_partition) {
         if (associated_warnings)
             tab_warnings = warnings.filter(w => associated_warnings.indexOf(w.warning) >= 0);
         if (tab_warnings.length > 0)
-            name = <><span className="pficon pficon-warning-triangle-o" /> {name}</>;
+            name = <div className="content-nav-item-warning"><ExclamationTriangleIcon className="ct-icon-exclamation-triangle" /> {name}</div>;
         tabs.push(
             {
                 name: name,
@@ -430,10 +431,10 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     // place.
 
     var last_column = null;
-    if (job_object)
+    if (job_object && client.path_jobs[job_object])
         last_column = (
-            <span className="spinner spinner-sm spinner-inline"
-                  style={{ visibility: client.path_jobs[job_object] ? "visible" : "hidden" }} />);
+            <Spinner size="md" />
+        );
     if (tabs.row_action) {
         if (last_column) {
             last_column = <span>{last_column}{tabs.row_action}</span>;
@@ -443,7 +444,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     }
 
     if (tabs.has_warnings) {
-        last_column = <span>{last_column}<span className="pficon pficon-warning-triangle-o" /></span>;
+        last_column = <span>{last_column}<ExclamationTriangleIcon className="ct-icon-exclamation-triangle" /></span>;
     }
 
     var cols = [
@@ -453,7 +454,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
             </span>
         },
         { title: name },
-        { title: last_column },
+        { title: last_column, props: { className: "content-action" } },
     ];
 
     function menuitem(action) {
@@ -462,7 +463,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
 
     var menu = null;
     if (tabs.menu_actions && tabs.menu_actions.length > 0)
-        menu = <StorageBarMenu id={"menu-" + name}>{tabs.menu_actions.map(menuitem)}</StorageBarMenu>;
+        menu = <StorageBarMenu id={"menu-" + name} menuItems={tabs.menu_actions.map(menuitem)} />;
 
     var actions = <>{tabs.actions}{menu}</>;
 

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -20,7 +20,12 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { Card, CardBody, CardTitle, CardHeader, CardActions, Text, TextVariants } from "@patternfly/react-core";
+import {
+    Card, CardBody, CardTitle, CardHeader, CardActions,
+    DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataList,
+    Text, TextVariants
+} from "@patternfly/react-core";
+import { EditIcon, MinusIcon, PlusIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 import sha1 from "js-sha1";
 import stable_stringify from "json-stable-stringify-without-jsonify";
@@ -353,7 +358,7 @@ function edit_tang_adv(client, block, key, url, adv, passphrase) {
 const RemovePassphraseField = (tag, key, dev) => {
     return {
         tag: tag,
-        title: <span className="pficon pficon-warning-triangle-o large" />,
+        title: <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="lg" />,
         options: { },
         initial_value: "",
 
@@ -416,7 +421,7 @@ function remove_passphrase_dialog(block, key) {
 const RemoveClevisField = (tag, key, dev) => {
     return {
         tag: tag,
-        title: <span className="pficon pficon-warning-triangle-o large" />,
+        title: <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="lg" />,
         options: { },
         initial_value: "",
 
@@ -541,24 +546,38 @@ export class CryptoKeyslots extends React.Component {
 
             var add_row = (slot, type, desc, edit, edit_excuse, remove) => {
                 rows.push(
-                    <tr key={slot}>
-                        <td className="shrink key-type">{ type }</td>
-                        <td>{ desc }</td>
-                        <td className="shrink key-slot">{ cockpit.format(_("Slot $0"), slot) }</td>
-                        <td className="shrink text-right">
-                            <StorageButton onClick={edit}
-                                           excuse={(keys.length == this.state.max_slots)
-                                               ? _("Editing a key requires a free slot")
-                                               : null}>
-                                <span className="pficon pficon-edit" />
-                            </StorageButton>
-                            { "\n" }
-                            <StorageButton onClick={remove}
-                                           excuse={keys.length == 1 ? _("The last key slot can not be removed") : null}>
-                                <span className="fa fa-minus" />
-                            </StorageButton>
-                        </td>
-                    </tr>
+                    <DataListItem key={slot}>
+                        <DataListItemRow>
+                            <DataListItemCells
+                                dataListCells={[
+                                    <DataListCell key="key-type">
+                                        { type }
+                                    </DataListCell>,
+                                    <DataListCell key="desc" isFilled={false}>
+                                        { desc }
+                                    </DataListCell>,
+                                    <DataListCell key="key-slot">
+                                        { cockpit.format(_("Slot $0"), slot) }
+                                    </DataListCell>,
+                                    <DataListCell key="text-right" isFilled={false} alignRight>
+                                        <StorageButton onClick={edit}
+                                                       ariaLabel={_("Edit")}
+                                                       excuse={(keys.length == this.state.max_slots)
+                                                           ? _("Editing a key requires a free slot")
+                                                           : null}>
+                                            <EditIcon />
+                                        </StorageButton>
+                                        { "\n" }
+                                        <StorageButton onClick={remove}
+                                                       ariaLabel={_("Remove")}
+                                                       excuse={keys.length == 1 ? _("The last key slot can not be removed") : null}>
+                                            <MinusIcon />
+                                        </StorageButton>
+                                    </DataListCell>,
+                                ]}
+                            />
+                        </DataListItemRow>
+                    </DataListItem>
                 );
             };
 
@@ -592,18 +611,19 @@ export class CryptoKeyslots extends React.Component {
                             { remaining < 6 ? (remaining ? cockpit.format(cockpit.ngettext("$0 slot remains", "$0 slots remain", remaining), remaining) : _("No available slots")) : null }
                         </span>
                         <StorageButton onClick={() => add_dialog(client, block)}
+                                       ariaLabel={_("Add")}
                                        excuse={(keys.length == this.state.max_slots)
                                            ? _("No free key slots")
                                            : null}>
-                            <span className="fa fa-plus" />
+                            <PlusIcon />
                         </StorageButton>
                     </CardActions>
                     <CardTitle><Text component={TextVariants.h2}>{_("Keys")}</Text></CardTitle>
                 </CardHeader>
                 <CardBody className="contains-list">
-                    <table className="table">
-                        <tbody>{ rows }</tbody>
-                    </table>
+                    <DataList isCompact className="crypto-keyslots-list" aria-label={_("Keys")}>
+                        {rows}
+                    </DataList>
                 </CardBody>
             </Card>
         );

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -109,7 +109,8 @@ export class CryptoTab extends React.Component {
             edit_config(function (config, commit) {
                 dialog_open({
                     Title: _("Encryption options"),
-                    Fields: crypto_options_dialog_fields(old_options),
+                    Fields: crypto_options_dialog_fields(old_options, undefined, undefined, false),
+                    isFormHorizontal: false,
                     Action: {
                         Title: _("Apply"),
                         action: function (vals) {

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -54,23 +54,14 @@ export function extract_option(split, opt) {
     }
 }
 
-export function crypto_options_dialog_fields(options, visible, include_store_passphrase) {
+export function crypto_options_dialog_fields(options, visible, include_store_passphrase, showLabel) {
     var split_options = parse_options(options);
     var opt_auto = !extract_option(split_options, "noauto");
     var opt_ro = extract_option(split_options, "readonly");
     var extra_options = unparse_options(split_options);
 
-    var fields = [
-        { title: _("Unlock at boot"), tag: "auto" },
-        { title: _("Unlock read only"), tag: "ro" },
-        { title: _("Custom encryption options"), tag: "extra", type: "checkboxWithInput" },
-    ];
-
-    if (include_store_passphrase)
-        fields = [{ title: _("Store passphrase"), tag: "store_passphrase" }].concat(fields);
-
-    return [
-        CheckBoxes("crypto_options", "",
+    let fields = [
+        CheckBoxes("crypto_options", showLabel ? _("Encryption options") : "",
                    {
                        visible: visible,
                        value: {
@@ -78,10 +69,26 @@ export function crypto_options_dialog_fields(options, visible, include_store_pas
                            ro: opt_ro,
                            extra: extra_options === "" ? false : extra_options
                        },
-                       fields: fields
+                       fields: [
+                           { title: _("Unlock at boot"), tag: "auto" },
+                           { title: _("Unlock read only"), tag: "ro" },
+                           { title: _("Custom encryption options"), tag: "extra", type: "checkboxWithInput" },
+                       ]
                    },
-        ),
+        )
     ];
+
+    if (include_store_passphrase)
+        fields = [
+            CheckBoxes("store_passphrase", "",
+                       {
+                           visible: visible,
+                           fields: [{ title: _("Store passphrase"), tag: "on" }]
+                       }
+            )
+        ].concat(fields);
+
+    return fields;
 }
 
 export function crypto_options_dialog_options(vals) {
@@ -227,7 +234,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                               },
                               visible: is_encrypted
                           })
-            ].concat(crypto_options_dialog_fields(crypto_options, is_encrypted, true)),
+            ].concat(crypto_options_dialog_fields(crypto_options, is_encrypted, true, true)),
             TextInput("mount_point", _("Mount point"),
                       {
                           visible: is_filesystem,
@@ -282,7 +289,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                         options: { t: 'ay', v: utils.encode_filename(crypto_options_dialog_options(vals)) },
                         "track-parents": { t: 'b', v: true }
                     };
-                    if (vals.crypto_options && vals.crypto_options.store_passphrase) {
+                    if (vals.crypto_options && vals.store_passphrase.on) {
                         item["passphrase-contents"] =
                                   { t: 'ay', v: utils.encode_filename(vals.passphrase) };
                     } else {

--- a/pkg/storaged/iscsi-panel.jsx
+++ b/pkg/storaged/iscsi-panel.jsx
@@ -20,6 +20,9 @@
 import cockpit from "cockpit";
 import React from "react";
 
+import { Button } from "@patternfly/react-core";
+import { CheckIcon, EditIcon, PlusIcon, TrashIcon } from "@patternfly/react-icons";
+
 import { SidePanel, SidePanelRow } from "./side-panel.jsx";
 import { } from "./utils.js";
 import { StorageButton } from "./storage-controls.jsx";
@@ -218,7 +221,7 @@ export class IscsiPanel extends React.Component {
             if (self.state.armed)
                 actions = (
                     <StorageButton kind="danger" onClick={iscsi_remove}>
-                        <span className="pficon pficon-delete" />
+                        <TrashIcon className="ct-TrashIcon" />
                     </StorageButton>
                 );
 
@@ -245,16 +248,16 @@ export class IscsiPanel extends React.Component {
         var actions = (
             <>
                 { sessions.length > 0
-                    ? <button className={"pf-c-button pf-m-secondary toggle-armed" + (this.state.armed ? " active" : "")}
-                  onClick={toggle_armed}><span className="fa fa-check" /></button> : null
+                    ? <Button aria-label={_("Toggle")} variant="secondary" className={"toggle-armed" + (this.state.armed ? " active" : "")}
+                  onClick={toggle_armed}><CheckIcon /></Button> : null
                 }
                 { "\n" }
-                <StorageButton onClick={iscsi_change_name} id="edit-iscsi">
-                    <span className="pficon pficon-edit" />
+                <StorageButton ariaLabel={_("Edit")} onClick={iscsi_change_name} id="edit-iscsi">
+                    <EditIcon />
                 </StorageButton>
                 { "\n" }
-                <StorageButton kind="primary" onClick={iscsi_discover} id="add-iscsi-portal">
-                    <span className="fa fa-plus" />
+                <StorageButton ariaLabel={_("Add")} kind="primary" onClick={iscsi_discover} id="add-iscsi-portal">
+                    <PlusIcon />
                 </StorageButton>
             </>
         );

--- a/pkg/storaged/jobs-panel.jsx
+++ b/pkg/storaged/jobs-panel.jsx
@@ -20,7 +20,11 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { Card, CardBody, CardTitle, Text, TextVariants } from "@patternfly/react-core";
+import {
+    Card, CardBody, CardTitle,
+    DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataList,
+    Text, TextVariants
+} from "@patternfly/react-core";
 
 import { StorageButton } from "./storage-controls.jsx";
 import { block_name, mdraid_name, lvol_name, format_delay } from "./utils.js";
@@ -118,14 +122,26 @@ class JobRow extends React.Component {
         }
 
         return (
-            <tr>
-                <td className="job-description">{make_description(this.props.client, job)}</td>
-                <td>{job.ProgressValid && (job.Progress * 100).toFixed() + "%"}</td>
-                <td>{remaining}</td>
-                <td className="job-action">
-                    { job.Cancelable ? <StorageButton onClick={cancel}>{_("Cancel")}</StorageButton> : null }
-                </td>
-            </tr>
+            <DataListItem>
+                <DataListItemRow>
+                    <DataListItemCells
+                        dataListCells={[
+                            <DataListCell key="desc" className="job-description" isFilled={false}>
+                                {make_description(this.props.client, job)}
+                            </DataListCell>,
+                            <DataListCell key="progress" isFilled={false}>
+                                <td>{job.ProgressValid && (job.Progress * 100).toFixed() + "%"}</td>
+                            </DataListCell>,
+                            <DataListCell key="remaining">
+                                {remaining}
+                            </DataListCell>,
+                            <DataListCell key="job-action" isFilled={false} alignRight>
+                                { job.Cancelable ? <StorageButton onClick={cancel}>{_("Cancel")}</StorageButton> : null }
+                            </DataListCell>,
+                        ]}
+                    />
+                </DataListItemRow>
+            </DataListItem>
         );
     }
 }
@@ -188,11 +204,9 @@ export class JobsPanel extends React.Component {
             <Card className="detail-jobs">
                 <CardTitle><Text component={TextVariants.h2}>{_("Jobs")}</Text></CardTitle>
                 <CardBody className="contains-list">
-                    <table className="table">
-                        <tbody>
-                            { jobs.map((p) => <JobRow key={p} client={client} job={client.jobs[p]} now={server_now} />) }
-                        </tbody>
-                    </table>
+                    <DataList isCompact aria-label={_("Jobs")}>
+                        { jobs.map((p) => <JobRow key={p} client={client} job={client.jobs[p]} now={server_now} />) }
+                    </DataList>
                 </CardBody>
             </Card>
         );

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -27,6 +27,7 @@ import {
     DescriptionListGroup,
     DescriptionListDescription
 } from "@patternfly/react-core";
+import { MinusIcon, PlusIcon } from "@patternfly/react-icons";
 import * as utils from "./utils.js";
 import { StdDetailsLayout } from "./details.jsx";
 import { SidePanel, SidePanelBlockRow } from "./side-panel.jsx";
@@ -138,8 +139,8 @@ class MDRaidSidebar extends React.Component {
             let action = null;
             if (dynamic_members)
                 action = (
-                    <StorageButton onClick={remove} excuse={remove_excuse}>
-                        <span className="fa fa-minus" />
+                    <StorageButton ariaLabel={_("Remove")} onClick={remove} excuse={remove_excuse}>
+                        <MinusIcon />
                     </StorageButton>);
 
             return (
@@ -157,8 +158,8 @@ class MDRaidSidebar extends React.Component {
         let action = null;
         if (dynamic_members)
             action = (
-                <StorageButton onClick={add_disk} excuse={add_excuse}>
-                    <span className="fa fa-plus" />
+                <StorageButton ariaLabel={_("Add")} onClick={add_disk} excuse={add_excuse}>
+                    <PlusIcon />
                 </StorageButton>);
 
         return (

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -20,6 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { PlusIcon } from '@patternfly/react-icons';
 
 import { ListingTable } from "cockpit-components-table.jsx";
 import { StorageButton, StorageUsageBar } from "./storage-controls.jsx";
@@ -62,8 +63,8 @@ export class NFSPanel extends React.Component {
         }
 
         var actions = (
-            <StorageButton kind="primary" onClick={add}>
-                <span className="fa fa-plus" />
+            <StorageButton ariaLabel={_("Add")} kind="primary" onClick={add}>
+                <PlusIcon />
             </StorageButton>
         );
 

--- a/pkg/storaged/side-panel.jsx
+++ b/pkg/storaged/side-panel.jsx
@@ -24,6 +24,7 @@ import { OptionalPanel } from "./optional-panel.jsx";
 import { get_block_link_parts, block_name } from "./utils.js";
 
 import { Button, Spinner, Flex, FlexItem } from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 const _ = cockpit.gettext;
 
@@ -104,9 +105,9 @@ export class SidePanelRow extends React.Component {
                     {this.props.actions}
                 </div>);
         else if (client.path_jobs[job_path])
-            decoration = <Spinner size="sm" />;
+            decoration = <Spinner size="md" />;
         else if (client.path_warnings[job_path])
-            decoration = <div className="pficon pficon-warning-triangle-o" />;
+            decoration = <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="md" />;
 
         return (
             <FlexItem data-testkey={this.props.testkey}

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -17,12 +17,13 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React from "react";
+import React, { useState } from 'react';
+
 import {
-    Button,
+    Button, Dropdown, DropdownItem, DropdownToggle,
+    Tooltip, TooltipPosition,
     Progress, ProgressMeasureLocation, ProgressVariant,
     Switch,
-    Tooltip, TooltipPosition,
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
 
@@ -94,14 +95,15 @@ function checked(callback) {
     };
 }
 
-export const StorageButton = ({ id, kind, excuse, onClick, children }) => (
+export const StorageButton = ({ id, kind, excuse, onClick, children, ariaLabel }) => (
     <StorageControl excuse={excuse}
                     content={excuse => (
                         <Button id={id}
-                                    onClick={checked(onClick)}
-                                    variant={kind || "secondary"}
-                                    isDisabled={!!excuse}
-                                    style={excuse ? { pointerEvents: 'none' } : null}>
+                                aria-label={ariaLabel}
+                                onClick={checked(onClick)}
+                                variant={kind || "secondary"}
+                                isDisabled={!!excuse}
+                                style={excuse ? { pointerEvents: 'none' } : null}>
                             {children}
                         </Button>
                     )} />
@@ -208,21 +210,26 @@ export const StorageUsageBar = ({ stats, critical }) => {
 };
 
 export const StorageMenuItem = ({ onClick, children }) => (
-    <li><a role="link" tabIndex="0" onKeyPress={checked(onClick)} onClick={checked(onClick)}>{children}</a></li>
+    <DropdownItem onKeyPress={checked(onClick)} onClick={checked(onClick)}>{children}</DropdownItem>
 );
 
-export const StorageBarMenu = ({ label, children }) => {
-    const toggle = excuse => (
-        <Button variant="primary" isDisabled={!!excuse} data-toggle="dropdown" aria-label={label}>
-            <BarsIcon />
-        </Button>
-    );
+export const StorageBarMenu = ({ label, menuItems }) => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    if (!client.superuser.allowed)
+        return null;
 
     return (
-        <div className="dropdown btn-group">
-            <StorageControl content={toggle} excuse_placement="bottom" />
-            <ul className="dropdown-menu dropdown-menu-right" role="menu">
-                {children}
-            </ul>
-        </div>);
+        <Dropdown onSelect={() => setIsOpen(!isOpen)}
+                  toggle={
+                      <DropdownToggle className="pf-m-primary" toggleIndicator={null}
+                                      onToggle={setIsOpen} aria-label={label}>
+                          <BarsIcon color="white" />
+                      </DropdownToggle>
+                  }
+                  isOpen={isOpen}
+                  isPlain
+                  position="right"
+                  dropdownItems={menuItems} />
+    );
 };

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -248,10 +248,6 @@ td.storage-icon {
     width: 48px;
 }
 
-td.storage-icon .spinner {
-    margin-top: 5px;
-}
-
 span.rate-gap {
     display: inline-block;
     width: 1em;
@@ -298,6 +294,10 @@ td.job-action {
     text-align: left;
 }
 
+.content-nav-item-warning:first-child {
+    padding-right: var(--pf-global--spacer--sm);
+}
+
 .content-item {
     width: 100%;
 }
@@ -306,22 +306,8 @@ td.job-action {
     width: 100%;
 }
 
-td.content-name {
-    text-align: left;
-}
-
-td.content-action {
+.content-action {
     text-align: right;
-}
-
-td.content-action > div {
-    display: inline-block;
-    margin-right: 5px;
-    vertical-align: middle;
-}
-
-td.content-action .spinner {
-    visibility: hidden;
 }
 
 table.mdraid-item {
@@ -366,25 +352,21 @@ td.vgroup-action {
 
 .dialog-item-tooltip {
     margin-left: 5px;
+    padding: 0;
     white-space: nowrap;
 }
 
-.dialog-checkbox-text {
-    width: 100%;
+.ct-storage-checkbox {
+    > .pf-c-check {
+        width: 100%;
+    }
     display: flex;
     flex-direction: row;
-}
-
-.dialog-checkbox-text :nth-child(2) {
-    flex: 1;
-    margin-left: 0.5em;
-}
-
-.form-control[hidden] {
-    display: none;
+    column-gap: var(--pf-global--spacer--sm);
 }
 
 .modal-footer-teardown {
+    padding-bottom: var(--pf-global--spacer--md);
     text-align: left;
 }
 
@@ -488,11 +470,6 @@ td.storage-action {
     word-break: break-all;
 }
 
-.panel-heading .spinner-inline {
-    vertical-align: middle;
-    margin-left: 0.5ex;
-}
-
 .just-installed {
     margin-right: 1em;
 }
@@ -520,19 +497,6 @@ td.storage-action {
     margin-right: 1em;
 }
 
-.shrink {
-    width: 1%;
-    white-space: nowrap;
-}
-
-.key-slot-panel .key-type {
-    padding-right: 1em;
-}
-
-.key-slot-panel .key-slot {
-    padding-right: 2em;
-}
-
 .sigkey-hash {
     font-family: monospace;
     font-size: 200%;
@@ -546,10 +510,6 @@ td.storage-action {
 .pf-c-modal-box h3 {
     margin-top: 0;
     line-height: 24px;
-}
-
-.pficon.large {
-    font-size: 200%;
 }
 
 .progressive-disclosure .form-group {
@@ -606,20 +566,6 @@ td.storage-action {
     width: 5em !important;
 }
 
-.select-space-row {
-    display: flex;
-    align-items: center;
-}
-
-.select-space-row :nth-child(1) {
-    margin-top: 0px;
-}
-
-.select-space-row :nth-child(2) {
-    flex-grow: 1;
-    margin-left: 10px;
-}
-
 .ct-form-box {
     margin-bottom: 1em;
 }
@@ -647,14 +593,22 @@ td.storage-action {
     font-size: var(--pf-global--FontSize--xs);
 }
 
-.sidepanel-row .spinner {
-    display: inline-block;
-}
-
 .panel-heading {
     position: static;
 }
 
 .storage_alert_action_buttons button {
     margin: 0.5rem 0.2rem 0.2rem 0;
+}
+
+// We wrap the data list row with a label to make checkboxes clickable from the whole row
+// we need this HACK in order to make alignRight property take effect
+.data-list-row-checkbox-label {
+    display: flex;
+    flex-wrap: wrap;
+    flex-grow: 1;
+}
+
+.crypto-keyslots-list {
+    border: none;
 }

--- a/pkg/storaged/things-panel.jsx
+++ b/pkg/storaged/things-panel.jsx
@@ -55,7 +55,7 @@ export class ThingsPanel extends React.Component {
                 }
             }
 
-            return <StorageMenuItem onClick={install_then_action}>{title}</StorageMenuItem>;
+            return <StorageMenuItem key={title} onClick={install_then_action}>{title}</StorageMenuItem>;
         }
 
         const lvm2_feature = {
@@ -63,11 +63,11 @@ export class ThingsPanel extends React.Component {
         };
 
         const actions = (
-            <StorageBarMenu id="devices-menu" label={_("Create devices")}>
-                { menu_item(null, _("Create RAID device"), () => create_mdraid(client)) }
-                { menu_item(lvm2_feature, _("Create volume group"), () => create_vgroup(client)) }
-                { menu_item(vdo_feature(client), _("Create VDO device"), () => create_vdo(client)) }
-            </StorageBarMenu>);
+            <StorageBarMenu id="devices-menu" label={_("Create devices")} menuItems={[
+                menu_item(null, _("Create RAID device"), () => create_mdraid(client)),
+                menu_item(lvm2_feature, _("Create volume group"), () => create_vgroup(client)),
+                menu_item(vdo_feature(client), _("Create VDO device"), () => create_vdo(client))].filter(item => item !== null)} />
+        );
 
         var devices = [].concat(
             mdraid_rows(client),

--- a/pkg/storaged/vgroup-details.jsx
+++ b/pkg/storaged/vgroup-details.jsx
@@ -27,6 +27,7 @@ import {
     DescriptionListGroup,
     DescriptionListDescription
 } from "@patternfly/react-core";
+import { PlusIcon, MinusIcon } from "@patternfly/react-icons";
 
 import * as utils from "./utils.js";
 import { fmt_to_fragments } from "./utilsx.jsx";
@@ -117,15 +118,15 @@ class VGroupSidebar extends React.Component {
                                     detail={cockpit.format(_("$0, $1 free"),
                                                            utils.fmt_size(pvol.Size),
                                                            utils.fmt_size(pvol.FreeSize))}
-                                    actions={<StorageButton onClick={remove_action} excuse={remove_excuse}>
-                                        <span className="fa fa-minus" />
+                                    actions={<StorageButton aria-label={_("Remove")} onClick={remove_action} excuse={remove_excuse}>
+                                        <MinusIcon />
                                     </StorageButton>}
                                     key={pvol.path} />);
         }
 
         return (
             <SidePanel title={_("Physical volumes")}
-                       actions={<StorageButton onClick={add_disk}><span className="fa fa-plus" /></StorageButton>}>
+                       actions={<StorageButton aria-label={_("Add")} onClick={add_disk}><PlusIcon /></StorageButton>}>
                 { pvols.map(render_pvol) }
             </SidePanel>
         );

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -170,7 +170,7 @@ class TestKdump(MachineCase):
         b.click(crashButton)
 
         # wait until we've actuall triggered a crash
-        b.wait_visible("div.spinner")
+        b.wait_visible(".dialog-wait-ct")
 
         # wait for disconnect and then try connecting again
         b.switch_to_top()

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -32,11 +32,11 @@ class TestStorageBasic(StorageCase):
         self.login_and_go("/storage", superuser=False)
 
         b.wait_visible("#devices")
-        b.wait_not_present("#devices [data-toggle=dropdown]")
+        b.wait_not_present("#devices .pf-c-dropdown button")
 
         b.relogin('/storage', superuser=True)
 
-        self.browser.wait_visible("#devices [data-toggle=dropdown]")
+        b.wait_visible("#devices .pf-c-dropdown button:not([disabled])")
 
         # Add a disk, partition it, format it, and finally remove it.
         disk = self.add_ram_disk()

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -120,6 +120,7 @@ class TestStorageFormat(StorageCase):
         self.dialog_set_val("mount_point", "/foo")
         self.dialog_apply()
         b.wait_in_text("footer", "Erasing /dev/mapper/superslow")
+        sit()
         self.dialog_cancel()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Unrecognized data")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -58,7 +58,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("name", "ENCRYPTED")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
-        self.dialog_set_val("crypto_options.store_passphrase", True)
+        self.dialog_set_val("store_passphrase.on", True)
         self.dialog_set_val("crypto_options.extra", "crypto,options")
         self.dialog_set_val("mount_point", mount_point_secret)
         self.dialog_set_val("mount_options.auto", False)
@@ -182,11 +182,11 @@ class TestStorageLuks(StorageCase):
         tab = self.content_tab_expand(1, 1)
         panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_visible(panel)
-        b.wait_in_text(panel + ".table tr:nth-child(1)", "Passphrase")
+        b.wait_in_text(panel + "ul li:nth-child(1)", "Passphrase")
 
         # Add a key
         #
-        b.click(panel + ".fa-plus")
+        b.click(panel + "[aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("type", "tang")
@@ -197,8 +197,8 @@ class TestStorageLuks(StorageCase):
         b.wait_in_text("#dialog", m.execute("jose jwk thp -i /var/db/tang/sig1.jwk").strip())
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_visible(panel + ".table tr:nth-child(2)")
-        b.wait_in_text(panel + ".table tr:nth-child(2)", "127.0.0.1")
+        b.wait_visible(panel + "ul li:nth-child(2)")
+        b.wait_in_text(panel + "ul li:nth-child(2)", "127.0.0.1")
 
         # Unlock it.  This should succeed without prompting.
         #
@@ -207,7 +207,7 @@ class TestStorageLuks(StorageCase):
 
         # Edit the key, without providing an existing passphrase
         #
-        b.click(panel + ".table tr:nth-child(2) .pficon-edit")
+        b.click(panel + "ul li:nth-child(2) [aria-label=Edit]")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
         self.dialog_wait_val("tang_url", "127.0.0.1")
@@ -217,13 +217,13 @@ class TestStorageLuks(StorageCase):
         b.wait_in_text("#dialog", m.execute("jose jwk thp -i /var/db/tang/sig1.jwk").strip())
         self.dialog_apply()
         self.dialog_wait_close()
-        b.wait_in_text(panel + ".table tr:nth-child(2)", "http://127.0.0.1/")
+        b.wait_in_text(panel + "ul li:nth-child(2)", "http://127.0.0.1/")
 
         # Remove key on client
         #
-        b.click(panel + ".table tr:nth-child(2) .fa-minus")
+        b.click(panel + "ul li:nth-child(2) button[aria-label=Remove]")
         self.confirm()
-        b.wait_not_present(panel + ".table tr:nth-child(2)")
+        b.wait_not_present(panel + "ul li:nth-child(2)")
 
     @skipImage("No clevis/tang", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")
     def testSlots(self):
@@ -258,7 +258,7 @@ class TestStorageLuks(StorageCase):
         tab = self.content_tab_expand(1, 1)
         panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_visible(panel)
-        b.click(panel + ".fa-plus")
+        b.click(panel + "[aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("type", "luks-passphrase")
@@ -280,7 +280,7 @@ class TestStorageLuks(StorageCase):
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
         self.content_row_wait_in_col(2, 1, "ext4 file system")
         # delete second key slot by providing passphrase
-        b.click(panel + "tr:nth-child(2) .fa-minus")
+        b.click(panel + "li:nth-child(2) button[aria-label=Remove]")
         self.dialog_wait_open()
         b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-1")
         self.dialog_apply()
@@ -298,7 +298,7 @@ class TestStorageLuks(StorageCase):
 
         # add more passphrases, seven exactly, to reach the limit of eight for LUKSv1
         for i in range(1, 8):
-            b.click(panel + ".fa-plus")
+            b.click(panel + "button[aria-label=Add]")
             self.dialog_wait_open()
             self.dialog_wait_apply_enabled()
             self.dialog_set_val("type", "luks-passphrase")
@@ -312,21 +312,21 @@ class TestStorageLuks(StorageCase):
             # check if add button is inactive
             b.wait_visible(panel + ".pf-c-card__header button:disabled")
             # check if edit button is inactive
-            slots_table = tab + " .pf-c-card table tr:first-child"
-            b.wait_visible(slots_table + " button:disabled")
+            slots_row = tab + " .pf-c-card ul li:first-child"
+            b.wait_visible(slots_row + " button:disabled")
 
         # remove one slot
-        slots_table = tab + " .pf-c-card table "
-        b.wait_visible(slots_table + "tbody tr:last-child .fa-minus")
-        b.click(slots_table + "tbody tr:last-child .fa-minus")
+        slots_list = tab + " .pf-c-card ul "
+        b.wait_visible(slots_list + "li:last-child button[aria-label=Remove]")
+        b.click(slots_list + "li:last-child button[aria-label=Remove]")
         b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-7")
         self.dialog_apply()
         self.dialog_wait_close()
         # check if buttons have become enabled after removing last slot
-        b.wait_not_present(slots_table + ":disabled")
+        b.wait_not_present(slots_list + ":disabled")
         b.wait_not_present(panel + ":disabled")
         # remove slot 0, with the original passphrase
-        b.click(slots_table + "tbody tr:nth-child(1) .fa-minus")
+        b.click(slots_list + "li:nth-child(1) button[aria-label=Remove]")
         b.click(self.dialog_field("passphrase") + " label:contains(Force remove passphrase in key slot 0)")
         self.dialog_apply()
         self.dialog_wait_close()
@@ -339,8 +339,8 @@ class TestStorageLuks(StorageCase):
         self.assertIn(b.text("h4.pf-c-alert__title:not(span)").split("Danger alert:", 1).pop(), error_messages)
         self.dialog_cancel()
         # change one of the passphrases
-        b.wait_visible(slots_table + "tbody tr:last-child .pficon-edit")
-        b.click(slots_table + "tbody tr:last-child .pficon-edit")
+        b.wait_visible(slots_list + "li:last-child [aria-label=Edit]")
+        b.click(slots_list + "li:last-child [aria-label=Edit]")
         self.dialog_wait_open()
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("old_passphrase", "vainu-reku-toma-rolle-kaja-6")

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -39,7 +39,7 @@ class TestStorageNfs(StorageCase):
         b.wait_visible("#nfs-mounts .pf-c-empty-state")
 
         # Add /home/foo
-        b.click("#nfs-mounts button .fa-plus")
+        b.click("#nfs-mounts button[aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/foo")
@@ -56,7 +56,7 @@ class TestStorageNfs(StorageCase):
                          "127.0.0.1:/home/foo /mnt nfs defaults")
 
         # Add /home/bar
-        b.click("#nfs-mounts button .fa-plus")
+        b.click("#nfs-mounts button[aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/bar")
@@ -157,7 +157,7 @@ class TestStorageNfs(StorageCase):
         m.write("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n")
         m.execute("systemctl restart nfs-server")
 
-        b.click("#nfs-mounts .fa-plus")
+        b.click("#nfs-mounts [aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
 
@@ -184,7 +184,7 @@ class TestStorageNfs(StorageCase):
         b.wait_visible("#nfs-mounts .pf-c-empty-state")
 
         # Add /home/foo
-        b.click("#nfs-mounts .fa-plus")
+        b.click("#nfs-mounts [aria-label=Add]")
         self.dialog_wait_open()
         self.dialog_set_val("server", "127.0.0.1")
         self.dialog_set_val("remote", "/home/foo")
@@ -276,7 +276,7 @@ class TestStoragePackagesNFS(PackageCase, StorageHelpers):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        b.wait_visible("#nfs-mounts button .fa-plus")
+        b.wait_visible("#nfs-mounts button[aria-label=Add]")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -61,7 +61,8 @@ mkpart logical ext2 24 48"""
         # are offered as free block devices.
 
         def check_free_block_devices():
-            blocks = b.eval_js("ph_texts('#dialog [data-field=\"disks\"] .select-space-row')")
+            blocks = b.eval_js("ph_texts('#dialog [data-field=\"disks\"] .select-space-details')")
+            print("blocks", blocks)
             # On Ubuntu we see /dev/ram devices as well
             # On Fedora 33 also /dev/zram0 - see https://github.com/cockpit-project/cockpit/issues/14516
             blocks = [block for block in blocks if "/dev/ram" not in block and "/dev/zram" not in block]

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -36,8 +36,8 @@ class TestStorageVDO(StorageCase):
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices [data-toggle=dropdown]")
-            b.wait_not_present("#devices .dropdown a:contains('VDO')")
+            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
+            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")
@@ -126,8 +126,8 @@ class TestStorageVDO(StorageCase):
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices [data-toggle=dropdown]")
-            b.wait_not_present("#devices .dropdown a:contains('VDO')")
+            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
+            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")
@@ -183,8 +183,8 @@ config: !Configuration
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices [data-toggle=dropdown]")
-            b.wait_not_present("#devices .dropdown a:contains('VDO')")
+            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
+            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -83,8 +83,8 @@ class StorageHelpers:
         self.machine.execute('echo 1 > /sys/block/%s/device/delete' % os.path.basename(device))
 
     def devices_dropdown(self, title):
-        self.browser.click("#devices .dropdown [data-toggle=dropdown]")
-        self.browser.click("#devices .dropdown a:contains('%s')" % title)
+        self.browser.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
+        self.browser.click("#devices .pf-c-dropdown a:contains('%s')" % title)
 
     # Content
 
@@ -118,8 +118,8 @@ class StorageHelpers:
 
     def content_dropdown_action(self, index, title):
         self.content_row_expand(index)
-        dropdown = self.content_row_tbody(index) + " .ct-listing-panel-actions .dropdown"
-        self.browser.click(dropdown + " [data-toggle=dropdown]")
+        dropdown = self.content_row_tbody(index) + " .ct-listing-panel-actions .pf-c-dropdown"
+        self.browser.click(dropdown + " button.pf-c-dropdown__toggle")
         self.browser.click(dropdown + " a:contains('%s')" % title)
 
     def content_tab_expand(self, row_index, tab_index):
@@ -234,7 +234,7 @@ class StorageHelpers:
             if self.browser.is_present(sel + " input[type=checkbox]:not(:checked)"):
                 return False
             else:
-                return self.browser.val(sel + "+ input[type=text]")
+                return self.browser.val(sel + " input[type=text]")
         elif ftype == "select":
             return self.browser.attr(sel, "data-value")
         else:
@@ -262,7 +262,7 @@ class StorageHelpers:
                 self.browser.set_checked(sel + " input[type=checkbox]", False)
             else:
                 self.browser.set_checked(sel + " input[type=checkbox]", True)
-                self.browser.set_input_text(sel + "+ input[type=text]", val)
+                self.browser.set_input_text(sel + " [type=text]", val)
         elif ftype == "combobox":
             self.browser.click(sel + " button.pf-c-select__toggle-button")
             self.browser.click(sel + " .pf-c-select__menu li:contains('{0}') button".format(val))
@@ -294,7 +294,7 @@ class StorageHelpers:
 
     def dialog_wait_error(self, field, val):
         # XXX - allow for more than one error
-        self.browser.wait_in_text('#dialog .dialog-error', val)
+        self.browser.wait_in_text('#dialog .pf-c-form__helper-text.pf-m-error', val)
 
     def dialog_wait_not_visible(self, field):
         self.browser.wait_not_visible(self.dialog_field(field))


### PR DESCRIPTION
This commit:
* replaces icons with components from react-icons, also makes sure these
  are accessible
* replaces custom lists with DataLists component
* replaces all dialog fields like TextInputs, Checkboxes, Radio buttons with PF4
  components
* replaces custom dropdowns with Dropdown component

Todo:

- [x] The journal has lost the markup for repated entries, https://github.com/cockpit-project/cockpit/pull/15261#issuecomment-783273679
- [x] Spinner and progress text are too close together in dialogs, https://github.com/cockpit-project/cockpit/pull/15261#issuecomment-783277169
- [x] "Encryption options" dialog repeats itself, https://github.com/cockpit-project/cockpit/pull/15261#issuecomment-783286187