### PR TITLE
webpack-jumpstart.yml: add separate "head" build

### DIFF
--- a/.github/workflows/webpack-jumpstart.yml
+++ b/.github/workflows/webpack-jumpstart.yml
@@ -34,8 +34,41 @@ jobs:
           path: webpack-jumpstart.tar
           retention-days: 1
 
+  build-head:
+    if: ${{ github.event.pull_request.merge_commit_sha != github.event.pull_request.head.sha }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: none
+    timeout-minutes: 20
+    env:
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+    steps:
+      - name: Build jumpstart tarball
+        run: |
+          id="$(docker container create -u node -w /home/node node /bin/sh -c \
+            'git init cockpit &&
+             cd cockpit &&
+             git fetch --depth 1 https://github.com/cockpit-project/cockpit "'"${HEAD_SHA}"'":build &&
+             git checkout build &&
+             pkg/build webpack-jumpstart.tar -j$(nproc)'
+          )"
+
+          docker container start --attach "${id}" >&2
+          docker container cp "${id}":/home/node/cockpit/webpack-jumpstart.tar .
+          docker container rm -f "${id}"
+
+      - name: Create artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: webpack-jumpstart-head
+          path: webpack-jumpstart.tar
+          retention-days: 1
+
   publish:
-    needs: build
+    needs:
+      - build
+      - build-head
+    if: ${{ !failure() && !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: none
@@ -72,9 +105,37 @@ jobs:
           git --work-tree worktree commit --quiet -m "Build for ${MERGE_SHA}"
           rm -rf worktree
 
-          git tag "sha-${HEAD_SHA}"
+          git tag "sha-${MERGE_SHA}"
 
       - name: Push git commit
+        run: |
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          git push cache tag "sha-${MERGE_SHA}"
+          ssh-add -D
+          ssh-agent -k
+
+      - name: Download "head" artifact
+        if: ${{ needs.build-head.result == 'success' }}
+        uses: actions/download-artifact@v2
+        with:
+          name: webpack-jumpstart-head
+          path: head-artifact
+
+      - name: Stage "head" git commit
+        if: ${{ needs.build-head.result == 'success' }}
+        run: |
+          set -ux
+          mkdir worktree
+          tar -C worktree -x --exclude '.git*' dist package-lock.json < head-artifact/webpack-jumpstart.tar
+          git --work-tree worktree add dist package-lock.json
+          git --work-tree worktree commit --allow-empty --quiet -m "Build for ${HEAD_SHA}"
+          rm -rf worktree
+
+          git tag "sha-${HEAD_SHA}"
+
+      - name: Push "head" git commit
+        if: ${{ needs.build-head.result == 'success' }}
         run: |
           eval $(ssh-agent)
           ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'


### PR DESCRIPTION
webpack-jumpstart has been telling a lie for the past while: we've been
building the "merge" commit but labelling it in the cache with the
"head" sha.  This occasionally results in some errors about
inconsistencies, particularly in the case where package-lock.json has
changed, and is preventing us from introducing more robust consistency
checking in #16005.

The reason we do this is in large part a crutch to get around the fact
that packit only knows how to test the head commit.  Our current "lies"
allow us to get some kind of "partial merge" into packit for testing.

Meanwhile, however, packit is working on switching over to building the
merge commit instead of the head commit, and it seems like this will not
be configurable.  When that happens, our current setup will break,
because packit will go looking in our cache based on the merge commit,
but it won't find it.

Let's stop labelling merge commit build results with the head commit
sha.  Instead, we'll label them with the correct sha: the sha of the
merge commit.  That way, when packit is changed, it will continue to
work for us.

We also add an additional build step to explicitly build the "head"
commit and correctly label it as the head commit.  This temporary
measure is gated by an `if:` to not occur in `push` events, but only in
pull requests (where we always have separate merge and head commits,
even if the branch is fully rebased).  This will allow packit to
continue to work with its current practice of checking out the head
commit, and will allow for a smooth transition when they flip the switch
over to using the merge commit.  These extra steps can be removed at
that point.

 - test run for push to main: https://github.com/allisoninc/cockpit/actions/runs/1048186668
 - test PR: https://github.com/allisoninc/cockpit/pull/2
 - test run from PR: https://github.com/allisoninc/cockpit/actions/runs/1048187526