### PR TITLE
Fix cockpit.file.watch() for binary files, fix watching of /run/utmp on users page

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3839,10 +3839,11 @@ function factory() {
                 if (watch_channel)
                     return;
 
-                var opts = extend({ }, base_channel_options, {
+                const opts = {
                     payload: "fswatch1",
-                    path: path
-                });
+                    path: path,
+                    superuser: base_channel_options.superuser,
+                };
                 watch_channel = cockpit.channel(opts);
                 watch_channel.addEventListener("message", function (event, message_string) {
                     var message;

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -138,7 +138,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
         get_details(user).then(setDetails);
 
         // Watch `/var/run/utmp` to register when user logs in or out
-        const handle = cockpit.file("/var/run/utmp", { superuser: "try" });
+        const handle = cockpit.file("/var/run/utmp", { superuser: "try", binary: true });
         handle.watch(() => {
             get_details(user).then(setDetails);
         });

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -260,6 +260,9 @@ OnCalendar=daily
         b.click("#display-language-modal footer button.pf-m-link") # Close the menu
 
         for language in languages:
+            # Remove failed units which will show up in the first terminal line
+            m.execute("systemctl reset-failed")
+
             b.go("/system")
             b.enter_page("/system")
 


### PR DESCRIPTION
Split out from #15350, and I fixed watching binary files.