### PR TITLE
cockpituous: Add Fedora 34 koji builds

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -30,6 +30,7 @@ job release-srpm
 job release-koji -k rawhide
 job release-koji f32
 job release-koji f33
+job release-koji f34
 
 # Upload release to github, using tarball
 job release-github


### PR DESCRIPTION
Fedora 34 branches from Rawhide today:
https://fedorapeople.org/groups/schedule/f-34/f-34-all-tasks.html

bodhi will get enabled in two weeks, so don't add that yet.