### PR TITLE
test: Relax expected "instance name lookup failed" PCP message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1199,7 +1199,7 @@ class MachineCase(unittest.TestCase):
 
         # starting out with empty PCP logs and pmlogger not running causes these metrics channel messages
         "pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name",
-        "pcp-archive: instance name lookup failed: network.interface.*",
+        "pcp-archive: instance name lookup failed:.*",
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")


### PR DESCRIPTION
It sometimes also looks like this:

    pcp-archive: instance name lookup failed: disk.dev.read_bytes.1: Instance identifier not defined in the PCP archive log

---

[example](https://logs.cockpit-project.org/logs/pull-16288-20210901-082742-3b5e484e-fedora-35/log.html#133)