### PR TITLE
test: Relax expected messages in TestConnection.testCockpitDesktop

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -737,7 +737,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.allow_journal_messages("Refusing to render service to dead parents.")
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages(".*Peer failed to perform TLS handshake.*")
-        self.allow_journal_messages("cannot reauthorize identity\\(s\\): unix-user:admin unix-user:fedora")
+        self.allow_journal_messages(r"cannot reauthorize identity\(s\): unix-user:.*")
 
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):


### PR DESCRIPTION
Sometimes it looks like this:

    cannot reauthorize identity(s): unix-user:admin

Spotted in https://github.com/cockpit-project/bots/pull/1912 where it caused [this random failure](https://logs.cockpit-project.org/logs/pull-1912-20210411-111351-7ebd59aa-ubuntu-stable-cockpit-project-cockpit/log.html#14)