### PR TITLE
containers: Speed up dist unit-tests scenario

### DIFF
--- a/containers/unit-tests/build.sh
+++ b/containers/unit-tests/build.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -eux
 
 ./autogen.sh --prefix=/usr --enable-strict
-make
+[ "${TEST_SCENARIO:-}" = "dist" ] || make

--- a/containers/unit-tests/scenario-dist.sh
+++ b/containers/unit-tests/scenario-dist.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -eux
 
-make NO_DIST_CACHE=1 dist
+make NO_DIST_CACHE=1 XZ_COMPRESS_FLAGS=-0 dist
 
 # container has a writable /results/ in the "dist" scenario, but not in others; copy dist tarball there
 if [ -w /results ]; then


### PR DESCRIPTION
Skip the full `make` build and xz extreme compression in the "start
dist" scenario.