### PR TITLE
move webpack jumpstart build to `node:14`

### DIFF
--- a/.github/workflows/webpack-jumpstart.yml
+++ b/.github/workflows/webpack-jumpstart.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Build jumpstart tarball
         run: |
-          id="$(docker container create -u node -w /home/node node /bin/sh -ec \
+          id="$(docker container create -u node -w /home/node node:14 /bin/sh -ec \
             "git init cockpit
              cd cockpit
              git config user.email '<>'

--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -48,7 +48,8 @@ init_cache() {
 # we use git fsck to to avoid problems with incomplete fetches: we want to make
 # sure the complete commit is there
 check_ref() {
-    git_cache fsck --no-dangling --connectivity-only "$1" 2>/dev/null
+    git_cache show "$1" >/dev/null 2>&1 && \
+      git_cache fsck --no-dangling --connectivity-only "$1" 2>/dev/null
 }
 
 # Fetch a specific commit ID into the cache

--- a/tools/node-modules
+++ b/tools/node-modules
@@ -14,7 +14,7 @@ cmd_remove() {
     message REMOVE node_modules
     rm -rf node_modules
     git submodule deinit node_modules
-    rm -rf "$(git rev-parse --absolute-git-dir)/modules/node_modules"
+    rm -rf -- "$(git rev-parse --absolute-git-dir)/modules/node_modules"
 }
 
 cmd_checkout() {


### PR DESCRIPTION
From the sunday-trainrides-with-nothing-to-do department:

`node:14` is a pre-cached image on GitHub, so it's faster.  I had to fix a few problems with old git versions, but it seems to work now.

See
 - https://github.com/allisoninc/cockpit/pull/3
 - https://github.com/allisoninc/cockpit/pull/3/checks?check_run_id=3213790366