### PR TITLE
metrics: Show active menu item and add documentation to pcp

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -136,8 +136,9 @@ $ cockpit-bridge --packages
       <varlistentry>
         <term>parent</term>
         <listitem><para>This option is used when module does not have its own menu item but is
-          a part of a different module. This is described by JSON object with property <code>component</code>
-          which takes name of the superordinate component.</para></listitem>
+          a part of a different module. This is described by JSON object with properties <code>component</code>
+          which takes name of the superordinate component and <code>docs</code> with list of documentation URLs
+          for the given page. See below for structure of <code>docs</code> property.</para></listitem>
       </varlistentry>
     </variablelist>
 

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -133,6 +133,12 @@ $ cockpit-bridge --packages
         explained below.
         </para></listitem>
       </varlistentry>
+      <varlistentry>
+        <term>parent</term>
+        <listitem><para>This option is used when module does not have its own menu item but is
+          a part of a different module. This is described by JSON object with property <code>component</code>
+          which takes name of the superordinate component.</para></listitem>
+      </varlistentry>
     </variablelist>
 
     <para>In addition, the following keys contain information about where components of the package

--- a/pkg/metrics/manifest.json
+++ b/pkg/metrics/manifest.json
@@ -1,5 +1,15 @@
 {
     "requires": {
         "cockpit": "137"
+    },
+
+    "parent": {
+        "component": "system",
+        "docs": [
+            {
+                "label": "Performance Co-Pilot",
+                "url": "https://pcp.readthedocs.io/en/latest/"
+            }
+        ]
     }
 }

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -467,6 +467,14 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 s = s.substring(0, s.lastIndexOf("/"));
             component = s;
         }
+
+        // Still don't know where it comes from, check for parent
+        if (!component) {
+            const comp = cockpit.manifests[state.component];
+            if (comp && comp.parent)
+                return comp.parent.component;
+        }
+
         return component;
     }
 

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -376,7 +376,19 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function update_docs(machine, state, compiled) {
+        let docs = [];
+
         const item = compiled.items[state.component];
+        if (item && item.docs)
+            docs = item.docs;
+
+        // Check for parent as well
+        if (docs.length === 0) {
+            const comp = cockpit.manifests[state.component];
+            if (comp && comp.parent && comp.parent.docs)
+                docs = comp.parent.docs;
+        }
+
         const docs_items = document.getElementById("navbar-docs-items");
         docs_items.innerHTML = "";
 
@@ -403,8 +415,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
         create_item(_("Web Console"), "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/index");
 
-        if (item && item.docs && item.docs.length > 0)
-            item.docs.forEach(e => create_item(_(e.label), e.url));
+        docs.forEach(e => create_item(_(e.label), e.url));
 
         // Add 'About Web Console' item
         const divider = document.createElement("li");

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -158,9 +158,11 @@ OnCalendar=daily
         b.switch_to_frame("cockpit1:localhost/playground/test")
         b.wait_not_visible("#hidden")
 
+        # Test 'parent' manifest option
         b.switch_to_top()
-
-        b.wait_visible("#nav-system")
+        b.go("/metrics")
+        b.wait_text("#host-apps .pf-m-current", "Overview")
+        self.checkDocs(["Performance Co-Pilot"])
 
         # Lets try changing the language
 

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -86,6 +86,7 @@ class TestMultiMachineKeyAuth(MachineCase):
             }}
         """.format(name, password))
         self.browser.eval_js("cockpit.user().done(load)")
+        self.browser.wait_js_cond('loaded === true')
 
     def check_keys(self, keys_md5, keys):
         def normalize(k):
@@ -145,13 +146,11 @@ class TestMultiMachineKeyAuth(MachineCase):
         # pam-ssh-add isn't used on OSTree
         if m1.ostree_image:
             self.load_key('id_rsa', 'foobar')
-            b.wait_js_cond('loaded === true')
             self.check_keys(["2048 93:40:9e:67:82:78:a8:99:89:39:d5:ba:e0:50:70:e1 id_rsa (RSA)"],
                             ["2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw id_rsa (RSA)"])
         else:
             # Check our keys were loaded.
             self.load_key("id_ed25519", "locked")
-            b.wait_js_cond('loaded === true')
             self.check_keys(KEY_IDS_MD5, KEY_IDS)
 
         # Add machine
@@ -259,7 +258,6 @@ Host 10.111.113.2
         b.switch_to_top()
 
         self.load_key('id_rsa', 'foobar')
-        b.wait_js_cond('loaded === true')
 
         b.click("#hosts-sel button")
         b.click("button:contains('Add new host')")


### PR DESCRIPTION
Currently when one  would navigate to `/metrics` (through "View details and history") no menu item would be shown as active. Also it was not possible to define documentation items for metrics.

Problem with this component is that it is being treated as separate component but it does not have separate menu entry. There are a few options how this could be fixed:
- Add 'Metrics' menu item
- Serve this on `/system/metrics` and move `pkg/metrics` source into `pkg/systemd/source`
- Do what I have done in this PR
- Some other hack/workaround I haven't though of (?)

Before I document this new option, write tests and  cleanup commits I would like to hear what others think. Is this step in a good direction or would you solve this differently?