### PR TITLE
networking: Remove duplicated CSS imports

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -1,12 +1,4 @@
-@import "../../node_modules/@patternfly/react-styles/css/components/Alert/alert.css";
-@import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
-@import "../../node_modules/@patternfly/patternfly/components/Page/page.css";
-@import "../../node_modules/@patternfly/patternfly/components/Breadcrumb/breadcrumb.css";
-@import "../../node_modules/@patternfly/patternfly/layouts/Gallery/gallery.css";
-@import "../../node_modules/@patternfly/patternfly/components/Card/card.css";
 @import "../../node_modules/@patternfly/patternfly/components/FormControl/form-control.css";
-@import "../../node_modules/@patternfly/patternfly/components/Table/table.css";
-@import "../../node_modules/@patternfly/patternfly/components/Table/table-grid.css";
 @import "../../node_modules/@patternfly/patternfly/components/Toolbar/toolbar.css";
 
 /* The following are needed for the Modal */


### PR DESCRIPTION
When debugging the networking page, I kept coming across a lot of duplicated CSS. I've found these lines to be the culprit. Removing them seems to fix it with no visual regressions I have been able to find.

(The remaining imports do have regressions when removed.)

This _may_ change when https://github.com/cockpit-project/cockpit/pull/16428/ lands.