### PR TITLE
Replace broken links with linux.die.net links

### DIFF
--- a/doc/guide/feature-pcp.xml
+++ b/doc/guide/feature-pcp.xml
@@ -18,8 +18,8 @@
     "Performance Metrics" page will enable and start this service.</para>
 
   <para>To see similar metrics data from the command line, you can use tools like
-    <ulink url="https://pcp.io/books/PCP_UAG/html/LE38515-PARENT.html#LE91266-PARENT"><code>pmstat</code></ulink>
-    or <ulink url="https://pcp.io/books/PCP_UAG/html/LE60452-PARENT.html"><code>pminfo</code></ulink>:</para>
+    <ulink url="https://linux.die.net/man/1/pmstat"><code>pmstat</code></ulink>
+    or <ulink url="https://linux.die.net/man/1/pminfo"><code>pminfo</code></ulink>:</para>
 
 <programlisting>
 $ <command>pmstat</command>


### PR DESCRIPTION
Update broken `pcpstat` and `pcpinfo` links with working linxu.die.net links. On PCP Metrics page

If you feel that the updated links are not the best choice feel free to edit or drop them below.
