### PR TITLE
storage: Offer choice of LUKS version 1 or 2 when formatting

### DIFF
--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -145,10 +145,6 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
         return vals.type != "empty" && vals.type != "dos-extended";
     }
 
-    function is_encrypted(vals) {
-        return vals.crypto.on;
-    }
-
     function add_fsys(storaged_name, entry) {
         if (storaged_name === true ||
             (client.fsys_info && client.fsys_info[storaged_name] && client.fsys_info[storaged_name].can_format)) {
@@ -157,13 +153,31 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
     }
 
     var filesystem_options = [];
-    add_fsys("xfs", { value: "xfs", title: "XFS - " + _("Recommended default") });
+    add_fsys("xfs", { value: "xfs", title: "XFS " + _("(recommended)") });
     add_fsys("ext4", { value: "ext4", title: "EXT4" });
     add_fsys("vfat", { value: "vfat", title: "VFAT" });
     add_fsys("ntfs", { value: "ntfs", title: "NTFS" });
     add_fsys(true, { value: "empty", title: _("No filesystem") });
     if (create_partition && enable_dos_extended)
         add_fsys(true, { value: "dos-extended", title: _("Extended partition") });
+
+    function is_encrypted(vals) {
+        return vals.crypto !== "none";
+    }
+
+    function add_crypto_type(value, title, recommended) {
+        if ((client.manager.SupportedEncryptionTypes && client.manager.SupportedEncryptionTypes.indexOf(value) != -1) ||
+            value == "luks1") {
+            crypto_types.push({
+                value: value,
+                title: title + (recommended ? " " + _("(recommended)") : "")
+            });
+        }
+    }
+
+    var crypto_types = [{ value: "none", title: _("No encryption") }];
+    add_crypto_type("luks1", "LUKS1", false);
+    add_crypto_type("luks2", "LUKS2", true);
 
     var usage = utils.get_active_usage(client, create_partition ? null : path);
 
@@ -211,12 +225,8 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                           validate: (name, vals) => utils.validate_fsys_label(name, vals.type),
                           visible: is_filesystem
                       }),
-            CheckBoxes("crypto", "",
-                       {
-                           fields: [
-                               { tag: "on", title: _("Encrypt data") }
-                           ]
-                       }),
+            SelectOne("crypto", _("Encryption"),
+                      { choices: crypto_types }),
             [
                 PassInput("passphrase", _("Passphrase"),
                           {
@@ -284,6 +294,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                 var config_items = [];
                 if (is_encrypted(vals)) {
                     options["encrypt.passphrase"] = { t: 's', v: vals.passphrase };
+                    options["encrypt.type"] = { t: 's', v: vals.crypto };
 
                     var item = {
                         options: { t: 'ay', v: utils.encode_filename(crypto_options_dialog_options(vals)) },

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -58,7 +58,7 @@ class TestStorageHidden(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "crypto.on": True,
+                     "crypto": self.default_crypto_type,
                      "name": "FS",
                      "passphrase": "einszweidrei",
                      "passphrase2": "einszweidrei",

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -54,7 +54,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("size", 17)
         self.dialog_set_val("type", "ext4")
-        self.dialog_set_val("crypto.on", True)
+        self.dialog_set_val("crypto", self.default_crypto_type)
         self.dialog_set_val("name", "ENCRYPTED")
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
@@ -66,6 +66,11 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Encrypted data")
         self.content_row_wait_in_col(2, 1, "ext4 file system")
+
+        if self.default_crypto_type == "luks1":
+            self.content_tab_wait_in_info(1, 2, "Encryption type", "LUKS1")
+        elif self.default_crypto_type == "luks2":
+            self.content_tab_wait_in_info(1, 2, "Encryption type", "LUKS2")
 
         self.wait_in_storaged_configuration(mount_point_secret)
         self.wait_in_storaged_configuration("crypto,options")
@@ -168,7 +173,7 @@ class TestStorageLuks(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "crypto.on": True,
+                     "crypto": self.default_crypto_type,
                      "name": "ENCRYPTED",
                      "mount_point": "/foo",
                      "mount_options.auto": False,
@@ -233,12 +238,11 @@ class TestStorageLuks(StorageCase):
         b.wait_not_present(panel + "ul li:nth-child(2)")
 
     @skipImage("No clevis/tang", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")
-    def testSlots(self):
+    def testLuks1Slots(self):
         self.allow_journal_messages("Device is not initialized.*", ".*could not be opened.")
         m = self.machine
         b = self.browser
 
-        luks_2 = m.image.startswith("rhel") or m.image.startswith("centos")
         error_base = "Error unlocking /dev/sda: Failed to activate device: "
         error_messages = [error_base + "Operation not permitted",
                           error_base + "Incorrect passphrase."]
@@ -252,7 +256,7 @@ class TestStorageLuks(StorageCase):
         # create volume and passphrase
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "crypto.on": True,
+                     "crypto": "luks1",
                      "name": "ENCRYPTED",
                      "mount_point": "/foo",
                      "mount_options.auto": False,
@@ -319,12 +323,11 @@ class TestStorageLuks(StorageCase):
             self.dialog_apply()
             self.dialog_wait_close()
 
-        if not luks_2:
-            # check if add button is inactive
-            b.wait_visible(panel + ".pf-c-card__header button:disabled")
-            # check if edit button is inactive
-            slots_row = tab + " .pf-c-card ul li:first-child"
-            b.wait_visible(slots_row + " button:disabled")
+        # check if add button is inactive
+        b.wait_visible(panel + ".pf-c-card__header button:disabled")
+        # check if edit button is inactive
+        slots_row = tab + " .pf-c-card ul li:first-child"
+        b.wait_visible(slots_row + " button:disabled")
 
         # remove one slot
         slots_list = tab + " .pf-c-card ul "
@@ -378,7 +381,7 @@ class TestStorageLuks(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog({"type": "empty",
-                     "crypto.on": True,
+                     "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
         self.content_row_wait_in_col(1, 1, "Encrypted data")
@@ -399,7 +402,7 @@ class TestStorageLuks(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "crypto.on": True,
+                     "crypto": self.default_crypto_type,
                      "crypto_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -132,7 +132,7 @@ class TestStorageMounting(StorageCase):
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
         self.dialog_set_val("type", "ext4")
-        self.dialog_set_val("crypto.on", True)
+        self.dialog_set_val("crypto", self.default_crypto_type)
 
         def wait_checked(field):
             b.wait_visible(self.dialog_field(field) + ":checked")
@@ -267,7 +267,7 @@ class TestStorageMounting(StorageCase):
         # Encrypt and format the first and give it /run/data as the mount point
         self.content_head_action(1, "Format")
         self.dialog({"type": "ext4",
-                     "crypto.on": "True",
+                     "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_point": "/run/data"})

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -32,8 +32,7 @@ class TestStorageResize(StorageCase):
         "0": {"memory_mb": 1536}
     }
 
-    def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None,
-                    need_passphrase=False):
+    def checkResize(self, fsys, crypto, can_shrink, can_grow, shrink_needs_unmount=None, grow_needs_unmount=None):
         m = self.machine
         b = self.browser
 
@@ -43,6 +42,8 @@ class TestStorageResize(StorageCase):
         else:
             fsys_row = 1
             fsys_tab = 2
+
+        need_passphrase = crypto and self.default_crypto_type == "luks2"
 
         self.login_and_go("/storage")
         m.add_disk("500M", serial="DISK1")
@@ -62,7 +63,7 @@ class TestStorageResize(StorageCase):
         self.dialog_set_val("type", fsys)
         self.dialog_set_val("mount_point", "/run/foo")
         if crypto:
-            self.dialog_set_val("crypto.on", crypto)
+            self.dialog_set_val("crypto", self.default_crypto_type)
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
             self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
@@ -128,15 +129,14 @@ class TestStorageResize(StorageCase):
 
     @skipImage("No NTFS support installed", "rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-5-distropkg", "rhel-9-0", "rhel-9-0-distropkg", "centos-8-stream")
     def testResizeNtfs(self):
-        self.checkResize("ntfs", None,
+        self.checkResize("ntfs", False,
                          can_shrink=True, shrink_needs_unmount=True,
                          can_grow=True, grow_needs_unmount=True)
 
     def testResizeLuks(self):
         self.checkResize("ext4", True,
                          can_shrink=True, shrink_needs_unmount=True,
-                         can_grow=True, grow_needs_unmount=False,
-                         need_passphrase=(self.machine.image.startswith("rhel") or self.machine.image.startswith("centos")))
+                         can_grow=True, grow_needs_unmount=False)
 
     def wait_not_present_with_udev_trigger(self, selector):
         # This is fundamentally the same as Browser.wait, but uses a
@@ -243,7 +243,7 @@ class TestStorageResize(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("name", "FSYS")
         self.dialog_set_val("type", "ext4")
-        self.dialog_set_val("crypto.on", True)
+        self.dialog_set_val("crypto", self.default_crypto_type)
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_set_val("mount_point", mountpoint)
@@ -259,7 +259,7 @@ class TestStorageResize(StorageCase):
         m.execute("lvresize TEST/vol -L+100M")
 
         def confirm_with_passphrase():
-            if not m.image.startswith("rhel") and not m.image.startswith("centos"):
+            if self.default_crypto_type == "luks1":
                 return
             self.dialog_wait_open()
             self.dialog_wait_apply_enabled()

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -460,6 +460,12 @@ class StorageCase(MachineCase, StorageHelpers):
         else:
             self.storaged_version = [0]
 
+        crypto_types = self.machine.execute("busctl --system get-property org.freedesktop.UDisks2 /org/freedesktop/UDisks2/Manager org.freedesktop.UDisks2.Manager SupportedEncryptionTypes || true")
+        if "luks2" in crypto_types:
+            self.default_crypto_type = "luks2"
+        else:
+            self.default_crypto_type = "luks1"
+
         if "debian" in self.machine.image or "ubuntu" in self.machine.image:
             # Debian's udisks has a patch to use FHS /media directory
             self.mount_root = "/media"


### PR DESCRIPTION
This is a sneaky attempt to solve a UI issue in #13192: By using a dropdown for switching on Encryption, we have a obvious place for adding the "Re-use old format and keys" option.