### PR TITLE
storage: Improve error message when org.storage.stratis2 is not found

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -968,6 +968,11 @@ client.stratis_start = () => {
                     stratis_start_polling();
                     return true;
                 });
+            })
+            .catch(err => {
+                if (err.problem == "not-found")
+                    err.message = "The name org.storage.stratis2 can not be activated on D-Bus.";
+                return Promise.reject(err);
             });
 };
 


### PR DESCRIPTION
This will happen when Stratis 3 appears and might help people better
understand why Cockpit doesn't support Stratis.