### PR TITLE
Test tracer on rhel-8-4

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -37,7 +37,7 @@ done
 """
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "ubuntu-testing",
-    "fedora-coreos", "rhel-8-4", "rhel-8-4-distropkg", "centos-8-stream"]
+    "fedora-coreos", "centos-8-stream"]
 
 class NoSubManCase(PackageCase):
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -218,7 +218,7 @@ class TestUpdates(NoSubManCase):
 
         b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
         # if tracer is not present, reboot is recommended
-        if m.execute("which tracer || true") == "":
+        if m.image in OSesWithoutTracer:
             b.wait_in_text("#app .pf-c-empty-state button.pf-m-primary", "Reboot system...")
         b.click("#ignore")
 
@@ -638,7 +638,7 @@ ExecStart=/usr/local/bin/{0}
         b.click(".expander-title button")
         self.assertHistory("ul", ["buggy", "norefs-bin", "norefs-doc"])
 
-        if m.execute("which tracer || true") == "":
+        if m.image in OSesWithoutTracer:
             # do the reboot; this will disconnect the web UI
             b.click("#app .pf-c-empty-state button.pf-m-primary")
             b.wait_visible("#shutdown-dialog")
@@ -656,7 +656,6 @@ ExecStart=/usr/local/bin/{0}
             b.login_and_go("/updates")
         else:
             b.click("#ignore")
-
 
         # new versions are now installed
         m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")


### PR DESCRIPTION
This is blocked still, but I mostly want to ensure that tracer works as expected on RHEL 8.4, so that we don't ship something broken.

 - [x] Add tracer to rhel-8-4 image: https://github.com/cockpit-project/bots/pull/1684