### PR TITLE
test: Drop waiting for team MAC address

### DIFF
--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -72,7 +72,6 @@ class TestTeam(NetworkCase):
 
         # Deactivate the team and make sure it is still there after a
         # reload.
-        b.wait_text_not("#network-interface-mac", "")
         self.wait_onoff(".pf-c-card__header:contains('tteam')", True)
         self.toggle_onoff(".pf-c-card__header:contains('tteam')")
         self.wait_for_iface_setting('Status', 'Inactive')


### PR DESCRIPTION
NetworkManager seems to sometimes not assign a MAC address to the team
interface. This is unrelated to what the test is trying to do, so drop
this particular check.

---

This breaks every other gating test. [Example](http://artifacts.dev.testing-farm.io/e76f2ea5-8429-42ad-91dc-26e8e07e37e6/).