### PR TITLE
fmf: Clean up broken stub epel repo

### DIFF
--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -22,6 +22,9 @@ rpm -q cockpit-system
 # HACK: chromium-headless ought to be enough, but version 88 has a crash: https://bugs.chromium.org/p/chromium/issues/detail?id=1170634
 if ! rpm -q chromium; then
     if grep -q 'ID=.*rhel' /etc/os-release; then
+        # There is no EPEL for RHEL 9 yet, force 8
+        # RHEL 9 has a broken stub epel.repo
+        rm -f /etc/yum.repos.d/epel.repo
         dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         dnf config-manager --enable epel
     fi


### PR DESCRIPTION
Current RHEL 9 Testing Farm instances have a broken and mostly empty
epel.repo file. Clean it up before installing the real epel-release rpm,
otherwise that rpm won't overwrite the stub.

---

This is the same fix as for c-machines in https://github.com/cockpit-project/cockpit-machines/pull/246 .