### PR TITLE
networkmanager: show an empty state if NM is not installed

### DIFF
--- a/pkg/networkmanager/app.jsx
+++ b/pkg/networkmanager/app.jsx
@@ -59,7 +59,7 @@ const App = () => {
     const plot_state_main = useObject(() => new PlotState(), null, []);
     const plot_state_iface = useObject(() => new PlotState(), null, []);
 
-    if (!model.ready || nmRunning_ref.current === undefined)
+    if (model.ready === undefined)
         return <EmptyStatePanel loading />;
 
     /* Show EmptyStatePanel when nm is not running */
@@ -78,6 +78,14 @@ const App = () => {
                                              {_("Troubleshoot…")}
                                          </Button>
                                      } />
+                </div>
+            );
+        } else if (!nmService.exists) {
+            return (
+                <div id="networking-nm-not-found">
+                    <EmptyStatePanel icon={ ExclamationCircleIcon }
+                                     title={ _("NetworkManager is not installed") } />
+
                 </div>
             );
         } else {

--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -205,6 +205,7 @@ export function NetworkManagerModel() {
     var objects = { };
 
     function complain() {
+        self.ready = false;
         console.warn.apply(console, arguments);
     }
 
@@ -1284,7 +1285,7 @@ export function NetworkManagerModel() {
     get_object("/org/freedesktop/NetworkManager", type_Manager);
     get_object("/org/freedesktop/NetworkManager/Settings", type_Settings);
 
-    self.ready = false;
+    self.ready = undefined;
     return self;
 }
 

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -128,6 +128,12 @@ class TestNetworkingBasic(NetworkCase):
                 b.wait_not_present("#networking-nm-crashed")
                 b.wait_visible("#networking-nm-disabled")
 
+        def assert_not_found():
+            # should hide graphs and actions and show the appropriate notification
+            b.wait_not_present("#networking-graphs")
+            b.wait_not_present("#networking-interfaces")
+            b.wait_visible("#networking-nm-not-found")
+
         self.login_and_go("/network")
         assert_running()
 
@@ -164,6 +170,14 @@ class TestNetworkingBasic(NetworkCase):
         b.click("#networking-nm-disabled button")
         assert_running()
         wait(lambda: m.execute("systemctl is-enabled NetworkManager"))
+
+        # /usr in coreos is readonly
+        if m.image not in ["fedora-coreos"]:
+        # remove the NM service file, test 'no-found' notification
+            # This works for ND tests since there is a self.addCleanup(m.execute, "systemctl enable --now NetworkManager") in the start of the test
+            self.restore_file('/usr/lib/systemd/system/NetworkManager.service')
+            m.execute("rm /usr/lib/systemd/system/NetworkManager.service && systemctl daemon-reload && systemctl stop NetworkManager")
+            assert_not_found()
 
         self.allow_journal_messages(".*org.freedesktop.NetworkManager.*")
 


### PR DESCRIPTION
Previously the page was stuck with a spinner.

Fixes #15245