### PR TITLE
tls: Fix quoting of locale check

### DIFF
--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -96,7 +96,7 @@ cmd_ipa_request() {
     kinit "${USER}@${REALM}" || exit 0
 
     # ensure this gets run with a non-C locale; ipa fails otherwise
-    if [ $(sh -c 'eval `locale`; echo $LC_CTYPE') = 'C' ]; then
+    if [ "$(sh -c 'eval `locale`; echo $LC_CTYPE')" = 'C' ]; then
         export LC_CTYPE=C.UTF-8
     fi
 


### PR DESCRIPTION
Spotted by coverity: "warning[SC2046]: Quote this to prevent word splitting."