### PR TITLE
machines: fix some alignment issues with checkboxes

### DIFF
--- a/pkg/machines/components/common/machinesConnectionSelector.jsx
+++ b/pkg/machines/components/common/machinesConnectionSelector.jsx
@@ -30,7 +30,7 @@ export const MachinesConnectionSelector = ({ onValueChanged, loggedUser, connect
         return null;
 
     return (
-        <FormGroup label={_("Connection")} isInline id={id} className="machines-connection-selector">
+        <FormGroup label={_("Connection")} isInline hasNoPaddingTop id={id} className="machines-connection-selector">
             <Radio isChecked={connectionName === LIBVIRT_SYSTEM_CONNECTION}
                    onChange={() => onValueChanged('connectionName', LIBVIRT_SYSTEM_CONNECTION)}
                    name="connectionName"

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -418,7 +418,7 @@ const UnattendedRow = ({ validationFailed, unattendedDisabled, unattendedInstall
     }, [rootPassword, validationFailed]);
 
     let unattendedInstallationCheckbox = (
-        <FormGroup fieldId="unattended-installation" isInline>
+        <FormGroup fieldId="unattended-installation">
             <Checkbox id="unattended-installation"
                       isChecked={unattendedInstallation}
                       isDisabled={unattendedDisabled}

--- a/pkg/machines/components/vm/disks/diskEdit.jsx
+++ b/pkg/machines/components/vm/disks/diskEdit.jsx
@@ -81,7 +81,7 @@ const BusRow = ({ onValueChanged, dialogValues, idPrefix, shutoff }) => {
 
 const AccessRow = ({ onValueChanged, dialogValues, driverType, idPrefix }) => {
     return (
-        <FormGroup fieldId={`${idPrefix}-access`} label={_("Access")} isInline>
+        <FormGroup fieldId={`${idPrefix}-access`} label={_("Access")} isInline hasNoPaddingTop>
             <Radio id={`${idPrefix}-readonly`}
                    name="access"
                    value="readonly"


### PR DESCRIPTION
hasNoPaddingTop is needed on FormGroups when these contain many inline
checkboxes or radios.

Remove redundant 'isInline' from FormGroup with only one child.