### PR TITLE
tests: Avoid "ReferenceError: cockpit is not defined" failures

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1329,7 +1329,7 @@ class MachineCase(unittest.TestCase):
         If the directory needs to survive reboot, `reboot_safe=True` needs to be specified; then this
         will just backup/restore the directory instead of bind-mounting, which is less robust.
         '''
-        if not self.is_nondestructive():
+        if not self.is_nondestructive() and not self.machine.ostree_image:
             return  # skip for efficiency reasons
 
         exists = self.machine.execute("if test -e %s; then echo yes; fi" % path).strip() != ""

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -123,6 +123,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
             self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
             self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
             self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+        # Also, quick logouts cause async preloads to run into "ReferenceError: cockpit is not defined"
+        self.disable_preload("packagekit", "playground", "systemd")
 
         self.machines["machine1"].execute("hostnamectl set-hostname localhost")
         self.machines["machine2"].execute("hostnamectl set-hostname machine2")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -347,6 +347,9 @@ class TestAccounts(MachineCase):
         b = self.browser
         new_password = "tqymuVh.Zf5"
 
+        # this test uses quick logouts; async preloads cause "ReferenceError: cockpit is not defined"
+        self.disable_preload("packagekit", "playground", "systemd")
+
         m.execute("useradd anton; echo anton:foobar | chpasswd")
         self.login_and_go("/users", user="root", superuser=False)
 


### PR DESCRIPTION
These two tests do logout() quickly after logging in. This often causes
the asynchronously loading preloads to load too late, running into
"ReferenceError: cockpit is not defined.

Avoid that by disabling the preloads in these tests, they are not
relevant for them.

----

Seen in https://logs.cockpit-project.org/logs/pull-15443-20210302-062758-9525688c-fedora-32-firefox/log.html in PR #15443