### PR TITLE
verify: revert recent changes to check-testlib

### DIFF
--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -128,12 +128,12 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestExample.testFail", "TestExample.testSkip"],
                                  env=env, capture_output=True)
         stdout = process.stdout
-        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)$")
-        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)$")
-        self.assertRegex(stdout, rb"^not ok 1 .*test/verify/check-example TestExample.testFail$")
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
         self.assertNotRegex(stdout, b"RETRY 3")
-        self.assertRegex(stdout, rb"^ok 2 .*test/verify/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)$")
-        self.assertRegex(stdout, rb"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
+        self.assertRegex(stdout, b"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
+        self.assertRegex(stdout, b"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
 
         # Check retry logic for changed tests
         test_file = os.path.join(VERIFY_DIR, "check-testlib")
@@ -148,17 +148,17 @@ class TestRunTest(MachineCase):
         stdout = process.stdout
 
         # Changed test need to succeed 3 times
-        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)$")
-        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)$")
-        self.assertRegex(stdout, rb"^ok 1 .*test/verify/check-testlib TestRetryExample.testBasic$")
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic\n")
         self.assertNotRegex(stdout, b"RETRY 3")
 
         # Changed test is never retried
-        self.assertRegex(stdout, rb"^not ok 2 .*test/verify/check-testlib TestRetryExample.testFail$")
+        self.assertRegex(stdout, b"\nnot ok 2 .*test\/verify\/check-testlib TestRetryExample.testFail\n")
         self.assertNotRegex(stdout, b"testFail # RETRY")
 
         # Using @no_retry_when_changed prevents this retry logic
-        self.assertRegex(stdout, b"^ok 3 .*test/verify/check-testlib TestRetryExample.testNoRetry$")
+        self.assertRegex(stdout, b"\nok 3 .*test\/verify\/check-testlib TestRetryExample.testNoRetry\n")
         self.assertNotRegex(stdout, b"testNoRetry # RETRY")
 
         # Check retry logic for changed source
@@ -174,12 +174,12 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "--list", "TestHostEditing.testLimits",
                                   "TestHostSwitching.testEdit"], env=env, capture_output=True)
         stdout = process.stdout
-        self.assertIn(b"\nTestHostEditing.testLimits # RETRY 1 (test affected tests 3 times)\n", stdout)
-        self.assertIn(b"\nTestHostEditing.testLimits # RETRY 2 (test affected tests 3 times)\n", stdout)
-        self.assertIn(b"\nTestHostEditing.testLimits\n", stdout)
-        self.assertNotIn(b"RETRY 3", stdout)
-        self.assertIn(b"\nTestHostSwitching.testEdit\n", stdout)
-        self.assertNotIn(b"TestHostSwitching.testEdit # RETRY", stdout)
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, b"\nTestHostEditing.testLimits\n")
+        self.assertNotRegex(stdout, b"RETRY 3")
+        self.assertRegex(stdout, b"\nTestHostSwitching.testEdit\n")
+        self.assertNotRegex(stdout, b"TestHostSwitching.testEdit # RETRY")
 
 
 @skipImage("Do not test BaseOS packages", "rhel-8-3-distropkg", "rhel-8-4-distropkg")

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -126,7 +126,8 @@ else
     # W504 and W503 are mutually exclusive (and both disabled by default)
     # explicitly giving '--ignore W504' here is actually more strict than the default
     # TODO: E402 should be fixed
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504 $PYFILES) || true
+    # TODO: W605 should be fixed very soon...
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504,W605 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"


### PR DESCRIPTION
The regexp changes here broke things, but the breakage was being
temporarily covered up by a separate bug, so they didn't show in the
initial round of tests on the PR.

At the same time, things are very much broken right now, so revert the
changes in check-testlib.

We need to add an exception to the static code checks again until we fix
this properly.