### PR TITLE
[WIP]: firewall: (in my opinion) simplify zones card

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -472,4 +472,27 @@ firewall.removeZone = (zone) => {
     });
 };
 
+/*
+ * Add port into the specified zone
+ *
+ * Returns a promise that resolves when the port is added.
+ */
+firewall.addPort = (zone, port) => {
+    return firewalld_dbus.call('/org/fedoraproject/FirewallD1/config',
+                               'org.fedoraproject.FirewallD1.config',
+                               'getZoneByName', [zone])
+            .then(path => firewalld_dbus.call(path[0], 'org.fedoraproject.FirewallD1.config.zone',
+                                              'addPort', [port[0], port[1]]));
+};
+
+/*
+ * Like addPort(), but adds multiple ports at once
+ * to the specified zones.
+ *
+ * Returns a promise that resolves when all ports are added.
+ */
+firewall.addPorts = (zone, ports) =>
+    Promise.all(ports.map(p => firewall.addPort(zone, p)))
+            .then(() => firewall.reload());
+
 export default firewall;

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -217,6 +217,10 @@ const ZoneSection = ({ zone, readonly, onRemoveZone, onRemoveService, openPortsD
                     />
                 </Tab>
                 <Tab eventKey={2} title={<TabTitleText>{_("Interfaces")}</TabTitleText>}>
+                    <Button variant="secondary"
+                            className="add-interfaces-button">
+                        {_("Add interfaces")}
+                    </Button>
                     <ListingTable columns={[{ title: _("Interfaces") }]}
                                   aria-label={zone.id}
                                   variant="compact"
@@ -235,6 +239,10 @@ const ZoneSection = ({ zone, readonly, onRemoveZone, onRemoveService, openPortsD
                     />
                 </Tab>
                 <Tab eventKey={3} title={<TabTitleText>{_("Sources")}</TabTitleText>}>
+                    <Button variant="secondary"
+                            className="add-sources-button">
+                        {_("Add sources")}
+                    </Button>
                     <ListingTable columns={[{ title: _("Sources") }]}
                                   aria-label={zone.id}
                                   variant="compact"

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -326,7 +326,6 @@ class AddServicesModal extends React.Component {
             selected: new Set(),
             filter: "",
             custom: false,
-            generate_custom_id: true,
             tcp_error: "",
             udp_error: "",
             avail_services: null,
@@ -359,7 +358,7 @@ class AddServicesModal extends React.Component {
     save() {
         let p;
         if (this.state.custom) {
-            p = firewall.createService(this.state.custom_id, this.createPorts(), this.props.zoneId);
+            p = firewall.addPorts(this.props.zoneId, this.createPorts());
         } else {
             p = firewall.addServices(this.props.zoneId, [...this.state.selected]);
         }
@@ -429,7 +428,6 @@ class AddServicesModal extends React.Component {
     setId(value) {
         this.setState({
             custom_id: value,
-            generate_custom_id: value.length === 0,
         });
     }
 
@@ -463,7 +461,6 @@ class AddServicesModal extends React.Component {
         if (event.target.id === "udp-ports")
             targets = ['udp', 'custom_udp_ports', 'udp_error', 'custom_udp_value'];
         const new_ports = [];
-        const event_id = event.target.id;
 
         this.setState(oldState => {
             const ports = value.split(',');
@@ -499,17 +496,6 @@ class AddServicesModal extends React.Component {
                 [targets[2]]: error,
                 [targets[3]]: value
             };
-
-            let all_ports = new_ports.concat(oldState.custom_udp_ports);
-            if (event_id === "udp-ports")
-                all_ports = oldState.custom_tcp_ports.concat(new_ports);
-
-            if (oldState.generate_custom_id) {
-                if (all_ports.length > 0)
-                    newState.custom_id = "custom--" + all_ports.map(this.getName).join('-');
-                else
-                    newState.custom_id = "";
-            }
 
             return newState;
         });

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -168,6 +168,7 @@ const ZoneSection = ({ zone, readonly, onRemoveZone, onRemoveService, openPortsD
         <CardHeader className="zone-section-heading">
             <CardTitle>
                 <h4>{ cockpit.format(_("$0 zone"), zone.id) }</h4>
+                <small>{zone.description}</small>
             </CardTitle>
             { !firewall.readonly && <CardActions className="zone-section-buttons">{deleteButton}</CardActions> }
         </CardHeader>

--- a/pkg/networkmanager/firewall.scss
+++ b/pkg/networkmanager/firewall.scss
@@ -1,0 +1,3 @@
+#firewall .services-table tr:not(.pf-c-table__expandable-row) > :first-child {
+    padding-left: 0;
+}

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -365,7 +365,7 @@ th {
 #firewall {
     height: 100%;
 
-    .ct-table tbody tr:first-of-type td:nth-child(2) {
+    .services-table tbody tr:first-of-type td:nth-child(2) {
         font-weight: var(--pf-global--FontWeight--bold);
     }
 }

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -368,6 +368,10 @@ th {
     .services-table tbody tr:first-of-type td:nth-child(2) {
         font-weight: var(--pf-global--FontWeight--bold);
     }
+
+    .add-services-button, .add-ports-button {
+        margin-top: var(--pf-global--spacer--md);
+    }
 }
 
 .zone-section-targets {

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -369,7 +369,7 @@ th {
         font-weight: var(--pf-global--FontWeight--bold);
     }
 
-    .add-services-button, .add-ports-button {
+    .add-services-button, .add-ports-button, .add-interfaces-button, .add-sources-button {
         margin-top: var(--pf-global--spacer--md);
     }
 }

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -436,10 +436,14 @@ class TestFirewall(NetworkCase):
             b.wait_visible("#zones-listing .zone-section[data-id='{}']".format(zone))
             b.wait_visible("#zones-listing .zone-section[data-id='{}'] tr[data-row-id='cockpit']".format(zone))
 
-        def removeZone(zone):
+        def removeZone(zone, xfail=None):
             b.click(".zone-section[data-id='{}'] .zone-section-buttons button.{}".format(zone, self.btn_danger))
             b.click("#delete-confirmation-dialog button.{}".format(self.btn_danger))
-            b.wait_not_present(".zone-section[data-id='{}']".format(zone))
+            if xfail:
+                b.wait_visible("#delete-confirmation-dialog .pf-c-alert.pf-m-danger:contains({})".format(xfail))
+                b.click("#delete-confirmation-dialog button.btn-cancel")
+            else:
+                b.wait_not_present(".zone-section[data-id='{}']".format(zone))
 
         self.login_and_go("/network/firewall")
         b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
@@ -465,7 +469,7 @@ class TestFirewall(NetworkCase):
         b.wait_not_present(".zone-section[data-id='work'] tr[data-row-id='pop3']")
 
         # remove predefined work zone
-        removeZone("work")
+        removeZone("work", xfail="BUILTIN_ZONE: 'work' is built-in zone")
         # add zone with previously unused interface
         addZone("home", interfaces=[home_iface])
         # Interfaces which already belong to an active zone shouldn't show up in
@@ -477,9 +481,12 @@ class TestFirewall(NetworkCase):
         b.wait_not_present("#add-zone-dialog")
 
         addServiceToZone("pop3", "home")
-        removeZone("home")
+        removeZone("home", xfail="BUILTIN_ZONE: 'home' is built-in zone")
 
-        addZone("work", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+        addZone("external", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+
+        m.execute("firewall-cmd --permanent --new-zone=custom-zone && systemctl restart firewalld && firewall-cmd --zone=custom-zone --add-source=192.168.2.15")
+        removeZone("custom-zone")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
So today I spent a short time in firewall page, I understood what the whole zones concept is about and I thought we can expose it better. The previous implementation was:
* quite complicated to understand - especially the Add services/Port dialog
* not possible to extend - see the need to add / remove interfaces and resources


This is far from being a ready implementation I just want some thumbs up or thumbs down, so that I know if it makes sense to look more into this direction.

Here are screenshots from the all the affected UI parts:

The dialog where split to 'Add ports' and 'Add services':
![Screen Shot 2021-04-21 at 18 05 45](https://user-images.githubusercontent.com/14921356/115428819-16706b80-a203-11eb-849e-5c624bb9fadf.png)
![Screen Shot 2021-04-21 at 18 05 30](https://user-images.githubusercontent.com/14921356/115428824-17090200-a203-11eb-858b-a6b6119eb851.png)

The different zone part were converted into tabs: 
![Screen Shot 2021-04-21 at 18 07 46](https://user-images.githubusercontent.com/14921356/115429062-52a3cc00-a203-11eb-9320-d4f83013313b.png)
![Screen Shot 2021-04-21 at 18 07 41](https://user-images.githubusercontent.com/14921356/115429067-533c6280-a203-11eb-9ecd-9ec6d68303ed.png)
![Screen Shot 2021-04-21 at 18 07 38](https://user-images.githubusercontent.com/14921356/115429069-53d4f900-a203-11eb-8b43-0ae9b7f04e4e.png)
![Screen Shot 2021-04-21 at 18 07 36](https://user-images.githubusercontent.com/14921356/115429070-53d4f900-a203-11eb-93ca-516104966745.png)



@garrett you mentioned that you were part of the initial design, do you have something against this direction? As I say, take this PR only as a proof of concept, not a ready to review bit.
