### PR TITLE
tools: Bump Debian debhelper compat to 12, Standards-Version to 4.6.0

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -2,7 +2,7 @@ Source: cockpit
 Section: admin
 Priority: optional
 Maintainer: Cockpit <cockpit@cockpit-project.org>
-Build-Depends: debhelper (>= 10),
+Build-Depends: debhelper (>= 12),
                dpkg-dev (>= 1.17.14),
                gettext (>= 0.19.7),
                libssh-dev (>= 0.8.5),
@@ -25,7 +25,7 @@ Build-Depends: debhelper (>= 10),
                glib-networking,
                openssh-client <!nocheck>,
                python3,
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
 Vcs-Browser: https://salsa.debian.org/utopia-team/cockpit


### PR DESCRIPTION
debhelper 12 is currently in Ubuntu 20.04 LTS, our earliest supported
release.

No changes necessary for new policy:
https://www.debian.org/doc/debian-policy/upgrading-checklist.html#version-4-6-0

-----

This is an excuse to run CI against the new tasks container from https://github.com/cockpit-project/cockpituous/pull/440 , hence running all tests.