### PR TITLE
make-bots: manually fetch COCKPIT_BOTS_REF, if specified

### DIFF
--- a/tools/make-bots
+++ b/tools/make-bots
@@ -14,7 +14,8 @@ cd "$(realpath -m "$0"/../..)"
 
 if [ ! -d bots ]; then
     [ -n "${quiet}" ] || set -x
-    fetch_to_cache # it's small, so keep everything cached
+    # it's small, so keep everything cached
+    fetch_to_cache ${COCKPIT_BOTS_REF+"${COCKPIT_BOTS_REF}"}
     clone_from_cache "${COCKPIT_BOTS_REF-master}"
 else
     echo "bots/ already exists, skipping"


### PR DESCRIPTION
This gets set when testing bots PRs.  If the PR was proposed from a
fork, then it won't be in the set of commits fetched by default, so
request it explicitly.