### PR TITLE
systemd: Ignore "To Be Filled By O.E.M." DMI values

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -101,7 +101,12 @@ function parseDMIFields(text) {
             return;
         const file = line.slice(0, sep);
         const key = file.slice(file.lastIndexOf('/') + 1);
-        const value = line.slice(sep + 1);
+        let value = line.slice(sep + 1);
+
+        // clean up after lazy OEMs
+        if (value.match(/to be filled by o\.?e\.?m\.?/i))
+            value = "";
+
         info[key] = value;
 
         if (key === "chassis_type")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -468,6 +468,20 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-c-description-list__group:nth-of-type(2) dd', "NAME")
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-c-description-list__group:nth-of-type(3) dd', "VENDOR")
 
+        # Clean up after lazy OEMs, falls back to board vendor/name
+        m.write("/sys/class/dmi/id/sys_vendor", "To Be Filled By O.E.M.")
+        m.write("/sys/class/dmi/id/product_name", "To Be Filled By O.E.M.")
+        m.write("/sys/class/dmi/id/board_vendor", "brdven")
+        m.write("/sys/class/dmi/id/board_name", "brdnam")
+        b.reload()
+        b.go("/system")
+        b.enter_page('/system')
+        b.wait_in_text('#system_information_hardware_text', "brdven brdnam")
+        b.click(hardware_page_link)
+        b.enter_page("/system/hwinfo")
+        b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-c-description-list__group:nth-of-type(2) dd', "brdnam")
+        b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-c-description-list__group:nth-of-type(3) dd', "brdven")
+
         # /proc/cpuinfo on x86; very incomplete, just what pkg/lib/machine-info.js looks at
         m.write("/tmp/cpuinfo", """processor\t: 0
 vendor_id\t: GenuineIntel


### PR DESCRIPTION
Cheap or self-built machines often have template DMI information which
was not set by the vendor. Ignore such fields and treat them like
empty/absent values. This will trigger the fallback to the board
name/vendor, which in many cases is present and valid; if that does not
work either, just don't show any hardware name/version at all.

Fixes #7476