### PR TITLE
containers: Bump bastion and ws containers to Fedora 34

### DIFF
--- a/containers/bastion/Dockerfile
+++ b/containers/bastion/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:34
 
 ARG VERSION
 ARG INSTALLER

--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:34
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 


### PR DESCRIPTION
Tested with
```
podman build -t cockpit/ws containers/ws
podman build -t cockpit/bastion containers/bastion

podman run -it --rm -p 9999:9090 localhost/cockpit/bastion
# ... and logging into my piware.de server
```

Our CI does not really cover this `FROM:`, as it replaces it with the pre-built `cockpit/base` container on our images. I.e. that already tests on Fedora 34. This only affects the official production container that we push during release.