### PR TITLE
webpack-watch: update webpack-make invocation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -184,7 +184,7 @@ option for copying the built webpack into the given SSH target's
 SSH `c` alias as described in [test/README.md](./test/README.md), you can use
 one of these commands:
 
-    tools/webpack-make -d dist/kdump/Makefile.deps -r c
+    tools/webpack-make kdump -r c
     tools/webpack-watch kdump -r c
 
 To make Cockpit again use the installed code, rather than that from your git

--- a/tools/webpack-watch
+++ b/tools/webpack-watch
@@ -14,4 +14,4 @@ shift
 # disable eslint by default, unless explicitly enabled
 export ESLINT=${ESLINT:-0}
 
-"tools/webpack-make" -d "dist/$page/Makefile.deps" -w "$@"
+"tools/webpack-make" "$page" -w "$@"


### PR DESCRIPTION
In 8d3a015dcc7c0cf1b the -d option was removed in favor of positional
arguments.