### PR TITLE
packagekit: Port from moment to timeformat

### DIFF
--- a/pkg/packagekit/history.jsx
+++ b/pkg/packagekit/history.jsx
@@ -17,12 +17,12 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import moment from 'moment';
 import React from "react";
 import PropTypes from "prop-types";
 
 import { Tooltip } from "@patternfly/react-core";
 import { ListingTable } from "cockpit-components-table.jsx";
+import * as timeformat from "timeformat.js";
 
 import cockpit from "cockpit";
 
@@ -46,7 +46,7 @@ export class History extends React.Component {
      * together for presentation.
      *
      * Returns a time sorted (descending) list of objects like
-     * { time: moment_object, num_packages: 2, packages: {names...}}
+     * { time: timestamp, num_packages: 2, packages: {names...}}
      */
     mergeHistory() {
         const history = [];
@@ -54,7 +54,7 @@ export class History extends React.Component {
 
         for (let i = 0; i < this.props.packagekit.length; ++i) {
             const packages = Object.keys(this.props.packagekit[i]).filter(i => i != "_time");
-            const time = moment(this.props.packagekit[i]._time);
+            const time = this.props.packagekit[i]._time;
             packages.sort();
 
             if (prevTime && (time - prevTime) <= 600000 /* 10 mins */ &&
@@ -79,8 +79,6 @@ export class History extends React.Component {
             return null;
 
         const rows = history.map((update, index) => {
-            const time = update.time.format("YYYY-MM-DD HH:mm");
-
             const pkgcount = (
                 <div className="list-view-pf-additional-info-item">
                     <span className="pficon pficon-bundle" />
@@ -92,7 +90,7 @@ export class History extends React.Component {
             return ({
                 props: { key: index },
                 columns: [
-                    { title: time },
+                    { title: timeformat.dateTime(update.time) },
                     { title: pkgcount, props: { className: "history-pkgcount" } },
                 ],
                 initiallyExpanded: index == 0,

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -23,7 +23,6 @@ import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";
 import ReactDOM from 'react-dom';
 
-import moment from "moment";
 import {
     Alert, Button, Gallery, Modal, Progress, Popover, Tooltip,
     Card, CardTitle, CardActions, CardHeader, CardBody,
@@ -55,6 +54,7 @@ import { ShutdownModal } from 'cockpit-components-shutdown.jsx';
 
 import { superuser } from 'superuser';
 import * as PK from "packagekit.js";
+import * as timeformat from "timeformat.js";
 
 import * as python from "python.js";
 import callTracerScript from 'raw-loader!./callTracer.py';
@@ -542,6 +542,7 @@ class ApplyUpdates extends React.Component {
         }
 
         const lastAction = this.state.actions[this.state.actions.length - 1];
+        const timeRemaining = this.state.timeRemaining && timeformat.distanceToNow(new Date().valueOf() + this.state.timeRemaining * 1000);
         return (
             <>
                 <div className="progress-main-view">
@@ -550,7 +551,7 @@ class ApplyUpdates extends React.Component {
                         <strong>{ PK_STATUS_STRINGS[lastAction.status] || PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE] }</strong>
                         &nbsp;{lastAction.package}
                     </div>
-                    <Progress title={this.state.timeRemaining && moment.duration(this.state.timeRemaining * 1000).humanize()} value={this.state.percentage} />
+                    <Progress title={timeRemaining} value={this.state.percentage} />
                     {cancelButton}
                 </div>
 
@@ -718,7 +719,7 @@ const UpdatesStatus = ({ updates, highestSeverity, timeSinceRefresh, tracerPacka
     const numRebootPackages = tracerPackages.reboot.length;
     let lastChecked;
     if (timeSinceRefresh !== null)
-        lastChecked = cockpit.format(_("Last checked: $0"), moment(moment().valueOf() - timeSinceRefresh * 1000).fromNow());
+        lastChecked = cockpit.format(_("Last checked: $0"), timeformat.distanceToNow(new Date().valueOf() - timeSinceRefresh * 1000, true));
 
     const notifications = [];
     if (numUpdates > 0) {
@@ -1510,7 +1511,6 @@ class OsUpdates extends React.Component {
 
 document.addEventListener("DOMContentLoaded", () => {
     document.title = cockpit.gettext(document.title);
-    moment.locale(cockpit.language);
     init();
     ReactDOM.render(<OsUpdates />, document.getElementById("app"));
 });

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -156,7 +156,7 @@ class TestUpdates(NoSubManCase):
         b.wait_not_present("#status")
         b.wait_in_text("#status", "System is up to date")
         # PK starts from a blank state, thus should force refresh and set the "time since" to 0
-        b.wait_in_text("#last-checked", "Last checked: a few seconds ago")
+        b.wait_in_text("#last-checked", "Last checked: less than a minute ago")
 
         install_lockfile = "/tmp/finish-pk"
         # create two updates; force installing chocolate before vanilla
@@ -170,7 +170,7 @@ class TestUpdates(NoSubManCase):
         # check again
         b.click("#status .pf-c-card__header button")
 
-        b.wait_in_text("#last-checked", "Last checked: a few seconds ago")
+        b.wait_in_text("#last-checked", "Last checked: less than a minute ago")
 
         b.wait_visible("#available-updates")
         b.wait_in_text("#status", "2 updates available")


### PR DESCRIPTION
This changes the "last checked" slightly for short time intervals (as
moment's and date-fns' durations are a bit different), and moves from
ISO to our standard localized format for the update history.

 - [x] builds on top of #16084 

"Last checked" on main:

![main-en](https://user-images.githubusercontent.com/200109/125405606-32c21580-e3b8-11eb-9dbb-c10544df5762.png)
![main-de](https://user-images.githubusercontent.com/200109/125405623-35246f80-e3b8-11eb-928c-bed1a6a022bf.png)

With this PR:
![pr-en](https://user-images.githubusercontent.com/200109/125405658-3d7caa80-e3b8-11eb-8094-6577ed8e6868.png)
![pr-de](https://user-images.githubusercontent.com/200109/125405663-3f466e00-e3b8-11eb-9fef-e9fe1dd10dbc.png)

History on main (all langs):

![history-main-en](https://user-images.githubusercontent.com/200109/125405686-453c4f00-e3b8-11eb-89cb-8b371eec861a.png)

History with this PR (standard localized format that we now use everywhere):
![history-pr-en](https://user-images.githubusercontent.com/200109/125405723-508f7a80-e3b8-11eb-9b4d-f27351409060.png)

