### PR TITLE
test: Disable browser log deduplication with --trace

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -81,7 +81,8 @@ function setupLogging(client) {
 
         messages.push([ info.type, msg ]);
         if (shownMessages.indexOf(msg) == -1) {
-            shownMessages.push(msg);
+            if (!enable_debug) // disable message de-duplication in --trace mode
+                shownMessages.push(msg);
             process.stderr.write("> " + info.type + ": " + msg + "\n")
         }
 
@@ -128,7 +129,8 @@ function setupLogging(client) {
             delete msg.args;
             const msgstr = JSON.stringify(msg);
             if (shownMessages.indexOf(msgstr) == -1) {
-                shownMessages.push(msgstr);
+                if (!enable_debug) // disable message de-duplication in --trace mode
+                    shownMessages.push(msgstr);
                 process.stderr.write("CDP: " + JSON.stringify(orig) + "\n");
             }
         }

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -81,7 +81,8 @@ function setupLogging(client) {
         let msg = info.args.map(v => (v.value || "").toString()).join(" ");
         messages.push([ info.type, msg ]);
         if (shownMessages.indexOf(msg) == -1) {
-            shownMessages.push(msg);
+            if (!enable_debug) // disable message de-duplication in --trace mode
+                shownMessages.push(msg);
             process.stderr.write("> " + info.type + ": " + msg + "\n")
         }
 
@@ -148,7 +149,8 @@ function setupLogging(client) {
                 delete msg.args;
                 const msgstr = JSON.stringify(msg);
                 if (shownMessages.indexOf(msgstr) == -1) {
-                    shownMessages.push(msgstr);
+                    if (!enable_debug) // disable message de-duplication in --trace mode
+                        shownMessages.push(msgstr);
                     process.stderr.write("CDP: " + JSON.stringify(orig) + "\n");
                 }
             }


### PR DESCRIPTION
This is useful to guard against log spam in production, but it severely
gets in the way when doing development and console.log()-style debugging
-- most developers are not aware of this, and this is responsible for
way too many hairs which got pulled out. Disable the deduplication in
--trace mode, which is a nice compromise.

-----

Tested with this:
```diff
--- test/verify/check-users
+++ test/verify/check-users
@@ -327,10 +327,12 @@ class TestAccounts(MachineCase):
 
         m.execute("useradd anton; echo anton:foobar | chpasswd")
         self.login_and_go("/users", user="anton", superuser=False)
+        b.eval_js('console.log("MOO!")')
         b.go("#/anton")
         b.wait_text("#account-user-name", "anton")
         b.wait_visible('#account-set-password:enabled')
         b.click('#account-set-password')
+        b.eval_js('console.log("MOO!")')
         b.wait_visible('#account-set-password-dialog')
         b.set_input_text("#account-set-password-old", "foobar")
         b.set_input_text("#account-set-password-pw1", new_password)
```

like this:
```
❱❱❱ TEST_OS=fedora-35 test/verify/check-users TestAccounts.testUnprivileged $RUNC  2>&1|grep 'log: MOO'
> log: MOO!

❱❱❱ TEST_OS=fedora-35 test/verify/check-users TestAccounts.testUnprivileged $RUNC -t 2>&1|grep 'log: MOO'
> log: MOO!
> log: MOO!
```
and once more with `TEST_BROWSER=firefox` (same result).