### PR TITLE
containers/unit-tests: Put back sassc

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -9,6 +9,9 @@ jobs:
   # we do both builds and all tests in a single run, so that we only upload the containers on success
   refresh:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     timeout-minutes: 180
     env:
       # current podman backport falls over as non-root, and completely breaks down with :i386 image
@@ -36,7 +39,7 @@ jobs:
         run: containers/unit-tests/start :i386 distcheck
 
       - name: Log into container registry
-        run: docker login -u cockpituous -p ${{ secrets.COCKPITUOUS_GHCR_TOKEN }} ghcr.io
+        run: docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Push containers to registry
         run: |

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -42,6 +42,7 @@ dependencies="\
     pyflakes3 \
     python3 \
     python3-pep8 \
+    sassc \
     ssh \
     strace \
     valgrind \


### PR DESCRIPTION
This was dropped prematurely in commit 012483503e53, our rhel-8.4 branch
still uses it and backporting the sass changes is too intrusive for a
stable branch.

Also, drop our `COCKPITUOUS_GHCR_TOKEN` from the unit-tests-refresh workflow. The only other consumer of that is cockpituous, which I dropped in https://github.com/cockpit-project/cockpituous/pull/426 . After that, we can eliminate that secret.

 - [x] [Rebuild unit-tests containers](https://github.com/cockpit-project/cockpit/actions/runs/1003182461): Succeeded and [pushed new images](https://github.com/cockpit-project/cockpit/pkgs/container/unit-tests)