### PR TITLE
login: Move forEach patch & noscript inline

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -7,6 +7,11 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="robots" content="noindex">
   <meta insert_dynamic_content_here>
+  <script type="text/javascript">
+    /* Patch IE to support forEach on NodeLists, used in show/hide */
+    if (window.NodeList && !NodeList.prototype.forEach)
+        NodeList.prototype.forEach = Array.prototype.forEach;
+  </script>
   <script type="text/javascript">/*insert_translations_here*/</script>
   <script type="text/javascript" src="cockpit/static/login.js"></script>
   <link href="cockpit/static/login.css" type="text/css" rel="stylesheet">
@@ -142,6 +147,11 @@
     <p id="login-note" class="login-note"></p>
   </div>
 
+  <script type="text/javascript">
+    /* Hide everything classed as "noscript" */
+    document.querySelectorAll('.noscript').forEach(function(element){
+      element.hidden = true;
+    });
+  </script>
 </body>
-
 </html>

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -1,7 +1,3 @@
-/* Patch IE to support forEach on NodeLists, used in show/hide */
-if (window.NodeList && !NodeList.prototype.forEach)
-    NodeList.prototype.forEach = Array.prototype.forEach;
-
 (function(console) {
     var localStorage;
 
@@ -289,8 +285,6 @@ if (window.NodeList && !NodeList.prototype.forEach)
 
     function boot() {
         window.onload = null;
-
-        hide(".noscript");
 
         translate();
         if (window.cockpit_po && window.cockpit_po[""])


### PR DESCRIPTION
Fixes #15992

The `forEach` patch is at the top so the fix for IE (which we still need to "support", to tell IE users we don't support them). Hiding the `noscript` elements is at the bottom so it runs immediately after the browser constructs the DOM. (It's like `document`'s `ready` event, without event binding.)