### PR TITLE
test: Adjust TestGrafanaClient for Grafana 8

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1071,6 +1071,12 @@ class TestGrafanaClient(MachineCase):
         b = self.browser
         mg = self.machines['services']
 
+        # avoid dynamic host name changes during PCP data collection, and start from clean slate
+        m.execute("""systemctl stop pmlogger
+                     systemctl reset-failed pmlogger
+                     rm -rf /var/log/pcp/pmlogger
+                     hostnamectl set-hostname grafana-client""")
+
         # start Grafana
         mg.execute("/root/run-grafana")
         m.execute("until curl --silent --show-error http://10.111.112.100:3000; do sleep 1; done")
@@ -1078,17 +1084,16 @@ class TestGrafanaClient(MachineCase):
         mg.execute("curl --silent --show-error -u admin:foobar -d '' 'http://127.0.0.1:3000/api/plugins/performancecopilot-pcp-app/settings?enabled=true'")
         self.login_and_go("/metrics")
 
-        # pmlogger data collection is not running by default on RHEL
-        if m.image.startswith("rhel") or m.image.startswith("centos"):
-            b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
-            b.wait_in_text(".pf-c-empty-state", "pmlogger.service is not running")
-            b.click(".pf-c-empty-state button.pf-m-primary")
-            b.wait_visible("#pcp-settings-modal")
-            b.wait_visible("#switch-pmlogger:not(:checked)")
-            b.click("#switch-pmlogger")
-            b.wait_visible("#switch-pmlogger:checked")
-            b.click("#pcp-settings-modal button.pf-m-primary")
-            b.wait_not_present("#pcp-settings-modal")
+        # pmlogger data collection is not running initially
+        b.wait_in_text(".pf-c-empty-state", "Metrics history could not be loaded")
+        b.wait_in_text(".pf-c-empty-state", "pmlogger.service is not running")
+        b.click(".pf-c-empty-state button.pf-m-primary")
+        b.wait_visible("#pcp-settings-modal")
+        b.wait_visible("#switch-pmlogger:not(:checked)")
+        b.click("#switch-pmlogger")
+        b.wait_visible("#switch-pmlogger:checked")
+        b.click("#pcp-settings-modal button.pf-m-primary")
+        b.wait_not_present("#pcp-settings-modal")
 
         # enable pmproxy+redis (none of our test OSes have both of them running by default)
         b.click("#metrics-header-section button.pf-m-secondary")
@@ -1127,8 +1132,7 @@ class TestGrafanaClient(MachineCase):
             # Grafana auto-discovers "host" variable for incoming metrics; it takes a while to receive the first
             # measurement; that event is not observable directly in Grafana, and the dashboard does not auto-update to
             # new variables; so probe the API until it appears
-            hostname = m.execute("hostname").strip()
-            wait(lambda: hostname in mg.execute(f"curl --max-time 10 --silent --show-error '{redis_url}/series/labels?names=hostname'"), delay=10, tries=30)
+            wait(lambda: "grafana-client" in mg.execute(f"curl --max-time 10 --silent --show-error '{redis_url}/series/labels?names=hostname'"), delay=10, tries=30)
             # ... and the load metrics as well
             wait(lambda: mg.execute(f"curl --max-time 10 --silent --show-error '{redis_url}/series/query?expr=kernel.all.load'").strip() != '[]', delay=10, tries=30)
 
@@ -1139,7 +1143,7 @@ class TestGrafanaClient(MachineCase):
             # .. and the dashboard name becomes clickable
             bg.click("a:contains('PCP Redis: Host Overview')")
 
-            bg.wait_in_text(".submenu-controls", hostname)
+            bg.wait_in_text(".submenu-controls", "grafana-client")
 
             # expect a "Load average" panel with a sensible number
             max_load = bg.text("div:contains('Load average') .graph-legend-series:contains('1 minute') .max")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1107,11 +1107,11 @@ class TestGrafanaClient(MachineCase):
         bg = Browser(mg.forward['3000'], label=self.label() + "-" + mg.label)
         try:
             bg.open("/")
-            bg.set_val("input[name='user']", "admin")
-            bg.set_val("input[name='password']", "foobar")
+            bg.set_input_text("input[name='user']", "admin")
+            bg.set_input_text("input[name='password']", "foobar")
             bg.click("button:contains('Log in')")
             bg.expect_load()
-            bg.wait_in_text(".dashboard-content", "Welcome to Grafana")
+            bg.wait_in_text("body", "Welcome to Grafana")
             bg.wait_visible(".sidemenu")
 
             # Add the PCP redis data source for our client machine
@@ -1121,7 +1121,7 @@ class TestGrafanaClient(MachineCase):
             bg.open("/datasources/new")
             bg.click("[aria-label='Data source plugin item PCP Redis']")
             bg.set_input_text("input[placeholder='http://localhost:44322']", redis_url)
-            bg.click("button:contains('Save & Test')")
+            bg.click("button:contains('Save &')")  # Save & [tT]est
             bg.wait_in_text(".page-body", "Data source is working")
 
             # Grafana auto-discovers "host" variable for incoming metrics; it takes a while to receive the first
@@ -1133,10 +1133,8 @@ class TestGrafanaClient(MachineCase):
             wait(lambda: mg.execute(f"curl --max-time 10 --silent --show-error '{redis_url}/series/query?expr=kernel.all.load'").strip() != '[]', delay=10, tries=30)
 
             # Switch to "Dashboards" tab, import "Host Overview"
-            bg.click("li[aria-label='Tab Dashboards'] a")
+            bg.click(".page-header__tabs a[href$='/dashboards']")
             bg.click("table:contains('PCP Redis: Host Overview') button")
-            # the "imported" notification is transient, avoid checking for this; but on success, there will be a delete button
-            bg.wait_visible("table:contains('PCP Redis: Host Overview') .btn-danger")
 
             # .. and the dashboard name becomes clickable
             bg.click("a:contains('PCP Redis: Host Overview')")
@@ -1144,7 +1142,7 @@ class TestGrafanaClient(MachineCase):
             bg.wait_in_text(".submenu-controls", hostname)
 
             # expect a "Load average" panel with a sensible number
-            max_load = bg.text(".panel-wrapper:contains('Load average') .graph-legend-series:contains('1 minute') .max")
+            max_load = bg.text("div:contains('Load average') .graph-legend-series:contains('1 minute') .max")
             self.assertGreater(float(max_load), 0)
         except Error:
             bg.snapshot("FAIL-grafana")


### PR DESCRIPTION
- The login form now requires actual typing to trigger the handlers.

- Dashboard CSS classes changed a bit. Let's avoid any assumption and be
  satisfied with the "Welcome" string appearing anywhere on the page.

- "Save & Test" button is now called "Save & test"

- The "Dashboard" tab's aria label moved from the containing `<li>` into
  the `<a>`. That makes a label-based selector awkward, so instead
  select by link target in the tabs section.

- The "Delete dashboard" button in the data source import does not have
  any useful properties any more, and that check is not important. Drop
  it.

- The dashboard panel classes changed in a non-overlapping way. Replace
  the `.panel-wrapper` selector with a generic `<div>` one.

With these changes the test works for both Grafana 7.5 and 8.0.

----

This blocks the services image refresh in https://github.com/cockpit-project/bots/pull/2183 . This happens to pick up a newer Grafana version.