### PR TITLE
metrics: Add switch for setting up pmproxy

### DIFF
--- a/pkg/lib/cockpit-components-firewalld-request.jsx
+++ b/pkg/lib/cockpit-components-firewalld-request.jsx
@@ -1,0 +1,170 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState } from 'react';
+import {
+    Alert, AlertActionCloseButton, AlertActionLink,
+    Button,
+    Select, SelectOption,
+    Toolbar, ToolbarItem, ToolbarContent, ToolbarGroup,
+    PageSection
+} from '@patternfly/react-core';
+
+import cockpit from 'cockpit';
+import './cockpit-components-firewalld-request.scss';
+
+const _ = cockpit.gettext;
+const firewalld = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
+
+function debug() {
+    if (window.debugging == "all" || window.debugging == "firewall")
+        console.debug.apply(console, arguments);
+}
+
+/* React component for an info alert to enable some new service in firewalld.
+ * Use this when enabling some network-facing service. The alert will only be shown
+ * if firewalld is running, has at least one active zone, and the service is not enabled
+ * in any zone yet. It will allow the user to enable the service in any active zone,
+ * or go to the firewall page  for more fine-grained configuration.
+ *
+ * Properties:
+ *   - service (string, required): firewalld service name
+ *   - title (string, required): Human readable/translated alert title
+ *   - pageSection (bool, optional, default false): Render the alert inside a <PageSection>
+ */
+export const FirewalldRequest = ({ service, title, pageSection }) => {
+    const [zones, setZones] = useState(null);
+    const [selectedZone, setSelectedZone] = useState(null);
+    const [zoneSelectorOpened, setZoneSelectorOpened] = useState(false);
+    const [enabledAnywhere, setEnabledAnywhere] = useState(null);
+    const [enableError, setEnableError] = useState(null);
+    debug("FirewalldRequest", service, "zones", JSON.stringify(zones), "selected zone", selectedZone, "enabledAnywhere", enabledAnywhere);
+
+    if (!service)
+        return null;
+
+    // query zones on component initialization
+    if (zones === null) {
+        firewalld.call("/org/fedoraproject/FirewallD1", "org.fedoraproject.FirewallD1.zone", "getActiveZones")
+                .then(([info]) => {
+                    const names = Object.keys(info);
+                    // TODO: superseded by org.fedoraproject.FirewallD1.zone.getZoneSettings2, but not available on Ubuntu 20.04 yet
+                    Promise.all(names.map(name => firewalld.call("/org/fedoraproject/FirewallD1", "org.fedoraproject.FirewallD1", "getZoneSettings", [name])))
+                            .then(zoneInfos => {
+                                setEnabledAnywhere(!!zoneInfos.find(zoneInfo => zoneInfo[0][5].indexOf(service) >= 0));
+                                setZones(names);
+                            })
+                            .catch(ex => {
+                                console.warn("FirewalldRequest: getZoneSettings failed:", JSON.stringify(ex));
+                                setZones([]);
+                            });
+
+                    firewalld.call("/org/fedoraproject/FirewallD1", "org.fedoraproject.FirewallD1", "getDefaultZone")
+                            .then(([zone]) => setSelectedZone(zone))
+                            .catch(ex => console.warn("FirewalldRequest: getDefaultZone failed:", JSON.stringify(ex)));
+                })
+                .catch(ex => {
+                    // firewalld not running
+                    debug("FirewalldRequest: getActiveZones failed, considering firewall inactive:", JSON.stringify(ex));
+                    setZones([]);
+                });
+    }
+
+    const onAddService = () => {
+        firewalld.call("/org/fedoraproject/FirewallD1", "org.fedoraproject.FirewallD1.zone", "addService",
+                       [selectedZone, service, 0])
+                // permanent config
+                .then(() => firewalld.call("/org/fedoraproject/FirewallD1/config",
+                                           "org.fedoraproject.FirewallD1.config",
+                                           "getZoneByName", [selectedZone]))
+                .then(([path]) => firewalld.call(path, "org.fedoraproject.FirewallD1.config.zone", "addService", [service]))
+                // all successful, hide alert
+                .then(() => setEnabledAnywhere(true))
+                .catch(ex => {
+                    // may already be enabled in permanent config, that's ok
+                    if (ex.message && ex.message.indexOf("ALREADY_ENABLED") >= 0) {
+                        setEnabledAnywhere(true);
+                        return;
+                    }
+
+                    setEnableError(ex.toString());
+                    setEnabledAnywhere(true);
+                    console.error("Failed to enable", service, "in firewalld:", JSON.stringify(ex));
+                });
+    };
+
+    let alert;
+
+    if (enableError) {
+        alert = (
+            <Alert isInline variant="warning"
+                   title={ cockpit.format(_("Failed to enable $0 in firewalld"), service) }
+                   actionClose={ <AlertActionCloseButton onClose={ () => setEnableError(null) } /> }
+                   actionLinks={
+                       <AlertActionLink onClick={() => cockpit.jump("/network/firewall")}>
+                           { _("Visit Firewall") }
+                       </AlertActionLink>
+                   }>
+                {enableError}
+            </Alert>
+        );
+    // don't show anything if firewalld is not active, or service is already enabled somewhere
+    } else if (!zones || zones.length === 0 || !selectedZone || enabledAnywhere) {
+        return null;
+    } else {
+        alert = (
+            <Alert isInline variant="info" title={title} className="pf-u-box-shadow-sm">
+                <Toolbar className="ct-alert-toolbar">
+                    <ToolbarContent>
+                        <ToolbarGroup spaceItems={{ default: "spaceItemsMd" }}>
+                            <ToolbarItem variant="label">{ _("Zone") }</ToolbarItem>
+                            <ToolbarItem>
+                                <Select
+                                    aria-label={_("Zone")}
+                                    onToggle={isOpen => setZoneSelectorOpened(isOpen)}
+                                    isOpen={zoneSelectorOpened}
+                                    onSelect={ (e, sel) => { setSelectedZone(sel); setZoneSelectorOpened(false) } }
+                                    selections={selectedZone}
+                                    toggleId={"firewalld-request-" + service}>
+                                    { zones.map(zone => <SelectOption key={zone} value={zone}>{zone}</SelectOption>) }
+                                </Select>
+                            </ToolbarItem>
+
+                            <ToolbarItem>
+                                <Button variant="primary" onClick={onAddService}>{ cockpit.format(_("Add $0"), service) }</Button>
+                            </ToolbarItem>
+                        </ToolbarGroup>
+
+                        <ToolbarItem variant="separator" />
+
+                        <ToolbarItem>
+                            <Button variant="link" onClick={() => cockpit.jump("/network/firewall")}>
+                                { _("Visit Firewall") }
+                            </Button>
+                        </ToolbarItem>
+                    </ToolbarContent>
+                </Toolbar>
+            </Alert>
+        );
+    }
+
+    if (pageSection)
+        return <PageSection className="ct-no-bottom-padding">{alert}</PageSection>;
+    else
+        return alert;
+};

--- a/pkg/lib/cockpit-components-firewalld-request.scss
+++ b/pkg/lib/cockpit-components-firewalld-request.scss
@@ -1,0 +1,11 @@
+@import "@patternfly/patternfly/utilities/BoxShadow/box-shadow.css";
+
+.pf-c-page__main-section.ct-no-bottom-padding {
+    --pf-c-page__main-section--PaddingBottom: 0;
+}
+
+// <Toolbar> embedded into an <Alert>
+.pf-c-toolbar.ct-alert-toolbar {
+    --pf-c-toolbar--BackgroundColor: transparent;
+    --pf-c-toolbar--PaddingBottom: 0;
+}

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -938,7 +938,7 @@ const PCPConfig = ({ buttonVariant }) => {
                    footer={<>
                        { dialogError && <ModalError dialogError={ _("Failed to configure PCP") } dialogErrorDetail={dialogError} /> }
 
-                       <Button variant='primary' onClick={handleSave} isDisabled={pending}>
+                       <Button variant='primary' onClick={handleSave} isDisabled={pending} isLoading={pending}>
                            { _("Save") }
                        </Button>
                        <Button variant='link' className='btn-cancel' onClick={ () => setDialogVisible(false) }>

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -1,6 +1,7 @@
 @import "../lib/page.scss";
 @import "../lib/ct-card.scss";
 @import "@patternfly/patternfly/components/Table/table.scss";
+@import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 #app {
     section.pf-c-page__main-breadcrumb {

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -506,6 +506,130 @@ class TestHistoryMetrics(MachineCase):
         self.assertIn(m.execute("systemctl is-active pmlogger || true").strip(), ["activating", "active"])
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
 
+    @nondestructive
+    @skipImage("no PCP support", "fedora-coreos")
+    @skipImage("pmproxy broken", "debian-stable")
+    def testPmProxySettings(self):
+        b = self.browser
+        m = self.machine
+
+        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+            redis = "redis-server"
+        else:
+            redis = "redis"
+        hostname = m.execute("hostname").strip()
+
+        self.addCleanup(m.execute, f"systemctl stop {redis}")
+
+        def checkEnable():
+            b.click("#metrics-header-section button.pf-m-secondary")
+            b.wait_visible("#pcp-settings-modal")
+            b.wait_visible("#switch-pmproxy:not(:checked)")
+            b.click('#switch-pmproxy')
+            b.wait_visible('#switch-pmproxy:checked')
+            b.click("#pcp-settings-modal button.pf-m-primary")
+            b.wait_not_present("#pcp-settings-modal")
+            m.execute('while [ $(systemctl is-active pmproxy) = activating ]; do sleep 1; done')
+            self.assertEqual(m.execute("systemctl is-active pmproxy").strip(), "active")
+            self.assertEqual(m.execute(f"systemctl is-active {redis}").strip(), "active")
+            self.assertEqual(m.execute("systemctl is-enabled pmproxy").strip(), "enabled")
+            self.assertIn("redis", m.execute("systemctl show -p Wants --value pmproxy").strip())
+            wait(lambda: hostname in m.execute("curl --max-time 10 --silent --show-error 'http://localhost:44322/series/labels?names=hostname'"), delay=10, tries=30)
+
+        def checkDisable():
+            b.click("#metrics-header-section button.pf-m-secondary")
+            b.wait_visible("#pcp-settings-modal")
+            b.wait_visible('#switch-pmproxy:checked')
+            b.click('#switch-pmproxy')
+            b.wait_visible("#switch-pmproxy:not(:checked)")
+            b.click("#pcp-settings-modal button.pf-m-primary")
+            b.wait_not_present("#pcp-settings-modal")
+            self.assertEqual(m.execute("! systemctl is-active pmproxy").strip(), "inactive")
+            self.assertEqual(m.execute("! systemctl is-enabled pmproxy").strip(), "disabled")
+            # keeps redis running, it's a shared service
+            self.assertEqual(m.execute(f"systemctl is-active {redis}").strip(), "active")
+            # but drops the pmproxy dependency
+            self.assertNotIn("redis", m.execute("systemctl show -p Wants --value pmproxy").strip())
+            m.execute("! curl --silent --show-error --max-time 10 'http://localhost:44322/series/labels?names=hostname' 2>&1")
+
+        # start in a defined state; all test images have pcp and redis pre-installed
+        m.execute(f"systemctl disable --now pmproxy {redis}")
+        self.login_and_go("/metrics")
+
+        # pmproxy can't be enabled without pmlogger
+        b.click("#metrics-header-section button.pf-m-secondary")
+        b.wait_visible("#pcp-settings-modal")
+        b.wait_visible("#switch-pmlogger:not(:checked)")
+        b.wait_visible("#switch-pmproxy:not(:checked)")
+        b.wait_visible("#switch-pmproxy:disabled")
+        # enable pmlogger
+        b.click('#switch-pmlogger')
+        b.wait_visible('#switch-pmlogger:checked')
+        b.click("#pcp-settings-modal button.pf-m-primary")
+        b.wait_not_present("#pcp-settings-modal")
+        m.execute('while [ $(systemctl is-active pmlogger) = activating ]; do sleep 1; done')
+        self.assertEqual(m.execute("systemctl is-active pmlogger").strip(), "active")
+
+        checkEnable()
+        checkDisable()
+
+        # redis already running
+        m.execute(f"systemctl start {redis}")
+        checkEnable()
+        checkDisable()
+
+        # pmproxy already running; 44322 queries hang without redis and until restart
+        # HACK: on older distros, pcp's init.d scripts sometimes don't send a proper "started" notify update
+        self.allow_restart_journal_messages()
+        b.logout()
+        m.execute(f"systemctl disable --now {redis}; systemctl start pmproxy")
+        b.login_and_go("/metrics")
+        checkEnable()
+
+        # reacts to service changes from outside; this is asynchronous and the dialog deliberately
+        # does not update automatically, so retry a few times
+        def checkEnabled(expected):
+            for retry in range(10):
+                b.click("#metrics-header-section button.pf-m-secondary")
+                b.wait_visible('#switch-pmproxy')
+                found = b.is_present("#switch-pmproxy" + (expected and ":checked" or ":not(:checked)"))
+                b.click("#pcp-settings-modal button.btn-cancel")
+                b.wait_not_present("#pcp-settings-modal")
+
+                if found:
+                    break
+                time.sleep(1)
+            else:
+                raise Error("PCP settings dialog did not get expected value")
+
+        m.execute(f"systemctl stop {redis}")
+        checkEnabled(False)
+        m.execute(f"systemctl start {redis}")
+        checkEnabled(True)
+        m.execute("systemctl stop pmproxy")
+        checkEnabled(False)
+        m.execute("systemctl start pmproxy")
+        checkEnabled(True)
+
+    @skipImage("no PCP support", "fedora-coreos")
+    @skipImage("pmproxy broken", "debian-stable")
+    def testPmProxyNoRedis(self):
+        b = self.browser
+        m = self.machine
+
+        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+            m.execute("dpkg --purge redis redis-server")
+        else:
+            m.execute("rpm --erase --verbose redis")
+
+        # pmproxy switch is not offered if redis is not installed (TODO: install it on demand)
+        self.login_and_go("/metrics")
+        b.click("#metrics-header-section button.pf-m-secondary")
+        b.wait_visible('#switch-pmlogger')
+        b.wait_not_present('#switch-pmproxy')
+        b.click("#pcp-settings-modal button.btn-cancel")
+        b.wait_not_present("#pcp-settings-modal")
+
 
 @skipDistroPackage()
 @nondestructive
@@ -854,14 +978,15 @@ class TestGrafanaClient(MachineCase):
             b.click("#pcp-settings-modal button.pf-m-primary")
             b.wait_not_present("#pcp-settings-modal")
 
-        # start redis and pmproxy on supervised machine (should become an UI element)
-        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            redis = 'redis-server'
-        else:
-            redis = 'redis'
-        m.execute("systemctl enable --now " + redis)
-        # re-start pmproxy to pick up redis
-        m.execute("systemctl restart pmproxy")
+        # enable pmproxy+redis (none of our test OSes have both of them running by default)
+        b.click("#metrics-header-section button.pf-m-secondary")
+        b.wait_visible("#pcp-settings-modal")
+        b.wait_visible("#switch-pmproxy:not(:checked)")
+        b.click('#switch-pmproxy')
+        b.wait_visible('#switch-pmproxy:checked')
+        b.click("#pcp-settings-modal button.pf-m-primary")
+        b.wait_not_present("#pcp-settings-modal")
+        # FIXME: move to UI
         m.execute("firewall-cmd --permanent --add-service pmproxy; firewall-cmd --reload")
 
         # Log into Grafana (usually http://127.0.0.2:3002 if you do it interactively)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -416,7 +416,7 @@ class TestHistoryMetrics(MachineCase):
         m.execute("""mount -t tmpfs tmpfs /var/log/pcp/pmlogger
                      chown -R pcp:pcp /var/log/pcp/pmlogger
                      restorecon /var/log/pcp/pmlogger || true""")
-        self.addCleanup(m.execute, "systemctl stop pmlogger; umount /var/log/pcp/pmlogger")
+        self.addCleanup(m.execute, "systemctl stop pmlogger; until umount /var/log/pcp/pmlogger; do sleep 1; done")
 
         self.login_and_go("/metrics")
 
@@ -440,6 +440,8 @@ class TestHistoryMetrics(MachineCase):
         with self.browser.wait_timeout(90):
             self.browser.wait_js_cond("ph_count('.metrics-data-cpu.valid-data') >= 1")
         b.wait_not_present(".pf-c-empty-state")
+
+        b.logout()
 
     @nondestructive
     @skipImage("no PCP support", "fedora-coreos")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -521,7 +521,7 @@ class TestHistoryMetrics(MachineCase):
 
         self.addCleanup(m.execute, f"systemctl stop {redis}")
 
-        def checkEnable():
+        def checkEnable(firewalld_alert):
             b.click("#metrics-header-section button.pf-m-secondary")
             b.wait_visible("#pcp-settings-modal")
             b.wait_visible("#switch-pmproxy:not(:checked)")
@@ -529,6 +529,10 @@ class TestHistoryMetrics(MachineCase):
             b.wait_visible('#switch-pmproxy:checked')
             b.click("#pcp-settings-modal button.pf-m-primary")
             b.wait_not_present("#pcp-settings-modal")
+            if firewalld_alert:
+                b.wait_visible(".pf-c-alert:contains(pmproxy)")
+            else:
+                b.wait_not_present(".pf-c-alert:contains(pmproxy)")
             m.execute('while [ $(systemctl is-active pmproxy) = activating ]; do sleep 1; done')
             self.assertEqual(m.execute("systemctl is-active pmproxy").strip(), "active")
             self.assertEqual(m.execute(f"systemctl is-active {redis}").strip(), "active")
@@ -544,6 +548,8 @@ class TestHistoryMetrics(MachineCase):
             b.wait_visible("#switch-pmproxy:not(:checked)")
             b.click("#pcp-settings-modal button.pf-m-primary")
             b.wait_not_present("#pcp-settings-modal")
+            # always clears the firewalld alert
+            b.wait_not_present(".pf-c-alert:contains(pmproxy)")
             self.assertEqual(m.execute("! systemctl is-active pmproxy").strip(), "inactive")
             self.assertEqual(m.execute("! systemctl is-enabled pmproxy").strip(), "disabled")
             # keeps redis running, it's a shared service
@@ -554,6 +560,9 @@ class TestHistoryMetrics(MachineCase):
 
         # start in a defined state; all test images have pcp and redis pre-installed
         m.execute(f"systemctl disable --now pmproxy {redis}")
+        m.execute("systemctl start firewalld")
+        # ensure pmproxy is not already opened in firewall
+        m.execute("firewall-cmd --remove-service pmproxy; firewall-cmd --permanent --remove-service pmproxy")
         self.login_and_go("/metrics")
 
         # pmproxy can't be enabled without pmlogger
@@ -569,13 +578,14 @@ class TestHistoryMetrics(MachineCase):
         b.wait_not_present("#pcp-settings-modal")
         m.execute('while [ $(systemctl is-active pmlogger) = activating ]; do sleep 1; done')
         self.assertEqual(m.execute("systemctl is-active pmlogger").strip(), "active")
+        b.wait_not_present(".pf-c-alert:contains(pmproxy)")
 
-        checkEnable()
+        checkEnable(True)
         checkDisable()
 
         # redis already running
         m.execute(f"systemctl start {redis}")
-        checkEnable()
+        checkEnable(True)
         checkDisable()
 
         # pmproxy already running; 44322 queries hang without redis and until restart
@@ -584,7 +594,65 @@ class TestHistoryMetrics(MachineCase):
         b.logout()
         m.execute(f"systemctl disable --now {redis}; systemctl start pmproxy")
         b.login_and_go("/metrics")
-        checkEnable()
+        checkEnable(True)
+
+        # without firewalld
+        m.execute("firewall-cmd --remove-service pmproxy; firewall-cmd --permanent --remove-service pmproxy")
+        m.execute("systemctl stop firewalld")
+        self.allow_journal_messages(".*org.fedoraproject.FirewallD1.*disconnected.*")
+        checkDisable()
+        checkEnable(False)
+        m.execute("systemctl start firewalld")
+
+        # Go to firewall page from alert
+        checkDisable()
+        checkEnable(True)
+        b.click(".pf-c-alert button.pf-m-link")
+        b.enter_page("/network/firewall")
+        b.wait_visible("#firewall-heading")
+        b.go("/metrics")
+        b.enter_page("/metrics")
+
+        # add pmproxy to default zone directly in alert
+        default_zone = m.execute("firewall-cmd --get-default-zone").strip()
+        b.wait_text("#firewalld-request-pmproxy", default_zone)
+        b.click(".pf-c-alert button.pf-m-primary")
+        b.wait_not_present(".pf-c-alert:contains(pmproxy)")
+        self.assertIn("pmproxy", m.execute("firewall-cmd --list-services").strip())
+        self.assertIn("pmproxy", m.execute("firewall-cmd --list-services --permanent").strip())
+
+        # now service is already enabled, does not show alert
+        checkDisable()
+        checkEnable(False)
+
+        # firewalld service enabled in permanent config already, does not trip over ALREADY_ENABLED
+        checkDisable()
+        m.execute("firewall-cmd --remove-service pmproxy")
+        checkEnable(True)
+        b.click(".pf-c-alert button.pf-m-primary")
+        b.wait_not_present(".pf-c-alert:contains(pmproxy)")
+        self.assertIn("pmproxy", m.execute("firewall-cmd --list-services").strip())
+
+        # error during zone addition: zone disappears underneath us
+        checkDisable()
+        m.execute("""set -eux
+                     firewall-cmd --permanent --remove-service pmproxy
+                     firewall-cmd --permanent --new-zone=comeandgo
+                     nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24
+                     firewall-cmd --permanent --zone public --remove-interface fake0
+                     firewall-cmd --permanent --zone comeandgo --add-interface fake0
+                     firewall-cmd --reload
+                  """)
+        self.addCleanup(m.execute, "nmcli con delete fake; firewall-cmd --permanent --delete-zone comeandgo || true; firewall-cmd  --reload")
+        checkEnable(True)
+        b.select_PF4("#firewalld-request-pmproxy", "comeandgo")
+        m.execute("firewall-cmd --permanent --delete-zone comeandgo; firewall-cmd  --reload")
+        b.click(".pf-c-alert button.pf-m-primary")
+        b.wait_in_text(".pf-c-alert.pf-m-warning", "Failed to enable pmproxy in firewalld")
+        b.wait_in_text(".pf-c-alert.pf-m-warning", "INVALID_ZONE: comeandgo")
+        # close warning
+        b.click(".pf-c-alert.pf-m-warning button.pf-m-plain")
+        b.wait_not_present(".pf-c-alert:contains(pmproxy)")
 
         # reacts to service changes from outside; this is asynchronous and the dialog deliberately
         # does not update automatically, so retry a few times

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1031,7 +1031,6 @@ class TestGrafanaClient(MachineCase):
         m.execute("until curl --silent --show-error http://10.111.112.100:3000; do sleep 1; done")
         # enable PCP plugin; like on Cog (Configuration) menu → Plugins → Performance Co-Pilot → Enable
         mg.execute("curl --silent --show-error -u admin:foobar -d '' 'http://127.0.0.1:3000/api/plugins/performancecopilot-pcp-app/settings?enabled=true'")
-
         self.login_and_go("/metrics")
 
         # pmlogger data collection is not running by default on RHEL
@@ -1054,8 +1053,10 @@ class TestGrafanaClient(MachineCase):
         b.wait_visible('#switch-pmproxy:checked')
         b.click("#pcp-settings-modal button.pf-m-primary")
         b.wait_not_present("#pcp-settings-modal")
-        # FIXME: move to UI
-        m.execute("firewall-cmd --permanent --add-service pmproxy; firewall-cmd --reload")
+
+        # enable pmproxy service in firewalld in the alert
+        b.wait_visible("#firewalld-request-pmproxy")
+        b.click(".pf-c-alert button.pf-m-primary")
 
         # Log into Grafana (usually http://127.0.0.2:3002 if you do it interactively)
         bg = Browser(mg.forward['3000'], label=self.label() + "-" + mg.label)


### PR DESCRIPTION
This is the next (and a rather major) step towards setting up a machine in Grafana.
    
 - [x] PR #15810 
 - [x] PR #15877

TODO:
 - [x] Use in TestGrafana
 - [x] don't disable redis with pmproxy; See https://github.com/performancecopilot/pcp/issues/1296
 - [x] consider a redis requires.d/ symlink instead of statically enabling
 - [x] pmproxy needs pmlogger, so disable button if pmlogger is off
 - [x] add link to firewall page if firewalld is running
 - [x] release note
 - [x] [fix testPmProxySettings flake](https://logs.cockpit-project.org/logs/pull-15812-20210601-120726-e08ecc5d-rhel-8-5/log.html#284) on rhel-8-5
 - [x] Add zone selector to alert
 - [x] Test pmproxy firewalld error
 - [x] Change TestGrafana to use the alert selector instead of the firewall page
 - [x] Add box shadow to alert
 - [x] Reduce alert/pagesection padding 
 - [ ] Fix [test flake](https://github.com/cockpit-project/cockpit/pull/15812#issuecomment-849514020)
    
## Metrics: Grafana client setup

The "Metrics settings" button introduced in [Cockpit 245](https://cockpit-project.org/blog/cockpit-245.html) has a new switch to set up exporting metrics to the network through the [PCP pmproxy service](https://linux.die.net/man/1/pmproxy) and the [Redis database](https://grafana-pcp.readthedocs.io/en/latest/datasources/redis.html):

![Screen Shot 2021-05-32 at 11 38 16](https://user-images.githubusercontent.com/200109/120173910-d4284a00-c204-11eb-99a6-3c61b91c03b2.png)

If the machine uses firewalld, you can allow pmproxy in a particular zone afterwards:

![fw-sel](https://user-images.githubusercontent.com/200109/121884597-66574480-cd13-11eb-9aef-c2627a200f53.png)

After that, a remote [Grafana](https://grafana.com/) instance can read the machine's metrics through the [PCP Grafana plugin](https://grafana-pcp.readthedocs.io/), as described on the [PCP metrics feature page](https://cockpit-project.org/guide/latest/feature-pcp.html).