### PR TITLE
lib: Fix service.js for privilege changes

### DIFF
--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -292,20 +292,7 @@ export function proxy(name, kind) {
 
     function call_manager_with_reload(method, args) {
         return call_manager(method, args).then(function () {
-            const dfd = cockpit.defer();
-            call_manager("Reload", [])
-                    .done(function () { dfd.resolve() })
-                    .fail(function (error) {
-                    // HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1560549
-                    // some systemd versions disconnect too fast from the bus
-                        if (error.name === "org.freedesktop.DBus.Error.NoReply") {
-                            refresh();
-                            dfd.resolve();
-                        } else {
-                            dfd.reject(error);
-                        }
-                    });
-            return dfd.promise();
+            return call_manager("Reload", [ ]);
         });
     }
 

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -86,7 +86,7 @@ let systemd_client;
 let systemd_manager;
 
 function wait_valid(proxy, callback) {
-    proxy.wait(function() {
+    proxy.wait(() => {
         if (proxy.valid)
             callback();
     });
@@ -97,9 +97,9 @@ function with_systemd_manager(done) {
         systemd_client = cockpit.dbus("org.freedesktop.systemd1", { superuser: "try" });
         systemd_manager = systemd_client.proxy("org.freedesktop.systemd1.Manager",
                                                "/org/freedesktop/systemd1");
-        wait_valid(systemd_manager, function() {
+        wait_valid(systemd_manager, () => {
             systemd_manager.Subscribe()
-                    .fail(function (error) {
+                    .catch(error => {
                         if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
                         error.name != "org.freedesktop.DBus.Error.FileExists")
                             console.warn("Subscribing to systemd signals failed", error);
@@ -173,7 +173,7 @@ export function proxy(name, kind) {
 
     with_systemd_manager(function () {
         systemd_manager.LoadUnit(name)
-                .done(function (path) {
+                .then(path => {
                     unit = systemd_client.proxy('org.freedesktop.systemd1.Unit', path);
                     unit.addEventListener('changed', update_from_unit);
                     wait_valid(unit, update_from_unit);
@@ -182,7 +182,7 @@ export function proxy(name, kind) {
                     details.addEventListener('changed', update_from_details);
                     wait_valid(details, update_from_details);
                 })
-                .fail(function () {
+                .catch(() => {
                     self.exists = false;
                     self.dispatchEvent('changed');
                 });
@@ -195,19 +195,17 @@ export function proxy(name, kind) {
         function refresh_interface(path, iface) {
             systemd_client.call(path,
                                 "org.freedesktop.DBus.Properties", "GetAll", [iface])
-                    .fail(function (error) {
-                        console.log(error);
-                    })
-                    .done(function (result) {
+                    .then(([result]) => {
                         const props = { };
-                        for (const p in result[0])
-                            props[p] = result[0][p].v;
+                        for (const p in result)
+                            props[p] = result[p].v;
                         const ifaces = { };
                         ifaces[iface] = props;
                         const data = { };
                         data[unit.path] = ifaces;
                         systemd_client.notify(data);
-                    });
+                    })
+                    .catch(error => console.log(error));
         }
 
         refresh_interface(unit.path, "org.freedesktop.systemd1.Unit");
@@ -241,7 +239,7 @@ export function proxy(name, kind) {
     // });
 
     // This is what we have to do:
-    systemd_manager.addEventListener("Reloading", function (event, reloading) {
+    systemd_manager.addEventListener("Reloading", (event, reloading) => {
         if (!reloading)
             refresh();
     });
@@ -261,7 +259,7 @@ export function proxy(name, kind) {
 
     const pending_jobs = { };
 
-    systemd_manager.addEventListener("JobRemoved", function (event, number, path, unit_id, result) {
+    systemd_manager.addEventListener("JobRemoved", (event, number, path, unit_id, result) => {
         if (pending_jobs[path]) {
             if (result == "done")
                 pending_jobs[path].resolve();
@@ -280,20 +278,16 @@ export function proxy(name, kind) {
     function call_manager_with_job(method, args) {
         const dfd = cockpit.defer();
         call_manager(method, args)
-                .done(function (results) {
-                    const path = results[0];
+                .then(([path]) => {
                     pending_jobs[path] = dfd;
                 })
-                .fail(function (error) {
-                    dfd.reject(error);
-                });
+                .catch(error => dfd.reject(error));
         return dfd.promise();
     }
 
     function call_manager_with_reload(method, args) {
-        return call_manager(method, args).then(function () {
-            return call_manager("Reload", [ ]);
-        });
+        return call_manager(method, args)
+                .then(() => call_manager("Reload", []));
     }
 
     function start() {

--- a/pkg/lib/service.js
+++ b/pkg/lib/service.js
@@ -199,11 +199,7 @@ export function proxy(name, kind) {
                         const props = { };
                         for (const p in result)
                             props[p] = result[p].v;
-                        const ifaces = { };
-                        ifaces[iface] = props;
-                        const data = { };
-                        data[unit.path] = ifaces;
-                        systemd_client.notify(data);
+                        systemd_client.notify({ [unit.path]: { [iface]: props } });
                     })
                     .catch(error => console.log(error));
         }

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -61,9 +61,9 @@ class TestTuned(MachineCase):
 
         # Disabled when not authorized
         b.relogin('/system', superuser=False)
-        trigger_selector = '#tuned-status-button.pf-m-aria-disabled'
-        b.wait_text(trigger_selector, recommended_profile)
-        b.relogin('/system', superuser=True)
+        b.wait_text('#tuned-status-button.pf-m-aria-disabled', recommended_profile)
+        # page adjusts to privilege changes, button becomes clickable
+        b.become_superuser()
 
         # Switch the profile
 


### PR DESCRIPTION
`systemd_client` gets cached forever, and thus never reacts to privilege
changes (adding/dropping sudo channel). We also can't just reinitialize
this, as this would break existing proxies.

Instead, keep the long-lived proxy as unprivileged, and only use it for
watching/reading. Use a fresh cockpit.dbus() instance with `superuser`
for all the actions instead -- cockpit.dbus() is cheap, and actions are
done rarely.

This requires reworking the `JobRemoved` handler: doing this on the
persistent unprivileged proxy sometimes misses events from the separate
D-Bus connections, so this must happen on the same connection that
started the job. Move the listener into call_manager_with_job() as an
one-off, and get rid of the persistent `pending_jobs` house-keeping.

----

Also do some code cleanup, while I'm at it. I noticed this in #16516, but it already affects current main.

 - [x] Land #16516 
 - [x] Check if we can revert the `NoReply` hack after all - Yes We Can! :wink: 
 - [x] Fix [race condition with outdated service.proxy() properties](https://logs.cockpit-project.org/logs/pull-16530-20211029-061219-307d5cab-fedora-34/log.html#60-2)
 - [x] Add a tuned test case that the dialog works after raising privileges, to validate the effect of this