### PR TITLE
reposchutz: improve change detection logic

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -10,6 +10,9 @@ jobs:
     timeout-minutes: 5
     env:
       GIT_DIR: git-dir.git
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+
     steps:
       - name: Clear .github-changes label
         if: ${{ !endsWith(github.event.action, 'labeled') }}
@@ -36,6 +39,6 @@ jobs:
           set -x
           git init -b main
           git remote add origin "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}"
-          git fetch --depth=1 origin '${{ github.event.pull_request.base.sha }}'
-          git fetch --depth=1 origin '${{ github.event.pull_request.head.sha }}'
-          git diff --exit-code '${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}' -- .github
+          # git fetch --shallow-exclude="${BASE_SHA}" origin "${BASE_SHA}"  # GitHub doesn't support this
+          git fetch origin "${BASE_SHA}" "${HEAD_SHA}"
+          git log --full-history --exit-code --patch "${HEAD_SHA}" --not "${BASE_SHA}" -- .github >&2


### PR DESCRIPTION
The workflow has a fairly simple strategy at present: if there are
changes to the `.github` directory (as per `git diff`) then fail.  That
has two problems:

 - the changes might have come from an unrelated PR that got merged in
   the meantime; and

 - the PR can "get away with" individual commits that make changes, as
   long as there are future commits that revert those changes.
   Depending on the merge/rebase strategy used when landing, thre are
   some creative way to sneak changes through anyway.

Replace the previous logic with a new one: list all commits which are:

 - reachable from the PR;

 - not already on the target branch; and

 - modify `.github`

and fail if the result is non-empty.

Factor out the context expressions for the relevant SHAs into
environment variables to improve readability.

Finally, since our new approach depends on more than just looking at the
two head commits, a shallow fetch isn't sufficient anymore.  `git fetch`
has a (somewhat new) relevant feature `--shallow-exclude=` which would
be very helpful to us here, but the GitHub server seems not to support
it, so just fetch a full history for the time being.