### PR TITLE
storaged: Replace --with-vdo-package and --with-nfs-client-package configure option with manifest maps

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,7 +136,6 @@ SUBST_RULE = \
 	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
 	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
 	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
-	-e 's,[@]with_nfs_client_package[@],$(with_nfs_client_package),g' \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -137,7 +137,6 @@ SUBST_RULE = \
 	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
 	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
 	-e 's,[@]with_nfs_client_package[@],$(with_nfs_client_package),g' \
-	-e 's,[@]with_vdo_package[@],$(with_vdo_package),g' \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -350,13 +350,6 @@ AC_ARG_WITH(nfs-client-package,
             [with_nfs_client_package='false'])
 AC_SUBST(with_nfs_client_package)
 
-AC_ARG_WITH(vdo-package,
-            AC_HELP_STRING([--with-vdo-package=JSON],
-                           [Package that is necessary to use VDO, or 'false']),
-            [],
-            [with_vdo_package='false'])
-AC_SUBST(with_vdo_package)
-
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])

--- a/configure.ac
+++ b/configure.ac
@@ -343,13 +343,6 @@ AC_ARG_WITH(appstream-data-packages,
             [with_appstream_data_packages='[[]]'])
 AC_SUBST(with_appstream_data_packages)
 
-AC_ARG_WITH(nfs-client-package,
-            AC_HELP_STRING([--with-nfs-client-package=JSON],
-                           [Package that is necessary for NFS clients, or 'false']),
-            [],
-            [with_nfs_client_package='false'])
-AC_SUBST(with_nfs_client_package)
-
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -52,7 +52,11 @@
     },
 
     "config": {
-        "nfs_client_package": @with_nfs_client_package@,
+        "nfs_client_package": {
+            "rhel": "nfs-utils", "fedora": "nfs-utils",
+            "opensuse": "nfs-client", "opensuse-leap": "nfs-client",
+            "debian": "nfs-common", "ubuntu": "nfs-common"
+        },
         "vdo_package": { "rhel": "vdo", "centos": "vdo" }
     },
     "content-security-policy": "img-src 'self' data:"

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -53,7 +53,7 @@
 
     "config": {
         "nfs_client_package": @with_nfs_client_package@,
-        "vdo_package": @with_vdo_package@
+        "vdo_package": { "rhel": "vdo", "centos": "vdo" }
     },
     "content-security-policy": "img-src 'self' data:"
 }

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -740,7 +740,11 @@ export function teardown_active_usage(client, usage) {
 
 export function get_config(name, def) {
     if (cockpit.manifests.storage && cockpit.manifests.storage.config) {
-        var val = cockpit.manifests.storage.config[name];
+        let val = cockpit.manifests.storage.config[name];
+        if (typeof val === 'object' && val !== null) {
+            const os_release = JSON.parse(window.localStorage['os-release'] || "{}");
+            val = val[os_release.ID];
+        }
         return val !== undefined ? val : def;
     } else {
         return def;

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -23,6 +23,10 @@ from storagelib import *
 from testlib import *
 
 
+# vdo only exists on RHEL
+SUPPORTED_OS = ["centos-8-stream", "rhel-8-4", "rhel-8-4-distropkg"]
+
+
 class TestStorageVDO(StorageCase):
 
     def testVdo(self):
@@ -31,7 +35,7 @@ class TestStorageVDO(StorageCase):
 
         self.login_and_go("/storage")
 
-        if m.execute("which vdo || true") == "":
+        if m.image not in SUPPORTED_OS:
             b.click("#devices [data-toggle=dropdown]")
             b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
@@ -121,7 +125,7 @@ class TestStorageVDO(StorageCase):
 
         self.login_and_go("/storage")
 
-        if m.execute("which vdo || true") == "":
+        if m.image not in SUPPORTED_OS:
             b.click("#devices [data-toggle=dropdown]")
             b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
@@ -178,7 +182,7 @@ config: !Configuration
 
         self.login_and_go("/storage")
 
-        if m.execute("which vdo || true") == "":
+        if m.image not in SUPPORTED_OS:
             b.click("#devices [data-toggle=dropdown]")
             b.wait_not_present("#devices .dropdown a:contains('VDO')")
             return
@@ -274,7 +278,7 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
         m = self.machine
         b = self.browser
 
-        if m.execute("which vdo || true") == "":
+        if m.image not in SUPPORTED_OS:
             self.skipTest("No vdo available")
 
         m.execute("pkcon remove -y vdo")

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -41,10 +41,6 @@
 
 %define __lib lib
 
-%if 0%{?rhel}
-%define vdo_on_demand 1
-%endif
-
 %if 0%{?suse_version}
 %define pamdir /%{_lib}/security
 %else
@@ -168,7 +164,7 @@ exec 2>&1
 %if 0%{?build_basic} == 0
     --disable-ssh \
 %endif
-    %{?vdo_on_demand:--with-vdo-package='"vdo"'}
+
 make -j4 %{?extra_flags} all
 
 %check

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -156,7 +156,6 @@ exec 2>&1
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
     --with-selinux-config-type=etc_t \
     --with-appstream-data-packages='[ "appstream-data" ]' \
-    --with-nfs-client-package='"nfs-utils"' \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -20,7 +20,6 @@ override_dh_auto_configure:
 		--with-cockpit-user=cockpit-ws \
 		--with-cockpit-ws-instance-user=cockpit-wsinstance \
 		--with-appstream-config-packages='[ "appstream" ]' \
-		--with-nfs-client-packages='"nfs-common"' \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 


### PR DESCRIPTION
This gets rid of one part of dynamic manifests, and thus makes them more
portable (~/.local/share/cockpit) and easier to generate by webpack. It
also avoids an "unbreak my build" configure argument for CentOS/RHEL.
The manifest is a much more "quirkable" text file which can be handled
through overrides by admins who know what they are doing.