### PR TITLE
lib: replace onHover custom function in plots with an inline tooltip

### DIFF
--- a/pkg/lib/cockpit-components-plot.jsx
+++ b/pkg/lib/cockpit-components-plot.jsx
@@ -308,7 +308,7 @@ const useLayoutSize = (init_width, init_height) => {
     return [ref, size];
 };
 
-export const SvgPlot = ({ title, config, plot_state, plot_id, onHover, className }) => {
+export const SvgPlot = ({ title, config, plot_state, plot_id, className }) => {
     const [container_ref, container_size] = useLayoutSize(0, 0);
     const [measure_ref, measure_size] = useLayoutSize(36, 20);
 
@@ -376,10 +376,12 @@ export const SvgPlot = ({ title, config, plot_state, plot_id, onHover, className
             d += cmd("L", w - m_right, h - m_bottom);
             d += "z";
 
-            return <path key={hover_arg} d={d}
-                         role="presentation"
-                         onMouseEnter={() => onHover && onHover(hover_arg)}
-                         onMouseLeave={() => onHover && onHover(null)} />;
+            return (
+                <path key={hover_arg} d={d}
+                      role="presentation">
+                    <title>{hover_arg}</title>
+                </path>
+            );
         }
 
         const paths = [];

--- a/pkg/networkmanager/network-interface-members.jsx
+++ b/pkg/networkmanager/network-interface-members.jsx
@@ -51,7 +51,6 @@ export const NetworkInterfaceMembers = ({
     interfaces,
     iface,
     usage_monitor,
-    highlight,
     privileged
 }) => {
     const model = useContext(ModelContext);
@@ -131,7 +130,6 @@ export const NetworkInterfaceMembers = ({
                     }
                 ],
                 props: {
-                    className: highlight == iface.Name ? ["highlight-ct"] : [],
                     key: iface.Name,
                     "data-interface": encodeURIComponent(iface.Name),
                     "data-sample-id": isActive ? encodeURIComponent(iface.Name) : null,

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -18,7 +18,7 @@
  */
 import $ from 'jquery';
 import cockpit from "cockpit";
-import React, { useState, useContext } from "react";
+import React, { useContext } from "react";
 import {
     Breadcrumb, BreadcrumbItem,
     Button,
@@ -70,7 +70,6 @@ export const NetworkInterfacePage = ({
     iface
 }) => {
     const model = useContext(ModelContext);
-    const [highlight, setHighlight] = useState(null);
 
     const dev_name = iface.Name;
     const dev = iface.Device;
@@ -667,7 +666,6 @@ export const NetworkInterfacePage = ({
                                      interfaces={interfaces}
                                      iface={iface}
                                      usage_monitor={usage_monitor}
-                                     highlight={highlight}
                                      privileged={privileged} />);
     }
 
@@ -755,7 +753,7 @@ export const NetworkInterfacePage = ({
                       </BreadcrumbItem>
                   </Breadcrumb>}>
             <PageSection variant={PageSectionVariants.light}>
-                <NetworkPlots plot_state={plot_state} onHover={setHighlight} />
+                <NetworkPlots plot_state={plot_state} />
             </PageSection>
             <PageSection>
                 <Gallery hasGutter>

--- a/pkg/networkmanager/network-main.jsx
+++ b/pkg/networkmanager/network-main.jsx
@@ -18,7 +18,7 @@
  */
 
 import cockpit from "cockpit";
-import React, { useState } from 'react';
+import React from 'react';
 import { useEvent } from "hooks";
 
 import {
@@ -47,7 +47,6 @@ const _ = cockpit.gettext;
 export const NetworkPage = ({ privileged, usage_monitor, plot_state, interfaces }) => {
     useEvent(firewall, "changed");
     useEvent(usage_monitor.grid, "notify");
-    const [highlight, setHighlight] = useState(null);
 
     const managed = [];
     const unmanaged = [];
@@ -84,7 +83,6 @@ export const NetworkPage = ({ privileged, usage_monitor, plot_state, interfaces 
                 { title: activeConnection ? activeConnection[0].innerHTML : activeConnection },
             ],
             props: {
-                className: highlight == iface.Name ? ["highlight-ct"] : [],
                 key: iface.Name,
                 "data-interface": encodeURIComponent(iface.Name),
                 "data-sample-id": show_traffic ? encodeURIComponent(iface.Name) : null,
@@ -143,7 +141,7 @@ export const NetworkPage = ({ privileged, usage_monitor, plot_state, interfaces 
     return (
         <Page id="networking">
             <PageSection id="networking-graphs" className="networking-graphs" variant={PageSectionVariants.light}>
-                <NetworkPlots plot_state={plot_state} onHover={setHighlight} />
+                <NetworkPlots plot_state={plot_state} />
             </PageSection>
             <PageSection>
                 <Gallery hasGutter>

--- a/pkg/networkmanager/plots.js
+++ b/pkg/networkmanager/plots.js
@@ -22,7 +22,7 @@ import React from "react";
 import { Split, SplitItem, Grid, GridItem } from '@patternfly/react-core';
 import { ZoomControls, SvgPlot, bits_per_sec_config } from "cockpit-components-plot.jsx";
 
-export const NetworkPlots = ({ plot_state, onHover }) => {
+export const NetworkPlots = ({ plot_state }) => {
     return (
         <>
             <Split>
@@ -33,12 +33,12 @@ export const NetworkPlots = ({ plot_state, onHover }) => {
                 <GridItem>
                     <SvgPlot className="network-graph"
                              title="Transmitting" config={bits_per_sec_config}
-                             plot_state={plot_state} plot_id='tx' onHover={onHover} />
+                             plot_state={plot_state} plot_id='tx' />
                 </GridItem>
                 <GridItem>
                     <SvgPlot className="network-graph"
                              title="Receiving" config={bits_per_sec_config}
-                             plot_state={plot_state} plot_id='rx' onHover={onHover} />
+                             plot_state={plot_state} plot_id='rx' />
                 </GridItem>
             </Grid>
         </>);

--- a/pkg/storaged/drives-panel.jsx
+++ b/pkg/storaged/drives-panel.jsx
@@ -86,7 +86,6 @@ export class DrivesPanel extends React.Component {
                               name={name}
                               devname={block_name(block)}
                               detail={desc}
-                              highlight={dev == props.highlight}
                               go={() => cockpit.location.go([dev])}
                               job_path={path}
                               key={path} />

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -34,43 +34,33 @@ import { OthersPanel } from "./others-panel.jsx";
 import { JobsPanel } from "./jobs-panel.jsx";
 import { StorageLogsPanel } from "./logs-panel.jsx";
 
-export class Overview extends React.Component {
-    constructor() {
-        super();
-        this.state = { highlight: false };
-    }
-
-    render() {
-        var client = this.props.client;
-
-        return (
-            <Page id="main-storage">
-                <Grid hasGutter>
-                    <GridItem md={8} lg={9}>
-                        <Gallery hasGutter>
-                            <Card>
-                                <CardBody>
-                                    <StoragePlots plot_state={this.props.plot_state}
-                                                  onHover={(dev) => this.setState({ highlight: dev })} />
-                                </CardBody>
-                            </Card>
-                            <FilesystemsPanel client={client} />
-                            <LockedCryptoPanel client={client} />
-                            <NFSPanel client={client} />
-                            <JobsPanel client={client} />
-                            <StorageLogsPanel />
-                        </Gallery>
-                    </GridItem>
-                    <GridItem md={4} lg={3} className="storage-sidebar">
-                        <Gallery hasGutter>
-                            <ThingsPanel client={client} />
-                            <DrivesPanel client={client} highlight={this.state.highlight} />
-                            <IscsiPanel client={client} />
-                            <OthersPanel client={client} />
-                        </Gallery>
-                    </GridItem>
-                </Grid>
-            </Page>
-        );
-    }
-}
+export const Overview = ({ client, plot_state }) => {
+    return (
+        <Page id="main-storage">
+            <Grid hasGutter>
+                <GridItem md={8} lg={9}>
+                    <Gallery hasGutter>
+                        <Card>
+                            <CardBody>
+                                <StoragePlots plot_state={plot_state} />
+                            </CardBody>
+                        </Card>
+                        <FilesystemsPanel client={client} />
+                        <LockedCryptoPanel client={client} />
+                        <NFSPanel client={client} />
+                        <JobsPanel client={client} />
+                        <StorageLogsPanel />
+                    </Gallery>
+                </GridItem>
+                <GridItem md={4} lg={3} className="storage-sidebar">
+                    <Gallery hasGutter>
+                        <ThingsPanel client={client} />
+                        <DrivesPanel client={client} />
+                        <IscsiPanel client={client} />
+                        <OthersPanel client={client} />
+                    </Gallery>
+                </GridItem>
+            </Grid>
+        </Page>
+    );
+};

--- a/pkg/storaged/plot.jsx
+++ b/pkg/storaged/plot.jsx
@@ -74,7 +74,7 @@ export function update_plot_state(ps, client) {
     }
 }
 
-export const StoragePlots = ({ plot_state, onHover }) => {
+export const StoragePlots = ({ plot_state }) => {
     return (
         <>
             <Split>
@@ -85,12 +85,12 @@ export const StoragePlots = ({ plot_state, onHover }) => {
                 <GridItem>
                     <SvgPlot className="storage-graph"
                              title="Reading" config={bytes_per_sec_config}
-                             plot_state={plot_state} plot_id='read' onHover={onHover} />
+                             plot_state={plot_state} plot_id='read' />
                 </GridItem>
                 <GridItem>
                     <SvgPlot className="storage-graph"
                              title="Writing" config={bytes_per_sec_config}
-                             plot_state={plot_state} plot_id='write' onHover={onHover} />
+                             plot_state={plot_state} plot_id='write' />
                 </GridItem>
             </Grid>
         </>);

--- a/pkg/storaged/side-panel.jsx
+++ b/pkg/storaged/side-panel.jsx
@@ -111,7 +111,7 @@ export class SidePanelRow extends React.Component {
 
         return (
             <FlexItem data-testkey={this.props.testkey}
-                      className={"sidepanel-row " + (this.props.highlight ? "highlight-ct" : "")}
+                      className="sidepanel-row"
                       role="link" tabIndex="0"
                       onKeyPress={this.props.go ? go : null}
                       onClick={this.props.go ? go : null}>


### PR DESCRIPTION
Previously when hovering on the resources, we highlighted them in the
relevant part of the screen. This has two main issues:

* The lists can get long so nothing guarantees that the resources of interest
are in the visible part of the screen

* The highlighted section was just changing background color which is
not helping people with limited vision.

This commit replaces this highlighted sections on hover with an inline
tootip that appears when the plot is focused.

Note: title is also read by screen reader software therefore is an accessibility
enhancement from our previous state.

Fixes #4006