### PR TITLE
HACKING.md: Document dbus-daemon as required unit test dependency

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -43,6 +43,10 @@ The following should work in a fresh Git clone:
       sudo dnf builddep --spec $TEMPFILE && \
       rm $TEMPFILE
 
+For running the browser unit tests, the following dependencies are required:
+
+    $ sudo dnf chromium-headless dbus-daemon
+
 For running integration tests, the following dependencies are required:
 
     $ sudo dnf install curl expect xz rpm-build chromium-headless \


### PR DESCRIPTION
GTestDBus [1], which we use in test-server, requires dbus-daemon and
can't work with dbus-broker. Document it as required dependency to run
the browser based unit tests.

[1] https://developer.gnome.org/gio/stable/GTestDBus.html

Fixes #14409