### PR TITLE
machines: fix alignment of radio buttons in 'add disk' dialog

### DIFF
--- a/pkg/machines/components/vm/disks/diskAdd.jsx
+++ b/pkg/machines/components/vm/disks/diskAdd.jsx
@@ -101,7 +101,7 @@ const PermanentChange = ({ idPrefix, onValueChanged, permanent, vm }) => {
     }
 
     return (
-        <FormGroup fieldId={`${idPrefix}-permanent`} label={_("Persistence")} isInline>
+        <FormGroup fieldId={`${idPrefix}-permanent`} label={_("Persistence")} hasNoPaddingTop>
             <Checkbox id={`${idPrefix}-permanent`}
                       isChecked={permanent}
                       label={_("Always attach")}
@@ -548,7 +548,7 @@ export class AddDiskModalBody extends React.Component {
             defaultBody = (
                 <Form isHorizontal>
                     <FormGroup fieldId={`${idPrefix}-source`}
-                               label={_("Source")} isInline>
+                               label={_("Source")} isInline hasNoPaddingTop>
                         <Radio id={`${idPrefix}-createnew`}
                                name="source"
                                label={_("Create new")}


### PR DESCRIPTION
Remove isInline from the "Persistence" group. This only makes sense to
use when more than one items are part of the group.