### PR TITLE
ws: Fix remotectl --ensure for read-only /etc

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -370,6 +370,15 @@ class TestConnection(MachineCase):
         self.assertRegex(
             output, "no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
+        # get along with read-only config directory, as long as certificate exists
+        # this does not work on coreos as the user/group IDs are not mapped correctly
+        if not m.ostree_image:
+            m.stop_cockpit()
+            m.execute("cp -a /etc/cockpit /tmp; mount -o bind -r /tmp/cockpit /etc/cockpit")
+            m.start_cockpit(tls=True)
+            self.assertIn("HTTP/1.1 200 OK", m.execute("curl -k --head https://127.0.0.1:9090"))
+            m.execute("umount /etc/cockpit")
+
         # Install a certificate chain, and make it accessible for cockpit
         m.upload(["verify/files/cert-chain.cert"], "/etc/cockpit/ws-certs.d")
         m.execute("cd /etc/cockpit/ws-certs.d; chgrp cockpit-ws cert-chain.cert; ! selinuxenabled || chcon --type etc_t cert-chain.cert")


### PR DESCRIPTION
If the certificate already exists, and ownership and permissions are
already as expected, then don't call chmod()/chown(). This avoids
failing on a read-only /etc/ once the certificate is set up.

https://bugs.debian.org/983514