### PR TITLE
test: Run browser in a different timezone

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -269,6 +269,8 @@ class CDP:
             environ = os.environ.copy()
             environ["HOME"] = self._browser_home
             environ["LC_ALL"] = "C.UTF-8"
+            # Run in Kolkota time zone that is shifted by +5:30 to GMT
+            environ["TZ"] = "Asia/Kolkata"
             # this might be set for the tests themselves, but we must isolate caching between tests
             try:
                 del environ["XDG_CACHE_HOME"]

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -169,7 +169,7 @@ class TestHistoryMetrics(MachineCase):
         # VM just started, we don't have 12 hours of data
         b.wait_in_text(".metrics .pf-c-alert", "No data available between")
         # initial data gap is < 24 hours, does not show date
-        year = m.execute("date +%Y").strip()
+        year = m.execute("TZ='Asia/Kolkata' date +%Y").strip()
         self.assertNotIn(year, b.text(".metrics .pf-c-alert"))
 
         # can try to load earlier data; only updates "no data" alert as there is no data

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -28,7 +28,7 @@ sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:conta
 class TestJournal(MachineCase):
     def setUp(self):
         super().setUp()
-        self.test_start_time = self.machine.execute("date +%s").strip()
+        self.test_start_time = self.machine.execute("TZ='Asia/Kolkata' date +%s").strip()
 
     def injectExtras(self):
         self.browser.inject_js("""

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -277,8 +277,8 @@ Unit=test.service
         b.wait_text(self.svc_sel('test-onboot.timer') + ' .service-unit-triggers', '')
         run_cmd(f"systemctl {params} start test-onboot.timer")
         # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
-        today_stamp = int(m.execute("date +%s").strip())
-        today_plus_200min = m.execute(f"date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
+        today_stamp = int(m.execute("TZ='Asia/Kolkata' date +%s").strip())
+        today_plus_200min = m.execute(f"TZ='Asia/Kolkata' date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
         run_cmd(f"systemctl {params} stop test-onboot.timer")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+import pytz
 
 import parent
 from testlib import *
@@ -294,7 +295,7 @@ class TestAccounts(MachineCase):
             b.go("#/admin")
             b.wait_visible("#account-logout[disabled]")
 
-            (year, month) = m.execute("date +'%Y %b'").strip().split()
+            (year, month) = m.execute("TZ='Asia/Kolkata' date +'%Y %b'").strip().split()
 
             # Log in as "admin" and the open details in other browser should update
             b2 = self.new_browser(m)
@@ -417,6 +418,8 @@ class TestAccounts(MachineCase):
         m = self.machine
         b = self.browser
 
+        tz = pytz.timezone('Asia/Kolkata')  # Same as browser, see test/common/cdp.py
+
         m.execute("useradd scruffy -s /bin/bash -c 'Scruffy' || true")
         m.execute("echo scruffy:foobar | chpasswd")
 
@@ -437,7 +440,7 @@ class TestAccounts(MachineCase):
         b.wait_text("#account-expiration .pf-c-form__helper-text.pf-m-error", "Invalid expiration date")
 
         # Now a valid date 30 days in the future
-        when = datetime.datetime.now() + datetime.timedelta(days=30)
+        when = datetime.datetime.now(tz) + datetime.timedelta(days=30)
         b.set_input_text("#account-expiration-input input", when.isoformat().split("T")[0])
         b.click("#account-expiration .pf-c-modal-box__footer button:contains(Change)")
         b.wait_not_present("#account-expiration")


### PR DESCRIPTION
Using Kolkata as that is 5 hours and 30 minutes ahead of UTC thus will
provide unexpected dates if we use something incorrectly.

Fixes #1957

When I run chromium with TZ it produces: (Notice computer time, system time in cockpit and last login time which normally would be the same as current time).
![timeZ](https://user-images.githubusercontent.com/12330670/113102686-a754b800-91fe-11eb-9e9c-ea1432d56f48.png)

Running tests to see if and what this breaks.
