### PR TITLE
clean up dist rules

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,12 @@ tools/debian/copyright: tools/debian/copyright.template $(MANIFESTS)
 	$(AM_V_GEN) $(srcdir)/tools/build-debian-copyright > $@.tmp
 	$(MV) $@.tmp $@
 
+# This is the stock rule with $(BUILT_SOURCES) dependency removed.
+# In the future, we can do this via "no-dist-built-sources" automake option:
+# https://git.savannah.gnu.org/cgit/automake.git/commit/?id=13659a7385
+distdir:
+	$(MAKE) $(AM_MAKEFLAGS) distdir-am
+
 # Build up the distribution using $COMMITTED_DIST and include node_modules licenses
 # also automatically update minimum base dependency in RPM spec file
 dist-hook:: $(MANIFESTS)

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -228,6 +228,8 @@ test_version_LDADD = $(libcockpit_common_a_LIBS)
 test_webresponse_SOURCES = \
 	src/common/test-webresponse.c \
 	src/common/mock-io-stream.c src/common/mock-io-stream.h \
+	$(NULL)
+nodist_test_webresponse_SOURCES = \
 	$(COCKPIT_ASSETS) \
 	$(NULL)
 test_webresponse_CFLAGS = $(libcockpit_common_a_CFLAGS)


### PR DESCRIPTION
    build: clean up distdir rules
    
    I've always wondered why we split our dist-hook up so randomly: it seems
    like some group of things is in one place and another group in another.
    Then there's the one for displaying the error message for the docs.
    
    Replace this with a combined override rule for `distdir`.  We're now in
    control of the process: of course, we call distdir-am first, but after
    that, we can do everything we need, and from one place instead of three
    different ones.
    
    In addition to cleanup, this has two positive impacts:
    
     - `make dist` after `--disable-doc` will now fail immediately, not
       after a bunch of work is already done
    
     - we no longer depend on `$(BUILT_SOURCES)` here, which avoids
       needlessly building some files which won't be disted anyway
