### PR TITLE
[r85] containers: Fix SELinux context of SSH private key

### DIFF
--- a/containers/bastion/README.md
+++ b/containers/bastion/README.md
@@ -7,7 +7,7 @@ By default on login cockpit will attempt to establish a ssh connection to the gi
 
 You can also mount an encrypted private key inside the container and set the environment variable `COCKPIT_SSH_KEY_PATH` to point to it.
 
-`docker run -e COCKPIT_SSH_KEY_PATH='/var/secret/id_rsa' -v ~/.ssh/id_rsa:/var/secret/id_rsa cockpit/bastion`
+`docker run -e COCKPIT_SSH_KEY_PATH='/var/secret/id_rsa' -v ~/.ssh/id_rsa:/var/secret/id_rsa cockpit/bastion:Z`
 
 When setup like this cockpit will use the provided password to attempt to decrypt the key and attempt to establish a ssh connection to the given host using that private key.
 

--- a/test/containers/check-bastion
+++ b/test/containers/check-bastion
@@ -32,7 +32,7 @@ class BastionContainerMachine(VirtMachine):
     def start_cockpit(self, *args, **kwargs):
         extra = ""
         if kwargs.get("key_based"):
-            extra = " -e COCKPIT_SSH_KEY_PATH='/var/secret/enc_rsa' -v /tmp/enc_rsa:/var/secret/enc_rsa"
+            extra = " -e COCKPIT_SSH_KEY_PATH='/var/secret/enc_rsa' -v /tmp/enc_rsa:/var/secret/enc_rsa:Z"
             self.upload([AUTH_KEY], "/tmp")
 
         self.execute("podman run -d -e G_MESSAGES_DEBUG=all -e COCKPIT_SSH_ALLOW_UNKNOWN=1{} -p 9090:9090 "


### PR DESCRIPTION
In Fedora ≥ 34, the container is not able to read the passed key any
more due to SELinux restrictions. Use the designated docker/podman
volume flag `:Z` to fix that.

Backported from main commit 5954eedaae0cf18