### PR TITLE
test-static-code: test more python files

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -125,11 +125,11 @@ def finish_test(opts, test, affected_tests):
             return None, 0
 
     # do we get a specific retry reason from tests-policy?
-    m = re.search(b"\s*# RETRY (.*)$", test.output, re.MULTILINE)
+    m = re.search(rb"\s*# RETRY (.*)$", test.output, re.MULTILINE)
     if m:
         retry_reason = m.group(1)
         # remove it from test output; we must not print it after the 3rd time, and going to print it separately
-        test.output = re.sub(b"\s*# RETRY .*\\n", b"", test.output)
+        test.output = re.sub(rb"\s*# RETRY .*\n", b"", test.output)
     elif affected: # Don't retry affected failed tests
         retry_reason = None
     else:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -130,7 +130,7 @@ def finish_test(opts, test, affected_tests):
         retry_reason = m.group(1)
         # remove it from test output; we must not print it after the 3rd time, and going to print it separately
         test.output = re.sub(rb"\s*# RETRY .*\n", b"", test.output)
-    elif affected: # Don't retry affected failed tests
+    elif affected:  # Don't retry affected failed tests
         retry_reason = None
     else:
         # HACK: many tests are unstable, always retry them 3 times
@@ -318,7 +318,7 @@ def run(opts, image):
                 web_address = "{0}:{1}".format(m.machine.web_address,
                                                m.machine.web_port)
 
-                if i == opts.batches - 1: # Last machine needs to resolve the rest
+                if i == opts.batches - 1:  # Last machine needs to resolve the rest
                     batch = serial_tests[batch_size * i:]
                 else:
                     batch = serial_tests[batch_size * i: batch_size * i + batch_size]

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -41,11 +41,11 @@ class Test:
 
 def test_name(test):
     return "{0} {1} {2}{3}".format(
-            test.test_id,
-            test.command[0],
-            test.command[-1],
-            " [ND@{0}]".format(test.serial_machine) if test.nondestructive else "",
-            )
+        test.test_id,
+        test.command[0],
+        test.command[-1],
+        " [ND@{0}]".format(test.serial_machine) if test.nondestructive else "",
+    )
 
 
 def flush_stdout():
@@ -74,16 +74,17 @@ def print_test(test, print_tap=True, retry_reason=""):
 
     print()  # Tap needs to start on a separate line
     if test.process.returncode == 0:
-        print("ok " +  test_name(test) + retry_reason)
+        print("ok " + test_name(test) + retry_reason)
     elif test.process.returncode == 77 or b"# SKIP " in test.output:
         # If the test was skipped, add the last line (which contains the reason
         # for the skip) to the result
         print("ok {0} {1}{2}".format(test_name(test),
-                                  test.output.splitlines()[-1].strip().decode() if test.process.returncode == 77 else "",
-                                  retry_reason))
+                                     test.output.splitlines()[-1].strip().decode() if test.process.returncode == 77 else "",
+                                     retry_reason))
     else:
         print("not ok " + test_name(test) + retry_reason)
     flush_stdout()
+
 
 def finish_test(opts, test, affected_tests):
     """Returns if a test should retry or not
@@ -145,12 +146,14 @@ def finish_test(opts, test, affected_tests):
         print_test(test, print_tap=opts.thorough)
     return None, 1
 
+
 def check_valid(filename):
     name = os.path.basename(filename)
     allowed = string.ascii_letters + string.digits + '-_'
     if not all(c in allowed for c in name):
         return None
     return name.replace("-", "_")
+
 
 def build_command(filename, test, opts):
     cmd = [filename]
@@ -164,6 +167,7 @@ def build_command(filename, test, opts):
         cmd.append("-l")
     cmd.append(test)
     return cmd
+
 
 class GlobalMachine:
     def __init__(self, restrict=True, cpus=None, memory_mb=None):
@@ -308,16 +312,16 @@ def run(opts, image):
 
             for i in range(opts.batches):
                 m = GlobalMachine(restrict=not opts.enable_network, cpus=opts.nondestructive_cpus, memory_mb=opts.nondestructive_memory_mb)
-                batch_tests[i] = { "working": None, "tests": [], "time": 0, "machine": m }
+                batch_tests[i] = {"working": None, "tests": [], "time": 0, "machine": m}
                 ssh_address = "{0}:{1}".format(m.machine.ssh_address,
                                                m.machine.ssh_port)
                 web_address = "{0}:{1}".format(m.machine.web_address,
                                                m.machine.web_port)
 
                 if i == opts.batches - 1: # Last machine needs to resolve the rest
-                    batch = serial_tests[batch_size * i : ]
+                    batch = serial_tests[batch_size * i:]
                 else:
-                    batch = serial_tests[batch_size * i : batch_size * i + batch_size]
+                    batch = serial_tests[batch_size * i: batch_size * i + batch_size]
 
                 for test in batch:
                     batch_tests[i]["tests"].append(test)
@@ -352,7 +356,6 @@ def run(opts, image):
                 test.process = subprocess.Popen(["timeout", str(test.timeout)] + test.command,
                                                 stdout=test.outfile, stderr=subprocess.STDOUT)
                 running_tests.append(test)
-
 
         for test in running_tests.copy():
             poll_result = test.process.poll()

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -680,6 +680,7 @@ class _DebugOutcome(unittest.case._Outcome):
 
     This will do screenshots, HTML dumps, and sitting before cleanup handlers run.
     '''
+
     def testPartExecutor(self, test_case, isTest=False):
         # we want to do the debug actions after the test function got called (isTest==True), but before
         # TestCase.run() calls tearDown(); thus remember whether we are after isTest and already ran

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -290,12 +290,12 @@ class Browser:
     def key_press_firefox(self, keys, modifiers=0, use_ord=False):
         # https://github.com/GoogleChrome/puppeteer/blob/master/lib/USKeyboardLayout.js
         keyMap = {
-            8: "Backspace",  # Backspace key
-            9: "Tab",        # Tab key
-            13: "Enter",     # Enter key
-            27: "Escape",    # Escape key
-            40: "ArrowDown", # Arrow key down
-            45: "Insert",    # Insert key
+            8: "Backspace",   # Backspace key
+            9: "Tab",         # Tab key
+            13: "Enter",      # Enter key
+            27: "Escape",     # Escape key
+            40: "ArrowDown",  # Arrow key down
+            45: "Insert",     # Insert key
         }
         for key in keys:
             args = {"type": "keyDown", "modifiers": modifiers}
@@ -324,9 +324,9 @@ class Browser:
     def set_input_text(self, selector, val, append=False, value_check=True):
         self.focus(selector)
         if not append:
-            self.key_press("a", 2) # Ctrl + a
+            self.key_press("a", 2)  # Ctrl + a
         if val == "":
-            self.key_press("\b") # Backspace
+            self.key_press("\b")  # Backspace
         else:
             self.key_press(val)
 
@@ -1128,7 +1128,7 @@ class MachineCase(unittest.TestCase):
             syslog_ids += ["systemd-coredump"]
         messages = machine.journal_messages(syslog_ids, 6, cursor=cursor)
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:
-            messages += machine.audit_messages("14", cursor=cursor) # 14xx is selinux
+            messages += machine.audit_messages("14", cursor=cursor)  # 14xx is selinux
 
         if self.image.startswith('debian'):
             # Debian images don't have any non-C locales (mostly deliberate, to test this scenario somewhere)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1056,9 +1056,9 @@ class MachineCase(unittest.TestCase):
         # The usual sudo finger wagging
         "We trust you have received the usual lecture from the local System",
         "Administrator. It usually boils down to these three things:",
-        "#1\) Respect the privacy of others.",
-        "#2\) Think before you type.",
-        "#3\) With great power comes great responsibility.",
+        r"#1\) Respect the privacy of others.",
+        r"#2\) Think before you type.",
+        r"#3\) With great power comes great responsibility.",
     ]
 
     allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")
@@ -1144,10 +1144,10 @@ class MachineCase(unittest.TestCase):
 
         if self.image in ['debian-testing', 'ubuntu-stable']:
             # HACK: https://bugs.debian.org/951477
-            self.allowed_messages.append('Process .* \(ip6?tables\) of user 0 dumped core.*')
-            self.allowed_messages.append('Process .* \(iptables-restor\) of user 0 dumped core.*')
-            self.allowed_messages.append('Process .* \(ip6tables-resto\) of user 0 dumped core.*')
-            self.allowed_messages.append('Process .* \(ebtables\) of user 0 dumped core.*')
+            self.allowed_messages.append(r'Process .* \(ip6?tables\) of user 0 dumped core.*')
+            self.allowed_messages.append(r'Process .* \(iptables-restor\) of user 0 dumped core.*')
+            self.allowed_messages.append(r'Process .* \(ip6tables-resto\) of user 0 dumped core.*')
+            self.allowed_messages.append(r'Process .* \(ebtables\) of user 0 dumped core.*')
             # don't ignore all stack traces
             self.allowed_messages.append('^#[0-9]+ .*(nftnl|xtables-nft|__libc_start_main).*')
             # but we have to ignore that general header line

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -33,6 +33,7 @@ from testvm import VirtMachine
 AUTH_KEY = os.path.join(test_dir, "containers/files/enc_rsa")
 PUB_AUTH_KEY = "{}.pub".format(AUTH_KEY)
 
+
 class BastionContainerMachine(VirtMachine):
 
     def start_cockpit(self, *args, **kwargs):
@@ -50,7 +51,7 @@ class TestBastion(MachineCase):
     machine_class = BastionContainerMachine
 
     provision = {
-        "machine1": { "address": "10.111.113.1/20" },
+        "machine1": {"address": "10.111.113.1/20"},
     }
 
     def approve_key(self, b):
@@ -141,6 +142,7 @@ class TestBastion(MachineCase):
         b.expect_load()
         b.wait_text('#current-username', 'admin')
         b.logout()
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -25,7 +25,7 @@ test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 sys.path.append(test_dir)
 
 from verify import parent
-parent # pyflakes
+parent  # pyflakes
 
 from testlib import *
 from testvm import VirtMachine

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -30,7 +30,7 @@ testdir = os.path.dirname(base_dir)
 sys.path.append(testdir)
 
 from verify import parent
-parent # pyflakes
+parent  # pyflakes
 
 from common import testlib
 

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -34,12 +34,14 @@ parent # pyflakes
 
 from common import testlib
 
+
 def check_valid(filename):
     name = os.path.basename(filename)
     allowed = string.ascii_letters + string.digits + '-_'
     if not all(c in allowed for c in name):
         return None
     return name.replace("-", "_")
+
 
 def run(opts):
     # Now actually load the tests, any modules that start with "check-*"
@@ -57,6 +59,7 @@ def run(opts):
     # And now load new testlib, and run all the tests we got
     return testlib.test_main(options=opts, suite=suite)
 
+
 def main():
     parser = testlib.arg_parser()
     parser.add_argument('-c', '--container', dest="container", action='store',
@@ -73,6 +76,7 @@ def main():
         return 1
     else:
         return 0
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -170,7 +170,7 @@ class TestApps(PackageCase):
             b.switch_to_top()
             b.click("#navbar-dropdown")
             b.click(".display-language-menu a")
-            if self.system_before(233): # Changed in #14890
+            if self.system_before(233):  # Changed in #14890
                 b.wait_popup('display-language')
                 b.set_val("#display-language select", lang)
                 b.click("#display-language-select-button")

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -29,7 +29,7 @@ class TestApps(PackageCase):
     def setUp(self):
         super().setUp()
         self.appstream_collection = set()
-        self.machine.upload([ "verify/files/test.png" ], "/var/tmp/")
+        self.machine.upload(["verify/files/test.png"], "/var/tmp/")
 
     def createAppStreamPackage(self, name, version, revision):
         self.createPackage(name, version, revision, content={
@@ -43,7 +43,7 @@ class TestApps(PackageCase):
   <launchable type="cockpit-manifest">{0}</launchable>
 </component>
 """.format(name),
-            "/usr/share/pixmaps/test.png":  { "path": "/var/tmp/test.png" }})
+            "/usr/share/pixmaps/test.png": {"path": "/var/tmp/test.png"}})
         self.appstream_collection.add(name)
 
     def createAppStreamRepoPackage(self):
@@ -71,7 +71,7 @@ class TestApps(PackageCase):
 {0}
 </components>
             """.format(body),
-            "/usr/share/app-info/icons/test/64x64/test.png": { "path": "/var/tmp/test.png" }})
+            "/usr/share/app-info/icons/test/64x64/test.png": {"path": "/var/tmp/test.png"}})
         self.enableRepo()
         self.machine.execute("systemctl stop packagekit && pkcon refresh force")
         # ignore the corresponding journal entry

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -368,7 +368,7 @@ class TestConnection(MachineCase):
         output = m.execute('! openssl s_client -connect 172.27.0.15:9090 -tls1_2 -cipher RC4 2>&1')
         self.assertNotIn("DONE", output)
         self.assertRegex(
-            output, "no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
+            output, r"no cipher match|no ciphers available|ssl handshake failure|Cipher is \(NONE\)")
 
         # get along with read-only config directory, as long as certificate exists
         # this does not work on coreos as the user/group IDs are not mapped correctly

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -314,7 +314,7 @@ class TestConnection(MachineCase):
             self.assertLess(active, 110)
         failed = int(m.execute("systemctl --no-legend list-units --state=failed 'cockpit-wsinstance-https@*' | wc -l").strip())
         self.assertGreater(failed, 0)
-        self.assertLess(failed, 60) # services and sockets
+        self.assertLess(failed, 60)  # services and sockets
 
         self.allow_journal_messages(".*cockpit-ws.*dumped core.*")
         self.allow_journal_messages(".*Error creating thread: Resource temporarily unavailable.*")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -394,7 +394,7 @@ class TestConnection(MachineCase):
         check_cert_chain()
 
         # *.crt file also works
-        m.execute ("mv /etc/cockpit/ws-certs.d/cert-chain.cert /etc/cockpit/ws-certs.d/cert-chain.crt")
+        m.execute("mv /etc/cockpit/ws-certs.d/cert-chain.cert /etc/cockpit/ws-certs.d/cert-chain.crt")
         check_cert_chain()
 
         # separate *.key file instead of merged .cert
@@ -669,22 +669,22 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         cases = [(['/cockpit/@localhost/system/index.html', 'system', 'system/index', 'system/'],
                   ['id="overview"']
-                 ),
+                  ),
                  (['/cockpit/@localhost/network/firewall.html', 'network/firewall'],
                   ['div id="firewall"', 'script src="firewall.js"']
-                 ),
+                  ),
                  (['/cockpit/@localhost/playground/react-patterns.html', 'playground/react-patterns'],
                   ['script src="react-patterns.js"']
-                 ),
+                  ),
                  # no ssh host
                  (['/cockpit/@localhost/manifests.json'],
                   ['"system"', '"Overview"']
-                 ),
+                  ),
                  # remote ssh host
                  (['/cockpit/@localhost/manifests.json test1@localhost'],
                   ['"system"', '"Overview"', '"HACK"']
-                 )
-                ]
+                  )
+                 ]
 
         # prepare fake ssh target; to verify that we really use that, fake dashboard manifest
         m.execute("""set -e; useradd test1
@@ -854,7 +854,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
 class TestReverseProxy(MachineCase):
 
     provision = {
-        "0": {"forward": {"443": 8443 }}
+        "0": {"forward": {"443": 8443}}
     }
 
     def setUp(self):
@@ -879,11 +879,11 @@ ProtocolHeader = X-Forwarded-Proto
         # should use nginx' certificate, not cockpit's; use --resolve so that SNI matches the certificate's CN
         (https_host, https_port) = self.machine.forward["443"].split(':')
         out = subprocess.check_output(
-                ["curl", "--verbose", "--head",
-                 "--resolve", "alice:%s:%s" % (https_port, https_host),
-                 "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
-                 "https://alice:%s/cockpit/static/login.html" % https_port],
-                stderr=subprocess.STDOUT)
+            ["curl", "--verbose", "--head",
+             "--resolve", "alice:%s:%s" % (https_port, https_host),
+             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
+             "https://alice:%s/cockpit/static/login.html" % https_port],
+            stderr=subprocess.STDOUT)
         self.assertIn(b"HTTP/1.1 200 OK", out)
         self.assertIn(b"subject: CN=alice; DC=COCKPIT", out)
 

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -58,7 +58,7 @@ class TestXHRProxy(MachineCase):
         b = self.browser
 
         # set up served directory
-        httpdir = self.vm_tmpdir + "/root";
+        httpdir = self.vm_tmpdir + "/root"
         m.execute("mkdir {0} && echo world > {0}/hello.txt".format(httpdir))
         # start webserver
         pid = m.spawn("cd %s && exec python3 -m http.server 12345" % httpdir, "httpserver")
@@ -111,7 +111,7 @@ class TestLongRunning(MachineCase):
         b.wait_text("#output", "")
 
         # run a command that the test can control synchronously
-        ack_file = self.vm_tmpdir + "/ack_a";
+        ack_file = self.vm_tmpdir + "/ack_a"
         b.set_val("#command", "date; echo STEP_A; until [ -e %s ]; do sleep 1; done; echo STEP_B; sleep 1; echo DONE" % ack_file)
         b.wait_text("button#run", "Start")
         b.click("button#run")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -93,7 +93,7 @@ class TestKdump(MachineCase):
             assertActive(False)
 
         # there shouldn't be any crash reports in the target directory
-        self.assertEqual(m.execute("""find "/var/crash" -maxdepth 1 -mindepth 1 -type d -exec echo {} \;"""), "")
+        self.assertEqual(m.execute("find /var/crash -maxdepth 1 -mindepth 1 -type d"), "")
 
         self.enableKdump()
         self.rebootMachine()
@@ -177,8 +177,7 @@ class TestKdump(MachineCase):
         b.wait_in_text("div.curtains-ct h1", "Disconnected")
         m.disconnect()
         m.wait_boot(timeout_sec=300)
-        self.assertNotEqual(
-            m.execute("""find "{0}" -maxdepth 1 -mindepth 1 -type d -exec echo {{}} \;""".format(customPath)), "")
+        self.assertNotEqual(m.execute(f"find '{customPath}' -maxdepth 1 -mindepth 1 -type d"), "")
 
     @nondestructive
     def testConfiguration(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -177,9 +177,6 @@ class TestKdump(MachineCase):
         b.wait_in_text("div.curtains-ct h1", "Disconnected")
         m.disconnect()
         m.wait_boot(timeout_sec=300)
-        #b.click("#machine-reconnect")
-        #b.expect_load()
-        #b.wait_visible("#login")
         self.assertNotEqual(
             m.execute("""find "{0}" -maxdepth 1 -mindepth 1 -type d -exec echo {{}} \;""".format(customPath)), "")
 

--- a/test/verify/check-machines-consoles
+++ b/test/verify/check-machines-consoles
@@ -21,6 +21,7 @@ import parent
 from machineslib import *
 from testlib import *
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 @no_retry_when_changed
@@ -56,7 +57,6 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.reload()
         b.enter_page("/machines")
         b.wait_in_text("body", "Virtual machines")
-
 
     def testInlineConsole(self, urlroot=""):
         b = self.browser

--- a/test/verify/check-machines-consoles
+++ b/test/verify/check-machines-consoles
@@ -36,15 +36,15 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running") # running or paused
+        b.wait_in_text("#vm-subVmTest1-state", "Running")  # running or paused
         self.goToVmPage("subVmTest1")
 
         # since VNC is not defined for this VM, the view for "Desktop Viewer" is rendered by default
         b.wait_in_text(".pf-c-console__manual-connection dl > div:first-child dd", "127.0.0.1")
         b.wait_in_text(".pf-c-console__manual-connection dl > div:nth-child(2) dd", "5900")
 
-        b.click(".pf-c-console__remote-viewer-launch-vv") # "Launch Remote Viewer" button
-        b.wait_visible("#dynamically-generated-file") # is .vv file generated for download?
+        b.click(".pf-c-console__remote-viewer-launch-vv")  # "Launch Remote Viewer" button
+        b.wait_visible("#dynamically-generated-file")  # is .vv file generated for download?
         self.assertEqual(b.attr("#dynamically-generated-file", "href"),
                          u"data:application/x-virt-viewer,%5Bvirt-viewer%5D%0Atype%3Dspice%0Ahost%3D127.0.0.1%0Aport%3D5900%0Adelete-this-file%3D1%0Afullscreen%3D0%0A")
 
@@ -70,7 +70,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow("subVmTest1")
 
-        b.wait_in_text("#vm-subVmTest1-state", "Running") # running or paused
+        b.wait_in_text("#vm-subVmTest1-state", "Running")  # running or paused
         self.goToVmPage("subVmTest1")
 
         # since VNC is defined for this VM, the view for "In-Browser Viewer" is rendered by default
@@ -97,7 +97,7 @@ class TestMachinesConsoles(VirtualMachinesCase):
         self.waitVmRow(name)
 
         self.goToVmPage(name)
-        b.wait_in_text("#vm-{0}-state".format(name), "Running") # running or paused
+        b.wait_in_text("#vm-{0}-state".format(name), "Running")  # running or paused
 
         b.click("#pf-c-console__type-selector")
         b.wait_visible("#pf-c-console__type-selector + .pf-c-select__menu")

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -28,6 +28,7 @@ from machineslib import *
 from testlib import *
 from machinesxmls import *
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 @no_retry_when_changed
@@ -429,9 +430,9 @@ class TestMachinesCreate(VirtualMachinesCase):
         # define again the default storage pool for system connection
         # we need so that the UI will know the remaining available space when we use that pool's path
         cmds = [
-                "virsh pool-define-as default --type dir --target /var/lib/libvirt/images",
-                "virsh pool-start default"
-                ]
+            "virsh pool-define-as default --type dir --target /var/lib/libvirt/images",
+            "virsh pool-start default"
+        ]
         self.machine.execute(" && ".join(cmds))
 
         self.browser.reload()
@@ -530,7 +531,6 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                                          env_is_empty=False), {"vm-name": "already exists"})
 
         self.machine.execute("virsh undefine existing-name")
-
 
         runner.createTest(TestMachinesCreate.VmDialog(self, sourceType='url',
                                                       location=config.VALID_URL,
@@ -1163,7 +1163,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             # adjust to how cockpit_format_bytes() formats sizes > 1024 MiB -- this depends on how much RAM
             # the host has (less or more than 1 GiB), and thus needs to be dynamic
             if dialog.memory_size >= 1024 and dialog.memory_size_unit == "MiB":
-                memory_text = "/ " + ("%.1f" % (dialog.memory_size/1024)).rstrip('.0') + " GiB"
+                memory_text = "/ " + ("%.1f" % (dialog.memory_size / 1024)).rstrip('.0') + " GiB"
             else:
                 memory_text = "/ " + ("%.1f" % dialog.memory_size).rstrip('.0') + " %s" % dialog.memory_size_unit
             b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", memory_text)
@@ -1227,8 +1227,8 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.machine.execute("until test -z $(ls /home/admin/.local/share/libvirt/images/ 2>/dev/null); do sleep 1; done")
 
             alerts = self.browser.call_js_func("ph_count", ".pf-c-alert-group li")
-            for i  in range(alerts):
-                    b.click(".pf-c-alert-group li:first-of-type .pf-c-alert .pf-c-button")
+            for i in range(alerts):
+                b.click(".pf-c-alert-group li:first-of-type .pf-c-alert .pf-c-button")
 
             b.wait_not_present(".pf-c-alert-group li .pf-c-alert")
 
@@ -1262,7 +1262,7 @@ class TestMachinesCreate(VirtualMachinesCase):
 
             if dialog.delete:
                 self._deleteVm(dialog) \
-                      .checkEnvIsEmpty()
+                    .checkEnvIsEmpty()
 
         def cancelDialogTest(self, dialog):
             dialog.open() \
@@ -1284,7 +1284,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                 .createAndVerifyVirtInstallArgsCloudInit()
             if dialog.delete:
                 self._deleteVm(dialog) \
-                      .checkEnvIsEmpty()
+                    .checkEnvIsEmpty()
 
         def createDownloadAnOSTest(self, dialog):
             dialog.open() \
@@ -1292,7 +1292,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                 .createAndVerifyVirtInstallArgsUnattended()
             if dialog.delete:
                 self._deleteVm(dialog) \
-                      .checkEnvIsEmpty()
+                    .checkEnvIsEmpty()
 
         def checkPXENotAvailableSessionTest(self, dialog):
             dialog.open() \
@@ -1303,10 +1303,10 @@ class TestMachinesCreate(VirtualMachinesCase):
 
         def createThenInstallTest(self, dialog, installFromVmDetails=False, tryWithFailInstall=False):
             self._tryCreateThenInstall(dialog, installFromVmDetails, tryWithFailInstall) \
-                  ._assertScriptFinished() \
-                  ._assertDomainDefined(dialog.name, dialog.connection) \
-                  ._deleteVm(dialog) \
-                  .checkEnvIsEmpty()
+                ._assertScriptFinished() \
+                ._assertDomainDefined(dialog.name, dialog.connection) \
+                ._deleteVm(dialog) \
+                .checkEnvIsEmpty()
 
         def checkDialogErrorTest(self, dialog, errors):
             dialog.open() \
@@ -1326,14 +1326,14 @@ class TestMachinesCreate(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
 
-        dialog = TestMachinesCreate.VmDialog(self,sourceType='file',
+        dialog = TestMachinesCreate.VmDialog(self, sourceType='file',
                                              name="VmNotInstalled",
                                              location=TestMachinesCreate.TestCreateConfig.NOVELL_MOCKUP_ISO_PATH,
                                              memory_size=256, memory_size_unit='MiB',
                                              storage_size=256, storage_size_unit='MiB',
                                              start_vm=False)
         dialog.open() \
-                .fill() \
+            .fill() \
 
         b.click(".pf-c-modal-box__footer button:contains(Create)")
         b.wait_not_present("#create-vm-dialog")

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -631,7 +631,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                      check_script_finished=True,
                      connection=None):
 
-            TestMachinesCreate.VmDialog.vmId += 1 # This variable is static - don't use self here
+            TestMachinesCreate.VmDialog.vmId += 1  # This variable is static - don't use self here
 
             if name is None:
                 self.name = 'subVmTestCreate' + str(TestMachinesCreate.VmDialog.vmId)
@@ -854,7 +854,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             else:
                 b.wait_visible("#start-vm")
                 if not self.start_vm:
-                    b.click("#start-vm") # TODO: fix this, do not assume initial state of the checkbox
+                    b.click("#start-vm")  # TODO: fix this, do not assume initial state of the checkbox
 
             if (self.connection):
                 b.set_checked("#connectionName-{0}".format(self.connection), True)
@@ -1435,7 +1435,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         # Wait for virt-install to define the VM and then stop it - otherwise we get 'domain is ready being removed' error
         wait(lambda: "VmNotInstalled" in m.execute("virsh list --persistent"), delay=3)
         logfile = "/var/log/libvirt/qemu/VmNotInstalled.log"
-        m.execute("> {0}".format(logfile)) # clear logfile
+        m.execute("> {0}".format(logfile))  # clear logfile
         self.performAction("VmNotInstalled", "forceOff", False)
         if m.image not in ["fedora-33", "fedora-34", "fedora-testing", "debian-testing"]:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1818089
@@ -1444,7 +1444,7 @@ class TestMachinesCreate(VirtualMachinesCase):
             wait(lambda: "char device" in self.machine.execute("cat {0}".format(logfile)), delay=3)
             self.performAction("VmNotInstalled", "forceOff", False)
         b.wait_in_text("#vm-VmNotInstalled-state", "Shut off")
-        wait(lambda: "307200" in m.execute("virsh dominfo VmNotInstalled | grep 'Used memory'"), delay=1) # Wait until memory parameters get adjusted after shutting the VM
+        wait(lambda: "307200" in m.execute("virsh dominfo VmNotInstalled | grep 'Used memory'"), delay=1)  # Wait until memory parameters get adjusted after shutting the VM
 
         # Check configuration changes survived installation
         # Check memory settings have persisted

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -446,11 +446,11 @@ class TestMachinesCreate(VirtualMachinesCase):
                                                       start_vm=False,
                                                       connection='session'))
         cmds = [
-            "mkdir -p /var/lib/libvirt/pools/tmp\ pool; chmod a+rwx /var/lib/libvirt/pools/tmp\ pool",
-            "virsh pool-define-as tmp\ pool --type dir --target /var/lib/libvirt/pools/tmp\ pool",
-            "virsh pool-start tmp\ pool",
-            "qemu-img create -f qcow2 /var/lib/libvirt/pools/tmp\ pool/vmTmpDestination.qcow2 128M",
-            "virsh pool-refresh tmp\ pool"
+            "mkdir -p '/var/lib/libvirt/pools/tmp pool'; chmod a+rwx '/var/lib/libvirt/pools/tmp pool'",
+            "virsh pool-define-as 'tmp pool' --type dir --target '/var/lib/libvirt/pools/tmp pool'",
+            "virsh pool-start 'tmp pool'",
+            "qemu-img create -f qcow2 '/var/lib/libvirt/pools/tmp pool/vmTmpDestination.qcow2' 128M",
+            "virsh pool-refresh 'tmp pool'"
         ]
         self.machine.execute(" && ".join(cmds))
 
@@ -689,7 +689,7 @@ class TestMachinesCreate(VirtualMachinesCase):
                 query_result = '{0}'.format(self.os_name)
                 # throws exception if grep fails
                 self.machine.execute(
-                    "osinfo-query os --fields=name | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g' | grep '{0}'".format(
+                    r"osinfo-query os --fields=name | tail -n +3 | sed -e 's/\s*|\s*/|/g; s/^\s*//g; s/\s*$//g' | grep '{0}'".format(
                         query_result))
 
             return self
@@ -755,7 +755,8 @@ class TestMachinesCreate(VirtualMachinesCase):
             self.browser.wait_text("#vm-{}-disks-sda-device".format(self.name), "cdrom")
             self.goToMainPage()
 
-            virt_install_cmd = "ps aux | grep 'virt\-install\ \-\-connect'"
+            # usual tricks: prevent grep from seeing itself in the output of ps
+            virt_install_cmd = "ps aux | grep '[v]irt-install --connect'"
 
             wait(lambda: self.machine.execute(virt_install_cmd), delay=3)
             virt_install_cmd_out = self.machine.execute(virt_install_cmd)
@@ -769,7 +770,8 @@ class TestMachinesCreate(VirtualMachinesCase):
                 self.browser.wait_text("#vm-{}-disks-vda-bus".format(self.name), "virtio")
                 self.goToMainPage()
 
-            virt_install_cmd = "ps aux | grep 'virt\-install\ \-\-connect'"
+            # usual tricks: prevent grep from seeing itself in the output of ps
+            virt_install_cmd = "ps aux | grep '[v]irt-install --connect'"
             wait(lambda: self.machine.execute(virt_install_cmd), delay=3)
             virt_install_cmd_out = self.machine.execute(virt_install_cmd)
             self.assertIn("--install os={}".format(self.os_short_id), virt_install_cmd_out)

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -23,6 +23,7 @@ import parent
 from machineslib import *
 from testlib import *
 
+
 def get_next_free_target(used_targets):
     i = 0
     while ("vd" + chr(97 + i) in used_targets):
@@ -30,6 +31,7 @@ def get_next_free_target(used_targets):
 
     used_targets.append("vd" + chr(97 + i))
     return used_targets
+
 
 def release_target(used_targets, target):
     used_targets.remove(target)
@@ -211,7 +213,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_visible("#vm-subVmTest1-disks-vda-device")
         b.wait_not_present("#vm-subVmTest1-disks-vdc-device")
 
-        # Check when no storage pool and adding existed disk 
+        # Check when no storage pool and adding existed disk
         # delete the default pool
         m.execute("virsh pool-destroy images && virsh pool-undefine images")
         # Open "add disk" dialog

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -46,7 +46,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b = self.browser
         try:
             with b.wait_timeout(10):
-                b.wait_visible("#vm-{0}-disks-{1}-used".format(name, target)) # wait for disk statistics to show up
+                b.wait_visible("#vm-{0}-disks-{1}-used".format(name, target))  # wait for disk statistics to show up
         except Error as ex:
             if not ex.msg.startswith('timeout'):
                 raise
@@ -64,7 +64,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         p1 = os.path.join(self.vm_tmpdir, "vm_one")
         m.execute("mkdir --mode 777 {0}".format(p1))
         m.execute("virsh pool-create-as myPoolOne --type dir --target {0}".format(p1))
-        m.execute("virsh vol-create-as myPoolOne mydisk --capacity 100M --format raw") # raw support shareable
+        m.execute("virsh vol-create-as myPoolOne mydisk --capacity 100M --format raw")  # raw support shareable
         m.execute("virsh vol-create-as myPoolOne mydisk2 --capacity 100M --format raw")
         m.execute("virsh vol-create-as myPoolOne mydisk3 --capacity 100M --format qcow2")
         wait(lambda: "mydisk" in m.execute("virsh vol-list myPoolOne"))
@@ -203,7 +203,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         self.wait_for_disk_stats("subVmTest1", "vdc")
         if b.is_present("#vm-subVmTest1-disks-vdc-used"):
             b.wait_in_text("#vm-subVmTest1-disks-vdc-used", "0.00")
-            b.wait_in_text("#vm-subVmTest1-disks-vdc-capacity", "0.13") # 128 MB
+            b.wait_in_text("#vm-subVmTest1-disks-vdc-capacity", "0.13")  # 128 MB
 
         # Test remove disk - by external action
         m.execute("virsh detach-disk subVmTest1 vdc")
@@ -273,7 +273,7 @@ class TestMachinesDisks(VirtualMachinesCase):
 
         def open(self):
             b = self.test_obj.browser
-            b.click("#vm-{0}-disks-adddisk".format(self.vm_name)) # button
+            b.click("#vm-{0}-disks-adddisk".format(self.vm_name))  # button
             b.wait_in_text(".pf-c-modal-box__title", "Add disk")
 
             b.wait_visible("label:contains(Create new)")
@@ -367,7 +367,7 @@ class TestMachinesDisks(VirtualMachinesCase):
                 self.test_obj.togglePoolRow(self.pool_name)
 
                 b.wait_visible("#pool-{0}-system-storage-volumes".format(self.pool_name))
-                b.click("#pool-{0}-system-storage-volumes".format(self.pool_name)) # open the "Storage volumes" subtab
+                b.click("#pool-{0}-system-storage-volumes".format(self.pool_name))  # open the "Storage volumes" subtab
                 b.wait_visible("#pool-{0}-system-volume-{1}-name".format(self.pool_name, self.volume_name))
 
                 b.click(".machines-listing-breadcrumb li a:contains(Virtual machines)")
@@ -658,7 +658,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         b.wait_in_text("#card-pf-storage-pools .active-resources:nth-of-type(2)", "0")
 
         self.goToVmPage('subVmTest1')
-        b.click("#vm-subVmTest1-disks-adddisk") # radio button label in modal dialog
+        b.click("#vm-subVmTest1-disks-adddisk")  # radio button label in modal dialog
         b.wait_visible("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
         b.click("label:contains(Use existing)")
         b.wait_visible("#vm-subVmTest1-disks-adddisk-dialog-add:disabled")
@@ -870,7 +870,7 @@ class TestMachinesDisks(VirtualMachinesCase):
         removeDiskAndChecks("vdf")
 
         # Test detaching disk of a paused domain
-        m.execute("> {0}".format(args["logfile"])) # clear logfile
+        m.execute("> {0}".format(args["logfile"]))  # clear logfile
         m.execute("virsh start subVmTest1")
         # Make sure that the VM booted normally before attempting to suspend it
         wait(lambda: "Linux version" in m.execute("cat {0}".format(args["logfile"])), delay=3)

--- a/test/verify/check-machines-disks
+++ b/test/verify/check-machines-disks
@@ -385,7 +385,7 @@ class TestMachinesDisks(VirtualMachinesCase):
                 if expected_format == "unknown" and m.execute("virsh --version") >= "5.6.0":
                     m.execute(detect_format_cmd.format(volume_xml, "/volume/target") + " | grep -qv format")
                 else:
-                    vol_xml = m.execute(detect_format_cmd.format(volume_xml, "/volume/target/format")).rstrip();
+                    vol_xml = m.execute(detect_format_cmd.format(volume_xml, "/volume/target/format")).rstrip()
                     self.test_obj.assertEqual(vol_xml, '<format type="{0}"/>'.format(self.volume_format or expected_format))
             else:
                 b.wait_in_text('#vm-{0}-disks-{1}-source-file'.format(self.vm_name, self.expected_target), self.file_path)

--- a/test/verify/check-machines-lifecycle
+++ b/test/verify/check-machines-lifecycle
@@ -74,7 +74,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         b.wait_in_text("#vm-subVmTest1-boot-order", "disk,network")
         emulated_machine = b.text("#vm-subVmTest1-emulated-machine")
-        self.assertTrue(len(emulated_machine) > 0) # emulated machine varies across test machines
+        self.assertTrue(len(emulated_machine) > 0)  # emulated machine varies across test machines
 
         # switch to and check Usage
         b.click("#vm-subVmTest1-usage")
@@ -261,7 +261,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         m.execute("systemctl stop {0}".format(libvirtServiceName))
         b.wait_in_text(".pf-c-empty-state", "Virtualization service (libvirt) is not active")
         b.wait_visible("#enable-libvirt:checked")
-        b.click("#enable-libvirt") # uncheck it ; ; TODO: fix this, do not assume initial state of the checkbox
+        b.click("#enable-libvirt")  # uncheck it ; ; TODO: fix this, do not assume initial state of the checkbox
         b.click(".pf-c-empty-state button.pf-m-primary")  # Start libvirt
         b.wait(lambda: not checkLibvirtEnabled())
         b.wait_in_text("body", "Virtual machines")
@@ -308,9 +308,9 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         def addDisk(volName, poolName):
             # Virsh does not offer some option to create disks of type volume
             # We have to do this from cockpit UI
-            b.click("#vm-subVmTest1-disks-adddisk") # button
+            b.click("#vm-subVmTest1-disks-adddisk")  # button
             b.wait_visible("#vm-subVmTest1-disks-adddisk-dialog-modal-window")
-            b.wait_visible("label:contains(Create new)") # radio button label in the modal dialog
+            b.wait_visible("label:contains(Create new)")  # radio button label in the modal dialog
 
             b.select_from_dropdown("#vm-subVmTest1-disks-adddisk-new-select-pool", poolName)
             b.set_input_text("#vm-subVmTest1-disks-adddisk-new-name", volName)

--- a/test/verify/check-machines-lifecycle
+++ b/test/verify/check-machines-lifecycle
@@ -23,6 +23,7 @@ import parent
 from machineslib import *
 from testlib import *
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 @no_retry_when_changed
@@ -125,7 +126,7 @@ class TestMachinesLifecycle(VirtualMachinesCase):
 
         # continue shut off validation - usage should drop to zero
         b.wait_in_text(".memory-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0 /")
-        b.wait_in_text(".vcpu-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0%" )
+        b.wait_in_text(".vcpu-usage-chart .pf-c-progress__status > .pf-c-progress__measure", "0%")
 
         # shut off of a transient VM will redirect us to the main page
         m.execute("virsh dumpxml subVmTest1 > /tmp/subVmTest1.xml")
@@ -299,7 +300,6 @@ class TestMachinesLifecycle(VirtualMachinesCase):
         self.login_and_go("/machines")
         b.wait_in_text("body", "Virtual machines")
         self.waitVmRow(name)
-
 
         m.execute("test -f {0}".format(img2))
 

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -26,7 +26,7 @@ from machinesxmls import *
 def getNetworkDevice(m):
     net_devices_str = m.execute("virsh iface-list")
     net_devices_str = net_devices_str.split("\n", 2)[2] # Remove first 2 lines of table header
-    if not net_devices_str in ["\n", "\r\n"]:
+    if net_devices_str not in ["\n", "\r\n"]:
         device = net_devices_str.split(' ', 2)[1] # Get the name of device, ignoring spacing before device string
     else: # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
         net_devices_str = m.execute("virsh nodedev-list net")
@@ -299,9 +299,9 @@ class TestMachinesNetworks(VirtualMachinesCase):
                         if self.ipv6_dhcp_start and self.ipv6_dhcp_start:
                             b.wait_in_text("#network-{0}-{1}-ipv6-dhcp-range".format(self.name, connectionName), self.ipv6_dhcp_start + " - " + self.ipv6_dhcp_end)
 
-                    if not "4" in self.ip_conf:
+                    if "4" not in self.ip_conf:
                         b.wait_not_present("#network-{0}-{1}-ipv4-address".format(self.name, connectionName))
-                    if not "6" in self.ip_conf:
+                    if "6" not in self.ip_conf:
                         b.wait_not_present("#network-{0}-{1}-ipv6-address".format(self.name, connectionName))
                 else:
                     b.wait_not_present("#network-{0}-{1}-ipv4-address".format(self.name, connectionName))

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -22,6 +22,7 @@ from machineslib import *
 from testlib import *
 from machinesxmls import *
 
+
 def getNetworkDevice(m):
     net_devices_str = m.execute("virsh iface-list")
     net_devices_str = net_devices_str.split("\n", 2)[2]; # Remove first 2 lines of table header
@@ -33,6 +34,7 @@ def getNetworkDevice(m):
         device = net_devices_str.split("_", 2)[1]; # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
 
     return device
+
 
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
@@ -273,7 +275,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
             def verify_overview(self):
                 # Check basic network properties
                 modes = {"nat": "NAT", "none": "None (isolated network)", "open": "Open", "route": "Routed", \
-                "bridge": "Bridge", "private": "Private", "vepa": "VEPA", "passthrough": "Passthrough", "hostdev": "Hostdev"}
+                         "bridge": "Bridge", "private": "Private", "vepa": "VEPA", "passthrough": "Passthrough", "hostdev": "Hostdev"}
                 connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
                 b.wait_in_text("#network-{0}-{1}-forwarding".format(self.name, connectionName), modes[self.forward_mode])
@@ -310,7 +312,6 @@ class TestMachinesNetworks(VirtualMachinesCase):
                     m.execute("virsh net-destroy {}".format(self.name))
                 m.execute("virsh net-undefine {0}".format(self.name))
 
-
         # Test various forward Modes
         duplicated_net = NetworkCreateDialog(
             self,
@@ -321,7 +322,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv4_netmask="255.255.255.0",
             remove=False,
             activate=True,
-            )
+        )
         duplicated_net.execute()
 
         # XFail: Activate a network which has a same ipv4 address with last one
@@ -411,8 +412,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv6_dhcp_end="",
             xfail=True,
             xfail_objects = ["name", "ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end", \
-            "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
-            xfail_error = "should not be empty",
+                            "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
+            xfail_error="should not be empty",
         ).execute()
 
         # Check "Invalid..." (invalid IP format or prefix length)
@@ -431,8 +432,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv6_dhcp_end="fd00:e81d:a6d7:55::1:1:1:1:1:1:1:1",
             xfail=True,
             xfail_objects = ["ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end", \
-            "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
-            xfail_error = "Invalid",
+                            "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
+            xfail_error="Invalid",
         ).execute()
 
         # Check "Address not within subnet"
@@ -450,8 +451,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv6_dhcp_start="fd00:e81d:a6d7:54::100",
             ipv6_dhcp_end="ad00:e81d:a6d7:55::100",
             xfail=True,
-            xfail_objects = ["ipv4_dhcp_start", "ipv4_dhcp_end", "ipv6_dhcp_start", "ipv6_dhcp_end"],
-            xfail_error = "Address not within subnet",
+            xfail_objects=["ipv4_dhcp_start", "ipv4_dhcp_end", "ipv6_dhcp_start", "ipv6_dhcp_end"],
+            xfail_error="Address not within subnet",
         ).execute()
 
         # Test network devices
@@ -477,8 +478,8 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv4_dhcp_start="192.168.100.0",
             ipv4_dhcp_end="191.168.100.255",
             xfail=True,
-            xfail_objects = ["ipv4_dhcp_start", "ipv4_dhcp_end"],
-            xfail_error = "Address not within subnet",
+            xfail_objects=["ipv4_dhcp_start", "ipv4_dhcp_end"],
+            xfail_error="Address not within subnet",
         ).execute()
 
     def testNetworkSettings(self):

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -25,13 +25,13 @@ from machinesxmls import *
 
 def getNetworkDevice(m):
     net_devices_str = m.execute("virsh iface-list")
-    net_devices_str = net_devices_str.split("\n", 2)[2]; # Remove first 2 lines of table header
+    net_devices_str = net_devices_str.split("\n", 2)[2] # Remove first 2 lines of table header
     if not net_devices_str in ["\n", "\r\n"]:
         device = net_devices_str.split(' ', 2)[1] # Get the name of device, ignoring spacing before device string
     else: # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
         net_devices_str = m.execute("virsh nodedev-list net")
-        net_devices_str = net_devices_str.split("\n", 2)[0];
-        device = net_devices_str.split("_", 2)[1]; # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
+        net_devices_str = net_devices_str.split("\n", 2)[0]
+        device = net_devices_str.split("_", 2)[1] # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
 
     return device
 
@@ -274,7 +274,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
 
             def verify_overview(self):
                 # Check basic network properties
-                modes = {"nat": "NAT", "none": "None (isolated network)", "open": "Open", "route": "Routed", \
+                modes = {"nat": "NAT", "none": "None (isolated network)", "open": "Open", "route": "Routed",
                          "bridge": "Bridge", "private": "Private", "vepa": "VEPA", "passthrough": "Passthrough", "hostdev": "Hostdev"}
                 connectionName = m.execute("virsh uri | head -1 | cut -d/ -f4").strip()
 
@@ -411,7 +411,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv6_dhcp_start="",
             ipv6_dhcp_end="",
             xfail=True,
-            xfail_objects = ["name", "ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end", \
+            xfail_objects=["name", "ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end",
                             "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
             xfail_error="should not be empty",
         ).execute()
@@ -431,7 +431,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
             ipv6_dhcp_start="fd00:e81d:a6d7:55:::100",
             ipv6_dhcp_end="fd00:e81d:a6d7:55::1:1:1:1:1:1:1:1",
             xfail=True,
-            xfail_objects = ["ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end", \
+            xfail_objects=["ipv4_address", "ipv4_netmask", "ipv4_dhcp_start", "ipv4_dhcp_end",
                             "ipv6_address", "ipv6_prefix", "ipv6_dhcp_start", "ipv6_dhcp_end"],
             xfail_error="Invalid",
         ).execute()

--- a/test/verify/check-machines-networks
+++ b/test/verify/check-machines-networks
@@ -25,13 +25,13 @@ from machinesxmls import *
 
 def getNetworkDevice(m):
     net_devices_str = m.execute("virsh iface-list")
-    net_devices_str = net_devices_str.split("\n", 2)[2] # Remove first 2 lines of table header
+    net_devices_str = net_devices_str.split("\n", 2)[2]  # Remove first 2 lines of table header
     if net_devices_str not in ["\n", "\r\n"]:
-        device = net_devices_str.split(' ', 2)[1] # Get the name of device, ignoring spacing before device string
-    else: # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
+        device = net_devices_str.split(' ', 2)[1]  # Get the name of device, ignoring spacing before device string
+    else:  # If $virsh-iface list did not return any device, check virsh nodedev-list net:noh
         net_devices_str = m.execute("virsh nodedev-list net")
         net_devices_str = net_devices_str.split("\n", 2)[0]
-        device = net_devices_str.split("_", 2)[1] # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
+        device = net_devices_str.split("_", 2)[1]  # Ignore prefix (example: net_enp0s31f6_8c_16_45_5f_77_34)
 
     return device
 
@@ -113,10 +113,10 @@ class TestMachinesNetworks(VirtualMachinesCase):
         # Transient network
         self.toggleNetworkRow("test_network4", connectionName)
         b.wait_in_text("#network-test_network4-{0}-persistent".format(connectionName), "no")
-        b.wait_not_present("#network-test_network4-{0}-autostart-checkbox".format(connectionName)) # Transient network shouldn't have autostart option
-        b.wait_visible('#delete-network-test_network4-{0}:disabled'.format(connectionName)) # Transient network cannot be deleted
-        b.click('#deactivate-network-test_network4-{0}'.format(connectionName)) # Deactivate transient network
-        self.waitNetworkRow("test_network4", connectionName, False) # Check it's not present after deactivation
+        b.wait_not_present("#network-test_network4-{0}-autostart-checkbox".format(connectionName))  # Transient network shouldn't have autostart option
+        b.wait_visible('#delete-network-test_network4-{0}:disabled'.format(connectionName))  # Transient network cannot be deleted
+        b.click('#deactivate-network-test_network4-{0}'.format(connectionName))  # Deactivate transient network
+        self.waitNetworkRow("test_network4", connectionName, False)  # Check it's not present after deactivation
 
     def testNetworksCreate(self):
         b = self.browser
@@ -699,7 +699,7 @@ class TestMachinesNetworks(VirtualMachinesCase):
         b.wait_visible("#network-test_network2-{0}-autostart-checkbox".format(connectionName))
 
         # set checkbox state and check state of checkbox
-        b.set_checked("#network-test_network2-{0}-autostart-checkbox".format(connectionName), True) # don't know the initial state of checkbox, so set it to checked
+        b.set_checked("#network-test_network2-{0}-autostart-checkbox".format(connectionName), True)  # don't know the initial state of checkbox, so set it to checked
         b.wait_visible("#network-test_network2-{0}-autostart-checkbox:checked".format(connectionName))
         # check virsh state
         autostartState = m.execute("virsh net-info test_network2 | grep 'Autostart:' | awk '{print $2}'").strip()

--- a/test/verify/check-machines-nics
+++ b/test/verify/check-machines-nics
@@ -82,7 +82,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         self.goToVmPage("subVmTest1")
 
         # No NICs present
-        b.wait_visible("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
+        b.wait_visible("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
 
         self.NICAddDialog(
             self,
@@ -110,7 +110,7 @@ class TestMachinesNICs(VirtualMachinesCase):
         ).execute()
 
         # Start vm and wait until kernel is booted
-        m.execute("> {0}".format(args["logfile"])) # clear logfile
+        m.execute("> {0}".format(args["logfile"]))  # clear logfile
         b.click("#vm-subVmTest1-run")
         b.wait_in_text("#vm-subVmTest1-state", "Running")
         wait(lambda: "Linux version" in self.machine.execute("cat {0}".format(args["logfile"])), delay=3)
@@ -217,7 +217,7 @@ class TestMachinesNICs(VirtualMachinesCase):
                 self.cleanup()
 
         def open(self):
-            self.browser.click("#vm-subVmTest1-add-iface-button") # open the Network Interfaces subtab
+            self.browser.click("#vm-subVmTest1-add-iface-button")  # open the Network Interfaces subtab
             self.browser.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Add virtual network interface")
 
         def fill(self):

--- a/test/verify/check-machines-nics
+++ b/test/verify/check-machines-nics
@@ -22,6 +22,7 @@ from machineslib import *
 from testlib import *
 from machinesxmls import *
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 @no_retry_when_changed
@@ -294,6 +295,7 @@ class TestMachinesNICs(VirtualMachinesCase):
                 # Check NIC is no longer in list
                 self.browser.wait_not_present("#vm-subVmTest1-network-{0}-mac".format(self.nic_num))
                 self.browser.wait_not_present(".pf-c-modal-box")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-machines-settings
+++ b/test/verify/check-machines-settings
@@ -24,6 +24,8 @@ from machinesxmls import *
 # If this test fails to run, the host machine needs:
 # echo "options kvm-intel nested=1" > /etc/modprobe.d/kvm-intel.conf
 # rmmod kvm-intel && modprobe kvm-intel || true
+
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 class TestMachinesSettings(VirtualMachinesCase):

--- a/test/verify/check-machines-settings
+++ b/test/verify/check-machines-settings
@@ -43,7 +43,7 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-state", "Running")
         self.goToVmPage("subVmTest1")
 
-        b.click("#vm-subVmTest1-vcpus-count button") # open VCPU modal detail window
+        b.click("#vm-subVmTest1-vcpus-count button")  # open VCPU modal detail window
 
         b.wait_visible(".pf-c-modal-box__body")
 
@@ -166,7 +166,7 @@ class TestMachinesSettings(VirtualMachinesCase):
             self.goToVmPage(vm_name)
 
             # set checkbox state and check state of checkbox
-            b.set_checked("#vm-{}-autostart-checkbox".format(vm_name), True) # don't know the initial state of checkbox, so set it to checked
+            b.set_checked("#vm-{}-autostart-checkbox".format(vm_name), True)  # don't know the initial state of checkbox, so set it to checked
             b.wait_visible("#vm-{}-autostart-checkbox:checked".format(vm_name))
             # check virsh state
             autostartState = m.execute("virsh dominfo %s | grep 'Autostart:' | awk '{print $2}'" % vm_name).strip()
@@ -381,10 +381,10 @@ class TestMachinesSettings(VirtualMachinesCase):
         b.click("#cpu-config-dialog-apply")
 
         # Change vCPUs setting
-        b.click("#vm-subVmTest1-vcpus-count button") # Open dialog
-        b.set_input_text("#machines-vcpu-max-field", "3") # Change values
+        b.click("#vm-subVmTest1-vcpus-count button")  # Open dialog
+        b.set_input_text("#machines-vcpu-max-field", "3")  # Change values
         b.set_input_text("#machines-vcpu-count-field", "3")
-        b.click("#machines-vcpu-modal-dialog-apply") # Save
+        b.click("#machines-vcpu-modal-dialog-apply")  # Save
         b.wait_not_present(".pf-c-modal-box__body")
 
         # Shut off domain

--- a/test/verify/check-machines-snapshots
+++ b/test/verify/check-machines-snapshots
@@ -25,6 +25,7 @@ import time
 
 distrosWithoutSnapshot = ["centos-8-stream", "debian-stable", "fedora-32", "fedora-coreos", "rhel-8-3", "rhel-8-3-distropkg", "rhel-8-4", "rhel-8-4-distropkg", "ubuntu-2004", "ubuntu-stable"]
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 class TestMachinesSnapshots(VirtualMachinesCase):
@@ -191,9 +192,9 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         # Test snapshot creation with predefined values
         SnapshotCreateDialog(
             self,
-            name = "test_snap_1",
-            description = "Description of test_snap_1",
-            state = "shutoff",
+            name="test_snap_1",
+            description="Description of test_snap_1",
+            state="shutoff",
         ).execute()
 
         b.click("#vm-subVmTest1-run")
@@ -202,9 +203,9 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         # Test snapshot creation on running VM
         SnapshotCreateDialog(
             self,
-            name = "test_snap_2",
-            description = "Description of test_snap_2",
-            state = "running",
+            name="test_snap_2",
+            description="Description of test_snap_2",
+            state="running",
         ).execute()
 
     def testSnapshotRevert(self):

--- a/test/verify/check-machines-snapshots
+++ b/test/verify/check-machines-snapshots
@@ -33,7 +33,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
     def testSnapshots(self):
         # Checks if difference of @time1 and @time2 is not greater than @difference (in seconds)
         def checkTimeDiff(time1, time2, difference):
-            tmp = time2.split(' ') # split "Today 13:13:13" into day and time
+            tmp = time2.split(' ')  # split "Today 13:13:13" into day and time
             if not tmp[1].startswith('00:') and not tmp[0] == "Today":
                 return False
 
@@ -58,13 +58,13 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         b.wait_in_text("#vm-subVmTest1-snapshots .pf-c-empty-state", "No snapshots")
 
         # Check snapshot for running VM
-        m.execute("virsh detach-disk --domain subVmTest1 --target vda --persistent") # vda is raw disk, which are not supported by internal snapshots
+        m.execute("virsh detach-disk --domain subVmTest1 --target vda --persistent")  # vda is raw disk, which are not supported by internal snapshots
         m.execute("qemu-img create -f qcow2 /var/lib/libvirt/images/foobar.qcow2 1M")
         m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/images/foobar.qcow2 --target vdb --persistent")
         time1 = datetime.now().strftime("%H:%M:%S")
         m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshotB --description 'Description of snapshotB' --disk-only")
 
-        b.reload() # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
+        b.reload()  # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
         b.enter_page('/machines')
         b.wait_in_text("#vm-subVmTest1-state", "Running")
 
@@ -81,7 +81,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         time1 = datetime.now().strftime("%H:%M:%S")
         m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshotC --description 'Description of snapshotC'")
 
-        b.reload() # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
+        b.reload()  # snapshots events not available yet: https://gitlab.com/libvirt/libvirt/-/issues/44
         b.enter_page('/machines')
 
         b.wait_in_text("#vm-subVmTest1-snapshot-0-name", "snapshotC")
@@ -215,7 +215,7 @@ class TestMachinesSnapshots(VirtualMachinesCase):
         self.createVm("subVmTest1")
 
         # Check snapshot for running VM
-        m.execute("virsh detach-disk --domain subVmTest1 --target vda --config") # vda is raw disk, which are not supported by internal snapshots
+        m.execute("virsh detach-disk --domain subVmTest1 --target vda --config")  # vda is raw disk, which are not supported by internal snapshots
         m.execute("qemu-img create -f qcow2 /var/lib/libvirt/images/foobar.qcow2 1M")
         m.execute("virsh attach-disk --domain subVmTest1 --source /var/lib/libvirt/images/foobar.qcow2 --target vdb --subdriver qcow2 --config")
         m.execute("virsh snapshot-create-as --domain subVmTest1 --name snapshotA --description 'Description of snapshotA'")

--- a/test/verify/check-machines-storage-pools
+++ b/test/verify/check-machines-storage-pools
@@ -58,7 +58,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         m.execute("mkdir --mode 777 {0} {1} {2}".format(p1, p2, p3))
         m.execute("virsh pool-define-as myPoolOne --type dir --target {0}; virsh pool-start myPoolOne".format(p1))
         m.execute("virsh pool-define-as myPoolTwo --type dir --target {0}; virsh pool-start myPoolTwo".format(p2))
-        m.execute("virsh pool-create-as myPoolThree --type dir --target {0}".format(p3)) # Transient pool
+        m.execute("virsh pool-create-as myPoolThree --type dir --target {0}".format(p3))  # Transient pool
 
         b.wait_in_text("#card-pf-storage-pools .card-pf-title-link", "3 Storage pools")
 
@@ -224,9 +224,9 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
         # Transient network
         self.togglePoolRow("myPoolThree", connectionName)
-        b.wait_not_present("#pool-myPoolThree-{0}-autostart".format(connectionName)) # Transient pool shouldn't have autostart option
-        b.wait_visible('#delete-pool-myPoolThree-{0}:disabled'.format(connectionName)) # Transient pool cannot be deleted
-        b.click('#deactivate-pool-myPoolThree-{0}'.format(connectionName)) # Deactivate transient pool
+        b.wait_not_present("#pool-myPoolThree-{0}-autostart".format(connectionName))  # Transient pool shouldn't have autostart option
+        b.wait_visible('#delete-pool-myPoolThree-{0}:disabled'.format(connectionName))  # Transient pool cannot be deleted
+        b.click('#deactivate-pool-myPoolThree-{0}'.format(connectionName))  # Deactivate transient pool
         # Check it's not present after deactivation
         self.waitPoolRow("myPoolThree", connectionName, False)
 
@@ -519,7 +519,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         m.execute("mkdir {0} {1} && echo '{1} 127.0.0.1/24(rw,sync,no_root_squash,no_subtree_check,fsid=0)' > /etc/exports".format(nfs_pool, mnt_exports))
         m.execute("systemctl restart nfs-server")
         m.execute("virsh pool-define-as nfs-pool --type netfs --target {0} --source-host 127.0.0.1 --source-path {1} && virsh pool-start nfs-pool".format(nfs_pool, mnt_exports))
-        self.addCleanup(m.execute, "virsh pool-destroy nfs-pool || true") # Destroy pool as it block removal of `nfs_pool`
+        self.addCleanup(m.execute, "virsh pool-destroy nfs-pool || true")  # Destroy pool as it block removal of `nfs_pool`
 
         # Prepare disk/block pool
         dev = self.add_ram_disk(10)
@@ -569,7 +569,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
                 self.test_obj.gotoVolumesTab(self.pool_name)
 
-                b.click("#{0}-system-create-volume-button".format(self.pool_name)) # open the "Storage volumes" subtab
+                b.click("#{0}-system-create-volume-button".format(self.pool_name))  # open the "Storage volumes" subtab
 
                 b.wait_visible("#create-volume-dialog-modal")
                 b.wait_in_text(".pf-c-modal-box .pf-c-modal-box__header .pf-c-modal-box__title", "Create storage volume")
@@ -671,8 +671,8 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             self,
             pool_name="disk-pool",
             pool_type="disk",
-            vol_name=dev.split("/")[-1] + "1", # Partition names must follow pattern of sda1, sda2...
-            size="2", # Only 10MiB available on disk-pool
+            vol_name=dev.split("/")[-1] + "1",  # Partition names must follow pattern of sda1, sda2...
+            size="2",  # Only 10MiB available on disk-pool
             unit="MiB",
             format="none",
             remove=True,

--- a/test/verify/check-machines-storage-pools
+++ b/test/verify/check-machines-storage-pools
@@ -23,6 +23,7 @@ import parent
 from machineslib import *
 from testlib import *
 
+
 @skipImage("Atomic cannot run virtual machines", "fedora-coreos")
 @nondestructive
 class TestMachinesStoragePools(VirtualMachinesCase):
@@ -539,7 +540,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
         class StorageVolumeCreateDialog(object):
             def __init__(
                 self, test_obj, pool_name, vol_name, size="128", unit="MiB", format='qcow2',
-                pool_type = "dir", xfail=False, xfail_object=None, xfail_error=None, remove=True,
+                pool_type="dir", xfail=False, xfail_object=None, xfail_error=None, remove=True,
             ):
                 self.test_obj = test_obj
                 self.pool_name = pool_name
@@ -594,7 +595,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
                 if not self.xfail:
                     # Creation of volumes might take longer for some pool types
-                    if self.pool_type  in ["disk", "netfs"]:
+                    if self.pool_type in ["disk", "netfs"]:
                         b.wait_visible(".pf-c-modal-box__footer button.pf-m-in-progress")
                         b.wait_visible(".pf-c-modal-box__footer button:contains(Create):disabled")
                     b.wait_not_present("#create-volume-dialog-modal")
@@ -617,9 +618,9 @@ class TestMachinesStoragePools(VirtualMachinesCase):
 
                 size = int(m.execute(xmllint_element.format(prop='capacity')).strip())
                 if self.unit == "GiB":
-                   size = round(size / (1024**3))
+                    size = round(size / (1024**3))
                 else:
-                   size = round(size / (1024**2))
+                    size = round(size / (1024**2))
                 self.test_obj.assertEqual(size, int(self.size))
 
             def cleanup(self):
@@ -641,7 +642,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             remove=True,
             xfail=True,
             xfail_object='size',
-            xfail_error = "exceed the storage pool",
+            xfail_error="exceed the storage pool",
         ).execute()
 
         # Check volume creation for various pool types
@@ -660,9 +661,9 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             pool_name="nfs-pool",
             pool_type="netfs",
             vol_name="volume_of_nfs_dir",
-            size="10", #Creation of big nfs vol might take so long it will result in timetout
+            size="10",  # Creation of big nfs vol might take so long it will result in timetout
             unit="MiB",
-            format="raw", #Creation of qcow2 nfs vol might take so long it will result in timetout
+            format="raw",  # Creation of qcow2 nfs vol might take so long it will result in timetout
             remove=True,
         ).execute()
 
@@ -698,6 +699,7 @@ class TestMachinesStoragePools(VirtualMachinesCase):
             format="",
             remove=True,
         ).execute()
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -454,7 +454,7 @@ class TestCurrentMetrics(MachineCase):
             b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 1) < 70)
             b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 2) > 20)
             b.wait(lambda: topServiceValue(b, "Top 5 CPU services", "%", 2) < 40)
-        except:
+        except BaseException:
             print(m.execute("top -b -n 1"))
             raise
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -474,11 +474,11 @@ class TestCurrentMetrics(MachineCase):
             m.execute("systemd-run --collect --slice cockpittest --unit load-hog sh -ec "
                       "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=10K count=500 status=none & done'")
             b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) > 15)
-            m.execute("systemctl stop load-hog 2>/dev/null || true") # ok to fail, as the command exits by itself
+            m.execute("systemctl stop load-hog 2>/dev/null || true")  # ok to fail, as the command exits by itself
         else:
             load_hog = m.spawn("for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=10K count=500 status=none & done", "load-hog.log")
             b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) > 15)
-            m.execute("kill %d 2>/dev/null || true" % load_hog) # ok to fail, as the command exits by itself
+            m.execute("kill %d 2>/dev/null || true" % load_hog)  # ok to fail, as the command exits by itself
 
         # this settles down slowly, don't wait for becoming really quiet
         with b.wait_timeout(180):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -43,7 +43,7 @@ def progressValue(browser, progress_bar_sel):
     browser.wait_visible(sel)
     browser.wait_attr_contains(sel, "style", "width:")
     style = browser.attr(sel, "style")
-    m = re.search("width: (\d+)%;", style)
+    m = re.search(r"width: (\d+)%;", style)
     return int(m.group(1))
 
 
@@ -587,12 +587,12 @@ class TestCurrentMetrics(MachineCase):
         self.assertLess(progressValue(b, ".pf-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)
         progress_sel = ".pf-c-progress[data-disk-usage-target='/var/cockpittest'] .pf-c-progress__status"
         # free size is anything between 40 and 50 MB
-        self.assertRegex(b.text(progress_sel), "^4\d\.\d MB free$")
+        self.assertRegex(b.text(progress_sel), r"^4\d\.\d MB free$")
         # total size is shown in tooltip
         b.mouse(progress_sel, "mouseenter")
         b.wait_in_text(".pf-c-tooltip", "total")
         # total size is anything between 40 and 50 MB
-        self.assertRegex(b.text(".pf-c-tooltip"), "^4\d\.\d MB total$")
+        self.assertRegex(b.text(".pf-c-tooltip"), r"^4\d\.\d MB total$")
         b.mouse(progress_sel, "mouseleave")
         # read-only loop devices are not shown
         self.assertFalse(b.is_present(".pf-c-progress[data-disk-usage-target='/var/cockpit-ro-test']"))

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -74,6 +74,7 @@ def prepareArchive(machine, name, time, hostname="localhost.localdomain"):
                        while systemctl is-active systemd-timesyncd; do sleep 1; done
                        timedatectl set-time @{1}""".format(command, time, hostname))
 
+
 def login(self):
     # HACK: Ubuntu and Debian need some time until metrics channel is available
     # Really no idea what it needs to wait for, so let's just try channel until it succeeds
@@ -529,7 +530,7 @@ class TestCurrentMetrics(MachineCase):
         if have_swap:
             # use even more memory to trigger swap
             m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 awk "
-                    """'BEGIN { x = sprintf("%700000000s",""); system("sleep infinity") }'""")
+                      """'BEGIN { x = sprintf("%700000000s",""); system("sleep infinity") }'""")
             b.wait(lambda: progressValue(b, "#current-swap-usage") > 0)
 
             m.execute("systemctl stop mem-hog mem-hog2")

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -21,6 +21,7 @@ import parent
 from netlib import *
 from testlib import *
 
+
 @nondestructive
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestNetworkingBasic(NetworkCase):
@@ -78,7 +79,7 @@ class TestNetworkingBasic(NetworkCase):
         # Disconnect
         self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, True)
         self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
-        self.wait_for_iface_setting('Status','Inactive')
+        self.wait_for_iface_setting('Status', 'Inactive')
 
         # Switch it back to "auto" from the command line and bring it
         # up again
@@ -173,7 +174,7 @@ class TestNetworkingBasic(NetworkCase):
 
         # /usr in coreos is readonly
         if m.image not in ["fedora-coreos"]:
-        # remove the NM service file, test 'no-found' notification
+            # remove the NM service file, test 'no-found' notification
             # This works for ND tests since there is a self.addCleanup(m.execute, "systemctl enable --now NetworkManager") in the start of the test
             self.restore_file('/usr/lib/systemd/system/NetworkManager.service')
             m.execute("rm /usr/lib/systemd/system/NetworkManager.service && systemctl daemon-reload && systemctl stop NetworkManager")

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -133,5 +133,6 @@ class TestNetworkingCheckpoints(NetworkCase):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
             b.wait_not_visible("#confirm-breaking-change-popup")
 
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -34,6 +34,7 @@ def wait_unit_state(machine, unit, state):
 
     wait(lambda: active_state(unit) == state, delay=0.2)
 
+
 def get_active_rules(machine):
     active_zones = machine.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split()
     active_rules = []
@@ -43,6 +44,7 @@ def get_active_rules(machine):
         if ports:
             active_rules += [ports]
     return active_rules
+
 
 @skipImage("no firewalld", "fedora-coreos")
 @nondestructive
@@ -236,7 +238,6 @@ class TestFirewall(NetworkCase):
         b.click("#add-services-dialog footer .{0}".format(self.btn_primary))
         b.wait_not_present(".pf-c-modal-box")
 
-
         def addService(zone, service):
             b.click(".zone-section[data-id='{}'] .add-services-button".format(zone))
             b.click("#add-services-dialog .service-list #firewall-service-{}".format(service))
@@ -292,7 +293,7 @@ class TestFirewall(NetworkCase):
         # remove service via cli and cockpit
         m.execute("firewall-cmd --remove-service=pop3")
         b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] button")
-        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr ."  + self.btn_danger)
+        b.click(".zone-section[data-id='public'] tr[data-row-id='pop3'] + tr ." + self.btn_danger)
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 
     def testAddCustomServices(self):
@@ -390,7 +391,6 @@ class TestFirewall(NetworkCase):
         # should have been removed in the reload
         b.wait_not_present("tr[data-row-id='http']")
 
-
     def testMultipleZones(self):
         b = self.browser
         m = self.machine
@@ -480,6 +480,7 @@ class TestFirewall(NetworkCase):
         removeZone("home")
 
         addZone("work", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -354,7 +354,7 @@ class TestFirewall(NetworkCase):
         set_field("#tcp-ports", "80", "custom--http")
         b.set_input_text("#service-name", "I-am-persistent")
         b.set_input_text("#tcp-ports", "7")
-        time.sleep(5) # We need to validate that the service name did not change
+        time.sleep(5)  # We need to validate that the service name did not change
         b.wait_val("#service-name", "I-am-persistent")
         save("I-am-persistent", "7", "")
 

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -101,6 +101,5 @@ class TestNetworkingMAC(NetworkCase):
             b.wait_not_present("#network-interface-mac button")
 
 
-
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -868,7 +868,7 @@ ExecStart=/usr/local/bin/{0}
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if not self.system_before(231): # Changed in #14740
+        if not self.system_before(231):  # Changed in #14740
             b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
             b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
             b.click(".pf-c-modal-box button:contains('Authenticate')")
@@ -1311,7 +1311,7 @@ class TestAutoUpdates(NoSubManCase):
         # become superuser
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if not self.system_before(231): # Changed in #14740
+        if not self.system_before(231):  # Changed in #14740
             b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "Please authenticate")
             b.set_input_text(".pf-c-modal-box:contains('Administrative access') input", "foobar")
             b.click(".pf-c-modal-box button:contains('Authenticate')")
@@ -1335,7 +1335,7 @@ class TestAutoUpdates(NoSubManCase):
         # Drop privileges
         b.switch_to_top()
         b.click("#super-user-indicator button")
-        if not self.system_before(231): # Changed in #14740
+        if not self.system_before(231):  # Changed in #14740
             b.click(".pf-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
             b.wait_not_present(".pf-c-modal-box:contains('Switch to limited access')")
         else:

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1115,7 +1115,7 @@ class TestAutoUpdates(NoSubManCase):
             else:
                 self.assertEqual(out, "")
             if dow:
-                self.assertRegex(out, "^%s\s" % dow)
+                self.assertRegex(out, r"^%s\s" % dow)
             else:
                 # "every day" should not have a "LEFT" time > 1 day
                 self.assertNotIn(" day", out)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -37,7 +37,8 @@ done
 """
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "ubuntu-testing",
-    "fedora-coreos", "centos-8-stream"]
+                     "fedora-coreos", "centos-8-stream"]
+
 
 class NoSubManCase(PackageCase):
 
@@ -267,7 +268,7 @@ class TestUpdates(NoSubManCase):
                     # setting app as static in tracer's helper file will cause it to require a reboot
                     m.execute("mkdir -p /etc/tracer")
                     self.testObj.write_file("/etc/tracer/applications.xml",
-"""
+                                            """
 <applications>
    <app name="{0}" type="static" />
 </applications>
@@ -279,11 +280,11 @@ class TestUpdates(NoSubManCase):
 ExecStart=/usr/local/bin/{0}
 """.format(self.packageName)
                 self.testObj.createPackage(self.packageName, "1", "1", install=True, changes="initial package with service and run script",
-                        content={ "/usr/local/bin/{0}".format(self.packageName): scriptContent, "/etc/systemd/system/{0}.service".format(self.packageName): unitContent },
-                        postinst="chmod a+x /usr/local/bin/{0}; systemctl daemon-reload; systemctl start {0}.service".format(self.packageName))
+                                           content={"/usr/local/bin/{0}".format(self.packageName): scriptContent, "/etc/systemd/system/{0}.service".format(self.packageName): unitContent},
+                                           postinst="chmod a+x /usr/local/bin/{0}; systemctl daemon-reload; systemctl start {0}.service".format(self.packageName))
                 self.testObj.createPackage(self.packageName, "1", "2",
-                        content={ "/usr/local/bin/{0}".format(self.packageName): scriptContent, "/etc/systemd/system/{0}.service".format(self.packageName): unitContent },
-                        postinst="chmod a+x /usr/local/bin/{0}".format(self.packageName))
+                                           content={"/usr/local/bin/{0}".format(self.packageName): scriptContent, "/etc/systemd/system/{0}.service".format(self.packageName): unitContent},
+                                           postinst="chmod a+x /usr/local/bin/{0}".format(self.packageName))
 
                 self.serviceStartTime = m.execute("systemctl show {0}.service --property=ExecMainStartTimestamp".format(self.packageName))
 
@@ -396,7 +397,6 @@ ExecStart=/usr/local/bin/{0}
                 if self.rebootRequired:
                     m.execute("rm /etc/tracer/applications.xml")
 
-
         Tracer(
             testObj=self,
             packageName="apple",
@@ -440,8 +440,8 @@ Type=simple
 ExecStart=/usr/local/bin/{0}
 """.format(packageName)
         self.createPackage(packageName, "1", "1", install=True, changes="initial package with service and run script",
-                content={ "/usr/local/bin/{0}".format(packageName): scriptContent, "/etc/systemd/system/{0}.service".format(packageName): unitContent },
-                postinst="chmod a+x /usr/local/bin/{0}; systemctl daemon-reload; systemctl start {1}.service".format(packageName, packageName))
+                           content={"/usr/local/bin/{0}".format(packageName): scriptContent, "/etc/systemd/system/{0}.service".format(packageName): unitContent},
+                           postinst="chmod a+x /usr/local/bin/{0}; systemctl daemon-reload; systemctl start {1}.service".format(packageName, packageName))
 
         scriptContent = "#!/bin/sh\nfalse"
         unitContent = """
@@ -451,7 +451,7 @@ RemainAfterExit=yes
 ExecStart=/usr/local/bin/{0}
 """.format(packageName)
         self.createPackage(packageName, "1", "2",
-                content={ "/usr/local/bin/{0}".format(packageName): scriptContent, "/etc/systemd/system/{0}.service".format(packageName): unitContent })
+                           content={"/usr/local/bin/{0}".format(packageName): scriptContent, "/etc/systemd/system/{0}.service".format(packageName): unitContent})
 
         self.enableRepo()
 
@@ -488,7 +488,6 @@ ExecStart=/usr/local/bin/{0}
         # tracer updated the list of services which need a restart, so our service is no longer present
         b.wait_not_in_text("#restart-services-modal .pf-c-modal-box__body", packageName)
         b.wait_visible("#restart-services-modal footer .pf-c-alert")
-
 
     def testInfoSecurity(self):
         b = self.browser
@@ -896,6 +895,7 @@ ExecStart=/usr/local/bin/{0}
         # should go back to updates overview, nothing pending any more
         # TODO make Packagekit GetUpdates work for tests properly
         b.wait_not_present("#available-updates")
+
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 class TestWsUpdate(NoSubManCase):
@@ -1332,7 +1332,6 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#automatic-updates-dialog button:contains('Save changes')")
         b.wait_in_text("#automatic-updates", "Updates will be applied")
 
-
         # Drop privileges
         b.switch_to_top()
         b.click("#super-user-indicator button")
@@ -1456,6 +1455,7 @@ WantedBy=basic.target
         # as dnf-automatic isn't actually installed DnfImpl.setConfig will fail,
         # but we can check that the backend is now enabled
         b.wait_visible("#automatic-updates-dialog")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -256,7 +256,7 @@ OnCalendar=daily
 
         self.open_lang_modal()
         languages = b.eval_js("ph_select('#display-language-list option').map(function(e) { return e.value })")
-        b.click("#display-language-modal footer button.pf-m-link") # Close the menu
+        b.click("#display-language-modal footer button.pf-m-link")  # Close the menu
 
         for language in languages:
             # Remove failed units which will show up in the first terminal line
@@ -475,7 +475,7 @@ OnCalendar=daily
         b.wait_not_present("#host-apps li a:contains('Services')")
         b.wait_visible("#host-apps li a:contains('Logs')")
         b.focus(filter_sel)
-        b.key_press(chr(27)) # escape
+        b.key_press(chr(27))  # escape
         b.wait_val(filter_sel, "")
         b.wait_visible("#host-apps li a:contains('Services')")
 
@@ -492,8 +492,8 @@ OnCalendar=daily
         b.focus(filter_sel)
         b.key_press("s")
         b.wait_not_present("#host-apps li a:contains('Logs')")
-        b.key_press(chr(40), use_ord=True) # arrow down
-        b.key_press(chr(40), use_ord=True) # arrow down
+        b.key_press(chr(40), use_ord=True)  # arrow down
+        b.key_press(chr(40), use_ord=True)  # arrow down
         b.key_press("\r")
         if m.image in ["fedora-coreos"]:
             b.enter_page("/users")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -617,8 +617,8 @@ OnCalendar=daily
 
         def read_mem_info(machine):
             info = {}
-            for l in machine.execute("cat /proc/meminfo").splitlines():
-                (name, value) = l.strip().split(":")
+            for line in machine.execute("cat /proc/meminfo").splitlines():
+                (name, value) = line.strip().split(":")
                 if value.endswith("kB"):
                     info[name] = int(value[:-2]) * 1024
                 else:

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -53,7 +53,6 @@ class TestPages(MachineCase):
         self.browser.click(".display-language-menu a")
         self.browser.wait_visible('#display-language-modal')
 
-
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -585,10 +584,10 @@ OnCalendar=daily
         m.execute("touch %s/file1.txt" % stuff)
         b.focus("#demo-file-ac input[type=text]")
         time.sleep(1)
-        b.key_press(["\b"]*5)
+        b.key_press(["\b"] * 5)
         # input is now $stuff/file
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", "file1.txt")
-        b.key_press(["\b"]*4)
+        b.key_press(["\b"] * 4)
         # input is now $stuff/, so all listings should be available
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
 
@@ -599,7 +598,7 @@ OnCalendar=daily
         # the previous directory and back to the directory we want to list.
         # This is an implementation choice, to avoid re-reading the directories
         # content with every user input change, which is definitely a performance cost
-        b.key_press(["\b"]*6)
+        b.key_press(["\b"] * 6)
         time.sleep(1)
         b.key_press("stuff/")
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "other")
@@ -706,6 +705,7 @@ OnCalendar=daily
         b.enter_page("/playground/notifications-receiver")
         b.wait_text("#received-type", "-")
         b.wait_text("#received-title", "-")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -20,6 +20,7 @@
 import parent
 from testlib import *
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestReauthorize(MachineCase):
 

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -208,7 +208,6 @@ class TestSelinux(MachineCase):
             # different outputs.
             return script.replace("permissive -D\n", "")
 
-
         b.click("button:contains('Ansible')")
         b.wait_in_text(ansible_script_sel, "- name: Allow zebra to write config")
 
@@ -216,7 +215,7 @@ class TestSelinux(MachineCase):
         ansible_m.execute("semanage module -D")
         ansible_m.execute("mkdir -p roles/selinux/tasks/")
         ansible_m.write("tests.yml",
-"""
+                        """
 - hosts: localhost
   connection: local
   roles:
@@ -270,7 +269,6 @@ class TestSelinux(MachineCase):
         b.wait_text("ul[aria-label='System modifications']", "No system modifications")
         b.relogin("/selinux/setroubleshoot", "admin", superuser=False)
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
-
 
     @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "fedora-coreos", "ubuntu-2004", "ubuntu-stable")
     def testEnforcingToggle(self):

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -64,7 +64,6 @@ class HostSwitcherHelpers:
           return true;
         })""", address)
 
-
     def add_machine(self, b, address, known_host=False):
         b.click("button:contains('Add new host')")
         b.wait_popup('hosts_setup_server_dialog')
@@ -102,6 +101,7 @@ class HostSwitcherHelpers:
 
         for m in self.machines:
             self.authorize_pubkey(self.machines[m], "admin", pubkey)
+
 
 @no_retry_when_changed
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
@@ -413,6 +413,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         time.sleep(60)
         self.assertNotIn(m2.execute("loginctl"), "admin")
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestHostEditing(MachineCase, HostSwitcherHelpers):
 
@@ -445,7 +446,6 @@ class TestHostEditing(MachineCase, HostSwitcherHelpers):
             b.click("#hosts_setup_server_dialog .pf-m-link")
 
         self.login_and_go(superuser=False)
-
 
         b.click("#hosts-sel button")
         self.wait_host_addresses(b, ["localhost"])

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -223,11 +223,11 @@ class TestKeys(MachineCase):
         b.click("tbody[data-name=id_rsa] li:contains('Public key') a")
         assert b.is_visible("tbody[data-name=id_rsa] textarea")
         self.assertEqual(b.text("tbody[data-name=id_rsa] textarea"),
-                         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDG4iipTovcMg0xn+089QLNKVGpP" +
-                         "2Pgq2duxHgAXre2XgA3dZL+kooioGFwBQSEjbWssKy82hKIN/W82/lQtL6krf7JQW" +
-                         "nT3LZwD5DPsvHFKhOLghbiFzSI0uEL4NFFcZOMo5tGLrM5LsZsaIkkv5QkAE0tHIy" +
-                         "eYinK6dQ2d8ZsfmgqxHDUQUWnz1T75X9fWQsUugSWI+8xAe0cfa4qZRz/IC+K7DEB" +
-                         "3x4Ot5pl8FBuydJj/gb+Lwo2Vs27/d87W/0KHCqOHNwaVC8RBb1WcmXRDDetLGH1A" +
+                         "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDG4iipTovcMg0xn+089QLNKVGpP"
+                         "2Pgq2duxHgAXre2XgA3dZL+kooioGFwBQSEjbWssKy82hKIN/W82/lQtL6krf7JQW"
+                         "nT3LZwD5DPsvHFKhOLghbiFzSI0uEL4NFFcZOMo5tGLrM5LsZsaIkkv5QkAE0tHIy"
+                         "eYinK6dQ2d8ZsfmgqxHDUQUWnz1T75X9fWQsUugSWI+8xAe0cfa4qZRz/IC+K7DEB"
+                         "3x4Ot5pl8FBuydJj/gb+Lwo2Vs27/d87W/0KHCqOHNwaVC8RBb1WcmXRDDetLGH1A"
                          "9m5x7Ip/KU/cyvWWxw8S4VKZkTIcrGUhFYJDnjtE3Axz+D7agtps41t test@test\n")
         b.click("tbody[data-name=id_rsa] tr.listing-ct-item")
         assert not b.is_visible("tbody[data-name=id_rsa] .listing-ct-body")

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -375,6 +375,5 @@ class TestKeys(MachineCase):
             b.wait_not_present("tbody.ssh-add-key-body[data-name='/tmp/new.rsa']")
 
 
-
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -734,7 +734,7 @@ class TestMultiMachine(MachineCase):
         # socket doesn't seem to work well.
         m2.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
         m2.disconnect()
-        m2 = None # No more access to m2
+        m2 = None  # No more access to m2
 
         self.login_and_go(None)
         b.go(machine_path)

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -76,6 +76,7 @@ def start_machine_troubleshoot(b, new=False, known_host=False, password=None):
         b.set_val('#login-custom-password', password)
         b.click('#troubleshoot-dialog .modal-footer button:contains(Log in)')
 
+
 def fail_login(b):
     b.click('#troubleshoot-dialog .modal-footer button:contains(Log in)')
     b.wait_visible('#troubleshoot-dialog .modal-footer button:contains(Log in):not([disabled])')
@@ -860,7 +861,6 @@ class TestMultiMachine(MachineCase):
         self.assertEqual(m1.execute("cat /home/admin/.ssh/id_rsa.pub"),
                          m2.execute("cat /home/fred/.ssh/authorized_keys"))
 
-
     def testSshKeySetupCustom(self):
         b = self.browser
         m1 = self.machine
@@ -891,6 +891,7 @@ class TestMultiMachine(MachineCase):
         b.wait_in_text('#troubleshoot-dialog', "The SSH key")
         b.wait_not_visible('.password-change-advice')
         b.wait_not_visible('.login-setup-auto')
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -40,10 +40,10 @@ def authorize_user(m, user, public_keys=["verify/files/ssh/id_rsa.pub"]):
 
 
 LOAD_KEYS = [
-    "id_rsa", # password: foobar
+    "id_rsa",  # password: foobar
     "id_ecdsa",  # no password
-    "id_dsa", # password: badbad
-    "id_ed25519", # password: locked
+    "id_dsa",  # password: badbad
+    "id_ed25519",  # password: locked
 ]
 
 KEY_IDS = [

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -26,6 +26,7 @@ def wait_addresses(b, expected):
     for address in expected:
         b.wait_visible("#nav-hosts .nav-item a[href='/@{0}']".format(address))
 
+
 def add_machine(b, address, password):
     b.click("button:contains('Add new host')")
     b.wait_popup('hosts_setup_server_dialog')
@@ -41,6 +42,7 @@ def add_machine(b, address, password):
 
     b.wait_popdown('hosts_setup_server_dialog')
 
+
 def wait_stock_addresses(b, expected):
     b.wait_js_func(
         """(function(expected) {
@@ -50,6 +52,7 @@ def wait_stock_addresses(b, expected):
             });
             return expected.sort().toString() == addresses.sort().toString();
         })""", expected)
+
 
 def add_stock_machine(b, address, password):
     b.click('#dashboard-add')
@@ -154,6 +157,7 @@ class TestMultiOS(MachineCase):
 
         # Messages from previous versions of cockpit
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestMultiOSDirect(MachineCase):

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -35,7 +35,7 @@ class TestSOS(MachineCase):
         b = self.browser
         m = self.machine
 
-        if m.image in ["centos-8-stream", "debian-stable"]: # Still has sos in version 3.x
+        if m.image in ["centos-8-stream", "debian-stable"]:  # Still has sos in version 3.x
             self.restore_file("/etc/sos.conf")
             m.write("/etc/sos.conf",
                     """

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -91,7 +91,6 @@ only-plugins=release,date,host,cgroups,networking
                     raise ex
                 time.sleep(1)
 
-
         self.allow_journal_messages('.*comm="sosreport".*')
 
     def testWithUrlRoot(self):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -559,12 +559,18 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
 
-        if m.image == 'debian-stable' or m.image.startswith('ubuntu'):
+        is_pam_tally2 = m.image == 'debian-stable' or m.image.startswith('ubuntu')
+
+        if is_pam_tally2:
             module = 'pam_tally2'
-            logfile = lambda user: '/var/log/tallylog'
         else:
             module = 'faillock'
-            logfile = lambda user: '/var/run/faillock/' + user
+
+        def logfile(user):
+            if is_pam_tally2:
+                return '/var/log/tallylog'
+            else:
+                return '/var/run/faillock/' + user
 
         def expect_fail_count(expected, user="admin", must_exist=True):
             if must_exist:
@@ -572,15 +578,15 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
             output = m.execute("{} --user {}".format(module, user))
 
-            if module == 'faillock':
+            if is_pam_tally2:
+                self.assertIn(' {} '.format(expected), output)
+
+            else: # faillock
                 n_lines = len(output.splitlines())
                 if n_lines:
                     n_lines -= 2 # remove the header, if it's there
 
                 self.assertEqual(expected, n_lines)
-
-            else: # pam_tally2
-                self.assertIn(' {} '.format(expected), output)
 
             # make sure the above command didn't change the file
             if must_exist:
@@ -600,7 +606,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m.execute("! grep -r '{}' /etc/pam.d".format(module))
 
         # add it to the pam config
-        if module == 'pam_tally2':
+        if is_pam_tally2:
             self.sed_file("/common-auth/ { iauth required pam_tally2.so deny=4\n }", "/etc/pam.d/cockpit")
         elif m.image == 'debian-testing':
             # enable pam_faillock.  see example in pam_faillock(8), adopted for sss
@@ -633,7 +639,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.login_and_go("/system")
         b.logout()
 
-        if module == 'pam_tally2':
+        if is_pam_tally2:
             # now we should have it
             m.execute("test -f {}".format(logfile('admin')))
 
@@ -658,12 +664,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             expect_failed_login("admin", "bad", n)
 
         # logging in should fail now
-        if module == 'pam_tally2': # this is counted differently by each module
+        if is_pam_tally2: # this is counted differently by each module
             n += 1
         expect_failed_login("admin", "foobar", n)
 
         # having given the correct password the last time should not have helped things
-        if module == 'pam_tally2':
+        if is_pam_tally2:
             n += 1
         expect_failed_login("admin", "foobar", n)
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -173,7 +173,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_restart_journal_messages()
 
-
     @skipImage("logs in via ssh, not cockpit-session", "fedora-coreos")
     def testLogging(self):
         m = self.machine
@@ -487,7 +486,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = [ ] # none yet :-(
+        working_images = [] # none yet :-(
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:
@@ -795,8 +794,8 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         m.execute('! curl -ksS --cert %s --key %s https://localhost:9090/cockpit/login' % (alice_cert_expired, alice_key))
         m.stop_cockpit()
         wait(lambda: re.search(r'.*Invalid TLS peer certificate.* expired',
-                m.execute("journalctl -ocat --cursor '%s' SYSLOG_IDENTIFIER=cockpit-tls" % journal_cursor)),
-            tries=10)
+                               m.execute("journalctl -ocat --cursor '%s' SYSLOG_IDENTIFIER=cockpit-tls" % journal_cursor)),
+             tries=10)
         self.allow_journal_messages('.*Invalid TLS peer certificate.* expired')
         self.allow_journal_messages('.*TLS handshake failed: Error in the certificate verification.*')
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -104,7 +104,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.login_and_go()
         b.wait_text('#current-username', 'admin')
 
-        if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
+        if m.image not in ['fedora-coreos']:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         # reload, which should log us in with the cookie
@@ -112,7 +112,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#content")
         b.wait_text('#current-username', 'admin')
 
-        if m.image not in ['fedora-coreos']: # logs in via ssh, not cockpit-session
+        if m.image not in ['fedora-coreos']:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         b.go("/users#/admin")
@@ -183,7 +183,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 b.wait_visible('#login-messages')
                 b.wait_visible('#last-login')
                 b.wait_in_text('#last-login', "Last login")
-                b.wait_in_text('#last-login', "from") # only present if IP was logged
+                b.wait_in_text('#last-login', "from")  # only present if IP was logged
 
                 if n_fail:
                     b.wait_visible('#last-failed-login')
@@ -310,7 +310,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_not_visible("#password-group")
         b.wait_not_visible("#user-group")
         b.wait_in_text("#conversation-prompt", "Retype")
-        b.set_val('#conversation-input', '123foobar!') # wrong
+        b.set_val('#conversation-input', '123foobar!')  # wrong
         b.click('#login-button')
 
         # We should see a message
@@ -486,7 +486,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = [] # none yet :-(
+        working_images = []  # none yet :-(
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:
@@ -581,10 +581,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             if is_pam_tally2:
                 self.assertIn(' {} '.format(expected), output)
 
-            else: # faillock
+            else:  # faillock
                 n_lines = len(output.splitlines())
                 if n_lines:
-                    n_lines -= 2 # remove the header, if it's there
+                    n_lines -= 2  # remove the header, if it's there
 
                 self.assertEqual(expected, n_lines)
 
@@ -664,7 +664,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             expect_failed_login("admin", "bad", n)
 
         # logging in should fail now
-        if is_pam_tally2: # this is counted differently by each module
+        if is_pam_tally2:  # this is counted differently by each module
             n += 1
         expect_failed_login("admin", "foobar", n)
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -166,9 +166,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.login_and_go()
 
         self.allow_journal_messages("Returning error-response ... with reason .*",
-                                    "pam_unix\(cockpit:auth\): authentication failure; .*",
-                                    "pam_unix\(cockpit:auth\): check pass; user unknown",
-                                    "pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
+                                    r"pam_unix\(cockpit:auth\): authentication failure; .*",
+                                    r"pam_unix\(cockpit:auth\): check pass; user unknown",
+                                    r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "noise-rc-.*")
 
         self.allow_restart_journal_messages()
@@ -437,9 +437,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.assertEqual(self.curl_auth_code('/cockpit/login', 'a' * 4000 + ':b\nc\n'), 401)
 
         self.allow_journal_messages("Returning error-response ... with reason .*",
-                                    "pam_unix\(cockpit:auth\): authentication failure; .*",
-                                    "pam_unix\(cockpit:auth\): check pass; user unknown",
-                                    "pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
+                                    r"pam_unix\(cockpit:auth\): authentication failure; .*",
+                                    r"pam_unix\(cockpit:auth\): check pass; user unknown",
+                                    r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "couldn't parse login input: Malformed input",
                                     "couldn't parse login input: Authentication failed")
 

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -125,5 +125,6 @@ class TestStorageFormat(StorageCase):
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Unrecognized data")
 
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -353,7 +353,6 @@ class TestStorageLuks(StorageCase):
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
         self.content_row_wait_in_col(2, 1, "ext4 file system")
 
-
     def testNoFsys(self):
         m = self.machine
         b = self.browser
@@ -400,7 +399,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(2, 1, "ext4 file system")
 
         # The filesystem should be mounted but have the "noauto" option
-        self.wait_mounted(2,1)
+        self.wait_mounted(2, 1)
         self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
 
         # Unmounting should keep the noauto option, as always
@@ -410,14 +409,14 @@ class TestStorageLuks(StorageCase):
 
         # Mounting should also keep the "noauto", but it should not show up in the extra options
         self.content_head_action(2, "Mount")
-        self.dialog_check({ "mount_options.extra": False })
+        self.dialog_check({"mount_options.extra": False})
         self.dialog_apply()
-        self.wait_mounted(2,1)
+        self.wait_mounted(2, 1)
         self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
 
         # As should updating the mount information
         self.content_tab_info_action(2, 1, "Mount point", wrapped=True)
-        self.dialog_check({ "mount_options.extra": False })
+        self.dialog_check({"mount_options.extra": False})
         self.dialog_apply()
         self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
 
@@ -427,6 +426,7 @@ class TestStorageLuks(StorageCase):
         b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
         b.click(fsys_tab + " button:contains(Do not mount automatically)")
         b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -21,6 +21,7 @@ import parent
 from storagelib import *
 from testlib import *
 
+
 @nondestructive
 class TestStorageLvm2(StorageCase):
 
@@ -234,7 +235,7 @@ class TestStorageLvm2(StorageCase):
         # Create a volume group out of disk1
         self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create volume group'),
                                expect=lambda: self.dialog_is_present('disks', disk1) and
-                                              self.dialog_is_present('disks', "unpartitioned space on Linux scsi_debug"),
+                               self.dialog_is_present('disks', "unpartitioned space on Linux scsi_debug"),
                                values={"disks": {disk1: True}})
 
         b.wait_in_text("#devices", "vgroup0")
@@ -297,6 +298,7 @@ class TestStorageLvm2(StorageCase):
 
         self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol0")
         b.wait_not_in_text("#storage-detail", "snap0")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -26,6 +26,7 @@ from time import sleep
 def info_field(name, image_name):
     return '#detail-header dt:contains("%s") + dd' % name
 
+
 class TestStorageMdRaid(StorageCase):
 
     def wait_states(self, states):
@@ -47,7 +48,7 @@ class TestStorageMdRaid(StorageCase):
     def raid_add_disk(self, name):
         self.dialog_open_with_retry(trigger=lambda: self.browser.click('#detail-sidebar .pf-c-card__header button'),
                                     expect=lambda: self.dialog_is_present('disks', name))
-        self.dialog_set_val("disks", { name: True })
+        self.dialog_set_val("disks", {name: True})
         self.dialog_apply_with_retry()
 
     def raid_remove_disk(self, name):
@@ -159,7 +160,7 @@ class TestStorageMdRaid(StorageCase):
 
         # HACK - wait a bit before stopping newly created device
         # https://github.com/storaged-project/udisks/issues/643
-        if m.image in ["debian-stable",  "debian-testing"]:
+        if m.image in ["debian-stable", "debian-testing"]:
             sleep(10)
 
         # Turn it off and on again

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -177,7 +177,6 @@ class TestStorageMounting(StorageCase):
         m.execute("grep 'noauto,readonly,x-foo' /etc/crypttab")
         m.execute("grep 'noauto,ro,x-foo' /etc/fstab")
 
-
     def testMountingHelp(self):
         m = self.machine
         b = self.browser
@@ -302,10 +301,11 @@ class TestStorageMounting(StorageCase):
 
         m.execute("! grep /run/data /etc/fstab")
         self.content_head_action(1, "Mount")
-        self.dialog({ "mount_point": "/run/data",
-                      "mount_options.extra": "x-foo" })
+        self.dialog({"mount_point": "/run/data",
+                     "mount_options.extra": "x-foo"})
         m.execute("grep /run/data /etc/fstab")
         m.execute("grep 'x-foo' /etc/fstab")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -316,5 +316,6 @@ class TestStorageResize(StorageCase):
         size = int(m.execute("lvs TEST/vol -o lv_size --noheading --units b --nosuffix"))
         self.assertLess(size, 250000000)
 
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -21,6 +21,7 @@ import parent
 from storagelib import *
 from testlib import *
 
+
 class TestStorageScaling(StorageCase):
 
     def testScaling(self):
@@ -33,6 +34,7 @@ class TestStorageScaling(StorageCase):
         b.click("#drives button:contains(Show all 202 drives)")
         b.wait_not_in_text("#drives", "Show all")
         b.wait_js_cond('ph_select("#drives .sidepanel-row").length == 202')
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -297,5 +297,6 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
         # A new dialog opens immediately
         b.wait_in_text("#dialog", "Create VDO device")
 
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -20,6 +20,7 @@
 import parent
 from testlib import *
 
+
 def allow_old_cockpit_ws_messsages(test):
     # noisy debug message from old cockpit-ws
     test.allow_journal_messages("logged in user session",
@@ -223,11 +224,12 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
         b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserOldShell(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20" },
-        "machine2": {"address": "10.111.113.2/20", "image": "centos-7" },
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20", "image": "centos-7"},
     }
 
     def test(self):
@@ -260,11 +262,12 @@ class TestSuperuserOldShell(MachineCase):
         b.click("#shutdown-dialog button:contains('Restart')")
         b.wait_popdown("shutdown-dialog")
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserOldWebserver(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "image": "centos-7" },
-        "machine2": {"address": "10.111.113.2/20" },
+        "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
+        "machine2": {"address": "10.111.113.2/20"},
     }
 
     def test(self):
@@ -357,8 +360,8 @@ class TestSuperuserOldWebserver(MachineCase):
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserDashboard(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20" },
-        "machine2": {"address": "10.111.113.2/20" },
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20"},
     }
 
     def test(self):
@@ -416,11 +419,12 @@ class TestSuperuserDashboard(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserOldDashboard(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "image": "centos-7" },
-        "machine2": {"address": "10.111.113.2/20" },
+        "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
+        "machine2": {"address": "10.111.113.2/20"},
     }
 
     def test(self):
@@ -482,8 +486,8 @@ class TestSuperuserOldDashboard(MachineCase):
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestSuperuserDashboardOldMachine(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20" },
-        "machine2": {"address": "10.111.113.2/20", "image": "centos-7" },
+        "machine1": {"address": "10.111.113.1/20"},
+        "machine2": {"address": "10.111.113.2/20", "image": "centos-7"},
     }
 
     def test(self):
@@ -510,6 +514,7 @@ class TestSuperuserDashboardOldMachine(MachineCase):
         b.wait_popup("shutdown-dialog")
         b.click("#shutdown-dialog button:contains('Restart')")
         b.wait_popdown("shutdown-dialog")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -721,7 +721,7 @@ insecure_connection=True
             b.wait_visible(sel)
             b.wait_attr_contains(sel, "style", "width:")
             style = b.attr(sel, "style")
-            m = re.search("width: (\d+)%;", style)
+            m = re.search(r"width: (\d+)%;", style)
             return int(m.group(1))
 
         self.login_and_go("/system")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -103,7 +103,7 @@ class TestSystemInfo(MachineCase):
         # support timesyncd for NTP configuration, so make sure chrony is not installed in the older
         # debian images which don't yet have systemd-timesyncd
         if self.machine.image in ["debian-stable"]:
-            self.machine.execute("dpkg --remove chrony");
+            self.machine.execute("dpkg --remove chrony")
 
         # Most OSes don't set nosmt by default, but there are some exceptions
         self.expect_smt_default = self.machine.image in ["fedora-coreos"]

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -79,6 +79,7 @@ Memory Device
 EOF
 """
 
+
 def ssh_reconnect(machine, timeout_sec=120):
     start_time = time.time()
     error = None
@@ -175,7 +176,7 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text("#system_information_ssh_keys .list-group", new_alt)
 
         b.wait_in_text('#system_information_os_text',
-                    "Foobar Adventure Linux Server 2.0 (Day of Doom)")
+                       "Foobar Adventure Linux Server 2.0 (Day of Doom)")
 
         b.click('#system_information_ssh_keys button:contains("Close")')
         b.wait_not_present("#system_information_ssh_keys")
@@ -535,7 +536,7 @@ revision\t: 2.3 (pvr 004e 1203)
                 if expect_smt_state is not None:
                     b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
                     b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
-                                (expect_smt_state and ":checked" or ":not(:checked)"))
+                                   (expect_smt_state and ":checked" or ":not(:checked)"))
 
                 b.logout()
             finally:
@@ -689,7 +690,7 @@ fi
         m.upload(["verify/files/mock-insights"], "/var/tmp")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
         m.write("/etc/insights-client/insights-client.conf",
-"""
+                """
 [insights-client]
 gpg=False
 auto_config=False
@@ -753,6 +754,7 @@ insecure_connection=True
         wait(lambda: progressValue(2) <= initial_usage)
         self.assertGreater(progressValue(2), 10)
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestPcp(packagelib.PackageCase):
 
@@ -787,7 +789,6 @@ class TestPcp(packagelib.PackageCase):
         b.click(".pf-c-modal-box__footer button:contains('Install')")
         b.wait_not_present(".pf-c-modal-box:contains('Install software')")
 
-
         b.wait_visible("#server-pmlogger-switch")
         b.wait_not_present("#system-configuration-enable-pcp-link")
 
@@ -798,6 +799,7 @@ class TestPcp(packagelib.PackageCase):
         m.execute("touch /tmp/pmlogger.start")
         b.wait_visible("#server-pmlogger-switch:not(:disabled)")
         b.wait_visible("#server-pmlogger-switch:checked")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -50,32 +50,32 @@ SMBIOS 2.7 present.
 
 Handle 0x0008, DMI type 17, 34 bytes
 Memory Device
-	Total Width: 64 bits
-	Size: 8192 MB
-	Form Factor: SODIMM
-	Locator: ChannelA-DIMM0
-	Bank Locator: BANK 0
-	Type: DDR3
-	Speed: 1600 MT/s
-	Manufacturer: Samsung
-	Asset Tag: None
-	Rank: Unknown
-	Configured Memory Speed: 1600 MT/s
+\tTotal Width: 64 bits
+\tSize: 8192 MB
+\tForm Factor: SODIMM
+\tLocator: ChannelA-DIMM0
+\tBank Locator: BANK 0
+\tType: DDR3
+\tSpeed: 1600 MT/s
+\tManufacturer: Samsung
+\tAsset Tag: None
+\tRank: Unknown
+\tConfigured Memory Speed: 1600 MT/s
 
 Handle 0x0009, DMI type 17, 34 bytes
 Memory Device
-	Total Width: 64 bits
-	Size: 8192 MB
-	Form Factor: SODIMM
-	Locator: ChannelB-DIMM0
-	Bank Locator: BANK 2
-	Memory technology: Awesome
-	Type: DDR3
-	Speed: 1600 MT/s
-	Manufacturer: Samsung
-	Asset Tag: None
-	Rank: 1
-	Configured Memory Speed: 1600 MT/s
+\tTotal Width: 64 bits
+\tSize: 8192 MB
+\tForm Factor: SODIMM
+\tLocator: ChannelB-DIMM0
+\tBank Locator: BANK 2
+\tMemory technology: Awesome
+\tType: DDR3
+\tSpeed: 1600 MT/s
+\tManufacturer: Samsung
+\tAsset Tag: None
+\tRank: 1
+\tConfigured Memory Speed: 1600 MT/s
 EOF
 """
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -135,7 +135,7 @@ class TestJournal(MachineCase):
         # output.
         #
         self.write_file("/etc/systemd/system/log123.service",
-                """
+                        """
 [Unit]
 Description=123 different log lines
 
@@ -144,7 +144,7 @@ ExecStart=/bin/sh -c '/usr/bin/seq 123; sleep 10'
 """)
 
         self.write_file("/etc/systemd/system/slow10.service",
-                """
+                        """
 [Unit]
 Description=Slowly log 10 identical lines
 
@@ -342,7 +342,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 5')")
 
         b.focus("#journal-grep")
-        b.key_press("\b"*13 + "[5-6]\r")
+        b.key_press("\b" * 13 + "[5-6]\r")
         b.wait_not_present("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 4')")
         b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 6')")
         b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('Message 5')")
@@ -514,7 +514,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                         ["check-journal", "BEFORE BOOT", ""],
                         "Load earlier entries"
                         ])
-
 
     @nondestructive
     def testBinary(self):
@@ -775,6 +774,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.click(sleep_crash_list_sel)
         b.click("#abrt-reporting .pf-l-split:first-child button:contains('Report')")
         b.wait_visible("#abrt-reporting .pf-l-split:first-child a[href$='/reports/bthash/123deadbeef'")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -604,7 +604,7 @@ ExecStart=/bin/true
         with open("src/tls/ca/alice.pem") as f:
             alice_cert = f.read().strip()
         # IPA does not like the ---BEGIN/END lines
-        alice_cert = '\n'.join([l for l in alice_cert.splitlines() if not l.startswith("----")])
+        alice_cert = '\n'.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
         # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
         ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
 ipa user-add --first=Alice --last="Developer" alice
@@ -689,7 +689,7 @@ class TestAD(TestRealms, CommonTests):
         with open("src/tls/ca/alice.pem") as f:
             alice_cert = f.read().strip()
         # mangle into form palatable for LDAP
-        alice_cert = ''.join([l for l in alice_cert.splitlines() if not l.startswith("----")])
+        alice_cert = ''.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
         # set up an AD user and import their TLS certificate; avoid using the common "userCertificate;binary",
         # as that does not work with Samba
         services_machine.execute(r"""podman exec -i samba sh -exc '

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -196,7 +196,7 @@ class CommonTests:
             b.wait_text_not(".realms-op-message", "")
             error = b.text(".realms-op-message")
             b.wait_not_visible(".realms-op-leave-only-row")
-            if not "Already running another action" in error:
+            if "Already running another action" not in error:
                 # "More" link is part of the message component, so this looks a little funny here
                 if self.expected_server_software == 'active-directory':
                     self.assertEqual(error, "Failed to join the domain More")
@@ -219,7 +219,7 @@ class CommonTests:
                     b.wait_in_text(".realms-op-diagnostics", "ipa-client-install command failed")
             b.click(".realms-op-cancel")
             b.wait_popdown("realms-op")
-            if not "Already running another action" in error:
+            if "Already running another action" not in error:
                 break
             print("Another operation running, retry")
             time.sleep(20)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -64,6 +64,8 @@ done
 
 # https://en.wikipedia.org/wiki/HMAC-based_One-time_Password_algorithm
 # https://stackoverflow.com/questions/8529265/google-authenticator-implementation-in-python
+
+
 def hotp_token(secret, counter, digits=6, hash_alg=hashlib.sha1):
     counter_bytes = struct.pack('>Q', int(counter))
     hs = hmac.new(secret, counter_bytes, hash_alg).digest()
@@ -696,7 +698,7 @@ printf "version: 1\ndn: cn=alice,cn=users,dc=cockpit,dc=lan\nchangetype: modify\
         ldapmodify -v -U Administrator -w '%(admin_pass)s'
 # for debugging:
 ldapsearch -v -U Administrator -w '%(admin_pass)s' -b 'cn=alice,cn=users,dc=cockpit,dc=lan'
-' """ % { "alice_pass": self.alice_password, "admin_pass": self.admin_password, "alice_cert": alice_cert })
+' """ % {"alice_pass": self.alice_password, "admin_pass": self.admin_password, "alice_cert": alice_cert})
 
         # set up sssd for certificate mapping to AD
         # see sssd.conf(5) "CERTIFICATE MAPPING SECTION" and sss-certmap(5)
@@ -997,6 +999,7 @@ class TestPackageInstall(packagelib.PackageCase):
 
         # should not have a tooltip any more
         b.wait_not_present("#system_information_domain_tooltip")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -21,6 +21,7 @@ import parent
 
 from testlib import *
 
+
 @skipImage("No realmd available", "fedora-coreos")
 @skipImage("freeipa not currently in testing", "debian-testing", "ubuntu-2004")
 @skipImage("Skip these for now, unsure what's broken", "ubuntu-stable", "debian-stable")
@@ -65,7 +66,7 @@ class TestS4USsh(MachineCase):
         # Allow retrieval of service keytab by admin
         ipa_machine.execute("podman exec freeipa bash -c 'ipa service-allow-retrieve-keytab --user=admin cockpitclient/sshclient.cockpit.lan'")
         # set up delegation rule
-        script="""set -e
+        script = """set -e
         ipa servicedelegationtarget-add cockpit-target
         ipa servicedelegationtarget-add-member cockpit-target --principals="host/sshserver.cockpit.lan@COCKPIT.LAN"
         ipa servicedelegationrule-add cockpit-delegation

--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -107,7 +107,7 @@ session    required     pam_limits.so
 session    include      system-auth
 """)
 
-        sshd_machine.execute(script="""#!/bin/sh
+        sshd_machine.execute(script=r"""#!/bin/sh
         sed -i '/\[domain\/cockpit.lan\]/ a pam_gssapi_services = sudo, sudo-i' /etc/sssd/sssd.conf
         systemctl restart sssd
         usermod -G wheel user

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -73,7 +73,7 @@ class TestServices(MachineCase):
     def wait_service_state(self, service, state):
         state_new = state
         if 'inactive' in state:
-            state_new  = 'Not running'
+            state_new = 'Not running'
         elif 'active' in state:
             state_new = 'Running'
         elif 'failed' in state:
@@ -97,7 +97,7 @@ class TestServices(MachineCase):
         b = self.browser
 
         self.write_file("/etc/systemd/system/test.service",
-                """
+                        """
 [Unit]
 Description=Test Service
 
@@ -109,7 +109,7 @@ ExecReload=/bin/sh true
 WantedBy=default.target
 """)
         self.write_file("/usr/local/bin/test-service",
-                """
+                        """
 #! /bin/sh
 
 trap "echo STOP" 0
@@ -121,7 +121,7 @@ while true; do
 done
 """)
         self.write_file("/etc/systemd/system/test-fail.service",
-                """
+                        """
 [Unit]
 Description=Failing Test Service
 
@@ -132,7 +132,7 @@ ExecStart=/usr/bin/false
 WantedBy=default.target
 """)
         self.write_file("/etc/systemd/system/test.timer",
-                """
+                        """
 [Unit]
 Description=Test Timer
 
@@ -140,7 +140,7 @@ Description=Test Timer
 OnCalendar=*:1/2
 """)
         self.write_file("/etc/systemd/system/test-onboot.timer",
-                """
+                        """
 [Unit]
 Description=Test OnBoot Timer
 
@@ -387,7 +387,7 @@ Unit=test.service
         b = self.browser
 
         self.write_file("/etc/systemd/system/test.service",
-                """
+                        """
 [Unit]
 Description=Test Service
 
@@ -425,7 +425,7 @@ WantedBy=default.target
         m = self.machine
         b = self.browser
         self.write_file("/etc/systemd/system/condtest.service",
-                """
+                        """
 [Unit]
 Description=Test Service
 ConditionDirectoryNotEmpty=/var/tmp/empty
@@ -472,7 +472,7 @@ WantedBy=multi-user.target
         b = self.browser
 
         self.write_file("/etc/systemd/system/test-a.service",
-                """
+                        """
 [Unit]
 Description=A Service
 Before=test-b.service
@@ -483,7 +483,7 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
 """)
 
         self.write_file("/etc/systemd/system/test-b.service",
-                """
+                        """
 [Unit]
 Description=B Service
 After=test-a.service
@@ -493,7 +493,7 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
 """)
 
         self.write_file("/etc/systemd/system/test-c.service",
-                """
+                        """
 [Unit]
 Description=C Service
 Conflicts=test-a.service
@@ -546,7 +546,7 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
         b = self.browser
 
         self.write_file("/etc/systemd/system/test.service",
-                """
+                        """
 [Unit]
 Description=Test Service
 Requires=not-found.service
@@ -575,7 +575,7 @@ ExecStart=/bin/true
         # Put it in /run instead of in /etc so that we can mask it,
         # which needs to put a symlink into /etc.
         self.write_file("/run/systemd/system/test-fail.service",
-                """
+                        """
 [Unit]
 Description=Failing Test Service
 
@@ -642,7 +642,7 @@ WantedBy=default.target
         # relative order depending on whether "aab" has failed or not.
 
         self.write_file("/etc/systemd/system/aaa.service",
-                """
+                        """
 [Unit]
 Description=First Row Service
 
@@ -650,7 +650,7 @@ Description=First Row Service
 ExecStart=/usr/bin/true
 """)
         self.write_file("/etc/systemd/system/aab-fail.service",
-                """
+                        """
 [Unit]
 Description=Failing Test Service
 
@@ -714,7 +714,7 @@ ExecStart=/usr/bin/false
         b = self.browser
 
         self.write_file("/etc/systemd/system/fail.mount",
-                """
+                        """
 [Unit]
 Description=Failing Mount
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -293,7 +293,7 @@ Unit=test.service
         b.relogin('/system/services#/test.service', superuser=True)
         self.wait_page_load()
 
-        self.toggle_onoff() # later on we need some disabled test
+        self.toggle_onoff()  # later on we need some disabled test
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
 
         # Check service that fails to start

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -21,7 +21,6 @@ import parent
 from testlib import *
 
 
-
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestShutdownRestart(MachineCase):
     provision = {

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -20,8 +20,10 @@
 import parent
 from testlib import *
 
+
 def line_sel(i):
     return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestTerminal(MachineCase):
@@ -243,6 +245,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         b.wait_js_cond("ph_text('.terminal').indexOf('uid=') == -1")
         b.key_press("id\r")
         b.wait_js_cond("ph_text('.terminal').indexOf('uid=') >= 0")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -167,8 +167,8 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         select_line(sel, 40)
 
         # Use keyboard shortcuts to copy text
-        b.key_press(chr(45), 2, use_ord=True) # Ctrl + Insert
-        b.key_press(chr(45), 8, use_ord=True) # Shift + Insert
+        b.key_press(chr(45), 2, use_ord=True)  # Ctrl + Insert
+        b.key_press(chr(45), 8, use_ord=True)  # Shift + Insert
 
         # Wait for text to show up
         wait_line(n + 2, prompt + "foo")

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -33,9 +33,9 @@ class TestTerminal(MachineCase):
         self.allow_journal_messages(".*external channel failed: terminated")
 
         # Make sure we get what we expect
-        self.write_file("/home/admin/.bashrc", """
-PS1="\\u@\\h \\W]\$ "
-PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
+        self.write_file("/home/admin/.bashrc", r"""
+PS1="\u@\h \W]\$ "
+PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/#$HOME/\~}"'
 """, append=True)
 
         # Remove failed units which will show up in the first terminal line

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -38,7 +38,7 @@ class TestTuned(MachineCase):
 
         m.execute("systemctl stop tuned")
         m.execute("systemctl disable tuned")
-        self.addCleanup(m.execute, "tuned-adm auto_profile") # Enable and set default profile
+        self.addCleanup(m.execute, "tuned-adm auto_profile")  # Enable and set default profile
 
         # Login and check initial state
 

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -20,6 +20,7 @@
 import parent
 from testlib import *
 
+
 @nondestructive
 @skipImage("No tuned packaged", "fedora-coreos")
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -128,12 +128,12 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestExample.testFail", "TestExample.testSkip"],
                                  env=env, capture_output=True)
         stdout = process.stdout
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
+        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)$")
+        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)$")
+        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail$")
         self.assertNotRegex(stdout, b"RETRY 3")
-        self.assertRegex(stdout, b"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
-        self.assertRegex(stdout, b"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
+        self.assertRegex(stdout, rb"^ok 2 .*test/verify/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)$")
+        self.assertRegex(stdout, rb"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
 
         # Check retry logic for changed tests
         test_file = os.path.join(VERIFY_DIR, "check-testlib")
@@ -148,17 +148,17 @@ class TestRunTest(MachineCase):
         stdout = process.stdout
 
         # Changed test need to succeed 3 times
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic\n")
+        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)$")
+        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)$")
+        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic$")
         self.assertNotRegex(stdout, b"RETRY 3")
 
         # Changed test is never retried
-        self.assertRegex(stdout, b"\nnot ok 2 .*test\/verify\/check-testlib TestRetryExample.testFail\n")
+        self.assertRegex(stdout, rb"^not ok 2 .*test/verify/check-testlib TestRetryExample.testFail$")
         self.assertNotRegex(stdout, b"testFail # RETRY")
 
         # Using @no_retry_when_changed prevents this retry logic
-        self.assertRegex(stdout, b"\nok 3 .*test\/verify\/check-testlib TestRetryExample.testNoRetry\n")
+        self.assertRegex(stdout, b"^ok 3 .*test/verify/check-testlib TestRetryExample.testNoRetry$")
         self.assertNotRegex(stdout, b"testNoRetry # RETRY")
 
         # Check retry logic for changed source
@@ -174,12 +174,12 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "--list", "TestHostEditing.testLimits",
                                   "TestHostSwitching.testEdit"], env=env, capture_output=True)
         stdout = process.stdout
-        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 1 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 2 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nTestHostEditing.testLimits\n")
-        self.assertNotRegex(stdout, b"RETRY 3")
-        self.assertRegex(stdout, b"\nTestHostSwitching.testEdit\n")
-        self.assertNotRegex(stdout, b"TestHostSwitching.testEdit # RETRY")
+        self.assertIn(b"\nTestHostEditing.testLimits # RETRY 1 (test affected tests 3 times)\n", stdout)
+        self.assertIn(b"\nTestHostEditing.testLimits # RETRY 2 (test affected tests 3 times)\n", stdout)
+        self.assertIn(b"\nTestHostEditing.testLimits\n", stdout)
+        self.assertNotIn(b"RETRY 3", stdout)
+        self.assertIn(b"\nTestHostSwitching.testEdit\n", stdout)
+        self.assertNotIn(b"TestHostSwitching.testEdit # RETRY", stdout)
 
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -30,9 +30,11 @@ run_tests = os.path.join(TEST_DIR, "common", "run-tests")
 VERIFY_DIR = os.path.join(TEST_DIR, "verify")
 ROOT_DIR = os.path.dirname(TEST_DIR)
 
+
 def writeFile(file, content):
     with open(file, 'w') as f:
         f.write(content)
+
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class TestRunTestListing(unittest.TestCase):
@@ -226,6 +228,7 @@ class TestTestlib(MachineCase):
         self.assertNotIn("cockpittest", self.machine.execute("cat /etc/passwd"))
         self.machine.execute("test ! -e /home/cockpittest")
 
+
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")
 class NoTestRetryExample(unittest.TestCase):
 
@@ -239,7 +242,6 @@ class NoTestRetryExample(unittest.TestCase):
 
     def testBasic(self):
         self.assertTrue(True)
-
 
 
 if __name__ == '__main__':

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -55,7 +55,7 @@ class TestAccounts(MachineCase):
         b.wait_text("#account-user-name", "anton")
         b.wait_text("#account-title", "anton")
         b.wait_not_attr("#account-delete", "disabled", "disabled")
-        b.set_input_text('#account-real-name', "") # Check that we can delete the name before setting it up
+        b.set_input_text('#account-real-name', "")  # Check that we can delete the name before setting it up
         b.set_input_text('#account-real-name', "Anton Arbitrary")
         b.blur("#account-real-name")
         b.wait_visible('#account-real-name:not([disabled])')
@@ -211,7 +211,7 @@ class TestAccounts(MachineCase):
         b.wait_visible(admin_role_sel + ":checked")
         b.set_checked(admin_role_sel, False)
         b.wait(lambda: not is_admin())
-        if m.image != "fedora-coreos": # User is not shown as logged in when logged in through Cockpit
+        if m.image != "fedora-coreos":  # User is not shown as logged in when logged in through Cockpit
             b.wait_visible("#account-roles .pf-c-alert.pf-m-info")
         m.execute("/usr/sbin/usermod jussi -G %s -a" % m.get_admin_group())
         b.wait_visible(admin_role_sel + ":checked:not([disabled])")
@@ -269,7 +269,7 @@ class TestAccounts(MachineCase):
         b.click('.cockpit-account-user-name a[href="#/damaged"]')
         b.wait_in_text("#account-title", "Damaged")
 
-        if m.image != "fedora-coreos": # User is not shown as logged in when logged in through Cockpit
+        if m.image != "fedora-coreos":  # User is not shown as logged in when logged in through Cockpit
             b.go("#/admin")
             b.wait_visible("#account-logout[disabled]")
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -106,7 +106,7 @@ class TestAccounts(MachineCase):
         b.wait_visible("#accounts-create")
 
         # Create a user from the UI
-        self.sed_file('s/^SHELL=.*$/SHELL=\/bin\/true/', '/etc/default/useradd')
+        self.sed_file('s@^SHELL=.*$@SHELL=/bin/true@', '/etc/default/useradd')
         b.click('#accounts-create')
         b.wait_visible('#accounts-create-dialog')
         b.set_input_text('#accounts-create-user-name', "berta")

--- a/test/verify/files/mock-range-server.py
+++ b/test/verify/files/mock-range-server.py
@@ -76,7 +76,7 @@ class RangeHTTPRequestHandler(SimpleHTTPRequestHandler):
 
         start, end = self.range
         infile.seek(start)
-        bufsize = 64 * 1024 # 64KB
+        bufsize = 64 * 1024  # 64KB
         while True:
             buf = infile.read(bufsize)
             if not buf:

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -98,7 +98,7 @@ class VirtualMachinesCaseHelpers:
         # Wait for the network 'default' to become active
         m.execute("virsh net-define /etc/libvirt/qemu/networks/default.xml || true")
         m.execute("virsh net-start default || true")
-        m.execute("until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
+        m.execute(r"until virsh net-info default | grep 'Active:\s*yes'; do sleep 1; done")
 
     def createVm(self, name, graphics='spice', ptyconsole=False, running=True, memory=128):
         m = self.machine
@@ -218,7 +218,7 @@ class VirtualMachinesCase(MachineCase, VirtualMachinesCaseHelpers, StorageHelper
         m.execute("systemctl stop firewalld; systemctl try-restart libvirtd")
 
         # FIXME: report downstream; AppArmor noisily denies some operations, but they are not required for us
-        self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')
+        self.allow_journal_messages(r'.* type=1400 .* apparmor="DENIED" operation="capable" profile="\S*libvirtd.* capname="sys_rawio".*')
         # AppArmor doesn't like the non-standard path for our storage pools
         self.allow_journal_messages('.* type=1400 .* apparmor="DENIED" operation="open" profile="virt-aa-helper" name="%s.*' % self.vm_tmpdir)
         if m.image in ["ubuntu-2004", "ubuntu-stable"]:

--- a/test/verify/machineslib.py
+++ b/test/verify/machineslib.py
@@ -41,7 +41,7 @@ class VirtualMachinesCaseHelpers:
             b.wait_in_text("#vm-{0}-state".format(vmName), "Shut off")
 
     def goToVmPage(self, vmName, connectionName='system'):
-        self.browser.click("tbody tr[data-row-id=vm-{0}-{1}] a.vm-list-item-name".format(vmName, connectionName)) # click on the row
+        self.browser.click("tbody tr[data-row-id=vm-{0}-{1}] a.vm-list-item-name".format(vmName, connectionName))  # click on the row
 
     def goToMainPage(self):
         self.browser.click(".machines-listing-breadcrumb li:first-of-type a")
@@ -55,12 +55,12 @@ class VirtualMachinesCaseHelpers:
             b.wait_not_present(vm_row)
 
     def togglePoolRow(self, poolName, connectionName="system"):
-        isExpanded = 'pf-m-expanded' in self.browser.attr("tbody tr[data-row-id=pool-{0}-{1}] + tr".format(poolName, connectionName), "class") # click on the row header
-        self.browser.click("tbody tr[data-row-id=pool-{0}-{1}] .pf-c-table__toggle button".format(poolName, connectionName)) # click on the row header
+        isExpanded = 'pf-m-expanded' in self.browser.attr("tbody tr[data-row-id=pool-{0}-{1}] + tr".format(poolName, connectionName), "class")  # click on the row header
+        self.browser.click("tbody tr[data-row-id=pool-{0}-{1}] .pf-c-table__toggle button".format(poolName, connectionName))  # click on the row header
         if isExpanded:
-            self.browser.wait_not_present("tbody tr[data-row-id=pool-{0}-{1}] + tr.pf-m-expanded".format(poolName, connectionName)) # click on the row header
+            self.browser.wait_not_present("tbody tr[data-row-id=pool-{0}-{1}] + tr.pf-m-expanded".format(poolName, connectionName))  # click on the row header
         else:
-            self.browser.wait_visible("tbody tr[data-row-id=pool-{0}-{1}] + tr.pf-m-expanded".format(poolName, connectionName)) # click on the row header
+            self.browser.wait_visible("tbody tr[data-row-id=pool-{0}-{1}] + tr.pf-m-expanded".format(poolName, connectionName))  # click on the row header
 
     def waitPoolRow(self, poolName, connectionName="system", present="true"):
         b = self.browser
@@ -71,12 +71,12 @@ class VirtualMachinesCaseHelpers:
             b.wait_not_present(pool_row)
 
     def toggleNetworkRow(self, networkName, connectionName="system"):
-        isExpanded = 'pf-m-expanded' in self.browser.attr("tbody tr[data-row-id=network-{0}-{1}] + tr".format(networkName, connectionName), "class") # click on the row header
-        self.browser.click("tbody tr[data-row-id=network-{0}-{1}] .pf-c-table__toggle button".format(networkName, connectionName)) # click on the row header
+        isExpanded = 'pf-m-expanded' in self.browser.attr("tbody tr[data-row-id=network-{0}-{1}] + tr".format(networkName, connectionName), "class")  # click on the row header
+        self.browser.click("tbody tr[data-row-id=network-{0}-{1}] .pf-c-table__toggle button".format(networkName, connectionName))  # click on the row header
         if isExpanded:
-            self.browser.wait_not_present("tbody tr[data-row-id=network-{0}-{1}] + tr.pf-m-expanded".format(networkName, connectionName)) # click on the row header
+            self.browser.wait_not_present("tbody tr[data-row-id=network-{0}-{1}] + tr.pf-m-expanded".format(networkName, connectionName))  # click on the row header
         else:
-            self.browser.wait_visible("tbody tr[data-row-id=network-{0}-{1}] + tr.pf-m-expanded".format(networkName, connectionName)) # click on the row header
+            self.browser.wait_visible("tbody tr[data-row-id=network-{0}-{1}] + tr.pf-m-expanded".format(networkName, connectionName))  # click on the row header
 
     def waitNetworkRow(self, networkName, connectionName="system", present="true"):
         b = self.browser

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -138,6 +138,7 @@ def module_copyright(moddir):
 # main
 #
 
+
 args = parse_args()
 
 with open(template_file, encoding='UTF-8') as f:

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -68,7 +68,7 @@ def module_copyright(moddir):
     mod = os.path.basename(moddir)
     copyrights = set()
     try:
-        out = subprocess.check_output(['env', '-u', 'LANGUAGE', 'LC_ALL=C.UTF-8', 'grep', '-hri', 'copyright.*\([1-9][0-9]\+\|(c)\)'],
+        out = subprocess.check_output(['env', '-u', 'LANGUAGE', 'LC_ALL=C.UTF-8', 'grep', '-hri', r'copyright.*\([1-9][0-9]\+\|(c)\)'],
                                       cwd=moddir).decode('UTF-8')
         for line in out.splitlines():
             # weed out some noise

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -28,9 +28,9 @@ def template_licenses(template):
     '''Return set of existing License: short names'''
 
     ids = set()
-    for l in template.splitlines():
-        if l.startswith('License:'):
-            ids.add(l.split(None, 1)[1].lower())
+    for line in template.splitlines():
+        if line.startswith('License:'):
+            ids.add(line.split(None, 1)[1].lower())
     return ids
 
 
@@ -40,10 +40,10 @@ def module_license(moddir):
     # First check if package.json has a "license" field
     try:
         with open(os.path.join(moddir, 'package.json'), encoding='UTF-8') as f:
-            l = json.load(f)['license']
-            if l.startswith('(MIT OR'):
+            license = json.load(f)['license']
+            if license.startswith('(MIT OR'):
                 return 'MIT'
-            return l
+            return license
     except (IOError, KeyError):
         pass
 
@@ -70,7 +70,7 @@ def module_copyright(moddir):
     try:
         out = subprocess.check_output(['env', '-u', 'LANGUAGE', 'LC_ALL=C.UTF-8', 'grep', '-hri', 'copyright.*\([1-9][0-9]\+\|(c)\)'],
                                       cwd=moddir).decode('UTF-8')
-        for l in out.splitlines():
+        for line in out.splitlines():
             # weed out some noise
             reject_substr = ['Binary file',
                              '{"version":',
@@ -87,27 +87,27 @@ def module_copyright(moddir):
                              'glyph-name=',
                              'copyright holder',
                              'WIPO copyright treaty']
-            if any(substr in l for substr in reject_substr):
+            if any(substr in line for substr in reject_substr):
                 continue
 
-            l = l.replace('<copyright>', '').replace('</copyright>', '')
-            l = l.replace('&copy;', '(c)').replace('copyright = ', '')
-            l = re.sub('@license.*Copyright', '', l)
-            l = l.strip(' \t*/\'|,#')
-            if not l.endswith('Inc.'):
+            line = line.replace('<copyright>', '').replace('</copyright>', '')
+            line = line.replace('&copy;', '(c)').replace('copyright = ', '')
+            line = re.sub('@license.*Copyright', '', line)
+            line = line.strip(' \t*/\'|,#')
+            if not line.endswith('Inc.'):
                 # avoids some duplicated lines which only differ in trailing dot
-                l = l.strip('.')
-            if l.startswith("u'") or l.startswith('u"'):  # Python unicode prefix
-                l = l[2:]
-            if 'Fixes #' in l:
+                line = line.strip('.')
+            if line.startswith("u'") or line.startswith('u"'):  # Python unicode prefix
+                line = line[2:]
+            if 'Fixes #' in line:
                 continue  # this is from a changelog
             # some noise fine-tuning for specific packages
-            if mod == 'bootstrap' and ('https://github.com' in l or l == 'Copyright 2015'):
+            if mod == 'bootstrap' and ('https://github.com' in line or line == 'Copyright 2015'):
                 continue
             if mod == 'patternfly':
-                l = re.sub(' and licensed.*', '', l)
+                line = re.sub(' and licensed.*', '', line)
 
-            copyrights.add(' ' + l)  # space prefix for debian/copyright RFC822 format
+            copyrights.add(' ' + line)  # space prefix for debian/copyright RFC822 format
     except subprocess.CalledProcessError:
         pass
 
@@ -176,9 +176,9 @@ for paragraph in sorted(paragraphs):
     output.append(f'Files: {files}\n{paragraph}')
 
 # force UTF-8 output, even when running in C locale
-for l in template.splitlines():
-    if '#NPM' in l:
+for line in template.splitlines():
+    if '#NPM' in line:
         sys.stdout.buffer.write('\n\n'.join(output).encode('UTF-8'))
     else:
-        sys.stdout.buffer.write(l.encode('UTF-8'))
+        sys.stdout.buffer.write(line.encode('UTF-8'))
     sys.stdout.buffer.write(b'\n')

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -59,16 +59,18 @@ def out(data, stream=None, flush=False):
                 continue
             raise
 
+
 def terminal_width():
     try:
         h, w, hp, wp = struct.unpack('HHHH',
-            fcntl.ioctl(1, termios.TIOCGWINSZ,
-            struct.pack('HHHH', 0, 0, 0, 0)))
+                                     fcntl.ioctl(1, termios.TIOCGWINSZ,
+                                                 struct.pack('HHHH', 0, 0, 0, 0)))
         return w
     except IOError as e:
         if e.errno != errno.ENOTTY:
             sys.stderr.write("%i %s %s\n" % (e.errno, e.strerror, sys.exc_info()))
         return sys.maxsize
+
 
 class Driver:
     def __init__(self, args):
@@ -99,7 +101,7 @@ class Driver:
         if self.color_tests:
             out('\x1b[m')
         out(": ")
-        msg = "".join([ self.test_name + " " ] + list(map(str, args)))
+        msg = "".join([self.test_name + " "] + list(map(str, args)))
         if code == "PASS" and len(msg) > self.width:
             out(msg[:self.width])
             out("...")
@@ -173,7 +175,7 @@ class TapDriver(Driver):
     def __init__(self, args):
         Driver.__init__(self, args)
         self.output = ""
-        self.reported = { }
+        self.reported = {}
         self.test_plan = None
         self.late_plan = False
         self.errored = False
@@ -368,6 +370,7 @@ class YesNoAction(argparse.Action):
     def __init__(self, option_strings, dest, **kwargs):
         argparse.Action.__init__(self, option_strings, dest, **kwargs)
         self.metavar = "[yes|no]"
+
     def __call__(self, parser, namespace, values, option_string=None):
         if not values or "yes" in values:
             setattr(namespace, self.dest, True)
@@ -377,7 +380,7 @@ class YesNoAction(argparse.Action):
 
 def main(argv):
     parser = argparse.ArgumentParser(description='Automake TAP driver')
-    parser.add_argument('--format', metavar='FORMAT', choices=[ "simple", "tap" ],
+    parser.add_argument('--format', metavar='FORMAT', choices=["simple", "tap"],
                         default="tap", help='The type of test to drive')
     parser.add_argument('--missing', metavar="TOOL", nargs='?',
                         help="Force the test to skip due to missing tool")
@@ -406,6 +409,7 @@ def main(argv):
     elif args.format == "tap":
         driver = TapDriver(args)
     return driver.run()
+
 
 if __name__ == "__main__":
     sys.exit(main(sys.argv))

--- a/tools/tap-driver
+++ b/tools/tap-driver
@@ -85,12 +85,12 @@ class Driver:
 
     def report(self, code, *args):
         CODES = {
-            "XPASS": '\x1b[0;31m', # red
-            "FAIL": '\x1b[0;31m', # red
-            "PASS": '\x1b[0;32m', # grn
-            "XFAIL": '\x1b[1;32m', # lgn
-            "SKIP": '\x1b[1;34m', # blu
-            "ERROR": '\x1b[0;35m', # mgn
+            "XPASS": '\x1b[0;31m',  # red
+            "FAIL": '\x1b[0;31m',  # red
+            "PASS": '\x1b[0;32m',  # grn
+            "XFAIL": '\x1b[1;32m',  # lgn
+            "SKIP": '\x1b[1;34m',  # blu
+            "ERROR": '\x1b[0;35m',  # mgn
         }
 
         # Print out to console

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -123,7 +123,9 @@ else
     #   - filename is *.py
     #   - executable matching ^#!/usr/bin/python3
     PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
-    # FIXME: Fix code for the warnings and re-enable them
+    # W504 and W503 are mutually exclusive (and both disabled by default)
+    # explicitly giving '--ignore W504' here is actually more strict than the default
+    # TODO: E402 should be fixed
     out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -119,8 +119,12 @@ fi
 if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
 else
+    # all normal files in test/ and tools/ which are either:
+    #   - filename is *.py
+    #   - executable matching ^#!/usr/bin/python3
+    PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run,test/verify.fmf,test/run-verify-host.sh,test/run-verify-host-user.sh) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E265,E261,W504,W605 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -124,7 +124,7 @@ else
     #   - executable matching ^#!/usr/bin/python3
     PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E265,E261,W504,W605 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E261,W504,W605 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -124,7 +124,7 @@ else
     #   - executable matching ^#!/usr/bin/python3
     PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E261,W504,W605 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E261,W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -124,7 +124,7 @@ else
     #   - executable matching ^#!/usr/bin/python3
     PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,E261,W504 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -124,7 +124,7 @@ else
     #   - executable matching ^#!/usr/bin/python3
     PYFILES="$(find test/ tools/ -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E261,W504 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,E261,W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -120,7 +120,7 @@ if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
 else
     # FIXME: Fix code for the warnings and re-enable them
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run,test/verify.fmf,test/run-verify-host.sh,test/run-verify-host-user.sh) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --ignore E402,E501,E265,E261,W504,W605 test/* --exclude=test/verify/nested-kvm,test/README.md,test/run,test/verify.fmf,test/run-verify-host.sh,test/run-verify-host-user.sh) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/title2sentence.py
+++ b/tools/title2sentence.py
@@ -66,6 +66,8 @@ patterns = [
 the_map = []
 
 # Replace exact positions
+
+
 def replace(s, old_s, word):
     if not word.strip():
         return s
@@ -77,12 +79,14 @@ def replace(s, old_s, word):
 
     return s
 
+
 def capitalize(s):
     for word in keep_words:
         if s.startswith(word):
             return s
 
     return s[0].upper() + s[1:]
+
 
 def main():
     parser = argparse.ArgumentParser(description="TODO")
@@ -144,6 +148,7 @@ def main():
 
     with open(opts.output, "w") as f:
         f.write(output)
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/tools/title2sentence.py
+++ b/tools/title2sentence.py
@@ -97,7 +97,7 @@ def main():
     with open(opts.input, "r") as f:
         for line in f:
             old_s = line.strip()
-            old_s = old_s[1:-1] # Remove first and last quotes
+            old_s = old_s[1:-1]  # Remove first and last quotes
 
             if not old_s:
                 continue

--- a/tools/title2sentence.py
+++ b/tools/title2sentence.py
@@ -143,8 +143,8 @@ def main():
     if the_map:
         output = "find pkg src test/verify -type f -exec sed -i \\\n"
         for pair in the_map:
-            output += '-e "s/\([^ ]\){0}/\\1{1}/" \\\n'.format(pair[0], pair[1])
-        output += "{} \;"
+            output += r'-e "s/\([^ ]\){0}/\1{1}/" \\\n'.format(pair[0], pair[1])
+        output += "'{}' ';'"
 
     with open(opts.output, "w") as f:
         f.write(output)


### PR DESCRIPTION
The recent changes to FMF (which included adjusting the exclude pattern
for the python static code checks) triggered an interesting (yet
very understandable) limitation in git: if you create the pre-push hook
in the recommended way:

  $ ln -s ../../tools/test-static-code .git/hooks/pre-push

and then use worktrees, then git will always run the check out of the
primary worktree, instead of the one you're working in.

That led to a bunch of newly-introduced files not being properly ignored
during the pycodestyle checks and a bunch of errors being thrown.

Upon looking into this a bit closer, I noticed that the way we're
invoking pycodestyle will cause it to check all the files immediately in
test/*, plus all files in subdiretcories with filenames of *.py, but to
skip everything else, including all of the test/verify/ scripts.

Here's a proposal for how we can improve the detection logic for which
scripts to scan, but because we went so long without checking anything
in test/verify/* and tools/*, there is an awful lot of cleanup to do
before we can merge this.