### PR TITLE
test: Ignore errors when removing self.tmpdir during teardown

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -973,7 +973,7 @@ class MachineCase(unittest.TestCase):
         if self.checkSuccess() and self.machine.ssh_reachable:
             self.check_journal_messages()
             self.check_browser_errors()
-        shutil.rmtree(self.tmpdir)
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def login_and_go(self, path=None, user=None, host=None, superuser=True, urlroot=None, tls=False):
         self.machine.start_cockpit(host, tls=tls)


### PR DESCRIPTION
The directory sometimes seems to disappear asynchronously, leading to
occasional errors like:

    FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp4n4loeh6'

This shouldn't happen, but life is too short to fix all the bugs in it.