### PR TITLE
ws: Don't let remotectl touch permissions of admin-provided certificates

### DIFF
--- a/src/ws/remotectl-certificate.c
+++ b/src/ws/remotectl-certificate.c
@@ -185,7 +185,13 @@ ensure_certificate (const gchar *user,
         g_warning ("Failed to remove %s: %m", path);
     }
 
-  ret = set_cert_attributes (path, user, group, selinux);
+  /* adjust permissions of the certificates that we manage automatically;
+   * don't touch admin-provided certs, they are often shared between multiple services */
+  if (g_str_has_suffix (path, "/0-self-signed.cert") ||
+      g_str_has_suffix (path, "/10-ipa.cert"))
+    ret = set_cert_attributes (path, user, group, selinux);
+  else
+    ret = 0;
 
 out:
   g_clear_object (&certificate);

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -89,7 +89,7 @@ setup (TestCase *tc,
   const TestFixture *fix = data;
   const gchar *old_val = g_getenv ("XDG_CONFIG_DIRS");
   gint i;
-  struct group *gr = NULL;
+  struct group *gr;
 
   g_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
   tc->cert_dir = g_build_filename (config_dir, "cockpit", "ws-certs.d", NULL);
@@ -130,12 +130,11 @@ setup (TestCase *tc,
   g_ptr_array_add (ptr, "--user");
   g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
 
-  gr = getgrnam (g_get_user_name ());
-  if (gr != NULL)
-    {
-      g_ptr_array_add (ptr, "--group");
-      g_ptr_array_add (ptr, (gchar *) g_get_user_name ());
-    }
+  /* determine user's primary group; we require that it exists for the tests */
+  gr = getgrgid (getgid ());
+  g_assert (gr);
+  g_ptr_array_add (ptr, "--group");
+  g_ptr_array_add (ptr, gr->gr_name);
 
   for (i = 0; fix->files[i] != NULL; i++)
     g_ptr_array_add (ptr, (gchar *) fix->files[i]);

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -370,9 +370,9 @@ class TestConnection(MachineCase):
         self.assertRegex(
             output, "no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
-        # Install a certificate chain, and give it an arbitrary bad file context
+        # Install a certificate chain, and make it accessible for cockpit
         m.upload(["verify/files/cert-chain.cert"], "/etc/cockpit/ws-certs.d")
-        m.execute("! selinuxenabled || chcon --type svirt_sandbox_file_t /etc/cockpit/ws-certs.d/cert-chain.cert")
+        m.execute("cd /etc/cockpit/ws-certs.d; chgrp cockpit-ws cert-chain.cert; ! selinuxenabled || chcon --type etc_t cert-chain.cert")
 
         def check_cert_chain():
             # This should also reset the file context


### PR DESCRIPTION
Only call set_cert_attributes() for our own managaged 0-self-signed
certificate. Administrator provided ones are often shared with other
services, and mangling the permissions on every cockpit.service start
can actively damage these.

Add unit tests which cover both "our own" and "admin managed" cases.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1907254