### PR TITLE
lib: Remove duplicate css rule

### DIFF
--- a/pkg/lib/ct-card.scss
+++ b/pkg/lib/ct-card.scss
@@ -34,11 +34,6 @@
   font-size: var(--pf-global--FontSize--2xl);
 }
 
-// Remove redundant padding from embedded toolbars (handled by header)
-.ct-card.pf-c-card .pf-c-toolbar {
-  padding: 0;
-}
-
 // Remove excess top padding from top-level empty state in cards,
 // as card headers already add enough space
 .ct-card > .pf-c-card__body > .pf-c-empty-state {


### PR DESCRIPTION
This exact same rule is defined a few lines below once again.