### PR TITLE
lib: table: parameterize expandId and contentId with the table id

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -204,8 +204,11 @@ export class ListingTable extends React.Component {
         if (this.props.rows.length == 0)
             tableProps.className += ' ct-table-empty';
 
-        if (this.props.id)
+        if (this.props.id) {
             tableProps.id = this.props.id;
+            tableProps.expandId = this.props.id + '-expandable-toggle';
+            tableProps.contentId = this.props.id + '-expanded-content';
+        }
 
         if (this.props.variant)
             tableProps.variant = this.props.variant;

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -184,6 +184,7 @@ function ZoneSection(props) {
         {props.zone.services.length > 0 &&
         <CardBody className="contains-list">
             <ListingTable columns={[{ title: _("Service"), props: { width: 40 } }, { title: _("TCP"), props: { width: 30 } }, { title: _("UDP"), props: { width: 30 } }]}
+                          id={props.zone.id}
                           aria-label={props.zone.id}
                           variant="compact"
                           emptyCaption={_("There are no active services in this zone")}


### PR DESCRIPTION
This fixes the duplicate Ids issues for expandable rows in networking firewall page.

Fixes #15193