### PR TITLE
test: Fix dnf-copr upgrade scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -28,7 +28,7 @@ case $TEST_SCENARIO in
         test/containers/run-tests --container ${TEST_SCENARIO#*-}
         ;;
     dnf-copr*)
-        bots/image-customize -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y update' $TEST_OS
+        bots/image-customize -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y --setopt=install_weak_deps=False update' $TEST_OS
         test/image-prepare --verbose --overlay $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;


### PR DESCRIPTION
Don't let dnf install Recommends on upgrade. We don't want that to
install cockpit's recommendations like c-packagekit, as this will make
the `rpm -e` commands from the *.install script fail.

----

Blocks https://github.com/cockpit-project/bots/pull/1828