### PR TITLE
tools: Rename Fedora rawhide branch in cockpituous control file

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -27,7 +27,7 @@ job release-srpm
 
 
 # Do fedora builds for the tag, using tarball
-job release-koji -k master
+job release-koji -k rawhide
 job release-koji f32
 job release-koji f33
 


### PR DESCRIPTION
Fedora "master" branches were renamed recently.