### PR TITLE
storage: Reload systemd before mounting after formatting

### DIFF
--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -356,8 +356,8 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                 return utils.teardown_active_usage(client, usage)
                         .then(utils.reload_systemd)
                         .then(format)
-                        .then(maybe_mount)
-                        .then(utils.reload_systemd);
+                        .then(utils.reload_systemd)
+                        .then(maybe_mount);
             }
         }
     });


### PR DESCRIPTION
Otherwise systemd might have outdated UUID / mount point mappings and
might unmount our new filesystem right away again.

Here are the details.  Start with this in /etc/fstab:

    UUID=<uuid1> /run/foo ...

This causes systemd to associate uuid1 with /run/foo.  Now uuid1 is
unmounted, the block device is formatted, and a new fstab is written
with the new uuid2 but with the same mount point:

    UUID=<uuid2> /run/foo ...

At this point, systemd sees that uuid1 has disappeared and will make
sure that /run/foo is not mounted, because it still associates
/run/foo with uuid1.  At the same time, Cockpit will mount the new
filesystem at /run/foo.  This is a race and sometimes Cockpit does the
mount, and then systemd does its cleanup and unmounts.  (If systemd
does the cleanup first, it will find /run/foo already unmounted and
not do anything.)

The race is avoided by reloading systemd before having Cockpit do the
mount.  This way, systemd will forget the uuid1 -> /run/foo
association.

- [ ] #15859 