### PR TITLE
tools: Don't delete manifest.json in webpack watch mode

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -89,11 +89,8 @@ function process_result(err, stats) {
             // Force "make" to re-create everything.  The results of
             // incremental building are not good enough for building
             // RPMs, for example.
-            var stamp = makefile.split("/").slice(0, -1).concat(["manifest.json"]).join("/");
             if (fs.existsSync(makefile))
                 fs.unlinkSync(makefile);
-            if (fs.existsSync(stamp))
-                fs.unlinkSync(stamp);
         }
     }
 }


### PR DESCRIPTION
Commit b82b22abef679 caused webpack-watch to always delete
manifest.json, which broke efficient local development pretty hard.

Leave the manifest.json alone, they actually *are* good enough for
building RPMs now, as these are just static file copes. Still keep the
cleanup of Makefile.deps though, until webpack-make gets cleaned up more
thoroughly.