### PR TITLE
test: Run cleanup handlers if debug artifact generation fails

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -693,10 +693,16 @@ class _DebugOutcome(unittest.case._Outcome):
                         assert err_case == test_case
                         # strip off the two topmost frames for testPartExecutor and TestCase.run(); uninteresting and breaks naughties
                         traceback.print_exception(exc_info[0], exc_info[1], exc_info[2].tb_next.tb_next)
-                        test_case.snapshot("FAIL")
-                        test_case.copy_js_log("FAIL")
-                        test_case.copy_journal("FAIL")
-                        test_case.copy_cores("FAIL")
+                        try:
+                            test_case.snapshot("FAIL")
+                            test_case.copy_js_log("FAIL")
+                            test_case.copy_journal("FAIL")
+                            test_case.copy_cores("FAIL")
+                        except (OSError, RuntimeError):
+                            # failures in these debug artifacts should not skip cleanup actions
+                            sys.stderr.write("Failed to generate debug artifact:\n")
+                            traceback.print_exc(file=sys.stderr)
+
                         if opts.sit:
                             sit(test_case.machines)
 


### PR DESCRIPTION
Sometimes, copy_journal() and friends can cause exceptions themselves,
e.g. due to timing out reading the journal. This previously circumvented
all addCleanup() handlers, which causes all subsequent tests to fail.

Handle runtime exceptions in these artifact generation methods locally
instead, and just print them.

----

This should fix  [this kind of follow-up failures](https://logs.cockpit-project.org/logs/pull-15355-20210217-032549-97d78124-ubuntu-2004/log.html#68) due to improper cleanup.