### PR TITLE
tls: add new cockpit-certificate-ensure tool, and use it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ depcomp
 /com.redhat.lvm2.c
 /com.redhat.lvm2.h
 /liblvmdbus.a
+/cockpit-certificate-ensure
 /cockpit-desktop
 /cockpit-tls
 /cockpit-wsinstance-factory

--- a/src/common/cockpitwebcertificate.h
+++ b/src/common/cockpitwebcertificate.h
@@ -20,7 +20,9 @@
 #ifndef __COCKPIT_WEBCERTIFICATE_H__
 #define __COCKPIT_WEBCERTIFICATE_H__
 
-char *  cockpit_certificate_locate   (char **error);
+#include <stdbool.h>
+
+char *  cockpit_certificate_locate   (bool missing_ok, char **error);
 char *  cockpit_certificate_key_path (const char *certfile);
 int     cockpit_certificate_parse    (const char *file, char **cert, char **key);
 

--- a/src/common/test-webcertificate.c
+++ b/src/common/test-webcertificate.c
@@ -38,7 +38,7 @@ do_locate_test (int dirfd, const char *certname, const char *expected_path, cons
       close (fd);
     }
 
-  path = cockpit_certificate_locate (&error);
+  path = cockpit_certificate_locate (false, &error);
 
   if (expected_path)
     cockpit_assert_strmatch (path, expected_path);

--- a/src/tls/Makefile-tls.am
+++ b/src/tls/Makefile-tls.am
@@ -1,4 +1,4 @@
-libexec_PROGRAMS += cockpit-tls cockpit-wsinstance-factory
+libexec_PROGRAMS += cockpit-tls cockpit-wsinstance-factory cockpit-certificate-ensure
 libexec_SCRIPTS += src/tls/cockpit-certificate-helper
 noinst_PROGRAMS += wsinstance-start
 
@@ -43,6 +43,21 @@ cockpit_tls_LDADD = \
 	libcockpit-common-nodeps.a \
 	$(COCKPIT_TLS_LIBS) \
 	$(NULL)
+
+cockpit_certificate_ensure_CFLAGS = \
+	-I$(top_srcdir)/src/tls \
+	$(COCKPIT_TLS_CFLAGS) \
+	$(NULL)
+
+cockpit_certificate_ensure_LDADD = \
+	libcockpit-common-nodeps.a \
+	$(COCKPIT_TLS_LIBS) \
+	$(NULL)
+
+cockpit_certificate_ensure_SOURCES = \
+	src/tls/certificate.h \
+	src/tls/certificate.c \
+	src/tls/cockpit-certificate-ensure.c
 
 # TESTS
 

--- a/src/tls/certificate.h
+++ b/src/tls/certificate.h
@@ -32,5 +32,8 @@ certificate_unref (Certificate *self);
 gnutls_certificate_credentials_t
 certificate_get_credentials (Certificate *self);
 
+time_t
+certificate_get_expiry (Certificate *self);
+
 Certificate *
 certificate_load (const char *filename);

--- a/src/tls/cockpit-certificate-ensure.c
+++ b/src/tls/cockpit-certificate-ensure.c
@@ -1,0 +1,68 @@
+#include <assert.h>
+#include <err.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <common/cockpitwebcertificate.h>
+
+#include "certificate.h"
+#include "utils.h"
+
+// Renew certificates with less than 30 days validity
+#define EXPIRY_THRESHOLD (30 * 24 * 60 * 60)
+
+static bool
+check_expiry (const char *filename)
+{
+  Certificate *certificate = certificate_load (filename);
+
+  time_t expires = certificate_get_expiry (certificate);
+
+  debug (ENSURE, "Certificate %s expires %ld", filename, (long) expires);
+
+  certificate_unref (certificate);
+
+  return expires > time (NULL) + EXPIRY_THRESHOLD;
+}
+
+static bool
+have_certificate (void)
+{
+  char *error = NULL;
+  char *filename = cockpit_certificate_locate (true, &error);
+
+  if (error != NULL)
+    errx (EXIT_FAILURE, "%s", error);
+
+  if (filename == NULL)
+    {
+      debug (ENSURE, "Couldn't locate any certificate");
+      return false;
+    }
+
+  if (strstr (filename, "/0-self-signed.cert"))
+    {
+      debug (ENSURE, "Certificate is self-signed, checking expiry");
+      return check_expiry (filename);
+    }
+
+  debug (ENSURE, "Certificate looks good: %s", filename);
+
+  return true;
+}
+
+#define COCKPIT_CERTIFICATE_HELPER   LIBEXECDIR "/cockpit-certificate-helper"
+
+int
+main (void)
+{
+  if (have_certificate ())
+    return 0;
+
+  debug (ENSURE, "Calling %s to create a certificate", COCKPIT_CERTIFICATE_HELPER);
+
+  execl (COCKPIT_CERTIFICATE_HELPER, COCKPIT_CERTIFICATE_HELPER, "selfsign", NULL);
+  err (EXIT_FAILURE, "execl: " COCKPIT_CERTIFICATE_HELPER);
+}

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -28,6 +28,65 @@ install_key() {
     fi
 }
 
+selfsign_sscg() {
+    sscg --quiet \
+        --lifetime "${DAYS}" \
+        --key-strength 2048 \
+        --cert-key-file "${KEYFILE}" \
+        --cert-file "${CERTFILE}" \
+        --ca-file "${CA_FILE}" \
+        --hostname "${HOSTNAME}" \
+        --organization "${MACHINE_ID}" \
+        --subject-alt-name localhost \
+        --subject-alt-name IP:127.0.0.1/255.255.255.255
+}
+
+selfsign_openssl() {
+    openssl req -x509 \
+        -days "${DAYS}" \
+        -newkey rsa:2048 \
+        -keyout "${KEYFILE}" \
+        -keyform PEM \
+        -nodes \
+        -out "${CERTFILE}" \
+        -outform PEM \
+        -subj "${MACHINE_ID:+/O=${MACHINE_ID}}/CN=${HOSTNAME}" \
+        -config - \
+        -extensions v3_req << EOF
+    [ req ]
+    req_extensions = v3_req
+    extensions = v3_req
+    distinguished_name = req_distinguished_name
+    [ req_distinguished_name ]
+    [ v3_req ]
+    subjectAltName=IP:127.0.0.1,DNS:localhost
+    basicConstraints = critical, CA:TRUE
+    keyUsage = critical, digitalSignature,cRLSign,keyCertSign,keyEncipherment,keyAgreement
+    extendedKeyUsage = serverAuth
+EOF
+}
+
+cmd_selfsign() {
+    # Common variables used by both methods
+    local MACHINE_ID="$(tr -d -c '[:xdigit:]' < /etc/machine-id)"
+    local HOSTNAME="${HOSTNAME:-$(hostname)}"
+    local CERTFILE="0-self-signed.cert"
+    local KEYFILE="0-self-signed.key"
+    local CA_FILE="0-self-signed-ca.pem"
+
+    # We renew certificates up to 30 days before expiry, so give ourselves a
+    # year, plus 30 days.  The maximum is variously mentioned to be 397 or 398.
+    local DAYS=395
+
+    # If sscg fails, try openssl
+    selfsign_sscg || selfsign_openssl
+
+    # Install the files and set permissions ($CA_FILE is only created by sscg)
+    test ! -e "${CA_FILE}" || install_cert "${CA_FILE}"
+    install_cert "${CERTFILE}"
+    install_key "${KEYFILE}"
+}
+
 cmd_ipa_request() {
     local USER="$1"
 
@@ -114,6 +173,9 @@ main() {
 
     # Dispatch subcommand
     case "$1" in
+        selfsign)
+            cmd_selfsign
+            ;;
         ipa)
             shift
             cmd_ipa "$@"

--- a/src/tls/main.c
+++ b/src/tls/main.c
@@ -112,7 +112,7 @@ main (int argc, char **argv)
   if (!arguments.no_tls)
     {
       char *error = NULL;
-      char *certfile = cockpit_certificate_locate (&error);
+      char *certfile = cockpit_certificate_locate (false, &error);
 
       if (error)
         errx (EXIT_FAILURE, "Could not locate server certificate: %s", error);

--- a/src/tls/utils.h
+++ b/src/tls/utils.h
@@ -36,6 +36,9 @@
 /* socket-activation-helper.c */
 #define DEBUG_HELPER 1
 
+/* cockpit-certificate-ensure.c */
+#define DEBUG_ENSURE 1
+
 /* testcases */
 #define DEBUG_TESTS 1
 

--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -9,7 +9,7 @@ After=cockpit-wsinstance-http.socket cockpit-wsinstance-http-redirect.socket coc
 RuntimeDirectory=cockpit/tls
 # systemd ≥ 241 sets this automatically
 Environment=RUNTIME_DIRECTORY=/run/cockpit/tls
-ExecStartPre=+@sbindir@/remotectl certificate --ensure --user=root --group=@group@ --selinux-type=@selinux_config_type@
+ExecStartPre=+@libexecdir@/cockpit-certificate-ensure
 ExecStart=@libexecdir@/cockpit-tls
 User=@user@
 Group=@group@

--- a/src/ws/cockpitcertificate.c
+++ b/src/ws/cockpitcertificate.c
@@ -326,7 +326,7 @@ gchar *
 cockpit_certificate_locate_gerror (GError **error)
 {
   gchar *error_str = NULL;
-  gchar *path = cockpit_certificate_locate (&error_str);
+  gchar *path = cockpit_certificate_locate (false, &error_str);
   if (error_str)
     {
       g_set_error_literal (error, G_IO_ERROR, G_IO_ERROR_NOT_FOUND, error_str);

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -261,7 +261,7 @@ done
 for lib in systemd tmpfiles.d; do
     rm -r %{buildroot}/%{_prefix}/%{__lib}/$lib
 done
-for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-desktop cockpit-certificate-helper; do
+for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-desktop cockpit-certificate-helper cockpit-certificate-ensure; do
     rm %{buildroot}/%{_libexecdir}/$libexec
 done
 rm -r %{buildroot}/%{_libdir}/security %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
@@ -476,6 +476,7 @@ authentication via sssd/FreeIPA.
 %{_libexecdir}/cockpit-wsinstance-factory
 %{_libexecdir}/cockpit-tls
 %{_libexecdir}/cockpit-desktop
+%{_libexecdir}/cockpit-certificate-ensure
 %{_libexecdir}/cockpit-certificate-helper
 %attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
 %{_datadir}/cockpit/branding

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -22,6 +22,7 @@ usr/lib/cockpit/cockpit-ws
 usr/lib/cockpit/cockpit-wsinstance-factory
 usr/lib/cockpit/cockpit-tls
 usr/lib/cockpit/cockpit-desktop
+usr/lib/cockpit/cockpit-certificate-ensure
 usr/lib/cockpit/cockpit-certificate-helper
 usr/sbin/remotectl
 usr/share/cockpit/branding/


### PR DESCRIPTION
This tool is a very small C program which does the following two things:

- uses the recently-split-out certificate handling support from cockpit-tls to check that a certificate is installed (and in the case of a self-signed certificate, not close to expiry)

- if not, uses the recently-added "selfsign" subcommand in cockpit-certificate-helper to create a new self-signed certificate

Even though we are the only user, we add a utility function to certificate.c to get the expiry of a certificate, because it's a better fit there.

Stop calling remotectl and use cockpit-certificate-ensure, instead.

 - [x] #15602
 - [x] #15601
 - [x] #15607 