### PR TITLE
autogen.sh: Download webpack cache during release

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -6,4 +6,9 @@ srcdir="$(realpath -m "$0"/..)"
 
 (cd "${srcdir}" && autoreconf -is --warnings obsolete)
 
+# When calling this as part of cockpituous release-source, download cached dist/
+if [ -n "${RELEASE_SOURCE:-}" ] && [ ! -d dist ]; then
+    tools/webpack-jumpstart --wait
+fi
+
 [ -n "${NOCONFIGURE:-}" ] || exec "${srcdir}/configure" "$@"


### PR DESCRIPTION
Our dist/ is very reliable now, and gets built in exactly the same
GitHub workflow environment as the release. So use it instead of
rebuilding everything again.

As cockpituous' release-source locally clones the checkout again, we
can't just put the webpack-jumpstart call into
tools/cockpituous-release. Do it in autogen.sh instead when releasing,
i.e. if `$RELEASE_SOURCE` is set.