### PR TITLE
lib: use new PF4 table (ComposableTable) implementation for all Table variants

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -54,12 +54,6 @@
         }
     }
 
-    .pf-c-table__expandable-row {
-        [data-label]::before {
-            display: None;
-        }
-    }
-
     // Don't wrap labels
     [data-label]::before {
         white-space: nowrap;

--- a/pkg/shell/active-pages-dialog.jsx
+++ b/pkg/shell/active-pages-dialog.jsx
@@ -54,7 +54,6 @@ export class ActivePagesDialogBody extends React.Component {
             return ({
                 props: {
                     key: frame.name,
-                    frame,
                     'data-row-id': frame.name
                 },
                 columns,
@@ -67,8 +66,8 @@ export class ActivePagesDialogBody extends React.Component {
                           columns={[{ title: _("Page name") }]}
                           aria-label={_("Active pages")}
                           emptyCaption={ _("There are currently no active pages") }
-                          onSelect={(_event, isSelected, rowIndex, rowData) => {
-                              const frame = rowData.props.frame;
+                          onSelect={(_event, isSelected, rowIndex) => {
+                              const frame = this.state.iframes[rowIndex];
                               const iframes = [...this.state.iframes];
                               iframes[rowIndex].selected = isSelected;
                               this.setState({ iframes });

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -528,7 +528,7 @@ ExecStart=/usr/local/bin/{0}
                 b.wait_in_text("#status", "System is up to date")
 
                 # history on "up to date" page should show the recent update (expanded by default)
-                self.testObj.assertHistory("#expanded-content1 > div > ul", [self.packageName])
+                self.testObj.assertHistory("#expanded-content0 > td > div > ul", [self.packageName])
 
             def verify_backend(self):
                 if not self.rebootRequired:
@@ -765,7 +765,7 @@ ExecStart=/usr/local/bin/{0}
         self.assertNotIn("secparse", b.text("#available-updates table"))
 
         # history should show the security updates
-        self.assertHistory("table.updates-history #expanded-content1 ul", ["secdeclare", "secparse", "sevcritical"])
+        self.assertHistory("table.updates-history #expanded-content0 ul", ["secdeclare", "secparse", "sevcritical"])
 
         # stop PackageKit (e. g. idle timeout) to make sure the page survives that
         m.execute("systemctl stop packagekit; systemctl reset-failed packagekit || true")

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -205,7 +205,7 @@ class TestStorageMdRaid(StorageCase):
         self.content_row_wait_in_col(1, 2, part_prefix + "1")
 
         # Create second partition
-        self.content_row_action(2, "Create partition")
+        self.content_row_action(2, "Create partition", False)
         self.dialog({"type": "ext4",
                      "mount_point": "/foo2",
                      "mount_options.auto": False,

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -39,7 +39,7 @@ class TestStorageMsDOS(StorageCase):
         # Format it with a DOS partition table
         b.click('button:contains(Create partition table)')
         self.dialog({"type": "dos"})
-        self.content_row_wait_in_col(1, 0, "Free space")
+        self.content_row_wait_in_col(1, 0, "Free space", False)
 
         # Create a primary partition
         self.content_row_action(1, "Create partition")
@@ -59,7 +59,7 @@ class TestStorageMsDOS(StorageCase):
         self.dialog_wait_close()
 
         # Create a extended partition to fill the rest of the disk
-        self.content_row_action(2, "Create partition")
+        self.content_row_action(2, "Create partition", False)
         self.dialog_wait_open()
         self.dialog_set_val("type", "dos-extended")
         self.dialog_wait_not_present("name")
@@ -68,11 +68,11 @@ class TestStorageMsDOS(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         self.content_row_wait_in_col(2, 1, "Extended partition")
-        self.content_row_wait_in_col(3, 1, "Free space")
+        self.content_row_wait_in_col(3, 1, "Free space", False)
 
         # Create logical partitions and check that "dos-extended" is
         # not offered.
-        self.content_row_action(3, "Create partition")
+        self.content_row_action(3, "Create partition", False)
         self.dialog_wait_open()
         b.wait_not_present("select option[value='dos-extended']")
         self.dialog_cancel()
@@ -83,7 +83,7 @@ class TestStorageMsDOS(StorageCase):
         self.content_dropdown_action(2, "Delete")
         self.confirm()
 
-        self.content_row_wait_in_col(2, 1, "Free space")
+        self.content_row_wait_in_col(2, 1, "Free space", False)
 
 
 if __name__ == '__main__':

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -449,7 +449,7 @@ class TestSystemInfo(MachineCase):
 
         # sort by model (no sort buttons in mobile mode)
         if not b.cdp.mobile:
-            b.click(pci_selector + ' thead th[data-label=Model] button')
+            b.click(pci_selector + ' thead th:nth-child(2) button')
             b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Model]', "440")
             b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Virtio SCSI")
             b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -106,16 +106,22 @@ class StorageHelpers:
             b.click(tbody + " tr td.pf-c-table__toggle button")
             b.wait_visible(tbody + ".pf-m-expanded")
 
-    def content_row_action(self, index, title):
-        btn = self.content_row_tbody(index) + " tr:first-child td button:contains(%s)" % title
+    def content_row_action(self, index, title, isExpandable=True):
+        if isExpandable:
+            btn = self.content_row_tbody(index) + " tr:first-child td button:contains(%s)" % title
+        else:
+            btn = "#detail-content > article > div > table > :nth-child(%d)" % index + " td button:contains(%s)" % title
         self.browser.click(btn)
 
     # The row might come and go a couple of times until it has the
     # expected content.  However, wait_in_text can not deal with a
     # temporarily disappearing element, so we use self.retry.
 
-    def content_row_wait_in_col(self, row_index, col_index, val):
-        col = self.content_row_tbody(row_index) + " tr:first-child > :nth-child(%d)" % (col_index + 1)
+    def content_row_wait_in_col(self, row_index, col_index, val, isExpandable=True):
+        if isExpandable:
+            col = self.content_row_tbody(row_index) + " tr:first-child > :nth-child(%d)" % (col_index + 1)
+        else:
+            col = "#detail-content > article > div > table > :nth-child(%d)" % row_index + " > :nth-child(%d)" % (col_index + 1)
         wait(lambda: self.browser.is_present(col) and val in self.browser.text(col))
 
     def content_dropdown_action(self, index, title):


### PR DESCRIPTION
The ListingTable component has already been partially ported to the non legacy PF4
table implementation, move it now completely.

This change is just an rewrite of the ListingTable component and should
not anyhow impact the consumers, as the properties and functionality
were not affected.