### PR TITLE
workflows: change 'master' to 'main' in a workflow

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -2,7 +2,7 @@ name: build-dist
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -120,7 +120,7 @@ class TestRunTest(MachineCase):
         env = os.environ.copy()
         env["TEST_FAILURES"] = "1"
         # pretend this was a PR against master (set by CI normally, or by the user with --base)
-        env["BASE_BRANCH"] = "master"
+        env["BASE_BRANCH"] = "main"
         try:
             del env["TEST_JOBS"]
         except KeyError:


### PR DESCRIPTION
This seems to be the only thing which needs to be changed immediately.
Everything else is URLs in documentation, and GitHub will automatically
forward those.