### PR TITLE
test: FIx TestLogin.testTally for debian-testing

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -603,8 +603,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             self.sed_file("/common-auth/ { iauth required pam_tally2.so deny=4\n }", "/etc/pam.d/cockpit")
         elif m.image == 'debian-testing':
             # enable pam_faillock.  see example in pam_faillock(8), adopted for sss
-            self.sed_file("""s/re.*pam_deny.so/[default=die] pam_faillock.so authfail/;
-                             s/re.*pam_permit.so/sufficient pam_faillock.so authsucc/;
+            self.sed_file("""s/re.*pam_deny.so/[default=die] pam_faillock.so authfail deny=4/;
+                             s/re.*pam_permit.so/sufficient pam_faillock.so authsucc deny=4/;
                           """, "/etc/pam.d/common-auth")
         else:
             # see https://access.redhat.com/solutions/62949


### PR DESCRIPTION
Configure pam_faillock on debian-testing the same way as on all other
OSes, with deny=4. The default is 3, which caused the test to fail.

This was previously hidden by our naughty for the missing `faillock`
binary (https://github.com/cockpit-project/bots/issues/1585), but this
was fixed in pam 1.4.0-3.