### PR TITLE
test: Fix TestActivePages races and bugs

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -795,6 +795,9 @@ class MachineCase(unittest.TestCase):
         for pkg in packages:
             path = "/usr/share/cockpit/%s" % pkg
             if self.machine.execute("if test -e %s; then echo yes; fi" % path):
+                if self.machine.ostree_image:
+                    # get a writable directory
+                    self.restore_dir(path)
                 self.write_file("%s/override.json" % path, '{ "preload": [ ] }')
 
     def enable_preload(self, package, *pages):

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -69,27 +69,25 @@ class TestActivePages(MachineCase):
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
 
-        b.focus(".terminal")
-
         def line_sel(i):
             return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
-        def line_text(t):
-            return t + u'\xa0' * (80 - len(t))
-
         # wait for prompt in first line
-        b.wait_text_not(line_sel(1), line_text(""))
+        b.wait_visible(".terminal .xterm-accessibility-tree")
+        b.wait_in_text(line_sel(1), '$')
 
-        # run the sleep command
-        b.key_press("sleep 999999\r")
+        # run a command that we can easily identify, and which will die with the terminal
+        b.key_press("bash -c 'exec -a kitten cat'\r")
 
-        # wait for it to be present in ps
-        wait(lambda: m.execute("ps ax | grep 'sleep 99.*999'"))
+        # wait for command to run
+        m.execute("until pgrep -afx kitten; do sleep 1; done")
 
         # now close the page
         showPagesAssertCount(3 + n_extra_preloaded)
 
-        # click on the other page as well
+        # terminal should be pre-checked by default
+        b.wait_visible('tr[data-row-id="cockpit1:localhost/system/terminal"] input[type=checkbox]:checked')
+        # click on the main page as well
         b.click('tr[data-row-id="cockpit1:localhost/system"] input[type=checkbox]')
         # wait until it's highlighted
         b.wait_visible('tr[data-row-id="cockpit1:localhost/system"] input[type=checkbox]:checked')
@@ -97,8 +95,12 @@ class TestActivePages(MachineCase):
         b.click("#active-pages-dialog button.pf-m-primary")
         b.wait_not_present("#active-pages-dialog")
 
+        # this should kill the two frames
+        b.wait_not_present("iframe[name='cockpit1:localhost/system']")
+        b.wait_not_present("iframe[name='cockpit1:localhost/system/terminal']")
+
         # running shell command should disappear on the system
-        wait(lambda: m.execute("ps ax | grep 'sleep 99.*999'"))
+        m.execute("while pgrep -afx kitten; do sleep 1; done")
 
         # there should only be the original pages left
         showPagesAssertCount(1 + n_extra_preloaded)

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -19,28 +19,20 @@
 
 import parent
 from testlib import *
-from machine_core.constants import TEST_OS_DEFAULT
 
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
+@nondestructive
 class TestActivePages(MachineCase):
 
     def testBasic(self):
         b = self.browser
         m = self.machine
 
-        self.login_and_go("/system")
+        # disable preloads; they are different between OSes, make the counting hard, and happen asynchronously
+        self.disable_preload("packagekit", "playground", "systemd")
 
-        # Preloading via manifests only happens with #12534
-        if m.ostree_image:
-            # /playground/preloaded and /system/services
-            n_extra_preloaded = 2
-        elif m.image == TEST_OS_DEFAULT:
-            # /playground/preloaded
-            n_extra_preloaded = 1
-        else:
-            # /playground/preloaded, /system/services, and /updates
-            n_extra_preloaded = 3
+        self.login_and_go("/system")
 
         b.wait_visible("#overview")
 
@@ -51,8 +43,8 @@ class TestActivePages(MachineCase):
             b.wait_visible("#active-pages-dialog")
             b.wait_js_func("ph_count_check", "#active-pages-dialog tr", count)
 
-        # Initially we have /system and maybe /playground/preloaded
-        showPagesAssertCount(1 + n_extra_preloaded)
+        # Initially we have /system
+        showPagesAssertCount(1)
         b.click("button.cancel")
         b.wait_not_present("#active-pages-dialog")
 
@@ -60,8 +52,8 @@ class TestActivePages(MachineCase):
         b.enter_page("/users")
         b.wait_visible("#accounts-list")
 
-        # now we want a third page to be present in the pages menu
-        showPagesAssertCount(2 + n_extra_preloaded)
+        # now we have the users page be present in the pages menu
+        showPagesAssertCount(2)
         b.click("button.cancel")
         b.wait_not_present("#active-pages-dialog")
 
@@ -83,8 +75,7 @@ class TestActivePages(MachineCase):
         m.execute("until pgrep -afx kitten; do sleep 1; done")
 
         # now close the page
-        showPagesAssertCount(3 + n_extra_preloaded)
-
+        showPagesAssertCount(3)
         # terminal should be pre-checked by default
         b.wait_visible('tr[data-row-id="cockpit1:localhost/system/terminal"] input[type=checkbox]:checked')
         # click on the main page as well
@@ -102,8 +93,8 @@ class TestActivePages(MachineCase):
         # running shell command should disappear on the system
         m.execute("while pgrep -afx kitten; do sleep 1; done")
 
-        # there should only be the original pages left
-        showPagesAssertCount(1 + n_extra_preloaded)
+        # there should only be the original page left
+        showPagesAssertCount(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With full chromium instead of chromium-headless, the `focus(".terminal")`
focused *away from* the actual element that receives the input, so that
typing the sleep command went into Nirvana. Just drop that, it's
unnecessary -- we want the Terminal page to automatically focus the
input. (check-system-terminal also does not focus explicitly).

Drop the weird `line_text()` helper, and wait until the terminal shows a
full prompt (with '`$`), instead of just "anything". This does the same
as check-system-terminal (albeit a bit simplified).

Wait for the default selection of the "delete frame" dialog to happen.
Previously the clickery started too early before the dialog got fully
initialized, and then missed to actually stop the terminal frame.

Fix the waiting for "sleep command goes away"; before it waited for the
command to be present, thus was a no-op.

Replace the broken `ps | grep` with `pgrep -x`, which avoids catching
itself. Despite the effort with using a regexp, the grep command still
found itself. Also, `sleep` is a bad program to use, as on Debian/Ubuntu
that just gets reparented to pid 1 after its parent (the terminal shell)
dies, so it never gets killed (this was hidden by the previous bug where
the second wait loop was the wrong way around). Replace this with `cat`,
which will properly exit on SIGPIPE, and rename it to `kitten` to
ensure that our pgrep does not catch some unrelated cat.

Use a single shell commmand to the VM instead of a heavy polling loop.

--- 

Broken out from #15378, as this test case was so broken that it needs a *lot* of attention. It's still not 100% right.