### PR TITLE
image-prepare: various cleanups, add --overlay option

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -43,7 +43,7 @@ def main():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
     parser.add_argument('-s', '--sit', action='store_true', help='Sit and wait if install script fails')
-    parser.add_argument('-q', '--quick', action='store_true', help='Build faster')
+    parser.add_argument('-q', '--quick', action='store_true', help='Skip unit tests to build faster')
     parser.add_argument('-b', '--build-image', action='store', help='Build in this image')
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -44,7 +44,6 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
     parser.add_argument('-s', '--sit', action='store_true', help='Sit and wait if install script fails')
     parser.add_argument('-q', '--quick', action='store_true', help='Build faster')
-    parser.add_argument('-f', '--force', action='store_true', help='Force update of images')
     parser.add_argument('-b', '--build-image', action='store', help='Build in this image')
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
     parser.add_argument('-s', '--sit', action='store_true', help='Sit and wait if install script fails')
     parser.add_argument('-q', '--quick', action='store_true', help='Skip unit tests to build faster')
+    parser.add_argument('-o', '--overlay', action='store_true', help='Install into existing test/image/ overlay instead of from pristine base image')
     parser.add_argument('-b', '--build-image', action='store', help='Build in this image')
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')
@@ -107,20 +108,21 @@ def upload_scripts(machine, args):
 
 
 # Create the necessary layered image for the build/install
-def prepare_install_image(base_image):
+def prepare_install_image(base_image, overlay=False):
     if "/" not in base_image:
         base_image = os.path.join(testvm.IMAGES_DIR, base_image)
     test_images = os.path.join(TEST, "images")
     os.makedirs(test_images, exist_ok=True)
     install_image = os.path.join(test_images, os.path.basename(base_image))
-    base_image = os.path.realpath(testvm.get_test_image(base_image))
-    qcow2_image = "{0}.qcow2".format(install_image)
-    subprocess.check_call(["qemu-img", "create", "-q", "-f", "qcow2",
-                           "-o", "backing_file={0},backing_fmt=qcow2".format(base_image),
-                           qcow2_image])
-    if os.path.lexists(install_image):
-        os.unlink(install_image)
-    os.symlink(os.path.basename(qcow2_image), install_image)
+    if not os.path.exists(install_image) or not overlay:
+        base_image = os.path.realpath(testvm.get_test_image(base_image))
+        qcow2_image = "{0}.qcow2".format(install_image)
+        subprocess.check_call(["qemu-img", "create", "-q", "-f", "qcow2",
+                               "-o", "backing_file={0},backing_fmt=qcow2".format(base_image),
+                               qcow2_image])
+        if os.path.lexists(install_image):
+            os.unlink(install_image)
+        os.symlink(os.path.basename(qcow2_image), install_image)
     return install_image
 
 
@@ -147,7 +149,7 @@ def run_install_script(machine, do_build, do_install, skips, arg, args):
 
 def build_and_install(build_image, build_results, skips, args):
     """Build and maybe install Cockpit into a test image"""
-    build_image = prepare_install_image(build_image)
+    build_image = prepare_install_image(build_image, args.overlay)
     machine = testvm.VirtMachine(verbose=args.verbose, image=build_image,
                                  memory_mb=2048, cpus=4, maintain=True, networking=networking)
     completed = False
@@ -197,7 +199,7 @@ def only_install(image, build_results, skips, args):
     if args.address:
         machine = testvm.Machine(address=args.address, verbose=args.verbose, image=image)
     else:
-        image = prepare_install_image(image)
+        image = prepare_install_image(image, args.overlay)
         machine = testvm.VirtMachine(verbose=args.verbose, image=image, networking=networking, maintain=True)
         machine.start()
         started = True

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -90,7 +90,7 @@ def main():
         if not args.install_only:
             build_and_install(build_image, results, skips, args)
         if not args.build_only and build_image != base_image:
-            only_install(base_image, results, skips, args, args.address)
+            only_install(base_image, results, skips, args)
     except (RuntimeError, testvm.Failure) as ex:
         sys.stderr.write("image-prepare: {0}\n".format(str(ex)))
         return 2
@@ -191,7 +191,7 @@ def build_and_install(build_image, build_results, skips, args):
             machine.stop()
 
 
-def only_install(image, build_results, skips, args, address):
+def only_install(image, build_results, skips, args):
     """Install Cockpit into a test image"""
     started = False
     if args.address:

--- a/test/run
+++ b/test/run
@@ -26,8 +26,8 @@ case $TEST_SCENARIO in
         test/containers/run-tests --container ${TEST_SCENARIO#*-}
         ;;
     dnf-copr*)
-        test/image-prepare --verbose $TEST_OS
         bots/image-customize -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y update' $TEST_OS
+        test/image-prepare --verbose --overlay $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;
     *)


### PR DESCRIPTION
I started this as preparation for replacing the fedora-testing image with a scenario. That will still need some discussion *where* to run these, similar to where to run the "nightly master" tests. I have an idea, but I'll discuss them in a meeting or on IRC.

In the meantime,  there is enough fodder here to warrant a full CI run. I also trigger the dnf-copr scenario, as this PR touches it.