### PR TITLE
lib/console: Force width to containment size

### DIFF
--- a/pkg/lib/console.css
+++ b/pkg/lib/console.css
@@ -55,3 +55,8 @@
         background: var(--ct-color-text);
     }
 }
+
+/* Ensure the console fits to its container (and doesn't attempt to go beyond the limits) */
+.xterm-screen {
+    width: 100% !important;
+}


### PR DESCRIPTION
The console likes to hardcode its width, causing layouts to break.

Forcing it to 100% makes it render within the boundaries.

Fixes #15472