### PR TITLE
systemd: Fix race condition in machine name detection

### DIFF
--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -41,7 +41,9 @@ const getDMI = info => machine_info.dmi_info()
 
 const getDeviceTree = info => machine_info.devicetree_info()
         .then(fields => {
-            info.system.name = fields.model;
+            // if getDMI sets a field first, let that win
+            if (fields.model && !info.system.name)
+                info.system.name = fields.model;
             return true;
         });
 


### PR DESCRIPTION
getDMI() and getDeviceTree() both set info.system.name. If the latter
finished after the former, it would overwrite the DMI name. On many
machines (like x86) that device tree name will be `null`, so depending
on the timing that would overwrite the valid DMI name with null.

To fix that, never overwrite the name with null, and let the DMI name win.

This got caught by occasional TestSystemInfo.testHardwareInfo()
failures.

----

[failure one](https://logs.cockpit-project.org/logs/pull-16527-20211028-054843-bdc2b337-rhel-8-6/log.html#293), [failure two](https://logs.cockpit-project.org/logs/pull-16516-20211028-090209-e30630f7-rhel-8-6/log.html#292-2)