### PR TITLE
storage: Layout fixes

### DIFF
--- a/pkg/storaged/nfs-details.jsx
+++ b/pkg/storaged/nfs-details.jsx
@@ -337,7 +337,7 @@ export class NFSDetails extends React.Component {
 
                         <DescriptionListGroup>
                             <DescriptionListTerm className="control-DescriptionListTerm">{_("Size")}</DescriptionListTerm>
-                            <DescriptionListDescription>
+                            <DescriptionListDescription className="pf-u-align-self-center">
                                 { entry.mounted
                                     ? <StorageUsageBar stats={fsys_size} critical={0.95} block={entry.fields[1]} />
                                     : "--"

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -19,7 +19,7 @@
 
 import React from "react";
 
-import { Page, Grid, GridItem, Card, CardBody, Gallery } from "@patternfly/react-core";
+import { Page, PageSection, Grid, GridItem, Card, CardBody, Gallery } from "@patternfly/react-core";
 
 import { StoragePlots } from "./plot.jsx";
 
@@ -37,30 +37,32 @@ import { StorageLogsPanel } from "./logs-panel.jsx";
 export const Overview = ({ client, plot_state }) => {
     return (
         <Page id="main-storage">
-            <Grid hasGutter>
-                <GridItem md={8} lg={9}>
-                    <Gallery hasGutter>
-                        <Card>
-                            <CardBody>
-                                <StoragePlots plot_state={plot_state} />
-                            </CardBody>
-                        </Card>
-                        <FilesystemsPanel client={client} />
-                        <LockedCryptoPanel client={client} />
-                        <NFSPanel client={client} />
-                        <JobsPanel client={client} />
-                        <StorageLogsPanel />
-                    </Gallery>
-                </GridItem>
-                <GridItem md={4} lg={3} className="storage-sidebar">
-                    <Gallery hasGutter>
-                        <ThingsPanel client={client} />
-                        <DrivesPanel client={client} />
-                        <IscsiPanel client={client} />
-                        <OthersPanel client={client} />
-                    </Gallery>
-                </GridItem>
-            </Grid>
+            <PageSection>
+                <Grid hasGutter>
+                    <GridItem md={8} lg={9}>
+                        <Gallery hasGutter>
+                            <Card>
+                                <CardBody>
+                                    <StoragePlots plot_state={plot_state} />
+                                </CardBody>
+                            </Card>
+                            <FilesystemsPanel client={client} />
+                            <LockedCryptoPanel client={client} />
+                            <NFSPanel client={client} />
+                            <JobsPanel client={client} />
+                            <StorageLogsPanel />
+                        </Gallery>
+                    </GridItem>
+                    <GridItem md={4} lg={3} className="storage-sidebar">
+                        <Gallery hasGutter>
+                            <ThingsPanel client={client} />
+                            <DrivesPanel client={client} />
+                            <IscsiPanel client={client} />
+                            <OthersPanel client={client} />
+                        </Gallery>
+                    </GridItem>
+                </Grid>
+            </PageSection>
         </Page>
     );
 };

--- a/pkg/storaged/side-panel.jsx
+++ b/pkg/storaged/side-panel.jsx
@@ -120,12 +120,12 @@ export class SidePanelRow extends React.Component {
                       onKeyPress={this.props.go ? go : null}
                       onClick={this.props.go ? go : null}>
                 <Flex flexWrap={{ default: 'nowrap' }}>
-                    <FlexItem grow={{ default: 'grow' }} className="sidepanel-row-name">{this.props.name}</FlexItem>
+                    <FlexItem grow={{ default: 'grow' }} className="sidepanel-row-name pf-u-text-break-word">{this.props.name}</FlexItem>
                     <FlexItem>{decoration}</FlexItem>
                 </Flex>
                 <Flex className="sidepanel-row-info">
                     <FlexItem grow={{ default: 'grow' }} className="sidepanel-row-detail">{this.props.detail}</FlexItem>
-                    <FlexItem className="sidepanel-row-devname">{this.props.devname}</FlexItem>
+                    <FlexItem className="sidepanel-row-devname pf-u-text-break-word">{this.props.devname}</FlexItem>
                 </Flex>
             </FlexItem>
         );

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -216,6 +216,10 @@ div.progress {
     min-width: 250px;
 }
 
+#storage-detail .ct-table {
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
+}
+
 td.usage-text {
     text-align: right;
 }
@@ -473,11 +477,7 @@ td.storage-action {
 
 .sidepanel-row {
     padding: var(--pf-global--spacer--sm) var(--pf-global--spacer--lg);
-    border-bottom: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
-}
-
-.sidepanel-row:last-child {
-    border-bottom: none;
+    border-top: var(--pf-global--BorderWidth--sm) solid var(--pf-global--BorderColor--100);
 }
 
 .sidepanel-row.pf-c-empty-state {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -28,15 +28,9 @@
     --pf-l-gallery--GridTemplateColumns: 1fr;
 }
 
-#main-storage.pf-c-page,
 #storage-detail .pf-c-page__main-section,
 #storage-detail .pf-c-page__main-nav {
-    padding: var(--pf-global--gutter);
     overflow: auto;
-}
-
-#main-storage > .pf-c-page__main {
-    padding-bottom: var(--pf-global--spacer--md);
 }
 
 #storage .create-storage {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -19,6 +19,7 @@
 @import "../lib/page.scss";
 @import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 @import "../lib/ct-card.scss";
+@import "@patternfly/patternfly/utilities/Flex/flex.scss";
 @import "@patternfly/patternfly/utilities/Text/text.scss";
 
 #storage .pf-c-card {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -491,7 +491,7 @@ td.storage-action {
 }
 
 .sidepanel-row-name {
-    font-size: var(--pf-global--FontSize--md);
+    font-size: var(--pf-global--FontSize--sm);
 }
 
 .sidepanel-row-info {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -19,6 +19,7 @@
 @import "../lib/page.scss";
 @import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 @import "../lib/ct-card.scss";
+@import "@patternfly/patternfly/utilities/Text/text.scss";
 
 #storage .pf-c-card {
     @extend .ct-card;


### PR DESCRIPTION
This is a bunch of little fixes of small, unrelated things for the storage page, including a fix for #15886.

I tried to use PF4 when possible, but fell back on some custom CSS changes in several places, as:
1. we're not using the latest PF4 (and cannot use the utility classes yet, so I crafted some fallbacks that should cause no harm — as they're simple and the same as PF4's classes — but the specific CSS still should be removed once we upgrade PF4)
2. in the storage page, we're also still using custom widgets for listing