### PR TITLE
build: don't "dist" test/reference

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -214,7 +214,7 @@ tools/debian/copyright: tools/debian/copyright.template $(MANIFESTS)
 # also automatically update minimum base dependency in RPM spec file
 dist-hook:: $(MANIFESTS)
 	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
-		tar --format=posix -C $(srcdir) -cf - -T - | tar -C $(distdir) -xf -
+		tar --format=posix -C $(srcdir) --exclude test/reference -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 


### PR DESCRIPTION
This is being accidentally included via the "commited dist" mechanism,
based on its presence in the git.  It doesn't make sense to do that,
though: this directory might contain reference images, be empty, or
might not exist at all.


So we probably actually need to discuss this: does it make sense to dist this, after all?  Does anyone do integration tests based on a tarball *on the host*?  What about the checks that say we only run the pixel tests on fedora-34?  Is this meaningful for packit?