### PR TITLE
tools: Stop shipping unit tests

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -170,8 +170,8 @@ function generateDeps(makefile, stats) {
             install += ".gz";
         }
 
-        // Debug output gets installed separately
-        if (!output.endsWith(".map") && !output.includes("included-modules"))
+        // Debug output and tests gets installed separately
+        if (!output.endsWith(".map") && output.indexOf("/test-") === -1 && !output.includes("included-modules"))
             installs[install] = install;
     }
 


### PR DESCRIPTION
The condition cleanup in commit d4ea3eacb719 was wrong: the previous
test only covers *.html files, but we don't want to install the unit
test *.js and *.css files either. Revert that part.

Spotted by rpmdiff.

Fixes #15376