### PR TITLE
base1: Fix D-Bus watch tests

### DIFF
--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -718,7 +718,7 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
         var cache = { };
 
         var dbus = cockpit.dbus(bus_name, channel_options);
-        const onnotify = (event, data) => Object.assign(cache, data);
+        const onnotify = (event, data) => deep_update(cache, data);
         dbus.addEventListener("notify", onnotify);
 
         dbus.watch({ path_namespace: "/otree" })
@@ -749,7 +749,7 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
         const cache = { };
 
         const dbus = cockpit.dbus(bus_name, channel_options);
-        const onnotify_cache = (event, data) => Object.assign(cache, data);
+        const onnotify_cache = (event, data) => deep_update(cache, data);
         dbus.addEventListener("notify", onnotify_cache);
 
         const onnotify_test = (event, data) => {


### PR DESCRIPTION
Similarly to commit dc2aaff1ab82c26898, the other two D-Bus watch tests
need a deep update of the cache as well. After commit 4e5a309f0af the
order of the messages changed (often), and we could get the "empty"
state updates after the "real" one.