### PR TITLE
Revert "webpack: Use relative resolve path for npm 7 compatibility"

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -254,7 +254,7 @@ const CockpitPoPlugin = require("./pkg/lib/cockpit-po-plugin");
 const srcdir = process.env.SRCDIR || __dirname;
 const builddir = process.env.BUILDDIR || __dirname;
 const libdir = path.resolve(srcdir, "pkg" + path.sep + "lib");
-const nodedir = path.relative(process.cwd(), path.resolve(srcdir, "node_modules"));
+const nodedir = path.resolve(srcdir, "node_modules");
 const section = process.env.ONLYDIR || null;
 
 /* A standard nodejs and webpack pattern */


### PR DESCRIPTION
This introduced a subtle bug in conjunction with cockpituous'
`release-source`: Generated dist/*/Makefile.deps now contain an
additional bogus `../package.json` dependency.

Back this out to unblock the release, until this gets investigated
properly.

This reverts commit 8c68b1ed85596431f1597f9c7726002f8351266c.

----

See my [notes](https://github.com/cockpit-project/cockpit-project.github.io/pull/466#issuecomment-942367063) for details.