### PR TITLE
Try to not step on PF4 when adjusting headings

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -180,7 +180,7 @@ export class ApplicationList extends React.Component {
             <Page>
                 <PageSection variant={PageSectionVariants.light}>
                     <Flex alignItems={{ default: 'alignItemsCenter' }}>
-                        <h2>{_("Applications")}</h2>
+                        <h2 className="pf-u-font-size-3xl">{_("Applications")}</h2>
                         <FlexItem align={{ default: 'alignRight' }}>
                             <Flex>
                                 {refresh_progress}

--- a/pkg/apps/application.css
+++ b/pkg/apps/application.css
@@ -1,3 +1,5 @@
+@import "@patternfly/patternfly/utilities/Text/text.css";
+
 /* Application list */
 
 .app-list-empty {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -5,24 +5,28 @@
 
 /* Globally resize headings */
 h1 {
-  font-size: var(--pf-global--FontSize--4xl);
+  --ct-heading-font-size: var(--pf-global--FontSize--4xl);
 }
 
 h2 {
-  font-size: var(--pf-global--FontSize--3xl);
+  --ct-heading-font-size: var(--pf-global--FontSize--3xl);
 }
 
 h3 {
-  font-size: var(--pf-global--FontSize--2xl);
+  --ct-heading-font-size: var(--pf-global--FontSize--2xl);
 }
 
 h4 {
-  font-size: var(--pf-global--FontSize--xl);
+  --ct-heading-font-size: var(--pf-global--FontSize--lg);
 }
 
-h4 {
-  font-size: var(--pf-global--FontSize--lg);
+// Only apply a custom font size when a heading does NOT have a PF4 class
+h1, h2, h3, h4 {
+    &:not([class*=pf-]) {
+        font-size: var(--ct-heading-font-size);
+    }
 }
+
 /* End of headings resize */
 
 a {

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -5,8 +5,14 @@ $font-family-mono: SFMono-Regular, menlo, monaco, consolas, "Liberation Mono", C
 
 // Resize headings
 h1, h2, h3, h4, h5, h6 {
-  line-height: var(--pf-global--LineHeight--sm);
-  font-family: var(--pf-global--FontFamily--redhatfont--heading--sans-serif);
+  // Reset to default after PF3+Bootstrap; prepare for PF4
+  font: unset;
+
+  // Only adjust font properties for non-PF4 elements
+  &:not([class*=pf-]) {
+    line-height: var(--pf-global--LineHeight--sm);
+    font-family: var(--pf-global--FontFamily--redhatfont--heading--sans-serif);
+  }
 
   .breadcrumb + & {
     // Vertically align contents of headings directly following breadcrumbs


### PR DESCRIPTION
Attempt to solve https://github.com/patternfly/patternfly/issues/4206 by:
- remove our heading override
- change our remaining overrides to not apply to PF4 (anything a "pf-" in the class attribute)
- fix anything that looks wrong afterward