### PR TITLE
ws: Move to session specific kerberos keyring

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -833,6 +833,9 @@ ExecStart=/bin/true
         self.configure_kerberos("/etc/cockpit/krb5.keytab")
         m.restart_cockpit()
 
+        # user has no cockpit kerberos session tickets initially
+        m.execute("! ls /run/user/$(id -u admin)/*.ccache")
+
         output = m.execute(['/usr/bin/curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
                             '--resolve', 'x0.cockpit.lan:9090:10.111.113.1',
                             'http://x0.cockpit.lan:9090/cockpit/login'])
@@ -846,12 +849,15 @@ ExecStart=/bin/true
         def line_sel(i):
             return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
-        # run kinit and see if got forwarded the kerberos ticket into the session
+        # kerberos ticket got forwarded into the session
         b.enter_page("/system/terminal")
         b.wait_visible(".terminal .xterm-accessibility-tree")
         b.wait_in_text(line_sel(1), "admin")
         b.key_press("klist\r")
         b.wait_in_text(line_sel(2), "Ticket cache")
+        b.wait_in_text(line_sel(3), "Default principal: admin@COCKPIT.LAN")
+        b.wait_in_text(line_sel(6), "krbtgt/COCKPIT.LAN")
+        self.assertIn("cockpit-session-", m.execute("ls /run/user/$(id -u admin)/*.ccache"))
 
         # Now connect to another machine
         self.assertNotIn("admin", m.execute("ps -xa | grep sshd"))
@@ -871,7 +877,10 @@ ExecStart=/bin/true
 
         # Make sure we connected via SSH
         self.assertIn("admin", m.execute("ps -xa | grep sshd"))
-        b.kill()
+
+        # forwarded ticket gets cleaned up with the session; this is not completely synchronous
+        b.logout()
+        m.execute("while ls /run/user/$(id -u admin)/*.ccache; do sleep 1; done", timeout=10)
 
         # Remove cockpit keytab
         m.execute("mv /etc/cockpit/krb5.keytab /etc/cockpit/bk.keytab")


### PR DESCRIPTION
Storing delegated kerberos tickets into the default (user-)global
default keyring is a bit problematic: It changes the available
credentials to all other currently running sessions of that user, and
prevents being able to clean up the ccache after the session ends. The
global default keyring is really aimed at users doing `kinit` explicitly
(or the initial desktop session login).

Move to what SSH does [1], create a session specific file ccache in the
user's XDG runtime directory, and export it through `$KRB5CCNAME`.
Delete the ccache at session end. logind will clean up the runtime
directory for us after a while as well, which is a nice second line of
defense.

The user can always copy the ticket somewhere else while the session is
running, so this does not need to be a 100% robust enforced measure. But
it may help to avoid leaking secrets and keeping them around
unnecessarily long, in particular as neither kernel KEYRING: nor KCM:
caches get cleaned up automatically when PAM sessions end (in particular
not by `PAM_DELETE_CRED`).

Defining the ccache location for ourselves also drops the last direct
krb5 API usage, cockpit-session now only uses the plain GSSAPI.

[1] https://github.com/openssh/openssh-portable/blob/57ed647ee07b/auth-krb5.c#L72



-----

While I was working on the S4U delegation stuff (for sudo/ssh with certificate authentication) I was rather surprised that this cleanup does not currently happen. I always had assumed that this was the very purpose of [pam_setcred()](https://linux.die.net/man/3/pam_setcred), as it explicitly advertises kerberos tickets.

But I am not sure if this is really a good idea, or if it could interfere with something else like parallel ssh sessions. Right now, starting a cockpit session (through GSSAPI auth) replaces an existing ticket in the default keyring, also for existing sessions (as the keyring is per user, not per session). With this PR, the ticket then gets removed, and the parallel running ssh session ends up having no ticket at all (and needs to `kinit` again).

Should cockpit-session perhaps not *ever* write into the default ccache, but use a classic cache file and set `$KRB5CCNAME` inside the session?


@simo5, @dpal, do you have some guidance/opinion here? Thanks!