### PR TITLE
lib: Adjust cockpit-po-plugin for webpack v5

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -627,7 +627,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # pam_faillock tries to chown the file to be owned by the user itself,
         # which is currently an selinux fail on the following distros:
-        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-33', 'fedora-34', 'rhel-8-4', 'rhel-8-5', 'rhel-8-5-distropkg']:
+        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-33', 'fedora-34', 'rhel-8-4', 'rhel-8-5', 'rhel-8-5-distropkg', 'rhel-9-0']:
             # https://bugzilla.redhat.com/show_bug.cgi?id=1836182
             self.allow_journal_messages('.*type=1400.*avc:  denied  { chown }.*comm="cockpit-session".*')
 


### PR DESCRIPTION
The plugin works with webpack v5, but throws a deprecation warning:

> [DEP_WEBPACK_COMPILATION_ASSETS] DeprecationWarning: Compilation.assets
> will be frozen in future, all modifications are deprecated.
> BREAKING CHANGE: No more changes should happen to Compilation.assets after sealing the Compilation.
> Do changes to assets earlier, e. g. in Compilation.hooks.processAssets.
> Make sure to select an appropriate stage from Compilation.PROCESS_ASSETS_STAGE_*.

When building with webpack v5, use the more fine-grained `processAssets`
hook, which is meant for adding extra assets. This API is not available
in v4 yet, so until we move all our projects to v5 we have to support
both cases.