### PR TITLE
packagekit: don't make the progress bar jump

### DIFF
--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -137,6 +137,11 @@ div.changelog {
     margin: 10ex auto 0;
 }
 
+/* workaround font not supporting tabular numbers yet https://github.com/cockpit-project/cockpit/issues/15090 */
+.pf-c-progress__status {
+    min-width: 3ch;
+}
+
 /* don't let the install progress bar get too wide */
 .progress-cancel {
     display: flex;


### PR DESCRIPTION
The Red Hat font numbers are not all the same size which makes the
progress bar "jump" when the progress changes. As a workaround, the
label now reserves enough space so the progress bar now doesn't jump
around.