### PR TITLE
storaged: Don't use modal-body class in CSS

### DIFF
--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -503,19 +503,7 @@ td.storage-action {
     visibility: hidden;
 }
 
-.modal-body .intermission {
-    margin-top: 1.5ex;
-    margin-bottom: 1ex;
-    white-space: normal;
-    line-height: 1.6666;
-    color: rgb(54, 54, 54);
-}
-
-.modal-body .medskip {
-    height: 2.5ex;
-}
-
-.modal-body .widest-title {
+.widest-title {
     visibility: hidden;
     height: 0px;
 }


### PR DESCRIPTION
Dialogs no longer have this class since some time ago.

- "intermission" is no longer used anywhere.

- "medskip" is used, but just a bare <div> without any CSS gives the
  right spacing now.

- "widest-title" needs to be invisible, so we keep that CSS paragraph
  but make it global.

Fixes #15337