### PR TITLE
Kpatch integration

### DIFF
--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -57,6 +57,9 @@ export function install_dialog(pkg, options) {
     var cancel = null;
     var done = null;
 
+    if (!Array.isArray(pkg))
+        pkg = [pkg];
+
     options = options || { };
 
     var prom = new Promise((resolve, reject) => { done = f => { if (f) resolve(); else reject(); } });
@@ -67,7 +70,7 @@ export function install_dialog(pkg, options) {
         let remove_details = null;
         let footer_message = null;
 
-        const missing_name = <strong>{pkg}</strong>;
+        const missing_name = <strong>{pkg.join(", ")}</strong>;
 
         if (data && data.extra_names.length > 0)
             extra_details = (
@@ -135,7 +138,7 @@ export function install_dialog(pkg, options) {
     }
 
     function check_missing() {
-        PK.check_missing_packages([pkg],
+        PK.check_missing_packages(pkg,
                                   p => {
                                       cancel = p.cancel;
                                       var pm = null;

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -25,7 +25,9 @@ import {
     FormSelect, FormSelectOption,
     Modal, Radio, Text, TextVariants,
     TimePicker,
+    Split, SplitItem,
 } from '@patternfly/react-core';
+import { InfoIcon } from "@patternfly/react-icons";
 
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import { validateTime } from "timepicker-helpers.js";
@@ -253,7 +255,7 @@ function getBackend(forceReinit) {
  * Properties:
  * onInitialized(enabled): (optional): callback once backend knowsn whether automatic updates are enabled
  */
-export const AutoUpdatesBody = (props) => {
+export const AutoUpdatesStatus = (props) => {
     const { enabled, type, day, time } = props;
     const days = {
         "": "every day",
@@ -274,7 +276,16 @@ export const AutoUpdatesBody = (props) => {
         str = _("Automatic updates are not set up");
     }
 
-    return (<Text component={TextVariants.p}>{str}</Text>);
+    return (
+        <Split hasGutter>
+            <SplitItem>
+                <InfoIcon />
+            </SplitItem>
+            <SplitItem isFilled>
+                <Text component={TextVariants.p}>{str}</Text>
+            </SplitItem>
+        </Split>
+    );
 };
 
 /**
@@ -283,7 +294,7 @@ export const AutoUpdatesBody = (props) => {
  * Properties:
  * onInitialized(enabled): (optional): callback once backend knowsn whether automatic updates are enabled
  */
-export class AutoUpdates extends React.Component {
+export class AutoUpdatesSettings extends React.Component {
     constructor() {
         super();
         this.state = {
@@ -405,21 +416,32 @@ export class AutoUpdates extends React.Component {
         );
 
         return (<>
-            <Button variant="secondary"
-                    isDisabled={!enabled}
-                    onClick={() => {
-                        if (!this.state.backend.installed) {
-                            install_dialog(this.state.backend.packageName)
-                                    .then(() => {
-                                        this.initializeBackend(true);
-                                        this.setState({ showModal: true });
-                                    }, () => null);
-                        } else {
-                            this.setState({ showModal: true });
-                        }
-                    }}>
-                {_("Edit")}
-            </Button>
+            <Split hasGutter>
+                <SplitItem>
+                    <Text component={TextVariants.h4}>{_("Automatic updates")}</Text>
+                </SplitItem>
+                <SplitItem isFilled>
+                    <Text component={TextVariants.small}>{this.state.enabled ? _("Enabled") : _("Disabled")}</Text>
+                </SplitItem>
+                <SplitItem>
+                    <Button variant="secondary"
+                            isDisabled={!enabled}
+                            isSmall
+                            onClick={() => {
+                                if (!this.state.backend.installed) {
+                                    install_dialog(this.state.backend.packageName)
+                                            .then(() => {
+                                                this.initializeBackend(true);
+                                                this.setState({ showModal: true });
+                                            }, () => null);
+                                } else {
+                                    this.setState({ showModal: true });
+                                }
+                            }}>
+                        {_("Edit")}
+                    </Button>
+                </SplitItem>
+            </Split>
             <Modal position="top" variant="small" id="automatic-updates-dialog" isOpen={this.state.showModal}
                 title={_("Automatic updates")}
                 onClose={() => this.setState({ showModal: false })}
@@ -444,7 +466,7 @@ export class AutoUpdates extends React.Component {
     }
 }
 
-AutoUpdates.propTypes = {
+AutoUpdatesSettings.propTypes = {
     privileged: PropTypes.bool.isRequired,
     onInitialized: PropTypes.func,
 };

--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -1,0 +1,319 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from 'prop-types';
+import {
+    Button,
+    List, ListItem,
+    Modal,
+    Split, SplitItem,
+    Stack, StackItem,
+    Switch,
+    Text, TextVariants
+} from '@patternfly/react-core';
+import { InfoIcon } from "@patternfly/react-icons";
+
+import cockpit from "cockpit";
+import { proxy as serviceProxy } from 'service';
+import { check_missing_packages } from "packagekit.js";
+import { install_dialog } from "cockpit-components-install-dialog.jsx";
+
+const _ = cockpit.gettext;
+
+export class KpatchSettings extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            auto: null,
+            loaded: false,
+            enabled: null,
+            missing: [],
+            unavailable: [],
+            updating: false,
+            showModal: false,
+            futureEnabled: null,
+            futureAuto: null,
+        };
+
+        this.kpatchService = serviceProxy("kpatch");
+
+        this.checkSetup = this.checkSetup.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.handleService = this.handleService.bind(this);
+        this.handleInstall = this.handleInstall.bind(this);
+        this.installPatches = this.installPatches.bind(this);
+    }
+
+    componentDidMount() {
+        check_missing_packages(["kpatch", "kpatch-dnf"])
+                .then(d => {
+                    this.setState({
+                        loaded: true,
+                        unavailable: d.unavailable_names || [],
+                        missing: d.missing_names || [],
+                    });
+
+                    if ((d.unavailable_names || []).length === 0 && (d.missing_names || []).length === 0)
+                        this.checkSetup();
+                })
+                .catch(e => {
+                    console.log("Failed to query info about availablity of kpatch");
+                });
+
+        this.kpatchService.addEventListener('changed', () => {
+            this.setState({ enabled: this.kpatchService.enabled, futureEnabled: this.kpatchService.enabled });
+        });
+    }
+
+    handleService(enable) {
+        if (enable)
+            return this.kpatchService.enable();
+        else
+            return this.kpatchService.disable();
+    }
+
+    installPatches(auto) {
+        return cockpit.spawn(["dnf", "-y", "kpatch", auto ? "auto" : "manual"], { superuser: "require", err: "message" });
+    }
+
+    checkSetup() {
+        return new Promise((resolve, reject) => {
+            cockpit.file("/etc/dnf/plugins/kpatch.conf").read()
+                    .then(data => {
+                        if (!data) {
+                            resolve();
+                        } else {
+                            const autoupdate = data.split("\n").find(l => l.indexOf("autoupdate") >= 0);
+                            const auto = autoupdate.endsWith("True");
+                            this.setState({ auto: auto, futureAuto: auto }, resolve);
+                        }
+                    })
+                    .catch(reject);
+        });
+    }
+
+    handleInstall() {
+        this.setState({ updating: true });
+        install_dialog(this.state.missing)
+                .then(() => {
+                    this.setState({ missing: [], updating: false });
+                })
+                .catch(() => this.setState({ updating: false }));
+    }
+
+    handleChange() {
+        this.setState({ updating: true });
+
+        const promises = [];
+
+        if (this.state.auto !== this.state.futureAuto)
+            promises.push(this.installPatches(this.state.futureAuto));
+
+        if (this.state.enabled !== this.state.futureEnabled)
+            promises.push(this.handleService(this.state.futureEnabled));
+
+        Promise.all(promises)
+                .then(() => this.setState({ showModal: false }))
+                .catch(console.log)
+                .finally(() => {
+                    this.checkSetup();
+                    this.setState({ updating: false });
+                });
+    }
+
+    render() {
+        // Not yet recognized
+        if (this.state.loaded === false)
+            return null;
+
+        // Not supported on this system
+        if (this.state.unavailable.length > 0)
+            return null;
+
+        let state = _("Enabled");
+        let actionText = _("Edit");
+        let action = () => this.setState({ showModal: true });
+
+        if (this.state.missing.length > 0 && this.state.unavailable.length === 0) {
+            state = _("Not installed");
+            actionText = _("Install");
+            action = this.handleInstall;
+        } else if (this.state.auto === false) {
+            state = _("Disabled");
+            actionText = _("Enable");
+        }
+
+        const details = [];
+        if (this.state.enabled !== this.state.futureEnabled) {
+            if (this.state.futureEnabled)
+                details.push(_("kpatch.service will be enabled. After each reboot patches will be applied."));
+            else
+                details.push(_("kpatch.service will be disabled. After reboot no patches will be applied."));
+        }
+        // FIXME - should we uninstall current patches as well?
+        if (this.state.auto !== this.state.futureAuto) {
+            if (this.state.futureAuto)
+                details.push(_("Current kernel patches will be installed. Also when a new kernel is available, patches will be automatically installed as well."));
+            else
+                details.push(_("For future kernel versions patches won't be installed."));
+        }
+
+        const body = <Stack hasGutter>
+            <StackItem>
+                <Switch isChecked={this.state.futureEnabled}
+                            label={_("Kernel live patching service is enabled")}
+                            labelOff={_("Kernel live patching service is disabled")}
+                            onChange={c => this.setState({ futureEnabled: c })} />
+            </StackItem>
+            <StackItem>
+                <Switch isChecked={this.state.futureAuto}
+                            label={_("Subscribed to available kernel patches")}
+                            labelOff={_("Not subscribed to kernel patches")}
+                            onChange={c => this.setState({ futureAuto: c })} />
+            </StackItem>
+            <StackItem>
+                <List>{details.map(d => <ListItem key={d}>{d}</ListItem>)}</List>
+            </StackItem>
+        </Stack>;
+
+        return (<>
+            <Split hasGutter>
+                <SplitItem>
+                    <Text component={TextVariants.h4}>{_("Kernel live patching")}</Text>
+                </SplitItem>
+                <SplitItem isFilled>
+                    <Text component={TextVariants.small}>{state}</Text>
+                </SplitItem>
+                <SplitItem>
+                    <Button variant="secondary"
+                            isSmall
+                            disabled={!this.props.privileged}
+                            onClick={action}>
+                        {actionText}
+                    </Button>
+                </SplitItem>
+            </Split>
+            <Modal position="top" variant="small" id="kpatch-setup" isOpen={this.state.showModal}
+                title={_("Kernel live patching settings")}
+                onClose={() => this.setState({ showModal: false })}
+                footer={
+                    <>
+                        <Button variant="primary"
+                                isLoading={ this.state.updating }
+                                isDisabled={ this.state.updating || details.length === 0 }
+                                onClick={ this.handleChange }>
+                            {_("Apply")}
+                        </Button>
+                        <Button variant="link"
+                                isDisabled={ this.state.updating }
+                                onClick={() => this.setState({ showModal: false })}>
+                            {_("Cancel")}
+                        </Button>
+                    </>
+                }>
+                {body}
+            </Modal>
+        </>);
+    }
+}
+
+KpatchSettings.propTypes = {
+    privileged: PropTypes.bool.isRequired,
+};
+
+export class KpatchStatus extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            loaded: [],
+            installed: [],
+            changelog: null, // FIXME - load changelog
+            opened: false,
+        };
+
+        this.checkSetup = this.checkSetup.bind(this);
+    }
+
+    checkSetup() {
+        cockpit.spawn(["kpatch", "list"], { superuser: "try", err: "ignore" })
+                .then(m => {
+                    const parts = m.trim().split("\n\n");
+                    if (parts.length !== 2 ||
+                        !parts[0].startsWith("Loaded patch modules:\n") ||
+                        !parts[1].startsWith("Installed patch modules:\n")) {
+                        console.warn("Unexpected output from `kpatch list`");
+                        return;
+                    }
+
+                    const loaded = parts[0].split("\n")
+                            .slice(1)
+                            .map(i => i.split(" ")[0]);
+                    const installed = parts[1].split("\n")
+                            .slice(1)
+                            .map(i => i.split(" ")[0]);
+                    this.setState({ loaded, installed });
+                })
+                .catch(() => true); // Ignore errors
+    }
+
+    componentDidMount() {
+        this.checkSetup();
+    }
+
+    componentWillUnmount() {
+        if (this.watch)
+            this.watch.close();
+    }
+
+    render() {
+        let text = [];
+        text = this.state.loaded.map(i =>
+            <Text key={i} component={TextVariants.p}>
+                { cockpit.format(_("Kernel patch $0 is active"), i) }
+            </Text>
+        );
+
+        // FIXME - when only installed offer to load
+        if (text.length === 0)
+            text = this.state.installed.map(i =>
+                <Text key={i} component={TextVariants.p}>
+                    { cockpit.format(_("Kernel patch $0 is installed"), i) }
+                </Text>
+            );
+
+        if (text.length > 0)
+            return (
+                <Split hasGutter>
+                    <SplitItem>
+                        <InfoIcon />
+                    </SplitItem>
+                    <SplitItem isFilled>
+                        <Stack>
+                            {text}
+                        </Stack>
+                    </SplitItem>
+                </Split>
+            );
+
+        return null;
+    }
+}

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -47,6 +47,7 @@ import { cellWidth, TableText } from "@patternfly/react-table";
 import { Remarkable } from "remarkable";
 
 import { AutoUpdatesSettings, AutoUpdatesStatus } from "./autoupdates.jsx";
+import { KpatchSettings, KpatchStatus } from "./kpatch.jsx";
 import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -831,11 +832,17 @@ class CardsPage extends React.Component {
                                        day={this.state.autoUpdatesDay}
                                        time={this.state.autoUpdatesTime} />
             </StackItem>
+            <StackItem>
+                <KpatchStatus />
+            </StackItem>
         </Stack>;
 
         const settingsContent = <Stack hasGutter>
             <StackItem>
                 <AutoUpdatesSettings onInitialized={newState => this.setState(newState)} privileged={this.props.privileged} />
+            </StackItem>
+            <StackItem>
+                <KpatchSettings privileged={this.props.privileged} />
             </StackItem>
         </Stack>;
 

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -333,22 +333,6 @@ table.header-buttons {
     padding-left: 0.5em;
 }
 
-.status-notification {
-    margin-bottom: 1rem;
-    #icon {
-        vertical-align: -25% !important;
-    }
-    .fa-lg {
-        font-size: 1.5rem;
-    }
-    #state {
-        margin-bottom: 0.3rem;
-    }
-    .pf-l-flex.pf-m-column > * {
-        margin: 0;
-    }
-}
-
 .cockpit-update-warning {
     margin-right: 1rem;
 }

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -38,6 +38,8 @@ done
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
                      "fedora-coreos", "centos-8-stream"]
+OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
+                     "fedora-coreos", "fedora-33", "fedora-34", "centos-8-stream"]
 
 
 class NoSubManCase(PackageCase):
@@ -136,6 +138,67 @@ class TestUpdates(NoSubManCase):
             time.sleep(1)
         else:
             self.fail("Timed out waiting for updates spinner to go away")
+
+    @skipImage("kpatch is not available", *OSesWithoutKpatch)
+    def testKpatch(self):
+        b = self.browser
+        m = self.machine
+
+        kernel_ver_arch = m.execute("uname -r").strip()
+        sanitized_kernel_ver = "_".join(kernel_ver_arch.split(".")[:-2])
+        self.createPackage("kpatch-patch-" + sanitized_kernel_ver, "0", "0", arch=self.secondary_arch,
+                           provides="kpatch-patch = {0}".format(kernel_ver_arch))
+        self.enableRepo()
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        # Enable and install kpatch
+        b.wait_in_text("#settings .pf-l-stack__item:nth-child(2)", "Kernel live patching")
+        b.wait_in_text("#settings .pf-l-stack__item:nth-child(2)", "Disabled")
+        b.click("button:contains('Enable')")
+
+        # Enable kpatch service
+        b.wait_not_in_text("#kpatch-setup", "kpatch.service will be enabled")
+        b.wait_visible(".pf-l-stack__item:first-child .pf-c-switch__input:not(:checked)")
+        b.click(".pf-l-stack__item:first-child .pf-c-switch__input")
+        b.wait_in_text("#kpatch-setup", "kpatch.service will be enabled")
+        b.wait_visible(".pf-l-stack__item:first-child .pf-c-switch__input:checked")
+
+        # Subscribe to patches
+        b.wait_not_in_text("#kpatch-setup", "Current kernel patches will be installed")
+        b.wait_visible(".pf-l-stack__item:nth-child(2) .pf-c-switch__input:not(:checked)")
+        b.click(".pf-l-stack__item:nth-child(2) .pf-c-switch__input")
+        b.wait_in_text("#kpatch-setup", "Current kernel patches will be installed.")
+        b.wait_in_text("#kpatch-setup", "kpatch.service will be enabled")
+        b.wait_visible(".pf-l-stack__item:nth-child(2) .pf-c-switch__input:checked")
+
+        b.click("button:contains('Apply')")
+        b.wait_not_present("#kpatch-setup")
+
+        b.wait(lambda: "True" in m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
+        b.wait(lambda: "active" in m.execute("systemctl is-active kpatch || true"))
+
+        # Faking real patches is really hard, so fake `kpatch list` command
+        # To make sure it has the same structure as we expect it to be first check the real command
+        self.assertEqual(m.execute("kpatch list"), "Loaded patch modules:\n\nInstalled patch modules:\n")
+
+        kpatch = """
+#!/bin/bash
+echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled patch modules:\nkpatch_3_10_0_1062_1_1 (3.10.0-1062.el7.x86_64)"
+"""
+
+        self.createPackage("kpatch-patch-" + sanitized_kernel_ver, "1", "0", arch=self.secondary_arch,
+                           provides="kpatch-patch = {0}".format(kernel_ver_arch),
+                           content={"/usr/local/bin/kpatch": kpatch},
+                           postinst="chmod +x /usr/local/bin/kpatch; rm /usr/sbin/kpatch; ln -s /usr/local/bin/kpatch /usr/sbin/kpatch")
+        self.enableRepo()
+
+        b.click("#status .pf-c-card__actions button")
+        b.wait_visible(".pf-c-badge:contains('patches')")
+        b.click("button:contains('Install all updates')")
+        b.click("button:contains('Continue')")
+        b.wait_in_text("#status", "Kernel patch kpatch_3_10_0_1062_1_1 is active")
 
     def testBasic(self):
         # no security updates, no changelogs

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -36,7 +36,7 @@ for x in $(seq 1 200); do
 done
 """
 
-OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "ubuntu-testing",
+OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
                      "fedora-coreos", "centos-8-stream"]
 
 

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -89,16 +89,21 @@ class PackageCase(MachineCase):
     #
 
     def createPackage(self, name, version, release, install=False,
-                      postinst=None, depends="", content=None, arch=None, **updateinfo):
+                      postinst=None, depends="", content=None, arch=None, provides=None, **updateinfo):
         '''Create a dummy package in repo_dir on self.machine
 
         If install is True, install the package. Otherwise, update the package
         index in repo_dir.
         '''
-        if self.backend == "apt":
-            self.createDeb(name, version + '-' + release, depends, postinst, install, content, arch)
+        if provides:
+            provides = "Provides: {0}".format(provides)
         else:
-            self.createRpm(name, version, release, depends, postinst, install, content, arch)
+            provides = ""
+
+        if self.backend == "apt":
+            self.createDeb(name, version + '-' + release, depends, postinst, install, content, arch, provides)
+        else:
+            self.createRpm(name, version, release, depends, postinst, install, content, arch, provides)
         if updateinfo:
             self.updateInfo[(name, version, release)] = updateinfo
 
@@ -125,18 +130,18 @@ class PackageCase(MachineCase):
                 else:
                     self.machine.write(dest, data)
         cmd = '''mkdir -p /tmp/b/DEBIAN {repo}
-                 printf "Package: {name}\nVersion: {ver}\nPriority: optional\nSection: test\nMaintainer: foo\nDepends: {deps}\nArchitecture: {arch}\nDescription: dummy {name}\n" > /tmp/b/DEBIAN/control
+                 printf "Package: {name}\nVersion: {ver}\nPriority: optional\nSection: test\nMaintainer: foo\nDepends: {deps}\nArchitecture: {arch}\nDescription: dummy {name}\n{provides}\n" > /tmp/b/DEBIAN/control
                  {post}
                  touch /tmp/b/stamp-{name}-{ver}
                  dpkg -b /tmp/b {deb}
                  rm -r /tmp/b
-                 '''.format(name=name, ver=version, deps=depends, deb=deb, post=postinstcode, repo=self.repo_dir, arch=arch)
+                 '''.format(name=name, ver=version, deps=depends, deb=deb, post=postinstcode, repo=self.repo_dir, arch=arch, provides=provides)
         if install:
             cmd += "dpkg -i " + deb
         self.machine.execute(cmd)
         self.addCleanup(self.machine.execute, "dpkg -P --force-depends --force-remove-reinstreq %s 2>/dev/null || true" % name)
 
-    def createRpm(self, name, version, release, requires, post, install, content, arch):
+    def createRpm(self, name, version, release, requires, post, install, content, arch, provides):
         '''Create a dummy rpm in repo_dir on self.machine
 
         If install is True, install the package. Otherwise, update the package
@@ -170,6 +175,7 @@ Name: {0}
 Version: {1}
 Release: {2}
 License: BSD
+{8}
 {7}
 {4}
 
@@ -183,7 +189,7 @@ Test package.
 {6}
 
 {3}
-""".format(name, version, release, postcode, requires, installcmds, installedfiles, architecture)
+""".format(name, version, release, postcode, requires, installcmds, installedfiles, architecture, provides)
         self.machine.write("/tmp/spec", spec)
         cmd = """
 rpmbuild --quiet -bb /tmp/spec


### PR DESCRIPTION
Note about commits:
Includes a few unrelated commits, I'll split them into separate PR once I get test runs on them. Almost certain at least one of them breaks tests but too many tests might be affected so I'll let bots do the dirty work.

Notes:
- I would really like to test this on real patches. To my knowledge there are no patches yet for 8.4, but I'll check it out again.
- Tests are not as I would like them - I would prefer to also test kernel update with patches for this new kernel - but I struggled to make it work so I just check that `dnf kpatch` is set to `auto` and hope it works as it is supposed to. I would also prefer to test `kpatch list` but making own patches that would be real was just impractical to do, so I ended up faking `kpatch` utility.
- We possibly could watch /sys/kernel/livepatch to recognize when patches are loaded, but seems rather corner case. When using our UI to install patches it will be updated after package updates
- There is corner case when for some reason patches are installed but not loaded. This would happen only if user would mangle with it in some way (like disabling service and rebooting machine). We could show `Install` button but I haven't implemented that yet.
- I don't show any changelog, follow up?

How it looks like: (sorry no screencast, computer does not want to collaborate)
(No patches installed nor loaded, but available):
![packgesandneabled](https://user-images.githubusercontent.com/12330670/111981387-eb153680-8b07-11eb-8d2f-f40be004761c.png)

The edit button (that can be `Install` when kpatch is not installed but available) opens this dialog. When user toggles switches a note is shown on bottom of what will happen if they press 'Apply'.
![willdostuff](https://user-images.githubusercontent.com/12330670/111981428-f5cfcb80-8b07-11eb-9947-5e16ae9e3655.png)

When some patches are also loaded (it will show also when some are only installed).
![withactivepatches](https://user-images.githubusercontent.com/12330670/111981594-2a438780-8b08-11eb-8a58-ade644ebe3ff.png)
