### PR TITLE
workflows: Run npm-update twice a week only

### DIFF
--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -1,7 +1,7 @@
 name: npm-update
 on:
   schedule:
-    - cron: '0 3 * * *'
+    - cron: '0 3 * * 1,4'
   # can be run manually on https://github.com/cockpit-project/cockpit/actions
   workflow_dispatch:
 jobs:


### PR DESCRIPTION
This is what we used to do when we still used npm-trigger. Some modules
like react-console are updated very often, and validating these
becomes too expensive/annoying.