### PR TITLE
make webpack-watch a symlink of webpack-make

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -15,8 +15,13 @@ const parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--config', { help: "Path to webpack.config.js", default: "webpack.config.js" })
 parser.add_argument('-r', '--rsync', { help: "rsync webpack to ssh target after build", metavar: "HOST" })
 parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable webpack watch mode" })
+parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting" })
 parser.add_argument('prefix', { help: "The directory to build (eg. base1, shell, ...)", metavar: "DIRECTORY" })
 args = parser.parse_args()
+
+if (args.no_eslint) {
+    process.env["ESLINT"] = "0";
+}
 
 if (args.prefix.includes('/')) {
     parser.error("Directory must not contain '/'")

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -11,11 +11,14 @@ const argparse = require("argparse");
 const fs = require("fs");
 const child_process = require("child_process");
 
+// argv0 is node
+const webpack_watch = process.argv[1].includes('webpack-watch');
+
 const parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--config', { help: "Path to webpack.config.js", default: "webpack.config.js" })
 parser.add_argument('-r', '--rsync', { help: "rsync webpack to ssh target after build", metavar: "HOST" })
-parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable webpack watch mode" })
-parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting" })
+parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable webpack watch mode", default: webpack_watch })
+parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting", default: webpack_watch })
 parser.add_argument('prefix', { help: "The directory to build (eg. base1, shell, ...)", metavar: "DIRECTORY" })
 args = parser.parse_args()
 

--- a/tools/webpack-watch
+++ b/tools/webpack-watch
@@ -1,17 +1,1 @@
-#!/bin/sh
-# Calls webpack-make in watch mode for the given pkg/<page>
-
-set -eu
-cd "$(realpath -m "$0"/../..)"
-
-if [ -z "${1:-}" ]; then
-    echo "Usage: $0 <page in pkg/> [webpack-make options..]" >&2
-    exit 1
-fi
-page="$1"
-shift
-
-# disable eslint by default, unless explicitly enabled
-export ESLINT=${ESLINT:-0}
-
-"tools/webpack-make" "$page" -w "$@"
+webpack-make


### PR DESCRIPTION
This removes the wrapper script `webpack-watch` and makes `webpack-make` if it's called as `webpack-watch`.