### PR TITLE
build: fix `make uninstall` if no debug is present

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -250,10 +250,12 @@ install-data-local:: $(WEBPACK_INSTALL)
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)
 	$(V_TAR) tar -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
 uninstall-local::
-	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \;
-	find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
-	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete
-	find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete
+	test ! -d $(DESTDIR)$(pkgdatadir) || \
+	  (find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \; && \
+	   find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
+	test ! -d $(DESTDIR)$(debugdir)$(pkgdatadir) || \
+	  (find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete && \
+	   find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_TEST_DEPS)
 	$(V_TAR) tar -cf - $^ | tar -C $(distdir) -xf -
 	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README


### PR DESCRIPTION
We have some custom rules in `make uninstall` to deal with removing the
installed files from dist/, including a separate rule for map files.
We don't always install map files anymore, and due to the changes in
96027bf8, don't even create the directory in that case.

This doesn't play nicely with our uninstall rule which assumes that the
directory will definitely exist.  Add a check.

Add a check also to the equivalent rule for the normal installation
files: this makes `make uninstall` nicely idempotent.