### PR TITLE
storage: Luks modal body fixes

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -124,7 +124,7 @@ export function clevis_recover_passphrase(block) {
             .then(output => output.trim());
 }
 
-/* Passphrase operations
+/* Passphrase and slot operations
  */
 
 function passphrase_add(block, new_passphrase, old_passphrase) {
@@ -139,19 +139,20 @@ function passphrase_change(block, key, new_passphrase, old_passphrase) {
                          { superuser: true, err: "message" }).input(old_passphrase + "\n" + new_passphrase + "\n");
 }
 
-function passphrase_remove(block, passphrase) {
-    var dev = decode_filename(block.Device);
-    return cockpit.spawn(["cryptsetup", "luksRemoveKey", dev],
-                         { superuser: true, err: "message" }).input(passphrase);
-}
+function slot_remove(block, slot, passphrase) {
+    const dev = decode_filename(block.Device);
+    const opts = { superuser: true, err: "message" };
+    const cmd = ["cryptsetup", "luksKillSlot", dev, slot.toString()];
+    if (passphrase === false) {
+        cmd.splice(2, 0, "-q");
+        opts.pty = true;
+    }
 
-/* Generic slot operations
- */
+    const spawn = cockpit.spawn(cmd, opts);
+    if (passphrase !== false)
+        spawn.input(passphrase + "\n");
 
-function slot_remove(block, slot) {
-    var dev = decode_filename(block.Device);
-    return cockpit.spawn(["cryptsetup", "luksKillSlot", "-q", dev, slot.toString()],
-                         { superuser: true, err: "message", pty: true });
+    return spawn;
 }
 
 /* Dialogs
@@ -409,10 +410,7 @@ function remove_passphrase_dialog(block, key) {
             DangerButton: true,
             Title: _("Remove"),
             action: function (vals) {
-                if (vals.passphrase === false)
-                    return slot_remove(block, key.slot);
-                else
-                    return passphrase_remove(block, vals.passphrase);
+                return slot_remove(block, key.slot, vals.passphrase);
             }
         }
     });

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -21,9 +21,10 @@ import cockpit from "cockpit";
 import React from "react";
 
 import {
-    Card, CardBody, CardTitle, CardHeader, CardActions,
+    Card, CardBody, CardTitle, CardHeader, CardActions, Checkbox,
+    Form, FormGroup,
     DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataList,
-    Text, TextVariants
+    Text, TextVariants, TextInput as TextInputPF, Stack,
 } from "@patternfly/react-core";
 import { EditIcon, MinusIcon, PlusIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
 
@@ -357,44 +358,38 @@ function edit_tang_adv(client, block, key, url, adv, passphrase) {
 }
 
 const RemovePassphraseField = (tag, key, dev) => {
+    function validate(val) {
+        if (val === "")
+            return _("Passphrase can not be empty");
+    }
+
     return {
         tag: tag,
-        title: <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="lg" />,
-        options: { },
+        title: null,
+        options: { validate: validate },
         initial_value: "",
+        bare: true,
 
-        render: (val, change) => {
-            const key_slot = cockpit.format(_("key slot $0"), key.slot);
+        render: (val, change, validated, error) => {
             return (
-                <div data-field={tag}>
-                    <h3>
-                        { fmt_to_fragments(_("Remove passphrase in $0?"), <b>{key_slot}</b>) }
-                    </h3>
+                <Stack hasGutter>
                     <p>{ fmt_to_fragments(_("Passphrase removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
-
-                    <div name="remove-passphrase" className="progressive-disclosure ct-form">
-                        <div className="form-group">
-                            <label>
-                                <input type="radio" checked={val !== false}
-                                       autoFocus
-                                       onChange={event => change("")} />
-                                {_("Confirm removal with passphrase")}
-                            </label>
-                            <input className="form-control" type="password" hidden={val === false}
-                                   value={val} onChange={event => change(event.target.value)} />
-                        </div>
-                        <div className="form-group">
-                            <label>
-                                <input type="radio" checked={val === false}
-                                       onChange={event => change(false)} />
-                                { fmt_to_fragments(_("Force remove passphrase in $0"), <b>{key_slot}</b>) }
-                            </label>
-                            <p className="slot-warning" hidden={val !== false}>
-                                Removing a passphrase without confirmation can be dangerous.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                    <Form>
+                        <Checkbox id="force-remove-passphrase"
+                                  isChecked={val !== false}
+                                  label={_("Confirm removal with an alternate passphrase")}
+                                  onChange={checked => change(checked ? "" : false)}
+                                  body={val === false
+                                      ? <p className="slot-warning">
+                                          {_("Removing a passphrase without confirmation of another passphrase may prevent unlocking or key management, if other passphrases are forgotten or lost.")}
+                                      </p>
+                                      : <FormGroup label={_("Passphrase from any other key slot")} fieldId="remove-passphrase">
+                                          <TextInputPF id="remove-passphrase" type="password" value={val} onChange={value => change(value)} />
+                                      </FormGroup>
+                                  }
+                        />
+                    </Form>
+                </Stack>
             );
         }
     };
@@ -402,10 +397,11 @@ const RemovePassphraseField = (tag, key, dev) => {
 
 function remove_passphrase_dialog(block, key) {
     dialog_open({
-        Title: _("Remove passphrase"),
+        Title: <><ExclamationTriangleIcon className="ct-icon-exclamation-triangle" /> {cockpit.format(_("Remove passphrase in key slot $0"), key.slot)}</>,
         Fields: [
             RemovePassphraseField("passphrase", key, block_name(block))
         ],
+        isFormHorizontal: false,
         Action: {
             DangerButton: true,
             Title: _("Remove"),

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -415,15 +415,16 @@ function remove_passphrase_dialog(block, key) {
 const RemoveClevisField = (tag, key, dev) => {
     return {
         tag: tag,
-        title: <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="lg" />,
+        title: null,
         options: { },
         initial_value: "",
+        bare: true,
 
         render: (val, change) => {
             return (
                 <div data-field={tag}>
-                    <h3>{ fmt_to_fragments(_("Remove $0?"), <b>{key.url}</b>) }</h3>
-                    <p>{ fmt_to_fragments(_("Keyserver removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
+                    <p>{ fmt_to_fragments(_("Remove $0?"), <b>{key.url}</b>) }</p>
+                    <p className="slot-warning">{ fmt_to_fragments(_("Keyserver removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
                 </div>
             );
         }
@@ -432,7 +433,7 @@ const RemoveClevisField = (tag, key, dev) => {
 
 function remove_clevis_dialog(client, block, key) {
     dialog_open({
-        Title: _("Remove Tang keyserver"),
+        Title: <><ExclamationTriangleIcon className="ct-icon-exclamation-triangle" /> {_("Remove Tang keyserver")}</>,
         Fields: [
             RemoveClevisField("keyserver", key, block_name(block))
         ],

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -253,7 +253,7 @@ const Row = ({ field, values, errors, onChange }) => {
         onChange(tag);
     }
 
-    const children = field.render(values[tag], change, validated);
+    const children = field.render(values[tag], change, validated, error);
 
     if (title || title == "") {
         let titleLabel = title;
@@ -271,14 +271,15 @@ const Row = ({ field, values, errors, onChange }) => {
                 { children }
             </FormGroup>
         );
-    } else {
+    } else if (!field.bare) {
         return (
             <FormGroup validated={validated}
                        helperTextInvalid={error} helperText={explanation} hasNoPaddingTop={field.hasNoPaddingTop}>
                 { children }
             </FormGroup>
         );
-    }
+    } else
+        return children;
 };
 
 function is_visible(field, values) {

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -226,7 +226,7 @@ import {
     Form, FormGroup,
     Radio,
     Select as TypeAheadSelect, SelectOption, SelectVariant,
-    Spinner,
+    Spinner, Split,
     TextInput as TextInputPF4,
     Tooltip, TooltipPosition,
 } from "@patternfly/react-core";
@@ -564,16 +564,17 @@ export const SelectOneRadio = (tag, title, options) => {
         title: title,
         options: options,
         initial_value: options.value || options.choices[0].value,
+        hasNoPaddingTop: true,
 
         render: (val, change) => {
             return (
-                <FormGroup isInline data-field={tag} data-field-type="select-radio">
+                <Split hasGutter data-field={tag} data-field-type="select-radio">
                     { options.choices.map(c => (
                         <Radio key={c.value} isChecked={val == c.value} data-data={c.value}
                             id={tag + '.' + c.value}
                             onChange={event => change(c.value)} label={c.title} />))
                     }
-                </FormGroup>
+                </Split>
             );
         }
     };

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -281,15 +281,14 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(2, 1, "ext4 file system")
         # delete second key slot
         b.click(panel + "li:nth-child(2) button[aria-label=Remove]")
-        self.dialog_wait_open()
         # do not accept the same passphrase
-        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-1")
-        self.dialog_apply()
+        b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja-1")
+        b.click("button:contains('Remove')")
         b.wait_in_text(".pf-c-alert__title", "No key available with this passphrase.")
         # delete with passphrase from slot 0
-        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja")
+        b.click("button:contains('Remove')")
+        b.wait_not_present("#remove-passphrase")
         # check that it is not possible to unlock with deleted passphrase
         self.content_dropdown_action(1, "Lock")
         b.wait_not_in_text("#detail-content", "ext4 file system")
@@ -324,17 +323,17 @@ class TestStorageLuks(StorageCase):
         slots_list = tab + " .pf-c-card ul "
         b.wait_visible(slots_list + "li:last-child button[aria-label=Remove]")
         b.click(slots_list + "li:last-child button[aria-label=Remove]")
-        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-6")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja-6")
+        b.click("button:contains('Remove')")
+        b.wait_not_present("#remove-passphrase")
         # check if buttons have become enabled after removing last slot
         b.wait_not_present(slots_list + ":disabled")
         b.wait_not_present(panel + ":disabled")
         # remove slot 0, with the original passphrase
         b.click(slots_list + "li:nth-child(1) button[aria-label=Remove]")
-        b.click(self.dialog_field("passphrase") + " label:contains(Force remove passphrase in key slot 0)")
-        self.dialog_apply()
-        self.dialog_wait_close()
+        b.click("#force-remove-passphrase")
+        b.click("button:contains('Remove')")
+        b.wait_not_present("#remove-passphrase")
         # check that it is not possible to unlock with deleted passphrase
         self.content_head_action(1, "Unlock")
         self.dialog_wait_open()

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -279,10 +279,15 @@ class TestStorageLuks(StorageCase):
         self.content_head_action(1, "Unlock")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
         self.content_row_wait_in_col(2, 1, "ext4 file system")
-        # delete second key slot by providing passphrase
+        # delete second key slot
         b.click(panel + "li:nth-child(2) button[aria-label=Remove]")
         self.dialog_wait_open()
+        # do not accept the same passphrase
         b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-1")
+        self.dialog_apply()
+        b.wait_in_text(".pf-c-alert__title", "No key available with this passphrase.")
+        # delete with passphrase from slot 0
+        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
         self.dialog_wait_close()
         # check that it is not possible to unlock with deleted passphrase
@@ -319,7 +324,7 @@ class TestStorageLuks(StorageCase):
         slots_list = tab + " .pf-c-card ul "
         b.wait_visible(slots_list + "li:last-child button[aria-label=Remove]")
         b.click(slots_list + "li:last-child button[aria-label=Remove]")
-        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-7")
+        b.set_input_text(self.dialog_field("passphrase") + " input[type=password]", "vainu-reku-toma-rolle-kaja-6")
         self.dialog_apply()
         self.dialog_wait_close()
         # check if buttons have become enabled after removing last slot

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -321,7 +321,7 @@ class TestStorageLuks(StorageCase):
 
         # remove one slot
         slots_list = tab + " .pf-c-card ul "
-        b.wait_visible(slots_list + "li:last-child button[aria-label=Remove]")
+        b.wait_visible(".pf-c-data-list__cell:contains('Slot 7')")
         b.click(slots_list + "li:last-child button[aria-label=Remove]")
         b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja-6")
         b.click("button:contains('Remove')")


### PR DESCRIPTION
- The first commit changes logic of how we remove keys. Fixes #15773

- The second commit changes UI:
Before it looked like this:
![removepassphrase](https://user-images.githubusercontent.com/12330670/117127046-e2b54a00-ad9b-11eb-894b-46b3568cbbe1.png)
Now it looks like this:
![afternewkeyslot](https://user-images.githubusercontent.com/12330670/117127097-f3fe5680-ad9b-11eb-84f8-df65e9e1e58d.png)
![forceremoval](https://user-images.githubusercontent.com/12330670/117127095-f3fe5680-ad9b-11eb-9ebe-3c694a8eaa48.png)
![uponerror](https://user-images.githubusercontent.com/12330670/117127093-f365c000-ad9b-11eb-861d-74fb05c6bc5c.png)

-The third commit fixes layout in `Add key` modal
Before it looked like this:
![lastcommitbefore](https://user-images.githubusercontent.com/12330670/117127309-358f0180-ad9c-11eb-98a0-96194fb0c766.png)
Now it looks like this:
![lastcommitfun](https://user-images.githubusercontent.com/12330670/117127260-28721280-ad9c-11eb-8b63-28a42088dce0.png)


@garrett WDYT? One thing is about 'Remaining passphrase' helper text. We probably want to mention that user should type in different passphrase, not the one that is removing. Should we just change label?

Needs tests fixes, working on them now.