### PR TITLE
Add a global CSS rule for extending pages height and avoid double scrollbar

### DIFF
--- a/pkg/apps/application.css
+++ b/pkg/apps/application.css
@@ -3,11 +3,6 @@
 @import "../lib/table.css";
 @import "../lib/cockpit-components-table.scss";
 
-.page-ct {
-    /* Remove margin above the header */
-    margin: 0;
-}
-
 .app-list-empty {
     color: var(--color-subtle-copy);
     text-align: center;

--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -30,11 +30,11 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   </head>
   <body class="pf-m-redhat-font" hidden>
 
-    <div id="list-page">
+    <div class="ct-page-fill" id="list-page">
       <div id="list"></div>
     </div>
 
-    <div id="app-page">
+    <div class="ct-page-fill" id="app-page">
       <div id="app"></div>
     </div>
 

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -32,6 +32,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div class="ct-page-fill" id="app"></div>
 </body>
 </html>

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -23,7 +23,7 @@ import React from "react";
 import {
     Button, Tooltip, TooltipPosition,
     Page, PageSection, PageSectionVariants,
-    Bullseye,
+    Flex,
     DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
     Switch, FormSelect, FormSelectOption,
 } from "@patternfly/react-core";
@@ -496,7 +496,7 @@ export class KdumpPage extends React.Component {
         return (
             <Page>
                 <PageSection variant={PageSectionVariants.light}>
-                    <Bullseye>
+                    <Flex justifyContent={{ default: "justifyContentCenter" }}>
                         <DescriptionList>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{_("kdump status")}</DescriptionListTerm>
@@ -538,7 +538,7 @@ export class KdumpPage extends React.Component {
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>
-                    </Bullseye>
+                    </Flex>
                 </PageSection>
             </Page>
         );

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -108,12 +108,6 @@ a.disabled:hover {
     padding-top: 4px;
 }
 
-/* HACK: Workaround for https://github.com/patternfly/patternfly/issues/174*/
-
-.page-ct {
-    margin-top: 20px;
-}
-
 .highlight-ct {
     background-color: var(--color-link-hover-bg);
 }
@@ -548,4 +542,14 @@ input[type=number]:not(.pf-c-form-control) {
     font-size: .875rem;
     line-height: 1.5;
     border-radius: .2rem;
+}
+
+// Let PF4 handle the scrolling through page component otherwise we might get double scrollbar
+html:not(.index-page) body {
+  overflow-y: hidden;
+
+  // Ensure UI fills the entire page (and does not run over)
+  .ct-page-fill {
+    height: 100% !important;
+  }
 }

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -431,7 +431,6 @@ small {
 
 // Bump content away from cards
 .content,
-.page-ct,
 .container {
   --container-padding-x: var(--pf-global--spacer--md);
   --container-padding-y: var(--pf-global--spacer--lg);
@@ -446,7 +445,6 @@ small {
 @media screen and (min-width: 768px) {
   // Add PF4 padding to desktop mode
   .content,
-  .page-ct,
   .container {
     --container-padding-x: var(--pf-global--spacer--lg);
     --container-padding-y: var(--pf-global--spacer--xl);
@@ -457,12 +455,6 @@ small {
     }
   }
 
-  // Rely on page-ct padding; don't duplicate
-  .page-ct .container,
-  .page-ct {
-    padding: 0;
-  }
-
   // Remove excess padding from dialogs
   .modal-dialog .content {
     padding: 0;
@@ -471,7 +463,6 @@ small {
 
 // Bump content away from cards
 .content,
-.page-ct,
 .container {
   .cards-pf + & {
     padding-top: 1rem;

--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -60,8 +60,6 @@
 @media screen and (max-width: 640px) {
     /* Remove _most_ of the gaps on the sides of small screens */
     /* to maximize space, but still keep the boxy panel look */
-    /* (page-ct adds 20px, so we remove 1/2 of that) */
-    .page-ct > .panel,
     .col-md-12 > .panel {
         margin-left: -10px;
         margin-right: -10px;

--- a/pkg/machines/index.html
+++ b/pkg/machines/index.html
@@ -12,7 +12,9 @@
   <script type="text/javascript" src="machines.js"></script>
 </head>
 
-<body class="pf-m-redhat-font" id="app">
+<body class="pf-m-redhat-font">
+    <div class="ct-page-fill" id="app">
+    </div>
 </body>
 </html>
 

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -31,6 +31,6 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div class="ct-page-fill" id="app"></div>
 </body>
 </html>

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -2,8 +2,6 @@
 @import "@patternfly/patternfly/components/Table/table.scss";
 
 #app {
-    height: 100%;
-
     section.pf-c-page__main-breadcrumb {
         padding-bottom: var(--pf-c-page__main-breadcrumb--PaddingTop);
      }

--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -30,6 +30,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   </head>
 
   <body class="pf-m-redhat-font">
-      <div id="firewall"></div>
+      <div class="ct-page-fill" id="firewall"></div>
   </body>
 </html>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -31,13 +31,13 @@
 </head>
 <body class="pf-m-redhat-font">
 
+  <div id="network-page" class="ct-page-fill network-page">
+  </div>
+
   <div id="testing-connection-curtain" class="curtains-ct blank-slate-pf" hidden>
     <h1><div class="spinner spinner-lg"></div></h1>
     <h1 id="testing-connection-curtain-testing" translate="yes">Testing connection</h1>
     <h1 id="testing-connection-curtain-restoring" translate="yes">Restoring connection</h1>
-  </div>
-
-  <div id="network-page" class="network-page">
   </div>
 
   <script id="network-vlan-settings-template" type="x-template/mustache">

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -19,7 +19,6 @@
 @import "../lib/ct-card.scss";
 
 #network-page {
-    height: 100%;
     .pf-c-card {
         @extend .ct-card;
     }

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -30,7 +30,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <script src="../*/po.js"></script>
 </head>
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div class="ct-page-fill" id="app"></div>
 </body>
 
 </html>

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -1,10 +1,6 @@
 @import "../lib/page.scss";
 @import "../lib/ct-card.scss";
 
-#app {
-    height: 100%;
-}
-
 /* Style the list cards as ct-cards */
 .pf-c-page__main-section .pf-c-card {
     @extend .ct-card;

--- a/pkg/selinux/setroubleshoot.html
+++ b/pkg/selinux/setroubleshoot.html
@@ -32,6 +32,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-    <div id="app"></div>
+    <div class="ct-page-fill" id="app"></div>
 </body>
 </html>

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -32,11 +32,6 @@
 
 /* Hacks on top for now */
 
-html, body {
-    height: 100%;
-    width: 100%;
-}
-
 html.index-page body {
     overflow: hidden;
 }

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -27,12 +27,21 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <script type="text/javascript" src="sosreport.js"></script>
   </head>
   <body class="pf-m-redhat-font" hidden>
-    <div class="page-ct">
-      <img src="sosreport.png" alt="">
-      <p translate="yes">This tool will collect system configuration and diagnostic information from this system for use with diagnosing problems with the system.</p>
-      <p translate="yes">The collected information will be stored locally on the system.</p>
-      <p id="switch-instructions" translate="yes">You need to switch to "Administrative access" in order to create reports.</p>
-      <button id="create-button" translate="yes" class="pf-c-button pf-m-primary">Create report</button>
+    <div class="pf-c-page">
+      <main class="pf-c-page__main" tabindex="-1">
+        <section class="pf-c-page__main-section pf-m-light">
+          <div class="pf-c-empty-state">
+            <div class="pf-c-empty-state__content">
+              <img class="pf-c-empty-state__icon" aria-hidden="true" src="sosreport.png" alt="">
+              <div class="pf-c-empty-state__body">
+                <p translate="yes">This tool will collect system configuration and diagnostic information from this system for use with diagnosing problems with the system.</p>
+                <p translate="yes">The collected information will be stored locally on the system.</p>
+                <p id="switch-instructions" translate="yes">You need to switch to "Administrative access" in order to create reports.</p>
+            </div>
+            <button id="create-button" translate="yes" class="pf-c-button pf-m-primary">Create report</button>
+          </div>
+        </section>
+      </main>
     </div>
 
     <div hidden aria-hidden="true" id="sos">

--- a/pkg/sosreport/sosreport.scss
+++ b/pkg/sosreport/sosreport.scss
@@ -2,6 +2,8 @@
 @import "../lib/table.css";
 @import "@patternfly/patternfly/components/Alert/alert.scss";
 @import "@patternfly/patternfly/components/Button/button.scss";
+@import "@patternfly/patternfly/components/Page/page.scss";
+@import "@patternfly/patternfly/components/EmptyState/empty-state.scss";
 
 /* The following are needed for the Modal */
 @import "@patternfly/patternfly/components/Backdrop/backdrop.scss";
@@ -13,10 +15,6 @@
     max-width:  100%;
     min-width:  100%;
     min-height: 200px;
-}
-
-.page-ct {
-    text-align: center;
 }
 
 #sos-progress > div:first-child,

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -29,5 +29,8 @@
     <script src="../*/po.js"></script>
     <script src="storage.js"></script>
 </head>
-<body class="pf-m-redhat-font" id="storage" hidden></body>
+<body class="pf-m-redhat-font">
+    <div class="ct-page-fill" id="storage">
+    </div>
+</body>
 </html>

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -8,7 +8,7 @@
     <script src="../*/po.js"></script>
 </head>
 <body class="pf-m-redhat-font">
-    <div id="hwinfo"></div>
+    <div class="ct-page-fill" id="hwinfo"></div>
     <script src="hwinfo.js"></script>
 </body>
 </html>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -14,7 +14,7 @@
   <script src="../manifests.js"></script>
 </head>
 <body class="pf-m-redhat-font">
-  <div id="overview"></div>
+  <div class="ct-page-fill" id="overview"></div>
   <script src="../performance/performance.js"></script>
 </body>
 </html>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -28,92 +28,94 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 </head>
 
 <body class="pf-m-redhat-font">
-  <div class="pf-c-page" id="journal">
-    <main class="pf-c-page__main" tabindex="-1">
-      <section class="pf-c-page__main-section content-header-extra">
-        <div class="filters">
-          <div class="filter">
-              <button id="log-filters" class="btn btn-default dropdown-toggle ct-select" type="button" data-toggle="dropdown">
-                <span translate>Time</span>
-                <div class="caret"></div>
-              </button>
-              <ul class="dropdown-menu" id="logs-predefined-filters">
-                <li><a tabindex="0" data-key="boot" data-value="0" translate>Current boot</a></li>
-                <li><a tabindex="0" data-key="boot" data-value="-1" translate>Previous boot</a></li>
-                <li><a tabindex="0" data-key="since" data-value="-24hours" translate>Last 24 hours</a></li>
-                <li><a tabindex="0" data-key="since" data-value="-7days" translate>Last 7 days</a></li>
-              </ul>
-          </div>
+  <div class="ct-page-fill" id="journal">
+    <div class="pf-c-page">
+      <main class="pf-c-page__main" tabindex="-1">
+        <section class="pf-c-page__main-section content-header-extra">
+          <div class="filters">
+            <div class="filter">
+                <button id="log-filters" class="btn btn-default dropdown-toggle ct-select" type="button" data-toggle="dropdown">
+                  <span translate>Time</span>
+                  <div class="caret"></div>
+                </button>
+                <ul class="dropdown-menu" id="logs-predefined-filters">
+                  <li><a tabindex="0" data-key="boot" data-value="0" translate>Current boot</a></li>
+                  <li><a tabindex="0" data-key="boot" data-value="-1" translate>Previous boot</a></li>
+                  <li><a tabindex="0" data-key="since" data-value="-24hours" translate>Last 24 hours</a></li>
+                  <li><a tabindex="0" data-key="since" data-value="-7days" translate>Last 7 days</a></li>
+                </ul>
+            </div>
 
-          <div class="filter">
-              <label for="journal-prio-menu" translate>Priority</label>
-              <select id="journal-prio-menu" class="ct-select">
-                <option value="emerg" translate>Only emergency</option>
-                <option value="alert" translate>Alert and above</option>
-                <option value="crit" translate>Critical and above</option>
-                <option value="err" translate>Error and above</option>
-                <option value="warning" translate>Warning and above</option>
-                <option value="notice" translate>Notice and above</option>
-                <option value="info" translate>Info and above</option>
-                <option value="debug" translate>Debug and above</option>
-              </select>
-          </div>
+            <div class="filter">
+                <label for="journal-prio-menu" translate>Priority</label>
+                <select id="journal-prio-menu" class="ct-select">
+                  <option value="emerg" translate>Only emergency</option>
+                  <option value="alert" translate>Alert and above</option>
+                  <option value="crit" translate>Critical and above</option>
+                  <option value="err" translate>Error and above</option>
+                  <option value="warning" translate>Warning and above</option>
+                  <option value="notice" translate>Notice and above</option>
+                  <option value="info" translate>Info and above</option>
+                  <option value="debug" translate>Debug and above</option>
+                </select>
+            </div>
 
-          <div class="filter">
-              <label for="journal-service-menu" translate>Identifier</label>
-              <select id="journal-service-menu" class="ct-select">
-                  <!-- This is filled by from logs.js !-->
-              </select>
-          </div>
+            <div class="filter">
+                <label for="journal-service-menu" translate>Identifier</label>
+                <select id="journal-service-menu" class="ct-select">
+                    <!-- This is filled by from logs.js !-->
+                </select>
+            </div>
 
-          <div class="filter text-search">
-              <label for="journal-grep" translate>Text</label>
-              <span class="filter-group">
-                  <input id="journal-grep" class="form-control" type="text" translate="placeholder" placeholder="Type to filter">
-                  <div id="logs-help" class="dropdown">
-                    <a role="link" tabindex="0" id="logs-help-toggle" class="dropdown-toggle dropdown-form-control" data-toggle="dropdown">
-                      <span class="pficon pficon-help"></span>
-                    </a>
-                    <div id="logs-help-menu" class="dropdown-menu">
-                      <span translate>Search the logs with a combination of terms:</span>
-                      <ul>
-                          <li><span translate>qualifiers</span>, <span translate>e.g.</span> 'priority:', 'identifier:', 'service:'</li>
-                          <li><span translate>log fields</span>, <span translate>e.g.</span> '_EXE=/usr/bin/python'</li>
-                          <li translate>any free-form string as regular expression</li>
-                      </ul>
-                      <span class="help-links">
-                          <a href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/reviewing-logs_system-management-using-the-rhel-8-web-console#filtering-logs-in-the-web-console_reviewing-logs" target="blank" rel="noopener noreferrer"><span translate>Learn more</span><i class="fa fa-external-link fa-xs"></i></a>
-                          <a href="https://www.freedesktop.org/software/systemd/man/journalctl.html" target="blank" rel="noopener noreferrer"><span translate>journalctl manpage</span><i class="fa fa-external-link fa-xs"></i></a>
-                      </span>
-                      <span class="journal-cmd">
-                          <pre id="journal-query"></pre>
-                          <button class="copy-cmd" id="journal-cmd-copy"><i class="fa fa-clipboard fa-xs"></i></button>
-                      </span>
+            <div class="filter text-search">
+                <label for="journal-grep" translate>Text</label>
+                <span class="filter-group">
+                    <input id="journal-grep" class="form-control" type="text" translate="placeholder" placeholder="Type to filter">
+                    <div id="logs-help" class="dropdown">
+                      <a role="link" tabindex="0" id="logs-help-toggle" class="dropdown-toggle dropdown-form-control" data-toggle="dropdown">
+                        <span class="pficon pficon-help"></span>
+                      </a>
+                      <div id="logs-help-menu" class="dropdown-menu">
+                        <span translate>Search the logs with a combination of terms:</span>
+                        <ul>
+                            <li><span translate>qualifiers</span>, <span translate>e.g.</span> 'priority:', 'identifier:', 'service:'</li>
+                            <li><span translate>log fields</span>, <span translate>e.g.</span> '_EXE=/usr/bin/python'</li>
+                            <li translate>any free-form string as regular expression</li>
+                        </ul>
+                        <span class="help-links">
+                            <a href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/reviewing-logs_system-management-using-the-rhel-8-web-console#filtering-logs-in-the-web-console_reviewing-logs" target="blank" rel="noopener noreferrer"><span translate>Learn more</span><i class="fa fa-external-link fa-xs"></i></a>
+                            <a href="https://www.freedesktop.org/software/systemd/man/journalctl.html" target="blank" rel="noopener noreferrer"><span translate>journalctl manpage</span><i class="fa fa-external-link fa-xs"></i></a>
+                        </span>
+                        <span class="journal-cmd">
+                            <pre id="journal-query"></pre>
+                            <button class="copy-cmd" id="journal-cmd-copy"><i class="fa fa-clipboard fa-xs"></i></button>
+                        </span>
+                      </div>
                     </div>
-                  </div>
-              </span>
+                </span>
+            </div>
           </div>
-        </div>
 
-        <div class="filter-separator"></div>
+          <div class="filter-separator"></div>
 
-        <div class="filter-actions">
+          <div class="filter-actions">
 
-          <span class="filters-toggle" hidden>
-            <button class="link-button" translate>Show filters</button>
-          </span>
+            <span class="filters-toggle" hidden>
+              <button class="link-button" translate>Show filters</button>
+            </span>
 
-          <button id="journal-follow" class="pf-c-button pf-m-secondary" type="button" translate>Pause</button>
-        </div>
-      </section>
-      <section id="journal-box" class="pf-c-page__main-section pf-m-light">
-        <div class="panel panel-default cockpit-log-panel" id="journal-logs" role="table"></div>
-        <div class="journal-start" id="start-box" role="rowgroup"></div>
-      </section>
-    </main>
+            <button id="journal-follow" class="pf-c-button pf-m-secondary" type="button" translate>Pause</button>
+          </div>
+        </section>
+        <section id="journal-box" class="pf-c-page__main-section pf-m-light">
+          <div class="panel panel-default cockpit-log-panel" id="journal-logs" role="table"></div>
+          <div class="journal-start" id="start-box" role="rowgroup"></div>
+        </section>
+      </main>
+    </div>
   </div>
 
-  <div id="journal-entry">
+  <div class="ct-page-fill" id="journal-entry">
 
   <script type="text/javascript" src="logs.js"></script>
 </body>

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -2,15 +2,8 @@
 @import "../lib/journal.css";
 @import "./system-global.scss";
 
-body {
-    // Ensure journal UI fills the entire page (and does not run over)
-    display: grid;
-}
-
 #journal {
-    display: grid;
     grid-template-rows: auto 1fr;
-    height: 100%;
 
     .cockpit-log-panel {
         border: none;
@@ -18,8 +11,6 @@ body {
 }
 
 #journal-entry {
-    height: 100%;
-
     .pf-l-gallery {
         --pf-l-gallery--GridTemplateColumns: 1fr;
     }

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -4,10 +4,6 @@
 /* System Time Modal dialog needs table.css */
 @import "../lib/table.css";
 
-#overview {
-  height: 100%;
-}
-
 .ct-limited-access-alert {
   align-items: center;
   background: var(--pf-global--active-color--200);

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -11,7 +11,7 @@
 </head>
 
 <body class="pf-m-redhat-font" id="services-page">
-  <div id="services"></div>
+  <div class="ct-page-fill" id="services"></div>
 
   <script id="repeat-hourly-tmpl" type="x-template/mustache">
   {{#repeat}}

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -4,11 +4,6 @@
 @import "./timer.scss";
 @import "../../lib/table.css";
 
-// Stretch content to fill viewport
-#services {
-    height: 100%;
-}
-
 /* There is too much padding between the Nav and the Toolbar */
 .pf-c-page__main-section:first-of-type {
     padding-bottom: 0;

--- a/pkg/systemd/terminal.html
+++ b/pkg/systemd/terminal.html
@@ -9,7 +9,7 @@
     <script src="../*/po.js"></script>
 </head>
 <body class="pf-m-redhat-font" hidden>
-    <div id="terminal"></div>
+    <div class="ct-page-fill" id="terminal"></div>
     <script src="terminal.js"></script>
 </body>
 </html>

--- a/pkg/systemd/terminal.scss
+++ b/pkg/systemd/terminal.scss
@@ -2,10 +2,7 @@
 @import "_global-variables.scss";
 @import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
 @import "../../node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss";
-
-html, body {
-        height: 100%;
-}
+@import "../lib/page.scss";
 
 .console-ct-container {
     height: 100%;
@@ -55,10 +52,6 @@ html, body {
 
 .white-theme {
     background-color: #ffffff;
-}
-
-#terminal {
-    height: 100%;
 }
 
 .terminal-group {

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -28,5 +28,7 @@
     <script src="../*/po.js"></script>
     <script src="users.js"></script>
 </head>
-<body class="pf-m-redhat-font" id="page" hidden>
+<body class="pf-m-redhat-font">
+    <div class="ct-page-fill" id="page">
+    </div>
 </body>


### PR DESCRIPTION

Remove all per page CSS for this purpose.

The single visual difference by this is that loading page spinner is in
the center of the page now, instead of the top that it was before.
This is the expected behavior.

Please review carefully :) Prone to :bug: 