### PR TITLE
tls: change "ipa" to "ipa request" in certificate helper

### DIFF
--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -401,7 +401,7 @@ function instance(realmd, mode, realm, state) {
         var password = $("#realms-op-admin-password").val();
         var helper = cockpit.manifests.system.libexecdir + "/cockpit-certificate-helper";
 
-        var proc = cockpit.spawn([helper, "ipa", kerberos.RealmName, user],
+        var proc = cockpit.spawn([helper, "ipa", "request", kerberos.RealmName, user],
                                  { superuser: "require", err: "message" });
         proc.input(password);
         return proc;

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -3,9 +3,9 @@
 set -eu
 
 # expected arguments
-[ "$1" = "ipa" ] || exit 1
-REALM="$2"
-USER="$3"
+[ "$1 $2" = "ipa request" ] || exit 1
+REALM="$3"
+USER="$4"
 
 HOST="$(hostname -f)"
 SERVICE="HTTP/${HOST}@${REALM}"


### PR DESCRIPTION
"ipa" turns out to have been a bad verb to use as a subcommand in
cockpit-certificate-helper: we will soon want to also add "ipa cleanup".

Since cockpit-certificate-helper has yet to appear in a release, we can
fix this before we introduce potential compatibility problems.  Do a
quick patch now to expect the arguments "ipa request" in order to make
it easier to add "ipa cleanup" later.