### PR TITLE
test: Relax system DMI string test

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -508,7 +508,7 @@ revision\t: 2.3 (pvr 004e 1203)
         # demidecode not available on certain images
         if not m.ostree_image:
             b.wait_in_text('#hwinfo #memory-listing' + heading_selector, "Memory")
-            b.wait_in_text('#hwinfo #memory-listing table', "DIMM 0")
+            b.wait_in_text('#hwinfo #memory-listing table', "DIMM")
             b.wait_in_text('#hwinfo #memory-listing table', "RAM")
 
             # Test more specific memory data with a fake dmidecode


### PR DESCRIPTION
In some cases, the VM's DMI reports the memory chip as "DIMM0" instead
of "DIMM 0". Let's not make too many assumptions about this, that's
outside of our control. Relax the string to just check for "DIMM".

[example](https://logs.cockpit-project.org/logs/pull-16217-20210809-081100-faea4110-rhel-9-0/log.html#218-2)