### PR TITLE
containers: Pull fedora image from registry.fedoraproject.org

### DIFF
--- a/containers/bastion/Dockerfile
+++ b/containers/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora:33
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:33
+FROM registry.fedoraproject.org/fedora:33
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=master
 


### PR DESCRIPTION
Otherwise it pulls from docker.io where we can hit pull rate limit.