### PR TITLE
workflows: Fix build-dist tarball name for PRs

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -14,6 +14,9 @@ jobs:
         with:
           # need this to also fetch tags
           fetch-depth: 0
+          # avoid checking out the default pull/NNN/head ref, as that gives
+          # mismatching SHAs in generated tarballs
+          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Run unit-tests container
         run: containers/unit-tests/start dist


### PR DESCRIPTION
actions/checkout uses the `pull/NNN/head` ref by default instead of the
proposed branch's HEAD. This lead to wrong tarball names:
The SHA in `cockpit-*.g<SHA>.tar.xz` did not match the artifact's
`dist-<SHA>` name and moreover not the local developer's `git describe`,
so that it is impossible to check whether the dist tarball for the
current local version was already downloaded.

Tell the checkout action to explicitly check out the PR's proposed
branch, exactly like in naming the artifact.

----

Our pre-built artifacts on github have a correct tarball name for `push` events:

```
❱❱❱ unzip -t dist-d6ba35c7ecebab22cbceba7757b6e7afab9b5621.zip 
Archive:  dist-d6ba35c7ecebab22cbceba7757b6e7afab9b5621.zip
    testing: cockpit-237.13.gd6ba35c7e.tar.xz   OK
```
But it is wrong for PRs:
```
❱❱❱ unzip -t dist-5037d961dcdebb36a4bfb1b4208942d844f030eb.zip 
Archive:  dist-5037d961dcdebb36a4bfb1b4208942d844f030eb.zip
    testing: cockpit-237.10.gbcc1821bf.tar.xz   OK
```
With that we can't ensure that we already have downloaded a correct tarball downloaded. I'd expect "cockpit-237.XX.g5037.." instead.

I have a hunch why that happens (actions/checkout uses the pull/NNN/head ref instead of the proposed branch's HEAD), but I need a PR to interactively debug it on github.