### PR TITLE
shell, systemd: Eliminate `var` keyword

### DIFF
--- a/pkg/shell/active-pages-dialog.jsx
+++ b/pkg/shell/active-pages-dialog.jsx
@@ -39,9 +39,9 @@ export class ActivePagesDialogBody extends React.Component {
     }
 
     render() {
-        var self = this;
-        var frames = self.state.iframes.map(function(frame) {
-            var columns = [{
+        const self = this;
+        const frames = self.state.iframes.map(function(frame) {
+            const columns = [{
                 title: <Split>
                     <SplitItem isFilled>
                         {frame.displayName}

--- a/pkg/shell/active-pages.js
+++ b/pkg/shell/active-pages.js
@@ -28,7 +28,7 @@ const _ = cockpit.gettext;
 
 // The argument is a Frames object from base_index.js
 export function showDialog (frames) {
-    var dataStore = { };
+    const dataStore = { };
 
     // we omit the host for all pages on our current system
     function displayName(address, component) {
@@ -38,11 +38,10 @@ export function showDialog (frames) {
     }
 
     function gatherIframes() {
-        var result = [];
-        var address, component, iframe;
-        for (address in frames.iframes) {
-            for (component in frames.iframes[address]) {
-                iframe = frames.iframes[address][component];
+        const result = [];
+        for (const address in frames.iframes) {
+            for (const component in frames.iframes[address]) {
+                const iframe = frames.iframes[address][component];
                 result.push({
                     frame: iframe,
                     component: component,
@@ -56,7 +55,7 @@ export function showDialog (frames) {
         return result;
     }
 
-    var selectedFrames = [];
+    const selectedFrames = [];
 
     dataStore.closePage = function() {
         // the user wants to close the selected pages
@@ -67,7 +66,7 @@ export function showDialog (frames) {
     };
 
     function selectionChanged(frame, selected) {
-        var index = selectedFrames.indexOf(frame);
+        const index = selectedFrames.indexOf(frame);
         if (selected) {
             if (index === -1)
                 selectedFrames.push(frame);
@@ -77,7 +76,7 @@ export function showDialog (frames) {
         }
     }
 
-    var iframes = gatherIframes();
+    const iframes = gatherIframes();
     // by default, select currently active (visible) frame
     iframes.forEach(function(f, index) {
         if (f.visible) {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -25,18 +25,18 @@ import ReactDOM from "react-dom";
 import { showDialog } from "./active-pages";
 import { LangModal, TimeoutModal, OopsModal } from "./shell-modals.jsx";
 
-var shell_embedded = window.location.pathname.indexOf(".html") !== -1;
+const shell_embedded = window.location.pathname.indexOf(".html") !== -1;
 const _ = cockpit.gettext;
 
 function component_checksum(machine, component) {
-    var parts = component.split("/");
-    var pkg = parts[0];
+    const parts = component.split("/");
+    const pkg = parts[0];
     if (machine.manifests && machine.manifests[pkg] && machine.manifests[pkg][".checksum"])
         return "$" + machine.manifests[pkg][".checksum"];
 }
 
 function Frames(index, setupIdleResetTimers) {
-    var self = this;
+    const self = this;
     let language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
     if (!language)
         language = "en-us";
@@ -50,14 +50,14 @@ function Frames(index, setupIdleResetTimers) {
     }
 
     self.remove = function remove(machine, component) {
-        var address;
+        let address;
         if (typeof machine == "string")
             address = machine;
         else if (machine)
             address = machine.address;
         if (!address)
             address = "localhost";
-        var list = self.iframes[address] || { };
+        const list = self.iframes[address] || { };
         if (!component)
             delete self.iframes[address];
         Object.keys(list).forEach(function(key) {
@@ -69,7 +69,7 @@ function Frames(index, setupIdleResetTimers) {
     };
 
     function frame_ready(frame, count) {
-        var ready = false;
+        let ready = false;
 
         window.clearTimeout(frame.timer);
         frame.timer = null;
@@ -105,9 +105,9 @@ function Frames(index, setupIdleResetTimers) {
     }
 
     self.lookup = function lookup(machine, component, hash) {
-        var host;
-        var address;
-        var new_frame = false;
+        let host;
+        let address;
+        let new_frame = false;
 
         if (typeof machine == "string") {
             address = host = machine;
@@ -121,26 +121,24 @@ function Frames(index, setupIdleResetTimers) {
         if (!address)
             address = host;
 
-        var list = self.iframes[address];
+        let list = self.iframes[address];
         if (!list)
             self.iframes[address] = list = { };
 
-        var name = "cockpit1:" + host + "/" + component;
-        var frame = list[component];
+        const name = "cockpit1:" + host + "/" + component;
+        let frame = list[component];
         if (frame && frame.getAttribute("name") != name) {
             remove_frame(frame);
             frame = null;
         }
 
-        var wind, src;
-
         /* A preloaded frame */
         if (!frame) {
-            wind = window.frames[name];
+            const wind = window.frames[name];
             if (wind)
                 frame = wind.frameElement;
             if (frame) {
-                src = frame.getAttribute('src');
+                const src = frame.getAttribute('src');
                 frame.url = src.split("#")[0];
                 list[component] = frame;
             }
@@ -155,7 +153,7 @@ function Frames(index, setupIdleResetTimers) {
             frame.setAttribute("data-host", host);
             frame.style.display = "none";
 
-            var base, checksum;
+            let base, checksum;
             if (machine) {
                 if (machine.manifests && machine.manifests[".checksum"])
                     checksum = "$" + machine.manifests[".checksum"];
@@ -190,7 +188,7 @@ function Frames(index, setupIdleResetTimers) {
 
         if (!hash)
             hash = "/";
-        src = frame.url + "#" + hash;
+        const src = frame.url + "#" + hash;
         if (frame.getAttribute('src') != src)
             frame.setAttribute('src', src);
 
@@ -205,21 +203,19 @@ function Frames(index, setupIdleResetTimers) {
 }
 
 function Router(index) {
-    var self = this;
+    const self = this;
 
-    var unique_id = 0;
-    var origin = cockpit.transport.origin;
-    var source_by_seed = { };
-    var source_by_name = { };
+    let unique_id = 0;
+    const origin = cockpit.transport.origin;
+    const source_by_seed = { };
+    const source_by_name = { };
 
     cockpit.transport.filter(function(message, channel, control) {
-        var seed, source, pos;
-
         /* Only control messages with a channel are forwardable */
         if (control) {
             if (control.channel !== undefined) {
-                for (seed in source_by_seed) {
-                    source = source_by_seed[seed];
+                for (const seed in source_by_seed) {
+                    const source = source_by_seed[seed];
                     if (!source.window.closed)
                         source.window.postMessage(message, origin);
                 }
@@ -231,10 +227,10 @@ function Router(index) {
 
         /* Forward message to relevant frame */
         } else if (channel) {
-            pos = channel.indexOf('!');
+            const pos = channel.indexOf('!');
             if (pos !== -1) {
-                seed = channel.substring(0, pos + 1);
-                source = source_by_seed[seed];
+                const seed = channel.substring(0, pos + 1);
+                const source = source_by_seed[seed];
                 if (source) {
                     if (!source.window.closed)
                         source.window.postMessage(message, origin);
@@ -248,12 +244,12 @@ function Router(index) {
     }, false);
 
     function perform_jump(child, control) {
-        var current_frame = index.current_frame();
+        const current_frame = index.current_frame();
         if (child !== window) {
             if (!current_frame || current_frame.contentWindow != child)
                 return;
         }
-        var str = control.location || "";
+        let str = control.location || "";
         if (str[0] != "/")
             str = "/" + str;
         if (control.host)
@@ -262,12 +258,11 @@ function Router(index) {
     }
 
     function perform_track(child) {
-        var hash;
-        var current_frame = index.current_frame();
+        const current_frame = index.current_frame();
         /* Note that we ignore tracknig for old shell code */
         if (current_frame && current_frame.contentWindow === child &&
             child.name && child.name.indexOf("/shell/shell") === -1) {
-            hash = child.location.hash;
+            let hash = child.location.hash;
             if (hash.indexOf("#") === 0)
                 hash = hash.substring(1);
             if (hash === "/")
@@ -277,7 +272,7 @@ function Router(index) {
     }
 
     function on_unload(ev) {
-        var source;
+        let source;
         if (ev.target.defaultView)
             source = source_by_name[ev.target.defaultView.name];
         else if (ev.view)
@@ -287,21 +282,21 @@ function Router(index) {
     }
 
     function on_hashchange(ev) {
-        var source = source_by_name[ev.target.name];
+        const source = source_by_name[ev.target.name];
         if (source)
             perform_track(source.window);
     }
 
     function on_load(ev) {
-        var source = source_by_name[ev.target.contentWindow.name];
+        const source = source_by_name[ev.target.contentWindow.name];
         if (source)
             perform_track(source.window);
     }
 
     function unregister(source) {
-        var child = source.window;
+        const child = source.window;
         cockpit.kill(null, child.name);
-        var frame = child.frameElement;
+        const frame = child.frameElement;
         if (frame)
             frame.removeEventListener("load", on_load);
         /* This is often invalid when the window is closed */
@@ -314,10 +309,10 @@ function Router(index) {
     }
 
     function register(child) {
-        var host, page;
-        var name = child.name || "";
+        let host, page;
+        const name = child.name || "";
         if (name.indexOf("cockpit1:") === 0) {
-            var parts = name.substring(9).split("/");
+            const parts = name.substring(9).split("/");
             host = parts[0];
             page = parts.slice(1).join("/");
         }
@@ -327,8 +322,8 @@ function Router(index) {
         }
 
         unique_id += 1;
-        var seed = (cockpit.transport.options["channel-seed"] || "undefined:") + unique_id + "!";
-        var source = {
+        const seed = (cockpit.transport.options["channel-seed"] || "undefined:") + unique_id + "!";
+        const source = {
             name: name,
             window: child,
             channel_seed: seed,
@@ -339,7 +334,7 @@ function Router(index) {
         source_by_seed[seed] = source;
         source_by_name[name] = source;
 
-        var frame = child.frameElement;
+        const frame = child.frameElement;
         frame.addEventListener("load", on_load);
         child.addEventListener("unload", on_unload);
         child.addEventListener("hashchange", on_hashchange);
@@ -361,9 +356,9 @@ function Router(index) {
         if (event.origin !== origin)
             return;
 
-        var forward_command = false;
-        var data = event.data;
-        var child = event.source;
+        let forward_command = false;
+        let data = event.data;
+        const child = event.source;
         if (!child)
             return;
 
@@ -379,7 +374,7 @@ function Router(index) {
         if (typeof data !== "string")
             return;
 
-        var source, control;
+        let source, control;
 
         /*
          * On Internet Explorer we see Access Denied when non Cockpit
@@ -413,8 +408,8 @@ function Router(index) {
                     source = register(child);
                 }
                 if (source) {
-                    var reply = $.extend({ }, cockpit.transport.options,
-                                         { command: "init", host: source.default_host, "channel-seed": source.channel_seed }
+                    const reply = $.extend({ }, cockpit.transport.options,
+                                           { command: "init", host: source.default_host, "channel-seed": source.channel_seed }
                     );
                     child.postMessage("\n" + JSON.stringify(reply), origin);
                     source.inited = true;
@@ -466,17 +461,16 @@ function Router(index) {
 
     self.start = function start(messages) {
         window.addEventListener("message", message_handler, false);
-        for (var i = 0, len = messages.length; i < len; i++)
+        for (let i = 0, len = messages.length; i < len; i++)
             message_handler(messages[i]);
     };
 
     self.hint = function hint(child, data) {
-        var message;
-        var source = source_by_name[child.name];
+        const source = source_by_name[child.name];
         /* This is often invalid when the window is closed */
         if (source && source.inited && !source.window.closed) {
             data.command = "hint";
-            message = "\n" + JSON.stringify(data);
+            const message = "\n" + JSON.stringify(data);
             source.window.postMessage(message, origin);
         }
     };
@@ -497,8 +491,8 @@ function Router(index) {
  * handled by the caller.
  */
 function Index() {
-    var self = this;
-    var current_frame;
+    const self = this;
+    let current_frame;
 
     if (typeof self.navigate !== "function")
         throw Error("Index requires a prototype with a navigate function");
@@ -579,16 +573,16 @@ function Index() {
     self.router = new Router(self);
 
     /* Watchdog for disconnect */
-    var watchdog = cockpit.channel({ payload: "null" });
+    const watchdog = cockpit.channel({ payload: "null" });
     $(watchdog).on("close", function(event, options) {
-        var watchdog_problem = options.problem || "disconnected";
+        const watchdog_problem = options.problem || "disconnected";
         console.warn("transport closed: " + watchdog_problem);
         $(self).triggerHandler("disconnect", watchdog_problem);
     });
 
     /* Handles an href link as seen below */
     $(document).on("click", "a[href]", function(ev) {
-        var a = this;
+        const a = this;
         if (!a.host || window.location.host === a.host) {
             self.jump(a.getAttribute('href'));
             ev.preventDefault();
@@ -596,7 +590,7 @@ function Index() {
         }
     });
 
-    var old_onerror = window.onerror;
+    const old_onerror = window.onerror;
     window.onerror = function cockpit_error_handler(msg, url, line) {
         self.show_oops();
         if (old_onerror)
@@ -629,12 +623,12 @@ function Index() {
      * generating a string for a link.
      */
     function encode(state, sidebar, with_root) {
-        var path = [];
+        const path = [];
         if (state.host && (sidebar || state.host !== "localhost"))
             path.push("@" + state.host);
         if (state.component)
             path.push.apply(path, state.component.split("/"));
-        var string = cockpit.location.encode(path, null, with_root);
+        let string = cockpit.location.encode(path, null, with_root);
         if (state.hash && state.hash !== "/")
             string += "#" + state.hash;
         return string;
@@ -642,15 +636,15 @@ function Index() {
 
     /* Decodes navigate state from a string */
     function decode(string) {
-        var state = { version: "v1", hash: "" };
-        var pos = string.indexOf("#");
+        const state = { version: "v1", hash: "" };
+        const pos = string.indexOf("#");
         if (pos !== -1) {
             state.hash = string.substring(pos + 1);
             string = string.substring(0, pos);
         }
         if (string[0] != '/')
             string = "/" + string;
-        var path = cockpit.location.decode(string);
+        const path = cockpit.location.decode(string);
         if (path[0] && path[0][0] == "@") {
             state.host = path.shift().substring(1);
             state.sidebar = true;
@@ -664,7 +658,7 @@ function Index() {
     }
 
     self.retrieve_state = function() {
-        var state = window.history.state;
+        let state = window.history.state;
         if (!state || state.version !== "v1") {
             if (shell_embedded)
                 state = decode("/" + window.location.hash);
@@ -675,17 +669,14 @@ function Index() {
     };
 
     function lookup_component_hash(address, component) {
-        var iframe, src;
-
         if (!address)
             address = "localhost";
 
-        var list = self.frames.iframes[address];
-        if (list)
-            iframe = list[component];
+        const list = self.frames.iframes[address];
+        const iframe = list ? list[component] : undefined;
 
         if (iframe) {
-            src = iframe.getAttribute('src');
+            const src = iframe.getAttribute('src');
             if (src)
                 return src.split("#")[1];
         }
@@ -712,7 +703,7 @@ function Index() {
         if (typeof (state) === "string")
             state = decode(state);
 
-        var current = self.retrieve_state();
+        const current = self.retrieve_state();
 
         /* Make sure we have the data we need */
         if (!state.host)
@@ -730,18 +721,14 @@ function Index() {
         if (!("component" in state))
             state.component = current.component || "";
 
-        var target;
-        var history = window.history;
-        var frame_change = (state.host !== current.host ||
+        const history = window.history;
+        const frame_change = (state.host !== current.host ||
                             state.component !== current.component);
 
         if (frame_change && !state.hash)
             state.hash = lookup_component_hash(state.host, state.component);
 
-        if (shell_embedded)
-            target = window.location;
-        else
-            target = encode(state, null, true);
+        const target = shell_embedded ? window.location : encode(state, null, true);
 
         if (replace) {
             history.replaceState(state, "", target);
@@ -783,7 +770,7 @@ function Index() {
 
     self.start = function() {
         /* window.messages is initialized in shell/indexes.js */
-        var messages = window.messages;
+        const messages = window.messages;
         if (messages)
             messages.cancel();
         self.router.start(messages || []);
@@ -806,7 +793,7 @@ function Index() {
     /* Menu items */
     /* The oops bar */
     function setup_oops(id) {
-        var oops = $(id);
+        const oops = $(id);
         if (!oops)
             return;
         oops.children("a").on("click", function() {
@@ -854,13 +841,13 @@ function Index() {
 }
 
 function CompiledComponents() {
-    var self = this;
+    const self = this;
     self.items = {};
 
     self.load = function(manifests, section) {
         $.each(manifests || { }, function(name, manifest) {
             $.each(manifest[section] || { }, function(prop, info) {
-                var item = {
+                const item = {
                     section: section,
                     label: cockpit.gettext(info.label) || prop,
                     order: info.order === undefined ? 1000 : info.order,
@@ -886,7 +873,7 @@ function CompiledComponents() {
                     item.path = name + "/" + prop;
 
                 /* Split out any hash in the path */
-                var pos = item.path.indexOf("#");
+                const pos = item.path.indexOf("#");
                 if (pos !== -1) {
                     item.hash = item.path.substr(pos + 1);
                     item.path = item.path.substr(0, pos);
@@ -903,14 +890,13 @@ function CompiledComponents() {
     };
 
     self.ordered = function(section) {
-        var x;
-        var list = [];
-        for (x in self.items) {
+        const list = [];
+        for (const x in self.items) {
             if (!section || self.items[x].section === section)
                 list.push(self.items[x]);
         }
         list.sort(function(a, b) {
-            var ret = a.order - b.order;
+            let ret = a.order - b.order;
             if (ret === 0)
                 ret = a.label.localeCompare(b.label);
             return ret;
@@ -919,8 +905,7 @@ function CompiledComponents() {
     };
 
     self.search = function(prop, value) {
-        var x;
-        for (x in self.items) {
+        for (const x in self.items) {
             if (self.items[x][prop] === value)
                 return self.items[x];
         }
@@ -937,7 +922,7 @@ function follow(arg) {
     }
 }
 
-var zz_value;
+let zz_value;
 
 /* For debugging utility in the index window */
 Object.defineProperties(window, {
@@ -949,7 +934,7 @@ Object.defineProperties(window, {
 });
 
 export function new_index_from_proto(proto) {
-    var o = new Object(proto); // eslint-disable-line no-new-object
+    const o = new Object(proto); // eslint-disable-line no-new-object
     Index.call(o);
     return o;
 }

--- a/pkg/shell/credentials.js
+++ b/pkg/shell/credentials.js
@@ -32,7 +32,7 @@ import "patterns";
 const _ = cockpit.gettext;
 
 export function setup() {
-    var keys;
+    let keys;
 
     function hide_add_key() {
         $("tbody.ssh-add-key-body").attr("data-name", "");

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -112,7 +112,7 @@ export class CockpitHosts extends React.Component {
     onHostEdit(event, machine) {
         this.mdialogs.render_dialog("add-machine", "hosts_setup_server_dialog", machine.address,
                                     (new_connection_string) => {
-                                        var parts = this.props.machines.split_connection_string(new_connection_string);
+                                        const parts = this.props.machines.split_connection_string(new_connection_string);
                                         if (machine == this.props.machine && parts.address != machine.address) {
                                             const addr = this.props.hostAddr({ host: parts.address }, true);
                                             this.props.jump(addr);

--- a/pkg/shell/index.js
+++ b/pkg/shell/index.js
@@ -24,25 +24,24 @@ import { new_machine_dialog_manager } from "./machines/machine-dialogs";
 import * as credentials from "./credentials";
 import * as indexes from "./indexes";
 
-var machines_inst = machines.instance();
-var loader = machines.loader(machines_inst);
-var dialogs = new_machine_dialog_manager(machines_inst);
+const machines_inst = machines.instance();
+const loader = machines.loader(machines_inst);
+const dialogs = new_machine_dialog_manager(machines_inst);
 
 credentials.setup();
 
 /* When alt is held down we display debugging menu items */
 document.addEventListener("click", function(ev) {
-    var i;
-    var visible = !!ev.altKey;
-    var advanced = document.querySelectorAll(".navbar-advanced");
-    for (i = 0; i < advanced.length; i++)
+    const visible = !!ev.altKey;
+    const advanced = document.querySelectorAll(".navbar-advanced");
+    for (let i = 0; i < advanced.length; i++)
         if (visible)
             advanced[i].removeAttribute("hidden");
         else
             advanced[i].setAttribute("hidden", "");
 }, true);
 
-var options = {
+const options = {
     logout_sel: "#go-logout",
     oops_sel: "#navbar-oops",
     killer_sel: "#active-pages",

--- a/pkg/shell/indexes.js
+++ b/pkg/shell/indexes.js
@@ -37,7 +37,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     if (!index_options)
         index_options = {};
 
-    var page_status = { };
+    const page_status = { };
     sessionStorage.removeItem("cockpit:page_status");
 
     index_options.navigate = function (state, sidebar) {
@@ -54,7 +54,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         }
     };
 
-    var index = base_index.new_index_from_proto(index_options);
+    const index = base_index.new_index_from_proto(index_options);
 
     /* Restarts */
     $(index).on("expect_restart", function (ev, host) {
@@ -62,14 +62,14 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     });
 
     /* Disconnection Dialog */
-    var watchdog_problem = null;
+    let watchdog_problem = null;
     $(index).on("disconnect", function (ev, problem) {
         watchdog_problem = problem;
         show_disconnected();
     });
 
     /* Is troubleshooting dialog open */
-    var troubleshooting = false;
+    let troubleshooting = false;
 
     $("#nav-system-item").on("click", function (ev) {
         $(this).toggleClass("active");
@@ -110,7 +110,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     });
 
     /* Navigation */
-    var ready = false;
+    let ready = false;
     function on_ready() {
         ready = true;
         index.ready();
@@ -156,7 +156,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             return;
         }
 
-        var current_frame = index.current_frame();
+        const current_frame = index.current_frame();
 
         if (current_frame)
             $(current_frame).hide();
@@ -173,8 +173,6 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
     /* Handles navigation */
     function navigate(state, reconnect) {
-        var machine;
-
         /* If this is a watchdog problem or we are troubleshooting
          * let the dialog handle it */
         if (watchdog_problem || troubleshooting)
@@ -182,7 +180,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
 
         if (!state)
             state = index.retrieve_state();
-        machine = machines.lookup(state.host);
+        let machine = machines.lookup(state.host);
 
         /* No such machine */
         if (!machine) {
@@ -202,7 +200,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             loader.connect(state.host);
         }
 
-        var compiled = compile(machine);
+        const compiled = compile(machine);
         if (machine.manifests && !state.component)
             state.component = choose_component(state, compiled);
 
@@ -449,16 +447,15 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function update_title(label, machine) {
-        var compiled;
         if (label)
             label += " - ";
         else
             label = "";
-        var suffix = index.default_title;
+        let suffix = index.default_title;
 
         if (machine) {
             if (machine.address === "localhost") {
-                compiled = compile(machine);
+                const compiled = compile(machine);
                 if (compiled.ordered("menu").length || compiled.ordered("tools").length)
                     suffix = (machine.user || current_user) + "@" + machine.label;
             } else {
@@ -490,15 +487,15 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function update_frame(machine, state, compiled) {
-        var title, message, connecting, restarting;
-        var current_frame = index.current_frame();
+        let current_frame = index.current_frame();
 
         if (machine.state != "connected") {
             $(current_frame).hide();
             current_frame = null;
             index.current_frame(current_frame);
 
-            connecting = (machine.state == "connecting");
+            const connecting = (machine.state == "connecting");
+            let title, message;
             if (machine.restarting) {
                 title = _("The machine is rebooting");
                 message = "";
@@ -510,7 +507,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 if (machine.problem == "not-found") {
                     message = _("Cannot connect to an unknown host");
                 } else {
-                    var error = machine.problem || machine.state;
+                    const error = machine.problem || machine.state;
                     if (error)
                         message = cockpit.message(error);
                     else
@@ -518,7 +515,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 }
             }
 
-            var troubleshooting;
+            let troubleshooting;
             if (!machine.restarting && mdialogs.needs_troubleshoot(machine)) {
                 $("#machine-troubleshoot").off()
                         .on("click", function () {
@@ -531,7 +528,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 $("#machine-troubleshoot").hide();
             }
 
-            restarting = !!machine.restarting;
+            const restarting = !!machine.restarting;
             $(".curtains-ct").prop("hidden", false);
             $(".curtains-ct .spinner").prop("hidden", !connecting && !restarting);
             $("#machine-reconnect").toggle(!connecting && machine.problem != "not-found" && !troubleshooting);
@@ -548,22 +545,19 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
                 return;
         }
 
-        var hash = state.hash;
-        var component = state.component;
+        let hash = state.hash;
+        let component = state.component;
 
         /* Old cockpit packages, used to be in shell/shell.html */
-        var compat;
         if (machine && compiled.compat) {
-            compat = compiled.compat[component];
+            const compat = compiled.compat[component];
             if (compat) {
                 component = "shell/shell";
                 hash = compat;
             }
         }
 
-        var frame;
-        if (component)
-            frame = index.frames.lookup(machine, component, hash);
+        const frame = component ? index.frames.lookup(machine, component, hash) : undefined;
         if (frame != current_frame) {
             $(current_frame).css('display', 'none');
             if (current_frame)
@@ -573,7 +567,6 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             index.current_frame(frame);
         }
 
-        var label, item;
         if (machine.state == "connected") {
             $(".curtains-ct").prop("hidden", true);
             $("#machine-spinner").toggle(frame && !$(frame).attr("data-ready"));
@@ -581,8 +574,8 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
             $(frame).attr('data-active', 'true');
 
             const component_manifest = find_component(state, compiled);
-            item = compiled.items[component_manifest];
-            label = item ? item.label : "";
+            const item = compiled.items[component_manifest];
+            const label = item ? item.label : "";
             update_title(label, machine);
             if (label)
                 $(frame).attr('title', label);
@@ -593,11 +586,11 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
         if (!machine.manifests || machine.address === "localhost")
             return null;
 
-        var shell = machine.manifests.shell || { };
-        var menu = shell.menu || { };
-        var tools = shell.tools || { };
+        const shell = machine.manifests.shell || { };
+        const menu = shell.menu || { };
+        const tools = shell.tools || { };
 
-        var mapping = { };
+        const mapping = { };
 
         /* The following were included in shell/shell.html in old versions */
         if ("_host_" in menu)
@@ -619,7 +612,7 @@ function MachinesIndex(index_options, machines, loader, mdialogs) {
     }
 
     function compile(machine) {
-        var compiled = base_index.new_compiled();
+        const compiled = base_index.new_compiled();
         compiled.load(machine.manifests, "tools");
         compiled.load(machine.manifests, "dashboard");
         compiled.load(machine.manifests, "menu");

--- a/pkg/shell/machines/machine-dialogs.js
+++ b/pkg/shell/machines/machine-dialogs.js
@@ -43,7 +43,7 @@ import "form-layout.scss";
 
 const _ = cockpit.gettext;
 
-var default_codes = {
+const default_codes = {
     "no-cockpit": "not-supported",
     "not-supported": "not-supported",
     "protocol-error": "not-supported",
@@ -57,10 +57,10 @@ var default_codes = {
 };
 
 function translate_and_init(tmpl) {
-    var tmp = $("<div>").append(tmpl);
+    const tmp = $("<div>").append(tmpl);
     tmp.find("[translate=\"yes\"]").each(function(i, e) {
-        var old = e.outerHTML;
-        var translated = cockpit.gettext(e.getAttribute("context"), $(e).text());
+        const old = e.outerHTML;
+        const translated = cockpit.gettext(e.getAttribute("context"), $(e).text());
         $(e).removeAttr("translate")
                 .text(translated);
         tmpl = tmpl.replace(old, e.outerHTML);
@@ -91,7 +91,7 @@ function fmt_to_array(fmt, args) {
     return fmt.split(fmt_re).map(replace);
 }
 
-var templates = {
+const templates = {
     "add-machine" : translate_and_init(add_tmpl),
     "auth-failed" : translate_and_init(auth_failed_tmpl),
     "change-auth" : translate_and_init(change_auth_tmpl),
@@ -104,7 +104,7 @@ var templates = {
 };
 
 function full_address(machines_ins, address) {
-    var machine = machines_ins.lookup(address);
+    const machine = machines_ins.lookup(address);
     if (machine && machine.address != "localhost")
         return machine.connection_string;
 
@@ -112,29 +112,29 @@ function full_address(machines_ins, address) {
 }
 
 function Dialog(selector, address, machines_ins, codes, caller_callback) {
-    var self = this;
+    const self = this;
 
     self.machines_ins = machines_ins;
     self.codes = codes;
     self.address = full_address(self.machines_ins, address);
 
-    var promise_callback = null;
+    let promise_callback = null;
 
-    var success_callback = null;
+    let success_callback = null;
 
-    var current_template = null;
-    var current_instance = null;
+    let current_template = null;
+    let current_instance = null;
 
     function address_or_label() {
-        var machine = self.machines_ins.lookup(self.address);
-        var host = self.machines_ins.split_connection_string(self.address).address;
+        const machine = self.machines_ins.lookup(self.address);
+        let host = self.machines_ins.split_connection_string(self.address).address;
         if (machine && machine.label)
             host = machine.label;
         return host;
     }
 
     function change_content(template, error_options) {
-        var old_instance = current_instance;
+        let old_instance = current_instance;
 
         if (current_template === template)
             return;
@@ -161,18 +161,18 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
     }
 
     self.try_to_connect = function(address, options) {
-        var dfd = $.Deferred();
-        var conn_options = $.extend({ payload: "echo", host: address }, options);
+        const dfd = $.Deferred();
+        const conn_options = $.extend({ payload: "echo", host: address }, options);
 
         conn_options["init-superuser"] = get_init_superuser_for_options(conn_options);
 
-        var machine = self.machines_ins.lookup(address);
+        const machine = self.machines_ins.lookup(address);
         if (machine && machine.host_key && !machine.on_disk) {
             conn_options['temp-session'] = false; /* Compatibility option */
             conn_options.session = 'shared';
             conn_options['host-key'] = machine.host_key;
         }
-        var client = cockpit.channel(conn_options);
+        const client = cockpit.channel(conn_options);
         client.send("x");
         $(client)
                 .on("message", function() {
@@ -188,7 +188,7 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
     };
 
     self.get_sel = function(child_selector) {
-        var ret_txt = selector;
+        let ret_txt = selector;
         if (child_selector)
             ret_txt = ret_txt + " " + child_selector;
         return $(ret_txt);
@@ -222,8 +222,8 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
         if (!template)
             template = current_template;
 
-        var address_data = self.machines_ins.split_connection_string(self.address);
-        var context = $.extend({
+        const address_data = self.machines_ins.split_connection_string(self.address);
+        const context = $.extend({
             host : address_or_label(),
             full_address : self.address,
             context_title : self.context_title,
@@ -234,13 +234,13 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
             }
         }, data, address_data);
 
-        var output = $(mustache.render(templates[template], context));
+        const output = $(mustache.render(templates[template], context));
         cockpit.translate(output);
         self.get_sel(".modal-content").html(output);
     };
 
     self.render_error = function render_error(error) {
-        var template;
+        let template;
         if (error.problem && error.command == "close")
             template = self.codes[error.problem];
 
@@ -259,7 +259,7 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
     };
 
     self.show = function () {
-        var sel = self.get_sel();
+        const sel = self.get_sel();
         sel.on('hide.bs.modal', function () {
             self.get_sel(".model-content").empty();
         });
@@ -267,8 +267,8 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
     };
 
     self.run = function (promise, failure_callback) {
-        var dialog_dfd = $.Deferred();
-        var promise_funcs = [];
+        const dialog_dfd = $.Deferred();
+        const promise_funcs = [];
 
         function next(i) {
             promise_funcs[i]()
@@ -305,15 +305,15 @@ function Dialog(selector, address, machines_ins, codes, caller_callback) {
 }
 
 function is_method_supported(methods, method) {
-    var result = methods[method];
+    const result = methods[method];
     return result ? result != "no-server-support" : false;
 }
 
 function MachineColorPicker(machines_ins) {
-    var self = this;
+    const self = this;
 
     self.render = function(selector, address, selected_color) {
-        var machine;
+        let machine;
 
         if (address && !selected_color) {
             machine = machines_ins.lookup(address);
@@ -324,14 +324,14 @@ function MachineColorPicker(machines_ins) {
         if (!selected_color)
             selected_color = machines_ins.unused_color();
 
-        var part;
-        var colors = [];
-        for (var i = 0; i < machines.colors.length; i += 6) {
+        let part;
+        const colors = [];
+        for (let i = 0; i < machines.colors.length; i += 6) {
             part = machines.colors.slice(i, i + 6);
             colors.push({ list : part });
         }
 
-        var text = mustache.render(templates["color-picker"], { colors : colors, });
+        const text = mustache.render(templates["color-picker"], { colors : colors, });
         $(selector).html(text);
 
         $("#host-edit-color", selector).css("background-color", selected_color);
@@ -341,7 +341,7 @@ function MachineColorPicker(machines_ins) {
 
         $('#host-edit-color-popover .popover-content .color-cell', selector)
                 .click(function() {
-                    var color = $(this).css('background-color');
+                    const color = $(this).css('background-color');
                     $('#host-edit-color', selector).css('background-color', color);
                 });
 
@@ -356,7 +356,7 @@ function MachineColorPicker(machines_ins) {
 }
 
 function Simple(dialog) {
-    var self = this;
+    const self = this;
 
     self.load = function() {
         dialog.render();
@@ -364,21 +364,21 @@ function Simple(dialog) {
 }
 
 function AddMachine(dialog) {
-    var self = this;
-    var selector = dialog.get_sel();
-    var run_error = null;
+    const self = this;
+    const selector = dialog.get_sel();
+    let run_error = null;
 
-    var user_name_dirty = false;
-    var unused_color = dialog.machines_ins.unused_color();
+    let user_name_dirty = false;
+    const unused_color = dialog.machines_ins.unused_color();
 
-    var invisible = dialog.machines_ins.addresses.filter(function(addr) {
-        var m = dialog.machines_ins.lookup(addr);
+    const invisible = dialog.machines_ins.addresses.filter(function(addr) {
+        const m = dialog.machines_ins.lookup(addr);
         return !m || !m.visible;
     });
 
     function existing_error(address) {
-        var ex = null;
-        var machine = dialog.machines_ins.lookup(address);
+        let ex = null;
+        const machine = dialog.machines_ins.lookup(address);
         if (machine && machine.visible && machine.on_disk && machine != self.old_machine) {
             ex = new Error(_("This machine has already been added."));
             ex.target = "#add-machine-address";
@@ -387,11 +387,11 @@ function AddMachine(dialog) {
     }
 
     function check_address(evt) {
-        var disabled = true;
-        var ex = null;
+        let disabled = true;
+        let ex = null;
 
-        var addr = $('#add-machine-address').val();
-        var button = dialog.get_sel(".modal-footer>.pf-m-primary");
+        const addr = $('#add-machine-address').val();
+        const button = dialog.get_sel(".modal-footer>.pf-m-primary");
 
         if (addr === "") {
             disabled = true;
@@ -412,7 +412,7 @@ function AddMachine(dialog) {
             selector.dialog("failure", ex);
 
         if (!user_name_dirty) {
-            var m = addr ? dialog.machines_ins.lookup(addr) : null;
+            const m = addr ? dialog.machines_ins.lookup(addr) : null;
             if (m && m.user)
                 $('#add-machine-user').val(m.user);
             if (m && m.color)
@@ -427,14 +427,14 @@ function AddMachine(dialog) {
     function add_machine() {
         run_error = null;
         dialog.address = $('#add-machine-address').val();
-        var user = $('#add-machine-user').val();
+        const user = $('#add-machine-user').val();
         if (user) {
-            var parts = dialog.machines_ins.split_connection_string(dialog.address);
+            const parts = dialog.machines_ins.split_connection_string(dialog.address);
             parts.user = user;
             dialog.address = dialog.machines_ins.generate_connection_string(user, parts.port, parts.address);
         }
 
-        var color = machines.colors.parse($('#add-machine-color-picker #host-edit-color').css('background-color'));
+        const color = machines.colors.parse($('#add-machine-color-picker #host-edit-color').css('background-color'));
 
         if (self.old_machine && dialog.address == self.old_machine.connection_string) {
             dialog.run(dialog.machines_ins.change(self.old_machine.key, { color: color }));
@@ -445,7 +445,7 @@ function AddMachine(dialog) {
             return;
 
         dialog.set_goal(function() {
-            var dfp = $.Deferred();
+            const dfp = $.Deferred();
             dialog.machines_ins.add(dialog.address, color)
                     .then(function () {
                         if (self.old_machine && self.old_machine != dialog.machines_ins.lookup(dialog.address)) {
@@ -455,8 +455,8 @@ function AddMachine(dialog) {
                             dfp.resolve();
                     })
                     .catch(function (ex) {
-                        var msg = cockpit.format(_("Failed to add machine: $0"),
-                                                 cockpit.message(ex));
+                        const msg = cockpit.format(_("Failed to add machine: $0"),
+                                                   cockpit.message(ex));
                         dfp.reject(msg);
                     });
 
@@ -465,9 +465,9 @@ function AddMachine(dialog) {
 
         dialog.run(dialog.try_to_connect(dialog.address), function (ex) {
             if (ex.problem == "no-host") {
-                var host_id_port = dialog.address;
-                var port_index = host_id_port.lastIndexOf(":");
-                var port = "22";
+                let host_id_port = dialog.address;
+                const port_index = host_id_port.lastIndexOf(":");
+                let port = "22";
                 if (port_index === -1)
                     host_id_port = dialog.address + ":22";
                 else
@@ -481,14 +481,14 @@ function AddMachine(dialog) {
     }
 
     self.load = function() {
-        var manifest = cockpit.manifests.shell || {};
-        var limit = parseInt(manifest["machine-limit"], 10);
-        var color_picker = new MachineColorPicker(dialog.machines_ins);
+        const manifest = cockpit.manifests.shell || {};
+        let limit = parseInt(manifest["machine-limit"], 10);
+        const color_picker = new MachineColorPicker(dialog.machines_ins);
         if (!limit || isNaN(limit))
             limit = 20;
 
         self.old_machine = null;
-        var address_parts = null;
+        let address_parts = null;
         if (dialog.address) {
             self.old_machine = dialog.machines_ins.lookup(dialog.address);
             if (self.old_machine && !self.old_machine.visible)
@@ -496,7 +496,7 @@ function AddMachine(dialog) {
             address_parts = dialog.machines_ins.split_connection_string(dialog.address);
         }
 
-        var host_address = ""; var host_user = "";
+        let host_address = ""; let host_user = "";
         if (address_parts) {
             host_address = address_parts.address;
             if (address_parts.port)
@@ -514,7 +514,7 @@ function AddMachine(dialog) {
             options : invisible,
         });
 
-        var button = dialog.get_sel(".modal-footer>.pf-m-primary");
+        const button = dialog.get_sel(".modal-footer>.pf-m-primary");
         button.on("click", add_machine);
 
         $("#add-machine-address").on("input focus change", check_address);
@@ -525,15 +525,15 @@ function AddMachine(dialog) {
 }
 
 function MachinePort(dialog) {
-    var self = this;
+    const self = this;
 
     function change_port() {
-        var dfp = $.Deferred();
-        var parts = dialog.machines_ins.split_connection_string(dialog.address);
+        const dfp = $.Deferred();
+        const parts = dialog.machines_ins.split_connection_string(dialog.address);
         parts.port = $("#edit-machine-port").val();
-        var address = dialog.machines_ins.generate_connection_string(parts.user,
-                                                                     parts.port,
-                                                                     parts.address);
+        const address = dialog.machines_ins.generate_connection_string(parts.user,
+                                                                       parts.port,
+                                                                       parts.address);
         function update_host(ex) {
             dialog.address = address;
             dialog.machines_ins.change(parts.address, { port: parts.port })
@@ -551,8 +551,8 @@ function MachinePort(dialog) {
                         }
                     })
                     .catch(function (ex) {
-                        var msg = cockpit.format(_("Failed to edit machine: $0"),
-                                                 cockpit.message(ex));
+                        const msg = cockpit.format(_("Failed to edit machine: $0"),
+                                                   cockpit.message(ex));
                         dfp.reject(msg);
                     });
         }
@@ -573,7 +573,7 @@ function MachinePort(dialog) {
     }
 
     self.load = function() {
-        var machine = dialog.machines_ins.lookup(dialog.address);
+        const machine = dialog.machines_ins.lookup(dialog.address);
         if (!machine) {
             dialog.get_sel().modal('hide');
             return;
@@ -587,13 +587,13 @@ function MachinePort(dialog) {
 }
 
 function HostKey(dialog, problem) {
-    var self = this;
-    var error_options = null;
-    var key = null;
+    const self = this;
+    let error_options = null;
+    let key = null;
 
     function add_key() {
-        var q;
-        var machine = dialog.machines_ins.lookup(dialog.address);
+        let q;
+        const machine = dialog.machines_ins.lookup(dialog.address);
         if (!machine || machine.on_disk) {
             q = dialog.machines_ins.add_key(key);
         } else {
@@ -604,8 +604,8 @@ function HostKey(dialog, problem) {
             });
         }
 
-        var promise = q.then(function () {
-            var inner = dialog.try_to_connect(dialog.address);
+        const promise = q.then(function () {
+            const inner = dialog.try_to_connect(dialog.address);
 
             inner.catch(function(ex) {
                 if ((ex.problem == "invalid-hostkey" ||
@@ -624,11 +624,11 @@ function HostKey(dialog, problem) {
     }
 
     function render() {
-        var promise = null;
-        var options = {};
-        var match_problem = problem;
-        var fp;
-        var key_type;
+        let promise = null;
+        const options = {};
+        let match_problem = problem;
+        let fp;
+        let key_type;
 
         if (error_options) {
             key = error_options["host-key"];
@@ -677,19 +677,19 @@ function HostKey(dialog, problem) {
 }
 
 function ChangeAuth(dialog) {
-    var self = this;
-    var error_options = null;
-    var identity_path = null;
-    var keys = null;
-    var machine = dialog.machines_ins.lookup(dialog.address);
-    var default_ssh_key = null;
+    const self = this;
+    let error_options = null;
+    let identity_path = null;
+    let keys = null;
+    const machine = dialog.machines_ins.lookup(dialog.address);
+    let default_ssh_key = null;
 
-    var offer_login_password;
-    var offer_key_password;
-    var use_login_password;
-    var use_key_password;
+    let offer_login_password;
+    let offer_key_password;
+    let use_login_password;
+    let use_key_password;
 
-    var offer_key_setup;
+    let offer_key_setup;
 
     self.user = { };
 
@@ -700,7 +700,7 @@ function ChangeAuth(dialog) {
             identity_path = error_options.error.split(": ")[1];
     }
 
-    var old_extra_state = null;
+    let old_extra_state = null;
 
     function update_key_setup() {
         if (!default_ssh_key)
@@ -713,7 +713,7 @@ function ChangeAuth(dialog) {
 
         const lmach = dialog.machines_ins.lookup(null);
 
-        var params = {
+        const params = {
             key: bold(default_ssh_key.name),
             luser: bold(self.user.name),
             lhost: bold(lmach ? lmach.label || lmach.address : "localhost"),
@@ -725,7 +725,7 @@ function ChangeAuth(dialog) {
         default_ssh_key.unaligned_passphrase =
             (default_ssh_key.encrypted && identity_path && identity_path == default_ssh_key.name);
 
-        var text, extra, state;
+        let text, extra, state;
         if (!default_ssh_key.exists) {
             state = "create";
             text = _("Create a new SSH key and authorize it.");
@@ -841,10 +841,10 @@ function ChangeAuth(dialog) {
     }
 
     function login() {
-        var options = {};
-        var user = dialog.machines_ins.split_connection_string(dialog.address).user || "";
-        var do_setup_keys = offer_key_setup && $("#login-setup-keys").prop('checked');
-        var do_key_password_change = do_setup_keys && default_ssh_key.unaligned_passphrase;
+        const options = {};
+        const user = dialog.machines_ins.split_connection_string(dialog.address).user || "";
+        const do_setup_keys = offer_key_setup && $("#login-setup-keys").prop('checked');
+        const do_key_password_change = do_setup_keys && default_ssh_key.unaligned_passphrase;
 
         if (use_login_password) {
             options.password = $("#login-custom-password").val();
@@ -860,23 +860,23 @@ function ChangeAuth(dialog) {
             }
         }
 
-        var key_password = dialog.get_sel(".locked-identity-password").val();
+        const key_password = dialog.get_sel(".locked-identity-password").val();
 
         if (use_key_password && !key_password) {
             show_error(_("The key password can not be empty"), ".locked-identity-password");
             return;
         }
 
-        var setup_new_key_password = dialog.get_sel(".login-setup-new-key-password").val();
-        var setup_new_key_password2 = dialog.get_sel(".login-setup-new-key-password2").val();
+        const setup_new_key_password = dialog.get_sel(".login-setup-new-key-password").val();
+        const setup_new_key_password2 = dialog.get_sel(".login-setup-new-key-password2").val();
 
         if (do_setup_keys && !do_key_password_change && setup_new_key_password != setup_new_key_password2) {
             show_error(_("The key passwords do not match"), ".login-setup-new-key-password2");
             return;
         }
 
-        var setup_login_password = dialog.get_sel(".login-setup-login-password").val();
-        var setup_login_password2 = dialog.get_sel(".login-setup-login-password2").val();
+        const setup_login_password = dialog.get_sel(".login-setup-login-password").val();
+        const setup_login_password2 = dialog.get_sel(".login-setup-login-password2").val();
 
         if (do_key_password_change && !setup_login_password) {
             show_error(_("The new key password can not be empty"), ".login-setup-login-password");
@@ -920,18 +920,18 @@ function ChangeAuth(dialog) {
     }
 
     function render() {
-        var promise = null;
-        var template = "change-auth";
-        var methods = null;
-        var available = null;
-        var locked_identity = false;
+        let promise = null;
+        let template = "change-auth";
+        let methods = null;
+        let available = null;
+        let locked_identity = false;
 
         if (error_options) {
             available = {};
 
             methods = error_options["auth-method-results"];
             if (methods) {
-                for (var method in methods) {
+                for (const method in methods) {
                     if (is_method_supported(methods, method)) {
                         available[method] = true;
                     }
@@ -1013,7 +1013,7 @@ function ChangeAuth(dialog) {
                 .always(function (user) {
                     cockpit.script(ssh_show_default_key_sh, [], { })
                             .then(function (data) {
-                                var info = data.split("\n");
+                                const info = data.split("\n");
                                 if (info[0])
                                     default_ssh_key = { name: info[0], exists: true, encrypted: info[1] == "encrypted" };
                                 else
@@ -1035,23 +1035,23 @@ function ChangeAuth(dialog) {
 }
 
 function MachineDialogManager(machines_ins, codes) {
-    var self = this;
+    const self = this;
 
     if (!codes)
         codes = default_codes;
 
-    var color_picker = new MachineColorPicker(machines_ins);
+    const color_picker = new MachineColorPicker(machines_ins);
 
     self.troubleshoot = function(target_id, machine) {
-        var selector = "#" + target_id;
+        const selector = "#" + target_id;
         if (!machine || !machine.problem)
             return;
 
-        var template = codes[machine.problem];
+        let template = codes[machine.problem];
         if (machine.problem == "no-host")
             template = "change-port";
 
-        var dialog = new Dialog(selector, machine.address, machines_ins, codes);
+        const dialog = new Dialog(selector, machine.address, machines_ins, codes);
         dialog.render_template(template);
         dialog.show();
     };
@@ -1067,8 +1067,8 @@ function MachineDialogManager(machines_ins, codes) {
     };
 
     self.render_dialog = function (template, target_id, address, callback) {
-        var selector = "#" + target_id;
-        var dialog = new Dialog(selector, address, machines_ins, codes, callback);
+        const selector = "#" + target_id;
+        const dialog = new Dialog(selector, address, machines_ins, codes, callback);
         dialog.render_template(template);
         dialog.show();
     };

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -3,7 +3,7 @@ import cockpit from "cockpit";
 
 import ssh_add_key_sh from "raw-loader!./ssh-add-key.sh";
 
-var mod = { };
+const mod = { };
 
 /*
  * We share the Machines state between multiple frames. Only
@@ -20,8 +20,8 @@ var mod = { };
  * because we don't ever want to write unprefixed keys.
  */
 
-var key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
-var session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
+const key = cockpit.sessionStorage.prefixedKey("v2-machines.json");
+const session_prefix = cockpit.sessionStorage.prefixedKey("v1-session-machine");
 
 function generate_session_key(host) {
     return session_prefix + "/" + host;
@@ -70,16 +70,16 @@ export function get_init_superuser_for_options(options) {
 }
 
 function Machines() {
-    var self = this;
+    const self = this;
 
-    var flat = null;
+    let flat = null;
     self.ready = false;
 
     /* parsed machine data */
-    var machines = { };
+    const machines = { };
 
     /* Data shared between Machines() instances */
-    var last = {
+    let last = {
         content: null,
         overlay: {
             localhost: {
@@ -97,21 +97,20 @@ function Machines() {
     window.addEventListener("storage", storage);
 
     window.setTimeout(function() {
-        var value = window.sessionStorage.getItem(key);
+        const value = window.sessionStorage.getItem(key);
         if (!self.ready && value)
             refresh(JSON.parse(value));
     });
 
-    var timeout = null;
+    let timeout = null;
 
     function sync(machine, values, overlay) {
-        var desired = $.extend({ }, values || { }, overlay || { });
-        var prop;
-        for (prop in desired) {
+        const desired = $.extend({ }, values || { }, overlay || { });
+        for (const prop in desired) {
             if (machine[prop] !== desired[prop])
                 machine[prop] = desired[prop];
         }
-        for (prop in machine) {
+        for (const prop in machine) {
             if (machine[prop] !== desired[prop])
                 delete machine[prop];
         }
@@ -132,27 +131,25 @@ function Machines() {
             }, 10);
         }
 
-        var host;
-        var hosts = { };
-        var content = shared.content || { };
-        var overlay = shared.overlay || { };
-        for (host in content)
+        const hosts = { };
+        const content = shared.content || { };
+        const overlay = shared.overlay || { };
+        for (const host in content)
             hosts[host] = true;
-        for (host in overlay)
+        for (const host in overlay)
             hosts[host] = true;
 
-        var events = [];
+        const events = [];
 
-        var machine, application;
-        for (host in hosts) {
-            var old_machine = machines[host] || { };
-            var old_conns = old_machine.connection_string;
+        for (const host in hosts) {
+            const old_machine = machines[host] || { };
+            const old_conns = old_machine.connection_string;
 
             /* Invert logic for color, always respect what's on disk */
             if (content[host] && content[host].color && overlay[host])
                 delete overlay[host].color;
 
-            machine = sync(old_machine, content[host], overlay[host]);
+            const machine = sync(old_machine, content[host], overlay[host]);
 
             /* Fill in defaults */
             machine.key = host;
@@ -165,7 +162,7 @@ function Machines() {
 
             if (!machine.label) {
                 if (host == "localhost" || host == "localhost.localdomain") {
-                    application = cockpit.transport.application();
+                    const application = cockpit.transport.application();
                     if (application.indexOf('cockpit+=') === 0)
                         machine.label = application.replace('cockpit+=', '');
                     else
@@ -183,9 +180,9 @@ function Machines() {
         }
 
         /* Remove any lost hosts */
-        for (host in machines) {
+        for (const host in machines) {
             if (!(host in hosts)) {
-                machine = machines[host];
+                const machine = machines[host];
                 delete machines[host];
                 delete overlay[host];
                 events.push(["removed", [machine, host]]);
@@ -193,17 +190,16 @@ function Machines() {
         }
 
         /* Fire off all events */
-        var i;
-        var sel = $(self);
-        var len = events.length;
-        for (i = 0; i < len; i++)
+        const sel = $(self);
+        const len = events.length;
+        for (let i = 0; i < len; i++)
             sel.triggerHandler(events[i][0], events[i][1]);
     }
 
     function update_session_machine(machine, host, values) {
         /* We don't save the whole machine object */
-        var skey = generate_session_key(host);
-        var data = $.extend({}, machine, values);
+        const skey = generate_session_key(host);
+        const data = $.extend({}, machine, values);
         window.sessionStorage.setItem(skey, JSON.stringify(data));
         self.overlay(host, values);
         return cockpit.when([]);
@@ -212,8 +208,8 @@ function Machines() {
     function update_saved_machine(host, values) {
         // wrap values in variants for D-Bus call; at least values.port can
         // be int or string, so stringify everything but the "visible" boolean
-        var values_variant = {};
-        for (var prop in values) {
+        const values_variant = {};
+        for (const prop in values) {
             if (values[prop] !== null) {
                 if (prop == "visible")
                     values_variant[prop] = cockpit.variant('b', values[prop]);
@@ -223,8 +219,8 @@ function Machines() {
         }
 
         // FIXME: investigate re-using the proxy from Loader (runs in different frame/scope)
-        var bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
-        var mod =
+        const bridge = cockpit.dbus(null, { bus: "internal", superuser: "try" });
+        const mod =
             bridge.call("/machines", "cockpit.Machines", "Update", ["99-webui.json", host, values_variant])
                     .catch(function(error) {
                         console.error("failed to call cockpit.Machines.Update(): ", error);
@@ -248,15 +244,15 @@ function Machines() {
     };
 
     self.add = function add(connection_string, color) {
-        var values = self.split_connection_string(connection_string);
-        var host = values.address;
+        let values = self.split_connection_string(connection_string);
+        const host = values.address;
 
         values = $.extend({
             visible: true,
             color: color || self.unused_color(),
         }, values);
 
-        var machine = self.lookup(host);
+        const machine = self.lookup(host);
         if (machine)
             machine.on_disk = true;
 
@@ -264,9 +260,8 @@ function Machines() {
     };
 
     self.unused_color = function unused_color() {
-        var i;
-        var len = mod.colors.length;
-        for (i = 0; i < len; i++) {
+        const len = mod.colors.length;
+        for (let i = 0; i < len; i++) {
             if (!color_in_use(mod.colors[i]))
                 return mod.colors[i];
         }
@@ -274,10 +269,9 @@ function Machines() {
     };
 
     function color_in_use(color) {
-        var key, machine;
-        var norm = mod.colors.parse(color);
-        for (key in machines) {
-            machine = machines[key];
+        const norm = mod.colors.parse(color);
+        for (const key in machines) {
+            const machine = machines[key];
             if (machine.color && mod.colors.parse(machine.color) == norm)
                 return true;
         }
@@ -285,7 +279,7 @@ function Machines() {
     }
 
     function merge(item, values) {
-        for (var prop in values) {
+        for (const prop in values) {
             if (values[prop] === null)
                 delete item[prop];
             else
@@ -294,7 +288,7 @@ function Machines() {
     }
 
     self.change = function change(host, values) {
-        var machine = self.lookup(host);
+        const machine = self.lookup(host);
 
         if (machine && !machine.on_disk)
             return update_session_machine(machine, host, values);
@@ -303,10 +297,9 @@ function Machines() {
     };
 
     self.data = function data(content) {
-        var host;
-        var changes = {};
+        const changes = {};
 
-        for (host in content) {
+        for (const host in content) {
             changes[host] = $.extend({ }, last.overlay[host] || { });
             merge(changes[host], { on_disk: true });
         }
@@ -314,7 +307,7 @@ function Machines() {
         /* It's a full reload, so data not
          * present is no longer from disk
          */
-        for (host in machines) {
+        for (const host in machines) {
             if (content && !content[host]) {
                 changes[host] = $.extend({ }, last.overlay[host] || { });
                 merge(changes[host], { on_disk: null });
@@ -328,8 +321,8 @@ function Machines() {
     };
 
     self.overlay = function overlay(host, values) {
-        var address = self.split_connection_string(host).address;
-        var changes = { };
+        const address = self.split_connection_string(host).address;
+        const changes = { };
         changes[address] = $.extend({ }, last.overlay[address] || { });
         merge(changes[address], values);
         refresh({
@@ -341,10 +334,9 @@ function Machines() {
     Object.defineProperty(self, "list", {
         enumerable: true,
         get: function get() {
-            var key;
             if (!flat) {
                 flat = [];
-                for (key in machines) {
+                for (const key in machines) {
                     if (machines[key].visible)
                         flat.push(machines[key]);
                 }
@@ -364,12 +356,12 @@ function Machines() {
     });
 
     self.lookup = function lookup(address) {
-        var parts = self.split_connection_string(address);
+        const parts = self.split_connection_string(address);
         return machines[parts.address || "localhost"] || null;
     };
 
     self.generate_connection_string = function (user, port, addr) {
-        var address = addr;
+        let address = addr;
         if (user)
             address = user + "@" + address;
 
@@ -380,9 +372,9 @@ function Machines() {
     };
 
     self.split_connection_string = function(conn_to) {
-        var parts = {};
-        var user_spot = -1;
-        var port_spot = -1;
+        const parts = {};
+        let user_spot = -1;
+        let port_spot = -1;
 
         if (conn_to) {
             user_spot = conn_to.lastIndexOf('@');
@@ -396,7 +388,7 @@ function Machines() {
         }
 
         if (port_spot > -1) {
-            var port = parseInt(conn_to.substring(port_spot + 1), 10);
+            const port = parseInt(conn_to.substring(port_spot + 1), 10);
             if (!isNaN(port)) {
                 parts.port = port;
                 conn_to = conn_to.substring(0, port_spot);
@@ -413,29 +405,28 @@ function Machines() {
 }
 
 function Loader(machines, session_only) {
-    var self = this;
+    const self = this;
 
     /* Have we loaded from cockpit session */
-    var session_loaded = false;
+    let session_loaded = false;
 
     /* echo channels to each machine */
-    var channels = { };
+    const channels = { };
 
     /* hostnamed proxies to each machine, if hostnamed available */
-    var proxies = { };
+    const proxies = { };
 
     /* clients for the bridge D-Bus API */
-    var bridge_dbus = { };
+    const bridge_dbus = { };
 
     function process_session_key(key, value) {
-        var host, values, machine;
-        var parts = key.split("/");
+        const parts = key.split("/");
         if (parts[0] == session_prefix &&
             parts.length === 2) {
-            host = parts[1];
+            const host = parts[1];
             if (value) {
-                values = JSON.parse(value);
-                machine = machines.lookup(host);
+                const values = JSON.parse(value);
+                const machine = machines.lookup(host);
                 if (!machine || !machine.on_disk)
                     machines.overlay(host, values);
                 else if (!machine.visible)
@@ -446,10 +437,9 @@ function Loader(machines, session_only) {
     }
 
     function load_from_session_storage() {
-        var i;
         session_loaded = true;
-        for (i = 0; i < window.sessionStorage.length; i++) {
-            var k = window.sessionStorage.key(i);
+        for (let i = 0; i < window.sessionStorage.length; i++) {
+            const k = window.sessionStorage.key(i);
             process_session_key(k, window.sessionStorage.getItem(k));
         }
     }
@@ -461,7 +451,7 @@ function Loader(machines, session_only) {
     window.addEventListener("storage", process_session_machines);
 
     function state(host, value, problem) {
-        var values = { state: value, problem: problem };
+        const values = { state: value, problem: problem };
         if (value == "connected") {
             values.restarting = false;
         } else if (problem) {
@@ -484,20 +474,20 @@ function Loader(machines, session_only) {
                 return;
         }
 
-        var props = proxies[host];
+        let props = proxies[host];
         if (!props || !props.valid)
             props = { };
 
-        var overlay = { };
+        const overlay = { };
 
         if (!machine.color)
             overlay.color = machines.unused_color();
 
-        var label = props.PrettyHostname || props.StaticHostname || props.Hostname;
+        const label = props.PrettyHostname || props.StaticHostname || props.Hostname;
         if (label && label !== machine.label)
             overlay.label = label;
 
-        var os = props.OperatingSystemPrettyName;
+        const os = props.OperatingSystemPrettyName;
         if (os && os != machine.os)
             overlay.os = props.OperatingSystemPrettyName;
 
@@ -524,15 +514,15 @@ function Loader(machines, session_only) {
     }
 
     self.connect = function connect(host) {
-        var machine = machines.lookup(host);
+        const machine = machines.lookup(host);
         if (!machine)
             return;
 
-        var channel = channels[host];
+        let channel = channels[host];
         if (channel)
             return;
 
-        var options = {
+        const options = {
             host: machine.connection_string,
             payload: "echo",
         };
@@ -548,13 +538,13 @@ function Loader(machines, session_only) {
         channel = cockpit.channel(options);
         channels[host] = channel;
 
-        var local = host === "localhost";
+        const local = host === "localhost";
 
         /* Request is null, and message is true when connected */
-        var request = null;
-        var open = local;
+        let request = null;
+        let open = local;
 
-        var url;
+        let url;
         if (!machine.manifests) {
             if (machine.checksum)
                 url = "../../" + machine.checksum + "/manifests.json";
@@ -573,8 +563,8 @@ function Loader(machines, session_only) {
         function request_manifest() {
             request = $.ajax({ url: url, dataType: "json", cache: true })
                     .done(function(manifests) {
-                        var overlay = { manifests: manifests };
-                        var etag = request.getResponseHeader("ETag");
+                        const overlay = { manifests: manifests };
+                        const etag = request.getResponseHeader("ETag");
                         if (etag) /* and remove quotes */
                             overlay.checksum = etag.replace(/^"(.+)"$/, '$1');
                         machines.overlay(host, overlay);
@@ -595,7 +585,7 @@ function Loader(machines, session_only) {
         */
 
         function watch_manifests() {
-            var dbus = cockpit.dbus(null, {
+            const dbus = cockpit.dbus(null, {
                 bus: "internal",
                 host: machine.connection_string
             });
@@ -608,7 +598,7 @@ function Loader(machines, session_only) {
                            function (path, iface, mamber, args) {
                                if (args[0] == "cockpit.Packages") {
                                    if (args[1].Manifests) {
-                                       var manifests = JSON.parse(args[1].Manifests.v);
+                                       const manifests = JSON.parse(args[1].Manifests.v);
                                        machines.overlay(host, { manifests: manifests });
                                    }
                                }
@@ -624,8 +614,8 @@ function Loader(machines, session_only) {
 
         function request_hostname() {
             if (!machine.static_hostname) {
-                var proxy = cockpit.dbus("org.freedesktop.hostname1",
-                                         { host: machine.connection_string }).proxy();
+                const proxy = cockpit.dbus("org.freedesktop.hostname1",
+                                           { host: machine.connection_string }).proxy();
                 proxies[host] = proxy;
                 proxy.wait(function() {
                     $(proxy).on("changed", function() {
@@ -650,7 +640,7 @@ function Loader(machines, session_only) {
                         whirl();
                     })
                     .on("close", function(ev, options) {
-                        var m = machines.lookup(host);
+                        const m = machines.lookup(host);
                         open = false;
                         // reset to clean state when removing machine (orderly disconnect), otherwise mark as failed
                         if (!options.problem && m && !m.visible)
@@ -679,21 +669,21 @@ function Loader(machines, session_only) {
         if (host === "localhost")
             return;
 
-        var channel = channels[host];
+        const channel = channels[host];
         delete channels[host];
         if (channel) {
             channel.close();
             $(channel).off();
         }
 
-        var proxy = proxies[host];
+        const proxy = proxies[host];
         delete proxies[host];
         if (proxy) {
             proxy.client.close();
             $(proxy).off();
         }
 
-        var dbus = bridge_dbus[host];
+        const dbus = bridge_dbus[host];
         delete bridge_dbus[host];
         if (dbus) {
             dbus.close();
@@ -701,7 +691,7 @@ function Loader(machines, session_only) {
     };
 
     self.expect_restart = function expect_restart(host) {
-        var parts = machines.split_connection_string(host);
+        const parts = machines.split_connection_string(host);
         machines.overlay(parts.address, {
             restarting: true,
             problem: null
@@ -715,20 +705,19 @@ function Loader(machines, session_only) {
         machines = null;
 
         window.removeEventListener("storage", process_session_machines);
-        var hosts = Object.keys(channels);
+        const hosts = Object.keys(channels);
         hosts.forEach(self.disconnect);
     };
 
     if (!session_only) {
-        var proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
+        const proxy = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Machines", "/machines");
         $(proxy).on("changed", function(data) {
             // unwrap variants from D-Bus call
-            var wrapped = proxy.Machines;
-            var data_unwrap = {};
-            var host_props;
-            for (var host in wrapped) {
-                host_props = {};
-                for (var prop in wrapped[host])
+            const wrapped = proxy.Machines;
+            const data_unwrap = {};
+            for (const host in wrapped) {
+                const host_props = {};
+                for (const prop in wrapped[host])
                     host_props[prop] = wrapped[host][prop].v;
                 data_unwrap[host] = host_props;
             }
@@ -781,9 +770,9 @@ mod.colors = [
 ];
 
 mod.colors.parse = function parse_color(input) {
-    var div = document.createElement('div');
+    const div = document.createElement('div');
     div.style.color = input;
-    var style = window.getComputedStyle(div, null);
+    const style = window.getComputedStyle(div, null);
     return style.getPropertyValue("color") || div.style.color;
 };
 

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -553,7 +553,6 @@ function Loader(machines, session_only) {
         /* Request is null, and message is true when connected */
         var request = null;
         var open = local;
-        var problem = null;
 
         var url;
         if (!machine.manifests) {
@@ -566,7 +565,7 @@ function Loader(machines, session_only) {
         function whirl() {
             if (!request && open)
                 state(host, "connected", null);
-            else if (!problem)
+            else
                 state(host, "connecting", null);
         }
 

--- a/pkg/shell/machines/test-machines.js
+++ b/pkg/shell/machines/test-machines.js
@@ -2,8 +2,8 @@ import cockpit from "cockpit";
 import QUnit from "qunit-tests";
 import { machines } from "./machines";
 
-var dbus = cockpit.dbus(null, { bus: "internal" });
-var configDir;
+const dbus = cockpit.dbus(null, { bus: "internal" });
+let configDir;
 
 QUnit.module("machines.d parsing tests", {
     beforeEach: () => cockpit.spawn(["mkdir", "-p", configDir + "/cockpit/machines.d"]),
@@ -19,11 +19,10 @@ function machinesParseTest(assert, machines_defs, expectedProperty) {
     const done = assert.async();
     assert.expect(3);
 
-    var setup = [];
-    var path;
+    const setup = [];
 
-    for (var fname in machines_defs) {
-        path = fname;
+    for (const fname in machines_defs) {
+        let path = fname;
         if (fname.indexOf('/') < 0)
             path = configDir + "/cockpit/machines.d/" + fname;
         setup.push(cockpit.file(path).replace(machines_defs[fname]));
@@ -144,7 +143,7 @@ function machinesUpdateTest(assert, origJson, host, props, expectedJson) {
     const done = assert.async();
     assert.expect(3);
 
-    var f = configDir + "/cockpit/machines.d/99-webui.json";
+    const f = configDir + "/cockpit/machines.d/99-webui.json";
 
     cockpit.file(f).replace(origJson)
             .done(function(tag) {
@@ -250,7 +249,7 @@ QUnit.test("colors.parse()", function (assert) {
 
 /* The test cockpit-bridge gets started with temp $XDG_CONFIG_DIRS instead of defaulting to /etc/.
  * Read it from the bridge so that we can put our test files into it. */
-var proxy = dbus.proxy("cockpit.Environment", "/environment");
+const proxy = dbus.proxy("cockpit.Environment", "/environment");
 proxy.wait(function () {
     configDir = proxy.Variables.XDG_CONFIG_DIRS;
     QUnit.start();

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -18,21 +18,21 @@ const KERBEROS_MEMBERSHIP = "org.freedesktop.realmd.KerberosMembership";
 const REALM = "org.freedesktop.realmd.Realm";
 
 function instance(realmd, mode, realm, state) {
-    var dialog = jQuery.parseHTML(operation_html)[0];
+    const dialog = jQuery.parseHTML(operation_html)[0];
 
     /* Scope the jQuery selector to our dialog */
-    var $ = function(selector, context) {
+    const $ = function(selector, context) {
         return new jQuery.fn.init(selector, context || dialog); // eslint-disable-line new-cap
     };
     $.fn = $.prototype = jQuery.fn;
     jQuery.extend($, jQuery);
 
-    var error_message = null;
-    var operation = null;
-    var checking = null;
-    var checked = null;
-    var kerberos_membership = null;
-    var kerberos = null;
+    let error_message = null;
+    let operation = null;
+    let checking = null;
+    let checked = null;
+    let kerberos_membership = null;
+    let kerberos = null;
 
     $(".realms-op-error").prop("hidden", true);
 
@@ -60,7 +60,7 @@ function instance(realmd, mode, realm, state) {
         $(".realms-op-diagnostics").prop("hidden", false);
     });
 
-    var timeout = null;
+    let timeout = null;
     $("#realms-op-address").on("keyup change", function() {
         if ($("#realms-op-address").val() != checked) {
             $(".realms-op-address-error").empty();
@@ -73,24 +73,24 @@ function instance(realmd, mode, realm, state) {
     });
 
     function hide_control(path) {
-        var e = $(path);
+        const e = $(path);
         e.hide();
         e.prev().hide(); // hide the associated label
     }
 
     function show_control(path) {
-        var e = $(path);
+        const e = $(path);
         e.show();
         e.prev().show(); // hide the associated label
     }
 
-    var auth = null;
+    let auth = null;
     function auth_changed(item) {
         auth = item.attr('data-value');
         $("#realms-op-auth span").text(item.text());
-        var parts = (auth || "").split("/");
-        var type = parts[0];
-        var owner = parts[1];
+        const parts = (auth || "").split("/");
+        const type = parts[0];
+        const owner = parts[1];
 
         hide_control("#realms-op-admin");
         hide_control("#realms-op-admin-password");
@@ -113,7 +113,7 @@ function instance(realmd, mode, realm, state) {
         auth_changed($(this));
     });
 
-    var title, label;
+    let title, label;
     if (mode == 'join') {
         title = _("page-title", _("Join a domain"));
         label = _("Join");
@@ -154,7 +154,7 @@ function instance(realmd, mode, realm, state) {
     $(".realms-op-field").val("");
 
     function check(name) {
-        var dfd = $.Deferred();
+        const dfd = $.Deferred();
 
         if (name === undefined)
             name = $("#realms-op-address").val();
@@ -175,8 +175,8 @@ function instance(realmd, mode, realm, state) {
                         return;
                     }
 
-                    var error, path;
-                    var result = [];
+                    let error;
+                    let result = [];
                     if (this.state() == "rejected") {
                         error = arguments[0];
                         $(".realms-op-message")
@@ -187,7 +187,7 @@ function instance(realmd, mode, realm, state) {
 
                     if (arguments[0][1])
                         result = arguments[0][1];
-                    path = result[0]; /* the first realm */
+                    const path = result[0]; /* the first realm */
 
                     if (!path) {
                         if (name) {
@@ -227,7 +227,7 @@ function instance(realmd, mode, realm, state) {
 
     function ensure() {
         if (mode != 'join') {
-            var dfd = $.Deferred();
+            const dfd = $.Deferred();
             dfd.resolve(realm);
             return dfd.promise();
         }
@@ -246,7 +246,7 @@ function instance(realmd, mode, realm, state) {
      * field key.
      */
     function find_detail(realm, field) {
-        var result = null;
+        let result = null;
         if (realm && realm.Details) {
             realm.Details.forEach(function(value) {
                 if (value[0] === field)
@@ -257,8 +257,6 @@ function instance(realmd, mode, realm, state) {
     }
 
     function update() {
-        var message;
-
         if (operation)
             $(".realms-op-apply").addClass("pf-m-in-progress");
         else
@@ -269,7 +267,7 @@ function instance(realmd, mode, realm, state) {
         $(".realms-op-apply").prop('disabled', !!operation);
         $(".realm-active-directory-only").hide();
 
-        var server = find_detail(realm, "server-software");
+        const server = find_detail(realm, "server-software");
 
         if (realm && kerberos_membership) {
             if (kerberos_membership.valid) {
@@ -282,7 +280,7 @@ function instance(realmd, mode, realm, state) {
                         .removeClass("has-error")
                         .addClass("has-success");
             } else {
-                message = cockpit.format(_("Domain $0 is not supported"), realm.Name);
+                const message = cockpit.format(_("Domain $0 is not supported"), realm.Name);
                 $(".realms-op-address-spinner").hide();
                 $(".realms-op-address-error").text(message);
                 $("#realms-op-address").parent()
@@ -303,27 +301,25 @@ function instance(realmd, mode, realm, state) {
             $("#realms-op-address")[0].placeholder = cockpit.format(_("e.g. \"$0\""), realm.Name);
         }
 
-        var placeholder = "";
+        let placeholder = "";
         if (kerberos_membership) {
             if (kerberos_membership.SuggestedAdministrator)
                 placeholder = cockpit.format(_("e.g. \"$0\""), kerberos_membership.SuggestedAdministrator);
         }
         $("#realms-op-admin")[0].placeholder = placeholder;
 
-        var list = $("#realms-op-auth .dropdown-menu");
-        var supported = (kerberos_membership && kerberos_membership.SupportedJoinCredentials) || [];
+        const list = $("#realms-op-auth .dropdown-menu");
+        const supported = (kerberos_membership && kerberos_membership.SupportedJoinCredentials) || [];
         supported.push(["password", "administrator"]);
 
-        var first = true;
-        var count = 0;
+        let first = true;
+        let count = 0;
 
         function add_choice(owner, type, text) {
-            var item, choice, i;
-            var length = supported.length;
-            for (i = 0; i < length; i++) {
+            for (let i = 0; i < supported.length; i++) {
                 if ((!owner || owner == supported[i][1]) && type == supported[i][0]) {
-                    choice = type + "/" + supported[i][1];
-                    item = $("<li>").attr("data-value", choice)
+                    const choice = type + "/" + supported[i][1];
+                    const item = $("<li>").attr("data-value", choice)
                             .append($("<a tabindex='0'>").text(text));
                     list.append(item);
                     if (first) {
@@ -348,11 +344,11 @@ function instance(realmd, mode, realm, state) {
     }
 
     function credentials() {
-        var creds, secret;
+        let creds;
 
-        var parts = (auth || "").split("/");
-        var type = parts[0];
-        var owner = parts[1];
+        const parts = (auth || "").split("/");
+        const type = parts[0];
+        const owner = parts[1];
 
         if (owner == "user" && type == "password") {
             creds = [
@@ -365,7 +361,7 @@ function instance(realmd, mode, realm, state) {
                 cockpit.variant('(ss)', [$("#realms-op-admin").val(), $("#realms-op-admin-password").val()])
             ];
         } else if (type == "secret") {
-            secret = $("#realms-op-ot-password").val();
+            const secret = $("#realms-op-ot-password").val();
             creds = [
                 type, owner,
                 cockpit.variant('ay', cockpit.utf8_encoder().encode(secret))
@@ -398,12 +394,12 @@ function instance(realmd, mode, realm, state) {
             return cockpit.resolve();
         }
 
-        var user = $("#realms-op-admin").val();
-        var password = $("#realms-op-admin-password").val();
-        var helper = cockpit.manifests.system.libexecdir + "/cockpit-certificate-helper";
+        const user = $("#realms-op-admin").val();
+        const password = $("#realms-op-admin-password").val();
+        const helper = cockpit.manifests.system.libexecdir + "/cockpit-certificate-helper";
 
-        var proc = cockpit.spawn([helper, "ipa", "request", kerberos.RealmName, user],
-                                 { superuser: "require", err: "message" });
+        const proc = cockpit.spawn([helper, "ipa", "request", kerberos.RealmName, user],
+                                   { superuser: "require", err: "message" });
         proc.input(password);
         return proc;
     }
@@ -414,7 +410,7 @@ function instance(realmd, mode, realm, state) {
         if (cockpit.transport.host !== "localhost")
             return cockpit.resolve();
 
-        var dfd = cockpit.defer();
+        const dfd = cockpit.defer();
 
         kerberos = realmd.proxy(KERBEROS, realm.path);
         kerberos.wait()
@@ -433,10 +429,10 @@ function instance(realmd, mode, realm, state) {
         return dfd.promise();
     }
 
-    var unique = 1;
+    let unique = 1;
 
     function perform() {
-        var id = "cockpit-" + unique;
+        const id = "cockpit-" + unique;
         unique += 1;
         busy(id);
         $(".realms-op-error").prop("hidden", true);
@@ -448,22 +444,22 @@ function instance(realmd, mode, realm, state) {
                     busy(null);
                 })
                 .done(function(realm) {
-                    var options = { operation: cockpit.variant('s', id) };
+                    const options = { operation: cockpit.variant('s', id) };
 
                     $(".realms-op-message").empty();
                     $(".realms-op-diagnostics").empty()
                             .prop("hidden", true);
 
-                    var diagnostics = "";
-                    var sub = realmd.subscribe({ member: "Diagnostics" }, function(path, iface, signal, args) {
+                    let diagnostics = "";
+                    const sub = realmd.subscribe({ member: "Diagnostics" }, function(path, iface, signal, args) {
                         if (args[1] === id) {
                             diagnostics += args[0];
                         }
                     });
 
-                    var call, computer_ou;
+                    let call;
                     if (mode == 'join') {
-                        computer_ou = $(".realms-join-computer-ou").val();
+                        const computer_ou = $(".realms-join-computer-ou").val();
                         if (computer_ou)
                             options["computer-ou"] = cockpit.variant('s', computer_ou);
                         if (kerberos_membership.valid) {
@@ -531,9 +527,9 @@ function instance(realmd, mode, realm, state) {
 }
 
 export function setup() {
-    var $ = jQuery;
+    const $ = jQuery;
 
-    var self = {
+    const self = {
         button_text: "",
         button_tooltip: null,
         button_disabled: false,
@@ -545,23 +541,23 @@ export function setup() {
 
     cockpit.event_target(self);
 
-    var realmd = null;
-    var realms = null;
+    let realmd = null;
+    let realms = null;
 
     /* The realm we are joined to */
-    var joined = null;
+    let joined = null;
 
-    var install_realmd = false;
+    let install_realmd = false;
 
     function update_realms() {
-        var text, path, realm;
         joined = [];
-        for (path in realms) {
-            realm = realms[path];
+        for (const path in realms) {
+            const realm = realms[path];
             if (realm.Configured)
                 joined.push(realm);
         }
 
+        let text;
         if (!joined || !joined.length) {
             text = _("Join domain");
             self.hostname_button_disabled = false;
@@ -629,7 +625,7 @@ export function setup() {
                 .catch(function() { }); // dialog cancelled
     }
 
-    var dialog = null;
+    let dialog = null;
     function handle_link_click() {
         if (dialog)
             $(dialog).remove();

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -50,8 +50,8 @@ export class SystemInfomationCard extends React.Component {
     }
 
     getMachineId() {
-        var machine_id = cockpit.file("/etc/machine-id");
-        var self = this;
+        const machine_id = cockpit.file("/etc/machine-id");
+        const self = this;
 
         machine_id.read()
                 .done(function(content) {
@@ -67,7 +67,7 @@ export class SystemInfomationCard extends React.Component {
     }
 
     getDMIInfo() {
-        var self = this;
+        const self = this;
 
         machine_info.dmi_info()
                 .then(fields => {

--- a/pkg/systemd/services/timer-dialog-helpers.js
+++ b/pkg/systemd/services/timer-dialog-helpers.js
@@ -56,28 +56,28 @@ export function create_timer({ name, description, command, delay, delayUnit, del
 }
 
 function create_timer_file({ timer_unit, delay }) {
-    var unit = "[Unit]\nDescription=";
-    var service = "\n[Service]\nExecStart=";
-    var timer = "\n[Timer]\n";
-    var install = "[Install]\nWantedBy=timers.target\n";
-    var service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n";
-    var timer_file = " ";
+    const unit = "[Unit]\nDescription=";
+    const service = "\n[Service]\nExecStart=";
+    const timer = "\n[Timer]\n";
+    const install = "[Install]\nWantedBy=timers.target\n";
+    const service_file = unit + timer_unit.Description + service + timer_unit.Command + "\n";
+    let timer_file = " ";
     if (delay == "system-boot") {
-        var boottimer = timer + "OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit + "\n";
+        const boottimer = timer + "OnBootSec=" + timer_unit.boot_time + timer_unit.boot_time_unit + "\n";
         timer_file = unit + timer_unit.Description + boottimer;
     } else if (timer_unit.OnCalendar) {
-        var calendartimer = timer + timer_unit.OnCalendar + "\n";
+        const calendartimer = timer + timer_unit.OnCalendar + "\n";
         timer_file = unit + timer_unit.Description + calendartimer;
     }
     timer_file += install;
     // writing to file
-    var service_path = "/etc/systemd/system/" + timer_unit.name + ".service";
-    var file = cockpit.file(service_path, { superuser: 'try' });
-    file.replace(service_file)
+    const service_path = "/etc/systemd/system/" + timer_unit.name + ".service";
+    cockpit.file(service_path, { superuser: 'try' })
+            .replace(service_file)
             .catch(error => console.log(error.toString()));
-    var timer_path = "/etc/systemd/system/" + timer_unit.name + ".timer";
-    file = cockpit.file(timer_path, { superuser: 'try' });
-    return file.replace(timer_file)
+    const timer_path = "/etc/systemd/system/" + timer_unit.name + ".timer";
+    return cockpit.file(timer_path, { superuser: 'try' })
+            .replace(timer_file)
             .then(tag => {
                 return systemd_client.call(SD_OBJ, SD_MANAGER, "EnableUnitFiles", [[timer_unit.name + ".timer"], false, false]);
             })

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -38,8 +38,8 @@ const _ = cockpit.gettext;
 
         constructor(props) {
             super(props);
-            var theme = document.cookie.replace(/(?:(?:^|.*;\s*)theme_cookie\s*=\s*([^;]*).*$)|^.*$/, "$1");
-            var size = document.cookie.replace(/(?:(?:^|.*;\s*)size_cookie\s*=\s*([^;]*).*$)|^.*$/, "$1");
+            const theme = document.cookie.replace(/(?:(?:^|.*;\s*)theme_cookie\s*=\s*([^;]*).*$)|^.*$/, "$1");
+            const size = document.cookie.replace(/(?:(?:^|.*;\s*)size_cookie\s*=\s*([^;]*).*$)|^.*$/, "$1");
             this.state = {
                 title: 'Terminal',
                 theme: theme || "black-theme",
@@ -108,16 +108,14 @@ const _ = cockpit.gettext;
         }
 
         render() {
-            var terminal;
-            if (this.state.channel)
-                terminal = (<Terminal ref={this.terminalRef}
-                     channel={this.state.channel}
-                     theme={this.state.theme}
-                     fontSize={this.state.size}
-                     parentId="the-terminal"
-                     onTitleChanged={this.onTitleChanged} />);
-            else
-                terminal = <span>Loading...</span>;
+            const terminal = this.state.channel
+                ? <Terminal ref={this.terminalRef}
+                            channel={this.state.channel}
+                            theme={this.state.theme}
+                            fontSize={this.state.size}
+                            parentId="the-terminal"
+                            onTitleChanged={this.onTitleChanged} />
+                : <span>Loading...</span>;
 
             return (
                 <div className="console-ct-container">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -354,7 +354,7 @@ const plugins = [
 if (eslint) {
     // temporary hack: not all pages got converted to no-var yet; drop this again once they are
     const overrideConfig = {};
-    if (section === "shell/" || section === "systemd/")
+    if (section === "shell/")
         overrideConfig.rules = { "no-var": "off" };
     plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"], overrideConfig }));
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -352,11 +352,7 @@ const plugins = [
 ];
 
 if (eslint) {
-    // temporary hack: not all pages got converted to no-var yet; drop this again once they are
-    const overrideConfig = {};
-    if (section === "shell/")
-        overrideConfig.rules = { "no-var": "off" };
-    plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"], overrideConfig }));
+    plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"] }));
 }
 
 if (section.startsWith('base1'))


### PR DESCRIPTION
These were the last webpack that still used `var`, so drop the temporary config override from webpack.config.js again. After this lands, I'll also eliminate the `no-var` hack from package.json again, but as that involves a `node_modules` rebuild, I'd like to do that separately.