### PR TITLE
Make description lists collapse to vertical mode when on xs screen sizes

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -35,14 +35,8 @@ svg {
     vertical-align: -0.125em;
 }
 
-// Patternfly horizontal lists should convert to vertical in small screens https://github.com/patternfly/patternfly/issues/3630
-@media (min-width: 640px) {
-    .pf-c-description-list {
-        --pf-c-description-list__group--GridTemplateColumns: var(--pf-c-description-list--m-horizontal__group--GridTemplateColumns);
-    }
-}
-
 // The default gap between the rows in horizontal lists is too large
+.pf-c-description-list.pf-m-horizontal-on-sm,
 .pf-c-description-list.pf-m-horizontal {
     --pf-c-description-list--RowGap: 1rem;
 }

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -473,7 +473,7 @@ class CurrentMetrics extends React.Component {
                         </div>
 
                         { this.state.loadAvg &&
-                            <DescriptionList isHorizontal>
+                            <DescriptionList className="pf-m-horizontal-on-sm">
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Load") }</DescriptionListTerm>
                                     <DescriptionListDescription id="load-avg">{this.state.loadAvg}</DescriptionListDescription>

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -775,7 +775,7 @@ export const NetworkInterfacePage = ({
                             </CardActions>
                         </CardHeader>
                         <CardBody>
-                            <DescriptionList isHorizontal id="network-interface-settings" className="network-interface-settings">
+                            <DescriptionList id="network-interface-settings" className="network-interface-settings pf-m-horizontal-on-sm">
                                 {renderActiveStatusRow()}
                                 {renderCarrierStatusRow()}
                                 {settingsRows}

--- a/pkg/storaged/block-details.jsx
+++ b/pkg/storaged/block-details.jsx
@@ -43,7 +43,7 @@ export class BlockDetails extends React.Component {
             <Card>
                 <CardTitle><Text component={TextVariants.h2}>{_("Block")}</Text></CardTitle>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("storage", "Capacity")}</DescriptionListTerm>
                             <DescriptionListDescription>{ utils.fmt_size_long(block.Size) }</DescriptionListDescription>

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -130,7 +130,7 @@ export class CryptoTab extends React.Component {
 
         return (
             <div>
-                <DescriptionList isHorizontal>
+                <DescriptionList className="pf-m-horizontal-on-sm">
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Stored passphrase")}</DescriptionListTerm>
                         <DescriptionListDescription>

--- a/pkg/storaged/drive-details.jsx
+++ b/pkg/storaged/drive-details.jsx
@@ -76,7 +76,7 @@ export class DriveDetails extends React.Component {
             <Card>
                 <CardTitle><Text component={TextVariants.h2}>{_("Drive")}</Text></CardTitle>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DriveDetailsRow title={_("storage", "Model")} value={drive.Model} />
                         <DriveDetailsRow title={_("storage", "Firmware version")} value={drive.Revision} />
                         <DriveDetailsRow title={_("storage", "Serial number")} value={drive.Serial} />

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -513,7 +513,7 @@ export class FilesystemTab extends React.Component {
 
         return (
             <div>
-                <DescriptionList isHorizontal>
+                <DescriptionList className="pf-m-horizontal-on-sm">
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
                         <DescriptionListDescription>

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -410,7 +410,7 @@ export class BlockVolTab extends React.Component {
 
         return (
             <div>
-                <DescriptionList isHorizontal>
+                <DescriptionList className="pf-m-horizontal-on-sm">
                     <DescriptionListGroup>
                         <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
                         <DescriptionListDescription>
@@ -468,7 +468,7 @@ export class PoolVolTab extends React.Component {
         }
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
                     <DescriptionListDescription>

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -324,7 +324,7 @@ export class MDRaidDetails extends React.Component {
                     </CardActions>
                 </CardHeader>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("storage", "Device")}</DescriptionListTerm>
                             <DescriptionListDescription>{ block ? utils.decode_filename(block.PreferredDevice) : "-" }</DescriptionListDescription>

--- a/pkg/storaged/nfs-details.jsx
+++ b/pkg/storaged/nfs-details.jsx
@@ -324,7 +324,7 @@ export class NFSDetails extends React.Component {
                     </CardActions>
                 </CardHeader>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DescriptionListGroup>
                             <DescriptionListTerm className="control-DescriptionListTerm">{_("Server")}</DescriptionListTerm>
                             <DescriptionListDescription>{entry.fields[0]}</DescriptionListDescription>

--- a/pkg/storaged/part-tab.jsx
+++ b/pkg/storaged/part-tab.jsx
@@ -35,7 +35,7 @@ export class PartitionTab extends React.Component {
         var block_part = this.props.client.blocks_part[this.props.block.path];
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
                     <DescriptionListDescription>{block_part.Name || "-"}</DescriptionListDescription>

--- a/pkg/storaged/pvol-tabs.jsx
+++ b/pkg/storaged/pvol-tabs.jsx
@@ -37,7 +37,7 @@ export class PVolTab extends React.Component {
         var vgroup = block_pvol && this.props.client.vgroups[block_pvol.VolumeGroup];
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Volume group")}</DescriptionListTerm>
                     <DescriptionListDescription>{vgroup
@@ -62,7 +62,7 @@ export class MDRaidMemberTab extends React.Component {
         var mdraid = this.props.client.mdraids[this.props.block.MDRaidMember];
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("RAID device")}</DescriptionListTerm>
                     <DescriptionListDescription>{mdraid
@@ -83,7 +83,7 @@ export class VDOBackingTab extends React.Component {
         var vdo = this.props.client.vdo_overlay.find_by_backing_block(this.props.block);
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("VDO device")}</DescriptionListTerm>
                     <DescriptionListDescription>{vdo

--- a/pkg/storaged/swap-tab.jsx
+++ b/pkg/storaged/swap-tab.jsx
@@ -65,7 +65,7 @@ export class SwapTab extends React.Component {
         }
 
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Used")}</DescriptionListTerm>
                     <DescriptionListDescription>{used}</DescriptionListDescription>

--- a/pkg/storaged/unrecognized-tab.jsx
+++ b/pkg/storaged/unrecognized-tab.jsx
@@ -32,7 +32,7 @@ const _ = cockpit.gettext;
 export class UnrecognizedTab extends React.Component {
     render() {
         return (
-            <DescriptionList isHorizontal>
+            <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Usage")}</DescriptionListTerm>
                     <DescriptionListDescription>{this.props.block.IdUsage || "-"}</DescriptionListDescription>

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -265,7 +265,7 @@ export class VDODetails extends React.Component {
                     </CardActions>
                 </CardHeader>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("Device file")}</DescriptionListTerm>
                             <DescriptionListDescription>{vdo.dev}</DescriptionListDescription>

--- a/pkg/storaged/vgroup-details.jsx
+++ b/pkg/storaged/vgroup-details.jsx
@@ -226,7 +226,7 @@ export class VGroupDetails extends React.Component {
                     </CardActions>
                 </CardHeader>
                 <CardBody>
-                    <DescriptionList isHorizontal>
+                    <DescriptionList className="pf-m-horizontal-on-sm">
                         <DescriptionListGroup>
                             <DescriptionListTerm>{_("storage", "UUID")}</DescriptionListTerm>
                             <DescriptionListDescription>{ vgroup.UUID }</DescriptionListDescription>

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -468,7 +468,7 @@ export class ServiceDetails extends React.Component {
 
         const extraRelationshipsList = (
             <ExpandableSection id="service-details-show-relationships" toggleText={triggerRelationshipsList.length ? _("Show more relationships") : _("Show relationships")}>
-                <DescriptionList isHorizontal>
+                <DescriptionList className="pf-m-horizontal-on-sm">
                     {relationshipsToList(relationships)}
                 </DescriptionList>
             </ExpandableSection>


### PR DESCRIPTION
We used to have an local override for this in
patternfly-4-overrides.scss which however stopped working at some point.

PF4 exposed a class to do that now, so use that class for this purpose.

See https://github.com/patternfly/patternfly/issues/3630

Note: There are some cases were we might still want horizontal lists
even on xs screen sizes, and that when both label and content take very
small space. See metrics -> disk load.