### PR TITLE
insights: Correctly align Insights status

### DIFF
--- a/pkg/systemd/overview-cards/insights.jsx
+++ b/pkg/systemd/overview-cards/insights.jsx
@@ -19,6 +19,7 @@
 
 import React from 'react';
 import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import cockpit from "cockpit";
 import * as service from "service.js";
@@ -182,7 +183,12 @@ export class InsightsStatus extends React.Component {
         return (
             <li className="system-health-insights">
                 {icon}
-                <Button variant="link" component='a' href={url}>{_("Insights: ")} {text}</Button>
+                <Button isInline variant="link" component='a' href={url}
+                        target="_blank" rel="noopener noreferrer"
+                        icon={<ExternalLinkAltIcon />}
+                        iconPosition="right">
+                    {_("Insights: ")} {text}
+                </Button>
             </li>);
     }
 }


### PR DESCRIPTION
Before:
![Screenshot from 2021-06-08 13-48-39currentinsights](https://user-images.githubusercontent.com/12330670/121181945-d9b80c80-c862-11eb-86d8-9d2ba35ed1cc.png)

After:
![Screenshot from 2021-06-08 14-05-40aftyerinsights](https://user-images.githubusercontent.com/12330670/121181963-de7cc080-c862-11eb-8090-f1008df01974.png)
