### PR TITLE
logs: Fixup services loading

### DIFF
--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -504,8 +504,8 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                         ["check-journal", "BEFORE BOOT", ""],
                         "Load earlier entries"
                         ])
-        # HACK: Figure out why this happens
-        self.allow_journal_messages(".*Failed to add match '00:03': Invalid argument.*")
+
+        b._wait_present("#journal-service-menu option[value='check-journal']")
 
         # New messages are not streamed when 'until' is in the past
         m.execute("logger -p user.err --tag check-journal RIGHT NOW")


### PR DESCRIPTION
The current approach had a bunch of issues:
- It was doing `sh -ec` instead of using `cockpit.script()`
- It was using `then()` and `done()` at the same time
- It would never fail (due to those `grep` and `sort`)
- It was doing grep which is ugly
- The `sort` was not necessary as we sort it anyway
- The `host` option was unused

But mainly it was not error prone since we introduced possible spaces in
qualifiers. We could now have `journalctl --since="2021-03-03 08:00"`
which would be then parsed in command as `["journalctl", "since=2021-03-03 08:00"]`.
That is fine because separate arguments are treated as such, but when
we did `join(" ")` it would generate `journalctl --since=2021-03-03 08:00` where `08:00`
would not be recognized anymore. This lead to not showing any services
on the logs page.