### PR TITLE
lib: Retaining keyboard-entered value in file autocompletion typeahead text field when focus leaves input away

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -168,6 +168,7 @@ export class FileAutoComplete extends React.Component {
             <Select
                 variant={SelectVariant.typeahead}
                 id={this.props.id}
+                isInputValuePersisted
                 onTypeaheadInputChanged={this.debouncedChange}
                 placeholderText={placeholder}
                 noResultsFoundText={this.state.error || _("No such file or directory")}


### PR DESCRIPTION
This will allow us to fix https://bugzilla.redhat.com/show_bug.cgi?id=1866225

Fixes https://github.com/cockpit-project/cockpit/issues/14491

See more info: https://github.com/patternfly/patternfly-react/issues/5502