### PR TITLE
test: fedora-testing does not have kpatch

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -38,7 +38,7 @@ done
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "fedora-coreos"]
 OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
-                     "fedora-coreos", "fedora-33", "fedora-34", "centos-8-stream"]
+                     "fedora-coreos", "fedora-33", "fedora-34", "fedora-testing", "centos-8-stream"]
 
 
 class NoSubManCase(PackageCase):


### PR DESCRIPTION
See [failure](https://logs.cockpit-project.org/logs/pull-2281-20210806-023413-e20d8773-fedora-testing-dnf-copr-cockpit-project-cockpit/log.html#93-2) in https://github.com/cockpit-project/bots/pull/2281