### PR TITLE
build: Fix `make dist` to preserve time stamps

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -207,9 +207,9 @@ package-lock.json: package.json
 
 install-data-local:: $(WEBPACK_INSTALL) $(MANIFESTS)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
-	$(V_TAR) tar -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+	$(V_TAR) tar --format=posix -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)
-	$(V_TAR) tar -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
+	$(V_TAR) tar --format=posix -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
 uninstall-local::
 	test ! -d $(DESTDIR)$(pkgdatadir) || \
 	  (find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \; && \
@@ -218,7 +218,7 @@ uninstall-local::
 	  (find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete && \
 	   find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_TEST_DEPS) $(MANIFESTS)
-	$(V_TAR) tar -cf - $^ | tar -C $(distdir) -xf -
+	$(V_TAR) tar --format=posix -cf - $^ | tar -C $(distdir) -xf -
 	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README
 	$(srcdir)/tools/build-copying $(distdir) > $(distdir)/COPYING.node
 
@@ -332,7 +332,7 @@ tools/debian/copyright: tools/debian/copyright.template $(MANIFESTS)
 # also automatically update minimum base dependency in RPM spec file
 dist-hook:: $(MANIFESTS)
 	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
-		tar -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
+		tar --format=posix -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -101,10 +101,6 @@ def download_cache(wait=False):
         message(f"make_dist: Extracting cached {unpack_path}...")
         p_git = subprocess.Popen(["git", "--git-dir", dist_git_checkout, "archive", tag, unpack_path],
                                  stdout=subprocess.PIPE)
-        # HACK: tar --touch does not deal with sub-second file mtimes, which can invert the relative mtime
-        # of package-lock.json vs. dist/*/manifest.json. Until this gets investigated/fixed properly, make sure that
-        # the files are at least one second apart
-        time.sleep(1)
         subprocess.check_call(["tar", "-x", "--touch"], stdin=p_git.stdout)
         result = p_git.wait()
         assert result == 0


### PR DESCRIPTION
When using cached dist/ files, `make dist` is very fast, and files are
often much less than one second apart. Copying files to the temporary
dist tree with plain `tar` dropped the sub-second mtimes, which often
leads to inverted mtime ordering. E.g. while the ordering is correct in
the build tree:

    $ stat -c %y package-lock.json  dist/shell/manifest.json
    2021-05-03 15:58:09.164707531 +0200
    2021-05-03 15:58:09.256708795 +0200

the manifest.json's mtime got stored as "15:58:09" in the generated
`make dist` tarball, and suddenly become older than package-lock.json.

This caused build failures in environments without npm/node (like during
RPM package build).

Consistently use the POSIX tar format when copying file trees around, so
that all files are copied with exact mtimes. This replaces the
`sleep(1)` hack from commit 62eeb7e001.

-----

Triggering tests manually to wait for publish-dist and actually use the dist cache.