### PR TITLE
packagekit: Accept arbitary minutes in the OnCalendar unit property validator

### DIFF
--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -99,7 +99,7 @@ class DnfImpl extends ImplBase {
                             if (output.indexOf("InactiveSec=1d\n") >= 0)
                                 this.day = this.time = "";
                             else
-                                this.supported = false;
+                                this.parsing_failed = true;
                         }
 
                         debug(`dnf getConfig: supported ${this.supported}, enabled ${this.enabled}, type ${this.type}, day ${this.day}, time ${this.time}, installed ${this.installed}; raw response '${output}'`);
@@ -135,7 +135,7 @@ class DnfImpl extends ImplBase {
         if (words.length == 1 && validTime.test(words[0]))
             this.time = words[0].replace(/^0+/, "");
         else
-            this.supported = false;
+            this.parsing_failed = true;
     }
 
     setConfig(enabled, type, day, time) {
@@ -359,6 +359,11 @@ export class AutoUpdates extends React.Component {
 
         return (<>
             <div id="autoupdates-settings">
+                {enabled && this.state.backend.parsing_failed &&
+                <Alert isInline
+                       variant="info"
+                       className="autoupdates-card-error"
+                       title={_("Failed to parse unit files for dnf-automatic.timer or dnf-automatic-install.timer. Please remove custom overrides to enable this feature.")} />}
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     <Flex grow={{ default: 'grow' }} alignItems={{ default: 'alignItemsBaseline' }}>
                         <FlexItem>

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -116,8 +116,7 @@ class DnfImpl extends ImplBase {
     parseCalendar(spec) {
         // see systemd.time(7); we only support what we write, otherwise we treat it as custom config and "unsupported"
         const daysOfWeek = ["mon", "tue", "wed", "thu", "fri", "sat", "sun"];
-        // TODO: allow arbitrary minutes once we support that in the UI widget
-        const validTime = /^((|0|1)[0-9]|2[0-3]):00$/;
+        const validTime = /^((|0|1)[0-9]|2[0-3]):[0-5][0-9]$/;
 
         var words = spec.trim().toLowerCase()
                 .split(/\s+/);

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -305,3 +305,7 @@ table.header-buttons {
 .cockpit-update-warning-text {
     color: var(--pf-global--warning-color--200);
 }
+
+.autoupdates-card-error {
+    margin-bottom: var(--pf-global--spacer--md);
+}

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1256,7 +1256,7 @@ class TestAutoUpdates(NoSubManCase):
             b.reload()
             b.enter_page("/updates")
             time.sleep(5)
-            b.wait_not_present("#autoupdates-settings")
+            b.wait_visible("#settings .pf-c-alert")
 
     def testWithAvailableUpdates(self):
         b = self.browser


### PR DESCRIPTION
Previously when the user would have had arbitary minutes already set up,
we would set supported=false and hide the autoupdates card from the UI.

Fixes #15712