### PR TITLE
selinux:  Allow cockpit_ws_t get attributes of fs_t filesystems

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -85,6 +85,7 @@ auth_use_nsswitch(cockpit_ws_t)
 
 corecmd_exec_bin(cockpit_ws_t)
 
+fs_getattr_xattr_fs(cockpit_ws_t)
 fs_read_efivarfs_files(cockpit_ws_t)
 
 init_read_state(cockpit_ws_t)


### PR DESCRIPTION
This permission is required by a cockpit.socket ExecStartPost script
which executes
"systemctl show --property Listen cockpit.socket"
in the cockpit-ws caller domain.

Resolves: rhbz#197918
Picked from https://github.com/fedora-selinux/selinux-policy/commit/95b6d266399