### PR TITLE
bridge: Tone down ENODEV message about reading cgroups

### DIFF
--- a/src/bridge/cockpitcgroupsamples.c
+++ b/src/bridge/cockpitcgroupsamples.c
@@ -58,7 +58,10 @@ read_file (int dirfd,
   const ssize_t len = read (fd, buf, bufsize);
   if (len < 0)
     {
-      g_message ("error loading file: %s/%s: %m", cgroup, fname);
+      if (errno == ENODEV) /* similar to error at open() */
+        g_debug ("error loading file: %s/%s: %m", cgroup, fname);
+      else
+        g_message ("error loading file: %s/%s: %m", cgroup, fname);
       goto out;
     }
   /* we really expect a much smaller read; if we get a full buffer, there's likely


### PR DESCRIPTION
It can happen that a cgroup goes away after opening an attribute file.
In that case, reading from the fd fails with ENODEV. This is essentially
the same as open() failing with ENODEV right away, so only write a
debugging message for this. This avoids breaking tests due to random
unexpected messages.

---

Seen in [this failure](https://logs.cockpit-project.org/logs/pull-2458-20210929-023815-e97ced59-fedora-34-cockpit-project-cockpit/log.html#54) of https://github.com/cockpit-project/bots/pull/2458