### PR TITLE
systemd: Port hwinfo page from moment to timeformat

### DIFF
--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -21,9 +21,10 @@ import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 
 import cockpit from "cockpit";
-import moment from 'moment';
 import React from "react";
 import ReactDOM from 'react-dom';
+
+import * as timeformat from 'timeformat';
 
 import {
     Alert, AlertActionCloseButton, Button,
@@ -74,6 +75,8 @@ class SystemInfo extends React.Component {
             </PrivilegedButton>
         );
 
+        const bios_date = Date.parse(info.bios_date); // NaN for undefined, null, or invalid dates
+
         return (
             <Flex id="hwinfo-system-info-list" direction={{ default: 'column', sm: 'row' }}>
                 <FlexItem className="hwinfo-system-info-list-item" flex={{ default: 'flex_1' }}>
@@ -107,7 +110,7 @@ class SystemInfo extends React.Component {
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("BIOS date") }</DescriptionListTerm>
-                                <DescriptionListDescription>{ moment(info.bios_date, "MM/DD/YYYY").isValid() ? moment(info.bios_date, "MM/DD/YYYY").format('L') : info.bios_date }</DescriptionListDescription>
+                                <DescriptionListDescription>{ bios_date ? timeformat.date(bios_date) : info.bios_date }</DescriptionListDescription>
                             </DescriptionListGroup>
                         </> }
                         { info.nproc !== undefined && <>
@@ -364,7 +367,6 @@ class HardwareInfo extends React.Component {
 
 document.addEventListener("DOMContentLoaded", () => {
     document.title = cockpit.gettext(document.title);
-    moment.locale(cockpit.language);
     detect().then(info => {
         ReactDOM.render(<HardwareInfo info={info} />, document.getElementById("hwinfo"));
     });

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -189,10 +189,12 @@ OnCalendar=daily
         # HACK: the timers' next run/last trigger (col 3/4) don't always get filled (issue #9439)
         # b.wait_in_text("tr[data-goto-unit='test\.timer'] td:nth-child(3)", "morgen um")
 
-        # BIOS date parsing using moment
+        # BIOS date parsing; we don't want to introduce too many assumptions, just that the original MM/DD/YYYY
+        # was parsed at all, and the bios is from the 21st century (20YY)
+        # TestSystemInfo.testHardwareInfo does this more carefully
         b.go("/system/hwinfo")
         b.enter_page("/system/hwinfo")
-        b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(3) dd', ".20")
+        b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(3) dd', " 20")
 
         # Check the playground page
         b.switch_to_top()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -407,8 +407,9 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-c-description-list__group:nth-of-type(2) dd', "Standard PC")
         # BIOS
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(1) dd', "SeaBIOS")
-        # BIOS date
-        b.wait_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(3) dd', m.execute("cat /sys/class/dmi/id/bios_date").strip())
+        # BIOS date gets parsed
+        parsed_bios_date = m.execute("date --date $(cat /sys/class/dmi/id/bios_date) '+%B %-d, %Y'").strip()
+        b.wait_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(3) dd', parsed_bios_date)
 
         pci_selector = '#hwinfo #pci-listing'
         heading_selector = ' .pf-c-card__title'


### PR DESCRIPTION
This changes the visible date format, but makes it consistent with other
pages.

Main:
![main-en](https://user-images.githubusercontent.com/200109/124090900-94e45780-da55-11eb-8bb6-dfb389564b49.png)


This PR:
![pr-en](https://user-images.githubusercontent.com/200109/124090887-901fa380-da55-11eb-9a5a-9650dcdf7845.png)

(There is no spacing change - this was just me selecting an arbitrary part of  the screen)