### PR TITLE
Make sure that cockpit.language is set also when that is english

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3905,10 +3905,10 @@ function factory() {
     var po_data = { };
     var po_plural;
 
-    cockpit.language = undefined;
+    cockpit.language = "en";
 
     cockpit.locale = function locale(po) {
-        var lang = cockpit.language || "en";
+        var lang = cockpit.language;
         var header;
 
         if (po) {


### PR DESCRIPTION
cockpit.language was previously set inside cockpit.locale. That function
was only called for the languages which have a matching 'po' file.
English as the default does not have a po file and therefore
cockpit.language was not set for it. Similarly there was not cockpitLang
cookie when english was used.