### PR TITLE
metrics: Adjust history metrics graph labels to avoid overlapping

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -232,7 +232,7 @@
 
 .metrics {
     --column-size: 10vw;
-    --half-column-size: 5vw;
+    --half-column-size: 8vw;
     --data-min-height: 5px;
 
     &-heading,
@@ -265,7 +265,7 @@
     }
 
     &-sublabels {
-        font-size: 65%;
+        font-size: var(--pf-global--FontSize--xs);
         color: rgba(0,0,0,0.7);
         display: flex;
     }
@@ -473,6 +473,18 @@
 
     .pf-c-card__body:first-child {
         padding-top: 0;
+    }
+}
+
+// Graph column labels are the widest part; scale down the labels for narrow widths
+@media (min-width: 800px) and (max-width: 1200px) {
+    .metrics-label-graph {
+        font-size: var(--pf-global--FontSize--s);
+    }
+}
+@media (max-width: 800px) {
+    .metrics-label-graph {
+        font-size: var(--pf-global--FontSize--xs);
     }
 }
 


### PR DESCRIPTION
metrics: Adjust history metrics graph labels to avoid overlapping

 * Increase the width of half-columns from 5% to 8%, as otherwise there
   is not enough space for the label even in English on wide pages. It
   does not hurt to use the space that we have to provide a little more
   detail on the half-column then.

 * Reduce the top label width for narrow browsers in two steps, as
   otherwise they begin to overlap.

 * Use absolute font sizes instead of relative ones, as otherwise the
   sublabels become too small (as they are relative to the parent label,
   not to the global default), and we can also assume that the PF
   standard sizes are sane.

Addresses half of #16016; very narrow sizes/mobile mode still needs to
be fixed (probably through rotating the labels).

### English, 1920p wide:

main:
![main-en-1920](https://user-images.githubusercontent.com/200109/125952993-678c5c06-d2d9-4ae3-9bba-1a4b00c42f51.png)

This PR:
![image](https://user-images.githubusercontent.com/200109/125953272-1c7cf055-5323-4bbe-af84-ab6689f793b6.png)


### English, 960p wide:
main:
![main-en-960](https://user-images.githubusercontent.com/200109/125953025-051bf7e1-faa4-487f-84c4-ae734753760a.png)

This PR:
![image](https://user-images.githubusercontent.com/200109/125953325-34c8558d-98cc-4c46-8221-5d21fc84d78a.png)


### German, 1920p wide:
main:
![main-de-1920](https://user-images.githubusercontent.com/200109/125953086-37188353-da93-4297-a703-8b26d11047f5.png)

This PR:
![image](https://user-images.githubusercontent.com/200109/125953401-e425d6e9-8769-4d44-af31-da1490c88bee.png)


### German, 960p wide:
main:
![main-de-960](https://user-images.githubusercontent.com/200109/125953105-a3a2af15-cbef-4629-bcb0-ccb46ffcac7a.png)

![image](https://user-images.githubusercontent.com/200109/125953445-9edf9e78-ae64-4ea2-837b-8b484c12aea0.png)

### Mobile

main:

![Screen Shot 2021-07-16 at 15 14 25](https://user-images.githubusercontent.com/200109/125953862-fc9c05bc-a882-4495-a7ad-6936165218a8.png)

This PR: A tad better, but still broken. See below:

![Screen Shot 2021-07-16 at 15 32 48](https://user-images.githubusercontent.com/200109/125956122-d6d836cb-0751-4288-83f5-e57f251ad55e.png)


Old version of PR with minimum width (regresses mobile mode):
![Screen Shot 2021-07-16 at 15 13 46](https://user-images.githubusercontent.com/200109/125953886-de37e463-87ef-463e-bab1-4eac2a6dc7b8.png)
