### PR TITLE
autogen: check for glib-gettextize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -34,6 +34,11 @@ PKG_NAME="Cockpit"
 olddir=$(pwd)
 cd $srcdir
 
+if [ -z "$(which glib-gettextize)" ]; then
+    echo glib-gettextize is required to build cockpit
+    exit 1
+fi
+
 test "${NO_NPM:-}" != "1" && tools/npm-install
 
 rm -rf autom4te.cache


### PR DESCRIPTION
Our configure.ac includes AM_GLIB_GNU_GETTEXT, which is pretty
oldschool.  We should definitely move away from that, as per:

  https://wiki.gnome.org/Initiatives/GnomeGoals/GettextMigration
  https://wiki.gnome.org/MigratingFromIntltoolToGettext

Until that time, however, add an explicit check for it in ./autogen.sh
to prevent autoreconf from failing with a message about "undefined macro
AM_GLIB_GNU_GETTEXT".

More to the point, though: this has the added side-effect of giving
LGTM/Semmle's deptrace machinery a chance to understand the dependency
and install the correct packages for us.