### PR TITLE
tls: set permissions of 10-ipa.cert on install

### DIFF
--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -41,6 +41,9 @@ if ipa-getcert request -f /run/cockpit/ipa.crt -k /run/cockpit/ipa.key -K "HTTP/
     mv -Z /run/cockpit/ipa.crt /etc/cockpit/ws-certs.d/10-ipa.cert
     mv -Z /run/cockpit/ipa.key /etc/cockpit/ws-certs.d/10-ipa.key
 
+    # The certificate should be world-readable
+    chmod a+r /etc/cockpit/ws-certs.d/10-ipa.cert
+
     # If COCKPIT_GROUP is set, then make sure the key is readable by that group too
     if [ -n "${COCKPIT_GROUP}" ]; then
         chown root:"${COCKPIT_GROUP}" /etc/cockpit/ws-certs.d/10-ipa.key

--- a/src/ws/remotectl-certificate.c
+++ b/src/ws/remotectl-certificate.c
@@ -193,8 +193,7 @@ ensure_certificate (const gchar *user,
 
   /* adjust permissions of the certificates that we manage automatically;
    * don't touch admin-provided certs, they are often shared between multiple services */
-  if (g_str_has_suffix (path, "/0-self-signed.cert") ||
-      g_str_has_suffix (path, "/10-ipa.cert"))
+  if (g_str_has_suffix (path, "/0-self-signed.cert"))
     return set_cert_attributes (path, user, group, selinux);
   else
     return 0;


### PR DESCRIPTION
This was never being explicitly done, under the assumption that the
certificate file, as created by IPA, would be world-readable by default.
It's not, so let's do it ourselves.

The reason this is working is because remotectl is coming along after
the fact and setting the permissions, incorrectly (under the assumption
that there was also a private key in there), but in a way that would
allow cockpit-tls to load it, at least.

Remove that code from remotectl now as well: we will soon stop running
remotectl in the normal case.

release blocker because: this is a bug that we should fix before the new ipa-certificate-creating script appears in its first release.