### PR TITLE
metrics: Add button to enable pmlogger.service

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -19,7 +19,7 @@ import cockpit from "cockpit";
  * Initially, any of the properties can be "null" until their
  * actual values have been retrieved in the background.
  *
- * - $(proxy).on('changed', function (event) { ... })
+ * - proxy.addEventListener('changed', event => { ... })
  *
  * The 'changed' event is emitted whenever one of the properties
  * of the proxy changes.

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -17,13 +17,9 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import cockpit from 'cockpit';
 import React from 'react';
 import moment from "moment";
 
-import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
-import { ListingTable } from "cockpit-components-table.jsx";
-import { JournalOutput } from "cockpit-components-logs-panel.jsx";
 import {
     Alert,
     Breadcrumb, BreadcrumbItem,
@@ -39,11 +35,15 @@ import {
 import { Table, TableHeader, TableBody, TableGridBreakpoint, TableVariant, TableText, RowWrapper, cellWidth } from '@patternfly/react-table';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
+import cockpit from 'cockpit';
 import * as machine_info from "../lib/machine-info.js";
 import * as packagekit from "packagekit.js";
-import { install_dialog } from "cockpit-components-install-dialog.jsx";
-
 import { journal } from "journal";
+
+import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
+import { ListingTable } from "cockpit-components-table.jsx";
+import { JournalOutput } from "cockpit-components-logs-panel.jsx";
+import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import "journal.css";
 
 const MSEC_PER_H = 3600000;

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -404,16 +404,52 @@ class TestHistoryMetrics(MachineCase):
 
     @nondestructive
     @skipImage("no PCP support", "fedora-coreos")
-    def testNoData(self):
+    @skipImage("init.d script is too impredictable", "debian-stable")
+    def testNoDataEnable(self):
         b = self.browser
         m = self.machine
 
-        m.execute("systemctl stop pmlogger && mount -t tmpfs tmpfs /var/log/pcp/pmlogger")
-        self.addCleanup(m.execute, "umount /var/log/pcp/pmlogger")
+        m.execute("""systemctl stop pmlogger
+                     mount -t tmpfs tmpfs /var/log/pcp/pmlogger
+                     chown -R pcp:pcp /var/log/pcp/pmlogger
+                     restorecon /var/log/pcp/pmlogger || true""")
+        self.addCleanup(m.execute, "systemctl stop pmlogger; umount /var/log/pcp/pmlogger")
 
         self.login_and_go("/metrics")
 
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+        b.wait_in_text(".pf-c-empty-state", "pmlogger.service is not running")
+        b.click(".pf-c-empty-state button.pf-m-primary")
+
+        # there is a transient "No data available" state, but sometimes it's very short, so don't assert that
+
+        # page auto-updates every minute and starts to receive data
+        with self.browser.wait_timeout(90):
+            self.browser.wait_js_cond("ph_count('.metrics-data-cpu.valid-data') >= 1")
+
+    @nondestructive
+    @skipImage("no PCP support", "fedora-coreos")
+    def testNoDataFailed(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute(r"""systemctl stop pmlogger
+                      mount -t tmpfs tmpfs /var/log/pcp/pmlogger
+                      mkdir -p /run/systemd/system/pmlogger.service.d/
+                      printf '[Service]\nExecStart=\nExecStart=/bin/false\n' > /run/systemd/system/pmlogger.service.d/break.conf
+                      systemctl daemon-reload
+                      systemctl start pmlogger || true""")
+        self.addCleanup(m.execute,
+                """systemctl reset-failed pmlogger
+                   rm -r /run/systemd/system/pmlogger.service.d/
+                   umount /var/log/pcp/pmlogger
+                   systemctl daemon-reload""")
+
+        self.login_and_go("/metrics")
+
+        b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+        b.wait_in_text(".pf-c-empty-state", "pmlogger.service has failed")
+
         # Troubleshoot
         b.click(".pf-c-empty-state button.pf-m-link")
         b.enter_page("/system/services")


### PR DESCRIPTION
If there is no data and pmlogger.service is not running, give a more
specific message, and offer to enable/start it if the user is
privileged.

Split the test case into two cases: pmlogger is stopped (then UI for
restarting it), or it's failing or hanging (then old troubleshoot link
UI).

-----

Limited access mode, not running:
![image](https://user-images.githubusercontent.com/200109/117447443-d2d56b80-af3d-11eb-8cf8-8c63e46bb86b.png)

Superuser access, not running -- this is the common case:
![image](https://user-images.githubusercontent.com/200109/117447556-f6001b00-af3d-11eb-8697-36aa6c713e71.png)

Unit failed (permissions  don't matter):
![image](https://user-images.githubusercontent.com/200109/117447706-1cbe5180-af3e-11eb-86bc-3c040c70b4ce.png)

And finally, if there's something "weird" going on, i. e. pmlogger is running, but it does not collect any data (hopefully most users will never see this):
![image](https://user-images.githubusercontent.com/200109/117447888-598a4880-af3e-11eb-968b-e4127b8fb319.png)
