### PR TITLE
reposchutz: drop superfluous check for tag

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -62,7 +62,6 @@ jobs:
                   exit 1
               fi
               [ "$(git rev-parse FETCH_HEAD)" = "${node_modules}" ]
-              [ "$(git rev-parse "sha-${node_modules}")" = "${node_modules}" ]
               node_modules_package_json="$(git rev-parse "${node_modules}:.package.json")"
               if [ "${package_json}" != "${node_modules_package_json}" ]; then
                   printf "Commit %s package.json and node_modules aren't in sync\n\n" "${commit}" >&2


### PR DESCRIPTION
`git fetch` isn't fetching the named tag, but rather just populating
`FETCH_HEAD`.  That's OK.  We already check that the fetch was
successful and we got the thing we expected, so checking that the tag is
also equal to the thing we expect is just superfluous.  We never use it
anyway.