### PR TITLE
build: Drop --with-networkmanager-needs-root configure option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,7 +136,6 @@ SUBST_RULE = \
 	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
 	-e 's,[@]admin_group[@],$(admin_group),g' \
 	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
-	-e 's,[@]with_networkmanager_needs_root[@],$(with_networkmanager_needs_root),g' \
 	-e 's,[@]with_storaged_iscsi_sessions[@],$(with_storaged_iscsi_sessions),g' \
 	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
 	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -349,18 +349,6 @@ AC_ARG_WITH(storaged-iscsi-sessions,
             [with_storaged_iscsi_sessions=yes])
 AC_SUBST(with_storaged_iscsi_sessions)
 
-# HACK - Debian has a broken policy for NetworkManager where it
-#        only allows local sessions or root to perform actions.
-#
-# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=808162
-
-AC_ARG_WITH(networkmanager-needs-root,
-	    AC_HELP_STRING([--with-networkmanager-needs-root=yes/no],
-			   [Whether NetworkManager requires root access]),
-            [],
-	    [with_networkmanager_needs_root=yes])
-AC_SUBST(with_networkmanager_needs_root)
-
 AC_ARG_WITH(appstream-config-packages,
             AC_HELP_STRING([--with-appstream-config-packages=JSON],
                            [List of packages that configure the system to retrieve AppStream collection metadata]),

--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -41,9 +41,5 @@
                 }
             ]
         }
-    },
-
-    "hacks": {
-        "with_networkmanager_needs_root": "@with_networkmanager_needs_root@"
     }
 }

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -17,7 +17,6 @@ endif
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
-		--with-networkmanager-needs-root=yes \
 		--with-cockpit-user=cockpit-ws \
 		--with-cockpit-ws-instance-user=cockpit-wsinstance \
 		--with-appstream-config-packages='[ "appstream" ]' \


### PR DESCRIPTION
This is not being used any more since commit 168f819ebd0.