### PR TITLE
Revert "testlib: Always output unexpected journal and browser messages"

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -970,9 +970,9 @@ class MachineCase(unittest.TestCase):
                         "xargs --no-run-if-empty -L1 loginctl terminate-session")
 
     def tearDown(self):
-        if self.machine.ssh_reachable:
+        if self.checkSuccess() and self.machine.ssh_reachable:
             self.check_journal_messages()
-        self.check_browser_errors()
+            self.check_browser_errors()
         shutil.rmtree(self.tmpdir)
 
     def login_and_go(self, path=None, user=None, host=None, superuser=True, urlroot=None, tls=False):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -622,6 +622,7 @@ class TestCurrentMetrics(MachineCase):
         b.wait_visible(progress_sel)
         self.assertFalse(b.is_present("#current-disks-usage button"))
 
+    @skipImage("no netcat on CoreOS", "fedora-coreos")
     def testNetwork(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This leads to many test failures not being retried, as with that commit
they started to fail twice: First for the real reason, then because of
whichever journal messages caused the failure.

In many cases that happens because tests tend to call
allow_journal_message() at the end, which they never get to if they fail
in the middle. But even if we'd change that, it's still conceptually
wrong -- tests should have one back trace and failure reason only, not
two.

This was introduced for
https://github.com/cockpit-project/bots/issues/1453 , but we don't
actually require that -- the naughty can match on the error that the
browser console writes.

This reverts commit 34ee9ee4036b59df5d04489b75c4587103e3ba49.

----

This fixes brittle tests like [this one](https://logs.cockpit-project.org/logs/pull-15614-20210330-051315-637dcdf0-rhel-9-0-bots-1860/log.html#225) which does not currently get retried.