### PR TITLE
systemd: Handle react DOM validation error

### DIFF
--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -82,12 +82,12 @@ export class SystemInfomationCard extends React.Component {
                     else
                         self.setState({ hardwareText: vendor + " " + name });
 
-                    self.setState({ assetTagText: fields.product_serial || fields.chassis_serial });
+                    self.setState({ assetTagText: fields.product_serial || fields.chassis_serial || undefined });
                 })
                 .catch(ex => {
                     // try DeviceTree
                     machine_info.devicetree_info()
-                            .then(fields => self.setState({ assetTagText: fields.serial, hardwareText: fields.model }))
+                            .then(fields => self.setState({ assetTagText: fields.serial, hardwareText: fields.model || undefined }))
                             .catch(dmiex => {
                                 console.debug("couldn't read dmi info: " + ex);
                                 console.debug("couldn't read DeviceTree info: " + dmiex.toString());


### PR DESCRIPTION
On my system fields.product_serial and fields.chassis_serial is empty
causing an warning to be logged in the developer console:

validateDOMNesting(...): Whitespace text nodes cannot appear as a child of <tbody>.