### PR TITLE
Hide unimportant details from service details and show some important ones instead

### DIFF
--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -524,7 +524,6 @@ export class ServiceDetails extends React.Component {
                                         { status }
                                     </DescriptionListDescription>
                                 </DescriptionListGroup>
-                                <hr />
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Path") }</DescriptionListTerm>
                                     <DescriptionListDescription id="path">{this.props.unit.FragmentPath}</DescriptionListDescription>
@@ -539,7 +538,6 @@ export class ServiceDetails extends React.Component {
                                         {cockpit.format("$0 ($1)", this.props.unit.Listen[0][1], this.props.unit.Listen[0][0])}
                                     </DescriptionListDescription>
                                 </DescriptionListGroup>}
-                                <hr />
                                 { notMetConditions.length > 0 &&
                                     <DescriptionListGroup>
                                         <DescriptionListTerm className="failed">{ _("Condition failed") }</DescriptionListTerm>
@@ -548,7 +546,6 @@ export class ServiceDetails extends React.Component {
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 }
-                                <hr />
                                 {triggerRelationshipsList}
                             </DescriptionList>
                             {extraRelationshipsList}

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -245,13 +245,11 @@ export class ServiceDetails extends React.Component {
             clearInterval(this.interval);
     }
 
-    shouldComponentUpdate(nextProps, nextState) {
-        // Don't update when only actions resolved, wait until API triggers some redrawing
-        if ((nextState.waitsAction === false && this.state.waitsAction === true) ||
-            (nextState.waitsFileAction === false && this.state.waitsFileAction === true) ||
-            nextProps.loadingUnits)
-            return false;
-        return true;
+    static getDerivedStateFromProps(nextProps, prevState) {
+        return {
+            waitsAction: nextProps.loadingUnits,
+            waitsFileAction: nextProps.loadingUnits,
+        };
     }
 
     doMemoryCurrentPolling() {
@@ -290,8 +288,7 @@ export class ServiceDetails extends React.Component {
             extra_args = ["fail"];
         this.setState({ waitsAction: true });
         systemd_client.call(SD_OBJ, SD_MANAGER, method, [this.props.unit.Names[0]].concat(extra_args))
-                .catch(error => this.setState({ error: error.toString() }))
-                .finally(() => this.setState({ waitsAction: false }));
+                .catch(error => this.setState({ error: error.toString(), waitsAction: false }));
     }
 
     unitFileAction(method, force) {
@@ -306,8 +303,7 @@ export class ServiceDetails extends React.Component {
                     /* Executing daemon reload after file operations is necessary -
                      * see https://github.com/systemd/systemd/blob/main/src/systemctl/systemctl.c [enable_unit function]
                      */
-                    systemd_client.call(SD_OBJ, SD_MANAGER, "Reload", null)
-                            .then(() => this.setState({ waitsFileAction: false }));
+                    systemd_client.call(SD_OBJ, SD_MANAGER, "Reload", null);
                 })
                 .catch(error => {
                     this.setState({

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -514,14 +514,14 @@ export class ServiceDetails extends React.Component {
                                     <DescriptionListGroup>
                                         <DescriptionListTerm className="failed">{ _("Condition failed") }</DescriptionListTerm>
                                         <DescriptionListDescription id="condition">
-                                            {notMetConditions.map(cond => <div key={cond.split(' ').join('')}>{cond}</div>)}
+                                            {notMetConditions.map(cond => <div key={cond}>{cond}</div>)}
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 }
                                 <hr />
                                 {relationships.map(rel =>
                                     rel.Units && rel.Units.length > 0 &&
-                                        <DescriptionListGroup key={rel.Name.split().join("")}>
+                                        <DescriptionListGroup key={rel.Name}>
                                             <DescriptionListTerm>{rel.Name}</DescriptionListTerm>
                                             <DescriptionListDescription id={rel.Name.split(" ").join("")}>
                                                 <ul className="comma-list">

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -24,6 +24,7 @@ import {
     Alert, Button,
     DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     Dropdown, DropdownItem, DropdownSeparator, KebabToggle,
+    ExpandableSection,
     Tooltip, TooltipPosition,
     Card, CardBody, CardTitle, Text, TextVariants,
     Modal, Switch
@@ -425,6 +426,13 @@ export class ServiceDetails extends React.Component {
         const tooltipMessage = enabled ? _("Stop and disable") : _("Start and enable");
         const hasLoadError = this.props.unit.LoadState !== "loaded" && this.props.unit.LoadState !== "masked";
         const loadError = this.props.unit.LoadError ? this.props.unit.LoadError[1] : null;
+
+        // These are relevant for socket and timer activated services
+        const triggerRelationships = [
+            { Name: _("Triggers"), Units: this.props.unit.Triggers },
+            { Name: _("Triggered by"), Units: this.props.unit.TriggeredBy },
+        ];
+
         const relationships = [
             { Name: _("Requires"), Units: this.props.unit.Requires },
             { Name: _("Requisite"), Units: this.props.unit.Requisite },
@@ -441,12 +449,34 @@ export class ServiceDetails extends React.Component {
             { Name: _("Before"), Units: this.props.unit.Before },
             { Name: _("After"), Units: this.props.unit.After },
             { Name: _("On failure"), Units: this.props.unit.OnFailure },
-            { Name: _("Triggers"), Units: this.props.unit.Triggers },
-            { Name: _("Triggered by"), Units: this.props.unit.TriggeredBy },
             { Name: _("Propagates reload to"), Units: this.props.unit.PropagatesReloadTo },
             { Name: _("Reload propagated from"), Units: this.props.unit.ReloadPropagatedFrom },
             { Name: _("Joins namespace of"), Units: this.props.unit.JoinsNamespaceOf }
         ];
+
+        const relationshipsToList = rels => {
+            return rels.filter(rel => rel.Units && rel.Units.length > 0)
+                    .map(rel =>
+                        <DescriptionListGroup key={rel.Name}>
+                            <DescriptionListTerm>{rel.Name}</DescriptionListTerm>
+                            <DescriptionListDescription id={rel.Name.split(" ").join("")}>
+                                <ul className="comma-list">
+                                    {rel.Units.map(unit => <li key={unit}><a href={"#/" + unit} className={this.props.isValid(unit) ? "" : "disabled"}>{unit}</a></li>)}
+                                </ul>
+                            </DescriptionListDescription>
+                        </DescriptionListGroup>
+                    );
+        };
+
+        const triggerRelationshipsList = relationshipsToList(triggerRelationships);
+
+        const extraRelationshipsList = (
+            <ExpandableSection id="service-details-show-relationships" toggleText={triggerRelationshipsList.length ? _("Show more relationships") : _("Show relationships")}>
+                <DescriptionList>
+                    {relationshipsToList(relationships)}
+                </DescriptionList>
+            </ExpandableSection>
+        );
 
         const conditions = this.props.unit.Conditions;
         const notMetConditions = [];
@@ -519,18 +549,9 @@ export class ServiceDetails extends React.Component {
                                     </DescriptionListGroup>
                                 }
                                 <hr />
-                                {relationships.map(rel =>
-                                    rel.Units && rel.Units.length > 0 &&
-                                        <DescriptionListGroup key={rel.Name}>
-                                            <DescriptionListTerm>{rel.Name}</DescriptionListTerm>
-                                            <DescriptionListDescription id={rel.Name.split(" ").join("")}>
-                                                <ul className="comma-list">
-                                                    {rel.Units.map(unit => <li key={unit}><a href={"#/" + unit} className={this.props.isValid(unit) ? "" : "disabled"}>{unit}</a></li>)}
-                                                </ul>
-                                            </DescriptionListDescription>
-                                        </DescriptionListGroup>
-                                )}
+                                {triggerRelationshipsList}
                             </DescriptionList>
+                            {extraRelationshipsList}
                         </CardBody>
                     </>
                 }

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -140,7 +140,7 @@ class ServiceActions extends React.Component {
 
             if (actions.length > 0) {
                 actions.push(
-                    <DropdownSeparator key="divider" divider />
+                    <DropdownSeparator key="divider" />
                 );
             }
 

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -472,7 +472,7 @@ export class ServiceDetails extends React.Component {
 
         const extraRelationshipsList = (
             <ExpandableSection id="service-details-show-relationships" toggleText={triggerRelationshipsList.length ? _("Show more relationships") : _("Show relationships")}>
-                <DescriptionList>
+                <DescriptionList isHorizontal>
                     {relationshipsToList(relationships)}
                 </DescriptionList>
             </ExpandableSection>
@@ -517,7 +517,7 @@ export class ServiceDetails extends React.Component {
                             }
                         </CardTitle>
                         <CardBody>
-                            <DescriptionList>
+                            <DescriptionList isHorizontal>
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Status") }</DescriptionListTerm>
                                     <DescriptionListDescription id="statuses">

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -457,7 +457,7 @@ export class ServiceDetails extends React.Component {
                             <DescriptionListTerm>{rel.Name}</DescriptionListTerm>
                             <DescriptionListDescription id={rel.Name.split(" ").join("")}>
                                 <ul className="comma-list">
-                                    {rel.Units.map(unit => <li key={unit}><a href={"#/" + unit} className={this.props.isValid(unit) ? "" : "disabled"}>{unit}</a></li>)}
+                                    {rel.Units.map(unit => <li key={unit}><Button isInline variant="link" component="a" href={"#/" + unit} isDisabled={!this.props.isValid(unit)}>{unit}</Button></li>)}
                                 </ul>
                             </DescriptionListDescription>
                         </DescriptionListGroup>

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -507,6 +507,7 @@ export class ServiceDetails extends React.Component {
                                         <Tooltip id="switch-unit-state" content={tooltipMessage} position={TooltipPosition.right}>
                                             <span>
                                                 <Switch isChecked={enabled}
+                                                        aria-label={tooltipMessage}
                                                         isDisabled={this.state.waitsAction || this.state.waitsFileAction}
                                                         onChange={this.onOnOffSwitch} />
                                             </span>

--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -14,6 +14,10 @@
     @extend .ct-card;
 }
 
+#service-details .pf-c-expandable-section {
+    margin-top: var(--pf-global--spacer--md);
+}
+
 .comma-list {
   display: inline;
   list-style: none;

--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -56,11 +56,6 @@
     margin-left: 2rem;
 }
 
-#service-details .ct-form > :not(hr) {
-    line-height: 1.5rem;
-    row-gap: normal;
-}
-
 .status-icon::before {
     color: inherit;
 }

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -4,11 +4,6 @@
 @import "./timer.scss";
 @import "../../lib/table.css";
 
-/* There is too much padding between the Nav and the Toolbar */
-.pf-c-page__main-section:first-of-type {
-    padding-bottom: 0;
-}
-
 .service-unit-failed {
     background-color: var(--ct-color-list-critical-bg);
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -611,7 +611,7 @@ ExecStart=/bin/true
         b.wait_js_cond('window.location.hash === "#/test.service"')
 
         b.click("#service-details-show-relationships button")
-        b.wait_attr("#Requires a:contains('not-found.service')", "class", "disabled")
+        b.wait_visible("#Requires a.pf-m-disabled:contains('not-found.service')")
 
     def testResetFailed(self):
         m = self.machine

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -329,6 +329,15 @@ Unit=test.service
 
         b.go("#/")
 
+        # Check that listen property is shown for socket units
+        self.pick_tab(3)
+        b.click(self.svc_sel("dbus.socket"))
+        b.wait_visible("#listen")
+        b.click(".pf-c-breadcrumb a:contains('Services')")
+
+        # Select services tab
+        self.pick_tab(1)
+
         # Filter by id
         init_filter_state()
         b.set_input_text("#services-text-filter", "fail.ser")
@@ -381,6 +390,35 @@ Unit=test.service
         # Check that journalbox shows empty state
         b.click(self.svc_sel("systemd-halt.service"))
         b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
+
+        b.go("#/")
+
+        self.write_file("/tmp/mem-hog.awk", 'BEGIN { system("while [ ! -f /tmp/continue ]; do sleep 1; done"); y = sprintf("%50000000s",""); system("sleep infinity") }')
+        self.write_file("/etc/systemd/system/mem-hog.service",
+                        """
+[Unit]
+Description=Mem Hog Service
+
+[Service]
+ExecStart=/bin/awk -f /tmp/mem-hog.awk
+""")
+
+        # After writing files out tell systemd about them
+        m.execute("systemctl daemon-reload")
+
+        # Check that MemoryCurrent is shown
+        b.click(self.svc_sel("mem-hog.service"))
+        b.wait_not_present("#memory")
+        m.execute("systemctl start mem-hog.service")
+        initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
+        self.assertGreater(initial_memory, 1)
+        m.execute("touch /tmp/continue")
+        # MemoryCurrent auto-updates every 30s - default timeout is 60s - when it updates the memory used should be ~50MiB
+        b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)
+        m.execute("systemctl stop mem-hog")
+        b.wait_not_present("#memory")
+        # Check that listen is not shown for .service units
+        b.wait_not_present("#listen")
 
     def testApi(self):
         m = self.machine

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -329,10 +329,11 @@ Unit=test.service
 
         b.go("#/")
 
-        # Check that listen property is shown for socket units
+        # Check that `Listen` and `Triggers` properties are shown for socket units
         self.pick_tab(3)
         b.click(self.svc_sel("dbus.socket"))
-        b.wait_visible("#listen")
+        self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen .pf-c-description-list__text"))
+        self.assertIn(b.text("#Triggers .pf-c-description-list__text"), ["dbus.service", "dbus-broker.service"])
         b.click(".pf-c-breadcrumb a:contains('Services')")
 
         # Select services tab
@@ -555,28 +556,33 @@ ExecStart=/bin/sh -c "while true; do sleep 5; done"
 
         # service a
         b.wait_js_cond('window.location.hash === "#/test-a.service"')
+        b.click("#service-details-show-relationships button")
         b.wait_visible(rel_sel("Before", "test-b.service"))
         b.wait_visible(rel_sel("Conflicts", "test-c.service"))
         b.click(rel_sel("Before", "test-b.service"))
 
         # service b
         b.wait_js_cond('window.location.hash === "#/test-b.service"')
+        b.click("#service-details-show-relationships button")
         b.wait_visible(rel_sel("After", "test-a.service"))
         b.click(rel_sel("After", "test-a.service"))
 
         # service a
         b.wait_js_cond('window.location.hash === "#/test-a.service"')
+        b.click("#service-details-show-relationships button")
         b.wait_visible(rel_sel("Conflicts", "test-c.service"))
         b.click(rel_sel("Conflicts", "test-c.service"))
 
         # service c
         b.wait_js_cond('window.location.hash === "#/test-c.service"')
+        b.click("#service-details-show-relationships button")
         b.wait_visible(rel_sel("Conflicts", "test-a.service"))
         b.wait_visible(rel_sel("Part of", "test-b.service"))
         b.click(rel_sel("Part of", "test-b.service"))
 
         # service b
         b.wait_js_cond('window.location.hash === "#/test-b.service"')
+        b.click("#service-details-show-relationships button")
         b.wait_visible(rel_sel("After", "test-a.service"))
 
     def testNotFound(self):
@@ -604,6 +610,7 @@ ExecStart=/bin/true
         b.click(self.svc_sel("test.service"))
         b.wait_js_cond('window.location.hash === "#/test.service"')
 
+        b.click("#service-details-show-relationships button")
         b.wait_attr("#Requires a:contains('not-found.service')", "class", "disabled")
 
     def testResetFailed(self):


### PR DESCRIPTION
So I was thinking how I can solve https://github.com/cockpit-project/cockpit/issues/14321 
Went to service details and I realized that so much information there are not useful for most scenarios, or at least they were never useful for me till now. 
So I though I should hide them by default, and display indead some more useful information, like the port a socket activated service is exposed at, for example.

Having the above mentioned property exposed we can move forward in the future with linking the service details of service sockets to the firewall page. 

What do you think? @marusak ?

With my changes cockpit.socket looks like this:
![Screen Shot 2021-04-16 at 18 50 18](https://user-images.githubusercontent.com/14921356/114907981-ee0bfa00-9e1b-11eb-8126-528ce6ce749a.png)
