### PR TITLE
Fix FMF tests for Fedora 34, enable in packit

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -16,3 +16,4 @@ jobs:
       targets:
       # once this works, move to fedora-all
       - fedora-33
+      - fedora-34

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -26,6 +26,10 @@ if [ ! -d node_modules/chrome-remote-interface ]; then
     npm install chrome-remote-interface sizzle
 fi
 
+# disable detection of affected tests; testing takes too long as there is no parallelization,
+# and TF machines are slow and brittle
+mv .git dot-git
+
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
 if [ "$TEST_OS" = "fedora-35" ]; then

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -102,11 +102,6 @@ done
 test/common/run-tests --test-dir test/verify --nondestructive $exclude_options \
     --machine localhost:22 --browser localhost:9090 $TESTS || RC=$?
 
-# check-shell-menu is not @nondestructive yet, keep it last
-if [ -n "$test_basic" ]; then
-    test/verify/check-shell-menu --machine localhost:22 --browser localhost:9090 || RC=$?
-fi
-
 echo $RC > "$LOGS/exitcode"
 cp --verbose Test* "$LOGS" || true
 # deliver test result via exitcode file

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -67,7 +67,6 @@ fi
 
 if [ -n "$test_basic" ]; then
     # TODO: fix for CI environment
-    EXCLUDES="$EXCLUDES TestLogin.testTally"
     EXCLUDES="$EXCLUDES TestAccounts.testBasic"
     EXCLUDES="$EXCLUDES TestLogin.testServer"
 

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -29,7 +29,7 @@ fi
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
 if [ "$TEST_OS" = "fedora-35" ]; then
-    export TEST_OS=fedora-33
+    export TEST_OS=fedora-34
 fi
 
 # HACK: CI hits this selinux denial. Unrelated to our tests.

--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -29,6 +29,11 @@ if rpm -q setroubleshoot-server; then
     dnf remove -y setroubleshoot-server
 fi
 
+if grep -q 'ID=.*fedora' /etc/os-release; then
+    # required by TestLogin.testBasic, but tcsh is not available in CentOS/RHEL
+    dnf install -y tcsh
+fi
+
 # make libpwquality less aggressive, so that our "foobar" password works
 printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
 

--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -23,6 +23,12 @@ if ! rpm -q chromium; then
     dnf install -y chromium
 fi
 
+# HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
+# and is hard to disable as it does not use systemd
+if rpm -q setroubleshoot-server; then
+    dnf remove -y setroubleshoot-server
+fi
+
 # make libpwquality less aggressive, so that our "foobar" password works
 printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
 

--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -13,6 +13,11 @@ LOGS="$(pwd)/logs"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 
+# show some system info
+nproc
+free -h
+rpm -q cockpit-system
+
 # install browser; on RHEL, use chromium from epel
 # HACK: chromium-headless ought to be enough, but version 88 has a crash: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
 if ! rpm -q chromium; then

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -82,7 +82,8 @@ class TestServices(MachineCase):
         self.browser.wait_in_text(self.svc_sel(service), state_new)
 
     def wait_page_load(self):
-        self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
+        with self.browser.wait_timeout(180):
+            self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
 
     def wait_service_in_panel(self, service, title):
         self.wait_service_state(service, title)


### PR DESCRIPTION
This was developed against my fork in https://github.com/martinpitt/cockpit/pull/13, with lots of intermediate/failing results (which justify the commits here).