### PR TITLE
test: Drop run-tests --base default branch name

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -215,14 +215,12 @@ def run(opts, image):
     # If file from `test-dir` was changed in the PR, all tests from it are considered affected
     changed_tests = []
     test_files = glob.glob(os.path.join(opts.test_dir, "check-*"))
-    if os.path.exists(os.path.join(os.path.dirname(testvm.TEST_DIR), ".git")):
+    if opts.base:
         # Detect affected tests from changed test files
-        cmd = ["git", "diff", "--name-only", "origin/" + opts.base, opts.test_dir]
-        r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        if r.returncode == 0:
-            # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
-            # This file provides only examples, there is no place for it being flaky, no need to retry
-            changed_tests = [test.decode("utf-8") for test in r.stdout.strip().splitlines() if not test.endswith(b"check-example")]
+        diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + opts.base, opts.test_dir])
+        # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
+        # This file provides only examples, there is no place for it being flaky, no need to retry
+        changed_tests = [test.decode("utf-8") for test in diff_out.strip().splitlines() if not test.endswith(b"check-example")]
 
         # If more than 3 test files were changed don't consider any of them as affected
         # as it might be a PR that changes more unrelated things.
@@ -237,11 +235,9 @@ def run(opts, image):
         # If affected tests get detected from pkg/* changes, don't apply the
         # "only do this for max. 3 check-* changes" (even if the PR also changes ≥ 3 check-*)
         # (this does not apply to other projects)
-        cmd = ["git", "diff", "--name-only", "origin/" + opts.base, "--", "pkg/"]
-        r = subprocess.run(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        if r.returncode == 0:
-            changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in r.stdout.strip().splitlines())
-            changed_tests.extend([test for test in test_files if any(pkg in test for pkg in changed_pkgs)])
+        diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + opts.base, "--", "pkg/"])
+        changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in diff_out.strip().splitlines())
+        changed_tests.extend([test for test in test_files if any(pkg in test for pkg in changed_pkgs)])
 
     seen_classes = {}
     for filename in test_files:
@@ -444,7 +440,8 @@ def main():
                         help="Number of CPUs for nondestructive test global machines")
     parser.add_argument('--nondestructive-memory-mb', type=int, default=None,
                         help="RAM size for nondestructive test global machines")
-    parser.add_argument('--base', default=os.environ.get("BASE_BRANCH", "master"), help="Base branch")
+    parser.add_argument('--base', default=os.environ.get("BASE_BRANCH"),
+                        help="Retry affected tests compared to given base branch; default: %(default)s")
     opts = parser.parse_args()
 
     if opts.machine:

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -26,10 +26,6 @@ if [ ! -d node_modules/chrome-remote-interface ]; then
     npm install chrome-remote-interface sizzle
 fi
 
-# disable detection of affected tests; testing takes too long as there is no parallelization,
-# and TF machines are slow and brittle
-mv .git dot-git
-
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
 if [ "$TEST_OS" = "fedora-35" ]; then

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -119,6 +119,8 @@ class TestRunTest(MachineCase):
 
         env = os.environ.copy()
         env["TEST_FAILURES"] = "1"
+        # pretend this was a PR against master (set by CI normally, or by the user with --base)
+        env["BASE_BRANCH"] = "master"
         try:
             del env["TEST_JOBS"]
         except KeyError:


### PR DESCRIPTION
This was inelegant (hardcoding) and often wrong: cockpit has stable
rhel-8.x branches, and cockpit-machines' default branch is "main".  E.g.
a local run-tests invocation in cockpit-machines or other project which
has a "main" instead of a "master" branch previous spat out this error:

    fatal: ambiguous argument 'origin/master': unknown revision or path not in the working tree.
    Use '--' to separate paths from revisions, like this:
    'git <command> [<revision>...] -- [<file>...]'
    fatal: bad revision 'origin/master'

It is also conceptually dubious: The "retry affected tests" logic is
intended for pull requests, which always have an explicit target branch.
It is not intended for downstream gating (where we previously had a hack
to disable it), nor particularly desirable for local test runs (where
developers usually want to investigate/re-run a test in a more
controlled fashion).

Change run-tests to require explicitly enabling the "retry affected
tests" mechanism by specifying a base branch, either through
`$BASE_BRANCH` or with `--base`. Once that is given, *require* that git
is available, the checkout is a git repo, and `git diff` succeeds. This
will prevent silently breaking this feature in our CI.