### PR TITLE
storaged: Drop obsolete --with-storaged-iscsi-sessions

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -136,7 +136,6 @@ SUBST_RULE = \
 	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
 	-e 's,[@]admin_group[@],$(admin_group),g' \
 	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
-	-e 's,[@]with_storaged_iscsi_sessions[@],$(with_storaged_iscsi_sessions),g' \
 	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
 	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
 	-e 's,[@]with_nfs_client_package[@],$(with_nfs_client_package),g' \

--- a/configure.ac
+++ b/configure.ac
@@ -337,18 +337,6 @@ AC_CHECK_FUNCS(fdwalk)
 
 # Package specific settings
 
-# HACK - Storaged before 2.5.3 doesn't tell us when it supports
-#        sessions, so we allow it to be switched off explicitly.
-#
-# https://github.com/storaged-project/udisks/pull/68
-
-AC_ARG_WITH(storaged-iscsi-sessions,
-            AC_HELP_STRING([--with-storaged-iscsi-sessions=yes/no],
-                           [Whether storaged supports listing iSCSI sessions]),
-            [],
-            [with_storaged_iscsi_sessions=yes])
-AC_SUBST(with_storaged_iscsi_sessions)
-
 AC_ARG_WITH(appstream-config-packages,
             AC_HELP_STRING([--with-appstream-config-packages=JSON],
                            [List of packages that configure the system to retrieve AppStream collection metadata]),

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -33,11 +33,6 @@ import { find_warnings } from "./warnings.jsx";
 /* STORAGED CLIENT
  */
 
-/* HACK: https://github.com/storaged-project/udisks/pull/68 */
-var hacks = { };
-if (cockpit.manifests.storage && cockpit.manifests.storage.hacks)
-    hacks = cockpit.manifests.storage.hacks;
-
 var client = {
     busy: 0
 };
@@ -401,9 +396,8 @@ function init_model(callback) {
                 wait_all([client.manager_lvm2, client.manager_iscsi],
                          function () {
                              client.features.lvm2 = client.manager_lvm2.valid;
-                             client.features.iscsi = (hacks.with_storaged_iscsi_sessions != "no" &&
-                                                     client.manager_iscsi.valid &&
-                                                     client.manager_iscsi.SessionsSupported !== false);
+                             client.features.iscsi = (client.manager_iscsi.valid &&
+                                                      client.manager_iscsi.SessionsSupported !== false);
                              defer.resolve();
                          });
                 return defer.promise;

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -51,10 +51,6 @@
         }
     },
 
-    "hacks": {
-        "with_storaged_iscsi_sessions": "@with_storaged_iscsi_sessions@"
-    },
-
     "config": {
         "nfs_client_package": @with_nfs_client_package@,
         "vdo_package": @with_vdo_package@


### PR DESCRIPTION
This was fixed in storaged 5 years ago, and all supported OSes have a
newer udisks version. This configure flag has not been actually used in
our spec/debian files for a long time.