### PR TITLE
ws: stop showing IPs, just show hostname:port pairs in motd

### DIFF
--- a/doc/guide/listen.xml
+++ b/doc/guide/listen.xml
@@ -46,7 +46,9 @@ ListenStream=192.168.1.1:443
 FreeBind=yes
 </programlisting>
 
-    <para>NOTE: The first empty line is intentional. <code>systemd</code> allows multiple <code>Listen</code> directives to be declared in a single socket unit. To change the activation port instead of adding a second port, use a full override unit instead of a snippet.</para>
+    <para>NOTE: The first empty line is intentional. <code>systemd</code> allows multiple <code>Listen</code> directives to be declared in a single socket unit.
+If the empty string is assigned to any of these options, the list of addresses to listen on is reset, all prior uses of any of these options will have no effect.
+    To add more <code>Listen</code> directives aside from the defaults, omit the first empty line.</para>
 
     <para>The <code>FreeBind</code> option is highly recommended when defining specific IP addresses. See the <ulink url="https://www.freedesktop.org/software/systemd/man/systemd.socket.html"><code>systemd.socket</code> manpage</ulink> for details.</para>
 

--- a/src/ws/update-motd
+++ b/src/ws/update-motd
@@ -1,24 +1,23 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
-# syntax: update-motd [port [hostname [ipaddr [protocol]]]]
+# syntax: update-motd [port [hostname [protocol]]]
 # each argument can be given as the empty string to use the default
-
-# port number from cmdline, then systemctl file, then 9090
-# take the last Listen line; this will be the user-specified one
-port=${1:-$(systemctl show --property Listen cockpit.socket |
-              sed -E '$!d;$s/.*[^0-9]([0-9]+).*/\1/;')}
-port=${port:-9090}
 
 # hostname from cmdline, then `hostname -f`
 hostname=${2:-$(hostname -f || hostname)}
 
-# ip addr from cmdline, then default route source addr
-ip=${3:-$(ip -o route get 255.0 2>/dev/null | sed -e 's/.*src \([^ ]*\) .*/\1/')}
-
 # protocol from cmdline, then https
-protocol=${4:-https}
+protocol=${3:-https}
 
-hostname_url="${protocol}://${hostname}:${port}/"
-ip_url="${ip:+ or ${protocol}://${ip}:${port}/}"
-
-printf 'Web console: %s%s\n\n' "${hostname_url}" "${ip_url}"  > /run/cockpit/active.motd
+printf 'Web console: \n' > /run/cockpit/active.motd
+# make newlines the only separator
+# IFS=$'\n'
+# port number from cmdline, then systemctl file
+for line in ${1:-$(systemctl show --value --property Listen cockpit.socket)}; do
+    port=${line##*:}
+    if [[ $port =~ [0-9]+ ]]; then
+        hostname_url="${protocol}://${hostname}:${port}/"
+        printf '%s\n' "${hostname_url}" >> /run/cockpit/active.motd
+    fi
+done
+printf '\n' >> /run/cockpit/active.motd

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -509,8 +509,8 @@ class TestConnection(MachineCase):
         checkMotdContent(':9090/', expected=False)
         m.start_cockpit()
 
-        checkMotdContent(':9090/')
         checkMotdContent('systemctl', expected=False)
+        checkMotdContent(':9090/')
         m.execute("systemctl stop cockpit.socket")
 
         # Change port according to documentation: https://cockpit-project.org/guide/latest/listen.html
@@ -521,11 +521,13 @@ class TestConnection(MachineCase):
         checkMotdContent('systemctl')
         checkMotdContent(':9090/', expected=False)
         checkMotdContent(':443/', expected=False)
+        checkMotdContent('/run/cockpit/sock', expected=False)
         m.start_cockpit(tls=True)
 
         checkMotdContent('systemctl', expected=False)
         checkMotdContent(':9090/', expected=False)
         checkMotdContent(':443/')
+        checkMotdContent('/run/cockpit/sock', expected=False)
 
         output = m.execute('curl -k https://localhost 2>&1 || true')
         self.assertIn('Loading...', output)
@@ -534,6 +536,21 @@ class TestConnection(MachineCase):
 
         output = m.execute('curl -k https://localhost:9090 2>&1 || true')
         self.assertIn('Connection refused', output)
+
+        m.execute(
+            'printf "[Socket]\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
+        m.start_cockpit(tls=True)
+
+        checkMotdContent('systemctl', expected=False)
+        checkMotdContent(':9090/')
+        checkMotdContent(':443/')
+        checkMotdContent('/run/cockpit/sock', expected=False)
+
+        output = m.execute('curl -k https://localhost:9090 2>&1 || true')
+        self.assertIn('Connection refused', output)
+
+        output = m.execute('curl -k https://localhost:443 2>&1 || true')
+        self.assertIn('Loading...', output)
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")
 


### PR DESCRIPTION
When restricting the ListenStream to specific IPs or when overriding the
default Ports do not advertise them anymore.

Fixes #12800