### PR TITLE
package.json: downgrade optimize-css-assets-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jed": "^1.1.1",
     "mini-css-extract-plugin": "^0.9.0",
     "null-loader": "^3.0.0",
-    "optimize-css-assets-webpack-plugin": "^5.0.4",
+    "optimize-css-assets-webpack-plugin": "5.0.6",
     "po2json": "^1.0.0-alpha",
     "raw-loader": "^4.0.0",
     "sass": "^1.26.5",


### PR DESCRIPTION
css-loader 3 depends on postcss 7 which is in conflict with the new ("11
hours ago") version 5.0.7 of optimize-css-assets-webpack-plugin.  This
is resulting in these warnings:

```
npm WARN postcss-discard-comments@5.0.1 requires a peer of postcss@^8.2.15 but none is installed. You must install peer dependencies yourself.
```

and the build failing like so:

```
/work/bots/make-checkout-workdir/node_modules/postcss/lib/processor.js:167
    throw new Error('PostCSS plugin ' + i.postcssPlugin + ' requires PostCSS 8.\n' + 'Migration guide for end-users:\n' + 'https://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users');
    ^

Error: PostCSS plugin postcss-discard-comments requires PostCSS 8.
```

There are already quite a lot of issues filed against
optimize-css-assets-webpack-plugin about this problem, for example:

https://github.com/NMFR/optimize-css-assets-webpack-plugin/issues/167

and it seems that they intend to retract the release.  In the meantime,
it's still on the npm site and mirrors, though.

Let's pin optimize-css-assets-webpack-plugin to 5.0.6 as the
conservative solution to avoid this problem.
