### PR TITLE
build: fix `make install` with `--disable-doc`

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -174,8 +174,13 @@ recheck-memory: valgrind-suppressions
 	        HTML_LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
 		$(AM_MAKEFLAGS) recheck
 
+if ENABLE_DOC
+DOCS_INSTALL_DEPS = dist/guide/html/index.html
+else
+DOCS_INSTALL_DEPS =
+endif
 
-install-data-local:: dist/guide/html/index.html
+install-data-local:: $(DOCS_INSTALL_DEPS)
 if ENABLE_DOC
 	$(MKDIR_P) $(DESTDIR)$(htmldir)
 	$(INSTALL_DATA) $(dir $<)/* $(DESTDIR)$(htmldir)


### PR DESCRIPTION
Commit a6e2689e848a0173b45a6e70cf15de2bf87b8696 rearranged the
conditionalisation of our docs targets and accidentally introduced an
unconditional dependency on dist/guide/html/index.html to the
install-data-local: rule, even if docs were disabled.

We can't conditionalise the rule itself, for fear of bringing back
automake's complaints about duplicated definitions, so introduce a
variable.  This isn't pretty, but it works.

Fixes #16064