### PR TITLE
updates: Get rid of the page header

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -930,9 +930,6 @@ class OsUpdates extends React.Component {
 
             return (
                 <>
-                    <PageSection variant={PageSectionVariants.light}>
-                        <h2 id="page-title">{_("Software updates")}</h2>
-                    </PageSection>
                     <PageSection>
                         <Gallery className='ct-cards-grid' hasGutter>
                             <CardsPage handleRefresh={this.handleRefresh}
@@ -988,9 +985,6 @@ class OsUpdates extends React.Component {
 
             return (
                 <>
-                    <PageSection variant={PageSectionVariants.light}>
-                        <h2 id="page-title">{_("Software updates")}</h2>
-                    </PageSection>
                     <PageSection>
                         <Gallery className='ct-cards-grid' hasGutter>
                             <CardsPage handleRefresh={this.handleRefresh} {...this.state} />


### PR DESCRIPTION
Page header is usually no longer present on other cockpit pages