### PR TITLE
tools: Add --rsync option to webpack-{watch,make}

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -178,6 +178,15 @@ as
 
 Then reload cockpit in your browser after building the page.
 
+Often you need to test your code in a VM. `webpack-make` has an `-r`/`--rsync`
+option for copying the built webpack into the given SSH target's
+/usr/share/cockpit/ directory. If you use cockpit's own test VMs and set up the
+SSH `c` alias as described in [test/README.md](./test/README.md), you can use
+one of these commands:
+
+    tools/webpack-make -d dist/kdump/Makefile.deps -r c
+    tools/webpack-watch kdump -r c
+
 To make Cockpit again use the installed code, rather than that from your git
 checkout directory, run the following, and log into Cockpit again:
 

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -9,10 +9,12 @@ const webpack = require("webpack");
 const path = require("path");
 const stdio = require("stdio");
 const fs = require("fs");
+const child_process = require("child_process");
 
-var ops = stdio.getopt({
+const ops = stdio.getopt({
     config: { key: "c", args: 1, description: "Path to webpack.config.js", default: "webpack.config.js" },
     deps: { key: "d", args: 1, description: "Output dependencies in Makefile format" },
+    rsync: { key: "r", args: 1, description: "rsync webpack to ssh target after build", default: "" },
     watch: { key: "w", args: 0, description: "Enable webpack watch mode" },
 });
 
@@ -61,6 +63,9 @@ function process_result(err, stats) {
             process.exit(1);
         return;
     }
+
+    if (ops.rsync)
+        rsync();
 
     generateDeps(makefile, stats);
 }
@@ -159,4 +164,12 @@ function generateDeps(makefile, stats) {
     lines.push(prefix + ": " + stampfile);
 
     fs.writeFileSync(makefile, lines.join("\n") + "\n");
+}
+
+function rsync() {
+    const ret = child_process.spawnSync("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
+                                        path.dirname(makefile), ops.rsync + ":/usr/share/cockpit/"],
+                                        { stdio: "inherit" });
+    if (ret.status !== 0)
+        process.exit(1);
 }

--- a/tools/webpack-watch
+++ b/tools/webpack-watch
@@ -4,12 +4,14 @@
 set -eu
 cd "$(realpath -m "$0"/../..)"
 
-if [ -z "${1:-}" ] || [ -n "${2:-}" ]; then
-    echo "Usage: $0 <page in pkg/>" >&2
+if [ -z "${1:-}" ]; then
+    echo "Usage: $0 <page in pkg/> [webpack-make options..]" >&2
     exit 1
 fi
+page="$1"
+shift
 
 # disable eslint by default, unless explicitly enabled
 export ESLINT=${ESLINT:-0}
 
-"tools/webpack-make" -d "dist/$1/Makefile.deps" -w
+"tools/webpack-make" -d "dist/$page/Makefile.deps" -w "$@"


### PR DESCRIPTION
This allows developers to rapidly iterate on code that gets tested in
our standard VMs without having to manually copy the code. This
minimizes the cycle to "save" -- "wait a bit" -- "press reload in the
browser".

webpack-watch has no actual option parsing, so relax the positional
argument checking and pass on any additional arguments to webpack-make.
This requires to put the options *after* the page name, but we'll get
used to that quickly.

----

As my laptop doesn't have libvirt, setroubleshoot etc. installed, I spend the majority of my development iteration with manually calling `scp -r` after each successful build. This gets rid of this annoyance, especially as I occasionally forget the scp and then get confused why my changes don't apply. It's not exactly a pretty implementation in webpack-make, but it gets the job done.. :man_shrugging: 

WDYT?