### PR TITLE
selinux: remove last usages of PF3 and stop including it

### DIFF
--- a/pkg/lib/cockpit-components-modifications.css
+++ b/pkg/lib/cockpit-components-modifications.css
@@ -12,6 +12,14 @@
     margin-left: 5px;
 }
 
+.automation-script-modal textarea {
+    min-height: 15rem;
+}
+
+.automation-script-modal .ansible-docs-link > svg {
+    padding-right: var(--pf-global--spacer--xs);
+}
+
 .green-icon {
     color: var(--pf-global--success-color--100);
 }

--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -22,8 +22,9 @@ import React from 'react';
 import {
     Button, Card, CardHeader, CardTitle, CardBody,
     DataList, DataListItem, DataListItemRow, DataListCell, DataListItemCells,
-    Modal, Tabs, Tab, Text, TextVariants
+    Modal, Tabs, Tab, Text, TextArea, TextVariants
 } from '@patternfly/react-core';
+import { CheckIcon, CopyIcon, ExternalLinkAltIcon, OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from "cockpit";
 import './listing.scss';
@@ -71,9 +72,8 @@ class ModificationsExportDialog extends React.Component {
     render() {
         const footer = (
             <>
-                <Button variant='secondary' onClick={this.copyToClipboard}>
-                    { this.state.copied ? <span className="fa fa-check fa-xs green-icon" /> : <span className="fa fa-clipboard fa-xs" /> }
-                    <span>{ _("Copy to clipboard") }</span>
+                <Button variant='secondary' className="btn-clipboard" onClick={this.copyToClipboard} icon={this.state.copied ? <CheckIcon className="green-icon" /> : <CopyIcon />}>
+                    { _("Copy to clipboard") }
                 </Button>
                 <Button variant='secondary' className='btn-cancel' onClick={this.props.onClose}>
                     { _("Close") }
@@ -88,22 +88,18 @@ class ModificationsExportDialog extends React.Component {
                    title={_("Automation script") }>
                 <Tabs activeKey={this.state.active_tab} onSelect={this.handleSelect}>
                     <Tab eventKey="shell" title={_("Shell script")}>
-                        <pre>
-                            {this.props.shell.trim()}
-                        </pre>
+                        <TextArea resizeOrientation='vertical' isReadOnly defaultValue={this.props.shell.trim()} />
                     </Tab>
                     <Tab eventKey="ansible" title={_("Ansible")}>
-                        <pre>
-                            {this.props.ansible.trim()}
-                        </pre>
-                        <div>
-                            <span className="fa fa-question-circle fa-xs" />
+                        <TextArea resizeOrientation='vertical' isReadOnly defaultValue={this.props.ansible.trim()} />
+                        <div className="ansible-docs-link">
+                            <OutlinedQuestionCircleIcon />
                             { _("Create new task file with this content.") }
-                            <a href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html"
-                                target="_blank" rel="noopener noreferrer">
-                                <i className="fa fa-external-link fa-xs" />
+                            <Button variant="link" component="a" href="https://docs.ansible.com/ansible/latest/user_guide/playbooks_reuse_roles.html"
+                                    target="_blank" rel="noopener noreferrer"
+                                    icon={<ExternalLinkAltIcon />}>
                                 { _("Ansible roles documentation") }
-                            </a>
+                            </Button>
                         </div>
                     </Tab>
                 </Tabs>

--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -22,7 +22,7 @@ import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
 
-import '../lib/patternfly/patternfly-cockpit.scss';
+import '../lib/patternfly/patternfly-4-cockpit.scss';
 
 import * as troubleshootClient from "./setroubleshoot-client";
 import * as selinuxClient from "./selinux-client.js";

--- a/pkg/selinux/setroubleshoot.scss
+++ b/pkg/selinux/setroubleshoot.scss
@@ -48,6 +48,11 @@
     font-size: 150%;
 }
 
+/* Table cells should collapse on mobile */
+.ct-table.pf-c-table tbody > tr > * {
+    word-break: break-word;
+}
+
 .list-group-item .alert {
     margin-top: 10px;
 }
@@ -56,12 +61,23 @@
     display: flex;
     flex-wrap: wrap;
     justify-content: space-between;
+
+    > div:first-child {
+        width: 70%;
+    }
+
+    + hr {
+        margin-bottom: var(--pf-global--spacer--sm);
+    }
+
+    .pf-c-expandable-section__content {
+        margin-top: unset;
+    }
 }
 
-.selinux-details pre {
-    width: 100%;
-    margin: 5px 0px 10px 0px;
-    padding: 10px;
+.selinux-details textarea {
+    margin-top: var(--pf-global--spacer--xs);
+    resize: none;
 }
 
 .selinux-state {

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -162,7 +162,7 @@ class TestSelinux(MachineCase):
             b.wait_in_text(row_selector + " tr.pf-m-expanded .ct-listing-panel-body", "you can run restorecon")
 
             # and it can be applied
-            btn_sel = "div.list-group-item:contains('you can run restorecon') button{}".format(self.default_btn_class)
+            btn_sel = ".selinux-details:contains('you can run restorecon') button{}".format(self.default_btn_class)
             b.click(btn_sel)
 
             # the button should disappear
@@ -193,8 +193,8 @@ class TestSelinux(MachineCase):
         b.wait_visible(".pf-c-data-list__cell:contains(Allow zebra to write config)")
         b.wait_visible(".pf-c-data-list__cell:contains(fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/')")
         b.click("button:contains('View automation script')")
-        shell_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(2) pre"
-        ansible_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(3) pre"
+        shell_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(2) textarea"
+        ansible_script_sel = ".automation-script-modal .pf-c-modal-box__body section:nth-child(3) textarea"
         b.wait_in_text(shell_script_sel, "boolean -D")
         b.wait_in_text(shell_script_sel, "fcontext -D")
         b.wait_in_text(shell_script_sel, "boolean -m -1 zebra_write_config")
@@ -249,7 +249,7 @@ class TestSelinux(MachineCase):
         # Check the content of clipboard by pasting the clipboard to the terminal
         b.click("button:contains('Shell script')")
         b.wait_in_text(shell_script_sel, "boolean -D")
-        b.click(".automation-script-modal .fa-clipboard")
+        b.click(".automation-script-modal .btn-clipboard")
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
         b.focus('.terminal')


### PR DESCRIPTION
This commit made the following changes:
* Replace icons with the React components from react-icons
* Replace `<pre>` with <TextArea>.` <pre> `in PF4 does not have a grey
  background
* Replace custom expandable section with ExpandableSection PF4
  component
* Replace list-group and list-group-items which are used for displaying
  solutions with Cards