### PR TITLE
build: Drop gzipped dist tarballs and make-source usage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -358,9 +358,9 @@ install-data-local:: dist/guide/html/index.html
 uninstall-local::
 	rm -rf $(DESTDIR)$(htmldir)
 
-# See bots/make-source
-dump-dist-gzip:
-	@echo "$(abs_builddir)/$(distdir).tar.gz"
+# See test/image-prepare
+dump-dist:
+	@echo "$(abs_builddir)/$(distdir).tar.xz"
 
 # Subdirectories to distribute everything that's committed to git
 COMMITTED_DIST = \
@@ -390,9 +390,6 @@ DIST_ARCHIVES = \
 # used from containers/unit-tests/run.sh
 XZ_COMPRESS_FLAGS = --extreme
 
-dist-gzip: distdir
-	$(DIST_TAR_MAIN) | GZIP=$(GZIP_ENV) gzip -c > $(distdir).tar.gz
-	find "$(distdir)" -type d ! -perm -200 -exec chmod u+w {} ';' && rm -rf "$(distdir)"
 dist-xz: distdir
 	$(DIST_TAR_MAIN) | xz $(XZ_COMPRESS_FLAGS) > $(distdir).tar.xz
 	[ -n "$$NO_DIST_CACHE" ] || $(DIST_TAR_CACHE) | xz $(XZ_COMPRESS_FLAGS) > cockpit-cache-$(VERSION).tar.xz

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -18,6 +18,7 @@
 
 import argparse
 import errno
+import multiprocessing
 import os
 import sys
 import subprocess
@@ -152,13 +153,23 @@ def build_and_install(build_image, build_results, skips, args):
                                  memory_mb=2048, cpus=4, maintain=True, networking=networking)
     completed = False
 
-    # While the machine is booting, make a tarball
+    # While the machine is booting, make a dist tarball
+
+    # we need to support completely clean git trees, unpacked release tarballs, and already configured trees
+    if not os.path.exists("Makefile"):
+        if os.path.exists('./configure'):
+            subprocess.check_call('./configure')
+        else:
+            subprocess.check_call('./autogen.sh')
+
     # Do a development build on the latest Fedora image so that we can spot React and other dev-only warnings
     env = os.environ.copy()
     if os.path.basename(build_image) == TEST_OS_DEFAULT:
         env["NODE_ENV"] = "development"
-    source = subprocess.check_output([os.path.join(BOTS, "make-source")],
-                                     universal_newlines=True, env=env).strip()
+    # this is for a development build, not a release, so we care about speed, not best size
+    subprocess.check_call(["make", "--silent", "-j%i" % multiprocessing.cpu_count(),
+                           "NO_DIST_CACHE=1", "XZ_COMPRESS_FLAGS=-0", "dist"], env=env)
+    source = subprocess.check_output(["make", "dump-dist"], universal_newlines=True).strip()
     machine.start()
     completed = False
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -60,7 +60,7 @@ URL:            https://cockpit-project.org/
 Version:        0
 %if %{defined wip}
 Release:        1.%{wip}%{?dist}
-Source0:        cockpit-%{version}.tar.gz
+Source0:        cockpit-%{version}.tar.xz
 %else
 Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz


### PR DESCRIPTION
Since the introduction of `$XZ_COMPRESS_FLAGS` in commit 67831b9d2f and
supressing the build of cockpit-cache-* tarballs in commit 3482db3f5
there is no reason to build a .tar.gz dist any more, as `xz -0` is even
faster than gzip.

Drop the `dist-gzip` make target, adjust the "dump file name" target for
xz, and switch the .spec and image-prepare to using the tar.xz
targets/tarballs.

bots/make-source defaults to `dist-gzip`, is rather hard to work with
for dist-xz even with a custom target, and most of it is a big cockpit
special case (and not used in any other project). Let's phase it out,
and just do the few build steps ourselves -- these are project specific
anyway, so let's not pretend we can do an "one size fits it all" script.
While at it, replace make-source's static `-j8` with a dynamic CPU
count.

This will unblock building images straight from the pre-generated dist
tarballs in GitHub action artifacts.

 - [x] Fix bots debian.install to get along with tar.xz: https://github.com/cockpit-project/bots/pull/1658

FTR: I *may* want to split this back out into a tools/make-source (python,not shell) when I add the logic to try and download a pre-built dist tarball from GitHub. That is then probably more reusable for local development than as part of image-prepare. But I'd like to do that as part of the "download artifacts PR, not here.