### PR TITLE
test: Fix comment for mock-insights setup

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -696,7 +696,8 @@ fi
 gpg=False
 auto_config=False
 base_url=localhost:8888/r/insights
-# HACK: despite the good insights.cert above, some later part of insights *still* does not respect that
+# even if we would add tls/ca/ca.pem (the signer of alice.pem) to /etc/pki, some later part of insights still
+# does not respect that; so just give in, and disable validation
 cert_verify=False
 username=admin
 password=foobar


### PR DESCRIPTION
The comment still refered to an earlier version of PR #15698 which
actually added ca.pem to the system trust store and generate a new
"insights.pem" certificate from that. The simpler version that finally
landed forgot to clean up the comment.