### PR TITLE
test: Re-ignore variant of PCP error message

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -118,7 +118,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
 
         # Something unknown sometimes goes wrong with PCP, see #15625
         self.allow_journal_messages("pcp-archive: no such metric: network.interface.* Unknown metric name",
-                                    "direct: instance name lookup failed: network.* Unknown or illegal instance identifier")
+                                    "direct: instance name lookup failed: network.*")
 
     def get_iface(self, m, mac):
         def getit():

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -467,4 +467,4 @@ class StorageCase(MachineCase, StorageHelpers):
             self.mount_root = "/run/media"
 
         # Something unknown sometimes goes wrong with PCP, see #15625
-        self.allow_journal_messages("pcp-archive: no such metric: disk.all.read_bytes: Unknown metric name")
+        self.allow_journal_messages("pcp-archive: no such metric: disk.*")


### PR DESCRIPTION
Commit 8bd081d8c1712c made the error message more specific, but it turns
out that a variant sometimes happens as well:

    pcp-archive: instance name lookup failed: network.interface.in.bytes.5: Instance identifier not defined in the PCP archive log

So change the pattern back to what we had before that commit.

----

[example](https://logs.cockpit-project.org/logs/pull-16224-20210810-144638-675c82b8-fedora-33/log.html#65-2)