### PR TITLE
apps: Replace --with-appstream* configure options with manifest map

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -134,8 +134,6 @@ SUBST_RULE = \
 	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
 	-e 's,[@]admin_group[@],$(admin_group),g' \
 	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
-	-e 's,[@]with_appstream_config_packages[@],$(with_appstream_config_packages),g' \
-	-e 's,[@]with_appstream_data_packages[@],$(with_appstream_data_packages),g' \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -326,23 +326,6 @@ changequote([,])dnl
 
 AC_CHECK_FUNCS(fdwalk)
 
-
-# Package specific settings
-
-AC_ARG_WITH(appstream-config-packages,
-            AC_HELP_STRING([--with-appstream-config-packages=JSON],
-                           [List of packages that configure the system to retrieve AppStream collection metadata]),
-            [],
-            [with_appstream_config_packages='[[]]'])
-AC_SUBST(with_appstream_config_packages)
-
-AC_ARG_WITH(appstream-data-packages,
-            AC_HELP_STRING([--with-appstream-data-packages=JSON],
-                           [List of packages that contain AppStream collection metadata]),
-            [],
-            [with_appstream_data_packages='[[]]'])
-AC_SUBST(with_appstream_data_packages)
-
 # Address sanitizer
 
 AC_MSG_CHECKING([for asan flags])

--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -129,11 +129,23 @@ export class ApplicationList extends React.Component {
             comps.push(this.props.metainfo_db.components[id]);
         comps.sort((a, b) => a.name.localeCompare(b.name));
 
+        function get_config(name, distro_id, def) {
+            if (cockpit.manifests.apps && cockpit.manifests.apps.config) {
+                let val = cockpit.manifests.apps.config[name];
+                if (typeof val === 'object' && val !== null && !Array.isArray(val))
+                    val = val[distro_id];
+                return val !== undefined ? val : def;
+            } else {
+                return def;
+            }
+        }
+
         function refresh() {
-            var config = cockpit.manifests.apps.config || { };
+            const distro_id = JSON.parse(window.localStorage['os-release'] || "{}").ID;
+
             PackageKit.refresh(self.props.metainfo_db.origin_files,
-                               config.appstream_config_packages || [],
-                               config.appstream_data_packages || [],
+                               get_config('appstream_config_packages', distro_id, []),
+                               get_config('appstream_data_packages', distro_id, []),
                                data => self.setState({ progress: data }))
                     .finally(() => self.setState({ progress: false }))
                     .catch(show_error);

--- a/pkg/apps/manifest.json.in
+++ b/pkg/apps/manifest.json.in
@@ -18,8 +18,11 @@
     "content-security-policy": "img-src *",
 
     "config": {
-        "appstream_config_packages": @with_appstream_config_packages@,
-        "appstream_data_packages": @with_appstream_data_packages@
+        "appstream_config_packages": {
+            "debian": ["appstream"], "ubuntu": ["appstream"]
+        },
+        "appstream_data_packages": {
+            "fedora": ["appstream-data"], "rhel": ["appstream-data"]
+        }
     }
-
 }

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -46,7 +46,7 @@ class TestApps(PackageCase):
             "/usr/share/pixmaps/test.png":  { "path": "/var/tmp/test.png" }})
         self.appstream_collection.add(name)
 
-    def enableAppStreamRepo(self):
+    def createAppStreamRepoPackage(self):
         body = ""
         for p in self.appstream_collection:
             body += """
@@ -76,7 +76,6 @@ class TestApps(PackageCase):
         self.machine.execute("systemctl stop packagekit && pkcon refresh force")
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
-        self.machine.execute("pkcon -y install appstream-data-test")
 
     def testBasic(self, urlroot=""):
         b = self.browser
@@ -87,6 +86,10 @@ class TestApps(PackageCase):
 
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
 
+        # instead of the actual distro packages, use our own fake repo data package
+        m.write("/usr/share/cockpit/apps/override.json",
+                '{ "config": { "appstream_data_packages": [ "appstream-data-test" ] } }')
+
         if urlroot != "":
             m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot=%s" > /etc/cockpit/cockpit.conf' % urlroot)
 
@@ -95,7 +98,10 @@ class TestApps(PackageCase):
         b.wait_visible(".app-list-empty")
 
         self.createAppStreamPackage("app-1", "1.0", "1")
-        self.enableAppStreamRepo()
+        self.createAppStreamRepoPackage()
+
+        # Refresh package info
+        b.click(".ct-table-actions button")
 
         b.click(".app-list #app-1")
         b.wait_visible('.app-links a[href="https://app-1.com"]')

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -155,7 +155,6 @@ exec 2>&1
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
     --with-selinux-config-type=etc_t \
-    --with-appstream-data-packages='[ "appstream-data" ]' \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -19,7 +19,6 @@ override_dh_auto_configure:
 	dh_auto_configure -- \
 		--with-cockpit-user=cockpit-ws \
 		--with-cockpit-ws-instance-user=cockpit-wsinstance \
-		--with-appstream-config-packages='[ "appstream" ]' \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
 


### PR DESCRIPTION
This gets rid of the remaining piece of manifests which depend on
./configure options. This gets us closer to making them fully portable
and buildable by webpack.

This uses the same approach as the storage page in commits
0b14a00754cd4 and 9e6a715adca: Put a per-distro map into the manifest,
which is easy enough to tweak/override by admins, and patch by
distributors.

# Release note

## Packaging: Removed ./configure options for distribution specific packages

The previous `--with-vdo-package`, `--with-nfs-client-package`, `--with-appstream-config-packages`, and `--with-appstream-data-packages` options for `./configure` got removed. This information is now contained in the respective manifest files, for example for the [Storage page](https://github.com/cockpit-project/cockpit/blob/master/pkg/storaged/manifest.json.in). This makes the manifest files portable across distributions. They can still be adjusted by administrators through [override.json files](https://cockpit-project.org/guide/latest/packages.html#package-replace).