### PR TITLE
po-refresh: eliminate COCKPITUOUS_TOKEN

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   po-refresh:
     runs-on: ubuntu-20.04
+    permissions:
+      contents: write
+      pull-requests: write
+      statuses: write
+    environment: cockpit-weblate
     steps:
       - name: Set up dependencies
         run: |
@@ -20,21 +25,37 @@ jobs:
 
       - name: Set up configuration and secrets
         run: |
-          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.gitconfig
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/github-token
-          # po-refresh pushes to weblate repo via https://github.com, that needs our cockpituous token
-          git config --global credential.helper store
-          echo 'https://token:${{ secrets.COCKPITUOUS_TOKEN }}@github.com' >> ~/.git-credentials
+          mkdir -p ~/.config/cockpit-dev ~/.config/git
+          printf '[user]\n\tname = Cockpit Project\n\temail=cockpituous@gmail.com\n' > ~/.config/git/config
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
 
       - name: Clone repository
         uses: actions/checkout@v2
         with:
           # need this to also fetch tags
           fetch-depth: 0
-          # the default GITHUB_TOKEN would override our ~/.git-credentials from above
-          token: '${{ secrets.COCKPITUOUS_TOKEN }}'
 
       - name: Run po-refresh bot
         run: |
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+
+          mkdir -p ~/.config/cockpit-dev
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
+
           tools/make-bots
           bots/po-refresh
+
+          ssh-add -D
+          ssh-agent -k
+
+      - name: Extra force-push with self-deploy-key
+        run: |
+          set -x
+
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.SELF_DEPLOY_KEY }}'
+          EDITOR=true git commit --amend
+          git push ssh://git@github.com/cockpit-project/cockpit -f HEAD
+          ssh-add -D
+          ssh-agent -k

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -5,7 +5,7 @@ GETTEXT_PACKAGE = cockpit
 LINGUAS = $(shell cat $(srcdir)/po/LINGUAS)
 
 WEBLATE_REPO=tmp/weblate-repo
-WEBLATE_REPO_URL=https://github.com/cockpit-project/cockpit-weblate.git
+WEBLATE_REPO_URL=ssh://git@github.com/cockpit-project/cockpit-weblate.git
 WEBLATE_REPO_BRANCH=main
 
 # The full list of various input and output file types


### PR DESCRIPTION
Replace the use of the COCKPITUOUS_TOKEN in our po-refresh GitHub
workflow with a mixture of two new tightly-scoped credentials:

  - for pushing to the `cockpit-weblate` repo we use a deploy key (and
    switch to pushing via ssh)

  - for pushing to the `cockpit` repo and opening the PR, we use the
    GITHUB_TOKEN from github-actions itself (still via https).  We add a
    `permissions:` line to ensure we have only the required permissions.


Did a test run here: https://github.com/cockpit-project/cockpit/runs/3027172789?check_suite_focus=true
Successfully pushed this: https://github.com/cockpit-project/cockpit-weblate/commit/a8ac4ccb48b6c12a2f92f759ec07ef037315448b

...but didn't open a PR :(