### PR TITLE
metrics: Change "Disks" history label to "Disk I/O"

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1273,7 +1273,7 @@ class MetricsHistory extends React.Component {
                         <div className="metrics-graphs">
                             <Label label={_("CPU")} items={[_("Usage"), _("Load")]} />
                             <Label label={_("Memory")} items={[_("Usage"), ...swapTotal !== undefined ? [_("Swap")] : []]} />
-                            <Label label={_("Disks")} items={[_("Usage")]} />
+                            <Label label={_("Disk I/O")} items={[_("Usage")]} />
                             <Label label={_("Network")} items={[_("Usage")]} />
                         </div>
                     </section>


### PR DESCRIPTION
During user testing it was reported several times that the "Disks"
history column is ambiguous wrt. whether it shows capacity usage or I/O.
It's the latter, so update the label. Keep it in the current metrics
though, as that shows both kinds of metrics (and further clarifies them
with labels).

Also keep "Network" instead of "Network I/O", as there is no ambiguity
there, and the label would get too wide.

https://bugzilla.redhat.com/show_bug.cgi?id=1969904