### PR TITLE
containers: Use correct $container type

### DIFF
--- a/containers/ws/atomic-install
+++ b/containers/ws/atomic-install
@@ -44,7 +44,7 @@ chown root:root /host/etc/cockpit/ws-certs.d /host/etc/cockpit/machines.d
 mkdir -p /etc/ssh
 
 # For podman, generate a systemd unit for starting on boot
-if [ "${container:-}" = podman ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
+if [ "${container:-}" = oci ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
     mkdir -p /host/etc/systemd/system/
     cat << EOF > /host/etc/systemd/system/cockpit.service
 [Unit]


### PR DESCRIPTION
In commit e87ad98d4 base image was changed which meant that now `$container` is `oci` and not `podman`.
