### PR TITLE
test: Reset failed units in TestKerberos.testNegotiate terminal test

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -849,6 +849,9 @@ ExecStart=/bin/true
         def line_sel(i):
             return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
 
+        # Remove failed units which will show up in the first terminal line
+        m.execute("systemctl reset-failed")
+
         # kerberos ticket got forwarded into the session
         b.enter_page("/system/terminal")
         b.wait_visible(".terminal .xterm-accessibility-tree")


### PR DESCRIPTION
Similarly to commit 7a6b68a8afc, reset failed systemd units. Otherwise
they appear as the first few lines in the terminal (through a bash
profile plugin) and break the test assumption of the prompt being in the
first line.

----

Seen in https://github.com/cockpit-project/bots/pull/2274 in [this failure](https://logs.cockpit-project.org/logs/pull-2274-20210803-145127-82795814-fedora-33-cockpit-project-cockpit/log.html#254-2)