### PR TITLE
test: change match string in selinux modifications table

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -95,7 +95,7 @@ class TestSelinux(MachineCase):
         self.machine.execute(script=FIX_AUDITD)
 
         # wait for Modifications table to initialize
-        b.wait_in_text(".modifications-table", "Allow zebra to write config")
+        b.wait_in_text(".modifications-table", "Allow zebra")
 
         # httpd_read_user_content should be off by default
         self.assertIn("-> off", m.execute("getsebool httpd_read_user_content"))


### PR DESCRIPTION
The message about "Allow zebra..." is changing in some distros and seems
likely to change again.  Instead of trying to build a regexp around
that, let's just match on a different item from the table.