### PR TITLE
test: Remount encrypted file system

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -88,6 +88,10 @@ class TestStorageResize(StorageCase):
                 self.content_head_action(fsys_row, "Mount")
                 self.confirm()
                 self.wait_mounted(fsys_row, fsys_tab)
+            if crypto:  # Encrypted FS is not remounted upon resizing
+                b.click("button:contains(Mount now)")
+                b.wait_not_present("button:contains(Mount now)")
+
             size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
             self.assertGreater(size, 300000)
         else:


### PR DESCRIPTION
Upon growing volume that contains encrypted file system this fs is
unmounted. Then `df` does not show from it what we expect.

I am not sure if this is expected behavior or if it is issue in cockpit or udisks.

See https://github.com/cockpit-project/bots/pull/1877