### PR TITLE
ws: Fix CockpitWebService.id leak

### DIFF
--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -293,6 +293,7 @@ cockpit_web_service_finalize (GObject *object)
 
   g_hash_table_destroy (self->host_by_checksum);
   g_hash_table_destroy (self->checksum_by_host);
+  g_free (self->id);
 
   G_OBJECT_CLASS (cockpit_web_service_parent_class)->finalize (object);
 }


### PR DESCRIPTION
Commit 20c24824fb forgot to free the allocation.

Spotted by `make check-memory TESTS=test-handlers` on current Fedora 33.