### PR TITLE
lib: Some page.scss cleanups

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -84,12 +84,6 @@ a.disabled:hover {
     max-height: 90vh;
 }
 
-/* Allow kebab menus to have a ^ with overflowing */
-/* Note: This means kebab menus cannot be _too_ long */
-.dropdown-kebab-pf > .dropdown-menu {
-    overflow: visible;
-}
-
 .highlight-ct {
     background-color: var(--ct-color-link-hover-bg);
 }

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -101,13 +101,6 @@ a.disabled:hover {
     position: fixed;
 }
 
-.panel .well {
-    margin-bottom: 0px;
-    border: none;
-    border-radius: 0px;
-    background-color: var(--pf-global--palette--black-200);
-}
-
 /* Dialog patterns */
 
 .dialog-wait-ct {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -95,12 +95,6 @@ a.disabled:hover {
     overflow: visible;
 }
 
-/* Align these buttons more nicely */
-.btn.fa-minus,
-.btn.fa-plus {
-    padding-top: 4px;
-}
-
 .highlight-ct {
     background-color: var(--ct-color-link-hover-bg);
 }

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -29,12 +29,6 @@ a {
     cursor: pointer;
 }
 
-p + p {
-    // The mix of PF3 and PF4 removes margin from paragraphs.
-    // We want successive paragraphs to have spaces between each other.
-    margin-top: var(--pf-global--spacer--md);
-}
-
 .disabled {
     pointer-events: auto;
 }
@@ -125,23 +119,6 @@ a.disabled:hover {
     background-color: var(--pf-global--palette--black-200);
 }
 
-.well.blank-slate-pf {
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05) inset;
-    padding-top: 40px;
-}
-
-.blank-slate-pf .spinner-lg {
-    height: 58px;
-    width: 58px;
-}
-
-/* Small list inside a dialog */
-/* Alert fixups */
-
-.modal-content .pf-c-alert {
-    text-align: left;
-    margin-bottom: 24px;
-}
 /* Dialog patterns */
 
 .dialog-wait-ct {
@@ -171,11 +148,6 @@ a.disabled:hover {
 /* HACK: https://github.com/patternfly/patternfly/issues/255 */
 input[type=number]:not(.pf-c-form-control) {
   padding: 0 0 0 5px;
-}
-
-/* Make a dialog visible */
-.dialog-ct-visible {
-    display: block;
 }
 
 :root {
@@ -233,11 +205,6 @@ html:not(.index-page) body {
   .ct-page-fill {
     height: 100% !important;
   }
-}
-
-// When there is an Alert above the Form add some spacing
-.pf-c-modal-box .pf-c-alert + .pf-c-form {
-    padding-top: var(--pf-global--FontSize--sm);
 }
 
 .ct-icon-exclamation-triangle {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -46,14 +46,9 @@ a {
   z-index: auto;
 }
 
-.btn-group, .btn-group-vertical {
+.btn-group {
     /* Fix button groups from wrapping in narrow widths */
     display: inline-flex;
-}
-
-.btn-group-vertical {
-    /* Vertical btn-groups should be vertical */
-    flex-direction: column;
 }
 
 a.disabled {

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -145,11 +145,6 @@ a.disabled:hover {
     margin-bottom: 0px;
 }
 
-/* HACK: https://github.com/patternfly/patternfly/issues/255 */
-input[type=number]:not(.pf-c-form-control) {
-  padding: 0 0 0 5px;
-}
-
 :root {
     /* Cockpit custom colors */
     --ct-color-light-red: #f8cccc;

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -142,3 +142,8 @@ svg {
         }
     }
 }
+
+// When there is an Alert above the Form add some spacing
+.pf-c-modal-box .pf-c-alert + .pf-c-form {
+    padding-top: var(--pf-global--FontSize--sm);
+}

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -348,12 +348,6 @@ select.form-control {
   }
 }
 
-// Kebab menu buttons should get special treatment
-.dropdown-kebab-pf > button {
-  border: none;
-  padding: 0.5rem 1rem !important;
-}
-
 // Restyle modals
 .modal {
   &-header {

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -627,3 +627,19 @@ input.pf-c-checkbox__input,
 input.pf-c-radio__input {
   margin: unset;
 }
+
+p + p {
+    // The mix of PF3 and PF4 removes margin from paragraphs.
+    // We want successive paragraphs to have spaces between each other.
+    margin-top: var(--pf-global--spacer--md);
+}
+
+.well.blank-slate-pf {
+    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05) inset;
+    padding-top: 40px;
+}
+
+.blank-slate-pf .spinner-lg {
+    height: 58px;
+    width: 58px;
+}

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -628,6 +628,13 @@ input.pf-c-radio__input {
   margin: unset;
 }
 
+// Adjust non-classed number inputs, to fix stepper alignment.
+// (PF4 always uses the pf-c-form-control class on number inputs.)
+// Issue: https://github.com/patternfly/patternfly-3/issues/255
+input[type=number]:not(.pf-c-form-control) {
+  padding: 0 0 0 5px;
+}
+
 p + p {
     // The mix of PF3 and PF4 removes margin from paragraphs.
     // We want successive paragraphs to have spaces between each other.

--- a/pkg/lib/patternfly/patternfly-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-overrides.scss
@@ -634,11 +634,6 @@ p + p {
     margin-top: var(--pf-global--spacer--md);
 }
 
-.well.blank-slate-pf {
-    box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.05) inset;
-    padding-top: 40px;
-}
-
 .blank-slate-pf .spinner-lg {
     height: 58px;
     width: 58px;

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -374,3 +374,9 @@ $desktop: $phone + 1px;
   margin-top: var(--pf-global--spacer--md);
   margin-bottom: var(--pf-global--spacer--md);
 }
+
+/* Alert fixups */
+.modal-content .pf-c-alert {
+    text-align: left;
+    margin-bottom: 24px;
+}

--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -79,17 +79,12 @@ class UnlockDialog extends React.Component {
 
             footer = (
                 <>
-                    <Button variant='primary' onClick={state.apply} isDisabled={state.busy}>
+                    <Button variant='primary' onClick={state.apply} isDisabled={state.busy} isLoading={state.busy}>
                         {_("Authenticate")}
                     </Button>
                     <Button variant='link' className='btn-cancel' onClick={state.cancel} isDisabled={!state.cancel}>
                         {_("Cancel")}
                     </Button>
-                    { state.busy &&
-                        <div className="dialog-wait-ct">
-                            <div className="spinner spinner-sm" />
-                        </div>
-                    }
                 </>);
         } else if (state.message) {
             title = _("Administrative access");


### PR DESCRIPTION
`.blank-slate-pf` is a PF3 (only) class, and the p + p margin hack only
happens on pages with PF3+PF4. Move these two to
patternfly-overrides.scss, so that they get cleaned up together with PF3
removal.

Similarly, the form group and modal box padding are PF4 specific fixes,
move them to patternfly-4-overrides.scss.

`.modal-content` is a PF3-only class which is only being used in the
shell -- move it to shell.scss.

Now page.scss only has `.ct-*` classes and changes which are genuinely
Cockpit specific (such as heading size changes).

Fixes #15425