### PR TITLE
firewall: call zone remove API method when deleting a zone from the UI

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -436,10 +436,14 @@ class TestFirewall(NetworkCase):
             b.wait_visible("#zones-listing .zone-section[data-id='{}']".format(zone))
             b.wait_visible("#zones-listing .zone-section[data-id='{}'] tr[data-row-id='cockpit']".format(zone))
 
-        def removeZone(zone):
+        def removeZone(zone, xfail=None):
             b.click(".zone-section[data-id='{}'] .zone-section-buttons button.{}".format(zone, self.btn_danger))
             b.click("#delete-confirmation-dialog button.{}".format(self.btn_danger))
-            b.wait_not_present(".zone-section[data-id='{}']".format(zone))
+            if xfail:
+                b.wait_visible("#delete-confirmation-dialog .pf-c-alert.pf-m-danger:contains({})".format(xfail))
+                b.click("#delete-confirmation-dialog button.btn-cancel")
+            else:
+                b.wait_not_present(".zone-section[data-id='{}']".format(zone))
 
         self.login_and_go("/network/firewall")
         b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
@@ -465,7 +469,7 @@ class TestFirewall(NetworkCase):
         b.wait_not_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # remove predefined work zone
-        removeZone("work")
+        removeZone("work", xfail="BUILTIN_ZONE: 'work' is built-in zone")
         # add zone with previously unused interface
         addZone("home", interfaces=[home_iface])
         # Interfaces which already belong to an active zone shouldn't show up in
@@ -477,9 +481,12 @@ class TestFirewall(NetworkCase):
         b.wait_not_present("#add-zone-dialog")
 
         addServiceToZone("pop3", "home")
-        removeZone("home")
+        removeZone("home", xfail="BUILTIN_ZONE: 'home' is built-in zone")
 
-        addZone("work", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+        addZone("external", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+
+        m.execute("firewall-cmd --permanent --new-zone=custom-zone && systemctl restart firewalld && firewall-cmd --zone=custom-zone --add-source=192.168.2.15")
+        removeZone("custom-zone")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update: so with @Gundersanne with agreed to block this PR, and make this change together with adding the ability to remove interfaces and sources from the zone, so that we don't actually remove a feature right now from the cockpit firewall UI.

Added blocked because this now needs design, to add the new features.

<hr />

Previously the delete operation of the UI did not actually remove the
zone from the firewalld configuration. Instead it emptied it, by
removing all the interfaces and sources from it.

That's especially problematic with predefined (builtin) zones, which get redefined
when the firewalld gets restarted. In other words, if the user deleted
from the UI a predefined zone and then reloaded the firewall, all their
changes would be reverted.

Let's simplify the logic here, by just calling remove method instead of our
logic of emptying the zone. In addition we now show an error in the UI if the zone
failed to get removed (in the case of built it zones for example).
This is much more useful instead of faking the deletion, and then
suprising the users by reappearing deleted zones.

This change lastly follows the idea that all changes performed from
firewall UI are persistent.

Fixes #12279