### PR TITLE
test: Fix TestFirewall.testNetworkingPage on ubuntu-stable

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -61,7 +61,7 @@ class TestFirewall(NetworkCase):
 
         # on images with running libvirt, wait until libvirt adds its zone, to avoid races in tests
         # (older versions don't do that yet)
-        if m.image not in ["ubuntu-2004", "ubuntu-stable"]:
+        if m.image not in ["ubuntu-2004"]:
             m.execute("if virsh net-list --name | grep -q default; then until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done; fi")
 
     def testNetworkingPage(self):


### PR DESCRIPTION
Since ubuntu-stable moved to 21.10, this now also configures a libvirt
firewalld zone. Wait for that, to fix a race condition for waiting for
an incorrect number of expected zones.

----

[example](https://logs.cockpit-project.org/logs/pull-16527-20211028-054835-bdc2b337-ubuntu-stable/log.html#80-1)