### PR TITLE
common: Fix crash in channel flush_buffer()

### DIFF
--- a/src/common/cockpitchannel.c
+++ b/src/common/cockpitchannel.c
@@ -399,6 +399,8 @@ flush_buffer (gpointer user_data)
       payload = g_bytes_ref (priv->out_buffer);
       g_bytes_unref (priv->out_buffer);
       priv->out_buffer = NULL;
+      if (priv->buffer_timeout)
+          g_source_remove(priv->buffer_timeout);
       priv->buffer_timeout = 0;
 
       cockpit_channel_actual_send (self, payload, FALSE);


### PR DESCRIPTION
If a text channel sends some invalid UTF-8 (such as reading utmp before
commit 05ce4d2aeb), cockpit_channel_send() queues (with a timer) a flush_buffer(),
so that the next received block can finish the incomplete glyph. But if
the channel got closed in the meantime, that ran into an already freed
`self`, and trying to access its properties crashed.

Fix that by stopping the timer in flush_buffer() if it is active --
closing the channel flushes the buffer in cockpit_channel_real_close()
anyway, so there is no point trying to write anything else afterwards.

https://bugzilla.redhat.com/show_bug.cgi?id=1943169