### PR TITLE
test: Centralize test decorator for distropkg

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -60,6 +60,7 @@ __all__ = (
     'nondestructive',
     'no_retry_when_changed',
     'skipImage',
+    'skipDistroPackage',
     'skipBrowser',
     'skipPackage',
     'enableAxe',
@@ -1429,6 +1430,17 @@ def skipImage(reason, *args):
     if testvm.DEFAULT_IMAGE in args:
         return unittest.skip("{0}: {1}".format(testvm.DEFAULT_IMAGE, reason))
     return generic_metadata_setter("_testlib__skipImage", args)
+
+
+def skipDistroPackage():
+    '''For tests which apply to BaseOS packages
+
+    With that, tests can evolve with latest code, without constantly breaking them when
+    running against older package versions in the -distropkg tests.
+    '''
+    if 'distropkg' in testvm.DEFAULT_IMAGE:
+        return unittest.skip(f"{testvm.DEFAULT_IMAGE}: Do not test BaseOS packages")
+    return lambda testEntity: set_obj_attribute(testEntity, "_testlib__skipImage", (testvm.DEFAULT_IMAGE, ))
 
 
 def skipPackage(*args):

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -31,7 +31,7 @@ from testlib import *
 
 
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestImageCustomize(unittest.TestCase):
 
     def checkBoot(self, image):
@@ -128,7 +128,7 @@ class TestImageCustomize(unittest.TestCase):
 
 
 @unittest.skipUnless("TEST_OS" in os.environ, "TEST_OS not set")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestBotsVM(unittest.TestCase):
 
     def testBasic(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -26,7 +26,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestConnection(MachineCase):
 
     def setUp(self):
@@ -850,7 +850,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.assertEqual(m.execute("curl -sfS http://localhost:9090/ca.cer"), "FAKE CERT FOR TESTING\n")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestReverseProxy(MachineCase):
 
     provision = {

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestEmbed(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -29,7 +29,7 @@ from fmf_metadata import FMF
 
 @FMF.tag("example")
 @skipPackage("example")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestExample(MachineCase):
 
     @unittest.expectedFailure
@@ -60,7 +60,7 @@ class TestExample(MachineCase):
 
 @FMF.tag("example")
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNondestructiveExample(MachineCase):
 
     def testOne(self):
@@ -71,7 +71,7 @@ class TestNondestructiveExample(MachineCase):
 
 
 @FMF.tag("example")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSimple(unittest.TestCase):
 
     def testOne(self):

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -12,7 +12,7 @@ EXAMPLES_DIR = os.path.join(os.path.dirname(TEST_DIR), "examples")
 
 @FMF.tag("example")
 @FMF.link("https://bugzilla.redhat.com/show_bug.cgi?id=1")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestPinger(MachineCase):
 
     def setUp(self):
@@ -43,7 +43,7 @@ class TestPinger(MachineCase):
 
 @FMF.tag("example")
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestXHRProxy(MachineCase):
     def setUp(self):
         super().setUp()
@@ -89,7 +89,7 @@ class TestXHRProxy(MachineCase):
 
 @FMF.tag("example")
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestLongRunning(MachineCase):
 
     def setUp(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -24,7 +24,7 @@ from testlib import *
 @skipImage("kexec-tools not installed", "fedora-coreos", "debian-stable",
            "debian-testing", "ubuntu-2004", "ubuntu-stable")
 @timeout(900)
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestKdump(MachineCase):
 
     def rreplace(self, s, old, new, count):

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -22,7 +22,7 @@ from testlib import *
 
 
 @skipImage("OSTree always uses loopback", "fedora-coreos")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestLoopback(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -105,7 +105,7 @@ def login(self):
         self.login_and_go("/metrics")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestHistoryMetrics(MachineCase):
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty
@@ -420,7 +420,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_in_text("#service-details", "pmlogger.service")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @nondestructive
 class TestCurrentMetrics(MachineCase):
     def setUp(self):
@@ -653,7 +653,7 @@ class TestCurrentMetrics(MachineCase):
         b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='Out']", "0")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestCockpitPcp(packagelib.PackageCase):
     def testNoCockpitPcp(self):
         b = self.browser
@@ -697,7 +697,7 @@ class TestCockpitPcp(packagelib.PackageCase):
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiCPU(MachineCase):
 
     provision = {

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingBasic(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -25,7 +25,7 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestBonding(NetworkCase):
     def testBasic(self):
         b = self.browser
@@ -264,7 +264,7 @@ class TestBonding(NetworkCase):
         b.wait_visible("#network-interface-members tr[data-interface='%s']" % iface)
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestBondingVirt(NetworkCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestBridge(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @skipImage("No network checkpoint support", "ubuntu-2004", "ubuntu-stable")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingCheckpoints(NetworkCase):
     def testCheckpoint(self):
         b = self.browser

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -48,7 +48,7 @@ def get_active_rules(machine):
 
 @skipImage("no firewalld", "fedora-coreos")
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestFirewall(NetworkCase):
     def setUp(self):
         MachineCase.setUp(self)

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingMAC(NetworkCase):
     provision = {
         "machine1": {},

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingMTU(NetworkCase):
     provision = {
         "machine1": {},

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -22,7 +22,7 @@ from netlib import *
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingOther(NetworkCase):
     def testOther(self):
         b = self.browser

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingSettings(NetworkCase):
     provision = {
         "machine1": {},

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @skipImage("NetworkManager-team not installed", "fedora-coreos")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @nondestructive
 class TestTeam(NetworkCase):
     def testBasic(self):

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -24,7 +24,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingUnmanaged(NetworkCase):
     provision = {
         "machine1": {},

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestNetworkingVLAN(NetworkCase):
     def testVlan(self):
         b = self.browser

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -26,7 +26,7 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestPages(MachineCase):
     def checkDocs(self, items):
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestReauthorize(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -56,7 +56,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 """
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSelinux(MachineCase):
     provision = {
         "0": {},

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSession(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @nondestructive
 class TestActivePages(MachineCase):
 

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -25,7 +25,7 @@ from testlib import *
 from machine_core.constants import TEST_OS_DEFAULT
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class HostSwitcherHelpers:
 
     def check_discovered_addresses(self, b, addresses):
@@ -104,7 +104,7 @@ class HostSwitcherHelpers:
 
 
 @no_retry_when_changed
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     provision = {
         'machine1': {"address": "10.111.113.1/20"},
@@ -414,7 +414,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.assertNotIn(m2.execute("loginctl"), "admin")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestHostEditing(MachineCase, HostSwitcherHelpers):
 
     def testLimits(self):

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -26,7 +26,7 @@ FP_SHA256 = "SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw"
 KEY = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDG4iipTovcMg0xn+089QLNKVGpP2Pgq2duxHgAXre2XgA3dZL+kooioGFwBQSEjbWssKy82hKIN/W82/lQtL6krf7JQWnT3LZwD5DPsvHFKhOLghbiFzSI0uEL4NFFcZOMo5tGLrM5LsZsaIkkv5QkAE0tHIyeYinK6dQ2d8ZsfmgqxHDUQUWnz1T75X9fWQsUugSWI+8xAe0cfa4qZRz/IC+K7DEB3x4Ot5pl8FBuydJj/gb+Lwo2Vs27/d87W/0KHCqOHNwaVC8RBb1WcmXRDDetLGH1A9m5x7Ip/KU/cyvWWxw8S4VKZkTIcrGUhFYJDnjtE3Axz+D7agtps41t test-name"
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestKeys(MachineCase):
 
     def testAuthorizedKeys(self):

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -23,7 +23,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMenu(MachineCase):
 
     @enableAxe

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -131,7 +131,7 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
     raise error
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiMachineAdd(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},
@@ -243,7 +243,7 @@ class TestMultiMachineAdd(MachineCase):
         b.wait_not_present("#page-sidebar .nav-status")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiMachine(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -59,7 +59,7 @@ KEY_IDS_MD5 = [
 ]
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiMachineKeyAuth(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -69,7 +69,7 @@ def add_stock_machine(b, address, password):
     b.wait_popdown('dashboard_setup_server_dialog')
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiOS(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20"},
@@ -159,7 +159,7 @@ class TestMultiOS(MachineCase):
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestMultiOSDirect(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20"},

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -28,7 +28,7 @@ from testlib import *
 
 @skipImage("No sosreport", "fedora-coreos")
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSOS(MachineCase):
 
     def testBasic(self, urlroot=""):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -27,7 +27,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestLogin(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -27,7 +27,7 @@ def allow_old_cockpit_ws_messsages(test):
                                 "New connection to session from.*")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuser(MachineCase):
 
     def testBasic(self):
@@ -225,7 +225,7 @@ session include system-auth
         b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuserOldShell(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},
@@ -263,7 +263,7 @@ class TestSuperuserOldShell(MachineCase):
         b.wait_popdown("shutdown-dialog")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuserOldWebserver(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
@@ -357,7 +357,7 @@ class TestSuperuserOldWebserver(MachineCase):
         allow_old_cockpit_ws_messsages(self)
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuserDashboard(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},
@@ -420,7 +420,7 @@ class TestSuperuserDashboard(MachineCase):
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuserOldDashboard(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
@@ -483,7 +483,7 @@ class TestSuperuserOldDashboard(MachineCase):
         allow_old_cockpit_ws_messsages(self)
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSuperuserDashboardOldMachine(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -94,7 +94,7 @@ def ssh_reconnect(machine, timeout_sec=120):
     raise error
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestSystemInfo(MachineCase):
     def setUp(self):
         super().setUp()
@@ -755,7 +755,7 @@ insecure_connection=True
         self.assertGreater(progressValue(2), 10)
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestPcp(packagelib.PackageCase):
 
     def testEnablePcpLink(self):

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -24,7 +24,7 @@ import time
 sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestJournal(MachineCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -74,7 +74,7 @@ def hotp_token(secret, counter, digits=6, hash_alg=hashlib.sha1):
     return numbers[-digits:].rjust(digits, '0')
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class CommonTests:
     def testQualifiedUsers(self):
         m = self.machine
@@ -396,7 +396,7 @@ class CommonTests:
 
 
 @skipImage("No realmd available", "fedora-coreos")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @no_retry_when_changed
 class TestRealms(MachineCase):
     '''Common variables and tests for all supported domain backends'''
@@ -416,7 +416,7 @@ class TestRealms(MachineCase):
 
 
 @skipImage("freeipa not currently available", "debian-testing")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
     def setUp(self):
@@ -623,7 +623,7 @@ ipa user-add-cert alice --certificate="%(cert)s"
 
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @no_retry_when_changed
 class TestAD(TestRealms, CommonTests):
     def setUp(self):
@@ -767,7 +767,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 @skipImage("No realmd available", "fedora-coreos")
 @skipImage("freeipa not currently available", "debian-testing")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @no_retry_when_changed
 class TestKerberos(MachineCase):
     provision = {
@@ -899,7 +899,7 @@ ExecStart=/bin/true
 
 
 @skipImage("Package (un)install does not work on OSTree", "fedora-coreos")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestPackageInstall(packagelib.PackageCase):
 
     def setUp(self):

--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -25,7 +25,7 @@ from testlib import *
 @skipImage("No realmd available", "fedora-coreos")
 @skipImage("freeipa not currently in testing", "debian-testing", "ubuntu-2004")
 @skipImage("Skip these for now, unsure what's broken", "ubuntu-stable", "debian-stable")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 @skipImage("Needs sssd >=2.4.1", "rhel-8-4", "rhel-8-5", "centos-8-stream")
 class TestS4USsh(MachineCase):
     provision = {

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -23,7 +23,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestServices(MachineCase):
 
     def setUp(self):
@@ -745,7 +745,7 @@ Where=/fail
         self.allow_journal_messages(".*type=1400 audit(.*): avc:  denied  { create } .* comm=\"systemd\" name=\"fail\".*")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestTimers(MachineCase):
     def svc_sel(self, service):
         return 'li[data-goto-unit="%s"]' % service

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestShutdownRestart(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20"},

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -25,7 +25,7 @@ def line_sel(i):
     return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestTerminal(MachineCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -23,7 +23,7 @@ from testlib import *
 
 @nondestructive
 @skipImage("No tuned packaged", "fedora-coreos")
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestTuned(MachineCase):
 
     def testBasic(self):

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -36,7 +36,7 @@ def writeFile(file, content):
         f.write(content)
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestRunTestListing(unittest.TestCase):
 
     def testBasic(self):
@@ -83,7 +83,7 @@ class TestRunTestListing(unittest.TestCase):
 
 # This can't be @nondestructive, as we run our own @nondestructive test nested inside this test. This will already call the
 # cleanup handlers, and the outside cleanup would then fail to do that again.
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestRunTest(MachineCase):
     def testExistingMachine(self):
         env = os.environ.copy()
@@ -184,7 +184,7 @@ class TestRunTest(MachineCase):
         self.assertNotRegex(stdout, b"TestHostSwitching.testEdit # RETRY")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestTestlib(MachineCase):
     @nondestructive
     def testRestoreAPI(self):
@@ -231,7 +231,7 @@ class TestTestlib(MachineCase):
         self.machine.execute("test ! -e /home/cockpittest")
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class NoTestRetryExample(unittest.TestCase):
 
     def testFail(self):

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -24,7 +24,7 @@ from testlib import *
 
 
 @nondestructive
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestAccounts(MachineCase):
 
     def tearDown(self):

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -21,7 +21,7 @@ import parent
 from testlib import *
 
 
-@skipImage("Do not test BaseOS packages", "rhel-8-4-distropkg", "rhel-8-5-distropkg")
+@skipDistroPackage()
 class TestRoles(MachineCase):
 
     def testBasic(self):


### PR DESCRIPTION
It is annoying and noisy having to bump the same thing in umpteen tests
each time we add or drop a new -distropkg image. Introduce a new
@skipDistroPackage decorator and use that everywhere.