### PR TITLE
machines: Fix label in mobile mode

### DIFF
--- a/pkg/machines/components/vms/hostvmslist.scss
+++ b/pkg/machines/components/vms/hostvmslist.scss
@@ -15,6 +15,13 @@
     --pf-c-table--cell--Width: 1%;
 }
 
+@media screen and (max-width: $pf-global--breakpoint--lg) {
+    // Fix labels to not fully stretch when in responsive mode
+    #virtual-machines-listing .pf-m-grid-md.pf-c-table [data-label]:not(:last-child) {
+        justify-items: start;
+    }
+}
+
 #virtual-machines-page-main-nav {
     padding: 0;
 }


### PR DESCRIPTION
Labels ("Shut off") do no longer fill the maximum area, as seen in this screenshot:

![Screenshot_2021-03-25 Virtual Machines - garrett Rain](https://user-images.githubusercontent.com/10246/112533389-2d5da280-8daa-11eb-85f3-d532d69769c9.png)

(There are a couple of other fixes here in this screenshot as well, but those are a part of a tangled web of commits intended to affect spacing for our card usage in general and empty state patterns specifically, soon to be landing in #15583.)