### PR TITLE
workflows: Fix unit-tests' "changed" detection to compare against correct target branch

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build unit test container if it changed
         run: |
-          changes=$(git diff --name-only origin/master..HEAD -- containers/unit-tests/)
+          changes=$(git diff --name-only origin/${{ github.event.pull_request.base.ref }}..HEAD -- containers/unit-tests/)
           if [ -n "${changes}" ]; then
             case '${{ matrix.startarg }}' in
               *:i386*) arch=i386;;


### PR DESCRIPTION
Hardcoding "master" does not work for PRs which target e.g. rhel-8.4.

---

As noticed in #15939