### PR TITLE
streamline dist workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -8,23 +8,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    env:
-      # current podman backport falls over as non-root, and completely breaks down with :i386 image
-      docker: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
-        with:
-          # need this to also fetch tags
-          fetch-depth: 0
 
-      - name: Run unit-tests container to build dist
-        run: |
-          containers/unit-tests/start dist
+      - name: Build jumpstart tarball
+        run: pkg/build -j$(nproc) webpack-jumpstart.tar
 
       - name: Create dist artifact
         uses: actions/upload-artifact@v2
         with:
-          name: dist
-          path: tmp/dist/cockpit-*.tar.xz
+          name: webpack-jumpstart
+          path: webpack-jumpstart.tar
           retention-days: 1

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -14,10 +14,10 @@ jobs:
         # 2.14.0; if you update this, audit the diff and ensure that it does not leak/abuse secrets
         uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
         with:
-          name: dist
+          name: webpack-jumpstart
           workflow: build-dist
           run_id: ${{ github.event.workflow_run.id }}
-          path: dist-unpack
+          path: artifact
 
       - name: Set up configuration and secrets
         run: |
@@ -31,22 +31,9 @@ jobs:
           set -ex
           mkdir dist-repo
           cd dist-repo
-          TARS=(../dist-unpack/cockpit-*.tar.xz)
-          if [ "${#TARS[@]}" -ne 1 ]; then
-              echo "Expected exactly one tarball" >&2
-              exit 1
-          fi
-          tar --strip-components=1 -xf "${TARS[0]}"
-
-          # prevent any sneaky/buggy stuff from build-dist
-          danger="$(find -maxdepth 1 -name '.git*')"
-          if [ -n "$danger" ]; then
-              printf "Unexpected files in dist artifact:\n%s\n" "$danger" >&2
-              exit 1
-          fi
-
+          tar -xf ../artifact/webpack-jumpstart.tar dist package-lock.json
           git init
-          git add dist/ node_modules/ package-lock.json tools/debian/copyright
+          git add dist package-lock.json
           git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
           tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"

--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ po*.js.gz
 /test_rsa_key
 /tmp-dist
 /valgrind-suppressions
+/webpack-jumpstart.tar
 
 /pkg/*/cockpit-components-*.js
 /pkg/*/cockpit-components-*.js

--- a/Makefile.am
+++ b/Makefile.am
@@ -60,10 +60,6 @@ V_COPY = $(V_COPY_$(V))
 V_COPY_ = $(V_COPY_$(AM_DEFAULT_VERBOSITY))
 V_COPY_0 = @echo "  COPY    " $@;
 
-V_TAR = $(V_TAR_$(V))
-V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
-V_TAR_0 = @echo "  TAR     " $@;
-
 MV = mv -f
 
 COPY_RULE = \

--- a/pkg/build
+++ b/pkg/build
@@ -32,6 +32,13 @@ MANIFESTS = \
 .PHONY: all-webpack
 all-webpack: $(MANIFESTS)
 
+V_TAR = $(V_TAR_$(V))
+V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
+V_TAR_0 = @echo "  TAR     " $@;
+
+webpack-jumpstart.tar: $(MANIFESTS) package-lock.json
+	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json
+
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/manifest.json=%)";


### PR DESCRIPTION
In summary:
 - use pkg/build instead of automake
 - run directly on the github actions runner

 - [x] #15922 