### PR TITLE
common: Use sigabbrev_np() instead of our own signal string table

### DIFF
--- a/src/common/cockpitunixsignal.c
+++ b/src/common/cockpitunixsignal.c
@@ -40,72 +40,20 @@
  * Copyright (C) 2014 Karel Zak <kzak@redhat.com>
  */
 
+/* for sigabbrev_np() */
+#define _GNU_SOURCE
+
+#include <string.h>
 #include <signal.h>
 #include "cockpitunixsignal.h"
-
-struct signv {
-  const char *name;
-  int val;
-} sys_signame[] = {
-  /* POSIX signals */
-  { "HUP",      SIGHUP },       /* 1 */
-  { "INT",      SIGINT },       /* 2 */
-  { "QUIT",     SIGQUIT },      /* 3 */
-  { "ILL",      SIGILL },       /* 4 */
-  { "TRAP",     SIGTRAP },      /* 5 */
-  { "ABRT",     SIGABRT },      /* 6 */
-  { "IOT",      SIGIOT },       /* 6, same as SIGABRT */
-#ifdef SIGEMT
-  { "EMT",      SIGEMT },       /* 7 (mips,alpha,sparc*) */
-#endif
-  { "BUS",      SIGBUS },       /* 7 (arm,i386,m68k,ppc), 10 (mips,alpha,sparc*) */
-  { "FPE",      SIGFPE },       /* 8 */
-  { "KILL",     SIGKILL },      /* 9 */
-  { "USR1",     SIGUSR1 },      /* 10 (arm,i386,m68k,ppc), 30 (alpha,sparc*), 16 (mips) */
-  { "SEGV",     SIGSEGV },      /* 11 */
-  { "USR2",     SIGUSR2 },      /* 12 (arm,i386,m68k,ppc), 31 (alpha,sparc*), 17 (mips) */
-  { "PIPE",     SIGPIPE },      /* 13 */
-  { "ALRM",     SIGALRM },      /* 14 */
-  { "TERM",     SIGTERM },      /* 15 */
-#ifdef SIGSTKFLT
-  { "STKFLT",   SIGSTKFLT },    /* 16 (arm,i386,m68k,ppc) */
-#endif
-  { "CHLD",     SIGCHLD },      /* 17 (arm,i386,m68k,ppc), 20 (alpha,sparc*), 18 (mips) */
-  { "CLD",      SIGCLD },       /* same as SIGCHLD (mips) */
-  { "CONT",     SIGCONT },      /* 18 (arm,i386,m68k,ppc), 19 (alpha,sparc*), 25 (mips) */
-  { "STOP",     SIGSTOP },      /* 19 (arm,i386,m68k,ppc), 17 (alpha,sparc*), 23 (mips) */
-  { "TSTP",     SIGTSTP },      /* 20 (arm,i386,m68k,ppc), 18 (alpha,sparc*), 24 (mips) */
-  { "TTIN",     SIGTTIN },      /* 21 (arm,i386,m68k,ppc,alpha,sparc*), 26 (mips) */
-  { "TTOU",     SIGTTOU },      /* 22 (arm,i386,m68k,ppc,alpha,sparc*), 27 (mips) */
-  { "URG",      SIGURG },       /* 23 (arm,i386,m68k,ppc), 16 (alpha,sparc*), 21 (mips) */
-  { "XCPU",     SIGXCPU },      /* 24 (arm,i386,m68k,ppc,alpha,sparc*), 30 (mips) */
-  { "XFSZ",     SIGXFSZ },      /* 25 (arm,i386,m68k,ppc,alpha,sparc*), 31 (mips) */
-  { "VTALRM",   SIGVTALRM },    /* 26 (arm,i386,m68k,ppc,alpha,sparc*), 28 (mips) */
-  { "PROF",     SIGPROF },      /* 27 (arm,i386,m68k,ppc,alpha,sparc*), 29 (mips) */
-  { "WINCH",    SIGWINCH },     /* 28 (arm,i386,m68k,ppc,alpha,sparc*), 20 (mips) */
-  { "IO",       SIGIO },        /* 29 (arm,i386,m68k,ppc), 23 (alpha,sparc*), 22 (mips) */
-  { "POLL",     SIGPOLL },      /* same as SIGIO */
-#ifdef SIGINFO
-  { "INFO",     SIGINFO },      /* 29 (alpha) */
-#endif
-#ifdef SIGLOST
-  { "LOST",     SIGLOST },      /* 29 (arm,i386,m68k,ppc,sparc*) */
-#endif
-  { "PWR",      SIGPWR },       /* 30 (arm,i386,m68k,ppc), 29 (alpha,sparc*), 19 (mips) */
-#ifdef SIGUNUSED
-  { "UNUSED",   SIGUNUSED },    /* 31 (arm,i386,m68k,ppc) */
-#endif
-  { "SYS",      SIGSYS },       /* 31 (mips,alpha,sparc*) */
-};
 
 gchar *
 cockpit_strsignal (int signum)
 {
-  size_t n;
+  const char *name = sigabbrev_np (signum);
 
-  for (n = 0; n < G_N_ELEMENTS (sys_signame); n++)
-    if (sys_signame[n].val == signum)
-      return g_strdup (sys_signame[n].name);
+  if (name)
+    return g_strdup (name);
 
 #ifdef SIGRTMIN
   if (SIGRTMIN <= signum && signum <= SIGRTMAX)


### PR DESCRIPTION
This has been available in glibc for a long time. All of our table
entries are present in glibc [1], except for these three aliases:
SIGCLD (same as SIGCHLD), SIGIO (same as SIGPOLL), and SIGUNUSED
(same as SIGSYS).

Still keep cockpit_strsignal() as such, as it also builds a name for
runtime signals and returns "UNKNOWN" instead of `NULL` for an unknown
signal.

[1] https://sourceware.org/git/?p=glibc.git;a=blob;f=sysdeps/generic/siglist.h