### PR TITLE
bridge: Fix PCP archives on 32 bit architectures

### DIFF
--- a/src/bridge/cockpitpcpmetrics.c
+++ b/src/bridge/cockpitpcpmetrics.c
@@ -121,7 +121,7 @@ result_meta_equal (CockpitPcpMetrics *self,
 static gint64
 timestamp_from_timeval (struct timeval *tv)
 {
-  return tv->tv_sec * 1000 + tv->tv_usec / 1000;
+  return (gint64) tv->tv_sec * 1000 + tv->tv_usec / 1000;
 }
 
 static JsonObject *
@@ -695,7 +695,7 @@ add_archive (CockpitPcpMetrics *self,
       return;
     }
 
-  info->start = label.ll_start.tv_sec * 1000 + label.ll_start.tv_usec / 1000;
+  info->start = (gint64) label.ll_start.tv_sec * 1000 + label.ll_start.tv_usec / 1000;
   self->archives = g_list_prepend (self->archives, info);
   return;
 }
@@ -963,7 +963,7 @@ cockpit_pcp_metrics_prepare (CockpitChannel *channel)
     {
       struct timeval now;
       gettimeofday (&now, NULL);
-      timestamp = (now.tv_sec * 1000 + now.tv_usec / 1000) + timestamp;
+      timestamp = ((gint64) now.tv_sec * 1000 + now.tv_usec / 1000) + timestamp;
     }
 
   /* "limit" option */


### PR DESCRIPTION
`label.ll_start.tv_sec` is a 32 bit type on armhf and other platforms.
Multiplying with 1000 causes an integer overflow, which completely
messes up the time stamp. Fix this by casting to a 64 bit type first.

Fixes #16083

------

I validated the bug and fix on my RasPi 3. The fix is good, but I'd like to create a unit test for this.

 - [x] Add unit test