### PR TITLE
test: Test output from failed tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -212,7 +212,7 @@ def run(opts, image):
     test_files = glob.glob(os.path.join(opts.test_dir, "check-*"))
     if os.path.exists(os.path.join(os.path.dirname(testvm.TEST_DIR), ".git")):
         # Detect affected tests from changed test files
-        cmd = ["git", "diff", "--name-only", "HEAD", "origin/master", opts.test_dir]
+        cmd = ["git", "diff", "--name-only", "origin/master", opts.test_dir]
         r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         if r.returncode == 0:
             changed_tests = [test.decode("utf-8") for test in r.stdout.strip().splitlines()]
@@ -225,7 +225,7 @@ def run(opts, image):
         # Detect affected tests from changed pkg/* subdirectories
         # If affected tests get detected from pkg/* changes, don't apply the
         # "only do this for max. 3 check-* changes" (even if the PR also changes ≥ 3 check-*)
-        cmd = ["git", "diff", "--name-only", "HEAD", "origin/master", "pkg/"]
+        cmd = ["git", "diff", "--name-only", "origin/master", "pkg/"]
         r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         if r.returncode == 0:
             changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in r.stdout.strip().splitlines())

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -57,8 +57,8 @@ def flush_stdout():
             time.sleep(0.1)
 
 
-def print_test(test, print_tap=True):
-    for line in test.output.splitlines(keepends=True):
+def print_test(test, print_tap=True, retry_reason=""):
+    for line in test.output.strip().splitlines(keepends=True):
         while line:
             try:
                 sys.stdout.buffer.write(line)
@@ -69,17 +69,20 @@ def print_test(test, print_tap=True):
     flush_stdout()
 
     if not print_tap:
+        print(retry_reason)
         return
 
+    print()  # Tap needs to start on a separate line
     if test.process.returncode == 0:
-        print("ok " +  test_name(test))
+        print("ok " +  test_name(test) + retry_reason)
     elif test.process.returncode == 77 or b"# SKIP " in test.output:
         # If the test was skipped, add the last line (which contains the reason
         # for the skip) to the result
-        print("ok {0} {1}".format(test_name(test),
-                                  test.output.splitlines()[-1].strip().decode() if test.process.returncode == 77 else ""))
+        print("ok {0} {1}{2}".format(test_name(test),
+                                  test.output.splitlines()[-1].strip().decode() if test.process.returncode == 77 else "",
+                                  retry_reason))
     else:
-        print("not ok " + test_name(test))
+        print("not ok " + test_name(test) + retry_reason)
     flush_stdout()
 
 def finish_test(opts, test, affected_tests):
@@ -96,8 +99,7 @@ def finish_test(opts, test, affected_tests):
     if test.process.returncode == 0 and affected and test.retry_when_affected and test.retries < 2:
         retry_reason = b"test affected tests 3 times"
         test.retries += 1
-        test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
-        print_test(test, not opts.list)
+        print_test(test, not opts.list, " # RETRY {0} ({1})".format(test.retries, retry_reason.decode("utf-8")))
         return retry_reason, 0
     elif test.process.returncode in [0, 77]:
         print_test(test, not opts.list)
@@ -136,8 +138,7 @@ def finish_test(opts, test, affected_tests):
     unexpected_message = testlib.UNEXPECTED_MESSAGE.encode() in test.output
     if test.retries < 2 and not unexpected_message and retry_reason:
         test.retries += 1
-        test.output += b" # RETRY %i (%s)\n" % (test.retries, retry_reason)
-        print_test(test, print_tap=opts.thorough)
+        print_test(test, opts.thorough, " # RETRY {0} ({1})".format(test.retries, retry_reason.decode("utf-8")))
         return retry_reason, 0
     else:
         test.output += b"\n"

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -215,12 +215,18 @@ def run(opts, image):
         cmd = ["git", "diff", "--name-only", "origin/master", opts.test_dir]
         r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         if r.returncode == 0:
-            changed_tests = [test.decode("utf-8") for test in r.stdout.strip().splitlines()]
+            # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
+            # This file provides only examples, there is no place for it being flaky, no need to retry
+            changed_tests = [test.decode("utf-8") for test in r.stdout.strip().splitlines() if not test.endswith(b"check-example")]
 
         # If more than 3 test files were changed don't consider any of them as affected
         # as it might be a PR that changes more unrelated things.
         if len(changed_tests) > 3:
-            changed_tests = []
+            # If 'test/verify/check-testlib' is affected, keep just that one - our tests for tests count on that
+            if "test/verify/check-testlib" in changed_tests:
+                changed_tests = ["test/verify/check-testlib"]
+            else:
+                changed_tests = []
 
         # Detect affected tests from changed pkg/* subdirectories
         # If affected tests get detected from pkg/* changes, don't apply the

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -90,7 +90,7 @@ def finish_test(opts, test, affected_tests):
     Return (retry_reason, exit_code). retry_reason can be None or a string.
     """
 
-    affected = test.command[0] in affected_tests
+    affected = any([test.command[0].endswith(t) for t in affected_tests])
 
     # Try affected tests 3 times
     if test.process.returncode == 0 and affected and test.retry_when_affected and test.retries < 2:

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 import time
 import unittest
@@ -32,9 +33,14 @@ from fmf_metadata import FMF
 class TestExample(MachineCase):
 
     @unittest.expectedFailure
-    def testFail(self):
+    def testExpectedFail(self):
         self.login_and_go("/system")
         self.assertFalse(True)
+
+    def testFail(self):
+        self.login_and_go("/system")
+        if os.environ.get('TEST_FAILURES'):
+            self.assertFalse(True)
 
     @unittest.skip
     def testSkip(self):

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -28,6 +28,11 @@ from testlib import *
 dirname = os.path.dirname(__file__)
 run_tests = os.path.join(TEST_DIR, "common", "run-tests")
 VERIFY_DIR = os.path.join(TEST_DIR, "verify")
+ROOT_DIR = os.path.dirname(TEST_DIR)
+
+def writeFile(file, content):
+    with open(file, 'w') as f:
+        f.write(content)
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestRunTestListing(unittest.TestCase):
@@ -105,6 +110,75 @@ class TestRunTest(MachineCase):
         self.assertIn(b"1..0", out)
         self.assertNotIn(b"TestExample", out)
 
+    def testRetry(self):
+        # Don't test this if not in git repo as we use `git diff` for this logic
+        if not os.path.exists(os.path.join(ROOT_DIR, ".git")):
+            return
+
+        env = os.environ.copy()
+        env["TEST_FAILURES"] = "1"
+        try:
+            del env["TEST_JOBS"]
+        except KeyError:
+            pass
+
+        # Check that we retry 3 times failing tests
+        process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestExample.testFail", "TestExample.testSkip"],
+                                 env=env, capture_output=True)
+        stdout = process.stdout
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
+        self.assertNotRegex(stdout, b"RETRY 3")
+        self.assertRegex(stdout, b"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
+        self.assertRegex(stdout, b"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
+
+        # Check retry logic for changed tests
+        test_file = os.path.join(VERIFY_DIR, "check-testlib")
+        with open(test_file, 'r') as f:
+            original_test = f.read()
+
+        self.addCleanup(writeFile, test_file, original_test)
+        writeFile(test_file, original_test.replace("class NoTest", "class Test"))
+
+        process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestRetryExample.testFail", "TestRetryExample.testBasic",
+                                  "TestRetryExample.testNoRetry"], env=env, capture_output=True)
+        stdout = process.stdout
+
+        # Changed test need to succeed 3 times
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic\n")
+        self.assertNotRegex(stdout, b"RETRY 3")
+
+        # Changed test is never retried
+        self.assertRegex(stdout, b"\nnot ok 2 .*test\/verify\/check-testlib TestRetryExample.testFail\n")
+        self.assertNotRegex(stdout, b"testFail # RETRY")
+
+        # Using @no_retry_when_changed prevents this retry logic
+        self.assertRegex(stdout, b"\nok 3 .*test\/verify\/check-testlib TestRetryExample.testNoRetry\n")
+        self.assertNotRegex(stdout, b"testNoRetry # RETRY")
+
+        # Check retry logic for changed source
+        shell = os.path.join("pkg", "shell", "hosts.jsx")
+        self.assertTrue(os.path.exists(shell))
+
+        with open(shell, 'r') as f:
+            original_source = f.read()
+
+        self.addCleanup(writeFile, shell, original_source)
+        writeFile(shell, original_source + "\n")
+
+        process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "--list", "TestHostEditing.testLimits",
+                                  "TestHostSwitching.testEdit"], env=env, capture_output=True)
+        stdout = process.stdout
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits\n")
+        self.assertNotRegex(stdout, b"RETRY 3")
+        self.assertRegex(stdout, b"\nTestHostSwitching.testEdit\n")
+        self.assertNotRegex(stdout, b"TestHostSwitching.testEdit # RETRY")
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestTestlib(MachineCase):
@@ -151,6 +225,21 @@ class TestTestlib(MachineCase):
         # NSS/home got restored
         self.assertNotIn("cockpittest", self.machine.execute("cat /etc/passwd"))
         self.machine.execute("test ! -e /home/cockpittest")
+
+@skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
+class NoTestRetryExample(unittest.TestCase):
+
+    def testFail(self):
+        if os.environ.get('TEST_FAILURES'):
+            self.assertFalse(True)
+
+    @no_retry_when_changed
+    def testNoRetry(self):
+        self.assertTrue(True)
+
+    def testBasic(self):
+        self.assertTrue(True)
+
 
 
 if __name__ == '__main__':

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -34,8 +34,10 @@ class TestRunTestListing(unittest.TestCase):
 
     def testBasic(self):
         # nondestructive tests are sorted alphabetically; ascending or descending depending on $TEST_OS 1-bit hash
-        forward_sort_env = {"TEST_OS": "evenstring", "PATH": os.environ["PATH"]}
-        rev_sort_env = {"TEST_OS": "oddstring1", "PATH": os.environ["PATH"]}
+        forward_sort_env = os.environ.copy()
+        forward_sort_env["TEST_OS"] = "evenstring"
+        rev_sort_env = os.environ.copy()
+        rev_sort_env["TEST_OS"] = "oddstring1"
 
         # Listing on check-* file
         self.assertEqual(subprocess.check_output([os.path.join(dirname, "check-example"), "-l", "TestNondestructiveExample"]).strip().decode(),


### PR DESCRIPTION
This test checks fix introduced in 7a790f2.

Question: I would like to also test retries for changed test files and changed source files. My idea is to change for example `FITNESS FOR A PARTICULAR PURPOSE` string in copyright in one test file (`test/verify/check-example`) and in one source file (maybe users or so) and then check it is retried 3 times. Possibly also testing these retries for tests that fail or tests that don't want these retries. But this involves changing files on the machine that runs tests. Is that a good practice?