### PR TITLE
various: replace 'master' with 'main' in urls

### DIFF
--- a/containers/bastion/cockpit-auth-ssh-key
+++ b/containers/bastion/cockpit-auth-ssh-key
@@ -33,7 +33,7 @@ COCKPIT_SSH_COMMAND = "/usr/libexec/cockpit-ssh"
 # Once finished we exec cockpit-ssh to actually establish the ssh connection.
 # All communication with cockpit-ws happens on stdin and stdout using the
 # cockpit protocol
-# (https://github.com/cockpit-project/cockpit/blob/master/doc/protocol.md)
+# (https://github.com/cockpit-project/cockpit/blob/main/doc/protocol.md)
 
 
 def usage():

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -88,7 +88,7 @@ it can do so by sending a `x-login-data` challenge. The command should have an a
 
 For a simple python example see:
 
-[https://github.com/cockpit-project/cockpit/blob/master/containers/bastion/cockpit-auth-ssh-key]
+[https://github.com/cockpit-project/cockpit/blob/main/containers/bastion/cockpit-auth-ssh-key]
 
 Remote machines
 ---------------
@@ -106,7 +106,7 @@ has the same options as the other authentication sections with the following add
  `/etc/ssh/ssh_known_hosts`). Set this to `true` is to allow those connections
  to proceed.
 
-This uses the [cockpit-ssh](https://github.com/cockpit-project/cockpit/tree/master/src/ssh)
+This uses the [cockpit-ssh](https://github.com/cockpit-project/cockpit/tree/main/src/ssh)
 bridge. After the user authentication with the `"*"` challenge, if the remote
 host is not already present in any local `known_hosts` file, this will send an
 `"x-host-key"` challenge:

--- a/doc/guide/authentication.xml
+++ b/doc/guide/authentication.xml
@@ -8,7 +8,7 @@
       same time, there is always a primary server your browser connects to
       that runs the Cockpit web service (cockpit-ws) through which connections to
       additional servers are established.
-      See <ulink url="https://raw.githubusercontent.com/cockpit-project/cockpit/master/doc/cockpit-transport.png">this diagram</ulink> for how it works.</para>
+      See <ulink url="https://raw.githubusercontent.com/cockpit-project/cockpit/main/doc/cockpit-transport.png">this diagram</ulink> for how it works.</para>
 
       <para>Normally, a session is established on the primary server,
       and you use the Shell UI of that session to connect to secondary
@@ -38,7 +38,7 @@
       card authentication</link>.
     </para>
 
-    <para>You can also <ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/authentication.md#actions">disable
+    <para>You can also <ulink url="https://github.com/cockpit-project/cockpit/blob/main/doc/authentication.md#actions">disable
     authentication schemes</ulink> to enforce authentication policies, or to suppress
     undesired browser GSSAPI authentication dialogs.</para>
 

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -151,7 +151,7 @@ ClientCertAuthentication = yes
  </warning>
 
   <para>When enabling this mode,
-    <ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/authentication.md">
+    <ulink url="https://github.com/cockpit-project/cockpit/blob/main/doc/authentication.md">
     other authentication types</ulink> commonly get disabled, so that <emphasis>only</emphasis>
     client certificate authentication will be accepted. By default, after a failed certificate
     authentication attempt, Cockpit's normal login page will appear and permit other login types

--- a/doc/guide/cockpit-http.xml
+++ b/doc/guide/cockpit-http.xml
@@ -36,7 +36,7 @@ http = cockpit.http(options)
       <varlistentry>
         <term><code>"tls"</code></term>
         <listitem><para>Object properties for an https connection. See
-        <code><ulink url="https://github.com/cockpit-project/cockpit/blob/master/doc/protocol.md#payload-http-stream2">http-stream2 TLS options</ulink></code>.</para></listitem>
+        <code><ulink url="https://github.com/cockpit-project/cockpit/blob/main/doc/protocol.md#payload-http-stream2">http-stream2 TLS options</ulink></code>.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"connection"</code></term>

--- a/doc/i18n.md
+++ b/doc/i18n.md
@@ -50,7 +50,7 @@ Translation process
  * Translatable strings from HTML, JavaScript (as above) and C files get
    extracted with various invocations of
    [xgettext](https://linux.die.net/man/1/xgettext), see
-   [po/Makefile.am](https://github.com/cockpit-project/cockpit/blob/master/po/Makefile.am).
+   [po/Makefile.am](https://github.com/cockpit-project/cockpit/blob/main/po/Makefile.am).
    Running `make po/cockpit.pot` will generate a standard PO template.
 
  * With `make upload-pot` the PO template gets uploaded to the
@@ -59,9 +59,9 @@ Translation process
 
  *  With `make download-po` Weblate's translations are downloaded to
     `po/XX.po`. This is done by
-   [bots/po-refresh](https://github.com/cockpit-project/cockpit/blob/master/bots/po-refresh)
+   [bots/po-refresh](https://github.com/cockpit-project/cockpit/blob/main/bots/po-refresh)
    which is invoked regularly by
-   [bots/po-trigger](https://github.com/cockpit-project/cockpit/blob/master/bots/po-trigger).
+   [bots/po-trigger](https://github.com/cockpit-project/cockpit/blob/main/bots/po-trigger).
 
  * Translations can also be done using any other tool or platform and be
    submitted via pull requests that update the `po/XX.po` files. In this case
@@ -98,5 +98,5 @@ release. Run these steps to initialize translations for it:
    repository to a branch you created in the previous step.
 
  * On the new cockpit branch, change `WEBLATE_REPO_BRANCH` in
-   [po/Makefile.am](https://github.com/cockpit-project/cockpit/blob/master/po/Makefile.am)
-   from "master" to the new branch name.
+   [po/Makefile.am](https://github.com/cockpit-project/cockpit/blob/main/po/Makefile.am)
+   from "main" to the new branch name.

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -182,7 +182,7 @@ function debug() {
 }
 
 // metrics channel samples are compressed, see
-// https://github.com/cockpit-project/cockpit/blob/master/doc/protocol.md#payload-metrics1
+// https://github.com/cockpit-project/cockpit/blob/main/doc/protocol.md#payload-metrics1
 // samples is the compressed metrics channel value, state the last valid values (initialize once to empty array)
 function decompress_samples(samples, state) {
     samples.forEach((sample, i) => {

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 # Run this with --help to see available options for tracing and debugging
-# See https://github.com/cockpit-project/cockpit/blob/master/test/common/testlib.py
+# See https://github.com/cockpit-project/cockpit/blob/main/test/common/testlib.py
 # "class Browser" and "class MachineCase" for the available API.
 
 import re

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -16,7 +16,7 @@
 #
 
 # This file is maintained at the following location:
-# https://github.com/cockpit-project/cockpit/blob/master/tools/cockpit.spec
+# https://github.com/cockpit-project/cockpit/blob/main/tools/cockpit.spec
 #
 # If you are editing this file in another location, changes will likely
 # be clobbered the next time an automated release is done.


### PR DESCRIPTION
We have a lot of links to our GitHub repository on the web littered
around in our source tree.  Change them all from master to main.