### PR TITLE
test: Fix TestShutdownRestart.testBasic for different OS timezones

### DIFF
--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -18,7 +18,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
-from datetime import date
 from testlib import *
 
 
@@ -176,9 +175,10 @@ class TestShutdownRestart(MachineCase):
 
         # Insert a date using the widget dropdown
         b.click("button[aria-label='Toggle date picker']")
-        today = date.today()
-        b.click(f".pf-c-calendar-month__dates-cell:not(.pf-m-adjacent-month) button[aria-label='{today.strftime('%-d %B %Y')}']")
-        b.wait_val(".shutdown-date-picker input", today.strftime("%-m/%-d/%Y"))
+        today_label = m.execute("date +'%d %B %Y'").strip()
+        today_format = m.execute("date +'%-m/%d/%Y'").strip()
+        b.click(f".pf-c-calendar-month__dates-cell:not(.pf-m-adjacent-month) button[aria-label='{today_label}']")
+        b.wait_val(".shutdown-date-picker input", today_format)
         b.blur(".shutdown-date-picker input")
 
         # Power off


### PR DESCRIPTION
This test queried the host's date to schedule a shutdown for the VM.
Our RHEL images run in the EDT time zone, so after 20:00 EDT the host
already moved to the next day, and the test would schedule the shutdown
for the wrong day. Avoid this by querying the VM's date instead.

----

This has broken pretty much every automatic RHEL/CentOS image refresh in a long time, as they keep running in the early UTC morning while it's still "yesterday" on these images. [example log](https://logs.cockpit-project.org/logs/pull-2450-20210924-023137-2306c660-rhel-8-5-cockpit-project-cockpit/log.html#273-2) from https://github.com/cockpit-project/bots/pull/2450