### PR TITLE
Clean up variable expansion in the router

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -403,6 +403,8 @@ read_package_manifest (const gchar *directory,
           cockpit_json_patch (manifest, override);
           json_object_unref (override);
         }
+
+      json_object_seal (manifest);
     }
 
   return manifest;

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -629,8 +629,7 @@ add_dynamic_args_to_array (gchar ***key,
     {
       GString *s = g_string_new ("");
       GBytes *input = g_bytes_new_static (config_args[i], strlen(config_args[i]) + 1);
-      GList *output = cockpit_template_expand (input, substitute_json_string,
-                                               "${", "}", options);
+      GList *output = cockpit_template_expand (input, "${", "}", substitute_json_string, options);
       GList *l;
       for (l = output; l != NULL; l = g_list_next (l))
         {
@@ -1251,8 +1250,7 @@ cockpit_router_add_bridge (CockpitRouter *self,
 
   /* See if we have any variables in the JSON */
   bytes = cockpit_json_write_bytes (config);
-  output = cockpit_template_expand (bytes, substitute_json_string,
-                                    "${", "}", NULL);
+  output = cockpit_template_expand (bytes, "${", "}", substitute_json_string, NULL);
   rule = g_new0 (RouterRule, 1);
   rule->config = json_object_ref (config);
 

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -1243,7 +1243,7 @@ cockpit_router_add_bridge (CockpitRouter *self,
   GBytes *bytes = NULL;
 
   g_return_if_fail (COCKPIT_IS_ROUTER (self));
-  g_return_if_fail (config != NULL);
+  g_return_if_fail (config && json_object_is_immutable (config));
 
   /* Actual descriptive warning displayed elsewhere */
   if (!cockpit_json_get_object (config, "match", NULL, &match))

--- a/src/bridge/test-router.c
+++ b/src/bridge/test-router.c
@@ -81,6 +81,7 @@ setup (TestCase *tc,
     {
       json_object_set_boolean_member (tc->mock_config, "privileged", TRUE);
     }
+  json_object_seal (tc->mock_config);
 
   tc->mock_match = json_object_new ();
   json_object_set_string_member (tc->mock_match, "payload", payload);
@@ -120,6 +121,7 @@ setup_dynamic (TestCase *tc,
       json_array_add_string_element (env, "COCKPIT_TEST_PARAM_ENV=${payload}");
       json_object_set_array_member (tc->mock_config, "environ", env);
     }
+  json_object_seal (tc->mock_config);
 
   json_object_set_null_member (match, "payload");
   json_object_set_object_member (tc->mock_config, "match", match);
@@ -570,6 +572,7 @@ make_bridge_configs (const gchar *payload, ...)
       JsonObject *config = json_object_new ();
       json_object_set_object_member (config, "match", match);
       json_object_set_array_member (config, "spawn", spawn);
+      json_object_seal (config);
 
       configs = g_list_prepend (configs, config);
 

--- a/src/common/cockpitjson.h
+++ b/src/common/cockpitjson.h
@@ -103,4 +103,11 @@ JsonObject *   cockpit_json_from_hash_table   (GHashTable *hash_table,
 
 GHashTable *   cockpit_json_to_hash_table     (JsonObject *object,
                                                const gchar **fields);
+
+typedef JsonNode * (* CockpitJsonWalkCallback) (JsonNode *node, gpointer user_data);
+
+JsonObject *   cockpit_json_walk              (JsonObject              *object,
+                                               CockpitJsonWalkCallback  callback,
+                                               gpointer                 user_data);
+
 #endif /* COCKPIT_JSON_H__ */

--- a/src/common/cockpittemplate.c
+++ b/src/common/cockpittemplate.c
@@ -21,6 +21,8 @@
 
 #include "cockpittemplate.h"
 
+#include "cockpitjson.h"
+
 #include <glib.h>
 
 #include <string.h>
@@ -155,4 +157,60 @@ cockpit_template_expand (GBytes *input,
     }
 
   return g_list_reverse (output);
+}
+
+typedef struct
+{
+  const gchar         *start;
+  const gchar         *end;
+  CockpitTemplateFunc  func;
+  gpointer             user_data;
+} TemplateClosure;
+
+static JsonNode *
+template_walk_func (JsonNode *node,
+                    gpointer  user_data)
+{
+  TemplateClosure *closure = user_data;
+  const gchar *string = json_node_get_string (node);
+
+  if (string == NULL)
+    return NULL;
+
+  if (strstr (string, closure->start) == NULL)
+    return NULL;
+
+  g_autoptr(GBytes) input = g_bytes_new_with_free_func (string, strlen (string),
+                                                        (GDestroyNotify) json_node_unref,
+                                                        json_node_ref (node));
+
+  GList *output = cockpit_template_expand (input, closure->start, closure->end, closure->func, closure->user_data);
+
+  g_autoptr(GString) result = g_string_new (NULL);
+  while (output)
+    {
+      g_autoptr(GBytes) fragment = output->data;
+      g_string_append_len (result, g_bytes_get_data (fragment, NULL), g_bytes_get_size (fragment));
+      output = g_list_delete_link (output, output);
+    }
+
+  if (g_str_equal (result->str, string))
+    return NULL;
+
+  node = json_node_new (JSON_NODE_VALUE);
+  json_node_set_string (node, result->str);
+
+  return node;
+}
+
+JsonObject *
+cockpit_template_expand_json (JsonObject *object,
+                              const gchar *start_marker,
+                              const gchar *end_marker,
+                              CockpitTemplateFunc func,
+                              gpointer user_data)
+{
+  TemplateClosure closure = { start_marker, end_marker, func, user_data };
+
+  return cockpit_json_walk (object, template_walk_func, &closure);
 }

--- a/src/common/cockpittemplate.c
+++ b/src/common/cockpittemplate.c
@@ -78,9 +78,9 @@ find_variable (const gchar *start_marker,
 
 GList *
 cockpit_template_expand (GBytes *input,
-                         CockpitTemplateFunc func,
                          const gchar *start_marker,
                          const gchar *end_marker,
+                         CockpitTemplateFunc func,
                          gpointer user_data)
 {
   GList *output = NULL;

--- a/src/common/cockpittemplate.h
+++ b/src/common/cockpittemplate.h
@@ -32,4 +32,10 @@ GList *           cockpit_template_expand         (GBytes *input,
                                                    CockpitTemplateFunc func,
                                                    gpointer user_data);
 
+JsonObject *      cockpit_template_expand_json    (JsonObject *object,
+                                                   const gchar *start_marker,
+                                                   const gchar *end_marker,
+                                                   CockpitTemplateFunc func,
+                                                   gpointer user_data);
+
 #endif /* COCKPIT_TEMPLATE_H__ */

--- a/src/common/cockpittemplate.h
+++ b/src/common/cockpittemplate.h
@@ -21,14 +21,15 @@
 #define COCKPIT_TEMPLATE_H__
 
 #include <glib.h>
+#include <json-glib/json-glib.h>
 
 typedef GBytes * (* CockpitTemplateFunc)          (const gchar *variable,
                                                    gpointer user_data);
 
 GList *           cockpit_template_expand         (GBytes *input,
-                                                   CockpitTemplateFunc func,
                                                    const gchar *start_marker,
                                                    const gchar *end_marker,
+                                                   CockpitTemplateFunc func,
                                                    gpointer user_data);
 
 #endif /* COCKPIT_TEMPLATE_H__ */

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1184,8 +1184,7 @@ cockpit_web_response_error (CockpitWebResponse *self,
 
   if (!input)
     input = g_bytes_new_static (default_failure_template, strlen (default_failure_template));
-  output = cockpit_template_expand (input, substitute_message,
-                                    "@@", "@@", (gpointer)message);
+  output = cockpit_template_expand (input, "@@", "@@", substitute_message, (gpointer) message);
   g_bytes_unref (input);
 
   /* If sending arbitrary messages, make sure they're escaped */
@@ -1380,7 +1379,7 @@ again:
   body = g_mapped_file_get_bytes (file);
   if (template_func)
     {
-      output = cockpit_template_expand (body, template_func, "${", "}", user_data);
+      output = cockpit_template_expand (body, "${", "}", template_func, user_data);
     }
   else
     {

--- a/src/common/test-template.c
+++ b/src/common/test-template.c
@@ -20,6 +20,7 @@
 #include "config.h"
 
 #include "cockpittemplate.h"
+#include "cockpitjson.h"
 
 #include "common/cockpittest.h"
 
@@ -69,6 +70,10 @@ typedef struct {
 } Fixture;
 
 static const Fixture expand_fixtures[] = {
+  { "@@", "@@", "empty-string", "", { NULL } },
+  { "@@", "@@", "no-vars", "Test no vars", { "Test no vars", NULL } },
+  { "@@", "@@", "only-var", "@@oh@@", { "marmalade", NULL } },
+  { "@@", "@@", "only-vars", "@@oh@@@@oh@@", { "marmalade", "marmalade", NULL } },
   { "@@", "@@", "simple", "Test @@oh@@ suffix", { "Test ", "marmalade", " suffix", NULL } },
   { "@@", "@@", "extra-at", "Te@st @@oh@@ suffix", { "Te@st ", "marmalade", " suffix", NULL } },
   { "@@", "@@", "no-ending", "Test @@oh@@ su@@ffix", { "Test ", "marmalade", " su@@ffix", NULL } },
@@ -79,6 +84,10 @@ static const Fixture expand_fixtures[] = {
   { "@@", "@@", "lots", "Oh @@oh@@ says Scruffy @@empty@@ the @@Scruffy@@",
       { "Oh ", "marmalade", " says Scruffy ", " the ", "janitor", NULL }
   },
+  { "${", "}", "brackets-empty-string", "", { NULL } },
+  { "${", "}", "brackets-no-vars", "Test no vars", { "Test no vars", NULL } },
+  { "${", "}", "brackets-only-var", "${oh}", { "marmalade", NULL } },
+  { "${", "}", "brackets-only-vars", "${oh}${oh}", { "marmalade", "marmalade", NULL } },
   { "${", "}", "brackets-simple", "Test ${oh} suffix", { "Test ", "marmalade", " suffix", NULL } },
   { "${", "}", "brackets-not-full", "Te$st ${oh} suffix", { "Te$st ", "marmalade", " suffix", NULL } },
   { "${", "}", "brackets-no-ending", "Test ${oh} su${ffix", { "Test ", "marmalade", " su${ffix", NULL } },
@@ -111,6 +120,64 @@ test_expand (TestCase *tc,
   g_list_free_full (output, (GDestroyNotify)g_bytes_unref);
 }
 
+static void
+test_json (TestCase *tc,
+           gconstpointer data)
+{
+  g_autoptr(JsonObject) input = json_object_new ();
+  g_autoptr(JsonObject) expected_at = json_object_new ();
+  g_autoptr(JsonObject) expected_brackets = json_object_new ();
+  g_autoptr(JsonObject) expected_both = json_object_new ();
+
+  for (int i = 0; i < G_N_ELEMENTS (expand_fixtures); i++)
+    {
+      const Fixture *fixture = &expand_fixtures[i];
+      g_autofree gchar *output = g_strjoinv ("", (gchar **) fixture->output);
+
+      json_object_set_string_member (input, fixture->name, fixture->input);
+
+      if (g_str_equal (fixture->start, "@@"))
+        {
+          /* ${...} won't expand anything here */
+          json_object_set_string_member (expected_brackets, fixture->name, fixture->input);
+
+          /* the other cases will */
+          json_object_set_string_member (expected_at, fixture->name, output);
+          json_object_set_string_member (expected_both, fixture->name, output);
+        }
+      else
+        {
+          g_assert (g_str_equal (fixture->start, "${"));
+
+          /* @@...@@ won't expand anything here */
+          json_object_set_string_member (expected_at, fixture->name, fixture->input);
+
+          /* the other cases will */
+          json_object_set_string_member (expected_brackets, fixture->name, output);
+          json_object_set_string_member (expected_both, fixture->name, output);
+        }
+    }
+
+  json_object_seal (input);
+
+  /* Let's try the cases now */
+  g_autoptr(JsonObject) at_results = cockpit_template_expand_json (input, "@@", "@@",
+                                                                   lookup_table, tc->variables);
+  g_assert (json_object_equal (at_results, expected_at));
+
+  g_autoptr(JsonObject) bracket_results = cockpit_template_expand_json (input, "${", "}",
+                                                                        lookup_table, tc->variables);
+  g_assert (json_object_equal (at_results, expected_at));
+
+  g_autoptr(JsonObject) bracket_at_results = cockpit_template_expand_json (bracket_results, "@@", "@@",
+                                                                           lookup_table, tc->variables);
+  g_assert (json_object_equal (bracket_at_results, expected_both));
+
+  g_autoptr(JsonObject) at_bracket_results = cockpit_template_expand_json (at_results, "${", "}",
+                                                                           lookup_table, tc->variables);
+  g_assert (json_object_equal (at_bracket_results, expected_both));
+}
+
 int
 main (int argc,
       char *argv[])
@@ -126,6 +193,8 @@ main (int argc,
       g_test_add (name, TestCase, expand_fixtures + i, setup, test_expand, teardown);
       g_free (name);
     }
+
+  g_test_add ("/template/expand/json", TestCase, NULL, setup, test_json, teardown);
 
   return g_test_run ();
 }

--- a/src/common/test-template.c
+++ b/src/common/test-template.c
@@ -101,7 +101,7 @@ test_expand (TestCase *tc,
 
   input = g_bytes_new_static (fixture->input, strlen (fixture->input));
 
-  output = cockpit_template_expand (input, lookup_table, fixture->start, fixture->end, tc->variables);
+  output = cockpit_template_expand (input, fixture->start, fixture->end, lookup_table, tc->variables);
   g_bytes_unref (input);
 
   for (i = 0, l = output; fixture->output[i] != NULL; i++, l = g_list_next (l))


### PR DESCRIPTION
This replaces the custom code for managing the argv/envp and variable expansions inside of them with a generic transform performed at the JSON level.  This already makes the code much easier to understand (since everything we do is eventually turned back into a JsonObject again anyway) and sets the stage for adding a second level of variable expansion without things getting wildly out of hand.