### PR TITLE
systemd: Move system uptime from moment to date-fns

### DIFF
--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -2,7 +2,7 @@
  * https://developer.mozilla.org/de/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat
  */
 import cockpit from "cockpit";
-import { parse } from 'date-fns';
+import { parse, formatDistanceToNow } from 'date-fns';
 import * as locales from 'date-fns/locale';
 
 // this needs to be dynamic, as some pages don't initialize cockpit.language right away
@@ -35,6 +35,8 @@ export const weekdayDate = t => formatter({ dateStyle: "full" }).format(t);
 // The following options are helpful for placeholders
 // yyyy/mm/dd
 export const dateShortFormat = () => locales[dateFormatLangDateFns()].formatLong.date({ width: 'short' });
+// about 1 hour [ago]
+export const distanceToNow = (t, addSuffix) => formatDistanceToNow(t, { locale: locales[dateFormatLangDateFns()], addSuffix });
 
 // Parse a string localized date like 30.06.21 to a Date Object
 export function parseShortDate(dateStr) {

--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -23,7 +23,7 @@ export const time = t => formatter({ timeStyle: "short" }).format(t);
 export const timeSeconds = t => formatter({ timeStyle: "medium" }).format(t);
 // June 30, 2021
 export const date = t => formatter({ dateStyle: "long" }).format(t);
-// 2021-06-30
+// 06/30/2021
 export const dateShort = t => formatter().format(t);
 // Jun 30, 2021, 7:41 AM
 export const dateTime = t => formatter({ dateStyle: "medium", timeStyle: "short" }).format(t);

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -18,10 +18,10 @@
  */
 import React from 'react';
 import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
-import moment from 'moment';
 
 import cockpit from "cockpit";
 import * as machine_info from "machine-info.js";
+import * as timeformat from "timeformat.js";
 
 import "./systemInformationCard.scss";
 
@@ -94,7 +94,8 @@ export class SystemInfomationCard extends React.Component {
         cockpit.file("/proc/uptime").read()
                 .then(content => {
                     const uptime = parseFloat(content.split(' ')[0]);
-                    this.setState({ systemUptime: moment.duration(uptime * 1000).humanize() });
+                    const bootTime = new Date().valueOf() - uptime * 1000;
+                    this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
                 })
                 .fail(ex => console.error("Error reading system uptime", ex));
     }

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -20,7 +20,6 @@
 import '../lib/patternfly/patternfly-cockpit.scss';
 import 'polyfills';
 import cockpit from "cockpit";
-import moment from "moment";
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -281,7 +280,6 @@ class OverviewPage extends React.Component {
 
 function init() {
     cockpit.translate();
-    moment.locale(cockpit.language);
     ReactDOM.render(<OverviewPage />, document.getElementById("overview"));
 }
 


### PR DESCRIPTION
Introduce a new timeformat.distanceToNow() wrapper for this.

Drop moment initialization from systemd page, as this was the last usage
of moment.

----

This looks a bit different now, date-fns adds the "about.." as it is rounded:

![image](https://user-images.githubusercontent.com/200109/125252825-1612d880-e2f9-11eb-88e2-4bffd8f1a058.png)


![image](https://user-images.githubusercontent.com/200109/125252785-0abfad00-e2f9-11eb-88b5-35c28a491f55.png)
