### PR TITLE
test: Adjust for changed services image

### DIFF
--- a/pkg/systemd/README-realmd.md
+++ b/pkg/systemd/README-realmd.md
@@ -9,13 +9,13 @@ with either Active Directory or IPA.
 ### Running a test domain
 
 To contribute to this component, run a test domain which ends
-up being rather easy. Install the stuff in ```test/README``` near the
-top. And then do the following:
+up being rather easy. Install the stuff in [test/README.md](../../test/README.md)
+near the top. And then do the following:
 
     $ bots/vm-run --network services
 
-In that VM, start `/run-freeipa` to start an IPA domain controller, or
-`/run-samba-domain` for a Samba AD domain controller. Now in
+In that VM, start `/root/run-freeipa` to start an IPA domain controller, or
+`/root/run-samba-domain` for a Samba AD domain controller. Now in
 another terminal do the following:
 
     $ sudo /bin/sh -c "echo -e 'domain cockpit.lan\nsearch cockpit.lan\nnameserver 10.111.112.100\n' > /etc/resolv.conf"

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -979,7 +979,7 @@ class TestUpdatesSubscriptions(PackageCase):
         m = self.machine
 
         # wait for candlepin to be active and verify
-        self.candlepin.execute("systemctl start tomcat")
+        self.candlepin.execute("/root/run-candlepin")
 
         # remove all existing products (RHEL server), as we can't control them
         m.execute("rm -f /etc/pki/product-default/*.pem /etc/pki/product/*.pem")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -423,7 +423,7 @@ class TestIPA(TestRealms, CommonTests):
         self.admin_password = "foobarfoo"
         self.alice_password = 'WonderLand123'
         self.expected_server_software = "ipa"
-        self.machines['services'].execute("/run-freeipa")
+        self.machines['services'].execute("/root/run-freeipa")
         # Wait for FreeIPA to come up and DNS to work as expected
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
         wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
@@ -442,7 +442,7 @@ ExecStart=/bin/true
             self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
 
         # wait until FreeIPA started up
-        self.machines['services'].execute("""docker exec -i freeipa sh -ec '
+        self.machines['services'].execute("""podman exec -i freeipa sh -ec '
             while ! echo %s | kinit -f %s; do sleep 5; done
             while ! ipa user-find >/dev/null; do sleep 5; done'
             """ % (self.admin_password, self.admin_user), timeout=300)
@@ -528,7 +528,7 @@ ExecStart=/bin/true
 
         # set up "alice" user with HOTP; that won't affect existing users (admin)
         # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/linux_domain_identity_authentication_and_policy_guide/otp
-        out = self.machines['services'].execute("""docker exec -i freeipa sh -ec '
+        out = self.machines['services'].execute("""podman exec -i freeipa sh -ec '
             ipa config-mod --user-auth-type=otp
             ipa user-add --first=Alice --last=Developer alice
             yes alicessecret | ipa user-mod --password alice
@@ -604,7 +604,7 @@ ExecStart=/bin/true
         # IPA does not like the ---BEGIN/END lines
         alice_cert = '\n'.join([l for l in alice_cert.splitlines() if not l.startswith("----")])
         # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
-        ipa_machine.execute(r"""docker exec -i freeipa sh -exc '
+        ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
 ipa user-add --first=Alice --last="Developer" alice
 yes "%(password)s" | ipa user-mod --password alice
 ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
@@ -629,8 +629,8 @@ class TestAD(TestRealms, CommonTests):
         self.alice_password = 'WonderLand123'
         self.expected_server_software = "active-directory"
         # necessary to run ldapmodify; FIXME: change this on the services image itself
-        self.machines['services'].execute("sed -i 's/-e/-e INSECURELDAP=true &/' /run-samba-domain")
-        self.machines['services'].execute("/run-samba-domain")
+        self.machines['services'].execute("sed -i 's/-e/-e INSECURELDAP=true &/' /root/run-samba-domain")
+        self.machines['services'].execute("/root/run-samba-domain")
 
         m = self.machine
 
@@ -673,7 +673,7 @@ class TestAD(TestRealms, CommonTests):
 
         m.start_cockpit()
         # create another AD user
-        self.machines['services'].execute("docker exec -i samba samba-tool user add alice %s" % self.alice_password)
+        self.machines['services'].execute("podman exec -i samba samba-tool user add alice %s" % self.alice_password)
         # ensure it works
         m.execute('id alice')
         b.login_and_go('/system', user='alice', password=self.alice_password)
@@ -690,7 +690,7 @@ class TestAD(TestRealms, CommonTests):
         alice_cert = ''.join([l for l in alice_cert.splitlines() if not l.startswith("----")])
         # set up an AD user and import their TLS certificate; avoid using the common "userCertificate;binary",
         # as that does not work with Samba
-        services_machine.execute(r"""docker exec -i samba sh -exc '
+        services_machine.execute(r"""podman exec -i samba sh -exc '
 samba-tool user add alice %(alice_pass)s
 printf "version: 1\ndn: cn=alice,cn=users,dc=cockpit,dc=lan\nchangetype: modify\nadd: userCertificate\nuserCertificate: %(alice_cert)s\n" | \
         ldapmodify -v -U Administrator -w '%(admin_pass)s'
@@ -787,7 +787,7 @@ ExecStart=/bin/true
             self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
 
     def configure_kerberos(self, keytab):
-        self.machines["services"].execute("/run-freeipa")
+        self.machines["services"].execute("/root/run-freeipa")
 
         # Setup a place for kerberos caches
         args = {"addr": "10.111.112.100", "password": "foobarfoo", "keytab": keytab}

--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -35,7 +35,7 @@ class TestS4USsh(MachineCase):
 
     def setUp(self):
         super().setUp()
-        self.machines['services'].execute("/run-freeipa")
+        self.machines['services'].execute("/root/run-freeipa")
         # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
         self.machines['1'].execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
 
@@ -56,14 +56,14 @@ class TestS4USsh(MachineCase):
         sshd_machine.execute("echo foobarfoo | realm join -U admin cockpit.lan")
 
         # configure ipa
-        ipa_machine.execute("docker exec freeipa bash -c 'echo foobarfoo | kinit admin@COCKPIT.LAN'")
+        ipa_machine.execute("podman exec freeipa bash -c 'echo foobarfoo | kinit admin@COCKPIT.LAN'")
         # add user to impersonate
-        ipa_machine.execute("docker exec freeipa bash -c 'ipa user-add --first=user --last=user user'")
-        ipa_machine.execute("docker exec freeipa bash -c 'echo foobarfoo | ipa user-mod user --password'")
+        ipa_machine.execute("podman exec freeipa bash -c 'ipa user-add --first=user --last=user user'")
+        ipa_machine.execute("podman exec freeipa bash -c 'echo foobarfoo | ipa user-mod user --password'")
         # add service which will be allowed to delegate creds
-        ipa_machine.execute("docker exec freeipa bash -c 'ipa service-add cockpitclient/sshclient.cockpit.lan@COCKPIT.LAN --ok-as-delegate=true --ok-to-auth-as-delegate=true'")
+        ipa_machine.execute("podman exec freeipa bash -c 'ipa service-add cockpitclient/sshclient.cockpit.lan@COCKPIT.LAN --ok-as-delegate=true --ok-to-auth-as-delegate=true'")
         # Allow retrieval of service keytab by admin
-        ipa_machine.execute("docker exec freeipa bash -c 'ipa service-allow-retrieve-keytab --user=admin cockpitclient/sshclient.cockpit.lan'")
+        ipa_machine.execute("podman exec freeipa bash -c 'ipa service-allow-retrieve-keytab --user=admin cockpitclient/sshclient.cockpit.lan'")
         # set up delegation rule
         script="""set -e
         ipa servicedelegationtarget-add cockpit-target
@@ -72,7 +72,7 @@ class TestS4USsh(MachineCase):
         ipa servicedelegationrule-add-member cockpit-delegation --principals="cockpitclient/sshclient.cockpit.lan@COCKPIT.LAN"
         ipa servicedelegationrule-add-target cockpit-delegation --servicedelegationtargets="cockpit-target"
         """
-        ipa_machine.execute("docker exec freeipa bash -ec '%s'" % script)
+        ipa_machine.execute("podman exec freeipa bash -ec '%s'" % script)
 
         # ssh client, get keytab for authenticating and make ccache using gssapi
         client_machine.write('/tmp/make-cache.py', """


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/1768 moves the services
image from CentOS 7 to Fedora CoreOS and containerizes the candlepin
server. Adjust tests accordingly.

 - [ ] Needs to land in lockstep with https://github.com/cockpit-project/bots/pull/1768