### PR TITLE
containers/unit-tests: Add missing ddebs for security updates

### DIFF
--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -65,6 +65,7 @@ EOF
 chmod +x /entrypoint
 
 echo "deb http://deb.debian.org/debian-debug/ stable-debug main" > /etc/apt/sources.list.d/ddebs.list
+echo "deb http://deb.debian.org/debian-debug/ stable-proposed-updates-debug main" >> /etc/apt/sources.list.d/ddebs.list
 # always install amd64 nodejs version; there is e.g. no i386 version for node-sass available
 dpkg --add-architecture amd64
 apt-get update


### PR DESCRIPTION
libssh got a recent security update, include corresponding debug symbol
repository.

---

 * Fixes [failed container refresh](https://github.com/cockpit-project/cockpit/runs/3519542139?check_suite_focus=true)