### PR TITLE
pkg: drop "version" from manifests

### DIFF
--- a/pkg/apps/manifest.json.in
+++ b/pkg/apps/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
 	"cockpit": "122"
     },

--- a/pkg/base1/manifest.json.in
+++ b/pkg/base1/manifest.json.in
@@ -1,4 +1,5 @@
 {
-    "version": "@VERSION@",
+    "version": "219",
+    "version-note": "last API change: https://github.com/cockpit-project/cockpit/pull/13482",
     "priority": -1
 }

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -27,7 +27,6 @@ QUnit.test("simple request", function (assert) {
     cockpit.http({ internal: "/test-server" }).get("/pkg/playground/manifest.json.in")
             .done(function(data) {
                 assert.deepEqual(JSON.parse(data), {
-                    version: "@VERSION@",
                     requires: {
                         cockpit: "122"
                     },

--- a/pkg/kdump/manifest.json.in
+++ b/pkg/kdump/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
         "cockpit": "122"
     },

--- a/pkg/machines/manifest.json.in
+++ b/pkg/machines/manifest.json.in
@@ -1,5 +1,4 @@
 {
-  "version": 0,
   "priority": 0,
   "requires": {
        "cockpit": "186"

--- a/pkg/metrics/manifest.json.in
+++ b/pkg/metrics/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
         "cockpit": "137"
     }

--- a/pkg/networkmanager/manifest.json.in
+++ b/pkg/networkmanager/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "name": "network",
     "requires": {
         "cockpit": "186"

--- a/pkg/packagekit/manifest.json.in
+++ b/pkg/packagekit/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "name": "updates",
     "priority": 0,
     "requires": {

--- a/pkg/playground/manifest.json.in
+++ b/pkg/playground/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
 	"cockpit": "122"
     },

--- a/pkg/selinux/manifest.json.in
+++ b/pkg/selinux/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
 	"cockpit": "122"
     },

--- a/pkg/shell/manifest.json.in
+++ b/pkg/shell/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
         "cockpit": "134.x"
     },

--- a/pkg/sosreport/manifest.json.in
+++ b/pkg/sosreport/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
 	"cockpit": "122"
     },

--- a/pkg/ssh/manifest.json.in
+++ b/pkg/ssh/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
         "cockpit": "138"
     },

--- a/pkg/storaged/manifest.json.in
+++ b/pkg/storaged/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "name": "storage",
     "requires": {
         "cockpit": "186"

--- a/pkg/systemd/manifest.json.in
+++ b/pkg/systemd/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "name": "system",
 
     "requires": {

--- a/pkg/tuned/manifest.json.in
+++ b/pkg/tuned/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "name": "performance",
     "requires": {
 	"cockpit": "122"

--- a/pkg/users/manifest.json.in
+++ b/pkg/users/manifest.json.in
@@ -1,5 +1,4 @@
 {
-    "version": "@VERSION@",
     "requires": {
 	"cockpit": "122"
     },


### PR DESCRIPTION
This field was introduced in #4964 as "purely informational for now",
and isn't even parsed by cockpit.  Meanwhile, it's one of the few things
preventing us from untangling our webpack build from autotools.

Even within cockpit, usage is inconsistent: most packages set "version"
to the string that @Version@ expands to, but machines had it set to the
integer 0, and pcp and static had no "version" field at all.

It seems nobody is going to miss this.  Just drop it.

The one place which did reference this was a test which directly read
the manifest.json.in file from the playground and does a direct
comparison on it.  That's been adjusted accordingly now.

 - [x] Drop obsolete remote login compat code, which reads base1 manifest version: PR #15423