### PR TITLE
jumpstart: use sha256sums file for consistency checking

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Build jumpstart tarball
         run: pkg/build -j$(nproc) webpack-jumpstart.tar
 
-      - name: Create dist artifact
+      - name: Create artifact
         uses: actions/upload-artifact@v2
         with:
           name: webpack-jumpstart

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -31,10 +31,9 @@ jobs:
           set -ex
           mkdir dist-repo
           cd dist-repo
-          tar -xf ../artifact/webpack-jumpstart.tar dist package-lock.json .sha256sums || true
+          tar -xf ../artifact/webpack-jumpstart.tar dist .sha256sums
           git init
           git add dist .sha256sums
-          [ ! -e package-lock.json ] || git add package-lock.json
           git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
           tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"

--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -31,9 +31,10 @@ jobs:
           set -ex
           mkdir dist-repo
           cd dist-repo
-          tar -xf ../artifact/webpack-jumpstart.tar dist package-lock.json
+          tar -xf ../artifact/webpack-jumpstart.tar dist package-lock.json .sha256sums || true
           git init
-          git add dist package-lock.json
+          git add dist .sha256sums
+          [ ! -e package-lock.json ] || git add package-lock.json
           git commit -m "Build for ${{ github.event.workflow_run.head_sha }}"
           tag='sha-${{ github.event.workflow_run.head_sha }}'
           git tag "$tag"

--- a/pkg/build
+++ b/pkg/build
@@ -41,7 +41,7 @@ ls-webpack-inputs:
 
 webpack-jumpstart.tar: $(MANIFESTS) package-lock.json pkg/build
 	@pkg/build -s ls-webpack-inputs | xargs sha256sum > .sha256sums
-	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json .sha256sums
+	$(V_TAR) tar cf webpack-jumpstart.tar dist .sha256sums
 	@rm -f .sha256sums
 
 V_WEBPACK = $(V_WEBPACK_$(V))

--- a/pkg/build
+++ b/pkg/build
@@ -29,15 +29,20 @@ MANIFESTS = \
 	pkg/ssh/manifest.json \
 	$(NULL)
 
-.PHONY: all-webpack
+.PHONY: all-webpack ls-webpack-inputs
 all-webpack: $(MANIFESTS)
 
 V_TAR = $(V_TAR_$(V))
 V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
 V_TAR_0 = @echo "  TAR     " $@;
 
+ls-webpack-inputs:
+	ls -1 package-lock.json $(WEBPACK_INPUTS) | uniq
+
 webpack-jumpstart.tar: $(MANIFESTS) package-lock.json pkg/build
-	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json
+	@pkg/build -s ls-webpack-inputs | xargs sha256sum > .sha256sums
+	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json .sha256sums
+	@rm -f .sha256sums
 
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))

--- a/pkg/build
+++ b/pkg/build
@@ -36,7 +36,7 @@ V_TAR = $(V_TAR_$(V))
 V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
 V_TAR_0 = @echo "  TAR     " $@;
 
-webpack-jumpstart.tar: $(MANIFESTS) package-lock.json
+webpack-jumpstart.tar: $(MANIFESTS) package-lock.json pkg/build
 	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json
 
 V_WEBPACK = $(V_WEBPACK_$(V))

--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -83,10 +83,22 @@ fetch_to_cache() {
     fi
 }
 
+# Given cache commit "$1", print content of file "$2"
+cat_from_cache() {
+    git_cache cat-file blob "$1:$2"
+}
+
 # Consistency checking: for a given cache commit "$1", check if it contains a
 # file "$2" which is equal to the file "$3" present in the working tree.
 cmp_from_cache() {
-    git_cache cat-file blob "$1:$2" | cmp "$3"
+    cat_from_cache "$1" "$2" | cmp "$3"
+}
+
+# Consistency checking: for a given cache commit "$1", check if it contains a
+# file ".sha256sums" which is a list of sha256 checksums which must match the
+# working tree.
+sha256sum_from_cache() {
+    cat_from_cache "$1" ".sha256sums" | sha256sum --check --quiet --strict
 }
 
 # Like `git clone` except that it uses the original origin url and supports

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -49,8 +49,8 @@ for try in $(seq 50 -1 0); do
     sleep 30s
 done
 
-if ! cmp_from_cache "${tag}" "package-lock.json" "package-lock.json"; then
-    echo "The cached package-lock.json doesn't match our own" >&2
+if ! sha256sum_from_cache "${tag}"; then
+    echo "The cache doesn't match our working tree" >&2
     exit 1
 fi
 


### PR DESCRIPTION
 - [ ] #16004 

This is going to fail until the new `publish-dist` workflow lands in #16004 

Merging this is also going to break packit builds for any branch that's not completely up-to-date with main at the time of merging.

This technically fixes #15960, but the "strictly correct" behaviour here will regress things a bit in the short term.  We might want to wait on packit/ogr#584 in order to not make a complete mess.