### PR TITLE
networkmanager: Fix device connection button

### DIFF
--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -123,7 +123,7 @@ export const NetworkInterfacePage = ({
     }
 
     function connect() {
-        if (iface.MainConnection && !(dev && ghostSettings))
+        if (!(iface.MainConnection || (dev && ghostSettings)))
             return;
 
         function fail(error) {
@@ -140,7 +140,7 @@ export const NetworkInterfacePage = ({
 
         with_checkpoint(model, modify,
                         {
-                            devices: self.dev ? [self.dev] : [],
+                            devices: dev ? [dev] : [],
                             fail_text: cockpit.format(_("Switching on <b>$0</b> will break the connection to the server, and will make the administration UI unavailable."), dev_name),
                             anyway_text: cockpit.format(_("Switch on $0"), dev_name)
                         });

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -81,6 +81,14 @@ class TestNetworkingBasic(NetworkCase):
         self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
         self.wait_for_iface_setting('Status', 'Inactive')
 
+        # Reconnect through the UI
+        self.toggle_onoff(".pf-c-card__header:contains('%s')" % iface)
+        b.wait_in_text("#network-interface .pf-c-card:contains('%s')" % iface, "1.2.3.4/18")
+
+        # Disconnect from the CLI, UI reacts
+        m.execute("nmcli device disconnect %s" % iface)
+        self.wait_onoff(".pf-c-card__header:contains('%s')" % iface, False)
+
         # Switch it back to "auto" from the command line and bring it
         # up again
         #


### PR DESCRIPTION
Commit 5c7b284a082 broke the "connect device" button. Fix the initial
condition in connect() to what we had before that commit: we can connect
if there is either a MainConnection that we can activate, or a device
with ghost settings. (Thanks to Marius Vollmer for this).

Also fix the modify call, `self.dev` is not a thing.

https://bugzilla.redhat.com/show_bug.cgi?id=1946874