### PR TITLE
build cleanups for cockpit.pot generation

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -235,7 +235,7 @@ bots:
 	tools/make-bots
 
 multi-word: po/cockpit.pot
-	$(MSGGREP) --no-wrap --msgid -e '\S\+\s' po/cockpit.pot | grep "^msgid " | cut -d " " -f2- | sort --reverse > titles
+	msggrep --no-wrap --msgid -e '\S\+\s' po/cockpit.pot | grep "^msgid " | cut -d " " -f2- | sort --reverse > titles
 
 title2sentence: multi-word
 	tools/title2sentence.py -i titles -o t2s.sh

--- a/configure.ac
+++ b/configure.ac
@@ -237,21 +237,11 @@ GETTEXT_PACKAGE=cockpit
 AC_SUBST([GETTEXT_PACKAGE])
 AC_DEFINE_UNQUOTED([GETTEXT_PACKAGE],["$GETTEXT_PACKAGE"],[gettext domain])
 
-AC_PATH_PROG(MSGCAT, msgcat)
-AC_PATH_PROG(MSGFMT, msgfmt)
-AC_PATH_PROG(MSGGREP, msggrep)
-AC_PATH_PROG(MSGMERGE, msgmerge)
-AC_PATH_PROG(XGETTEXT, xgettext)
-AC_MSG_CHECKING(for gettext binaries)
-if test -x "$MSGCAT" -a -x "$MSGFMT" -a -x "$MSGMERGE" -a -x "$MSGGREP" -a -x "$XGETTEXT"; then
-  AC_SUBST(MSGCAT)
-  AC_SUBST(MSGFMT)
-  AC_SUBST(MSGGREP)
-  AC_SUBST(MSGMERGE)
-  AC_SUBST(XGETTEXT)
-  AC_MSG_RESULT(yes)
-else
-  AC_MSG_ERROR([no. Please install gettext tools])
+# We need msgcat, msgfmt, msggrep, msgmerge, but they're all in the same
+# package as xgettext, and we find them by PATH, so just check for the one.
+AC_PATH_PROG([XGETTEXT], [xsltproc], [no])
+if test "$XGETTEXT" = "no"; then
+        AC_MSG_ERROR([Please install gettext tools])
 fi
 
 # usermod

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -82,12 +82,12 @@ po/cockpit.manifest.pot: package-lock.json
 
 po/cockpit.appstream.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$(abs_builddir)/$@ \
+	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$@ \
 		$$(find $(TRANSLATE) -name '*.appdata.xml.in')
 
 po/cockpit.polkit.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$(abs_builddir)/$@ \
+	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$@ \
 		$$(find $(TRANSLATE) -name '*.policy.in')
 
 # Combine the above pot files into one

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -1,3 +1,11 @@
+# Defaults for standalone operation
+srcdir ?= .
+AM_DEFAULT_VERBOSITY ?= 0
+MKDIR_P ?= mkdir -p
+
+AM_V_GEN ?= $(AM_V_GEN_$(V))
+AM_V_GEN_ ?= $(AM_V_GEN_$(AM_DEFAULT_VERBOSITY))
+AM_V_GEN_0 ?= @echo "  GEN " $@;
 
 GETTEXT_PACKAGE = cockpit
 

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -19,12 +19,12 @@ FILTER_PO_SRC_WS = sed -ne 's|.*\(\(\.\./\)\?src/ws/[^:]\+\).*|-N \1|p' $<
 # A filtered po file with just src/ws
 src/ws/%.po: po/%.po
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(MSGGREP) `$(FILTER_PO_SRC_WS)` $< > $@.tmp && mv $@.tmp $@
+	msggrep `$(FILTER_PO_SRC_WS)` $< > $@.tmp && mv $@.tmp $@
 
 # Build a binary mo file from po
 .po.mo:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(MSGFMT) -o $@.tmp $< && mv $@.tmp $@ && touch $@
+	msgfmt -o $@.tmp $< && mv $@.tmp $@ && touch $@
 
 # Always build the binary gettext data
 all-local:: $(MO_FILES)
@@ -50,7 +50,7 @@ TRANSLATE = \
 # Extract from GLib based C code files
 po/cockpit.c.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(XGETTEXT) --default-domain=cockpit --output=$@ --language=C \
+	xgettext --default-domain=cockpit --output=$@ --language=C \
 		--keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=Q_ \
 		--keyword=g_dgettext:2 --keyword=g_dngettext:2,3 --keyword=g_dpgettext:2 \
 		--keyword=g_dpgettext2=2c,3 \
@@ -65,7 +65,7 @@ po/cockpit.html.pot: package-lock.json
 # Extract cockpit style javascript translations
 po/cockpit.js.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(XGETTEXT) --default-domain=cockpit --output=- --language=C --keyword= \
+	xgettext --default-domain=cockpit --output=- --language=C --keyword= \
 		--keyword=_:1,1t --keyword=_:1c,2,2t --keyword=C_:1c,2 \
 		--keyword=N_ --keyword=NC_:1c,2 \
 		--keyword=gettext:1,1t --keyword=gettext:1c,2,2t \
@@ -82,23 +82,23 @@ po/cockpit.manifest.pot: package-lock.json
 
 po/cockpit.appstream.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po $(XGETTEXT) --output=$(abs_builddir)/$@ \
+	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$(abs_builddir)/$@ \
 		$$(find $(TRANSLATE) -name '*.appdata.xml.in')
 
 po/cockpit.polkit.pot:
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po $(XGETTEXT) --output=$(abs_builddir)/$@ \
+	cd $(srcdir) && GETTEXTDATADIRS=$(srcdir)/po xgettext --output=$(abs_builddir)/$@ \
 		$$(find $(TRANSLATE) -name '*.policy.in')
 
 # Combine the above pot files into one
 po/cockpit.pot: po/cockpit.c.pot po/cockpit.html.pot po/cockpit.js.pot po/cockpit.manifest.pot po/cockpit.appstream.pot po/cockpit.polkit.pot
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(MSGCAT) --sort-output --output-file=$@ $^
+	msgcat --sort-output --output-file=$@ $^
 
 # Actually update the old translations with new translatable text
 update-po: po/cockpit.pot
 	for lang in $(LINGUAS); do \
-		$(MSGMERGE) --output-file=$(srcdir)/po/$$lang.po $(srcdir)/po/$$lang.po $<; \
+		msgmerge --output-file=$(srcdir)/po/$$lang.po $(srcdir)/po/$$lang.po $<; \
 	done
 
 $(WEBLATE_REPO):

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -67,7 +67,7 @@ po/cockpit.c.pot:
 # Extract translate attribute, Glade style, angular-gettext HTML translations
 po/cockpit.html.pot: package-lock.json
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(srcdir)/po/html2po -d $(srcdir) -o $@ \
+	$(srcdir)/po/html2po -d $(srcdir) -o $@ \
 		$$(cd $(srcdir) && find $(TRANSLATE) -name '*.html')
 
 # Extract cockpit style javascript translations
@@ -85,7 +85,7 @@ po/cockpit.js.pot:
 
 po/cockpit.manifest.pot: package-lock.json
 	$(AM_V_GEN) $(MKDIR_P) $(dir $@) && \
-	$(srcdir)/tools/missing $(srcdir)/po/manifest2po -d $(srcdir) -o $@ \
+	$(srcdir)/po/manifest2po -d $(srcdir) -o $@ \
 		$$(cd $(srcdir) && find $(TRANSLATE) -name 'manifest.json')
 
 po/cockpit.appstream.pot:

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -264,7 +264,7 @@ polkitdir        = $(datadir)/polkit-1/actions
 polkit_DATA = $(polkit_in_files:.policy.in=.policy)
 
 %.policy: %.policy.in $(PO_FILES)
-	GETTEXTDATADIRS=$(srcdir)/po $(MSGFMT) --xml -d $(top_srcdir)/po --template $< --output $@
+	GETTEXTDATADIRS=$(srcdir)/po msgfmt --xml -d $(top_srcdir)/po --template $< --output $@
 
 CLEANFILES += $(polkit_DATA)
 endif

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -183,7 +183,7 @@ nodist_appdata_DATA = src/ws/cockpit.appdata.xml
 appdata_in = src/ws/cockpit.appdata.xml.in
 
 $(nodist_appdata_DATA): $(appdata_in) $(PO_FILES)
-	$(AM_V_GEN) $(MSGFMT) --xml -d $(top_srcdir)/po --template $< --output $@
+	$(AM_V_GEN) msgfmt --xml -d $(top_srcdir)/po --template $< --output $@
 
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = src/ws/cockpit.png

--- a/tools/node-modules
+++ b/tools/node-modules
@@ -56,8 +56,8 @@ EOF
 
 cmd_rebuild() {
     for file in npm-shrinkwrap.json package-lock.json yarn.lock; do
-        if [ -e "${top_srcdir}/${file}" ]; then
-            echo "Please delete ${file} from ${top_srcdir} and start again"
+        if [ -e "${file}" ]; then
+            echo "Please delete ${file} from $(pwd) and start again"
             exit 1
         fi
     done
@@ -161,9 +161,6 @@ EOF
 }
 
 main() {
-    local top_srcdir="$(realpath -m "$0"/../..)"
-    cd "${top_srcdir}"
-
     local cmd="${1-}"
 
     if [ -z "${cmd}" ]; then


### PR DESCRIPTION
Here's a bunch of changes to `po/Makefile.am` to make it possible to build `cockpit.pot` without needing to do the whole automake thing.

You can see it in use from a new workflow here: 
 - https://github.com/allisoninc/cockpit-weblate/blob/main/.github/workflows/sync-pot.yml
 - https://github.com/allisoninc/cockpit-weblate/runs/3048500342?check_suite_focus=true

Together with the new workflow this solves one half of the "what do we do about weblate?" cockpituous token puzzle: this part ends up requiring no credentials at all, since it runs out of the -weblate repository.

The other half still open, of course, is getting the .po files from the weblate back into cockpit and opening a PR and running tests.  That's gonna be a bit of work still....

The changes here are more or less harmless on their own and can go in already, I think.  Then I'd probably try to land the `cockpit-weblate` `sync-pot` workflow at the same time as disabling the synchronisation from the `cockpit` repo side.