### PR TITLE
storage: take into consideration x-systemd.automount when showing warning in fs tab

### DIFF
--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -118,6 +118,7 @@ export function check_mismounted_fsys(client, path, enter_warning) {
     const [, dir, opts] = get_fstab_config(block);
     const split_options = parse_options(opts);
     const opt_noauto = extract_option(split_options, "noauto");
+    const opt_systemd_automount = split_options.indexOf("x-systemd.automount") >= 0;
     const is_mounted = mounted_at.indexOf(dir) >= 0;
     const other_mounts = mounted_at.filter(m => m != dir);
     const crypto_backing_noauto = get_cryptobacking_noauto(client, block);
@@ -133,7 +134,7 @@ export function check_mismounted_fsys(client, path, enter_warning) {
             type = "locked-on-boot-mount";
         else if (!is_mounted && !opt_noauto)
             type = "mount-on-boot";
-        else if (is_mounted && opt_noauto && !crypto_backing_noauto)
+        else if (is_mounted && opt_noauto && !crypto_backing_noauto && !opt_systemd_automount)
             type = "no-mount-on-boot";
     } else if (other_mounts.length > 0) {
         type = "mounted-no-config";

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -243,6 +243,12 @@ class TestStorageMounting(StorageCase):
         b.click(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
 
+        # Using noauto,x-systemd.automount should not show a warning
+        m.execute("sed -i -e 's/auto defaults/auto noauto/' /etc/fstab")
+        b.wait_visible(fsys_tab + " button:contains(Mount also automatically on boot)")
+        m.execute("sed -i -e 's/noauto/noauto,x-systemd.automount/' /etc/fstab")
+        b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
+
     def testDuplicateMountPoints(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
When the FS is currently mounted and x-systemd.automount is used
together with noauto, do not show a warning about inconsistent mount
point.

The FS will be mounted, will just not block early boot.

Closes #15902