### PR TITLE
base1: Fix and simplify cockpit.js loading

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -4617,30 +4617,8 @@ function factory() {
 } /* scope end */
 
 /*
- * Register this script as a module and/or with globals
+ * Register this script as global
  */
 
-var self_module_id;
-
-/* Check how we're being loaded */
-var last = document.scripts[document.scripts.length - 1].src || "";
-var pos = last.indexOf("/cockpit.js");
-if (pos === -1)
-    pos = last.indexOf("/cockpit.min.js");
-if (pos !== -1)
-    pos = last.substring(0, pos).lastIndexOf("/");
-
-/* cockpit.js is being loaded as a <script>  and no other loader around? */
-if (pos !== -1) {
-    self_module_id = last.substring(pos + 1, last.indexOf(".", pos + 1));
-    window.cockpit = factory();
-}
-
-/* Cockpit loaded via AMD loader */
-if (is_function(window.define) && window.define.amd) {
-    if (self_module_id)
-        define(self_module_id, [], window.cockpit); // eslint-disable-line no-undef
-    else
-        define([], factory); // eslint-disable-line no-undef
-}
+window.cockpit = factory();
 })();


### PR DESCRIPTION
Checking `documents.scripts` was buggy: It only ever considered the last
`<script>` (introduced 7 years ago in commit c4935df4bf16).
This breaks browsers like Brave (and presumably others), where
cockpit.js is the second-to-last script (the last one is some unnamed
empty entry).

But all of that complicated checking isn't necessary any more: The last
vestiges of require.js and the AMD loader got dropped three years ago in
commit ff5149ec5e. There days there is one and *only* one way to use
cockpit.js: Through a global `<script>` import. (Our webpack
configuration (and that of starter-kit and all cockpit-* derivates)
declares `cockpit` as an external.)

So drop the unnecessary, broken, and hard to understand/debug code, and
always register cockpit on the global `window` object.

Fixes #12745

----

I tested this with cockpit-{machines,ostree,composer,podman,session-recording}. They all work fine.