### PR TITLE
make dist fixes, allow building in a minimal environment, re-enable packit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -290,10 +290,6 @@ recheck-memory: valgrind-suppressions
 
 if ENABLE_DOC
 
-include doc/Makefile-doc.am
-include doc/guide/Makefile-guide.am
-include doc/man/Makefile-man.am
-
 dist-doc-hook:
 	@true
 
@@ -389,3 +385,6 @@ include src/tls/Makefile-tls.am
 include src/retest/Makefile.am
 include src/pam-ssh-add/Makefile.am
 include containers/Makefile.am
+include doc/Makefile-doc.am
+include doc/guide/Makefile-guide.am
+include doc/man/Makefile-man.am

--- a/configure.ac
+++ b/configure.ac
@@ -156,9 +156,6 @@ AM_CONDITIONAL(WITH_COCKPIT_SSH, test "$enable_ssh" = "yes")
 AC_CHECK_HEADER([security/pam_appl.h], ,
   [AC_MSG_ERROR([Couldn't find PAM headers. Try installing pam-devel])]
 )
-AC_CHECK_LIB(pam, pam_open_session, [ true ],
-  [AC_MSG_ERROR([Couldn't find PAM library. Try installing pam-devel])]
-)
 PAM_LIBS="-lpam"
 COCKPIT_SESSION_LIBS="$COCKPIT_SESSION_LIBS $PAM_LIBS"
 COCKPIT_WS_LIBS="$COCKPIT_WS_LIBS $PAM_LIBS"

--- a/configure.ac
+++ b/configure.ac
@@ -216,11 +216,6 @@ fi
 
 AM_CONDITIONAL([ENABLE_PCP], [test "$enable_pcp" = "yes"])
 
-# gssapi
-AC_CHECK_LIB(gssapi_krb5, gss_store_cred, [ true ],
-  [AC_MSG_ERROR([Couldn't find GSSAPI KRB5 library. Try installing krb5-devel])]
-)
-
 # systemd
 AC_ARG_WITH([systemdunitdir], [AC_HELP_STRING([--with-systemdunitdir=DIR],
                                               [directory to install systemd unit files in])])

--- a/doc/Makefile-doc.am
+++ b/doc/Makefile-doc.am
@@ -3,8 +3,12 @@ EXTRA_DIST += \
 	doc/cockpit-transport.png \
 	$(NULL)
 
+if ENABLE_DOC
+
 render-doc-images:
 	 inkscape --without-gui --export-area-page \
 		--export-width=1280 --export-height=960 \
 		--export-png=$(srcdir)/doc/cockpit-transport.png \
 		$(srcdir)/doc/cockpit-transport.svg
+
+endif

--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -1,4 +1,3 @@
-
 GUIDE_DOCBOOK = doc/guide/cockpit-guide.xml
 
 GUIDE_INCLUDES = \
@@ -80,6 +79,8 @@ EXTRA_DIST += \
 	doc/guide/version.in \
 	$(NULL)
 
+if ENABLE_DOC
+
 # we require fonts from `npm install` to build the docs
 noinst_DATA += $(GUIDE_HTML($SKIP_NODE))
 
@@ -122,3 +123,5 @@ check-local::
 		echo "Unexpected generated id in the documentation" >&2; \
 		exit 1; \
 	fi
+
+endif

--- a/doc/man/Makefile-man.am
+++ b/doc/man/Makefile-man.am
@@ -1,9 +1,19 @@
-man_MANS += \
-	doc/man/cockpit-bridge.1 \
+EXTRA_DIST += \
+	doc/man/cockpit.xml \
+	doc/man/cockpit-bridge.xml \
+	doc/man/cockpit-ws.xml \
+	doc/man/cockpit-tls.xml \
+	doc/man/cockpit-desktop.xml \
+	doc/man/cockpit.conf.xml \
+	doc/man/pam_cockpit_cert.xml \
+	doc/man/pam_ssh_add.xml \
+	doc/man/remotectl.xml \
 	$(NULL)
 
-EXTRA_DIST += \
-	doc/man/cockpit-bridge.xml \
+if ENABLE_DOC
+
+man_MANS += \
+	doc/man/cockpit-bridge.1 \
 	$(NULL)
 
 man_MANS += \
@@ -17,17 +27,6 @@ man_MANS += \
 	doc/man/remotectl.8 \
 	$(NULL)
 
-EXTRA_DIST += \
-	doc/man/cockpit.xml \
-	doc/man/cockpit-ws.xml \
-	doc/man/cockpit-tls.xml \
-	doc/man/cockpit-desktop.xml \
-	doc/man/cockpit.conf.xml \
-	doc/man/pam_cockpit_cert.xml \
-	doc/man/pam_ssh_add.xml \
-	doc/man/remotectl.xml \
-	$(NULL)
-
 MAN_PROC = $(MKDIR_P) doc/man/ && $(XSLTPROC) -nonet --param man.output.quietly 1 --output $@ \
 	http://docbook.sourceforge.net/release/xsl/current/manpages/docbook.xsl $<
 
@@ -37,3 +36,5 @@ MAN_PROC = $(MKDIR_P) doc/man/ && $(XSLTPROC) -nonet --param man.output.quietly 
 	$(AM_V_GEN) $(MAN_PROC)
 .xml.5:
 	$(AM_V_GEN) $(MAN_PROC)
+
+endif ENABLE_DOC

--- a/packit.yaml
+++ b/packit.yaml
@@ -6,7 +6,7 @@ actions:
     - sh -c 'sed "s/%{npm-version:.*}/0/" tools/cockpit.spec > cockpit.spec'
     # this is being triggered immediately on a pull_request event; wait for
     # build-dist.yml to generate the dist tarball
-    - test/make_dist.py --wait
+    - env AUTOGEN_CONFIGURE_ARGS='--disable-polkit --disable-ssh --disable-pcp --disable-doc --with-systemdunitdir=/invalid CPPFLAGS=-Itools/mock-build-env PKG_CONFIG_PATH=$PWD/tools/mock-build-env' test/make_dist.py --wait
     # packit service insists of a single line of output
     - sh -c 'ls cockpit-*.tar.xz'
 jobs:

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -255,15 +255,17 @@ EXTRA_DIST += \
 # -----------------------------------------------------------------------------
 # polkit
 
+# make sure this ends up in the tarball, even with --disable-ssh
+polkit_in_files  = src/bridge/org.cockpit-project.cockpit-bridge.policy.in
+EXTRA_DIST += $(polkit_in_files)
+
 if WITH_POLKIT
 polkitdir        = $(datadir)/polkit-1/actions
-polkit_in_files  = src/bridge/org.cockpit-project.cockpit-bridge.policy.in
 polkit_DATA = $(polkit_in_files:.policy.in=.policy)
 
 %.policy: %.policy.in $(PO_FILES)
 	GETTEXTDATADIRS=$(srcdir)/po $(MSGFMT) --xml -d $(top_srcdir)/po --template $< --output $@
 
-EXTRA_DIST += $(polkit_in_files)
 CLEANFILES += $(polkit_DATA)
 endif
 

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -1,3 +1,16 @@
+EXTRA_DIST += \
+	src/ssh/mock_rsa_key \
+	src/ssh/mock_dsa_key \
+	src/ssh/test_rsa \
+	src/ssh/test_rsa.pub \
+	src/ssh/mock_known_hosts \
+	src/ssh/mock-pid-cat \
+	src/ssh/mock-bin/sss_ssh_knownhostsproxy \
+	src/ssh/mock-config \
+	src/ssh/invalid_known_hosts \
+	src/ssh/mock_known_hosts_2 \
+	$(NULL)
+
 if WITH_COCKPIT_SSH
 
 noinst_LIBRARIES += libcockpit-ssh.a
@@ -68,19 +81,6 @@ noinst_DATA += test_rsa_key
 
 CLEANFILES += \
 	test_rsa_key \
-	$(NULL)
-
-EXTRA_DIST += \
-	src/ssh/mock_rsa_key \
-	src/ssh/mock_dsa_key \
-	src/ssh/test_rsa \
-	src/ssh/test_rsa.pub \
-	src/ssh/mock_known_hosts \
-	src/ssh/mock-pid-cat \
-	src/ssh/mock-bin/sss_ssh_knownhostsproxy \
-	src/ssh/mock-config \
-	src/ssh/invalid_known_hosts \
-	src/ssh/mock_known_hosts_2 \
 	$(NULL)
 
 noinst_SCRIPTS += \

--- a/tools/mock-build-env/README.md
+++ b/tools/mock-build-env/README.md
@@ -1,0 +1,5 @@
+These are some stub pkg-config and include files that allow us to run
+`make dist` in a restricted build environment without the regular build
+dependencies, in particular [Packit](https://packit.dev/)'s [sandcastle container](https://github.com/packit/sandcastle).
+
+These are used in [packit.yaml](./packit.yaml).

--- a/tools/mock-build-env/gnutls.pc
+++ b/tools/mock-build-env/gnutls.pc
@@ -1,0 +1,3 @@
+Name: GnuTLS
+Description: Mock PC for gnutls
+Version: 3.6.12.fake

--- a/tools/mock-build-env/json-glib-1.0.pc
+++ b/tools/mock-build-env/json-glib-1.0.pc
@@ -1,0 +1,3 @@
+Name: JSON-GLib
+Description: Mock PC for json-glib
+Version: 1.6.fake

--- a/tools/mock-build-env/krb5-gssapi.pc
+++ b/tools/mock-build-env/krb5-gssapi.pc
@@ -1,0 +1,3 @@
+Name: krb5-gssapi
+Description: Mock PC for krb5-gssapi
+Version: 1.18.2.fake

--- a/tools/mock-build-env/krb5.pc
+++ b/tools/mock-build-env/krb5.pc
@@ -1,0 +1,3 @@
+Name: krb5
+Description: Fake PC for krb5
+Version: 1.18.2.fake

--- a/tools/mock-build-env/security/pam_appl.h
+++ b/tools/mock-build-env/security/pam_appl.h
@@ -1,0 +1,1 @@
+/* stub header to satisfy configure check */


### PR DESCRIPTION
This re-enables packit tests after commit c4908fe050dda.

This is a hack, but at least we have all our tests to tell us when we break this again.

- [ ] ~add some missing build dependencies to sandcastle container: https://github.com/packit/sandcastle/pull/122~