### PR TITLE
storage: Tang key hash improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "bootstrap-select": "1.13.18",
     "deep-equal": "2.0.5",
     "jquery": "3.5.1",
+    "js-sha1": "0.6.0",
     "js-sha256": "0.9.0",
     "json-stable-stringify-without-jsonify": "1.0.1",
     "moment": "2.29.1",

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -307,28 +307,9 @@ function edit_clevis_dialog(client, block, key) {
     get_existing_passphrase(dlg, block).then(pp => { recovered_passphrase = pp });
 }
 
-class Revealer extends React.Component {
-    constructor() {
-        super();
-        this.state = { revealed: false };
-    }
-
-    render() {
-        if (this.state.revealed)
-            return <div>{this.props.children}</div>;
-        else
-            return (
-                <button className="button-link" onClick={event => { if (event.button == 0) this.setState({ revealed: true }); }}>
-                    {this.props.summary}
-                </button>
-            );
-    }
-}
-
 function edit_tang_adv(client, block, key, url, adv, passphrase) {
     var parsed = parse_url(url);
     var cmd = cockpit.format("ssh $0 tang-show-keys $1", parsed.hostname, parsed.port);
-    var cmd_alt = cockpit.format("ssh $0 \"curl -s localhost$1/adv |\n  jose fmt -j- -g payload -y -o- |\n  jose jwk use -i- -r -u verify -o- |\n  jose jwk thp -i-\"", parsed.hostname, parsed.port ? ":" + parsed.port : "");
 
     var sigkey_thps = compute_sigkey_thps(tang_adv_payload(adv));
 
@@ -345,11 +326,6 @@ function edit_tang_adv(client, block, key, url, adv, passphrase) {
                 { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s.sha1}</div>) }
                 <br />
                 <div>{_("Manually check with SSH: ")}<pre className="inline-pre">{cmd}</pre></div>
-                <br />
-                <Revealer summary={_("What if tang-show-keys is not available?")}>
-                    <p>{_("If tang-show-keys is not available, run the following:")}</p>
-                    <pre>{cmd_alt}</pre>
-                </Revealer>
             </div>
         ),
         Action: {

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -27,6 +27,7 @@ import {
 } from "@patternfly/react-core";
 import { EditIcon, MinusIcon, PlusIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
 
+import sha1 from "js-sha1";
 import sha256 from "js-sha256";
 import stable_stringify from "json-stable-stringify-without-jsonify";
 
@@ -82,7 +83,10 @@ function compute_thp(jwk) {
     var req = REQUIRED_ATTRS[jwk.kty];
     var norm = { };
     req.forEach(k => { if (k in jwk) norm[k] = jwk[k]; });
-    return jwk_b64_encode(sha256.digest(stable_stringify(norm)));
+    return {
+        sha256: jwk_b64_encode(sha256.digest(stable_stringify(norm))),
+        sha1: jwk_b64_encode(sha1.digest(stable_stringify(norm)))
+    };
 }
 
 function compute_sigkey_thps(adv) {
@@ -332,8 +336,13 @@ function edit_tang_adv(client, block, key, url, adv, passphrase) {
         Title: _("Verify key"),
         Body: (
             <div>
-                <div>{_("Make sure the key hash from the Tang server matches:")}</div>
-                { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s}</div>) }
+                <div>{_("Make sure the key hash from the Tang server matches one of the following:")}</div>
+                <br />
+                <div>{_("SHA256")}</div>
+                { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s.sha256}</div>) }
+                <br />
+                <div>{_("SHA1")}</div>
+                { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s.sha1}</div>) }
                 <br />
                 <div>{_("Manually check with SSH: ")}<pre className="inline-pre">{cmd}</pre></div>
                 <br />

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -324,7 +324,7 @@ class Revealer extends React.Component {
 function edit_tang_adv(client, block, key, url, adv, passphrase) {
     var parsed = parse_url(url);
     var cmd = cockpit.format("ssh $0 tang-show-keys $1", parsed.hostname, parsed.port);
-    var cmd_alt = cockpit.format("ssh $0 \"curl -s localhost:$1/adv |\n  jose fmt -j- -g payload -y -o- |\n  jose jwk use -i- -r -u verify -o- |\n  jose jwk thp -i-\"", parsed.hostname, parsed.port);
+    var cmd_alt = cockpit.format("ssh $0 \"curl -s localhost$1/adv |\n  jose fmt -j- -g payload -y -o- |\n  jose jwk use -i- -r -u verify -o- |\n  jose jwk thp -i-\"", parsed.hostname, parsed.port ? ":" + parsed.port : "");
 
     var sigkey_thps = compute_sigkey_thps(tang_adv_payload(adv));
 

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -402,7 +402,7 @@ td.storage-action {
 
 .sigkey-hash {
     font-family: monospace;
-    font-size: 200%;
+    font-size: 140%;
 }
 
 .inline-pre {

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -144,14 +144,6 @@ class TestStorageLuks(StorageCase):
         m = self.machine
         b = self.browser
 
-        # We generate the keys and cache explicitly before starting
-        # the socket.  This allows us to control their names, which
-        # helps later on.
-
-        m.execute("rm -rf /var/db/tang/*")
-        m.execute("jose jwk gen -i '{\"alg\":\"ES512\"}' >/var/db/tang/sig1.jwk")
-        m.execute("jose jwk gen -i '{\"alg\":\"ECMR\"}' -o /var/db/tang/enc1.jwk")
-
         m.execute("systemctl start tangd.socket")
 
         self.login_and_go("/storage")
@@ -193,8 +185,8 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("tang_url", "127.0.0.1")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
-        b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches:")
-        b.wait_in_text("#dialog", m.execute("jose jwk thp -a S256 -i /var/db/tang/sig1.jwk").strip())
+        b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches")
+        b.wait_in_text("#dialog", m.execute("tang-show-keys").strip())
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_visible(panel + "ul li:nth-child(2)")
@@ -213,8 +205,8 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_val("tang_url", "127.0.0.1")
         self.dialog_set_val("tang_url", "http://127.0.0.1/")
         self.dialog_apply()
-        b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches:")
-        b.wait_in_text("#dialog", m.execute("jose jwk thp -a S256 -i /var/db/tang/sig1.jwk").strip())
+        b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches")
+        b.wait_in_text("#dialog", m.execute("tang-show-keys").strip())
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_in_text(panel + "ul li:nth-child(2)", "http://127.0.0.1/")


### PR DESCRIPTION
tang-show-keys is now widely enough available to use it in our tests instead of jose.

However, different versions of tang-show-keys use different hashing algorithms, so we need to account for all possibilities in our dialog.

This PR also removes from the dialog the alternative command that people might use if they don't have tang-show-keys. The assumption again is that everybody has it now, and having this in the dialog just adds to the perceived complexity of the task.