### PR TITLE
test: Fix retry reason printing in run-tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -66,10 +66,10 @@ def print_test(test, print_tap=True, retry_reason=""):
             except BlockingIOError as e:
                 line = line[e.characters_written:]
                 time.sleep(0.1)
-    flush_stdout()
 
     if not print_tap:
         print(retry_reason)
+        flush_stdout()
         return
 
     print()  # Tap needs to start on a separate line


### PR DESCRIPTION
Commit a0c8d08f10 changed the retry_reason printing to happen after
flushing stdout. This kept it stuck in Python's IOStream buffer until
more output (from the next few tests) was printed, and thus eventually
put the marker onto the wrong test.

Fix this by flushing after the retry reason in the `!print_tap` case.
With `print_tap`, the flushing happens at the end of the function, and
it is ok and desirable to buffer the entire output and flush it out just
once.

Fixes #15414