### PR TITLE
test: Re-drop redundant Browser.is_mobile

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -125,7 +125,6 @@ class Browser:
                            inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")])
         self.password = "foobar"
         self.timeout_factor = int(os.getenv("TEST_TIMEOUT_FACTOR", "1"))
-        self.is_mobile = bool(os.environ.get("TEST_MOBILE"))
         self.failed_pixel_tests = 0
 
     def title(self):
@@ -702,7 +701,7 @@ class Browser:
 
         ignore_rects = list(map(relative_clip, map(lambda item: selector + " " + item, ignore)))
         base = self.pixels_label + "-" + key
-        if self.is_mobile:
+        if self.cdp.mobile:
             base += "-mobile"
         filename = base + "-pixels.png"
         ref_filename = os.path.join(reference_dir, filename)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -359,7 +359,7 @@ Unit=test.service
         b.set_input_text("#services-text-filter input", "Test Service")
         self.wait_service_present("test.service")
         self.wait_service_present("test-fail.service")
-        if b.is_mobile:
+        if b.cdp.mobile:
             # close the expanded toolbar again to see the whole list
             b.click("#services-page .pf-c-toolbar__toggle button")
             b.wait_not_visible("#services-page .pf-m-search-filter")


### PR DESCRIPTION
This was introduced in commit e62035b8a0af, but Browser.cdp already has
a `mobile` flag. Use that instead.