### PR TITLE
test: Fix VMVirtualMachinesCaseHelpers.performAction() for disabled elements

### DIFF
--- a/test/verify/check-machines-settings
+++ b/test/verify/check-machines-settings
@@ -236,7 +236,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.select_from_dropdown("#cpu-model-select-group select", "host-model")
         b.click("#cpu-config-dialog-apply")
         b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "host")
-        self.performAction("subVmTest1", "run")
+        b.click("#vm-subVmTest1-run")
         b.wait_in_text("#vm-subVmTest1-cpu-model .pf-c-description-list__text", "custom")
         # In the test ENV libvirt does not properly set the CPU model so we see a tooltip https://bugzilla.redhat.com/show_bug.cgi?id=1913337
         # b.wait_not_present("#cpu-tooltip")

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -28,7 +28,7 @@ class VirtualMachinesCaseHelpers:
         b = self.browser
         b.click("#vm-{0}-action-kebab button".format(vmName))
         b.wait_visible("#vm-{0}-action-kebab > .pf-c-dropdown__menu".format(vmName))
-        b.click("#vm-{0}-{1}".format(vmName, action))
+        b.click("#vm-{0}-{1} a".format(vmName, action))
 
         if not checkExpectedState:
             return


### PR DESCRIPTION
The kebab actions with disabled elements are rendered like this
(simplified):

    <li role="menuitem" id="vm-subVmTest1-clone">
        <a aria-disabled="true" class="pf-m-disabled pf-c-dropdown__menu-item">Clone</a>
    </li>

Thus clicking on the -clone ID directly happily clicked into the void
even if the contained `<a>` link was still disabled.

This fixes at least `TestMachinesLifecycle.testBasic` and possibly other
flakes as well.

Fixes #15441