### PR TITLE
fmf: Don't install npm

### DIFF
--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -10,7 +10,7 @@ require:
   # build/test infra dependencies
   - git
   - make
-  - npm
+  - nodejs
   - python3
   # required by tests
   - NetworkManager-team


### PR DESCRIPTION
The release tarballs include the necessary test dependencies already.