### PR TITLE
users: Add an list of recent logins to the account details

### DIFF
--- a/pkg/systemd/overview-cards/lastLogin.jsx
+++ b/pkg/systemd/overview-cards/lastLogin.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import React, { useState, useEffect } from 'react';
-import { Flex, FlexItem } from '@patternfly/react-core';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
 import { ExclamationTriangleIcon, UserIcon } from "@patternfly/react-icons";
 
 import * as timeformat from "timeformat";
@@ -52,6 +52,7 @@ const getFormattedDateTime = (time) => {
 
 const LastLogin = () => {
     const [messages, setLoginMessages] = useState(null);
+    const [name, setName] = useState(null);
 
     useEffect(() => {
         if (messages === null) {
@@ -71,7 +72,10 @@ const LastLogin = () => {
                         console.error("failed to fetch login messages:", error);
                     });
         }
-    }, [messages]);
+        if (name === null) {
+            cockpit.user().then(user => setName(user.name));
+        }
+    }, [messages, name]);
 
     if (messages === null || !messages['last-login-time']) {
         return null;
@@ -123,6 +127,15 @@ const LastLogin = () => {
                     {failedLogins &&
                     <FlexItem id="system_last_login_success" className="pf-u-text-break-word">
                         {lastLoginText}
+                    </FlexItem>
+                    }
+                    {name &&
+                    <FlexItem>
+                        <Button variant="link" isInline
+                                className="pf-u-font-size-sm"
+                                onClick={() => cockpit.jump("/users#/" + name)}>
+                            {_("View login history")}
+                        </Button>
                     </FlexItem>
                     }
                 </Flex>

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -38,6 +38,7 @@ import { delete_account_dialog } from "./delete-account-dialog.js";
 import { account_expiration_dialog, password_expiration_dialog } from "./expiration-dialogs.js";
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountRoles } from "./account-roles.js";
+import { AccountLogs } from "./account-logs-panel.jsx";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
 import * as timeformat from "timeformat.js";
 
@@ -371,6 +372,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                         </CardBody>
                     </Card>
                     <AuthorizedKeys name={account.name} home={account.home} allow_mods={self_mod_allowed} />
+                    <AccountLogs name={account.name} />
                 </Gallery>
             </PageSection>
         </Page>);

--- a/pkg/users/account-logs-panel.jsx
+++ b/pkg/users/account-logs-panel.jsx
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2021 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React, { useState, useEffect } from 'react';
+
+import { Card, CardTitle, CardBody, Text } from '@patternfly/react-core';
+import { ListingTable } from 'cockpit-components-table.jsx';
+
+import * as timeformat from "timeformat.js";
+
+const _ = cockpit.gettext;
+
+export function AccountLogs({ name }) {
+    const [logins, setLogins] = useState([]);
+    useEffect(() => {
+        if (logins.length === 0) {
+            cockpit.spawn(["/usr/bin/last", "--time-format", "iso", "-n", 25, name], { environ: ["LC_ALL=C"] })
+                    .then(data => {
+                        let logins = [];
+                        data.split('\n').forEach(line => {
+                            // Exclude still logged in and non user lines
+                            if (!line.includes(name) || line.includes('still')) {
+                                return;
+                            }
+                            // Exclude tmux/screen lines
+                            if (line.includes('tmux') || line.includes('screen')) {
+                                return;
+                            }
+
+                            // format:
+                            // admin    web console  ::ffff:172.27.0. 2021-09-24T09:02:13+00:00 - 2021-09-24T09:04:20+00:00  (00:02)
+                            const lines = line.split(/ +/);
+                            const ended = new Date(lines[lines.length - 2]);
+                            const started = new Date(lines[lines.length - 4]);
+                            const from = lines[lines.length - 5];
+                            if (isNaN(started.getTime()) || isNaN(ended.getTime())) {
+                                return;
+                            }
+
+                            logins.push({
+                                started,
+                                ended,
+                                from
+                            });
+                        });
+
+                        // Only show 15 login lines
+                        logins = logins.slice(0, 15);
+                        setLogins(logins);
+                    })
+                    .catch((ex) => {
+                        console.error(ex);
+                    });
+        }
+    }, [logins, name]);
+
+    return (
+        <Card id="account-logs">
+            <CardTitle>
+                <Text component="h2">{_("Login history")}</Text>
+            </CardTitle>
+            <CardBody className="contains-list">
+                <ListingTable variant="compact" aria-label={ _("Login history list") }
+                    columns={ [
+                        { title: _("Started") },
+                        { title: _("Ended") },
+                        { title: _("From") },
+                    ] }
+                    rows={ logins.map((line, index) => ({
+                        props: { key: index },
+                        columns: [timeformat.dateTime(line.started), timeformat.dateTime(line.ended), line.from]
+                    }))} />
+            </CardBody>
+        </Card>);
+}

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -508,6 +508,24 @@ class TestAccounts(MachineCase):
         b.wait_in_text("#password-expiration-text", "Password must be changed")
         self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "password must be changed")
 
+    @skipImage("User is not shown as logged in when logged in through Cockpit", "fedora-coreos")
+    def testAccountLogs(self):
+        b = self.browser
+        m = self.machine
+
+        # Clean out the relevant logfiles
+        m.execute("truncate -s0 /var/log/{[bw]tmp,lastlog} /var/run/utmp")
+
+        # Login once to create an entry
+        self.login_and_go("/users")
+        b.logout()
+
+        self.login_and_go("/users")
+        b.go("#/admin")
+        b.wait_visible("#account-logs")
+        # Header + one line of logins
+        b.wait_js_func("ph_count_check", "#account-logs tr", 2)
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Show a list of the 15 recent logins on the account details page, the last
login health card now includes a link to the account detail page.

Closes: #28

---

# Users: Login history

The user account details page now includes a list of your 15 most recent logins.

![users-login-history](https://user-images.githubusercontent.com/10246/135265518-8db81238-c25d-44b9-b461-e5d5be22565f.png)


