### PR TITLE
lib: Move ServerTime component to PF4 TimePicker

### DIFF
--- a/pkg/lib/serverTime.scss
+++ b/pkg/lib/serverTime.scss
@@ -1,0 +1,3 @@
+.ct-serverTime-time-picker {
+    max-width: 7rem;
+}

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -542,7 +542,7 @@ revision\t: 2.3 (pvr 004e 1203)
             # Test more specific memory data with a fake dmidecode
             m.write('/tmp/dmidecode', dmidecode)
             m.execute('chmod +x /tmp/dmidecode; mount -o bind /tmp/dmidecode $(which dmidecode)')
-            self.addCleanup(m.execute, 'umount $(which dmidecode)')
+            self.addCleanup(m.execute, 'until umount $(which dmidecode); do sleep 1; done')
             b.reload()
             b.enter_page('/system/hwinfo')
             # first DIMM has unknown technology and rank

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -267,8 +267,23 @@ class TestSystemInfo(MachineCase):
         b.wait_visible("#system_information_change_systime")
         self.set_change_time_dialog_mode("Manually")
         b.set_input_text("#systime-date-input input", "2037-01-24")
-        b.set_input_text("#systime-time-hours", "08")
-        b.set_input_text("#systime-time-minutes", "03")
+        # invalid time
+        b.set_input_text("#systime-time-input-input", "25:61")
+        b.click("#system_information_change_systime .apply")
+        b.wait_text("#systime-manual-row .dialog-error", "Invalid time format")
+        # valid time
+        b.set_input_text("#systime-time-input-input", "08:03")
+        # wait until icon settles down
+        b.wait_visible("#systime-time-input-input[aria-invalid='false']")
+        b.wait_not_present("#systime-manual-row .dialog-error")
+        # avoid blinking cursor
+        b.blur("#systime-time-input-input")
+        if b.cdp.mobile:
+            # HACK: the clock icon in the <input> has too much jitter on mobile
+            ignore = ["#systime-time-input-input"]
+        else:
+            ignore = []
+        b.assert_pixels("#system_information_change_systime", "systime-manual-time", ignore=ignore)
         b.click("#system_information_change_systime .apply")
         b.wait_not_present("#system_information_change_systime")
 
@@ -292,8 +307,7 @@ class TestSystemInfo(MachineCase):
         b.wait_visible("#system_information_change_systime")
         self.set_change_time_dialog_mode("Manually")
         b.set_input_text("#systime-date-input input", "2018-06-04")
-        b.set_input_text("#systime-time-hours", "06")
-        b.set_input_text("#systime-time-minutes", "34")
+        b.set_input_text("#systime-time-input-input", "06:34")
         b.click("#system_information_change_systime .apply")
         b.wait_not_present("#system_information_change_systime")
 


### PR DESCRIPTION
This brings it in line with the shutdown and Services timer dialog, and
avoids an unsightly dialog layout on mobile.

Change the state keeping to just have a single tiem string as variable,
as that's overall easier to manage. Move the minute normalization into
get_current_time(), as that's the only place where it's really necessary
-- writing out the values does not care about leading zeros.

Add a pixel test for the manual time setting. This does not capture the
whole expanded time picker list, as that grows beyond the dialog, but
still captures enough to make sure it looks as expected. There is no way
to collapse it again, but we want to do the screenshot after setting a
manual date and time, to include these input value strings into the
pixel test.

----

In main, the mobile dialog looks like this, with an unhappy break:

![manual-time-mobile](https://user-images.githubusercontent.com/200109/134662772-5c30fffa-70d1-4840-80e9-fd4545aaa2d3.png)

See the pixel tests for how the dialog looks like now:

![desktop](https://raw.githubusercontent.com/cockpit-project/pixel-test-reference/7229019d0bfede4e9c1b0ca3ccb1a761ec2edf70/TestSystemInfo-testTime-systime-manual-time-pixels.png)

![mobile](https://raw.githubusercontent.com/cockpit-project/pixel-test-reference/7229019d0bfede4e9c1b0ca3ccb1a761ec2edf70/TestSystemInfo-testTime-systime-manual-time-mobile-pixels.png)