### PR TITLE
pixel tests: checkout submodule on demand

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -57,8 +57,6 @@ if test -z "${NOCONFIGURE:-}"; then
     fi
 fi
 
-test/common/pixel-tests pull
-
 if test -n "${NOCONFIGURE:-}"; then
     exit 0
 fi

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -673,10 +673,14 @@ class Browser:
                     r['x'] - rect['x'] + r['width'],
                     r['y'] - rect['y'] + r['height'])
 
+        reference_dir = os.path.join(TEST_DIR, 'reference')
+        if not os.path.exists(os.path.join(reference_dir, '.git')):
+            subprocess.check_call([f'{TEST_DIR}/common/pixel-tests', 'pull'])
+
         ignore_rects = list(map(relative_clip, map(lambda item: selector + " " + item, ignore)))
         base = self.pixels_label + "-" + key
         filename = base + "-pixels.png"
-        ref_filename = os.path.join(TEST_DIR, "reference", filename)
+        ref_filename = os.path.join(reference_dir, filename)
         ret = self.cdp.invoke("Page.captureScreenshot", clip=rect, no_trace=True)
         png_now = base64.standard_b64decode(ret["data"])
         png_ref = os.path.exists(ref_filename) and open(ref_filename, "rb").read()

--- a/test/run
+++ b/test/run
@@ -6,7 +6,6 @@
 set -eu
 
 tools/make-bots
-test/common/pixel-tests pull
 
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 TEST_OS_DEFAULT=$(PYTHONPATH=bots python3 -c 'from machine.machine_core.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')


### PR DESCRIPTION
Totally "throw it over the fence" drive-by.

I think we can (and should) do better.