### PR TITLE
systemd: Don't show the current year for logins

### DIFF
--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -29,6 +29,8 @@ export const dateShort = t => formatter().format(t);
 export const dateTime = t => formatter({ dateStyle: "medium", timeStyle: "short" }).format(t);
 // Jun 30, 2021, 7:41:23 AM
 export const dateTimeSeconds = t => formatter({ dateStyle: "medium", timeStyle: "medium" }).format(t);
+// Jun 30, 7:41 AM
+export const dateTimeNoYear = t => formatter({ month: 'short', day: '2-digit', hour: '2-digit', minute: '2-digit' }).format(t);
 // Wednesday, June 30, 2021
 export const weekdayDate = t => formatter({ dateStyle: "full" }).format(t);
 

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -104,10 +104,19 @@ class LoginMessages extends React.Component {
             return message;
         }
 
+        function getFormattedDateTime(time) {
+            const now = new Date();
+            const date = new Date(time);
+            if (date.getFullYear() == now.getFullYear()) {
+                return timeformat.dateTimeNoYear(date);
+            }
+            return timeformat.dateTime(date);
+        }
+
         let last_login_message;
         if (messages['last-login-time']) {
             // time is a Unix time stamp, convert to ms since epoch
-            const datetime = timeformat.dateTime(messages['last-login-time'] * 1000);
+            const datetime = getFormattedDateTime(messages['last-login-time'] * 1000);
             const host = messages['last-login-host'];
             const line = messages['last-login-line'];
             last_login_message = generate_line(host, line, datetime);
@@ -115,7 +124,7 @@ class LoginMessages extends React.Component {
 
         let last_fail_message;
         if (messages['last-fail-time']) {
-            const datetime = timeformat.dateTime(messages['last-fail-time'] * 1000);
+            const datetime = getFormattedDateTime(messages['last-fail-time'] * 1000);
             const host = messages['last-fail-host'];
             const line = messages['last-fail-line'];
             last_fail_message = generate_line(host, line, datetime);


### PR DESCRIPTION
As part of #13882 improvements, when the succesful/failed login date is
in the same year as the current year drop the year in the date time
output. Intl.DateTimeFormat has no standard preset without a year in it.