### PR TITLE
Two coverity fixes

### DIFF
--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -375,6 +375,7 @@ teardown (TestCase *tc, gconstpointer data)
   g_assert_cmpint (wait (NULL), ==, -1);
   g_assert_cmpint (errno, ==, ECHILD);
   /* connection should fail */
+  /* coverity[leaked_handle : FALSE] */
   g_assert_cmpint (do_connect (tc), ==, -ECONNREFUSED);
   g_unsetenv ("COCKPIT_WS_PROCESS_IDLE");
 

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -899,7 +899,7 @@ test_multi_step_fail (Test *test,
 {
   GHashTable *headers = NULL;
   gint spot = 0;
-  gchar *id = NULL;
+  g_autofree gchar *id = NULL;
   gchar *prompt = NULL;
   const ErrorMultiFixture *fix = data;
 


### PR DESCRIPTION
RHEL's Coverity scanner got fixed to get along with glib ref counting, so the scan results are down to just two unit test issues. These are both false positives, but let's address them to have a clean slate.

https://bugzilla.redhat.com/show_bug.cgi?id=1938693