### PR TITLE
test: Enable TLS for mock insights server

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -686,19 +686,20 @@ fi
         m.write("/usr/share/cockpit/subscription-manager/override.json", '{ "features": { "insights": true } }')
 
         # Run a mock version of the Insights API locally and configure
-        # insights-client to access it.
-
-        m.upload(["verify/files/mock-insights"], "/var/tmp")
+        # insights-client to access it. That requires a good enough
+        # TLS mock insights server certificate
+        m.upload(["verify/files/mock-insights", "../src/tls/ca/alice.key", "../src/tls/ca/alice.pem"], "/var/tmp")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
         m.write("/etc/insights-client/insights-client.conf",
                 """
 [insights-client]
 gpg=False
 auto_config=False
-base_url=127.0.0.1:8888/r/insights
+base_url=localhost:8888/r/insights
+# HACK: despite the good insights.cert above, some later part of insights *still* does not respect that
+cert_verify=False
 username=admin
 password=foobar
-insecure_connection=True
 """)
 
         # Initially we are not registered

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -20,6 +20,7 @@
 from http.server import *
 import json
 import re
+import ssl
 
 systems = {}
 
@@ -137,7 +138,9 @@ class handler(BaseHTTPRequestHandler):
 
 
 def insights_server(port):
-    HTTPServer(('', port), handler).serve_forever()
+    httpd = HTTPServer(('', port), handler)
+    httpd.socket = ssl.wrap_socket(httpd.socket, certfile='/var/tmp/alice.pem', keyfile='/var/tmp/alice.key', server_side=True)
+    httpd.serve_forever()
 
 
 insights_server(8888)


### PR DESCRIPTION
Latest insights-client dropped the `insecure_connection` option and only
accepts TLS. Change mock-insights to serve TLS, and re-use our "alice"
certificate for it.

Disable certificate verification, as apparently there is no way to
convince the later stages of insights-client to accept a locally added
CA.