### PR TITLE
test/make_dist: Don't download if ./dist/ already exists

### DIFF
--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -151,7 +151,6 @@ def make_dist(download_only=False, wait_download=False):
         if not download_only and not wait_download:
             source = build_dist()
         else:
-            print("make_dist: Download failed: pre-built dist tarball does not exist")
             sys.exit(1)
     return source
 

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -142,11 +142,12 @@ def download_dist(wait=False):
 
 
 def make_dist(download_only=False, wait_download=False):
-    # first try to download a pre-generated dist tarball; this is a lot faster
-    # but these tarballs are built for production NPM mode
     source = None
-    if os.getenv("NODE_ENV") != "development":
+    # on an unbuilt tree, try to download a pre-generated dist tarball; this is a lot faster
+    # these tarballs are built for production NPM mode
+    if not os.path.exists("dist") and os.getenv("NODE_ENV") != "development":
         source = download_dist(wait_download)
+
     if not source:
         if not download_only and not wait_download:
             source = build_dist()


### PR DESCRIPTION
Prefer an existing local build/webpack, to make sure that local
developer settings are applied.