### PR TITLE
ws: Create S4UProxy user ticket on tlscert authentication

### DIFF
--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -202,4 +202,83 @@ CPUQuota=30%
 
   </section>
 
+  <section id="certauth-forwarding">
+    <title>Authentication to other services like sudo and ssh</title>
+
+    <para>Once you logged into Cockpit with a certificate, you likely need to switch to administative mode
+      (root privileges through sudo), or connect to remote machines through SSH. If your user account has a password,
+      that can be used for authenticating to sudo or ssh as usual.</para>
+
+    <para><emphasis>Supported with FreeIPA only:</emphasis> As an alternative to password authentication, you can
+      also declare the initial Cockpit certificate authentication as trusted for authenticating to SSH,
+      sudo, or other services. For that purpose, Cockpit automatically creates an
+      <ulink url="https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-sfu/bde93b0e-f3c9-4ddf-9f44-e1453be7af5a">S4U2Proxy Kerberos ticket</ulink>
+      in the user session:
+    </para>
+
+<programlisting>
+$ klist
+Ticket cache: FILE:/run/user/1894000001/cockpit-session-3692.ccache
+Default principal: user@EXAMPLE.COM
+
+Valid starting     Expires            Service principal
+07/30/21 09:19:06  07/31/21 09:19:06  HTTP/myhost.example.com@EXAMPLE.COM
+07/30/21 09:19:06  07/31/21 09:19:06  krbtgt/EXAMPLE.COM@EXAMPLE.COM
+	for client HTTP/myhost.example.com@EXAMPLE.COM
+</programlisting>
+
+    <para>You can set up <ulink url="https://www.freeipa.org/page/V4/Service_Constraint_Delegation">constrained delegation rules</ulink>
+      to enumerate which hosts (including its own) that ticket is trusted to access. For example, if the cockpit session runs on host
+      <code>myhost.example.com</code> and should be trusted to access its own host (through sudo) and another host
+      <code>remote.example.com</code> (through ssh), create a delegation like this:
+    </para>
+
+<programlisting>
+# a list of target machines which can be accessed by a particular rule
+ipa servicedelegationtarget-add cockpit-target
+ipa servicedelegationtarget-add-member cockpit-target \
+  --principals=host/myhost.example.com@EXAMPLE.COM \
+  --principals=host/remote.example.com@EXAMPLE.COM
+
+# allow cockpit sessions (HTTP/ principal) to access that host list
+ipa servicedelegationrule-add cockpit-delegation
+ipa servicedelegationrule-add-member cockpit-delegation \
+  --principals=HTTP/myhost.example.com@EXAMPLE.COM
+ipa servicedelegationrule-add-target cockpit-delegation \
+  --servicedelegationtargets=cockpit-target
+</programlisting>
+
+    <para>In addition, you need to enable GSS (Kerberos) authentication in the corresponding services.</para>
+
+    <itemizedlist>
+      <listitem>
+        <para>For SSH, enable <code>GSSAPIAuthentication yes</code> in
+          <ulink url="https://linux.die.net/man/5/sshd_config">/etc/ssh/sshd_config</ulink>.</para>
+      </listitem>
+
+      <listitem>
+        <para>For sudo, enable <code>pam_sss_gss</code> as described in the
+          <ulink url="https://www.mankier.com/8/pam_sss_gss">manpage</ulink>:
+          In <code>/etc/sssd/sssd.conf</code>: Add an entry for your domain:</para>
+
+<programlisting>
+[domain/example.com]
+pam_gssapi_services = sudo, sudo-i
+</programlisting>
+
+        <para>In <code>/etc/pam.d/sudo</code>, enable the module in the first line:</para>
+
+<programlisting>
+auth sufficient pam_sss_gss.so
+</programlisting>
+
+      </listitem>
+    </itemizedlist>
+
+    <para><emphasis>Caveat:</emphasis> The delegated S4U ticket is not yet forwarded to remote SSH
+    hosts when connecting to them from Cockpit, so authenticating to sudo on the remote host with
+    that ticket does not work. This will be provided in a future version.</para>
+
+  </section>
+
 </chapter>

--- a/doc/guide/sso.xml
+++ b/doc/guide/sso.xml
@@ -46,11 +46,20 @@ _kerberos._udp.example.com has SRV record 0 100 88 dc.example.com
     <para>When joining an IPA domain with Cockpit and the <code>ipa</code> command line tool is
       available, both the service principal name and a <code>/etc/cockpit/krb5.keytab</code> get
       created automatically, so that Kerberos based single sign on into Cockpit works out of the
-      box. If you want/need to do this by hand or in a script, the
-      corresponding commands with IPA are:</para>
+      box. If you want/need to do this by hand or in a script, first create or modify the
+      <code>HTTP/</code> service principal:</para>
 
 <programlisting>
-$ sudo ipa service-add --ok-as-delegate=true --force HTTP/server.example.com@EXAMPLE.COM
+$ sudo ipa service-add --ok-as-delegate=true --ok-to-auth-as-delegate=true \
+    HTTP/server.example.com@EXAMPLE.COM
+# or, if it already exists, just enable delegation:
+$ sudo ipa service-mod --ok-as-delegate=true --ok-to-auth-as-delegate=true \
+    HTTP/server.example.com@EXAMPLE.COM
+</programlisting>
+
+    <para>Then generate a key for that principal:</para>
+
+<programlisting>
 $ sudo ipa-getkeytab -p HTTP/server.example.com@EXAMPLE.COM -k /etc/cockpit/krb5.keytab
 </programlisting>
 

--- a/pkg/systemd/README-realmd.md
+++ b/pkg/systemd/README-realmd.md
@@ -76,7 +76,7 @@ the computer running Cockpit.
 
     $ sudo -s
     # kinit admin@COCKPIT.LAN
-    # ipa service-add --ok-as-delegate=true --force HTTP/my-server.cockpit.lan@COCKPIT.LAN
+    # ipa service-add --ok-as-delegate=true --ok-to-auth-as-delegate=true --force HTTP/my-server.cockpit.lan@COCKPIT.LAN
     # ipa-getkeytab -q -s services.cockpit.lan -p HTTP/my-server.cockpit.lan -k /etc/krb5.keytab
 
 Now when you go to your cockpit instance you should be able to log in without

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -102,7 +102,7 @@ cmd_ipa_request() {
 
     # create a kerberos Service Principal Name for cockpit-ws, unless already present
     ipa service-show "${SERVICE}" || \
-        ipa service-add --ok-as-delegate=true --force "${SERVICE}"
+        ipa service-add --ok-as-delegate=true --ok-to-auth-as-delegate=true --force "${SERVICE}"
 
     # add cockpit-ws key, unless already present
     klist -k "${KEYTAB}" | grep -qF "${SERVICE}" || \

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -460,6 +460,9 @@ ExecStart=/bin/true
             while ! ipa user-find >/dev/null; do sleep 5; done'
             """ % (self.admin_password, self.admin_user), timeout=300)
 
+        # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
+        self.machine.execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
+
         # HACK: Figure out why this happens
         self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
                                     'cockpit-session:$')
@@ -626,6 +629,9 @@ ipa user-add --first=Alice --last="Developer" --shell=/bin/bash alice
 yes "%(password)s" | ipa user-mod --password alice
 ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
 ipa user-add-cert alice --certificate="%(cert)s"
+# make alice an admin
+ipa group-add-member admins --users=alice
+ipa-advise enable-admins-sudo | sh -ex
 ' """ % {"cert": alice_cert, "password": self.alice_password})
 
         # On Debian 9, D-Bus activation of ifp is disabled, enable it manually; see https://bugs.debian.org/925026
@@ -641,6 +647,20 @@ ipa user-add-cert alice --certificate="%(cert)s"
         else:
             alice_klist_cmd = 'su -c klist alice'
         persistent_ticket = m.execute(alice_klist_cmd)
+
+        # enable sudo GSSAPI authentication
+        m.execute(script=r"""#!/bin/sh -eu
+        sed -i '/\[domain\/cockpit.lan\]/ a pam_gssapi_services = sudo, sudo-i' /etc/sssd/sssd.conf
+        sed -i '1 a auth sufficient pam_sss_gss.so' /etc/pam.d/sudo
+        systemctl restart sssd
+        """)
+
+        # enable ssh GSSAPI authentication
+        m.execute("sed -ri 's/#GSSAPIAuthentication.*/GSSAPIAuthentication yes/' /etc/ssh/sshd_config")
+        m.execute("systemctl restart sshd")
+
+        # avoid "unknown host" error in SSH
+        m.execute("su -c 'mkdir -p ~/.ssh; ssh-keyscan localhost > ~/.ssh/known_hosts' alice")
 
         # the test below assumes exactly one running bridge
         m.execute("! pgrep cockpit-bridge")
@@ -671,13 +691,74 @@ ipa user-add-cert alice --certificate="%(cert)s"
         # does not interfere with persistent ticket in other sessions
         self.assertEqual(m.execute(alice_klist_cmd), persistent_ticket)
 
+        # destroy global user ccache, so that sudo/ssh really have to use the ccache_env one
+        m.execute("su -c 'kdestroy || true' alice")
+
+        # sanity check: sudo and ssh do not work without a ticket and password
+        self.assertIn("no askpass program", m.execute("su -c '! sudo -A whoami' alice 2>&1"))
+        self.assertIn("Permission denied", m.execute("su -c '! ssh x0.cockpit.lan 2>&1' alice"))
+
+        # in default configuration, ticket is not trusted by IPA
+        self.assertIn("no askpass program", m.execute(f"su -c '! {ccache_env} sudo -A whoami' alice 2>&1"))
+        self.assertIn("Permission denied", m.execute(f"su -c '! {ccache_env} ssh x0.cockpit.lan 2>&1' alice"))
+        b.switch_to_top()
+        b.click("#super-user-indicator button")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for alice:")
+        b.click(".pf-c-modal-box:contains('Switch to administrative access') .btn-cancel")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
+
+        # set up delegation rule
+        script = f"""
+        ipa servicedelegationtarget-add cockpit-target
+        ipa servicedelegationtarget-add-member cockpit-target --principals="host/x0.cockpit.lan@COCKPIT.LAN"
+        ipa servicedelegationrule-add cockpit-delegation
+        ipa servicedelegationrule-add-member cockpit-delegation --principals="HTTP/x0.cockpit.lan@COCKPIT.LAN"
+        ipa servicedelegationrule-add-target cockpit-delegation --servicedelegationtargets="cockpit-target"
+        """
+        ipa_machine.execute("podman exec freeipa bash -euc '%s'" % script)
+
+        # now sudo works with the delegated ticket
+        # this requires https://github.com/sudo-project/sudo/commit/3b7977a42c0 (see https://bugzilla.redhat.com/show_bug.cgi?id=1917379)
+        # to actually work, so on older distros it fails
+        supports_sudo_krb = m.image not in ["rhel-8-5", "centos-8-stream", "debian-stable", "ubuntu-2004", "ubuntu-stable"]
+        b.click("#super-user-indicator button")
+
+        if supports_sudo_krb:
+            b.wait_in_text(".pf-c-modal-box:contains('Administrative access')", "You now have administrative access")
+            self.assertEqual("root\n", m.execute(f"su -c '{ccache_env} sudo -A whoami' alice"))
+            b.click(".pf-c-modal-box:contains('Administrative access') .btn-cancel")
+            b.wait_not_present(".pf-c-modal-box:contains('Administrative access')")
+
+            b.go("/system")
+            b.enter_page("/system")
+            b.wait_visible("#reboot-button")
+        else:
+            b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for alice:")
+            b.click(".pf-c-modal-box:contains('Switch to administrative access') .btn-cancel")
+            b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
+            self.assertIn("no askpass program", m.execute(f"su -c '! {ccache_env} sudo -A whoami' alice 2>&1"))
+
+        # ssh works with the delegated ticket
+        out = m.execute(f"su -c '{ccache_env} ssh -vv -K x0.cockpit.lan echo hello' alice")
+        self.assertEqual(out.strip(), "hello")
+
+        # cockpit-ssh works with the delegated ticket
+        b.switch_to_top()
+        b.click("#hosts-sel button")
+        b.click(".nav-hosts-actions button")
+        b.set_val("#add-machine-address", "x0.cockpit.lan")
+        b.click("#hosts_setup_server_dialog .pf-m-primary")
+        b.click(".view-hosts a[href='/@x0.cockpit.lan']")
+        b.wait_js_cond("window.location.pathname == '/@x0.cockpit.lan/system'")
+        # no root privs in that session
+        b.enter_page("/system", "x0.cockpit.lan")
+        b.wait_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
+        b.wait_not_present("#reboot-button")
+
         # S4U proxy ticket gets cleaned up on logout
         b.logout()
         m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
         m.execute(f"! su -c '{ccache_env} klist' alice")
-
-        # original persistent ticket remains in other sessions
-        self.assertEqual(m.execute(alice_klist_cmd), persistent_ticket)
 
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -307,10 +307,22 @@ class CommonTests:
         This assumes that IdM and sssd are all set up correctly already.
         '''
         m = self.machine
+        b = self.browser
 
         # join domain, wait until it works
         m.write("/etc/realmd.conf", "[cockpit.lan]\nfully-qualified-names = no\n", append=True)
-        m.execute("echo %s | realm join -vU %s cockpit.lan" % (self.admin_password, self.admin_user), timeout=300)
+        # join client machine with Cockpit, to create the HTTP/ principal and /etc/cockpit/krb5.keytab
+        self.login_and_go("/system")
+        b.click("#system_information_domain_button")
+        b.wait_popup("realms-op")
+        b.set_val("#realms-op-address", "cockpit.lan")
+        b.wait_text(".realms-op-address-error", "Contacted domain")
+        b.set_val("#realms-op-admin", self.admin_user)
+        b.set_val("#realms-op-admin-password", self.admin_password)
+        b.click(".realms-op-apply")
+        with b.wait_timeout(300):
+            b.wait_popdown("realms-op")
+        b.logout()
         m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
 
         # upload certificates to client machine
@@ -601,6 +613,7 @@ ExecStart=/bin/true
 
     def testClientCertAuthentication(self):
         m = self.machine
+        b = self.browser
 
         ipa_machine = self.machines['services']
         with open("src/tls/ca/alice.pem") as f:
@@ -609,7 +622,7 @@ ExecStart=/bin/true
         alice_cert = '\n'.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
         # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
         ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
-ipa user-add --first=Alice --last="Developer" alice
+ipa user-add --first=Alice --last="Developer" --shell=/bin/bash alice
 yes "%(password)s" | ipa user-mod --password alice
 ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
 ipa user-add-cert alice --certificate="%(cert)s"
@@ -620,6 +633,51 @@ ipa user-add-cert alice --certificate="%(cert)s"
             m.write("/etc/sssd/conf.d/ifp.conf", "[sssd]\nservices = nss, sudo, pam, ssh, ifp\n", perm="0600")
 
         self.checkClientCertAuthentication()
+
+        # the above password login implicitly creates a persistent user ticket
+        if m.image == 'debian-stable':
+            # on Debian 9, the default kerberos config is a per-session FILE: keyring, so klist fails
+            alice_klist_cmd = 'su -c klist alice || true'
+        else:
+            alice_klist_cmd = 'su -c klist alice'
+        persistent_ticket = m.execute(alice_klist_cmd)
+
+        # the test below assumes exactly one running bridge
+        m.execute("! pgrep cockpit-bridge")
+
+        # check S4U proxy ticket for the user (not functional for anything without delegation rules)
+        # this is specific to IPA, as with AD cockpit-ws does not get a keytab
+
+        # as we can't do cert auth in the browser, splice socat in between to do that for us
+        m.execute(f'''! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443
+                      mkdir -p /run/systemd/system/cockpit.socket.d/
+                      printf "[Socket]\nListenStream=\nListenStream=443" > /run/systemd/system/cockpit.socket.d/listen.conf
+                      sed -i '/\[WebService/ aOrigins = http://{m.web_address}:{m.web_port}' /etc/cockpit/cockpit.conf''')
+        m.spawn("socat TCP-LISTEN:9090,reuseaddr,fork OPENSSL:x0.cockpit.lan:443,cert=/var/tmp/alice.pem,key=/var/tmp/alice.key", "socat-certauth.log")
+        m.start_cockpit(tls=True)
+
+        # S4U ticket is in the session
+        b.open("/system/terminal")
+        b.expect_load()
+        b.enter_page("/system/terminal")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "alice")
+        b.key_press("klist\r")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Ticket cache: FILE:/run/user")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Default principal: alice@COCKPIT.LAN")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "for client HTTP/x0.cockpit.lan@COCKPIT.LAN")
+        self.assertIn("cockpit-session-", m.execute("ls /run/user/$(id -u alice)/*.ccache"))
+        ccache_env = m.execute("xargs -0n1 < /proc/$(pgrep cockpit-bridge)/environ | grep KRB5CCNAME=").strip()
+
+        # does not interfere with persistent ticket in other sessions
+        self.assertEqual(m.execute(alice_klist_cmd), persistent_ticket)
+
+        # S4U proxy ticket gets cleaned up on logout
+        b.logout()
+        m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
+        m.execute(f"! su -c '{ccache_env} klist' alice")
+
+        # original persistent ticket remains in other sessions
+        self.assertEqual(m.execute(alice_klist_cmd), persistent_ticket)
 
 
 @skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004")

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -66,14 +66,23 @@ class TestS4USsh(MachineCase):
         b.click(".realms-op-apply")
         with b.wait_timeout(300):
             b.wait_popdown("realms-op")
+        b.logout()
+        # the above installed a new certificate; pick this up, enable cert auth and TLS
+        client_machine.write("/etc/cockpit/cockpit.conf", '[WebService]\nClientCertAuthentication = true\n', append=True)
+        client_machine.start_cockpit(tls=True)
 
         # configure ipa to trust cockpit-generated S4U tickets for accessing our hosts
-        script = """set -eu
+        with open("src/tls/ca/alice.pem") as f:
+            alice_cert = f.read().strip()
+        # IPA does not like the ---BEGIN/END lines
+        alice_cert = '\n'.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
+        script = f"""set -eu
         echo foobarfoo | kinit admin@COCKPIT.LAN
 
         # add user to impersonate
         ipa user-add --first=user --last=user user
         echo foobarfoo | ipa user-mod user --password
+        ipa user-add-cert user --certificate="{ alice_cert }"
 
         # set up delegation rule
         ipa servicedelegationtarget-add cockpit-target
@@ -98,28 +107,12 @@ class TestS4USsh(MachineCase):
             usermod -G wheel user
             """)
 
-        # get keytab for authenticating and make ccache using gssapi (this will be done by cockpit-session eventually)
-        client_machine.write('/tmp/make-cache.py', """
-import gssapi, pwd, os
-
-user = 'user@COCKPIT.LAN'
-uid = pwd.getpwnam(user).pw_uid
-ccache = f'/run/user/{uid}/cockpit-s4u.ccache'
-ccache_dir = os.path.dirname(ccache)
-os.makedirs(ccache_dir)
-
-serverCred = gssapi.creds.rcred_cred_store.acquire_cred_from(store = { b'client_keytab': b'/etc/cockpit/krb5.keytab' }, usage='initiate', lifetime=30)
-impersonee = gssapi.Name(user, gssapi.NameType.kerberos_principal)
-credResults4u2self = gssapi.creds.rcred_s4u.acquire_cred_impersonate_name(serverCred.creds, impersonee)
-gssapi.creds.rcred_cred_store.store_cred_into({ b'ccache': f'FILE:{ccache}'.encode() }, credResults4u2self.creds, overwrite=True)
-# make it readable for the user
-os.chmod(ccache, 0o400)
-os.chown(ccache_dir, uid, -1)
-os.chown(ccache, uid, -1)
-print(ccache)
-""")
-        ccache = client_machine.execute(["python3", "/tmp/make-cache.py"]).strip()
-        ccache_env = 'KRB5CCNAME=FILE:' + ccache
+        # log into Cockpit with certificate, and grab the keytab
+        client_machine.upload(["alice.pem", "alice.key"], "/var/tmp", relative_dir="src/tls/ca/")
+        out = client_machine.execute(['curl', '-ksS', '-D-', '--cert', '/var/tmp/alice.pem', '--key', '/var/tmp/alice.key',
+                                      'https://localhost:9090/cockpit/login'])
+        self.assertIn("csrf-token", out)
+        ccache_env = client_machine.execute("xargs -0n1 < /proc/$(pgrep cockpit-bridge)/environ | grep KRB5CCNAME=").strip()
 
         # SSH with the delegated ticket
         out = client_machine.execute(f"su -c 'KRB5_TRACE=/dev/stderr {ccache_env} ssh -vvv -K  user@sshserver.cockpit.lan echo hello' user")

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -75,9 +75,6 @@ class TestS4USsh(MachineCase):
         ipa user-add --first=user --last=user user
         echo foobarfoo | ipa user-mod user --password
 
-        # allow our cockpit/ws service to delegate creds; FIXME: do this by default, and document transition from existing ones
-        ipa service-mod HTTP/sshclient.cockpit.lan@COCKPIT.LAN --ok-to-auth-as-delegate=true
-
         # set up delegation rule
         ipa servicedelegationtarget-add cockpit-target
         # FIXME: how to allow this to all machines in the network? https://pagure.io/freeipa/issue/8927


### PR DESCRIPTION
Turn the Proof of Concept in check-system-s4u-ssh into cockpit-session
code to create an S4U ticket for the user in tlscert authentication
mode. This will be used in the future to further authenticate to sudo or
ssh, but this requires further configuration. In the default FreeIPA
configuration, these tickets are not trusted by anything, so it is
harmless to create them by default.

The testClientCertAuthentication in TestIPA covers the successful case,
in TestAD the "not available" case (no unexpected error messages), and
in TestLogin the case where the machine is not joined to a domain.

Adjust check-system-s4u-ssh to acquire the S4U ticket from cockpit
through a TLS certificate login, instead of the custom Python script.

-----

Documentation preview is on https://piware.de/tmp/guide-s4u . In particular, look at the [SSO server setup](https://piware.de/tmp/guide-s4u/sso.html#sso-server) and the [Authentication to other services](https://piware.de/tmp/guide-s4u/cert-authentication.html#certauth-forwarding) parts.

 - [x] Builds on top of PR #16167 
 - [x] Builds on top of PR #16172
 - [x] Test authentication to sudo
 - [x] Test authentication to ssh
 - [x] Add documentation

## Certificate/smart card authentication to ssh and sudo

Once you logged into Cockpit with a certificate, you likely need to switch to administative mode, or connect to remote machines through SSH. If your machine is part of a FreeIPA domain, and your user account does not have a password, you can now set up [constrained delegation rules](https://www.freeipa.org/page/V4/Service_Constraint_Delegation) so that the Cockpit certificate authentication gets forwarded to sudo and/or ssh. Please see the [Client certification documentation](https://cockpit-project.org/guide/latest/cert-authentication.html) for details.