### PR TITLE
branding: Add Arch Linux branding

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -243,6 +243,7 @@ title2sentence: multi-word
 
 include po/Makefile.am
 include pkg/Makefile.am
+include src/branding/arch/Makefile.am
 include src/branding/centos/Makefile.am
 include src/branding/debian/Makefile.am
 include src/branding/default/Makefile.am

--- a/src/branding/arch/Makefile.am
+++ b/src/branding/arch/Makefile.am
@@ -1,0 +1,12 @@
+archbrandingdir = $(datadir)/cockpit/branding/arch
+
+archbranding_DATA = \
+	src/branding/arch/branding.css \
+	$(NULL)
+
+EXTRA_DIST += $(archbranding_DATA)
+
+install-data-hook::
+	$(LN_S) -f /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
+	$(LN_S) -f /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
+	$(LN_S) -f /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico

--- a/src/branding/arch/branding.css
+++ b/src/branding/arch/branding.css
@@ -1,0 +1,26 @@
+body.login-pf {
+    background: url("bg-plain.jpg") no-repeat 50% 0;
+    background-size: cover;
+    background-color: #101010;
+}
+
+#badge {
+    width: 225px;
+    height: 80px;
+    background-image: url("logo.png");
+    background-size: contain;
+    background-repeat: no-repeat;
+}
+
+#brand {
+    font-size: 18pt;
+    text-transform: uppercase;
+}
+
+#brand:before {
+    content: "${NAME} <b>${VARIANT}</b>";
+}
+
+#index-brand:before {
+    content: "${NAME} <b>${VARIANT}</b>";
+}


### PR DESCRIPTION
Add branding for the Arch Linux distribution, this requires the
filesystem package to be installed which provides the Arch Linux logo.

---

## branding: Arch Linux Branding

Cockpit now includes branding for the [Arch Linux distribution](https://archlinux.org/).

![image](https://user-images.githubusercontent.com/67428/133798656-292563a3-3837-4a14-b9ed-c65912083fef.png)
