### PR TITLE
lib: Only offer configuring specific NTP servers with enabled systemd-timesyncd

### DIFF
--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -265,7 +265,7 @@ export function ServerTime() {
          * - systemd-timedated is answering for
          *   org.freedesktop.timedate1 as opposed to, say, timedatex.
          *
-         * - systemd-timesyncd is actually available.
+         * - systemd-timesyncd is enabled (false if chrony is being used)
          *
          * The better alternative would be to have an API in
          * o.fd.timedate1 for managing the list of NTP server
@@ -282,8 +282,8 @@ export function ServerTime() {
             return Promise.resolve(result);
         }
 
-        if (!timesyncd_service.exists) {
-            console.log("systemd-timesyncd not available, ntp server configuration not supported");
+        if (!timesyncd_service.enabled) {
+            console.log("systemd-timesyncd not enabled, ntp server configuration not supported");
             return Promise.resolve(result);
         }
 

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -640,30 +640,16 @@ function change_systime_dialog(server_time, timezone) {
                                                                     state.manual_hours,
                                                                     state.manual_minutes));
                     } else {
-                    /* HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1272085
-                     *
-                     * Switch off NTP, bump the clock by one microsecond to
-                     * clear the NTPSynchronized status, write the config
-                     * file, and switch NTP back on.
-                     *
-                     */
+                        // Switch off NTP, write the config file, and switch NTP back on
                         return server_time.set_ntp(false)
-                                .then(function() {
-                                    return server_time.bump_time(1);
-                                })
-                                .then(function() {
+                                .then(() => {
                                     if (state.custom_ntp.supported)
                                         return server_time.set_custom_ntp(state.custom_ntp.servers.filter(s => !!s),
                                                                           state.mode == "ntp_time_custom");
                                     else
                                         return Promise.resolve();
                                 })
-                                .then(function() {
-                                    // NTPSynchronized should be false now.  Make
-                                    // sure we pick that up immediately.
-                                    server_time.poll_ntp_synchronized();
-                                    return server_time.set_ntp(true);
-                                });
+                                .then(() => server_time.set_ntp(true));
                     }
                 });
     }

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -226,8 +226,8 @@ export function ServerTime() {
             sub_status: null
         };
 
-        // flag for tests that timedated proxy got activated
-        if (timedate.CanNTP !== undefined && timedate1_service.unit && timedate1_service.unit.Id)
+        // flag for tests that timedated/timesyncd proxies got initialized
+        if (timedate.CanNTP !== undefined && timedate1_service.unit && timedate1_service.unit.Id && timesyncd_service.enabled !== null)
             status.initialized = true;
 
         status.active = timedate.NTP;

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -271,22 +271,18 @@ export function ServerTime() {
          * o.fd.timedate1 for managing the list of NTP server
          * candidates.
          */
-
-        const timedate1 = timedate1_service;
-        const timesyncd = timesyncd_service;
-
         const result = {
             supported: false,
             enabled: false,
             servers: []
         };
 
-        if (!timedate1.exists || timedate1.unit.Id !== "systemd-timedated.service") {
+        if (!timedate1_service.exists || timedate1_service.unit.Id !== "systemd-timedated.service") {
             console.log("systemd-timedated not in use, ntp server configuration not supported");
             return Promise.resolve(result);
         }
 
-        if (!timesyncd.exists) {
+        if (!timesyncd_service.exists) {
             console.log("systemd-timesyncd not available, ntp server configuration not supported");
             return Promise.resolve(result);
         }

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -291,10 +291,12 @@ class TestSystemInfo(MachineCase):
         self.assertIn("Mon Jun  4 06:34:", m.execute("date"))
         self.assertIn("EEST 2018\n", m.execute("date"))
 
-    @skipImage("Uses timedatex, no NTP servers config", "rhel-8-4", "rhel-8-5", "centos-8-stream")
     def testTimeServers(self):
         m = self.machine
         b = self.browser
+
+        # Fedora/RHEL/CentOS use chrony
+        uses_timesyncd = m.image.startswith("debian") or m.image.startswith("ubuntu")
 
         conf = "/etc/systemd/timesyncd.conf.d/50-cockpit.conf"
 
@@ -303,10 +305,17 @@ class TestSystemInfo(MachineCase):
         # Wait until everything is ready to go...
         b.wait_attr("#system_information_systime_button", "data-timedated-initialized", "true")
 
-        # Add two NTP servers.  We can't expect the servers to be used, so
-        # we only test that they get added.
         b.click("#system_information_systime_button")
         b.wait_visible("#system_information_change_systime")
+
+        # when not using timesyncd, the "specific NTP servers" option should be disabled
+        if not uses_timesyncd:
+            b.click("#system_information_change_systime label:contains('Set time') + div button")
+            b.wait_visible("#change_systime button:contains('Automatically using specific NTP servers').pf-m-disabled")
+            return
+
+        # Add two NTP servers.  We can't expect the servers to be used, so
+        # we only test that they get added.
         self.set_change_time_dialog_mode("Automatically using specific NTP servers")
         b.set_input_text("#systime-ntp-servers tr:nth-child(1) input", "0.pool.ntp.org")
         b.click('#systime-ntp-servers tr:nth-child(1) .fa-plus')

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -314,6 +314,11 @@ class TestSystemInfo(MachineCase):
             b.wait_visible("#change_systime button:contains('Automatically using specific NTP servers').pf-m-disabled")
             return
 
+        def get_timesyncd_start():
+            return int(m.execute("systemctl show -p ExecMainStartTimestampMonotonic --value systemd-timesyncd").strip())
+
+        prev_timesyncd_start = get_timesyncd_start()
+
         # Add two NTP servers.  We can't expect the servers to be used, so
         # we only test that they get added.
         self.set_change_time_dialog_mode("Automatically using specific NTP servers")
@@ -326,9 +331,14 @@ class TestSystemInfo(MachineCase):
         self.assertIn("0.pool.ntp.org", m.execute("grep '^NTP=' %s" % conf))
         self.assertIn("1.pool.ntp.org", m.execute("grep '^NTP=' %s" % conf))
 
+        # restarts timesyncd to pick up the new config
+        wait(lambda: get_timesyncd_start() > prev_timesyncd_start, delay=0.2)
+        prev_timesyncd_start = get_timesyncd_start()
+
         # Set conf from the outside, check that we pick that up, and
         # switch to default servers.
         m.write(conf, "[Time]\nNTP=2.pool.ntp.org\n")
+        b.wait_attr("#system_information_systime_button", "data-timedated-initialized", "true")
         b.click("#system_information_systime_button")
         b.wait_visible("#system_information_change_systime")
         b.wait_val("#systime-ntp-servers tr:nth-child(1) input", "2.pool.ntp.org")
@@ -338,6 +348,9 @@ class TestSystemInfo(MachineCase):
         b.wait_not_present("#system_information_change_systime")
 
         self.assertIn("2.pool.ntp.org", m.execute("grep '^#NTP=' %s" % conf))
+
+        # restarts timesyncd to pick up the new config
+        wait(lambda: get_timesyncd_start() > prev_timesyncd_start, delay=0.2)
 
     def testMotd(self):
         m = self.machine


### PR DESCRIPTION
Checking for the service unit existence is not sufficient: On Fedora,
systemd-timesyncd.service does exist, but is disabled and never actually
used, as chronyd.service is running. Thus setting any custom NTP servers
has no effect, and is thus highly misleading.

Run `TestSystemInfo.testTimeServers` on all OSes, and ensure that the
"specific NTP servers" option is disabled when timesyncd is not in use.

----

I noticed that while investigating our [long-standing testTimeServers unstable test](https://logs.cockpit-project.org/logs/pull-15810-20210510-174243-2cab9769-fedora-34/log.html#280), and thought "WTH? That doesn't make any sense"..