### PR TITLE
network: flip direction of the MAC dropdown in add bond dialog

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -236,6 +236,13 @@ th {
     font-weight: normal;
 }
 
+// Flip the MAC address dropdown to the inner of the modal
+// Bootstrap dropdown cannot escape the PF4 modal and it ends up cropped otherwise
+#network-bond-settings-mac-menu.dropdown-menu {
+    left: unset;
+    right: 0;
+}
+
 // Temporary curtain to hide the conten as it loads
 #testing-connection-curtain {
     z-index: 2000;


### PR DESCRIPTION
Relevant to: https://bugzilla.redhat.com/show_bug.cgi?id=1946877

This is far from optimal but I was not able to find a way to let it
escape the PF4 dialog.
It needs to be ported to PF4 anyway, which will properly solve the issue.