### PR TITLE
metrics: Don't show swap column when no is being used

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -638,7 +638,11 @@ const MetricsHour = ({ startTime, data, clipLeading }) => {
 
         ['cpu', 'memory', 'disks', 'network'].forEach(resource => {
             // not all resources have a saturation metric
-            const have_sat = !!RESOURCES["sat_" + resource];
+            let have_sat = !!RESOURCES["sat_" + resource];
+
+            // If there is no swap, don't render it
+            if (resource === "memory" && swapTotal === undefined)
+                have_sat = false;
 
             let graph;
             if (minute_events[minute]) {
@@ -712,7 +716,7 @@ const MetricsHour = ({ startTime, data, clipLeading }) => {
     };
 
     return (
-        <div id={ "metrics-hour-" + startTime.toString() } style={{ "--metrics-minutes": minutes }} className="metrics-hour" onMouseMove={updateTooltip}>
+        <div id={ "metrics-hour-" + startTime.toString() } style={{ "--metrics-minutes": minutes, "--has-swap": swapTotal === undefined ? "var(--half-column-size)" : "var(--column-size)" }} className="metrics-hour" onMouseMove={updateTooltip}>
             { events }
             { graphs }
             <h3 className="metrics-time"><time>{ moment(startTime).format("LT ddd YYYY-MM-DD") }</time></h3>
@@ -986,7 +990,7 @@ class MetricsHistory extends React.Component {
         return (
             <div className="metrics">
                 <div className="metrics-history-heading-sticky">
-                    <section className="metrics-history metrics-history-heading">
+                    <section className="metrics-history metrics-history-heading" style={{ "--has-swap": swapTotal === undefined ? "var(--half-column-size)" : "var(--column-size)" }}>
                         <Select
                             className="select-min metrics-label"
                             aria-label={_("Jump to")}
@@ -999,7 +1003,7 @@ class MetricsHistory extends React.Component {
                             {options}
                         </Select>
                         <Label label={_("CPU")} items={[_("Usage"), _("Load")]} />
-                        <Label label={_("Memory")} items={[_("Usage"), _("Swap")]} />
+                        <Label label={_("Memory")} items={[_("Usage"), ...swapTotal !== undefined ? [_("Swap")] : []]} />
                         <Label label={_("Disks")} items={[_("Usage")]} />
                         <Label label={_("Network")} items={[_("Usage")]} />
                     </section>

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -237,7 +237,7 @@
     &-hour {
         display: grid;
         grid-template: "events cpu memory disks net";
-        grid-template-columns: [events] 3fr [cpu] var(--column-size) [memory] var(--column-size) [disks] var(--half-column-size) [network] var(--half-column-size);
+        grid-template-columns: [events] 3fr [cpu] var(--column-size) [memory] var(--has-swap) [disks] var(--half-column-size) [network] var(--half-column-size);
         grid-column: 1 / -1;
         position: relative;
     }

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -282,22 +282,30 @@ class TestHistoryMetrics(MachineCase):
         # Memory
         #
 
+        have_swap = m.execute("swapon --show").strip()
+
         prepareArchive(m, "memory.tar.gz", 1600248000)
         login(self)
         b.wait_in_text(".metrics-history-heading", "CPU")
 
         # basic RAM consumption after boot; it's still a network spike, thus event+SVG
         self.assertLessEqual(getMaximumSpike(b, "memory", False, 1600236000000, 44), 0.3)
-        self.assertAlmostEqual(getMaximumSpike(b, "memory", True, 1600236000000, 44), 0)
         self.assertNotIn("Memory spike", events_at(1600236000000, 44))
-        self.assertNotIn("Swap", events_at(1600236000000, 44))
+        if have_swap:
+            self.assertAlmostEqual(getMaximumSpike(b, "memory", True, 1600236000000, 44), 0)
+            self.assertNotIn("Swap", events_at(1600236000000, 44))
 
-        # swap event from :46 to :47
-        self.assertGreater(getMaximumSpike(b, "memory", True, 1600236000000, 46), 0.9)
-        self.assertIn("Swap", events_at(1600236000000, 46))
-        # continuous, no new Swap event, but still a Memory+Network event
-        self.assertGreater(getMaximumSpike(b, "memory", True, 1600236000000, 47), 0.9)
-        self.assertNotIn("Swap", events_at(1600236000000, 47))
+            # swap event from :46 to :47
+            self.assertGreater(getMaximumSpike(b, "memory", True, 1600236000000, 46), 0.9)
+            self.assertIn("Swap", events_at(1600236000000, 46))
+            # continuous, no new Swap event, but still a Memory+Network event
+            self.assertGreater(getMaximumSpike(b, "memory", True, 1600236000000, 47), 0.9)
+            self.assertNotIn("Swap", events_at(1600236000000, 47))
+
+        else:
+            # If no swap, the column is hidden
+            self.assertNotIn(b.text(".metrics-history-heading"), "Swap")
+            b.wait_not_present(".metrics-data-memory .saturation")
 
         # memory spike in :47
         self.assertGreater(getMaximumSpike(b, "memory", False, 1600236000000, 47), 0.6)
@@ -309,11 +317,13 @@ class TestHistoryMetrics(MachineCase):
 
         # continued memory spike in :54, but no new events
         self.assertGreater(getCompressedMinuteValue(b, "memory", False, 1600236000000, 54), 0.8)
-        self.assertAlmostEqual(getCompressedMinuteValue(b, "memory", True, 1600236000000, 54), 0.0)
+        if have_swap:
+            self.assertAlmostEqual(getCompressedMinuteValue(b, "memory", True, 1600236000000, 54), 0.0)
 
         # everything is quiet in :55
         self.assertLess(getCompressedMinuteValue(b, "memory", False, 1600236000000, 55), 0.4)
-        self.assertAlmostEqual(getCompressedMinuteValue(b, "memory", True, 1600236000000, 55), 0.0)
+        if have_swap:
+            self.assertAlmostEqual(getCompressedMinuteValue(b, "memory", True, 1600236000000, 55), 0.0)
 
         b.logout()
 


### PR DESCRIPTION
Fixes #14807

![nowswap](https://user-images.githubusercontent.com/12330670/108403790-66d94600-721f-11eb-856b-f88fc36d702c.png)
