### PR TITLE
networkmanager: Fix JavaScript error when applying settings

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1268,7 +1268,7 @@ export function syn_click(model, fun) {
     return function() {
         const self = this;
         const self_args = arguments;
-        model.synchronize().then(function() {
+        return model.synchronize().then(function() {
             fun.apply(self, self_args);
         });
     };
@@ -1556,11 +1556,7 @@ export function with_checkpoint(model, modify, options) {
                                         .catch(function () {
                                             show_breaking_change_dialog({
                                                 ...options,
-                                                action: () => {
-                                                    syn_click(model, function () {
-                                                        modify();
-                                                    });
-                                                }
+                                                action: syn_click(model, modify)
                                             });
                                         })
                                         .finally(hide_curtain);


### PR DESCRIPTION
show_modal_dialog expects an action to be a function which returns a
promise, as it didn't you would get an error that undefined has no
method 'then'. The issue was introduced in 3899b9b5d79df.