### PR TITLE
webpack-make refactors

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -76,9 +76,17 @@ function generateDeps(makefile, stats) {
     var pkgdir = path.dirname(makefile);
     var stampfile = pkgdir + '/manifest.json';
 
-    stats.compilation.fileDependencies.forEach(function(file) {
-        maybePushInput(inputs, file);
-    });
+    for (const file of stats.compilation.fileDependencies) {
+        // node modules  are handled by the dependency on package-lock.json
+        if (file.includes('/node_modules/'))
+            continue;
+
+        // Webpack 5 includes directories: https://github.com/webpack/webpack/issues/11971
+        if (fs.lstatSync(file).isDirectory())
+            continue;
+
+        inputs[path.relative(srcdir, file)] = true;
+    }
 
     // All the dependent files
     var asset, output;
@@ -166,25 +174,4 @@ function generateDeps(makefile, stats) {
 
     data = lines.join("\n") + "\n";
     fs.writeFileSync(makefile, data);
-}
-
-function maybePushInput(inputs, input) {
-    // Don't include node_modules
-    if (input.includes("/node_modules")) {
-        return;
-    }
-
-    // Don't include sub-directories of input
-    // Webpack 5 includes these: https://github.com/webpack/webpack/issues/11971
-    const stat = fs.lstatSync(input);
-    if (stat.isDirectory())
-        return;
-
-    // Strip cwd and srcdir absolute paths from input file and add it
-    if (input.startsWith(cwd + '/'))
-        input = input.substr(cwd.length + 1);
-    if (input.startsWith(srcdir + '/'))
-        input = input.substr(srcdir.length + 1);
-
-    inputs[input] = true;
 }

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -66,16 +66,11 @@ function process_result(err, stats) {
 }
 
 function generateDeps(makefile, stats) {
+    const stampfile = path.dirname(makefile) + '/manifest.json';
+    const dir = path.relative('', stats.compilation.outputOptions.path);
+    const now = Math.floor(Date.now() / 1000);
 
-    // Note that these are cheap ways of doing a set
-    var inputs = { };
-    var outputs = { };
-    var installs = { };
-    var tests = { };
-
-    var pkgdir = path.dirname(makefile);
-    var stampfile = pkgdir + '/manifest.json';
-
+    const inputs = new Set();
     for (const file of stats.compilation.fileDependencies) {
         // node modules  are handled by the dependency on package-lock.json
         if (file.includes('/node_modules/'))
@@ -85,17 +80,8 @@ function generateDeps(makefile, stats) {
         if (fs.lstatSync(file).isDirectory())
             continue;
 
-        inputs[path.relative(srcdir, file)] = true;
+        inputs.add(path.relative(srcdir, file));
     }
-
-    // All the dependent files
-    var asset, output;
-    var now = Math.floor(Date.now() / 1000);
-
-    // Strip cwd from output paths
-    var dir = stats.compilation.outputOptions.path;
-    if (dir.startsWith(cwd + '/'))
-        dir = dir.substr(cwd.length + 1);
 
     const uncompressed_patterns = [
         '/manifest.json$', '/override.json$',
@@ -104,16 +90,19 @@ function generateDeps(makefile, stats) {
         '\.png$', '\.woff$', '\.woff2$', '\.gif$'
     ].map((r) => new RegExp(r));
 
-    for (asset in stats.compilation.assets) {
-        output = path.join(dir, asset);
+    const outputs = new Set();
+    const installs = new Set();
+    const tests = new Set();
+    for (const asset in stats.compilation.assets) {
+        const output = path.join(dir, asset);
         fs.utimesSync(output, now, now);
 
         if (!output.endsWith("/manifest.json") && !output.endsWith(".map"))
-            outputs[output] = output;
+            outputs.add(output);
 
         if (output.includes("/test-")) {
             if (output.endsWith(".html")) {
-                tests[output] = output;
+                tests.add(output);
             }
             continue;
         }
@@ -122,25 +111,19 @@ function generateDeps(makefile, stats) {
             continue;
 
         if (uncompressed_patterns.some((s) => output.match(s))) {
-            installs[output] = true;
+            installs.add(output);
         } else {
-            installs[output + '.gz'] = true;
+            installs.add(output + '.gz');
         }
     }
 
-    // Finalize all the sets into arrays
-    inputs = Object.keys(inputs).sort();
-    outputs = Object.keys(outputs).sort();
-    installs = Object.keys(installs).sort();
-    tests = Object.keys(tests).sort();
+    const lines = [ "# Generated Makefile data for " + prefix ];
 
-    var lines = [ "# Generated Makefile data for " + prefix ];
-
-    function makeArray(name, values) {
+    function makeArray(name, set) {
         lines.push(name + " = \\");
-        values.forEach(function(value) {
+        for (const value of [...set.keys()].sort()) {
             lines.push("\t" + value + " \\");
-        });
+        }
         lines.push("\t$(NULL)");
         lines.push("");
     }
@@ -154,15 +137,15 @@ function generateDeps(makefile, stats) {
     lines.push(stampfile + ": $(" + prefix + "_INPUTS)");
     lines.push("");
 
-    outputs.forEach(function(name) {
+    for (const name of [...outputs.keys()].sort()) {
         lines.push(name + ": " + stampfile);
         lines.push("")
-    });
+    }
 
-    inputs.forEach(function(name) {
+    for (const name of [...inputs.keys()].sort()) {
         lines.push(name + ":");
         lines.push("")
-    });
+    }
 
     lines.push("WEBPACK_INPUTS += $(" + prefix + "_INPUTS)");
     lines.push("WEBPACK_OUTPUTS += $(" + prefix + "_OUTPUTS)");
@@ -172,6 +155,5 @@ function generateDeps(makefile, stats) {
 
     lines.push(prefix + ": " + stampfile);
 
-    data = lines.join("\n") + "\n";
-    fs.writeFileSync(makefile, data);
+    fs.writeFileSync(makefile, lines.join("\n") + "\n");
 }

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -100,38 +100,35 @@ function generateDeps(makefile, stats) {
     if (dir.startsWith(cwd + '/'))
         dir = dir.substr(cwd.length + 1);
 
-    for(asset in stats.compilation.assets) {
+    const uncompressed_patterns = [
+        '/manifest.json$', '/override.json$',
+        '^dist/static/', // cockpit-ws cannot currently serve compressed login page
+        '^dist/shell/index.html$',  // COMPAT: Support older cockpit-ws binaries. See #14673
+        '\.png$', '\.woff$', '\.woff2$', '\.gif$'
+    ].map((r) => new RegExp(r));
+
+    for (asset in stats.compilation.assets) {
         output = path.join(dir, asset);
         fs.utimesSync(output, now, now);
 
         if (!output.endsWith("/manifest.json") && !output.endsWith(".map"))
             outputs[output] = output;
 
-	if (output.indexOf("/test-") !== -1 && output.endsWith(".html")) {
-            tests[output] = output;
+        if (output.includes("/test-")) {
+            if (output.endsWith(".html")) {
+                tests[output] = output;
+            }
             continue;
         }
 
-        var install = output;
-	if (!output.endsWith("manifest.json") &&
-            !output.endsWith("override.json") &&
-            // COMPAT: Support older cockpit-ws binaries. See #14673
-            !output.endsWith("shell/index.html") &&
-            // cockpit-ws cannot currently serve compressed login page
-            output.indexOf("static/login") < 0 &&
-            output.indexOf("static/po.") < 0 &&
-            !output.endsWith(".png") &&
-            !output.endsWith(".map") &&
-            !output.endsWith(".ttf") &&
-            !output.endsWith(".woff") &&
-            !output.endsWith(".woff2") &&
-            !output.endsWith(".gif")) {
-            install += ".gz";
-        }
+        if (output.endsWith(".map") || output.includes("included-modules"))
+            continue;
 
-        // Debug output and tests gets installed separately
-        if (!output.endsWith(".map") && output.indexOf("/test-") === -1 && !output.includes("included-modules"))
-            installs[install] = install;
+        if (uncompressed_patterns.some((s) => output.match(s))) {
+            installs[output] = true;
+        } else {
+            installs[output + '.gz'] = true;
+        }
     }
 
     // Finalize all the sets into arrays

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -76,17 +76,6 @@ function generateDeps(makefile, stats) {
     var pkgdir = path.dirname(makefile);
     var stampfile = pkgdir + '/manifest.json';
 
-    stats.compilation.modules.forEach(function(module) {
-        // skip external, multi, and other "not quite" modules
-        if (module.constructor.name !== 'NormalModule')
-            return;
-        var parts = module.identifier().split("!");
-        parts.concat(module.fileDependencies || []).forEach(function(part) {
-            var input = part.split("?")[0];
-            maybePushInput(inputs, input);
-        });
-    });
-
     stats.compilation.fileDependencies.forEach(function(file) {
         maybePushInput(inputs, file);
     });
@@ -180,12 +169,6 @@ function generateDeps(makefile, stats) {
 }
 
 function maybePushInput(inputs, input) {
-    // Don't include or external refs
-    if (input.endsWith('/') ||
-        input.indexOf("external ") === 0 || input.indexOf("multi ") === 0) {
-        return;
-    }
-
     // Don't include node_modules
     if (input.includes("/node_modules")) {
         return;


### PR DESCRIPTION
Here's a few commits to tidy up `webpack-make` and teach it a more modern dialect of JS.

These are pretty much exclusively focused around the `Makefile.deps` generation code.

This PR doesn't change the result.  It's pure cleanup, with no side-effects:

```
⬢[lis@f34 cockpit]$ diff -ur master/dist webpack-make-refactors/dist
⬢[lis@f34 cockpit]$ 
```