### PR TITLE
test: Use basic.target instead of sockets.target in TestServices

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -184,7 +184,7 @@ Unit=test.service
         # Selects Targets tab
         self.pick_tab(2)
         b.wait_not_in_text("#services-list", "test")
-        self.wait_service_state("sockets.target", "active")
+        self.wait_service_state("basic.target", "active")
 
         # Make sure that symlinked services also appear in the list
         self.wait_service_state("reboot.target", "inactive")


### PR DESCRIPTION
In some test environments sockets.target is (inexplicably) not running,
even though basic.target `Wants=` it. Check `basic.target` instead,
which is in the critical path for a successful boot, and also
alphabetically earlier so that we can see it in screenshots.

Fixes #15838