### PR TITLE
test: Allow restart messages in TestSuperuser.testBasic

### DIFF
--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -68,6 +68,8 @@ class TestSuperuser(MachineCase):
         b.leave_page()
         b.wait_text("#super-user-indicator", "Administrative access")
 
+        self.allow_restart_journal_messages()
+
     def testNoPasswd(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The test calls Browser.relogin().

---

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-15803-20210507-143509-d9ddecc7-fedora-33-firefox/log.html#198)