### PR TITLE
shell: Drop pkexec/sudo path hardcoding into manifest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -128,8 +128,6 @@ SUBST_RULE = \
 	-e 's,[@]prefix[@],$(prefix),g' \
 	-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
 	-e 's,[@]VERSION[@],$(VERSION),g' \
-	-e 's,[@]PKEXEC[@],$(PKEXEC),g' \
-	-e 's,[@]SUDO[@],$(SUDO),g' \
 	-e 's,[@]user[@],$(COCKPIT_USER),g' \
 	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
 	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -298,14 +298,6 @@ fi
 AC_PATH_PROG([CHPASSWD], [chpasswd], [/usr/sbin/chpasswd], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
 AC_DEFINE_UNQUOTED([PATH_CHPASSWD],["$CHPASSWD"],[Location of chpasswd binary])
 
-# pkexec
-AC_PATH_PROG([PKEXEC], [pkexec], [/usr/bin/pkexec], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
-AC_SUBST(PKEXEC)
-
-# sudo
-AC_PATH_PROG([SUDO], [sudo], [/usr/bin/sudo], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
-AC_SUBST(SUDO)
-
 # ssh-add
 AC_PATH_PROG([SSH_ADD], [ssh-add], [/usr/bin/ssh-add], [$PATH:/usr/local/sbin:/usr/sbin:/sbin])
 AC_DEFINE_UNQUOTED([PATH_SSH_ADD], ["$SSH_ADD"], [Location of ssh-add binary])
@@ -635,10 +627,8 @@ echo "
         cockpit-ssh:                ${enable_ssh}
         Supports key auth:          ${key_auth}
 
-        pkexec:                     ${PKEXEC}
         ssh-add:                    ${SSH_ADD}
         ssh-agent:                  ${SSH_AGENT}
-        sudo:                       ${SUDO}
         usermod:                    ${USERMOD}
         chcon:                      ${CHCON}
 "

--- a/pkg/shell/manifest.json.in
+++ b/pkg/shell/manifest.json.in
@@ -32,7 +32,7 @@
                 "SUDO_ASKPASS=@libexecdir@/cockpit-askpass"
             ],
             "spawn": [
-                "@SUDO@",
+                "sudo",
                 "-A",
                 "cockpit-bridge",
                 "--privileged"
@@ -41,7 +41,7 @@
         {
             "privileged": true,
             "spawn": [
-                "@PKEXEC@",
+                "pkexec",
                 "--disable-internal-agent",
                 "cockpit-bridge",
                 "--privileged"


### PR DESCRIPTION
There is little reason to do that. On any sensible system these programs
belong into `$PATH`, and as we don't build-depend on pkexec nor sudo,
the shipped manifests will always have /usr/bin/{sudo,pkexec} anyway.

This gets rid of one part of dynamic manifests, and thus makes them
more portable (~/.local/share/cockpit) and easier to generate by webpack.

Fixes #14347

-----

This is the easiest part of our attempt to not have to deal with *.manifest.in and having to invoke configure and make to build them. It'd be a lot nicer for manifests to be part of static dist and the release tarballs.

 - [x] Requires a truckload of testActivePages fixes: PR #15385