### PR TITLE
systemd: fix _global-variables.scss import path

### DIFF
--- a/pkg/systemd/reporting.scss
+++ b/pkg/systemd/reporting.scss
@@ -1,4 +1,4 @@
-@import "./_global-variables.scss";
+@import "_global-variables.scss";
 @import "../lib/ct-card.scss";
 
 #log-details .pf-c-card {


### PR DESCRIPTION
1a28f9788e0fc9075ee5bb32fc563e20a5f947b5 introduced an @import of
"./_global-variables.scss" in reporting.scss.

I'm not sure why this got imported with "./" but since that's not in the
same directory, it seems wrong.  Furthermore, although it works under
sassc, it breaks with Dart Sass.

Other users seem to import this as "_global-variables.scss" and rely on
path resolution to find it in pkg/lib, so let's do the same here.