### PR TITLE
test: Check for unexpected info level journal messages

### DIFF
--- a/src/ws/cockpitwsinstancecert.c
+++ b/src/ws/cockpitwsinstancecert.c
@@ -34,6 +34,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "../tls/utils.h"
+
 #define CGROUP_REGEX         "^(0:|1:name=systemd):/system.slice/system-cockpithttps.slice/" \
                              "cockpit-wsinstance-https@([0-9a-f]{64}).service$"
 #define CGROUP_REGEX_FLAGS   (REG_EXTENDED | REG_NEWLINE)
@@ -132,6 +134,8 @@ https_instance_has_certificate_file (char   *contents,
   ssize_t r;
 
   if (https_instance == NULL) /* already warned */
+    goto out;
+  if (strcmp (https_instance, SHA256_NIL) == 0)
     goto out;
 
   dirfd = open ("/run/cockpit/tls", O_PATH | O_DIRECTORY | O_NOFOLLOW);

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -102,6 +102,7 @@ class TestReauthorize(MachineCase):
         m.execute("useradd user -s /bin/bash -c 'Barney' || true")
         m.execute("echo user:foobar | chpasswd")
 
+        self.allow_failed_sudo_journal_messages()
         b.default_user = "user"
         self.login_and_go("/playground/test")
         b.click(".super-channel button")

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -36,6 +36,7 @@ class TestKeys(MachineCase):
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -m -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
+        self.allow_failed_sudo_journal_messages()
 
         m.start_cockpit()
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -807,7 +807,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         m = self.machine
         b = self.browser
 
-        m.execute("useradd user")
+        m.execute("useradd --create-home user")
         m.execute("echo user:foobar | chpasswd")
         m.start_cockpit()
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -80,6 +80,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.try_login("user", "gfedcba")
         b.wait_text_not("#login-error-message", "")
         self.assertNotIn("web", m.execute("who"))
+        self.allow_journal_messages(".* user: Authentication failure.*")
 
         # Try to login as user with correct password
         b.try_login("user", "abcdefg")
@@ -167,7 +168,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages("Returning error-response ... with reason .*",
                                     "pam_unix\(cockpit:auth\): authentication failure; .*",
                                     "pam_unix\(cockpit:auth\): check pass; user unknown",
-                                    "pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*")
+                                    "pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
+                                    "noise-rc-.*")
 
         self.allow_restart_journal_messages()
 
@@ -339,11 +341,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#content")
         b.wait_text('#current-username', 'admin')
 
-        self.allow_journal_messages('Error executing command as another user: Not authorized',
-                                    'This incident has been reported.',
-                                    'sudo: a password is required',
-                                    'sudo: Account or password is expired, reset your password and try again',
-                                    'sudo: sorry, you must have a tty to run sudo')
+        self.allow_journal_messages('.*You are required to change your password immediately.*',
+                                    '.*user account or password has expired.*',
+                                    '.*BAD PASSWORD.*',
+                                    '.*Sorry, passwords do not match.')
+        self.allow_failed_sudo_journal_messages()
         self.allow_restart_journal_messages()
 
     def testConversation(self):
@@ -400,7 +402,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
         b.logout()
 
-        self.allow_journal_messages(".*value for the SHELL variable was not found the /etc/shells.*")
+        self.allow_journal_messages(".*value for the SHELL variable was not found the /etc/shells.*",
+                                    "Locale charset is ANSI.*",
+                                    "Assuming locale environment is lost.*",
+                                    "ATTENTION! Your session is being recorded!")
+        self.allow_failed_sudo_journal_messages()
 
     def curl_auth(self, url, userpass):
         header = "Authorization: Basic " + base64.b64encode(userpass.encode()).decode()
@@ -460,8 +466,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         b.logout()
         # not allowed to restricted users
-        self.allow_journal_messages("sudo:.* Operation not permitted")
-        self.allow_journal_messages("sudo:.* Permission denied")
+        self.allow_failed_sudo_journal_messages()
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
 
@@ -538,6 +543,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_visible("#safari-cert-help")
         else:
             b.wait_not_visible("#safari-cert-help")
+
+        self.allow_failed_sudo_journal_messages()
 
     @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
     @skipImage("Starting on OSTree is weird", "fedora-coreos")
@@ -676,6 +683,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             expect_successful_login("root", "foobar")
 
         self.allow_restart_journal_messages()
+        self.allow_journal_messages(".*Account locked due to .* failed logins")
 
     @skipImage("sssd not available", "fedora-coreos")
     @skipImage("sssd can't do cert mapping yet", "debian-stable")
@@ -756,6 +764,8 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 
             m.stop_cockpit()
 
+        self.allow_failed_sudo_journal_messages()
+        # from sssd
         self.allow_journal_messages("alice is not allowed to run sudo.*")
 
         # cert auth should not be enabled by default

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -464,11 +464,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages("sudo:.* Permission denied")
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
-        if m.image in ["centos-8-stream"]:
-            # older releases have more noise
-            self.allow_journal_messages("sudo: no valid sudoers.*")
-            self.allow_journal_messages("sudo: unable to initialize policy plugin")
-            self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="pkexec".* scontext=user_u.*')
 
         # sysadm_u
         m.execute("semanage login -a -s sysadm_u admin")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -20,6 +20,12 @@
 import parent
 from testlib import *
 
+def allow_old_cockpit_ws_messsages(test):
+    # noisy debug message from old cockpit-ws
+    test.allow_journal_messages("logged in user session",
+                                "New connection to session from.*")
+
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuser(MachineCase):
 
@@ -127,6 +133,8 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
         b.wait_text("#super-user-indicator", "Limited access")
 
+        self.allow_failed_sudo_journal_messages()
+
     def testNotAdmin(self):
         b = self.browser
         m = self.machine
@@ -139,7 +147,7 @@ session include system-auth
             m.execute("sed -i -e '/^%admin/d' /etc/sudoers")
 
         m.execute("gpasswd -d admin %s" % m.get_admin_group())
-        self.allow_journal_messages("admin is not in the sudoers file.  This incident will be reported.")
+        self.allow_failed_sudo_journal_messages()
 
         self.login_and_go()
         b.wait_text("#super-user-indicator", "Limited access")
@@ -293,6 +301,8 @@ class TestSuperuserOldWebserver(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
+        allow_old_cockpit_ws_messsages(self)
+
     def testNotAuth(self):
         b = self.browser
         m = self.machine
@@ -340,6 +350,9 @@ class TestSuperuserOldWebserver(MachineCase):
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
+
+        allow_old_cockpit_ws_messsages(self)
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserDashboard(MachineCase):
@@ -462,6 +475,9 @@ class TestSuperuserOldDashboard(MachineCase):
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
+
+        allow_old_cockpit_ws_messsages(self)
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserDashboardOldMachine(MachineCase):

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -504,6 +504,8 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                         ["check-journal", "BEFORE BOOT", ""],
                         "Load earlier entries"
                         ])
+        # HACK: Figure out why this happens
+        self.allow_journal_messages(".*Failed to add match '00:03': Invalid argument.*")
 
         # New messages are not streamed when 'until' is in the past
         m.execute("logger -p user.err --tag check-journal RIGHT NOW")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -450,6 +450,7 @@ ExecStart=/bin/true
         # HACK: Figure out why this happens
         self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
                                     'cockpit-session:$')
+        self.allow_journal_messages('/bin/bash: /home/admin/.bashrc: Permission denied')
 
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''
@@ -650,6 +651,7 @@ class TestAD(TestRealms, CommonTests):
         # HACK: Figure out why this happens
         self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
                                     'cockpit-session:$')
+        self.allow_journal_messages('/bin/bash: /home/admin/.bashrc: Permission denied')
 
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -236,6 +236,7 @@ class CommonTests:
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()
+        self.allow_failed_sudo_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
@@ -296,6 +297,7 @@ class CommonTests:
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()
+        self.allow_failed_sudo_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
@@ -360,6 +362,8 @@ class CommonTests:
 
             m.stop_cockpit()
 
+        self.allow_failed_sudo_journal_messages()
+        # from sssd
         self.allow_journal_messages("alice is not allowed to run sudo on x0.  This incident will be reported.")
 
         # cert auth should not be enabled by default
@@ -877,6 +881,7 @@ ExecStart=/bin/true
                             '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
                             'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 401 Authentication disabled", output)
+        self.allow_journal_messages(".*Request ticket server HTTP/x0.cockpit.lan@COCKPIT.LAN not found in keytab.*")
 
 
 @skipImage("Package (un)install does not work on OSTree", "fedora-coreos")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -447,6 +447,10 @@ ExecStart=/bin/true
             while ! ipa user-find >/dev/null; do sleep 5; done'
             """ % (self.admin_password, self.admin_user), timeout=300)
 
+        # HACK: Figure out why this happens
+        self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
+                                    'cockpit-session:$')
+
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''
 
@@ -642,6 +646,10 @@ class TestAD(TestRealms, CommonTests):
 
         # HACK: work around https://bugzilla.redhat.com/show_bug.cgi?id=1839805
         m.write("/etc/sssd/conf.d/rhbz1839805.conf", "[domain/cockpit.lan]\nad_gpo_access_control=disabled\n", perm="0600")
+
+        # HACK: Figure out why this happens
+        self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
+                                    'cockpit-session:$')
 
     def checkBackendSpecifics(self):
         '''Check domain backend specific integration'''

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -31,6 +31,7 @@ class TestRoles(MachineCase):
         # Create a user without any role
         m.execute("useradd user -s /bin/bash -c 'User' || true")
         m.execute("echo user:foobar | chpasswd")
+        self.allow_failed_sudo_journal_messages()
 
         m.start_cockpit()
 


### PR DESCRIPTION
service stdout/err output appear as journal priority "info" (6) instead
of "notice". This rendered a large portion of our
allow_journal_messages() inert (and explains why commit cf82ab8b132
"worked"), and more importantly, does not spot glib warnings that we
really want to see, such as in issue #14704 or #14896.

Allow cockpit-session's "last failed login" messages for every test for
now, they don't indicate a failure or unexpected condition in most cases
-- a lot of tests check logins which are supposed to fail.

Bring back a cleaner variant of commit cf82ab8b132 with a more specific
name `allow_failed_sudo_journal_messages()`, and use it in the tests
which explicitly test becoming administrator with unprivileged users.

Add specific expected messages to the remaining tests which produce
them.