### PR TITLE
metrics: Initialize top most timestamp to something usable

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1119,6 +1119,7 @@ class MetricsHistory extends React.Component {
                 .then(out => {
                     const now = parseInt(out.trim()) * 1000;
                     const current_hour = Math.floor(now / MSEC_PER_H) * MSEC_PER_H;
+                    this.most_recent = current_hour;
                     this.load_data(current_hour - LOAD_HOURS * MSEC_PER_H, undefined, true);
                     this.today_midnight = new Date(current_hour).setHours(0, 0, 0, 0);
                     this.setState({


### PR DESCRIPTION
When the initial load of the last 12 hours does not return any data
then after one minute when we try to update the last minute we load all
the data there is.
The updating logic calls `load_data` with `this.most_recent`. This variable
has initial value `0` and is updated when some data are parsed.
Calling `load_data(0)` translates to loading all the data it can find.

Fixes #16462