### PR TITLE
[rhel-9.0] backport FMF hacks

### DIFF
--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -43,6 +43,9 @@ if grep -q 'ID=.*fedora' /etc/os-release; then
     dnf install -y tcsh
 fi
 
+#HACK: unbreak rhel-9-0's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
+sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
+
 # make libpwquality less aggressive, so that our "foobar" password works
 printf 'dictcheck = 0\nminlen = 6\n' >> /etc/security/pwquality.conf
 

--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -27,7 +27,7 @@ ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd
 if rpm -q setroubleshoot-server; then
-    dnf remove -y setroubleshoot-server
+    dnf remove -y --noautoremove setroubleshoot-server
 fi
 
 if grep -q 'ID=.*fedora' /etc/os-release; then


### PR DESCRIPTION
We should have https://github.com/cockpit-project/cockpit/pull/16252 on the rhel-9.0 branch to reflect reality, and get a clean fmf `ref:`.