### PR TITLE
Fix packagekit dependency, fix firefox install in rawhide

### DIFF
--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -19,8 +19,8 @@ free -h
 rpm -q cockpit-system
 
 # install browser; on RHEL, use firefox-nightly as chromium broke CDP on rhel-9
-# Install firefox to pull in all the deps
-dnf -y install firefox
+# Install firefox to pull in all the deps; but see rhbz#2005760
+dnf install --disablerepo=fedora-cisco-openh264 -y firefox
 curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /usr/local/lib/ -xj
 ln -s /usr/local/lib/firefox/firefox /usr/local/bin/
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -146,7 +146,7 @@ Requires: cockpit-system
 
 # Optional components
 Recommends: (cockpit-storaged if udisks2)
-Recommends: cockpit-packagekit
+Recommends: (cockpit-packagekit if dnf)
 Suggests: cockpit-pcp
 
 %if 0%{?rhel} == 0


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2005760
https://bugzilla.redhat.com/show_bug.cgi?id=2008154

See [this downstream gating failure](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-pipeline/job/master/78495/testReport/(root)/tests/_test_verify/) for an example how firefox has failed to install for the last weeks.