### PR TITLE
testlib: force use of prepared images

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -853,15 +853,17 @@ class MachineCase(unittest.TestCase):
 
     def new_machine(self, image=None, forward={}, restrict=True, cleanup=True, **kwargs):
         machine_class = self.machine_class
-        if image is None:
-            image = self.image
         if opts.address:
             if machine_class or forward:
                 raise unittest.SkipTest("Cannot run this test when specific machine address is specified")
-            machine = testvm.Machine(address=opts.address, image=image, verbose=opts.trace, browser=opts.browser)
+            machine = testvm.Machine(address=opts.address, image=image or self.image, verbose=opts.trace, browser=opts.browser)
             if cleanup:
                 self.addCleanup(machine.disconnect)
         else:
+            if image is None:
+                image = os.path.join(TEST_DIR, "images", self.image)
+                if not os.path.exists(image):
+                    raise FileNotFoundError("Can't run tests without a prepared image; use test/image-prepare")
             if not machine_class:
                 machine_class = testvm.VirtMachine
             if not self.network:


### PR DESCRIPTION
For images not explicitly specified by a provision, assume that we want
the image to have been created by test/image-prepare.

Throw an early exception with a useful message, for ourselves, if it
doesn't exist.

Note that passing a pathname as the image name is explicitly supported,
and the basename (without extension) will be used for setting the
Machine.image variable.