### PR TITLE
test: Clean up NSS users more thoroughly

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1124,6 +1124,9 @@ class MachineCase(unittest.TestCase):
         self.restore_file("/etc/passwd")
         self.restore_file("/etc/group")
         self.restore_file("/etc/shadow")
+        self.restore_file("/etc/gshadow")
+        self.restore_file("/etc/subuid")
+        self.restore_file("/etc/subgid")
         home_dirs = m.execute("ls /home").strip().split()
 
         def cleanup_home_dirs():


### PR DESCRIPTION
Don't leave test users/groups behind in gshadow and sub[ug]id.

----

I have unsuccessfully tried to reproduce or understand [this failure](https://logs.cockpit-project.org/logs/pull-16527-20211028-125028-f2c56fb0-fedora-34/log.html#285-1), but maybe this helps.