### PR TITLE
storaged: Check for udisks manager proxy failure

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -505,7 +505,15 @@ function init_model(callback) {
     Promise.allSettled([client.manager.wait(),
         client.mdraids.wait(), client.vgroups.wait(), client.drives.wait(),
         client.blocks.wait(), client.blocks_ptable.wait(), client.blocks_lvm2.wait(), client.blocks_fsys.wait()
-    ]).then(() => {
+    ]).then(results => {
+        // we at least need the manager object; if it doesn't exist, wait for the next proxy onchanged
+        if (results[0].status !== 'fulfilled') {
+            console.warn("init_model(): udisks manager proxy failed:", JSON.stringify(results[0].reason));
+            client.features = false;
+            callback();
+            return;
+        }
+
         pull_time().then(function() {
             enable_features().then(function() {
                 query_fsys_info().then(function(fsys_info) {
@@ -841,7 +849,8 @@ client.init = function init_storaged(callback) {
                                         "/org/freedesktop/UDisks2/Manager", { watch: true });
 
     udisks_manager.wait().then(() => init_client(udisks_manager, callback))
-            .catch(() => {
+            .catch(ex => {
+                console.warn("client.init(): udisks manager proxy failed:", JSON.stringify(ex));
                 client.features = false;
                 callback();
             });


### PR DESCRIPTION
If the client.manager.wait() is rejected, the following initializations
then can't detect any features, which sets client.features = {}. This
tricks the UI into thinking that initialization is complete, but nothing
really works: There are no known features or file systems.

To make this less hilariously hard to debug, do the same as
client.init() does on a wait failure and return `client.features =
false`. This keeps the overview page in the "initialization" empty
state.

If there is a "changed" signal from the manager proxy after that, it
will then re-trigger the initialization properly. Otherwise, the page
remains in "Storage can not be managed on this system", which is more
honest than offering broken dialogs everywhere.

----

Spotted in https://github.com/cockpit-project/bots/pull/1952 where various storage tests fail very often. See
the debugging odyssey [in the ubuntu-stable image refresh](https://github.com/cockpit-project/bots/pull/1952#issuecomment-827310787) and below for details.

The root cause of this was fixed in PR #15761 , but this is still a nice robustification IMHO.