### PR TITLE
livetest: stop spinning up a vm every single time anyone writes any comment on any PR or issue

### DIFF
--- a/.github/workflows/livetest.yml
+++ b/.github/workflows/livetest.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   pr-info:
+    if: startsWith(github.event.comment.body, '/livetest')
     runs-on: ubuntu-20.04
     steps:
       - name: Query author repository permissions


### PR DESCRIPTION
If we put a `if:` on each `job:` then the workflow will dispatch, but at
least it won't start any VMs.