### PR TITLE
More mobile test fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -677,6 +677,18 @@ class Browser:
 
         self.switch_to_frame(cur_frame)
 
+    def click_system_menu(self, path):
+        '''Click on a "System" menu entry with given URL path
+
+        Enters the given target frame afterwards.
+        '''
+        self.switch_to_top()
+        if self.cdp.mobile:
+            self.click("#nav-system-item")
+        self.click(f"#host-apps a[href='{path}']")
+        # strip off parameters after hash
+        self.enter_page(path.split('#')[0].rstrip('/'))
+
     def ignore_ssl_certificate_errors(self, ignore):
         action = ignore and "continue" or "cancel"
         if opts.trace:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -677,17 +677,19 @@ class Browser:
 
         self.switch_to_frame(cur_frame)
 
-    def click_system_menu(self, path):
+    def click_system_menu(self, path, enter=True):
         '''Click on a "System" menu entry with given URL path
 
-        Enters the given target frame afterwards.
+        Enters the given target frame afterwards, unless enter=False is given
+        (useful for remote hosts).
         '''
         self.switch_to_top()
         if self.cdp.mobile:
             self.click("#nav-system-item")
         self.click(f"#host-apps a[href='{path}']")
-        # strip off parameters after hash
-        self.enter_page(path.split('#')[0].rstrip('/'))
+        if enter:
+            # strip off parameters after hash
+            self.enter_page(path.split('#')[0].rstrip('/'))
 
     def ignore_ssl_certificate_errors(self, ignore):
         action = ignore and "continue" or "cancel"

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -52,7 +52,6 @@ test_html = """
 @nondestructive
 class TestPackages(MachineCase):
 
-    @skipMobile()
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -62,7 +61,12 @@ class TestPackages(MachineCase):
         self.login_and_go("/playground/pkgs")
 
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.wait_visible("#nav-system li:contains(Terminal)")
+        if b.cdp.mobile:
+            # close menu again
+            b.click("#nav-system-item")
 
         m.execute("mkdir /usr/share/cockpit/test")
         m.write("/usr/share/cockpit/test/manifest.json", test_manifest)
@@ -71,6 +75,8 @@ class TestPackages(MachineCase):
         b.click("#reload")
 
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.click("#nav-system a:contains(Test)")
 
         b.enter_page("/test/test")
@@ -82,7 +88,12 @@ class TestPackages(MachineCase):
         b.click("#reload")
 
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.wait_not_present("#nav-system a:contains(Test)")
+        if b.cdp.mobile:
+            # close menu again
+            b.click("#nav-system-item")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -118,14 +118,11 @@ OnCalendar=daily
         b.wait_text(".service-name", "Test Service")
 
         # check that navigating away and back preserves place
-        b.switch_to_top()
-        b.click("a[href='/system']")
-        b.enter_page("/system")
+        b.click_system_menu("/system")
         b.wait_visible("#system_information_systime_button")
         b.switch_to_top()
         self.checkDocs(["Configuring system settings"])
-        b.click("a[href='/system/services']")
-        b.enter_page("/system/services")
+        b.click_system_menu("/system/services")
         b.wait_visible("ol.pf-c-breadcrumb__list")
         b.wait_text(".service-name", "Test Service")
         b.switch_to_top()
@@ -134,9 +131,7 @@ OnCalendar=daily
 
         # check that when inside the component clicking the navbar
         # takes you home
-        b.switch_to_top()
-        b.click("a[href='/system/services']")
-        b.enter_page("/system/services")
+        b.click_system_menu("/system/services")
         b.wait_visible("#services-list")
         b.wait_not_present("#service-details")
         b.switch_to_top()

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -27,7 +27,6 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 @nondestructive
 @skipDistroPackage()
-@skipMobile()
 class TestPages(MachineCase):
     def checkDocs(self, items):
         m = self.machine
@@ -49,6 +48,20 @@ class TestPages(MachineCase):
         b.wait_collected_text("#navbar-docs-items", expected)
         b.click("#navbar-docs > a")
         b.wait_not_visible("#navbar-docs-items")
+
+    def check_system_menu(self, label, present):
+        b = self.browser
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
+
+        if present:
+            b.wait_visible(f"#host-apps li a:contains('{label}')")
+        else:
+            b.wait_not_present(f"#host-apps li a:contains('{label}')")
+
+        if b.cdp.mobile:
+            # close menu again
+            b.click("#nav-system-item")
 
     def open_lang_modal(self):
         self.browser.switch_to_top()
@@ -160,7 +173,7 @@ OnCalendar=daily
         # Test 'parent' manifest option
         b.switch_to_top()
         b.go("/metrics")
-        b.wait_text("#host-apps .pf-m-current", "Overview")
+        self.check_system_menu("Overview", True)
         self.checkDocs(["Performance Co-Pilot"])
 
         # Lets try changing the language
@@ -412,13 +425,13 @@ OnCalendar=daily
 
         self.login_and_go()
 
-        b.wait_in_text("#host-apps", "Overview")
+        self.check_system_menu("Overview", True)
         self.restore_dir("/home/admin")
         m.execute("mkdir -p /home/admin/.local/share/cockpit/foo")
         m.write("/home/admin/.local/share/cockpit/foo/manifest.json",
                 '{ "menu": { "index": { "label": "FOO!" } } }')
         b.reload()
-        b.wait_in_text("#host-apps", "FOO!")
+        self.check_system_menu("FOO!", True)
 
         self.allow_restart_journal_messages()
 
@@ -430,6 +443,8 @@ OnCalendar=daily
         self.allow_journal_messages("invalid or unusable locale: de_DE.UTF-8")
 
         self.login_and_go()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
 
         filter_sel = ".filter-menus"
 
@@ -471,6 +486,9 @@ OnCalendar=daily
 
         # Visited page, search should be cleaned up
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
+            b.focus(filter_sel)
         b.wait_val(filter_sel, "")
 
         # Check that escape cleans the search
@@ -505,6 +523,8 @@ OnCalendar=daily
 
         # Check we jump into subpage when defined in manifest
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.focus(filter_sel)
         b.key_press("firew")
         b.wait_visible("#host-apps li a:contains('Networking')")
@@ -533,6 +553,8 @@ OnCalendar=daily
         b.wait_in_text(".ct-overview-header", "Neustart")
 
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.wait_visible("#host-apps li a:contains('Dienste')")
         b.wait_visible("#host-apps li a:contains('Protokolle')")
         b.focus(filter_sel)
@@ -693,6 +715,8 @@ OnCalendar=daily
         b.click("#set-status")
 
         b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
         b.wait_visible("#development-info")
         b.mouse("#development-info", "mouseenter")
         b.wait_in_text(".pf-c-tooltip", "My Little Page Status")

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -22,7 +22,6 @@ from testlib import *
 
 
 @skipDistroPackage()
-@skipMobile()
 class TestSession(MachineCase):
 
     def testBasic(self):
@@ -73,7 +72,7 @@ class TestSession(MachineCase):
         # Kill session from the inside
         b.switch_to_top()
         b.wait_visible("#content")
-        b.wait_text('#current-username', 'admin')
+        b.wait_visible("#nav-hosts-sel")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -329,7 +329,6 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         self.check_discovered_addresses(b, [])
         self.check_discovered_addresses(b2, [])
 
-    @skipMobile()
     def testEdit(self):
         b = self.browser
         m1 = self.machines['machine1']
@@ -376,7 +375,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
         b.wait_visible("iframe.container-frame[name='cockpit1:franz@10.111.113.3/system']")
 
-        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "franz@machine3")
+        if not b.cdp.mobile:
+            b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "franz@machine3")
         b.click("#hosts-sel button")
         b.wait_text(".nav-item span[data-for='/@10.111.113.3']", "franz @machine3")
         b.click("button:contains('Edit hosts')")
@@ -393,7 +393,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click('#hosts_setup_server_dialog .pf-m-primary')
         b.wait_popdown('hosts_setup_server_dialog')
 
-        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@machine2")
+        if not b.cdp.mobile:
+            b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@machine2")
 
         # Changing the address of a host will navigate to that host,
         # and that will close the host switcher.  Let's open it again

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -82,9 +82,7 @@ class TestMenu(MachineCase):
         self.check_axe("Test-navigation")
 
         # Check that we can use a link with a hash in it
-        b.switch_to_top()
-        b.click("a[href='/system/#/memory']")
-        b.enter_page("/system")
+        b.click_system_menu("/system/#/memory")
 
         # Ensure that our tests pick up unhandled JS exceptions
         b.switch_to_top()

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -27,7 +27,6 @@ from testlib import *
 class TestMenu(MachineCase):
 
     @enableAxe
-    @skipMobile()
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -52,7 +51,7 @@ class TestMenu(MachineCase):
         # Test session timeout
         time.sleep(20)
         b.wait_not_present("#session-timeout-modal")
-        b.wait_visible("#nav-system")
+        b.wait_visible("#nav-hosts-sel")
         b.enter_page("/system")
         b.mouse("#system_information_hardware_text", "mousemove", 24, 24)
         b.switch_to_top()
@@ -77,7 +76,7 @@ class TestMenu(MachineCase):
         b.switch_to_top()
         time.sleep(75)
         b.wait_not_present("#session-timeout-modal")
-        b.wait_visible("#nav-system")
+        b.wait_visible("#nav-hosts-sel")
 
         self.check_axe("Test-navigation")
 
@@ -89,8 +88,12 @@ class TestMenu(MachineCase):
         b.go("/playground/exception")
 
         # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
-        b.wait_visible("#host-apps .pf-m-current")
-        b.wait_visible("#host-apps .pf-m-current:contains('Development')")
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
+        b.wait_in_text("#host-apps .pf-m-current", "Development")
+        if b.cdp.mobile:
+            # close menu again
+            b.click("#nav-system-item")
 
         b.enter_page("/playground/exception")
         b.wait_visible("button")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -405,7 +405,6 @@ class TestMultiMachine(MachineCase):
         self.machine.start_cockpit()
         self.checkDirectLogin('/')
 
-    @skipMobile()
     def testUrlRoot(self):
         b = self.browser
         m = self.machine
@@ -440,7 +439,7 @@ class TestMultiMachine(MachineCase):
         b.wait_js_cond('window.location.pathname == "/cockpit-new/@10.111.113.2/system"')
 
         # Test subnav
-        b.click('a[href="/@10.111.113.2/users"]')
+        b.click_system_menu("/@10.111.113.2/users", enter=False)
         b.enter_page("/users", host="10.111.113.2")
         b.wait_visible("#accounts-list")
         b.click("#accounts-list .pf-c-card:first-child")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -30,7 +30,16 @@ from testlib import *
 @skipDistroPackage()
 class TestLogin(MachineCase):
 
-    @skipMobile()
+    def check_shell(self):
+        b = self.browser
+        b.wait_visible("#content")
+        if b.cdp.mobile:
+            b.click("#hosts-sel button")
+            b.wait_in_text(".view-hosts .pf-m-current", "admin @")
+            b.click("#hosts-sel button")
+        else:
+            b.wait_text('#current-username', 'admin')
+
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -103,15 +112,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Login as admin
         b.open("/system")
         b.login_and_go()
-        b.wait_text('#current-username', 'admin')
+        self.check_shell()
 
         if m.image not in ['fedora-coreos']:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         # reload, which should log us in with the cookie
         b.reload()
-        b.wait_visible("#content")
-        b.wait_text('#current-username', 'admin')
+        self.check_shell()
 
         if m.image not in ['fedora-coreos']:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
@@ -244,7 +252,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # But after that login, they should be gone again
         verify_correct(True, 0)
 
-    @skipMobile()
     def testExpired(self):
         m = self.machine
         b = self.browser
@@ -337,8 +344,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         b.expect_load()
-        b.wait_visible("#content")
-        b.wait_text('#current-username', 'admin')
+        self.check_shell()
 
         self.allow_journal_messages('.*You are required to change your password immediately.*',
                                     '.*user account or password has expired.*',
@@ -346,7 +352,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     '.*Sorry, passwords do not match.')
         self.allow_restart_journal_messages()
 
-    @skipMobile()
     def testConversation(self):
         m = self.machine
         b = self.browser
@@ -382,8 +387,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.click('#login-button')
 
         b.expect_load()
-        b.wait_visible("#content")
-        b.wait_text('#current-username', 'admin')
+        self.check_shell()
 
         self.allow_restart_journal_messages()
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -386,7 +386,6 @@ class TestSystemInfo(MachineCase):
         self.allow_restart_journal_messages()
 
     @nondestructive
-    @skipMobile()
     def testHardwareInfo(self):
         b = self.browser
         m = self.machine
@@ -421,11 +420,12 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Class]', "Bridge")
         b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Class]', "Unclassified")
 
-        # sort by model
-        b.click(pci_selector + ' thead th[data-label=Model] button')
-        b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Model]', "440")
-        b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Virtio SCSI")
-        b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
+        # sort by model (no sort buttons in mobile mode)
+        if not b.cdp.mobile:
+            b.click(pci_selector + ' thead th[data-label=Model] button')
+            b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Model]', "440")
+            b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Virtio SCSI")
+            b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
 
         # go back to system page
         b.click('.pf-c-breadcrumb li:first a')

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -71,7 +71,6 @@ class TestJournal(MachineCase):
         sleep = m.spawn("sleep 1m", "sleep.log")
         m.execute("kill -SEGV %d" % (sleep))
 
-    @skipMobile()
     def testBasic(self):
         b = self.browser
         b.wait_timeout(120)
@@ -213,6 +212,9 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_log_present("THE SERVICE")
         wait_log_present("JUST ERROR")
 
+        if b.cdp.mobile:
+            b.click(".pf-c-toolbar__toggle button")
+
         # We cannot open this select with tests but we need to wait until it gets loaded
         b.select_PF4("#journal-identifier-menu .pf-c-select__toggle", "just-a-service")
         wait_log_not_present("JUST ERROR")
@@ -328,7 +330,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         self.allow_journal_messages(".*Data from the specified boot .* is not available: No such boot ID in journal.*")
 
-    @skipMobile()
     def testRebootAndTime(self):
         b = self.browser
         m = self.machine
@@ -446,6 +447,9 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                         ["", "Reboot", ""],
                         ["check-journal", "BEFORE BOOT", ""]
                         ])
+        if b.cdp.mobile:
+            b.click(".pf-c-toolbar__toggle button")
+
         b.focus("#journal-grep input")
         b.key_press("until:2038-01-01\\ 00:03")
         b.click("#journal-grep button[aria-label=Search]")
@@ -496,7 +500,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_text(".pf-c-card__title", "[no data]")
 
     @nondestructive
-    @skipMobile()
     def testLogLevel(self):
 
         b = self.browser
@@ -509,6 +512,9 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.login_and_go("/system/logs#/?tag=check-journal&since=@" + self.test_start_time)
 
         journal_line_selector = "#journal-box .cockpit-logline:has(span:contains({0}))"
+
+        if b.cdp.mobile:
+            b.click(".pf-c-toolbar__toggle button")
 
         self.browser.select_PF4("#journal-prio-menu", "Only emergency")
         b.wait_visible(journal_line_selector.format("EMERGENCY_MESSAGE"))
@@ -528,7 +534,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
                "ubuntu-2004", "fedora-coreos", "rhel-8-4", "rhel-8-5", "rhel-9-0", "centos-8-stream")
     @nondestructive
-    @skipMobile()
     def testAbrtSegv(self):
         b = self.browser
         m = self.machine
@@ -537,6 +542,9 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.crash()
 
         self.login_and_go("/system/logs#/?since=@" + self.test_start_time)
+        if b.cdp.mobile:
+            b.click(".pf-c-toolbar__toggle button")
+
         self.browser.select_PF4("#journal-prio-menu", "Critical and above")
         b.wait_visible(sleep_crash_list_sel)
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -932,7 +932,6 @@ ExecStart=/bin/true
         self.machine.execute(script=WAIT_KRB_SCRIPT.format("admin"), timeout=300)
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
-    @skipMobile()
     def testNegotiate(self):
         self.allow_hostkey_messages()
         b = self.browser
@@ -976,20 +975,17 @@ ExecStart=/bin/true
         b.open("/system/terminal", cookie={"name": "cockpit", "value": cookie, "domain": m.web_address, "path": "/"})
         b.wait_visible('#content')
 
-        def line_sel(i):
-            return '.terminal .xterm-accessibility-tree div:nth-child(%d)' % i
-
         # Remove failed units which will show up in the first terminal line
         m.execute("systemctl reset-failed")
 
         # kerberos ticket got forwarded into the session
         b.enter_page("/system/terminal")
-        b.wait_visible(".terminal .xterm-accessibility-tree")
-        b.wait_in_text(line_sel(1), "admin")
+        # wait for prompt
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "admin")
         b.key_press("klist\r")
-        b.wait_in_text(line_sel(2), "Ticket cache")
-        b.wait_in_text(line_sel(3), "Default principal: admin@COCKPIT.LAN")
-        b.wait_in_text(line_sel(6), "krbtgt/COCKPIT.LAN")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Ticket cache")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "Default principal: admin@COCKPIT.LAN")
+        b.wait_in_text(".terminal .xterm-accessibility-tree", "krbtgt/COCKPIT.LAN")
         self.assertIn("cockpit-session-", m.execute("ls /run/user/$(id -u admin)/*.ccache"))
 
         # Now connect to another machine

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -806,8 +806,7 @@ ExecStart=/usr/bin/false
         health_message = "1 service has failed" if n_failures == 1 else "%s services have failed" % n_failures
 
         # System page should have notification
-        b.click('#host-apps a[href="/system"]')
-        b.enter_page('/system')
+        b.click_system_menu("/system")
         b.wait_in_text(".system-health-events", health_message)
 
         # Clear aab-fail
@@ -815,8 +814,7 @@ ExecStart=/usr/bin/false
 
         # aab-fail should not be at the top
         b.switch_to_top()
-        b.click('#host-apps a[href="/system/services"]')
-        b.enter_page('/system/services')
+        b.click_system_menu("/system/services")
         b.wait_not_present('li:nth-child(1)[data-goto-unit="aab-fail.service"]')
 
         if self.count_failures() == 0:
@@ -828,8 +826,7 @@ ExecStart=/usr/bin/false
             b.wait_not_present("#services-error")
 
             # System page should not have notification
-            b.click('#host-apps a[href="/system"]')
-            b.enter_page('/system')
+            b.click_system_menu('/system')
             b.wait_not_in_text(".system-health-events", "service has failed")
             b.wait_not_in_text(".system-health-events", "services have failed")
 
@@ -862,8 +859,7 @@ Where=/fail
             b.wait_not_present("#services-error")
 
             # System page should not have notification
-            b.click('#host-apps a[href="/system"]')
-            b.enter_page('/system')
+            b.click_system_menu("/system")
             b.wait_not_in_text(".system-health-events", "service has failed")
             b.wait_not_in_text(".system-health-events", "services have failed")
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -759,7 +759,19 @@ WantedBy=default.target
     def count_failures(self):
         return int(self.machine.execute("systemctl --failed --plain --no-legend | wc -l"))
 
-    @skipMobile()
+    def check_system_menu_services_error(self, expected):
+        b = self.browser
+        b.switch_to_top()
+        if b.cdp.mobile:
+            b.click("#nav-system-item")
+        if expected:
+            b.wait_visible("#services-error")
+        else:
+            b.wait_not_present("#services-error")
+        if b.cdp.mobile:
+            # close menu again
+            b.click("#nav-system-item")
+
     def testNotifyFailed(self):
         m = self.machine
         b = self.browser
@@ -802,8 +814,7 @@ ExecStart=/usr/bin/false
         b.wait_visible('tr[data-goto-unit="aab-fail.service"] .service-unit-status:contains("Failed")')
 
         # Nav link should have icon
-        b.switch_to_top()
-        b.wait_visible("#services-error")
+        self.check_system_menu_services_error(True)
 
         n_failures = self.count_failures()
         health_message = "1 service has failed" if n_failures == 1 else "%s services have failed" % n_failures
@@ -825,15 +836,13 @@ ExecStart=/usr/bin/false
             b.wait_not_present('a:contains("System services") .ct-exclamation-circle')
 
             # Nav link should not have icon
-            b.switch_to_top()
-            b.wait_not_present("#services-error")
+            self.check_system_menu_services_error(False)
 
             # System page should not have notification
             b.click_system_menu('/system')
             b.wait_not_in_text(".system-health-events", "service has failed")
             b.wait_not_in_text(".system-health-events", "services have failed")
 
-    @skipMobile()
     def testHiddenFailure(self):
         m = self.machine
         b = self.browser
@@ -858,8 +867,7 @@ Where=/fail
 
         if self.count_failures() == 1:
             # Nav link should not have icon
-            b.switch_to_top()
-            b.wait_not_present("#services-error")
+            self.check_system_menu_services_error(False)
 
             # System page should not have notification
             b.click_system_menu("/system")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -472,7 +472,6 @@ ExecStart=/bin/awk -f /tmp/mem-hog.awk
         # Check that listen is not shown for .service units
         b.wait_not_present("#listen")
 
-    @skipMobile()
     def testLogs(self):
         b = self.browser
 
@@ -494,6 +493,8 @@ ExecStart=/bin/awk -f /tmp/mem-hog.awk
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
         t = b.text("#journal-box .cockpit-log-panel > div:nth-child(3)") + b.text("#journal-box .cockpit-log-panel > div:nth-child(4)")
         self.assertIn("START", t)
+        if b.cdp.mobile:
+            b.click("button[aria-label='Show Filters']")
         b.wait_val("#journal-grep input", "priority:debug service:test.service ")
         b.go("/system/services#test.service")
         b.enter_page("/system/services")
@@ -503,6 +504,8 @@ ExecStart=/bin/awk -f /tmp/mem-hog.awk
         b.enter_page("/system/logs")
         b.wait_text(".pf-c-card__title", "WORKING")
         b.click(".pf-c-breadcrumb a:contains('Logs')")
+        if b.cdp.mobile:
+            b.click("button[aria-label='Show Filters']")
         b.wait_val("#journal-grep input", "priority:debug service:test.service ")
         b.go("/system/services#test.service")
         b.enter_page("/system/services")

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -24,7 +24,6 @@ from testlib import *
 @skipDistroPackage()
 class TestRoles(MachineCase):
 
-    @skipMobile()
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -47,7 +46,12 @@ class TestRoles(MachineCase):
         b.expect_load()
         b.enter_page("/system")
         b.switch_to_top()
-        b.wait_text('#current-username', 'user')
+        if b.cdp.mobile:
+            b.click("#hosts-sel button")
+            b.wait_in_text(".view-hosts .pf-m-current", "user @")
+            b.click("#hosts-sel button")
+        else:
+            b.wait_text('#current-username', 'user')
 
         b.go("/users#/user")
         b.enter_page("/users")


### PR DESCRIPTION
At some point there should probably be some factorization for "check something in the system menu", but it's not yet clear to me how this could look like. I suggest we first fix all tests, and then look at all the mobile special cases.

Remaining `@skipMobile`s:
 - `check-metrics TestGrafanaClient`: Let's not bother testing Grafana in mobile mode
 - `check-storage-partitions testSizeSlider`: Mobile mode has a too narrow slider that can't make precise enough settings, so the numbers are off; we may think about how to fix that, but I'd keep it out of this PR.