### PR TITLE
webpack-jumpstart.yml: perform merge for ourselves

### DIFF
--- a/.github/workflows/webpack-jumpstart.yml
+++ b/.github/workflows/webpack-jumpstart.yml
@@ -11,17 +11,21 @@ jobs:
       pull-requests: none
     timeout-minutes: 20
     env:
-      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      BASE_SHA: ${{ github.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Build jumpstart tarball
         run: |
-          id="$(docker container create -u node -w /home/node node /bin/sh -c \
-            'git init cockpit &&
-             cd cockpit &&
-             git fetch --depth 1 https://github.com/cockpit-project/cockpit "'"${MERGE_SHA}"'":build &&
-             git checkout build &&
-             pkg/build webpack-jumpstart.tar -j$(nproc)'
-          )"
+          id="$(docker container create -u node -w /home/node node /bin/sh -ec \
+            "git init cockpit
+             cd cockpit
+             git config user.email '<>'
+             git config user.name 'nobody'
+             git remote add origin ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}
+             git fetch --no-tags origin ${BASE_SHA}:base ${HEAD_SHA}:head
+             git checkout --detach base
+             git merge --no-edit head
+             pkg/build webpack-jumpstart.tar -j$(nproc)")"
 
           docker container start --attach "${id}" >&2
           docker container cp "${id}":/home/node/cockpit/webpack-jumpstart.tar .
@@ -43,7 +47,7 @@ jobs:
     timeout-minutes: 5
     env:
       GIT_DIR: git-dir.git
-      MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
+      BASE_SHA: ${{ github.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       - name: Set up work area
@@ -67,9 +71,10 @@ jobs:
         run: |
           set -ux
           mkdir worktree
-          tar -C worktree -x --exclude '.git*' dist package-lock.json < artifact/webpack-jumpstart.tar
-          git --work-tree worktree add dist package-lock.json
-          git --work-tree worktree commit --quiet -m "Build for ${MERGE_SHA}"
+          tar -C worktree -x --exclude '.git*' dist package-lock.json tree < artifact/webpack-jumpstart.tar
+          echo "${BASE_SHA}" > worktree/merge-base
+          git --work-tree worktree add dist package-lock.json merge-base tree
+          git --work-tree worktree commit --quiet -m "Build for ${HEAD_SHA}"
           rm -rf worktree
 
           git tag "sha-${HEAD_SHA}"

--- a/.gitignore
+++ b/.gitignore
@@ -145,6 +145,7 @@ po*.js.gz
 /.vagrant
 /test_rsa_key
 /tmp-dist
+/tree
 /valgrind-suppressions
 /webpack-jumpstart.tar
 

--- a/pkg/build
+++ b/pkg/build
@@ -36,8 +36,8 @@ V_TAR = $(V_TAR_$(V))
 V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))
 V_TAR_0 = @echo "  TAR     " $@;
 
-webpack-jumpstart.tar: $(MANIFESTS) package-lock.json
-	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json
+webpack-jumpstart.tar: $(MANIFESTS) package-lock.json tree
+	$(V_TAR) tar cf webpack-jumpstart.tar dist package-lock.json tree
 
 V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
@@ -75,3 +75,15 @@ V_NODE_MODULES_0 = @V=0
 FORCE:
 package-lock.json: FORCE
 	$(V_NODE_MODULES) $(srcdir)/tools/node-modules make_package_lock_json
+
+# Write the current git tree hash, and touch the file only if it changed.
+# Make sure the tree is clean, first.  Gets included in the jumpstart tar.
+tree: FORCE
+	@test -z "$$(git status --porcelain)" || (git status && false)
+	@git rev-parse HEAD^{tree} > tree.tmp && \
+	if cmp -s tree tree.tmp; then \
+		rm tree.tmp; \
+	else \
+		printf "  %-8s %s\n" GEN "tree  [$$(cat tree.tmp)]"; \
+		mv tree.tmp tree; \
+	fi


### PR DESCRIPTION
    Using the .merge_commit_sha from GitHub is seriously dangerous (it's
    usually not up to date when the workflow gets launched) and kinda
    pointless (it's completely transient, and will change next time someone
    pushes main).
    
    Perform the merge for ourselves to dodge the first problem and provide
    some information to help reproduce the merge in order to solve the
    second problem.

 - https://github.com/allisoninc/cockpit/pull/2
 - (main push) https://github.com/allisoninc/cockpit/runs/3162944269?check_suite_focus=true
 - (PR) https://github.com/allisoninc/cockpit/runs/3162948761?check_suite_focus=true