### PR TITLE
services: fix missing icons from the services details UI

### DIFF
--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -26,8 +26,13 @@ import {
     ExpandableSection,
     Tooltip, TooltipPosition,
     Card, CardBody, CardTitle, Text, TextVariants,
-    Modal, Switch
+    Modal, Spinner, Switch
 } from "@patternfly/react-core";
+import {
+    AsleepIcon,
+    BanIcon, ErrorCircleOIcon, OnRunningIcon, OffIcon,
+    OkIcon, UserIcon,
+} from "@patternfly/react-icons";
 
 import cockpit from "cockpit";
 import { systemd_client, SD_MANAGER, SD_OBJ } from "./services.jsx";
@@ -327,7 +332,7 @@ export class ServiceDetails extends React.Component {
         if (masked) {
             status.push(
                 <div key="masked" className="status-masked">
-                    <span className="fa fa-ban status-icon" />
+                    <BanIcon className="status-icon" />
                     <span className="status">{ _("Masked") }</span>
                     <span className="side-note font-xs">{ _("Forbidden from running") }</span>
                 </div>
@@ -337,7 +342,7 @@ export class ServiceDetails extends React.Component {
         if (!enabled && !active && !masked && !isStatic) {
             status.push(
                 <div key="disabled" className="status-disabled">
-                    <span className="pficon pficon-off status-icon" />
+                    <OffIcon className="status-icon" />
                     <span className="status">{ _("Disabled") }</span>
                 </div>
             );
@@ -346,7 +351,7 @@ export class ServiceDetails extends React.Component {
         if (failed) {
             status.push(
                 <div key="failed" className="status-failed">
-                    <span className="pficon pficon-error-circle-o status-icon" />
+                    <ErrorCircleOIcon className="status-icon" />
                     <span className="status">{ _("Failed to start") }</span>
                     { this.props.permitted &&
                         <Button variant="secondary" className="action-button" onClick={() => this.unitAction("StartUnit") }>{ _("Start service") }</Button>
@@ -359,7 +364,7 @@ export class ServiceDetails extends React.Component {
             if (active) {
                 status.push(
                     <div key="running" className="status-running">
-                        <span className="pficon pficon-on-running status-icon" />
+                        <OnRunningIcon className="status-icon" />
                         <span className="status">{ _("Running") }</span>
                         <span className="side-note font-xs">{ _("Active since ") + timeformat.dateTime(this.props.unit.ActiveEnterTimestamp / 1000) }</span>
                     </div>
@@ -367,7 +372,7 @@ export class ServiceDetails extends React.Component {
             } else {
                 status.push(
                     <div key="stopped" className="status-stopped">
-                        <span className="pficon pficon-off status-icon" />
+                        <OffIcon className="status-icon" />
                         <span className="status">{ _("Not running") }</span>
                     </div>
                 );
@@ -377,7 +382,7 @@ export class ServiceDetails extends React.Component {
         if (isStatic && !masked) {
             status.unshift(
                 <div key="static" className="status-static">
-                    <span className="pficon pficon-asleep status-icon" />
+                    <AsleepIcon className="status-icon" />
                     <span className="status">{ _("Static") }</span>
                     { this.props.unit.WantedBy && this.props.unit.WantedBy.length > 0 &&
                         <>
@@ -394,7 +399,7 @@ export class ServiceDetails extends React.Component {
         if (!this.props.permitted) {
             status.unshift(
                 <div key="readonly" className="status-readonly">
-                    <span className="fa fa-user status-icon" />
+                    <UserIcon className="status-icon" />
                     <span className="status">{ _("Read-only") }</span>
                     <span className="side-note font-xs">{ _("Requires administration access to edit") }</span>
                 </div>
@@ -404,7 +409,7 @@ export class ServiceDetails extends React.Component {
         if (enabled) {
             status.push(
                 <div key="enabled" className="status-enabled">
-                    <span className="pficon pficon-ok status-icon" />
+                    <OkIcon className="status-icon" />
                     <span className="status">{ _("Automatically starts") }</span>
                 </div>
             );
@@ -423,7 +428,7 @@ export class ServiceDetails extends React.Component {
         if (this.state.waitsAction || this.state.waitsFileAction) {
             status = [
                 <div key="updating" className="status-updating">
-                    <span className="spinner spinner-inline spinner-xs status-icon" />
+                    <Spinner isSVG size="md" className="status-icon" />
                     <span className="status">{ _("Updating status...") }</span>
                 </div>
             ];

--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -61,14 +61,8 @@
 }
 
 .status-icon {
-    padding-right: 0.5rem;
-    color: var(--pf-global--icon--Color--light);
-}
-
-.status-icon.spinner.spinner-xs {
-    height: 1rem;
-    width: 1rem;
     margin-right: 0.5rem;
+    color: var(--pf-global--icon--Color--light);
 }
 
 .status-running > .status-icon,

--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -20,6 +20,7 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Nav, NavList, NavItem } from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from "cockpit";
 
@@ -56,7 +57,7 @@ export function ServiceTabs({ onChange, activeTab, tabErrors }) {
                                  isActive={activeItem == key}>
                             <a href="#">
                                 {service_tabs[key]}
-                                {tabErrors[key] ? <span className="fa fa-exclamation-circle" /> : null}
+                                {tabErrors[key] ? <ExclamationCircleIcon className="ct-exclamation-circle" /> : null}
                             </a>
                         </NavItem>
                     );

--- a/pkg/systemd/services/services-list.jsx
+++ b/pkg/systemd/services/services-list.jsx
@@ -25,6 +25,7 @@ import {
     Tooltip, TooltipPosition, Badge,
 } from '@patternfly/react-core';
 import { ListingTable } from 'cockpit-components-table.jsx';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import cockpit from "cockpit";
 
@@ -99,7 +100,7 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
             title: (
                 <Flex id={cockpit.format("$0-service-unit-state", Id)} className='service-unit-status-flex-container'>
                     {CombinedState && <FlexItem flex={{ default: 'flex_2' }} className={"service-unit-status" + (HasFailed ? " service-unit-status-failed" : "")}>
-                        {HasFailed && <span className='fa fa-exclamation-circle' />}
+                        {HasFailed && <ExclamationCircleIcon className='ct-exclamation-circle' />}
                         {CombinedState}
                     </FlexItem>}
                     <FlexItem flex={{ default: 'flex_1' }}>

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
-import '../../lib/patternfly/patternfly-cockpit.scss';
+import '../../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 
 import React from "react";

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -49,7 +49,7 @@
 }
 
 // Add some spacing between the tab label and the icon
-.pf-c-nav__link > .fa {
+.pf-c-nav__link > .ct-exclamation-circle {
     margin-left: 0.5rem;
 }
 .services-header.pf-c-page__main-nav {
@@ -70,7 +70,7 @@
 }
 
 // Add some spacing between the icon and the status string in the list
-.service-unit-status-failed > .fa {
+.service-unit-status-failed > .ct-exclamation-circle {
     margin-right: 0.5rem;
 }
 

--- a/pkg/systemd/system-global.scss
+++ b/pkg/systemd/system-global.scss
@@ -13,7 +13,7 @@
     color: var(--pf-global--warning-color--100);
 }
 
-.fa-exclamation-circle {
+.fa-exclamation-circle, .ct-exclamation-circle {
     color: var(--pf-global--danger-color--100);
 }
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -779,7 +779,7 @@ ExecStart=/usr/bin/false
 
         # Services tab should have icon
         # Aab-fail should be at the top, and have failed
-        b.wait_visible('a:contains("System services") .fa-exclamation-circle')
+        b.wait_visible('a:contains("System services") .ct-exclamation-circle')
         b.wait_visible('tr[data-goto-unit="aab-fail.service"]')
         b.wait_visible('tr[data-goto-unit="aab-fail.service"] .service-unit-status:contains("Failed")')
 
@@ -806,7 +806,7 @@ ExecStart=/usr/bin/false
 
         if self.count_failures() == 0:
             # Services tab should not have icon
-            b.wait_not_present('a:contains("System services") .fa-exclamation-circle')
+            b.wait_not_present('a:contains("System services") .ct-exclamation-circle')
 
             # Nav link should not have icon
             b.switch_to_top()


### PR DESCRIPTION
pficon classes seem to not work any more, at least for the services
page.

Start using the icons from @patternfly/react-icons, which will make the
icons reappear.

This also enables us to stop including PF3 in this page.