### PR TITLE
test: Re-generalize missing kernel.all.cpu.nice metrics message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1196,6 +1196,9 @@ class MachineCase(unittest.TestCase):
         r"#1\) Respect the privacy of others.",
         r"#2\) Think before you type.",
         r"#3\) With great power comes great responsibility.",
+
+        # starting out with empty PCP logs and pmlogger not running causes this metrics channel message
+        "pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name",
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -117,9 +117,6 @@ class TestHistoryMetrics(MachineCase):
         super().setUp()
         # start with a clean slate and avoid running into restart limits
         self.machine.execute("systemctl stop pmlogger pmproxy; systemctl reset-failed pmlogger pmproxy 2>/dev/null || true")
-        # failing to load the metrics (stopped pmlogger and cleaned /var/log/pcp) generates this message
-        # from the metrics channel at first try
-        self.allow_journal_messages("pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name")
 
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty
@@ -689,9 +686,6 @@ class TestCurrentMetrics(MachineCase):
         super().setUp()
         # packagekit/dnf often eats a lot of CPU; silence it to have better control over CPU usage
         self.machine.execute("systemctl mask packagekit && killall -9 /usr/libexec/packagekitd && killall -9 dnf || true")
-        # failing to load the metrics (stopped pmlogger and cleaned /var/log/pcp) generates this message
-        # from the metrics channel at first try
-        self.allow_journal_messages("pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name")
 
         self.addCleanup(self.machine.execute, "systemctl unmask packagekit")
         # make sure to clean up our test resource consumers on failures
@@ -1083,9 +1077,6 @@ class TestGrafanaClient(MachineCase):
                      systemctl reset-failed pmlogger
                      rm -rf /var/log/pcp/pmlogger
                      hostnamectl set-hostname grafana-client""")
-
-        # starting out with empty PCP logs and pmlogger not running causes this metrics channel message
-        self.allow_journal_messages("pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name")
 
         # start Grafana
         mg.execute("/root/run-grafana")


### PR DESCRIPTION
This particular message can hit other tests, as pretty much all of them
start on the Overview page, which displays the CPU/memory metrics.

So go back to ignoring this particular message globally. We had that
until commit 8bd081d8c1, but with a much wider pattern.

---

[seen here](https://logs.cockpit-project.org/logs/pull-2339-20210826-022419-7ecbd8ec-ubuntu-2004-cockpit-project-cockpit/log.html#110)