### PR TITLE
test: Fix race in TestStorageMounting.testEncryptedMountingHelp harder

### DIFF
--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -240,6 +240,9 @@ class TestStorageMounting(StorageCase):
 
         m.execute("umount /run/foo")
         m.execute("udisksctl lock -b %s" % dev)
+        # wait until the UI updated to the locking
+        self.content_tab_wait_in_info(1, 2, "Cleartext device", "-")
+        fsys_tab = self.content_tab_expand(1, 1)
         b.click(fsys_tab + " button:contains(Do not mount automatically on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically on boot)")
 


### PR DESCRIPTION
Commit 96659e58 fixed the first instance of the race, but forgot the one
right after it.

---

[example](https://logs.cockpit-project.org/logs/pull-16362-20210917-080806-1911acc8-debian-testing/log.html#190-2)