### PR TITLE
test: Work around Firefox CDP mis-handling promise rejections

### DIFF
--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -383,7 +383,19 @@ CDP(options)
                             fail(message.split("\n")[0]);
                             clearExceptions();
                         }
-                    }, fail);
+                    }, err => {
+                        // HACK: Runtime.evaluate() fails with "Debugger: expected Debugger.Object, got Proxy"
+                        // translate that into a proper timeout exception
+                        if (err.response && err.response.data && err.response.data.indexOf("setTimeout handler*ph_wait_cond") > 0) {
+                            success({exceptionDetails: {
+                                exception: {
+                                    type: "string",
+                                    value: "timeout",
+                                }
+                            }});
+                        } else
+                            fail(err);
+                    });
 
                     input_buf = input_buf.slice(i+1);
                 }


### PR DESCRIPTION
When Runtime.evaluate() encounters a rejected promise, it fails with
```
    "response": {
        "message": "Debugger: expected Debugger.Object, got Proxy",
        "data": "_returnError@chrome://remote/content/cdp/domains/content/runtime/ExecutionContext.jsm:193:22\nevaluate@chrome://remote/content/cdp/domains/content/runtime/ExecutionContext.jsm:173:23\nsetTimeout handler*ph_wait_cond/<@debugger eval code:242:25\nph_wait_cond@debugger eval code:238:12\n@debugger eval code:1:13\nevaluate@chrome://remote/content/cdp/domains/content/runtime/ExecutionContext.jsm:147:29\nevaluate@chrome://remote/content/cdp/domains/content/Runtime.jsm:279:20\nexecute@chrome://remote/content/cdp/domains/DomainCache.jsm:101:25\nreceiveMessage@chrome://remote/content/cdp/sessions/ContentProcessSession.jsm:84:45\n"
    }
```

instead of returning a "subtype: error" result like Chromium does. This
causes wait timeouts to fail with such a generic `RuntimeError` instead
of the expected `testlib.Error: timeout`, breaking naughty patterns.

This was fallout from commit 90b39a51b104b82aaf -- previously, the
firefox CDP driver emulated Runtime.evaluate() for promises. The actual
waiting part does work fine, but translate the useless error from above
into a synthetic "timeout" exception.

Firefox issue: https://bugzilla.mozilla.org/show_bug.cgi?id=1702860

Fixes #15646 