### PR TITLE
[r79] test: Adjust for changed services image

### DIFF
--- a/pkg/realmd/README.md
+++ b/pkg/realmd/README.md
@@ -12,9 +12,11 @@ To contribute to this component, run a test domain which ends
 up being rather easy. Install the stuff in ```test/README``` near the
 top. And then do the following:
 
-    $ bots/vm-run --network ipa
+    $ bots/vm-run --network services
 
-That runs an IPA domain. Now in another terminal do the following:
+In that VM, start `/run-freeipa` to start an IPA domain controller, or
+`/run-samba-domain` for a Samba AD domain controller. Now in
+another terminal do the following:
 
     $ sudo /bin/sh -c "echo -e 'domain cockpit.lan\nsearch cockpit.lan\nnameserver 10.111.112.100\n' > /etc/resolv.conf"
 
@@ -22,8 +24,9 @@ Make sure this works:
 
     $ realm discover cockpit.lan
 
-And now you're ready to use the feature. There's an account called
-"admin" with the password "foobarfoo".
+And now you're ready to use the feature. For IPA there's an account called
+"admin" with the password "foobarfoo", for Samba AD it is user "Administrator"
+with password "foobarFoo123".
 
 To test your DNS, the following should succeed without any error messages
 on your server with cockpit:
@@ -35,6 +38,19 @@ above.
 
     $ kinit admin@COCKPIT.LAN
     Password for admin@COCKPIT.LAN:
+
+## Running a Microsoft AD server in AWS
+
+If you want to test against Microsoft Active Directory instead of Samba or FreeIPA, the
+simplest way is to start a temporary
+[managed AD in AWS](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_microsoft_ad.html)
+(or another cloud provider). Just follow the few
+[setup steps](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_getting_started_create_directory.html):
+Select the smallest edition, specify a directory DNS name (e. g. `ad.cockpit.lan`) and a password for the `Admin` user,
+and about 20 minutes later the domain server should be set up. The details page
+of the created domain shows the DNS server's IP; put that into `/etc/resolv.conf`.
+
+From then on, joining that domain with `realm` or Cockpit works in the same way.
 
 ## Setting up Single Sign on
 
@@ -53,7 +69,7 @@ the domain name. If it does not, then rename the computer Cockpit is running on:
 
     $ sudo hostnamectl set-hostname my-server.domain.com
 
-**BUG:** If your domain is an IPA domain, then you need to explictly add a service
+**BUG:** If your domain is an IPA domain, then you need to explicitly add a service
 before Cockpit can be used with Single Sign on. The following must be done on
 the computer running Cockpit.
 [realmd bug](https://bugzilla.redhat.com/show_bug.cgi?id=1144292)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -666,7 +666,7 @@ class TestUpdatesSubscriptions(PackageCase):
         m = self.machine
 
         # wait for candlepin to be active and verify
-        self.candlepin.execute("systemctl start tomcat")
+        self.candlepin.execute("/root/run-candlepin")
 
         # remove all existing products (RHEL server), as we can't control them
         m.execute("rm -f /etc/pki/product-default/*.pem /etc/pki/product/*.pem")

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -75,7 +75,7 @@ class TestRealms(MachineCase):
             self.op_address = "#realms-op-address"
             self.op_admin = "#realms-op-admin"
             self.op_admin_password = "#realms-op-admin-password"
-        self.machines['services'].execute("/run-freeipa")
+        self.machines['services'].execute("/root/run-freeipa")
 
     def testIpa(self):
         m = self.machine
@@ -453,7 +453,7 @@ class TestKerberos(MachineCase):
     }
 
     def configure_kerberos(self, keytab):
-        self.machines["services"].execute("/run-freeipa")
+        self.machines["services"].execute("/root/run-freeipa")
 
         # Setup a place for kerberos caches
         args = {"addr": "10.111.112.100", "password": "foobarfoo", "keytab": keytab}

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -62,23 +62,11 @@ for x in $(seq 1 200); do
 done
 """
 
-ACTIVATION_KEY_COMMAND = """curl -s --insecure --request GET --user admin:admin https://localhost:8443/candlepin/activation_keys | python -c "
-import sys
-import json
+ACTIVATION_KEY_COMMAND = """curl -s --insecure --request GET --user admin:admin https://localhost:8443/candlepin/activation_keys |
+    jq -r '.[] | select(.name == "awesome_os_pool") | select(.owner.displayName == "Admin Owner") | .id' """
 
-data = json.loads(sys.stdin.read())
-print [e['id'] for e in data if e['name'] == 'awesome_os_pool' and e['owner']['displayName'] == 'Admin Owner'][0]
-"
-"""
-
-POOL_COMMAND = """curl -s --insecure --request GET --user admin:admin https://localhost:8443/candlepin/pools | python -c "
-import sys
-import json
-
-data = json.loads(sys.stdin.read())
-print [ e['id'] for e in data if e['owner']['key'] == 'admin' and e['contractNumber'] == '0' and [p for p in e['providedProducts'] if p['productId'] == '88888'] ][0]
-"
-"""
+POOL_COMMAND = """curl -s --insecure --request GET --user admin:admin https://localhost:8443/candlepin/pools |
+    jq -r '.[] | select(.owner.key == "admin") | select(.contractNumber == "0") | select(.providedProducts[0].productId == "88888") | .id' """
 
 class SubscriptionsCase(MachineCase):
     provision = {
@@ -91,7 +79,7 @@ class SubscriptionsCase(MachineCase):
         self.candlepin = self.machines['services']
 
         # wait for candlepin to be active and verify
-        self.candlepin.execute("systemctl start tomcat")
+        self.candlepin.execute("/root/run-candlepin")
 
         # download product info from the candlepin machine
         product_file_one = os.path.join(self.tmpdir, "6050.pem")
@@ -105,7 +93,7 @@ class SubscriptionsCase(MachineCase):
 
         # Install Candlepin CA cert to where curl,
         # subscription-manager, and insights-client can find it.
-        candlepin_ca_cert = self.candlepin.execute("cat /etc/candlepin/certs/candlepin-ca.crt")
+        candlepin_ca_cert = self.candlepin.execute("podman exec candlepin cat /etc/candlepin/certs/candlepin-ca.crt")
         m.write("/tmp/candlepin-ca.crt", candlepin_ca_cert)
         m.execute("cat /tmp/candlepin-ca.crt >>/etc/rhsm/ca/redhat-uep.pem")
         m.execute("cat /tmp/candlepin-ca.crt >>/etc/pki/tls/certs/ca-bundle.crt")


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/1768 moves the services
image from CentOS 7 to Fedora CoreOS and containerizes the candlepin
server. Adjust tests accordingly.

Cherry-picked from master commit d2c9f0c269ac29612

Changes:

 - Completely sync over pkg/realmd/README.md from current master, as the
   information here was heavily out of date (e.g. the "ipa" image has
   not existed for some time).

 - Replace the JSON filtering in Python with `jq`, as there is no Python
   on Fedora CoreOS.

 - [x] fix hostname in candlepin container: https://github.com/cockpit-project/bots/pull/1816