### PR TITLE
[WIP]: metrics: Here is a demo for integrating perf CPU data analysis in cockpit using flamegraphs :fire: :arrow_right:  :chart_with_upwards_trend: 

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@patternfly/react-table": "4.29.58",
     "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "bootstrap": "3.4.1",
+    "d3-flame-graph": "^4.1.1",
     "deep-equal": "2.0.5",
     "jquery": "3.5.1",
     "js-sha1": "0.6.0",

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -2,6 +2,7 @@
 @import "../lib/ct-card.scss";
 @import "@patternfly/patternfly/components/Table/table.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
+@import "d3-flame-graph/dist/d3-flamegraph.css";
 
 #app {
     section.pf-c-page__main-breadcrumb {


### PR DESCRIPTION
What it currently does:

* When first entering the page a graph is auto-generated for the user
using a 10 seconds data sampling time
  * This can be improved by:
    - Showing a progress bar
    - Allowing the user to specify the data recording time

What it needs to do:
  * It should offer to the user to install the required packages (perf) if not present
  For now just install 'perf'
  https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-perf_monitoring-and-managing-system-status-and-performance#installing-perf_getting-started-with-perf

Some discussion is happening here: https://issues.redhat.com/projects/COCKPIT/issues/COCKPIT-794

How is currently looks:
![Screen Shot 2021-10-28 at 17 01 28](https://user-images.githubusercontent.com/14921356/139283262-73b41f39-cbf0-4ec1-b774-db6dfcc9b70d.png)
