### PR TITLE
storaged: Check transient hostname as well for RAID name

### DIFF
--- a/pkg/storaged/test-util.js
+++ b/pkg/storaged/test-util.js
@@ -67,9 +67,15 @@ QUnit.test("mdraid_name_remote", function (assert) {
     utils.mock_hostnamed(null);
 });
 
-QUnit.test("mdraid_name_local", function (assert) {
+QUnit.test("mdraid_name_local_static", function (assert) {
     utils.mock_hostnamed({ StaticHostname: "sweethome" });
-    assert.strictEqual(utils.mdraid_name({ Name: "sweethome:mydev" }), "mydev", "expected name for local host");
+    assert.strictEqual(utils.mdraid_name({ Name: "sweethome:mydev" }), "mydev", "expected name for static local host");
+    utils.mock_hostnamed(null);
+});
+
+QUnit.test("mdraid_name_local_transient", function (assert) {
+    utils.mock_hostnamed({ Hostname: "sweethome" });
+    assert.strictEqual(utils.mdraid_name({ Name: "sweethome:mydev" }), "mydev", "expected name for transient local host");
     utils.mock_hostnamed(null);
 });
 


### PR DESCRIPTION
Some hosts don't have a static host name in /etc/hostname, or it is set
to "localhost" (which some OSes also count as "not really set"). These
get their host names via DHCP, which hostnamed considers "transient".

Consider the transient host name as well to decide whether a RAID is
local or not.

-----

This was spotted in https://github.com/cockpit-project/bots/pull/2168 , see that PR for details. I trigger an additional run against that PR to make sure it works now.