### PR TITLE
cockpit-po-plugin: improve fuzzy flag matching

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -107,7 +107,7 @@ module.exports = class {
                     if (!this.check_reference_patterns(patterns, references))
                         continue;
 
-                    if (translation.comments.flag === 'fuzzy')
+                    if (translation.comments.flag && translation.comments.flag.match(/\bfuzzy\b/))
                         continue;
 
                     const key = JSON.stringify(context_prefix + msgid);


### PR DESCRIPTION
We might have more than one flag, so look for the word "fuzzy" in the
entire flags string.

We use \b because JS RE doesn't seem to support < and > or \< and \>.