### PR TITLE
workflows: Run release workflow in release environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   cockpituous:
     runs-on: ubuntu-latest
+    environment: release
     container:
       image: ghcr.io/cockpit-project/release
     steps:


### PR DESCRIPTION
This partitions our secrets and limits their potential exposure/leakage.

This environment can be created with github-upload-action-secrets in [1].

[1] https://github.com/cockpit-project/bots/pull/2164