### PR TITLE
tools: Fix webpack-make's detection of files outside the project directory

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -97,13 +97,15 @@ function generateDeps(makefile, stats) {
         if (fs.lstatSync(file).isDirectory())
             continue;
 
+        const input = path.relative(srcdir, file);
+
         // HACK: webpack looks at files in parent dir: https://github.com/webpack/webpack/issues/14481
-        if (!file.startsWith(srcdir)) {
+        if (input.startsWith("../")) {
             process.stderr.write(`webpack-make: Ignoring file dependency ${file} outside of project directory: ${srcdir}\n`);
             continue;
         }
 
-        inputs.add(path.relative(srcdir, file));
+        inputs.add(input);
     }
 
     const uncompressed_patterns = [


### PR DESCRIPTION
commit ae558a06 did not account for `srcdir` being `.`, which is the
default when running webpack-make directly (as developer). This causes
tons of messages like

    webpack-make: Ignoring file dependency /home/martin/upstream/cockpit/po/es.po outside of project directory: .

Instead, convert the path to a relative one first, and then check if it
refers to the parent directory. This works fine with both relative and
absolute srcdir.

-----

I tested this with a direct `tools/webpack-make sosreport` (no wrong messages any more), as well with the original reproducer for the [release failure](https://github.com/cockpit-project/cockpit-project.github.io/pull/466#issuecomment-942367063):
```
❱❱❱ rm -rf source.XXX && mkdir source.XXX && git clone -q . source.XXX && (cd source.XXX/ && env -u MAKEFLAGS pkg/build WEBPACK_PACKAGES=sosreport && head dist/sosreport/Makefile.deps)
  REMOVE   node_modules
  CLONE    node_modules  [ref: 481f38795576cb2753092e4314c04f51a93fdd82]
  COPY     package-lock.json
  WEBPACK  sosreport
webpack-make: Ignoring file dependency /var/home/martin/upstream/cockpit/package.json outside of project directory: /var/home/martin/upstream/cockpit/source.XXX
# Generated Makefile data for sosreport
sosreport_INPUTS = \
	.babelrc.json \
	package.json \
	pkg/lib/_global-variables.scss \
	pkg/lib/page.scss \
	pkg/lib/patternfly/_fonts.scss \
	pkg/lib/patternfly/patternfly-4-cockpit.scss \
	pkg/lib/patternfly/patternfly-4-overrides.scss \
	pkg/lib/patternfly/patternfly-cockpit.scss \
```

So `INPUTS` is clean (no `../package.json`), there is the expected message for ignoring the file from the parent dir. I.e. for the make-invoked webpack-make the behaviour is the same as before.