### PR TITLE
machines: Live VM migration

### DIFF
--- a/pkg/machines/components/vm/vmActions.jsx
+++ b/pkg/machines/components/vm/vmActions.jsx
@@ -43,6 +43,7 @@ import {
 
 import { CloneDialog } from './vmCloneDialog.jsx';
 import { DeleteDialog } from "./deleteDialog.jsx";
+import { MigrateDialog } from './vmMigrateDialog.jsx';
 import LibvirtDBus from '../../libvirt-dbus.js';
 
 const _ = cockpit.gettext;
@@ -50,6 +51,7 @@ const _ = cockpit.gettext;
 const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetailsPage }) => {
     const [isActionOpen, setIsActionOpen] = useState(false);
     const [showDeleteDialog, toggleDeleteModal] = useState(false);
+    const [showMigrateDialog, toggleMigrateDialog] = useState(false);
     const [showCloneDialog, toggleCloneModal] = useState(false);
     const [operationInProgress, setOperationInProgress] = useState(false);
     const [prevVmState, setPrevVmState] = useState(vm.state);
@@ -312,6 +314,27 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
         );
     }
 
+    if (vm.state !== "shut off") {
+        dropdownItems.push(
+            <DropdownItem key={`${id}-migrate`}
+                          id={`${id}-migrate`}
+                          onClick={() => toggleMigrateDialog(true)}>
+                {_("Migrate")}
+            </DropdownItem>
+        );
+        dropdownItems.push(<DropdownSeparator key="separator-migrate" />);
+    }
+
+    let migrateAction;
+    if (showMigrateDialog) {
+        migrateAction = (
+            <MigrateDialog key='action-migrate'
+                           vmId={vm.id}
+                           connectionName={vm.connectionName}
+                           toggleModal={() => toggleMigrateDialog(!showMigrateDialog)} />
+        );
+    }
+
     let deleteAction = null;
     if (state !== undefined && LibvirtDBus.canDelete && LibvirtDBus.canDelete(state, vm.id)) {
         if (!vm.persistent) {
@@ -345,6 +368,7 @@ const VmActions = ({ vm, dispatch, storagePools, onAddErrorNotification, isDetai
             {install}
             {deleteAction}
             {cloneAction}
+            {migrateAction}
             <Dropdown onSelect={() => setIsActionOpen(!isActionOpen)}
                       id={`${id}-action-kebab`}
                       toggle={<KebabToggle isDisabled={vm.isUi} onToggle={isOpen => setIsActionOpen(isOpen)} />}

--- a/pkg/machines/components/vm/vmMigrateDialog.jsx
+++ b/pkg/machines/components/vm/vmMigrateDialog.jsx
@@ -1,0 +1,193 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { useState } from 'react';
+import {
+    Button,
+    Checkbox,
+    Form,
+    FormGroup,
+    Modal,
+    Radio,
+    TextInput,
+    Tooltip
+} from '@patternfly/react-core';
+import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
+
+import { migrateToUri } from '../../libvirt-dbus.js';
+import { isEmpty, isObjectEmpty } from '../../helpers.js';
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+
+const _ = cockpit.gettext;
+
+const DestUriRow = ({ validationFailed, destUri, setDestUri }) => {
+    return (
+        <FormGroup label={_("Destination URI")} fieldId="dest-uri"
+                   id="dest-uri"
+                   validated={validationFailed.destUri ? "error" : "default"}>
+            <TextInput id='dest-uri-input'
+                       validated={validationFailed.destUri ? "error" : "default"}
+                       value={destUri}
+                       placeholder={cockpit.format(_("Example, $0"), "qemu+ssh://192.0.2.16/system")}
+                       onChange={setDestUri} />
+        </FormGroup>
+    );
+};
+
+const OptionsRow = ({ temporary, live, setTemporary, setLive, setStorage }) => {
+    return (
+        <FormGroup label={_("Options")}
+                   fieldId="options"
+                   id="options"
+                   hasNoPaddingTop>
+            <Checkbox id="live"
+                      isChecked={live}
+                      label={_("Run after migration")}
+                      onChange={b => {
+                          setLive(b);
+                          if (!b)
+                              setStorage("shared");
+                      }} />
+            {live && <Checkbox id="temporary"
+                               isChecked={temporary}
+                               label={
+                                   <>
+                                       {_("Move temporarily")}
+                                       <Tooltip
+                                           position="top"
+                                           content={
+                                               <>
+                                                   <p>{_("When shut off on the destination, virtual machine will return to the original host in a shut off state.")}</p>
+                                                   <p>{_("This feature is often used for hardware maintanance or load-balacing.")}</p>
+                                               </>}>
+                                           <OutlinedQuestionCircleIcon id="migrate-tooltip" />
+                                       </Tooltip>
+                                   </>
+                               }
+                               onChange={setTemporary} />
+            }
+        </FormGroup>
+    );
+};
+
+const StorageRow = ({ storage, setStorage, live }) => {
+    const copyDisabled = !live;
+    let copyRadio = (
+        <Radio id="copy"
+               name="source"
+               label={_("Copy storage")}
+               isDisabled={copyDisabled}
+               isChecked={storage === "copy"}
+               onChange={() => setStorage("copy")} />
+    );
+
+    if (copyDisabled) {
+        copyRadio = (
+            <Tooltip id="storage-copy-tooltip"
+                     content={_("Offline migration doesn't allow copying storage")}>
+                {copyRadio}
+            </Tooltip>
+        );
+    }
+
+    return (
+        <FormGroup label={_("Storage")}
+                   fieldId="storage"
+                   id="storage"
+                   hasNoPaddingTop>
+            <Radio id="shared"
+                   name="source"
+                   label={_("I have shared storage set up")}
+                   isChecked={storage === "shared"}
+                   onChange={() => setStorage("shared")} />
+            {copyRadio}
+        </FormGroup>
+    );
+};
+
+export const MigrateDialog = ({ vmId, connectionName, toggleModal }) => {
+    const [destUri, setDestUri] = useState("");
+    const [error, setDialogError] = useState({});
+    const [inProgress, setInProgress] = useState(false);
+    const [storage, setStorage] = useState("shared");
+    const [temporary, setTemporary] = useState(false);
+    const [live, setLive] = useState(true);
+    const [validationFailed, setValidationFailed] = useState(false);
+
+    function validateParams() {
+        const validation = {};
+        if (isEmpty(destUri.trim()))
+            validation.destUri = _("Destination URI must not be empty");
+
+        return validation;
+    }
+
+    function onMigrate() {
+        if (!isObjectEmpty(validateParams())) {
+            setValidationFailed(true);
+            return;
+        }
+
+        setInProgress(true);
+        return migrateToUri(connectionName, vmId, destUri, storage, live, temporary)
+                .then(toggleModal, exc => {
+                    setInProgress(false);
+                    setDialogError({ dialogError: _("Migration failed"), message: exc.message });
+                });
+    }
+
+    const body = (
+        <Form isHorizontal>
+            <DestUriRow destUri={destUri}
+                        setDestUri={setDestUri}
+                        validationFailed={validationFailed} />
+            <StorageRow storage={storage}
+                        setStorage={setStorage}
+                        live={live} />
+            <OptionsRow temporary={temporary}
+                        live={live}
+                        setStorage={setStorage}
+                        setTemporary={setTemporary}
+                        setLive={setLive} />
+        </Form>
+    );
+
+    const footer = (
+        <>
+            {!isObjectEmpty(error) && <ModalError dialogError={error.dialogError} dialogErrorDetail={error.message} />}
+            <Button variant='primary'
+                    isLoading={inProgress}
+                    onClick={onMigrate}>
+                {_("Migrate")}
+            </Button>
+            <Button variant='link' onClick={toggleModal}>
+                {_("Cancel")}
+            </Button>
+        </>
+    );
+
+    return (
+        <Modal position="top" variant="medium" isOpen onClose={toggleModal}
+           title={_("Migrate VM to another host")}
+           footer={footer}>
+            {body}
+        </Modal>
+    );
+};

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -165,6 +165,25 @@ const Enum = {
     VIR_NETWORK_EVENT_LAST: 4,
     // Keycodes
     VIR_KEYCODE_SET_LINUX: 0,
+    // Migrate
+    VIR_MIGRATE_LIVE: 1,
+    VIR_MIGRATE_PEER2PEER: 2,
+    VIR_MIGRATE_TUNNELLED: 4,
+    VIR_MIGRATE_PERSIST_DEST: 8,
+    VIR_MIGRATE_UNDEFINE_SOURCE: 16,
+    VIR_MIGRATE_PAUSED: 32,
+    VIR_MIGRATE_NON_SHARED_DISK: 64,
+    VIR_MIGRATE_NON_SHARED_INC: 128,
+    VIR_MIGRATE_CHANGE_PROTECTION: 256,
+    VIR_MIGRATE_UNSAFE: 512,
+    VIR_MIGRATE_OFFLINE: 1024,
+    VIR_MIGRATE_COMPRESSED: 2048,
+    VIR_MIGRATE_ABORT_ON_ERROR: 4096,
+    VIR_MIGRATE_AUTO_CONVERGE: 8192,
+    VIR_MIGRATE_RDMA_PIN_ALL: 16384,
+    VIR_MIGRATE_POSTCOPY: 32768,
+    VIR_MIGRATE_TLS: 65536,
+    VIR_MIGRATE_PARALLEL: 131072,
 };
 
 const LIBVIRT_DBUS_PROVIDER = {
@@ -1520,6 +1539,28 @@ function initResource(connectionName, method, updateOrAddMethod, flags) {
                 return Promise.all(objPaths[0].map(() => updateOrAddMethod({})));
             })
             .catch(ex => console.warn('initResource action failed:', ex.toString()));
+}
+
+export function migrateToUri(connectionName, objPath, destUri, storage, live, temporary) {
+    // direct migration is not supported by QEMU, so it's opposite, the P2P migration should always be used
+    let flags = Enum.VIR_MIGRATE_PEER2PEER;
+
+    if (!live) {
+        flags = flags | Enum.VIR_MIGRATE_OFFLINE | Enum.VIR_MIGRATE_PERSIST_DEST;
+    } else {
+        flags = flags | Enum.VIR_MIGRATE_LIVE;
+
+        if (!temporary)
+            flags = flags | Enum.VIR_MIGRATE_PERSIST_DEST;
+    }
+
+    if (storage === "copy")
+        flags = flags | Enum.VIR_MIGRATE_NON_SHARED_DISK;
+
+    if (temporary)
+        flags = flags | Enum.VIR_MIGRATE_UNDEFINE_SOURCE;
+
+    return call(connectionName, objPath, 'org.libvirt.Domain', 'MigrateToURI3', [destUri, {}, flags], { timeout, type: 'sa{sv}u' });
 }
 
 export function networkActivate(connectionName, objPath) {

--- a/pkg/machines/machines.scss
+++ b/pkg/machines/machines.scss
@@ -143,7 +143,7 @@
 }
 
 #vcpus-tooltip.pficon-pending, #boot-order-tooltip.pficon-pending,
-.machines-disks .pficon-pending, .pficon-ok{
+#migrate-tooltip, .machines-disks .pficon-pending, .pficon-ok{
     margin-left: 0.5rem;
 }
 

--- a/test/verify/check-machines-lifecycle
+++ b/test/verify/check-machines-lifecycle
@@ -22,11 +22,15 @@ import subprocess
 import parent
 from machineslib import *
 from testlib import *
+from machine_core.constants import TEST_OS_DEFAULT
 
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
-@nondestructive
 @no_retry_when_changed
 class TestMachinesLifecycle(VirtualMachinesCase):
+    provision = {
+        "machine1": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
+        "destination_host": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dns": "10.111.112.100"},
+    }
 
     def testBasic(self):
         self._testBasic()
@@ -98,30 +102,39 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         wait(lambda: "login as 'cirros' user." in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
 
         # Send Non-Maskable Interrupt (no change in VM state is expected)
-        self.performAction("subVmTest1", "sendNMI")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-sendNMI")
 
         b.wait(lambda: "NMI received" in self.machine.execute("cat {0}".format(args["logfile"])))
 
         # pause
-        self.performAction("subVmTest1", "pause")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-pause")
+        b.wait_in_text("#vm-subVmTest1-state", "Paused")
 
         # resume
-        self.performAction("subVmTest1", "resume")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-resume")
+        b.wait_in_text("#vm-subVmTest1-state", "Running")
 
         # reboot
         self.machine.execute("echo '' > {0}".format(args["logfile"]))
-        self.performAction("subVmTest1", "reboot")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-reboot")
         wait(lambda: "reboot: Power down" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
         b.wait_in_text("#vm-subVmTest1-state", "Running")
 
         # force reboot
         self.machine.execute("echo '' > {0}".format(args["logfile"]))
-        self.performAction("subVmTest1", "forceReboot")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-forceReboot")
         wait(lambda: "Initializing cgroup subsys" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
         b.wait_in_text("#vm-subVmTest1-state", "Running")
 
         # shut off
-        self.performAction("subVmTest1", "forceOff")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-forceOff")
+        b.wait_in_text("#vm-subVmTest1-state", "Shut off")
 
         # continue shut off validation - usage should drop to zero
         b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0 /")
@@ -131,12 +144,14 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute("virsh dumpxml subVmTest1 > /tmp/subVmTest1.xml")
         m.execute("virsh start {0} && virsh undefine {0}".format("subVmTest1"))
         b.wait_visible("div[data-vm-transient=\"true\"]")
-        self.performAction("subVmTest1", "forceOff", False)
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-forceOff")
         b.wait_in_text("#virtual-machines-listing .pf-c-empty-state", "No VM is running")
         m.execute("virsh define --file /tmp/subVmTest1.xml")
 
         # clone
-        self.performAction("subVmTest1", "clone")
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-clone a[aria-disabled=false]")
 
         b.wait_text(".pf-c-modal-box__title-text", "Create a clone VM based on subVmTest1")
         b.click("footer button.pf-m-primary")
@@ -166,7 +181,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
             b.wait_in_text("#vm-subVmTest2-state", "Running")
 
         # stop second VM, event handling should still work
-        self.performAction("subVmTest2", "forceOff")
+        b.click("#vm-subVmTest2-action-kebab button")
+        b.click("#vm-subVmTest2-forceOff")
+        b.wait_in_text("#vm-subVmTest2-state", "Shut off")
 
         b.click("#vm-subVmTest2-run")
 
@@ -330,7 +347,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         addDisk(secondDiskVolName, poolName)
 
-        self.performAction(name, "delete")
+        b.click("#vm-{0}-action-kebab button".format(name))
+        b.click("#vm-{0}-delete".format(name))
 
         b.wait_visible("#vm-{0}-delete-modal-dialog .modal-body:contains(The VM is running)".format(name))
         b.wait_visible("#vm-{1}-delete-modal-dialog ul li:first-child #disk-source-file:contains({0})".format(img2, name))
@@ -358,7 +376,8 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         self.machine.execute("virsh -c qemu:///system suspend {0}".format(name))
         b.wait_in_text("#vm-{0}-state".format(name), "Paused")
-        self.performAction(name, "delete")
+        b.click("#vm-{0}-action-kebab button".format(name))
+        b.click("#vm-{0}-delete".format(name))
         b.click("#vm-{0}-delete-modal-dialog button:contains(Delete)".format(name))
         self.waitVmRow(name, 'system', False)
 
@@ -377,6 +396,51 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.allow_browser_errors("Disconnection timed out.")
         self.allow_journal_messages(".* couldn't shutdown fd: Transport endpoint is not connected")
 
+    def testMigrate(self):
+        b = self.browser
+        m = self.machines['destination_host']
+
+        self.createVm("subVmTest1")
+
+        self.login_and_go("/machines")
+        m.execute("echo '10.111.113.1 destination-host' >> /etc/hosts")
+        self.machines['machine1'].execute("echo '10.111.113.1 destination-host' >> /etc/hosts")
+
+        self.machines['machine1'].execute("echo 'migration_host = \"10.111.113.1\"' >> /etc/libvirt/qemu.conf")
+        self.machines['machine1'].execute("systemctl restart libvirtd.service")
+
+        # setup key authentization
+        m.execute("mkdir -p $HOME/.ssh")
+        m.execute("chmod 0700 $HOME/.ssh")
+        m.execute("ssh-keygen -t rsa -N \"\" -f $HOME/.ssh/id_rsa")
+        m.execute("echo 'StrictHostKeyChecking no' > $HOME/.ssh/config")
+        m.execute("sshpass -p 'foobar' ssh-copy-id -i $HOME/.ssh/id_rsa.pub admin@destination-host")
+        self.machines['machine1'].execute("mkdir -p $HOME/.ssh")
+        self.machines['machine1'].execute("chmod 0700 $HOME/.ssh")
+        self.machines['machine1'].execute("ssh-keygen -t rsa -N \"\" -f $HOME/.ssh/id_rsa")
+        self.machines['machine1'].execute("echo 'StrictHostKeyChecking no' > $HOME/.ssh/config")
+        self.machines['machine1'].execute("sshpass -p 'foobar' ssh-copy-id -i $HOME/.ssh/id_rsa.pub admin@destination-host")
+        self.machines['machine1'].execute("usermod --append --groups libvirt admin")
+
+        xml = POOL_XML.format(path="/var/lib/libvirt/images")
+        self.machines['machine1'].execute("echo \"{0}\" > /tmp/xml && virsh pool-define /tmp/xml && virsh pool-start images".format(xml))
+
+        self.waitVmRow("subVmTest1")
+        self.goToVmPage("subVmTest1")
+
+        b.click("#vm-subVmTest1-action-kebab button")
+        b.click("#vm-subVmTest1-migrate")
+
+        b.wait_visible(".pf-c-modal-box")
+        b.set_input_text("#dest-uri-input", "qemu+ssh://admin@destination-host/system")
+        b.click("#type #offline")
+
+        output = self.machines['machine1'].execute("virsh list --all")
+        self.assertFalse("subVmTest1" in output)
+        b.click("footer button.pf-m-primary")
+        b.wait_not_present(".pf-c-modal-box")
+        output = self.machines['machine1'].execute("virsh list --all")
+        self.assertTrue("subVmTest1" in output)
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Transport live VM to another host. Configurable options are:
- Destination URI
- Migrated VM's state: This defines how will VM look at the destination
  host. It can either be persistent and running, transient and running
  or it can be shut off. Note that if shut off option is chosen, then
  the VM on source host will be paused for the duration of the
  migration and "Copy storage" is disabled.
- Storage: User can either choose to copy all read-only disks, or they
  can choose that they have a shared storage setup where both source and
  destination hosts have access too. In the latter that case, no disks
  are transported.
- Undefine source: VM at the source host will be undefined after
  migration is finished. Not this option is enabled when state of
  Migrated VM is "transient".

![Screenshot from 2021-02-23 14-52-59](https://user-images.githubusercontent.com/42733240/108854850-9c4bae00-75e8-11eb-97ac-6a7794590963.png)
![Screenshot from 2021-02-23 14-53-32](https://user-images.githubusercontent.com/42733240/108854848-9bb31780-75e8-11eb-8197-f9ad0b5e1451.png)

And the things I would like to discuss: 
1. virt-manager offers also data transport type option, where user can choose if they want to use hypervisor native transport or tunnelled transport. But after looking at migration related topics on serverfault.com, stackoverflow.com and various blogs, I get the feeling it's not so much used options, so perhaps it's possible to omit it?
2. Perhaps "Undefine source" can be merged with some other option? Like apart from "Live transient", it could automatically undefine source VM once the migration is succesfully finished? Or is that too risky move?
3. There is also an "unsafe" flag. Is some cases, libvirt might decide that migration is too unsafe and may lead to data corruption. It's safe to migrate without data corruption when filesystems are cache-coherent (i.e. GFS2, OCFS or CEPH) and disks have cache option configured (disk XML property is `cache != 'none'`). If that's not the case, migration may lead to data corruption. What should be done about this situation? I can check the above mentioned conditions, and if they pass, I can either pass "unsafe" flag automatically + show warning that migration may lead to data corruption. Or I can display the "unsafe" option in Migrate dialog.
4. In this PR the migration is enabled only for running VM. But I'm not really sure if it should be disabled... Migrating shut off VM only takes xml from source host and moves it to the destination host and it cannot copy disks. So the same can be achieved by running:
```
virsh dumpxml FOO > foo.xml
scp foo.xml <targethost>
virsh define foo.xml
```