### PR TITLE
metrics: Fix enabling pmlogger in Metrics Settings if pcp is not installed

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1255,7 +1255,7 @@ class MetricsHistory extends React.Component {
         if (this.state.needsLogout)
             return <EmptyStatePanel
                         icon={ExclamationCircleIcon}
-                        title={_("You need to relogin to be able to see metrics")}
+                        title={_("You need to relogin to be able to see metrics history")}
                         action={<Button onClick={() => cockpit.logout(true)}>{_("Log out")}</Button>} />;
 
         if (cockpit.manifests && !cockpit.manifests.pcp)

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1059,7 +1059,6 @@ class MetricsHistory extends React.Component {
             isDatepickerOpened: false,
             selectedDate: null,
             packagekitExists: false,
-            needsLogout: false,
         };
 
         this.handleMoreData = this.handleMoreData.bind(this);
@@ -1130,9 +1129,7 @@ class MetricsHistory extends React.Component {
 
     handleInstall() {
         install_dialog("cockpit-pcp")
-                .then(() => {
-                    this.setState({ needsLogout: true });
-                })
+                .then(() => this.props.setNeedsLogout(true))
                 .catch(() => null); // ignore cancel
     }
 
@@ -1253,7 +1250,7 @@ class MetricsHistory extends React.Component {
     }
 
     render() {
-        if (this.state.needsLogout)
+        if (this.props.needsLogout)
             return <EmptyStatePanel
                         icon={ExclamationCircleIcon}
                         title={_("You need to relogin to be able to see metrics history")}
@@ -1377,6 +1374,7 @@ class MetricsHistory extends React.Component {
 
 export const Application = () => {
     const [firewalldRequest, setFirewalldRequest] = useState(null);
+    const [needsLogout, setNeedsLogout] = useState(false);
 
     return <Page groupProps={{ sticky: 'top' }}
           additionalGroupedContent={
@@ -1400,7 +1398,9 @@ export const Application = () => {
             <CurrentMetrics />
         </PageSection>
         <PageSection>
-            <MetricsHistory firewalldRequest={setFirewalldRequest} />
+            <MetricsHistory firewalldRequest={setFirewalldRequest}
+                            needsLogout={needsLogout}
+                            setNeedsLogout={setNeedsLogout} />
         </PageSection>
     </Page>;
 };

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1132,7 +1132,8 @@ class MetricsHistory extends React.Component {
         install_dialog("cockpit-pcp")
                 .then(() => {
                     this.setState({ needsLogout: true });
-                });
+                })
+                .catch(() => null); // ignore cancel
     }
 
     load_data(load_timestamp, limit, show_spinner) {

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -945,21 +945,26 @@ class TestCockpitPcp(packagelib.PackageCase):
             b.wait_not_present(".pf-c-empty-state button.pf-m-primary")
             return
 
-        m.execute("mount -t tmpfs tmpfs /usr/share/cockpit/pcp")
-        self.addCleanup(m.execute, "umount /usr/share/cockpit/pcp")
-
-        m.execute("pkcon remove -y pcp")
+        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
+            m.execute("dpkg --purge cockpit-pcp-dbgsym || true; dpkg --purge cockpit-pcp pcp")
+        else:
+            m.execute("rpm --erase --verbose cockpit-pcp pcp")
 
         cpcp = {
             "/usr/share/cockpit/pcp/manifest.json": '{"requires": {"cockpit": "134.x"}, "bridges": [{"match": { "payload": "metrics1"},"spawn": [ "/usr/libexec/cockpit-pcp" ]}]}',
             "/usr/libexec/cockpit-pcp": "true",
         }
+        pcp = {
+            "/lib/systemd/system/pmlogger.service": "[Service]\nExecStart=/bin/sleep infinity\n[Install]\nWantedBy=multi-user.target\n"
+        }
 
-        self.createPackage("cockpit-pcp", "999", "1", content=cpcp,
+        self.createPackage("cockpit-pcp", "999", "1", content=cpcp, depends="pcp",
                            postinst="chmod +x /usr/libexec/cockpit-pcp")
+        self.createPackage("pcp", "999", "1", content=pcp, postinst="systemctl daemon-reload")
         self.enableRepo()
         m.execute("pkcon refresh")
 
+        # install it from the empty state
         self.login_and_go("/metrics")
         b.wait_in_text(".pf-c-empty-state", "cockpit-pcp is missing")
         b.click(".pf-c-empty-state button.pf-m-primary")
@@ -975,6 +980,38 @@ class TestCockpitPcp(packagelib.PackageCase):
         b.expect_load()
         b.enter_page("/metrics")
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+        b.logout()
+
+        # install it from the Metrics Settings dialog
+        m.execute("pkcon remove -y cockpit-pcp pcp")
+        self.login_and_go("/metrics")
+        b.click("#metrics-header-section button.pf-m-secondary")
+        b.wait_visible("#pcp-settings-modal")
+        b.wait_visible("#switch-pmlogger:not(:checked)")
+        b.click("#switch-pmlogger")
+        b.wait_visible("#switch-pmlogger:checked")
+        b.click("#pcp-settings-modal button.pf-m-primary")
+        b.wait_not_present("#pcp-settings-modal")
+        # install dialog
+        b.click("#dialog button:contains('Install')")
+        b.wait_not_present("#dialog")
+        # sets up pmlogger correctly; this is asynchronous, as it happens in the background after closing install dialog
+        m.execute('until [ $(systemctl is-enabled pmlogger) = enabled ]; do sleep 1; done')
+        # also needs to wait for activating → active
+        m.execute('until [ $(systemctl is-active pmlogger) = active ]; do sleep 1; done')
+        # triggers "needs logout"
+        b.click("button:contains('Log out')")
+        b.leave_page()
+        b.click("button:contains('Reconnect')")
+        b.expect_load()
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        b.click('#login-button')
+        b.expect_load()
+        b.enter_page("/metrics")
+        # this is just a fake cockpit-pcp package
+        b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+        b.wait_in_text(".pf-c-empty-state", "pmlogger.service is failing to collect data")
 
 
 @skipDistroPackage()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -687,7 +687,7 @@ These files are not required for running Cockpit.
 %package -n cockpit-pcp
 Summary: Cockpit PCP integration
 Requires: cockpit-bridge >= %{required_base}
-Requires(post): pcp
+Requires: pcp
 
 %description -n cockpit-pcp
 Cockpit support for reading PCP metrics and loading PCP archives.


### PR DESCRIPTION
Previously this just failed with "unit pmlogger.service does not exist".
Instead, when enabling pmlogger, offer to install the package. Just like
with the button in the empty state, request a relogin afterwards to pick
up the new manifest.