### PR TITLE
packit: Enable Rawhide

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -17,4 +17,5 @@ jobs:
       targets:
       - fedora-33
       - fedora-34
+      - fedora-rawhide
       - centos-stream-8-x86_64


### PR DESCRIPTION
Even though this is prone to instability, we'd still rather like to learn about OS regressions earlier than later.
