### PR TITLE
test: Fix test.service cleanup in TestServices

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -2316,7 +2316,7 @@ function factory() {
              * at all, but I guess that is ok.
              *
              * For example,
-             * https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout
+             * https://developer.mozilla.org/en-US/docs/Web/API/setTimeout
              * says:
              *
              *    Browsers including Internet Explorer, Chrome,

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -152,7 +152,7 @@ done
 
         # When the test fails while `test.service` is active, the process keeps running and
         # `systemct status test.service` still shows it as active until this process dies
-        self.addCleanup(self.machine.execute, "systemctl stop test")
+        self.addCleanup(self.machine.execute, "for op in stop reset-failed disable; do systemctl $op test || true; done")
 
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
If a test fails at the "wrong" time, it may happen that test.service is
still enabled. The previous cleanup only stopped it, but not disablled
it again, so that the next test retry would unexpectedly find
test.service already enabled.

Clean up more thoroughly.

https://bugzilla.redhat.com/show_bug.cgi?id=2008208

---

I piggy-backed the trivial fix for https://github.com/cockpit-project/cockpit/issues/16221#issuecomment-928756101 on this PR.