### PR TITLE
build: handle .gz file output explicitly

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,31 +36,18 @@ clean-local::
 	find $(srcdir) -name '*.pyc' -delete
 
 SUFFIXES = \
-	.css .css.gz \
-	.html .html.gz \
-	.js .js.gz \
 	.jsx \
-	.map .map.gz \
 	.mo .po \
 	.service .service.in \
 	.socket .socket.in \
-	.svg .svg.gz \
 	.1 .8 .5 \
 	$(NULL)
-
-V_GZIP = $(V_GZIP_$(V))
-V_GZIP_ = $(V_GZIP_$(AM_DEFAULT_VERBOSITY))
-V_GZIP_0 = @echo "  GZIP    " $@;
 
 MV = mv -f
 
 CAT_RULE = \
         $(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
 	cat $^ > $@.tmp && $(MV) $@.tmp $@
-
-GZ_RULE = \
-	$(V_GZIP) $(MKDIR_P) $(dir $@) && \
-	gzip -n -c $< > $@.tmp && $(MV) $@.tmp $@
 
 SUBST_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && sed \
@@ -77,20 +64,10 @@ SUBST_RULE = \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 
-.css.css.gz:
-	$(GZ_RULE)
-.html.html.gz:
-	$(GZ_RULE)
-.js.js.gz:
-	$(GZ_RULE)
-.map.map.gz:
-	$(GZ_RULE)
 .service.in.service:
 	$(SUBST_RULE)
 .socket.in.socket:
 	$(SUBST_RULE)
-.svg.svg.gz:
-	$(GZ_RULE)
 
 # Webpack related
 include pkg/build
@@ -110,6 +87,13 @@ clean-local::
 install-data-local:: $(WEBPACK_INSTALL) $(MANIFESTS)
 	$(MKDIR_P) $(DESTDIR)$(pkgdatadir)
 	$(V_TAR) tar --format=posix -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+install-data-local:: $(WEBPACK_GZ_INSTALL)
+	@for file in $^; do \
+		target="$(DESTDIR)$(pkgdatadir)/$${file##*dist/}.gz"; \
+		mkdir -p "$${target%/*}"; \
+		echo "$${file} → $${target}"; \
+		gzip -9 < "$${file}" > "$${target}"; \
+	done
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)
 	$(V_TAR) tar --format=posix -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
 uninstall-local::

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,24 +64,16 @@ GZ_RULE = \
 
 SUBST_RULE = \
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && sed \
-	-e 's,[@]datadir[@],$(datadir),g' \
-	-e 's,[@]libexecdir[@],$(libexecdir),g' \
-	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
-	-e 's,[@]libdir[@],$(libdir),g' \
-	-e 's,[@]includedir[@],$(includedir),g' \
-	-e 's,[@]bindir[@],$(bindir),g' \
-	-e 's,[@]sbindir[@],$(sbindir),g' \
-	-e 's,[@]prefix[@],$(prefix),g' \
-	-e 's,[@]exec_prefix[@],$(exec_prefix),g' \
-	-e 's,[@]prefix[@],$(prefix),g' \
 	-e 's,[@]PACKAGE[@],$(PACKAGE),g' \
-	-e 's,[@]VERSION[@],$(VERSION),g' \
-	-e 's,[@]user[@],$(COCKPIT_USER),g' \
-	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
-	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \
-	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
 	-e 's,[@]admin_group[@],$(admin_group),g' \
-	-e 's,[@]selinux_config_type[@],$(COCKPIT_SELINUX_CONFIG_TYPE),g' \
+	-e 's,[@]datadir[@],$(datadir),g' \
+	-e 's,[@]group[@],$(COCKPIT_GROUP),g' \
+	-e 's,[@]libexecdir[@],$(libexecdir),g' \
+	-e 's,[@]prefix[@],$(prefix),g' \
+	-e 's,[@]sysconfdir[@],$(sysconfdir),g' \
+	-e 's,[@]user[@],$(COCKPIT_USER),g' \
+	-e 's,[@]wsinstancegroup[@],$(COCKPIT_WSINSTANCE_GROUP),g' \
+	-e 's,[@]wsinstanceuser[@],$(COCKPIT_WSINSTANCE_USER),g' \
 	$< > $@.tmp && $(MV) $@.tmp $@ \
 	$(NULL)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,23 +48,11 @@ SUFFIXES = \
 	.1 .8 .5 \
 	$(NULL)
 
-V_CHECK = $(V_CHECK_$(V))
-V_CHECK_ = $(V_CHECK_$(AM_DEFAULT_VERBOSITY))
-V_CHECK_0 = @echo "  CHECK   " $@;
-
 V_GZIP = $(V_GZIP_$(V))
 V_GZIP_ = $(V_GZIP_$(AM_DEFAULT_VERBOSITY))
 V_GZIP_0 = @echo "  GZIP    " $@;
 
-V_COPY = $(V_COPY_$(V))
-V_COPY_ = $(V_COPY_$(AM_DEFAULT_VERBOSITY))
-V_COPY_0 = @echo "  COPY    " $@;
-
 MV = mv -f
-
-COPY_RULE = \
-        $(V_COPY) $(MKDIR_P) $(dir $@) && \
-	cp -L $< $@.tmp && $(MV) $@.tmp $@
 
 CAT_RULE = \
         $(AM_V_GEN) $(MKDIR_P) $(dir $@) && \

--- a/pkg/build
+++ b/pkg/build
@@ -49,6 +49,7 @@ WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =
 WEBPACK_OUTPUTS =
 WEBPACK_INSTALL =
+WEBPACK_GZ_INSTALL =
 WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/Makefile.deps)
 
 noinst_SCRIPTS += $(MANIFESTS)

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -92,6 +92,7 @@ function generateDeps(makefile, stats) {
 
     const outputs = new Set();
     const installs = new Set();
+    const gz_installs = new Set();
     const tests = new Set();
     for (const asset in stats.compilation.assets) {
         const output = path.join(dir, asset);
@@ -113,7 +114,7 @@ function generateDeps(makefile, stats) {
         if (uncompressed_patterns.some((s) => output.match(s))) {
             installs.add(output);
         } else {
-            installs.add(output + '.gz');
+            gz_installs.add(output);
         }
     }
 
@@ -132,6 +133,7 @@ function generateDeps(makefile, stats) {
     makeArray(prefix + "_OUTPUTS", outputs);
 
     makeArray(prefix + "_INSTALL", installs);
+    makeArray(prefix + "_GZ_INSTALL", gz_installs);
     makeArray(prefix + "_TESTS", tests);
 
     lines.push(stampfile + ": $(" + prefix + "_INPUTS)");
@@ -150,6 +152,7 @@ function generateDeps(makefile, stats) {
     lines.push("WEBPACK_INPUTS += $(" + prefix + "_INPUTS)");
     lines.push("WEBPACK_OUTPUTS += $(" + prefix + "_OUTPUTS)");
     lines.push("WEBPACK_INSTALL += $(" + prefix + "_INSTALL)");
+    lines.push("WEBPACK_GZ_INSTALL += $(" + prefix + "_GZ_INSTALL)");
     lines.push("TESTS += $(" + prefix + "_TESTS)");
     lines.push("");
 


### PR DESCRIPTION
    Using make to implicitly generate .gz output at `make install` time has
    two major problems:
    
     1) in srcdir!=builddir builds, these are the only files that land in
        the builddir/dist/ directory, since all of the webpack outputs come
        already shipped with the tarball
    
     2) since `make install` is often run as root, these files end up
        in your build tree, owned by root
    
    At the same time, we don't want to integrate that into the webpack
    process, because it would slow things down during development.
    
    Move the .gz outputs to a separate variable in webpack-make, and deal
    with them in a more explicit fashion from the Makefile, from an install
    hook.

 - [x] #15967 