### PR TITLE
test: Drop obsolete libvirt restart hack from check-networkmanager-firewall

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -62,7 +62,6 @@ class TestFirewall(NetworkCase):
         # many tests expect the "libvirt" zone; on images with libvirt, wait until libvirt adds its zone
         # (older versions don't do that yet)
         if m.image not in ["ubuntu-2004", "ubuntu-stable"]:
-            m.execute("systemctl restart libvirtd")  # https://bugzilla.redhat.com/show_bug.cgi?id=1813830
             m.execute("virsh net-list | grep -qw default || virsh net-start default")
             m.execute("until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done")
 


### PR DESCRIPTION
The bug was fixed long ago, and this now gets in the way on Fedora 35
where libvirtd moved to socket activation.