### PR TITLE
test: Work around selenium Edge driver bug (scroll into view version)

### DIFF
--- a/test/selenium/selenium-base.py
+++ b/test/selenium/selenium-base.py
@@ -33,6 +33,9 @@ class BasicTestSuite(SeleniumTest):
         self.wait_frame("services")
         self.wait_id("services-list")
         self.click(self.wait_text("Socket", cond=clickable))
+        if os.environ.get("BROWSER") == 'edge':
+            # HACK: Edge does not see elements (kdump menu entry) which are below the visible window area
+            self.driver.execute_script('document.getElementById("systemd-udevd-control.socket").scrollIntoView()')
         self.wait_text("udev")
         self.wait_id("services-list")
         self.click(self.wait_text("Target", cond=clickable))


### PR DESCRIPTION
Commit 9113eb5f60 triggered the old Edge selenium driver bug again where
elements that are scrolled off-page too far are not "visible" to
Selenium any more. Scroll the udev service into view,
similar to commit b960b0fc.