### PR TITLE
all: Rename occurances of "Apply" to "Save", fix racy TestNetworkingBasic pixel test

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -181,7 +181,7 @@ class KdumpTargetBody extends React.Component {
  * kdumpActive       kdump service status
  * onSetServiceState called when the OnOff state is toggled (for kdumpActive), parameter: desired state
  * stateChanging     whether we're currently waiting for our last change to take effect
- * onApplySettings   called with current dialog settings when the user clicks apply
+ * onSaveSettings   called with current dialog settings when the user clicks Save
  * kdumpStatus       object as described in kdump-client
  * reservedMemory    memory reserved at boot time for kdump use
  * onCrashKernel     callback to crash the kernel via kdumpClient, expects a promise
@@ -279,11 +279,11 @@ export class KdumpPage extends React.Component {
         this.state.dialogObj.render();
     }
 
-    handleApplyClick() {
+    handleSaveClick() {
         return new Promise((resolve, reject) => {
-            this.props.onApplySettings(this.state.dialogSettings)
+            this.props.onSaveSettings(this.state.dialogSettings)
                     .then(resolve)
-                    .catch(error => reject(cockpit.format(_("Unable to apply settings: $0"), String(error))));
+                    .catch(error => reject(cockpit.format(_("Unable to save settings: $0"), String(error))));
         });
     }
 
@@ -356,8 +356,8 @@ export class KdumpPage extends React.Component {
         const footerProps = {
             actions: [
                 {
-                    clicked: this.handleApplyClick.bind(this),
-                    caption: _("Apply"),
+                    clicked: this.handleSaveClick.bind(this),
+                    caption: _("Save"),
                     style: 'primary',
                 },
             ],

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -37,7 +37,7 @@ const initStore = function(rootElement) {
 
     dataStore.kdumpClient = new kdumpClient.KdumpClient();
 
-    dataStore.applySettings = settings =>
+    dataStore.saveSettings = settings =>
         dataStore.kdumpClient.validateSettings(settings)
                 .then(() => dataStore.kdumpClient.writeSettings(settings));
 
@@ -63,7 +63,7 @@ const initStore = function(rootElement) {
             stateChanging: dataStore.stateChanging,
             reservedMemory: dataStore.kdumpMemory,
             kdumpStatus: dataStore.kdumpStatus,
-            onApplySettings: dataStore.applySettings,
+            onSaveSettings: dataStore.saveSettings,
             onCrashKernel: dataStore.kdumpClient.crashKernel,
         }), rootElement);
     };

--- a/pkg/networkmanager/bond.jsx
+++ b/pkg/networkmanager/bond.jsx
@@ -28,7 +28,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon, HelpIcon } from '@patternfly/react-icons';
 
-import { MacMenu, MemberInterfaceChoices, NetworkModal, Name, dialogApply } from './dialogs-common.jsx';
+import { MacMenu, MemberInterfaceChoices, NetworkModal, Name, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -110,7 +110,7 @@ export const BondDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/bridge.jsx
+++ b/pkg/networkmanager/bridge.jsx
@@ -26,7 +26,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { MemberInterfaceChoices, NetworkModal, Name, dialogApply } from './dialogs-common.jsx';
+import { MemberInterfaceChoices, NetworkModal, Name, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -71,7 +71,7 @@ export const BridgeDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/bridgeport.jsx
+++ b/pkg/networkmanager/bridgeport.jsx
@@ -25,7 +25,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 const _ = cockpit.gettext;
@@ -55,7 +55,7 @@ export const BridgePortDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -145,8 +145,8 @@ export const NetworkModal = ({ dialogError, help, idPrefix, setIsOpen, title, on
             title={title}
             footer={
                 <>
-                    <Button variant='primary' id={idPrefix + "-apply"} onClick={onSubmit}>
-                        {_("Apply")}
+                    <Button variant='primary' id={idPrefix + "-save"} onClick={onSubmit}>
+                        {_("Save")}
                     </Button>
                     <Button variant='link' id={idPrefix + "-cancel"} onClick={() => setIsOpen(false)}>
                         {_("Cancel")}
@@ -155,7 +155,7 @@ export const NetworkModal = ({ dialogError, help, idPrefix, setIsOpen, title, on
             }
         >
             <Form id={idPrefix + "-body"} onSubmit={onSubmit} isHorizontal={isFormHorizontal !== false}>
-                {dialogError && <ModalError id={idPrefix + "-error"} dialogError={_("Failed to apply settings")} dialogErrorDetail={dialogError} />}
+                {dialogError && <ModalError id={idPrefix + "-error"} dialogError={_("Failed to save settings")} dialogErrorDetail={dialogError} />}
                 {children}
             </Form>
         </Modal>
@@ -247,7 +247,7 @@ function reactivateConnection({ con, dev }) {
     }
 }
 
-export const dialogApply = ({ model, dev, connection, members, membersInit, settings, setDialogError, setIsOpen }) => {
+export const dialogSave = ({ model, dev, connection, members, membersInit, settings, setDialogError, setIsOpen }) => {
     const apply_settings = settings_applier(model, dev, connection);
     const iface = settings.connection.interface_name;
     const type = settings.connection.type;

--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -32,7 +32,7 @@ import {
 
 import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
-import { NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 const _ = cockpit.gettext;
@@ -113,7 +113,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, setIsOpen, settings }
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/mac.jsx
+++ b/pkg/networkmanager/mac.jsx
@@ -23,7 +23,7 @@ import {
     FormGroup,
 } from '@patternfly/react-core';
 
-import { MacMenu, NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { MacMenu, NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 const _ = cockpit.gettext;
@@ -48,7 +48,7 @@ export const MacDialog = ({ connection, dev, setIsOpen, settings }) => {
             return;
         }
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/mtu.jsx
+++ b/pkg/networkmanager/mtu.jsx
@@ -24,7 +24,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 const _ = cockpit.gettext;
@@ -51,7 +51,7 @@ export const MtuDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/team.jsx
+++ b/pkg/networkmanager/team.jsx
@@ -26,7 +26,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { MemberInterfaceChoices, NetworkModal, Name, dialogApply } from './dialogs-common.jsx';
+import { MemberInterfaceChoices, NetworkModal, Name, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -129,7 +129,7 @@ export const TeamDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/teamport.jsx
+++ b/pkg/networkmanager/teamport.jsx
@@ -25,7 +25,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 const _ = cockpit.gettext;
@@ -59,7 +59,7 @@ export const TeamPortDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/networkmanager/vlan.jsx
+++ b/pkg/networkmanager/vlan.jsx
@@ -26,7 +26,7 @@ import {
     TextInput,
 } from '@patternfly/react-core';
 
-import { Name, NetworkModal, dialogApply } from './dialogs-common.jsx';
+import { Name, NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
 
 import { v4 as uuidv4 } from 'uuid';
@@ -68,7 +68,7 @@ export const VlanDialog = ({ connection, dev, setIsOpen, settings }) => {
             }
         });
 
-        dialogApply({
+        dialogSave({
             model,
             dev,
             connection,

--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -302,7 +302,7 @@ export class KpatchSettings extends React.Component {
                                 isLoading={ this.state.updating }
                                 isDisabled={ this.state.updating }
                                 onClick={ this.handleChange }>
-                            {_("Apply")}
+                            {_("Save")}
                         </Button>
                         <Button variant="link"
                                 isDisabled={ this.state.updating }

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -155,7 +155,7 @@ export class CryptoTab extends React.Component {
                                   })
                     ],
                     Action: {
-                        Title: _("Apply"),
+                        Title: _("Save"),
                         action: function (vals) {
                             config["passphrase-contents"] = {
                                 t: 'ay',
@@ -199,7 +199,7 @@ export class CryptoTab extends React.Component {
                     ],
                     isFormHorizontal: false,
                     Action: {
-                        Title: _("Apply"),
+                        Title: _("Save"),
                         action: function (vals) {
                             let opts = [];
                             if (is_fsys && content_block)

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -368,7 +368,7 @@ export function mounting_dialog(client, block, mode, forced_options) {
     const mode_action = {
         mount: _("Mount"),
         unmount: _("Unmount"),
-        update: _("Apply")
+        update: _("Save")
     };
 
     function do_unmount() {
@@ -484,7 +484,7 @@ export class FilesystemTab extends React.Component {
                               })
                 ],
                 Action: {
-                    Title: _("Apply"),
+                    Title: _("Save"),
                     action: function (vals) {
                         return block_fsys.SetLabel(vals.name, {});
                     }

--- a/pkg/storaged/nfs-details.jsx
+++ b/pkg/storaged/nfs-details.jsx
@@ -183,7 +183,7 @@ export function nfs_fstab_dialog(client, entry) {
                     check_server(dlg, vals.server, 500);
             },
             Action: {
-                Title: entry ? _("Apply") : _("Add"),
+                Title: entry ? _("Save") : _("Add"),
                 action: function (vals) {
                     const location = cockpit.location;
                     const fields = [vals.server + ":" + vals.remote,

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -160,10 +160,10 @@ const CryptoPolicyDialog = ({
                footer={
                    <>
                        {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
-                       <Button id="crypto-policy-apply-reboot" variant='primary' onClick={() => setPolicy(true)}>
+                       <Button id="crypto-policy-save-reboot" variant='primary' onClick={() => setPolicy(true)}>
                            {_("Save and reboot")}
                        </Button>
-                       <Button id="crypto-policy-apply-reboot-later" variant='secondary' onClick={() => setPolicy(false)}>
+                       <Button id="crypto-policy-save-reboot-later" variant='secondary' onClick={() => setPolicy(false)}>
                            {_("Save only")}
                        </Button>
                        <Button variant='link' onClick={close}>

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -161,10 +161,10 @@ const CryptoPolicyDialog = ({
                    <>
                        {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
                        <Button id="crypto-policy-apply-reboot" variant='primary' onClick={() => setPolicy(true)}>
-                           {_("Apply and reboot")}
+                           {_("Save and reboot")}
                        </Button>
                        <Button id="crypto-policy-apply-reboot-later" variant='secondary' onClick={() => setPolicy(false)}>
-                           {_("Apply only")}
+                           {_("Save only")}
                        </Button>
                        <Button variant='link' onClick={close}>
                            {_("Cancel")}

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -110,10 +110,10 @@ class TestKdump(KdumpHelpers):
         mountInput = "#kdump-settings-nfs-mount"
         b.set_input_text(mountInput, ":/var/crash")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_visible(".pf-c-alert__title:contains('Unable to apply settings')")
+        b.wait_visible(".pf-c-alert__title:contains('Unable to save settings')")
         b.set_input_text(mountInput, "localhost:")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_visible(".pf-c-alert__title:contains('Unable to apply settings')")
+        b.wait_visible(".pf-c-alert__title:contains('Unable to save settings')")
         b.click("#kdump-settings-dialog button.cancel")
         b.wait_not_present("#kdump-settings-dialog")
 
@@ -153,7 +153,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text(pathInput, customPath)
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         # we should get an error
-        b.wait_visible("h4.pf-c-alert__title:contains('Unable to apply settings')")
+        b.wait_visible("h4.pf-c-alert__title:contains('Unable to save settings')")
         # also allow the journal message about failed touch
         self.allow_journal_messages(".*mktemp: failed to create file via template.*")
         # create the directory and try again
@@ -191,7 +191,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text("#kdump-settings-ssh-server", "admin@localhost")
         b.set_input_text("#kdump-settings-ssh-key", "/home/admin/.ssh/id_rsa")
         b.set_input_text("#kdump-settings-ssh-directory", "/var/tmp/crash")
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn("path /var/tmp/crash", conf)
@@ -203,7 +203,7 @@ class TestKdump(KdumpHelpers):
         b.wait_visible("#kdump-settings-dialog")
         b.set_val("#kdump-settings-location", "nfs")
         b.set_input_text("#kdump-settings-nfs-mount", "someserver:/srv")
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn("nfs someserver:/srv", conf)
@@ -215,7 +215,7 @@ class TestKdump(KdumpHelpers):
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")
         b.set_input_text("#kdump-settings-nfs-directory", "dumps")
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn("nfs someserver:/srv", conf)
@@ -226,7 +226,7 @@ class TestKdump(KdumpHelpers):
         b.wait_visible("#kdump-settings-dialog")
         b.set_val("#kdump-settings-location", "local")
         b.set_input_text("#kdump-settings-local-directory", "/var/tmp")
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn("path /var/tmp", conf)
@@ -237,7 +237,7 @@ class TestKdump(KdumpHelpers):
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")
         b.set_checked("#kdump-settings-compression", True)
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn(current + " -c", conf)
@@ -304,7 +304,7 @@ class TestKdumpNFS(KdumpHelpers):
         b.set_input_text("#kdump-settings-nfs-directory", "dumps")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         # dumps directory does not exist, error
-        b.wait_visible("h4.pf-c-alert__title:contains('Unable to apply settings')")
+        b.wait_visible("h4.pf-c-alert__title:contains('Unable to save settings')")
         # create the directory on the NFS server
         self.machines["nfs"].execute("mkdir /srv/kdump/dumps")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -86,10 +86,10 @@ class TestNetworkingBasic(NetworkCase):
 
         b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
         b.set_input_text('#network-ip-settings-netmask-0', "255.255.0.8")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_text_not("#network-ip-settings-error h4", "")
         b.set_input_text('#network-ip-settings-netmask-0', "255.255.192.0")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
         b.wait_in_text(f"#network-interface .pf-c-card:contains('{iface}')", "1.2.3.4/18")
 
@@ -123,7 +123,7 @@ class TestNetworkingBasic(NetworkCase):
         self.toggle_onoff("#network-ip-settings-dialog [data-field='dns']")
         # The "DNS search domains" setting should follow suit
         self.wait_onoff("#network-ip-settings-dialog [data-field='dns_search']", False)
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
 
         wait(lambda: "yes" in m.execute(f"nmcli -f ipv4.ignore-auto-dns connection show '{con_id}'"))

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -46,26 +46,16 @@ class TestNetworkingBasic(NetworkCase):
         b.wait_in_text("#networking-graphs", "Transmitting")
         b.wait_in_text("#networking-graphs", "Receiving")
 
-        ifaces = list(m.execute("ls /sys/class/net").split())
-        ifaces.remove("lo")
-        try:
-            # not a real interface
-            ifaces.remove("bonding_masters")
-        except ValueError:
-            pass
-        ignore = []
-        for iface_name in ifaces:
-            ignore.append(f"tr[data-interface={iface_name}] td[data-label=Sending]")
-            if not any(status in b.text(f"tr[data-interface={iface_name}] td[data-label=Sending]") for status in ["Inactive", "No carrier"]):
-                ignore.append(f"tr[data-interface={iface_name}] td[data-label=Receiving]")
-            ignore.append(f"tr[data-interface={iface_name}] td[data-label='IP address']")
-        ignore.append("#networking-graphs .pf-l-grid")
-        ignore.append(".cockpit-log-panel .pf-c-card__body")
-        ignore.append("#networking-firewall-summary .pf-c-card__body")
-
         b.assert_pixels(
             "#networking", "network-main",
-            ignore
+            [
+                "td[data-label=Sending]",
+                "td[data-label=Receiving]",
+                "td[data-label='IP address']",
+                "#networking-graphs .pf-l-grid",
+                ".cockpit-log-panel .pf-c-card__body",
+                "#networking-firewall-summary .pf-c-card__body",
+            ]
         )
 
         # Details of test iface

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -65,7 +65,7 @@ class TestBonding(NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", True)
         b.set_checked(f"input[data-iface='{iface2}']", True)
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbond']")
 
@@ -157,7 +157,7 @@ class TestBonding(NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", True)
         b.set_checked(f"input[data-iface='{iface2}']", True)
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         b.click("#networking-interfaces tr[data-interface='tbond'] button")
@@ -183,7 +183,7 @@ class TestBonding(NetworkCase):
         b.select_from_dropdown("#network-bond-settings-link-monitoring-select", "arp")
         b.set_input_text("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Rename while it is active
@@ -201,7 +201,7 @@ class TestBonding(NetworkCase):
         b.wait_val("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
 
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond3000")
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
         b.wait_text("#network-interface-name", "tbond3000")
 
@@ -226,7 +226,7 @@ class TestBonding(NetworkCase):
         b.set_checked(f"input[data-iface='{iface}']", True)
         b.click("#network-bond-settings-mac-input")
         b.click("li button:contains('(cockpit1)')")
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the interface and the right IP address
@@ -293,7 +293,7 @@ class TestBondingVirt(NetworkCase):
         b.wait_visible("#network-bond-settings-dialog")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface}']", True)
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address
@@ -332,7 +332,7 @@ class TestBondingVirt(NetworkCase):
         b.wait_visible("#network-bond-settings-dialog")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface}']", True)
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -56,7 +56,7 @@ class TestBridge(NetworkCase):
         b.set_input_text("#network-bridge-settings-interface-name-input", "tbridge")
         b.set_checked(f"input[data-iface='{iface1}']", True)
         b.set_checked(f"input[data-iface='{iface2}']", True)
-        b.click("#network-bridge-settings-dialog button:contains('Apply')")
+        b.click("#network-bridge-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bridge-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
 
@@ -104,7 +104,7 @@ class TestBridge(NetworkCase):
         b.wait_visible("#network-bridge-settings-dialog")
         b.set_input_text("#network-bridge-settings-interface-name-input", "tbridge")
         b.set_checked(f"input[data-iface='{iface}']", True)
-        b.click("#network-bridge-settings-dialog button:contains('Apply')")
+        b.click("#network-bridge-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bridge-settings-dialog")
 
         # Check that it has the interface and the right IP address
@@ -120,7 +120,7 @@ class TestBridge(NetworkCase):
         b.set_input_text("#network-bridge-port-settings-prio-input", "35")
         b.set_input_text("#network-bridge-port-settings-path-cost-input", "90")
         b.set_checked("#network-bridge-port-settings-hairPin-mode-input", True)
-        b.click("#network-bridge-port-settings-apply")
+        b.click("#network-bridge-port-settings-save")
         b.wait_not_present("#network-bridge-port-settings-dialog")
 
         # Confirm that bridge port settings are applied

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -59,7 +59,7 @@ class TestNetworkingCheckpoints(NetworkCase):
             b.select_from_dropdown("#network-ip-settings-select-method", "manual")
             b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
             b.set_input_text('#network-ip-settings-netmask-0', "24")
-            b.click("#network-ip-settings-apply")
+            b.click("#network-ip-settings-save")
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
             b.wait_not_present("#confirm-breaking-change-popup")
 

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -53,7 +53,7 @@ class TestNetworkingMAC(NetworkCase):
             b.wait_visible("#network-mac-settings-dialog")
             b.set_input_text('#network-mac-settings-mac-input-select-typeahead', new_mac)
             b.click(".pf-c-select ul > li > button")
-            b.click("#network-mac-settings-apply")
+            b.click("#network-mac-settings-save")
             b.wait_not_present("#network-mac-settings-dialog")
 
             b.wait_text("#network-interface-mac", new_mac.upper())
@@ -79,7 +79,7 @@ class TestNetworkingMAC(NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", True)
         b.set_checked(f"input[data-iface='{iface2}']", True)
-        b.click("#network-bond-settings-dialog button:contains('Apply')")
+        b.click("#network-bond-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         self.select_iface('tbond')
@@ -94,7 +94,7 @@ class TestNetworkingMAC(NetworkCase):
             b.wait_visible("#network-mac-settings-dialog")
             b.set_input_text('#network-mac-settings-mac-input-select-typeahead', new_mac)
             b.click(".pf-c-select ul > li > button")
-            b.click("#network-mac-settings-apply")
+            b.click("#network-mac-settings-save")
             b.wait_not_present("#network-mac-settings-dialog")
 
             b.wait_text("#network-interface-mac", new_mac.upper())

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -55,7 +55,7 @@ class TestNetworkingMTU(NetworkCase):
 
         b.set_checked('#network-mtu-settings-custom', True)
         b.set_input_text('#network-mtu-settings-input', "1400")
-        b.click("#network-mtu-settings-apply")
+        b.click("#network-mtu-settings-save")
         b.wait_not_present("#network-mtu-settings-dialog")
         self.wait_for_iface_setting('MTU', '1400')
 

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -49,7 +49,7 @@ class TestNetworkingOther(NetworkCase):
         b.select_from_dropdown("#network-ip-settings-dialog select", "manual")
         b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
         b.set_input_text('#network-ip-settings-netmask-0', "24")
-        b.click("#network-ip-settings-dialog button:contains('Apply')")
+        b.click("#network-ip-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('Status', '1.2.3.4/24')
 

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -57,7 +57,7 @@ class TestNetworkingSettings(NetworkCase):
         b.select_from_dropdown("#network-ip-settings-select-method", "manual")
         b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
         b.set_input_text('#network-ip-settings-netmask-0', "24")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('IPv4', 'Address 1.2.3.4/24')
 
@@ -99,7 +99,7 @@ class TestNetworkingSettings(NetworkCase):
         b.set_input_text("#network-ip-settings-dns-server-0", "1.2.3.4")
         b.click("#network-ip-settings-dns-search-add")
         b.set_input_text("#network-ip-settings-search-domain-0", "foo.com")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
 
         assert_connection_setting(con_id, "ipv4.ignore-auto-dns", "yes")
@@ -117,7 +117,7 @@ class TestNetworkingSettings(NetworkCase):
         self.configure_iface_setting('IPv6')
         b.wait_visible("#network-ip-settings-dialog")
         b.select_from_dropdown("#network-ip-settings-select-method", "disabled")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
 
         assert_connection_setting(con_id, "ipv6.method", "disabled")
@@ -141,7 +141,7 @@ class TestNetworkingSettings(NetworkCase):
         self.configure_iface_setting('IPv4')
         b.wait_visible("#network-ip-settings-dialog")
         b.select_from_dropdown("#network-ip-settings-select-method", "shared")
-        b.click("#network-ip-settings-apply")
+        b.click("#network-ip-settings-save")
         b.wait_not_present("#network-ip-settings-dialog")
 
         self.assertEqual(m.execute(f"nmcli -m tabular -t -f ipv4.method con show '{con_id}'").strip(),
@@ -162,7 +162,7 @@ class TestNetworkingSettings(NetworkCase):
         b.set_input_text('#network-ip-settings-route-netmask-0', "60")
         b.set_input_text('#network-ip-settings-route-gateway-0', "fe80:2::3")
         b.set_input_text('#network-ip-settings-route-metric-0', "42")
-        b.click('#network-ip-settings-apply')
+        b.click('#network-ip-settings-save')
         b.wait_not_present("#network-ip-settings-dialog")
 
         # setting should be applied

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -57,7 +57,7 @@ class TestTeam(NetworkCase):
         b.set_input_text("#network-team-settings-interface-name-input", "tteam")
         b.set_checked(f"input[data-iface='{iface1}']", True)
         b.set_checked(f"input[data-iface='{iface2}']", True)
-        b.click("#network-team-settings-dialog button:contains('Apply')")
+        b.click("#network-team-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-team-settings-dialog")
 
         b.wait_attr("#networking", "data-test-wait", "false")
@@ -119,7 +119,7 @@ class TestTeam(NetworkCase):
         b.wait_visible("#network-team-settings-dialog")
         b.set_input_text("#network-team-settings-interface-name-input", "tteam")
         b.set_checked(f"input[data-iface='{iface}']", True)
-        b.click("#network-team-settings-dialog button:contains('Apply')")
+        b.click("#network-team-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-team-settings-dialog")
 
         b.wait_attr("#networking", "data-test-wait", "false")
@@ -137,7 +137,7 @@ class TestTeam(NetworkCase):
         b.wait_visible("#network-team-port-settings-dialog")
         b.set_input_text("#network-team-port-settings-activebackup-prio-input", "10")
         b.set_checked("#network-team-port-settings-activebackup-sticky-input", True)
-        b.click("#network-team-port-settings-apply")
+        b.click("#network-team-port-settings-save")
         b.wait_not_present("#network-team-port-settings-dialog")
 
         b.wait_attr("#network-interface", "data-test-wait", "false")

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -50,7 +50,7 @@ class TestNetworkingVLAN(NetworkCase):
         b.select_from_dropdown("#network-vlan-settings-parent-select", iface)
         b.set_input_text("#network-vlan-settings-interface-name-input", "tvlan")
         b.set_input_text("#network-vlan-settings-vlan-id-input", "123")
-        b.click("#network-vlan-settings-dialog button:contains('Apply')")
+        b.click("#network-vlan-settings-dialog button:contains('Save')")
         b.wait_not_present("#network-vlan-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tvlan']")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -174,7 +174,7 @@ class TestUpdates(NoSubManCase):
         b.wait_visible("#apply-kpatch:checked")
         b.wait_visible("#current-future:checked")
 
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kpatch-setup")
 
         self.assertIn("True", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
@@ -211,7 +211,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_visible("#current-future:not(:checked)")
         b.wait_visible("#current-only:checked")
 
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kpatch-setup")
 
         self.assertIn("False", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))
@@ -226,7 +226,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.click("#apply-kpatch")
         b.wait_visible("#apply-kpatch:not(:checked)")
 
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kpatch-setup")
 
         b.wait_in_text("#kpatch-settings", "Disabled")
@@ -258,7 +258,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_visible("#current-future:not(:checked)")
         b.wait_visible("#current-only:checked")
 
-        b.click("button:contains('Apply')")
+        b.click("button:contains('Save')")
         b.wait_not_present("#kpatch-setup")
 
         self.assertIn("False", m.execute("grep autoupdate /etc/dnf/plugins/kpatch.conf"))

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -846,9 +846,9 @@ password=foobar
             profile_button_name = shown_profile_text(new_profile)
             b.click(f".pf-c-menu__item-main .pf-c-menu__item-text:contains('{profile_button_name}')")
             if reboot:
-                b.click("#crypto-policy-apply-reboot")
+                b.click("#crypto-policy-save-reboot")
             else:
-                b.click("#crypto-policy-apply-reboot-later")
+                b.click("#crypto-policy-save-reboot-later")
                 b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
                 profile = m.execute(cmd + " --show").strip()
                 self.assertEqual(new_profile, profile)


### PR DESCRIPTION
"Apply" buttons should be "Save".

Reason: "Save" always means "make the changes and close this dialog", whereas "Apply" sometimes does this too but more often means "Just make the changes now and keep the dialog open", famously in Windows, where most of our users are. Making the options "Save" and "Cancel" is much clearer.