### PR TITLE
shell: Genuine sudo errors

### DIFF
--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { Button, FormSelect, FormSelectOption, Modal } from '@patternfly/react-core';
+import { Alert, Button, Modal } from '@patternfly/react-core';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { host_superuser_storage_key } from './machines/machines';
 
@@ -27,60 +27,87 @@ import "form-layout.scss";
 
 const _ = cockpit.gettext;
 
+function sudo_polish(msg) {
+    if (!msg)
+        return msg;
+
+    msg = msg.replace(/^\[sudo] /, "");
+    msg = msg[0].toUpperCase() + msg.slice(1);
+
+    return msg;
+}
+
 class UnlockDialog extends React.Component {
     render() {
         const { state } = this.props;
 
+        let title = null;
+        let title_icon = null;
         let body = null;
+        let footer = null;
+
         if (state.prompt) {
             if (!state.prompt.message && !state.prompt.prompt) {
                 state.prompt.message = _("Please authenticate to gain administrative access");
                 state.prompt.prompt = _("Password");
             }
-            body = <form className="ct-form" onSubmit={state.apply}>
-                { state.prompt.message && <span>{state.prompt.message}</span> }
-                { state.prompt.prompt && <label className="control-label">{state.prompt.prompt}</label> }
-                <input type={state.prompt.echo ? "text" : "password"} className="form-control" value={state.prompt.value}
-                       autoFocus
-                       onChange={event => {
-                           state.change(event.target.value);
-                       }} />
-            </form>;
-        } else if (state.method)
-            body = <form className="ct-form" onSubmit={state.apply}>
-                <label className="control-label" htmlFor="unlock-dialog-method">{_("Method")}</label>
-                <FormSelect value={state.method}
-                            id="unlock-dialog-method"
-                            onChange={state.change}>
-                    {state.methods.map(m => <FormSelectOption key={m} value={m} label={m} />)}
-                </FormSelect>
-            </form>;
-        else if (state.message)
-            body = <p>{state.message}</p>;
 
-        const footer = (
-            <>
-                { state.error && <ModalError dialogError={state.error} />}
-                { !state.message &&
-                <Button variant='primary' onClick={state.apply} isDisabled={state.busy}>
-                    {_("Authenticate")}
-                </Button>
-                }
-                <Button variant='link' className='btn-cancel' onClick={state.cancel} isDisabled={!state.cancel}>
-                    {state.message ? _("Close") : _("Cancel")}
-                </Button>
-                { state.busy &&
-                <div className="dialog-wait-ct">
-                    <div className="spinner spinner-sm" />
-                </div>
-                }
-            </>
-        );
+            title = _("Switch to administrative access");
+
+            body = (
+                <>
+                    { state.error && <><Alert variant={state.error_variant || 'danger'} isInline title={state.error} /><br /></> }
+                    <form className="ct-form"
+                          onSubmit={event => { state.apply(); event.preventDefault(); return false }}>
+                        { state.prompt.message && <span>{state.prompt.message}</span> }
+                        { state.prompt.prompt && <label className="control-label">{state.prompt.prompt}</label> }
+                        <input className="form-control" type={state.prompt.echo ? "text" : "password"}
+                               value={state.prompt.value}
+                               autoFocus
+                               disabled={state.busy}
+                               onChange={event => {
+                                   state.change(event.target.value);
+                               }} />
+                    </form>
+                </>);
+
+            footer = (
+                <>
+                    <Button variant='primary' onClick={state.apply} isDisabled={state.busy}>
+                        {_("Authenticate")}
+                    </Button>
+                    <Button variant='link' className='btn-cancel' onClick={state.cancel} isDisabled={!state.cancel}>
+                        {_("Cancel")}
+                    </Button>
+                    { state.busy &&
+                        <div className="dialog-wait-ct">
+                            <div className="spinner spinner-sm" />
+                        </div>
+                    }
+                </>);
+        } else if (state.message) {
+            title = _("Administrative access");
+            body = <p>{state.message}</p>;
+            footer = (
+                <Button variant="secondary" className='btn-cancel' onClick={state.cancel}>
+                    {_("Close")}
+                </Button>);
+        } else if (state.error) {
+            title_icon = "danger";
+            title = _("Problem becoming administrator");
+            body = <p>{state.error}</p>;
+            footer = (
+                <Button variant="secondary" className='btn-cancel' onClick={state.cancel}>
+                    {_("Close")}
+                </Button>);
+        }
+
         return (
             <Modal isOpen={!state.closed} position="top" variant="medium"
-                onClose={this.props.onClose}
-                title={_("Administrative access")}
-                footer={footer}>
+                   onClose={this.props.onClose}
+                   title={title}
+                   titleIconVariant={title_icon}
+                   footer={footer}>
                 {body}
             </Modal>);
     }
@@ -213,34 +240,42 @@ export class SuperuserDialogs extends React.Component {
         this.set_unlock_state(Object.assign(this.state.unlock_dialog_state, state));
     }
 
-    unlock(error) {
+    unlock() {
         this.superuser.Stop().always(() => {
-            this.start("sudo", error);
+            this.start("sudo");
         });
     }
 
-    start(method, error) {
+    start(method) {
         const cancel = () => {
             this.superuser.Stop();
-            this.set_unlock_state({ busy: true, prompt: this.state.unlock_dialog_state.prompt });
+            this.set_unlock_state({
+                busy: true,
+                prompt: this.state.unlock_dialog_state.prompt,
+                error: this.state.unlock_dialog_state.error
+            });
         };
 
         this.set_unlock_state({
             busy: true,
-
-            error: error,
+            prompt: this.state.unlock_dialog_state.prompt,
             cancel: cancel
         });
 
         let did_prompt = false;
 
         const onprompt = (event, message, prompt, def, echo, error) => {
-            did_prompt = true;
-            const p = { message: message, prompt: prompt, value: def, echo: echo };
+            const p = {
+                message: sudo_polish(message),
+                prompt: sudo_polish(prompt),
+                value: def,
+                echo: echo
+            };
             this.set_unlock_state({
                 prompt: p,
 
-                error: error || this.state.unlock_dialog_state.error,
+                error: sudo_polish(error) || this.state.unlock_dialog_state.error,
+                error_variant: did_prompt ? 'danger' : 'warning',
                 change: val => {
                     p.value = val;
                     this.update_unlock_state({ prompt: p });
@@ -250,10 +285,12 @@ export class SuperuserDialogs extends React.Component {
                     this.superuser.Answer(p.value);
                     this.set_unlock_state({
                         busy: true,
+                        prompt: this.state.unlock_dialog_state.prompt,
                         cancel: cancel
                     });
                 }
             });
+            did_prompt = true;
         };
 
         this.superuser.addEventListener("Prompt", onprompt);
@@ -277,8 +314,7 @@ export class SuperuserDialogs extends React.Component {
                     this.superuser.removeEventListener("Prompt", onprompt);
                     if (err && err.message != "cancelled") {
                         this.set_unlock_state({
-                            message: _("This did not work."),
-                            error: err.toString(),
+                            error: sudo_polish(err.toString()),
                             cancel: () => this.set_unlock_state({ closed: true })
                         });
                     } else

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -532,7 +532,7 @@ if (window.NodeList && !NodeList.prototype.forEach)
             var password = id("login-password-input").value;
 
             var superuser_key = "superuser:" + user + (machine ? ":" + machine : "");
-            var superuser = localStorage.getItem(superuser_key) || "any";
+            var superuser = localStorage.getItem(superuser_key) || "none";
             localStorage.setItem("superuser-key", superuser_key);
             localStorage.setItem(superuser_key, superuser);
 

--- a/pkg/systemd/superuser-alert.jsx
+++ b/pkg/systemd/superuser-alert.jsx
@@ -24,7 +24,7 @@ import {
     Alert, Button
 } from '@patternfly/react-core';
 
-import { SuperuserDialogs, can_do_sudo } from "../shell/superuser.jsx";
+import { SuperuserDialogs } from "../shell/superuser.jsx";
 
 const _ = cockpit.gettext;
 
@@ -33,18 +33,13 @@ export class SuperuserAlert extends React.Component {
         super();
         this.superuser = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Superuser", "/superuser");
         this.superuser.addEventListener("changed", () => { this.setState({}) });
-        this.state = { can_do_sudo: false };
-        can_do_sudo().then(can_do => this.setState({ can_do_sudo: can_do }));
     }
 
     render () {
         const actions =
-            <SuperuserDialogs create_trigger={(unlocked, onclick) => {
-                if (this.state.can_do_sudo)
-                    return <Button onClick={onclick}>{_("Turn on administrative access")}</Button>;
-                else
-                    return null;
-            }} />;
+            <SuperuserDialogs create_trigger={(unlocked, onclick) =>
+                <Button onClick={onclick}>{_("Turn on administrative access")}</Button>}
+            />;
 
         // The SuperuserDialogs element above needs to be in the DOM
         // regardless of the superuser level so that the dialogs are

--- a/src/bridge/askpass.c
+++ b/src/bridge/askpass.c
@@ -142,7 +142,6 @@ main (int argc,
   gchar *user = NULL;
   gchar *cookie = NULL;
   gchar *challenge = NULL;
-  const gchar *prompt;
   gint ret = 1;
 
   static GOptionEntry entries[] = {
@@ -185,14 +184,10 @@ main (int argc,
   challenge = g_strdup_printf ("plain1:%s:", user);
   cookie = g_strdup_printf ("askpass%u%u", (unsigned int)getpid (), (unsigned int)time (NULL));
 
-  prompt = argv[1];
-  if (strstr (prompt, "[sudo] ") == prompt)
-    prompt = NULL;
-
   request = cockpit_transport_build_json ("command", "authorize",
                                           "challenge", challenge,
                                           "cookie", cookie,
-                                          "prompt", prompt,
+                                          "prompt", argv[1],
                                           NULL);
 
   /* Yes, we write to stdin which we expect to be a socketpair() */

--- a/src/bridge/cockpitpeer.h
+++ b/src/bridge/cockpitpeer.h
@@ -30,7 +30,7 @@ G_BEGIN_DECLS
 
 typedef struct _CockpitPeer        CockpitPeer;
 
-typedef void CockpitPeerDoneFunction (const gchar *error, gpointer data);
+typedef void CockpitPeerDoneFunction (const gchar *error, const gchar *stderr, gpointer data);
 
 typedef struct _CockpitPeerClass {
   GObjectClass parent_class;

--- a/src/bridge/cockpitpipechannel.c
+++ b/src/bridge/cockpitpipechannel.c
@@ -302,28 +302,11 @@ return_stderr_message (CockpitChannel *channel,
                        CockpitPipe *pipe)
 {
   JsonObject *options;
-  GByteArray *buffer;
-  GBytes *bytes;
-  GBytes *clean;
   gchar *data;
-  gsize length;
 
-  buffer = cockpit_pipe_get_stderr (pipe);
-  if (!buffer)
+  data = cockpit_pipe_take_stderr_as_utf8 (pipe);
+  if (data == NULL)
     return;
-
-  /* A little more complicated to avoid big copies */
-  g_byte_array_ref (buffer);
-  g_byte_array_append (buffer, (guint8 *)"x", 1); /* place holder for null terminate */
-  bytes = g_byte_array_free_to_bytes (buffer);
-  clean = cockpit_unicode_force_utf8 (bytes);
-  g_bytes_unref (bytes);
-
-  data = g_bytes_unref_to_data (clean, &length);
-
-  /* Fill in null terminate, for x above */
-  g_assert (length > 0);
-  data[length - 1] = '\0';
 
   options = cockpit_channel_close_options (channel);
   json_object_set_string_member (options, "message", data);

--- a/src/bridge/cockpitpolkitagent.c
+++ b/src/bridge/cockpitpolkitagent.c
@@ -220,7 +220,7 @@ on_request (PolkitAgentSession *session,
       polkit_agent_session_response (session, "");
     }
   else if (caller->self->router)
-    cockpit_router_prompt (caller->self->router, caller->user, NULL, on_answer, caller);
+    cockpit_router_prompt (caller->self->router, caller->user, NULL, NULL, on_answer, caller);
 }
 
 static void

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -1674,7 +1674,7 @@ cockpit_router_prompt (CockpitRouter *self,
                                      "/superuser",
                                      "cockpit.Superuser",
                                      "Prompt",
-                                     g_variant_new ("(sssbs)", prompt, "", "", FALSE, previous_error),
+                                     g_variant_new ("(sssbs)", "", prompt, "", FALSE, previous_error),
                                      NULL);
     }
   else if (self->superuser_init_in_progress)

--- a/src/bridge/cockpitrouter.h
+++ b/src/bridge/cockpitrouter.h
@@ -65,6 +65,7 @@ void                cockpit_router_dbus_startup                    (CockpitRoute
 void                cockpit_router_prompt                          (CockpitRouter *self,
                                                                     const gchar *user,
                                                                     const gchar *prompt,
+                                                                    const gchar *previous_error,
                                                                     CockpitRouterPromptAnswerFunction *answer,
                                                                     gpointer data);
 

--- a/src/common/cockpitpipe.h
+++ b/src/common/cockpitpipe.h
@@ -87,6 +87,10 @@ GByteArray *       cockpit_pipe_get_buffer   (CockpitPipe *self);
 
 GByteArray *       cockpit_pipe_get_stderr   (CockpitPipe *self);
 
+gchar *            cockpit_pipe_take_stderr_as_utf8 (CockpitPipe *self);
+
+void               cockpit_pipe_stop_stderr_capture (CockpitPipe *self);
+
 gboolean           cockpit_pipe_get_pid      (CockpitPipe *self,
                                               GPid *pid);
 

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -192,7 +192,7 @@ test_basic_good (TestCase *test,
 
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (application, ==, cockpit_creds_get_application (creds));
-  g_assert_cmpstr (PASSWORD, ==, g_bytes_get_data (cockpit_creds_get_password (creds), NULL));
+  g_assert_null (cockpit_creds_get_password (creds));
 
   g_hash_table_unref (out_headers);
   g_object_unref (service);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -304,7 +304,7 @@ test_login_accept (Test *test,
   g_assert (service != NULL);
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (cockpit_creds_get_user (creds), ==, "me");
-  g_assert_cmpstr (g_bytes_get_data (cockpit_creds_get_password (creds), NULL), ==, PASSWORD);
+  g_assert_null (cockpit_creds_get_password (creds));
 
   token = cockpit_creds_get_csrf_token (creds);
   g_assert (strstr (output, token));

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -595,15 +595,8 @@ class Browser:
         self.expect_load()
 
     def relogin(self, path=None, user=None, superuser=None):
-        if user is None:
-            user = self.default_user
         self.logout()
-        self.wait_visible("#login")
-        self.set_val("#login-user-input", user)
-        self.set_val("#login-password-input", self.password)
-        if superuser is not None:
-            self.eval_js('window.localStorage.setItem("superuser:%s", "%s");' % (user, "any" if superuser else "none"))
-        self.click('#login-button')
+        self.try_login(user, superuser=superuser)
         self.expect_load()
         self._wait_present('#content')
         self.wait_visible('#content')

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1116,14 +1116,6 @@ class MachineCase(unittest.TestCase):
                                     'which: no python in .*'
                                     )
 
-    def allow_failed_sudo_journal_messages(self):
-        self.allow_journal_messages(".* is not in the sudoers file.  This incident will be reported.",
-                                    "Error executing command as another user: Not authorized",
-                                    "This incident has been reported.",
-                                    "Sorry, try again.",
-                                    ".*incorrect password attempt.*",
-                                    "sudo:.*")
-
     def check_journal_messages(self, machine=None):
         """Check for unexpected journal entries."""
         machine = machine or self.machine

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -594,8 +594,10 @@ class Browser:
             self.click('#go-logout')
         self.expect_load()
 
-    def relogin(self, path=None, user=None, superuser=None):
+    def relogin(self, path=None, user=None, superuser=None, wait_remote_session_machine=None):
         self.logout()
+        if wait_remote_session_machine:
+            wait_remote_session_machine.execute("while pgrep -a cockpit-ssh; do sleep 1; done")
         self.try_login(user, superuser=superuser)
         self.expect_load()
         self._wait_present('#content')

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -108,9 +108,6 @@ class TestBastion(MachineCase):
         b.wait_text('#current-username', 'admin')
         b.logout()
 
-        # key login doesn't give us a password for sudo
-        self.allow_failed_sudo_journal_messages()
-
     def testBasicLogin(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -843,6 +843,7 @@ ExecStart=/usr/local/bin/{0}
         b.wait_text(self.update_text, "Loading available updates failed")
         self.assertIn("exclamation", b.attr(self.update_icon, "class"))
 
+    @skipDistroPackage()
     def testUnprivileged(self):
         b = self.browser
         m = self.machine
@@ -865,10 +866,10 @@ ExecStart=/usr/local/bin/{0}
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
 
         b.wait_text("#super-user-indicator", "Administrative access")
 
@@ -1281,6 +1282,7 @@ class TestAutoUpdates(NoSubManCase):
         else:
             raise NotImplementedError(self.backend)
 
+    @skipDistroPackage()
     def testPrivilegeChange(self):
         b = self.browser
         m = self.machine
@@ -1298,10 +1300,10 @@ class TestAutoUpdates(NoSubManCase):
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.switch_to_frame("cockpit1:localhost/updates")
 
         # enable auto-updates

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -103,7 +103,6 @@ class TestReauthorize(MachineCase):
         m.execute("useradd user -s /bin/bash -c 'Barney' || true")
         m.execute("echo user:foobar | chpasswd")
 
-        self.allow_failed_sudo_journal_messages()
         b.default_user = "user"
         self.login_and_go("/playground/test")
         b.click(".super-channel button")

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -36,7 +36,6 @@ class TestKeys(MachineCase):
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -m -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
-        self.allow_failed_sudo_journal_messages()
 
         m.start_cockpit()
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -106,7 +106,26 @@ class TestKeys(MachineCase):
         # Log in as admin
         login("admin", "foobar", "Administrator")
         b.go("#/user")
-        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
+
+        if "ubuntu" not in m.image and "debian" not in m.image:
+            b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child",
+                           "You do not have permission to view the authorized public keys for this account.")
+
+        # Get admin privs
+        b.leave_page()
+        b.wait_text("#super-user-indicator", "Limited access")
+        b.click("#super-user-indicator button")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
+        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        # users page reloads on superuser change
+        b.expect_load_frame("cockpit1:localhost/users")
+        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_text("#super-user-indicator", "Administrative access")
+        b.enter_page("/users")
+
+        b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child",
+                       "no authorized public keys")
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
         # Adding keys sets permissions properly

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -115,12 +115,12 @@ class TestKeys(MachineCase):
         b.leave_page()
         b.wait_text("#super-user-indicator", "Limited access")
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         # users page reloads on superuser change
         b.expect_load_frame("cockpit1:localhost/users")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
         b.enter_page("/users")
 

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -611,6 +611,7 @@ class TestMultiMachine(MachineCase):
 
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "data-ready", null)' % frame)
         b.eval_js('ph_set_attr("iframe[name=\'%s\']", "src", "../playground/test.html?i=1#/")' % frame)
+        b.expect_load_frame(frame)
         b.wait_visible("iframe.container-frame[name='%s'][data-ready]" % frame)
 
         b.enter_page("/playground/test", "10.111.113.2")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -817,12 +817,12 @@ class TestMultiMachine(MachineCase):
                          m2.execute("cat /home/fred/.ssh/authorized_keys"))
 
         # Relogin.  This should now work seamlessly.
-        b.relogin(None)
+        b.relogin(None, wait_remote_session_machine=m1)
         b.enter_page("/system", host="fred@10.111.113.2")
 
         # De-authorize key and relogin, then re-authorize.
         m2.execute("rm /home/fred/.ssh/authorized_keys")
-        b.relogin(None)
+        b.relogin(None, wait_remote_session_machine=m1)
         b.wait_visible("#machine-troubleshoot")
         b.click('#machine-troubleshoot')
         b.wait_popup('troubleshoot-dialog')
@@ -839,7 +839,7 @@ class TestMultiMachine(MachineCase):
         # Put a 'better' passphrase on the key and relogin, then
         # change the passphrase back to the login password
         m1.execute("ssh-keygen -q -f /home/admin/.ssh/id_rsa -p -P foobar -N foobarfoo")
-        b.relogin(None)
+        b.relogin(None, wait_remote_session_machine=m1)
         b.wait_visible("#machine-troubleshoot")
         b.click('#machine-troubleshoot')
         b.wait_popup('troubleshoot-dialog')
@@ -858,7 +858,7 @@ class TestMultiMachine(MachineCase):
         # stack.)
         #
         if not m1.ostree_image:
-            b.relogin(None)
+            b.relogin(None, wait_remote_session_machine=m1)
             b.enter_page("/system", host="fred@10.111.113.2")
 
         # The authorized_keys files should still only have a single key

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -342,7 +342,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     '.*user account or password has expired.*',
                                     '.*BAD PASSWORD.*',
                                     '.*Sorry, passwords do not match.')
-        self.allow_failed_sudo_journal_messages()
         self.allow_restart_journal_messages()
 
     def testConversation(self):
@@ -403,7 +402,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     "Locale charset is ANSI.*",
                                     "Assuming locale environment is lost.*",
                                     "ATTENTION! Your session is being recorded!")
-        self.allow_failed_sudo_journal_messages()
 
     def curl_auth(self, url, userpass):
         header = "Authorization: Basic " + base64.b64encode(userpass.encode()).decode()
@@ -463,7 +461,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         b.logout()
         # not allowed to restricted users
-        self.allow_failed_sudo_journal_messages()
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="systemd".*')
@@ -541,8 +538,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_visible("#safari-cert-help")
         else:
             b.wait_not_visible("#safari-cert-help")
-
-        self.allow_failed_sudo_journal_messages()
 
     @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
     @skipImage("Starting on OSTree is weird", "fedora-coreos")
@@ -768,7 +763,6 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 
             m.stop_cockpit()
 
-        self.allow_failed_sudo_journal_messages()
         # from sssd
         self.allow_journal_messages("alice is not allowed to run sudo.*")
 
@@ -859,8 +853,6 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         check_server("::1", True)
         # by IPv6 address and port
         check_server("[::1]:22", True)
-
-        self.allow_failed_sudo_journal_messages()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -143,8 +143,6 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.wait_text("#super-user-indicator", "Limited access")
 
-        self.allow_failed_sudo_journal_messages()
-
     def testNotAdmin(self):
         b = self.browser
         m = self.machine
@@ -157,7 +155,6 @@ session include system-auth
             m.execute("sed -i -e '/^%admin/d' /etc/sudoers")
 
         m.execute("gpasswd -d admin %s" % m.get_admin_group())
-        self.allow_failed_sudo_journal_messages()
 
         self.login_and_go()
         b.wait_text("#super-user-indicator", "Limited access")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -32,6 +32,7 @@ class TestSuperuser(MachineCase):
 
     def testBasic(self):
         b = self.browser
+        m = self.machine
 
         # Log in with all defaults
         self.login_and_go()
@@ -48,12 +49,18 @@ class TestSuperuser(MachineCase):
         b.leave_page()
         b.wait_text("#super-user-indicator", "Limited access")
 
-        # Get them back
+        # We want to be lectured again
+        m.execute("rm -rf /var/{db,lib}/sudo/lectured/admin")
+
+        # Get the privileges back
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        if "ubuntu" not in m.image:
+            b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')",
+                           "We trust you have received the usual lecture")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
 
         # Check we still have them after logout
@@ -103,13 +110,13 @@ session include system-auth
 """)
 
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "universe and everything")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "42")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "universe and everything")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "42")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
 
     def testWrongPasswd(self):
@@ -120,20 +127,20 @@ session include system-auth
         b.wait_text("#super-user-indicator", "Limited access")
 
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wrong")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "wrong")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Sorry, try again")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wronger")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Sorry, try again")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "wronger")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Sorry, try again")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wrongest")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Sorry, try again")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "wrongest")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "sudo: 3 incorrect password attempts")
-        b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_in_text(".pf-c-modal-box:contains('Problem becoming administrator')", "Sudo: 3 incorrect password attempts")
+        b.click(".pf-c-modal-box:contains('Problem becoming administrator') button:contains('Close')")
+        b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.wait_text("#super-user-indicator", "Limited access")
 
         self.allow_failed_sudo_journal_messages()
@@ -156,11 +163,11 @@ session include system-auth
         b.wait_text("#super-user-indicator", "Limited access")
 
         b.click("#super-user-indicator button")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "admin is not in the sudoers file.  This incident will be reported.")
-        b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_in_text(".pf-c-modal-box:contains('Problem becoming administrator')", "Admin is not in the sudoers file.  This incident will be reported.")
+        b.click(".pf-c-modal-box:contains('Problem becoming administrator') button:contains('Close')")
+        b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
 
     def testBrokenBridgeConfig(self):
         b = self.browser
@@ -183,13 +190,17 @@ session include system-auth
 }
 """)
 
+        # We don't want to be lectured in this test just to control
+        # the content of the dialog better.
+        m.execute("touch /var/{db,lib}/sudo/lectured/admin 2>/dev/null || true")
+
         self.login_and_go(superuser=False)
         b.wait_text("#super-user-indicator", "Limited access")
 
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "sudo: no askpass program specified, try setting SUDO_ASKPASS")
-        b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_in_text(".pf-c-modal-box:contains('Problem becoming administrator')", "Sudo: no askpass program specified, try setting SUDO_ASKPASS")
+        b.click(".pf-c-modal-box:contains('Problem becoming administrator') button:contains('Close')")
+        b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.wait_text("#super-user-indicator", "Limited access")
 
     def testRemoveBridgeConfig(self):
@@ -219,10 +230,10 @@ session include system-auth
         self.login_and_go("/system", superuser=False)
         b.wait_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
         b.click(".pf-c-alert:contains('Web console is running in limited access mode.') button:contains('Turn on')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
 
@@ -344,10 +355,10 @@ class TestSuperuserOldWebserver(MachineCase):
 
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
         b.go("/playground/test")
         b.enter_page("/playground/test")
@@ -410,10 +421,10 @@ class TestSuperuserDashboard(MachineCase):
 
         b.leave_page()
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_text("#super-user-indicator", "Administrative access")
         b.enter_page("/playground/test", host="10.111.113.2")
         b.click(".super-channel button")
@@ -472,10 +483,10 @@ class TestSuperuserOldDashboard(MachineCase):
         b.go("/@10.111.113.2")
         b.enter_page("/system", host="10.111.113.2")
         b.click(".ct-overview-header-actions button:contains('Limited access')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_visible(".ct-overview-header-actions button:contains('Administrative access')")
         b.go("/@10.111.113.2/playground/test")
         b.enter_page("/playground/test", host="10.111.113.2")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -124,13 +124,15 @@ session include system-auth
         b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wrong")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Sorry, try again")
         b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wronger")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Sorry, try again")
         b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "wrongest")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "This didn't work")
-        b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Cancel')")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "sudo: 3 incorrect password attempts")
+        b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
         b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
         b.wait_text("#super-user-indicator", "Limited access")
 
@@ -154,7 +156,9 @@ session include system-auth
         b.wait_text("#super-user-indicator", "Limited access")
 
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "You can not gain administrative access")
+        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "admin is not in the sudoers file.  This incident will be reported.")
         b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
         b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
 
@@ -179,14 +183,11 @@ session include system-auth
 }
 """)
 
-        self.allow_journal_messages("sudo: no askpass program specified, try setting SUDO_ASKPASS")
-
         self.login_and_go(superuser=False)
         b.wait_text("#super-user-indicator", "Limited access")
 
         b.click("#super-user-indicator button")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Something went wrong")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "internal-error")
+        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "sudo: no askpass program specified, try setting SUDO_ASKPASS")
         b.click(".pf-c-modal-box:contains('Administrative access') button:contains('Close')")
         b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
         b.wait_text("#super-user-indicator", "Limited access")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -246,10 +246,10 @@ class TestSystemInfo(MachineCase):
 
         # Gain admin access
         b.click(".pf-c-alert:contains('Web console is running in limited access mode.') button:contains('Turn on')")
-        b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
-        b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
         # Change the date

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -238,7 +238,6 @@ class CommonTests:
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()
-        self.allow_failed_sudo_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
@@ -299,7 +298,6 @@ class CommonTests:
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()
-        self.allow_failed_sudo_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
@@ -364,7 +362,6 @@ class CommonTests:
 
             m.stop_cockpit()
 
-        self.allow_failed_sudo_journal_messages()
         # from sssd
         self.allow_journal_messages("alice is not allowed to run sudo on x0.  This incident will be reported.")
 

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -43,17 +43,9 @@ class TestShutdownRestart(MachineCase):
         m.execute("useradd user -s /bin/bash -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
         m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
+        self.password = "foobar"
 
-        m.start_cockpit()
-
-        # login
-        b.open("/system")
-        b.wait_visible("#login")
-        b.set_val("#login-user-input", "user")
-        b.set_val("#login-password-input", "foobar")
-        b.click('#login-button')
-        b.expect_load()
-        b.enter_page("/system")
+        self.login_and_go("/system", user="user")
 
         # shutdown button should be enabled and working
         b.click("#reboot-button")

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -31,7 +31,6 @@ class TestRoles(MachineCase):
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
-        self.allow_failed_sudo_journal_messages()
 
         m.start_cockpit()
 


### PR DESCRIPTION
- [x] #15666 
- [x] #15536
- [x] New screenshot for release notes
- [x] new test that expects the lecture
- [x] use "Switch to administrative access" as dialog title when there is a input field in it
- [x] move error to top in dialog
- [x] figure out `allow_failed_sudo_journal_messages`. Remove all calls?
- [ ] fix [race condition with reading lecture from sudo](https://logs.cockpit-project.org/logs/pull-15293-20210429-054124-d5fe5495-centos-8-stream/log.html#234-2)

This avoids running sudo without explicit request. This means that we don't probe anymore with `sudo -vn` but instead show the actual error message from sudo.

Demo: https://www.youtube.com/watch?v=Z1Cz-TTPsUs

----
## Shell: No opportunistic sudo invocation

Cockpit will no longer try to run sudo on the very first login, and you have to explicitly turn on administrative access once for each browser profile that you use to access Cockpit. This prevents cockpit's use of sudo being noisy in the journal.

In addition, Cockpit now shows sudo's exact messages in the "Administrative access" dialog.

![image](https://user-images.githubusercontent.com/3228183/114555372-4b634800-9c70-11eb-9d8b-30696ed69387.png)

