### PR TITLE
release-guide: update to push to main branch

### DIFF
--- a/tools/release-guide
+++ b/tools/release-guide
@@ -126,7 +126,7 @@ layout: guide\
 commit()
 (
     trace "Pushing changes to guide"
-    git -C $WORKDIR/repo push origin master
+    git -C $WORKDIR/repo push origin main
     rm -rf $WORKDIR
 )
 


### PR DESCRIPTION
This script only ever gets called on the cockpit-project.github.io
repository, and the default branch there is called 'main' now, so change
the script accordingly.