### PR TITLE
cockpit.spec: python3 Requires is malformed

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -648,7 +648,7 @@ Recommends: udisks2-lvm2 >= 2.6
 Recommends: udisks2-iscsi >= 2.6
 Recommends: device-mapper-multipath
 Recommends: clevis-luks
-Requires: %{__python3}
+Requires: python3
 %if 0%{?suse_version}
 Requires: python3-dbus-python
 %else


### PR DESCRIPTION
gen-spec-dependencies does not replace this line with something that dnf builddep can use. python3-dbus follows shortly after. So I assume that hardcoding python3 is also fine.