### PR TITLE
metrics: Install redis package on demand

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -915,18 +915,27 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
         return null;
 
     const handleSave = () => {
-        // when enabling pmlogger, install cockpit-pcp/pcp on demand
-        if (!deferSaveOnInstall && dialogLoggerValue && s_pmlogger.state === undefined) {
-            debug("PCPConfig: request to enable pmlogger, but missing pmlogger.service, offering install");
-            setDialogVisible(false);
-            install_dialog("cockpit-pcp")
-                    .then(() => {
-                        debug("PCPConfig: cockpit-pcp installation successful");
-                        setNeedsLogout(true);
-                        setDeferSaveOnInstall(true); // avoid recursive install_dialog
-                    })
-                    .catch(() => null); // ignore cancel
-            return;
+        debug("PCPConfig handleSave(): dialogLoggerValue", dialogLoggerValue, "dialogInitialProxyValue", dialogInitialProxyValue, "dialogProxyValue", dialogProxyValue);
+        // when enabling services, install missing packages on demand
+        if (!deferSaveOnInstall) {
+            const missing = [];
+            if (dialogLoggerValue && !s_pmlogger.exists)
+                missing.push("cockpit-pcp");
+            if (dialogProxyValue && !real_redis.exists)
+                missing.push("redis");
+            if (missing.length > 0) {
+                debug("PCPConfig: missing packages", JSON.stringify(missing), ", offering install");
+                setDialogVisible(false);
+                install_dialog(missing)
+                        .then(() => {
+                            debug("PCPConfig: package installation successful");
+                            if (missing.indexOf("cockpit-pcp") >= 0)
+                                setNeedsLogout(true);
+                            setDeferSaveOnInstall(true); // avoid recursive install_dialog
+                        })
+                        .catch(() => null); // ignore cancel
+                return;
+            }
         }
 
         setPending(true);
@@ -971,30 +980,13 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
     };
 
     // handle deferred Save after package installation finished and pmlogger starts to exist
-    if (deferSaveOnInstall && dialogLoggerValue && s_pmlogger.exists) {
+    if (deferSaveOnInstall &&
+            (!dialogLoggerValue || s_pmlogger.exists) &&
+            (!dialogProxyValue || (s_pmproxy.exists && real_redis.exists))) {
         debug("PCPConfig: handling deferred Save after package installation");
         setDeferSaveOnInstall(false);
         handleSave();
         return;
-    }
-
-    // the package is likely not installed; TODO: install it on demand
-    let pmproxy_option = null;
-    if (real_redis.exists && s_pmproxy.exists) {
-        pmproxy_option = (
-            <Switch id="switch-pmproxy"
-                    label={
-                        <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
-                            <FlexItem>{ _("Export to network") }</FlexItem>
-                            <TextContent>
-                                <Text component={TextVariants.small}>(pmproxy.service)</Text>
-                            </TextContent>
-                        </Flex>
-                    }
-                    isDisabled={ !dialogLoggerValue }
-                    isChecked={dialogProxyValue}
-                    onChange={enable => setDialogProxyValue(enable)} />
-        );
     }
 
     return (
@@ -1003,7 +995,7 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
                     isDisabled={ invalidService(s_pmlogger) || invalidService(s_pmproxy) || invalidService(s_redis) || invalidService(s_redis_server) }
                     onClick={ () => {
                         setDialogLoggerValue(runningService(s_pmlogger));
-                        const proxy_value = pmproxy_option ? (runningService(s_pmproxy) && runningService(real_redis)) : null;
+                        const proxy_value = runningService(s_pmproxy) && runningService(real_redis);
                         setDialogInitialProxyValue(proxy_value);
                         setDialogProxyValue(proxy_value);
                         setDialogError(null);
@@ -1058,7 +1050,18 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
                                 setDialogProxyValue(false);
                         }} />
 
-                {pmproxy_option}
+                <Switch id="switch-pmproxy"
+                        isChecked={dialogProxyValue}
+                        label={
+                            <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
+                                <FlexItem>{ _("Export to network") }</FlexItem>
+                                <TextContent>
+                                    <Text component={TextVariants.small}>(pmproxy.service)</Text>
+                                </TextContent>
+                            </Flex>
+                        }
+                        isDisabled={ !dialogLoggerValue }
+                        onChange={enable => setDialogProxyValue(enable)} />
             </Modal>}
         </>);
 };

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -873,8 +873,9 @@ class MetricsHour extends React.Component {
     }
 }
 
-const persistentServiceState = proxy => ['running', 'stopped', 'failed', undefined].indexOf(proxy.state) >= 0;
-const validServiceState = proxy => ['running', 'stopped'].indexOf(proxy.state) >= 0;
+// null means "not initialized yet"
+const invalidService = proxy => proxy.state === null;
+const runningService = proxy => ['running', 'starting'].indexOf(proxy.state) >= 0;
 
 const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogout }) => {
     const [dialogVisible, setDialogVisible] = useState(false);
@@ -990,7 +991,7 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
                             </TextContent>
                         </Flex>
                     }
-                    isDisabled={ !dialogLoggerValue || !validServiceState(s_pmproxy) || !validServiceState(real_redis) }
+                    isDisabled={ !dialogLoggerValue }
                     isChecked={dialogProxyValue}
                     onChange={enable => setDialogProxyValue(enable)} />
         );
@@ -999,10 +1000,10 @@ const PCPConfig = ({ buttonVariant, firewalldRequest, needsLogout, setNeedsLogou
     return (
         <>
             <Button variant={buttonVariant} icon={<CogIcon />}
-                    isDisabled={ !persistentServiceState(s_pmlogger) || !persistentServiceState(s_pmproxy) || !persistentServiceState(s_redis) || !persistentServiceState(s_redis_server) }
+                    isDisabled={ invalidService(s_pmlogger) || invalidService(s_pmproxy) || invalidService(s_redis) || invalidService(s_redis_server) }
                     onClick={ () => {
-                        setDialogLoggerValue(s_pmlogger.state === 'running');
-                        const proxy_value = pmproxy_option ? (s_pmproxy.state === 'running' && real_redis.state === 'running') : null;
+                        setDialogLoggerValue(runningService(s_pmlogger));
+                        const proxy_value = pmproxy_option ? (runningService(s_pmproxy) && runningService(real_redis)) : null;
                         setDialogInitialProxyValue(proxy_value);
                         setDialogProxyValue(proxy_value);
                         setDialogError(null);
@@ -1093,9 +1094,9 @@ class MetricsHistory extends React.Component {
         /* supervise pmlogger.service, to diagnose missing history */
         this.pmlogger_service = service.proxy("pmlogger.service");
         this.pmlogger_service.addEventListener("changed", () => {
-            if (persistentServiceState(this.pmlogger_service) && this.pmlogger_service.state !== this.state.pmLoggerState) {
+            if (!invalidService(this.pmlogger_service) && this.pmlogger_service.state !== this.state.pmLoggerState) {
                 // when it got enabled while the page is running (e.g. through Settings dialog), start data collection
-                if (!this.state.metricsAvailable && this.pmlogger_service.state === 'running')
+                if (!this.state.metricsAvailable && runningService(this.pmlogger_service))
                     this.initialLoadData();
                 this.setState({ pmLoggerState: this.pmlogger_service.state });
             }

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -75,6 +75,12 @@ def prepareArchive(machine, name, time, hostname="localhost.localdomain"):
                        timedatectl set-time @{1}""".format(command, time, hostname))
 
 
+def redisService(image):
+    if image.startswith("debian") or image.startswith("ubuntu"):
+        return "redis-server"
+    return "redis"
+
+
 def login(self):
     # HACK: Ubuntu and Debian need some time until metrics channel is available
     # Really no idea what it needs to wait for, so let's just try channel until it succeeds
@@ -513,10 +519,7 @@ class TestHistoryMetrics(MachineCase):
         b = self.browser
         m = self.machine
 
-        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            redis = "redis-server"
-        else:
-            redis = "redis"
+        redis = redisService(m.image)
         hostname = m.execute("hostname").strip()
 
         self.addCleanup(m.execute, f"systemctl stop {redis}")
@@ -674,25 +677,6 @@ class TestHistoryMetrics(MachineCase):
         checkEnabled(False)
         m.execute("systemctl start pmproxy")
         checkEnabled(True)
-
-    @skipImage("no PCP support", "fedora-coreos")
-    @skipImage("pmproxy broken", "debian-stable")
-    def testPmProxyNoRedis(self):
-        b = self.browser
-        m = self.machine
-
-        if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            m.execute("dpkg --purge redis redis-server")
-        else:
-            m.execute("rpm --erase --verbose redis")
-
-        # pmproxy switch is not offered if redis is not installed (TODO: install it on demand)
-        self.login_and_go("/metrics")
-        b.click("#metrics-header-section button.pf-m-secondary")
-        b.wait_visible('#switch-pmlogger')
-        b.wait_not_present('#switch-pmproxy')
-        b.click("#pcp-settings-modal button.btn-cancel")
-        b.wait_not_present("#pcp-settings-modal")
 
 
 @skipDistroPackage()
@@ -930,8 +914,8 @@ class TestCurrentMetrics(MachineCase):
 
 
 @skipDistroPackage()
-class TestCockpitPcp(packagelib.PackageCase):
-    def testNoCockpitPcp(self):
+class TestMetricsPackages(packagelib.PackageCase):
+    def testBasic(self):
         b = self.browser
         m = self.machine
 
@@ -942,25 +926,36 @@ class TestCockpitPcp(packagelib.PackageCase):
             return
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
-            m.execute("dpkg --purge cockpit-pcp-dbgsym || true; dpkg --purge cockpit-pcp pcp")
+            m.execute("dpkg --purge cockpit-pcp-dbgsym || true; dpkg --purge cockpit-pcp pcp redis redis-server")
         else:
-            m.execute("rpm --erase --verbose cockpit-pcp pcp")
+            m.execute("rpm --erase --verbose cockpit-pcp pcp redis")
+        if "centos-8" in m.image or "rhel-8" in m.image:
+            # RHEL 8 ships this in a module, make sure that doesn't hide our fake package
+            m.execute("dnf module disable -y redis || true")
 
-        cpcp = {
+        redis_service = redisService(m.image)
+        dummy_service = "[Service]\nExecStart=/bin/sleep infinity\n[Install]\nWantedBy=multi-user.target\n"
+
+        cpcp_content = {
             "/usr/share/cockpit/pcp/manifest.json": '{"requires": {"cockpit": "134.x"}, "bridges": [{"match": { "payload": "metrics1"},"spawn": [ "/usr/libexec/cockpit-pcp" ]}]}',
             "/usr/libexec/cockpit-pcp": "true",
         }
-        pcp = {
-            "/lib/systemd/system/pmlogger.service": "[Service]\nExecStart=/bin/sleep infinity\n[Install]\nWantedBy=multi-user.target\n"
+        pcp_content = {
+            "/lib/systemd/system/pmlogger.service": dummy_service,
+            "/lib/systemd/system/pmproxy.service": dummy_service,
+        }
+        redis_content = {
+            f"/lib/systemd/system/{redis_service}.service": dummy_service,
         }
 
-        self.createPackage("cockpit-pcp", "999", "1", content=cpcp, depends="pcp",
+        self.createPackage("cockpit-pcp", "999", "1", content=cpcp_content, depends="pcp",
                            postinst="chmod +x /usr/libexec/cockpit-pcp")
-        self.createPackage("pcp", "999", "1", content=pcp, postinst="systemctl daemon-reload")
+        self.createPackage("pcp", "999", "1", content=pcp_content, postinst="systemctl daemon-reload")
+        self.createPackage("redis", "999", "1", content=redis_content, postinst="systemctl daemon-reload")
         self.enableRepo()
         m.execute("pkcon refresh")
 
-        # install it from the empty state
+        # install c-pcp from the empty state
         self.login_and_go("/metrics")
         b.wait_in_text(".pf-c-empty-state", "cockpit-pcp is missing")
         b.click(".pf-c-empty-state button.pf-m-primary")
@@ -978,7 +973,7 @@ class TestCockpitPcp(packagelib.PackageCase):
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
         b.logout()
 
-        # install it from the Metrics Settings dialog
+        # install c-pcp from the Metrics Settings dialog
         m.execute("pkcon remove -y cockpit-pcp pcp")
         self.login_and_go("/metrics")
         b.click("#metrics-header-section button.pf-m-secondary")
@@ -1008,6 +1003,23 @@ class TestCockpitPcp(packagelib.PackageCase):
         # this is just a fake cockpit-pcp package
         b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
         b.wait_in_text(".pf-c-empty-state", "pmlogger.service is failing to collect data")
+
+        # install redis
+        b.click("#metrics-header-section button.pf-m-secondary")
+        b.wait_visible("#pcp-settings-modal")
+        b.wait_visible("#switch-pmproxy:not(:checked)")
+        b.click("#switch-pmproxy")
+        b.wait_visible("#switch-pmproxy:checked")
+        b.click("#pcp-settings-modal button.pf-m-primary")
+        b.wait_not_present("#pcp-settings-modal")
+        # install dialog
+        b.click("#dialog button:contains('Install')")
+        b.wait_not_present("#dialog")
+        # sets up redis correctly; this is asynchronous, as it happens in the background after closing install dialog
+        m.execute('until [ $(systemctl is-enabled pmproxy) = enabled ]; do sleep 1; done')
+        m.execute('until [ $(systemctl is-active pmproxy) = active ]; do sleep 1; done')
+        m.execute(f'until [ $(systemctl is-active {redis_service}) = active ]; do sleep 1; done')
+        self.assertIn("redis", m.execute("systemctl show -p Wants --value pmproxy").strip())
 
 
 @skipDistroPackage()


### PR DESCRIPTION
Always show the "Export to network" switch. Install the redis package if
redis.service does not exist.

Change the pmlogger existence check from `.state === undefined` to
`.exists`, as that is easier to understand, and we were already using
the latter for pmproxy.

Rename TestCockpitPcp to TestMetricsPackages, as this covers more
packages than just cockpit-pcp now.

-----

I interactively tested that with

      systemctl stop pmlogger pmproxy redis; rpm -e --verbose cockpit-pcp pcp redis; systemctl daemon-reload

and then enabling pmlogger and pmproxy either one by one, or both together. After pmlogger and relogin (as advertised), history appears, and after pmproxy, querying metrics with

    curl 'http://localhost:44322/series/labels?names=hostname'

works. Our integration tests can only test package install and actual service configuration separately.

 - [x] Builds on top of #15998
 - [x] Builds on top of #16018

There isn't any thing visually/CSS-y new here, but screenshots for reference.

## Metrics: Install packages on demand

[Cockpit 247](https://cockpit-project.org/blog/cockpit-247.html) introduced setting up a machine for Grafana metrics. However, this only worked if the `pcp` and `redis` packages were already installed. With this Cockpit version, the options will always work, and missing packages get installed on demand.

![image](https://user-images.githubusercontent.com/200109/123632840-b1e01700-d818-11eb-815a-7df59dfb60df.png)

![image](https://user-images.githubusercontent.com/200109/123632886-be646f80-d818-11eb-84d7-b7a914a10ebc.png)
