### PR TITLE
.gitignore: ignore /bots even if it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ depcomp
 tmp/weblate-repo
 /src/selinux/tmp
 /src/selinux/cockpit.pp
-/bots/
+/bots
 /test/images/*
 /test/verify/naughty-*/*
 /test/container-probe*


### PR DESCRIPTION
Having a / at the end of the ignore pattern causes a symlink not to be
ignored.  For some time now, tools/make-bots can put a symlink there, so
ignore that too.