### PR TITLE
users: Fix lastlog parsing - April the 1st edition

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -68,7 +68,8 @@ function get_last_login(name) {
             return null;
 
         // line looks like this: admin            web cons ::ffff:172.27.0. Tue Mar 23 14:49:04 +0000 2021
-        const date_fields = line.split(' ').slice(-5);
+        // or like this:         admin            web cons ::ffff:172.27.0. Thu Apr  1 08:58:51 +0000 2021
+        const date_fields = line.split(/ +/).slice(-5);
         const d = new Date(date_fields.join(' '));
         if (d.getTime() > 0)
             return d;


### PR DESCRIPTION
This parsing has been changed in 299e6f6f51 on 23.3.2021.
Therefore we only tested it on dates with double digit dates which
failed to notice that when date is single digit it does not work correctly.

We split the string on space, which produces:
`Tue Mar 23 14:49:04 +0000 2021` => ["Thu", "Mar", "23", "14:49:04", "+0000", "2021"]
`Thu Apr  1 08:58:51 +0000 2021` => ["Thu", "Apr", "", "1", "08:58:51", "+0000", "2021"]

When we then take last 5 fields in the latter case we don't get month
which breaks subsequent parsing.