### PR TITLE
lib: make cockpit-logs-panels independent from PF3

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -20,7 +20,8 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { Card, CardHeader, CardActions, CardTitle, CardBody } from '@patternfly/react-core';
+import { Badge, Card, CardHeader, CardActions, CardTitle, CardBody } from '@patternfly/react-core';
+import { AngleRightIcon, ExclamationTriangleIcon, TimesCircleIcon } from '@patternfly/react-icons';
 
 import { journal } from "journal";
 import "journal.css";
@@ -68,11 +69,11 @@ export class JournalOutput {
                 onKeyPress={ev => this.onEvent(ev, entry.__CURSOR)}>
                 <div className="cockpit-log-warning" role="cell">
                     { warning
-                        ? <i className="fa fa-exclamation-triangle" />
+                        ? <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="sm" />
                         : null
                     }
                     { problem
-                        ? <i className="fa fa-times-circle-o" />
+                        ? <TimesCircleIcon className="ct-icon-times-circle" size="sm" />
                         : null
                     }
                 </div>
@@ -82,7 +83,7 @@ export class JournalOutput {
                     count > 1
                         ? <div className="cockpit-log-service-container" role="cell">
                             <div className="cockpit-log-service-reduced" role="cell">{ident}</div>
-                            <span className="badge" role="cell">{count}&#160;<i className="fa fa-caret-right" /></span>
+                            <Badge isRead key={count} role="cell">{count}&#160;<AngleRightIcon /></Badge>
                         </div>
                         : <div className="cockpit-log-service" role="cell">{ident}</div>
                 }

--- a/pkg/lib/journal.css
+++ b/pkg/lib/journal.css
@@ -138,19 +138,17 @@
 
 .cockpit-log-message,
 .cockpit-log-service,
-.cockpit-log-service-reduced,
-.cockpit-log-service-container > .badge {
+.cockpit-log-service-reduced {
     font-size: var(--pf-global--FontSize--sm);
+}
+
+.cockpit-log-service-container > .pf-c-badge {
+    margin-left: var(--pf-global--spacer--xs);
 }
 
 .cockpit-log-service-container {
     display: flex;
     align-items: baseline;
-}
-
-.cockpit-log-service-container > .badge {
-    min-width: 2.5em;
-    text-align: right;
 }
 
 @media screen and (max-width: 428px) {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -345,3 +345,7 @@ html:not(.index-page) body {
 .ct-icon-exclamation-triangle {
     color: var(--pf-global--warning-color--100);
 }
+
+.ct-icon-times-circle {
+    color: var(--pf-global--danger-color--100);
+}

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -16,7 +16,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
-import '../lib/patternfly/patternfly-cockpit.scss';
+import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 
 // This is needed by the bootstrap bits pulled in by various

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -68,7 +68,7 @@ class TestJournal(MachineCase):
                     if (e.querySelectorAll('.cockpit-log-service-container').length > 0) {
                         ident = e.querySelector('.cockpit-log-service-reduced').textContent;
                         // we need to slice the whitespace
-                        count = e.querySelector('.badge').textContent.slice(0, -1);
+                        count = e.querySelector('.pf-c-badge').textContent.slice(0, -1);
                     } else {
                         ident = e.querySelector('.cockpit-log-service');
                         ident = ident ? ident.textContent : "";


### PR DESCRIPTION
The badges look different in bootstrap compared to PF4. Are we happy with the change?

Before:
![Screen Shot 2021-03-10 at 14 59 31](https://user-images.githubusercontent.com/14921356/110643127-0a30d180-81b4-11eb-9168-d2d7c85f5c68.png)

After:
![Screen Shot 2021-03-10 at 14 59 20](https://user-images.githubusercontent.com/14921356/110643130-0ac96800-81b4-11eb-8dee-dfc31f2e9505.png)
