### PR TITLE
workflows: rename environments and secrets

### DIFF
--- a/.github/workflows/npm-install.yml
+++ b/.github/workflows/npm-install.yml
@@ -139,7 +139,7 @@ jobs:
     needs: [start, build]
     if: ${{ needs.build.result == 'success' }}
     runs-on: ubuntu-20.04
-    environment: node-cache upload
+    environment: node-cache
     permissions:
       pull-requests: write
     env:
@@ -201,7 +201,7 @@ jobs:
       - name: Push git commit
         run: |
           eval $(ssh-agent)
-          ssh-add - <<< '${{ secrets.NODE_CACHE_DEPLOY_KEY }}'
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
           git push cache tag "sha-$(cat sha)"
           ssh-add -D
           ssh-agent -k

--- a/.github/workflows/prune-dist.yml
+++ b/.github/workflows/prune-dist.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: none
-    environment: cockpit-dist upload
+    environment: cockpit-dist
     env:
       HEAD_SHA: ${{ github.sha }}
       DIST_REPO: ssh://git@github.com/${{ github.repository }}-dist.git
@@ -21,7 +21,7 @@ jobs:
           set -ex
 
           eval $(ssh-agent)
-          ssh-add - <<< '${{ secrets.COCKPIT_DIST_DEPLOY_KEY }}'
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
 
           git clone "${DIST_REPO}" dist-repo
 

--- a/.github/workflows/webpack-jumpstart.yml
+++ b/.github/workflows/webpack-jumpstart.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: none
-    environment: cockpit-dist upload
+    environment: cockpit-dist
     timeout-minutes: 5
     env:
       GIT_DIR: git-dir.git
@@ -77,7 +77,7 @@ jobs:
       - name: Push git commit
         run: |
           eval $(ssh-agent)
-          ssh-add - <<< '${{ secrets.COCKPIT_DIST_DEPLOY_KEY }}'
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
           git push cache tag "sha-${HEAD_SHA}"
           ssh-add -D
           ssh-agent -k


### PR DESCRIPTION
After a bit of a trial period, the names `cockpit-dist upload` and
`COCKPIT_DIST_DEPLOY_KEY` seem a bit awkward.  Rename them to just
`cockpit-dist` and `DEPLOY_KEY`.

Ditto `node-cache upload` and `NODE_CACHE_DEPLOY_KEY`.

The new environments and secrets have already been deployed.  The old
ones can be pulled down after we land this.