### PR TITLE
Rework pre-built dist upload/download

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -15,12 +15,18 @@ jobs:
           # need this to also fetch tags
           fetch-depth: 0
 
-      - name: Run unit-tests container
-        run: sudo containers/unit-tests/start dist
+      - name: Run unit-tests container to build dist
+        run: |
+          sudo containers/unit-tests/start dist
+          tar --strip-components=1 -xf tmp/dist/cockpit-*.tar.xz
 
-      - name: Create dist tarball artifact
+      - name: Create dist artifact
         uses: actions/upload-artifact@v2
         with:
           name: dist
-          path: tmp/dist/cockpit-*.tar.xz
-          retention-days: 7
+          path: |
+            dist/
+            node_modules/
+            package-lock.json
+            tools/debian/copyright
+          retention-days: 1

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -14,9 +14,6 @@ jobs:
         with:
           # need this to also fetch tags
           fetch-depth: 0
-          # avoid checking out the default pull/NNN/head ref, as that gives
-          # mismatching SHAs in generated tarballs
-          ref: "${{ github.event.pull_request.head.sha || github.sha }}"
 
       - name: Run unit-tests container
         run: sudo containers/unit-tests/start dist
@@ -24,8 +21,6 @@ jobs:
       - name: Create dist tarball artifact
         uses: actions/upload-artifact@v2
         with:
-          # https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions
-          # for pull_requests, use HEAD of the proposed branch, for pushes to origin the current SHA
-          name: "dist-${{ github.event.pull_request.head.sha || github.sha }}"
+          name: dist
           path: tmp/dist/cockpit-*.tar.xz
           retention-days: 7

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -1,4 +1,4 @@
-# truncate the cockpit-dist history every Sunday night, to avoid unbounded growth
+# truncate the -dist history every Sunday night, to avoid unbounded growth
 name: prune-dist
 on:
   schedule:
@@ -13,7 +13,6 @@ jobs:
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
           # we push to -dist repo via https://github.com, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
@@ -22,18 +21,23 @@ jobs:
         run: |
           git clone https://github.com/${{ github.repository }}-dist.git dist-repo
 
-      - name: Truncate history of -dist repo
+      - name: Delete old tags
         run: |
           set -ex
+
+          # head commit SHA of default branch
+          HEAD=$(git ls-remote 'https://github.com/${{ github.repository }}' main master | cut -f1 | head -n1)
+
           cd dist-repo
-          # oldest commit that applies to any still present tarball
-          REF=$(git log --pretty=format:%H * | tail -n1)
-
-          git checkout --orphan temp $REF
-          git commit -m "Truncated history"
-          git rebase --onto temp $REF master
-          git branch -D temp
-          git reflog expire --expire=now --all
-
-      - name: Force-push -dist repo
-        run: git -C dist-repo push -f
+          now="$(date +%s)"
+          for tag in $(git tag -l); do
+              tag_time="$(git show -s --format=%at $tag)"
+              if [ "$tag" = "sha-${HEAD}" ]; then
+                  echo "$tag refers to current project default branch HEAD, keeping"
+              elif [ $((now - tag_time)) -ge 604800 ]; then
+                  echo "$tag is older than 7 days, deleting..."
+                  git push origin ":$tag"
+              else
+                  echo "$tag is younger than 7 days, keeping"
+              fi
+          done

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -8,6 +8,7 @@ jobs:
   run:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Download build-dist artifacts
         # 2.14.0; if you update this, audit the diff and ensure that it does not leak/abuse secrets
@@ -16,52 +17,23 @@ jobs:
           name: dist
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
-          path: dist
+          path: dist-repo
 
       - name: Set up configuration and secrets
         run: |
           printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
           # we push to -dist repo via https://github.com, that needs our cockpituous token
           git config --global credential.helper store
           echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
 
-      - name: Commit dist tarball dist repo
+      - name: Commit to dist repo
         run: |
           set -ex
+          cd dist-repo
+          git init
+          git add .
+          git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
+          tag='sha-${{ github.event.workflow_run.head_sha }}'
+          git tag "$tag"
 
-          # we need a fully predictable name/URL, and git introduces these
-          # additional numbers into the version; so wrap it in a predictable named tar
-          sha='${{ github.event.workflow_run.head_sha }}'
-
-          # multiple parallel workflows race against each other, so the final
-          # `git push` may fail
-          rc=1
-          for retry in $(seq 5); do
-              git clone https://github.com/${{ github.repository }}-dist.git dist-repo
-              tar -cvf "dist-repo/${sha}.tar" -C dist/
-
-              # freshly created empty repo?
-              cd dist-repo
-              git rev-parse HEAD >/dev/null 2>&1 || git init
-              git add "${sha}.tar"
-              git commit -m "Build for $sha"
-
-              # remove tarballs older than 3 days
-              now=$(date +%s)
-              for f in *.tar; do
-                  fmtime=$(git log --pretty=%at -n1 -- $f)
-                  [ $(($now - $fmtime)) -lt 259200 ] || git rm $f
-              done
-              [ -z "$(git status --short)" ] || git commit -m 'Drop old builds'
-
-              if git push; then
-                  rc=0
-                  break
-              else
-                  echo "ERROR: conflict? Retrying git commit"
-                  rm -rf dist-repo
-              fi
-          done
-          exit $rc
-
+          git push https://github.com/${{ github.repository }}-dist.git "$tag"

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download build-dist artifacts
-        uses: dawidd6/action-download-artifact@v2
+        # 2.14.0; if you update this, audit the diff and ensure that it does not leak/abuse secrets
+        uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
         with:
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -13,8 +13,10 @@ jobs:
         # 2.14.0; if you update this, audit the diff and ensure that it does not leak/abuse secrets
         uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
         with:
+          name: dist
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
+          path: dist
 
       - name: Set up configuration and secrets
         run: |
@@ -30,14 +32,14 @@ jobs:
 
           # we need a fully predictable name/URL, and git introduces these
           # additional numbers into the version; so wrap it in a predictable named tar
-          sha=$(ls -d dist-* | sed 's/dist-//')
+          sha='${{ github.event.workflow_run.head_sha }}'
 
           # multiple parallel workflows race against each other, so the final
           # `git push` may fail
           rc=1
           for retry in $(seq 5); do
               git clone https://github.com/${{ github.repository }}-dist.git dist-repo
-              tar -cvf "dist-repo/${sha}.tar" -C "dist-$sha" .
+              tar -cvf "dist-repo/${sha}.tar" -C dist/
 
               # freshly created empty repo?
               cd dist-repo


### PR DESCRIPTION
In publish-dist, directly commit dist/ and related files to the -dist
repo (the ones which make_dist actually needs), and tag the commit with
the SHA, so that they are still easy to look up.  Drop the "old tarball"
removal. This uses git in a much more efficient way, as it now only
stores the deltas. In particular, for commits/PRs which don't change
src/, that will just add an additional tag to the previous build and
store no extra files at all. This avoids regularly overflowing the -dist
repo and making `git push` hang.

Simplify build-dist to do away with the intermediate tarball, as there
are not so many files to make upload-artifact inefficient.

Push every build as an individual tag only, without having them on a
branch. That avoids the need for force-pushing and history rewriting,
which fixes the race of publish-dist against prune-dist.  There is also
no more race condition between parallel publish-dist workflows.

Change prune-dist to keep the tags of the last 7 days plus current
master HEAD, and let garbage collection take care of cleaning up older
ones.

Rework make_dist to get the dist repo in ~/.cache/cockpit-dev/, so that
it persists across project checkouts, and shallow-fetch the desired SHA
build. Unpacking requires some care: Unfortunately our dist tarball
generation does not deal with sub-second file mtime differences, which
can invert the relative mtime of package-lock.json vs.
dist/*/manifest.json; to avoid this, only touch the webpack-built files,
but leave the `npm install` ones alone.

Taken from cockpit-machines:
https://github.com/cockpit-project/cockpit-machines/commit/612bb6aa8d1f
https://github.com/cockpit-project/cockpit-machines/commit/ae57e6249397

-----

I tested this on my fork. The [dist repo](https://github.com/martinpitt/cockpit-dist) now has two tags, and otherwise just an empty master branch. [build-dist](https://github.com/martinpitt/cockpit/actions/runs/784970139) and [publish-dist](https://github.com/martinpitt/cockpit/actions/runs/784999140) look as expected. I also ran [prune-dist](https://github.com/martinpitt/cockpit/runs/2436773139?check_suite_focus=true) -- of course there are not yet any tags older than a week, but it shows that it correctly recognized current master HEAD and the two tags.

The difference to the cockpit-machines workflows is now minimal. I will send a follow-up workflow to c-machines to further reduce it.

Downloading also works fine. I tested this with:

    git clean -ffdx; ln -s ../bots; GITHUB_BASE=martinpitt/cockpit test/image-prepare -qv fedora-34

```
[...]
From https://github.com/martinpitt/cockpit-dist
 * tag               sha-8b214e16d7ea3088131209567212d7aa29af5f59 -> FETCH_HEAD
make_dist: Extracting cached node_modules...
make_dist: Extracting cached package-lock.json...
make_dist: Extracting cached dist...
make_dist: Extracting cached tools/debian/copyright...
```
This uses the cached download, and then making the tarball is rather fast (~ 10 s).