### PR TITLE
logs: Fix unclosed div as a result of dde47795

### DIFF
--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -115,7 +115,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     </div>
   </div>
 
-  <div class="ct-page-fill" id="journal-entry">
+  <div class="ct-page-fill" id="journal-entry"></div>
 
   <script type="text/javascript" src="logs.js"></script>
 </body>


### PR DESCRIPTION
Logs was missing a `</div>`

I found this as I had the file opened (for whatever reason) and VS Code bugged me about it. :wink: