### PR TITLE
pf4: Add override to draw input group focus ring above other elements

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -108,3 +108,9 @@ svg {
         padding-top: var(--pf-global--spacer--md);
     }
 }
+
+// Make sure focus ring is not truncated when input group element is focused.
+// https://github.com/patternfly/patternfly/issues/3926
+.pf-c-input-group :focus {
+    z-index: 2;
+}


### PR DESCRIPTION
This is being tracked upstream at:
https://github.com/patternfly/patternfly/issues/3926