### PR TITLE
hwinfo: Don't oops when some hw details are missing

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -217,7 +217,7 @@ function processMemory(info) {
     for (const dimm in info) {
         const memoryProperty = info[dimm];
 
-        let memorySize = memoryProperty.Size;
+        let memorySize = memoryProperty.Size || _("Unknown");
         if (memorySize.includes("MB")) {
             const memorySizeValue = parseInt(memorySize, 10);
             memorySize = memorySizeValue / 1024 + " GB";
@@ -227,20 +227,20 @@ function processMemory(info) {
         if (!memoryTechnology || memoryTechnology == "<OUT OF SPEC>")
             memoryTechnology = _("Unknown");
 
-        let memoryRank = memoryProperty.Rank;
+        let memoryRank = memoryProperty.Rank || _("Unknown");
         if (memoryRank == 1)
             memoryRank = _("Single rank");
         if (memoryRank == 2)
             memoryRank = _("Dual rank");
 
         memoryArray.push({
-            locator: memoryProperty.Locator,
+            locator: memoryProperty.Locator || _("Unknown"),
             technology: memoryTechnology,
-            type: memoryProperty.Type,
+            type: memoryProperty.Type || _("Unknown"),
             size: memorySize,
             state: memoryProperty["Total Width"] == "Unknown" ? _("Absent") : _("Present"),
             rank: memoryRank,
-            speed: memoryProperty.Speed
+            speed: memoryProperty.Speed || _("Unknown")
         });
     }
 

--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -45,8 +45,8 @@ function findPCI(udevdb, info) {
         const props = udevdb[syspath];
         if (props.SUBSYSTEM === "pci")
             info.pci.push({
-                slot: props.PCI_SLOT_NAME || syspath.split("/").pop(),
-                cls: props.ID_PCI_CLASS_FROM_DATABASE || props.PCI_CLASS.toString(),
+                slot: props.PCI_SLOT_NAME || syspath.split("/").pop() || "",
+                cls: props.ID_PCI_CLASS_FROM_DATABASE || props.PCI_CLASS.toString() || "",
                 vendor: props.ID_VENDOR_FROM_DATABASE || "",
                 model: props.ID_MODEL_FROM_DATABASE || props.PCI_ID || ""
             });


### PR DESCRIPTION
It seems that 'Rank' is not always defined. It not being present would
make the whole page oops.
While on that I made sure, that any missing field would not be
represented as `undefined` but would have some (at least empty string)
value.

Fixes #15631
Related: https://bugzilla.redhat.com/show_bug.cgi?id=1966686