### PR TITLE
test: Adjust for PackageKit 1.2.4 severity parsing support

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1097,7 +1097,7 @@ class OsUpdates extends React.Component {
                         Package: (info, packageId, _summary) => {
                             const id_fields = packageId.split(";");
                             packageSummaries[id_fields[0]] = _summary;
-                            // HACK: dnf backend yields wrong severity (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
+                            // HACK: dnf backend yields wrong severity with PK < 1.2.4 (https://github.com/PackageKit/PackageKit/issues/268)
                             if (info < PK.Enum.INFO_LOW || info > PK.Enum.INFO_SECURITY)
                                 info = PK.Enum.INFO_NORMAL;
                             updates[packageId] = { name: id_fields[0], version: id_fields[1], severity: info, arch: id_fields[2] };

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -61,9 +61,13 @@ class TestUpdates(NoSubManCase):
     def setUp(self):
         super().setUp()
 
-        # only the yum backend properly recognizes "enhancement" severity; apt
-        # does not have that metadata and PackageKit-dnf does not parse it
-        if self.backend == "yum":
+        pkcon_version = self.machine.execute("pkcon --version").strip()
+
+        # only the yum and PackageKit ≥ 1.2.4 dnf (https://github.com/PackageKit/PackageKit/issues/268) backends
+        # properly recognize "enhancement" severity; apt does not have that metadata
+        self.supports_severity = not (self.backend == "apt" or pkcon_version < "1.2.4")
+
+        if self.supports_severity:
             self.enhancement_severity = "enhancement"
         else:
             self.enhancement_severity = "bug"
@@ -688,9 +692,7 @@ ExecStart=/usr/local/bin/{0}
         self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
 
         # security fix without CVE URLs
-        # PackageKit's dnf backend does not recognize this (https://bugs.freedesktop.org/show_bug.cgi?id=101070)
-        # and PackageKit's deb backend does not know about severity at all, so only test this on RPM
-        if self.backend == "yum":
+        if self.supports_severity:
             self.createPackage("secnocve", "1", "1", install=True)
             self.createPackage("secnocve", "1", "2", severity="security", changes="Fix leak")
             self.enableRepo()

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -822,6 +822,7 @@ ExecStart=/usr/local/bin/{0}
         b = self.browser
         m = self.machine
 
+        m.execute("systemctl stop packagekit")
         system_service = m.execute("systemctl show -p FragmentPath packagekit.service | cut -f2 -d=").strip()
         m.execute('''mv {0} {0}.disabled
                      mv /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service.disabled


### PR DESCRIPTION
PackageKit 1.2.4 finally fixed a long standing bug [1] about mis-parsing
the "severity" field for an update. The current version now finally
returns correct results. Adjust the tests to factorize the "supports
severities" into a `self.supports_severity` flag, and make it dynamic
based on the PackageKit version.

Also adjust the old bugs.freedesktop.org reference to the current one
(the bug tracker got migrated to GitHub a while ago).

[1] https://github.com/PackageKit/PackageKit/issues/268

----

Blocks https://github.com/cockpit-project/bots/pull/2265