### PR TITLE
lib/pf4: Use alert font style for alert titles

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -118,3 +118,12 @@ svg {
 .pf-c-input-group :focus {
     z-index: 2;
 }
+
+// Alerts use elements that have fonts set in other frameworks (including PF3);
+// generally, this is an H4 that often has a font size and sometimes family set.
+// Therefore, it should inherit from the alert font set at the pf-c-alert level.
+// https://github.com/patternfly/patternfly/issues/4004
+.pf-c-alert__title {
+    font-size: inherit;
+    font-family: inherit;
+}


### PR DESCRIPTION
Fixes #15639

PF4 uses H4 for titles. However, H4 is often set with different font family and
size in other frameworks; notably, but not limited to PatternFly 3.