### PR TITLE
Build `make dist` artifact for every master commit and PR

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -1,0 +1,28 @@
+name: build-dist
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+        with:
+          # need this to also fetch tags
+          fetch-depth: 0
+
+      - name: Run unit-tests container
+        run: containers/unit-tests/start dist
+
+      - name: Create dist tarball artifact
+        uses: actions/upload-artifact@v2
+        with:
+          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
+          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
+          name: "dist-${{ github.event.pull_request.head.sha || github.sha }}"
+          path: tmp/dist/cockpit-*.tar.xz
+          retention-days: 7

--- a/Makefile.am
+++ b/Makefile.am
@@ -395,7 +395,7 @@ dist-gzip: distdir
 	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 dist-xz: distdir
 	$(DIST_TAR_MAIN) | xz $(XZ_COMPRESS_FLAGS) > $(distdir).tar.xz
-	$(DIST_TAR_CACHE) | xz $(XZ_COMPRESS_FLAGS) > cockpit-cache-$(VERSION).tar.xz
+	[ -n "$$NO_DIST_CACHE" ] || $(DIST_TAR_CACHE) | xz $(XZ_COMPRESS_FLAGS) > cockpit-cache-$(VERSION).tar.xz
 	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 
 distcheck-hook::

--- a/containers/unit-tests/scenario-dist.sh
+++ b/containers/unit-tests/scenario-dist.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -eux
+
+if [ "${NO_NPM:-}" = "1" ]; then
+    # We can't 'make dist' with NO_NPM, so unset it and finish the build
+    unset NO_NPM
+    test ! -d /tmp/source/node_modules # this shouldn't be here
+    if [ -d /source/node_modules ]; then
+        cp -r /source/node_modules /tmp/source
+    fi
+    tools/npm-install
+    test -d /tmp/source/node_modules # this must surely be here now
+    make
+fi
+
+make NO_DIST_CACHE=1 dist
+
+# container has a writable /results/ in the "dist" scenario, but not in others; copy dist tarball there
+if [ -w /results ]; then
+    cp cockpit-*.tar.xz /results/
+fi

--- a/containers/unit-tests/scenario-distcheck.sh
+++ b/containers/unit-tests/scenario-distcheck.sh
@@ -1,21 +1,7 @@
 #!/bin/sh -eux
 
-if [ "${NO_NPM:-}" = "1" ]; then
-    # We can't 'make dist' with NO_NPM, so unset it and finish the build
-    unset NO_NPM
-    test ! -d /tmp/source/node_modules # this shouldn't be here
-    if [ -d /source/node_modules ]; then
-        cp -r /source/node_modules /tmp/source
-    fi
-    tools/npm-install
-    test -d /tmp/source/node_modules # this must surely be here now
-    make
-fi
-
-make XZ_COMPRESS_FLAGS='-0' V=0 distcheck 2>&1 || {
-  find -name test-suite.log | xargs cat
-  exit 1
-}
+# build dist tarball fist
+"$(dirname "$0")"/scenario-dist.sh
 
 # check translation build
 make po/cockpit.pot

--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -1,4 +1,5 @@
-#!/bin/sh -e
+#!/bin/sh
+set -eu
 
 top_srcdir=$(realpath -m "$0"/../../..)
 image=ghcr.io/cockpit-project/unit-tests:latest
@@ -6,6 +7,7 @@ no_npm=''
 scenario=''
 flags=''
 cmd=''
+results_vol=''
 
 while test $# -gt 0; do
   case "$1" in
@@ -16,6 +18,12 @@ while test $# -gt 0; do
     shell) flags=-it; cmd=/bin/bash;;
     :*) image=ghcr.io/cockpit-project/unit-tests"$1";;
     distcheck|check-memory) scenario="--env=TEST_SCENARIO=$1";;
+    dist)
+        scenario="--env=TEST_SCENARIO=$1"
+        results_vol="--volume=${top_srcdir}/tmp/dist:/results:Z"
+        mkdir -m 777 -p "${top_srcdir}/tmp/dist"
+        ;;
+
     *) echo "Unknown option '$1'"; exit 1;;
   esac
   shift
@@ -33,4 +41,5 @@ fi
 
 set -ex
 exec ${docker} run --shm-size=512M --volume "${top_srcdir}":/source:ro \
+       ${results_vol:+"$results_vol"} \
        ${ccarg:+"$ccarg"} $scenario $no_npm $flags -- "$image" $cmd


### PR DESCRIPTION
The npm install/webpack steps are very expensive, and annoying to do
locally for reviewing PRs or updating a local checkout. Introduce a new
"build-dist" workflow which creates a downloadable dist tarball for each
interesting commit (PRs and pushes to master for now).

Split out the building part from scenario-distcheck.sh into a new "dist"
scenario, so that we can finish this workflow in the least possible
amount of time, as we soon want to trigger the tests after this
workflow, to re-use the built dist tarball.

Skip building the cockpit-cache*.tar.xz for this workflow -- we don't
need it for CI and it's expensive to build.

------

Note: This does not yet use the built dist tarball in unit nor integration tests. I'd like to build this one step at a time. The next step would be to adjust image-prepare or perhaps make-source to try and download that tarball, and we can see how that works for us developers. After we settle this, and @allisonkarlitskaya is done with her "optimize dist tarball" work, we can take the next steps.