### PR TITLE
spec: Fix syntax error in PAM grep

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -545,7 +545,7 @@ fi
 test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 
 # check for deprecated PAM config
-if grep --color=auto pam_cockpit_cert {_sysconfdir}/pam.d/cockpit; then
+if grep --color=auto pam_cockpit_cert %{_sysconfdir}/pam.d/cockpit; then
     echo '**** WARNING:'
     echo '**** WARNING: pam_cockpit_cert is a no-op and will be removed in a'
     echo '**** WARNING: future release; remove it from your /etc/pam.d/cockpit.'


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1983077

----

Validated  with

    test/image-prepare -qB fedora-34
    rpm -q --scripts -p tmp/build-results/cockpit-ws-*.rpm

Now it is correct:
```
# check for deprecated PAM config
if grep --color=auto pam_cockpit_cert /etc/pam.d/cockpit; then
```