### PR TITLE
Restyle selinux to fit other pages

### DIFF
--- a/pkg/lib/cockpit-components-modifications.css
+++ b/pkg/lib/cockpit-components-modifications.css
@@ -1,23 +1,3 @@
-.modifications-table {
-    border: solid 1px var(--color-border);
-}
-
-.modifications-table .listing-ct-empty {
-    border-top: inherit;
-}
-
-.modification-row:not(:last-child){
-    border-bottom: 1px solid var(--color-gray-1);
-}
-
-.modification-row:last-child{
-    border-bottom: 1px solid var(--color-light-gray);
-}
-
-.modification-row td {
-    padding: 5px 10px;
-}
-
 .automation-script-modal pre {
     max-height: 20em;
     margin-bottom: 5px;
@@ -30,10 +10,6 @@
 .automation-script-modal i.fa {
     margin-right: 2px;
     margin-left: 5px;
-}
-
-.automation-script-modal .modal-footer button:first-child {
-    float: left;
 }
 
 .green-icon {

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -19,7 +19,11 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Button, Modal, Tabs, Tab } from '@patternfly/react-core';
+import {
+    Button, Card, CardHeader, CardTitle, CardActions, CardBody,
+    DataList, DataListItem, DataListItemRow, DataListCell, DataListItemCells,
+    Modal, Tabs, Tab, Text, TextVariants
+} from '@patternfly/react-core';
 
 import cockpit from "cockpit";
 import './listing.scss';
@@ -138,44 +142,48 @@ export class Modifications extends React.Component {
         let fail_message = this.props.permitted ? _("No system modifications") : _("The logged in user is not permitted to view system modifications");
         fail_message = this.props.failed ? _("Error running semanage to discover system modifications") : fail_message;
         if (this.props.entries === null) {
-            emptyRow = <thead className="listing-ct-empty">
-                <tr className="modification-row">
-                    <td>
-                        <div className="spinner spinner-sm" />
-                        <span>{_("Loading system modifications...")}</span>
-                    </td>
-                </tr>
-            </thead>;
+            emptyRow = <DataListItem>
+                <DataListItemRow>
+                    <DataListItemCells dataListCells={[<DataListCell key="loading">{_("Loading system modifications...")}</DataListCell>]} />
+                </DataListItemRow>
+            </DataListItem>;
         }
         if (this.props.entries !== null && this.props.entries.length === 0) {
-            emptyRow = <thead className="listing-ct-empty">
-                <tr className="modification-row">
-                    <td>
-                        { fail_message }
-                    </td>
-                </tr>
-            </thead>;
+            emptyRow = <DataListItem>
+                <DataListItemRow>
+                    <DataListItemCells dataListCells={[<DataListCell key={fail_message}>{fail_message}</DataListCell>]} />
+                </DataListItemRow>
+            </DataListItem>;
         }
 
         return (
-            <section className="ct-listing">
+            <>
                 <ModificationsExportDialog show={this.state.showDialog} shell={this.props.shell} ansible={this.props.ansible} onClose={ () => this.setState({ showDialog: false }) } />
-                <header>
-                    <h3 className="listing-ct-heading">{this.props.title}</h3>
-                    <div className="listing-ct-actions">
+                <Card className="modifications-table">
+                    <CardHeader>
+                        <CardTitle><Text component={TextVariants.h2}>{this.props.title}</Text></CardTitle>
                         { !emptyRow &&
-                            <button className="link-button modifications-export" onClick={ () => this.setState({ showDialog: true }) }>{_("View automation script")}</button>
+                        <CardActions>
+                            <Button variant="link" onClick={() => this.setState({ showDialog: true }) }>
+                                {_("View automation script")}
+                            </Button>
+                        </CardActions>
                         }
-                    </div>
-                </header>
-                <table className="listing-ct listing-ct-wide modifications-table">
-                    { emptyRow ||
-                        <tbody>
-                            {this.props.entries.map(entry => <tr className="modification-row" key={entry.split(' ').join('')}><td>{entry}</td></tr>)}
-                        </tbody>
-                    }
-                </table>
-            </section>
+                    </CardHeader>
+                    <CardBody className="contains-list">
+                        <DataList aria-label={this.props.title} isCompact>
+                            { emptyRow ||
+                                this.props.entries.map(entry => <DataListItem key={entry}>
+                                    <DataListItemRow>
+                                        <DataListItemCells dataListCells={[<DataListCell key={entry}>{entry}</DataListCell>]} />
+                                    </DataListItemRow>
+                                </DataListItem>
+                                )
+                            }
+                        </DataList>
+                    </CardBody>
+                </Card>
+            </>
         );
     }
 }

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -23,7 +23,7 @@ import React from "react";
 import {
     Alert, AlertActionCloseButton, Button,
     Page, PageSection, PageSectionVariants,
-    Switch
+    Switch, Stack, StackItem,
 } from "@patternfly/react-core";
 import { ExclamationCircleIcon, TrashIcon } from "@patternfly/react-icons";
 
@@ -462,7 +462,7 @@ export class SETroubleshootPage extends React.Component {
             />
         );
 
-        var errorMessage;
+        let errorMessage;
         if (this.props.error) {
             errorMessage = (
                 <Alert isInline
@@ -473,6 +473,7 @@ export class SETroubleshootPage extends React.Component {
 
         return (
             <Page>
+                {errorMessage}
                 <PageSection variant={PageSectionVariants.light}>
                     <SELinuxStatus
                         selinuxStatus={this.props.selinuxStatus}
@@ -480,9 +481,12 @@ export class SETroubleshootPage extends React.Component {
                         changeSelinuxMode={this.props.changeSelinuxMode}
                         dismissError={this.props.dismissStatusError}
                     />
-                    {errorMessage}
-                    {modifications}
-                    {troubleshooting}
+                </PageSection>
+                <PageSection>
+                    <Stack hasGutter>
+                        <StackItem>{modifications}</StackItem>
+                        <StackItem>{troubleshooting}</StackItem>
+                    </Stack>
                 </PageSection>
             </Page>
         );

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -22,8 +22,9 @@ import cockpit from "cockpit";
 import React from "react";
 import {
     Alert, AlertGroup, AlertActionCloseButton, Button,
+    Card, CardHeader, CardTitle, CardBody,
     Page, PageSection, PageSectionVariants,
-    Switch, Stack, StackItem,
+    Switch, Stack, StackItem, Text, TextVariants,
 } from "@patternfly/react-core";
 import { ExclamationCircleIcon, TrashIcon } from "@patternfly/react-icons";
 
@@ -443,12 +444,19 @@ export class SETroubleshootPage extends React.Component {
         }
 
         troubleshooting = (
-            <ListingTable caption={ title }
-                          emptyCaption={ emptyCaption }
-                          columns={[{ title: _("Alert") }, { title: _("Error message"), header: true }, { title: _("Occurances") }]}
-                          showHeader={false}
-                          variant="compact"
-                          rows={entries} />
+            <Card>
+                <CardHeader>
+                    <CardTitle><Text component={TextVariants.h2}>{title}</Text></CardTitle>
+                </CardHeader>
+                <CardBody className="contains-list">
+                    <ListingTable aria-label={ title }
+                                  emptyCaption={ emptyCaption }
+                                  columns={[{ title: _("Alert") }, { title: _("Error message"), header: true }, { title: _("Occurances") }]}
+                                  showHeader={false}
+                                  variant="compact"
+                                  rows={entries} />
+                </CardBody>
+            </Card>
         );
 
         modifications = (

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 
 import React from "react";
 import {
-    Alert, AlertActionCloseButton, Button,
+    Alert, AlertGroup, AlertActionCloseButton, Button,
     Page, PageSection, PageSectionVariants,
     Switch, Stack, StackItem,
 } from "@patternfly/react-core";
@@ -465,30 +465,35 @@ export class SETroubleshootPage extends React.Component {
         let errorMessage;
         if (this.props.error) {
             errorMessage = (
-                <Alert isInline
-                    variant='danger' title={this.props.error}
-                    actionClose={<AlertActionCloseButton onClose={this.handleDismissError} />} />
+                <AlertGroup isToast>
+                    <Alert
+                        isLiveRegion
+                        variant='danger' title={this.props.error}
+                        actionClose={<AlertActionCloseButton onClose={this.handleDismissError} />} />
+                </AlertGroup>
             );
         }
 
         return (
-            <Page>
+            <>
                 {errorMessage}
-                <PageSection variant={PageSectionVariants.light}>
-                    <SELinuxStatus
-                        selinuxStatus={this.props.selinuxStatus}
-                        selinuxStatusError={this.props.selinuxStatusError}
-                        changeSelinuxMode={this.props.changeSelinuxMode}
-                        dismissError={this.props.dismissStatusError}
-                    />
-                </PageSection>
-                <PageSection>
-                    <Stack hasGutter>
-                        <StackItem>{modifications}</StackItem>
-                        <StackItem>{troubleshooting}</StackItem>
-                    </Stack>
-                </PageSection>
-            </Page>
+                <Page>
+                    <PageSection variant={PageSectionVariants.light}>
+                        <SELinuxStatus
+                            selinuxStatus={this.props.selinuxStatus}
+                            selinuxStatusError={this.props.selinuxStatusError}
+                            changeSelinuxMode={this.props.changeSelinuxMode}
+                            dismissError={this.props.dismissStatusError}
+                        />
+                    </PageSection>
+                    <PageSection>
+                        <Stack hasGutter>
+                            <StackItem>{modifications}</StackItem>
+                            <StackItem>{troubleshooting}</StackItem>
+                        </Stack>
+                    </PageSection>
+                </Page>
+            </>
         );
     }
 }

--- a/pkg/selinux/setroubleshoot.scss
+++ b/pkg/selinux/setroubleshoot.scss
@@ -18,9 +18,10 @@
  */
 
 @import "../lib/page.scss";
+@import "../lib/ct-card.scss";
 
-#app .ct-listing {
-    margin-bottom: var(--pf-global--spacer--lg);
+#app .pf-c-card {
+    @extend .ct-card;
 }
 
 .setroubleshoot-log {
@@ -45,11 +46,6 @@
     color: #c00;
     vertical-align: middle;
     font-size: 150%;
-}
-
-/* if we have an error at the top of the page, give it some space */
-.alert-ct-top {
-    margin: 1rem 0;
 }
 
 .list-group-item .alert {

--- a/pkg/selinux/setroubleshoot.scss
+++ b/pkg/selinux/setroubleshoot.scss
@@ -71,11 +71,6 @@
 .selinux-state {
     display: flex;
     align-items: center;
-    margin: 0 0 1rem;
-}
-
-.selinux-state .pf-c-switch {
-    vertical-align: text-bottom;
 }
 
 .selinux-state .status {

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -189,8 +189,8 @@ class TestSelinux(MachineCase):
             # fallback for older Chrome releases
             b.grant_permissions("clipboardRead", "clipboardWrite")
 
-        b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
-        b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
+        b.wait_visible(".pf-c-data-list__cell:contains(Allow zebra to write config)")
+        b.wait_visible(".pf-c-data-list__cell:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
         b.click("button:contains('View automation script')")
         shell_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(2) pre"
         ansible_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(3) pre"
@@ -234,7 +234,7 @@ class TestSelinux(MachineCase):
         m.execute("semanage boolean --modify --off zebra_write_config")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_visible("tr.modification-row > td:contains(Disallow zebra to write config)")
+        b.wait_visible(".pf-c-data-list__cell:contains(Disallow zebra to write config)")
         b.click("button:contains('View automation script')")
         b.click("button:contains('Ansible')")
         ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
@@ -266,9 +266,9 @@ class TestSelinux(MachineCase):
         b.enter_page("/selinux/setroubleshoot")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_text("table.listing-ct.modifications-table > thead > tr > td", "No system modifications")
+        b.wait_text("ul[aria-label='System modifications']", "No system modifications")
         b.relogin("/selinux/setroubleshoot", "admin", superuser=False)
-        b.wait_text("table.listing-ct.modifications-table > thead > tr > td", "The logged in user is not permitted to view system modifications")
+        b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 
 
     @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "fedora-coreos", "ubuntu-2004", "ubuntu-stable")

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -191,7 +191,7 @@ class TestSelinux(MachineCase):
 
         b.wait_visible("tr.modification-row > td:contains(Allow zebra to write config)")
         b.wait_visible("tr.modification-row > td:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
-        b.click(".modifications-export")
+        b.click("button:contains('View automation script')")
         shell_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(2) pre"
         ansible_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(3) pre"
         b.wait_in_text(shell_script_sel, "boolean -D")
@@ -235,7 +235,7 @@ class TestSelinux(MachineCase):
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
         b.wait_visible("tr.modification-row > td:contains(Disallow zebra to write config)")
-        b.click(".modifications-export")
+        b.click("button:contains('View automation script')")
         b.click("button:contains('Ansible')")
         ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
         se_before = se_after


### PR DESCRIPTION
No difference functionally, just looks.

Before:
![beforeselinux](https://user-images.githubusercontent.com/12330670/108243644-99ffd480-714e-11eb-88cf-893f817c64ee.png)


Now:
![newandhsiny](https://user-images.githubusercontent.com/12330670/108243534-7dfc3300-714e-11eb-8449-7a96781769de.png)
