### PR TITLE
bridge: Explicitly filter DBus signals by sender when cache watching

### DIFF
--- a/src/bridge/cockpitdbuscache.h
+++ b/src/bridge/cockpitdbuscache.h
@@ -83,6 +83,10 @@ void                  cockpit_dbus_cache_introspect        (CockpitDBusCache *se
                                                             CockpitDBusIntrospectFunc callback,
                                                             gpointer user_data);
 
+void                  cockpit_dbus_cache_set_name_owner    (CockpitDBusCache *self,
+                                                            const gchar *name_owner);
+
+
 GHashTable *          cockpit_dbus_interface_info_new      (void);
 
 GDBusInterfaceInfo *  cockpit_dbus_interface_info_lookup   (GHashTable *interface_info,

--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -2676,6 +2676,10 @@ on_name_appeared (GDBusConnection *connection,
 
   g_object_ref (self);
 
+  CockpitDBusPeer *peer = g_hash_table_lookup (self->peers, name);
+  if (peer)
+    cockpit_dbus_cache_set_name_owner (peer->cache, name_owner);
+
   if (!self->default_appeared)
     {
       self->default_appeared = TRUE;
@@ -2696,6 +2700,10 @@ on_name_vanished (GDBusConnection *connection,
   CockpitChannel *channel = COCKPIT_CHANNEL (self);
 
   send_owned (self, name, NULL);
+
+  CockpitDBusPeer *peer = g_hash_table_lookup (self->peers, name);
+  if (peer)
+    cockpit_dbus_cache_set_name_owner (peer->cache, NULL);
 
   if (!G_IS_DBUS_CONNECTION (connection) || g_dbus_connection_is_closed (connection))
     cockpit_channel_close (channel, "disconnected");


### PR DESCRIPTION
This matters when the watch rules are not sufficiently narrow.  For
example, when there is no rule at all, a cache for o.fd.NetworkManager
would react to PropertiesChanged notifications from o.fd.systemd1.

It would cache and distribute values for systemd1 properties (which is
wasteful but mostly harmless), and would ask o.fd.NetworkManager for
values of systemd properties that have been invalidated (which is
clearly wrong).