### PR TITLE
lib: Add included file dependencies in sassc-loader

### DIFF
--- a/pkg/lib/sassc-loader.js
+++ b/pkg/lib/sassc-loader.js
@@ -4,7 +4,6 @@ const childProcess = require('child_process');
 
 const srcdir = process.env.SRCDIR || path.resolve(__dirname, '..', '..');
 const nodedir = path.resolve(srcdir, 'node_modules');
-const production = process.env.NODE_ENV === 'production';
 
 /* source is not used. This must be the first loader in the chain, using this.resource, so that sassc can include the scss file's directory in the include path */
 module.exports = function() {
@@ -21,19 +20,21 @@ module.exports = function() {
             '--load-path=' + path.resolve(nodedir, 'font-awesome-sass/assets/stylesheets'),
             '--load-path=' + path.resolve(nodedir, 'patternfly/dist/sass'),
             '--load-path=' + path.resolve(nodedir, 'bootstrap-sass/assets/stylesheets'),
-            '--style=compressed', production ? '--' : '--sourcemap', this.resource, out
+            '--style=compressed', '--sourcemap', this.resource, out
         ],
         { stdio: ['pipe', 'inherit', 'inherit'] });
 
     const css = fs.readFileSync(out, 'utf8');
+    const cssmap = fs.readFileSync(out + ".map", 'utf8');
+
+    // source map contains included files, add them as dependencies
+    (JSON.parse(cssmap).sources || []).forEach(f => {
+        if (f.indexOf('node_modules/') < 0)
+            this.addDependency(path.resolve(workdir, f));
+    });
+
     fs.unlinkSync(out);
-
-    let cssmap;
-    if (!production) {
-        cssmap = fs.readFileSync(out + ".map", 'utf8');
-        fs.unlinkSync(out + ".map");
-    }
-
+    fs.unlinkSync(out + ".map");
     fs.rmdirSync(workdir);
 
     this.callback(null, css, cssmap);


### PR DESCRIPTION
Revert the sassc-loader.js part of commit 13376b031b and always have
sassc build a source map. The actual .map file is written by later
stages in the pipeline (mini-css-extract-plugin), so this does not
add back the map files into dist/ in production mode.

Parse the processed scss file's included files from the source map and
declare them as dependencies. This fixes both `webpack-watch` and `make`
to properly rebuild a webpack if any included file from a .scss file
gets changed.

Fixes #15398