### PR TITLE
Revert "test: Enable subscription-manager in dnf in TestUpdatesSubscriptions

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -997,8 +997,6 @@ class TestUpdatesSubscriptions(PackageCase):
 
         # make sure that rhsm skips certificate checks for the server
         self.sed_file("s/insecure = 0/insecure = 1/g", "/etc/rhsm/rhsm.conf")
-        # enable subscriptions in dnf
-        self.sed_file("s/^enabled=0/enabled=1/", "/etc/yum/pluginconf.d/subscription-manager.conf")
 
         # Wait for the web service to be accessible
         m.execute(script=WAIT_SCRIPT % {"addr": "10.111.112.100"})


### PR DESCRIPTION
This reverts commit 33d1a9bc6f5cf046a159466fd36ef52607480421.

This was really the wrong thing to do. Ideally rhsm would revert the
recent change that broke the default subscription-manager.conf, but if
that really has to stay, then our page needs another approach of
figuring out whether subscriptions are really required.