### PR TITLE
systemd: Read hardware info from DeviceTree

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -131,6 +131,24 @@ export function dmi_info(address) {
     return pr;
 }
 
+// decode a binary Uint8Array with a trailing null byte
+function decode_proc_str(s) {
+    return cockpit.utf8_decoder().decode(s.slice(0, -1));
+}
+
+export function devicetree_info() {
+    let model, serial;
+
+    return Promise.all([
+        // these succeed with content === null if files are absent
+        cockpit.file("/proc/device-tree/model", { binary: true }).read()
+                .then(content => { model = content ? decode_proc_str(content) : null }),
+        cockpit.file("/proc/device-tree/serial-number", { binary: true }).read()
+                .then(content => { serial = content ? decode_proc_str(content) : null }),
+    ])
+            .then(() => ({ model, serial }));
+}
+
 /* we expect udev db paragraphs like this:
  *
    P: /devices/virtual/mem/null

--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -39,6 +39,12 @@ const getDMI = info => machine_info.dmi_info()
             return true;
         });
 
+const getDeviceTree = info => machine_info.devicetree_info()
+        .then(fields => {
+            info.system.name = fields.model;
+            return true;
+        });
+
 // Add info.pci [{slot, cls, vendor, model}] list
 function findPCI(udevdb, info) {
     for (const syspath in udevdb) {
@@ -66,8 +72,13 @@ export default function detect() {
 
     tasks.push(getDMI(info)
             .catch(error => {
-                // DMI only works on x86 machines; check devicetree (or what lshw does) on other arches
                 console.warn("Failed to get DMI information:", error.toString());
+                return true;
+            }));
+
+    tasks.push(getDeviceTree(info)
+            .catch(error => {
+                console.debug("Failed to get DeviceTree information:", error.toString());
                 return true;
             }));
 

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -81,20 +81,21 @@ class SystemInfo extends React.Component {
             <Flex id="hwinfo-system-info-list" direction={{ default: 'column', sm: 'row' }}>
                 <FlexItem className="hwinfo-system-info-list-item" flex={{ default: 'flex_1' }}>
                     <DescriptionList className="pf-m-horizontal-on-md">
-                        { info.type && <>
+                        { info.type &&
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("Type") }</DescriptionListTerm>
                                 <DescriptionListDescription>{ info.type }</DescriptionListDescription>
-                            </DescriptionListGroup>
+                            </DescriptionListGroup> }
+                        { info.name &&
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("Name") }</DescriptionListTerm>
                                 <DescriptionListDescription>{ info.name }</DescriptionListDescription>
-                            </DescriptionListGroup>
+                            </DescriptionListGroup> }
+                        { info.version &&
                             <DescriptionListGroup>
                                 <DescriptionListTerm>{ _("Version") }</DescriptionListTerm>
                                 <DescriptionListDescription>{ info.version }</DescriptionListDescription>
-                            </DescriptionListGroup>
-                        </> }
+                            </DescriptionListGroup> }
                     </DescriptionList>
                 </FlexItem>
                 <FlexItem className="hwinfo-system-info-list-item" flex={{ default: 'flex_1' }}>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -70,7 +70,7 @@ export class SystemInfomationCard extends React.Component {
         var self = this;
 
         machine_info.dmi_info()
-                .then(function(fields) {
+                .then(fields => {
                     let vendor = fields.sys_vendor;
                     let name = fields.product_name;
                     if (!vendor || !name) {
@@ -83,10 +83,16 @@ export class SystemInfomationCard extends React.Component {
                         self.setState({ hardwareText: vendor + " " + name });
 
                     self.setState({ assetTagText: fields.product_serial || fields.chassis_serial });
-                }, function(ex) {
-                    // FIXME show proper Alerts
-                    console.debug("couldn't read dmi info: " + ex);
-                    self.setState({ assetTagText: undefined, hardwareText: undefined });
+                })
+                .catch(ex => {
+                    // try DeviceTree
+                    machine_info.devicetree_info()
+                            .then(fields => self.setState({ assetTagText: fields.serial, hardwareText: fields.model }))
+                            .catch(dmiex => {
+                                console.debug("couldn't read dmi info: " + ex);
+                                console.debug("couldn't read DeviceTree info: " + dmiex.toString());
+                                self.setState({ assetTagText: undefined, hardwareText: undefined });
+                            });
                 });
     }
 


### PR DESCRIPTION
If DMI is not available, fall back to reading the model and serial
number from /proc/device-tree/

----

On my RasPi 3  on main, Overview and hwinfo:

![raspi-overview-main](https://user-images.githubusercontent.com/200109/128676226-7772041a-d8b5-4c1a-8eea-9611cbbab9aa.png)

![raspi-hwinfo-main](https://user-images.githubusercontent.com/200109/128676233-44b18fa6-3bac-4512-818a-8d7c17d930e4.png)

On this PR:

![raspi-overview-pr](https://user-images.githubusercontent.com/200109/128676382-0df36db2-b446-449f-ac8b-ab2c2c206c16.png)

![raspi-hwinfo-pr](https://user-images.githubusercontent.com/200109/128676467-7e66562f-a140-4a19-8a02-e068b69233f6.png)

As I [mentioned here](https://github.com/cockpit-project/cockpit/issues/7476#issuecomment-894980354), I tried hard to fake a /proc/device-tree in our tests, but did not find a way to do this. So for now I tested this on my actual RasPi.