### PR TITLE
workflows: Go back to tarball artifact output in build-dist

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -18,15 +18,10 @@ jobs:
       - name: Run unit-tests container to build dist
         run: |
           sudo containers/unit-tests/start dist
-          tar --strip-components=1 -xf tmp/dist/cockpit-*.tar.xz
 
       - name: Create dist artifact
         uses: actions/upload-artifact@v2
         with:
           name: dist
-          path: |
-            dist/
-            node_modules/
-            package-lock.json
-            tools/debian/copyright
+          path: tmp/dist/cockpit-*.tar.xz
           retention-days: 1

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -17,7 +17,7 @@ jobs:
           name: dist
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
-          path: dist-repo
+          path: dist-unpack
 
       - name: Set up configuration and secrets
         run: |
@@ -29,9 +29,24 @@ jobs:
       - name: Commit to dist repo
         run: |
           set -ex
+          mkdir dist-repo
           cd dist-repo
+          TARS=(../dist-unpack/cockpit-*.tar.xz)
+          if [ "${#TARS[@]}" -ne 1 ]; then
+              echo "Expected exactly one tarball" >&2
+              exit 1
+          fi
+          tar --strip-components=1 -xf "${TARS[0]}"
+
+          # prevent any sneaky/buggy stuff from build-dist
+          danger="$(find -maxdepth 1 -name '.git*')"
+          if [ -n "$danger" ]; then
+              printf "Unexpected files in dist artifact:\n%s\n" "$danger" >&2
+              exit 1
+          fi
+
           git init
-          git add .
+          git add dist/ node_modules/ package-lock.json tools/debian/copyright
           git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
           tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"


### PR DESCRIPTION
While putting the individual files into the artifact zip works (done in
commit cf04588de554fa6), the artifact becomes much bigger (8.5 MB → 39
MB), much slower to create/upload (1 s → 40s [sic]), and also slower to
download/unpack (1 s → 13s).

So go back to storing the entire dist tarball as artifact (we already
have it anyway), and move the file selection to publish-dist.

-----

Tested on my fork. Compare the step times and artifact sizes of [build-dist](https://github.com/martinpitt/cockpit/runs/2493417211?check_suite_focus=true) and [publish-dist](https://github.com/martinpitt/cockpit/runs/2493492640?check_suite_focus=true) against a [build-dist](https://github.com/cockpit-project/cockpit/runs/2493135975?check_suite_focus=true) and [publish-dist](https://github.com/cockpit-project/cockpit/runs/2493208898?check_suite_focus=true) run on master.

I tested `GITHUB_BASE=martinpitt/cockpit test/image-prepare -q fedora-34` in a clean tree, and that correctly downloads and uses the cache, and successfully builds an image.