### PR TITLE
cockpituous: bodhi for Fedora 34, drop Fedora 32

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -28,7 +28,6 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k rawhide
-job release-koji f32
 job release-koji f33
 job release-koji f34
 
@@ -42,8 +41,8 @@ job release-copr @cockpit/cockpit-preview
 job release-dockerhub cockpit-project/cockpit-container
 
 # Push out a Bodhi update
-job release-bodhi F32
 job release-bodhi F33
+job release-bodhi F34
 
 # Upload documentation
 job tools/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
bodhi activation for Fedora 34 is today [1]. Drop Fedora 32 instead,
which is soon EOL.

[1] https://fedorapeople.org/groups/schedule/f-34/f-34-key-tasks.html