### PR TITLE
cockpiterror.c: Use glib macro instead of our own implementation

### DIFF
--- a/src/common/cockpiterror.c
+++ b/src/common/cockpiterror.c
@@ -29,16 +29,4 @@
  * Error codes.
  */
 
-GQuark
-cockpit_error_quark (void)
-{
-  static GQuark domain = 0;
-  static volatile gsize quark_volatile = 0;
-
-  if (g_once_init_enter (&quark_volatile)) {
-      domain = g_quark_from_static_string ("cockpit-error");
-      g_once_init_leave (&quark_volatile, 1);
-  }
-
-  return domain;
-}
+G_DEFINE_QUARK(cockpit-error, cockpit_error)


### PR DESCRIPTION
I've just updated to F34 and cannot `make` cockpit due to:
```
In file included from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from src/common/cockpiterror.h:23,
                 from src/common/cockpiterror.c:22:
src/common/cockpiterror.c: In function ‘cockpit_error_quark’:
/usr/include/glib-2.0/glib/gatomic.h:117:5: error: argument 2 of ‘__atomic_load’ discards ‘volatile’ qualifier [-Werror=incompatible-pointer-types]
  117 |     __atomic_load (gapg_temp_atomic, &gapg_temp_newval, __ATOMIC_SEQ_CST); \
      |     ^~~~~~~~~~~~~
/usr/include/glib-2.0/glib/gthread.h:260:7: note: in expansion of macro ‘g_atomic_pointer_get’
  260 |     (!g_atomic_pointer_get (location) &&                             \
      |       ^~~~~~~~~~~~~~~~~~~~
src/common/cockpiterror.c:38:7: note: in expansion of macro ‘g_once_init_enter’
   38 |   if (g_once_init_enter (&quark_volatile)) {
      |       ^~~~~~~~~~~~~~~~~
```

This is quick fix. @allisonkarlitskaya does that make sense?