### PR TITLE
Fix unstable TestHostSwitching.testNoAutoconnect , clean up unexpected messages a bit

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1097,6 +1097,7 @@ class MachineCase(unittest.TestCase):
                                     ".*: failed to retrieve resource: terminated",
                                     ".*: external channel failed: terminated",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
+                                    ".*No session for cookie",
 
                                     'localhost: dropping message while waiting for child to exit',
                                     '.*: GDBus.Error:org.freedesktop.PolicyKit1.Error.Failed: .*',

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -30,10 +30,8 @@ class TestSession(MachineCase):
 
         self.allow_restart_journal_messages()
         # Might happen when killing the bridge.
-        self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
-                                    "Error executing command as another user: Not authorized",
+        self.allow_journal_messages("Error executing command as another user: Not authorized",
                                     ".*No session for cookie",
-                                    ".*external channel failed: terminated",
                                     )
 
         def wait_session(should_exist):

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -28,11 +28,8 @@ class TestSession(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.allow_restart_journal_messages()
         # Might happen when killing the bridge.
-        self.allow_journal_messages("Error executing command as another user: Not authorized",
-                                    ".*No session for cookie",
-                                    )
+        self.allow_restart_journal_messages()
 
         def wait_session(should_exist):
             def cond():

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -417,6 +417,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         time.sleep(60)
         self.assertNotIn(m2.execute("loginctl"), "admin")
 
+        self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
 
 


### PR DESCRIPTION
Examples: [one](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-15680-20210419-065427-0bb1666b-fedora-33/log.html#87), [two](https://logs.cockpit-project.org/logs/pull-15679-20210412-093836-32d61aac-ubuntu-stable/log.html), [three](https://logs.cockpit-project.org/logs/pull-15698-20210415-161600-83597863-rhel-8-5/log.html), and it's on our weather report.