### PR TITLE
po: Replace `upload-pot` rule with @true

### DIFF
--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -104,10 +104,8 @@ update-po: po/cockpit.pot
 $(WEBLATE_REPO):
 	git clone --depth=1 -b $(WEBLATE_REPO_BRANCH) $(WEBLATE_REPO_URL) $(WEBLATE_REPO)
 
-upload-pot: po/cockpit.pot $(WEBLATE_REPO)
-	cp $(builddir)/po/cockpit.pot $(WEBLATE_REPO)
-	git -C $(WEBLATE_REPO) commit -m "Update source file" -- cockpit.pot
-	git -C $(WEBLATE_REPO) push
+upload-pot:
+	@true
 
 clean-po:
 	rm $(srcdir)/po/*.po


### PR DESCRIPTION
We no longer need to upload cockpit.pot from our side, since
cockpit-weblate is pulling it for itself.

We need to keep the rule, however, since bots/po-refresh assumes that it
exists.  We'll do a cleanup round later.

 - [x] #16087 
 - [ ] cockpit-project/cockpit-weblate#3 (land simultaneously)