### PR TITLE
test: Look at more journal messages

### DIFF
--- a/src/bridge/cockpitcgroupsamples.c
+++ b/src/bridge/cockpitcgroupsamples.c
@@ -242,7 +242,7 @@ notice_cgroups_in_hierarchy (CockpitSamples *samples,
                   collect (samples, dfd, f);
                   close (dfd);
                 }
-              else
+              else if (errno != ENOENT)
                 {
                   g_message ("error opening cgroup directory: %s: %m", ent->fts_path);
                 }

--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -177,7 +177,7 @@ build_meta (CockpitPcpMetrics *self,
               rc = pmNameInDom (self->metrics[i].desc.indom, vs->vlist[j].inst, &instance);
               if (rc != 0)
                 {
-                  g_warning ("%s: instance name lookup failed: %s", self->name, pmErrStr (rc));
+                  g_warning ("%s: instance name lookup failed: %s.%d: %s", self->name, self->metrics[i].name, vs->vlist[j].inst, pmErrStr (rc));
                   instance = NULL;
                 }
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1161,8 +1161,8 @@ class MachineCase(unittest.TestCase):
             # Debian images don't have any non-C locales (mostly deliberate, to test this scenario somewhere)
             self.allowed_messages.append("invalid or unusable locale: .*")
 
-        if self.image.startswith('fedora'):
-            # Fedora switched to dbus-broker
+        if self.image.startswith('fedora') or self.image.startswith('rhel-9'):
+            # Fedora and RHEL 9 have switched to dbus-broker
             self.allowed_messages.append("dbus-daemon didn't send us a dbus address; not installed?.*")
 
         if self.image in ['fedora-34']:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1082,6 +1082,8 @@ class MachineCase(unittest.TestCase):
     def allow_hostkey_messages(self):
         self.allow_journal_messages('.*: .* host key for server is not known: .*',
                                     '.*: refusing to connect to unknown host: .*',
+                                    '.*: .* host key for server has changed to: .*',
+                                    '.*: host key for this server changed key type: .*',
                                     '.*: failed to retrieve resource: hostkey-unknown')
 
     def allow_restart_journal_messages(self):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1061,6 +1061,11 @@ class MachineCase(unittest.TestCase):
         r"#1\) Respect the privacy of others.",
         r"#2\) Think before you type.",
         r"#3\) With great power comes great responsibility.",
+
+        # Something unknown sometimes goes wrong with PCP, see #15625
+        "pcp-archive: instance name lookup failed: .*",
+        "direct: instance name lookup failed: .*",
+        "pcp-archive: no such metric: .*"
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -115,6 +115,9 @@ class TestBastion(MachineCase):
         b.wait_text('#current-username', 'admin')
         b.logout()
 
+        # key login doesn't give us a password for sudo
+        self.allow_failed_sudo_journal_messages()
+
     def testBasicLogin(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -81,6 +81,8 @@ class TestApps(PackageCase):
         b = self.browser
         m = self.machine
 
+        self.allow_journal_messages("can't remove watch: Invalid argument")
+
         # Make sure none of the appstream directories exist.  They
         # will be created later and we need to cope with that.
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -737,6 +737,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.allow_journal_messages("Refusing to render service to dead parents.")
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages(".*Peer failed to perform TLS handshake.*")
+        self.allow_journal_messages("cannot reauthorize identity\\(s\\): unix-user:admin unix-user:fedora")
 
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -323,6 +323,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.check_discovered_addresses(b, [])
         self.check_discovered_addresses(b2, [])
 
+        self.allow_hostkey_messages()
+
     def testEdit(self):
         b = self.browser
         m1 = self.machines['machine1']
@@ -395,6 +397,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_not_present(".nav-item span[data-for='/@10.111.113.3']")
         b.wait_text(".nav-item span[data-for='/@10.111.113.2']", "admin @machine2")
 
+        self.allow_hostkey_messages()
+
     def testNoAutoconnect(self):
         b = self.browser
         m2 = self.machines["machine2"]
@@ -412,6 +416,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.relogin()
         time.sleep(60)
         self.assertNotIn(m2.execute("loginctl"), "admin")
+
+        self.allow_hostkey_messages()
 
 
 @skipDistroPackage()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -242,6 +242,8 @@ class TestMultiMachineAdd(MachineCase):
         b.wait_visible("a[href='/@m3']")
         b.wait_not_present("#page-sidebar .nav-status")
 
+        self.allow_hostkey_messages()
+
 
 @skipDistroPackage()
 class TestMultiMachine(MachineCase):
@@ -376,7 +378,8 @@ class TestMultiMachine(MachineCase):
         # Might happen when we switch away.
         self.allow_hostkey_messages()
         self.allow_journal_messages(".*: Connection reset by peer",
-                                    "connection unexpectedly closed by peer")
+                                    "connection unexpectedly closed by peer",
+                                    ".* Failed to resolve hostname bad .*")
 
     def testDirectLogin(self):
         self.machine.start_cockpit()
@@ -861,6 +864,8 @@ class TestMultiMachine(MachineCase):
         self.assertEqual(m1.execute("cat /home/admin/.ssh/id_rsa.pub"),
                          m2.execute("cat /home/fred/.ssh/authorized_keys"))
 
+        self.allow_hostkey_messages()
+
     def testSshKeySetupCustom(self):
         b = self.browser
         m1 = self.machine
@@ -891,6 +896,8 @@ class TestMultiMachine(MachineCase):
         b.wait_in_text('#troubleshoot-dialog', "The SSH key")
         b.wait_not_visible('.password-change-advice')
         b.wait_not_visible('.login-setup-auto')
+
+        self.allow_hostkey_messages()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -861,6 +861,8 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # by IPv6 address and port
         check_server("[::1]:22", True)
 
+        self.allow_failed_sudo_journal_messages()
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -419,6 +419,8 @@ class TestSuperuserDashboard(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
+        self.allow_hostkey_messages()
+
 
 @skipDistroPackage()
 class TestSuperuserOldDashboard(MachineCase):
@@ -481,6 +483,7 @@ class TestSuperuserOldDashboard(MachineCase):
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
         allow_old_cockpit_ws_messsages(self)
+        self.allow_hostkey_messages()
 
 
 @skipDistroPackage()
@@ -514,6 +517,8 @@ class TestSuperuserDashboardOldMachine(MachineCase):
         b.wait_popup("shutdown-dialog")
         b.click("#shutdown-dialog button:contains('Restart')")
         b.wait_popdown("shutdown-dialog")
+
+        self.allow_hostkey_messages()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the "cockpit/ssh" syslog identifier, which is used for
messages written to stderr on remote machines, and adds all the
GLIB_DOMAINS that are used by core Cockpit.
