### PR TITLE
metrics: Don't show too much empty space for future events

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -617,7 +617,7 @@ const MetricsHour = ({ startTime, data }) => {
             </dl>);
     }
 
-    for (let minute = 0; minute < 60; ++minute) {
+    for (let minute = 59; minute >= 0; --minute) {
         const dataOffset = minute * SAMPLES_PER_MIN;
         const dataSlice = normData.slice(dataOffset, dataOffset + SAMPLES_PER_MIN);
         const first = dataSlice.find(i => i !== null);

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -244,7 +244,7 @@
 
     &-hour {
         grid-gap: var(--data-gap);
-        grid-template-rows: repeat(60, minmax(var(--data-min-height), auto));
+        grid-template-rows: repeat(var(--metrics-minutes), minmax(var(--data-min-height), auto));
     }
 
     &-time,
@@ -288,7 +288,7 @@
 
     &-events {
         grid-column: events;
-        grid-row: calc(60 - var(--metrics-minute));
+        grid-row: calc(var(--metrics-minutes) - var(--metrics-minute));
         display: grid;
         grid-template-columns: [info] 1fr [time] 1fr;
         align-items: baseline;
@@ -305,12 +305,12 @@
     }
 
     &-info {
-        grid-row: calc(60 - var(--metrics-minute));
+        grid-row: calc(var(--metrics-minutes) - var(--metrics-minute));
         grid-column: information;
     }
 
     &-data {
-        grid-row: calc(60 - var(--metrics-minute));
+        grid-row: calc(var(--metrics-minutes) - var(--metrics-minute));
         display: grid;
         contain: strict;
         margin-left: 0.5rem;

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -103,11 +103,27 @@ class TestHistoryMetrics(MachineCase):
         # should only have at most <current_max> valid minutes, the rest should be empty
         valid_start = self.browser.call_js_func("ph_count", ".metrics-data-cpu.valid-data")
         self.assertLessEqual(valid_start, current_max)
-        # leave one minute wiggle room, in case the page updates between these two checks
-        self.assertGreaterEqual(self.browser.call_js_func("ph_count", ".metrics-data-cpu.empty-data"), 59 - valid_start)
         # page auto-updates every minute
         with self.browser.wait_timeout(90):
             self.browser.wait_js_func("(exp => ph_count('.metrics-data-cpu.valid-data') == exp)", valid_start + 1)
+
+        # Should never show more then 4 empty leading minutes (block of 5 minutes but always at least one used)
+        leading_empty = self.browser.call_js_func("""(function () {
+            const lines = document.getElementsByClassName("metrics-data-cpu");
+            let counter = 0;
+
+            Array.from(lines).every(l => {
+                if (l.classList.contains("empty-data")) {
+                    counter++;
+                    return true;
+                } else {
+                    return false;;
+                }
+            });
+
+            return counter;
+        })""")
+        self.assertLessEqual(leading_empty, 4)
 
     @skipImage("no PCP support", "fedora-coreos")
     def testBasic(self):
@@ -200,6 +216,10 @@ class TestHistoryMetrics(MachineCase):
         # swap usage is not shown if there is no swap
         b.wait_visible("#current-memory-usage")
         self.assertFalse(b.is_present("#current-swap-usage"))
+
+        # Check that we don't show too much empty minutes in the first hour
+        self.assertLessEqual(b.call_js_func("ph_count", ".metrics-data-cpu"), 35)
+
         b.logout()
 
         #


### PR DESCRIPTION
Show maximum of 5 empty minutes in the current hour. This does not affect missing data in general, only the current hour if cut short. See example: (this is extreme, takes two minutes after full hour)

Before:
![1402old](https://user-images.githubusercontent.com/12330670/107955733-6b42fc00-6f9e-11eb-979d-c228c3c2dd95.png)

Now:
![1402](https://user-images.githubusercontent.com/12330670/107955746-70a04680-6f9e-11eb-9d3e-9de1fc5f6ab1.png)
