### PR TITLE
[r79] test: Make expected exception a bit more general

### DIFF
--- a/test/verify/check-menu
+++ b/test/verify/check-menu
@@ -58,7 +58,7 @@ class TestMenu(MachineCase):
         b.click("a[href='/playground/exception']")
         b.enter_page("/playground/exception")
         b.wait_visible("button")
-        with self.assertRaisesRegex(RuntimeError, "TypeError:.*value.*undefined"):
+        with self.assertRaisesRegex(RuntimeError, "TypeError:.*undefined"):
             b.click("button")
             # Some round trips, one of which should update the deferred exception
             for i in range(0, 5):


### PR DESCRIPTION
Firefox returns a bit different wording.

Cherry-picked from main commit 6eebd26109a

----

This started to fail with upgrading Chromium in our tasks container.  The error now looks like this:

    TypeError: Cannot set properties of undefined (setting 'value')

See [failing log](https://logs.cockpit-project.org/logs/pull-2431-20210921-023749-80bec242-rhel-7-9-cockpit-project-cockpit-rhel-7.9/log.html#227-2).