### PR TITLE
metrics: sticky header for day selector should be after the sticky breadcrumb section

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -353,7 +353,7 @@
 
         &-sticky {
             position: sticky;
-            top: 0;
+            top: 3.75rem;
             z-index: 99;
         }
     }


### PR DESCRIPTION
Closes #15435

I left some space between the two sticky bars, thought it makes sense, but I am not sure.
![Screen Shot 2021-04-23 at 17 18 29](https://user-images.githubusercontent.com/14921356/115740082-c58d7e00-a38e-11eb-9da3-28706eb91fab.png)
