### PR TITLE
networkmanager: Align add button next to adresses selection

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -93,7 +93,7 @@
     }
 
     tr td .pf-m-secondary {
-        margin-right: 4px;
+        margin-right: 0px;
     }
 }
 
@@ -453,6 +453,10 @@ th {
 #add-zone-services-readonly legend {
     padding: 0;
     line-height: 1;
+}
+
+.network-ip-settings-row .pull-right {
+    display: flex;
 }
 
 // Animation for Firewall's add service dialog,


### PR DESCRIPTION
Use display flex to allow space for the "add button", so it appears on
the same line as the select element. To keep the minus buttons button
aligned with the other buttons the margin-right has to be explictly
removed.

Fixes: #16219