### PR TITLE
test: Drop libvirt startup in check-networkmanager-firewall

### DIFF
--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -25,9 +25,6 @@ require:
   - targetcli
   - tlog
   - tuned
-  # only required for check-networkmanager-firewall, very expensive; TODO: make tests work without these
-  - libvirt-daemon-kvm
-  - libvirt-client
 
 test: ./run-verify-host.sh
 duration: 4h

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -59,12 +59,10 @@ class TestFirewall(NetworkCase):
         self.btn_primary = "pf-m-primary"
         self.default_zone = "public zone"
 
-        # many tests expect the "libvirt" zone; on images with libvirt, wait until libvirt adds its zone
+        # on images with running libvirt, wait until libvirt adds its zone, to avoid races in tests
         # (older versions don't do that yet)
         if m.image not in ["ubuntu-2004", "ubuntu-stable"]:
-            m.execute("systemctl restart libvirtd")  # https://bugzilla.redhat.com/show_bug.cgi?id=1813830
-            m.execute("virsh net-list | grep -qw default || virsh net-start default")
-            m.execute("until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done")
+            m.execute("if virsh net-list --name | grep -q default; then until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done; fi")
 
     def testNetworkingPage(self):
         b = self.browser
@@ -305,9 +303,6 @@ class TestFirewall(NetworkCase):
 
         self.login_and_go("/network/firewall")
         b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
-        # wait until all zones are present, including the ones added at runtime
-        if m.image not in ["ubuntu-2004", "ubuntu-stable"]:
-            b.wait_visible("#zones-listing .zone-section[data-id='libvirt']")
 
         # add a service to the runtime configuration via the cli, after all the
         # operations it should be removed, indicating a reload took place


### PR DESCRIPTION
It is not actually being used any more by tests, it has loads of race
conditions due to being a dynamically added zone, and requires expensive
libvirt test dependencies in FMF/gating tests.

Only keep waiting for the libvirt zone in firewalld if libvirt is
actually running and the default network exists. Otherwise this could
happen during tests and confuse the expected zone count.

---

This is a more intrusive, but better (if it works) alternative to PR #16287.

This should hopefully help for failures like [this (our CI)](https://logs.cockpit-project.org/logs/pull-16281-20210831-184227-dbe34f3f-fedora-35/log.html#56-2) and [this (testing farm)](http://artifacts.dev.testing-farm.io/e76f2ea5-8429-42ad-91dc-26e8e07e37e6/). This is our second and third biggest flake right now.