### PR TITLE
lib: Pass Python scripts via "-c" instead of stdin

### DIFF
--- a/pkg/lib/python.js
+++ b/pkg/lib/python.js
@@ -20,12 +20,12 @@
 import cockpit from "cockpit";
 
 // FIXME: eventually convert all images to python 3
-const pyinvoke = ["sh", "-ec", "exec $(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) $@", "--", "-"];
+const pyinvoke = ["sh", "-ec", "exec $(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) -c \"$@\"", "--"];
 
 export function spawn (script_pieces, args, options) {
     const script = (typeof script_pieces == "string")
         ? script_pieces
         : script_pieces.join("\n");
 
-    return cockpit.spawn(pyinvoke.concat(args), options).input(script);
+    return cockpit.spawn(pyinvoke.concat([script]).concat(args), options);
 }


### PR DESCRIPTION
This frees up stdin for use by the actual program.

Also, this fixes quoting of $@ to allow spaces in the arguments.