### PR TITLE
storage: Make sidepanel hover consistent

### DIFF
--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -487,7 +487,8 @@ td.storage-action {
 }
 
 .sidepanel-row:not(.pf-c-empty-state):hover {
-    background-color: var(--ct-color-link-hover-bg);
+    color: var(--ct-color-list-hover-text);
+    cursor: pointer;
 }
 
 .sidepanel-row-name {


### PR DESCRIPTION
This is a super-simple alternative to #15914, with the minimum changes to fix hovering of the sidepanel, to make it consistent with the other panels in the middle of the page.