### PR TITLE
Fix tests for current RHEL 9.0

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1164,7 +1164,7 @@ class MachineCase(unittest.TestCase):
             # Fedora and RHEL 9 have switched to dbus-broker
             self.allowed_messages.append("dbus-daemon didn't send us a dbus address; not installed?.*")
 
-        if self.image in ['fedora-34']:
+        if self.image in ['fedora-34', 'rhel-9-0']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1929259
             self.allow_journal_messages('audit:.*denied.*comm="pmdakvm" lockdown_reason="debugfs access".*')
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -32,15 +32,8 @@ class TestKdump(MachineCase):
         return new.join(li)
 
     def enableKdump(self):
-        if self.machine.image in ["rhel-8-4", "rhel-8-5"]:
-            # these images use BootLoaderSpec and grubenv
-            self.sed_file('/^kernelopts=/ { s/crashkernel=[^ ]*//; s/$/ crashkernel=256M/; }', '/boot/grub2/grubenv')
-        else:
-            lines = self.machine.execute(command="cat /etc/default/grub", quiet=True).split("\n")
-            lines = map(lambda line: self.rreplace(line, '"', ' crashkernel=256M"', 1)
-                        if line.startswith("GRUB_CMDLINE_LINUX") else line, lines)
-            self.machine.write("/etc/default/grub", "\n".join(lines))
-            self.machine.execute("grub2-mkconfig -o /boot/grub2/grub.cfg")
+        # all current Fedora/CentOS/RHEL images use BootLoaderSpec
+        self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
         self.machine.execute("mkdir -p /var/crash")
 
     def enableLocalSsh(self):


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1929259 has crept into RHEL
9.0.

----

Blocks the image refresh in https://github.com/cockpit-project/bots/pull/1955, see [failed test](https://logs.cockpit-project.org/logs/pull-1955-20210423-050736-4d7f63e8-rhel-9-0-cockpit-project-cockpit/log.html#51)