### PR TITLE
 packagekit: filter duplicate error messages and display them in separate lines

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1361,7 +1361,7 @@ class OsUpdates extends React.Component {
                                              </Text>
                                          </TextContent>
                                      }
-                    />;
+                    />
                 </>
             );
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1352,7 +1352,9 @@ class OsUpdates extends React.Component {
                                      paragraph={
                                          <TextContent>
                                              <Text component={TextVariants.p}>
-                                                 {this.state.errorMessages.map(m => <span key={m}>{m}</span>)}
+                                                 {this.state.errorMessages
+                                                         .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                                         .map(m => <div key={m}>{m}</div>)}
                                              </Text>
                                              <Text component={TextVariants.p}>
                                                  {_("Please reload the page after resolving the issue.")}

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -780,7 +780,7 @@ ExecStart=/usr/local/bin/{0}
         # error message visible
         b.wait_visible("#app .pf-c-page .pf-c-empty-state__body")
 
-        self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body span:first-of-type"),
+        self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body .pf-c-content div:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory")
 
         # not expecting any buttons


### PR DESCRIPTION
Fixes #15512