### PR TITLE
tests: robustify testResizeLuks

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -87,7 +87,7 @@ class TestStorageResize(StorageCase):
             if grow_needs_unmount:
                 self.content_head_action(fsys_row, "Mount")
                 self.confirm()
-                self.wait_mounted(fsys_row, fsys_tab)
+            self.wait_mounted(fsys_row, fsys_tab)
             size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
             assert (size > 300000)
         else:


### PR DESCRIPTION
When growing the partition always check the the filesystem keep being
mounted after the operation is ready.

Some debugging notes here:

I noticed in the journal of the failing test, that systemd unmounted the FSYS which makes the footer warning on schrink not show up.

The relevant logs:
```
Mar 30 17:25:32 localhost systemd[1]: Unmounting /run/foo...
Mar 30 17:25:32 localhost systemd[1742]: run-foo.mount: Succeeded.
Mar 30 17:25:32 localhost systemd[1517]: run-foo.mount: Succeeded.
Mar 30 17:25:32 localhost udisksd[1643]: Cleaning up mount point /run/foo (device 253:1 is not mounted)
Mar 30 17:25:32 localhost systemd[1]: run-foo.mount: Succeed
```

Copied from: https://logs.cockpit-project.org/logs/pull-15623-20210330-165121-87cf409c-fedora-33-firefox/TestStorageResize-testResizeLuks-fedora-33-127.0.0.2-2601-FAIL.log.gz

This adjustment will probably not make the test succeed rather fail slightly earlier, let's see.

Might be also related to: https://github.com/cockpit-project/bots/issues/1739