### PR TITLE
build: stop using gresource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,8 +117,7 @@ tmp/weblate-repo
 /src/ws/cockpit*.service
 /src/ws/cockpit*.socket
 /src/ws/cockpit-tempfiles.conf
-src/common/cockpitassets.c
-src/common/cockpitassets.h
+/src/common/fail.html.c
 cockpit-pcp
 cockpitd
 /doc/man/cockpit.1

--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -1,5 +1,4 @@
-build-for-flatpak: $(BUILT_SOURCES)
-	$(MAKE) cockpit-ws
+build-for-flatpak: cockpit-ws
 
 install-for-flatpak: \
 		install-cockpitwsPROGRAMS \

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -119,7 +119,7 @@ QUnit.test("not found", function (assert) {
                 assert.strictEqual(ex.problem, null, "mapped to cockpit code");
                 assert.strictEqual(ex.status, 404, "has status code");
                 assert.equal(ex.message, "Not Found", "has reason");
-                assert.equal(data, "<html><head><title>Not Found</title></head><body>Not Found</body></html>\n", "got body");
+                assert.true(data.includes('<h1>Not Found</h1>'), "got body");
             })
             .always(function() {
                 assert.equal(this.state(), "rejected", "should fail");

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -37,7 +37,6 @@
 #include "cockpitrouter.h"
 #include "cockpitwebsocketstream.h"
 
-#include "common/cockpitassets.h"
 #include "common/cockpitchannel.h"
 #include "common/cockpitcloserange.h"
 #include "common/cockpitfdpassing.h"
@@ -404,9 +403,6 @@ run_bridge (const gchar *interactive,
         polkit_agent = cockpit_polkit_agent_register (transport, router, NULL);
     }
 #endif
-
-  g_resources_register (cockpitassets_get_resource ());
-  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
   cockpit_dbus_user_startup (pwd);
   cockpit_dbus_process_startup ();

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -1209,6 +1209,10 @@ main (int argc,
 
   cockpit_test_init (&argc, &argv);
 
+  extern const gchar *cockpit_webresponse_fail_html_text;
+  cockpit_webresponse_fail_html_text =
+    "<html><head><title>@@message@@</title></head><body>@@message@@</body></html>\n";
+
   g_test_add ("/packages/simple", TestCase, &fixture_simple,
               setup, test_simple, teardown);
   g_test_add ("/packages/forwarded", TestCase, &fixture_forwarded,

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -1,23 +1,6 @@
-src/common/cockpitassets.h: src/common/cockpitassets.gresource.xml
-	@mkdir -p $(dir $@)
-	$(AM_V_GEN) glib-compile-resources --target=$@ --generate-header --sourcedir=$(dir $<) $<
-src/common/cockpitassets.c: src/common/cockpitassets.gresource.xml src/common/fail.html
-	@mkdir -p $(dir $@)
-	$(AM_V_GEN) glib-compile-resources --target=$@ --generate-source --sourcedir=$(dir $<) $<
-
-COCKPIT_ASSETS = \
-       src/common/cockpitassets.h \
-       src/common/cockpitassets.c \
-       $(NULL)
-
-BUILT_SOURCES += $(COCKPIT_ASSETS)
-CLEANFILES += $(COCKPIT_ASSETS)
-
 EXTRA_DIST += \
 	src/common/mock-content \
 	src/common/mock-stderr \
-	src/common/cockpitassets.gresource.xml \
-	src/common/fail.html \
 	$(test_locale_PO) \
 	$(NULL)
 
@@ -106,9 +89,11 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitwebserver.c \
 	$(NULL)
 
-nodist_libcockpit_common_a_SOURCES = \
-	$(COCKPIT_ASSETS) \
-	$(NULL)
+src/common/fail.html.c: src/common/fail.html
+	$(AM_V_GEN) $(top_srcdir)/tools/escape-to-c cockpit_webresponse_fail_html_text < $< > $@.tmp && mv $@.tmp $@
+nodist_libcockpit_common_a_SOURCES = src/common/fail.html.c
+CLEANFILES += src/common/fail.html.c
+EXTRA_DIST += src/common/fail.html
 
 libcockpit_common_a_CFLAGS = \
 	-fPIC \
@@ -227,9 +212,6 @@ test_version_LDADD = $(libcockpit_common_a_LIBS)
 
 test_webresponse_SOURCES = \
 	src/common/test-webresponse.c \
-	$(NULL)
-nodist_test_webresponse_SOURCES = \
-	$(COCKPIT_ASSETS) \
 	$(NULL)
 test_webresponse_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_webresponse_LDADD = $(libcockpit_common_a_LIBS)

--- a/src/common/cockpitassets.gresource.xml
+++ b/src/common/cockpitassets.gresource.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<gresources>
-  <gresource prefix="/org/cockpit-project/Cockpit/">
-    <file>fail.html</file>
-  </gresource>
-</gresources>

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -57,8 +57,6 @@ typedef struct _CockpitWebResponse        CockpitWebResponse;
 
 extern const gchar *  cockpit_web_exception_escape_root;
 
-extern const gchar *  cockpit_web_failure_resource;
-
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           const gchar *original_path,
                                                           const gchar *path,

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -233,17 +233,6 @@ test_return_gerror_headers (TestCase *tc,
 }
 
 static void
-test_return_error_resource (TestCase *tc,
-                            gconstpointer user_data)
-{
-  const gchar *roots[] = { srcdir, NULL };
-  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
-  cockpit_web_response_file (tc->response, "/non-existent", roots);
-  cockpit_assert_strmatch (output_as_string (tc), "HTTP/1.1 404 Not Found*<img*Not Found*");
-  cockpit_web_failure_resource = NULL;
-}
-
-static void
 test_file_not_found (TestCase *tc,
                      gconstpointer user_data)
 {
@@ -1455,6 +1444,10 @@ int
 main (int argc,
       char *argv[])
 {
+  extern const gchar *cockpit_webresponse_fail_html_text;
+  cockpit_webresponse_fail_html_text =
+    "<html><head><title>@@message@@</title></head><body>@@message@@</body></html>\n";
+
   gint ret;
 
   srcdir = realpath (SRCDIR, NULL);
@@ -1472,8 +1465,6 @@ main (int argc,
               setup, test_return_error_headers, teardown);
   g_test_add ("/web-response/return-gerror-headers", TestCase, NULL,
               setup, test_return_gerror_headers, teardown);
-  g_test_add ("/web-response/return-error-resource", TestCase, NULL,
-              setup, test_return_error_resource, teardown);
   g_test_add ("/web-response/file/not-found", TestCase, NULL,
               setup, test_file_not_found, teardown);
   g_test_add ("/web-response/file/directory-denied", TestCase, NULL,

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -33,7 +33,6 @@
 #include "cockpithandlers.h"
 #include "cockpitbranding.h"
 
-#include "common/cockpitassets.h"
 #include "common/cockpitconf.h"
 #include "common/cockpithacks-glib.h"
 #include "common/cockpitmemory.h"
@@ -98,10 +97,6 @@ setup_static_roots (GHashTable *os_release)
     }
 
   roots = cockpit_branding_calculate_static_roots (os_id, os_variant_id, os_id_like, TRUE);
-
-  /* Load the fail template */
-  g_resources_register (cockpitassets_get_resource ());
-  cockpit_web_failure_resource = "/org/cockpit-project/Cockpit/fail.html";
 
   return roots;
 }

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -1079,6 +1079,9 @@ main (int argc,
 {
   cockpit_test_init (&argc, &argv);
 
+  extern const gchar *cockpit_webresponse_fail_html_text;
+  cockpit_webresponse_fail_html_text =
+    "<html><head><title>@@message@@</title></head><body>@@message@@</body></html>\n";
 
   /* Try to debug crashing during tests */
   signal (SIGSEGV, cockpit_test_signal_backtrace);

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -1073,26 +1073,12 @@ test_resource_head (TestResourceCase *tc,
   g_object_unref (response);
 }
 
-static gboolean
-on_hack_raise_sigchld (gpointer user_data)
-{
-  raise (SIGCHLD);
-  return TRUE;
-}
-
 int
 main (int argc,
       char *argv[])
 {
   cockpit_test_init (&argc, &argv);
 
-  /*
-   * HACK: Work around races in glib SIGCHLD handling.
-   *
-   * https://bugzilla.gnome.org/show_bug.cgi?id=731771
-   * https://bugzilla.gnome.org/show_bug.cgi?id=711090
-   */
-  g_timeout_add_seconds (1, on_hack_raise_sigchld, NULL);
 
   /* Try to debug crashing during tests */
   signal (SIGSEGV, cockpit_test_signal_backtrace);

--- a/tools/escape-to-c
+++ b/tools/escape-to-c
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+# ...until #embed comes along...
+# eg: tools/escape-to-c cockpit_webresponse_fail_html_text < fail.html > fail.html.c
+
+import json
+import sys
+
+# Use a pointer to allow overriding the value
+print(f'const char *', sys.argv[1], '=\n',
+      *[json.dumps(line) + '\n' for line in sys.stdin],
+      ';')


### PR DESCRIPTION
We use glib-compile-resources to get a single html file bundled.  That
seems like overkill.

Ideally, we'd use #embed for this, but that seems like it'll take a
while longer, so use a small Python script to convert the .html into C,
and compile the resulting file in the usual way.

Formerly, cockpitwebresponse would default to serving a minimalist
internally-hardcoded document for errors, unless the resource was
provided.  Since this resource was provided from both -bridge and -ws,
the internal document was only used for testing.  That was for good
reason: the full document would be a pain to test on, and we'd have to
update the tests any time someone modified the html.

Let's turn the logic around there and default to the real document and
give the tests a mechanism to inject their minimal one.  We use a
pointer instead of a constant, allowing it to be directly overridden
from the tests, and simplifying the code in cockpitwebresponse a bit.

We tried another approach with the usual `ld -b binary` tricks to
convert the file directly to a linkable symbol, but this was causing
strange crashes on rhel and fedora.  Going via C is a sure thing.