### PR TITLE
[r85] Backport dbus unit-test fix

### DIFF
--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -58,7 +58,7 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
         dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
                   "NeverReturn", [], { timeout: 10 })
                 .done(function(reply) {
-                    assert(false, "should not be reached");
+                    assert.ok(false, "should not be reached");
                 })
                 .fail(function(ex) {
                     assert.equal(ex.name, "org.freedesktop.DBus.Error.Timeout");

--- a/src/ws/mock-service.c
+++ b/src/ws/mock-service.c
@@ -51,7 +51,6 @@ on_handle_hello_world (TestFrobber *object,
 static gboolean
 on_handle_never_return (TestFrobber *object,
                         GDBusMethodInvocation *invocation,
-                        const gchar *greeting,
                         gpointer user_data)
 {
   return TRUE;


### PR DESCRIPTION
I saw this happening in PO refreshes, let's backport this to stable branches.