### PR TITLE
more pycodestyle fixes

### DIFF
--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -36,7 +36,7 @@ class TestEmbed(MachineCase):
 
         # replace the shell with our embedded page, this way we can avoid
         # cross-origin errors when executing js in the iframe
-        m.write("/etc/cockpit/cockpit.conf","""
+        m.write("/etc/cockpit/cockpit.conf", """
 [WebService]
 Shell=/embed-cockpit/index.html
 """)
@@ -45,7 +45,7 @@ Shell=/embed-cockpit/index.html
 
         b.wait_visible("#embed-loaded")
         b.wait_visible("#embed-address")
-        m.write("/etc/cockpit/cockpit.conf","""
+        m.write("/etc/cockpit/cockpit.conf", """
 [WebService]
 Shell=/shell/index.html
 """)

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -130,12 +130,12 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestExample.testFail", "TestExample.testSkip"],
                                  env=env, capture_output=True)
         stdout = process.stdout
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
-        self.assertRegex(stdout, b"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
+        self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 1 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
+        self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
         self.assertNotRegex(stdout, b"RETRY 3")
-        self.assertRegex(stdout, b"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
-        self.assertRegex(stdout, b"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
+        self.assertRegex(stdout, rb"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
+        self.assertRegex(stdout, rb"# 1 TESTS FAILED \[\d*s on .*, 0 serial tests: \]")
 
         # Check retry logic for changed tests
         test_file = os.path.join(VERIFY_DIR, "check-testlib")
@@ -150,17 +150,17 @@ class TestRunTest(MachineCase):
         stdout = process.stdout
 
         # Changed test need to succeed 3 times
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic\n")
+        self.assertRegex(stdout, rb"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, rb"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, rb"\nok 1 .*test\/verify\/check-testlib TestRetryExample.testBasic\n")
         self.assertNotRegex(stdout, b"RETRY 3")
 
         # Changed test is never retried
-        self.assertRegex(stdout, b"\nnot ok 2 .*test\/verify\/check-testlib TestRetryExample.testFail\n")
+        self.assertRegex(stdout, rb"\nnot ok 2 .*test\/verify\/check-testlib TestRetryExample.testFail\n")
         self.assertNotRegex(stdout, b"testFail # RETRY")
 
         # Using @no_retry_when_changed prevents this retry logic
-        self.assertRegex(stdout, b"\nok 3 .*test\/verify\/check-testlib TestRetryExample.testNoRetry\n")
+        self.assertRegex(stdout, rb"\nok 3 .*test\/verify\/check-testlib TestRetryExample.testNoRetry\n")
         self.assertNotRegex(stdout, b"testNoRetry # RETRY")
 
         # Check retry logic for changed source
@@ -176,8 +176,8 @@ class TestRunTest(MachineCase):
         process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "--list", "TestHostEditing.testLimits",
                                   "TestHostSwitching.testEdit"], env=env, capture_output=True)
         stdout = process.stdout
-        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 1 \(test affected tests 3 times\)\n")
-        self.assertRegex(stdout, b"\nTestHostEditing.testLimits # RETRY 2 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, rb"\nTestHostEditing.testLimits # RETRY 1 \(test affected tests 3 times\)\n")
+        self.assertRegex(stdout, rb"\nTestHostEditing.testLimits # RETRY 2 \(test affected tests 3 times\)\n")
         self.assertRegex(stdout, b"\nTestHostEditing.testLimits\n")
         self.assertNotRegex(stdout, b"RETRY 3")
         self.assertRegex(stdout, b"\nTestHostSwitching.testEdit\n")

--- a/test/verify/files/measure-cpu
+++ b/test/verify/files/measure-cpu
@@ -4,7 +4,8 @@ import sys
 import os
 import ctypes
 
-CLOCK_MONOTONIC_RAW = 4 # see <linux/time.h>
+CLOCK_MONOTONIC_RAW = 4  # see <linux/time.h>
+
 
 class timespec(ctypes.Structure):
     _fields_ = [
@@ -12,21 +13,25 @@ class timespec(ctypes.Structure):
         ('tv_nsec', ctypes.c_long)
     ]
 
+
 librt = ctypes.CDLL('librt.so.1', use_errno=True)
 clock_gettime = librt.clock_gettime
 clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(timespec)]
 
+
 def monotonic_time():
     t = timespec()
-    if clock_gettime(CLOCK_MONOTONIC_RAW , ctypes.pointer(t)) != 0:
+    if clock_gettime(CLOCK_MONOTONIC_RAW, ctypes.pointer(t)) != 0:
         errno_ = ctypes.get_errno()
         raise OSError(errno_, os.strerror(errno_))
     return t.tv_sec + t.tv_nsec * 1e-9
 
+
 def cpu_stat():
-    for l in open("/proc/stat", "r").readlines():
-        if l.startswith("cpu "):
-            return int(l.split()[1])
+    for line in open("/proc/stat", "r").readlines():
+        if line.startswith("cpu "):
+            return int(line.split()[1])
+
 
 if sys.argv[1] == "start":
     print(repr((monotonic_time(), cpu_stat())))

--- a/test/verify/files/mock-escrow-server
+++ b/test/verify/files/mock-escrow-server
@@ -3,6 +3,7 @@
 import sys
 from http.server import HTTPServer, BaseHTTPRequestHandler
 
+
 class handler(BaseHTTPRequestHandler):
     def do_GET(self):
         self.send_response(200)
@@ -14,12 +15,15 @@ class handler(BaseHTTPRequestHandler):
         global secret
         len = int(self.headers.get('content-length', 0))
         secret = self.rfile.read(len)
-        with open(store, "wb") as f: f.write(secret)
+        with open(store, "wb") as f:
+            f.write(secret)
         self.send_response(200)
         self.end_headers()
 
+
 def escrow_server(port):
     HTTPServer(('', port), handler).serve_forever()
+
 
 store = sys.argv[1]
 

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -21,7 +21,8 @@ from http.server import *
 import json
 import re
 
-systems = { }
+systems = {}
+
 
 class handler(BaseHTTPRequestHandler):
     def match(self, p):
@@ -134,7 +135,9 @@ class handler(BaseHTTPRequestHandler):
         self.send_response(404)
         self.end_headers()
 
+
 def insights_server(port):
     HTTPServer(('', port), handler).serve_forever()
+
 
 insights_server(8888)

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -118,11 +118,13 @@ fi
 
 if [ -z "${PYTHON_STYLE_CHECKER-}" ]; then
     echo "ok 7 pycodestyle test # SKIP pycodestyle not installed"
+elif [ ! -e .git ]; then
+    echo "ok 7 pycodestyle test # SKIP not a git tree"
 else
     # all normal files which are either:
     #   - filename is *.py
     #   - executable matching ^#!/usr/bin/python3
-    PYFILES="$(find . -type f '(' -name '*.py' -o -executable -execdir grep -q '^#!/usr/bin/python3' '{}' ';' ')'  -print)"
+    PYFILES="$(git grep -lI '^#!.*python3') $(git ls-files "*.py")"
     # W504 and W503 are mutually exclusive (and both disabled by default)
     # explicitly giving '--ignore W504' here is actually more strict than the default
     # TODO: E402 should be fixed

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -129,8 +129,7 @@ else
     # W504 and W503 are mutually exclusive (and both disabled by default)
     # explicitly giving '--ignore W504' here is actually more strict than the default
     # TODO: E402 should be fixed
-    # TODO: W605 should be fixed very soon...
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504,W605 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -4,7 +4,6 @@ set -eu
 
 echo "1..7"
 
-builddir=$(pwd)
 cd "${srcdir:-.}"
 fail=0
 
@@ -86,8 +85,10 @@ fi
 #
 # Bad paths or modifications in patternfly for fonts
 #
-
-if grep "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" `ls dist/*/*.css $builddir/dist/*/*.css` >&2; then
+cssfiles="$(echo dist/*/*.css)"
+if [ -z "${cssfiles}" ]; then
+    echo "ok 5 patternfly-font-paths # skip dist/ not built"
+elif grep "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" ${cssfiles} >&2; then
     echo "ERROR: invalid patternfly fonts paths found" >&2
     echo "not ok 5 patternfly-font-paths"
     fail=1

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -38,6 +38,7 @@ TASK_NAME = "Validate all URLs"
 known_redirects = ["https://access.redhat.com/security/updates/classification/#",
                    "https://firefox.com/", "https://www.microsoft.com/"]
 
+
 def main():
     parser = argparse.ArgumentParser(description=TASK_NAME)
     parser.add_argument("-v", "--verbose", action="store_true", help="Verbose output")
@@ -85,6 +86,7 @@ def main():
                 new_issue = task.api.post("issues", data)
                 task.api.post("issues/{0}".format(new_issue["number"]), {"state": "closed"})
 
+
 def check_urls(verbose):
     command = r'git grep -IEho "(https?)://[-a-zA-Z0-9@:%_\+.~#?&=/]+" -- pkg ":!*.svg" | sort -u'
     urls = subprocess.check_output(command, shell=True, universal_newlines=True).split("\n")
@@ -94,7 +96,7 @@ def check_urls(verbose):
         if not url:
             continue
 
-        if "example.com" in url: # Some tests use demo urls
+        if "example.com" in url:  # Some tests use demo urls
             continue
 
         if verbose:
@@ -103,7 +105,7 @@ def check_urls(verbose):
         try:
             # Specify agent as some websites otherwise block requests
             req = Request(url=url, headers={"User-Agent": "Mozilla/5.0"})
-            resp =  urlopen(req)
+            resp = urlopen(req)
             if resp.geturl() != url and url not in known_redirects:
                 redirects.append(url)
             if resp.getcode() >= 400:
@@ -120,6 +122,7 @@ def check_urls(verbose):
         if redirects:
             success += "\nFollowing URLs are redirected:\n    {0}".format("\n    ".join(redirects))
     return (success, err)
+
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
The first one of these is pretty important: the test-static-code script, when run in a directory with nodes_modules/ checked out will try to scan all the python it finds in there, and reject an awful lot of it, which (if you have the git hook setup) will pretty much prevent you from ever pushing anything.