### PR TITLE
Restyle language menu to select

### DIFF
--- a/pkg/lib/menu-select-widget.scss
+++ b/pkg/lib/menu-select-widget.scss
@@ -1,0 +1,35 @@
+// FIXME: Remove this custom implementation once a component exists upstream.
+// PF overrides to fake a multiselect widget (as one does not currently exist in PF4).
+// A menu gives us the interaction we want, but the styling is a bit off.
+// Therefore, we're changing the visuals here locally.
+// PF4 upstream request for multi-select @ https://github.com/patternfly/patternfly/issues/4027
+.ct-menu-select-widget.pf-c-menu {
+    // It's  not really a menu, so it shouldn't have a shadow
+    box-shadow: none;
+
+    // Divider is silly between the widgets in this context
+    .pf-c-divider {
+        display: none;
+    }
+
+    &__content {
+        // An overflow multi-select widget needs an outline
+        border: 1px solid var(--pf-global--BorderColor--100);
+        // There should be minimal space between the widgets (replacing the divider)
+        margin-top: var(--pf-global--spacer--sm);
+    }
+
+    // Search should not be inset when there's no border containing it
+    &__search {
+        padding: 0;
+    }
+
+    // Keep the background on a selected item even when it doesn't have
+    // focus, allowing keyboard control to have the only background color
+    // when active but also keep the background color when the list loses
+    // focus (such as when the keyboard or mouse navigates outside,
+    // including initial rendering of the list.
+    &__list:not(:focus-within) .pf-m-selected {
+        background-color: var(--pf-c-menu__list-item--hover--BackgroundColor);
+    }
+}

--- a/pkg/lib/menu-select-widget.scss
+++ b/pkg/lib/menu-select-widget.scss
@@ -12,7 +12,7 @@
         display: none;
     }
 
-    &__content {
+    .pf-c-menu__content {
         // An overflow multi-select widget needs an outline
         border: 1px solid var(--pf-global--BorderColor--100);
         // There should be minimal space between the widgets (replacing the divider)
@@ -20,7 +20,7 @@
     }
 
     // Search should not be inset when there's no border containing it
-    &__search {
+    .pf-c-menu__search {
         padding: 0;
     }
 
@@ -29,7 +29,7 @@
     // when active but also keep the background color when the list loses
     // focus (such as when the keyboard or mouse navigates outside,
     // including initial rendering of the list.
-    &__list:not(:focus-within) .pf-m-selected {
+    .pf-c-menu__list:not(:focus-within) .pf-m-selected {
         background-color: var(--pf-c-menu__list-item--hover--BackgroundColor);
     }
 }

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -22,6 +22,7 @@ import React from "react";
 import {
     Button,
     Divider,
+    Flex,
     Menu, MenuList, MenuItem, MenuContent, MenuInput,
     Modal,
     TextInput,
@@ -94,31 +95,33 @@ export class LangModal extends React.Component {
                        <Button variant='link' onClick={this.props.onClose}>{_("Cancel")}</Button>
                    </>}
             >
-                <p>{_("Choose the language to be used in the application")}</p>
-                <Menu id="display-language-list"
-                      onSelect={(_, selected) => this.setState({ selected })}
-                      activeItemId={this.state.selected}
-                      selected={this.state.selected}>
-                    <MenuInput>
-                        <TextInput
-                            value={this.state.searchInput}
-                            aria-label={_("Filter menu items")}
-                            iconVariant="search"
-                            type="search"
-                            onChange={searchInput => this.setState({ searchInput })}
-                        />
-                    </MenuInput>
-                    <Divider />
-                    <MenuContent>
-                        <MenuList>
-                            {Object.keys(manifest.locales || { })
-                                    .filter(key => !this.state.searchInput || manifest.locales[key].toLowerCase().includes(this.state.searchInput.toString().toLowerCase()))
-                                    .map(key => {
-                                        return <MenuItem itemId={key} key={key} data-value={key}>{manifest.locales[key]}</MenuItem>;
-                                    })}
-                        </MenuList>
-                    </MenuContent>
-                </Menu>
+                <Flex direction={{ default: 'column' }}>
+                    <p>{_("Choose the language to be used in the application")}</p>
+                    <Menu id="display-language-list"
+                          onSelect={(_, selected) => this.setState({ selected })}
+                          activeItemId={this.state.selected}
+                          selected={this.state.selected}>
+                        <MenuInput>
+                            <TextInput
+                                value={this.state.searchInput}
+                                aria-label={_("Filter menu items")}
+                                iconVariant="search"
+                                type="search"
+                                onChange={searchInput => this.setState({ searchInput })}
+                            />
+                        </MenuInput>
+                        <Divider />
+                        <MenuContent>
+                            <MenuList>
+                                {Object.keys(manifest.locales || { })
+                                        .filter(key => !this.state.searchInput || manifest.locales[key].toLowerCase().includes(this.state.searchInput.toString().toLowerCase()))
+                                        .map(key => {
+                                            return <MenuItem itemId={key} key={key} data-value={key}>{manifest.locales[key]}</MenuItem>;
+                                        })}
+                            </MenuList>
+                        </MenuContent>
+                    </Menu>
+                </Flex>
             </Modal>);
     }
 }

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -28,6 +28,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
+import "menu-select-widget.scss";
 import "form-layout.scss";
 
 const _ = cockpit.gettext;
@@ -98,6 +99,7 @@ export class LangModal extends React.Component {
                 <Flex direction={{ default: 'column' }}>
                     <p>{_("Choose the language to be used in the application")}</p>
                     <Menu id="display-language-list"
+                          className="ct-menu-select-widget"
                           onSelect={(_, selected) => this.setState({ selected })}
                           activeItemId={this.state.selected}
                           selected={this.state.selected}>

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -84,7 +84,7 @@ export class LangModal extends React.Component {
         const manifest = cockpit.manifests.shell || { };
 
         return (
-            <Modal isOpen position="top" variant="medium"
+            <Modal isOpen position="top" variant="small"
                    id="display-language-modal"
                    className="display-language-modal"
                    onClose={this.props.onClose}

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -127,10 +127,46 @@ html.index-page body {
         max-height: 20rem;
         overflow: auto;
     }
-}
 
-#display-language-list {
-    margin-bottom: var(--pf-global--spacer--sm);
+    p:not(:last-child) {
+        // Since we're using PF3 and it redefines several base elements, reset it to what PF4 does by default
+        margin-bottom: var(--pf-global--spacer--md);
+    }
+
+    // PF overrides to fake a multiselect widget (as one does not currently exist in PF4).
+    // A menu gives us the interaction we want, but the styling is a bit off.
+    // Therefore, we're changing the visuals here locally.
+    // PF4 upstream request for multi-select @ https://github.com/patternfly/patternfly/issues/4027
+    .pf-c-menu {
+        // It's  not really a menu, so it shouldn't have a shadow
+        box-shadow: none;
+
+        // Divider is silly between the widgets in this context
+        .pf-c-divider {
+            display: none;
+        }
+
+        &__content {
+            // An overflow multi-select widget needs an outline
+            border: 1px solid var(--pf-global--BorderColor--100);
+            // There should be minimal space between the widgets (replacing the divider)
+            margin-top: var(--pf-global--spacer--sm);
+        }
+
+        // Search should not be inset when there's no border containing it
+        &__search {
+            padding: 0;
+        }
+
+        // Keep the background on a selected item even when it doesn't have
+        // focus, allowing keyboard control to have the only background color
+        // when active but also keep the background color when the list loses
+        // focus (such as when the keyboard or mouse navigates outside,
+        // including initial rendering of the list.
+        &__list:not(:focus-within) .pf-m-selected {
+            background-color: var(--pf-c-menu__list-item--hover--BackgroundColor);
+        }
+      }
 }
 
 iframe.container-frame {

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -128,11 +128,6 @@ html.index-page body {
         overflow: auto;
     }
 
-    p:not(:last-child) {
-        // Since we're using PF3 and it redefines several base elements, reset it to what PF4 does by default
-        margin-bottom: var(--pf-global--spacer--md);
-    }
-
     // PF overrides to fake a multiselect widget (as one does not currently exist in PF4).
     // A menu gives us the interaction we want, but the styling is a bit off.
     // Therefore, we're changing the visuals here locally.

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -127,41 +127,6 @@ html.index-page body {
         max-height: 20rem;
         overflow: auto;
     }
-
-    // PF overrides to fake a multiselect widget (as one does not currently exist in PF4).
-    // A menu gives us the interaction we want, but the styling is a bit off.
-    // Therefore, we're changing the visuals here locally.
-    // PF4 upstream request for multi-select @ https://github.com/patternfly/patternfly/issues/4027
-    .pf-c-menu {
-        // It's  not really a menu, so it shouldn't have a shadow
-        box-shadow: none;
-
-        // Divider is silly between the widgets in this context
-        .pf-c-divider {
-            display: none;
-        }
-
-        &__content {
-            // An overflow multi-select widget needs an outline
-            border: 1px solid var(--pf-global--BorderColor--100);
-            // There should be minimal space between the widgets (replacing the divider)
-            margin-top: var(--pf-global--spacer--sm);
-        }
-
-        // Search should not be inset when there's no border containing it
-        &__search {
-            padding: 0;
-        }
-
-        // Keep the background on a selected item even when it doesn't have
-        // focus, allowing keyboard control to have the only background color
-        // when active but also keep the background color when the list loses
-        // focus (such as when the keyboard or mouse navigates outside,
-        // including initial rendering of the list.
-        &__list:not(:focus-within) .pf-m-selected {
-            background-color: var(--pf-c-menu__list-item--hover--BackgroundColor);
-        }
-      }
 }
 
 iframe.container-frame {


### PR DESCRIPTION
The language selection dialog now looks like this in the PR:
![Screenshot_2021-04-26 Esittely - garrett Rain](https://user-images.githubusercontent.com/10246/116112051-7c536c00-a6b7-11eb-8a93-9fa0e852d761.png)

I've worked on interactions a little too. Check out background override with the `:focus-within` selector. It improves both keyboard and mouse usage, keeping the background highlight on the selected item even when something else is being selected or when the focus is outside of the list.