### PR TITLE
services: show user owned systemd units in the services page

### DIFF
--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -36,7 +36,7 @@ export const service_tabs_suffixes = ["service", "target", "socket", "timer", "p
  */
 export function ServiceTabs({ onChange, activeTab, tabErrors }) {
     const service_tabs = {
-        service: _("System services"),
+        service: _("Services"),
         target: _("Targets"),
         socket: _("Sockets"),
         timer: _("Timers"),

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -58,6 +58,7 @@ export class Service extends React.Component {
             return null;
 
         const serviceDetails = <ServiceDetails unit={this.props.unit}
+                                owner={this.props.owner}
                                 permitted={superuser.allowed}
                                 loadingUnits={this.props.loadingUnits}
                                 isValid={this.props.unitIsValid} />;
@@ -76,7 +77,7 @@ export class Service extends React.Component {
                   id="service-details"
                   breadcrumb={
                       <Breadcrumb>
-                          <BreadcrumbItem to='#'>{_("Services")}</BreadcrumbItem>
+                          <BreadcrumbItem to={"#" + cockpit.location.href.replace(cockpit.location.path[0], '')}>{_("Services")}</BreadcrumbItem>
                           <BreadcrumbItem isActive>
                               {this.props.unit.Id}
                           </BreadcrumbItem>
@@ -84,7 +85,7 @@ export class Service extends React.Component {
                 <PageSection>
                     <Gallery hasGutter>
                         <GalleryItem>{serviceDetails}</GalleryItem>
-                        {(this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") &&
+                        {((this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") && this.props.owner == "system") &&
                         <GalleryItem>
                             <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", service: cur_unit_id }} />
                         </GalleryItem>}

--- a/pkg/systemd/services/services-list.jsx
+++ b/pkg/systemd/services/services-list.jsx
@@ -88,7 +88,7 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
                     <Button className='service-unit-id'
                             isInline
                             component="a"
-                            href={'#/' + shortId}
+                            onClick={() => cockpit.location.go([shortId], cockpit.location.options)}
                             variant='link'>
                         {props.displayName}
                     </Button>

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -54,18 +54,13 @@
 }
 .services-header.pf-c-page__main-nav {
     padding-bottom: 1rem;
+    padding-right: 0;
 
-    // Display tabs and 'Create timer' button in the same line if possible
-    display: flex;
-    flex-wrap: wrap;
-
-    // Add spacing between the tabs and the 'Create timer' button in mobile
-    row-gap: var(--pf-global--spacer--sm);
-
-    // Align 'Create timer' button with the right side of the services list card
-    > button {
+    > .pf-l-flex {
+        // Add spacing between the tabs and the 'Create timer' button in mobile
+        row-gap: var(--pf-global--spacer--sm);
+        // Align 'Create timer' button with the right side of the services list card
         margin-right: var(--pf-c-page__main-section--PaddingRight);
-        margin-left: auto;
     }
 }
 

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -42,7 +42,7 @@ import "./timers.scss";
 
 const _ = cockpit.gettext;
 
-export const CreateTimerDialog = () => {
+export const CreateTimerDialog = ({ owner }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
@@ -56,12 +56,12 @@ export const CreateTimerDialog = () => {
                     }}>
                 {_("Create timer")}
             </Button>
-            {isOpen && <CreateTimerDialogBody setIsOpen={setIsOpen} />}
+            {isOpen && <CreateTimerDialogBody setIsOpen={setIsOpen} owner={owner} />}
         </>
     );
 };
 
-const CreateTimerDialogBody = ({ setIsOpen }) => {
+const CreateTimerDialogBody = ({ setIsOpen, owner }) => {
     const [command, setCommand] = useState('');
     const [delay, setDelay] = useState('specific-time');
     const [delayNumber, setDelayNumber] = useState(0);
@@ -108,7 +108,7 @@ const CreateTimerDialogBody = ({ setIsOpen }) => {
             return false;
 
         setInProgress(true);
-        create_timer({ name, description, command, delay, delayUnit, delayNumber, repeat, specificTime, repeatPatterns })
+        create_timer({ name, description, command, delay, delayUnit, delayNumber, repeat, specificTime, repeatPatterns, owner })
                 .then(() => setIsOpen(false), exc => {
                     setDialogError(exc.message);
                     setInProgress(false);

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -40,6 +40,9 @@ class TestServices(MachineCase):
         # Also `reset-failed` as failed units can be still listed with `systemctl` even when all files
         # were removed and daemon reloaded.
         self.restore_dir("/etc/systemd/system", "systemctl daemon-reload && systemctl reset-failed", True)
+        user_post_restore = "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload && systemctl --user reset-failed'"
+        self.restore_dir("/etc/systemd/user", user_post_restore, True)
+        self.restore_dir("/etc/xdg/systemd/user", user_post_restore, True)
 
     def pick_tab(self, n):
         self.browser.click('#services-filter li:nth-child({0}) a'.format(n))
@@ -122,8 +125,8 @@ class TestServices(MachineCase):
     def wait_service_not_present(self, service):
         self.browser.wait_not_present(self.svc_sel(service))
 
-    def make_test_service(self):
-        self.write_file("/etc/systemd/system/test.service",
+    def make_test_service(self, path="/etc/systemd/system/"):
+        self.write_file(f"{path}/test.service",
                         """
 [Unit]
 Description=Test Service
@@ -149,16 +152,26 @@ done
 """)
         # After writing files out tell systemd about them
         self.machine.execute("systemctl daemon-reload")
+        self.machine.execute("su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload || true'")
 
         # When the test fails while `test.service` is active, the process keeps running and
         # `systemct status test.service` still shows it as active until this process dies
-        self.addCleanup(self.machine.execute, "for op in stop reset-failed disable; do systemctl $op test || true; done")
+        self.addCleanup(self.machine.execute, "for op in stop reset-failed disable; do systemctl $op test test-fail || true; done")
+        self.addCleanup(self.machine.execute, "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); for op in stop reset-failed disable; do systemctl --user $op test test-fail || true; done'")
 
     def testBasic(self):
+        self._testBasic()
+
+    def testBasicSession(self):
+        self._testBasic(True)
+
+    def _testBasic(self, user=False):
         m = self.machine
         b = self.browser
 
-        self.write_file("/etc/systemd/system/test-fail.service",
+        path = "/etc/systemd/user" if user else "/etc/systemd/system"
+
+        self.write_file(f"{path}/test-fail.service",
                         """
 [Unit]
 Description=Failing Test Service
@@ -169,7 +182,7 @@ ExecStart=/usr/bin/false
 [Install]
 WantedBy=default.target
 """)
-        self.write_file("/etc/systemd/system/test.timer",
+        self.write_file(f"{path}/test.timer",
                         """
 [Unit]
 Description=Test Timer
@@ -177,7 +190,7 @@ Description=Test Timer
 [Timer]
 OnCalendar=*:1/2
 """)
-        self.write_file("/etc/systemd/system/test-onboot.timer",
+        self.write_file(f"{path}/test-onboot.timer",
                         """
 [Unit]
 Description=Test OnBoot Timer
@@ -187,29 +200,38 @@ OnBootSec=200min
 Unit=test.service
 """)
 
-        self.make_test_service()
-        self.machine.execute("systemctl start default.target")
+        params = "--user" if user else ""
 
-        self.login_and_go("/system/services")
+        def run_cmd(cmd):
+            if user:
+                m.execute(f"su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); {cmd}'")
+            else:
+                m.execute(cmd)
+
+        self.make_test_service(path)
+        self.machine.execute(f"systemctl {params} start default.target")
+
+        url = "/system/services#/?owner=user" if user else "/system/services"
+        self.login_and_go(url, user="admin")
         self.wait_page_load()
 
         self.wait_service_present("test.service")
         self.wait_service_in_panel("test.service", "Disabled")
         self.wait_service_state("test.service", "inactive")
 
-        m.execute("systemctl start test.service")
+        run_cmd(f"systemctl {params} start test.service")
         self.wait_service_state("test.service", "active")
         self.wait_service_in_panel("test.service", "Disabled")
 
-        m.execute("systemctl stop test.service")
+        run_cmd(f"systemctl {params} stop test.service")
         self.wait_service_state("test.service", "inactive")
         self.wait_service_in_panel("test.service", "Disabled")
 
-        m.execute("systemctl enable test.service")
+        run_cmd(f"systemctl {params} enable test.service")
         self.wait_service_state("test.service", "inactive")
         self.wait_service_in_panel("test.service", "Enabled")
 
-        m.execute("systemctl start test.service")
+        run_cmd(f"systemctl {params} start test.service")
 
         b.wait_attr("#services-toolbar", "data-loading", "false")
 
@@ -218,13 +240,14 @@ Unit=test.service
         b.wait_not_in_text("#services-list", "test")
         self.wait_service_state("basic.target", "active")
 
-        # Make sure that symlinked services also appear in the list
-        self.wait_service_state("reboot.target", "inactive")
-        self.wait_service_state("ctrl-alt-del.target", "inactive")
-        self.wait_service_state("runlevel6.target", "inactive")
-        self.goto_service("runlevel6.target")
-        b.wait_in_text(".service-name", "Reboot")
-        b.click("#services-page .pf-c-breadcrumb__link")
+        if not user:
+            # Make sure that symlinked services also appear in the list
+            self.wait_service_state("reboot.target", "inactive")
+            self.wait_service_state("ctrl-alt-del.target", "inactive")
+            self.wait_service_state("runlevel6.target", "inactive")
+            self.goto_service("runlevel6.target")
+            b.wait_in_text(".service-name", "Reboot")
+            b.click("#services-page .pf-c-breadcrumb__link")
 
         # Selects Sockets tab
         self.pick_tab(3)
@@ -240,7 +263,7 @@ Unit=test.service
         b.wait_visible(self.svc_sel('test.timer'))
         b.wait_text(self.svc_sel('test.timer') + ' .service-unit-triggers', '')
         today = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format()")
-        m.execute("systemctl start test.timer")
+        run_cmd(f"systemctl {params} start test.timer")
         b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-next-trigger', today)  # next run
         b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
 
@@ -250,31 +273,35 @@ Unit=test.service
         b.wait_in_text('.service-unit-last-trigger', "unknown")  # last trigger
         b.click(".pf-c-breadcrumb a:contains('Services')")
 
-        m.execute("systemctl stop test.timer")
+        run_cmd(f"systemctl {params} stop test.timer")
 
         b.wait_visible(self.svc_sel('test-onboot.timer'))
         b.wait_text(self.svc_sel('test-onboot.timer') + ' .service-unit-triggers', '')
-        m.execute("systemctl start test-onboot.timer")
+        run_cmd(f"systemctl {params} start test-onboot.timer")
         # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
         today_stamp = int(m.execute("date +%s").strip())
         today_plus_200min = m.execute(f"date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
-        m.execute("systemctl stop test-onboot.timer")
+        run_cmd(f"systemctl {params} stop test-onboot.timer")
 
-        # Selects Paths tab
-        self.pick_tab(5)
-        b.wait_not_in_text("#services-list", "test")
-        b.wait_not_in_text("#services-list", ".target")
-        b.wait_not_in_text("#services-list", ".socket")
-        b.wait_not_in_text("#services-list", ".timer")
-        b.wait_visible(self.svc_sel("systemd-ask-password-console.path"))
+        # Selects Paths tab - the test VM does not have any user path units
+        if not user:
+            self.pick_tab(5)
+            b.wait_not_in_text("#services-list", "test")
+            b.wait_not_in_text("#services-list", ".target")
+            b.wait_not_in_text("#services-list", ".socket")
+            b.wait_not_in_text("#services-list", ".timer")
+            b.wait_visible(self.svc_sel("systemd-ask-password-console.path"))
 
         # Selects Services tab
         self.pick_tab(1)
 
         # Survives a burst of events
-        b.go("#/")
+        suffix = ''
+        if user:
+            suffix = "?owner=user"
+        b.go(f"#/{suffix}")
         self.wait_service_present("test.service")
         m.execute("udevadm trigger; udevadm settle")
         self.goto_service("test.service")
@@ -286,29 +313,31 @@ Unit=test.service
         self.toggle_onoff()
         self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
 
+        testUrl = f'/system/services#/test.service{suffix}'
         # Check without permissions
-        b.relogin('/system/services#/test.service', superuser=False)
+        b.relogin(testUrl, superuser=False)
         self.wait_page_load()
 
-        b.relogin('/system/services#/test.service', superuser=True)
+        b.relogin(testUrl, superuser=True)
         self.wait_page_load()
         self.toggle_onoff()  # later on we need some disabled test
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
 
         # Check service that fails to start
-        b.go("#/")
+        b.go(f'/system/services#/{suffix}')
         self.goto_service("test-fail.service")
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
         self.toggle_onoff()
         self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
-        b.assert_pixels("#service-details", "details-test-fail", ignore=[".cockpit-log-panel .pf-c-card__body"])
+        if not user:
+            b.assert_pixels("#service-details", "details-test-fail", ignore=[".cockpit-log-panel .pf-c-card__body"])
         b.click(".action-button:contains('Start service')")
-        b.go("#/")
+        b.go(f'/system/services#/{suffix}')
         self.wait_service_present("test-fail.service")
         self.wait_service_state("test-fail.service", "failed")
 
         # Check static service
-        self.goto_service("systemd-halt.service")
+        self.goto_service("systemd-exit.service")
         self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)"], True, onoff=False)
 
         # Mask and unmask
@@ -336,12 +365,15 @@ Unit=test.service
             self.wait_service_present("test.service")
             self.wait_service_present("test-fail.service")
 
-        b.go("#/")
+        b.go(f'/system/services#/{suffix}')
 
         # Check that `Listen` and `Triggers` properties are shown for socket units
         self.pick_tab(3)
         self.goto_service("dbus.socket")
-        self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen .pf-c-description-list__text"))
+        if not user:
+            self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen .pf-c-description-list__text"))
+        else:
+            self.assertIn("/run/user/", b.text("#listen .pf-c-description-list__text"))
         self.assertIn(b.text("#Triggers .pf-c-description-list__text"), ["dbus.service", "dbus-broker.service"])
         b.click(".pf-c-breadcrumb a:contains('Services')")
 
@@ -368,7 +400,8 @@ Unit=test.service
             while b.call_js_func("ph_attr", nav_scroll_btn, "disabled") is None:
                 b.click(nav_scroll_btn)
                 time.sleep(0.5)
-        b.assert_pixels("#services-page", "text-filter-test")
+        if not user:
+            b.assert_pixels("#services-page", "text-filter-test")
 
         # Filter by description capitalization not matching the unit description
         init_filter_state()
@@ -377,23 +410,25 @@ Unit=test.service
         self.wait_service_present("test-fail.service")
 
         # Filter by Id capitalization not matching the unit Id
-        init_filter_state()
-        b.set_input_text("#services-text-filter input", "networkmanager")
-        self.wait_service_present("NetworkManager.service")
+        # NetworkManager exists only as a system service, skip user test
+        if not user:
+            init_filter_state()
+            b.set_input_text("#services-text-filter input", "networkmanager")
+            self.wait_service_present("NetworkManager.service")
 
         # Select only static services
         init_filter_state()
         self.select_file_state("Static")
         self.wait_service_not_present("test.service")
         self.wait_service_not_present("test-fail.service")
-        self.wait_service_present("systemd-halt.service")
+        self.wait_service_present("systemd-exit.service")
 
         # Select only disabled services
         init_filter_state()
         self.select_file_state("Disabled")
         self.wait_service_present("test.service")
         self.wait_service_not_present("test-fail.service")
-        self.wait_service_not_present("systemd-halt.service")
+        self.wait_service_not_present("systemd-exit.service")
 
         # Select only stopped services
         init_filter_state()
@@ -407,11 +442,13 @@ Unit=test.service
         self.wait_service_not_present("test.service")
         self.wait_service_present("test-fail.service")
 
-        # Select Indirect and Masked services
-        init_filter_state()
-        self.select_file_state(["Indirect", "Masked"])
-        self.wait_service_not_present("test.service")
-        self.wait_service_present("getty@tty1.service")
+        # Select Alias and Masked services
+        # No indirect user services exist, skip user test
+        if not user:
+            init_filter_state()
+            self.select_file_state(["Indirect", "Masked"])
+            self.wait_service_not_present("test.service")
+            self.wait_service_present("getty@tty1.service")
 
         # Check filtering and selecting together - empty state
         init_filter_state()
@@ -424,7 +461,7 @@ Unit=test.service
         b.click("#clear-all-filters")
         self.wait_service_present("test.service")
         self.wait_service_present("test-fail.service")
-        self.wait_service_present("systemd-halt.service")
+        self.wait_service_present("systemd-exit.service")
         self.assertEqual(b.val("#services-text-filter input"), "")
 
         # Check that closing filter chip groups or single chips works
@@ -439,36 +476,42 @@ Unit=test.service
         b.wait_not_present(".pf-c-chip-group")
 
         # Check that journalbox shows empty state
-        self.goto_service("systemd-halt.service")
-        b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
+        self.goto_service("systemd-exit.service")
+        if not user:
+            b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
+        else:
+            b.wait_not_present('.cockpit-log-panel')
         b.wait_not_present("button:contains('View all logs')")
 
-        b.go("#/")
+        b.go(f'/system/services#/{suffix}')
 
-        self.write_file("/tmp/mem-hog.awk", 'BEGIN { system("while [ ! -f /tmp/continue ]; do sleep 1; done"); y = sprintf("%50000000s",""); system("sleep infinity") }')
-        self.write_file("/etc/systemd/system/mem-hog.service",
-                        """
+        self.write_file(f"/tmp/mem-hog{params}.awk", f'BEGIN {{ system("while [ ! -f /tmp/continue{params} ]; do sleep 1; done"); y = sprintf("%50000000s",""); system("sleep infinity") }}')
+        self.write_file(f"{path}/mem-hog.service",
+                        f"""
 [Unit]
 Description=Mem Hog Service
 
 [Service]
-ExecStart=/bin/awk -f /tmp/mem-hog.awk
+ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
 """)
 
         # After writing files out tell systemd about them
-        m.execute("systemctl daemon-reload")
+        run_cmd(f"systemctl {params} daemon-reload")
 
         # Check that MemoryCurrent is shown
         self.goto_service("mem-hog.service")
         b.wait_not_present("#memory")
-        m.execute("systemctl start mem-hog.service")
-        initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
-        self.assertGreater(initial_memory, 0.5)
-        m.execute("touch /tmp/continue")
-        # MemoryCurrent auto-updates every 30s - default timeout is 60s - when it updates the memory used should be ~50MiB
-        b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)
-        m.execute("systemctl stop mem-hog")
-        b.wait_not_present("#memory")
+        # In some distros systemctl is showing memory current as [Not Set] for user units
+        if not user or m.image not in ["rhel-8-5", "rhel-8-6", "ubuntu-2004", "centos-8-stream"]:
+            run_cmd(f"systemctl {params} start mem-hog.service")
+            initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
+            self.assertGreater(initial_memory, 0.5)
+            run_cmd(f"touch /tmp/continue{params}")
+            self.addCleanup(m.execute, f"rm /tmp/continue{params}")
+            # MemoryCurrent auto-updates every 30s - default timeout is 60s - when it updates the memory used should be ~50MiB
+            b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)
+            run_cmd(f"systemctl {params} stop mem-hog")
+            b.wait_not_present("#memory")
         # Check that listen is not shown for .service units
         b.wait_not_present("#listen")
 
@@ -809,7 +852,7 @@ ExecStart=/usr/bin/false
 
         # Services tab should have icon
         # Aab-fail should be at the top, and have failed
-        b.wait_visible('a:contains("System services") .ct-exclamation-circle')
+        b.wait_visible('a:contains("Services") .ct-exclamation-circle')
         b.wait_visible('tr[data-goto-unit="aab-fail.service"]')
         b.wait_visible('tr[data-goto-unit="aab-fail.service"] .service-unit-status:contains("Failed")')
 
@@ -833,7 +876,7 @@ ExecStart=/usr/bin/false
 
         if self.count_failures() == 0:
             # Services tab should not have icon
-            b.wait_not_present('a:contains("System services") .ct-exclamation-circle')
+            b.wait_not_present('a:contains("Services") .ct-exclamation-circle')
 
             # Nav link should not have icon
             self.check_system_menu_services_error(False)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -330,7 +330,7 @@ Unit=test.service
         self.toggle_onoff()
         self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
         if not user:
-            b.assert_pixels("#service-details", "details-test-fail", ignore=[".cockpit-log-panel .pf-c-card__body"])
+            b.assert_pixels("#service-details", "details-test-fail", ignore=[".cockpit-log-panel .pf-c-card__body", ".pf-c-switch__toggle"])
         b.click(".action-button:contains('Start service')")
         b.go(f'/system/services#/{suffix}')
         self.wait_service_present("test-fail.service")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -504,6 +504,8 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         # In some distros systemctl is showing memory current as [Not Set] for user units
         if not user or m.image not in ["rhel-8-5", "rhel-8-6", "ubuntu-2004", "centos-8-stream"]:
             run_cmd(f"systemctl {params} start mem-hog.service")
+            # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
+            self.addCleanup(run_cmd, f"systemctl {params} stop mem-hog.service || true")
             initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
             self.assertGreater(initial_memory, 0.5)
             run_cmd(f"touch /tmp/continue{params}")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -244,8 +244,7 @@ Unit=test.service
             # Make sure that symlinked services also appear in the list
             self.wait_service_state("reboot.target", "inactive")
             self.wait_service_state("ctrl-alt-del.target", "inactive")
-            self.wait_service_state("runlevel6.target", "inactive")
-            self.goto_service("runlevel6.target")
+            self.goto_service("ctrl-alt-del.target")
             b.wait_in_text(".service-name", "Reboot")
             b.click("#services-page .pf-c-breadcrumb__link")
 


### PR DESCRIPTION
## services: Show user owned systemd units

Most users are commonly familiar with the system systemd units. However, systemd offers the ability for unprivileged users to control and configure per-user units. Such units can now be managed from web console UI, the same way system-wide units are. 

![Screen Shot 2021-11-05 at 09 51 35](https://user-images.githubusercontent.com/14921356/140483853-7c31cd69-4d5d-4b37-8cdc-4498e1daf813.png)



