### PR TITLE
webpack-make: drop a "watch mode" special case

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -82,17 +82,7 @@ function process_result(err, stats) {
         return;
     }
 
-    if (makefile) {
-        if (!ops.watch)
-            generateDeps(makefile, stats);
-        else {
-            // Force "make" to re-create everything.  The results of
-            // incremental building are not good enough for building
-            // RPMs, for example.
-            if (fs.existsSync(makefile))
-                fs.unlinkSync(makefile);
-        }
-    }
+    generateDeps(makefile, stats);
 }
 
 function generateDeps(makefile, stats) {


### PR DESCRIPTION
Stop removing Makefile.deps in watch mode.  There's no good reason for
it anymore, and it's causing problems.

Also, drop conditionalising the generation of the dependencies on the -m
argument having been passed.  This argument is mandatory.