### PR TITLE
package.json: bump sass-loader to 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "null-loader": "^4.0.0",
     "raw-loader": "^4.0.0",
     "sass": "~1.32.0",
-    "sass-loader": "^10.0.0",
+    "sass-loader": "^12.1.0",
     "sizzle": "^2.3.5",
     "stdio": "^2.1.1",
     "strict-loader": "^1.2.0",


### PR DESCRIPTION
Now that we're on Webpack 5, we can move to sass-loader 12.  It's a bit
smaller, mostly due to fewer internal dependencies.

```
⬢[lis@f34 cockpit]$ diff -ru master/dist sass-loader-12/dist
⬢[lis@f34 cockpit]$ 
```