### PR TITLE
test: Add IdentitiesOnly to the ssh config example

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -217,6 +217,7 @@ log in to test machines without authentication:
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
         IdentityFile ~/src/cockpit/bots/machine/identity
+        IdentitiesOnly yes
 
 Many cockpit developers take it a step further, and add an alias to
 allow typing `ssh c`:


### PR DESCRIPTION
With the IdentitiesOnly option, ssh only offers the configured
IdentitiyFile. This option is useful for situations where the ssh agent
offers too many different identities causing an authentication failure.