### PR TITLE
Fix version 250 Coverity regressions, fix pycodestyle regressions

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -220,7 +220,11 @@ setup_ssh_agent (gpointer data)
 {
   g_unsetenv ("G_DEBUG");
   prctl (PR_SET_PDEATHSIG, SIGTERM);
-  cockpit_close_range (3, INT_MAX, 0);
+  if (cockpit_close_range (3, INT_MAX, 0) < 0)
+    {
+      g_printerr ("couldn't close file descriptors: %m\n");
+      _exit (127);
+    }
 }
 
 static GPid

--- a/src/common/cockpitconf.c
+++ b/src/common/cockpitconf.c
@@ -293,11 +293,16 @@ cockpit_conf_get_dirs (void)
 
   if (!initialized)
     {
-      char *env = getenv ("XDG_CONFIG_DIRS");
+      static char *env;
 
       initialized = true;
+      env = getenv ("XDG_CONFIG_DIRS");
       if (env && env[0])
-        system_config_dirs = strsplit (strdup (env), ':');
+        {
+          /* strsplit() modifies the string inline, so copy and keep a ref */
+          env = strdup (env);
+          system_config_dirs = strsplit (env, ':');
+        }
     }
 
   return (const char * const *) system_config_dirs ?: cockpit_config_dirs;

--- a/src/ws/cockpit-session-client-certificate.c
+++ b/src/ws/cockpit-session-client-certificate.c
@@ -86,6 +86,7 @@ read_proc_self_cgroup (size_t *out_length)
 
   fclose (fp);
 
+  assert (result != NULL);
 
   *out_length = strlen (result);
 
@@ -93,7 +94,6 @@ read_proc_self_cgroup (size_t *out_length)
    * newline: this could only fail if the kernel retuned something
    * unexpected.
    */
-  assert (result != NULL);
   assert (*out_length >= 5); /* "0::/\n" */
   assert (result[*out_length - 1] == '\n');
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -150,7 +150,7 @@ class TestUpdates(NoSubManCase):
         kernel_ver_arch = m.execute("uname -r").strip()
         fields = kernel_ver_arch.split("-")
         kpp_kernel_version = fields[0].replace(".", "_")
-        release = fields[1].split(".")[:-2] # remove el8.x86_64
+        release = fields[1].split(".")[:-2]  # remove el8.x86_64
         kpp_kernel_release = "_".join(release)
 
         sanitized_kernel_ver = "_".join(kernel_ver_arch.split(".")[:-2])
@@ -244,7 +244,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         m.execute("umount /usr/sbin/kpatch")
         m.execute("systemctl restart kpatch")
         m.execute("dnf -y remove kpatch-patch-" + sanitized_kernel_ver)
-        b.reload() # Not listening on patches being removed
+        b.reload()  # Not listening on patches being removed
         b.enter_page("/updates")
 
         b.wait_in_text("#kpatch-settings", "Disabled")
@@ -265,7 +265,6 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         self.assertEqual(m.execute("systemctl is-active kpatch").strip(), "active")
         # Patches should be installed
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
-
 
     def testBasic(self):
         # no security updates, no changelogs
@@ -1081,6 +1080,7 @@ class TestWsUpdate(NoSubManCase):
 
         self.allow_restart_journal_messages()
 
+
 @skipImage("kpatch is not available", *OSesWithoutKpatch)
 class TestKpatchInstall(NoSubManCase):
     def testBasic(self):
@@ -1112,6 +1112,7 @@ class TestKpatchInstall(NoSubManCase):
 
         # kpatch and kpatch-dnf should be installed
         m.execute("rpm -q kpatch kpatch-dnf")
+
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",


### PR DESCRIPTION
It seems we really need to update our unit-tests container to pull in a recent pycodestyle.. I'm doing that in PR #16207