### PR TITLE
machines: add support for passing cloud-init metadata when creating VMs with cloud images

### DIFF
--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -298,9 +298,9 @@ const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, 
                     {cloudInitSupported ? <FormSelectOption value={CLOUD_IMAGE}
                                       label={_("Cloud base image")} /> : null}
                     <FormSelectOption value={LOCAL_INSTALL_MEDIA_SOURCE}
-                                      label={_("Local install media")} />
+                                      label={_("Local install media (ISO image or distro install tree)")} />
                     <FormSelectOption value={URL_SOURCE}
-                                      label={_("URL")} />
+                                      label={_("URL (ISO image or distro install tree)")} />
                     {connectionName == 'system' &&
                     <FormSelectOption value={PXE_SOURCE}
                                       label={_("Network boot (PXE)")} />}

--- a/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
+++ b/pkg/machines/components/create-vm-dialog/createVmDialog.jsx
@@ -69,6 +69,7 @@ const _ = cockpit.gettext;
 
 const URL_SOURCE = 'url';
 const LOCAL_INSTALL_MEDIA_SOURCE = 'file';
+const CLOUD_IMAGE = 'cloud';
 const DOWNLOAD_AN_OS = 'os';
 const EXISTING_DISK_IMAGE_SOURCE = 'disk_image';
 const PXE_SOURCE = 'pxe';
@@ -145,6 +146,7 @@ function validateParams(vmParams) {
         case PXE_SOURCE:
             break;
         case LOCAL_INSTALL_MEDIA_SOURCE:
+        case CLOUD_IMAGE:
         case EXISTING_DISK_IMAGE_SOURCE:
             if (!vmParams.source.startsWith("/")) {
                 validationFailed.source = _("Invalid filename");
@@ -206,7 +208,7 @@ const NameRow = ({ vmName, onValueChanged, validationFailed }) => {
     );
 };
 
-const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, os, osInfoList, downloadOSSupported, onValueChanged, validationFailed }) => {
+const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, os, osInfoList, cloudInitSupported, downloadOSSupported, onValueChanged, validationFailed }) => {
     let installationSource;
     let installationSourceId;
     let installationSourceWarning;
@@ -218,6 +220,15 @@ const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, 
         installationSource = (
             <FileAutoComplete id={installationSourceId}
                 placeholder={_("Path to ISO file on host's file system")}
+                onChange={value => onValueChanged('source', value)}
+                superuser="try" />
+        );
+        break;
+    case CLOUD_IMAGE:
+        installationSourceId = "source-file";
+        installationSource = (
+            <FileAutoComplete id={installationSourceId}
+                placeholder={_("Path to cloud image file on host's file system")}
                 onChange={value => onValueChanged('source', value)}
                 superuser="try" />
         );
@@ -284,6 +295,8 @@ const SourceRow = ({ connectionName, source, sourceType, networks, nodeDevices, 
                     {downloadOSSupported
                         ? <FormSelectOption value={DOWNLOAD_AN_OS}
                                             label={_("Download an OS")} /> : null}
+                    {cloudInitSupported ? <FormSelectOption value={CLOUD_IMAGE}
+                                      label={_("Cloud base image")} /> : null}
                     <FormSelectOption value={LOCAL_INSTALL_MEDIA_SOURCE}
                                       label={_("Local install media")} />
                     <FormSelectOption value={URL_SOURCE}
@@ -395,6 +408,67 @@ const UnattendedRow = ({
     userLogin, userPassword,
     validationFailed,
 }) => {
+    let unattendedInstallationCheckbox = (
+        <Checkbox id="unattended-installation"
+                  isChecked={unattendedInstallation}
+                  isDisabled={unattendedDisabled}
+                  onChange={checked => onValueChanged('unattendedInstallation', checked)}
+                  label={_("Run unattended installation")} />
+    );
+    if (unattendedDisabled) {
+        unattendedInstallationCheckbox = (
+            <Tooltip id='os-unattended-installation-tooltip' content={_("The selected operating system does not support unattended installation")} position={TooltipPosition.left}>
+                {unattendedInstallationCheckbox}
+            </Tooltip>
+        );
+    }
+
+    return (
+        <FormGroup fieldId="unattended-installation">
+            {unattendedInstallationCheckbox}
+            {!unattendedDisabled && unattendedInstallation && <>
+                {os.profiles.length > 0 &&
+                <FormGroup fieldId="profile-select"
+                           label={_("Profile")}>
+                    <FormSelect id="profile-select"
+                                value={profile || (os.profiles && os.profiles[0])}
+                                onChange={e => onValueChanged('profile', e)}>
+                        { (os.profiles || []).sort()
+                                .reverse() // Let jeos (Server) appear always first on the list since in osinfo-db it's not consistent
+                                .map(profile => {
+                                    let profileName;
+                                    if (profile == 'jeos')
+                                        profileName = 'Server';
+                                    else if (profile == 'desktop')
+                                        profileName = 'Workstation';
+                                    else
+                                        profileName = profile;
+                                    return <FormSelectOption value={profile}
+                                                             key={profile}
+                                                             label={profileName} />;
+                                }) }
+                    </FormSelect>
+                </FormGroup>}
+                <UsersConfigurationRow rootPassword={rootPassword}
+                                       rootPasswordLabelInfo={_("Leave the password blank if you do not wish to have a root account created")}
+                                       showUserFields={unattendedUserLogin}
+                                       userLogin={userLogin}
+                                       userPassword={userPassword}
+                                       validationFailed={validationFailed}
+                                       onValueChanged={onValueChanged} />
+            </>}
+        </FormGroup>
+    );
+};
+
+const UsersConfigurationRow = ({
+    rootPassword,
+    rootPasswordLabelInfo,
+    showUserFields,
+    userLogin, userPassword,
+    onValueChanged,
+    validationFailed,
+}) => {
     const [root_pwd_strength, setRootPasswordStrength] = useState('');
     const [root_pwd_message, setRootPasswordMessage] = useState('');
     const [root_pwd_errors, setRootPasswordErrors] = useState({});
@@ -447,75 +521,60 @@ const UnattendedRow = ({
         }
     }, [userPassword, validationFailed]);
 
-    let unattendedInstallationCheckbox = (
-        <Checkbox id="unattended-installation"
-                  isChecked={unattendedInstallation}
-                  isDisabled={unattendedDisabled}
-                  onChange={checked => onValueChanged('unattendedInstallation', checked)}
-                  label={_("Run unattended installation")} />
-    );
-    if (unattendedDisabled) {
-        unattendedInstallationCheckbox = (
-            <Tooltip id='os-unattended-installation-tooltip' content={_("The selected operating system does not support unattended installation")} position={TooltipPosition.left}>
-                {unattendedInstallationCheckbox}
-            </Tooltip>
-        );
-    }
-
     return (
-        <FormGroup fieldId="unattended-installation">
-            {unattendedInstallationCheckbox}
-            {!unattendedDisabled && unattendedInstallation && <>
-                {os.profiles.length > 0 &&
-                <FormGroup fieldId="profile-select"
-                           label={_("Profile")}>
-                    <FormSelect id="profile-select"
-                                value={profile || (os.profiles && os.profiles[0])}
-                                onChange={e => onValueChanged('profile', e)}>
-                        { (os.profiles || []).sort()
-                                .reverse() // Let jeos (Server) appear always first on the list since in osinfo-db it's not consistent
-                                .map(profile => {
-                                    let profileName;
-                                    if (profile == 'jeos')
-                                        profileName = 'Server';
-                                    else if (profile == 'desktop')
-                                        profileName = 'Workstation';
-                                    else
-                                        profileName = profile;
-                                    return <FormSelectOption value={profile}
-                                                             key={profile}
-                                                             label={profileName} />;
-                                }) }
-                    </FormSelect>
-                </FormGroup>}
-                <PasswordFormFields password={rootPassword}
-                                    password_label={_("Root password")}
-                                    password_strength={root_pwd_strength}
-                                    idPrefix="create-vm-dialog-root-password"
-                                    password_message={root_pwd_message}
-                                    password_label_info={_("Leave the password blank if you do not wish to have a root account created")}
-                                    error_password={validationFailed && root_pwd_errors.password}
-                                    change={(_, value) => onValueChanged('rootPassword', value)} />
-                {unattendedUserLogin && <>
-                    <FormGroup fieldId="user-login"
-                               helperTextInvalid={validationFailed.userLogin}
+        <>
+            <PasswordFormFields password={rootPassword}
+                                password_label={_("Root password")}
+                                password_strength={root_pwd_strength}
+                                idPrefix="create-vm-dialog-root-password"
+                                password_message={root_pwd_message}
+                                password_label_info={rootPasswordLabelInfo}
+                                error_password={validationFailed && root_pwd_errors.password}
+                                change={(_, value) => onValueChanged('rootPassword', value)} />
+            {showUserFields &&
+            <>
+                <FormGroup fieldId="user-login"
+                           helperTextInvalid={validationFailed.userLogin}
+                           validated={validationFailed.userLogin ? "error" : "default"}
+                           label={_("User login")}>
+                    <TextInput id='user-login'
                                validated={validationFailed.userLogin ? "error" : "default"}
-                               label={_("User login")}>
-                        <TextInput id='user-login'
-                                   validated={validationFailed.userLogin ? "error" : "default"}
-                                   value={userLogin || ''}
-                                   onChange={value => onValueChanged('userLogin', value)} />
-                    </FormGroup>
-                    <PasswordFormFields password={userPassword}
-                                        password_label={_("User password")}
-                                        password_strength={user_pwd_strength}
-                                        idPrefix="create-vm-dialog-user-password"
-                                        password_message={user_pwd_message}
-                                        password_label_info={_("Leave the password blank if you do not wish to have a user account created")}
-                                        error_password={validationFailed && (validationFailed.userLogin ? validationFailed.userLogin : user_pwd_errors.password)}
-                                        change={(_, value) => onValueChanged('userPassword', value)} />
-                </>}
+                               value={userLogin || ''}
+                               onChange={value => onValueChanged('userLogin', value)} />
+                </FormGroup>
+                <PasswordFormFields password={userPassword}
+                                    password_label={_("User password")}
+                                    password_strength={user_pwd_strength}
+                                    idPrefix="create-vm-dialog-user-password"
+                                    password_message={user_pwd_message}
+                                    password_label_info={_("Leave the password blank if you do not wish to have a user account created")}
+                                    error_password={validationFailed && (validationFailed.userLogin ? validationFailed.userLogin : user_pwd_errors.password)}
+                                    change={(_, value) => onValueChanged('userPassword', value)} />
             </>}
+        </>
+    );
+};
+
+const CloudInitOptionsRow = ({
+    useCloudInit,
+    onValueChanged,
+    rootPassword,
+    userLogin, userPassword,
+    validationFailed,
+}) => {
+    return (
+        <FormGroup fieldId="cloud-init-checkbox">
+            <Checkbox id="cloud-init-checkbox"
+                      isChecked={useCloudInit}
+                      onChange={checked => onValueChanged('useCloudInit', checked)}
+                      label={_("Cloud init parameters")} />
+            {useCloudInit && <UsersConfigurationRow rootPassword={rootPassword}
+                                                    rootPasswordLabelInfo={_("Leave the password blank if you do not wish to set a root password")}
+                                                    showUserFields
+                                                    userLogin={userLogin}
+                                                    userPassword={userPassword}
+                                                    validationFailed={validationFailed}
+                                                    onValueChanged={onValueChanged} />}
         </FormGroup>
     );
 };
@@ -567,7 +626,7 @@ const MemoryRow = ({ memorySize, memorySizeUnit, nodeMaxMemory, minimumMemory, o
     );
 };
 
-const StorageRow = ({ connectionName, storageSize, storageSizeUnit, onValueChanged, minimumStorage, storagePoolName, storagePools, storageVolume, vms, validationFailed }) => {
+const StorageRow = ({ connectionName, allowNoDisk, storageSize, storageSizeUnit, onValueChanged, minimumStorage, storagePoolName, storagePools, storageVolume, vms, validationFailed }) => {
     let validationStateStorage = validationFailed.storage ? 'error' : 'default';
     const poolSpaceAvailable = getSpaceAvailable(storagePools, connectionName);
     let helperTextNewVolume = (
@@ -611,7 +670,7 @@ const StorageRow = ({ connectionName, storageSize, storageSizeUnit, onValueChang
                             value={storagePoolName}
                             onChange={e => onValueChanged('storagePool', e)}>
                     <FormSelectOption value="NewVolume" key="NewVolume" label={_("Create new volume")} />
-                    <FormSelectOption value="NoStorage" key="NoStorage" label={_("No storage")} />
+                    { allowNoDisk && <FormSelectOption value="NoStorage" key="NoStorage" label={_("No storage")} />}
                     <FormSelectOptionGroup key="Storage pools" label={_("Storage pools")}>
                         { storagePools.map(pool => {
                             if (pool.volumes && pool.volumes.length)
@@ -682,6 +741,7 @@ class CreateVmModal extends React.Component {
             connectionName: LIBVIRT_SYSTEM_CONNECTION,
             sourceType: defaultSourceType,
             unattendedInstallation: false,
+            useCloudInit: false,
             source: '',
             os: undefined,
             memorySize: Math.min(convertToUnit(1024, units.MiB, units.GiB), // tied to Unit
@@ -695,7 +755,7 @@ class CreateVmModal extends React.Component {
             minimumMemory: 0,
             minimumStorage: 0,
 
-            // Unattended installation options
+            // Unattended installation or cloud init options for cloud images
             userPassword: '',
             rootPassword: '',
             userLogin: '',
@@ -861,6 +921,7 @@ class CreateVmModal extends React.Component {
                 userPassword: this.state.userPassword,
                 rootPassword: this.state.rootPassword,
                 userLogin: this.state.userLogin,
+                useCloudInit: this.state.useCloudInit,
             };
 
             return timeoutedPromise(
@@ -937,6 +998,7 @@ class CreateVmModal extends React.Component {
                     sourceType={this.state.sourceType}
                     os={this.state.os}
                     osInfoList={this.props.osInfoList}
+                    cloudInitSupported={this.props.cloudInitSupported}
                     downloadOSSupported={this.props.downloadOSSupported}
                     onValueChanged={this.onValueChanged}
                     validationFailed={validationFailed} />
@@ -954,6 +1016,7 @@ class CreateVmModal extends React.Component {
 
                 { this.state.sourceType != EXISTING_DISK_IMAGE_SOURCE &&
                 <StorageRow
+                    allowNoDisk={this.state.sourceType !== CLOUD_IMAGE}
                     connectionName={this.state.connectionName}
                     storageSize={this.state.storageSize}
                     storageSizeUnit={this.state.storageSizeUnit}
@@ -977,6 +1040,7 @@ class CreateVmModal extends React.Component {
 
                 {this.state.sourceType != PXE_SOURCE &&
                  this.state.sourceType != EXISTING_DISK_IMAGE_SOURCE &&
+                 this.state.sourceType != CLOUD_IMAGE &&
                  this.props.unattendedSupported &&
                  <>
                      <UnattendedRow
@@ -992,7 +1056,16 @@ class CreateVmModal extends React.Component {
                          onValueChanged={this.onValueChanged} />
                  </>}
 
-                {startVmCheckbox}
+                {this.state.sourceType == CLOUD_IMAGE &&
+                 this.props.cloudInitSupported &&
+                 <CloudInitOptionsRow validationFailed={validationFailed}
+                                      rootPassword={this.state.rootPassword}
+                                      userLogin={this.state.userLogin}
+                                      userPassword={this.state.userPassword}
+                                      useCloudInit={this.state.useCloudInit}
+                                      onValueChanged={this.onValueChanged} />}
+
+                {this.state.sourceType !== CLOUD_IMAGE && startVmCheckbox}
             </Form>
         );
 
@@ -1025,6 +1098,7 @@ export class CreateVmAction extends React.Component {
         this.state = {
             showModal: false,
             virtInstallAvailable: undefined,
+            cloudInitSupported: undefined,
             downloadOSSupported: undefined,
             unattendedSupported: undefined,
             unattendedUserLogin: undefined,
@@ -1040,6 +1114,10 @@ export class CreateVmAction extends React.Component {
                     cockpit.spawn(['virt-install', '--install=?'], { err: 'ignore' })
                             .then(() => this.setState({ downloadOSSupported: true }),
                                   () => this.setState({ downloadOSSupported: false }));
+
+                    cockpit.spawn(['virt-install', '--cloud-init=?'], { err: 'ignore' })
+                            .then(() => this.setState({ cloudInitSupported: true }),
+                                  () => this.setState({ cloudInitSupported: false }));
 
                     cockpit.spawn(['virt-install', '--unattended=?'], { err: 'ignore' })
                             .then(options => this.setState({ unattendedSupported: true, unattendedUserLogin: options.includes('user-login') }),
@@ -1107,6 +1185,7 @@ export class CreateVmAction extends React.Component {
                     vms={this.props.vms}
                     osInfoList={this.props.systemInfo.osInfoList}
                     onAddErrorNotification={this.props.onAddErrorNotification}
+                    cloudInitSupported={this.state.cloudInitSupported}
                     downloadOSSupported={this.state.downloadOSSupported}
                     unattendedSupported={this.state.unattendedSupported}
                     unattendedUserLogin={this.state.unattendedUserLogin}

--- a/pkg/machines/libvirt-common.js
+++ b/pkg/machines/libvirt-common.js
@@ -991,7 +991,8 @@ export function CREATE_VM({
     rootPassword,
     userPassword,
     userLogin,
-    profile
+    profile,
+    useCloudInit,
 }) {
     logDebug(`${this.name}.CREATE_VM(${vmName}):`);
     return dispatch => {
@@ -1022,6 +1023,7 @@ export function CREATE_VM({
             userPassword,
             userLogin,
             profile,
+            useCloudInit,
         ], opts)
                 .done(() => {
                     finishVmCreateInProgress(dispatch, vmName, connectionName);

--- a/pkg/machines/scripts/create_machine.sh
+++ b/pkg/machines/scripts/create_machine.sh
@@ -16,13 +16,14 @@ ROOT_PASSWORD="${12}"
 USER_PASSWORD="${13}"
 USER_LOGIN="${14}"
 PROFILE="${15}"
+USE_CLOUD_INIT="${16}"
 
 vmExists(){
    virsh -c "$CONNECTION_URI" list --all | awk  '{print $2}' | grep -q --line-regexp --fixed-strings "$1"
 }
 
 err_handler () {
-    rm -f "$ROOT_PASSWORD_FILE" "$XMLS_FILE"
+    rm -f "$ROOT_PASSWORD_FILE" "$XMLS_FILE" "$USER_DATA_FILE"
 }
 
 handleFailure(){
@@ -34,6 +35,7 @@ trap err_handler EXIT
 XMLS_FILE="`mktemp`"
 ROOT_PASSWORD_FILE="`mktemp`"
 USER_PASSWORD_FILE="`mktemp`"
+USER_DATA_FILE="`mktemp`"
 
 if [ "$UNATTENDED" = "true" ]; then
     if [ -z "$PROFILE" ]; then
@@ -63,6 +65,32 @@ else
     UNATTENDED_PARAMS=""
 fi
 
+if [ "$USE_CLOUD_INIT" = "true" ]; then
+    if [ -z "$USER_PASSWORD" ]; then
+        USER_LINE=""
+        CREATE_USER_LINE=""
+    else
+        USER_LINE="    $USER_LOGIN:$USER_PASSWORD"
+        CREATE_USER_LINE="users:"$'\n'"  - name: $USER_LOGIN"
+    fi
+    if [ -z "$ROOT_PASSWORD" ]; then
+        ROOT_LINE=""
+    else
+        ROOT_LINE="    root:$ROOT_PASSWORD"$'\n'
+    fi
+    cat <<EOT >> $USER_DATA_FILE
+#cloud-config
+$CREATE_USER_LINE
+chpasswd:
+  list: |
+$ROOT_LINE$USER_LINE
+  expire: False
+EOT
+    CLOUD_INIT_PARAMS="--cloud-init user-data=$USER_DATA_FILE"
+else
+    CLOUD_INIT_PARAMS=""
+fi
+
 # prepare virt-install parameters
 if [ "$SOURCE_TYPE" = "disk_image" ]; then
     DISK_OPTIONS="'$SOURCE',device=disk"
@@ -74,6 +102,9 @@ else
         DISK_OPTIONS="vol='$STORAGE_POOL/$STORAGE_VOLUME'"
     else
         DISK_OPTIONS="size=$STORAGE_SIZE,format=qcow2"
+    fi
+    if [ "$USE_CLOUD_INIT" = "true" ]; then
+        DISK_OPTIONS="$DISK_OPTIONS,backing_store='$SOURCE'"
     fi
 fi
 
@@ -94,7 +125,9 @@ if [ "$SOURCE_TYPE" = "pxe" ]; then
 elif [ "$SOURCE_TYPE" = "os" ]; then
     INSTALL_METHOD="--install os=$OS"
 elif [ "$START_VM" = "true" ]; then
-    if [ "$SOURCE_TYPE" = "disk_image" ]; then
+    if [ $USE_CLOUD_INIT = "true" ]; then
+        INSTALL_METHOD=""
+    elif [ "$SOURCE_TYPE" = "disk_image" ]; then
         INSTALL_METHOD="--import"
     elif ( [ "${SOURCE#/}" != "$SOURCE" ] && [ -f "${SOURCE}" ] ) || ( [ "$SOURCE_TYPE" = "url" ] && [ "${SOURCE%.iso}" != "$SOURCE" ] ); then
         INSTALL_METHOD="--cdrom '$SOURCE'"
@@ -146,6 +179,7 @@ eval virt-install \
     "$INSTALL_METHOD" \
     "$GRAPHICS_PARAM" \
     "$UNATTENDED_PARAMS" \
+    "$CLOUD_INIT_PARAMS" \
 > "$XMLS_FILE" || handleFailure $?
 
 # The VM got deleted while being installed

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -165,8 +165,10 @@ class TestMachinesCreate(VirtualMachinesCase):
         self.browser.wait_in_text("body", "Virtual machines")
 
         # try to CREATE few machines
-        if m.image in ['debian-stable', 'debian-testing', 'centos-8-stream']:
-            self.browser.wait_not_present('select option[value=os]')
+        if m.image in ['debian-stable']:
+            b.click("#create-new-vm")
+            b.wait_visible("#create-vm-dialog")
+            b.wait_not_present('select option[value=os]')
         else:
             runner.createDownloadAnOSTest(TestMachinesCreate.VmDialog(self, sourceType='os',
                                                                       expected_memory_size=128,

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -354,7 +354,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig
 
-        dev = self.add_ram_disk()
+        dev = self.add_ram_disk(1)
         partition = dev.split('/')[2] + "1"
         cmds = [
             "virsh pool-define-as poolDisk disk - - {0} - {1}".format(dev, os.path.join(self.vm_tmpdir, "poolDiskImages")),

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -127,6 +127,33 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          start_vm=False),
                                              {"source-url": "Installation source must not be empty"})
 
+    def testCreateCloudBaseImage(self):
+        runner = TestMachinesCreate.CreateVmRunner(self)
+        config = TestMachinesCreate.TestCreateConfig
+
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/machines")
+        self.browser.wait_in_text("body", "Virtual machines")
+
+        # try to CREATE few machines
+        # --cloud-init user-data option exists since virt-install >= 3.0.0
+        if m.image in ['fedora-32', 'centos-8-stream', 'rhel-8-3', 'rhel-8-3-distropkg', "rhel-8-4", "rhel-8-4-distropkg", 'ubuntu-stable', 'ubuntu-2004', 'debian-stable']:
+            b.click("#create-new-vm")
+            b.wait_visible("#create-vm-dialog")
+            self.browser.wait_not_present('select option[value=cloud]')
+        else:
+            runner.createCloudBaseImageTest(TestMachinesCreate.VmDialog(self, sourceType='cloud',
+                                                                        storage_size=10, storage_size_unit='MiB',
+                                                                        location=config.VALID_DISK_IMAGE_PATH,
+                                                                        os_name=config.FEDORA_28,
+                                                                        os_short_id=config.FEDORA_28_SHORTID,
+                                                                        user_password="catsaremybestfr13nds",
+                                                                        user_login="foo",
+                                                                        root_password="dogsaremybestfr13nds",
+                                                                        start_vm=True))
+
     def testCreateDownloadAnOS(self):
         runner = TestMachinesCreate.CreateVmRunner(self)
         config = TestMachinesCreate.TestCreateConfig
@@ -716,7 +743,23 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.browser.wait_not_present("#source-type option[value='{0}']".format(self.sourceType))
             return self
 
-        def createAndVerifyVirtInstallArgs(self):
+        def createAndVerifyVirtInstallArgsCloudInit(self):
+            self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
+            self.browser.wait_not_present("#create-vm-dialog")
+
+            self.goToVmPage(self.name)
+            self.browser.wait_text("#vm-{}-disks-vda-bus".format(self.name), "virtio")
+            # A cloud-init NoCloud ISO file is generated, and attached to the VM as a CDROM device.
+            self.browser.wait_text("#vm-{}-disks-sda-device".format(self.name), "cdrom")
+            self.goToMainPage()
+
+            virt_install_cmd = "ps aux | grep 'virt\-install\ \-\-connect'"
+
+            wait(lambda: self.machine.execute(virt_install_cmd), delay=3)
+            virt_install_cmd_out = self.machine.execute(virt_install_cmd)
+            self.assertIn("--cloud-init user-data=", virt_install_cmd_out)
+
+        def createAndVerifyVirtInstallArgsUnattended(self):
             self.browser.click(".pf-c-modal-box__footer button:contains(Create)")
             self.browser.wait_not_present("#create-vm-dialog")
             if self.storage_pool != "NoStorage":
@@ -748,7 +791,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                 b.select_from_dropdown("#source-type", self.sourceType)
             else:
                 b.wait_not_present("#source-type")
-            if self.sourceType == 'file':
+            if self.sourceType == 'file' or self.sourceType == 'cloud':
                 b.set_file_autocomplete_val("#source-file-group", self.location)
             elif self.sourceType == 'disk_image':
                 b.set_file_autocomplete_val("#source-disk-group", self.location)
@@ -802,16 +845,22 @@ class TestMachinesCreate(VirtualMachinesCase):
             else:
                 b.wait_val("#memory-size", self.expected_memory_size)
 
-            b.wait_visible("#start-vm")
-            if not self.start_vm:
-                b.click("#start-vm") # TODO: fix this, do not assume initial state of the checkbox
-            # b.set_checked("#start-vm", self.start_vm)
+            if self.sourceType == "cloud":
+                b.wait_not_present("#start-vm")
+            else:
+                b.wait_visible("#start-vm")
+                if not self.start_vm:
+                    b.click("#start-vm") # TODO: fix this, do not assume initial state of the checkbox
 
             if (self.connection):
                 b.set_checked("#connectionName-{0}".format(self.connection), True)
 
-            if self.is_unattended:
-                b.click("#unattended-installation")
+            if self.is_unattended or self.sourceType == "cloud":
+                if self.is_unattended:
+                    b.click("#unattended-installation")
+                else:
+                    b.click("#cloud-init-checkbox")
+
                 if self.profile:
                     b.select_from_dropdown("#profile-select", self.profile)
                 if self.user_password:
@@ -1227,10 +1276,18 @@ class TestMachinesCreate(VirtualMachinesCase):
             self._assertScriptFinished() \
                 .checkEnvIsEmpty()
 
+        def createCloudBaseImageTest(self, dialog):
+            dialog.open() \
+                .fill() \
+                .createAndVerifyVirtInstallArgsCloudInit()
+            if dialog.delete:
+                self._deleteVm(dialog) \
+                      .checkEnvIsEmpty()
+
         def createDownloadAnOSTest(self, dialog):
             dialog.open() \
                 .fill() \
-                .createAndVerifyVirtInstallArgs()
+                .createAndVerifyVirtInstallArgsUnattended()
             if dialog.delete:
                 self._deleteVm(dialog) \
                       .checkEnvIsEmpty()

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -502,7 +502,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b = self.browser
         m = self.machine
 
-        dev = self.add_ram_disk()
+        dev = self.add_ram_disk(2)
         used_targets = ['vda']
 
         args = self.createVm("subVmTest1")
@@ -528,7 +528,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             pool_name='pool-disk',
             pool_type='disk',
             volume_name=partition,
-            volume_size=10,
+            volume_size=1,
             volume_size_unit='MiB',
             expected_target=get_next_free_target(used_targets)[-1],
         ).execute()

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -728,15 +728,11 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         used_targets = ['vda']
 
-        args = self.createVm("subVmTest1")
-
-        # Wait for the login prompt before we try to live attach disks - we need the OS to be fully responsive
-        wait(lambda: "login as 'cirros' user" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
+        self.createVm("subVmTest1", running=False)
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running")
         self.goToVmPage("subVmTest1")
 
         # prepare libvirt storage pools
@@ -751,7 +747,6 @@ class TestMachinesDisks(VirtualMachinesCase):
             volume_name='writeback_cache_disk',
             mode='create-new',
             volume_size=2,
-            permanent=True,
             cache_mode='writeback',
             expected_target=get_next_free_target(used_targets)[-1],
         ).execute()
@@ -776,9 +771,6 @@ class TestMachinesDisks(VirtualMachinesCase):
             expected_target='sdb',
         ).execute()
 
-        # shut off
-        self.performAction("subVmTest1", "forceOff")
-
         # testing sata disk after VM shutoff because sata disk cannot be hotplugged
         self.VMAddDiskDialog(
             self,
@@ -786,7 +778,7 @@ class TestMachinesDisks(VirtualMachinesCase):
             volume_name='sata_bus_disk',
             mode='create-new',
             bus_type='sata',
-            expected_target='sda',
+            expected_target='sdc',
         ).execute()
 
     def testDetachDisk(self):

--- a/test/verify/check-machines-lifecycle
+++ b/test/verify/check-machines-lifecycle
@@ -77,9 +77,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # switch to and check Usage
         b.click("#vm-subVmTest1-usage")
-        b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "256 MiB")
+        b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "128 MiB")
         b.wait_not_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0 /")
-        usage = b.text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure").split("/ 256 MiB")[0]
+        usage = b.text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure").split("/ 128 MiB")[0]
         wait(lambda: float(usage) > 0.0, delay=3)
 
         b.wait_in_text(".vcpu-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "1 vCPU")

--- a/test/verify/check-machines-settings
+++ b/test/verify/check-machines-settings
@@ -298,7 +298,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b = self.browser
         m = self.machine
 
-        args = self.createVm("subVmTest1")
+        args = self.createVm("subVmTest1", memory=256)
 
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")

--- a/test/verify/check-machines-storage-pools
+++ b/test/verify/check-machines-storage-pools
@@ -444,7 +444,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         ).execute()
 
         # Prepare a disk with gpt partition table to test the disk storage pool type
-        dev = self.add_ram_disk()
+        dev = self.add_ram_disk(2)
         m.execute("parted %s mklabel gpt" % dev)
 
         StoragePoolCreateDialog(
@@ -521,7 +521,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         self.addCleanup(m.execute, "virsh pool-destroy nfs-pool || true") # Destroy pool as it block removal of `nfs_pool`
 
         # Prepare disk/block pool
-        dev = self.add_ram_disk()
+        dev = self.add_ram_disk(10)
         cmds = [
             "virsh pool-define-as disk-pool disk - - {0} - {1}".format(dev, os.path.join(self.vm_tmpdir, "poolDiskImages")),
             "virsh pool-build disk-pool --overwrite",
@@ -671,7 +671,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             pool_name="disk-pool",
             pool_type="disk",
             vol_name=dev.split("/")[-1] + "1", # Partition names must follow pattern of sda1, sda2...
-            size="10", # Only 50MiB available on disk-pool
+            size="2", # Only 10MiB available on disk-pool
             unit="MiB",
             format="none",
             remove=True,
@@ -694,7 +694,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             self,
             pool_name="lvm-pool",
             vol_name="lvm_vol",
-            size="20",
+            size="4",
             format="",
             remove=True,
         ).execute()

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -100,7 +100,7 @@ class VirtualMachinesCaseHelpers:
         m.execute("virsh net-start default || true")
         m.execute("until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
 
-    def createVm(self, name, graphics='spice', ptyconsole=False, running=True):
+    def createVm(self, name, graphics='spice', ptyconsole=False, running=True, memory=128):
         m = self.machine
 
         image_file = m.pull("cirros")
@@ -113,6 +113,7 @@ class VirtualMachinesCaseHelpers:
             "image": img,
             "logfile": None,
             "console": "",
+            "memory": memory,
         }
 
         if ptyconsole:

--- a/test/verify/machinesxmls.py
+++ b/test/verify/machinesxmls.py
@@ -120,8 +120,8 @@ DOMAIN_XML = """
     <boot dev='hd'/>
     <boot dev='network'/>
   </os>
-  <memory unit='MiB'>256</memory>
-  <currentMemory unit='MiB'>256</currentMemory>
+  <memory unit='MiB'>{memory}</memory>
+  <currentMemory unit='MiB'>{memory}</currentMemory>
   <features>
     <acpi/>
   </features>


### PR DESCRIPTION
### Machines: support authentication against cloud images

Distro cloud images have locked login accounts by default. The user can now specify the root and user account login credentials when creating VMs based on cloud images. The cloud image itself will be used as the backing store for the VM's disk.

![Screen Shot 2021-03-17 at 12 03 18](https://user-images.githubusercontent.com/14921356/111457653-c93b3e80-8718-11eb-89aa-1862099dfb3d.png)

