### PR TITLE
networkmanager: Fix interface table alignment

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -148,9 +148,10 @@ th {
     th[data-label=Name] button {
         font-weight: var(--pf-global--FontWeight--bold);
 
+        // Preserve the same baseline as other elements, so items align
+        display: inline;
         // Expand the link to the container, for easier clickability
-        display: block;
-        text-align: left;
+        width: 100%;
     }
 }
 


### PR DESCRIPTION
I've fixed the vertical alignment of the table and adjusted the code to make clicking the "links" (which are implemented as buttons here) more clickable, as the comment indicates.

The use of a button set to block was causing the baseline to be different for the device name than the rest of the values, shifting everything else down. This corrects it and causes everything to be vertically aligned to the baseline again.