### PR TITLE
test: Stop making Browser.text() wait for the element

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -252,7 +252,6 @@ class Browser:
         self.call_js_func('ph_set_val', selector, val)
 
     def text(self, selector):
-        self.wait_visible(selector)
         return self.call_js_func('ph_text', selector)
 
     def attr(self, selector, attr):


### PR DESCRIPTION
This was accidental and overzealous in commit f3e4fa70b0 -- b.text() was
always intended to give the current text, not wait for anything.

This wreaks havoc when Browser.text() is being used in a waiting loop [1],
as the implicit wait loop results in a quadratic loop and thus very long
test hangs and global timeouts.

[1] https://github.com/cockpit-project/cockpit-machines/blob/2832eab8afa/test/check-machines-create#L1176

----

 - [ ] Fix [test/verify/check-system-services TestServices.testBasic](https://logs.cockpit-project.org/logs/pull-16200-20210804-121156-11b5fdda-fedora-coreos/log.html#259-2)

This currently makes an utter mess of the downstream cockpit-machines gating when the sub-VM crashes (running out of memory), and hence every iteration of wait() waits in vain for one minute for a selector which will never appear. I'll apply a workaround to cockpit-machines, but let's fix this for good.