### PR TITLE
systemd: Set auto-detected realm domain/admin as proper input values

### DIFF
--- a/pkg/systemd/overview-cards/realmd-operation.html
+++ b/pkg/systemd/overview-cards/realmd-operation.html
@@ -88,7 +88,7 @@
                                 <span class="pf-c-spinner__tail-ball"></span>
                             </span>
                         </span>
-                        <span translate="yes">Next</span>
+                        <span translate="yes">Join</span>
                     </button>
                     <button class="pf-c-button pf-m-link realms-op-cancel" translate="yes">Cancel</button>
                     <span class="realms-op-wait-message" translate="yes" hidden>This may take a while</span>

--- a/pkg/systemd/overview-cards/realmd-operation.html
+++ b/pkg/systemd/overview-cards/realmd-operation.html
@@ -34,7 +34,7 @@
                         <label class="control-label" for="realms-op-address" translate="yes">Domain address</label>
 
                         <div class="ct-validation-wrapper">
-                          <input id="realms-op-address" class="realms-op-field form-control" type="text" value="" />
+                          <input id="realms-op-address" class="realms-op-field form-control" type="text" placeholder="domain.example.com" value="" />
 
                           <div class="help-block">
                             <span class="realms-op-address-spinner" hidden></span>
@@ -61,7 +61,7 @@
                         <input id="realms-op-user-password" class="realms-op-field form-control" type="password" value=""/>
 
                         <label class="control-label" for="realms-op-admin" translate="yes">Domain administrator name</label>
-                        <input id="realms-op-admin" class="realms-op-field form-control" type="text" value=""/>
+                        <input id="realms-op-admin" class="realms-op-field form-control" type="text" placeholder="admin" value=""/>
 
                         <label class="control-label" for="realms-op-admin-password" translate="yes">Domain administrator password</label>
                         <input id="realms-op-admin-password" class="realms-op-field form-control" type="password" value=""/>

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -113,13 +113,11 @@ function instance(realmd, mode, realm, state) {
         auth_changed($(this));
     });
 
-    let title, label;
+    let title;
     if (mode == 'join') {
         title = _("page-title", _("Join a domain"));
-        label = _("Join");
         $(".realms-op-join-only").show();
         $(".realms-op-leave-only-row").hide();
-        $(".realms-op-apply").text(label);
         check("");
     } else {
         title = _("page-title", _("Domain"));

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -195,6 +195,9 @@ function instance(realmd, mode, realm, state) {
                             $("#realms-op-address").parent()
                                     .removeClass("has-success")
                                     .addClass("has-error");
+                            $("#realms-op-address").attr("data-discover", "failed");
+                        } else {
+                            $("#realms-op-address").attr("data-discover", "empty");
                         }
 
                         realm = null;
@@ -211,6 +214,12 @@ function instance(realmd, mode, realm, state) {
                         realm = realmd.proxy(REALM, path);
                         $(realm).on("changed", update);
                         realm.wait(function() {
+                            // fill in unset realm/user with autodetected values
+                            if (realm.Name && !$("#realms-op-address").val())
+                                $("#realms-op-address").val(realm.Name);
+                            if (kerberos_membership.SuggestedAdministrator && !$("#realms-op-admin").val())
+                                $("#realms-op-admin").val(kerberos_membership.SuggestedAdministrator);
+
                             dfd.resolve(realm);
                         });
                     }
@@ -294,17 +303,6 @@ function instance(realmd, mode, realm, state) {
             return;
 
         $(".realm-active-directory-only").toggle(!server || server == "active-directory");
-
-        if (realm && realm.Name && !$("#realms-op-address")[0].placeholder) {
-            $("#realms-op-address")[0].placeholder = cockpit.format(_("e.g. \"$0\""), realm.Name);
-        }
-
-        let placeholder = "";
-        if (kerberos_membership) {
-            if (kerberos_membership.SuggestedAdministrator)
-                placeholder = cockpit.format(_("e.g. \"$0\""), kerberos_membership.SuggestedAdministrator);
-        }
-        $("#realms-op-admin")[0].placeholder = placeholder;
 
         const list = $("#realms-op-auth .dropdown-menu");
         const supported = (kerberos_membership && kerberos_membership.SupportedJoinCredentials) || [];

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -99,14 +99,23 @@ class CommonTests:
 
         wait_number_domains(0)
 
+        def set_address():
+            # old realmd/IPA don't support realmd auto-detection yet
+            if m.image.startswith("rhel-8") or m.image in ["centos-8-stream", "ubuntu-2004"]:
+                b.wait_attr("#realms-op-address", "data-discover", "empty")
+                b.wait_val(self.op_address, "")
+                b.set_val(self.op_address, "cockpit.lan")
+            else:
+                # on current OSes, domain and suggested admin get auto-detected
+                b.wait_val(self.op_address, "cockpit.lan")
+
         # Join cockpit.lan
         b.click(self.domain_sel)
         b.wait_popup("realms-op")
-        b.set_val(self.op_address, "cockpit.lan")
-        with b.wait_timeout(300):
-            b.wait_text(".realms-op-address-error", "Contacted domain")
-        b.wait_attr(self.op_admin, "placeholder", 'e.g. "%s"' % self.admin_user)
-        b.set_val(self.op_admin, self.admin_user)
+        set_address()
+        b.wait_text(".realms-op-address-error", "Contacted domain")
+        # admin gets  auto-detected
+        b.wait_val(self.op_admin, self.admin_user)
         b.set_val(self.op_admin_password, self.admin_password)
         b.wait_not_visible(".realms-op-leave-only-row")
         b.click(".realms-op-apply")
@@ -193,9 +202,8 @@ class CommonTests:
             # Send a wrong password
             b.click(self.domain_sel)
             b.wait_popup("realms-op")
-            b.set_val(self.op_address, "cockpit.lan")
-            b.wait_attr(self.op_admin, "placeholder", 'e.g. "%s"' % self.admin_user)
-            b.set_val(self.op_admin, self.admin_user)
+            set_address()
+            b.wait_val(self.op_admin, self.admin_user)
             b.set_val(self.op_admin_password, "foo")
             b.click(".realms-op-apply")
             b.wait_text_not(".realms-op-message", "")
@@ -609,6 +617,8 @@ ExecStart=/bin/true
         b.wait_popup("realms-op")
         b.set_val(self.op_address, "cockpit.lan")
         b.wait_in_text(".realms-op-address-error", "Domain cockpit.lan is not supported")
+        # no admin name auto-detection for unsupported domains
+        b.wait_val(self.op_admin, "")
         b.set_val(self.op_admin, self.admin_user)
         b.set_val(self.op_admin_password, self.admin_password)
         b.click(".realms-op-apply")
@@ -1137,6 +1147,11 @@ class TestPackageInstall(packagelib.PackageCase):
         # should continue straight to join dialog
         b.wait_visible("#realms-op")
         b.wait_popup("realms-op")
+
+        # no auto-detected domain/admin
+        b.wait_attr("#realms-op-address", "data-discover", "empty")
+        self.assertEqual(b.val("#realms-op-address"), "")
+        self.assertEqual(b.val("#realms-op-admin"), "")
 
         # no running IPA server for this test, so just cancel
         b.click(".realms-op-cancel")


### PR DESCRIPTION
Setting them as placeholders was confusing:
 - They got prefixed with "e.g.", quoted, and greyed out, and thus did
   not look like proper values.
 - Leaving the "domain" field empty used the auto-detected value; but
   leaving the "admin" field empty literally tried to authenticate as
   empty user name, so that field had to be filled.

Bring the dialog in line with the standard behaviour, use static fixed
placeholders (in case there is no auto-detected domain), and set
auto-detected realm/user names as actual values. With that, joining a
domain only requires to fill the admin password, everything else has
sane defaults.

Update the tests to expect pre-filled autodetected domain/admin names.
In TestPackageInstall.testDialogTransition, check that they remain empty
if there is no realm available. Introduce a `data-discover` attribute so
that the test can know when discovery finished and found no realms.

Fixes #16390

----

I also added a second commit which fixes the "Join" button spinner to actually appear. Right now, it's just a static gray misaligned button.

It looks like this now right after clicking the "Join domain.." link in the Configuration card:

![image](https://user-images.githubusercontent.com/200109/135044090-576e47df-2fdb-4c27-996c-52bb58e22d5d.png)

And like this if there is no detected domain:

![image](https://user-images.githubusercontent.com/200109/135044310-c132eb92-9b8c-4e4e-b0f6-8e995e35cef0.png)

There are more things wrong with this dialog: The "Join" button is not disabled while there is incomplete input, and the dropdown triangle  is oddly placed. I plan to address these when rewriting this dialog in React/PF4.