### PR TITLE
Fix two coverity errors

### DIFF
--- a/src/common/cockpitjson.c
+++ b/src/common/cockpitjson.c
@@ -1059,7 +1059,7 @@ cockpit_json_walk_node (JsonNode    *node,
         if (copy)
           {
             new_node = json_node_new (JSON_NODE_ARRAY);
-            json_node_take_array (new_node, copy ?: json_array_ref (array));
+            json_node_take_array (new_node, copy);
           }
 
         break;
@@ -1073,7 +1073,7 @@ cockpit_json_walk_node (JsonNode    *node,
         if (copy)
           {
             new_node = json_node_new (JSON_NODE_OBJECT);
-            json_node_take_object (new_node, copy ?: json_object_ref (object));
+            json_node_take_object (new_node, copy);
           }
 
         break;

--- a/src/common/cockpitwebcertificate.c
+++ b/src/common/cockpitwebcertificate.c
@@ -99,6 +99,7 @@ cockpit_certificate_locate (bool missing_ok,
 {
   const char * const *dirs = cockpit_conf_get_dirs ();
 
+  assert (error != NULL);
   assert (*error == NULL);
 
   for (int i = 0; dirs[i]; i++)
@@ -117,7 +118,7 @@ cockpit_certificate_locate (bool missing_ok,
         return cert_path;
     }
 
-  if (error && !missing_ok)
+  if (!missing_ok)
     asprintfx (error, "No certificate found in dir: %s/cockpit/ws-certs.d", dirs[0]);
 
   return NULL;


### PR DESCRIPTION
Spotted by coverity:

    src/common/cockpitjson.c:1073: cond_notnull: Condition "copy", taking true branch. Now the value of "copy" is not "NULL".
    src/common/cockpitjson.c:1076: notnull: At condition "copy", the value of "copy" cannot be "NULL".
    src/common/cockpitjson.c:1076: dead_error_condition: The condition "copy" must be true.
    src/common/cockpitjson.c:1076: dead_error_line: Execution cannot reach the expression "json_object_ref(object)" inside this statement: "json_node_take_object(new_n...".