### PR TITLE
lib/patternfly: Fix "form select" padding

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -28,6 +28,21 @@ ul.pf-c-select__menu {
     overflow-y: auto;
 }
 
+/* Adjust padding on form selects to resemble PF non-form selects */
+/* (This can be seen when the longest text is selected on a non-stretched select) */
+/* Upstream: https://github.com/patternfly/patternfly/issues/4387 */
+/* Cockpit-Podman: https://github.com/cockpit-project/cockpit-podman/issues/755 */
+select.pf-c-form-control {
+    --pf-c-form-control--PaddingRight: 41px;
+    --pf-c-form-control--PaddingLeft: 8px;
+
+    // Firefox's select text has additional padding (4px)
+    @-moz-document url-prefix() {
+        --pf-c-form-control--PaddingRight: 37px;
+        --pf-c-form-control--PaddingLeft: 4px;
+    }
+}
+
 /* All SVGs used in PF4 have some inline style to align them
  * https://github.com/patternfly/patternfly-react/issues/4767
  */


### PR DESCRIPTION
PatternFly's form select does not use similar spacing compared to PF's select.

This causes issues when the form select is not stretched. Seen @:
https://github.com/cockpit-project/cockpit-podman/issues/755

Upstream issue:
https://github.com/patternfly/patternfly/issues/4387