### PR TITLE
test: Allow selinux denials regarding "dma_heap"

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1261,9 +1261,11 @@ class MachineCase(unittest.TestCase):
             # Fedora and RHEL 9 have switched to dbus-broker
             self.allowed_messages.append("dbus-daemon didn't send us a dbus address; not installed?.*")
 
-        if self.image in ['fedora-34', 'rhel-9-0']:
+        if self.image in ['fedora-34', 'fedora-testing', 'rhel-9-0']:
             # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1929259
             self.allow_journal_messages('audit:.*denied.*comm="pmdakvm" lockdown_reason="debugfs access".*')
+            # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1965743
+            self.allow_journal_messages('audit:.*denied.*name="dma_heap".*')
 
         if self.image in ['debian-testing', 'ubuntu-stable']:
             # HACK: https://bugs.debian.org/951477


### PR DESCRIPTION
They don't seem to affect operations significantly but are blocking
image refreshes.