### PR TITLE
test: Generalize allow_failed_sudo_journal_messages()

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1110,17 +1110,11 @@ class MachineCase(unittest.TestCase):
 
     def allow_failed_sudo_journal_messages(self):
         self.allow_journal_messages(".* is not in the sudoers file.  This incident will be reported.",
-                                    "sudo:.* Operation not permitted",
-                                    "sudo:.* Permission denied",
                                     "Error executing command as another user: Not authorized",
                                     "This incident has been reported.",
-                                    "sudo: a password is required",
-                                    "sudo: Account or password is expired, reset your password and try again",
-                                    "sudo: sorry, you must have a tty to run sudo",
                                     "Sorry, try again.",
-                                    "sudo: no password was provided",
-                                    "sudo: account validation failure.*",
-                                    ".*incorrect password attempt.*")
+                                    ".*incorrect password attempt.*",
+                                    "sudo:.*")
 
     def check_journal_messages(self, machine=None):
         """Check for unexpected journal entries."""


### PR DESCRIPTION
This has been a game of whack-a-rat, and there's still new messages
appearing, like "sudo: no valid sudoers sources found, quitting".

But this is non-sense: Simplifiy the function to allow *all* messages
from sudo; that's what we are effectively trying to do, and we only use
it in tests where we expect sudo to fail.