### PR TITLE
test: Relax setroubleshootd disconnect message

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -73,7 +73,7 @@ class TestSelinux(MachineCase):
         m.execute("semanage fcontext --add -t samba_share_t /var/tmp/")
         m.execute("semanage boolean --modify --on zebra_write_config")
         self.allow_journal_messages("audit: type=1405 .* bool=zebra_write_config val=1 old_val=0.*")
-        self.allow_journal_messages(".*couldn't introspect /org/fedoraproject/Setroubleshootd: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Remote peer disconnected.*")
+        self.allow_journal_messages(".*couldn't introspect /org/fedoraproject/Setroubleshootd: GDBus.Error:org.freedesktop.DBus.Error.NoReply:.*disconnected.*")
 
         self.login_and_go("/selinux/setroubleshoot")
 


### PR DESCRIPTION
In new rhel-8-5 CI has seen:
```
org.fedoraproject.Setroubleshootd: couldn't introspect /org/fedoraproject/Setroubleshootd: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Message recipient disconnected from message bus without replying
```