### PR TITLE
bridge: Filter more DBus signals by sender when cache watching

### DIFF
--- a/src/bridge/cockpitdbuscache.c
+++ b/src/bridge/cockpitdbuscache.c
@@ -1229,6 +1229,12 @@ on_manager_signal (GDBusConnection *connection,
   const gchar * manager_added;
   ProcessInterfacesData *pis;
 
+  /* We have to filter the sender ourselves; glib doesn't do that for
+     well-known names.
+   */
+  if (self->name_owner && g_strcmp0 (sender, self->name_owner) != 0)
+    return;
+
   /* Note that this is an ObjectManager */
   manager_added = cockpit_paths_add (self->managed_not_ready, path);
 


### PR DESCRIPTION
Manager signals also need to be filtered, just as we did for property
signals in 11bea587f9a9385d262bb896155afe7aa30747be.