### PR TITLE
Fedora 34

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1117,6 +1117,10 @@ class MachineCase(unittest.TestCase):
             # Fedora switched to dbus-broker
             self.allowed_messages.append("dbus-daemon didn't send us a dbus address; not installed?.*")
 
+        if self.image in ['fedora-34']:
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1929259
+            self.allow_journal_messages('audit:.*denied.*comm="pmdakvm" lockdown_reason="debugfs access".*')
+
         if self.image in ['debian-testing', 'ubuntu-stable']:
             # HACK: https://bugs.debian.org/951477
             self.allowed_messages.append('Process .* \(ip6?tables\) of user 0 dumped core.*')

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -220,7 +220,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         # We don't want to use start_vm == False because if we get a separate install phase
         # virt-install will overwrite our changes.
 
-        if self.machine.image not in ["fedora-33", "fedora-testing", "debian-testing"]:
+        if self.machine.image not in ["fedora-33", "fedora-34", "fedora-testing", "debian-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             self.machine.execute("virsh destroy pxe-guest")
@@ -1310,7 +1310,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
 
         # Change the os boot firmware configuration
-        supports_firmware_config = m.image in ['fedora-32', 'fedora-33', 'fedora-testing', 'centos-8-stream', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
+        supports_firmware_config = m.image in ['fedora-32', 'fedora-33', 'fedora-34', 'fedora-testing', 'centos-8-stream', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
         if supports_firmware_config:
             b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
             b.click("#vm-VmNotInstalled-firmware")
@@ -1338,7 +1338,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             # HACK: Capabilities are not updated dynamically
             # https://bugzilla.redhat.com/show_bug.cgi?id=1807198
             def hack_broken_caps():
-                if m.image in ["fedora-32", "fedora-33", "fedora-testing", "centos-8-stream", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg", "ubuntu-2004", "ubuntu-stable", "debian-testing"]:
+                if m.image in ["fedora-32", "fedora-33", "fedora-34", "fedora-testing", "centos-8-stream", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg", "ubuntu-2004", "ubuntu-stable", "debian-testing"]:
                     m.execute("systemctl restart libvirtd")
                     # We don't get events for shut off VMs so reload the page
                     b.reload()
@@ -1364,7 +1364,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
         m.execute("> {0}".format(logfile)) # clear logfile
         self.performAction("VmNotInstalled", "forceOff", False)
-        if m.image not in ["fedora-33", "fedora-testing", "debian-testing"]:
+        if m.image not in ["fedora-33", "fedora-34", "fedora-testing", "debian-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
             # After shutting it off virt-install will restart the domain and exit because of the above bug
             # We need to wait till it's restarted and shut if off again in order to edit the offline VM configuration

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -64,7 +64,7 @@ class TestBonding(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
+        if m.image not in ["fedora-coreos", "fedora-33", "fedora-34", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed and both On

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -55,7 +55,7 @@ class TestBridge(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
+        if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-33", "fedora-34", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Check that the members are displayed and both On

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -248,7 +248,7 @@ class TestFirewall(NetworkCase):
         # now add pop3
         addService('public', 'pop3')
         # firewalld > 0.7.0 supports including services into another service
-        if m.image in ['rhel-8-3', 'rhel-8-4', 'debian-testing', 'fedora-testing', "fedora-32", "fedora-33"]:
+        if m.image in ['rhel-8-3', 'rhel-8-4', 'debian-testing', 'fedora-testing', "fedora-32", "fedora-33", "fedora-34"]:
             addService('public', 'freeipa-4')
             b.click(".zone-section[data-id='public'] tr[data-row-id='freeipa-4'] button")
             b.wait_visible(".zone-section[data-id='public'] tbody.pf-m-expanded .pf-c-table__expandable-row:contains(Included Services)")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -55,7 +55,7 @@ class TestTeam(NetworkCase):
 
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-33", "fedora-testing"]:
+        if m.image not in ["fedora-coreos", "fedora-33", "fedora-34", "fedora-testing"]:
             m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -962,7 +962,7 @@ class TestWsUpdate(NoSubManCase):
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",
-           "fedora-32", "fedora-33", "fedora-testing", "ubuntu-2004", "ubuntu-stable")
+           "fedora-32", "fedora-33", "fedora-34", "fedora-testing", "ubuntu-2004", "ubuntu-stable")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -58,6 +58,8 @@ class TestActivePages(MachineCase):
         b.wait_not_present("#active-pages-dialog")
 
         # open the terminal page and start a session we can see on the machine
+        # Remove failed units which will show up in the first terminal line
+        m.execute("systemctl reset-failed")
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -620,7 +620,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # pam_faillock tries to chown the file to be owned by the user itself,
         # which is currently an selinux fail on the following distros:
-        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-32', 'fedora-33', 'rhel-8-3', 'rhel-8-4']:
+        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-32', 'fedora-33', 'fedora-34', 'rhel-8-3', 'rhel-8-4']:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1836182
             self.allow_journal_messages('.*type=1400.*avc:  denied  { chown }.*comm="cockpit-session".*')
 

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -31,6 +31,9 @@ class TestStorageISCSI(StorageCase):
         b = self.browser
         b.wait_timeout(120)
 
+        # ensure that we generate a /etc/iscsi/initiatorname.iscsi
+        m.execute("systemctl start iscsid && systemctl stop iscsid")
+
         target_iqn = "iqn.2015-09.cockpit.lan"
         initiator_iqn = "iqn.2015-10.cockpit.lan"
 
@@ -59,7 +62,6 @@ class TestStorageISCSI(StorageCase):
         self.login_and_go("/storage")
 
         # Set initiator IQN
-        #
         orig_iqn = m.execute("sed </etc/iscsi/initiatorname.iscsi -e 's/^.*=//'").rstrip()
         b.click('#edit-iscsi')
         self.dialog(expect={"name": orig_iqn},

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -228,12 +228,16 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_journal_empty()
 
         def wait_slow10():
-            if m.image.startswith("rhel") or m.image.startswith("centos"): # Older systemd does not show when unit finishes
-                wait_log_lines([["sh", "SLOW", "10"],
-                               ["systemd", "Started Slowly log 10 identical lines.", ""]])
+            systemd_version = int(m.execute("systemctl --version | awk '{print $2; exit}'").strip())
+
+            if systemd_version >= 248:
+                # changed in https://github.com/systemd/systemd/commit/f5ec78e503
+                stop_message = "Deactivated successfully."
             else:
-                wait_log_lines([["systemd", "slow10.service: Succeeded.", ""], ["sh", "SLOW", "10"],
-                               ["systemd", "Started Slowly log 10 identical lines.", ""]])
+                stop_message = "Succeeded."
+
+            wait_log_lines([["systemd", "slow10.service: " + stop_message, ""], ["sh", "SLOW", "10"],
+                            ["systemd", "Started Slowly log 10 identical lines.", ""]])
 
         def wait_log_present(message):
             b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('%s')" % message)

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -36,6 +36,9 @@ PS1="\\u@\\h \\W]\$ "
 PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
 """, append=True)
 
+        # Remove failed units which will show up in the first terminal line
+        self.machine.execute("systemctl reset-failed")
+
     @skipBrowser("Firefox needs http to access clipboard", "firefox")
     @nondestructive
     def testBasic(self):


### PR DESCRIPTION
 - [x] Move our fedora-33 image to cloud first, and fix tests: https://github.com/cockpit-project/bots/pull/1719 (as a lot of failures are due to that)
 - [x] `test/verify/check-kdump TestKdump.testBasic`: [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1933970), known issue https://github.com/cockpit-project/bots/issues/1734 , needs naughty pattern
 - [x] `test/verify/check-static-login TestLogin.testBasic` root bridge core dump -- *update*: pitti can't reproduce any more, likely fixed with the utmp binary fix below. Will re-open if CI disagrees.
 - [x]  test/verify/check-system-journal TestJournal.testBasic systemd changed log message https://github.com/systemd/systemd/commit/f5ec78e503212855eb2adf92628023148afcea6f
 - [x]  test/verify/check-shell-active-pages, check-systemd-terminal fail because of failed unit appearing on the first terminal line
 - [x]  test/verify/check-users TestAccounts.test* parsing utmp closes the cockpit channel - passing the binary: true option fixes the issue
 - [x] check-realms realm join failure for AD: [bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1934124), known issue https://github.com/cockpit-project/bots/issues/1735 : https://github.com/cockpit-project/bots/pull/1740
 - [x] `TestStorageFormat.testFormatTypes` failure is https://github.com/cockpit-project/bots/issues/1733 , needs applying the naughty to fedora-34 as well (dosfstools-4.2-1.fc34.x86_64)
 - [x] `TestCurrentMetrics.testMemory`: fixed in PR #15454
 - [x]  check-storage-resize TestStorageResize.testResizeLuks: direct issue from https://bugzilla.redhat.com/show_bug.cgi?id=1934567, fixed locally
 - [x] fix watching binary channels: PR #15467