### PR TITLE
containers: Properly run test-static-code during unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
          - CC=clang distcheck
          - :i386 distcheck
       fail-fast: false
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
       # current podman backport falls over as non-root, and completely breaks down with :i386 image
       docker: docker
@@ -34,4 +34,5 @@ jobs:
           fi
 
       - name: Run unit-tests container
+        timeout-minutes: 20
         run: containers/unit-tests/start ${{ matrix.startarg }}

--- a/containers/unit-tests/scenario-distcheck.sh
+++ b/containers/unit-tests/scenario-distcheck.sh
@@ -17,6 +17,9 @@ grep -q 'src/bridge/cockpitpackages.c' po/cockpit.pot
 # Check that we are lint clean
 npm run eslint
 
+# run full test-static-code with git tree (several tests get skipped during distcheck)
+tools/test-static-code
+
 # validate that "distclean" does not remove too much
 mkdir _distcleancheck
 tar -C _distcleancheck -xf cockpit-[0-9]*.tar.xz


### PR DESCRIPTION
Since commit 4077dee3d2f65b our unit test runs did not run pycodestyle
any more, as that started to skip the pycodestyle check in a non-git
tree (such as the unpacked tree that `distcheck` runs in). As
test-static-code does not run in `check-memory` either, none of the four
scenarios ended up running it.
    
So explicitly call it in the distcheck scenario, and relatively early so
that failures (which happen quite often) are easier to spot in the log.

----

Spotted in PR #16204 , which also has a commit to actually fix the current pycodestyle errors. Until that lands, this PR should fail.

Also fix the timeout in the workflow.