### PR TITLE
Stop disting node_modules/ fragments

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -376,7 +376,7 @@ dist-hook:: $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/tools/build-copying $(distdir)/node_modules > $(distdir)/COPYING.node
 	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README
-	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(distdir)/node_modules > $(distdir)/tools/debian/copyright
+	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(distdir) > $(distdir)/tools/debian/copyright
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - "$(distdir)"

--- a/Makefile.am
+++ b/Makefile.am
@@ -265,6 +265,8 @@ uninstall-local::
 	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_TEST_DEPS)
 	$(V_TAR) tar -cf - $^ | tar -C $(distdir) -xf -
+	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README
+	$(srcdir)/tools/build-copying $(distdir) > $(distdir)/COPYING.node
 
 #
 
@@ -374,8 +376,6 @@ dist-hook:: $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
 	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
 		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
-	$(srcdir)/tools/build-copying $(distdir)/node_modules > $(distdir)/COPYING.node
-	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README
 	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(distdir) > $(distdir)/tools/debian/copyright
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 

--- a/pkg/lib/included-modules-plugin.js
+++ b/pkg/lib/included-modules-plugin.js
@@ -1,0 +1,37 @@
+module.exports = class {
+    constructor(filename) {
+        this.filename = filename;
+    }
+
+    apply(compiler) {
+        compiler.hooks.emit.tap('IncludedModulesPlugin', compilation => {
+            let modules = { };
+
+            for (const file of compilation.fileDependencies) {
+                const parts = file.split("/");
+                const node_modules_index = parts.indexOf("node_modules");
+                let module_index = parts.lastIndexOf("node_modules") + 1;
+
+                if (node_modules_index && module_index) {
+                    if (parts[module_index].startsWith("@")) {
+                        module_index++;
+                    }
+
+                    const dir = parts.slice(node_modules_index, module_index + 1).join("/");
+                    modules[dir] = true;
+                }
+            }
+
+            modules = Object.keys(modules).sort();
+            let content = modules.join("\n");
+            if (content) {
+                content += "\n";
+            }
+
+            compilation.assets[this.filename] = {
+                source: () => content,
+                size: () => content.length
+            };
+        });
+    }
+};

--- a/tools/build-copying
+++ b/tools/build-copying
@@ -1,18 +1,23 @@
 #!/bin/sh
 
-set -euf
+set -eu
+distdir="$1"
 
-if [ -f $1/README ]; then
-    cat $1/README
-fi
+cat "${distdir}/node_modules/README"
+
+# include license information for
+#   a) all directly-shipped node_modules
+#   b) all node modules included by things we ship in dist/
+modules="${distdir}/node_modules $(cat ${distdir}/dist/*/included-modules)"
+files="$(find ${modules} -name 'COPYING' -o -name '*LICENSE*' | LC_ALL=C sort)"
 
 found=""
-find $1 -name 'COPYING' -o -name '*LICENSE*' -print | LC_ALL=C sort | while read filename; do
+for filename in ${files}; do
     directory=$(dirname $filename)
     name=$(basename $directory)
 
-    case $found in
-    "* $name *")
+    case "$found" in
+    *" $name "*)
         # skip
         ;;
     *)

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -20,7 +20,7 @@ template_file = os.path.join(debian_dir, 'copyright.template')
 
 def parse_args():
     p = argparse.ArgumentParser(description='Generate debian/copyright file from template and node_modules')
-    p.add_argument('node_modules', help='path to node_modules directory')
+    p.add_argument('distdir', help='path to toplevel distribution directory')
     return p.parse_args()
 
 
@@ -71,18 +71,29 @@ def module_copyright(moddir):
         out = subprocess.check_output(['env', '-u', 'LANGUAGE', 'LC_ALL=C.UTF-8', 'grep', '-hri', 'copyright.*\([1-9][0-9]\+\|(c)\)'],
                                       cwd=moddir).decode('UTF-8')
         for l in out.splitlines():
-            # ignore compiled .css.map files
-            if l.startswith('{"version":') or '*//*!' in l:
-                continue
             # weed out some noise
-            if 'grunt.template.today' in l or 'copyright-mark' in l or '@font-face' in l or 'Binary file' in l:
+            reject_substr = ['Binary file',
+                             '{"version":',
+                             'function(',
+                             'eval("',
+                             '*//*!',
+                             '"!="',
+                             'Code released under the',
+                             'Add copyright statements',
+                             'grunt.template.today',
+                             'copyright-mark',
+                             '@font-face',
+                             '<name of author>',
+                             'glyph-name=',
+                             'copyright holder',
+                             'WIPO copyright treaty']
+            if any(substr in l for substr in reject_substr):
                 continue
-            if '<name of author>' in l:
-                continue
+
             l = l.replace('<copyright>', '').replace('</copyright>', '')
             l = l.replace('&copy;', '(c)').replace('copyright = ', '')
             l = re.sub('@license.*Copyright', '', l)
-            l = l.strip(' \t*/\'|,')
+            l = l.strip(' \t*/\'|,#')
             if not l.endswith('Inc.'):
                 # avoids some duplicated lines which only differ in trailing dot
                 l = l.strip('.')
@@ -116,6 +127,9 @@ def module_copyright(moddir):
         except (IOError, KeyError):
             pass
 
+    if not copyrights and moddir.startswith('node_modules/@patternfly/'):
+        return module_copyright('node_modules/patternfly')
+
     if not copyrights:
         raise SystemError('Did not find any copyrights in %s' % moddir)
     return copyrights
@@ -130,25 +144,40 @@ with open(template_file, encoding='UTF-8') as f:
     template = f.read()
 
 license_ids = template_licenses(template)
-paragraphs = []
-for module in sorted(os.listdir(args.node_modules)):
-    if module.startswith('.'):
+module_users = {}
+
+for pkg in sorted(os.listdir(f'{args.distdir}/dist')):
+    if pkg in ['guide', 'ssh', 'pcp']:
         continue
-    if module == 'README':
-        continue
-    moddir = os.path.join(args.node_modules, module)
+    with open(f'{args.distdir}/dist/{pkg}/included-modules') as included_modules:
+        for module in included_modules:
+            module = module.strip()
+            # collect all packages pointing to one node module
+            if module not in module_users:
+                module_users[module] = set()
+            module_users[module].add(f'dist/{pkg}/*')
+
+paragraphs = {}
+for moddir in module_users:
     license = module_license(moddir)
     if license.lower() not in license_ids:
-        raise KeyError('%s has license %s which is not in %s' % (module, license, template_file))
-    copyrights = module_copyright(moddir)
-    paragraphs.append('''Files: node_modules/%s/*
-Copyright:%s
-License: %s''' % (module, '\n'.join(sorted(copyrights)), license))
+        raise KeyError('%s has license %s which is not in %s' % (moddir, license, template_file))
+    copyrights = '\n'.join(sorted(module_copyright(moddir)))
+    paragraph = f'Copyright:{copyrights}\nLicense: {license}'
+    # collect all modules with identical licence/copyright
+    if paragraph not in paragraphs:
+        paragraphs[paragraph] = set()
+    paragraphs[paragraph].update(module_users[moddir])
+
+output = []
+for paragraph in sorted(paragraphs):
+    files = '\n '.join(f'{dir}' for dir in sorted(paragraphs[paragraph]))
+    output.append(f'Files: {files}\n{paragraph}')
 
 # force UTF-8 output, even when running in C locale
 for l in template.splitlines():
     if '#NPM' in l:
-        sys.stdout.buffer.write('\n\n'.join(paragraphs).encode('UTF-8'))
+        sys.stdout.buffer.write('\n\n'.join(output).encode('UTF-8'))
     else:
         sys.stdout.buffer.write(l.encode('UTF-8'))
     sys.stdout.buffer.write(b'\n')

--- a/tools/debian/copyright.template
+++ b/tools/debian/copyright.template
@@ -108,6 +108,23 @@ License: GPL-2+
  On Debian systems, the complete text of the GNU General
  Public License can be found in "/usr/share/common-licenses/GPL-2".
 
+License: LGPL-3.0-or-later
+ This package is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ .
+ This package is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License
+ along with this program. If not, see <https://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU Lesser General
+ Public License can be found in "/usr/share/common-licenses/LGPL-3".
+
 License: BSD-3-clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -165,6 +182,18 @@ License: BSD-4-clause
  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  SUCH DAMAGE.
+
+License: 0BSD
+ Permission to use, copy, modify, and/or distribute this software for any
+ purpose with or without fee is hereby granted.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH
+ REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+ AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+ INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+ LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+ OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+ PERFORMANCE OF THIS SOFTWARE.
 
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -248,3 +277,16 @@ License: MPL-2.0
  .
  On Debian systems, the complete text of the Mozilla Public License
  can be found in "/usr/share/common-licenses/MPL-2.0".
+
+License: ISC
+ Permission to use, copy, modify, and distribute this software for any
+ purpose with or without fee is hereby granted, provided that the above
+ copyright notice and this permission notice appear in all copies.
+ .
+ THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -118,19 +118,11 @@ function generateDeps(makefile, stats) {
         parts.concat(module.fileDependencies || []).forEach(function(part) {
             var input = part.split("?")[0];
             maybePushInput(inputs, input);
-
-            /* We distribute licenses, so treat them as inputs */
-            moduleLicenses(input).forEach(function(input) {
-                maybePushInput(inputs, input);
-            });
         });
     });
 
     stats.compilation.fileDependencies.forEach(function(file) {
         maybePushInput(inputs, file);
-        moduleLicenses(file).forEach(function(input) {
-            maybePushInput(inputs, input);
-        });
     });
 
     // All the dependent files
@@ -182,7 +174,7 @@ function generateDeps(makefile, stats) {
         // Debug output and tests gets installed separately
         if (endsWith(install, ".map"))
             debugs[install] = install;
-        else if (output.indexOf("/test-") === -1)
+        else if (output.indexOf("/test-") === -1 && !output.includes("included-modules"))
             installs[install] = install;
     }
 
@@ -240,22 +232,6 @@ function generateDeps(makefile, stats) {
     fs.writeFileSync(makefile, data);
 }
 
-function moduleLicenses(input) {
-    var parts = input.split(path.sep);
-    var pos = parts.indexOf("node_modules");
-    var directory, results = [];
-    if (pos !== -1) {
-        directory = parts.slice(0, pos + 2).join(path.sep);
-        fs.readdirSync(directory).forEach(function(name) {
-            if (name.indexOf("COPYING") !== -1 || name.indexOf("LICENSE") !== -1 ||
-                name.indexOf("README.md") !== -1 || name.indexOf("package.json") !== -1)
-                results.push(path.join(directory, name));
-        });
-    }
-
-    return results;
-}
-
 function maybePushInput(inputs, input) {
     // Don't include or external refs
     if (endsWith(input, '/') || endsWith(input, 'manifest.json.in') ||
@@ -263,14 +239,9 @@ function maybePushInput(inputs, input) {
         return;
     }
 
-    // Don't include node devDependencies
-    var parts = input.split(path.sep);
-    var pos = parts.indexOf("node_modules");
-    if (pos !== -1) {
-        deps = npm["dependencies"] || { };
-        have = parts[pos + 1] in deps;
-        if (!have)
-            return;
+    // Don't include node_modules
+    if (input.includes("/node_modules/")) {
+        return;
     }
 
     // The latest modified date

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -259,6 +259,7 @@ const html = require('html-webpack-plugin');
 const miniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
+const IncludedModulesPlugin = require("./pkg/lib/included-modules-plugin");
 
 /* These can be overridden, typically from the Makefile.am */
 const srcdir = process.env.SRCDIR || __dirname;
@@ -348,6 +349,7 @@ function get_msggrep_options () {
 }
 
 const plugins = [
+    new IncludedModulesPlugin((section || "") + "included-modules"),
     new copy(info.files),
     new miniCssExtractPlugin("[name].css"),
     new OptimizeCSSAssetsPlugin({cssProcessorOptions: {map: {inline: false} } }),


### PR DESCRIPTION
This is the branch to stop disting fragments of node_modules/ for copyright and dependency purposes.

I'm currently locally inspecting in detail the difference between the generated tarballs, but it looks pretty promising so far...