### PR TITLE
test: Wait for networking dialog initialization before pixel test

### DIFF
--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -46,7 +46,11 @@ class TestBonding(NetworkCase):
         # Bond them
         b.click("button:contains('Add bond')")
         b.wait_popup("network-bond-settings-dialog")
-
+        # wait until dialog initialized
+        b.wait_visible("#network-bond-settings-close-button")
+        b.wait_visible("#network-bond-settings-mac-input")
+        # menu is not visible by default, but gets initialized dynamically
+        b._wait_present("#network-bond-settings-mac-menu")
         b.assert_pixels("#network-bond-settings-dialog .pf-c-modal-box", "networking-bond-settings-dialog")
 
         b.click("#network-bond-settings-dialog #network-bond-settings-close-button")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -47,6 +47,9 @@ class TestBridge(NetworkCase):
         b.click("button:contains('Add bridge')")
         b.wait_popup("network-bridge-settings-dialog")
 
+        # wait until dialog initialized
+        b.wait_visible("#network-bridge-settings-close-button")
+        b.wait_in_text("#network-bridge-settings-body", "cockpit2")
         b.assert_pixels("#network-bridge-settings-dialog .pf-c-modal-box", "networking-bridge-settings-dialog")
 
         b.set_val("#network-bridge-settings-name-input", "tbridge")

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -47,6 +47,9 @@ class TestNetworkingMTU(NetworkCase):
         self.configure_iface_setting('MTU')
         b.wait_popup("network-mtu-settings-dialog")
 
+        # wait until dialog initialized
+        b.wait_visible("#network-mtu-settings-close-button")
+        b.wait_visible("#network-mtu-settings-custom")
         b.assert_pixels("#network-mtu-settings-dialog .pf-c-modal-box", "networking-mtu-settings-dialog")
 
         b.set_checked('#network-mtu-settings-custom', True)

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -47,6 +47,9 @@ class TestTeam(NetworkCase):
         b.click("button:contains('Add team')")
         b.wait_popup("network-team-settings-dialog")
 
+        # wait until dialog initialized
+        b.wait_visible("#network-team-settings-close-button")
+        b.wait_in_text("#network-team-settings-body", "cockpit2")
         b.assert_pixels("#network-team-settings-dialog .pf-c-modal-box", "networking-team-settings-dialog")
 
         b.set_val("#network-team-settings-interface-name-input", "tteam")

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -40,6 +40,9 @@ class TestNetworkingVLAN(NetworkCase):
         b.click("button:contains('Add VLAN')")
         b.wait_popup("network-vlan-settings-dialog")
 
+        # wait until dialog initialized
+        b.wait_visible("#network-vlan-settings-close-button")
+        b.wait_visible("#network-vlan-settings-interface-name-input")
         b.assert_pixels("#network-vlan-settings-dialog .pf-c-modal-box", "networking-vlan-settings-dialog")
 
         b.select_from_dropdown("#network-vlan-settings-body form select", iface)


### PR DESCRIPTION
Otherwise it could happen that the dialog is not fully rendered yet.
Observed in the wild with the bonding dialog's MAC dropdown triangle
(presumably as the list was still empty).

----

[Failed test example](https://logs.cockpit-project.org/logs/pull-16087-20210712-163822-6a95f0da-fedora-34/log.html#64-2)