### PR TITLE
test: Use correct selectors for listing toggles in check-selinux

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -82,10 +82,10 @@ class TestSelinux(MachineCase):
         # there are some distros with broken SELinux policies which always appear; so first, clean these up
         while True:
             # we either have no alerts, or an expand button in the table
-            b.wait_js_cond("ph_in_text('body', 'No SELinux alerts.') || ph_is_present('tbody .listing-ct-toggle')")
+            b.wait_js_cond("ph_in_text('body', 'No SELinux alerts.') || ph_is_present('tbody .pf-c-table__toggle')")
             if "No SELinux alerts." in b.text('body'):
                 break
-            b.click('tbody:first-of-type .listing-ct-toggle')
+            b.click('tbody:first-of-type .pf-c-table__toggle button')
             b.click(dismiss_sel)
             b.wait_not_present(dismiss_sel)
 


### PR DESCRIPTION
Looks like we always had a spiffy clean SELinux record.  But a new
rhel-9-0 image now needs this code to work again.