### PR TITLE
pkg/build: new script for standalone webpack

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -119,44 +119,7 @@ SUBST_RULE = \
 	$(GZ_RULE)
 
 # Webpack related
-
-WEBPACK_PACKAGES = \
-	base1 \
-	apps \
-	kdump \
-	metrics \
-	networkmanager \
-	packagekit \
-	playground \
-	selinux \
-	shell \
-	sosreport \
-	static \
-	storaged \
-	systemd \
-	tuned \
-	users \
-	$(NULL)
-
-MANIFESTS = \
-	pkg/pcp/manifest.json \
-	pkg/ssh/manifest.json \
-	$(NULL)
-
-MANIFESTS += $(WEBPACK_PACKAGES:%=dist/%/manifest.json)
-
-V_WEBPACK = $(V_WEBPACK_$(V))
-V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
-V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/manifest.json=%)";
-
-WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) BUILDDIR=$(abspath $(builddir)) \
-	       timeout 15m $(srcdir)/tools/missing $(srcdir)/tools/webpack-make
-
-WEBPACK_CONFIG = $(srcdir)/webpack.config.js
-WEBPACK_INPUTS =
-WEBPACK_OUTPUTS =
-WEBPACK_INSTALL =
-WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=$(top_srcdir)/dist/%/Makefile.deps)
+include pkg/build
 
 # required for running unit and integration tests; commander and ws are deps of chrome-remote-interface
 WEBPACK_TEST_DEPS = \
@@ -166,33 +129,9 @@ WEBPACK_TEST_DEPS = \
 	node_modules/ws \
 	$(NULL)
 
-noinst_SCRIPTS += $(MANIFESTS)
-EXTRA_DIST += $(MANIFESTS) $(WEBPACK_DEPS) webpack.config.js
-
-# Nothing generates this directly, but it's included as a dependency in
-# various places.  It will automatically appear as part of the webpack
-# build.
-dist/%/Makefile.deps:
-	@true
-
-dist/%/manifest.json: $(WEBPACK_CONFIG) $(srcdir)/tools/webpack-make $(srcdir)/package-lock.json
-	$(V_WEBPACK) $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG)
-
--include $(WEBPACK_DEPS)
-
 # the rules above copy a lot of stuff into builddir; clean it up so that distcleancheck works
 clean-local::
 	$(AM_V_at)test "$(srcdir)" == "$(builddir)" || rm -rf dist/
-
-V_NODE_MODULES = $(V_NODE_MODULES_$(V))
-V_NODE_MODULES_ = $(V_NODE_MODULES_$(AM_DEFAULT_VERBOSITY))
-V_NODE_MODULES_0 = @V=0
-
-# We want tools/node-modules to run every time package-lock.json is requested
-# See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
-FORCE:
-package-lock.json: FORCE
-	$(V_NODE_MODULES) $(top_srcdir)/tools/node-modules make_package_lock_json
 
 install-data-local:: $(WEBPACK_INSTALL) $(MANIFESTS)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,3 @@
-export PATH := $(PATH):$(abs_srcdir)/node_modules/.bin
-
 NULL =
 man_MANS =
 BUILT_SOURCES =

--- a/pkg/build
+++ b/pkg/build
@@ -1,0 +1,70 @@
+#!/usr/bin/make -f
+
+# Need some reasonable defaults in case we're run standalone
+srcdir ?= .
+AM_DEFAULT_VERBOSITY ?= 0
+NODE_ENV ?= production
+
+WEBPACK_PACKAGES = \
+	base1 \
+	apps \
+	kdump \
+	metrics \
+	networkmanager \
+	packagekit \
+	playground \
+	selinux \
+	shell \
+	sosreport \
+	static \
+	storaged \
+	systemd \
+	tuned \
+	users \
+	$(NULL)
+
+MANIFESTS = \
+	$(WEBPACK_PACKAGES:%=dist/%/manifest.json) \
+	pkg/pcp/manifest.json \
+	pkg/ssh/manifest.json \
+	$(NULL)
+
+.PHONY: all-webpack
+all-webpack: $(MANIFESTS)
+
+V_WEBPACK = $(V_WEBPACK_$(V))
+V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
+V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/manifest.json=%)";
+
+WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) \
+              timeout 15m $(srcdir)/tools/webpack-make
+
+WEBPACK_CONFIG = $(srcdir)/webpack.config.js
+WEBPACK_INPUTS =
+WEBPACK_OUTPUTS =
+WEBPACK_INSTALL =
+WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/Makefile.deps)
+
+noinst_SCRIPTS += $(MANIFESTS)
+EXTRA_DIST += $(MANIFESTS) $(WEBPACK_DEPS) webpack.config.js
+
+# Nothing generates this directly, but it's included as a dependency in
+# various places.  It will automatically appear as part of the webpack
+# build.
+dist/%/Makefile.deps:
+	@true
+
+dist/%/manifest.json: $(srcdir)/tools/webpack-make $(srcdir)/package-lock.json $(WEBPACK_CONFIG)
+	$(V_WEBPACK) $(WEBPACK_MAKE) -d dist/$*/Makefile.deps -c $(WEBPACK_CONFIG)
+
+-include $(WEBPACK_DEPS)
+
+V_NODE_MODULES = $(V_NODE_MODULES_$(V))
+V_NODE_MODULES_ = $(V_NODE_MODULES_$(AM_DEFAULT_VERBOSITY))
+V_NODE_MODULES_0 = @V=0
+
+# We want tools/node-modules to run every time package-lock.json is requested
+# See https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
+FORCE:
+package-lock.json: FORCE
+	$(V_NODE_MODULES) $(srcdir)/tools/node-modules make_package_lock_json

--- a/pkg/build
+++ b/pkg/build
@@ -36,8 +36,7 @@ V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/manifest.json=%)";
 
-WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) \
-              timeout 15m $(srcdir)/tools/webpack-make
+WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) $(srcdir)/tools/webpack-make
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -16,25 +16,19 @@ var ops = stdio.getopt({
     watch: { key: "w", args: 0, description: "Enable webpack watch mode" },
 });
 
-var srcdir = (process.env.SRCDIR || ".").replace(/\/$/, '');
-var makefile = ops.deps;
-var prefix = "packages";
-var npm = { "dependencies": { } };
+const makefile = ops.deps;
+const prefix = makefile.split("/").slice(-2, -1)[0];
+process.env["ONLYDIR"] = prefix + "/";
 
-if (makefile) {
-    prefix = makefile.split("/").slice(-2, -1)[0];
-    process.env["ONLYDIR"] = prefix + "/";
-    npm = JSON.parse(fs.readFileSync(path.join(srcdir, "package.json"), "utf8"));
-}
-
-var cwd = process.cwd();
-var config_path = path.resolve(cwd, ops.config);
-var config = require(config_path);
+const srcdir = (process.env.SRCDIR || ".").replace(/\/$/, '');
+const cwd = process.cwd();
+const config_path = path.resolve(cwd, ops.config);
+const config = require(config_path);
 
 // The latest input file time updated and used below
-var latest = fs.statSync(config_path).mtime;
+let latest = fs.statSync(config_path).mtime;
 
-compiler = webpack(config);
+const compiler = webpack(config);
 
 if (ops.watch) {
     compiler.hooks.watchRun.tap("WebpackInfo", compilation => {

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -27,7 +27,7 @@ var ops = stdio.getopt({
     watch: { key: "w", args: 0, description: "Enable webpack watch mode" },
 });
 
-var srcdir = process.env.SRCDIR || ".";
+var srcdir = (process.env.SRCDIR || ".").replace(/\/$/, '');
 var makefile = ops.deps;
 var prefix = "packages";
 var npm = { "dependencies": { } };
@@ -115,10 +115,10 @@ function generateDeps(makefile, stats) {
     var asset, output;
     var now = Math.floor(Date.now() / 1000);
 
-    // Strip builddir from output paths
+    // Strip cwd from output paths
     var dir = stats.compilation.outputOptions.path;
-    if (dir.indexOf(cwd) === 0)
-        dir = dir.substr(cwd.length+1);
+    if (dir.startsWith(cwd + '/'))
+        dir = dir.substr(cwd.length + 1);
 
     for(asset in stats.compilation.assets) {
         output = path.join(dir, asset);
@@ -219,12 +219,11 @@ function maybePushInput(inputs, input) {
     if (stats.mtime > latest)
         latest = stats.mtime;
 
-    // Strip builddir and srcdir absolute paths from input file and add it
-    if (input.indexOf(cwd) === 0)
-        input = input.substr(cwd.length+1);
-    if (srcdir && input.indexOf(srcdir) === 0) {
-        input = input.substr(srcdir.length+1);
-    }
+    // Strip cwd and srcdir absolute paths from input file and add it
+    if (input.startsWith(cwd + '/'))
+        input = input.substr(cwd.length + 1);
+    if (input.startsWith(srcdir + '/'))
+        input = input.substr(srcdir.length + 1);
 
     inputs[input] = true;
 }

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -5,21 +5,10 @@
  * lists all dependencies, inputs, outputs, and installable files
  */
 
-function fatal(message, code) {
-    console.log("webpack-make: " + message);
-    process.exit(code || 1);
-}
-
-var webpack, path, stdio, fs;
-
-try {
-    webpack = require("webpack");
-    path = require("path");
-    stdio = require("stdio");
-    fs = require("fs");
-} catch(ex) {
-    fatal(ex.message, 127); /* missing looks for this */
-}
+const webpack = require("webpack");
+const path = require("path");
+const stdio = require("stdio");
+const fs = require("fs");
 
 var ops = stdio.getopt({
     config: { key: "c", args: 1, description: "Path to webpack.config.js", default: "webpack.config.js" },


### PR DESCRIPTION
Split the necessary variables and rules for building dist/ out of the
primary Makefile.am and into pkg/build.  Include that back into the main
Makefile.am.

The only changes are to the invocation of webpack-make:

 - don't set the BUILDDIR.  Nothing uses that anymore.

 - don't call webpack-make via tools/missing.  This won't work without
   autogen, and it never made sense anyway, mostly leading to non-sense
   error messages.

 - stop using timeout.  We don't seem to get stuck builds all that often
   anymore, and besides, we have better ways of dealing with those these days.
   Meanwhile, using this tool interferes with signal delivery (which is why we
   often see node running long after terminating a build).

This file is a makefile, but has `#!/usr/bin/make -p` on top, and is
marked as executable, so it can be invoked as a script, like so:

```sh
pkg/build -j$(nproc)
```

from a clean checkout.  This allows building dist/ without first running
./autogen.sh.

Meanwhile, from the standpoint of a normal build, nothing has changed.
