### PR TITLE
containers: Adjust label commands in cockpit/ws Dockerfile to follow man page example

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -11,9 +11,9 @@ RUN echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview
 # Again see above ... we do our branching in shell script
 RUN /container/install-package.sh && /container/prep-container.sh
 
-LABEL INSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-install IMAGE"
-LABEL UNINSTALL="/usr/bin/docker run --rm --privileged -v /:/host IMAGE /container/atomic-uninstall"
-LABEL RUN="/usr/bin/docker run -d --name NAME --privileged --pid=host -v /:/host IMAGE /container/atomic-run --local-ssh"
+LABEL INSTALL="/usr/bin/docker run --rm --privileged -v /:/host -e IMAGE=\${IMAGE} \${IMAGE} /container/atomic-install \${IMAGE}"
+LABEL UNINSTALL="/usr/bin/docker run --rm --privileged -v /:/host -e IMAGE=\${IMAGE} \${IMAGE} /container/atomic-uninstall"
+LABEL RUN="/usr/bin/docker run -d --name \${NAME} --privileged --pid=host -v /:/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} /container/atomic-run --local-ssh"
 
 # Look ma, no EXPOSE
 


### PR DESCRIPTION
The label commands where adjusted to contain IMAGE and NAME as env variables.
With newer podman, these are apparently just passed into the environment of the
docker run call itself, instead of being string-substituted on the command line.

See containers/podman#10192