### PR TITLE
storaged: Handle null slots

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -506,7 +506,7 @@ export class CryptoKeyslots extends React.Component {
             }
         }
 
-        var keys = slots.map(decode_clevis_slot).filter(k => !!k);
+        var keys = slots ? slots.map(decode_clevis_slot).filter(k => !!k) : [];
 
         var rows;
         if (keys.length == 0) {


### PR DESCRIPTION
The previous checks in CryptoKeyslots don't completely rule out that
slots === null, which is a potential crash. The code below does error
handling based on "keys is empty", so set it to an empty list on a null
slots value.

Spotted by Coverity.

Fixes #15988