### PR TITLE
package.json: add fibers package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "eslint-webpack-plugin": "^2.5.3",
     "expose-loader": "^1.0.1",
+    "fibers": "*",
     "gettext-parser": "^2.0.0",
     "html-webpack-plugin": "^4.0.1",
     "htmlparser": "^1.7.7",


### PR DESCRIPTION
Add the "fibers" package to our node_modules/

sass-loader will detect if this package is present and inject it into
Dart Sass, enabling faster builds by avoiding async call overhead.