### PR TITLE
make-bots: support symlinking to another bots dir

### DIFF
--- a/tools/make-bots
+++ b/tools/make-bots
@@ -12,11 +12,16 @@ set -eu
 cd "$(realpath -m "$0"/../..)"
 . tools/git-utils.sh
 
-if [ ! -d bots ]; then
+if [ ! -e bots ]; then
     [ -n "${quiet}" ] || set -x
-    # it's small, so keep everything cached
-    fetch_to_cache ${COCKPIT_BOTS_REF+"${COCKPIT_BOTS_REF}"}
-    clone_from_cache "${COCKPIT_BOTS_REF-master}"
+    if [ -h ~/.config/cockpit-dev/bots ]; then
+        message SYMLINK "bots → $(realpath --relative-to=. ~/.config/cockpit-dev/bots)"
+        ln -sfT "$(realpath --relative-to=. ~/.config/cockpit-dev)/bots" bots
+    else
+        # it's small, so keep everything cached
+        fetch_to_cache ${COCKPIT_BOTS_REF+"${COCKPIT_BOTS_REF}"}
+        clone_from_cache "${COCKPIT_BOTS_REF-master}"
+    fi
 else
     echo "bots/ already exists, skipping"
 fi


### PR DESCRIPTION
We probably all have a checkout of `bots/` somewhere already.  Martin
mentioned that he likes to setup a symlink to it when creating a new
worktree.  Let's automate that process in an elegant way.

Modify `tools/make-bots` to check for the presence of a symlink at
`~/.config/cockpit-dev/bots`.  If one is found, use the directory that
it points to as a target for a symlink from `bots`, as an alternative
to checking out our own copy.

A small matter of taste: we print the (relative) directory name of the
specified bots directory in the log message, but we actually link to the
`~/.config/cockpit-dev/bots` symlink itself.  That way you can update the
symlink as-needed (if working on another branch, for example) and all
existing cockpit repository worktrees will automatically switch over.