### PR TITLE
ssystemd: show last three days of logs by default -- FIX COMMIT MESSAGE ON MERGE: systemd: show 24 hours of logs by default

### DIFF
--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -56,7 +56,7 @@ const _ = cockpit.gettext;
 const timeFilterOptions = [
     { key: "boot", value: 0, toString: () => _("Current boot"), },
     { key: "boot", value: "-1", toString: () => _("Previous boot") },
-    { key: "since", value: "-24hours", toString: () => _("Last 24 hours") },
+    { key: "since", value: "-24hours", toString: () => _("Last 24 hours"), default: true },
     { key: "since", value: "-7days", toString: () => _("Last 7 days") },
 ];
 
@@ -83,8 +83,7 @@ const getTimeFilterOption = options => {
         return timeFilterOptions.find(option => option.key == 'boot' && option.value == options.boot);
     else if (options.since)
         return timeFilterOptions.find(option => option.key == 'since' && option.value == options.since);
-    else
-        return undefined;
+    return timeFilterOptions.find(option => 'default' in option); // Use the default key
 };
 
 export const LogsPage = () => {
@@ -273,6 +272,7 @@ export const LogsPage = () => {
                          variant={PageSectionVariants.light}
                          id="journal-box">
                 <JournalBox dataFollowing={dataFollowing}
+                            defaultSince={timeFilter ? timeFilter.value : getTimeFilterOption({}).value}
                             setCurrentIdentifiers={setCurrentIdentifiers}
                             setFilteredQuery={setFilteredQuery}
                             updateIdentifiersList={updateIdentifiersList}

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -87,7 +87,7 @@ export class JournalBox extends React.Component {
 
         this.options = cockpit.location.options;
         this.match = getGrepFiltersFromOptions({ options: this.options })[1];
-        const { dataFollowing, updateIdentifiersList, setFilteredQuery } = this.props;
+        const { dataFollowing, defaultSince, updateIdentifiersList, setFilteredQuery } = this.props;
         const { priority, grep, boot, since, until } = this.options;
         let last = dataFollowing ? null : 1;
         let count = 0;
@@ -109,7 +109,7 @@ export class JournalBox extends React.Component {
             grep,
             priority,
             reverse: true, /* reverse: Reverse output so that the newest entries are displayed first */
-            since,
+            since: since || defaultSince,
             until
         };
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -234,7 +234,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         # Test inline help
         b.click("#journal-grep button[aria-label='Open advanced search']")
-        b.wait_val("#journal-cmd-copy input", "journalctl --no-tail --priority=notice --reverse -- SYSLOG_IDENTIFIER=test-stream")
+        b.wait_val("#journal-cmd-copy input", "journalctl --no-tail --since=-24hours --priority=notice --reverse -- SYSLOG_IDENTIFIER=test-stream")
         b.click("#journal-grep button[aria-label='Open advanced search']")
         b.wait_not_present("#journal-cmd-copy")
 


### PR DESCRIPTION
To circumvent loading a lot of logs by default which can be fairly slow
set the default preset to showing the last three days of logs.

Fixes: #15085