### PR TITLE
storage: Improved passphrase handling

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -97,13 +97,22 @@ class TestStorageLuks(StorageCase):
         self.assertNotEqual(m.execute("grep 'weird,options' /etc/crypttab"), "")
         self.wait_in_storaged_configuration("weird,options")
 
-        # Change passphrase
+        # Change stored passphrase
         edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + dd button"
         self.dialog_with_retry(trigger=lambda: b.click(edit_button),
                                expect={"passphrase": "vainu-reku-toma-rolle-kaja"},
                                values={"passphrase": "wrong-passphrase"})
 
         self.assertEqual(m.execute("cat /etc/luks-keys/*"), "wrong-passphrase")
+
+        # Lock it
+        self.content_dropdown_action(1, "Lock")
+        b.wait_not_in_text("#detail-content", "ext4 file system")
+
+        # Unlock, this tries the wrong passphrase but eventually prompts.
+        self.content_head_action(1, "Unlock")
+        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
+        self.content_row_wait_in_col(2, 1, "ext4 file system")
 
         # Remove passphrase
         edit_button = self.content_tab_info_label(1, 2, "Stored passphrase") + " + dd button"
@@ -186,10 +195,13 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_apply_enabled()
         self.dialog_set_val("type", "tang")
         self.dialog_set_val("tang_url", "127.0.0.1")
-        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_set_val("passphrase", "wrong-passphrase")
         self.dialog_apply()
         b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches")
         b.wait_in_text("#dialog", m.execute("tang-show-keys").strip())
+        self.dialog_apply()
+        b.wait_in_text("#dialog", "No key available with this passphrase.")
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_visible(panel + "ul li:nth-child(2)")


### PR DESCRIPTION
Whenever a passphrase is needed, we now also try the stored passphrase
in addition to one recovered from Clevis.

But while a passphrase recovered from Clevis can be assumed to work, a
stored passphrase can easily be wrong.  Therefore, if a operation that
requires a passphrase fails, we now give the use the opportunity to
provide a different one.

This also fixes the flow when adding/changing Clevis keys.  Earlier,
this was done with two dialogs where the first asks for the passphrase
and the second will show the error if that passphrase was wrong,
without giving the user a opportunity to correct the passphrase.  Now
this is still done in two steps, but the second one will show a
passphrase input if the operation failed because of a wrong
passphrase.

Unlocking a disk is one of the operations that the above applies to.
It is however a bit special: It is possible to unlock a disk with a
stored passphrase or a Clevis passphrase without having the passphrase
travel through the Browser.  So we do this.

Besides improving passphrase handling for the existing operations,
this also lays the groundwork for a upcoming combined Unlock-and-Mount
operation.  That operation needs to automatically use a stored
passphrase, not let the passphrase travel through the Browser, fall
back to asking for a passphrase if the recovered one fails, and open a
dialog without doing any opportunistic unlocking just to see what will
work.

And if we anyway need all these features, why not use them in all
places that deal with passphrases.  Hence this change. 