### PR TITLE
test: Fix race in TestStorageMounting.testEncryptedMountingHelp

### DIFF
--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -224,12 +224,13 @@ class TestStorageMounting(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
         self.content_tab_wait_in_info(1, 1, "Mount point", "/run/foo")
 
-        fsys_tab = self.content_tab_expand(1, 1)
-
         # Unmount and lock externally, unlock and remount with Cockpit
 
         m.execute("umount /run/foo")
         m.execute("udisksctl lock -b %s" % dev)
+        # wait until the UI updated to the locking
+        self.content_tab_wait_in_info(1, 2, "Cleartext device", "-")
+        fsys_tab = self.content_tab_expand(1, 1)
         b.click(fsys_tab + " button:contains(Mount now)")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
         b.wait_not_present(fsys_tab + " button:contains(Mount now)")


### PR DESCRIPTION
The `udisksctl lock` is async by itself (triggers an internal udisks
job), and its completion notification to the UI is async as well. The
test must wait until the UI picked up the locking before trying to mount
it -- otherwise it's trying to call .Mount() on the
still-existing-but-about-to-go-away unlocked udisks device.

Fixes #16358

----
[example](https://logs.cockpit-project.org/logs/pull-14109-20210915-131047-376af3d1-debian-testing/log.html#182-2)

I validated this locally by putting that part of the test in a `for i in range(10)` loop, and it works reliably for me now. See #16358 for the debugging notes and details.