### PR TITLE
workflows: Tag node-cache on releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,3 +33,35 @@ jobs:
           export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
           cd /build
           release-runner -r https://github.com/$GITHUB_REPOSITORY -t $(basename $GITHUB_REF) tools/cockpituous-release
+
+  release-node-cache:
+    runs-on: ubuntu-latest
+    environment: node-cache
+    # done via deploy key, token needs no write permissions at all
+    permissions:
+      contents: read
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Set up git
+        run: |
+            git config user.name "GitHub Workflow"
+            git config user.email "cockpituous@cockpit-project.org"
+
+      - name: Tag node-cache
+        run: |
+          set -eux
+          TAG="$(basename $GITHUB_REF)"
+
+          tools/node-modules checkout
+          cd node_modules
+          git tag "$TAG"
+
+          git remote add cache "ssh://git@github.com/${GITHUB_REPOSITORY%/*}/node-cache"
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          # make this idempotent: delete an existing tag
+          git push cache :"$TAG" || true
+          git push cache tag "$TAG"
+          ssh-add -D


### PR DESCRIPTION
We want our node-cache to have tags corresponding to cockpit releases
[1], so that we get a proper replacement for the old manually built
cockpit-cache-XXX.tar.xz artifacts. These are useful for having a
straightforward way for taking a release tarball, getting a matching
node_modules, and thus being able to patch/build cockpit from a release
(i.e. what distributions do all the time).

So far we have manually tagged node-cache for a few releases, and it's
part of our release process [2], but we have forgotten a few times --
and this is perfectly automatable.

Add this to our standard release workflow. It must run in a separate
job, as it uses the deploy key from the "node-cache" environment; this
secret is (deliberately) not present in the "release" environment for
the container. Delete the tag on the GitHub repo first, so that this
stays idempotent -- we want to be able to re-run a failed release.

[1] https://github.com/cockpit-project/node-cache/tags
[2] https://github.com/cockpit-project/cockpit/wiki/ReleaseProcess