### PR TITLE
storage: More robust testing of content listing tabs

### DIFF
--- a/pkg/lib/cockpit-components-listing-panel.jsx
+++ b/pkg/lib/cockpit-components-listing-panel.jsx
@@ -100,9 +100,9 @@ export class ListingPanel extends React.Component {
                 continue;
             row = <Renderer key={ this.props.tabRenderers[tabIdx].name } hidden={ (tabIdx !== activeTab) } {...rendererData} />;
             if (tabIdx === activeTab)
-                tabs.push(<div className="ct-listing-panel-body" key={tabIdx}>{row}</div>);
+                tabs.push(<div className="ct-listing-panel-body" key={tabIdx} data-key={tabIdx}>{row}</div>);
             else
-                tabs.push(<div className="ct-listing-panel-body" key={tabIdx} hidden>{row}</div>);
+                tabs.push(<div className="ct-listing-panel-body" key={tabIdx} data-key={tabIdx} hidden>{row}</div>);
         }
 
         let listingDetail;

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -124,7 +124,7 @@ class StorageHelpers:
 
     def content_tab_expand(self, row_index, tab_index):
         tab_btn = self.content_row_tbody(row_index) + " .ct-listing-panel-head > nav ul li:nth-child(%d) a" % tab_index
-        tab = self.content_row_tbody(row_index) + " .ct-listing-panel-body:nth-child(%d)" % (tab_index + 1)
+        tab = self.content_row_tbody(row_index) + " .ct-listing-panel-body[data-key=%d]" % (tab_index - 1)
         self.content_row_expand(row_index)
         self.browser.click(tab_btn)
         self.browser.wait_visible(tab)
@@ -164,7 +164,7 @@ class StorageHelpers:
             row = self.content_row_tbody(row_index)
             row_item = row + " tr td.pf-c-table__toggle button"
             tab_btn = row + " .ct-listing-panel-head > nav ul li:nth-child(%d) a" % tab_index
-            tab = row + " .ct-listing-panel-body:nth-child(%d)" % (tab_index + 1)
+            tab = row + " .ct-listing-panel-body[data-key=%d]" % (tab_index - 1)
             cell = tab + " dt:contains(%s) + *" % title
 
             # The DOM might change at any time while we are inspecting


### PR DESCRIPTION
The tests used to identify tabs by their position in the DOM, but that
isn't reliable since the ListingPanel instantiates tabs dynamically.
Thus, while the tests might look for the third .ct-listing-panel-body
for the third tab, only two tabs might have been instantiated and the
.ct-listing-panel-body for the third tab is actually the second one in
the DOM.

To make this reliable, let's put the actual tab index into the DOM as
an attribute and have the tests look for that.

We never actually got bitten by this, but we will in the future when
we have more tabs than two.