### PR TITLE
lib: Don't reload systemd after enabling/disabling a service

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -249,6 +249,8 @@ export function proxy(name, kind) {
     systemd_manager.addEventListener("JobNew", on_job_new_removed_refresh);
     systemd_manager.addEventListener("JobRemoved", on_job_new_removed_refresh);
 
+    systemd_manager.addEventListener("UnitFilesChanged", refresh);
+
     function wait(callback) {
         wait_callbacks.promise.then(callback);
     }

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -292,25 +292,6 @@ export function proxy(name, kind) {
         return dfd.promise();
     }
 
-    function call_manager_with_reload(method, args) {
-        return call_manager(method, args).then(function () {
-            var dfd = cockpit.defer();
-            call_manager("Reload", [])
-                    .done(function () { dfd.resolve() })
-                    .fail(function (error) {
-                    // HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1560549
-                    // some systemd versions disconnect too fast from the bus
-                        if (error.name === "org.freedesktop.DBus.Error.NoReply") {
-                            refresh();
-                            dfd.resolve();
-                        } else {
-                            dfd.reject(error);
-                        }
-                    });
-            return dfd.promise();
-        });
-    }
-
     function start() {
         return call_manager_with_job("StartUnit", [name, "replace"]);
     }
@@ -328,11 +309,11 @@ export function proxy(name, kind) {
     }
 
     function enable() {
-        return call_manager_with_reload("EnableUnitFiles", [[name], false, false]);
+        return call_manager("EnableUnitFiles", [[name], false, false]);
     }
 
     function disable() {
-        return call_manager_with_reload("DisableUnitFiles", [[name], false]);
+        return call_manager("DisableUnitFiles", [[name], false]);
     }
 
     return self;

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -439,7 +439,7 @@ WantedBy=default.target
 
         # After writing files out tell systemd about them
         m.execute("systemctl daemon-reload")
-        m.execute("systemctl stop test")
+        m.execute("systemctl disable --now test")
 
         self.login_and_go("/playground/service#/test")
 
@@ -456,6 +456,26 @@ WantedBy=default.target
         b.wait_text('#enabled', 'true')
         b.click('#disable')
         b.wait_text('#enabled', 'false')
+
+        # reacts to outside changes with systemctl
+        m.execute("systemctl enable test")
+        b.wait_text('#enabled', 'true')
+        m.execute("systemctl disable test")
+        b.wait_text('#enabled', 'false')
+        m.execute("systemctl start test")
+        b.wait_text('#state', '"running"')
+        m.execute("systemctl stop test")
+        b.wait_text('#state', '"stopped"')
+
+        # reacts to outside changes with systemd API
+        m.execute("busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager EnableUnitFiles asbb 1 test.service false false")
+        b.wait_text('#enabled', 'true')
+        m.execute("busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager DisableUnitFiles asb 1 test.service false")
+        b.wait_text('#enabled', 'false')
+        m.execute("busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager StartUnit ss test.service replace")
+        b.wait_text('#state', '"running"')
+        m.execute("busctl call org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager StopUnit ss test.service replace")
+        b.wait_text('#state', '"stopped"')
 
         b.go('#/foo')
         b.wait_text('#exists', 'false')


### PR DESCRIPTION
There is no good reason for doing that -- systemd will automatically
update the unit's state with these API calls. This is causing lockups of
services when e.g. pmlogger.services gets started and enabled at the
same time, as the parallel reload messes up the "activating"
transaction.

This was introduced in the original code in commit 6cbbcec8c2 without a
particular justification, so probably it was just working around an
early systemd bug back then?

 - [x] wait for after the release