### PR TITLE
test: allow for existing /var/cache/krb5rcache

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -461,7 +461,7 @@ ExecStart=/bin/true
             """ % (self.admin_password, self.admin_user), timeout=300)
 
         # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
-        self.machine.execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
+        self.machine.execute("mkdir -pZ /var/cache/krb5rcache")
 
         # HACK: Figure out why this happens
         self.allow_journal_messages('''.*didn't receive expected "authorize" message''',

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -38,8 +38,8 @@ class TestS4USsh(MachineCase):
         super().setUp()
         self.machines['services'].execute("/root/run-freeipa")
         # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
-        self.machines['0'].execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
-        self.machines['1'].execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
+        self.machines['0'].execute("mkdir -pZ /var/cache/krb5rcache")
+        self.machines['1'].execute("mkdir -pZ /var/cache/krb5rcache")
 
     def testBasic(self):
         client_machine = self.machine


### PR DESCRIPTION
[ regression introduced in #16168 ]

It's true that we clean up /var/cache on creating images, but sometimes
we install packages onto the system after image creation (for the copr
variant, for example) and that can recreate the directory.

Use `mkdir -p` to avoid the error.

Also: use `mkdir -Z` instead of running `restorecon` separately.


That should help us with some of these failures: https://logs.cockpit-project.org/logs/pull-2313-20210817-130647-dde6097b-fedora-testing-dnf-copr-cockpit-project-cockpit/log.html#250-2

```
# testClientCertAuthentication (__main__.TestIPA)
Error: unknown connection 'eth1'.
Error: cannot delete unknown connection(s): 'eth1'.
time="2021-08-17T13:35:52Z" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
mkdir: cannot create directory '/var/cache/krb5rcache': File exists
Traceback (most recent call last):
  File "/work/bots/make-checkout-workdir/test/verify/check-system-realms", line 464, in setUp
    self.machine.execute("mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache")
  File "/work/bots/make-checkout-workdir/bots/machine/machine_core/ssh_connection.py", line 359, in execute
    raise subprocess.CalledProcessError(proc.returncode, command, output=output)
subprocess.CalledProcessError: Command 'mkdir /var/cache/krb5rcache && restorecon /var/cache/krb5rcache' returned non-zero exit status 1.

# Result testClientCertAuthentication (__main__.TestIPA) failed
# 1 TEST FAILED [79s on 3-cockpit-8]
not ok 250 test/verify/check-system-realms TestIPA.testClientCertAuthentication
```