### PR TITLE
users: Replace moment with Intl.DateTimeFormat

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -19,7 +19,6 @@
 
 import cockpit from 'cockpit';
 import React, { useState, useEffect } from 'react';
-import moment from "moment";
 import { superuser } from "superuser";
 import { apply_modal_dialog } from "cockpit-components-dialog.jsx";
 
@@ -93,6 +92,8 @@ function get_expire(name) {
         let password_expiration = '';
         let password_days = null;
 
+        const date_fmt = new Intl.DateTimeFormat(cockpit.language, { dateStyle: "long" });
+
         data.split('\n').forEach(line => {
             const fields = line.split(': ');
             if (fields[0] && fields[0].indexOf("Password expires") === 0) {
@@ -101,14 +102,14 @@ function get_expire(name) {
                 } else if (fields[1].indexOf("password must be changed") === 0) {
                     password_expiration = _("Password must be changed");
                 } else {
-                    password_expiration = cockpit.format(_("Require password change on $0"), moment(fields[1]).format('LL'));
+                    password_expiration = cockpit.format(_("Require password change on $0"), date_fmt.format(new Date(fields[1])));
                 }
             } else if (fields[0] && fields[0].indexOf("Account expires") === 0) {
                 if (fields[1].indexOf("never") === 0) {
                     account_expiration = _("Never expire account");
                 } else {
                     account_date = new Date(fields[1] + " 12:00:00 UTC");
-                    account_expiration = cockpit.format(_("Expire account on $0"), moment(fields[1]).format('LL'));
+                    account_expiration = cockpit.format(_("Expire account on $0"), date_fmt.format(new Date(fields[1])));
                 }
             } else if (fields[0] && fields[0].indexOf("Maximum number of days between password change") === 0) {
                 password_days = fields[1];
@@ -249,7 +250,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
     else if (!details.logged.last)
         last_login = _("Never");
     else
-        last_login = moment(details.logged.last).format('LLL');
+        last_login = new Intl.DateTimeFormat(cockpit.language, { dateStyle: "long", timeStyle: "short" }).format(new Date(details.logged.last));
 
     return (
         <Page groupProps={{ sticky: 'top' }}

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -19,8 +19,6 @@
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 
-import cockpit from 'cockpit';
-import moment from "moment";
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { superuser } from "superuser";
@@ -30,7 +28,6 @@ import { etc_passwd_syntax, etc_group_syntax } from "./parsers.js";
 import { AccountsList } from "./accounts-list.js";
 import { AccountDetails } from "./account-details.js";
 
-moment.locale(cockpit.language);
 superuser.reload_page_on_change();
 
 function AccountsPage() {


### PR DESCRIPTION
moment is deprecated, and the users page only uses absolute dates/times.

See #15979

-----

This is the first page for trying this, it's easy to convert. Let's discuss general style/coding issues here, then I'm happy to port some more pages.

The difference is negligible, with Intl it even looks a tiny bit better in "last login", and it's identical for "Access":

Master, English:
![user-master-en](https://user-images.githubusercontent.com/200109/123508717-57f11d00-d671-11eb-9d14-945114aa1630.png)

This PR, English:
![image](https://user-images.githubusercontent.com/200109/123508698-41e35c80-d671-11eb-8aa4-950b6dd43ba8.png)

Master, German:
![user-master-de](https://user-images.githubusercontent.com/200109/123508723-60495800-d671-11eb-9378-5e6b1627f049.png)

This PR, German:
![image](https://user-images.githubusercontent.com/200109/123508688-2bd59c00-d671-11eb-8af1-2e32dd6c2886.png)
