### PR TITLE
base1: Add option to disable file reading for cockpit.file().watch()

### DIFF
--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -36,7 +36,7 @@ promise
     .then((new_content, new_tag) => { ... })
     .catch(error => { ... })
 
-file.watch((content, tag, [error]) => { })
+file.watch((content, tag, [error]) => { }, [ { read: boolean } ])
 
 file.close()
 </programlisting>
@@ -200,6 +200,8 @@ cockpit.file("/path/to/file").modify(shout)
       external changes.
 <programlisting>
 handle = file.watch(callback);
+
+handle_no_read = file.watch(callback, { read: false });
 </programlisting>
       Whenever a change occurs, the <code>callback()</code> is called with
       the new content and tag of the file.  This might happen because of
@@ -207,10 +209,12 @@ handle = file.watch(callback);
       <code>replace()</code>, and <code>modify()</code>.</para>
     <para>When a read error occurs, the <code>callback()</code> is called with
       an error as a third argument. Write errors are not reported via the watch callback.</para>
-    <para>Calling <code>watch()</code> will also automatically call
-      <code>read()</code> to get the initial content of the file.</para>
-    <para>Thus, you normally don't need to call <code>read()</code> at all when
-      using <code>watch()</code>.</para>
+    <para>Calling <code>watch()</code> will also automatically call <code>read()</code>
+      to get the initial content of the file. Thus, you normally don't need to call
+      <code>read()</code> at all when using <code>watch()</code>.</para>
+    <para>To disable the automatic reading, e.g. for large files or unreadable
+      file system objects, set the <code>read</code> option to <code>false</code>. The first
+      <code>content</code> argument of the callback will then always be <code>null</code>.</para>
     <para>To free the resources used for monitoring, call <code>handle.remove()</code>.</para>
   </refsection>
 

--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -3834,7 +3834,7 @@ function factory() {
         var watch_channel = null;
         var watch_tag;
 
-        function ensure_watch_channel() {
+        function ensure_watch_channel(options) {
             if (n_watch_callbacks > 0) {
                 if (watch_channel)
                     return;
@@ -3847,9 +3847,17 @@ function factory() {
                 watch_channel = cockpit.channel(opts);
                 watch_channel.addEventListener("message", function (event, message_string) {
                     var message;
-                    try { message = JSON.parse(message_string) } catch (e) { message = null }
-                    if (message && message.path == path && message.tag && message.tag != watch_tag)
-                        read();
+                    try {
+                        message = JSON.parse(message_string);
+                    } catch (e) {
+                        message = null;
+                    }
+                    if (message && message.path == path && message.tag && message.tag != watch_tag) {
+                        if (options && options.read !== undefined && !options.read)
+                            fire_watch_callbacks(null, message.tag);
+                        else
+                            read();
+                    }
                 });
             } else {
                 if (watch_channel) {
@@ -3864,11 +3872,11 @@ function factory() {
             invoke_functions(watch_callbacks, self, arguments);
         }
 
-        function watch(callback) {
+        function watch(callback, options) {
             if (callback)
                 watch_callbacks.push(callback);
             n_watch_callbacks += 1;
-            ensure_watch_channel();
+            ensure_watch_channel(options);
 
             watch_tag = null;
             read();
@@ -3882,7 +3890,7 @@ function factory() {
                             watch_callbacks[index] = null;
                     }
                     n_watch_callbacks -= 1;
-                    ensure_watch_channel();
+                    ensure_watch_channel(options);
                 }
             };
         }

--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -457,6 +457,34 @@ QUnit.test("syntax watching", function (assert) {
     }
 });
 
+QUnit.test("watching without reading", function (assert) {
+    const done = assert.async();
+    assert.expect(7);
+
+    var file = cockpit.file(dir + "/foobar");
+    var watch = file.watch(changed, { read: false });
+
+    var n = 0;
+    function changed(content, tag) {
+        n += 1;
+        if (n == 1) {
+            assert.equal(content, null, "initially non-existent");
+            assert.equal(tag, "-", "empty tag");
+            cockpit.spawn(["bash", "-c", "cd " + dir + " && echo 1234 > foobar.tmp && mv foobar.tmp foobar"]);
+        } else if (n == 2) {
+            assert.equal(content, null, "no content as reading is disabled");
+            assert.notEqual(tag, "-");
+            assert.ok(tag.length > 5, "tag has a reasonable size");
+            cockpit.spawn(["bash", "-c", "rm " + dir + "/foobar"]);
+        } else if (n == 3) {
+            assert.equal(content, null, "finally non-existent");
+            assert.equal(tag, "-", "empty tag");
+            watch.remove();
+            done();
+        }
+    }
+});
+
 QUnit.test("closing", function (assert) {
     const done = assert.async();
     assert.expect(2);

--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -382,7 +382,7 @@ QUnit.test("modify with conflict", function (assert) {
 
 QUnit.test("watching", function (assert) {
     const done = assert.async();
-    assert.expect(3);
+    assert.expect(7);
 
     var file = cockpit.file(dir + "/foobar");
     var watch = file.watch(changed);
@@ -392,12 +392,16 @@ QUnit.test("watching", function (assert) {
         n += 1;
         if (n == 1) {
             assert.equal(content, null, "initially non-existent");
+            assert.equal(tag, "-", "empty tag");
             cockpit.spawn(["bash", "-c", "cd " + dir + " && echo 1234 > foobar.tmp && mv foobar.tmp foobar"]);
         } else if (n == 2) {
             assert.equal(content, "1234\n", "correct new content");
+            assert.notEqual(tag, "-");
+            assert.ok(tag.length > 5, "tag has a reasonable size");
             cockpit.spawn(["bash", "-c", "rm " + dir + "/foobar"]);
         } else if (n == 3) {
             assert.equal(content, null, "finally non-existent");
+            assert.equal(tag, "-", "empty tag");
             watch.remove();
             done();
         }


### PR DESCRIPTION
This is useful when watching large files or non-readable devices, i.e.
when the caller is only interested in the actual change notification.

Add a `read` option to watch(), which can be set to `false` to disable
reading. If not present, keep the original default to not break
backwards compatibility.

Fixes #14188