### PR TITLE
pycodestyle: E402 fixups (import at top of file)

### DIFF
--- a/test/common/parent.py
+++ b/test/common/parent.py
@@ -1,8 +1,10 @@
 import os
 import sys
 
-TEST_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-BOTS_DIR = os.path.join(os.path.dirname(TEST_DIR), "bots")
-sys.path.append(os.path.join(BOTS_DIR))  # for lib
-sys.path.append(os.path.join(BOTS_DIR, "machine"))
-sys.path.append(os.path.join(TEST_DIR, "common"))
+BASE_DIR = os.path.realpath(f'{__file__}/../../..')
+TEST_DIR = f'{BASE_DIR}/test'
+BOTS_DIR = f'{BASE_DIR}/bots'
+
+sys.path.append(BOTS_DIR)
+sys.path.append(f'{TEST_DIR}/common')
+sys.path.append(f'{BOTS_DIR}/machine')

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -19,18 +19,11 @@
 
 
 import os
-import sys
-
-test_dir = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-sys.path.append(test_dir)
-
-from verify import parent
-parent  # pyflakes
-
+from parent import TEST_DIR
 from testlib import *
 from testvm import VirtMachine
 
-AUTH_KEY = os.path.join(test_dir, "containers/files/enc_rsa")
+AUTH_KEY = os.path.join(TEST_DIR, "containers/files/enc_rsa")
 PUB_AUTH_KEY = "{}.pub".format(AUTH_KEY)
 
 

--- a/test/containers/parent.py
+++ b/test/containers/parent.py
@@ -1,0 +1,1 @@
+../common/parent.py

--- a/test/containers/run-tests
+++ b/test/containers/run-tests
@@ -22,17 +22,11 @@ import imp
 import os
 import string
 import unittest
+from parent import TEST_DIR, BASE_DIR
+import testlib
+
 
 sys.dont_write_bytecode = True
-
-base_dir = os.path.dirname(os.path.realpath(__file__))
-testdir = os.path.dirname(base_dir)
-sys.path.append(testdir)
-
-from verify import parent
-parent  # pyflakes
-
-from common import testlib
 
 
 def check_valid(filename):
@@ -47,7 +41,7 @@ def run(opts):
     # Now actually load the tests, any modules that start with "check-*"
     loader = unittest.TestLoader()
     suite = unittest.TestSuite()
-    for filename in glob.glob(os.path.join(base_dir,
+    for filename in glob.glob(os.path.join(TEST_DIR, "containers",
                                            "check-{0}*".format(opts.container))):
         name = check_valid(filename)
         if not name or not os.path.isfile(filename):
@@ -68,7 +62,7 @@ def main():
     if not opts.container:
         opts.container = 'bastion'
 
-    if not os.path.isdir(os.path.abspath(os.path.join(testdir, "..", "containers", opts.container))):
+    if not os.path.isdir(os.path.abspath(os.path.join(BASE_DIR, "containers", opts.container))):
         sys.stderr.write("Unable to run tests for unknown container {0}.\n".format(opts.container))
         exit(1)
 

--- a/tools/parent.py
+++ b/tools/parent.py
@@ -1,0 +1,1 @@
+../test/common/parent.py

--- a/tools/test-static-code
+++ b/tools/test-static-code
@@ -128,8 +128,7 @@ else
     PYFILES="$(git grep -lI '^#!.*python3') $(git ls-files "*.py")"
     # W504 and W503 are mutually exclusive (and both disabled by default)
     # explicitly giving '--ignore W504' here is actually more strict than the default
-    # TODO: E402 should be fixed
-    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore E402,W504 $PYFILES) || true
+    out=$(python3 -m "$PYTHON_STYLE_CHECKER" --max-line-length=415 --ignore W504 $PYFILES) || true
     if [ -n "$out" ]; then
         echo "$out" >&2
         echo "not ok 7 $PYTHON_STYLE_CHECKER test"

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -30,8 +30,6 @@ from urllib.request import urlopen, Request
 sys.path.append(os.path.join(dirname(dirname(abspath(__file__))), "bots"))
 import task
 
-sys.dont_write_bytecode = True
-
 DAYS = 7
 TASK_NAME = "Validate all URLs"
 

--- a/tools/urls-check
+++ b/tools/urls-check
@@ -18,16 +18,13 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 
-import os
-from os.path import dirname, abspath
 import sys
 import time
 import argparse
 import subprocess
 import urllib
 from urllib.request import urlopen, Request
-
-sys.path.append(os.path.join(dirname(dirname(abspath(__file__))), "bots"))
+from parent import BASE_DIR
 import task
 
 DAYS = 7
@@ -87,7 +84,7 @@ def main():
 
 def check_urls(verbose):
     command = r'git grep -IEho "(https?)://[-a-zA-Z0-9@:%_\+.~#?&=/]+" -- pkg ":!*.svg" | sort -u'
-    urls = subprocess.check_output(command, shell=True, universal_newlines=True).split("\n")
+    urls = subprocess.check_output(command, shell=True, universal_newlines=True, cwd=BASE_DIR).split("\n")
     redirects = []
     failed = []
     for url in urls:


### PR DESCRIPTION
We have two classes of of cases where our imports are not at the top of
the file:

 - various tricks to manipulate the path before importing other modules

 - gi.require_version()

For gi.require_version() we could probably just drop it, but let's leave
it there and add a #NOQA comment.

For the path manipulation, let's up our game a bit.  We avoid this issue
in test/verify/ by symlinking path.py from test/common/.  Do the same
thing for test/container/ and tools/.

Fix a bug in path.py: it uses abspath() instead of realpath() when
determining the value of TEST_DIR, which means that it's not resolving
the symlink.  That's worked up to this point only because path.py has
only ever been linked to from the same depth as its original location in
test/common/.  Linking it from tools/ breaks that assumption.

Make some minor adjustment for not having access to the variable defined
as a side effect of the path manipulations (but we can still get them
from path.py).

Remove also a spurious dont_write_bytecode = True from tools/urls-check.
We're not doing this at all consistently from other places that import
parent.py.

Adjust tools/test-static-code to remove the E402 exception.