### PR TITLE
test: Drop unnecessary kinit admin@COCKPIT.LAN in check-system-s4u-ssh

### DIFF
--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -106,7 +106,6 @@ os.chmod(ccache, 0o400)
 os.chown(ccache, u.pw_uid, -1)
 """)
         client_machine.execute(script="""#!/bin/sh -eu
-        echo foobarfoo | kinit admin@COCKPIT.LAN
         kinit -k -t /etc/cockpit/krb5.keytab HTTP/sshclient.cockpit.lan@COCKPIT.LAN
         python3 /tmp/make-cache.py
         """)

--- a/test/verify/check-system-s4u-ssh
+++ b/test/verify/check-system-s4u-ssh
@@ -95,20 +95,16 @@ import gssapi, pwd, os
 user = 'user@COCKPIT.LAN'
 ccache = f'/run/cockpit/tls/{user}.ccache'
 
-principal = gssapi.Name('HTTP/sshclient.cockpit.lan@COCKPIT.LAN', gssapi.NameType.kerberos_principal)
-credResult = gssapi.creds.rcred_cred_store.acquire_cred_from(store = { 'keytab'.encode(): '/etc/cockpit/krb5.keytab'.encode() }, name=principal)
+serverCred = gssapi.creds.rcred_cred_store.acquire_cred_from(store = { b'client_keytab': b'/etc/cockpit/krb5.keytab' }, lifetime=30)
 impersonee = gssapi.Name(user, gssapi.NameType.kerberos_principal)
-credResults4u2self = gssapi.creds.rcred_s4u.acquire_cred_impersonate_name(credResult.creds, impersonee)
-gssapi.creds.rcred_cred_store.store_cred_into({ 'ccache'.encode(): f'FILE:{ccache}'.encode(), 'keytab'.encode(): '/etc/cockpit/krb5.keytab'.encode() }, credResults4u2self.creds, overwrite=True)
+credResults4u2self = gssapi.creds.rcred_s4u.acquire_cred_impersonate_name(serverCred.creds, impersonee)
+gssapi.creds.rcred_cred_store.store_cred_into({ b'ccache': f'FILE:{ccache}'.encode(), b'keytab': b'/etc/cockpit/krb5.keytab' }, credResults4u2self.creds, overwrite=True)
 # make it readable for the user
 u = pwd.getpwnam(user)
 os.chmod(ccache, 0o400)
 os.chown(ccache, u.pw_uid, -1)
 """)
-        client_machine.execute(script="""#!/bin/sh -eu
-        kinit -k -t /etc/cockpit/krb5.keytab HTTP/sshclient.cockpit.lan@COCKPIT.LAN
-        python3 /tmp/make-cache.py
-        """)
+        client_machine.execute(["python3", "/tmp/make-cache.py"])
 
         # enable gssapiauth for ssh
         sshd_machine.execute("sed -ri 's/#GSSAPIAuthentication (yes|no)/GSSAPIAuthentication yes/' /etc/ssh/sshd_config")


### PR DESCRIPTION
Creating the impersonating S4U ticket for the user will eventually
happen in cockpit-session. This must not require the admin
password/kinit. Conceptually, it is supposed to only use the cockpit
krb5.keytab.

Drop the call, it works fine without it.