### PR TITLE
fmf: Really force EPEL 8 on RHEL 9

### DIFF
--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -26,6 +26,7 @@ if ! rpm -q chromium; then
         # RHEL 9 has a broken stub epel.repo
         rm -f /etc/yum.repos.d/epel.repo
         dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+        sed -i 's/$releasever/8/' /etc/yum.repos.d/epel*.repo
         dnf config-manager --enable epel
     fi
     dnf install -y chromium


### PR DESCRIPTION
Do the same as in cockpit-machines:
https://github.com/cockpit-project/cockpit-machines/blob/main/test/browser/browser.sh#L23