### PR TITLE
systemd: Fix realmd join crash if given address is not the domain name

### DIFF
--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -343,8 +343,7 @@ const JoinDialog = ({ realmd_client, onClose }) => {
                         if (name == "") {
                             if (!address)
                                 setAddress(reply.realm.Name);
-                        } else if (name != reply.realm.Name)
-                            throw new Error("checkRealm returned domain", reply.realm.Name, "for query", name);
+                        }
 
                         if (reply.kerberos_membership && reply.kerberos_membership.valid) {
                             setAddressValid("success");

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -250,6 +250,20 @@ class CommonTests:
         b.click("#realms-join-dialog button.pf-m-link")
         b.wait_not_present("#realms-join-dialog")
 
+        # Join a domain with the server as address (input differs from domain name)
+        b.click(self.domain_sel)
+        b.wait_popup("realms-join-dialog")
+        b.wait_attr("#realms-op-address", "data-discover", "done")
+        b.set_input_text(self.op_address, "f0.cockpit.lan")
+        b.wait_text("#realms-op-address-helper", "Contacted domain")
+        # admin gets auto-detected
+        b.wait_val(self.op_admin, self.admin_user)
+        b.set_input_text(self.op_admin_password, self.admin_password)
+        b.click(f"#realms-join-dialog button{self.primary_btn_class}")
+        with b.wait_timeout(300):
+            b.wait_not_present("#realms-join-dialog")
+        wait_number_domains(1)
+
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()
         # sometimes polling for info and joining a domain creates this noise


### PR DESCRIPTION
It is actually possible and legit for the "Address:" input to be the DNS
name of the IdM server instead of the actual domain name. realmd's
Discover API is fine with that, and just returns the actual domain name
in `reply.realm.Name`.

Commit c277263aaa introduced an additional assertion that the queried
and returned domain names are the same, but this does not hold with the
above. Drop the assertion, and add an integration test which covers this
scenario.

Fixes #16477