### PR TITLE
systemd: Fix insights URL

### DIFF
--- a/pkg/systemd/overview-cards/insights.jsx
+++ b/pkg/systemd/overview-cards/insights.jsx
@@ -132,7 +132,7 @@ export class InsightsStatus extends React.Component {
 
         let url;
         if (this.state.id)
-            url = "https://cloud.redhat.com/insights/inventory/" + this.state.id + "/insights";
+            url = "https://cloud.redhat.com/insights/inventory/" + this.state.id;
         else
             url = "https://cloud.redhat.com/insights";
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -440,10 +440,10 @@ class TestHistoryMetrics(MachineCase):
                       systemctl daemon-reload
                       systemctl start pmlogger || true""")
         self.addCleanup(m.execute,
-                """systemctl reset-failed pmlogger
-                   rm -r /run/systemd/system/pmlogger.service.d/
-                   umount /var/log/pcp/pmlogger
-                   systemctl daemon-reload""")
+                        """systemctl reset-failed pmlogger
+                        rm -r /run/systemd/system/pmlogger.service.d/
+                        umount /var/log/pcp/pmlogger
+                        systemctl daemon-reload""")
 
         self.login_and_go("/metrics")
 


### PR DESCRIPTION
Drop the extra /insights suffix, which is not valid.

https://bugzilla.redhat.com/show_bug.cgi?id=1958379