### PR TITLE
test: Make ignored pixel test rectangles slightly larger

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -704,7 +704,9 @@ class Browser:
             #
             # - The call to assert_pixels specifies a list of
             #   rectangles (via CSS selectors).  Pixels within those
-            #   rectangles are ignored.
+            #   rectangles (and slightly outside) are ignored.  Pixels
+            #   just outside the rectangles are also ignored to avoid
+            #   issues with rounding coordinates.
             #
             # - The RGB values of pixels can differ by up to 2.
             #
@@ -716,7 +718,7 @@ class Browser:
 
             def ignorable_coord(x, y):
                 for (x0, y0, x1, y1) in ignore_rects:
-                    if x >= x0 and x < x1 and y >= y0 and y < y1:
+                    if x >= x0 - 2 and x < x1 + 2 and y >= y0 - 2 and y < y1 + 2:
                         return True
                 return False
 


### PR DESCRIPTION
The content of such a rectangle seems to stick out by one pixel
sometimes, probably because coordinates are rounded wrongly at some
point.