### PR TITLE
storage: Polish for the Format dialog

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -230,7 +230,7 @@ import {
     TextInput as TextInputPF4,
     Tooltip, TooltipPosition,
 } from "@patternfly/react-core";
-import { InfoCircleIcon } from "@patternfly/react-icons";
+import { InfoCircleIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 
@@ -238,6 +238,7 @@ import { fmt_size, block_name, format_size_and_text } from "./utils.js";
 import client from "./client.js";
 
 import "form-layout.scss";
+import "@patternfly/patternfly/components/HelperText/helper-text.css";
 
 const _ = cockpit.gettext;
 
@@ -318,6 +319,16 @@ function flatten(arr1) {
     return arr1.reduce((acc, val) => Array.isArray(val) ? acc.concat(flatten(val)) : acc.concat(val), []);
 }
 
+const HelperTextWarning = ({ text }) =>
+    <div className="pf-c-helper-text">
+        <div className="pf-c-helper-text__item pf-m-warning">
+            <span className="pf-c-helper-text__item-icon">
+                <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" />
+            </span>
+            <span className="pf-c-helper-text__item-text">{text}</span>
+        </div>
+    </div>;
+
 export const dialog_open = (def) => {
     const nested_fields = def.Fields || [];
     const fields = flatten(nested_fields);
@@ -393,7 +404,7 @@ export const dialog_open = (def) => {
 
         const extra = <div>
             { def.Footer }
-            { def.Action && def.Action.Danger ? <Alert isInline variant='danger' title={def.Action.Danger} /> : null }
+            { def.Action && def.Action.Danger ? <HelperTextWarning text={def.Action.Danger} /> : null }
         </div>;
 
         return {

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -288,6 +288,14 @@ function is_visible(field, values) {
 }
 
 const Body = ({ body, fields, values, errors, isFormHorizontal, onChange }) => {
+    let error_alert = null;
+
+    if (errors && errors.toString() != "[object Object]") {
+        // This is a global error from a failed action
+        error_alert = <Alert variant='danger' isInline title={errors.toString()} />;
+        errors = null;
+    }
+
     function make_row(field, index) {
         if (field.length !== undefined)
             return make_rows(field, index);
@@ -309,6 +317,7 @@ const Body = ({ body, fields, values, errors, isFormHorizontal, onChange }) => {
 
     return (
         <>
+            { error_alert }
             { body || null }
             { make_rows(fields) }
         </>
@@ -387,13 +396,14 @@ export const dialog_open = (def) => {
                                         else
                                             return def.Action.action(visible_values, progress_callback);
                                     })
-                                    .catch(error => {
-                                        if (error.toString() != "[object Object]") {
-                                            return Promise.reject(error);
-                                        } else {
-                                            update(error, null);
-                                            return Promise.reject();
+                                    .catch(errors => {
+                                        if (errors && errors.toString() != "[object Object]") {
+                                            // Log errors from failed actions, for debugging and
+                                            // to allow the test suite to catch known issues.
+                                            console.warn(errors.toString());
                                         }
+                                        update(errors, null);
+                                        return Promise.reject();
                                     });
                         };
                         return client.run(func);

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -129,6 +129,15 @@ export function initial_mount_options(client, block) {
     return initial_tab_options(client, block, true);
 }
 
+function teardown_and_format_title(usage) {
+    if (usage.Teardown && usage.Teardown.Mounts)
+        return _("Unmount and format");
+    else if (usage.Teardown && (usage.Teardown.PhysicalVolumes || usage.Teardown.MDRaidMembers))
+        return _("Remove and format");
+    else
+        return _("Format");
+}
+
 export function format_dialog(client, path, start, size, enable_dos_extended) {
     var block = client.blocks[path];
     var block_ptable = client.blocks_ptable[path];
@@ -273,7 +282,7 @@ export function format_dialog(client, path, start, size, enable_dos_extended) {
                 dlg.set_nested_values("crypto_options", { ro: false });
         },
         Action: {
-            Title: create_partition ? _("Create partition") : _("Format"),
+            Title: create_partition ? _("Create partition") : teardown_and_format_title(usage),
             Danger: (create_partition ? null : _("Formatting a storage device will erase all data on it.")),
             wrapper: job_progress_wrapper(client, block.path),
             action: function (vals) {

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -44,7 +44,7 @@ class TestStorageFormat(StorageCase):
         self.dialog_set_val("mount_options.auto", False)
         self.dialog_apply()
 
-        b.wait_in_text(".pf-c-modal-box__footer > div.pf-m-danger:nth-child(1)", "Error creating file system")
+        b.wait_in_text("#dialog", "Error creating file system")
 
     def testFormatTypes(self):
         m = self.machine

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -116,7 +116,7 @@ class TestStorageFormat(StorageCase):
 
         self.content_head_action(1, "Format")
         self.dialog_wait_open()
-        self.dialog_set_val("erase", "zero")
+        self.dialog_set_val("erase.on", True)
         self.dialog_set_val("mount_point", "/foo")
         self.dialog_apply()
         b.wait_in_text("footer", "Erasing /dev/mapper/superslow")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -62,6 +62,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("crypto_options.extra", "crypto,options")
         self.dialog_set_val("mount_point", mount_point_secret)
         self.dialog_set_val("mount_options.auto", True)
+        b.assert_pixels("#dialog", "format")
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 1, "Encrypted data")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -205,7 +205,7 @@ class TestStorageLvm2(StorageCase):
 
         # use almost all of the pool by erasing the thin volume
         self.content_head_action(2, "Format")
-        self.dialog({"erase": "zero",
+        self.dialog({"erase.on": True,
                      "type": "ext4",
                      "mount_point": mount_point_thin})
         self.content_row_wait_in_col(2, 1, "ext4 file system")


### PR DESCRIPTION
Release note:

### Storage: the Format dialog has been polished

Fields have been re-ordered and warnings and errors are now consistent with Cockpit's common styling.

![image](https://user-images.githubusercontent.com/3228183/122435368-9d8e5580-cfa0-11eb-86c2-4753c2cb9aba.png)
