### PR TITLE
test: Fix TestServices.testBasic for different VM/browser time zones

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -232,7 +232,7 @@ Unit=test.service
         b.wait_not_in_text("#services-list", ".socket")
         b.wait_visible(self.svc_sel('test.timer'))
         b.wait_text(self.svc_sel('test.timer') + ' .service-unit-triggers', '')
-        today = m.execute("date '+%b %-d, %Y'").strip()
+        today = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format()")
         m.execute("systemctl start test.timer")
         b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-next-trigger', today)  # next run
         b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger


### PR DESCRIPTION
Our RHEL images have EDT timezone, so when TestServices.testBasic was
started after 20:00 EDT, `date` would still print the previous day
(evening), while the browser (which runs in UTC) would already show the
next day morning. So to determine what the browser considers as "today",
make a JavaScript query instead of `date`.

This was a regression from commit 08541cbe5.

---

[example](https://logs.cockpit-project.org/logs/pull-2284-20210807-023327-c580b9a5-rhel-8-5-cockpit-project-cockpit/log.html#259-2) (commonly happen around image refreshes).

Reproducer: `timedatectl set-ntp off; timedatectl set-time '23:00:00'`