### PR TITLE
Drop obsolete "Atomic" references

### DIFF
--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -37,15 +37,6 @@ _Steps 3 to 5 are optional if the CoreOS machine will only be connected to from 
 
 Afterward, use a web browser to log into port `9090` on your host IP address as usual.
 
-# Cockpit Web Service Container on Atomic
-
-Fedora and Red Hat Enterprise Linux Atomic contains the Cockpit bridge (cockpit-bridge package) and basic pages (cockpit-system package). Thus you can connect from remote Cockpit hosts through ssh without further modification.
-
-These older operating systems use docker instead of podman and have an `atomic` command that wraps it. To start a web service directly on these hosts, run
-```
-atomic run cockpit/ws
-```
-
 ## More Info
 
  * [Cockpit Project](https://cockpit-project.org)

--- a/doc/guide/feature-sosreport.xml
+++ b/doc/guide/feature-sosreport.xml
@@ -5,8 +5,6 @@
   <title>SOS Report</title>
 
   <para>If present on the system Cockpit can use <code>sosreport</code> to collect system configuration and diagnostic information.</para>
-  <para>If <code>sosreport</code> is not found on an Atomic system, cockpit will attempt to run <code>sosreport</code> in the <code>rhel7/support-tools</code> docker container.</para>
-  <para>
-    To perform similar tasks from the command line, use the <code>sosreport</code> command.</para>
+  <para>To perform similar tasks from the command line, use the <code>sosreport</code> command.</para>
 
 </chapter>

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -578,7 +578,7 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 200 OK\r\n", headers)
         self.assertIn("Content-Type: text/html\r\n", headers)
         self.assertIn("Cross-Origin-Resource-Policy: same-origin\r\n", headers)
-        # login.html is not always accessible as a file (e. g. in Atomic), so just assert a reasonable content length
+        # login.html is not always accessible as a file (e.g. on CoreOS), so just assert a reasonable content length
         self.assertIn("Content-Length: ", headers)
         length = int(headers.split('Content-Length: ', 1)[1].split()[0])
         self.assertGreater(length, 5000)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -157,7 +157,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 m.execute("mv /etc/passwd.bak /etc/passwd")
 
             # login with user shell that prints some stdout/err noise
-            # having stdout output in ~/.bashrc confuses docker, so don't run on Atomic
+            # having stdout output in ~/.bashrc confuses docker, so don't run on OSTree
             m.execute("set -e; cd ~admin; cp -a .bashrc .bashrc.bak; [ ! -e .profile ] || cp -a .profile .profile.bak; "
                       "echo 'echo noise-rc-out; echo noise-rc-err >&2' >> .bashrc; "
                       "echo 'echo noise-profile-out; echo noise-profile-err >&2' >> .profile")


### PR DESCRIPTION
Fedora/RHEL Atomic are both end-of-life, so clean up the ws container
and guide documentation.

Adjust some test comments to say "OSTree" instead.