### PR TITLE
test: Make unexpected PCP error messages more specific

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1185,12 +1185,6 @@ class MachineCase(unittest.TestCase):
         r"#1\) Respect the privacy of others.",
         r"#2\) Think before you type.",
         r"#3\) With great power comes great responsibility.",
-
-        # Something unknown sometimes goes wrong with PCP, see #15625
-        "pcp-archive: instance name lookup failed: .*",
-        "direct: instance name lookup failed: .*",
-        "pcp-archive: couldn't create pcp archive context for.*",
-        "pcp-archive: no such metric: .*"
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -117,6 +117,9 @@ class TestHistoryMetrics(MachineCase):
         super().setUp()
         # start with a clean slate and avoid running into restart limits
         self.machine.execute("systemctl stop pmlogger pmproxy; systemctl reset-failed pmlogger pmproxy 2>/dev/null || true")
+        # failing to load the metrics (stopped pmlogger and cleaned /var/log/pcp) generates this message
+        # from the metrics channel at first try
+        self.allow_journal_messages("pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name")
 
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty
@@ -1076,6 +1079,9 @@ class TestGrafanaClient(MachineCase):
                      systemctl reset-failed pmlogger
                      rm -rf /var/log/pcp/pmlogger
                      hostnamectl set-hostname grafana-client""")
+
+        # starting out with empty PCP logs and pmlogger not running causes this metrics channel message
+        self.allow_journal_messages("pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name")
 
         # start Grafana
         mg.execute("/root/run-grafana")

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -116,6 +116,10 @@ class NetworkCase(MachineCase, NetworkHelpers):
         else:
             self.networkmanager_version = [0]
 
+        # Something unknown sometimes goes wrong with PCP, see #15625
+        self.allow_journal_messages("pcp-archive: no such metric: network.interface.* Unknown metric name",
+                                    "direct: instance name lookup failed: network.* Unknown or illegal instance identifier")
+
     def get_iface(self, m, mac):
         def getit():
             path = m.execute("grep -li '%s' /sys/class/net/*/address" % mac)

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -465,3 +465,6 @@ class StorageCase(MachineCase, StorageHelpers):
             self.mount_root = "/media"
         else:
             self.mount_root = "/run/media"
+
+        # Something unknown sometimes goes wrong with PCP, see #15625
+        self.allow_journal_messages("pcp-archive: no such metric: disk.all.read_bytes: Unknown metric name")


### PR DESCRIPTION
Only two of these messagess still actually appear, drop the other two.

The two "no such metric: kernel.all.cpu.nice: Unknown metric name"
instances in check-metrics happen because these two tests start with
an empty /var/log/pcp and pmlogger.service stopped, so that indeed the
metrics channel will not be able to find any metric (and
`kernel.all.cpu.nice` is just the first one that it tries). So these are
legitimate, ignore these in the specific tests with a comment.

Move the networking/storage ones into the particular test classes and
make them more specific, to avoid introducing more of them.

See #15625