### PR TITLE
test: Fix race condition in TestGrafanaClient initialization

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -854,11 +854,12 @@ class TestGrafanaClient(MachineCase):
 
         # start redis and pmproxy on supervised machine (should become an UI element)
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            m.execute("systemctl enable --now redis-server")
-            # pmproxy is runnning by default, re-start it to pick up redis
-            m.execute("systemctl restart pmproxy")
+            redis = 'redis-server'
         else:
-            m.execute("systemctl enable --now redis pmproxy")
+            redis = 'redis'
+        m.execute("systemctl enable --now " + redis)
+        # re-start pmproxy to pick up redis
+        m.execute("systemctl restart pmproxy")
         m.execute("firewall-cmd --permanent --add-service pmproxy; firewall-cmd --reload")
 
         # Log into Grafana (usually http://127.0.0.2:3002 if you do it interactively)


### PR DESCRIPTION
On Fedora/RHEL systems, starting pmproxy and redis in parallel does not
work: pmproxy needs to start *after* redis is already running, so that
its metrics API actually works. So use the same code structure on all
operating systems.

PR #15812 will fix that properly and get rid of that manual
initialization, but that still takes a while to land.