### PR TITLE
test: Ubuntu 20.10 has fixed sudo for kerberos authentication

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -758,7 +758,7 @@ ipa-advise enable-admins-sudo | sh -ex
         # now sudo works with the delegated ticket
         # this requires https://github.com/sudo-project/sudo/commit/3b7977a42c0 (see https://bugzilla.redhat.com/show_bug.cgi?id=1917379)
         # to actually work, so on older distros it fails
-        supports_sudo_krb = m.image not in ["rhel-8-5", "rhel-8-6", "centos-8-stream", "ubuntu-2004", "ubuntu-stable"]
+        supports_sudo_krb = m.image not in ["rhel-8-5", "rhel-8-6", "centos-8-stream", "ubuntu-2004"]
         b.open_superuser_dialog()
 
         if supports_sudo_krb:


### PR DESCRIPTION
Ubuntu 20.10 was released recently, so the ubuntu-stable image refresh
in https://github.com/cockpit-project/bots/pull/2542 moves from 20.04 to
20.10. This version has a fixed sudo for kerberos authentication.

----

This needs to land in lockstep with https://github.com/cockpit-project/bots/pull/2542