### PR TITLE
lib: workaround missing dataLabel property in <Th> PF4 component

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -333,7 +333,8 @@ const ComposableTableBasic = ({
 
                                     if (cells[cellIndex].header)
                                         return (
-                                            <Th key={key || `row_${rowKey}_cell_${dataLabel}`} dataLabel={dataLabel} {...cellProps}>
+                                            /* FIXME: https://github.com/patternfly/patternfly-react/pull/5406 */
+                                            <Th key={key || `row_${rowKey}_cell_${dataLabel}`} data-label={dataLabel} {...cellProps}>
                                                 {typeof cell == 'object' ? cell.title : cell}
                                             </Th>
                                         );


### PR DESCRIPTION
When we use `<Th>` as cell elements, the dataLabel property is not applied
correctly and we got a warning in the console. In addition in the mobile
mode the missing `data-label` was causing the cell labels to not exist.

Use the original `data-label` property to fix the visual regression until it's fixed upstream by:
https://github.com/patternfly/patternfly-react/pull/5406