### PR TITLE
test: fix an allowed journal message regexp

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -791,7 +791,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.allow_journal_messages("Refusing to render service to dead parents.")
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages(".*Peer failed to perform TLS handshake.*")
-        self.allow_journal_messages(r"cannot reauthorize identity\(s\): unix-user:.*")
+        self.allow_journal_messages(r".*cannot reauthorize identity\(s\): unix-user:.*")
 
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):


### PR DESCRIPTION
We have a regexp to allow the journal message:

self.allow_journal_messages(r"cannot reauthorize identity\(s\): unix-user:.*")

which is occasionally thrown by cockpitpolkitagent.  Sometimes this
message ends up coming over ssh, though, and then it hits the journal
looking like this:

Aug 16 05:26:22 rhel-8-5-127-0-0-2-2201 cockpit/ssh[2210]: cockpit-bridge-Message: 05:26:22.822: cannot reauthorize identity(s): unix-user:admin

(ie: a journal message from 'cockpit/ssh' containing a glib-formatted
message string, as was written by cockpit-bridge to ssh's stderr).

We can fix that by adding a `.*` to the start of the message pattern.

The reason that we weren't seeing this failure more often is that it's
extremely rare: I had to run the test 30 times in a loop to get the
failure, and I think even that was a lucky break.

In order to properly test this change, I modified cockpit-bridge to
always print the message and verified that the test reliably failed to
match it.  Then I modified the pattern and verified that it reliably
succeeded.