### PR TITLE
test: Allow another variant of pcp-archive messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1197,8 +1197,9 @@ class MachineCase(unittest.TestCase):
         r"#2\) Think before you type.",
         r"#3\) With great power comes great responsibility.",
 
-        # starting out with empty PCP logs and pmlogger not running causes this metrics channel message
+        # starting out with empty PCP logs and pmlogger not running causes these metrics channel messages
         "pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name",
+        "pcp-archive: instance name lookup failed: network.interface.*",
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")


### PR DESCRIPTION
Sometimes `TestPages.testBasic` produces this after looking at network
related pages. Put it back into generally allowed patterns (partial
revert from commit 8bd081d8c).

----

[example](https://logs.cockpit-project.org/logs/pull-16281-20210831-121051-a153938e-debian-testing/log.html#93)