### PR TITLE
test: Generalize set_input_text() blurring

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -345,7 +345,7 @@ class Browser:
         else:
             self.wait_text(f"{selector} .pf-c-select__toggle-text", value)
 
-    def set_input_text(self, selector, val, append=False, value_check=True):
+    def set_input_text(self, selector, val, append=False, value_check=True, blur=True):
         self.focus(selector)
         if not append:
             self.key_press("a", 2)  # Ctrl + a
@@ -353,6 +353,8 @@ class Browser:
             self.key_press("\b")  # Backspace
         else:
             self.key_press(val)
+        if blur:
+            self.blur(selector)
 
         if value_check:
             self.wait_val(selector, val)

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -233,7 +233,6 @@ class TestFirewall(NetworkCase):
         b.set_input_text("#filter-services-input", "")
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-imap")
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-pop3")
-        b.blur("#filter-services-input")
 
         b.assert_pixels(".pf-c-modal-box", "firewall-add-services-to-zone-modal")
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -301,9 +301,6 @@ class TestKeys(MachineCase):
         b.set_input_text("#id_dsa-old-password", "badbad")
         b.set_input_text("#id_dsa-new-password", "foobar")
         b.set_input_text("#id_dsa-confirm-password", "foobar")
-
-        # avoid blinking cursor and blurry focus ring
-        b.blur("#id_dsa-confirm-password")
         b.assert_pixels("#credentials-modal", "ssh-keys-dialog", ignore=[".ct-icon-info-circle", "tbody:nth-child(1) .pf-c-table__toggle-icon"])
 
         b.click("#id_dsa-change-password")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -276,8 +276,6 @@ class TestSystemInfo(MachineCase):
         # wait until icon settles down
         b.wait_visible("#systime-time-input-input[aria-invalid='false']")
         b.wait_not_present("#systime-manual-row .dialog-error")
-        # avoid blinking cursor
-        b.blur("#systime-time-input-input")
         if b.cdp.mobile:
             # HACK: the clock icon in the <input> has too much jitter on mobile
             ignore = ["#systime-time-input-input"]

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -939,7 +939,6 @@ class TestTimers(MachineCase):
         b.set_input_text("#command", "/bin/sh -c '/bin/date >> /tmp/date'")
         b.click("input[value=specific-time]")
         b.set_input_text(".create-timer-time-picker input", "24:6s")
-        b.blur(".create-timer-time-picker input")
         b.click("#timer-save-button")
 
         # checks for invalid input messages

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -153,7 +153,7 @@ class TestShutdownRestart(MachineCase):
         b.wait_not_val("#shutdown-time-input", "")
         b.wait_not_present("#delay-helper")
         old = b.val("#shutdown-time-input")
-        b.set_input_text("#shutdown-time-input", "blah")
+        b.set_input_text("#shutdown-time-input", "blah", blur=False)
         b.wait_not_present("#delay-helper")
         b.blur("#shutdown-time-input")
         b.wait_text("#delay-helper", "Invalid time format")
@@ -161,12 +161,11 @@ class TestShutdownRestart(MachineCase):
 
         # Now set a correct time
         b.set_input_text("#shutdown-time-input", old)
-        b.blur("#shutdown-time-input")
         b.wait_visible("#shutdown-dialog button{0}:not(disabled)".format(self.danger_btn_class))
         b.wait_not_present("#delay-helper")
 
         # Try to insert an invalid date
-        b.set_input_text(".shutdown-date-picker input", "20/0x/2021")
+        b.set_input_text(".shutdown-date-picker input", "20/0x/2021", blur=False)
         b.wait_not_present("#delay-helper")
         b.blur(".shutdown-date-picker input")
         b.wait_val(".shutdown-date-picker input", "20/0x/2021")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -57,14 +57,12 @@ class TestAccounts(MachineCase):
         b.wait_not_attr("#account-delete", "disabled", "disabled")
         b.set_input_text('#account-real-name', "")  # Check that we can delete the name before setting it up
         b.set_input_text('#account-real-name', "Anton Arbitrary")
-        b.blur("#account-real-name")
         b.wait_visible('#account-real-name:not([disabled])')
         b.wait_text("#account-title", "Anton Arbitrary")
         self.assertIn(":Anton Arbitrary:", m.execute("grep anton /etc/passwd"))
 
         # Add some other GECOS fields
         b.set_input_text('#account-real-name', "Anton Arbitrary,1,123")
-        b.blur("#account-real-name")
         b.wait_visible('#account-real-name:not([disabled])')
         self.assertIn(":Anton Arbitrary,1,123:", m.execute("grep anton /etc/passwd"))
         # Table title only shows real name, no other GECOS fields


### PR DESCRIPTION
Generalize the blurring of the input element after typing keys in
set_input_text(). We keep running into the same problems with pixel
tests, and if tests need a particular item to be focussed, they should
be explicit in that.

The time/date validation checks in check-system-shutdown-restart *are*
dependent on keeping the focus, so provide a flag to disable the blurring.