### PR TITLE
lgtm.yml: don't webpack when checking C code

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,5 @@
+extraction:
+  cpp:
+    index:
+      build_command:
+        - make -j$(nproc) WEBPACK_PACKAGES=


### PR DESCRIPTION
Add a lgtm.yml file to override the default command for the C build: we
gain nothing from running the full webpack build, so skip it.