### PR TITLE
packit.yaml: workaround to fix docs build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,6 +1,10 @@
 specfile_path: cockpit.spec
 actions:
   create-archive:
+    # HACK: until we get the doc building depends in the sandcastle...
+    - tools/webpack-jumpstart --wait
+    - mkdir -p dist/guide/html
+    - touch dist/guide/html/RedHatText-Regular.woff2 dist/guide/html/RedHatText-Medium.woff2 dist/guide/links.html dist/guide/index.html
     # the upstream git spec file has unresolved macros which are normally put
     # in at `make dist` time; they are not important for CI
     # also, build optional packages for CentOS 8

--- a/test/make_dist.py
+++ b/test/make_dist.py
@@ -20,7 +20,6 @@ import multiprocessing
 import os
 import subprocess
 import sys
-import time
 import argparse
 
 
@@ -51,19 +50,16 @@ def build_dist():
 
 
 def download_cache(wait=False):
-    tries = 50 if wait else 1  # 25 minutes, once every 30s
-    for retry in range(tries):
-        try:
-            subprocess.check_call(["tools/webpack-jumpstart"])
-            return True
-        except subprocess.CalledProcessError as e:
-            if e.returncode != 2 or not wait:
-                break
-            message("make_dist: pre-built dist not yet available, waiting...")
-            time.sleep(30)
+    cmd = ['tools/webpack-jumpstart']
+    if wait:
+        cmd.append('--wait')
 
-    message("make_dist: Downloading pre-built dist failed")
-    return False
+    try:
+        subprocess.check_call(cmd)
+        return True
+    except subprocess.CalledProcessError:
+        message("make_dist: Downloading pre-built dist failed")
+        return False
 
 
 def make_dist(download_only=False, wait_download=False):

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -37,10 +37,17 @@ if ! git diff --quiet -- ':^test' ':^packit.yaml' ':^.github'; then
 fi
 
 tag="sha-$(git rev-parse HEAD)"
-if ! fetch_to_cache tag "${tag}"; then
-    echo "There is no cache entry ${tag}" >&2
-    exit 2
-fi
+for try in $(seq 50 -1 0); do
+    if fetch_to_cache tag "${tag}"; then
+        break
+    fi
+    if [ "${1-}" != '--wait' -o "$try" = '0' ]; then
+        echo "There is no cache entry ${tag}" >&2
+        exit 1
+    fi
+    message WAIT 30s
+    sleep 30s
+done
 
 if ! cmp_from_cache "${tag}" "package-lock.json" "package-lock.json"; then
     echo "The cached package-lock.json doesn't match our own" >&2


### PR DESCRIPTION
We don't get docs built by the build workflow anymore, so try building
them in the sandcastle.

update: That didn't work.  Let's add a nasty workaround, instead.