### PR TITLE
storage: Use semantic HTML in verify key modal

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -21,7 +21,8 @@ import cockpit from "cockpit";
 import React from "react";
 
 import {
-    Card, CardBody, CardTitle, CardHeader, CardActions, Checkbox,
+    Card, CardBody, CardTitle, CardHeader, CardActions,
+    Checkbox, ClipboardCopy,
     Form, FormGroup,
     DataListItem, DataListItemRow, DataListItemCells, DataListCell, DataList,
     Text, TextVariants, TextInput as TextInputPF, Stack,
@@ -356,17 +357,25 @@ function edit_tang_adv(client, block, key, url, adv, passphrase) {
     const dlg = dialog_open({
         Title: _("Verify key"),
         Body: (
-            <div>
-                <div>{_("Make sure the key hash from the Tang server matches one of the following:")}</div>
-                <br />
-                <div>{_("SHA256")}</div>
-                { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s.sha256}</div>) }
-                <br />
-                <div>{_("SHA1")}</div>
-                { sigkey_thps.map(s => <div key={s} className="sigkey-hash">{s.sha1}</div>) }
-                <br />
-                <div>{_("Manually check with SSH: ")}<pre className="inline-pre">{cmd}</pre></div>
-            </div>
+            <>
+                <p>{_("Make sure the key hash from the Tang server matches one of the following:")}</p>
+
+                <h2 className="sigkey-heading">{_("SHA256")}</h2>
+                { sigkey_thps.map(s => <p key={s} className="sigkey-hash">{s.sha256}</p>) }
+
+                <h2 className="sigkey-heading">{_("SHA1")}</h2>
+                { sigkey_thps.map(s => <p key={s} className="sigkey-hash">{s.sha1}</p>) }
+
+                <p>
+                    {_("Manually check with SSH: ")}
+                    <ClipboardCopy hoverTip={_("Copy to clipboard")}
+                                   clickTip={_("Successfully copied to clipboard!")}
+                                   variant="inline-compact"
+                                   isCode>
+                        {cmd}
+                    </ClipboardCopy>
+                </p>
+            </>
         ),
         Fields: existing_passphrase_fields(_("Saving a new passphrase requires unlocking the disk. Please provide a current disk passphrase.")),
         Action: {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -296,14 +296,15 @@ td.storage-action {
     margin-right: 1em;
 }
 
+.sigkey-heading {
+    color: var(--pf-global--Color--dark-100);
+    font-size: var(--pf-global--FontSize--sm);
+    margin: var(--pf-global--spacer--md) 0 0;
+}
+
 .sigkey-hash {
     font-family: monospace;
     font-size: 140%;
-}
-
-.inline-pre {
-    display: inline-block;
-    padding: 4px;
 }
 
 .pf-c-modal-box h3 {


### PR DESCRIPTION
Follow-up to #15844, to fix the HTML.

Would've been in #15870, but I wanted the previous fix to be implemented quickly. This changes a lot more.