### PR TITLE
Generalize ignoring test output files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,11 +161,8 @@ po*.js.gz
 .vscode/
 
 # Test output
-Test*.log
+/Test*
 cockpit-*.tar*
-Test*.png
-Test*.html
-Test*.json
 
 /pkg/networkmanager/override.json
 /pkg/storaged/override.json


### PR DESCRIPTION
Ignore all Test file extensions in a general manner so for example
Test*.gz is not missing.