### PR TITLE
make_dist: Changes in tests are not reason to skip download

### DIFF
--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -66,7 +66,7 @@ def download_dist():
         message("make_dist: not a git repository")
         return None
 
-    if subprocess.call(["git", "diff", "--quiet"]) > 0:
+    if subprocess.call(["git", "diff", "--quiet", "--", ":^test"]) > 0:
         message("make_dist: uncommitted local changes, skipping download")
         return None
 


### PR DESCRIPTION
Common workflow is to fix tests in existing PR. One would adjust tests
and then prepare machine to validate these changes. But due to changes
in tests the downloading would be unnecessary skipped.