### PR TITLE
packagekit: Fix one accidentally untranslated UI string

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -449,7 +449,7 @@ class RestartServices extends React.Component {
                                    title={_("Web Console will restart")}
                                    isInline>
                                    <p>
-                                       _("When the Web Console is restarted, you will no longer see progress information. However, the update process will continue in the background. Reconnect to continue watching the update process.")
+                                       {_("When the Web Console is restarted, you will no longer see progress information. However, the update process will continue in the background. Reconnect to continue watching the update process.")}
                                    </p>
                                </Alert>}
                            <Button variant='primary'


### PR DESCRIPTION
This fixes this untranslated string:

![image](https://user-images.githubusercontent.com/3228183/138103291-b254b9ab-dfcb-42a4-b318-38a993c079a9.png)
