### PR TITLE
test: More robust pixel-tests pushing

### DIFF
--- a/test/common/pixel-tests
+++ b/test/common/pixel-tests
@@ -24,7 +24,7 @@ cmd_pull() {
 
 cmd_status() {
     ( cd "$SUBDIR"
-      git rm --cached --quiet '*.png'
+      git rm --force --cached --quiet '*.png'
       git add *.png
       if git diff-index --name-status --cached --exit-code HEAD; then
           echo No changes
@@ -34,17 +34,18 @@ cmd_status() {
 
 cmd_push() {
     ( cd "$SUBDIR"
-      git rm --cached --quiet '*.png'
+      git rm --force --cached --quiet '*.png'
       git add *.png
       if ! git diff-index --name-status --cached --exit-code HEAD; then
+          git fetch origin empty:empty
           git reset --soft empty
           git commit --quiet -m "$(date)"
-          tag="sha-$(git rev-parse HEAD)"
-          git tag "$tag" HEAD
-          git push "$PUSH_REMOTE" "$tag"
       else
           echo No changes
       fi
+      tag="sha-$(git rev-parse HEAD)"
+      [ $(git tag -l "$tag") ] || git tag "$tag" HEAD
+      git push "$PUSH_REMOTE" "$tag"
     )
     git add "$SUBDIR"
 }


### PR DESCRIPTION
Use --force to really blow away the index.  Git otherwise refuses to
remove things from it that are neither in the HEAD commit nor in the
working tree.

Fetch the "empty" branch before using it.

Always push to the remote, even when there are no changes.  The previous push might have failed and this is an easy way to try again.