### PR TITLE
ws: Enable sandbox in cockpit-desktop's webkit browser

### DIFF
--- a/src/ws/cockpit-desktop.in
+++ b/src/ws/cockpit-desktop.in
@@ -53,6 +53,7 @@ class Browser(Gtk.Window):
 
         self.set_size_request(800, 600)
 
+        WebKit2.WebContext.get_default().set_sandbox_enabled(True)
         self.webview = WebKit2.WebView()
         self.add(self.webview)
         self.webview.show()


### PR DESCRIPTION
Fixes #13700

---

Our integration tests don't/can't cover this, this needs to be tested manually. I did that on a clean Fedora 33 live system, with `/usr/libexec/cockpit-desktop /` and `/usr/libexec/cockpit-desktop metrics`, it works fine.