### PR TITLE
metrics: Going over 80% does not mean necessary event

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -598,7 +598,7 @@ const MetricsHour = ({ startTime, data, clipLeading }) => {
                 return;
             const value = samples[type];
             // either high enough slope, or crossing the 80% threshold
-            if (prev_val !== null && (value - prev_val > 0.25 || (prev_val < 0.8 && value >= 0.8))) {
+            if (prev_val !== null && (value - prev_val > 0.25 || (prev_val < 0.75 && value >= 0.8))) {
                 const minute = Math.floor(i / SAMPLES_PER_MIN);
                 if (minute_events[minute] === undefined)
                     minute_events[minute] = [];

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -318,12 +318,9 @@ class TestHistoryMetrics(MachineCase):
         self.assertGreater(getMaximumSpike(b, "memory", False, 1600236000000, 47), 0.6)
         self.assertIn("Memory spike", events_at(1600236000000, 47))
 
-        # bigger memory spike in :53
-        self.assertGreater(getMaximumSpike(b, "memory", False, 1600236000000, 53), 0.8)
-        self.assertIn("Memory spike", events_at(1600236000000, 53))
-
-        # continued memory spike in :54, but no new events
+        # at :54 the machine is loaded to ~80% so no event even if elevated
         self.assertGreater(getCompressedMinuteValue(b, "memory", False, 1600236000000, 54), 0.8)
+        b.wait_not_present("#metrics-hour-1600236000000 .metrics-events[style='--metrics-minute:54;']")
         if have_swap:
             self.assertAlmostEqual(getCompressedMinuteValue(b, "memory", True, 1600236000000, 54), 0.0)
 
@@ -344,8 +341,8 @@ class TestHistoryMetrics(MachineCase):
         b.wait_text(".pf-c-select__toggle-text", "Today")
 
         b.select_PF4("#date-picker-select-toggle", "Wednesday, Sep 16, 2020")
-        self.assertGreater(getMaximumSpike(b, "memory", False, 1600236000000, 53), 0.8)
-        self.assertIn("Memory spike", events_at(1600236000000, 53))
+        self.assertGreater(getMaximumSpike(b, "memory", False, 1600236000000, 51), 0.5)
+        self.assertIn("Memory spike", events_at(1600236000000, 51))
 
         b.click(".pf-c-select__toggle")
         b.click(".pf-c-select__menu-item:contains('Today')")


### PR DESCRIPTION
If the processor (for example) is loaded to around 80% all the time and just
fluxes one or two % up and down it is interpreted as event every minute.

Lets consider the rise over 80% to be at least somewhat significant.

I was working on this page while my CPU was busy and noticed I had waaay to many events, even though the graphs looked pretty stable. Loaded machine !== something bad is happening. Better ideas are welcomed. I was thinking about taking average from all points and then checking if the 80% mark is not close to average or so, but I though to start with something simple and see what others think.

Before:
![justspikesandnothingelse](https://user-images.githubusercontent.com/12330670/108893203-1c860980-7611-11eb-8dda-3396afcfba88.png)

After:
![werejustspikes](https://user-images.githubusercontent.com/12330670/108893225-214abd80-7611-11eb-99e8-d5256466f8a1.png)
