### PR TITLE
po-refresh.yml: split out pot upload to weblate

### DIFF
--- a/.github/workflows/po-refresh.yml
+++ b/.github/workflows/po-refresh.yml
@@ -7,6 +7,43 @@ on:
   # can be run manually on https://github.com/cockpit-project/cockpit/actions
   workflow_dispatch:
 jobs:
+  pot-upload:
+    environment: cockpit-weblate
+    permissions:
+      pull-requests: write
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Set up dependencies
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends gettext
+
+      - name: Clone source repository
+        uses: actions/checkout@v2
+        with:
+          path: src
+
+      - name: Install node_modules
+        run: make -C src -f pkg/build package-lock.json
+
+      - name: Generate .pot file
+        run: make -C src -f po/Makefile.am po/cockpit.pot
+
+      - name: Clone weblate repository
+        uses: actions/checkout@v2
+        with:
+          path: weblate
+          repository: ${{ github.repository }}-weblate
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
+
+      - name: Commit .pot to weblate repo
+        run: |
+          cp src/po/cockpit.pot weblate/cockpit.pot
+          git config --global user.name "GitHub Workflow"
+          git config --global user.email "cockpituous@cockpit-project.org"
+          git -C weblate commit -m "Update source file" -- cockpit.pot
+          git -C weblate push
+
   po-refresh:
     runs-on: ubuntu-20.04
     steps:

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -112,10 +112,8 @@ update-po: po/cockpit.pot
 $(WEBLATE_REPO):
 	git clone --depth=1 -b $(WEBLATE_REPO_BRANCH) $(WEBLATE_REPO_URL) $(WEBLATE_REPO)
 
-upload-pot: po/cockpit.pot $(WEBLATE_REPO)
-	cp $(builddir)/po/cockpit.pot $(WEBLATE_REPO)
-	git -C $(WEBLATE_REPO) commit -m "Update source file" -- cockpit.pot
-	git -C $(WEBLATE_REPO) push
+upload-pot:
+	@true
 
 clean-po:
 	rm $(srcdir)/po/*.po


### PR DESCRIPTION
The current po-refresh job does two things:

  - generates an updated cockpit.pot and commits it to the weblate repo

  - copies .po files from the weblate repo and opens a PR with them

These two things are actually completely independent from each other, so
let's separate them out to allow for more fine-grained use of
credentials.

Introduce a update-pot job to the existing po-refresh workflow which
takes care of updating cockpit.pot and committing the results to the
weblate repository.  This job requires very few permissions: it only
needs to write to the weblate repository and it does that by way of a
deploy key.

Meanwhile, remove the commands from the `update-pot` rule in
po/Makefile.am to prevent this job from being done twice.  We need to
keep the target itself because bots/po-refresh expects it to exist.

 * [x] successful test run: https://github.com/cockpit-project/cockpit/runs/3733559193?check_suite_focus=true → https://github.com/cockpit-project/cockpit-weblate/commit/b7e48b2344968dd10854efb84a647446e92b7ea6