### PR TITLE
    test/run: add a "/devel" scenario

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -900,7 +900,7 @@ class MachineCase(unittest.TestCase):
         return getattr(test_method, "_testlib__non_destructive", False)
 
     def is_devel_build(self):
-        return self.machine.image == testvm.TEST_OS_DEFAULT
+        return os.environ.get('NODE_ENV') == 'development'
 
     def disable_preload(self, *packages):
         for pkg in packages:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -899,6 +899,9 @@ class MachineCase(unittest.TestCase):
         test_method = getattr(self.__class__, self._testMethodName)
         return getattr(test_method, "_testlib__non_destructive", False)
 
+    def is_devel_build(self):
+        return self.machine.image == testvm.TEST_OS_DEFAULT
+
     def disable_preload(self, *packages):
         for pkg in packages:
             path = "/usr/share/cockpit/%s" % pkg
@@ -1007,8 +1010,7 @@ class MachineCase(unittest.TestCase):
 
             # Pages with debug enabled are huge and loading/executing them is heavy for browsers
             # To make it easier for browsers and thus make tests quicker, disable packagekit and systemd preloads
-            # Only "TEST_OS_DEFAULT" has debug build enabled, see `build_and_install()` in `test/image-prepare`
-            if self.machine.image == testvm.TEST_OS_DEFAULT:
+            if self.is_devel_build():
                 self.disable_preload("packagekit", "systemd")
 
     def nonDestructiveSetup(self):

--- a/test/run
+++ b/test/run
@@ -11,11 +11,8 @@ TEST_SCENARIO=${TEST_SCENARIO:-verify}
 TEST_OS_DEFAULT=$(PYTHONPATH=bots python3 -c 'from machine.machine_core.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
 
 case $TEST_SCENARIO in
-    verify|firefox)
-        # do a development build on the latest Fedora image so that we can spot React and other dev-only warnings
-        if [ "$TEST_OS" = "$TEST_OS_DEFAULT" ]; then
-            export NODE_ENV=development
-        fi
+    verify|devel|firefox|firefox-devel)
+        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || export NODE_ENV=development
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
         test/image-prepare --verbose $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify

--- a/test/run
+++ b/test/run
@@ -11,17 +11,14 @@ TEST_SCENARIO=${TEST_SCENARIO:-verify}
 TEST_OS_DEFAULT=$(PYTHONPATH=bots python3 -c 'from machine.machine_core.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
 
 case $TEST_SCENARIO in
-    verify)
+    verify|firefox)
         # do a development build on the latest Fedora image so that we can spot React and other dev-only warnings
         if [ "$TEST_OS" = "$TEST_OS_DEFAULT" ]; then
             export NODE_ENV=development
         fi
+        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
         test/image-prepare --verbose $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
-        ;;
-    firefox)
-        test/image-prepare --quick --verbose $TEST_OS
-        TEST_BROWSER=firefox test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;
     container-*)
         test/image-prepare --quick --containers --verbose $TEST_OS

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -22,7 +22,6 @@ import time
 
 import parent
 from testlib import *
-from machine_core.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
@@ -118,7 +117,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         # Disable preloading on all machines ("machine1" is done in testlib.py)
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.machine.image == TEST_OS_DEFAULT:
+        if self.is_devel_build():
             for machine in ["machine2", "machine3"]:
                 for pkg in ["packagekit", "systemd", "playground"]:
                     self.machines[machine].write(f"/usr/share/cockpit/{pkg}/override.json", '{ "preload": [ ] }')

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -23,7 +23,6 @@ import time
 
 import parent
 from testlib import *
-from machine_core.constants import TEST_OS_DEFAULT
 
 
 def break_hostkey(m, address):
@@ -160,7 +159,7 @@ class TestMultiMachineAdd(MachineCase):
         # Disable preloading on all machines ("machine1" is done in testlib.py)
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.machine.image == TEST_OS_DEFAULT:
+        if self.is_devel_build():
             self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
             self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
             self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
@@ -264,7 +263,7 @@ class TestMultiMachine(MachineCase):
         # Disable preloading on all machines ("machine1" is done in testlib.py)
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.machine.image == TEST_OS_DEFAULT:
+        if self.is_devel_build():
             self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
             self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
             self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -22,7 +22,6 @@ import subprocess
 
 import parent
 from testlib import *
-from machine_core.constants import TEST_OS_DEFAULT
 
 
 def kill_user_admin(machine):
@@ -115,7 +114,7 @@ class TestMultiMachineKeyAuth(MachineCase):
         # Disable preloading on all machines ("machine1" is done in testlib.py)
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.machine.image == TEST_OS_DEFAULT:
+        if self.is_devel_build():
             self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
             self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
 


### PR DESCRIPTION
    
    Remove the logic of setting `NODE_ENV=development` for default
    `TEST_OS`, and set it according to the addition of a new test scenario
    called `/devel`.
    
    Add also the option for `/firefox-devel` to be able to test a devel
    build against Firefox.
