### PR TITLE
Replace 'restart' with 'reboot' when related to a system reboot

### DIFF
--- a/doc/guide/feature-systemd.xml
+++ b/doc/guide/feature-systemd.xml
@@ -55,7 +55,7 @@ Africa/Algiers
     <code>ntpd</code> can cause the <code>timedated</code> daemon to
     behave inconsistently with regards to time synchronization.</para>
 
-  <para>Cockpit restarts or powers down the machine by using the
+  <para>Cockpit reboots or powers down the machine by using the
     <ulink url="https://www.freedesktop.org/software/systemd/man/shutdown.html"><code>shutdown</code></ulink>
     command. To perform similar tasks from the command line, run it directly:</para>
 

--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -244,14 +244,14 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
             <DropdownItem key={`${id}-reboot`}
                           id={`${id}-reboot`}
                           onClick={() => onReboot()}>
-                {_("Restart")}
+                {_("Reboot")}
             </DropdownItem>
         );
         dropdownItems.push(
             <DropdownItem key={`${id}-forceReboot`}
                           id={`${id}-forceReboot`}
                           onClick={() => onForceReboot()}>
-                {_("Force restart")}
+                {_("Force reboot")}
             </DropdownItem>
         );
         dropdownItems.push(<DropdownSeparator key="separator-reset" />);

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -481,7 +481,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
             connecting = (machine.state == "connecting");
             if (machine.restarting) {
-                title = _("The machine is restarting");
+                title = _("The machine is rebooting");
                 message = "";
             } else if (connecting) {
                 title = _("Connecting to the machine");

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -203,8 +203,8 @@ class OverviewPage extends React.Component {
     render() {
         const { actionIsOpen } = this.state;
         const dropdownItems = [
-            <DropdownItem key="restart" id="restart" onClick={() => this.setState({ restartModal: true })} component="button">
-                {_("Restart")}
+            <DropdownItem key="reboot" id="reboot" onClick={() => this.setState({ rebootModal: true })} component="button">
+                {_("Reboot")}
             </DropdownItem>,
             <DropdownItem key="shutdown" id="shutdown" onClick={() => this.setState({ shutdownModal: true })} component="button">
                 {_("Shutdown")}
@@ -218,10 +218,10 @@ class OverviewPage extends React.Component {
                           toggle={
                               <DropdownToggle
                             splitButtonItems={[
-                                <DropdownToggleAction id='restart-button' variant="secondary"
-                                    key='restart-button'
-                                    onClick={() => this.setState({ restartModal: true })}>
-                                    {_("Restart")}
+                                <DropdownToggleAction id='reboot-button' variant="secondary"
+                                    key='reboot-button'
+                                    onClick={() => this.setState({ rebootModal: true })}>
+                                    {_("Reboot")}
                                 </DropdownToggleAction>
                             ]}
                             splitButtonVariant="action"
@@ -240,7 +240,7 @@ class OverviewPage extends React.Component {
 
         return (
             <>
-                {this.state.restartModal && <ShutdownModal onClose={() => this.setState({ restartModal: false })} />}
+                {this.state.rebootModal && <ShutdownModal onClose={() => this.setState({ rebootModal: false })} />}
                 {this.state.shutdownModal && <ShutdownModal shutdown onClose={() => this.setState({ shutdownModal: false })} />}
                 <Page>
                     <SuperuserAlert />

--- a/pkg/systemd/shutdown.jsx
+++ b/pkg/systemd/shutdown.jsx
@@ -177,9 +177,9 @@ export class ShutdownModal extends React.Component {
             <Modal isOpen position="top" variant="medium"
                    onClose={this.props.onClose}
                    id="shutdown-dialog"
-                   title={this.props.shutdown ? _("Shut down") : _("Restart")}
+                   title={this.props.shutdown ? _("Shut down") : _("Reboot")}
                    footer={<>
-                       <Button variant='danger' isDisabled={this.state.error || this.state.dateError} onClick={this.onSubmit}>{this.props.shutdown ? _("Shut down") : _("Restart")}</Button>
+                       <Button variant='danger' isDisabled={this.state.error || this.state.dateError} onClick={this.onSubmit}>{this.props.shutdown ? _("Shut down") : _("Reboot")}</Button>
                        <Button variant='link' onClick={this.props.onClose}>{_("Cancel")}</Button>
                    </>}
             >

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -177,7 +177,7 @@ OnCalendar=daily
         # Check that the system page is translated
         b.go("/system")
         b.enter_page("/system")
-        b.wait_in_text(".ct-overview-header", "Neustarten")
+        b.wait_in_text(".ct-overview-header", "Neustart")
 
         # Systemd timer localization
         b.go("/system/services")
@@ -518,7 +518,7 @@ OnCalendar=daily
         b.wait_visible("#content")
         b.go("/system")
         b.enter_page("/system")
-        b.wait_in_text(".ct-overview-header", "Neustarten")
+        b.wait_in_text(".ct-overview-header", "Neustart")
 
         b.switch_to_top()
         b.wait_visible("#host-apps li a:contains('Dienste')")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -283,13 +283,13 @@ class CommonTests:
         b.enter_page('/system')
         # shutdown button should be enabled and working
         # it takes a while for the permission check to finish, it is always enabled at first
-        b.click("#overview #restart-button")
+        b.click("#overview #reboot-button")
 
         b.wait_popup("shutdown-dialog")
         b.click("#delay")
         b.click("button:contains('No delay')")
         b.wait_text("#delay .pf-c-select__toggle-text", "No delay")
-        b.click("#shutdown-dialog button:contains(Restart)")
+        b.click("#shutdown-dialog button:contains(Reboot)")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
         m.wait_reboot()

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -57,9 +57,9 @@ class TestShutdownRestart(MachineCase):
         b.enter_page("/system")
 
         # shutdown button should be enabled and working
-        b.click("#restart-button")
+        b.click("#reboot-button")
         b.wait_popup("shutdown-dialog")
-        b.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Restart')
+        b.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Reboot')
         b.click("#delay")
         b.click("button:contains('No delay')")
         b.wait_text("#delay .pf-c-select__toggle-text", "No delay")
@@ -82,9 +82,9 @@ class TestShutdownRestart(MachineCase):
         self.login_and_go("/system")
 
         # Reboot
-        b.click("#restart-button")
+        b.click("#reboot-button")
         b.wait_popup("shutdown-dialog")
-        b.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Restart')
+        b.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Reboot')
         b.click("#delay")
         b.click("button:contains('No delay')")
         b.wait_text("#delay .pf-c-select__toggle-text", "No delay")
@@ -123,10 +123,10 @@ class TestShutdownRestart(MachineCase):
         b2.enter_page("/system", host="10.111.113.1")
         b2.wait_text("#system_information_hostname_text", "machine1")
 
-        # Check auto reconnect on restart
-        b2.click("#restart-button")
+        # Check auto reconnect on reboot
+        b2.click("#reboot-button")
         b2.wait_popup("shutdown-dialog")
-        b2.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Restart')
+        b2.wait_in_text("#shutdown-dialog button{0}".format(self.danger_btn_class), 'Reboot')
         b2.click("#delay")
         b2.click("button:contains('No delay')")
         b2.wait_text("#delay .pf-c-select__toggle-text", "No delay")
@@ -135,7 +135,7 @@ class TestShutdownRestart(MachineCase):
 
         b2.wait_visible(".curtains-ct")
         b2.wait_visible(".curtains-ct .spinner")
-        b2.wait_in_text(".curtains-ct h1", "restarting")
+        b2.wait_in_text(".curtains-ct h1", "rebooting")
 
         m.wait_reboot()
 


### PR DESCRIPTION
This should make clearer distinction between 'restart' (often used in relation to a service restart) and a 'reboot' (used in relation to a system reboot)

Fixes #15273