### PR TITLE
build: re-prevent node from messing with stdio

### DIFF
--- a/pkg/build
+++ b/pkg/build
@@ -43,7 +43,7 @@ V_WEBPACK = $(V_WEBPACK_$(V))
 V_WEBPACK_ = $(V_WEBPACK_$(AM_DEFAULT_VERBOSITY))
 V_WEBPACK_0 = @echo "  WEBPACK  $(@:dist/%/manifest.json=%)";
 
-WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) $(srcdir)/tools/webpack-make
+WEBPACK_MAKE = NODE_ENV=$(NODE_ENV) SRCDIR=$(abspath $(srcdir)) $(srcdir)/tools/termschutz -- $(srcdir)/tools/webpack-make
 
 WEBPACK_CONFIG = $(srcdir)/webpack.config.js
 WEBPACK_INPUTS =

--- a/tools/termschutz
+++ b/tools/termschutz
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import sys
+
+# Implement `command < /dev/null 2>&1 | cat >&2` with `command`
+# as the main process (for signals, return status, etc).
+
+# This protects us against node setting stdio non-blocking.
+
+# NB: as of today (node v14.17.0) node doesn't mess with the
+# controlling terminal.
+
+parser = argparse.ArgumentParser()
+parser.add_argument('cmd', nargs='+', help='The command to run')
+args = parser.parse_args()
+
+n = os.open('/dev/null', os.O_RDONLY)
+r, w = os.pipe()
+
+if os.fork():
+    os.dup2(n, 0)  # stdin from /dev/null
+    os.dup2(w, 1)  # stdout to cat
+    os.dup2(w, 2)  # stderr to cat
+    os.execvp(args.cmd[0], args.cmd)
+else:
+    os.dup2(r, 0)  # read from wrapped process
+    os.dup2(2, 1)  # all output to stderr
+    os.execvp('cat', ['cat'])


### PR DESCRIPTION
node does some ioctls on startup which seem to be resulting in our
terminal landing in a non-blocking state in some situations.  This
problem has plagued us for a long time, but was brought back again
(somewhat) recently with cef1502c21, which removed use of the timeout
command (which, as a side effect, gave us a protective pty wrapping).

Add a small python script which should suffice to get us this protection
back again.