### PR TITLE
users: Fix lastlog parsing

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -63,14 +63,18 @@ function get_logged(name) {
 
 function get_last_login(name) {
     function parse_last_login(data) {
-        data = data.split('\n')[1]; // throw away header
-        if (data.length === 0) return null;
-        data = data.split('   '); // get last column - separated by spaces
-
-        if (data[data.length - 1].indexOf('**Never logged in**') > -1)
+        const line = data.split('\n')[1]; // throw away header
+        if (!line || line.length === 0 || line.indexOf('**Never logged in**') > -1)
             return null;
-        else
-            return new Date(data[data.length - 1]);
+
+        // line looks like this: admin            web cons ::ffff:172.27.0. Tue Mar 23 14:49:04 +0000 2021
+        const date_fields = line.split(' ').slice(-5);
+        const d = new Date(date_fields.join(' '));
+        if (d.getTime() > 0)
+            return d;
+
+        console.warn("Failed to parse date from lastlog line:", line);
+        return null;
     }
 
     return cockpit.spawn(["/usr/bin/lastlog", "-u", name], { environ: ["LC_ALL=C"] })

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -273,6 +273,8 @@ class TestAccounts(MachineCase):
             b.go("#/admin")
             b.wait_visible("#account-logout[disabled]")
 
+            (year, month) = m.execute("date +'%Y %B'").strip().split()
+
             # Log in as "admin" and the open details in other browser should update
             b2 = self.new_browser(m)
             b2.login_and_go("/system")
@@ -281,14 +283,16 @@ class TestAccounts(MachineCase):
 
             # Now log out and it should update again
             b2.logout()
-            b.wait_not_in_text("#account-last-login", "Logged in")
+            b.wait_in_text("#account-last-login", year)
+            b.wait_in_text("#account-last-login", month)
             b.wait_visible("#account-logout[disabled]")
 
             # Terminate session
             b2.login_and_go("/system")
             b.wait_text("#account-last-login", "Logged in")
             b.click("#account-details button:contains('Terminate session')")
-            b.wait_not_in_text("#account-last-login", "Logged in")
+            b.wait_in_text("#account-last-login", year)
+            b.wait_in_text("#account-last-login", month)
             b.wait_visible("#account-logout[disabled]")
 
         self.allow_journal_messages("Password quality check failed:")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -276,19 +276,19 @@ class TestAccounts(MachineCase):
             # Log in as "admin" and the open details in other browser should update
             b2 = self.new_browser(m)
             b2.login_and_go("/system")
-            b.wait_in_text("#account-details", "Logged in")
+            b.wait_text("#account-last-login", "Logged in")
             b.wait_visible("#account-logout:not(:disabled)")
 
             # Now log out and it should update again
             b2.logout()
-            b.wait_not_in_text("#account-details", "Logged in")
+            b.wait_not_in_text("#account-last-login", "Logged in")
             b.wait_visible("#account-logout[disabled]")
 
             # Terminate session
             b2.login_and_go("/system")
-            b.wait_in_text("#account-details", "Logged in")
+            b.wait_text("#account-last-login", "Logged in")
             b.click("#account-details button:contains('Terminate session')")
-            b.wait_not_in_text("#account-details", "Logged in")
+            b.wait_not_in_text("#account-last-login", "Logged in")
             b.wait_visible("#account-logout[disabled]")
 
         self.allow_journal_messages("Password quality check failed:")


### PR DESCRIPTION
get_last_login() made the assumption that the date is separated by three
spaces. But that's not the case in reality, as the "From:" column can
become very wide. As there is no reliable column size or separator that
sets apart the date, just take the last five words from the line
instead, which should be the date.

With the previous code, this tried to parse "web cons ::ffff:172.27.0.
Tue Mar..." as a date, which returned an invalid `Date` object. This
confused the `!details.logged.last` check -- it was a proper object (and
thus not falsy), but stringifying it yielded `null`, and thus moment
spat out "Invalid date". Avoid that by explicitly testing whether
getTime() is an actual number -- for invalid dates this will be `NaN`.

This was not caught by the tests because they just asserted that the
message changed away from "Logged in", thus they were happy with
"Invalid date". Instead, make sure the line contains something date-ish
which at least contains the current month name and year.

Fixes #15452