### PR TITLE
test: Fix initial expected memory in TestServices.testBasic

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -412,7 +412,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog.awk
         b.wait_not_present("#memory")
         m.execute("systemctl start mem-hog.service")
         initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
-        self.assertGreater(initial_memory, 1)
+        self.assertGreater(initial_memory, 0.5)
         m.execute("touch /tmp/continue")
         # MemoryCurrent auto-updates every 30s - default timeout is 60s - when it updates the memory used should be ~50MiB
         b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)


### PR DESCRIPTION
This often starts out with being exactly "1.0 MB", which fails the
previous condition. There is no particular expectation how much memory
this initially uses, so just reduce it.

----

I've seen this at least twice today, most recently [here](https://logs.cockpit-project.org/logs/pull-15761-20210429-145258-8dad8c4e-rhel-8-5/log.html#252)