### PR TITLE
 File filter...  lib: packagekit: update progress bars by using the PK backend provided value

### DIFF
--- a/pkg/apps/packagekit.js
+++ b/pkg/apps/packagekit.js
@@ -23,8 +23,8 @@ import * as PK from "packagekit.js";
 function progress_reporter(base, range, callback) {
     if (callback) {
         return function (data) {
-            if (data.percentage >= 0)
-                data.percentage = base + data.percentage / 100 * range;
+            if (data.absolute_percentage >= 0)
+                data.percentage = base + data.absolute_percentage / 100 * range;
             callback(data);
         };
     }

--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -242,7 +242,7 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
         let allow_wait_status = false;
         const progress_data = {
             waiting: false,
-            percentage: 0,
+            absolute_percentage: 0,
             cancel: null
         };
 
@@ -256,10 +256,10 @@ export function cancellableTransaction(method, arglist, progress_cb, signalHandl
                 if ("Status" in props)
                     status = props.Status;
                 progress_data.waiting = allow_wait_status && (status === Enum.STATUS_WAIT || status === Enum.STATUS_WAITING_FOR_LOCK);
-                if ("Percentage" in props && props.Percentage <= 100)
-                    progress_data.percentage = props.Percentage;
                 if ("AllowCancel" in props)
                     progress_data.cancel = props.AllowCancel ? cancel : null;
+                if ("Percentage" in props && props.Percentage <= 100)
+                    progress_data.absolute_percentage = props.Percentage;
 
                 progress_cb(progress_data);
             }


### PR DESCRIPTION

progress_reporter (see pkg/apps/packagekit.js) is combining progress
from multiple operations by using the base/range logic.

The only way for this concept to work is to only have this callback get
called when the percentage has changed.

Otherwise, we just keep adding progress without any actual change
happening in the backend.

Example:

method = InstallPackages
base = 1, range: 99

PK backend: Properties changed: { Percentage: 0 }
progress_reporter: data_percentage = 1 + 0 * 100/99 = 1

PK backend: Properties changed: { Percentage: 1 }
progress_reporter: data_percentage = 1 + 1 * 100/99 ~= 2.01

PK backend: Properties changed: { Status: 2 }
progress_reporter: data_percentage = 1 + 2.01 * 100/99 <--- here the
percentage increased but it should not! Percentage property did not change

Fixes #13953