### PR TITLE
test: Always end up test with a new line

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -140,6 +140,7 @@ def finish_test(opts, test, affected_tests):
         print_test(test, print_tap=opts.thorough)
         return retry_reason, 0
     else:
+        test.output += b"\n"
         print_test(test, print_tap=opts.thorough)
     return None, 1
 


### PR DESCRIPTION
Every failed test that is not retried (like the third run) does not have
new line after test name. Example:
```
not ok 59 test/verify/check-machines-disks TestMachinesDisks.testAddDiskAdditionalOptions [ND@1]# ----------------------------------------------------------------------
```

This causes issues for storing tests. We have workaround for stripping `# ---` from test names.
But sometimes when things go haywire, we don't get this devider, but we
might get something like:
```
not ok 294 test/verify/check-testlib TestRunTestListing.testBasictimeout: failed to run command `test/verify/check-shell-active-pages`: No such file or directory
```

Always putting new line at the end of the output prevents this unwanted behaviour.

Example logs:
- With having `timeout:` on the same line - [here](https://logs.cockpit-project.org/logs/pull-13525-20210210-172320-340bdad7-fedora-32-firefox/log) (look for testLockedDefaultIdentity)
- With having `# ---` on the same line - [here](https://logs.cockpit-project.org/logs/pull-15183-20210211-123910-98379a38-rhel-8-4-distropkg/log) (look for testAddDiskAdditionalOptions)