### PR TITLE
[r79] test: Use predictable host names in check-multi-machine

### DIFF
--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -175,7 +175,7 @@ class TestMultiMachineAdd(MachineCase):
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname != "/dashboard"')
         b.enter_page("/system", host="10.111.113.2")
-        b.wait_text_not("#system_information_hostname_button", "")
+        b.wait_text("#system_information_hostname_button", "machine2")
         b.switch_to_top()
         b.go("/dashboard")
         b.enter_page("/dashboard")
@@ -185,7 +185,7 @@ class TestMultiMachineAdd(MachineCase):
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname != "/dashboard"')
         b.enter_page("/system", host=m3_host)
-        b.wait_text_not("#system_information_hostname_button", "")
+        b.wait_text("#system_information_hostname_button", "machine3")
         b.switch_to_top()
         b.go("/dashboard")
         b.enter_page("/dashboard")
@@ -232,16 +232,16 @@ class TestMultiMachine(MachineCase):
 
     def setUp(self):
         MachineCase.setUp(self)
+        self.machine.execute("hostnamectl set-hostname machine1")
         self.machine2 = self.machines['machine2']
         self.machine2.execute("hostnamectl set-hostname machine2")
+        self.machines['machine3'].execute("hostnamectl set-hostname machine3")
         atomiclib.overlay_dashboard(self.machine)
 
     def checkDirectLogin(self, root='/'):
         b = self.browser
         m2 = self.machine2
         m = self.machine
-
-        name = self.machine.execute("hostname")
 
         # Change os-release pretty name on m2
         m2.execute("sed -i '/NAME=.*/d' /etc/os-release")
@@ -250,7 +250,7 @@ class TestMultiMachine(MachineCase):
         b.switch_to_top()
         b.go("{}/system".format(root))
         b.enter_page("/system")
-        b.wait_in_text('#system_information_hostname_button', name.strip())
+        b.wait_text('#system_information_hostname_button', "machine1")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "{0}system"'.format(root))
         b.click("a[href='/dashboard']")


### PR DESCRIPTION
This makes the test stricter, and also makes them work on OSes that
don't set a host name by default (like fedora-coreos). The new Overview
page doesn't render `#system_information_hostname_text` at all without a
host name.

Cherry-picked from master commit 1cfa5787b6be1

----

This should unbreak the rhel-atomic refresh in https://github.com/cockpit-project/bots/pull/1822