### PR TITLE
Add custom selinux policy

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ MAINTAINERCLEANFILES = \
 	$(NULL)
 
 EXTRA_DIST = \
+	selinux \
 	package.json \
 	package-lock.json \
 	node_modules/.stamp \

--- a/selinux/cockpit.fc
+++ b/selinux/cockpit.fc
@@ -1,0 +1,16 @@
+/usr/lib/systemd/system/cockpit.*		--	gen_context(system_u:object_r:cockpit_unit_file_t,s0)
+/etc/systemd/system/cockpit.*	--	gen_context(system_u:object_r:cockpit_unit_file_t,s0)
+
+/usr/libexec/cockpit-ws		--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+/usr/libexec/cockpit-tls	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+/usr/libexec/cockpit-wsinstance-factory	--	gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+
+/usr/libexec/cockpit-session	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
+/usr/libexec/cockpit-ssh	--	gen_context(system_u:object_r:cockpit_session_exec_t,s0)
+
+/usr/share/cockpit/motd/update-motd    -- gen_context(system_u:object_r:cockpit_ws_exec_t,s0)
+
+/var/lib/cockpit(/.*)?      gen_context(system_u:object_r:cockpit_var_lib_t,s0)
+
+/var/run/cockpit(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)
+/var/run/cockpit-ws(/.*)?   gen_context(system_u:object_r:cockpit_var_run_t,s0)

--- a/selinux/cockpit.if
+++ b/selinux/cockpit.if
@@ -1,0 +1,279 @@
+## <summary>policy for cockpit</summary>
+
+########################################
+## <summary>
+##	Execute TEMPLATE in the cockpit domin.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`cockpit_ws_domtrans',`
+	gen_require(`
+		type cockpit_ws_t, cockpit_ws_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, cockpit_ws_exec_t, cockpit_ws_t)
+')
+
+########################################
+## <summary>
+##	Execute TEMPLATE in the cockpit domin.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`cockpit_session_domtrans',`
+	gen_require(`
+		type cockpit_session_t, cockpit_session_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, cockpit_session_exec_t, cockpit_session_t)
+')
+
+########################################
+## <summary>
+##	Read and write cockpit_session_t unnamed pipes.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_rw_pipes',`
+	gen_require(`
+		type cockpit_session_t;
+	')
+
+	allow $1 cockpit_session_t:fifo_file rw_fifo_file_perms;
+')
+
+########################################
+## <summary>
+##	Create cockpit unix_stream_sockets.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_manage_unix_stream_sockets',`
+	gen_require(`
+		type cockpit_ws_t;
+	')
+
+	allow $1 cockpit_ws_t:unix_stream_socket { create_stream_socket_perms connectto };
+')
+
+########################################
+## <summary>
+##	Search cockpit lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_search_lib',`
+	gen_require(`
+		type cockpit_var_lib_t;
+	')
+
+	allow $1 cockpit_var_lib_t:dir search_dir_perms;
+	files_search_var_lib($1)
+')
+
+########################################
+## <summary>
+##	Read cockpit lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_read_lib_files',`
+	gen_require(`
+		type cockpit_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	read_files_pattern($1, cockpit_var_lib_t, cockpit_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage cockpit lib files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_manage_lib_files',`
+	gen_require(`
+		type cockpit_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_files_pattern($1, cockpit_var_lib_t, cockpit_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Manage cockpit lib directories.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_manage_lib_dirs',`
+	gen_require(`
+		type cockpit_var_lib_t;
+	')
+
+	files_search_var_lib($1)
+	manage_dirs_pattern($1, cockpit_var_lib_t, cockpit_var_lib_t)
+')
+
+########################################
+## <summary>
+##	Read cockpit pid files.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_read_pid_files',`
+	gen_require(`
+		type cockpit_var_run_t;
+	')
+
+	read_files_pattern($1, cockpit_var_run_t, cockpit_var_run_t)
+	read_lnk_files_pattern($1, cockpit_var_run_t, cockpit_var_run_t)
+')
+
+########################################
+## <summary>
+##	Manage cockpit pid dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_manage_pid_dirs',`
+	gen_require(`
+		type cockpit_var_run_t;
+	')
+
+	manage_dirs_pattern($1, cockpit_var_run_t, cockpit_var_run_t)
+')
+
+########################################
+## <summary>
+##	Manage cockpit pid dirs.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`cockpit_manage_pid_files',`
+	gen_require(`
+		type cockpit_var_run_t;
+	')
+
+	manage_files_pattern($1, cockpit_var_run_t, cockpit_var_run_t)
+')
+
+########################################
+## <summary>
+##	Execute cockpit server in the cockpit domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed to transition.
+##	</summary>
+## </param>
+#
+interface(`cockpit_systemctl',`
+	gen_require(`
+		type cockpit_ws_t;
+		type cockpit_unit_file_t;
+	')
+
+	systemd_exec_systemctl($1)
+	init_reload_services($1)
+        systemd_read_fifo_file_passwd_run($1)
+	allow $1 cockpit_unit_file_t:file read_file_perms;
+	allow $1 cockpit_unit_file_t:service manage_service_perms;
+
+	ps_process_pattern($1, cockpit_ws_t)
+')
+
+
+########################################
+## <summary>
+##	All of the rules required to administrate
+##	an cockpit environment
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+## <rolecap/>
+#
+interface(`cockpit_admin',`
+	gen_require(`
+		type cockpit_ws_t;
+		type cockpit_session_t;
+		type cockpit_var_lib_t;
+		type cockpit_var_run_t;
+		type cockpit_unit_file_t;
+	')
+
+	allow $1 cockpit_ws_t:process { signal_perms };
+	ps_process_pattern($1, cockpit_ws_t)
+
+	allow $1 cockpit_session_t:process { signal_perms };
+	ps_process_pattern($1, cockpit_session_t)
+
+	tunable_policy(`deny_ptrace',`',`
+		allow $1 cockpit_ws_t:process ptrace;
+		allow $1 cockpit_session_t:process ptrace;
+	')
+
+	files_search_var_lib($1)
+	admin_pattern($1, cockpit_var_lib_t)
+
+	files_search_pids($1)
+	admin_pattern($1, cockpit_var_run_t)
+
+	cockpit_systemctl($1)
+	admin_pattern($1, cockpit_unit_file_t)
+	allow $1 cockpit_unit_file_t:service all_service_perms;
+	optional_policy(`
+		systemd_passwd_agent_exec($1)
+		systemd_read_fifo_file_passwd_run($1)
+	')
+')

--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -1,0 +1,180 @@
+policy_module(cockpit, 1.0.0)
+
+########################################
+#
+# Declarations
+#
+
+type cockpit_ws_t;
+type cockpit_ws_exec_t;
+init_daemon_domain(cockpit_ws_t,cockpit_ws_exec_t)
+init_nnp_daemon_domain(cockpit_ws_t)
+
+type cockpit_tmp_t;
+files_tmp_file(cockpit_tmp_t)
+
+type cockpit_tmpfs_t;
+userdom_user_tmpfs_file(cockpit_tmpfs_t)
+
+type cockpit_var_run_t;
+files_pid_file(cockpit_var_run_t)
+systemd_mount_dir(cockpit_var_run_t)
+
+type cockpit_unit_file_t;
+systemd_unit_file(cockpit_unit_file_t)
+
+type cockpit_var_lib_t;
+files_type(cockpit_var_lib_t)
+
+type cockpit_session_t;
+type cockpit_session_exec_t;
+domain_type(cockpit_session_t)
+domain_entry_file(cockpit_session_t,cockpit_session_exec_t)
+
+########################################
+#
+# cockpit_ws_t local policy
+#
+
+allow cockpit_ws_t self:capability net_admin;
+allow cockpit_ws_t self:process setrlimit;
+allow cockpit_ws_t self:tcp_socket create_stream_socket_perms;
+
+kernel_read_system_state(cockpit_ws_t)
+
+# cockpit-tls can execute cockpit-ws
+can_exec(cockpit_ws_t,cockpit_ws_exec_t)
+
+# cockpit-ws can execute cockpit-session
+can_exec(cockpit_ws_t,cockpit_session_exec_t)
+
+# cockpit-ws can read from /dev/urandom
+dev_read_urand(cockpit_ws_t) # for authkey
+dev_read_rand(cockpit_ws_t)  # for libssh
+
+corenet_tcp_bind_websm_port(cockpit_ws_t)
+
+# cockpit-ws can connect to other hosts via ssh
+corenet_tcp_connect_ssh_port(cockpit_ws_t)
+
+# cockpit-ws can write to its temp files
+manage_dirs_pattern(cockpit_ws_t, cockpit_tmp_t, cockpit_tmp_t)
+manage_files_pattern(cockpit_ws_t, cockpit_tmp_t, cockpit_tmp_t)
+files_tmp_filetrans(cockpit_ws_t, cockpit_tmp_t, { dir file })
+
+manage_dirs_pattern(cockpit_ws_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
+manage_files_pattern(cockpit_ws_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
+fs_tmpfs_filetrans(cockpit_ws_t, cockpit_tmpfs_t, { file })
+
+manage_dirs_pattern(cockpit_ws_t, cockpit_var_run_t, cockpit_var_run_t)
+manage_files_pattern(cockpit_ws_t, cockpit_var_run_t, cockpit_var_run_t)
+manage_lnk_files_pattern(cockpit_ws_t, cockpit_var_run_t, cockpit_var_run_t)
+manage_sock_files_pattern(cockpit_ws_t, cockpit_var_run_t, cockpit_var_run_t)
+files_pid_filetrans(cockpit_ws_t, cockpit_var_run_t, { file dir sock_file })
+
+manage_files_pattern(cockpit_ws_t, cockpit_var_lib_t, cockpit_var_lib_t)
+manage_dirs_pattern(cockpit_ws_t, cockpit_var_lib_t, cockpit_var_lib_t)
+
+allow cockpit_ws_t cockpit_unit_file_t:service manage_service_perms;
+
+kernel_read_network_state(cockpit_ws_t)
+
+auth_use_nsswitch(cockpit_ws_t)
+
+corecmd_exec_bin(cockpit_ws_t)
+
+fs_read_efivarfs_files(cockpit_ws_t)
+
+init_read_state(cockpit_ws_t)
+init_stream_connect(cockpit_ws_t)
+
+logging_send_syslog_msg(cockpit_ws_t)
+
+sysnet_exec_ifconfig(cockpit_ws_t)
+
+# cockpit-ws launches cockpit-session
+cockpit_session_domtrans(cockpit_ws_t)
+allow cockpit_ws_t cockpit_session_t:process signal_perms;
+
+# cockpit-session communicates back with cockpit-ws
+allow cockpit_session_t cockpit_ws_t:unix_stream_socket rw_stream_socket_perms;
+
+# cockpit-tls and cockpit-ws communicate over a Unix socket
+allow cockpit_ws_t cockpit_ws_t:unix_stream_socket { create_stream_socket_perms connectto };
+
+optional_policy(`
+    hostname_exec(cockpit_ws_t)
+')
+
+optional_policy(`
+    kerberos_use(cockpit_ws_t)
+    kerberos_etc_filetrans_keytab(cockpit_ws_t)
+')
+
+optional_policy(`
+    miscfiles_dontaudit_map_generic_certs(cockpit_ws_t)
+')
+
+optional_policy(`
+    systemd_exec_systemctl(cockpit_ws_t)
+')
+
+optional_policy(`
+	ssh_read_user_home_files(cockpit_ws_t)
+')
+
+#########################################################
+#
+#  cockpit-session local policy
+#
+
+# cockpit-session changes to the actual logged in user
+allow cockpit_session_t self:capability { sys_admin dac_read_search dac_override setuid setgid sys_resource};
+allow cockpit_session_t self:process { setexec setsched signal_perms setrlimit };
+
+read_files_pattern(cockpit_session_t, cockpit_var_lib_t, cockpit_var_lib_t)
+list_dirs_pattern(cockpit_session_t, cockpit_var_lib_t, cockpit_var_lib_t)
+
+manage_dirs_pattern(cockpit_session_t, cockpit_tmp_t, cockpit_tmp_t)
+manage_files_pattern(cockpit_session_t, cockpit_tmp_t, cockpit_tmp_t)
+manage_sock_files_pattern(cockpit_session_t, cockpit_tmp_t, cockpit_tmp_t)
+files_tmp_filetrans(cockpit_session_t, cockpit_tmp_t, { dir file sock_file })
+
+manage_dirs_pattern(cockpit_session_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
+manage_files_pattern(cockpit_session_t, cockpit_tmpfs_t, cockpit_tmpfs_t)
+fs_tmpfs_filetrans(cockpit_session_t, cockpit_tmpfs_t, { file })
+
+read_files_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
+list_dirs_pattern(cockpit_session_t, cockpit_var_run_t, cockpit_var_run_t)
+
+kernel_read_network_state(cockpit_session_t)
+
+# cockpit-session runs a full pam stack, including pam_selinux.so
+auth_login_pgm_domain(cockpit_session_t)
+# cockpit-session resseting expired passwords
+auth_manage_passwd(cockpit_session_t)
+auth_manage_shadow(cockpit_session_t)
+auth_write_login_records(cockpit_session_t)
+
+corenet_tcp_bind_ssh_port(cockpit_session_t)
+corenet_tcp_connect_ssh_port(cockpit_session_t)
+
+# cockpit-session can execute cockpit-agent as the user
+userdom_spec_domtrans_all_users(cockpit_session_t)
+usermanage_read_crack_db(cockpit_session_t)
+
+optional_policy(`
+    ssh_agent_signal(cockpit_session_t)
+')
+
+optional_policy(`
+    sssd_dbus_chat(cockpit_session_t)
+')
+
+optional_policy(`
+    userdom_signal_all_users(cockpit_session_t)
+')
+
+optional_policy(`
+	unconfined_domtrans(cockpit_session_t)
+')

--- a/selinux/cockpit_session_selinux.8
+++ b/selinux/cockpit_session_selinux.8
@@ -1,0 +1,255 @@
+.TH  "cockpit_session_selinux"  "8"  "21-04-16" "cockpit_session" "SELinux Policy cockpit_session"
+.SH "NAME"
+cockpit_session_selinux \- Security Enhanced Linux Policy for the cockpit_session processes
+.SH "DESCRIPTION"
+
+Security-Enhanced Linux secures the cockpit_session processes via flexible mandatory access control.
+
+The cockpit_session processes execute with the cockpit_session_t SELinux type. You can check if you have these processes running by executing the \fBps\fP command with the \fB\-Z\fP qualifier.
+
+For example:
+
+.B ps -eZ | grep cockpit_session_t
+
+
+.SH "ENTRYPOINTS"
+
+The cockpit_session_t SELinux type can be entered via the \fBcockpit_session_exec_t\fP file type.
+
+The default entrypoint paths for the cockpit_session_t domain are the following:
+
+/usr/libexec/cockpit-ssh, /usr/libexec/cockpit-session
+.SH PROCESS TYPES
+SELinux defines process types (domains) for each process running on the system
+.PP
+You can see the context of a process using the \fB\-Z\fP option to \fBps\bP
+.PP
+Policy governs the access confined processes have to files.
+SELinux cockpit_session policy is very flexible allowing users to setup their cockpit_session processes in as secure a method as possible.
+.PP
+The following process types are defined for cockpit_session:
+
+.EX
+.B cockpit_session_t
+.EE
+.PP
+Note:
+.B semanage permissive -a cockpit_session_t
+can be used to make the process type cockpit_session_t permissive. SELinux does not deny access to permissive process types, but the AVC (SELinux denials) messages are still generated.
+
+.SH BOOLEANS
+SELinux policy is customizable based on least access required.  cockpit_session policy is extremely flexible and has several booleans that allow you to manipulate the policy and run cockpit_session with the tightest access possible.
+
+
+.PP
+If you want to allow all domains to execute in fips_mode, you must turn on the fips_mode boolean. Enabled by default.
+
+.EX
+.B setsebool -P fips_mode 1
+
+.EE
+
+.PP
+If you want to allow confined applications to run with kerberos, you must turn on the kerberos_enabled boolean. Enabled by default.
+
+.EX
+.B setsebool -P kerberos_enabled 1
+
+.EE
+
+.PP
+If you want to allow system to run with NIS, you must turn on the nis_enabled boolean. Disabled by default.
+
+.EX
+.B setsebool -P nis_enabled 1
+
+.EE
+
+.PP
+If you want to enable polyinstantiated directory support, you must turn on the polyinstantiation_enabled boolean. Disabled by default.
+
+.EX
+.B setsebool -P polyinstantiation_enabled 1
+
+.EE
+
+.SH "MANAGED FILES"
+
+The SELinux process type cockpit_session_t can manage files labeled with the following file types.  The paths listed are the default paths for these file types.  Note the processes UID still need to have DAC permissions.
+
+.br
+.B auth_cache_t
+
+	/var/cache/coolkey(/.*)?
+.br
+
+.br
+.B auth_home_t
+
+	/root/\.yubico(/.*)?
+.br
+	/root/\.config/Yubico(/.*)?
+.br
+	/root/\.google_authenticator
+.br
+	/root/\.google_authenticator~
+.br
+	/home/[^/]+/\.yubico(/.*)?
+.br
+	/home/[^/]+/\.config/Yubico(/.*)?
+.br
+	/home/[^/]+/\.google_authenticator
+.br
+	/home/[^/]+/\.google_authenticator~
+.br
+
+.br
+.B faillog_t
+
+	/var/log/btmp.*
+.br
+	/var/log/faillog.*
+.br
+	/var/log/tallylog.*
+.br
+	/var/run/faillock(/.*)?
+.br
+
+.br
+.B initrc_var_run_t
+
+	/var/run/utmp
+.br
+	/var/run/random-seed
+.br
+	/var/run/runlevel\.dir
+.br
+	/var/run/setmixer_flag
+.br
+
+.br
+.B lastlog_t
+
+	/var/log/lastlog.*
+.br
+
+.br
+.B pam_var_run_t
+
+	/var/(db|adm)/sudo(/.*)?
+.br
+	/var/lib/sudo(/.*)?
+.br
+	/var/run/sudo(/.*)?
+.br
+	/var/run/pam_ssh(/.*)?
+.br
+	/var/run/sepermit(/.*)?
+.br
+	/var/run/pam_mount(/.*)?
+.br
+	/var/run/pam_timestamp(/.*)?
+.br
+
+.br
+.B security_t
+
+	/selinux
+.br
+
+.br
+.B shadow_t
+
+	/etc/shadow.*
+.br
+	/etc/gshadow.*
+.br
+	/etc/nshadow.*
+.br
+	/var/db/shadow.*
+.br
+	/etc/security/opasswd
+.br
+	/etc/security/opasswd\.old
+.br
+
+.br
+.B var_auth_t
+
+	/var/ace(/.*)?
+.br
+	/var/rsa(/.*)?
+.br
+	/var/lib/abl(/.*)?
+.br
+	/var/lib/rsa(/.*)?
+.br
+	/var/lib/pam_ssh(/.*)?
+.br
+	/var/lib/pam_shield(/.*)?
+.br
+	/var/opt/quest/vas/vasd(/.*)?
+.br
+	/var/lib/google-authenticator(/.*)?
+.br
+
+.br
+.B wtmp_t
+
+	/var/log/wtmp.*
+.br
+
+.SH FILE CONTEXTS
+SELinux requires files to have an extended attribute to define the file type.
+.PP
+You can see the context of a file using the \fB\-Z\fP option to \fBls\bP
+.PP
+Policy governs the access confined processes have to these files.
+SELinux cockpit_session policy is very flexible allowing users to setup their cockpit_session processes in as secure a method as possible.
+.PP
+
+.I The following file types are defined for cockpit_session:
+
+
+.EX
+.PP
+.B cockpit_session_exec_t
+.EE
+
+- Set files with the cockpit_session_exec_t type, if you want to transition an executable to the cockpit_session_t domain.
+
+.br
+.TP 5
+Paths:
+/usr/libexec/cockpit-ssh, /usr/libexec/cockpit-session
+
+.PP
+Note: File context can be temporarily modified with the chcon command.  If you want to permanently change the file context you need to use the
+.B semanage fcontext
+command.  This will modify the SELinux labeling database.  You will need to use
+.B restorecon
+to apply the labels.
+
+.SH "COMMANDS"
+.B semanage fcontext
+can also be used to manipulate default file context mappings.
+.PP
+.B semanage permissive
+can also be used to manipulate whether or not a process type is permissive.
+.PP
+.B semanage module
+can also be used to enable/disable/install/remove policy modules.
+
+.B semanage boolean
+can also be used to manipulate the booleans
+
+.PP
+.B system-config-selinux
+is a GUI tool available to customize SELinux policy settings.
+
+.SH AUTHOR
+This manual page was auto-generated using
+.B "sepolicy manpage".
+
+.SH "SEE ALSO"
+selinux(8), cockpit_session(8), semanage(8), restorecon(8), chcon(1), sepolicy(8), setsebool(8)

--- a/selinux/cockpit_ws_selinux.8
+++ b/selinux/cockpit_ws_selinux.8
@@ -1,0 +1,207 @@
+.TH  "cockpit_ws_selinux"  "8"  "21-04-16" "cockpit_ws" "SELinux Policy cockpit_ws"
+.SH "NAME"
+cockpit_ws_selinux \- Security Enhanced Linux Policy for the cockpit_ws processes
+.SH "DESCRIPTION"
+
+Security-Enhanced Linux secures the cockpit_ws processes via flexible mandatory access control.
+
+The cockpit_ws processes execute with the cockpit_ws_t SELinux type. You can check if you have these processes running by executing the \fBps\fP command with the \fB\-Z\fP qualifier.
+
+For example:
+
+.B ps -eZ | grep cockpit_ws_t
+
+
+.SH "ENTRYPOINTS"
+
+The cockpit_ws_t SELinux type can be entered via the \fBcockpit_ws_exec_t\fP file type.
+
+The default entrypoint paths for the cockpit_ws_t domain are the following:
+
+/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/share/cockpit/motd/update-motd, /usr/libexec/cockpit-wsinstance-factory
+.SH PROCESS TYPES
+SELinux defines process types (domains) for each process running on the system
+.PP
+You can see the context of a process using the \fB\-Z\fP option to \fBps\bP
+.PP
+Policy governs the access confined processes have to files.
+SELinux cockpit_ws policy is very flexible allowing users to setup their cockpit_ws processes in as secure a method as possible.
+.PP
+The following process types are defined for cockpit_ws:
+
+.EX
+.B cockpit_ws_t
+.EE
+.PP
+Note:
+.B semanage permissive -a cockpit_ws_t
+can be used to make the process type cockpit_ws_t permissive. SELinux does not deny access to permissive process types, but the AVC (SELinux denials) messages are still generated.
+
+.SH BOOLEANS
+SELinux policy is customizable based on least access required.  cockpit_ws policy is extremely flexible and has several booleans that allow you to manipulate the policy and run cockpit_ws with the tightest access possible.
+
+
+.PP
+If you want to allow all domains to execute in fips_mode, you must turn on the fips_mode boolean. Enabled by default.
+
+.EX
+.B setsebool -P fips_mode 1
+
+.EE
+
+.SH "MANAGED FILES"
+
+The SELinux process type cockpit_ws_t can manage files labeled with the following file types.  The paths listed are the default paths for these file types.  Note the processes UID still need to have DAC permissions.
+
+.br
+.B cluster_conf_t
+
+	/etc/cluster(/.*)?
+.br
+
+.br
+.B cluster_var_lib_t
+
+	/var/lib/pcsd(/.*)?
+.br
+	/var/lib/cluster(/.*)?
+.br
+	/var/lib/openais(/.*)?
+.br
+	/var/lib/pengine(/.*)?
+.br
+	/var/lib/corosync(/.*)?
+.br
+	/usr/lib/heartbeat(/.*)?
+.br
+	/var/lib/heartbeat(/.*)?
+.br
+	/var/lib/pacemaker(/.*)?
+.br
+
+.br
+.B cluster_var_run_t
+
+	/var/run/crm(/.*)?
+.br
+	/var/run/cman_.*
+.br
+	/var/run/rsctmp(/.*)?
+.br
+	/var/run/aisexec.*
+.br
+	/var/run/heartbeat(/.*)?
+.br
+	/var/run/pcsd-ruby.socket
+.br
+	/var/run/corosync-qnetd(/.*)?
+.br
+	/var/run/corosync-qdevice(/.*)?
+.br
+	/var/run/corosync\.pid
+.br
+	/var/run/cpglockd\.pid
+.br
+	/var/run/rgmanager\.pid
+.br
+	/var/run/cluster/rgmanager\.sk
+.br
+
+.br
+.B cockpit_var_lib_t
+
+	/var/lib/cockpit(/.*)?
+.br
+
+.br
+.B cockpit_var_run_t
+
+	/var/run/cockpit(/.*)?
+.br
+	/var/run/cockpit-ws(/.*)?
+.br
+
+.br
+.B krb5_keytab_t
+
+	/var/kerberos/krb5(/.*)?
+.br
+	/etc/krb5\.keytab
+.br
+	/etc/krb5kdc/kadm5\.keytab
+.br
+	/var/kerberos/krb5kdc/kadm5\.keytab
+.br
+
+.br
+.B root_t
+
+	/sysroot/ostree/deploy/.*-atomic/deploy(/.*)?
+.br
+	/
+.br
+	/initrd
+.br
+
+.br
+.B systemd_passwd_var_run_t
+
+	/var/run/systemd/ask-password(/.*)?
+.br
+	/var/run/systemd/ask-password-block(/.*)?
+.br
+
+.SH FILE CONTEXTS
+SELinux requires files to have an extended attribute to define the file type.
+.PP
+You can see the context of a file using the \fB\-Z\fP option to \fBls\bP
+.PP
+Policy governs the access confined processes have to these files.
+SELinux cockpit_ws policy is very flexible allowing users to setup their cockpit_ws processes in as secure a method as possible.
+.PP
+
+.I The following file types are defined for cockpit_ws:
+
+
+.EX
+.PP
+.B cockpit_ws_exec_t
+.EE
+
+- Set files with the cockpit_ws_exec_t type, if you want to transition an executable to the cockpit_ws_t domain.
+
+.br
+.TP 5
+Paths:
+/usr/libexec/cockpit-ws, /usr/libexec/cockpit-tls, /usr/share/cockpit/motd/update-motd, /usr/libexec/cockpit-wsinstance-factory
+
+.PP
+Note: File context can be temporarily modified with the chcon command.  If you want to permanently change the file context you need to use the
+.B semanage fcontext
+command.  This will modify the SELinux labeling database.  You will need to use
+.B restorecon
+to apply the labels.
+
+.SH "COMMANDS"
+.B semanage fcontext
+can also be used to manipulate default file context mappings.
+.PP
+.B semanage permissive
+can also be used to manipulate whether or not a process type is permissive.
+.PP
+.B semanage module
+can also be used to enable/disable/install/remove policy modules.
+
+.B semanage boolean
+can also be used to manipulate the booleans
+
+.PP
+.B system-config-selinux
+is a GUI tool available to customize SELinux policy settings.
+
+.SH AUTHOR
+This manual page was auto-generated using
+.B "sepolicy manpage".
+
+.SH "SEE ALSO"
+selinux(8), cockpit_ws(8), semanage(8), restorecon(8), chcon(1), sepolicy(8), setsebool(8)


### PR DESCRIPTION
This policy will be shipped in cockpit-ws package on rhel-9 onward and fedora-33 onward.
This policy is taken from Fedora rawhide.

We don't plan to backport to rhel-8 and centos-8. Debian/suse may come later.