### PR TITLE
workflows: Regularly prune -dist repository

### DIFF
--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -1,0 +1,39 @@
+# truncate the cockpit-dist history every Sunday night, to avoid unbounded growth
+name: prune-dist
+on:
+  schedule:
+    - cron: '0 1 * * 0'
+  # can be run manually on https://github.com/cockpit-project/cockpit/actions
+  workflow_dispatch:
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up configuration and secrets
+        run: |
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
+          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
+          # we push to -dist repo via https://github.com, that needs our cockpituous token
+          git config --global credential.helper store
+          echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
+
+      - name: Clone -dist repo
+        run: |
+          git clone https://github.com/${{ github.repository }}-dist.git dist-repo
+
+      - name: Truncate history of -dist repo
+        run: |
+          set -ex
+          cd dist-repo
+          # oldest commit that applies to any still present tarball
+          REF=$(git log --pretty=format:%H * | tail -n1)
+
+          git checkout --orphan temp $REF
+          git commit -m "Truncated history"
+          git rebase --onto temp $REF master
+          git branch -D temp
+          git reflog expire --expire=now --all
+
+      - name: Force-push -dist repo
+        run: git -C dist-repo push -f


### PR DESCRIPTION
This avoids unbounded growth of the -dist repository. This force-pushes,
so is prone to race with parallel publish-dist jobs. So run this at
Sunday night, where the probability of human PRs is very low; no other
workflows run at this time either.

-----

I tested this on my fork. Before:
```
$ git clone https://github.com/martinpitt/cockpit-dist c
$ du -hs c/.git; du -hs c
314M	c/.git
562M	c
```

Then in [ran the workflow](https://github.com/martinpitt/cockpit/actions/runs/675122930), and now it [shows the truncated history](https://github.com/martinpitt/cockpit-dist/commits/master) and is smaller:
```
$ git clone https://github.com/martinpitt/cockpit-dist c2
$ du -hs c2/.git; du -hs c2
281M	c2/.git
529M	c2
```
I expect that the effect will be a lot more dramatic on the real cockpit repo.