### PR TITLE
overview: buttons in the health card are used inline and should be using the isInline property

### DIFF
--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -55,12 +55,12 @@ export class PageStatusNotifications extends React.Component {
                 let action;
                 if (status.details && status.details.link !== undefined) {
                     if (status.details.link)
-                        action = <Button variant="link" component="a" href="#"
+                        action = <Button variant="link" isInline component="a" href="#"
                                          onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + status.details.link) } }>{status.title}</Button>;
                     else
                         action = <span>{status.title}</span>; // no link
                 } else {
-                    action = <Button variant="link" component="a" href="#"
+                    action = <Button variant="link" isInline component="a" href="#"
                                      onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + page) } }>{status.title}</Button>;
                 }
 


### PR DESCRIPTION
This removes the unwanted padding added.

Fixes #15591