### PR TITLE
storage: Redesign "content rows" everywhere

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -154,9 +154,9 @@ export const ListingTable = ({
             <React.Fragment key={rowKey + "-inner-row"}>
                 <Tr {...rowProps}>
                     {isExpandable
-                        ? (row.expandedContent
-                            ? <Td expand={
-                                {
+                        ? <Td expand={
+                            row.expandedContent
+                                ? {
                                     rowKey,
                                     isExpanded,
                                     onToggle: () => {
@@ -164,9 +164,8 @@ export const ListingTable = ({
                                             afterToggle(!expanded[rowKey]);
                                         setExpanded({ ...expanded, [rowKey]: !expanded[rowKey] });
                                     }
-                                }} />
-                            : <Td />
-                        ) : null}
+                                } : null} />
+                        : null}
                     {onSelect &&
                         <Td select={{
                             rowIndex,

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -420,7 +420,7 @@ function create_tabs(client, target, is_partition, is_extended) {
 }
 
 function block_description(client, block) {
-    let type, used_for, link, size;
+    let type, used_for, link, size, critical_size;
     const block_stratis_blockdev = client.blocks_stratis_blockdev[block.path];
     const block_stratis_locked_pool = client.blocks_stratis_locked_pool[block.path];
     const vdo = client.vdo_overlay.find_by_backing_block(block);
@@ -458,6 +458,7 @@ function block_description(client, block) {
             used_for = vgroup.Name;
             link = ["vg", used_for];
             size = [block_pvol.Size - block_pvol.FreeSize, block_pvol.Size];
+            critical_size = 1;
         } else if (client.mdraids[block.MDRaidMember]) {
             const mdraid = client.mdraids[block.MDRaidMember];
             type = _("RAID member");
@@ -498,7 +499,8 @@ function block_description(client, block) {
         type: type,
         used_for: used_for,
         link: link,
-        size: size
+        size: size,
+        critical_size: critical_size
     };
 }
 
@@ -543,7 +545,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
         { title: desc.link ? <StorageLink onClick={() => cockpit.location.go(desc.link)}>{desc.used_for}</StorageLink> : desc.used_for },
         {
             title: desc.size.length
-                ? <StorageUsageBar stats={desc.size} critical={0.95} block={name} />
+                ? <StorageUsageBar stats={desc.size} critical={desc.critical_size || 0.95} block={name} />
                 : utils.fmt_size(desc.size),
             props: { className: "ct-text-align-right" }
         },

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -742,21 +742,16 @@ export const Block = ({ client, block, allow_partitions }) => {
 };
 
 function append_logical_volume_block(client, rows, level, block, lvol) {
-    let tabs, desc;
-    if (client.blocks_ptable[block.path]) {
-        // XXX - just make this a link to the details page for the block device?
-        desc = {
+    const desc = client.blocks_ptable[block.path]
+        ? {
             size: block.Size,
-            type: lvol.Name
-        };
-        tabs = create_tabs(client, block, false);
-        append_row(client, rows, level, lvol.Name, utils.block_name(block), desc, tabs, block.path);
-        append_partitions(client, rows, level + 1, block);
-    } else {
-        const tabs = create_tabs(client, block, false);
-        const desc = block_description(client, block);
-        append_row(client, rows, level, block.path, lvol.Name, desc, tabs, block.path);
-    }
+            type: _("Partitioned block device"),
+            used_for: utils.block_name(block),
+            link: [utils.block_name(block).replace(/^\/dev\//, "")]
+        }
+        : block_description(client, block);
+    const tabs = create_tabs(client, block, false);
+    append_row(client, rows, level, block.path, lvol.Name, desc, tabs, block.path);
 }
 
 function append_logical_volume(client, rows, level, lvol) {

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -549,8 +549,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
                 : utils.fmt_size(desc.size),
             props: { className: "ct-text-align-right" }
         },
-        { title: actions, props: { className: "content-action" } },
-        { title: menu, props: { className: "content-action" } }
+        { title: <>{actions}{menu}</>, props: { className: "pf-c-table__action content-action" } },
     ];
 
     rows.push({
@@ -589,8 +588,7 @@ function append_partitions(client, rows, level, block) {
             { },
             { },
             { title: utils.fmt_size(size), props: { className: "ct-text-align-right" } },
-            { title: btn, props: { className: "content-action" } },
-            { props: { className: "content-action" } }
+            { title: btn, props: { className: "pf-c-table__action content-action" } },
         ];
 
         rows.push({
@@ -728,8 +726,7 @@ const BlockContent = ({ client, block, allow_partitions }) => {
             <CardBody className="contains-list">
                 <ListingTable rows={ block_rows(client, block) }
                               aria-label={_("Content")}
-                              variant="compact"
-                              columns={[_("Name"), _("Type"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
+                              columns={[_("Name"), _("Type"), _("Used for"), _("Size")]}
                               showHeader={false} />
             </CardBody>
         </Card>
@@ -984,9 +981,8 @@ export class VGroup extends React.Component {
                 <CardBody className="contains-list">
                     <ListingTable emptyCaption={_("No logical volumes")}
                                   aria-label={_("Logical volumes")}
-                                  columns={[_("Name"), _("Type"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
+                                  columns={[_("Name"), _("Type"), _("Used for"), _("Size")]}
                                   showHeader={false}
-                                  variant="compact"
                                   rows={vgroup_rows(client, vgroup)} />
                 </CardBody>
             </Card>

--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -75,7 +75,7 @@ export class LockedCryptoPanel extends React.Component {
         return (
             <OptionalPanel id="locked-cryptos"
                 title={_("Locked devices")}>
-                <ListingTable variant='compact'
+                <ListingTable
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Locked devices")}
                     className={locked_cryptos.length ? 'table-hover' : ''}

--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { SortByDirection } from '@patternfly/react-table';
 
 import { ListingTable } from "cockpit-components-table.jsx";
 import { block_name, get_block_link_parts, go_to_block } from "./utils.js";
@@ -81,8 +81,8 @@ export class LockedCryptoPanel extends React.Component {
                     className={locked_cryptos.length ? 'table-hover' : ''}
                     onRowClick={onRowClick}
                     columns={[
-                        { title: _("Name"), transforms: [cellWidth(30)], sortable: true },
-                        { title: _("Device"), transforms: [cellWidth(30)], sortable: true },
+                        { title: _("Name"), sortable: true },
+                        { title: _("Device"), sortable: true },
                     ]}
                     rows={locked_cryptos} />
             </OptionalPanel>

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -20,7 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { Page, PageSection, Grid, GridItem, Breadcrumb, BreadcrumbItem } from "@patternfly/react-core";
+import { Page, PageSection, Grid, GridItem, Breadcrumb, BreadcrumbItem, Flex, FlexItem } from "@patternfly/react-core";
 
 import * as utils from "./utils.js";
 import { BlockDetails } from "./block-details.jsx";
@@ -43,14 +43,19 @@ export class StdDetailsLayout extends React.Component {
                         { this.props.alert }
                         { this.props.header }
                     </GridItem>
-                    <GridItem md={8} lg={9}>
-                        <div id="detail-content">
-                            { this.props.content }
-                        </div>
-                        <JobsPanel client={this.props.client} />
-                    </GridItem>
-                    <GridItem id="detail-sidebar" md={4} lg={3}>
-                        { this.props.sidebar }
+                    <GridItem span={12}>
+                        <Flex direction={{ default: 'column', xl: 'row', "2xl": 'row' }}>
+                            <FlexItem flex={{ default: 'flex_3' }}>
+                                <div id="detail-content">
+                                    { this.props.content }
+                                    <JobsPanel client={this.props.client} />
+                                </div>
+                            </FlexItem>
+                            <FlexItem id="detail-sidebar"
+                                      flex={{ default: 'flex_1' }}>
+                                { this.props.sidebar }
+                            </FlexItem>
+                        </Flex>
                     </GridItem>
                 </>
             );

--- a/pkg/storaged/fsys-panel.jsx
+++ b/pkg/storaged/fsys-panel.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { SortByDirection } from '@patternfly/react-table';
 
 import { ListingTable } from "cockpit-components-table.jsx";
 import { StorageUsageBar } from "./storage-controls.jsx";
@@ -168,10 +168,10 @@ export class FilesystemsPanel extends React.Component {
                     className={mounts.length ? 'table-hover' : ''}
                     onRowClick={onRowClick}
                     columns={[
-                        { title: _("Source"), transforms: [cellWidth(25)], sortable: true },
-                        { title: _("Type"), transforms: [cellWidth(15)], sortable: true },
-                        { title: _("Mount"), transforms: [cellWidth(25)], sortable: true },
-                        { title:  _("Size"), transforms: [cellWidth(35)] }
+                        { title: _("Source"), sortable: true },
+                        { title: _("Type"), sortable: true },
+                        { title: _("Mount"), sortable: true },
+                        { title:  _("Size") }
                     ]}
                     rows={mounts.concat(flatten(pools))} />
             </OptionalPanel>

--- a/pkg/storaged/fsys-panel.jsx
+++ b/pkg/storaged/fsys-panel.jsx
@@ -162,7 +162,7 @@ export class FilesystemsPanel extends React.Component {
         return (
             <OptionalPanel id="mounts" className="storage-mounts"
                 title={_("Filesystems")}>
-                <ListingTable variant='compact'
+                <ListingTable
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Filesystems")}
                     className={mounts.length ? 'table-hover' : ''}

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -487,24 +487,6 @@ export class FilesystemTab extends React.Component {
             for (const opt of forced_options)
                 extract_option(split_options, opt);
 
-        let used;
-        if (stratis_fsys) {
-            if (stratis_fsys.Used[0])
-                used = utils.fmt_size(Number(stratis_fsys.Used[1]));
-            else
-                used = "-";
-        } else if (is_filesystem_mounted) {
-            const samples = self.props.client.fsys_sizes.data[old_dir];
-            if (samples)
-                used = cockpit.format(_("$0 of $1"),
-                                      utils.fmt_size(samples[0]),
-                                      utils.fmt_size(samples[1]));
-            else
-                used = _("Unknown");
-        } else {
-            used = "-";
-        }
-
         let mount_point_text = null;
         if (old_dir) {
             if (old_opts && old_opts != "defaults") {
@@ -711,10 +693,6 @@ export class FilesystemTab extends React.Component {
                             }
                             { extra_text }
                         </DescriptionListDescription>
-                    </DescriptionListGroup>
-                    <DescriptionListGroup>
-                        <DescriptionListTerm>{_("Used")}</DescriptionListTerm>
-                        <DescriptionListDescription>{used}</DescriptionListDescription>
                     </DescriptionListGroup>
                 </DescriptionList>
                 { mismounted_section }

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -19,7 +19,7 @@
 
 import cockpit from "cockpit";
 import React from "react";
-import { cellWidth, SortByDirection } from '@patternfly/react-table';
+import { SortByDirection } from '@patternfly/react-table';
 import { PlusIcon } from '@patternfly/react-icons';
 
 import { ListingTable } from "cockpit-components-table.jsx";
@@ -99,9 +99,9 @@ export class NFSPanel extends React.Component {
                     className={mounts.length ? 'table-hover' : ''}
                     emptyCaption={_("No NFS mounts set up")}
                     columns={[
-                        { title: _("Server"), transforms: [cellWidth(30)], sortable: true },
-                        { title: _("Mount point"), transforms: [cellWidth(33)], sortable: true },
-                        { title:  _("Size"), transforms: [cellWidth(40)] }
+                        { title: _("Server"), sortable: true },
+                        { title: _("Mount point"), sortable: true },
+                        { title:  _("Size") }
                     ]}
                     rows={mounts} />
             </OptionalPanel>

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -92,7 +92,7 @@ export class NFSPanel extends React.Component {
                        feature={nfs_feature}
                        not_installed_text={_("NFS support not installed")}
                        install_title={_("Install NFS support")}>
-                <ListingTable variant='compact'
+                <ListingTable
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("NFS mounts")}
                     onRowClick={onRowClick}

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -379,6 +379,7 @@ td.storage-action {
 
 .sidepanel-row-info {
     font-size: var(--pf-global--FontSize--xs);
+    max-width: 50ch;
 }
 
 .panel-heading {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -166,7 +166,7 @@ td.job-action {
 
 .content-action {
     text-align: right;
-    width: 1% !important;
+    white-space: nowrap !important;
 }
 
 .dialog-item-tooltip {

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -195,7 +195,7 @@ tr[class*=content-level-] {
 
     // Add space for the button and offset
     > .pf-c-table__toggle + td {
-        padding-left: var(--offset);
+        padding-left: calc(var(--offset) + var(--pf-c-table--cell--PaddingLeft));
     }
 }
 

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -410,7 +410,7 @@ td.storage-action {
     max-width: 30ch;
 }
 
-#mounts .pf-c-progress__measure, #nfs-mounts .pf-c-progress__measure {
+#mounts .pf-c-progress__measure, #nfs-mounts .pf-c-progress__measure, #detail-content .pf-c-progress__measure {
     min-width: 7rem;
 }
 

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -620,12 +620,8 @@ export const StratisPoolDetails = ({ client, pool }) => {
                 props: { className: "ct-text-align-right" }
             },
             {
-                title: actions,
-                props: { className: "content-action" }
-            },
-            {
-                title: <StorageBarMenu key="menu" menuItems={menuitems} isKebab />,
-                props: { className: "content-action" }
+                title: <>{actions}<StorageBarMenu key="menu" menuItems={menuitems} isKebab /></>,
+                props: { className: "pf-c-table__action content-action" }
             }
         ];
 
@@ -656,9 +652,8 @@ export const StratisPoolDetails = ({ client, pool }) => {
             <CardBody className="contains-list">
                 <ListingTable emptyCaption={_("No filesystems")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
+                              columns={[_("Name"), _("Used for"), _("Size")]}
                               showHeader={false}
-                              variant="compact"
                               rows={rows.filter(row => !!row)} />
             </CardBody>
         </Card>);
@@ -794,9 +789,8 @@ export const StratisLockedPoolDetails = ({ client, uuid }) => {
             <CardBody className="contains-list">
                 <ListingTable emptyCaption={_("Unlock pool to see filesystems.")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
+                              columns={[_("Name"), _("Used for"), _("Size")]}
                               showHeader={false}
-                              variant="compact"
                               rows={[]} />
             </CardBody>
         </Card>);

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -447,7 +447,7 @@ export const StratisPoolDetails = ({ client, pool }) => {
 
     const sidebar = <StratisPoolSidebar client={client} pool={pool} />;
 
-    function render_fsys(fsys) {
+    function render_fsys(fsys, offset, total) {
         const block = client.slashdevs_block[fsys.Devnode];
 
         if (!block) {
@@ -578,19 +578,6 @@ export const StratisPoolDetails = ({ client, pool }) => {
         if (info)
             info = <>{"\n"}{info}</>;
 
-        const cols = [
-            {
-                title: (
-                    <span key={name}>
-                        {mount_point || "-"}
-                        {info}
-                    </span>)
-            },
-            {
-                title: fsys.Devnode
-            }
-        ];
-
         const tabs = [
             {
                 name: name,
@@ -608,23 +595,39 @@ export const StratisPoolDetails = ({ client, pool }) => {
         if (!fs_is_mounted)
             actions.push(<StorageButton key="mount" onClick={mount}>{_("Mount")}</StorageButton>);
 
-        cols.push({
-            title: actions,
-            props: { className: "content-action" }
-        });
-
         const menuitems = [];
-
         if (fs_is_mounted)
             menuitems.push(<StorageMenuItem key="unmount" onClick={unmount}>{_("Unmount")}</StorageMenuItem>);
-
         menuitems.push(<StorageMenuItem key="rename" onClick={rename_fsys}>{_("Rename")}</StorageMenuItem>);
         menuitems.push(<StorageMenuItem key="snapshot" onClick={snapshot_fsys}>{_("Snapshot")}</StorageMenuItem>);
         menuitems.push(<StorageMenuItem key="del" onClick={delete_fsys}>{_("Delete")}</StorageMenuItem>);
-        cols.push({
-            title: <StorageBarMenu key="menu" menuItems={menuitems} isKebab />,
-            props: { className: "content-action" }
-        });
+
+        const cols = [
+            {
+                title: (
+                    <span>
+                        {fsys.Name}
+                        {info}
+                    </span>)
+            },
+            {
+                title: mount_point
+            },
+            {
+                title: <StorageUsageBar stats={[Number(fsys.Used[0] && Number(fsys.Used[1])),
+                    Number(pool.TotalPhysicalSize)]}
+                                        critical={1} total={total} offset={offset} />,
+                props: { className: "ct-text-align-right" }
+            },
+            {
+                title: actions,
+                props: { className: "content-action" }
+            },
+            {
+                title: <StorageBarMenu key="menu" menuItems={menuitems} isKebab />,
+                props: { className: "content-action" }
+            }
+        ];
 
         return {
             props: { key: fsys.Name },
@@ -632,6 +635,15 @@ export const StratisPoolDetails = ({ client, pool }) => {
             expandedContent: <ListingPanel tabRenderers={tabs} />
         };
     }
+
+    const offsets = [];
+    let total = 0;
+    filesystems.forEach(fs => {
+        offsets.push(total);
+        total += fs.Used[0] ? Number(fs.Used[1]) : 0;
+    });
+
+    const rows = filesystems.map((fs, i) => render_fsys(fs, offsets[i], total));
 
     const content = (
         <Card>
@@ -644,10 +656,10 @@ export const StratisPoolDetails = ({ client, pool }) => {
             <CardBody className="contains-list">
                 <ListingTable emptyCaption={_("No filesystems")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), { title: _("Blockdev"), header: true }, _("Actions"), _("Menu")]}
+                              columns={[_("Name"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
                               showHeader={false}
                               variant="compact"
-                              rows={filesystems.map(render_fsys).filter(row => !!row)} />
+                              rows={rows.filter(row => !!row)} />
             </CardBody>
         </Card>);
 
@@ -782,7 +794,7 @@ export const StratisLockedPoolDetails = ({ client, uuid }) => {
             <CardBody className="contains-list">
                 <ListingTable emptyCaption={_("Unlock pool to see filesystems.")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), { title: _("Blockdev"), header: true }, _("Actions"), _("Menu")]}
+                              columns={[_("Name"), _("Used for"), _("Size"), _("Actions"), _("Menu")]}
                               showHeader={false}
                               variant="compact"
                               rows={[]} />

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -113,6 +113,8 @@ export function format_fsys_usage(used, total) {
     units = parts[1];
 
     parts = cockpit.format_bytes(used, units, true);
+    if (parts[0].indexOf("0.") == 0)
+        parts[0] = parts[0].substring(0, 4);
     return parts[0] + text;
 }
 

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -43,7 +43,7 @@ class TestStorageBasic(StorageCase):
 
         b.click(f'.sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
 
         def info_field_value(name):
             return b.text(f'#detail-header dt:contains("{name}") + dd')
@@ -52,13 +52,13 @@ class TestStorageBasic(StorageCase):
 
         m.execute(f'parted -s {disk} mktable gpt')
         m.execute(f'parted -s {disk} mkpart primary ext2 1M 8M')
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
         self.content_tab_wait_in_info(1, 1, "Name", "primary")
 
         # create filesystem on the first partition
         # HACK - the block device might disappear briefly when udevd does its BLKRRPART.
         wait(lambda: m.execute(f'mke2fs {disk}1'), delay=1, tries=5)
-        self.content_row_wait_in_col(1, 1, "ext2 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext2 filesystem")
 
         self.content_tab_expand(1, 1)
         b.assert_pixels("#detail-content", "partition", ignore=["dt:contains(UUID) + dd"])

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -72,7 +72,7 @@ class TestStorageFormat(StorageCase):
             self.dialog_set_val("name", "X" * label_limit)
             self.dialog_apply()
             self.dialog_wait_close()
-            self.content_row_wait_in_col(1, 1, type + " filesystem")
+            self.content_row_wait_in_col(1, 2, type + " filesystem")
 
         def check_unsupported_type(type):
             self.content_dropdown_action(1, "Format")
@@ -112,7 +112,7 @@ class TestStorageFormat(StorageCase):
         b.wait_in_text("footer", "Creating filesystem on /dev/mapper/superslow")
         self.dialog_cancel()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
 
         self.content_row_action(1, "Format")
         self.dialog_wait_open()
@@ -122,7 +122,7 @@ class TestStorageFormat(StorageCase):
         b.wait_in_text("footer", "Erasing /dev/mapper/superslow")
         self.dialog_cancel()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -54,7 +54,7 @@ class TestStorageHidden(StorageCase):
         self.dialog({'purpose': "block",
                      'name': "lvol",
                      'size': 48})
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol")
+        self.content_row_wait_in_col(1, 1, "lvol")
 
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
@@ -65,7 +65,7 @@ class TestStorageHidden(StorageCase):
                      "mount_point": mount_point_1,
                      "mount_options.auto": False,
                      "crypto_options": "my-crypto-tag"})
-        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
         self.wait_in_configuration("/dev/TEST/lvol", "crypttab", "options", "my-crypto-tag")
         self.wait_in_child_configuration("/dev/TEST/lvol", "fstab", "dir", mount_point_1)
         self.wait_in_lvol_child_configuration("lvol", "crypttab", "options", "my-crypto-tag")
@@ -74,7 +74,7 @@ class TestStorageHidden(StorageCase):
         # Now the filesystem is hidden because the LUKS device is
         # locked.  Doubly hide it by deactivating /dev/TEST/lvol
         self.content_dropdown_action(1, "Deactivate")
-        self.content_row_wait_in_col(1, 1, "48 MiB Inactive volume")
+        self.content_row_wait_in_col(1, 2, "Inactive volume")
 
         # Deleting the volume group should still remove the fstab entry
         b.click('.pf-c-card__header:contains("LVM2 volume group") button:contains("Delete")')
@@ -112,7 +112,7 @@ class TestStorageHidden(StorageCase):
         self.dialog({"type": "ext4",
                      "name": "FS2",
                      "mount_point": mount_point_2})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_in_configuration("/dev/md127", "fstab", "dir", mount_point_2)
 
         # we need to wait for mdadm --monitor to stop using the device before delete

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -34,7 +34,7 @@ class TestStorageIgnored(StorageCase):
         b.wait_in_text("#drives", disk)
 
         m.execute(f"yes | mke2fs -q -L TEST {disk}")
-        b.wait_in_text("#mounts", "TEST")
+        b.wait_in_text("#mounts", disk)
 
         # Hide it via a udev rule
         m.execute("mkdir -p /run/udev/rules.d")
@@ -42,7 +42,7 @@ class TestStorageIgnored(StorageCase):
                 'SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="TEST", ENV{UDISKS_IGNORE}="1"\n')
         self.addCleanup(m.execute, "rm /run/udev/rules.d/99-ignore.rules; udevadm control --reload; udevadm trigger")
         m.execute("udevadm control --reload; udevadm trigger")
-        b.wait_not_in_text("#mounts", "TEST")
+        b.wait_not_in_text("#mounts", disk)
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -99,12 +99,12 @@ class TestStorageISCSI(StorageCase):
 
         b.click('#drives .sidepanel-row:contains("LIO-ORG test")')
         b.wait_visible('#storage-detail')
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "name": "FILESYSTEM",
                      "mount_point": "/data"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         # _netdev should have been prefilled
         self.content_tab_wait_in_info(1, 1, "Mount point", "_netdev")
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -65,7 +65,7 @@ class TestStorageLuks(StorageCase):
         b.assert_pixels("#dialog", "format")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
         self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_secret)
 
         dev = "/dev/sda1"
@@ -113,7 +113,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_val("mount_point", mount_point_secret)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
         self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
         self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
@@ -141,7 +141,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
 
         self.wait_mounted(1, 2)
         self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
@@ -162,7 +162,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_action(1, "Mount")
         self.dialog({"mount_options.ro": True,
                      "passphrase": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_mounted(1, 2)
         self.assertIn("ro", m.execute(f"findmnt -s -n -o OPTIONS {mount_point_secret}"))
         self.wait_in_configuration(dev, "crypttab", "options", "readonly")
@@ -214,7 +214,7 @@ class TestStorageLuks(StorageCase):
                      "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
         self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 
         self.content_tab_wait_in_info(1, 2, "Options", "none")
@@ -249,7 +249,7 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_val("mount_point", mount_point_secret)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
 
         # Edit the key, without providing an existing passphrase
         #
@@ -300,7 +300,7 @@ class TestStorageLuks(StorageCase):
                      "mount_options.auto": False,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
         self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
         self.content_tab_wait_in_info(1, 2, "Encryption type", "LUKS1")
         self.content_tab_wait_in_info(1, 2, "Options", "none")
@@ -324,7 +324,7 @@ class TestStorageLuks(StorageCase):
         # unlock with first passphrase
         self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
         self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         # unlock with second passphrase
@@ -334,7 +334,7 @@ class TestStorageLuks(StorageCase):
         self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
         self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
         self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         # delete second key slot
@@ -413,7 +413,7 @@ class TestStorageLuks(StorageCase):
         # unlock volume with the newly created passphrase
         self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_mounted(1, 1)
         self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
         self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
@@ -435,11 +435,11 @@ class TestStorageLuks(StorageCase):
                      "crypto": self.default_crypto_type,
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja"})
-        self.content_row_wait_in_col(1, 1, "Unrecognized data (encrypted)")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data (encrypted)")
 
         # Lock it
         self.content_dropdown_action(1, "Lock")
-        self.content_row_wait_in_col(1, 1, "Locked encrypted data")
+        self.content_row_wait_in_col(1, 2, "Locked encrypted data")
 
         # Make it readonly
         self.content_tab_info_action(1, 1, "Options")
@@ -454,7 +454,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
     def testKeepKeys(self):
         m = self.machine
@@ -476,7 +476,7 @@ class TestStorageLuks(StorageCase):
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_options.auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         # Format it again but keep the keys
 
@@ -485,7 +485,7 @@ class TestStorageLuks(StorageCase):
                      "crypto": " keep",
                      "mount_options.auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         # Unmount (and lock) it
 
@@ -501,7 +501,7 @@ class TestStorageLuks(StorageCase):
                      "old_passphrase": "vainu-reku-toma-rolle-kaja",
                      "mount_options.auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
     def testReboot(self):
         m = self.machine
@@ -524,7 +524,7 @@ class TestStorageLuks(StorageCase):
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_options.auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -56,14 +56,13 @@ class TestStorageLvm2(StorageCase):
 
         # Create two logical volumes
         m.execute("lvcreate TEST1 -n one -L 20m")
-        self.content_row_wait_in_col(1, 2, "/dev/TEST1/one")
+        self.content_row_wait_in_col(1, 1, "one")
         m.execute("lvcreate TEST1 -n two -L 20m")
-        self.content_row_wait_in_col(2, 2, "/dev/TEST1/two")
+        self.content_row_wait_in_col(2, 1, "two")
 
         # Deactivate one
         m.execute("lvchange TEST1/one -a n")
-        self.content_row_wait_in_col(1, 1, "Inactive volume")
-        self.content_row_wait_in_col(1, 2, "one")
+        self.content_row_wait_in_col(1, 2, "Inactive volume")
 
         # and remove it
         m.execute("until lvremove -f TEST1/one; do sleep 5; done")
@@ -88,9 +87,9 @@ class TestStorageLvm2(StorageCase):
 
         # Thin volumes
         m.execute("lvcreate TEST1 --thinpool pool -L 20m")
-        self.content_row_wait_in_col(1, 2, "pool")
+        self.content_row_wait_in_col(1, 1, "pool")
         m.execute("lvcreate -T TEST1/pool -n thin -V 100m")
-        self.content_row_wait_in_col(2, 2, "/dev/TEST1/thin")
+        self.content_row_wait_in_col(2, 1, "thin")
         m.execute("dd if=/dev/urandom of=/dev/mapper/TEST1-thin bs=1M count=10 status=none")
         self.content_tab_wait_in_info(1, 1, "Data used", "50%")
         m.execute("until lvremove -f TEST1/thin; do sleep 5; done")
@@ -130,7 +129,7 @@ class TestStorageLvm2(StorageCase):
         self.dialog(expect={"name": "lvol0"},
                     values={"purpose": "block",
                             "size": 20})
-        self.content_row_wait_in_col(1, 2, "/dev/vgroup0/lvol0")
+        self.content_row_wait_in_col(1, 1, "lvol0")
 
         # check that the next default name is "lvol1"
         b.click("button:contains(Create new logical volume)")
@@ -147,7 +146,7 @@ class TestStorageLvm2(StorageCase):
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mount_point": mount_point_one})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
         self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_one)
 
@@ -177,13 +176,13 @@ class TestStorageLvm2(StorageCase):
                     values={"purpose": "pool",
                             "name": "pool",
                             "size": 38})
-        self.content_row_wait_in_col(1, 2, "pool")
+        self.content_row_wait_in_col(1, 1, "pool")
 
         self.content_row_action(1, "Create thin volume")
         self.dialog(expect={"name": "lvol0"},
                     values={"name": "thin",
                             "size": 50})
-        self.content_row_wait_in_col(2, 2, "/dev/vgroup0/thin")
+        self.content_row_wait_in_col(2, 1, "thin")
 
         # add a disk and resize the pool
         b.click('#detail-sidebar .pf-c-card__header button')
@@ -208,7 +207,7 @@ class TestStorageLvm2(StorageCase):
         self.dialog({"erase.on": True,
                      "type": "ext4",
                      "mount_point": mount_point_thin})
-        self.content_row_wait_in_col(2, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(2, 2, "ext4 filesystem")
         self.wait_in_configuration("/dev/vgroup0/thin", "fstab", "dir", mount_point_thin)
 
         # remove pool
@@ -223,11 +222,11 @@ class TestStorageLvm2(StorageCase):
         b.click("button:contains(Create new logical volume)")
         self.dialog(expect={"name": "lvol0"},
                     values={"purpose": "block"})
-        self.content_row_wait_in_col(1, 2, "/dev/vgroup0/lvol0")
+        self.content_row_wait_in_col(1, 1, "lvol0")
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mount_point": mount_point_one})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
         self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_one)
 
@@ -298,7 +297,7 @@ class TestStorageLvm2(StorageCase):
 
         m.execute("lvcreate TEST --thinpool pool -L 10m")
         m.execute("lvcreate -T TEST/pool -n thin -V 30m")
-        self.content_row_wait_in_col(2, 2, "/dev/TEST/thin")
+        self.content_row_wait_in_col(2, 1, "thin")
 
         # Create a logical volume and take a snapshot of it.  We will
         # later check that the snapshot isn't shown.
@@ -308,22 +307,22 @@ class TestStorageLvm2(StorageCase):
 
         # the above lvol0 will be the new first entry in the table, so
         # TEST/thin moves to he third row
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol0")
-        self.content_row_wait_in_col(2, 2, "pool")
-        self.content_row_wait_in_col(3, 2, "/dev/TEST/thin")
+        self.content_row_wait_in_col(1, 1, "lvol0")
+        self.content_row_wait_in_col(2, 1, "pool")
+        self.content_row_wait_in_col(3, 1, "thin")
 
         # Take a snapshot of the thin volume and check that it appears
 
         self.content_dropdown_action(3, "Create snapshot")
         self.dialog({"name": "mysnapshot"})
-        self.content_row_wait_in_col(3, 2, "mysnapshot")
+        self.content_row_wait_in_col(3, 1, "mysnapshot")
 
         # Now check that the traditional snapshot is not shown.  We do
         # this here to be sure that Cockpit is fully caught up and has
         # actually ignored it instead of just not having gotten around
         # to showing it.
 
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/lvol0")
+        self.content_row_wait_in_col(1, 1, "lvol0")
         b.wait_not_in_text("#storage-detail", "snap0")
 
 

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -201,8 +201,8 @@ class TestStorageMdRaid(StorageCase):
                      "mount_point": "/foo1",
                      "mount_options.auto": False,
                      "name": "One"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
-        self.content_row_wait_in_col(1, 2, part_prefix + "1")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 1, part_prefix + "1")
 
         # Create second partition
         self.content_row_action(2, "Create partition", False)
@@ -211,8 +211,8 @@ class TestStorageMdRaid(StorageCase):
                      "mount_options.auto": False,
                      "name": "Two"})
 
-        self.content_row_wait_in_col(2, 1, "ext4 filesystem")
-        self.content_row_wait_in_col(2, 2, part_prefix + "2")
+        self.content_row_wait_in_col(2, 2, "ext4 filesystem")
+        self.content_row_wait_in_col(2, 1, part_prefix + "2")
         b.wait_not_in_text("#detail-content", "Free space")
 
         # Replace a disk by adding a spare and then removing a "In sync" disk

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -63,7 +63,7 @@ class TestStorageMounting(StorageCase):
         self.dialog_set_val("mount_point", mount_point_foo)
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
         self.wait_in_configuration("/dev/sda", "fstab", "dir", mount_point_foo)
 
@@ -107,13 +107,13 @@ class TestStorageMounting(StorageCase):
 
         b.go("#/")
         b.wait_in_text("table[aria-label=Filesystems]", mount_point_bar)
-        bar_selector = f'table[aria-label=Filesystems] tr:contains("{mount_point_bar}") td:nth-child(3)'
+        bar_selector = f'table[aria-label=Filesystems] tr:contains("{mount_point_bar}") td:nth-child(4)'
         wait_ratio_in_range(bar_selector, 0.0, 0.1)
         m.execute(f"dd if=/dev/zero of={mount_point_bar}/zero bs=1M count=30 status=none")
         wait_ratio_in_range(bar_selector, 0.5, 1.0)
         m.execute(f"rm {mount_point_bar}/zero")
         wait_ratio_in_range(bar_selector, 0.0, 0.1)
-        b.click('table[aria-label=Filesystems] tr:contains("filesystem")')
+        b.click('table[aria-label=Filesystems] tr:contains("%s")' % mount_point_bar)
         b.wait_visible("#storage-detail")
 
         def wait_info_field_value(name, value):
@@ -142,7 +142,7 @@ class TestStorageMounting(StorageCase):
         self.dialog_set_val("mount_point", "/run/foo")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
         self.content_tab_wait_in_info(1, 1, "Mount point", "/run/foo")
 
@@ -220,7 +220,7 @@ class TestStorageMounting(StorageCase):
         self.dialog_set_val("mount_point", "/run/foo")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
         self.content_tab_wait_in_info(1, 1, "Mount point", "/run/foo")
 
@@ -284,8 +284,8 @@ class TestStorageMounting(StorageCase):
         m.execute("vgcreate test /dev/sda && lvcreate test -n one -L 20M && lvcreate test -n two -L 20M")
         b.click('#devices .sidepanel-row:contains("test")')
         b.wait_visible("#storage-detail")
-        self.content_row_wait_in_col(1, 2, "/dev/test/one")
-        self.content_row_wait_in_col(2, 2, "/dev/test/two")
+        self.content_row_wait_in_col(1, 1, "one")
+        self.content_row_wait_in_col(2, 1, "two")
 
         # Encrypt and format the first and give it /run/data as the mount point
         self.content_row_action(1, "Format")
@@ -294,7 +294,7 @@ class TestStorageMounting(StorageCase):
                      "passphrase": "vainu-reku-toma-rolle-kaja",
                      "passphrase2": "vainu-reku-toma-rolle-kaja",
                      "mount_point": "/run/data"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 2, "Mount point", "/run/data")
 
         # Format the second and also try to use /run/data as the mount point
@@ -312,7 +312,7 @@ class TestStorageMounting(StorageCase):
         self.content_dropdown_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mount_point": "/run/data"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 2, "Mount point", "/run/data")
 
     def testFirstMount(self):
@@ -326,7 +326,7 @@ class TestStorageMounting(StorageCase):
         b.wait_visible("#storage-detail")
 
         m.execute("mkfs.ext4 /dev/sda")
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
 
         m.execute("! grep /run/data /etc/fstab")
         self.content_row_action(1, "Mount")
@@ -356,7 +356,7 @@ class TestStorageMounting(StorageCase):
                      "mount_options.auto": True,
                      "mount_options.never_auto": True,
                      "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem (encrypted)")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
         self.content_tab_wait_in_info(1, 1, "Mount point", "never mounted at boot")
 
         # The filesystem should be mounted but have the "noauto"

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -48,7 +48,7 @@ class TestStorageMsDOS(StorageCase):
                      "mount_point": "/foo",
                      "mount_options.auto": False,
                      "name": "FIRST"})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 2, "Name", "FIRST")
 
         # Open dialog for formatting the primary partition and check that "dos-extended" is not offered.
@@ -67,7 +67,7 @@ class TestStorageMsDOS(StorageCase):
         self.dialog_wait_not_present("mount_options")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.content_row_wait_in_col(2, 1, "Extended partition")
+        self.content_row_wait_in_col(2, 2, "Extended partition")
         self.content_row_wait_in_col(3, 1, "Free space", False)
 
         # Create logical partitions and check that "dos-extended" is

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -54,7 +54,7 @@ class TestStoragePartitions(StorageCase):
         self.dialog({"type": "ext4",
                      "mount_point": "/foo",
                      "mount_options.auto": True})
-        self.content_row_wait_in_col(1, 1, "ext4 filesystem")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
 
         self.content_dropdown_action(1, "Delete")
         self.confirm()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -50,7 +50,7 @@ class TestStorageResize(StorageCase):
         b.wait_in_text("#devices", "TEST")
         b.click('#devices .sidepanel-row:contains("TEST")')
         b.wait_visible("#storage-detail")
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
+        self.content_row_wait_in_col(1, 1, "vol")
 
         self.content_row_action(1, "Format")
         self.dialog_wait_open()
@@ -178,7 +178,7 @@ class TestStorageResize(StorageCase):
         b.wait_in_text("#devices", "TEST")
         b.click('#devices .sidepanel-row:contains("TEST")')
         b.wait_visible("#storage-detail")
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
+        self.content_row_wait_in_col(1, 1, "vol")
 
         mountpoint = "/run/foo"
         self.content_row_action(1, "Format")
@@ -232,7 +232,7 @@ class TestStorageResize(StorageCase):
         b.wait_in_text("#devices", "TEST")
         b.click('#devices .sidepanel-row:contains("TEST")')
         b.wait_visible("#storage-detail")
-        self.content_row_wait_in_col(1, 2, "/dev/TEST/vol")
+        self.content_row_wait_in_col(1, 1, "vol")
 
         mountpoint = "/run/foo"
         self.content_row_action(1, "Format")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -163,7 +163,6 @@ class TestStorageStratis(StorageCase):
         b.click('#detail-header button:contains(Rename)')
         self.dialog({'name': "pool0-renamed"})
         b.wait_in_text('#detail-header', "pool0-renamed")
-        b.wait_in_text('#detail-content', "/dev/stratis/pool0-renamed/fsys2")
 
         # Create another filesystem
         b.click("button:contains(Create new filesystem)")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -65,7 +65,7 @@ class TestStorageVDO(StorageCase):
         # pool name gets auto-generated
         pool_name = "vpool0"
 
-        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo0")
+        self.content_row_wait_in_col(1, 1, "vdo0")
         # the pool does not appear as a top-level volume
         b.wait_not_in_text("#detail-content", pool_name)
         # Volume tab
@@ -85,17 +85,17 @@ class TestStorageVDO(StorageCase):
         self.dialog({"type": "xfs",
                      "name": "vdofs",
                      "mount_point": "/run/data"})
-        self.content_row_wait_in_col(1, 1, "xfs filesystem")
+        self.content_row_wait_in_col(1, 2, "xfs filesystem")
 
         # compressible data should affect logical usage
         m.execute("dd if=/dev/zero of=/run/data/empty bs=1M count=1000")
-        self.content_tab_wait_in_info(1, 3, "Used", "1.08 GiB of 9.99 GiB")
+        self.content_row_wait_in_col(1, 4, "1.08 / 9.99 GiB")
         # but not physical usage
         self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
 
         # incompressible data
         m.execute("dd if=/dev/urandom of=/run/data/gibberish bs=1M count=1000")
-        self.content_tab_wait_in_info(1, 3, "Used", "2.05 GiB of 9.99 GiB")
+        self.content_row_wait_in_col(1, 4, "2.05 / 9.99 GiB")
         # equal amount of physical space (not completely predictable due to random data)
         self.content_tab_wait_in_info(1, 2, "Data used", "4.8", "4.9")
         self.content_tab_wait_in_info(1, 2, "Data used", cond=lambda sel: re.search(r"\(8[1234]%\)", b.text(sel)))
@@ -149,7 +149,7 @@ class TestStorageVDO(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
 
-        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo0")
+        self.content_row_wait_in_col(1, 1, "vdo0")
         # Volume tab
         self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
         self.content_tab_wait_in_info(1, 1, "Size", "20 GiB")
@@ -168,7 +168,7 @@ class TestStorageVDO(StorageCase):
 
         # react to CLI
         m.execute("lvcreate --type vdo --size 6g --virtualsize 10g --name vdo1 --yes vdo_vgroup")
-        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo1")
+        self.content_row_wait_in_col(1, 1, "vdo1")
         m.execute("lvremove --yes /dev/vdo_vgroup/vdo1")
         b.wait_in_text("#detail-content", "No logical volumes")
 
@@ -211,17 +211,17 @@ class TestStorageLegacyVDO(StorageCase):
 
         # Make a filesystem on it
 
-        self.content_row_wait_in_col(1, 1, "Unrecognized data")
+        self.content_row_wait_in_col(1, 2, "Unrecognized data")
         self.content_row_action(1, "Format")
         self.dialog({"type": "xfs",
                      "name": "FILESYSTEM",
                      "mount_point": "/run/data"})
-        self.content_row_wait_in_col(1, 1, "xfs filesystem")
+        self.content_row_wait_in_col(1, 2, "xfs filesystem")
         # _netdev etc should have been prefilled
         self.content_tab_wait_in_info(1, 1, "Mount point", "_netdev")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.device-timeout=0")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.requires=vdo.service")
-        self.content_tab_wait_in_info(1, 1, "Used", "of 4.99 GiB", "of 5.0 GiB")
+        self.content_row_wait_in_col(1, 4, "/ 4.99 GiB", alternate_val="/ 5.0 GiB")
 
         # Grow physical
 
@@ -236,7 +236,7 @@ class TestStorageLegacyVDO(StorageCase):
         b.click(detail(4) + " button:contains(Grow)")
         self.dialog({"lsize": 10 * 1024})
         b.wait_in_text(detail(4), "used of 10 GiB")
-        self.content_tab_wait_in_info(1, 1, "Used", "of 9.99 GiB", "of 10.0 GiB")
+        self.content_row_wait_in_col(1, 4, "/ 9.99 GiB", alternate_val="/ 10.0 GiB")
 
         # Stop
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -117,12 +117,12 @@ class StorageHelpers:
     # expected content.  However, wait_in_text can not deal with a
     # temporarily disappearing element, so we use self.retry.
 
-    def content_row_wait_in_col(self, row_index, col_index, val, isExpandable=True):
+    def content_row_wait_in_col(self, row_index, col_index, val, isExpandable=True, alternate_val=None):
         if isExpandable:
             col = self.content_row_tbody(row_index) + " tr:first-child > :nth-child(%d)" % (col_index + 1)
         else:
             col = "#detail-content > article > div > table > :nth-child(%d)" % row_index + " > :nth-child(%d)" % (col_index + 1)
-        wait(lambda: self.browser.is_present(col) and val in self.browser.text(col))
+        wait(lambda: self.browser.is_present(col) and (val in self.browser.text(col) or (alternate_val and alternate_val in self.browser.text(col))))
 
     def content_dropdown_action(self, index, title):
         dropdown = self.content_row_tbody(index) + " tr td:last-child .pf-c-dropdown"


### PR DESCRIPTION
This is a step towards https://github.com/cockpit-project/cockpit/discussions/16440

Screenshot (up-to-date): https://github.com/cockpit-project/cockpit/pull/16518#issuecomment-972712100
Demo (not pixel-perfect, but still valid): https://www.youtube.com/watch?v=xLfxxm-VKmU

------

### Storage: More information in table rows

The rows of the various tables now show more information about filesystems and other things.  You can now immediately see where a filesystem is mounted, there are links to the pages for volume groups etc, and the usage level is shown.

![image](https://user-images.githubusercontent.com/3228183/143840731-225503c1-4559-4db1-a9b8-7f0880a6fefb.png)

