### PR TITLE
lib: Check installed Red Hat products instead of yum config file

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -18,7 +18,7 @@
  */
 
 import cockpit from "cockpit";
-import { superuser } from 'superuser';
+import { superuser } from './superuser';
 
 const _ = cockpit.gettext;
 
@@ -279,7 +279,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
                             progress_cb = null;
                             reject(new TransactionError(cancelled ? "cancelled" : code, detail));
                         },
-                        Finished: (exit, runtime) => {
+                        Finished: exit => {
                             progress_cb = null;
                             resolve(exit);
                         },


### PR DESCRIPTION
The `enabled=` option in subscription-manager.conf is not a reliable
indicator whether the installed system needs any subscriptions. On at
least the qcow image, the dnf plugins (both subscription-manager and
product-id) are disabled by default, and the first invocation of
subscription-manager auto-enables them.

Instead, ask RHSM if there are any installed Red Hat products on the
system. That list is empty on Fedora/CentOS. As before, if RHSM itself
is absent, quietly consider this as "system does not need subscription".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1931429