### PR TITLE
lib: python.js: detect python path and then spawn the python script seperately

### DIFF
--- a/pkg/lib/python.js
+++ b/pkg/lib/python.js
@@ -20,8 +20,6 @@
 import cockpit from "cockpit";
 
 // FIXME: eventually convert all images to python 3
-const pyinvoke = ["sh", "-ec", "exec $(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) $@", "--", "-"];
-
 export function spawn (script_pieces, args, options) {
     var script;
     if (typeof script_pieces == "string")
@@ -29,5 +27,6 @@ export function spawn (script_pieces, args, options) {
     else
         script = script_pieces.join("\n");
 
-    return cockpit.spawn(pyinvoke.concat(args), options).input(script);
+    return cockpit.spawn(["/bin/sh", "-c", "which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python"])
+                .then(pyexe => cockpit.spawn([pyexe.trim(), "--", "-", args], options).input(script));
 }


### PR DESCRIPTION
Previously python.js was passing the python command through the shell,
resulting in the args with special chars breaking formatting.