### PR TITLE
systemd: Drop computer-ou input field from realm join dialog

### DIFF
--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -39,7 +39,6 @@ export class ConfigurationCard extends React.Component {
         super(props);
 
         this.state = {
-            serverTime: '',
             hostEditModal: false,
             showKeysModal: false,
         };

--- a/pkg/systemd/overview-cards/realmd-operation.html
+++ b/pkg/systemd/overview-cards/realmd-operation.html
@@ -42,9 +42,6 @@
                           </div>
                         </div>
 
-                        <label class="control-label realm-active-directory-only" for="realms-op-computer-ou" translate="yes">Computer OU</label>
-                        <input id="realms-op-computer-ou" class="realms-op-field form-control realm-active-directory-only" type="text" value=""/>
-
                         <label class="control-label" for="realms-op-auth" translate="yes">Authentication</label>
                         <div id="realms-op-auth" class="btn-group bootstrap-select dropdown form-control">
                           <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">

--- a/pkg/systemd/overview-cards/realmd-operation.js
+++ b/pkg/systemd/overview-cards/realmd-operation.js
@@ -272,9 +272,6 @@ function instance(realmd, mode, realm, state) {
         $(".realms-op-wait-message").toggle(!!operation);
         $(".realms-op-field").prop('disabled', !!operation);
         $(".realms-op-apply").prop('disabled', !!operation);
-        $(".realm-active-directory-only").hide();
-
-        const server = find_detail(realm, "server-software");
 
         if (realm && kerberos_membership) {
             if (kerberos_membership.valid) {
@@ -301,8 +298,6 @@ function instance(realmd, mode, realm, state) {
 
         if (mode != 'join')
             return;
-
-        $(".realm-active-directory-only").toggle(!server || server == "active-directory");
 
         const list = $("#realms-op-auth .dropdown-menu");
         const supported = (kerberos_membership && kerberos_membership.SupportedJoinCredentials) || [];
@@ -455,9 +450,6 @@ function instance(realmd, mode, realm, state) {
 
                     let call;
                     if (mode == 'join') {
-                        const computer_ou = $(".realms-join-computer-ou").val();
-                        if (computer_ou)
-                            options["computer-ou"] = cockpit.variant('s', computer_ou);
                         if (kerberos_membership.valid) {
                             call = kerberos_membership.call("Join", [credentials(), options]).then(install_ws_credentials);
                         } else {


### PR DESCRIPTION
This has never worked -- literally the first-ever commit (87325b96bc343)
got this wrong (the code queried `.realms-join-computer-ou`, while the
HTML defines `#realms-op-computer-ou`). This never had an integration
test, testing it does not work with our Samba server (as it does not
define any "Computers" OU and `adcli show-computer` does not show the OU
either). Also, that feature is incomplete (there are many more fields
that one can set [1]), and nobody complained in all the years.

So let's just remove this, and only bring it back in the future when
there is some actual demand. This also gets rid of the
`.realm-active-directory-only` class special case.

[1] https://freedesktop.org/software/realmd/docs/gdbus-org.freedesktop.realmd.KerberosMembership.html