### PR TITLE
Check g_setenv() failure

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -201,7 +201,7 @@ start_dbus_daemon (void)
 
   if (address)
     {
-      g_setenv ("DBUS_SESSION_BUS_ADDRESS", address, TRUE);
+      cockpit_setenv_check ("DBUS_SESSION_BUS_ADDRESS", address, TRUE);
       g_debug ("session bus address: %s", address);
     }
   else
@@ -296,7 +296,7 @@ start_ssh_agent (void)
     }
 
   g_debug ("launched %s", agent_argv[0]);
-  g_setenv ("SSH_AUTH_SOCK", bind_address, TRUE);
+  cockpit_setenv_check ("SSH_AUTH_SOCK", bind_address, TRUE);
 
 out:
   g_clear_error (&error);
@@ -420,13 +420,13 @@ run_bridge (const gchar *interactive,
     }
   else
     {
-      g_setenv ("USER", pwd->pw_name, TRUE);
-      g_setenv ("HOME", pwd->pw_dir, TRUE);
-      g_setenv ("SHELL", pwd->pw_shell, TRUE);
+      cockpit_setenv_check ("USER", pwd->pw_name, TRUE);
+      cockpit_setenv_check ("HOME", pwd->pw_dir, TRUE);
+      cockpit_setenv_check ("SHELL", pwd->pw_shell, TRUE);
     }
 
   /* Set a path if nothing is set */
-  g_setenv ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", 0);
+  cockpit_setenv_check ("PATH", "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", FALSE);
 
   /*
    * The bridge always runs from within $XDG_RUNTIME_DIR
@@ -679,10 +679,10 @@ main (int argc,
    * to do this very early.
    */
   if (!g_getenv ("XDG_DATA_DIRS") && !g_str_equal (DATADIR, "/usr/share"))
-    g_setenv ("XDG_DATA_DIRS", DATADIR, TRUE);
+    cockpit_setenv_check ("XDG_DATA_DIRS", DATADIR, TRUE);
 
-  g_setenv ("LANG", "C.UTF-8", FALSE);
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("LANG", "C.UTF-8", FALSE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
 
   context = g_option_context_new (NULL);
   g_option_context_add_main_entries (context, entries, NULL);

--- a/src/bridge/cockpitpcp.c
+++ b/src/bridge/cockpitpcp.c
@@ -27,6 +27,7 @@
 #include "common/cockpithacks-glib.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitpipetransport.h"
+#include "common/cockpitsystem.h"
 
 #include <errno.h>
 #include <stdio.h>
@@ -101,9 +102,9 @@ main (int argc,
 
   signal (SIGPIPE, SIG_IGN);
 
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   context = g_option_context_new (NULL);
   g_option_context_add_main_entries (context, entries, NULL);

--- a/src/bridge/mock-bridge.c
+++ b/src/bridge/mock-bridge.c
@@ -23,6 +23,7 @@
 #include "common/cockpithacks-glib.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitpipetransport.h"
+#include "common/cockpitsystem.h"
 
 #include <glib-unix.h>
 
@@ -302,9 +303,9 @@ main (int argc,
 
   signal (SIGPIPE, SIG_IGN);
 
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   context = g_option_context_new (NULL);
   g_option_context_add_main_entries (context, entries, NULL);

--- a/src/bridge/test-bridge.c
+++ b/src/bridge/test-bridge.c
@@ -22,6 +22,7 @@
 #include "common/cockpitjson.h"
 #include "common/cockpitpipe.h"
 #include "common/cockpitpipetransport.h"
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 
 #include <string.h>
@@ -293,8 +294,8 @@ int
 main (int argc,
       char *argv[])
 {
-  g_assert_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
-  g_assert_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
+  cockpit_setenv_check ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  cockpit_setenv_check ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
 
   cockpit_test_init (&argc, &argv);
 

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -26,6 +26,7 @@
 
 #include "common/cockpitchannel.h"
 #include "common/cockpitjson.h"
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 #include "common/mock-transport.h"
 
@@ -1202,8 +1203,8 @@ int
 main (int argc,
       char *argv[])
 {
-  g_assert_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
-  g_assert_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
+  cockpit_setenv_check ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  cockpit_setenv_check ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
 
   cockpit_bridge_local_address = "127.0.0.1";
 

--- a/src/common/cockpitlocale.c
+++ b/src/common/cockpitlocale.c
@@ -18,6 +18,7 @@
  */
 
 #include "cockpitlocale.h"
+#include "common/cockpitsystem.h"
 
 #include <locale.h>
 #include <string.h>
@@ -99,7 +100,7 @@ cockpit_locale_set_language (const gchar *value)
   else
     {
       g_debug ("set bridge locale to: %s", locale);
-      g_setenv ("LANG", locale, TRUE);
+      cockpit_setenv_check ("LANG", locale, TRUE);
     }
 
   strncpy (previous, value, sizeof (previous) - 1);

--- a/src/common/cockpitsystem.c
+++ b/src/common/cockpitsystem.c
@@ -198,3 +198,12 @@ cockpit_system_session_id (void)
       return NULL;
     }
 }
+
+void
+cockpit_setenv_check (const char *variable,
+                      const char *value,
+                      gboolean overwrite)
+{
+  if (!g_setenv (variable, value, overwrite))
+    g_error("could not set $%s to %s", variable, value);
+}

--- a/src/common/cockpitsystem.h
+++ b/src/common/cockpitsystem.h
@@ -33,6 +33,10 @@ guint64              cockpit_system_process_start_time         (void);
 
 char *               cockpit_system_session_id                 (void);
 
+void                 cockpit_setenv_check                     (const char *variable,
+                                                               const char *value,
+                                                               gboolean overwrite);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_SYSTEM_H__ */

--- a/src/common/cockpittest.c
+++ b/src/common/cockpittest.c
@@ -24,6 +24,7 @@
 #include "cockpitjson.h"
 
 #include "cockpitconf.h"
+#include "common/cockpitsystem.h"
 
 #include <glib-object.h>
 
@@ -213,12 +214,12 @@ cockpit_test_init (int *argc,
 
   signal (SIGPIPE, SIG_IGN);
 
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
 
   g_assert (g_snprintf (path, sizeof (path), "%s:%s", BUILDDIR, g_getenv ("PATH")) < sizeof (path));
-  g_setenv ("PATH", path, TRUE);
+  cockpit_setenv_check ("PATH", path, TRUE);
 
   /* For our process (children are handled through $G_DEBUG) */
   g_log_set_always_fatal (G_LOG_LEVEL_ERROR | G_LOG_LEVEL_CRITICAL | G_LOG_LEVEL_WARNING);
@@ -739,7 +740,7 @@ cockpit_test_allow_warnings (void)
   /* make some noise if this gets called twice */
   g_return_if_fail (orig_g_debug == NULL);
   orig_g_debug = g_getenv ("G_DEBUG");
-  g_setenv ("G_DEBUG", "fatal-criticals", TRUE);
+  cockpit_setenv_check ("G_DEBUG", "fatal-criticals", TRUE);
 }
 
 void
@@ -747,7 +748,7 @@ cockpit_test_reset_warnings (void)
 {
   if (orig_g_debug != NULL)
     {
-      g_setenv ("G_DEBUG", orig_g_debug, TRUE);
+      cockpit_setenv_check ("G_DEBUG", orig_g_debug, TRUE);
       orig_g_debug = NULL;
     }
 }
@@ -808,12 +809,4 @@ cockpit_assertion_message_error_matches (const char     *domain,
     g_string_append_printf (gstring, "%s is NULL", expr);
 
   g_assertion_message (domain, file, line, func, gstring->str);
-}
-
-void
-g_assert_setenv (const gchar *variable,
-                 const gchar *value,
-                 gboolean overwrite) {
-    gboolean result = g_setenv (variable, value, overwrite);
-    g_assert (result);
 }

--- a/src/common/cockpittest.h
+++ b/src/common/cockpittest.h
@@ -145,10 +145,6 @@ void             cockpit_assertion_message_error_matches (const char     *domain
                                              #err, err, dom, c, message_pattern); \
   } G_STMT_END
 
-void        g_assert_setenv                            (const gchar *variable,
-                                                        const gchar *value,
-                                                        gboolean overwrite);
-
 G_END_DECLS
 
 #endif /* __COCKPIT_TEST_H__ */

--- a/src/common/test-config.c
+++ b/src/common/test-config.c
@@ -21,6 +21,7 @@
 
 #include "cockpitconf.h"
 
+#include "cockpitsystem.h"
 #include "cockpittest.h"
 
 #include <glib.h>
@@ -133,7 +134,7 @@ test_get_strvs (void)
 static void
 test_load_dir (void)
 {
-  g_assert_setenv("XDG_CONFIG_DIRS", "/does-not-exist:" SRCDIR "/src/ws/mock-config", 1);
+  cockpit_setenv_check("XDG_CONFIG_DIRS", "/does-not-exist:" SRCDIR "/src/ws/mock-config", TRUE);
   cockpit_config_file = "cockpit.conf";
 
   g_assert_cmpstr (cockpit_conf_string ("Section2", "value1"), ==, "string");

--- a/src/common/test-pipe.c
+++ b/src/common/test-pipe.c
@@ -21,6 +21,7 @@
 
 #include "cockpitpipe.h"
 
+#include "cockpitsystem.h"
 #include "cockpittest.h"
 #include "mock-pressure.h"
 
@@ -1234,8 +1235,8 @@ test_get_environ (void)
   const gchar *input[] = { "ENVIRON=Marmalaaade", "ANOTHER=zerog", NULL };
   gchar **environ;
 
-  g_assert_setenv ("BLAH", "exists", TRUE);
-  g_assert_setenv ("ANOTHER", "original", TRUE);
+  cockpit_setenv_check ("BLAH", "exists", TRUE);
+  cockpit_setenv_check ("ANOTHER", "original", TRUE);
 
   environ = cockpit_pipe_get_environ (input, "/directory");
 
@@ -1266,8 +1267,8 @@ test_get_environ_null (void)
 {
   gchar **environ;
 
-  g_assert_setenv ("BLAH", "exists", TRUE);
-  g_assert_setenv ("ANOTHER", "original", TRUE);
+  cockpit_setenv_check ("BLAH", "exists", TRUE);
+  cockpit_setenv_check ("ANOTHER", "original", TRUE);
 
   environ = cockpit_pipe_get_environ (NULL, NULL);
 

--- a/src/common/test-webcertificate.c
+++ b/src/common/test-webcertificate.c
@@ -23,6 +23,7 @@
 
 #include "cockpitwebcertificate.h"
 
+#include "cockpitsystem.h"
 #include "cockpittest.h"
 
 static void
@@ -64,7 +65,7 @@ test_locate (void)
   int cert_dir_fd;
 
   g_assert (g_mkdtemp (workdir) == workdir);
-  g_assert_setenv ("XDG_CONFIG_DIRS", workdir, TRUE);
+  cockpit_setenv_check ("XDG_CONFIG_DIRS", workdir, TRUE);
 
   /* nonexisting dir, nothing found */
   do_locate_test (-1, NULL, NULL, "No certificate found in dir: */ws-certs.d");

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -22,6 +22,7 @@
 #include "cockpitwebserver.h"
 #include "cockpitwebresponse.h"
 
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 
 #include "websocket/websocket.h"
@@ -1054,9 +1055,9 @@ int
 main (int argc,
       char *argv[])
 {
-  g_assert_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_assert_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_assert_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   cockpit_test_init (&argc, &argv);
 

--- a/src/ssh/ssh.c
+++ b/src/ssh/ssh.c
@@ -23,6 +23,7 @@
 
 #include "common/cockpithacks-glib.h"
 #include "common/cockpittest.h"
+#include "common/cockpitsystem.h"
 
 #include "cockpitsshrelay.h"
 
@@ -51,9 +52,9 @@ main (int argc,
   signal (SIGSEGV, cockpit_test_signal_backtrace);
 #endif
 
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   context = g_option_context_new ("- cockpit-ssh [user@]host[:port]");
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -135,12 +135,12 @@ main (int argc,
   CockpitHandlerData data;
 
   signal (SIGPIPE, SIG_IGN);
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   /* Any interaction with a krb5 ccache should be explicit */
-  g_setenv ("KRB5CCNAME", "FILE:/dev/null", TRUE);
+  cockpit_setenv_check ("KRB5CCNAME", "FILE:/dev/null", TRUE);
 
   memset (&data, 0, sizeof (data));
 

--- a/src/ws/remotectl.c
+++ b/src/ws/remotectl.c
@@ -25,6 +25,8 @@
 
 #include <unistd.h>
 
+#include <common/cockpitsystem.h>
+
 typedef struct {
     const char *name;
     int (* callback) (int, char *[]);
@@ -71,9 +73,9 @@ main (int argc,
   g_log_set_handler (G_LOG_DOMAIN, G_LOG_LEVEL_MESSAGE,
                      message_handler, NULL);
 
-  g_setenv ("GSETTINGS_BACKEND", "memory", TRUE);
-  g_setenv ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
-  g_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GSETTINGS_BACKEND", "memory", TRUE);
+  cockpit_setenv_check ("GIO_USE_PROXY_RESOLVER", "dummy", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   g_set_prgname ("remotectl");
 

--- a/src/ws/test-auth.c
+++ b/src/ws/test-auth.c
@@ -25,6 +25,7 @@
 
 #include "common/cockpitconf.h"
 #include "common/cockpiterror.h"
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 
 #include "websocket/websocket.h"
@@ -1192,7 +1193,7 @@ main (int argc,
   cockpit_ws_session_program = BUILDDIR "/mock-auth-command";
   cockpit_ws_service_idle = 1;
 
-  g_assert_setenv ("COCKPIT_WS_PROCESS_IDLE", "2", TRUE);
+  cockpit_setenv_check ("COCKPIT_WS_PROCESS_IDLE", "2", TRUE);
 
   cockpit_test_init (&argc, &argv);
 

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -23,6 +23,7 @@
 #include "cockpitws.h"
 #include "mock-auth.h"
 
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 #include "common/cockpitwebserver.h"
 #include "common/cockpiterror.h"
@@ -255,8 +256,8 @@ main (int argc,
 {
   cockpit_ws_ssh_program = BUILDDIR "/cockpit-ssh";
 
-  g_assert_setenv ("COCKPIT_SSH_KNOWN_HOSTS_FILE", SRCDIR "/src/ssh/mock_known_hosts", TRUE);
-  g_assert_setenv ("COCKPIT_SSH_BRIDGE_COMMAND", BUILDDIR "/cockpit-bridge", TRUE);
+  cockpit_setenv_check ("COCKPIT_SSH_KNOWN_HOSTS_FILE", SRCDIR "/src/ssh/mock_known_hosts", TRUE);
+  cockpit_setenv_check ("COCKPIT_SSH_BRIDGE_COMMAND", BUILDDIR "/cockpit-bridge", TRUE);
 
   cockpit_test_init (&argc, &argv);
 

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -26,6 +26,7 @@
 
 #include "common/cockpitconf.h"
 #include "common/cockpitsocket.h"
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 #include "common/cockpitwebserver.h"
 #include "common/mock-io-stream.h"
@@ -371,15 +372,15 @@ setup_default (Test *test,
   cockpit_config_file = fixture->config;
 
   if (fixture->config)
-    g_assert_setenv ("XDG_CONFIG_DIRS", fixture->config, TRUE);
+    cockpit_setenv_check ("XDG_CONFIG_DIRS", fixture->config, TRUE);
   else
     g_unsetenv ("XDG_CONFIG_DIRS");
 
-  g_assert_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  cockpit_setenv_check ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
   if (fixture->with_home)
-    g_assert_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
+    cockpit_setenv_check ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
   else
-    g_assert_setenv ("XDG_DATA_HOME", "/nonexistent", TRUE);
+    cockpit_setenv_check ("XDG_DATA_HOME", "/nonexistent", TRUE);
 
   base_setup (test);
   test->response = cockpit_web_response_new (test->io,

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -22,6 +22,7 @@
 #include "cockpitauth.h"
 #include "cockpitws.h"
 
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 #include "common/cockpitwebserver.h"
 
@@ -277,8 +278,8 @@ test_authenticate (TestCase *test,
   JsonObject *response;
   GError *error = NULL;
 
-  g_assert_setenv ("COCKPIT_TEST_KEEP_PATH", "1", TRUE);
-  g_assert_setenv ("COCKPIT_TEST_KEEP_KTAB", "1", TRUE);
+  cockpit_setenv_check ("COCKPIT_TEST_KEEP_PATH", "1", TRUE);
+  cockpit_setenv_check ("COCKPIT_TEST_KEEP_KTAB", "1", TRUE);
 
   if (!mock_kdc_available)
     {
@@ -451,12 +452,12 @@ mock_kdc_up (void)
   const gchar *value;
   g_hash_table_iter_init (&iter, mock_kdc.environ);
   while (g_hash_table_iter_next (&iter, (gpointer *)&name, (gpointer *)&value))
-    g_assert_setenv (name, value, TRUE);
+    cockpit_setenv_check (name, value, TRUE);
 
   /* Explicitly tell server side of GSSAPI about our keytab */
   value = g_hash_table_lookup (mock_kdc.environ, "KRB5_KTNAME");
   if (value)
-    g_assert_setenv ("KRB5_KTNAME", value, TRUE);
+    cockpit_setenv_check ("KRB5_KTNAME", value, TRUE);
 }
 
 static void

--- a/src/ws/test-remotectlcertificate.c
+++ b/src/ws/test-remotectlcertificate.c
@@ -21,6 +21,7 @@
 
 #include "remotectl.h"
 
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 
 #include <glib.h>
@@ -94,7 +95,7 @@ setup (TestCase *tc,
   gint i;
   struct group *gr;
 
-  g_assert_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
+  cockpit_setenv_check ("XDG_CONFIG_DIRS", config_dir, TRUE);
   tc->cert_dir = g_build_filename (config_dir, "cockpit", "ws-certs.d", NULL);
 
   /* make sure we start clean */
@@ -150,7 +151,7 @@ setup (TestCase *tc,
 
   g_ptr_array_free (ptr, TRUE);
   if (old_val)
-    g_assert_setenv ("XDG_CONFIG_DIRS", old_val, TRUE);
+    cockpit_setenv_check ("XDG_CONFIG_DIRS", old_val, TRUE);
   else
     g_unsetenv ("XDG_CONFIG_DIRS");
 }

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -27,6 +27,7 @@
 #include "common/cockpitpipe.h"
 #include "common/cockpitconf.h"
 #include "common/cockpitpipetransport.h"
+#include "common/cockpitsystem.h"
 #include "common/cockpittest.h"
 #include "common/cockpitwebserver.h"
 #include "common/cockpitwebinject.h"
@@ -772,7 +773,7 @@ setup_path (const char *argv0)
                           old ? ":" : "",
                           old ? old : NULL);
 
-  g_assert_setenv ("PATH", path, TRUE);
+  cockpit_setenv_check ("PATH", path, TRUE);
 
   g_free (path);
   g_free (dir);
@@ -848,7 +849,7 @@ main (int argc,
 
   signal (SIGPIPE, SIG_IGN);
   /* avoid gvfs (http://bugzilla.gnome.org/show_bug.cgi?id=526454) */
-  g_assert_setenv ("GIO_USE_VFS", "local", TRUE);
+  cockpit_setenv_check ("GIO_USE_VFS", "local", TRUE);
 
   /* playground config directory */
   config_dir = g_dir_make_tmp ("cockpit.config.XXXXXX", NULL);
@@ -857,9 +858,9 @@ main (int argc,
   g_assert (g_mkdir_with_parents (machines_dir, 0755) == 0);
   g_free (machines_dir);
 
-  g_assert_setenv ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
-  g_assert_setenv ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
-  g_assert_setenv ("XDG_CONFIG_DIRS", config_dir, TRUE);
+  cockpit_setenv_check ("XDG_DATA_HOME", SRCDIR "/src/bridge/mock-resource/home", TRUE);
+  cockpit_setenv_check ("XDG_DATA_DIRS", SRCDIR "/src/bridge/mock-resource/system", TRUE);
+  cockpit_setenv_check ("XDG_CONFIG_DIRS", config_dir, TRUE);
 
   setup_path (argv[0]);
 


### PR DESCRIPTION
Coverity keeps complaining about issues like

    check_return: Calling "g_setenv("DBUS_SESSION_BUS_ADDRESS", address, 1)" without checking return value.
    This library function may fail and return an error code.

This is a "Should Not Happen™": `g_setenv()` is just a light wrapper
around setenv(3). This can only fail for bad input pointers or names
containing `=`, all of which is under our control.

Introduce a cockpit_setenv_check() wrapper which
aborts on failure, and use it in all places.

This replaces the previous `g_assert_setenv()` in cockpittest.c.
