### PR TITLE
systemd: Correct typo HostName -> Hostname

### DIFF
--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -493,7 +493,7 @@ function Loader(machines, session_only) {
         if (!machine.color)
             overlay.color = machines.unused_color();
 
-        var label = props.PrettyHostname || props.StaticHostname;
+        var label = props.PrettyHostname || props.StaticHostname || props.Hostname;
         if (label && label !== machine.label)
             overlay.label = label;
 

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -182,7 +182,7 @@ class OverviewPage extends React.Component {
 
         const pretty_hostname = this.state.hostnameData.PrettyHostname;
         const static_hostname = this.state.hostnameData.StaticHostname;
-        let str = this.state.hostnameData.HostName;
+        let str = this.state.hostnameData.Hostname;
 
         if (pretty_hostname && static_hostname && static_hostname != pretty_hostname)
             str = pretty_hostname + " (" + static_hostname + ")";
@@ -250,7 +250,7 @@ class OverviewPage extends React.Component {
                     <PageSection className='ct-overview-header' variant={PageSectionVariants.light}>
                         <div className='ct-overview-header-hostname'>
                             <h1>
-                                {this.hostname_text() || ""}
+                                {this.hostname_text()}
                             </h1>
                             {this.state.hostnameData &&
                              this.state.hostnameData.OperatingSystemPrettyName &&

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -135,6 +135,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
 
     def testBasic(self):
         b = self.browser
+        m1 = self.machines["machine1"]
         m2 = self.machines["machine2"]
         m3 = self.machines["machine3"]
 
@@ -148,6 +149,12 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.wait_host_addresses(b, ["localhost"])
 
         b.wait_not_present("button:contains('Edit hosts')")
+
+        # Test that transient hostname shows up
+        m1.execute("hostnamectl set-hostname ''")
+        m1.execute("hostnamectl set-hostname --transient 'mydhcpname'")
+        b.wait_in_text("#nav-hosts .nav-item a", "mydhcpname")
+        m1.execute("hostnamectl set-hostname 'localhost'")
 
         self.add_machine(b, "10.111.113.2")
         self.wait_host_addresses(b, ["localhost", "10.111.113.2"])

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -193,6 +193,10 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#system_information_hostname_text', "Adventure Box (host1.cockpit.lan)")
         self.assertEqual(m.execute("hostname").strip(), "host1.cockpit.lan")
 
+        m.execute("hostnamectl set-hostname ''")
+        m.execute("hostnamectl set-hostname --transient 'mydhcpname'")
+        b.wait_in_text('#system_information_hostname_text', 'mydhcpname')
+
         b.logout()
         m.execute("chattr -i /etc/os-release && rm /etc/os-release")
         m.execute("rm /usr/lib/os-release || true")


### PR DESCRIPTION
The systemd hostnamed D-Bus API returns Hostname for the configured
system hostname. This issue is only visible when no static hostname is
configured as PrettyHostname and StaticHostname are then empty.

Fixes #9909