### PR TITLE
implement `tools/webpack-jumpstart --rebase`

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -1,14 +1,17 @@
 specfile_path: cockpit.spec
 actions:
   post-upstream-clone:
+    # this is being triggered immediately on a pull_request event; wait for
+    # build-dist.yml to generate the dist tarball.  git rebase needs an
+    # identity in order to rewrite the committer field.
+    - git config --global user.name 'nobody'
+    - git config --global user.email '<>'
+    - tools/webpack-jumpstart --wait --rebase
     # the upstream git spec file has unresolved macros which are normally put
     # in at `make dist` time; they are not important for CI
     # also, build optional packages for CentOS 8
     - sh -c 'sed "s/%{npm-version:.*}/0/; s/build_optional 0/build_optional 1/" tools/cockpit.spec > cockpit.spec'
   create-archive:
-    # this is being triggered immediately on a pull_request event; wait for
-    # build-dist.yml to generate the dist tarball
-    - tools/webpack-jumpstart --wait
     - ./autogen.sh --disable-polkit --disable-ssh --disable-pcp --with-systemdunitdir=/invalid CPPFLAGS=-Itools/mock-build-env PKG_CONFIG_PATH=tools/mock-build-env
     - make XZ_OPT=-0 dist
     - sh -c 'echo cockpit-*.tar.xz'

--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -83,10 +83,15 @@ fetch_to_cache() {
     fi
 }
 
+# Get the content of "$2" from cache commit "$1"
+cat_from_cache() {
+    git_cache cat-file blob "$1:$2"
+}
+
 # Consistency checking: for a given cache commit "$1", check if it contains a
 # file "$2" which is equal to the file "$3" present in the working tree.
 cmp_from_cache() {
-    git_cache cat-file blob "$1:$2" | cmp "$3"
+    cat_from_cache "$1" "$2" | cmp "$3"
 }
 
 # Like `git clone` except that it uses the original origin url and supports

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -31,8 +31,6 @@ done
 
 [ -n "${quiet}" ] || set -x
 
-tools/node-modules make_package_lock_json
-
 if [ -e dist ]; then
     echo "jumpstart: dist/ already exists, skipping" >&2
     exit 1
@@ -60,6 +58,8 @@ for try in $(seq 50 -1 0); do
     message WAIT 30s
     sleep 30s
 done
+
+tools/node-modules make_package_lock_json
 
 if ! cmp_from_cache "${tag}" "package-lock.json" "package-lock.json"; then
     echo "The cached package-lock.json doesn't match our own" >&2

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -17,6 +17,18 @@ set -eu
 cd "$(realpath -m "$0"/../..)"
 . tools/git-utils.sh
 
+wait=''
+while [ $# != 0 ] ; do
+    case "$1" in
+        --wait)
+            wait=1;;
+        *)
+            echo "usage: $0 [--wait]" >&2
+            exit 1
+    esac
+    shift
+done
+
 [ -n "${quiet}" ] || set -x
 
 tools/node-modules make_package_lock_json
@@ -41,7 +53,7 @@ for try in $(seq 50 -1 0); do
     if fetch_to_cache tag "${tag}"; then
         break
     fi
-    if [ "${1-}" != '--wait' -o "$try" = '0' ]; then
+    if [ -z "${wait}" -o "$try" = '0' ]; then
         echo "There is no cache entry ${tag}" >&2
         exit 1
     fi

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -18,12 +18,15 @@ cd "$(realpath -m "$0"/../..)"
 . tools/git-utils.sh
 
 wait=''
+rebase=''
 while [ $# != 0 ] ; do
     case "$1" in
         --wait)
             wait=1;;
+        --rebase)
+            rebase=1;;
         *)
-            echo "usage: $0 [--wait]" >&2
+            echo "usage: $0 [--rebase] [--wait]" >&2
             exit 1
     esac
     shift
@@ -58,6 +61,21 @@ for try in $(seq 50 -1 0); do
     message WAIT 30s
     sleep 30s
 done
+
+if [ -n "${rebase}" ]; then
+    if [ -n "$(git status --porcelain)" ]; then
+        echo 'Refusing to rebase tree with local changes' >&2
+        git status >&2
+        exit 1
+    fi
+    merge_base="$(cat_from_cache "${tag}" merge-base)"
+    # If we don't already have that commit, we'll need to go fetch it
+    if ! git fsck --no-dangling --connectivity-only "${merge_base}"; then
+        message FETCH ".  [${merge_base}]"
+        git fetch --no-write-fetch-head origin "${merge_base}"
+    fi
+    git rebase -- "${merge_base}"
+fi
 
 tools/node-modules make_package_lock_json
 

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -77,11 +77,16 @@ if [ -n "${rebase}" ]; then
     git rebase -- "${merge_base}"
 fi
 
-tools/node-modules make_package_lock_json
-
-if ! cmp_from_cache "${tag}" "package-lock.json" "package-lock.json"; then
-    echo "The cached package-lock.json doesn't match our own" >&2
-    exit 1
+target_tree="$(cat_from_cache "${tag}" tree)"
+if [ "$(git rev-parse HEAD^{tree})" != "${target_tree}" ]; then
+    if [ -n "${rebase-}" ]; then
+        echo "Internal error: even after rebase, don't have the correct tree" >&2
+        exit 1
+    else
+        echo "The current working tree needs to be rebased: try --rebase" >&2
+        exit 1
+    fi
 fi
 
+tools/node-modules make_package_lock_json
 unpack_from_cache "${tag}"


### PR DESCRIPTION
 - a `--rebase` option will allow rebasing the local tree to get the same tree we built the cache against
 - update packit to use `--rebase`