### PR TITLE
manifest and stamp reform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,6 @@ depcomp
 /com.redhat.lvm2.c
 /com.redhat.lvm2.h
 /liblvmdbus.a
-/cockpit-desktop
 /cockpit-tls
 /cockpit-wsinstance-factory
 /wsinstance-start
@@ -108,6 +107,7 @@ tmp/weblate-repo
 /mock/
 *.min.html
 /src/ws/cockpit.appdata.xml
+/src/ws/cockpit-desktop
 /src/ws/cockpit*.service
 /src/ws/cockpit*.socket
 /src/ws/cockpit-tempfiles.conf

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,9 +15,6 @@ noinst_DATA =
 nodist_noinst_DATA =
 nodist_noinst_SCRIPTS =
 
-dist_systemdunit_DATA   =
-nodist_systemdunit_DATA =
-
 TESTS = $(NULL)
 
 CLEANFILES = \
@@ -48,12 +45,9 @@ SUFFIXES = \
 	.css .css.gz \
 	.html .html.gz \
 	.js .js.gz \
-	.json .json.in \
 	.jsx \
 	.map .map.gz \
 	.mo .po \
-	.service .service.in \
-	.socket .socket.in \
 	.svg .svg.gz \
 	.1 .8 .5 \
 	$(NULL)
@@ -114,37 +108,6 @@ GZ_RULE = \
 	$(V_GZIP) $(MKDIR_P) $(dir $@) && \
 	gzip -n -c $< > $@.tmp && $(MV) $@.tmp $@
 
-SUBST_RULE = \
-	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && sed \
-	-e 's,[@]datadir[@],$(datadir),g' \
-	-e 's,[@]libexecdir[@],$(libexecdir),g' \
-	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
-	-e 's,[@]libdir[@],$(libdir),g' \
-	-e 's,[@]includedir[@],$(includedir),g' \
-	-e 's,[@]bindir[@],$(bindir),g' \
-	-e 's,[@]sbindir[@],$(sbindir),g' \
-	-e 's,[@]prefix[@],$(prefix),g' \
-	-e 's,[@]exec_prefix[@],$(exec_prefix),g' \
-	-e 's,[@]prefix[@],$(prefix),g' \
-	-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
-	-e 's,[@]VERSION[@],$(VERSION),g' \
-	-e 's,[@]PKEXEC[@],$(PKEXEC),g' \
-	-e 's,[@]SUDO[@],$(SUDO),g' \
-	-e 's,[@]user[@],$(COCKPIT_USER),g' \
-	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
-	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \
-	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
-	-e 's,[@]admin_group[@],$(admin_group),g' \
-	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
-	-e 's,[@]with_networkmanager_needs_root[@],$(with_networkmanager_needs_root),g' \
-	-e 's,[@]with_storaged_iscsi_sessions[@],$(with_storaged_iscsi_sessions),g' \
-	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
-	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
-	-e 's,[@]with_nfs_client_package[@],$(with_nfs_client_package),g' \
-	-e 's,[@]with_vdo_package[@],$(with_vdo_package),g' \
-	$< > $@.tmp && $(MV) $@.tmp $@ \
-	$(NULL)
-
 .css.css.gz:
 	$(GZ_RULE)
 .html.html.gz:
@@ -153,10 +116,6 @@ SUBST_RULE = \
 	$(GZ_RULE)
 .map.map.gz:
 	$(GZ_RULE)
-.service.in.service:
-	$(SUBST_RULE)
-.socket.in.socket:
-	$(SUBST_RULE)
 .svg.svg.gz:
 	$(GZ_RULE)
 
@@ -196,7 +155,6 @@ WEBPACK_OUTPUTS =
 WEBPACK_INSTALL = $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
 WEBPACK_DEPS = $(WEBPACK_PACKAGES$(SKIP_NODE):%=dist/%/Makefile.deps)
 WEBPACK_STAMPS = $(WEBPACK_PACKAGES$(SKIP_NODE):%=dist/%/stamp)
-WEBPACK_MANIFEST_IN = $(WEBPACK_PACKAGES:%=pkg/%/manifest.json.in)
 
 # required for running unit and integration tests; commander and ws are deps of chrome-remote-interface
 WEBPACK_TEST_DEPS = \
@@ -208,7 +166,7 @@ WEBPACK_TEST_DEPS = \
 
 noinst_SCRIPTS += $(WEBPACK_STAMPS) $(WEBPACK_INSTALL)
 MAINTAINERCLEANFILES += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_OUTPUTS)
-EXTRA_DIST += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) $(WEBPACK_MANIFEST_IN) webpack.config.js
+EXTRA_DIST += $(WEBPACK_STAMPS) $(WEBPACK_DEPS) webpack.config.js
 
 PRINT_COPY_MSG_0 = echo "  COPY    " $@ &&
 PRINT_COPY_MSG_ = $(PRINT_COPY_MSG_$(AM_DEFAULT_VERBOSITY))
@@ -230,8 +188,9 @@ dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/node_modu
 	(if ls $(srcdir)/pkg/$*/*.js >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
 	  touch $@
 
-dist/%/manifest.json: pkg/%/manifest.json.in
-	$(SUBST_RULE)
+dist/%/manifest.json: pkg/%/manifest.json
+	@$(MKDIR_P) $(dir $@)
+	$(AM_V_GEN) ln -sfrT $< $@
 
 -include $(WEBPACK_DEPS)
 
@@ -254,7 +213,7 @@ node_modules/.stamp: package.json
 
 install-data-local:: $(WEBPACK_INSTALL)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	$(V_TAR) tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+	$(V_TAR) tar -chf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)
 	$(V_TAR) tar -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
 uninstall-local::

--- a/Makefile.am
+++ b/Makefile.am
@@ -186,7 +186,7 @@ dist/%/Makefile.deps:
 # This is the primary rule for running webpack; some pkgs like ssh or pcp only
 # have a manifest, no actual webpack, so don't call webpack-make for these
 dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/node_modules/.stamp
-	$(V_WEBPACK) $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG) && touch $@
+	$(V_WEBPACK) $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG)
 
 dist/%/manifest.json: pkg/%/manifest.json
 	@$(MKDIR_P) $(dir $@)

--- a/Makefile.am
+++ b/Makefile.am
@@ -128,19 +128,21 @@ WEBPACK_PACKAGES = \
 	machines \
 	metrics \
 	networkmanager \
-	pcp \
 	packagekit \
 	playground \
 	selinux \
 	shell \
 	sosreport \
-	ssh \
 	static \
 	storaged \
 	systemd \
 	tuned \
 	users \
 	$(NULL)
+
+MANIFEST_ONLY_PACKAGES = ssh pcp
+MANIFEST_PACKAGES = $(WEBPACK_PACKAGES) $(MANIFEST_ONLY_PACKAGES)
+MANIFEST_SYMLINKS = $(MANIFEST_PACKAGES:%=dist/%/manifest.json)
 
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
@@ -152,7 +154,7 @@ WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(abspa
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =
 WEBPACK_OUTPUTS =
-WEBPACK_INSTALL = $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
+WEBPACK_INSTALL =
 WEBPACK_DEPS = $(WEBPACK_PACKAGES$(SKIP_NODE):%=dist/%/Makefile.deps)
 WEBPACK_STAMPS = $(WEBPACK_PACKAGES$(SKIP_NODE):%=dist/%/stamp)
 
@@ -184,9 +186,7 @@ dist/%/Makefile.deps:
 # This is the primary rule for running webpack; some pkgs like ssh or pcp only
 # have a manifest, no actual webpack, so don't call webpack-make for these
 dist/%/stamp: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/node_modules/.stamp
-	$(V_WEBPACK) $(MKDIR_P) dist/$* && \
-	(if ls $(srcdir)/pkg/$*/*.js >/dev/null 2>&1; then $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG); else touch dist/$*/Makefile.deps; fi ) && \
-	  touch $@
+	$(V_WEBPACK) $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG) && touch $@
 
 dist/%/manifest.json: pkg/%/manifest.json
 	@$(MKDIR_P) $(dir $@)
@@ -211,7 +211,7 @@ node_modules/.stamp: package.json
 	@echo ''
 	@false
 
-install-data-local:: $(WEBPACK_INSTALL)
+install-data-local:: $(WEBPACK_INSTALL) $(MANIFEST_SYMLINKS)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
 	$(V_TAR) tar -chf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)

--- a/configure.ac
+++ b/configure.ac
@@ -409,58 +409,32 @@ AC_MSG_RESULT($asan_status)
 # User and group for running cockpit web server (cockpit-tls or -ws in customized setups)
 
 AC_ARG_WITH(cockpit_user,
-	    AS_HELP_STRING([--with-cockpit-user=<user>],
-			   [User for running cockpit (root)]
-                          )
-           )
+            AS_HELP_STRING([--with-cockpit-user=<user>],
+                           [User for running cockpit (root)]),
+            [cockpit_user=$withval], [cockpit_user=root])
 AC_ARG_WITH(cockpit_group,
-	    AS_HELP_STRING([--with-cockpit-group=<group>],
-			   [Group for running cockpit]
-                          )
-           )
-if test -z "$with_cockpit_user"; then
-    COCKPIT_USER=root
-    COCKPIT_GROUP=
-else
-    COCKPIT_USER=$with_cockpit_user
-    if test -z "$with_cockpit_group"; then
-        COCKPIT_GROUP=$with_cockpit_user
-    else
-	COCKPIT_GROUP=$with_cockpit_group
-    fi
-fi
-
-AC_SUBST(COCKPIT_USER)
-AC_SUBST(COCKPIT_GROUP)
+            AS_HELP_STRING([--with-cockpit-group=<group>],
+                           [Group for running cockpit]),
+            [cockpit_group=$withval], [cockpit_group=$with_cockpit_user])
 
 # User for running cockpit-ws instances from cockpit-tls
 
 AC_ARG_WITH(cockpit_ws_instance_user,
-	    AS_HELP_STRING([--with-cockpit-ws-instance-user=<user>],
-			   [User for running cockpit-ws instances from cockpit-tls (root)]
-                          )
+            AS_HELP_STRING([--with-cockpit-ws-instance-user=<user>],
+                           [User for running cockpit-ws instances from cockpit-tls (root)]),
+            [cockpit_ws_instance_user=$withval],
+            [cockpit_ws_instance_user=root]
            )
 AC_ARG_WITH(cockpit_ws_instance_group,
-	    AS_HELP_STRING([--with-cockpit-ws-instance-group=<group>],
-			   [Group for running cockpit-ws instances from cockpit-tls]
-                          )
+            AS_HELP_STRING([--with-cockpit-ws-instance-group=<group>],
+                           [Group for running cockpit-ws instances from cockpit-tls]),
+            [cockpit_ws_instance_group=$withval],
+            [cockpit_ws_instance_group=$cockpit_ws_instance_user]
            )
-if test -z "$with_cockpit_ws_instance_user"; then
-    if test "$COCKPIT_USER" != "root"; then
-        AC_MSG_ERROR([--with-cockpit-ws-instance-user is required when setting --with-cockpit-user])
-    fi
-    COCKPIT_WSINSTANCE_USER=root
-else
-    COCKPIT_WSINSTANCE_USER=$with_cockpit_ws_instance_user
-    if test -z "$with_cockpit_ws_instance_group"; then
-        COCKPIT_WSINSTANCE_GROUP=$with_cockpit_ws_instance_user
-    else
-        COCKPIT_WSINSTANCE_GROUP=$with_cockpit_ws_instance_group
-    fi
-fi
 
-AC_SUBST(COCKPIT_WSINSTANCE_USER)
-AC_SUBST(COCKPIT_WSINSTANCE_GROUP)
+if test "$cockpit_ws_instance_user" = "root" -a "$cockpit_user" != "root"; then
+    AC_MSG_ERROR([--with-cockpit-ws-instance-user is required when setting --with-cockpit-user])
+fi
 
 # admin users group
 AC_ARG_WITH([admin-group],
@@ -478,17 +452,18 @@ AC_ARG_WITH([admin-group],
                 AC_MSG_ERROR([none of '${CANDIDATE_GROUPS}' exist: please specify a group with --with-admin-group=])
               fi
             ])
+
+AC_SUBST(cockpit_user)
+AC_SUBST(cockpit_group)
+AC_SUBST(cockpit_ws_instance_user)
+AC_SUBST(cockpit_ws_instance_group)
 AC_SUBST(admin_group)
 
-
 AC_ARG_WITH(selinux_config_type,
-	    AS_HELP_STRING([--with-selinux-config-type=<type>],
-			   [SELinux context type for cockpit config files]
-                          )
-           )
-
-COCKPIT_SELINUX_CONFIG_TYPE=$with_selinux_config_type
-AC_SUBST(COCKPIT_SELINUX_CONFIG_TYPE)
+            AS_HELP_STRING([--with-selinux-config-type=<type>],
+                           [SELinux context type for cockpit config files]),
+            [selinux_config_type=$withval], [])
+AC_SUBST(selinux_config_type)
 
 # Documentation
 
@@ -595,16 +570,61 @@ AC_MSG_RESULT($enable_strict)
 m4_define_default([_AM_PYTHON_INTERPRETER_LIST], [python3 python2 python])
 AM_PATH_PYTHON([2.7])
 
+abs_expand() {
+  test "$prefix" = NONE && local prefix=$ac_default_prefix
+  test "$exec_prefix" = NONE && local exec_prefix="${prefix}"
+  local result=$1
+  for in in 0 1 2 3 4 5; do
+      eval result=${result}
+  done
+  echo "$result"
+}
+
+# for direct substitution in unit files and manifest.json
+AC_SUBST(abs_libexecdir, $(abs_expand $libexecdir))
+AC_SUBST(abs_datadir, $(abs_expand $datadir))
+AC_SUBST(abs_sbindir, $(abs_expand $sbindir))
+
 # Generate
 #
 
 AC_SUBST(PAM_LIBS)
 
 AC_OUTPUT([
-Makefile
-doc/guide/version
+    src/ws/cockpit-desktop
+    src/ws/cockpit-motd.service
+    src/ws/cockpit-tempfiles.conf
+    src/ws/cockpit-wsinstance-http-redirect.service
+    src/ws/cockpit-wsinstance-http-redirect.socket
+    src/ws/cockpit-wsinstance-http.service
+    src/ws/cockpit-wsinstance-http.socket
+    src/ws/cockpit-wsinstance-https-factory.socket
+    src/ws/cockpit-wsinstance-https-factory@.service
+    src/ws/cockpit-wsinstance-https@.service
+    src/ws/cockpit-wsinstance-https@.socket
+    src/ws/cockpit.service
+    src/ws/cockpit.socket
+    pkg/apps/manifest.json
+    pkg/base1/manifest.json
+    pkg/kdump/manifest.json
+    pkg/machines/manifest.json
+    pkg/metrics/manifest.json
+    pkg/networkmanager/manifest.json
+    pkg/packagekit/manifest.json
+    pkg/pcp/manifest.json
+    pkg/playground/manifest.json
+    pkg/selinux/manifest.json
+    pkg/shell/manifest.json
+    pkg/sosreport/manifest.json
+    pkg/ssh/manifest.json
+    pkg/static/manifest.json
+    pkg/storaged/manifest.json
+    pkg/systemd/manifest.json
+    pkg/tuned/manifest.json
+    pkg/users/manifest.json
+    doc/guide/version
+    Makefile
 ])
-
 
 dnl ==========================================================================
 echo "
@@ -614,11 +634,11 @@ echo "
         prefix:                     ${prefix}
         exec_prefix:                ${exec_prefix}
         libdir:                     ${libdir}
-        libexecdir:                 ${libexecdir}
+        libexecdir:                 ${libexecdir} (${abs_libexecdir})
         bindir:                     ${bindir}
-        sbindir:                    ${sbindir}
+        sbindir:                    ${sbindir} (${abs_sbindir})
         datarootdir:                ${datarootdir}
-        datadir:                    ${datadir}
+        datadir:                    ${datadir} (${abs_datadir})
         sysconfdir:                 ${sysconfdir}
         localstatedir:              ${localstatedir}
         pamdir:                     ${pamdir}
@@ -630,8 +650,8 @@ echo "
 
         cockpit-ws user:            ${COCKPIT_USER}
         cockpit-ws group:           ${COCKPIT_GROUP}
-        cockpit-ws instance user:   ${COCKPIT_WSINSTANCE_USER}
-        cockpit-ws instance group:  ${COCKPIT_WSINSTANCE_GROUP}
+        cockpit-ws instance user:   ${wsinstanceuser}
+        cockpit-ws instance group:  ${wsinstancegroup}
         admin group:                ${admin_group}
         selinux config type:        ${COCKPIT_SELINUX_CONFIG_TYPE}
 

--- a/pkg/lib/stampfile-plugin.js
+++ b/pkg/lib/stampfile-plugin.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const assert = require('assert');
+
+module.exports = class {
+    apply(compiler) {
+        compiler.hooks.afterEmit.tap('StampfilePlugin', compilation => {
+            const stamps = { };
+
+            for (const output in compilation.assets) {
+                const path = compilation.assets[output].existsAt;
+
+                /* `output` will be like
+                 *
+                 *   base1/cockpit.js
+                 *
+                 * `path` will be like
+                 *
+                 *   /build/dir/dist/base1/cockpit.js
+                 *
+                 * We want to get the full absolute path, up to and
+                 * including the first directory component of `output`.
+                 */
+                assert(path.startsWith("/"));
+                assert(path.endsWith(output));
+
+                const first_slash = output.indexOf('/');
+                const dir_length = path.length - output.length + first_slash;
+                const dir = path.slice(0, dir_length);
+
+                /* As per the above example, `dir` would be
+                 *
+                 *   /build/dir/dist/base1
+                 *
+                 * Let's put a stamp there.
+                 */
+                stamps[dir + '/stamp'] = true;
+            }
+
+            for (const stampfile in stamps) {
+                fs.writeFileSync(stampfile, '');
+            }
+        });
+    }
+};

--- a/pkg/pcp/manifest.json.in
+++ b/pkg/pcp/manifest.json.in
@@ -5,7 +5,7 @@
     "bridges": [
         {
             "match": { "payload": "metrics1" },
-            "spawn": [ "@libexecdir@/cockpit-pcp" ]
+            "spawn": [ "@abs_libexecdir@/cockpit-pcp" ]
         }
     ]
 }

--- a/pkg/shell/manifest.json.in
+++ b/pkg/shell/manifest.json.in
@@ -29,7 +29,7 @@
         {
             "privileged": true,
             "environ": [
-                "SUDO_ASKPASS=@libexecdir@/cockpit-askpass"
+                "SUDO_ASKPASS=@abs_libexecdir@/cockpit-askpass"
             ],
             "spawn": [
                 "@SUDO@",

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -9,7 +9,7 @@
             "match": { "session": "private", "user": null, "host": null },
             "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
-            "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
+            "spawn": [ "@abs_libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
@@ -17,19 +17,19 @@
             "match": { "session": "private", "host": null },
             "environ": [ "COCKPIT_SSH_CONNECT_TO_UNKNOWN_HOSTS=true",
                          "COCKPIT_PRIVATE_${channel}=${channel}" ],
-            "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
+            "spawn": [ "@abs_libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "user": null, "host": null },
-            "spawn": [ "@libexecdir@/cockpit-ssh", "${user}@${host}" ],
+            "spawn": [ "@abs_libexecdir@/cockpit-ssh", "${user}@${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         },
         {
             "match": { "host": null },
-            "spawn": [ "@libexecdir@/cockpit-ssh", "${host}" ],
+            "spawn": [ "@abs_libexecdir@/cockpit-ssh", "${host}" ],
             "timeout": 30,
             "problem": "not-supported"
         }

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -101,22 +101,20 @@ remotectl_LDADD = \
 	$(COCKPIT_LIBS) \
 	$(NULL)
 
-systemd_units_in = \
-	src/ws/cockpit-motd.service.in \
-	src/ws/cockpit.service.in \
-	src/ws/cockpit.socket.in \
-	src/ws/cockpit-wsinstance-http.service.in \
-	src/ws/cockpit-wsinstance-http.socket.in \
-	src/ws/cockpit-wsinstance-http-redirect.service.in \
-	src/ws/cockpit-wsinstance-http-redirect.socket.in \
-	src/ws/cockpit-wsinstance-https-factory@.service.in \
-	src/ws/cockpit-wsinstance-https-factory.socket.in \
-	src/ws/cockpit-wsinstance-https@.service.in \
-	src/ws/cockpit-wsinstance-https@.socket.in \
+dist_systemdunit_DATA = src/ws/system-cockpithttps.slice
+systemdunit_DATA = \
+	src/ws/cockpit-motd.service \
+	src/ws/cockpit.service \
+	src/ws/cockpit.socket \
+	src/ws/cockpit-wsinstance-http.service \
+	src/ws/cockpit-wsinstance-http.socket \
+	src/ws/cockpit-wsinstance-http-redirect.service \
+	src/ws/cockpit-wsinstance-http-redirect.socket \
+	src/ws/cockpit-wsinstance-https-factory@.service \
+	src/ws/cockpit-wsinstance-https-factory.socket \
+	src/ws/cockpit-wsinstance-https@.service \
+	src/ws/cockpit-wsinstance-https@.socket \
 	$(NULL)
-
-nodist_systemdunit_DATA += $(patsubst %.in,%,$(systemd_units_in))
-dist_systemdunit_DATA += src/ws/system-cockpithttps.slice
 
 motddir = $(datadir)/$(PACKAGE)/motd/
 dist_motd_DATA = src/ws/inactive.motd
@@ -130,11 +128,7 @@ install-exec-hook::
 	$(LN_S) -nf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
-nodist_tempconf_DATA = src/ws/cockpit-tempfiles.conf
-tempconf_in = src/ws/cockpit-tempfiles.conf.in
-
-$(nodist_tempconf_DATA): $(tempconf_in)
-	$(SUBST_RULE)
+tempconf_DATA = src/ws/cockpit-tempfiles.conf
 
 # If running cockpit-ws as a non-standard user, we also set up
 # cockpit-session to be setuid root, but only runnable by cockpit-session
@@ -158,22 +152,7 @@ install-exec-local::
 uninstall-local::
 	$(RM) -f $(DESTDIR)$(pamdir)/pam_cockpit_cert.so
 
-libexec_SCRIPTS = cockpit-desktop
-
-cockpit-desktop: src/ws/cockpit-desktop.in
-	$(SUBST_RULE)
-
-EXTRA_DIST += \
-	$(systemd_units_in) \
-	src/ws/cockpit-desktop.in \
-	$(tempconf_in) \
-	$(NULL)
-
-CLEANFILES += \
-	$(patsubst %.in,%,$(systemd_units_in)) \
-	$(nodist_tempconf_DATA) \
-	cockpit-desktop \
-	$(NULL)
+libexec_SCRIPTS = src/ws/cockpit-desktop
 
 appdatadir = $(datadir)/metainfo
 nodist_appdata_DATA = src/ws/cockpit.appdata.xml

--- a/src/ws/cockpit-motd.service.in
+++ b/src/ws/cockpit-motd.service.in
@@ -6,4 +6,4 @@ After=network-online.target cockpit.socket
 
 [Service]
 Type=oneshot
-ExecStart=-@datadir@/@PACKAGE@/motd/update-motd
+ExecStart=-@abs_datadir@/@PACKAGE@/motd/update-motd

--- a/src/ws/cockpit-tempfiles.conf.in
+++ b/src/ws/cockpit-tempfiles.conf.in
@@ -1,3 +1,3 @@
-C /run/cockpit/inactive.motd 0640 root @admin_group@ - @datadir@/@PACKAGE@/motd/inactive.motd
+C /run/cockpit/inactive.motd 0640 root @admin_group@ - @abs_datadir@/@PACKAGE@/motd/inactive.motd
 f /run/cockpit/active.motd   0640 root @admin_group@ -
 L+ /run/cockpit/motd - - - - inactive.motd

--- a/src/ws/cockpit-wsinstance-http-redirect.service.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.service.in
@@ -4,6 +4,6 @@ BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Service]
-ExecStart=@libexecdir@/cockpit-ws --proxy-tls-redirect --no-tls --port 0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@
+ExecStart=@abs_libexecdir@/cockpit-ws --proxy-tls-redirect --no-tls --port 0
+User=@cockpit_ws_instance_user@
+Group=@cockpit_ws_instance_group@

--- a/src/ws/cockpit-wsinstance-http-redirect.socket.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.socket.in
@@ -5,5 +5,5 @@ Documentation=man:cockpit-ws(8)
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/http-redirect.sock
-SocketUser=@user@
+SocketUser=@cockpit_user@
 SocketMode=0600

--- a/src/ws/cockpit-wsinstance-http.service.in
+++ b/src/ws/cockpit-wsinstance-http.service.in
@@ -4,6 +4,6 @@ BindsTo=cockpit.service
 Documentation=man:cockpit-ws(8)
 
 [Service]
-ExecStart=@libexecdir@/cockpit-ws --no-tls --port=0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@
+ExecStart=@abs_libexecdir@/cockpit-ws --no-tls --port=0
+User=@cockpit_ws_instance_user@
+Group=@cockpit_ws_instance_group@

--- a/src/ws/cockpit-wsinstance-http.socket.in
+++ b/src/ws/cockpit-wsinstance-http.socket.in
@@ -5,5 +5,5 @@ Documentation=man:cockpit-ws(8)
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/http.sock
-SocketUser=@user@
+SocketUser=@cockpit_user@
 SocketMode=0600

--- a/src/ws/cockpit-wsinstance-https-factory.socket.in
+++ b/src/ws/cockpit-wsinstance-https-factory.socket.in
@@ -6,5 +6,5 @@ Documentation=man:cockpit-ws(8)
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https-factory.sock
 Accept=yes
-SocketUser=@user@
+SocketUser=@cockpit_user@
 SocketMode=0600

--- a/src/ws/cockpit-wsinstance-https-factory@.service.in
+++ b/src/ws/cockpit-wsinstance-https-factory@.service.in
@@ -3,5 +3,5 @@ Description=Cockpit Web Service https instance factory
 Documentation=man:cockpit-ws(8)
 
 [Service]
-ExecStart=@libexecdir@/cockpit-wsinstance-factory
+ExecStart=@abs_libexecdir@/cockpit-wsinstance-factory
 User=root

--- a/src/ws/cockpit-wsinstance-https@.service.in
+++ b/src/ws/cockpit-wsinstance-https@.service.in
@@ -5,6 +5,6 @@ Documentation=man:cockpit-ws(8)
 
 [Service]
 Slice=system-cockpithttps.slice
-ExecStart=@libexecdir@/cockpit-ws --for-tls-proxy --port=0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@
+ExecStart=@abs_libexecdir@/cockpit-ws --for-tls-proxy --port=0
+User=@cockpit_ws_instance_user@
+Group=@cockpit_ws_instance_group@

--- a/src/ws/cockpit-wsinstance-https@.socket.in
+++ b/src/ws/cockpit-wsinstance-https@.socket.in
@@ -9,5 +9,5 @@ Documentation=man:cockpit-ws(8)
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https@%i.sock
-SocketUser=@user@
+SocketUser=@cockpit_user@
 SocketMode=0600

--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -9,10 +9,10 @@ After=cockpit-wsinstance-http.socket cockpit-wsinstance-http-redirect.socket coc
 RuntimeDirectory=cockpit/tls
 # systemd ≥ 241 sets this automatically
 Environment=RUNTIME_DIRECTORY=/run/cockpit/tls
-ExecStartPre=+@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
-ExecStart=@libexecdir@/cockpit-tls
-User=@user@
-Group=@group@
+ExecStartPre=+@abs_sbindir@/remotectl certificate --ensure --user=root --group=@cockpit_group@ --selinux-type=@selinux_config_type@
+ExecStart=@abs_libexecdir@/cockpit-tls
+User=@cockpit_user@
+Group=@cockpit_group@
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true

--- a/src/ws/cockpit.socket.in
+++ b/src/ws/cockpit.socket.in
@@ -5,7 +5,7 @@ Wants=cockpit-motd.service
 
 [Socket]
 ListenStream=9090
-ExecStartPost=-@datadir@/@PACKAGE@/motd/update-motd '' localhost
+ExecStartPost=-@abs_datadir@/@PACKAGE@/motd/update-motd '' localhost
 ExecStartPost=-/bin/ln -snf active.motd /run/cockpit/motd
 ExecStopPost=-/bin/ln -snf inactive.motd /run/cockpit/motd
 

--- a/tools/min-base-version
+++ b/tools/min-base-version
@@ -29,7 +29,7 @@ proj_dir = os.path.dirname(os.path.dirname(os.path.realpath(sys.argv[0])))
 
 max_version = ''
 
-for manifest in glob('dist/*/manifest.json'):
+for manifest in glob('pkg/*/manifest.json'):
     # if pkg names are given on the command line, then only look at those,
     # otherwise on all of them
     if len(sys.argv) > 1:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -260,6 +260,7 @@ const miniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
 const IncludedModulesPlugin = require("./pkg/lib/included-modules-plugin");
+const StampfilePlugin = require("./pkg/lib/stampfile-plugin.js");
 
 /* These can be overridden, typically from the Makefile.am */
 const srcdir = process.env.SRCDIR || __dirname;
@@ -352,6 +353,7 @@ const cssProcessorOptions = production ? { } : { map: {inline: false} };
 
 const plugins = [
     new IncludedModulesPlugin((section || "") + "included-modules"),
+    new StampfilePlugin(),
     new copy(info.files),
     new OptimizeCSSAssetsPlugin({cssProcessorOptions: cssProcessorOptions}),
     new miniCssExtractPlugin("[name].css"),


### PR DESCRIPTION
Here's a few more patches on our way to cleaning up our build system...

I know the stamp plugin is contentious, but the motivation is basically this: I want to get to a place where running `webpack` directly is equivalent to what happens when we type `make`.  For that, I want to shrink the relevant make rule to almost nothing.  That means the `touch` needs to go.