### PR TITLE
machines: use toast notifications in the VM's details page

### DIFF
--- a/pkg/machines/app.jsx
+++ b/pkg/machines/app.jsx
@@ -18,7 +18,7 @@
  */
 import React from 'react';
 import PropTypes from 'prop-types';
-import { AlertGroup, Alert, Button, AlertActionCloseButton } from '@patternfly/react-core';
+import { AlertGroup, Button } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { superuser } from "superuser.js";
 import cockpit from 'cockpit';
@@ -165,10 +165,12 @@ class App extends React.Component {
                                 .filter(notification => notification.resourceId == vm.id)
                                 .map(notification => {
                                     return (
-                                        <Alert variant='danger' key={notification.index}
-                                               isInline
-                                               actionClose={<AlertActionCloseButton onClose={() => this.onDismissErrorNotification(notification.index)} />}
-                                               title={notification.text}>{notification.detail}</Alert>
+                                        <InlineNotification type='danger' key={notification.index}
+                                               isLiveRegion
+                                               isInline={false}
+                                               onDismiss={() => this.onDismissErrorNotification(notification.index)}
+                                               text={notification.text}
+                                               detail={notification.detail} />
                                     );
                                 })
                         : undefined}

--- a/pkg/machines/components/vm/vmDetailsPage.jsx
+++ b/pkg/machines/components/vm/vmDetailsPage.jsx
@@ -69,7 +69,7 @@ export const VmDetailsPage = ({
                            onAddErrorNotification={onAddErrorNotification}
                            isDetailsPage />
             </div>
-            {notifications && <AlertGroup className="vm-notifications">{notifications}</AlertGroup>}
+            {notifications && <AlertGroup isToast>{notifications}</AlertGroup>}
         </PageSection>
     );
 

--- a/pkg/machines/components/vm/vmDetailsPage.scss
+++ b/pkg/machines/components/vm/vmDetailsPage.scss
@@ -27,10 +27,6 @@
   }
 }
 
-.vm-notifications {
-    margin-top: 2rem;
-}
-
 .pf-l-gallery.ct-vm-overview {
   $ctVmBreakpoint: 1000px;
 


### PR DESCRIPTION
The VM details page can get quite long, and notifications were stored
before this commit on the top of the page. When the problematic operation was
initiated from somewhere in the bottom of the page, the notifications
panel was not visibile for usual screen sizes. Let's make the notifications
sticky as we do in the main page.

Previously:
![Screen Shot 2021-02-02 at 10 12 19](https://user-images.githubusercontent.com/14921356/106578106-78dc9880-653f-11eb-988e-7ef01c72b040.png)


Now:
![Screen Shot 2021-02-02 at 10 11 30](https://user-images.githubusercontent.com/14921356/106578129-7d08b600-653f-11eb-875b-e2e05da86731.png)
