### PR TITLE
overview: remove some unused CSS

### DIFF
--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -141,7 +141,7 @@ export class SystemInfomationCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a href="#" className="no-left-padding" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
+                    <a href="#" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
                         {_("View hardware details")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -145,7 +145,7 @@ export class UsageCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <a href="#" className="no-left-padding" onClick={ev => { ev.preventDefault(); cockpit.jump("/metrics", cockpit.transport.host) }}>
+                    <a href="#" onClick={ev => { ev.preventDefault(); cockpit.jump("/metrics", cockpit.transport.host) }}>
                         {_("View details and history")}
                     </a>
                 </CardFooter>

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -302,55 +302,6 @@
   margin-top: 3px;
 }
 
-#sich-hostname-helper {
-    white-space: break-spaces;
-}
-
-.small-messages {
-  font-size: smaller;
-}
-
-.systime-inline {
-  .form-control {
-    margin: 0 4px;
-  }
-
-  .form-group {
-    &:first-of-type .form-control {
-      margin: 0 4px 0 0;
-    }
-
-    .form-control {
-      width: 214px;
-    }
-  }
-
-  .form-inline {
-    background: #f4f4f4;
-    border: 1px solid #bababa;
-    padding: 4px;
-
-    &:not(:first-of-type) {
-      border-top-width: 0;
-    }
-  }
-
-  form {
-    .pficon-close,
-    .fa-plus {
-      float: right;
-      margin-left: 5px;
-      padding: 4px;
-      height: 26px;
-      width: 26px;
-    }
-  }
-}
-
-.pf-c-button.no-left-padding {
-    padding-left: 0;
-}
-
 /* Add a subtle dropshadow to the alerts, to separate them from the background, similar to the cards on the page */
 .pf-c-page__main-section:not(.ct-overview-header),
 .pf-l-gallery {


### PR DESCRIPTION
no-left-padding class is redundant - the padding of the 'a' element
was 0 by default

The rest of the rules don't apply at all.