### PR TITLE
test: fix linter warning: expected 2 blank lines after class or funct…

### DIFF
--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -127,5 +127,6 @@ class TestBridge(NetworkCase):
         self.assertEqual(m.execute("nmcli con show cockpit1 | grep -i bridge-port.path-cost | awk '{print $2}'").strip(), "90")
         self.assertEqual(m.execute("nmcli con show cockpit1 | grep -i bridge-port.hairpin-mode | awk '{print $2}'").strip(), "yes")
 
+
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -149,5 +149,6 @@ class TestTeam(NetworkCase):
         self.assertEqual(team_port_config.get("prio"), "10")
         self.assertTrue(team_port_config.get("sticky"))
 
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
…ion definition, found 1