### PR TITLE
tools: Dynamically manage motd/issue symlinks in package scripts

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -537,6 +537,57 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")
 
+    @skipImage("Can't remove/upgrade packages on OSTree", "fedora-coreos")
+    def testWsPackage(self):
+        m = self.machine
+
+        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+            # clean up debug symbols, they get in the way of upgrading
+            m.execute("dpkg --purge cockpit-ws-dbgsym")
+        elif m.image.startswith("rhel"):
+            # subscription-manager-cockpit depends on cockpit-ws
+            m.execute("rpm --erase subscription-manager-cockpit")
+
+        def install():
+            if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+                m.execute("dpkg --install /var/tmp/build-results/cockpit-ws_*.deb")
+            else:
+                # FIXME: current package complains about mode change on /run/cockpit and selinux
+                m.execute("if rpm -q cockpit-ws; then rpm -V --nomode cockpit-ws; fi")
+                m.execute("rpm --upgrade --force /var/tmp/build-results/cockpit-ws-*.rpm")
+                m.execute("rpm -V --nomode cockpit-ws")
+
+        def remove():
+            if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+                m.execute("dpkg --purge cockpit cockpit-ws")
+            else:
+                m.execute("rpm --erase cockpit cockpit-ws")
+
+        # upgrade from distro version (our images have cockpit-ws preinstalled) sets up dynamic motd/issue symlink
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
+        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+
+        # package upgrade keeps them
+        install()
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
+        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+
+        # manual change/removal is respected on upgrade
+        m.execute("ln -sf /dev/null /etc/motd.d/cockpit; rm /etc/issue.d/cockpit.issue")
+        install()
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/dev/null")
+        m.execute("test ! -e /etc/issue.d/cockpit.issue")
+
+        # removing the package cleans up the links
+        remove()
+        m.execute("test ! -e /etc/motd.d/cockpit")
+        m.execute("test ! -e /etc/issue.d/cockpit.issue")
+
+        # fresh install (most of our test images have cockpit-ws preinstalled, so the first test above does not cover that)
+        install()
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
+        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     def testCommandline(self):
         m = self.machine

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -119,10 +119,9 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
         if self.machine.image == TEST_OS_DEFAULT:
-            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+            for machine in ["machine2", "machine3"]:
+                for pkg in ["packagekit", "systemd", "playground"]:
+                    self.machines[machine].write(f"/usr/share/cockpit/{pkg}/override.json", '{ "preload": [ ] }')
         # Also, quick logouts cause async preloads to run into "ReferenceError: cockpit is not defined"
         self.disable_preload("packagekit", "playground", "systemd")
 

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -130,6 +130,10 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.machines["machine3"].execute("hostnamectl set-hostname machine3")
         self.setup_ssh_auth()
 
+        # removing machines interrupts channels
+        self.allow_restart_journal_messages()
+        self.allow_hostkey_messages()
+
     def testBasic(self):
         b = self.browser
         m2 = self.machines["machine2"]
@@ -238,9 +242,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_js_cond('window.location.pathname == "/system"')
         b.enter_page("/system", "localhost")
 
-        # removing machines interrupts channels
-        self.allow_restart_journal_messages()
-        self.allow_hostkey_messages()
         self.allow_journal_messages(".*server offered unsupported authentication methods: password public-key.*")
 
     def testBasicAsAdmin(self):
@@ -322,8 +323,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.check_discovered_addresses(b, [])
         self.check_discovered_addresses(b2, [])
 
-        self.allow_hostkey_messages()
-
     def testEdit(self):
         b = self.browser
         m1 = self.machines['machine1']
@@ -396,8 +395,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_not_present(".nav-item span[data-for='/@10.111.113.3']")
         b.wait_text(".nav-item span[data-for='/@10.111.113.2']", "admin @machine2")
 
-        self.allow_hostkey_messages()
-
     def testNoAutoconnect(self):
         b = self.browser
         m2 = self.machines["machine2"]
@@ -415,9 +412,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.relogin()
         time.sleep(60)
         self.assertNotIn(m2.execute("loginctl"), "admin")
-
-        self.allow_restart_journal_messages()
-        self.allow_hostkey_messages()
 
 
 @skipDistroPackage()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -476,8 +476,9 @@ authentication via sssd/FreeIPA.
 %dir %{_sysconfdir}/cockpit
 %config(noreplace) %{_sysconfdir}/cockpit/ws-certs.d
 %config(noreplace) %{_sysconfdir}/pam.d/cockpit
-%config %{_sysconfdir}/issue.d/cockpit.issue
-%config %{_sysconfdir}/motd.d/cockpit
+# created in %post, so that users can rm the files
+%ghost %{_sysconfdir}/issue.d/cockpit.issue
+%ghost %{_sysconfdir}/motd.d/cockpit
 %ghost /run/cockpit/motd
 %ghost %dir /run/cockpit
 %dir %{_datadir}/cockpit/motd
@@ -534,6 +535,13 @@ if %{_sbindir}/selinuxenabled 2>/dev/null; then
     %selinux_relabel_post -s %{selinuxtype}
 fi
 %endif
+
+# set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
+if [ "$1" = 1 ]; then
+    mkdir -p /etc/motd.d /etc/issue.d
+    ln -s /run/cockpit/motd /etc/motd.d/cockpit
+    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+fi
 
 %tmpfiles_create cockpit-tempfiles.conf
 %systemd_post cockpit.socket cockpit.service

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -1,6 +1,4 @@
 etc/cockpit/ws-certs.d
-etc/issue.d/cockpit.issue
-etc/motd.d/cockpit
 etc/pam.d/cockpit
 lib/systemd/system/cockpit.service
 lib/systemd/system/cockpit-motd.service

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -20,3 +20,10 @@ fi
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then
     deb-systemd-invoke try-restart cockpit.service >/dev/null || true
 fi
+
+# set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
+if [ "$1" = "configure" ] && [ -z "$2" ]; then
+    mkdir -p /etc/motd.d /etc/issue.d
+    ln -s /run/cockpit/motd /etc/motd.d/cockpit
+    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+fi

--- a/tools/debian/cockpit-ws.postrm
+++ b/tools/debian/cockpit-ws.postrm
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+#DEBHELPER#
+
+# clean up dynamic motd/issue symlinks on removal
+if [ "$1" = purge ]; then
+    [ -L /etc/motd.d/cockpit ] && rm /etc/motd.d/cockpit || true
+    [ -L /etc/issue.d/cockpit.issue ] && rm /etc/issue.d/cockpit.issue || true
+fi

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -40,6 +40,9 @@ endif
 	for d in rhel fedora centos scientific; do rm -r debian/tmp/usr/share/cockpit/branding/$$d; done
 	dpkg-vendor --derives-from ubuntu || rm -r debian/tmp/usr/share/cockpit/branding/ubuntu
 
+	# handled by package maintainer scripts
+	rm debian/tmp/etc/motd.d/cockpit debian/tmp/etc/issue.d/cockpit.issue
+
 	# unpackaged modules
 	for m in kdump selinux; do rm -r debian/tmp/usr/share/cockpit/$$m; done
 	rm debian/tmp/usr/share/metainfo/org.cockpit-project.cockpit-kdump.metainfo.xml


### PR DESCRIPTION
Users commonly want to just remove /etc/motd.d/cockpit or
/etc/issue.d/cockpit.issue, instead of symlinking them to /dev/null.
However, rpms' %config handling does not respect that, and brings back
the files on upgrade. This also raises an alarm in `rpm --verify`.

Likewise, dpkg's conffile logic only handles plain file content changes
or removals, not symlinks.

Stop packaging the symlinks, and create/remove them in the package
scrips instead.

https://bugzilla.redhat.com/show_bug.cgi?id=1876848