### PR TITLE
test: Flush stdout after printing result

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -413,6 +413,7 @@ def run(opts, image):
             print("# {0} TESTS FAILED {1}".format(result, details))
         else:
             print("# TESTS PASSED {0}".format(details))
+        flush_stdout()
 
     return result
 


### PR DESCRIPTION
This is the last place in run-tests that uses print() without flushing.
As the output is heavily interleaved with stderr and direct
sys.stdout.buffer writes, unflushed print()s mess up the log file.

----
This may help with a mess like [this](https://logs.cockpit-project.org/logs/pull-1262-20210312-060925-9dd70cbb-fedora-33-firefox/log.html). The main fix for that should be https://github.com/cockpit-project/bots/pull/1787 but I think it can't hurt being thorough here.