### PR TITLE
Restore package-lock.json from cached dist tarballs

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -39,7 +39,7 @@ if [ -z "$(which glib-gettextize)" ]; then
     exit 1
 fi
 
-tools/npm-install
+[ -e package-lock.json ] || tools/npm-install
 
 rm -rf autom4te.cache
 

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -68,7 +68,7 @@ def download_dist(wait=False):
         message("make_dist: not a git repository")
         return None
 
-    if subprocess.call(["git", "diff", "--quiet", "--", ":^test"]) > 0:
+    if subprocess.call(["git", "diff", "--quiet", "--", ":^test", ":^packit.yaml", ":^.github"]) > 0:
         message("make_dist: uncommitted local changes, skipping download")
         return None
 

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -130,13 +130,13 @@ def download_dist(wait=False):
         ftar.extract(names[0])
         tar_path = os.path.realpath(names[0])
 
-    # Extract node_modules and dist locally for speeding up the build and allowing integration tests to run
-    unpack_dirs = [d for d in ["dist", "node_modules"] if not os.path.exists(d)]
-    if unpack_dirs:
-        message("make_dist: Extracting directories from tarball:", ' '.join(unpack_dirs))
+    # Extract npm/webpack related files locally for speeding up the build and allowing integration tests to run
+    unpack_paths = [d for d in ["dist", "node_modules", "package-lock.json"] if not os.path.exists(d)]
+    if unpack_paths:
+        message("make_dist: Extracting from tarball:", ' '.join(unpack_paths))
         prefix = os.path.basename(tar_path).split('.tar')[0] + '/'
-        prefixed_unpack_dirs = [prefix + d for d in unpack_dirs]
-        subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_dirs)
+        prefixed_unpack_paths = [prefix + d for d in unpack_paths]
+        subprocess.check_call(["tar", "--touch", "--strip-components=1", "-xf", tar_path] + prefixed_unpack_paths)
 
     return tar_path
 


### PR DESCRIPTION
Commit d3f51710dda moved from node_modules/.stamp to package-lock.json
as our canonical stamp file, which regressed make_dist. This fixes
running autogen/configure/make dist with pre-built dist again, as it
does not pointlessly rebuild everything again.

In autogen.sh, don't run npm install if package-lock.json already
exists.

----

These two are the harmless/obvious changes from PR #15720.