### PR TITLE
Fix missing borders in Selects

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -433,7 +433,15 @@ module.exports = {
 
     optimization: {
         minimize: production,
-        minimizer: [new TerserJSPlugin({ extractComments : false }), new CssMinimizerPlugin()],
+        minimizer: [
+           new TerserJSPlugin({ extractComments : false }),
+           new CssMinimizerPlugin({
+               minimizerOptions: {
+                   preset: ['default', { mergeLonghand: false }]
+               }
+           })
+       ],
+
     },
 
     module: {


### PR DESCRIPTION
Disable mergeLongHand in cssnano.

The official fix has already landed upstream but we unfortunately can't
update cssnano without updating also CssMinimizerPlugin.
An update of CssMinimizerPlugin will not work without webpack-5.

Therefore let's keep the WA for now.