### PR TITLE
terminal: show an alert if navigator.clipboard.readText API is not supported

### DIFF
--- a/pkg/lib/cockpit-components-terminal.jsx
+++ b/pkg/lib/cockpit-components-terminal.jsx
@@ -19,9 +19,15 @@
 
 import React from "react";
 import PropTypes from "prop-types";
+import { Modal, Button } from "@patternfly/react-core";
 import { Terminal as Term } from "xterm";
+
 import { ContextMenu } from "cockpit-components-context-menu.jsx";
+import cockpit from "cockpit";
+
 import "console.css";
+
+const _ = cockpit.gettext;
 
 const theme_core = {
     yellow: "#b58900",
@@ -116,7 +122,8 @@ export class Terminal extends React.Component {
             cursorBlink: true,
             fontSize: props.fontSize || 16,
             fontFamily: 'Menlo, Monaco, Consolas, monospace',
-            screenReaderMode: true
+            screenReaderMode: true,
+            showPastingModal: false,
         });
 
         this.terminalRef = React.createRef();
@@ -191,6 +198,18 @@ export class Terminal extends React.Component {
     render() {
         return (
             <>
+                <Modal title={_("Paste error")}
+                       position="top"
+                       variant="small"
+                       isOpen={this.state.showPastingModal}
+                       onClose={() => this.setState({ showPastingModal: false })}
+                       actions={[
+                           <Button key="cancel" variant="secondary" onClick={() => this.setState({ showPastingModal: false })}>
+                               {_("Close")}
+                           </Button>
+                       ]}>
+                    {_("Your browser does not allow paste from the context menu. You can use Shift+Insert.")}
+                </Modal>
                 <div ref={this.terminalRef}
                      key={this.state.terminal}
                      className="console-ct"
@@ -213,10 +232,10 @@ export class Terminal extends React.Component {
         try {
             navigator.clipboard.readText()
                     .then(text => this.props.channel.send(text))
-                    .catch(e => console.error('Text could not be pasted, use Shift+Insert ', e ? e.toString() : ""))
+                    .catch(e => this.setState({ showPastingModal: true }))
                     .finally(() => this.state.terminal.focus());
         } catch (error) {
-            console.error('Text could not be pasted, use Shift+Insert:', error.toString());
+            this.setState({ showPastingModal: true });
         }
     }
 

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -1,4 +1,5 @@
 import cockpit from "cockpit";
+import '../lib/patternfly/patternfly-4-cockpit.scss';
 
 import React from "react";
 import ReactDOM from "react-dom";
@@ -7,7 +8,6 @@ import {
     Toolbar, ToolbarContent, ToolbarItem
 } from "@patternfly/react-core";
 
-import '../lib/patternfly/patternfly-4-cockpit.scss';
 import { Terminal } from "cockpit-components-terminal.jsx";
 
 const _ = cockpit.gettext;


### PR DESCRIPTION
Note: The patternfly import needs to be done before the react-core imports,
otherwise it resets the styles. (resulting is false modal background)

Fixes #12939

The alert modal looks like this:
![Screen Shot 2021-04-20 at 18 56 14](https://user-images.githubusercontent.com/14921356/115274553-160f9c00-a141-11eb-87aa-f61e0877f40b.png)
