### PR TITLE
login: Add check for String.prototype.replaceAll

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -212,6 +212,7 @@ if (window.NodeList && !NodeList.prototype.forEach)
                req("console", window) &&
                req("pushState", window.history) &&
                req("textContent", document) &&
+               req("replaceAll", String.prototype) &&
                req("supports", window.CSS) &&
                css("display", "flex") &&
                css("display", "grid");


### PR DESCRIPTION
As we're using `"".replaceAll()` in Cockpit already, we should have a check for it.

This bumps up our minimum supported browser versions to mid-2020.