### PR TITLE
test: Disable font hinting with Chromium

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -174,6 +174,7 @@ class CDP:
             return [exe, "--headless" if not self.show_browser else "", "--disable-gpu", "--no-sandbox", "--disable-setuid-sandbox",
                     "--disable-namespace-sandbox", "--disable-seccomp-filter-sandbox",
                     "--disable-sandbox-denial-logging", "--disable-pushstate-throttle",
+                    "--font-render-hinting=none",
                     "--v=0", "--window-size=1920x1200", "--remote-debugging-port=%i" % cdp_port, "about:blank"]
         elif self.browser == "firefox":
             subprocess.Popen([exe, "--headless", "--no-remote", "-CreateProfile", "blank"], env=env).communicate()


### PR DESCRIPTION
Hinting seems to involve some randomness and might produce slightly
different glyphs on different runs.  This is trouble for the pixel
tests.  Let's switch it off.