### PR TITLE
test: Drop usage of Machine.atomic_image

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -109,29 +109,28 @@ class TestConnection(MachineCase):
             self.assertTrue(cookie["httpOnly"])
         self.assertFalse(cookie["secure"])
 
-        if not m.atomic_image:  # cannot write to /usr on Atomics, and cockpit-session is in a container
-            # damage cockpit-session permissions (Fedora-ish and Debian-ish path), expect generic error message
-            m.execute("chmod g-x /usr/libexec/cockpit-session 2>/dev/null || chmod g-x /usr/lib/cockpit/cockpit-session")
-            b.open("/system")
-            b.wait_in_text('#login-fatal-message', "Internal error in login process")
-            m.execute("chmod g+x /usr/libexec/cockpit-session 2>/dev/null || chmod g+x /usr/lib/cockpit/cockpit-session")
+        # damage cockpit-session permissions (Fedora-ish and Debian-ish path), expect generic error message
+        m.execute("chmod g-x /usr/libexec/cockpit-session 2>/dev/null || chmod g-x /usr/lib/cockpit/cockpit-session")
+        b.open("/system")
+        b.wait_in_text('#login-fatal-message', "Internal error in login process")
+        m.execute("chmod g+x /usr/libexec/cockpit-session 2>/dev/null || chmod g+x /usr/lib/cockpit/cockpit-session")
 
-            self.allow_journal_messages(".*cockpit-session: bridge program failed.*")
+        self.allow_journal_messages(".*cockpit-session: bridge program failed.*")
 
-            # pretend cockpit-bridge is not installed, expect specific error message
-            m.execute("mv /usr/bin/cockpit-bridge /usr/bin/cockpit-bridge.disabled")
-            b.open("/system")
-            b.wait_visible("#login")
-            b.set_val("#login-user-input", "admin")
-            b.set_val("#login-password-input", "foobar")
-            b.click('#login-button')
-            b.wait_visible('#login-fatal-message')
-            if m.image not in ["rhel-7-6-distropkg"]:
-                b.wait_text('#login-fatal-message', "The cockpit package is not installed")
-            else:
-                # cockpit-ws < 184 had an unspecific error message
-                b.wait_in_text('#login-fatal-message', "Internal error")
-            m.execute("mv /usr/bin/cockpit-bridge.disabled /usr/bin/cockpit-bridge")
+        # pretend cockpit-bridge is not installed, expect specific error message
+        m.execute("mv /usr/bin/cockpit-bridge /usr/bin/cockpit-bridge.disabled")
+        b.open("/system")
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        b.click('#login-button')
+        b.wait_visible('#login-fatal-message')
+        if m.image not in ["rhel-7-6-distropkg"]:
+            b.wait_text('#login-fatal-message', "The cockpit package is not installed")
+        else:
+            # cockpit-ws < 184 had an unspecific error message
+            b.wait_in_text('#login-fatal-message', "Internal error")
+        m.execute("mv /usr/bin/cockpit-bridge.disabled /usr/bin/cockpit-bridge")
 
         # Reauthorization can fail due to disconnects above
         self.allow_authorize_journal_messages()

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -32,21 +32,11 @@ class TestKdump(MachineCase):
 
     def enableKdump(self):
         # we need to make sure that the kernel command line options include our crashkernel parameter
-        if self.machine.atomic_image:
-            # on atomic we have a crashkernel option already, but for auto
-            contents = self.machine.execute(command="cat /boot/grub2/grub.cfg", quiet=True)
-            self.assertIn("crashkernel=auto", contents)
-            self.machine.write("/boot/grub2/grub.cfg", contents.replace("crashkernel=auto", "crashkernel=256M"))
-        elif self.machine.image in ["rhel-8-0", "rhel-8-0-distropkg", "rhel-8-1"]:
-            # these images use BootLoaderSpec and grubenv
-            self.machine.execute(
-                "sed -i '/^kernelopts=/ { s/crashkernel=[^ ]*//; s/$/ crashkernel=256M/; }' /boot/grub2/grubenv")
-        else:
-            lines = self.machine.execute(command="cat /etc/default/grub", quiet=True).split("\n")
-            lines = map(lambda line: self.rreplace(line, '"', ' crashkernel=256M"', 1)
-                        if line.startswith("GRUB_CMDLINE_LINUX") else line, lines)
-            self.machine.write("/etc/default/grub", "\n".join(lines))
-            self.machine.execute("grub2-mkconfig -o /boot/grub2/grub.cfg")
+        lines = self.machine.execute(command="cat /etc/default/grub", quiet=True).split("\n")
+        lines = map(lambda line: self.rreplace(line, '"', ' crashkernel=256M"', 1)
+                    if line.startswith("GRUB_CMDLINE_LINUX") else line, lines)
+        self.machine.write("/etc/default/grub", "\n".join(lines))
+        self.machine.execute("grub2-mkconfig -o /boot/grub2/grub.cfg")
         self.machine.execute("mkdir -p /var/crash")
 
     def enableLocalSsh(self):

--- a/test/verify/check-login
+++ b/test/verify/check-login
@@ -75,19 +75,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # Try to login as user with correct password
         login("user", "abcdefg")
-        if m.atomic_image:
-            b.wait_in_text("#login-error-message", "Server closed connection")
-        else:
-            b.wait_text("#login-error-message", "Permission denied")
+        b.wait_text("#login-error-message", "Permission denied")
 
-        # Try to login with disabled shell; this does not work on Atomic where
-        # we log in through ssh
-        if not m.atomic_image:
-            m.execute("usermod --shell /bin/false admin; sync")
-            b.reload()
-            login("admin", "foobar")
-            b.wait_text_not("#login-error-message", "")
-            m.execute("usermod --shell /bin/bash admin; sync")
+        # Try to login with disabled shell
+        m.execute("usermod --shell /bin/false admin; sync")
+        b.reload()
+        login("admin", "foobar")
+        b.wait_text_not("#login-error-message", "")
+        m.execute("usermod --shell /bin/bash admin; sync")
 
         # Login as admin
         b.open("/system")
@@ -127,20 +122,18 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#option-group")
 
         # And now we remove cockpit-ssh which affects the default
-        if not m.atomic_image:
-            m.execute("rm -f /usr/libexec/cockpit-ssh /usr/lib/cockpit/cockpit-ssh")
-            m.restart_cockpit()
-            b.open("/system")
-            b.wait_not_visible("#option-group")
+        m.execute("rm -f /usr/libexec/cockpit-ssh /usr/lib/cockpit/cockpit-ssh")
+        m.restart_cockpit()
+        b.open("/system")
+        b.wait_not_visible("#option-group")
 
-        if not m.atomic_image:
-            # login with user shell that prints some stdout/err noise
-            # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
-            m.execute("echo 'echo noise-rc-out; echo noise-rc-err >&2' >> ~admin/.bashrc")
-            m.execute("echo 'echo noise-profile-out; echo noise-profile-err >&2' >> ~admin/.profile")
-            login("admin", "foobar")
-            b.expect_load()
-            b.wait_present("#content")
+        # login with user shell that prints some stdout/err noise
+        # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
+        m.execute("echo 'echo noise-rc-out; echo noise-rc-err >&2' >> ~admin/.bashrc")
+        m.execute("echo 'echo noise-profile-out; echo noise-profile-err >&2' >> ~admin/.profile")
+        login("admin", "foobar")
+        b.expect_load()
+        b.wait_present("#content")
 
         self.allow_journal_messages("Returning error-response ... with reason .*",
                                     "pam_unix\(cockpit:auth\): authentication failure; .*",
@@ -152,13 +145,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     def testExpired(self):
         m = self.machine
         b = self.browser
-
-        # On atomic this happens over ssh
-        if m.atomic_image:
-            m.execute(
-                "sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config", direct=True)
-            m.execute(
-                "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
 
         m.execute("chage -d 0 admin")
         m.start_cockpit()
@@ -175,10 +161,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_visible("#conversation-group")
         b.wait_not_visible("#password-group")
         b.wait_not_visible("#user-group")
-        if m.atomic_image:
-            b.wait_in_text("#conversation-prompt", "You are required to change your password")
-        else:
-            b.wait_in_text("#conversation-message", "You are required to change your password")
+        b.wait_in_text("#conversation-message", "You are required to change your password")
         b.set_val('#conversation-input', 'foobar')
         b.click('#login-button')
 
@@ -192,10 +175,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         # We should see a message
-        if m.atomic_image:
-            b.wait_in_text("#conversation-prompt", "BAD PASSWORD")
-        else:
-            b.wait_in_text("#conversation-message", "BAD PASSWORD")
+        b.wait_in_text("#conversation-message", "BAD PASSWORD")
 
         # Now choose a better password
         b.wait_not_present("#login-button:disabled")
@@ -215,10 +195,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         # We should see a message
-        if m.atomic_image:
-            b.wait_in_text("#conversation-prompt", "passwords do not match")
-        else:
-            b.wait_in_text("#conversation-message", "passwords do not match")
+        b.wait_in_text("#conversation-message", "passwords do not match")
 
         # Type the password again
         b.wait_visible("#conversation-group")
@@ -254,13 +231,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
         path = "/usr/lib/cockpit-test-assets/mock-pam-conv-mod.so"
         conf = "/etc/pam.d/cockpit"
-        if m.atomic_image:
-            conf = "/etc/pam.d/sshd"
-            m.execute(
-                "sed -i 's/.*ChallengeResponseAuthentication.*/ChallengeResponseAuthentication yes/' /etc/ssh/sshd_config", direct=True)
-            m.execute(
-                "( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service", direct=True)
-
         m.execute("sed -i '5 a auth       required    {0}' {1}".format(path, conf))
 
         m.start_cockpit()

--- a/test/verify/check-multi-machine
+++ b/test/verify/check-multi-machine
@@ -279,14 +279,10 @@ class TestMultiMachine(MachineCase):
         b.wait_js_cond('window.location.pathname == "{0}=10.111.113.2/system"'.format(root))
         m2_dashboard_name = "machine2"
 
-        # Dashboard is not installed on secondary atomic machines
-        if not m2.atomic_image:
-            b.click("a[href='/dashboard']")
-            b.enter_page("/dashboard")
-            b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
-            b.wait_not_present("a[data-address='10.111.113.2']")
-        else:
-            b.wait_not_present("a[href='/dashboard']")
+        b.click("a[href='/dashboard']")
+        b.enter_page("/dashboard")
+        b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
+        b.wait_not_present("a[data-address='10.111.113.2']")
         b.logout()
 
         # Bad host key
@@ -437,13 +433,10 @@ class TestMultiMachine(MachineCase):
             b.switch_to_top()
             b.wait_js_cond('window.location.pathname == "{0}=10.111.113.2/system"'.format(root))
 
-            if not m2.atomic_image:
-                b.click("a[href='/dashboard']")
-                b.enter_page("/dashboard")
-                b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
-                b.wait_not_present("a[data-address='10.111.113.2']")
-            else:
-                b.wait_not_present("a[href='/dashboard']")
+            b.click("a[href='/dashboard']")
+            b.enter_page("/dashboard")
+            b.wait_in_text("a[data-address='localhost']", m2_dashboard_name)
+            b.wait_not_present("a[data-address='10.111.113.2']")
 
         # Might happen when we switch away.
         self.allow_hostkey_messages()

--- a/test/verify/check-multi-machine-key
+++ b/test/verify/check-multi-machine-key
@@ -130,15 +130,8 @@ class TestMultiMachineKeyAuth(MachineCase):
         except subprocess.CalledProcessError:
             assert False, "No running ssh-agent found"
 
-        # pam-ssh-add isn't used on atomic
-        if m1.atomic_image:
-            self.load_key('id_rsa', 'foobar')
-            b.wait_js_cond('loaded === true')
-            self.check_keys(["2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 id_rsa (RSA)"],
-                            ["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])
-        else:
-            # Check our keys were loaded.
-            self.check_keys(KEY_IDS_MD5, KEY_IDS)
+        # Check our keys were loaded.
+        self.check_keys(KEY_IDS_MD5, KEY_IDS)
 
         # Add machine
         b.switch_to_top()
@@ -164,9 +157,8 @@ class TestMultiMachineKeyAuth(MachineCase):
         b.wait_not_in_text("#login-available", "Login Password")
         b.wait_in_text("#login-available", "id_rsa")
 
-        if not m1.atomic_image:
-            b.wait_in_text("#login-available", "id_ecdsa")
-            b.wait_in_text("#login-available", "id_ed25519")
+        b.wait_in_text("#login-available", "id_ecdsa")
+        b.wait_in_text("#login-available", "id_ed25519")
 
         # add key
         authorize_user(m2, "user")
@@ -189,9 +181,6 @@ class TestMultiMachineKeyAuth(MachineCase):
 
         self.login_and_go("/system")
         b.switch_to_top()
-        # pam-ssh-add isn't used on atomic
-        if m1.atomic_image:
-            self.load_key('id_rsa', 'foobar')
 
         b.go("/@10.111.113.2")
         b.wait_visible("#machine-troubleshoot")

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -50,10 +50,9 @@ class TestSession(MachineCase):
         self.login_and_go("/system")
         wait_session(True)
 
-        # Check session type (fixed in PR #10963)
-        if not m.atomic_image and m.image not in ["rhel-7-6-distropkg", "rhel-8-0-distropkg"]:
-            id = m.execute("loginctl list-sessions | awk '/admin/ {print $1}'").strip()
-            self.assertEqual(m.execute("loginctl show-session -p Type %s" % id).strip(), "Type=web")
+        # Check session type
+        id = m.execute("loginctl list-sessions | awk '/admin/ {print $1}'").strip()
+        self.assertEqual(m.execute("loginctl show-session -p Type %s" % id).strip(), "Type=web")
 
         # Logout
         b.logout()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -169,10 +169,7 @@ class TestSystemInfo(MachineCase):
         b.click("#system_information_change_hostname button:contains('Change')")
         b.wait_popdown("system_information_change_hostname")
 
-        if m.atomic_image:
-            b.wait_text('#system-ostree-version-link', "cockpit-base.1")
-        else:
-            b.wait_not_visible("#system-ostree-version-link")
+        b.wait_not_visible("#system-ostree-version-link")
 
         b.wait_text('#system_information_hostname_button', "Adventure Box (host1.cockpit.lan)")
         # HACK /usr/bin/hostname output is delayed in systemd v208, so that DBus gets notified early
@@ -470,8 +467,7 @@ class TestSystemInfo(MachineCase):
         # - no BLS, options go into /etc/default/grub and grub.cfg (oldest)
         # - BLS, options go directly into entries (RHEL 8.0)
         # - BLS, entries use $kernelopt, that is defined in grubenv (newest)
-        if not m.atomic_image:
-            m.execute(r"""set -e
+        m.execute(r"""set -e
 . /etc/os-release
 touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
 if type update-grub >/dev/null 2>&1; then
@@ -489,7 +485,7 @@ grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
     grep -q '^options.*$kernelopts' /boot/loader/entries/*42.0.0*.conf )
 """)
             # clean up so that next reboot works
-            m.execute(r"""set -e
+        m.execute(r"""set -e
 . /etc/os-release
 rm /boot/vmlinuz-42.0.0
 if type update-grub >/dev/null 2>&1; then
@@ -548,13 +544,6 @@ class TestPcp(packagelib.PackageCase):
     def testEnablePcpLink(self):
         m = self.machine
         b = self.browser
-
-        # the atomics don't have pcp and can't install additional software
-        if m.atomic_image:
-            self.login_and_go("/system")
-            b.wait_not_visible("#server-pmlogger-switch")
-            b.wait_not_visible("#system-information-enable-pcp-link")
-            return
 
         m.execute("pkcon remove -y pcp")
 

--- a/test/verify/check-terminal
+++ b/test/verify/check-terminal
@@ -165,10 +165,7 @@ PROMPT_COMMAND='printf "\\033]0;%s@%s:%s\\007" "${USER}" "${HOSTNAME%%.*}" "${PW
         # don't use wait_line() for the full match here, as line breaks get in the way; just wait until command has run
         wait_line(n + 1, "$")
         path = m.execute("cat /tmp/path").strip()
-        if m.atomic_image:
-            self.assertIn("/usr/local/bin:/usr/bin", path)
-        else:
-            self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", path)
+        self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", path)
         self.assertNotIn(":/.local", path)  # would happen with empty $HOME
 
         def check_theme_select(name, style):

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -29,10 +29,6 @@ class PackageCase(MachineCase):
 
         self.repo_dir = "/var/tmp/repo"
 
-        if self.machine.atomic_image:
-            warnings.warn("PackageCase: atomic images can't install additional packages")
-            return
-
         # expected backend; hardcode this on image names to check the auto-detection
         if self.machine.image.startswith("debian") or self.machine.image.startswith("ubuntu"):
             self.backend = "apt"


### PR DESCRIPTION
This was dropped in
https://github.com/cockpit-project/bots/commit/ac9b124ee1a7

Drop cases which were really Atomic specific, and replace most others
with `ostree_image`.