### PR TITLE
tools: Provide eslint mode for webpack-watch

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -171,10 +171,8 @@ which reduces the build time to less than a third. E. g.
 
     $ tools/webpack-watch systemd
 
-Note that this disables eslint by default -- if you want to enable it, run it
-as
-
-    $ ESLINT=1 tools/webpack-watch systemd
+Note that this enables eslint by default -- if you want to disable it, run it
+with `-e`/`--no-eslint`.
 
 Then reload cockpit in your browser after building the page.
 

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -18,7 +18,7 @@ const parser = argparse.ArgumentParser()
 parser.add_argument('-c', '--config', { help: "Path to webpack.config.js", default: "webpack.config.js" })
 parser.add_argument('-r', '--rsync', { help: "rsync webpack to ssh target after build", metavar: "HOST" })
 parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable webpack watch mode", default: webpack_watch })
-parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting", default: webpack_watch })
+parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting" })
 parser.add_argument('prefix', { help: "The directory to build (eg. base1, shell, ...)", metavar: "DIRECTORY" })
 args = parser.parse_args()
 


### PR DESCRIPTION
Since commit 92acdea1e1ee3 it is not possible any more to run
webpack-watch with eslint, as there is no option to enable it, and the
program overwrites `ESLINT=1` from the environment.

Drop the weird inconsistency between webpack-{make,watch}), and default
to running eslint in both modes. Then `--no-eslint` can be used to
disable it.