### PR TITLE
firewall: Change order of aattributes to make tests happy

### DIFF
--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -30,6 +30,6 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   </head>
 
   <body class="pf-m-redhat-font">
-      <div class="ct-page-fill" id="firewall"></div>
+      <div id="firewall" class="ct-page-fill"></div>
   </body>
 </html>


### PR DESCRIPTION
One test checks that `<div id="firewall"` exists.
This was introduced in 9113eb5f.