### PR TITLE
overview: remove some custom styling from our superuser alert 

### DIFF
--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -138,7 +138,7 @@ class LoginMessages extends React.Component {
             <Alert id='login-messages'
                    variant={this.state.messages.type}
                    isInline={!fail_count_message}
-                   className={!fail_count_message ? "no-title" : ""}
+                   className={!fail_count_message ? "login-messages" : ""}
                    actionClose={<AlertActionCloseButton onClose={this.close} />}
                    title={fail_count_message || last_log_item}
             >
@@ -262,8 +262,8 @@ class OverviewPage extends React.Component {
                         </div>
                     </PageSection>
                     <PageSection variant={PageSectionVariants.default}>
-                        <LoginMessages />
                         <Gallery className='ct-system-overview' hasGutter>
+                            <LoginMessages />
                             <MotdCard />
                             <HealthCard />
                             <UsageCard />

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -243,7 +243,9 @@ class OverviewPage extends React.Component {
                 {this.state.rebootModal && <ShutdownModal onClose={() => this.setState({ rebootModal: false })} />}
                 {this.state.shutdownModal && <ShutdownModal shutdown onClose={() => this.setState({ shutdownModal: false })} />}
                 <Page>
-                    <SuperuserAlert />
+                    <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
+                        <SuperuserAlert />
+                    </PageSection>
                     <PageSection className='ct-overview-header' variant={PageSectionVariants.light}>
                         <div className='ct-overview-header-hostname'>
                             <h1>

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -5,36 +5,10 @@
 @import "../lib/table.css";
 
 .ct-limited-access-alert {
-  align-items: center;
-  background: var(--pf-global--active-color--200);
-  margin-bottom: 0;
-  padding: 1rem 1.5rem;
-
-  // Override PF4 spacing to better align to the overview page
-  // and rely on ct-limited-access-alert for padding & alignment
-  &.pf-c-alert.pf-m-info.pf-m-inline {
-    > .pf-c-alert__icon,
-    > .pf-c-alert__title,
-    > .pf-c-alert__action {
-      padding: 0;
-    }
-
-    > .pf-c-alert__icon {
-      // Make the icon slightly darker, to compensate for the background
-      color: var(--pf-global--active-color--400);
-      padding-right: 1rem;
-    }
-  }
-
-  // Remove the left-side stripe
-  &:before {
-    display: none;
-  }
-
   // Deconstruct nicely on small screen sizes (especially mobile)
   // This will not be needed in a future PF4 update
   //
-  // References: 
+  // References:
   // - https://github.com/cockpit-project/cockpit/issues/14106
   // - https://github.com/patternfly/patternfly/issues/3125
   // - https://github.com/patternfly/patternfly/pull/2921
@@ -48,6 +22,12 @@
   @media (max-width: 320px) {
     // Allow the action button to have a bit more space on iPhone SE sized phones
     grid-template-areas: "icon title" ". content" "action action";
+  }
+
+  // Set the right padding so that the button aligns with the other alerts in the page on the side
+  padding-right: var(--pf-c-page__main-section--PaddingRight);
+  > .pf-c-alert__action {
+      margin-right: 0;
   }
 }
 
@@ -381,6 +361,10 @@
 #motd-box > .pf-c-alert {
   /* Spacing between the MOTD is handled by the .pf-l-gallery grid */
   margin-bottom: 0;
+}
+
+.pf-c-alert.no-title {
+    margin-bottom: 24px;
 }
 
 .pf-c-alert.no-title h4 {

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -80,7 +80,7 @@
   --card-width: 22rem;
   --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, minmax(var(--card-width), 1fr));
 
-  .motd-box {
+  .motd-box, .login-messages {
     grid-column: 1 / -1;
   }
 
@@ -363,17 +363,13 @@
   margin-bottom: 0;
 }
 
-.pf-c-alert.no-title {
-    margin-bottom: 24px;
-}
-
-.pf-c-alert.no-title h4 {
+.pf-c-alert.login-messages h4 {
     font-weight: normal;
     color: black;
     font-family: inherit;
 }
 
-.pf-c-alert.no-title .pf-c-alert__description {
+.pf-c-alert.login-messages .pf-c-alert__description {
     padding-bottom: 0px;
 }
 

--- a/pkg/systemd/system-global.scss
+++ b/pkg/systemd/system-global.scss
@@ -1,10 +1,6 @@
 @import "../lib/page.scss";
 @import '../lib/form-layout.scss';
 
-.pf-c-alert {
-    margin-bottom: 24px;
-}
-
 .fa-check-circle-o {
     color: var(--pf-global--success-color--100);
 }


### PR DESCRIPTION
Before:
![Screen Shot 2021-04-01 at 14 06 22](https://user-images.githubusercontent.com/14921356/113292407-c33a8580-92f4-11eb-9101-d705f129d717.png)


After:
![Screen Shot 2021-04-01 at 14 18 23](https://user-images.githubusercontent.com/14921356/113292699-24625900-92f5-11eb-965a-a78fdfe76014.png)
