### PR TITLE
Adjust check-connection for OpenSSL 3, fix TestNetworkingBasic.testBasic regression

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -360,7 +360,7 @@ class TestConnection(MachineCase):
         # Some operating systems fail SSL3 on the server side
         self.assertRegex(output, "Secure Renegotiation IS NOT supported|"
                          "ssl handshake failure|"
-                         "Option unknown option -ssl3|"
+                         "[uU]nknown option.* -ssl3|"
                          "null ssl method passed|"
                          "wrong version number")
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -343,7 +343,7 @@ class TestConnection(MachineCase):
 
         # has proper keyUsage and SAN (both with sscg and with self-signed)
         output = m.execute("openssl s_client -showcerts -connect 172.27.0.15:9090 |"
-                           "openssl x509 -in - -noout -ext keyUsage,extendedKeyUsage,subjectAltName")
+                           "openssl x509 -noout -ext keyUsage,extendedKeyUsage,subjectAltName")
         # keyUsage
         self.assertIn("Digital Signature", output)
         self.assertIn("Key Encipherment", output)

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -43,6 +43,11 @@ class TestNetworkingBasic(NetworkCase):
 
         ifaces = list(m.execute("ls /sys/class/net").split())
         ifaces.remove("lo")
+        try:
+            # not a real interface
+            ifaces.remove("bonding_masters")
+        except ValueError:
+            pass
         ignore = []
         for iface_name in ifaces:
             ignore.append("tr[data-interface={0}] td[data-label=Sending]".format(iface_name))


### PR DESCRIPTION
As spotted in the rhel-9-0 image refresh: https://github.com/cockpit-project/bots/pull/2144