### PR TITLE
Create time format helper library, port Overview and Journal pages from moment to that

### DIFF
--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -18,9 +18,7 @@
  */
 
 import cockpit from "cockpit";
-import moment from "moment";
-
-moment.locale(cockpit.language);
+import * as timeformat from "timeformat";
 
 const _ = cockpit.gettext;
 
@@ -295,12 +293,12 @@ journal.renderer = function renderer(output_funcs) {
     // 'day', all of which are strings.
 
     function format_entry(journal_entry) {
-        var d = moment(journal_entry.__REALTIME_TIMESTAMP / 1000); // timestamps are in µs
+        const d = journal_entry.__REALTIME_TIMESTAMP / 1000; // timestamps are in µs
         return {
             cursor: journal_entry.__CURSOR,
             full: journal_entry,
-            day: d.format('LL'),
-            time: d.format('LT'),
+            day: timeformat.date(d),
+            time: timeformat.time(d),
             bootid: journal_entry._BOOT_ID,
             ident: journal_entry.SYSLOG_IDENTIFIER || journal_entry._COMM,
             prio: journal_entry.PRIORITY,

--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -1,0 +1,22 @@
+/* Wrappers around Intl.DateTimeFormat which use Cockpit's current locale, and define a few standard formats.
+ * https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
+ */
+import cockpit from "cockpit";
+
+// this needs to be dynamic, as some pages don't initialize cockpit.language right away
+const dateFormatLang = () => cockpit.language.replace('_', '-');
+
+// general Intl.DateTimeFormat formatter object
+export const formatter = options => new Intl.DateTimeFormat(dateFormatLang(), options);
+
+// common formatters; try to use these as much as possible, for UI consistency
+// 07:41 AM
+export const time = t => formatter({ timeStyle: "short" }).format(t);
+// 7:41:26 AM
+export const timeSeconds = t => formatter({ timeStyle: "medium" }).format(t);
+// June 30, 2021
+export const date = t => formatter({ dateStyle: "long" }).format(t);
+// Jun 30, 2021, 7:41 AM
+export const dateTime = t => formatter({ dateStyle: "medium", timeStyle: "short" }).format(t);
+// Wednesday, June 30, 2021
+export const weekdayDate = t => formatter({ dateStyle: "full" }).format(t);

--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -18,5 +18,7 @@ export const timeSeconds = t => formatter({ timeStyle: "medium" }).format(t);
 export const date = t => formatter({ dateStyle: "long" }).format(t);
 // Jun 30, 2021, 7:41 AM
 export const dateTime = t => formatter({ dateStyle: "medium", timeStyle: "short" }).format(t);
+// Jun 30, 2021, 7:41:23 AM
+export const dateTimeSeconds = t => formatter({ dateStyle: "medium", timeStyle: "medium" }).format(t);
 // Wednesday, June 30, 2021
 export const weekdayDate = t => formatter({ dateStyle: "full" }).format(t);

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -18,8 +18,8 @@
  */
 
 import cockpit from "cockpit";
-import moment from "moment";
 import { journal } from "journal";
+import * as timeformat from "timeformat";
 
 import React from 'react';
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -153,16 +153,16 @@ export class LogEntry extends React.Component {
             content = <EmptyStatePanel loading title={ _("Loading...") } />;
         else if (this.state.entry) {
             const entry = this.state.entry;
-            const date = moment(new Date(entry.__REALTIME_TIMESTAMP / 1000));
+            const date = timeformat.dateTimeSeconds(entry.__REALTIME_TIMESTAMP / 1000);
 
             if (this.state.problemPath) {
-                breadcrumb = cockpit.format(_("$0: crash at $1"), entry.PROBLEM_BINARY, date.format("YYYY-MM-DD HH:mm:ss"));
+                breadcrumb = cockpit.format(_("$0: crash at $1"), entry.PROBLEM_BINARY, date);
                 content = <AbrtLogDetails problem={this.state.problemPath}
                                           entry={entry}
                                           service={this.state.abrtService}
                                           reloadProblems={this.goHome} />;
             } else {
-                breadcrumb = cockpit.format(_("Entry at $0"), date.format("YYYY-MM-DD HH:mm:ss"));
+                breadcrumb = cockpit.format(_("Entry at $0"), date);
                 content = <LogDetails entry={entry} />;
             }
         }

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -32,6 +32,7 @@ import {
 } from '@patternfly/react-core';
 
 import { superuser } from "superuser";
+import * as timeformat from "timeformat";
 
 import { SystemInfomationCard } from './overview-cards/systemInformationCard.jsx';
 import { ConfigurationCard } from './overview-cards/configurationCard.jsx';
@@ -106,7 +107,8 @@ class LoginMessages extends React.Component {
 
         let last_login_message;
         if (messages['last-login-time']) {
-            const datetime = moment.unix(messages['last-login-time']).format('ll LTS');
+            // time is a Unix time stamp, convert to ms since epoch
+            const datetime = timeformat.dateTime(messages['last-login-time'] * 1000);
             const host = messages['last-login-host'];
             const line = messages['last-login-line'];
             last_login_message = generate_line(host, line, datetime);
@@ -114,7 +116,7 @@ class LoginMessages extends React.Component {
 
         let last_fail_message;
         if (messages['last-fail-time']) {
-            const datetime = moment.unix(messages['last-fail-time']).format('ll LTS');
+            const datetime = timeformat.dateTime(messages['last-fail-time'] * 1000);
             const host = messages['last-fail-host'];
             const line = messages['last-fail-line'];
             last_fail_message = generate_line(host, line, datetime);

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -39,9 +39,9 @@ import { account_expiration_dialog, password_expiration_dialog } from "./expirat
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountRoles } from "./account-roles.js";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
+import * as timeformat from "timeformat.js";
 
 const _ = cockpit.gettext;
-const dateFormatLang = cockpit.language.replace('_', '-');
 
 function log_unexpected_error(error) {
     console.warn("Unexpected error", error);
@@ -93,8 +93,6 @@ function get_expire(name) {
         let password_expiration = '';
         let password_days = null;
 
-        const date_fmt = new Intl.DateTimeFormat(dateFormatLang, { dateStyle: "long" });
-
         data.split('\n').forEach(line => {
             const fields = line.split(': ');
             if (fields[0] && fields[0].indexOf("Password expires") === 0) {
@@ -103,14 +101,14 @@ function get_expire(name) {
                 } else if (fields[1].indexOf("password must be changed") === 0) {
                     password_expiration = _("Password must be changed");
                 } else {
-                    password_expiration = cockpit.format(_("Require password change on $0"), date_fmt.format(new Date(fields[1])));
+                    password_expiration = cockpit.format(_("Require password change on $0"), timeformat.date(new Date(fields[1])));
                 }
             } else if (fields[0] && fields[0].indexOf("Account expires") === 0) {
                 if (fields[1].indexOf("never") === 0) {
                     account_expiration = _("Never expire account");
                 } else {
                     account_date = new Date(fields[1] + " 12:00:00 UTC");
-                    account_expiration = cockpit.format(_("Expire account on $0"), date_fmt.format(new Date(fields[1])));
+                    account_expiration = cockpit.format(_("Expire account on $0"), timeformat.date(new Date(fields[1])));
                 }
             } else if (fields[0] && fields[0].indexOf("Maximum number of days between password change") === 0) {
                 password_days = fields[1];
@@ -251,7 +249,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
     else if (!details.logged.last)
         last_login = _("Never");
     else
-        last_login = new Intl.DateTimeFormat(dateFormatLang, { dateStyle: "long", timeStyle: "short" }).format(new Date(details.logged.last));
+        last_login = timeformat.dateTime(new Date(details.logged.last));
 
     return (
         <Page groupProps={{ sticky: 'top' }}

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -261,7 +261,7 @@ class TestSystemInfo(MachineCase):
         b.click("#system_information_change_systime .apply")
         b.wait_not_present("#system_information_change_systime")
 
-        b.wait_text("#system_information_systime_button", "Jan 24, 2037 8:03 AM")
+        b.wait_text("#system_information_systime_button", "Jan 24, 2037, 8:03 AM")
 
         self.assertFalse(ntp_enabled())
         self.assertIn("Sat Jan 24 08:03:", m.execute("date"))

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -288,7 +288,7 @@ class TestAccounts(MachineCase):
             b.go("#/admin")
             b.wait_visible("#account-logout[disabled]")
 
-            (year, month) = m.execute("date +'%Y %B'").strip().split()
+            (year, month) = m.execute("date +'%Y %b'").strip().split()
 
             # Log in as "admin" and the open details in other browser should update
             b2 = self.new_browser(m)


### PR DESCRIPTION
This is now the third page that moves from moment.js to Intl.DateTimeFormat, and we have enough commonality to factorize this. The Overview page is also part of check-page's "iterate through all known languages", so we get some nice test coverage with this.

 - [x] Builds on top of PR #16015

This changes the format a bit, but it's now consistent between users, metrics, and overview pages:

German on main:
![main-systemtime](https://user-images.githubusercontent.com/200109/123917511-2d5dd780-d983-11eb-8afe-e1420891008f.png)
![main-lastlogin](https://user-images.githubusercontent.com/200109/123917503-2c2caa80-d983-11eb-8396-9600bef0f5df.png)

German on this branch:
![image](https://user-images.githubusercontent.com/200109/123917553-377fd600-d983-11eb-8be8-0e826e84f042.png)
![image](https://user-images.githubusercontent.com/200109/123917573-3cdd2080-d983-11eb-9938-21397518d7ad.png)

English on main:
![image](https://user-images.githubusercontent.com/200109/123917794-79a91780-d983-11eb-80a5-c33951e7a0bc.png)
![image](https://user-images.githubusercontent.com/200109/123917821-80378f00-d983-11eb-9ec5-a769ef9f580d.png)

English on this branch:
![image](https://user-images.githubusercontent.com/200109/123917656-52524a80-d983-11eb-8acc-2c3ba3899cf3.png)
![image](https://user-images.githubusercontent.com/200109/123917681-57af9500-d983-11eb-897a-f578802302f7.png)

Journal details page header on main:
![image](https://user-images.githubusercontent.com/200109/123957627-4f1f8480-d9ac-11eb-9741-f4c69d93a192.png)

Journal details page header on this branch:
![image](https://user-images.githubusercontent.com/200109/123957555-3c0cb480-d9ac-11eb-9df5-169bef82a734.png)
