### PR TITLE
Show busiest CPU cores

### DIFF
--- a/src/bridge/cockpitcpusamples.c
+++ b/src/bridge/cockpitcpusamples.c
@@ -24,6 +24,8 @@
 #include <stdio.h>
 #include <unistd.h>
 
+#define CPU_CORE_MAXLEN 8
+
 gint cockpit_cpu_user_hz = -1;
 
 static gint
@@ -71,28 +73,39 @@ cockpit_cpu_samples (CockpitSamples *samples)
       guint64 system;
       guint64 idle;
       guint64 iowait;
+      gchar cpu_core[CPU_CORE_MAXLEN + 1];
 
-      if (!(g_str_has_prefix (line, "cpu ")))
+      if (!(g_str_has_prefix (line, "cpu")))
         continue;
 
       #define FMT64 "%" G_GUINT64_FORMAT " "
-      if (sscanf (line + sizeof ("cpu ") - 1, FMT64 FMT64 FMT64 FMT64 FMT64,
+      if (sscanf (line, "%" G_STRINGIFY (CPU_CORE_MAXLEN) "s " FMT64 FMT64 FMT64 FMT64 FMT64,
+                  cpu_core,
                   &user,
                   &nice,
                   &system,
                   &idle,
-                  &iowait) != 5)
+                  &iowait) != 6)
         {
           g_warning ("Error parsing line %d of /proc/stat with content `%s'", n, line);
           continue;
         }
 
       user_hz = ensure_user_hz ();
-      cockpit_samples_sample (samples, "cpu.basic.nice", NULL, nice*1000/user_hz);
-      cockpit_samples_sample (samples, "cpu.basic.user", NULL, user*1000/user_hz);
-      cockpit_samples_sample (samples, "cpu.basic.system", NULL, system*1000/user_hz);
-      cockpit_samples_sample (samples, "cpu.basic.iowait", NULL, iowait*1000/user_hz);
-      break;
+      if (strlen (cpu_core) > 3)
+        {
+          cockpit_samples_sample (samples, "cpu.core.nice", cpu_core + 3, nice*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.core.user", cpu_core + 3, user*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.core.system", cpu_core + 3, system*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.core.iowait", cpu_core + 3, iowait*1000/user_hz);
+        }
+      else
+        {
+          cockpit_samples_sample (samples, "cpu.basic.nice", NULL, nice*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.basic.user", NULL, user*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.basic.system", NULL, system*1000/user_hz);
+          cockpit_samples_sample (samples, "cpu.basic.iowait", NULL, iowait*1000/user_hz);
+        }
     }
 
 out:

--- a/src/bridge/cockpitinternalmetrics.c
+++ b/src/bridge/cockpitinternalmetrics.c
@@ -69,6 +69,10 @@ static MetricDescription metric_descriptions[] = {
   { "cpu.basic.user",   "millisec", "counter", FALSE, CPU_SAMPLER },
   { "cpu.basic.system", "millisec", "counter", FALSE, CPU_SAMPLER },
   { "cpu.basic.iowait", "millisec", "counter", FALSE, CPU_SAMPLER },
+  { "cpu.core.nice",   "millisec", "counter", TRUE, CPU_SAMPLER },
+  { "cpu.core.user",   "millisec", "counter", TRUE, CPU_SAMPLER },
+  { "cpu.core.system", "millisec", "counter", TRUE, CPU_SAMPLER },
+  { "cpu.core.iowait", "millisec", "counter", TRUE, CPU_SAMPLER },
 
   { "memory.free",      "bytes", "instant", FALSE, MEMORY_SAMPLER },
   { "memory.used",      "bytes", "instant", FALSE, MEMORY_SAMPLER },

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -626,6 +626,15 @@ class TestMultiCPU(MachineCase):
         self.assertGreaterEqual(getMaximumSpike(b, "cpu", False, 1598968800000, 45), 0.5)
         self.assertLessEqual(getMaximumSpike(b, "cpu", False, 1598968800000, 45), 1.0)
 
+        # Test current usage of cores
+        b.wait(lambda: progressValue(b, "#current-cpu-usage") < 20)
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
+        b.wait(lambda: progressValue(b, "#current-cpu-usage") > 40)
+        b.mouse("#current-cpu-usage", "mouseenter")
+        b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:first-child div:nth-child(2)")[:-1]) > 50)
+        b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:nth-child(2) div:nth-child(2)")[:-1]) > 20)
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
![Screenshot from 2021-02-09 13-55-02](https://user-images.githubusercontent.com/12330670/107366733-c2e4f180-6ade-11eb-9052-6593825945cb.png)

Shows up to 16 cores ordered by their load. I picked 16 as it is a number that the UI manages just fine, is still human parsable (having list of 150 items is not) and standard user will see all their cores and on big servers it will be obvious that the list is shorter.