### PR TITLE
lib: Drop redundant error message in alert modals

### DIFF
--- a/pkg/lib/cockpit-components-inline-notification.jsx
+++ b/pkg/lib/cockpit-components-inline-notification.jsx
@@ -89,7 +89,7 @@ InlineNotification.propTypes = {
 export const ModalError = ({ dialogError, dialogErrorDetail }) => {
     return (
         <Alert variant='danger' isInline title={dialogError}>
-            { dialogErrorDetail && <p> {_("Error message")}: <samp>{dialogErrorDetail}</samp> </p> }
+            { dialogErrorDetail && <p> {dialogErrorDetail} </p> }
         </Alert>
     );
 };

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -479,7 +479,7 @@ class TestFirewall(NetworkCase):
         addServiceToZone("pop3", "home")
         removeZone("home")
 
-        addZone("work", sources="totally invalid address", error="Error message: org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
+        addZone("work", sources="totally invalid address", error="org.fedoraproject.FirewallD1.Exception: INVALID_ADDR: totally invalid address")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Alerts are already visibly errors and provide ARIA to screen readers.

Additionally, `<kbd>` is not passed to screen readers in any special way.
By default, `<kbd>` just unnessarily changes the font to mono.