### PR TITLE
fmf: Increase plan timeout and duration for Fedora

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -103,6 +103,9 @@ You can set these environment variables to configure the test suite:
     TEST_SHOW_BROWSER  Set to run browser interactively. When not specified,
                        browser is run in headless mode.
 
+    TEST_TIMEOUT_FACTOR Scale normal timeouts by given integer. Useful for
+                        slow/busy testbeds or architectures.
+
 ## Test machines and their images
 
 The code under test is executed in one or more dedicated virtual

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -107,6 +107,7 @@ class Browser:
         self.cdp = cdp.CDP("C.utf8", verbose=opts.trace, trace=opts.trace,
                            inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")])
         self.password = "foobar"
+        self.timeout_factor = int(os.getenv("TEST_TIMEOUT_FACTOR", "1"))
 
     def title(self):
         return self.cdp.eval('document.title')
@@ -145,14 +146,14 @@ class Browser:
     def expect_load(self):
         if opts.trace:
             print("-> expect_load")
-        self.cdp.command('expectLoad(%i)' % (self.cdp.timeout * 1000))
+        self.cdp.command('expectLoad(%i)' % (self.cdp.timeout * self.timeout_factor * 1000))
         if opts.trace:
             print("<- expect_load done")
 
     def expect_load_frame(self, name):
         if opts.trace:
             print("-> expect_load_frame " + name)
-        self.cdp.command('expectLoadFrame(%s, %i)' % (jsquote(name), self.cdp.timeout * 1000))
+        self.cdp.command('expectLoadFrame(%s, %i)' % (jsquote(name), self.cdp.timeout * self.timeout_factor * 1000))
         if opts.trace:
             print("<- expect_load_frame %s done" % name)
 
@@ -368,7 +369,7 @@ class Browser:
         return r
 
     def wait(self, predicate):
-        for _ in range(self.cdp.timeout * 5):
+        for _ in range(self.cdp.timeout * self.timeout_factor * 5):
             val = predicate()
             if val:
                 return val
@@ -377,7 +378,7 @@ class Browser:
 
     def wait_js_cond(self, cond):
         result = self.cdp.invoke("Runtime.evaluate",
-                                 expression="ph_wait_cond(() => %s, %i)" % (cond, self.cdp.timeout * 1000),
+                                 expression="ph_wait_cond(() => %s, %i)" % (cond, self.cdp.timeout * self.timeout_factor * 1000),
                                  silent=False, awaitPromise=True, trace="wait: " + cond)
         if "exceptionDetails" in result:
             trailer = "\n".join(self.cdp.get_js_log())

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -36,6 +36,11 @@ if [ "$TEST_OS" = "fedora-35" ]; then
     export TEST_OS=fedora-34
 fi
 
+if [ "$ID" = "fedora" ]; then
+    # Testing Farm machines are really slow at some times of the day
+    export TEST_TIMEOUT_FACTOR=3
+fi
+
 # HACK: CI hits this selinux denial. Unrelated to our tests.
 export TEST_ALLOW_JOURNAL_MESSAGES=".*Permission denied:.*/var/cache/app-info/xmls.*"
 

--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -28,4 +28,4 @@ require:
   - tuned
 
 test: ./run-verify-host.sh
-duration: 2h
+duration: 4h

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -82,8 +82,7 @@ class TestServices(MachineCase):
         self.browser.wait_in_text(self.svc_sel(service), state_new)
 
     def wait_page_load(self):
-        with self.browser.wait_timeout(180):
-            self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
+        self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
 
     def wait_service_in_panel(self, service, title):
         self.wait_service_state(service, title)


### PR DESCRIPTION
In the European evenings/American mornings, the tests on Testing Farm
are really slow (supposedly, AWS spot instances with lots of noisy
neighbors?), have a hard time finishing in two hours, and lots of tests
fail because expensive actions (such as loading the Services page or the
Terminal torture test) actually take more than one minute.

Introduce a `$TEST_TIMEOUT_FACTOR` environment variable to globally
scale the timeouts, use it for FMF tests on Fedora, and bump the global
plan timeout to four hours.

[example from yesterday evening](http://artifacts.dev.testing-farm.io/b0212fd2-d876-457f-bdfd-d0cfded5b77a/)