### PR TITLE
Move last login to system `Health` card

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -23,6 +23,7 @@ import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import cockpit from "cockpit";
 import { PageStatusNotifications } from "../page-status.jsx";
 import { InsightsStatus } from "./insights.jsx";
+import LastLogin from "./lastLogin.jsx";
 
 import "./healthCard.scss";
 
@@ -37,6 +38,7 @@ export class HealthCard extends React.Component {
                     <ul className="system-health-events">
                         <PageStatusNotifications />
                         <InsightsStatus />
+                        <LastLogin />
                     </ul>
                 </CardBody>
                 <CardFooter />

--- a/pkg/systemd/overview-cards/lastLogin.jsx
+++ b/pkg/systemd/overview-cards/lastLogin.jsx
@@ -1,0 +1,134 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState, useEffect } from 'react';
+import { Flex, FlexItem } from '@patternfly/react-core';
+import { ExclamationTriangleIcon, UserIcon } from "@patternfly/react-icons";
+
+import * as timeformat from "timeformat";
+
+import cockpit from "cockpit";
+
+import './lastLogin.scss';
+
+const _ = cockpit.gettext;
+
+// Do the full combinatorial thing to improve translatability
+const generate_line = (host, line) => {
+    let message = "";
+    if (host && line) {
+        message = cockpit.format(_("from <host> on <terminal>", "from $0 on $1"), host, line);
+    } else if (host) {
+        message = cockpit.format(_("from <host>", "from $0"), host);
+    } else if (line) {
+        message = cockpit.format(_("on <terminal>", "on $0"), line);
+    }
+    return message;
+};
+
+const getFormattedDateTime = (time) => {
+    const now = new Date();
+    const date = new Date(time);
+    if (date.getFullYear() == now.getFullYear()) {
+        return timeformat.dateTimeNoYear(date);
+    }
+    return timeformat.dateTime(date);
+};
+
+const LastLogin = () => {
+    const [messages, setLoginMessages] = useState(null);
+
+    useEffect(() => {
+        if (messages === null) {
+            const bridge = cockpit.dbus(null, { bus: "internal" });
+            bridge.call("/LoginMessages", "cockpit.LoginMessages", "Get", [])
+                    .then(reply => {
+                        const obj = JSON.parse(reply[0]);
+                        if (obj.version == 1) {
+                            setLoginMessages(obj);
+                        } else {
+                        // empty reply is okay -- older bridges just don't send that information
+                            if (obj.version !== undefined)
+                                console.error("unknown login-messages:", reply[0]);
+                        }
+                    })
+                    .catch(error => {
+                        console.error("failed to fetch login messages:", error);
+                    });
+        }
+    }, [messages]);
+
+    if (messages === null || !messages['last-login-time']) {
+        return null;
+    }
+
+    let icon = null;
+    let headerText = null;
+    let underlineText = null;
+    let headerClass = "pf-u-text-break-word";
+    let underlineClass = "pf-u-text-break-word";
+    const lastLoginText = _("Last successful login:") + " " + getFormattedDateTime(messages['last-login-time'] * 1000);
+    const failedLogins = messages['fail-count'];
+
+    if (failedLogins) {
+        let iconClass = "system-information-failed-login-warning-icon";
+        if (failedLogins > 5) {
+            iconClass = "system-information-failed-login-danger-icon";
+            headerClass += " system-information-failed-login-danger";
+        } else {
+            headerClass += " system-information-failed-login-warning";
+        }
+
+        icon = <ExclamationTriangleIcon className={iconClass} size="sm" />;
+        headerText = cockpit.format(cockpit.ngettext("$0 failed login attempt", "$0 failed login attempts", failedLogins), failedLogins);
+        underlineText = getFormattedDateTime(messages['last-login-time'] * 1000) + " " + generate_line(messages['last-login-host'], messages['last-login-line']);
+    } else {
+        icon = <UserIcon className="system-information-last-login-icon" size="sm" />;
+        headerText = lastLoginText;
+        underlineClass += " ct-grey-text pf-u-font-size-sm";
+        underlineText = generate_line(messages['last-login-host'], messages['last-login-line']);
+    }
+
+    return (
+        <li className="last-login" id="page_status_last_login">
+            <Flex flexWrap={{ default: 'nowrap' }}>
+                <FlexItem spacer={{ default: 'spacerSm' }} className="last-login-icon">{icon}</FlexItem>
+                <Flex direction={{ default: 'column' }}>
+                    <FlexItem id="system_last_login"
+                            className={headerClass}
+                            spacer={{ default: 'spacerNone' }}
+                    >
+                        {headerText}
+                    </FlexItem>
+                    <FlexItem id="system_last_login_from"
+                              className={underlineClass}
+                    >
+                        {underlineText}
+                    </FlexItem>
+                    {failedLogins &&
+                    <FlexItem id="system_last_login_success" className="pf-u-text-break-word">
+                        {lastLoginText}
+                    </FlexItem>
+                    }
+                </Flex>
+            </Flex>
+        </li>
+    );
+};
+
+export default LastLogin;

--- a/pkg/systemd/overview-cards/lastLogin.scss
+++ b/pkg/systemd/overview-cards/lastLogin.scss
@@ -1,0 +1,32 @@
+@import "_global-variables.scss";
+@import '@patternfly/patternfly/utilities/Text/text.scss';
+
+.system-information-failed-login-warning-icon {
+	color: var(--pf-global--warning-color--100);
+}
+
+.system-information-failed-login-warning {
+	color: var(--pf-global--warning-color--200);
+	font-weight: bold;
+}
+
+.system-information-failed-login-danger-icon {
+	color: var(--pf-global--danger-color--100);
+}
+
+.system-information-failed-login-danger {
+	color: var(--pf-global--danger-color--200);
+	font-weight: bold;
+}
+
+.system-information-last-login-icon {
+	color: var(--pf-global--Color--200);
+}
+
+.ct-grey-text {
+   color: var(--pf-global--Color--200);
+}
+
+.last-login-icon {
+	flex-basis: 1.25rem;
+}

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -94,7 +94,7 @@
   --card-width: 22rem;
   --pf-l-gallery--GridTemplateColumns: repeat(auto-fill, minmax(var(--card-width), 1fr));
 
-  .motd-box, .login-messages {
+  .motd-box {
     grid-column: 1 / -1;
   }
 
@@ -320,16 +320,6 @@
 #motd-box > .pf-c-alert {
   /* Spacing between the MOTD is handled by the .pf-l-gallery grid */
   margin-bottom: 0;
-}
-
-.pf-c-alert.login-messages h4 {
-    font-weight: normal;
-    color: black;
-    font-family: inherit;
-}
-
-.pf-c-alert.login-messages .pf-c-alert__description {
-    padding-bottom: 0px;
 }
 
 .pf-c-alert .pf-c-alert__description a {

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -189,22 +189,17 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         def assert_messages(has_last, n_fail):
             if has_last:
-                b.wait_visible('#login-messages')
-                b.wait_visible('#last-login')
-                b.wait_in_text('#last-login', "Last login")
-                b.wait_in_text('#last-login', "from")  # only present if IP was logged
+                b.wait_visible('#system_last_login')
+                b.wait_in_text('#system_last_login', "Last successful login")
+                b.wait_in_text('#system_last_login_from', "from")  # only present if IP was logged
 
-                if n_fail:
-                    b.wait_visible('#last-failed-login')
-                    b.wait_in_text('#last-failed-login', "from")
-                    b.wait_in_text('#login-messages', 'There were {} failed'.format(n_fail))
-                else:
-                    self.assertFalse(b.is_present('#last-failed-login'))
-                    b.wait_not_in_text('#login-messages', 'failed')
-
+            if n_fail:
+                b.wait_visible('#system_last_login')
+                b.wait_in_text('#system_last_login', '{} failed login'.format(n_fail))
+                b.wait_in_text('#system_last_login_from', "from")
+                b.wait_in_text('#system_last_login_success', "Last successful login")
             else:
-                self.assertEqual(n_fail, 0)
-                b.wait_not_present('#login-messages')
+                self.assertFalse(b.is_present('#system_last_login_success'))
 
         def verify_correct(has_last, n_fail):
             b.login_and_go('/system')
@@ -214,16 +209,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.reload()
             b.enter_page('/system')
             assert_messages(has_last, n_fail)
-
-            if has_last:
-                # dismiss and make sure it's gone
-                b.click('#login-messages button')
-                assert_messages(False, 0)
-
-                # reload and make sure it's still gone
-                b.reload()
-                b.enter_page('/system')
-                assert_messages(False, 0)
 
             b.logout()
 
@@ -247,7 +232,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.wait_text_not("#login-error-message", "")
 
         # We should see those bogus attempts now
-        verify_correct(True, 3)
+        verify_correct(False, 3)
 
         # But after that login, they should be gone again
         verify_correct(True, 0)
@@ -463,8 +448,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # not an admin
         b.wait_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
-        b.wait_in_text('#last-login', "Last login:")
-        b.wait_in_text('#last-login', "web console")
+        b.wait_in_text('#system_last_login', "Last successful login")
+        b.wait_in_text('#system_last_login_from', "web console")
 
         b.logout()
         # not allowed to restricted users
@@ -479,8 +464,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # passing login info memfd should work
         b.logout()
         b.login_and_go("/system")
-        b.wait_in_text('#last-login', "Last login:")
-        b.wait_in_text('#last-login', "web console")
+        b.wait_in_text('#system_last_login', "Last successful login")
+        b.wait_in_text('#system_last_login_from', "web console")
 
         b.go("/playground/test")
         b.enter_page("/playground/test")


### PR DESCRIPTION
Always show the last login information under system information and only
show failed logins as a notification.

Closes: #13882

---

## Overview: move last login to Health Card

Previously, last successful or failed logins were shown in a dismissable alert, which took a lot of space. That login information was moved to the Health card.

![image](https://user-images.githubusercontent.com/67428/133969313-59e5541e-ce37-4871-845e-234bed6d93d1.png)

A failed login:

![image](https://user-images.githubusercontent.com/67428/133970408-0ee21921-cb87-407e-a950-901ed069e305.png)

