### PR TITLE
run-tests: Compare changed tests/files against base branch

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -213,7 +213,7 @@ def run(opts, image):
     test_files = glob.glob(os.path.join(opts.test_dir, "check-*"))
     if os.path.exists(os.path.join(os.path.dirname(testvm.TEST_DIR), ".git")):
         # Detect affected tests from changed test files
-        cmd = ["git", "diff", "--name-only", "origin/master", opts.test_dir]
+        cmd = ["git", "diff", "--name-only", "origin/" + opts.base, opts.test_dir]
         r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         if r.returncode == 0:
             # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
@@ -233,7 +233,7 @@ def run(opts, image):
         # If affected tests get detected from pkg/* changes, don't apply the
         # "only do this for max. 3 check-* changes" (even if the PR also changes ≥ 3 check-*)
         # (this does not apply to other projects)
-        cmd = ["git", "diff", "--name-only", "origin/master", "--", "pkg/"]
+        cmd = ["git", "diff", "--name-only", "origin/" + opts.base, "--", "pkg/"]
         r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
         if r.returncode == 0:
             changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in r.stdout.strip().splitlines())
@@ -436,6 +436,7 @@ def main():
                         help="Exclude test (exact match only); can be specified multiple times")
     parser.add_argument('-b', '--batches', type=int,
                         default=max(jobs // 2, 1), help="Number of concurrent batches of nondestructive tests")
+    parser.add_argument('--base', default=os.environ.get("BASE_BRANCH", "master"), help="Base branch")
     opts = parser.parse_args()
 
     if opts.machine:


### PR DESCRIPTION
When testing stable branch, we don't want to compare against `master` as
the diff is not interesting for us. We want to compare against stable
branch head instead.

Together with https://github.com/cockpit-project/bots/pull/1744:

If I would run command that ^ generated for https://github.com/cockpit-project/cockpit/pull/15463 and then checked `changed_tests` variable, it would be an empty array. If I would then remove `BASE_BRANCH=rhel-8.4` from this command it would produce:
```
['test/verify/check-shell-multi-machine', 'test/verify/check-machines-snapshots', 'test/verify/check-networkmanager-unmanaged', 'test/verify/check-shell-host-switching', 'test/verify/check-machines-lifecycle', 'test/verify/check-networkmanager-checkpoints', 'test/verify/check-networkmanager-mtu', 'test/verify/check-machines-disks', 'test/verify/check-shell-multi-os', 'test/verify/check-networkmanager-other', 'test/verify/check-networkmanager-vlan', 'test/verify/check-apps', 'test/verify/check-networkmanager-firewall', 'test/verify/check-packagekit', 'test/verify/check-networkmanager-bridge', 'test/verify/check-static-login', 'test/verify/check-system-s4u-ssh', 'test/verify/check-sosreport', 'test/verify/check-networkmanager-team', 'test/verify/check-users-roles', 'test/verify/check-kdump', 'test/verify/check-shell-keys', 'test/verify/check-networkmanager-settings', 'test/verify/check-machines-create', 'test/verify/check-metrics', 'test/verify/check-machines-consoles', 'test/verify/check-selinux', 'test/verify/check-shell-active-pages', 'test/verify/check-machines-settings', 'test/verify/check-system-tuned', 'test/verify/check-shell-multi-machine-key', 'test/verify/check-users', 'test/verify/check-networkmanager-basic', 'test/verify/check-machines-nics', 'test/verify/check-machines-storage-pools', 'test/verify/check-testlib', 'test/verify/check-machines-networks', 'test/verify/check-networkmanager-mac', 'test/verify/check-shell-menu', 'test/verify/check-networkmanager-bond']
```
which is exactly what we see in https://github.com/cockpit-project/cockpit/pull/15463 that these tests are being retried 3 times even though there was no change.