### PR TITLE
storage: Use FormGroup helperText consistently in dialogs

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -274,7 +274,7 @@ const Row = ({ field, values, errors, onChange }) => {
     } else {
         return (
             <FormGroup validated={validated}
-                       helperTextInvalid={error || explanation} hasNoPaddingTop={field.hasNoPaddingTop}>
+                       helperTextInvalid={error} helperText={explanation} hasNoPaddingTop={field.hasNoPaddingTop}>
                 { children }
             </FormGroup>
         );


### PR DESCRIPTION
The two uses of FormGroup in Row looked inconsistent to me re helperText, but I didn't investigate this further
