### PR TITLE
test: Fix unstable TestKeys.testPrivateKeys pixel test

### DIFF
--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -302,6 +302,8 @@ class TestKeys(MachineCase):
         b.set_input_text("#id_dsa-new-password", "foobar")
         b.set_input_text("#id_dsa-confirm-password", "foobar")
 
+        # avoid blinking cursor and blurry focus ring
+        b.blur("#id_dsa-confirm-password")
         b.assert_pixels("#credentials-modal", "ssh-keys-dialog", ignore=[".ct-icon-info-circle", "tbody:nth-child(1) .pf-c-table__toggle-icon"])
 
         b.click("#id_dsa-change-password")


### PR DESCRIPTION
Unfocus the input line, to avoid the blinking cursor and the slightly
unpredictable rounded corners of the focus ring.

----

[example failure](https://logs.cockpit-project.org/logs/pull-16538-20211102-104210-427b29b1-fedora-34-mobile/pixeldiff.html#TestKeys-testPrivateKeys-ssh-keys-dialog-mobile), this has plagued us for a while