### PR TITLE
packagekit: Introduce kpatch integration

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -1,0 +1,372 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+import PropTypes from "prop-types";
+import {
+    Alert, Button, Checkbox,
+    Flex, FlexItem,
+    Modal, Radio,
+    Split, SplitItem,
+    Stack,
+    Text, TextVariants
+} from "@patternfly/react-core";
+import { InfoIcon } from "@patternfly/react-icons";
+
+import cockpit from "cockpit";
+import { proxy as serviceProxy } from "service";
+import { check_missing_packages } from "packagekit.js";
+import { install_dialog } from "cockpit-components-install-dialog.jsx";
+
+const _ = cockpit.gettext;
+
+export class KpatchSettings extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            loaded: false,
+            auto: null, // `dnf kpatch` is set to `auto`
+            enabled: null, // kpatch.service is enabled
+            missing: [], // missing packages from `kpatch`, `kpatch-dnf`
+            unavailable: [], // unavailable packages from `kpatch`, `kpatch-dnf`
+
+            // Modal states
+            error: "",
+            updating: false,
+            showModal: false,
+            applyCheckbox: false, // state of the checkbox
+            justCurrent: null, // radio state
+
+            kernelName: "", // uname -r
+            patchName: null, // kpatch-patch name
+            patchInstalled: null, // kpatch-patch installed
+            patchUnavailable: null, // kpatch-patch available
+        };
+
+        this.kpatchService = serviceProxy("kpatch");
+
+        this.checkSetup = this.checkSetup.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.onClose = this.onClose.bind(this);
+        this.handleInstall = this.handleInstall.bind(this);
+    }
+
+    // Only current patches or also future ones
+    current(enabled, installed, unavailable) {
+        return enabled && (installed || unavailable);
+    }
+
+    componentDidMount() {
+        check_missing_packages(["kpatch", "kpatch-dnf"])
+                .then(d =>
+                    this.checkSetup().then(() =>
+                        this.setState({
+                            loaded: true,
+                            unavailable: d.unavailable_names || [],
+                            missing: d.missing_names || [],
+                        })
+                    )
+                )
+                .catch(e => console.log("Could not determine kpatch availability:", JSON.stringify(e)));
+
+        this.kpatchService.addEventListener('changed', () => {
+            this.setState(state => {
+                const current = this.current(this.kpatchService.enabled, state.patchInstalled, state.patchUnavailable);
+                return ({
+                    enabled: this.kpatchService.enabled,
+                    justCurrent: current && !state.auto,
+                    applyCheckbox: current,
+                });
+            });
+        });
+    }
+
+    checkSetup() {
+        // TODO - replace both with `dnf kpatch status` once https://github.com/dynup/kpatch-dnf/pull/8 lands
+        const kpatch_promise = cockpit.file("/etc/dnf/plugins/kpatch.conf").read()
+                .then(data => {
+                    if (data) {
+                        const auto = /autoupdate\s*=\s*True/i.test(data);
+                        this.setState((state, _) => {
+                            const current = this.current(state.enabled, state.patchInstalled, state.patchUnavailable);
+                            return ({
+                                auto: !!auto,
+                                justCurrent: current && !auto,
+                                applyCheckbox: current,
+                            });
+                        });
+                    }
+                })
+                .catch(() => true); // Ignore errors, most likely just does not exist
+
+        const uname_promise = cockpit.spawn(["uname", "-r"])
+                .then(data => {
+                    const fields = data.split("-");
+                    const kpp_kernel_version = fields[0].replaceAll(".", "_");
+                    let release = fields[1].split(".");
+                    release = release.slice(0, release.length - 2); // remove el8.x86_64
+                    const kpp_kernel_release = release.join("_");
+                    const patch_name = ["kpatch-patch", kpp_kernel_version, kpp_kernel_release].join("-");
+                    return check_missing_packages([patch_name])
+                            .then(d =>
+                                this.setState((state, _) => {
+                                    const installed = (d.unavailable_names || []).length === 0 && (d.missing_names || []).length === 0;
+                                    const unavailable = (d.unavailable_names || []).length > 0;
+                                    const current = this.current(state.enabled, installed, unavailable);
+                                    return ({
+                                        kernelName: data,
+                                        patchName: patch_name,
+                                        patchInstalled: installed,
+                                        patchUnavailable: unavailable,
+                                        justCurrent: current && !state.auto,
+                                        applyCheckbox: current,
+                                    });
+                                })
+                            );
+                })
+                .catch(console.error);
+
+        return Promise.allSettled([kpatch_promise, uname_promise]);
+    }
+
+    handleInstall() {
+        this.setState({ updating: true });
+        install_dialog(this.state.missing)
+                .then(() => this.setState({ missing: [], updating: false }))
+                .catch(() => this.setState({ updating: false }));
+    }
+
+    onClose() {
+        this.setState((state, _) => {
+            const current = this.current(state.enabled, state.patchInstalled, state.patchUnavailable);
+            return ({
+                justCurrent: current && !state.auto,
+                applyCheckbox: current,
+                showModal: false,
+                error: "",
+            });
+        });
+    }
+
+    handleChange() {
+        this.setState({ updating: true });
+
+        if (this.state.applyCheckbox) {
+            let install = Promise.resolve(true);
+            if (this.state.justCurrent) {
+                install = new Promise((resolve, reject) => {
+                    cockpit.spawn(["dnf", "-y", "kpatch", "manual"], { superuser: "require", err: "message" })
+                            .then(() => {
+                                if (!this.state.patchUnavailable && !this.state.patchInstalled)
+                                    // TODO - replace with `dnf kpatch install` once https://github.com/dynup/kpatch-dnf/pull/8 lands
+                                    cockpit.spawn(["dnf", "-y", "install", this.state.patchName], { superuser: "require", err: "message" }).then(resolve)
+                                            .catch(reject);
+                                else
+                                    resolve();
+                            })
+                            .catch(reject);
+                });
+            } else {
+                install = cockpit.spawn(["dnf", "-y", "kpatch", "auto"], { superuser: "require", err: "message" });
+            }
+            install
+                    .then(() =>
+                        this.kpatchService.enable().then(() =>
+                            this.kpatchService.start().then(() =>
+                                this.setState({ showModal: false, error: "" })
+                            )
+                        )
+                    )
+                    .catch(e => this.setState({ error: e.toString() }))
+                    .finally(() => this.checkSetup().then(() => this.setState({ updating: false })));
+        } else {
+            cockpit.spawn(["dnf", "-y", "kpatch", "manual"], { superuser: "require", err: "message" })
+                    .then(() =>
+                        this.kpatchService.disable().then(() =>
+                            this.kpatchService.stop().then(() =>
+                                this.setState({ showModal: false, error: "" })
+                            )
+                        )
+                    )
+                    .catch(e => this.setState({ error: e.toString() }))
+                    .finally(() => this.checkSetup().then(() => this.setState({ updating: false })));
+        }
+    }
+
+    render() {
+        // Not yet recognized
+        if (this.state.loaded === false || this.state.patchName === null)
+            return null;
+
+        // Not supported on this system
+        if (this.state.unavailable.length > 0)
+            return null;
+
+        let state = _("Enabled");
+        let actionText = _("Edit");
+        let action = () => this.setState({ showModal: true });
+
+        if (this.state.missing.length > 0) {
+            state = _("Not installed");
+            actionText = _("Install");
+            action = this.handleInstall;
+        } else if (!this.state.enabled) {
+            state = _("Disabled");
+            actionText = _("Enable");
+        }
+
+        const kernel_name = this.state.kernelName ? " (" + this.state.kernelName + ")" : "";
+        const error = this.state.error ? <Alert variant='danger' isInline title={this.state.error} /> : null;
+
+        const body = <Checkbox id="apply-kpatch"
+                               isChecked={this.state.applyCheckbox}
+                               label={_("Apply kernel patches")}
+                               onChange={checked => this.setState({ applyCheckbox: checked })}
+                               body={<>
+                                   <Radio id="current-future"
+                                          label={_("for current and future kernels")}
+                                          onChange={() => this.setState({ justCurrent: false })}
+                                          isDisabled={!this.state.applyCheckbox}
+                                          isChecked={!this.state.justCurrent} />
+                                   <Radio id="current-only"
+                                          label={_("for current kernel only") + kernel_name}
+                                          onChange={() => this.setState({ justCurrent: true })}
+                                          isDisabled={!this.state.applyCheckbox}
+                                          isChecked={this.state.justCurrent} />
+                               </>}
+        />;
+
+        return (<>
+            <div id="kpatch-settings">
+                <Flex alignItems={{ default: 'alignItemsCenter' }}>
+                    <Flex grow={{ default: 'grow' }} alignItems={{ default: 'alignItemsBaseline' }}>
+                        <FlexItem>
+                            <b>{_("Kernel patching")}</b>
+                        </FlexItem>
+                        <FlexItem>
+                            {state}
+                        </FlexItem>
+                    </Flex>
+                    <Flex>
+                        <Button variant="secondary"
+                                isSmall
+                                isDisabled={!this.props.privileged || this.state.updating}
+                                onClick={action}>
+                            {actionText}
+                        </Button>
+                    </Flex>
+                </Flex>
+            </div>
+            <Modal position="top" variant="small" id="kpatch-setup" isOpen={this.state.showModal}
+                title={_("Kernel patch settings")}
+                onClose={ this.onClose }
+                footer={
+                    <>
+                        <Button variant="primary"
+                                isLoading={ this.state.updating }
+                                isDisabled={ this.state.updating }
+                                onClick={ this.handleChange }>
+                            {_("Apply")}
+                        </Button>
+                        <Button variant="link"
+                                isDisabled={ this.state.updating }
+                                onClick={ this.onClose }>
+                            {_("Cancel")}
+                        </Button>
+                    </>
+                }>
+                <>
+                    {error}
+                    {body}
+                </>
+            </Modal>
+        </>);
+    }
+}
+
+KpatchSettings.propTypes = {
+    privileged: PropTypes.bool.isRequired,
+};
+
+export class KpatchStatus extends React.Component {
+    constructor() {
+        super();
+
+        this.state = {
+            loaded: [],
+            installed: [],
+            changelog: null, // FIXME - load changelog
+        };
+    }
+
+    componentDidMount() {
+        cockpit.spawn(["kpatch", "list"], { superuser: "try", err: "ignore", environ: ["LC_MESSAGES=C"] })
+                .then(m => {
+                    const parts = m.trim().split("\n\n");
+                    if (parts.length !== 2 ||
+                        !parts[0].startsWith("Loaded patch modules:") ||
+                        !parts[1].startsWith("Installed patch modules:")) {
+                        console.warn("Unexpected output from `kpatch list`", m);
+                        return;
+                    }
+
+                    const loaded = parts[0].split("\n")
+                            .slice(1)
+                            .map(i => i.split(" ")[0]);
+                    const installed = parts[1].split("\n")
+                            .slice(1)
+                            .map(i => i.split(" ")[0]);
+                    this.setState({ loaded, installed });
+                })
+                .catch(() => true); // Ignore errors
+    }
+
+    render() {
+        let text = [];
+        text = this.state.loaded.map(i =>
+            <Text key={i} component={TextVariants.p}>
+                { cockpit.format(_("Kernel patch $0 is active"), i) }
+            </Text>
+        );
+
+        if (text.length === 0)
+            text = this.state.installed.map(i =>
+                <Text key={i} component={TextVariants.p}>
+                    { cockpit.format(_("Kernel patch $0 is installed"), i) }
+                </Text>
+            );
+
+        if (text.length > 0)
+            return (
+                <Split hasGutter>
+                    <SplitItem>
+                        <InfoIcon />
+                    </SplitItem>
+                    <SplitItem isFilled>
+                        <Stack>
+                            {text}
+                        </Stack>
+                    </SplitItem>
+                </Split>
+            );
+
+        return null;
+    }
+}

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -24,7 +24,7 @@ import React, { useState, useEffect } from "react";
 import ReactDOM from 'react-dom';
 
 import {
-    Alert, Button, Gallery, Modal, Progress, Popover, Tooltip,
+    Alert, Badge, Button, Gallery, Modal, Progress, Popover, Tooltip,
     Card, CardTitle, CardActions, CardHeader, CardBody,
     DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     Flex, FlexItem,
@@ -45,6 +45,7 @@ import { cellWidth, TableText } from "@patternfly/react-table";
 import { Remarkable } from "remarkable";
 
 import { AutoUpdates, getBackend } from "./autoupdates.jsx";
+import { KpatchSettings, KpatchStatus } from "./kpatch.jsx";
 import { History, PackageList } from "./history.jsx";
 import { page_status } from "notifications";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -271,9 +272,13 @@ function updateItem(info, pkgNames, key) {
         </Tooltip>)
     );
     const pkgs = pkgList;
-    let pkgsTruncated = pkgs;
+    const pkgsTruncated = pkgList.slice(0, 4);
+
     if (pkgList.length > 4)
-        pkgsTruncated = pkgList.slice(0, 4).concat(<span key="more">…</span>);
+        pkgsTruncated.push(<span key="more">…</span>);
+
+    if (pkgNames.some(p => p.name.startsWith("kpatch-patch")))
+        pkgsTruncated.push(<>{" "}<Badge>{_("patches")}</Badge></>);
 
     let descriptionFirstLine = (info.description || "").trim();
     if (descriptionFirstLine.indexOf("\n") >= 0)
@@ -822,15 +827,21 @@ class CardsPage extends React.Component {
     render() {
         const cardContents = [];
         let settingsContent = null;
-        const statusContent = <UpdatesStatus key="updates-status"
+        const statusContent = <Stack hasGutter>
+            <UpdatesStatus key="updates-status"
                                 updates={this.props.updates}
                                 onValueChanged={this.props.onValueChanged}
                                 tracerPackages={this.props.tracerPackages}
                                 highestSeverity={this.props.highestSeverity}
-                                timeSinceRefresh={this.props.timeSinceRefresh} />;
+                                timeSinceRefresh={this.props.timeSinceRefresh} />
+            <KpatchStatus />
+        </Stack>;
 
         if (this.state.backend) {
-            settingsContent = <AutoUpdates backend={this.state.backend} privileged={this.props.privileged} />;
+            settingsContent = <Stack hasGutter>
+                <AutoUpdates backend={this.state.backend} privileged={this.props.privileged} />
+                <KpatchSettings privileged={this.props.privileged} />
+            </Stack>;
         }
 
         cardContents.push({

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -37,6 +37,8 @@ done
 """
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "fedora-coreos"]
+OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
+                     "fedora-coreos", "fedora-33", "fedora-34", "centos-8-stream"]
 
 
 class NoSubManCase(PackageCase):
@@ -136,6 +138,131 @@ class TestUpdates(NoSubManCase):
         else:
             self.fail("Timed out waiting for updates spinner to go away")
 
+    @skipImage("kpatch is not available", *OSesWithoutKpatch)
+    def testKpatch(self):
+        b = self.browser
+        m = self.machine
+
+        kernel_ver_arch = m.execute("uname -r").strip()
+        fields = kernel_ver_arch.split("-")
+        kpp_kernel_version = fields[0].replace(".", "_")
+        release = fields[1].split(".")[:-2] # remove el8.x86_64
+        kpp_kernel_release = "_".join(release)
+
+        sanitized_kernel_ver = "_".join(kernel_ver_arch.split(".")[:-2])
+        self.createPackage("-".join(["kpatch-patch", kpp_kernel_version, kpp_kernel_release]), "0", "0", arch=self.secondary_arch,
+                           provides="kpatch-patch = {0}".format(kernel_ver_arch))
+        self.enableRepo()
+
+        self.restore_file("/etc/dnf/plugins/kpatch.conf")
+        m.execute("systemctl disable --now kpatch")
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+
+        # Enable and install kpatch
+        b.wait_in_text("#kpatch-settings", "Disabled")
+        b.click("#kpatch-settings button:contains('Enable')")
+
+        # Apply kernel patches for current and future kernels
+        b.click("#apply-kpatch")
+        b.wait_visible("#apply-kpatch:checked")
+        b.wait_visible("#current-future:checked")
+
+        b.click("button:contains('Apply')")
+        b.wait_not_present("#kpatch-setup")
+
+        self.assertIn("True", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
+        self.assertEqual(m.execute("systemctl is-enabled kpatch").strip(), "enabled")
+        self.assertEqual(m.execute("systemctl is-active kpatch").strip(), "active")
+        # Patches should be installed
+        m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
+
+        # Faking real patches is really hard, so fake `kpatch list` command
+        # To make sure it has the same structure as we expect it to be first check the real command
+        self.assertEqual(m.execute("kpatch list"), "Loaded patch modules:\n\nInstalled patch modules:\n")
+
+        kpatch = """
+#!/bin/bash
+echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled patch modules:\nkpatch_3_10_0_1062_1_1 (3.10.0-1062.el7.x86_64)"
+"""
+
+        self.createPackage("kpatch-patch-" + sanitized_kernel_ver, "1", "0", arch=self.secondary_arch,
+                           provides="kpatch-patch = {0}".format(kernel_ver_arch),
+                           content={"/usr/local/bin/kpatch": kpatch},
+                           postinst="chmod +x /usr/local/bin/kpatch; mount -o bind /usr/local/bin/kpatch /usr/sbin/kpatch")
+        self.enableRepo()
+        self.addCleanup(m.execute, "umount /usr/sbin/kpatch")
+
+        b.click("#status .pf-c-card__actions button")
+        b.wait_visible(".pf-c-badge:contains('patches')")
+        b.click("button:contains('Install all updates')")
+        b.click("button:contains('Continue')")
+        b.wait_in_text("#status", "Kernel patch kpatch_3_10_0_1062_1_1 is active")
+
+        # Switch to 'for current kernel only'
+        b.click("#kpatch-settings button:contains('Edit')")
+        b.click("#current-only")
+        b.wait_visible("#current-future:not(:checked)")
+        b.wait_visible("#current-only:checked")
+
+        b.click("button:contains('Apply')")
+        b.wait_not_present("#kpatch-setup")
+
+        self.assertIn("False", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
+        self.assertEqual(m.execute("systemctl is-enabled kpatch").strip(), "enabled")
+        self.assertEqual(m.execute("systemctl is-active kpatch").strip(), "active")
+        # Patches should be installed
+        m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
+
+        # Test disabling applying patches
+        b.click("#kpatch-settings button:contains('Edit')")
+        b.wait_visible("#apply-kpatch:checked")
+        b.click("#apply-kpatch")
+        b.wait_visible("#apply-kpatch:not(:checked)")
+
+        b.click("button:contains('Apply')")
+        b.wait_not_present("#kpatch-setup")
+
+        b.wait_in_text("#kpatch-settings", "Disabled")
+        b.click("#kpatch-settings button:contains('Enable')")
+
+        # Test closing of the dialog and resetting of changes
+        b.wait_visible("#apply-kpatch:not(:checked)")
+        b.click("#apply-kpatch")
+        b.wait_visible("#apply-kpatch:checked")
+        b.click("button:contains('Cancel')")
+        b.wait_not_present("#kpatch-setup")
+        b.click("#kpatch-settings button:contains('Enable')")
+        b.wait_visible("#apply-kpatch:not(:checked)")
+
+        # Test 'for current kernel only' from clean state
+        m.execute("umount /usr/sbin/kpatch")
+        m.execute("systemctl restart kpatch")
+        m.execute("dnf -y remove kpatch-patch-" + sanitized_kernel_ver)
+        b.reload() # Not listening on patches being removed
+        b.enter_page("/updates")
+
+        b.wait_in_text("#kpatch-settings", "Disabled")
+        b.click("#kpatch-settings button:contains('Enable')")
+
+        # Apply kernel patches for current and future kernels
+        b.click("#apply-kpatch")
+        b.wait_visible("#apply-kpatch:checked")
+        b.click("#current-only")
+        b.wait_visible("#current-future:not(:checked)")
+        b.wait_visible("#current-only:checked")
+
+        b.click("button:contains('Apply')")
+        b.wait_not_present("#kpatch-setup")
+
+        self.assertIn("False", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
+        self.assertEqual(m.execute("systemctl is-enabled kpatch").strip(), "enabled")
+        self.assertEqual(m.execute("systemctl is-active kpatch").strip(), "active")
+        # Patches should be installed
+        m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
+
+
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -153,7 +280,6 @@ class TestUpdates(NoSubManCase):
         # no updates on the Software Updates page
         b.go("/updates")
         b.enter_page("/updates")
-        b.wait_not_present("#status")
         b.wait_in_text("#status", "System is up to date")
         # PK starts from a blank state, thus should force refresh and set the "time since" to 0
         b.wait_in_text("#last-checked", "Last checked: less than a minute ago")
@@ -949,6 +1075,37 @@ class TestWsUpdate(NoSubManCase):
 
         self.allow_restart_journal_messages()
 
+@skipImage("kpatch is not available", *OSesWithoutKpatch)
+class TestKpatchInstall(NoSubManCase):
+    def testBasic(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("rpm --erase --verbose kpatch kpatch-dnf")
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+        b.wait_visible("#status")
+        time.sleep(5)
+        b.wait_not_present("#kpatch-settings")
+
+        dummy_service = "[Service]\nExecStart=/bin/sleep infinity\n[Install]\nWantedBy=multi-user.target\n"
+        self.createPackage("kpatch", "999", "1", content={"/lib/systemd/system/kpatch.service": dummy_service})
+        self.createPackage("kpatch-dnf", "999", "1", content={"/etc/dnf/plugins/kpatch.conf": ""})
+        self.enableRepo()
+
+        b.reload()
+        b.enter_page("/updates")
+
+        b.wait_in_text("#kpatch-settings", "Not installed")
+        b.click("#kpatch-settings button:contains('Install')")
+        b.wait_in_text("#dialog", "kpatch, kpatch-dnf will be installed")
+        b.click("#dialog button:contains('Install')")
+
+        b.wait_in_text("#kpatch-settings", "Disabled")
+
+        # kpatch and kpatch-dnf should be installed
+        m.execute("rpm -q kpatch kpatch-dnf")
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -270,6 +270,9 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
 
         self.enable_preload("packagekit", "index")
 
+        # Refresh cache so cockpit does not try to reload page
+        m.execute("pkcon refresh")
+
         m.start_cockpit()
         b.login_and_go("/system")
         # status on /system front page: no repos at all, thus no updates


### PR DESCRIPTION
Now there are patches available, I tested this on real rhel 8.4 machine.
@garrett and @martinpitt WDYT?

kpatch is available, but not installed:
![Screenshot from 2021-06-07 12-48-03Install](https://user-images.githubusercontent.com/12330670/121004166-a4da8580-c78e-11eb-9f5f-d1d85ccecdc8.png)

kpatch settings dialog:
![image](https://user-images.githubusercontent.com/200109/126266415-f3ef3914-341e-4081-9516-66c2e0b35d57.png)

Kpatch is installed, enabled and all the fun stuff. Also patches are available (see in the list)
![Screenshot from 2021-06-07 12-35-49k1](https://user-images.githubusercontent.com/12330670/121003808-38f81d00-c78e-11eb-9871-ba1fec1fe21c.png)

There are some patches applied:
![Screenshot from 2021-06-07 12-36-42k2](https://user-images.githubusercontent.com/12330670/121003821-3bf30d80-c78e-11eb-9815-d371c768bf1d.png)

This one is probably something we don't want. I run different kernel, but I have patches for different kernel installed. I guess I should not list it? (the other kernel is still available, I just don't use it right now). Should it list only installed patches for the current kernel?
![Screenshot from 2021-06-07 12-42-06installed](https://user-images.githubusercontent.com/12330670/121003832-3e556780-c78e-11eb-9514-337d0ddb2f57.png)

Release note:

## Software Updates: Introduce basic kpatch support

On operating systems with support for live kernel patching Cockpit now offers to enable this feature. Software updates page shows if `kpatch` is supported, if there are any patches active as well as supports enabling subscribing to patches for future kernel versions.  

![kpatch1](https://user-images.githubusercontent.com/12330670/127810350-e188a489-27d7-4f3e-81ed-539a07959dce.png)

