### PR TITLE
machines: correct few details in storage page when pool's deactivated

### DIFF
--- a/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
+++ b/pkg/machines/components/storagePools/storagePoolVolumesTab.jsx
@@ -112,7 +112,7 @@ export class StoragePoolVolumesTab extends React.Component {
                 <ListingTable variant='compact'
                     actions={actions}
                     aria-label={`Storage pool ${storagePool.name} Volumes`}
-                    emptyCaption={_("No storage volumes defined for this storage pool")}
+                    emptyCaption={storagePool.active ? _("No storage volumes defined for this storage pool") : _("Activate the storage pool to administer volumes")}
                     columns={columnTitles}
                     onSelect={this.onSelect}
                     rows={rows} />

--- a/pkg/machines/components/storagePools/storageVolumeCreate.jsx
+++ b/pkg/machines/components/storagePools/storageVolumeCreate.jsx
@@ -143,7 +143,7 @@ export class StorageVolumeCreate extends React.Component {
         const poolTypesNotSupportingVolumeCreation = ['iscsi', 'iscsi-direct', 'gluster', 'mpath'];
 
         const createButton = () => {
-            if (!poolTypesNotSupportingVolumeCreation.includes(this.props.storagePool.type)) {
+            if (!poolTypesNotSupportingVolumeCreation.includes(this.props.storagePool.type) && this.props.storagePool.active) {
                 return (
                     <Button id={`${idPrefix}-button`}
                         variant='secondary'
@@ -154,7 +154,7 @@ export class StorageVolumeCreate extends React.Component {
             } else {
                 return (
                     <Tooltip id='create-tooltip'
-                             content={_("Pool type doesn't support volume creation")}>
+                             content={this.props.storagePool.active ? _("Pool type doesn't support volume creation") : _("Pool needs to be active to create volume")}>
                         <span>
                             <Button id={`${idPrefix}-button`}
                                     variant='secondary'

--- a/test/verify/check-machines-storage-pools
+++ b/test/verify/check-machines-storage-pools
@@ -139,12 +139,16 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
         # Test operations on storage pools
         self.togglePoolRow("myPoolOne", connectionName)
+        self.gotoVolumesTab("myPoolOne")
 
         # Try deactivating and activating a pool
         b.click("#deactivate-pool-myPoolOne-{0}".format(connectionName))
         b.wait_in_text("#pool-myPoolOne-{0}-state".format(connectionName), "inactive")
+        b.wait_in_text("tr[data-row-id=pool-myPoolOne-{0}] + tr table td".format(connectionName), "Activate the storage pool to administer volumes")
+        b.wait_visible('#myPoolOne-{0}-create-volume-button:disabled'.format(connectionName))
         b.click("#activate-pool-myPoolOne-{0}".format(connectionName))
         b.wait_in_text("#pool-myPoolOne-{0}-state".format(connectionName), "active")
+        b.wait_visible('#myPoolOne-{0}-create-volume-button:enabled'.format(connectionName))
 
         # See deletion of Pool is disabled because this pool is referenced by VM's disk
         b.wait_visible("#delete-pool-myPoolTwo-{0}:disabled".format(connectionName))
@@ -389,10 +393,14 @@ class TestMachinesStoragePools(VirtualMachinesCase):
                     b.wait_in_text("#pool-{0}-{1}-source-path".format(self.name, connectionName), self.source["source_path"])
 
                 self.test_obj.gotoVolumesTab(self.name)
+                b.click("#activate-pool-{}-{}".format(self.name, connectionName))
+                b.wait_in_text("#pool-{}-{}-state".format(self.name, connectionName), "active")
                 if "iscsi" in self.pool_type:
                     b.wait_visible('#{}-{}-create-volume-button:disabled'.format(self.name, connectionName))
                 else:
                     b.wait_visible('#{}-{}-create-volume-button:enabled'.format(self.name, connectionName))
+                b.click("#deactivate-pool-{}-{}".format(self.name, connectionName))
+                b.wait_in_text("#pool-{}-{}-state".format(self.name, connectionName), "inactive")
 
             def cleanup(self):
                 m.execute("virsh pool-undefine {0}".format(self.name))


### PR DESCRIPTION
It's impossible to create a volume when a storage pool is deactived.
But right now, user has to fill out the form only to find this out.
Also when storage pool is deactivated, the "No storage volumes defined
for this storage pool" string is shown in volumes list. That's incorrect.
There are no volumes because libvirt API cannot fetch any information
about volumes for deactivated storage pool. 
Therefore to fix both problems, just hide the storage volumes list if pool
is deactivated and instead show a warning telling to user to activate the
pool

### Before:
![Screenshot from 2021-02-16 13-35-15](https://user-images.githubusercontent.com/42733240/108063689-e4ecef80-705b-11eb-9c4c-01eae92746f3.png)
![Screenshot from 2021-02-16 13-35-34](https://user-images.githubusercontent.com/42733240/108063696-e6b6b300-705b-11eb-8c01-607564771fe4.png)

### After:
![Screenshot from 2021-02-16 13-28-14](https://user-images.githubusercontent.com/42733240/108063337-58423180-705b-11eb-82e7-3b2201b7459d.png)
