### PR TITLE
workflows: Run unit-tests container as root

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -19,7 +19,7 @@ jobs:
           ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Run unit-tests container
-        run: containers/unit-tests/start dist
+        run: sudo containers/unit-tests/start dist
 
       - name: Create dist tarball artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,8 +27,8 @@ jobs:
               *:i386*) arch=i386;;
               *) arch=amd64;;
             esac
-            containers/unit-tests/build $arch
+            sudo containers/unit-tests/build $arch
           fi
 
       - name: Run unit-tests container
-        run: 'containers/unit-tests/start ${{ matrix.startarg }}'
+        run: 'sudo containers/unit-tests/start ${{ matrix.startarg }}'


### PR DESCRIPTION
On the latest GitHub 20.04 image, podman can't pull our unit-tests
container any more:

    Error committing the finished image: error adding layer with blob "sha256:...":
    Error processing tar file(exit status 1): operation not permitted

Let's run the containers as root. This does not matter much for the
host, and until podman is officially supported in Ubuntu, system podman
has fewer potential permission problems.

----

These spontaneously started to fail today, like [build-dist here](https://github.com/cockpit-project/cockpit/pull/15732/checks?check_run_id=2408260405) or [unit-tests here](https://github.com/cockpit-project/cockpit/pull/15732/checks?check_run_id=2408145586).

[tested build-dist on my fork](https://github.com/martinpitt/cockpit/actions/runs/773717557), but not unit-tests. Let's do that here.