### PR TITLE
shel: Make our SCSS Dart Sass friendly

### DIFF
--- a/pkg/shell/listing.scss
+++ b/pkg/shell/listing.scss
@@ -93,7 +93,7 @@ tr.listing-ct-item > td {
 /* Listing actions can be used directly as a cell */
 tr.listing-ct-item td.listing-ct-actions,
 td.listing-ct-actions {
-    padding: $listing-ct-padding / 2 $listing-ct-padding;
+    padding: $listing-ct-padding * 0.5 $listing-ct-padding;
     text-align: right;
     float: none;
 }
@@ -170,7 +170,7 @@ tbody.active .listing-ct-head {
     font-weight: normal;
     font-size: 18px;
     margin-top: 0px;
-    margin-left: $listing-ct-padding / 2;
+    margin-left: $listing-ct-padding * 0.5;
     margin-bottom: $listing-ct-padding;
 }
 


### PR DESCRIPTION
If we divide by multiplying fractions, it works without any odd Sass functions and imports.