### PR TITLE
reposchutz: use pull_request.base.sha

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -36,6 +36,6 @@ jobs:
           set -x
           git init -b main
           git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-          git fetch --depth=1 origin '${{ github.sha }}'
+          git fetch --depth=1 origin '${{ github.event.pull_request.base.sha }}'
           git fetch --depth=1 origin '${{ github.event.pull_request.head.sha }}'
-          git diff --exit-code '${{ github.sha }}' '${{ github.event.pull_request.head.sha }}' -- .github
+          git diff --exit-code '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}' -- .github


### PR DESCRIPTION
github.sha seems to refer to the current state of the main branch of the
repository, not the base branch that the PR was proposed against.  That
means that if someone else lands a github workflow change in the
meantime, unrelated PRs will start going red.

Change that to be based on github.event.pull_request.base.sha.