### PR TITLE
Fix debian/copyright failure during `make dist` with pre-built dist/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 *.policy
 *.so
 *.mo
+*.tmp
 test-*.log
 test-*.trs
 *~

--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,7 @@ EXTRA_DIST = \
 	package.json \
 	package-lock.json \
 	README.md \
+	tools/debian/copyright \
 	$(NULL)
 
 clean-local::
@@ -322,13 +323,16 @@ COMMITTED_DIST = \
 	test \
 	$(NULL)
 
+tools/debian/copyright: tools/debian/copyright.template $(MANIFESTS)
+	$(AM_V_GEN) $(srcdir)/tools/build-debian-copyright > $@.tmp
+	$(MV) $@.tmp $@
+
 # Build up the distribution using $COMMITTED_DIST and include node_modules licenses
 # also automatically update minimum base dependency in RPM spec file
 dist-hook:: $(MANIFESTS)
 	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
 		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
-	[ ! -d $(distdir)/tools/debian ] || $(srcdir)/tools/build-debian-copyright $(distdir) > $(distdir)/tools/debian/copyright
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 DIST_TAR_MAIN = tar --format=posix -cf - "$(distdir)"

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -131,12 +131,15 @@ def download_dist(wait=False):
         tar_path = os.path.realpath(names[0])
 
     # Extract npm/webpack related files locally for speeding up the build and allowing integration tests to run
-    unpack_paths = [d for d in ["dist", "node_modules", "package-lock.json"] if not os.path.exists(d)]
+    unpack_paths = [d for d in ["dist", "node_modules", "package-lock.json", "tools/debian/copyright"] if not os.path.exists(d)]
     if unpack_paths:
         message("make_dist: Extracting from tarball:", ' '.join(unpack_paths))
         prefix = os.path.basename(tar_path).split('.tar')[0] + '/'
         prefixed_unpack_paths = [prefix + d for d in unpack_paths]
         subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
+        # after the above, dist manifests may be newer than copyright due to tar touching order
+        # restore file time stamps as they would be after a build
+        subprocess.check_call(["touch", "tools/debian/copyright"])
 
     return tar_path
 

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -20,7 +20,6 @@ template_file = os.path.join(debian_dir, 'copyright.template')
 
 def parse_args():
     p = argparse.ArgumentParser(description='Generate debian/copyright file from template and node_modules')
-    p.add_argument('distdir', help='path to toplevel distribution directory')
     return p.parse_args()
 
 
@@ -147,11 +146,10 @@ with open(template_file, encoding='UTF-8') as f:
 license_ids = template_licenses(template)
 module_users = {}
 
-for pkg in sorted(os.listdir(f'{args.distdir}/dist')):
-    if pkg in ['guide', 'ssh', 'pcp']:
-        continue
-    with open(f'{args.distdir}/dist/{pkg}/included-modules') as included_modules:
-        for module in included_modules:
+for included_modules in sorted(glob("dist/*/included-modules")):
+    pkg = os.path.basename(os.path.dirname(included_modules))
+    with open(included_modules) as f:
+        for module in f:
             module = module.strip()
             # collect all packages pointing to one node module
             if module not in module_users:


### PR DESCRIPTION
Our current [cockpit-dist](https://github.com/cockpit-project/cockpit-dist/) approach is broken: it becomes too big too quickly, and causes [prune-dist](https://github.com/cockpit-project/cockpit/actions/workflows/prune-dist.yml) to just error out on `git push -f`. In cockpit-machines we recently [reworked the dist storing](https://github.com/cockpit-project/cockpit-machines/pull/84) to keep the literal files in git, not the full tarballs.

For that to work in cockpit, we need to have `make dist` *not* do npm/webpack after unpacking pre-built dist/ and package-lock.json. It should be fast (well under 1 minute) to retain the "fast local PR testing/development" behaviour that we have right now.

The main thing that is currently broken is the generated debian/copyright file.

With the fixes here, this sequence works:

    git clean -ffdx; test/make_dist.py && time sh -c './autogen.sh && make --silent NO_DIST_CACHE=1 XZ_COMPRESS_FLAGS=-0 dist'

The first make_dist downloads the tarball, and the `make` just does an actual local tarball build to validate that this works. This has to run autogen.sh, configure, and the `make dist` part, which takes about 14s in total. This is still bearable IMHO.

 - [x] #15719
 - [x] #15727