### PR TITLE
machines: Expose editing disk cache mode

### DIFF
--- a/pkg/machines/components/vm/disks/diskAdd.jsx
+++ b/pkg/machines/components/vm/disks/diskAdd.jsx
@@ -27,7 +27,7 @@ import cockpit from 'cockpit';
 
 import { FileAutoComplete } from 'cockpit-components-file-autocomplete.jsx';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { units, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getStorageVolumeDiskTarget } from '../../../helpers.js';
+import { diskCacheModes, units, convertToUnit, getDefaultVolumeFormat, getNextAvailableTarget, getStorageVolumesUsage, getStorageVolumeDiskTarget } from '../../../helpers.js';
 import { volumeCreateAndAttach, attachDisk, getVm, getAllStoragePools } from '../../../actions/provider-actions.js';
 import { VolumeCreateBody } from '../../storagePools/storageVolumeCreateBody.jsx';
 import LibvirtDBus, { updateDiskAttributes } from '../../../libvirt-dbus.js';
@@ -140,8 +140,6 @@ class AdditionalOptions extends React.Component {
     }
 
     render() {
-        const cacheModes = ['default', 'none', 'writethrough', 'writeback', 'directsync', 'unsafe'];
-
         return (
             <ExpandableSection toggleText={ this.state.expanded ? _("Hide additional options") : _("Show additional options")}
                                onToggle={() => this.setState({ expanded: !this.state.expanded })} isExpanded={this.state.expanded} className="add-disk-additional-options">
@@ -151,7 +149,7 @@ class AdditionalOptions extends React.Component {
                             onChange={value => this.props.onValueChanged('cacheMode', value)}
                             value={this.props.cacheMode}
                             className='ct-form-split'>
-                            {cacheModes.map(cacheMode => {
+                            {diskCacheModes.map(cacheMode => {
                                 return (
                                     <FormSelectOption value={cacheMode} key={cacheMode}
                                                       label={cacheMode} />

--- a/pkg/machines/helpers.js
+++ b/pkg/machines/helpers.js
@@ -37,6 +37,8 @@ export function toReadableNumber(number) {
     }
 }
 
+export const diskCacheModes = ['default', 'none', 'writethrough', 'writeback', 'directsync', 'unsafe'];
+
 export const units = {
     B: {
         name: "B",

--- a/pkg/machines/libvirt-dbus.js
+++ b/pkg/machines/libvirt-dbus.js
@@ -1432,10 +1432,10 @@ export function attachIface({ connectionName, vmId, mac, permanent, hotplug, sou
     return attachDevice({ connectionName, vmId, permanent, hotplug, xmlDesc });
 }
 
-export function updateDiskAttributes({ connectionName, objPath, target, readonly, shareable, busType, existingTargets }) {
+export function updateDiskAttributes({ connectionName, objPath, target, readonly, shareable, busType, existingTargets, cache }) {
     return call(connectionName, objPath, 'org.libvirt.Domain', 'GetXMLDesc', [Enum.VIR_DOMAIN_XML_INACTIVE], { timeout, type: 'u' })
             .then(domXml => {
-                const updatedXML = updateDisk({ diskTarget: target, domXml, readonly, shareable, busType, existingTargets });
+                const updatedXML = updateDisk({ diskTarget: target, domXml, readonly, shareable, busType, existingTargets, cache });
                 return call(connectionName, '/org/libvirt/QEMU', 'org.libvirt.Connect', 'DomainDefineXML', [updatedXML], { timeout, type: 's' });
             });
 }

--- a/pkg/machines/libvirt-xml-update.js
+++ b/pkg/machines/libvirt-xml-update.js
@@ -1,7 +1,7 @@
 import { getElem, getSingleOptionalElem } from './libvirt-common.js';
 import { getNextAvailableTarget } from './helpers.js';
 
-export function updateDisk({ domXml, diskTarget, readonly, shareable, busType, existingTargets }) {
+export function updateDisk({ domXml, diskTarget, readonly, shareable, busType, existingTargets, cache }) {
     const domainElem = getElem(domXml);
     if (!domainElem)
         throw new Error("updateBootOrder: domXML has no domain element");
@@ -39,6 +39,10 @@ export function updateDisk({ domXml, diskTarget, readonly, shareable, busType, e
                 const addressElem = getSingleOptionalElem(disk, "address");
                 addressElem.remove();
             }
+
+            const driverElem = disk.getElementsByTagName("driver")[0];
+            if (cache)
+                driverElem.setAttribute("cache", cache);
         }
     }
 

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -131,25 +131,29 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_not_present("#vm-subVmTest1-disks-vde-access-tooltip")
 
         b.wait_in_text("#vm-subVmTest1-disks-vde-bus", "virtio")
-        # Change bus type to scsi
+        b.wait_not_present("#vm-subVmTest1-disks-vde-cache")
+        # Change bus type to scsi and cache mode to writeback
         b.click("#vm-subVmTest1-disks-vde-edit")
         b.wait_visible("#vm-subVmTest1-disks-vde-edit-dialog")
         b.select_from_dropdown("#vm-subVmTest1-disks-vde-edit-bus-type", "scsi")
+        b.select_from_dropdown("#vm-subVmTest1-disks-vde-edit-cache-mode", "writeback")
 
         # Close dialog
         b.click("#vm-subVmTest1-disks-vde-edit-dialog-save")
         b.wait_not_present("#vm-subVmTest1-disks-vde-edit-dialog")
         # Target has changed from vdX to sdX
         b.wait_in_text("#vm-subVmTest1-disks-sda-bus", "scsi")
+        b.wait_in_text("#vm-subVmTest1-disks-sda-cache", "writeback")
 
         # Start Vm
         b.click("#vm-subVmTest1-run")
         b.wait_in_text("#vm-subVmTest1-state", "Running")
 
-        # Test disk's bus cannot be changed on running VM
+        # Test disk's bus and cache cannot be changed on running VM
         b.click("#vm-subVmTest1-disks-sda-edit")
         b.wait_visible("#vm-subVmTest1-disks-sda-edit-dialog")
         b.wait_visible("#vm-subVmTest1-disks-sda-edit-bus-type:disabled")
+        b.wait_visible("#vm-subVmTest1-disks-sda-edit-cache-mode:disabled")
 
         # Disks on non-persistent VM cannot be edited
         m.execute("virsh undefine subVmTest1")


### PR DESCRIPTION
Cache is a disk property which says if and how is I/O cached.
It is already exposed when adding a disk. It can be edited only
for a shutoff VM.

The motivation to implement this was https://github.com/cockpit-project/cockpit/pull/15407 , where migration could be considered unsafe and end up with an error `Migration may lead to data corruption if disks use cache other than none or directsync`. So it's good to allow user to change cache in order to fix the error.

![Screenshot from 2021-02-25 12-22-27](https://user-images.githubusercontent.com/42733240/109146597-50be0f00-7764-11eb-86ea-a6ddbb07048c.png)
