### PR TITLE
lib: Drop Promise.finally polyfill

### DIFF
--- a/pkg/lib/polyfills.js
+++ b/pkg/lib/polyfills.js
@@ -23,18 +23,3 @@
 
 // Don't complain about extending native data types -- that's what polyfills do
 /* eslint-disable no-extend-native */
-
-// For almost everyone
-if (!Promise.prototype.finally) {
-    Promise.prototype.finally = function (f) {
-        return this.then(function (value) {
-            return Promise.resolve(f()).then(function () {
-                return value;
-            });
-        }, function (err) {
-            return Promise.resolve(f()).then(function () {
-                throw err;
-            });
-        });
-    };
-}

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -213,6 +213,7 @@ if (window.NodeList && !NodeList.prototype.forEach)
                req("pushState", window.history) &&
                req("textContent", document) &&
                req("replaceAll", String.prototype) &&
+               req("finally", Promise.prototype) &&
                req("supports", window.CSS) &&
                css("display", "flex") &&
                css("display", "grid");


### PR DESCRIPTION
Our most recent browser version bump in commit 1c8084d7e7a05c4 now
ensures that all our supported browsers have `Promise.finally()`:
https://caniuse.com/?search=Promise.prototype.finally

Drop our polyfill and add a corresponding check to the login page.

Fixes #12151