### PR TITLE
npm-install workflow: ignore *.pyc files

### DIFF
--- a/.github/workflows/npm-install.yml
+++ b/.github/workflows/npm-install.yml
@@ -257,5 +257,5 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body: `> /npm install\n\nThe workflow failed.  See here for more information: https://github.com/${owner}/${repo}/actions/runs/${context.runId}`
+                body: `> /npm install\n\nThe workflow failed.  See here for more information: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });

--- a/.github/workflows/npm-install.yml
+++ b/.github/workflows/npm-install.yml
@@ -187,7 +187,10 @@ jobs:
           EOF
           rm artifact/npm-install.log
           rmdir artifact
-          echo /.cache >> node_modules/.gitignore
+          cat > node_modules/.gitignore <<EOF
+          *.pyc
+          /.cache
+          EOF
           git --work-tree node_modules add --all
           git --work-tree node_modules commit --quiet -F - < commit-message
           rm -rf node_modules


### PR DESCRIPTION
These are being created/deleted semi-randomly, resulting in the
submodule showing up with a "dirty" diff in the parent project.
    
Ignore the noise.


bonus: fix up a bug in the error handling code of the workflow that I caught while testing it.

The working case can be observed here:
 - https://github.com/allisonkarlitskaya/cockpit/pull/11#issuecomment-872198505
 - https://github.com/allisonkarlitskaya/node-cache/blob/d981c33c850313d78f0ff81bd1650b24c7f9ef8d/.gitignore

The functional failure handling can be seen here (in response to a deliberately introduced syntax error in `package.json`, for testing purposes):
 - https://github.com/allisonkarlitskaya/cockpit/pull/11#issuecomment-872202367