### PR TITLE
test: check out the bots on an as-needed basis

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -57,7 +57,6 @@ if test -z "${NOCONFIGURE:-}"; then
     fi
 fi
 
-tools/make-bots
 test/common/pixel-tests pull
 
 if test -n "${NOCONFIGURE:-}"; then

--- a/test/common/parent.py
+++ b/test/common/parent.py
@@ -1,4 +1,6 @@
+import importlib
 import os
+import subprocess
 import sys
 
 BASE_DIR = os.path.realpath(f'{__file__}/../../..')
@@ -8,3 +10,9 @@ BOTS_DIR = f'{BASE_DIR}/bots'
 sys.path.append(BOTS_DIR)
 sys.path.append(f'{TEST_DIR}/common')
 sys.path.append(f'{BOTS_DIR}/machine')
+
+
+def ensure_bots():
+    if not os.path.isdir(BOTS_DIR):
+        subprocess.check_call([f'{BASE_DIR}/tools/make-bots'])
+        importlib.invalidate_caches()

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -16,6 +16,7 @@ import importlib.machinery
 import importlib.util
 
 import parent
+parent.ensure_bots()  # NOQA: testvm lives in bots/
 import testlib
 import testvm
 

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -24,14 +24,11 @@ import subprocess
 
 import make_dist
 
-from common.parent import ensure_bots
+from common.parent import BASE_DIR, TEST_DIR, BOTS_DIR, ensure_bots
 ensure_bots()  # NOQA: testvm lives in bots/
 import testvm
 
-TEST = os.path.abspath(os.path.dirname(__file__))
-BASE = os.path.normpath(os.path.join(TEST, ".."))
-BOTS = os.path.join(BASE, "bots")
-os.environ["PATH"] = "{0}:{1}".format(os.environ.get("PATH"), BOTS)
+os.environ["PATH"] = "{0}:{1}".format(os.environ.get("PATH"), BOTS_DIR)
 
 networking = None
 
@@ -101,16 +98,16 @@ def main():
 def upload_scripts(machine, args):
     machine.execute("rm -rf /var/lib/testvm")
     machine.upload([os.path.join(testvm.SCRIPTS_DIR, "lib")], "/var/lib/testvm")
-    machine.upload([os.path.join(BASE, "tools", "make-srpm")], "/var/lib/testvm")
+    machine.upload([os.path.join(BASE_DIR, "tools", "make-srpm")], "/var/lib/testvm")
     machine.upload([os.path.join(testvm.SCRIPTS_DIR, "%s.install" % machine.image)], "/var/tmp")
-    machine.upload([os.path.join(BASE, "containers")], "/var/tmp")
+    machine.upload([os.path.join(BASE_DIR, "containers")], "/var/tmp")
 
 
 # Create the necessary layered image for the build/install
 def prepare_install_image(base_image, overlay=False):
     if "/" not in base_image:
         base_image = os.path.join(testvm.IMAGES_DIR, base_image)
-    test_images = os.path.join(TEST, "images")
+    test_images = os.path.join(TEST_DIR, "images")
     os.makedirs(test_images, exist_ok=True)
     install_image = os.path.join(test_images, os.path.basename(base_image))
     if not os.path.exists(install_image) or not overlay:

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -22,11 +22,11 @@ import os
 import sys
 import subprocess
 
-from verify import parent
 import make_dist
-import testvm
 
-parent  # pyflakes
+from common.parent import ensure_bots
+ensure_bots()  # NOQA: testvm lives in bots/
+import testvm
 
 TEST = os.path.abspath(os.path.dirname(__file__))
 BASE = os.path.normpath(os.path.join(TEST, ".."))


### PR DESCRIPTION
Most python things that need to use the bots first import parent.py to
set up the path to enable importing things from the bots directory.

Use this as a nice place for a hook to check out the bots, if they're
not already there.

With this in place, we no longer need the blanket call in autogen.