### PR TITLE
cockpituous: Stop releasing to Fedora 33

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -28,7 +28,6 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k rawhide
-job release-koji f33
 job release-koji f34
 job release-koji f35
 
@@ -42,7 +41,6 @@ job release-copr @cockpit/cockpit-preview
 job release-dockerhub cockpit-project/cockpit-container
 
 # Push out a Bodhi update
-job release-bodhi F33
 job release-bodhi F34
 job release-bodhi F35
 


### PR DESCRIPTION
Only support two releases at a time.