### PR TITLE
test: Add pixel tests for Services list and details

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -125,6 +125,7 @@ class Browser:
                            inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")])
         self.password = "foobar"
         self.timeout_factor = int(os.getenv("TEST_TIMEOUT_FACTOR", "1"))
+        self.is_mobile = bool(os.environ.get("TEST_MOBILE"))
         self.failed_pixel_tests = 0
 
     def title(self):
@@ -701,7 +702,7 @@ class Browser:
 
         ignore_rects = list(map(relative_clip, map(lambda item: selector + " " + item, ignore)))
         base = self.pixels_label + "-" + key
-        if bool(os.environ.get("TEST_MOBILE", "")):
+        if self.is_mobile:
             base += "-mobile"
         filename = base + "-pixels.png"
         ref_filename = os.path.join(reference_dir, filename)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import time
+
 import parent
 import testvm
 from testlib import *
@@ -299,6 +301,7 @@ Unit=test.service
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
         self.toggle_onoff()
         self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
+        b.assert_pixels("#service-details", "details-test-fail", ignore=[".cockpit-log-panel .pf-c-card__body"])
         b.click(".action-button:contains('Start service')")
         b.go("#/")
         self.wait_service_present("test-fail.service")
@@ -356,6 +359,16 @@ Unit=test.service
         b.set_input_text("#services-text-filter input", "Test Service")
         self.wait_service_present("test.service")
         self.wait_service_present("test-fail.service")
+        if b.is_mobile:
+            # close the expanded toolbar again to see the whole list
+            b.click("#services-page .pf-c-toolbar__toggle button")
+            b.wait_not_visible("#services-page .pf-m-search-filter")
+            # scroll the menu navbar all the way to the left
+            nav_scroll_btn = ".services-header button[aria-label='Scroll left']"
+            while b.call_js_func("ph_attr", nav_scroll_btn, "disabled") is None:
+                b.click(nav_scroll_btn)
+                time.sleep(0.5)
+        b.assert_pixels("#services-page", "text-filter-test")
 
         # Filter by description capitalization not matching the unit description
         init_filter_state()


### PR DESCRIPTION
Test the list when searching for all "Test service", so that the whole
page contents is entirely defined by the test, and only shows
test.service and test-fail.service.

Test details with making sure that the log card is present, but ignore
the date heading and actual log contents. In mobile mode, this has an
interesting additional challenge of making sure that the horizontally
scrollable nav bar is all the way to the left -- if we need this more
often, this could become a testlib helper.
