### PR TITLE
workflows: Reduce unit test timeout to 20 minutes

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
          - CC=clang distcheck
          - :i386 distcheck
       fail-fast: false
-    timeout-minutes: 60
+    timeout-minutes: 20
     env:
       # current podman backport falls over as non-root, and completely breaks down with :i386 image
       docker: docker


### PR DESCRIPTION
Sometimes they hang eternally, and it's annoying to be told only that
late. They normally take 13 minutes, and we don't want them to take
longer than 20.