### PR TITLE
test: Add nondestructive VM CPU/RAM size options to run-tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -166,11 +166,11 @@ def build_command(filename, test, opts):
     return cmd
 
 class GlobalMachine:
-    def __init__(self, restrict=True):
+    def __init__(self, restrict=True, cpus=None, memory_mb=None):
         self.image = testvm.DEFAULT_IMAGE
         self.network = testvm.VirtNetwork(image=self.image)
         self.networking = self.network.host(restrict=restrict)
-        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image)
+        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image, cpus=cpus, memory_mb=memory_mb)
         if not os.path.exists(self.machine.image_file):
             self.machine.pull(self.machine.image_file)
         self.machine.start()
@@ -307,7 +307,7 @@ def run(opts, image):
             batch_size = len(serial_tests) // opts.batches
 
             for i in range(opts.batches):
-                m = GlobalMachine(restrict=not opts.enable_network)
+                m = GlobalMachine(restrict=not opts.enable_network, cpus=opts.nondestructive_cpus, memory_mb=opts.nondestructive_memory_mb)
                 batch_tests[i] = { "working": None, "tests": [], "time": 0, "machine": m }
                 ssh_address = "{0}:{1}".format(m.machine.ssh_address,
                                                m.machine.ssh_port)
@@ -436,6 +436,10 @@ def main():
                         help="Exclude test (exact match only); can be specified multiple times")
     parser.add_argument('-b', '--batches', type=int,
                         default=max(jobs // 2, 1), help="Number of concurrent batches of nondestructive tests")
+    parser.add_argument('--nondestructive-cpus', type=int, default=None,
+                        help="Number of CPUs for nondestructive test global machines")
+    parser.add_argument('--nondestructive-memory-mb', type=int, default=None,
+                        help="RAM size for nondestructive test global machines")
     parser.add_argument('--base', default=os.environ.get("BASE_BRANCH", "master"), help="Base branch")
     opts = parser.parse_args()
 


### PR DESCRIPTION
This will allow cockpit-composer to use bigger global machines, so that
all of its tests can go back to being nondestructive (and thus once
again run in Fedora/RHEL gating). See
https://github.com/osbuild/cockpit-composer/commit/a7577b988c1fd3
(which was a quick hack to unbreak the tests)