### PR TITLE
test: Generalize some OS special cases

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -72,7 +72,7 @@ class TestKdump(MachineCase):
         def assertActive(active):
             b.wait_visible(".pf-c-switch__input" + (active and ":checked" or ":not(:checked)"))
 
-        if m.image in ["rhel-8-4", "rhel-8-5", "centos-8-stream"]:
+        if m.image.startswith("rhel-") or m.image in ["centos-8-stream"]:
             # some OSes have kdump enabled by default (crashkernel=auto)
             b.wait_in_text("#app", "Service is running")
             assertActive(True)

--- a/test/verify/check-machines-create
+++ b/test/verify/check-machines-create
@@ -1383,7 +1383,7 @@ class TestMachinesCreate(VirtualMachinesCase):
         m.execute("virsh attach-interface --persistent VmNotInstalled bridge virbr0")
 
         # Change the os boot firmware configuration
-        supports_firmware_config = m.image in ['fedora-33', 'fedora-34', 'fedora-testing', 'centos-8-stream', 'rhel-8-4', 'rhel-8-4-distropkg', "rhel-8-5", "rhel-8-5-distropkg", 'debian-testing', 'ubuntu-stable', 'ubuntu-2004']
+        supports_firmware_config = m.image not in ['debian-stable']
         if supports_firmware_config:
             b.wait_in_text("#vm-VmNotInstalled-firmware", "BIOS")
             b.click("#vm-VmNotInstalled-firmware")

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -85,7 +85,7 @@ class TestStorageFormat(StorageCase):
         check_type("ext4", 16)
         check_type("vfat", 11)
 
-        if m.image in ["rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-5-distropkg", "centos-8-stream"]:
+        if m.image.startswith("rhel") or m.image.startswith("centos"):
             check_unsupported_type("ntfs")
         else:
             check_type("ntfs", 128)

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -231,7 +231,7 @@ class TestStorageLuks(StorageCase):
         m = self.machine
         b = self.browser
 
-        luks_2 = m.image in ["rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-5-distropkg", "centos-8-stream"]
+        luks_2 = m.image.startswith("rhel") or m.image.startswith("centos")
         error_base = "Error unlocking /dev/sda: Failed to activate device: "
         error_messages = [error_base + "Operation not permitted",
                           error_base + "Incorrect passphrase."]

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -136,7 +136,7 @@ class TestStorageResize(StorageCase):
         self.checkResize("ext4", True,
                          can_shrink=True, shrink_needs_unmount=True,
                          can_grow=True, grow_needs_unmount=False,
-                         need_passphrase=(self.machine.image in ["rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-5-distropkg", "centos-8-stream"]))
+                         need_passphrase=(self.machine.image.startswith("rhel") or self.machine.image.startswith("centos")))
 
     def wait_not_present_with_udev_trigger(self, selector):
         # This is fundamentally the same as Browser.wait, but uses a
@@ -259,7 +259,7 @@ class TestStorageResize(StorageCase):
         m.execute("lvresize TEST/vol -L+100M")
 
         def confirm_with_passphrase():
-            if m.image not in ["rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-5-distropkg", "centos-8-stream"]:
+            if not m.image.startswith("rhel") and not m.image.startswith("centos"):
                 return
             self.dialog_wait_open()
             self.dialog_wait_apply_enabled()

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -36,7 +36,7 @@ class PackageCase(MachineCase):
             self.backend = "apt"
             self.primary_arch = "all"
             self.secondary_arch = "amd64"
-        elif self.machine.image.startswith("fedora") or self.machine.image.startswith("rhel-8") or self.machine.image.startswith("centos-8"):
+        elif self.machine.image.startswith("fedora") or self.machine.image.startswith("rhel-") or self.machine.image.startswith("centos-"):
             self.backend = "dnf"
             self.primary_arch = "noarch"
             self.secondary_arch = "x86_64"


### PR DESCRIPTION
Use name prefix matching for tests which clearly apply to all
RHEL/CentOS images by design choice (as opposed to "specific bugs").

Invert the feature/bug OS lists in check-machines-create, so that it
captures the old behaviour and go to zero, as opposed to having to be
extended with each new OS (which is error prone).

----

Prerequisite for fixing tests for RHEL 9 (see #15614)