### PR TITLE
test: Don't restart NM while deleting devices at the same time

### DIFF
--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -79,12 +79,12 @@ class NetworkCase(MachineCase, NetworkHelpers):
 
             def cleanupDevs():
                 new = devs() - self.orig_devs
-                self.machine.execute("for d in %s; do ip link del dev $d; done" % ' '.join(new))
+                self.machine.execute("for d in %s; do nmcli dev del $d; done" % ' '.join(new))
 
             self.orig_devs = devs()
-            self.addCleanup(cleanupDevs)
             self.restore_dir("/etc/NetworkManager", post_restore_action="systemctl try-restart NetworkManager")
             self.restore_dir("/etc/sysconfig/network-scripts")
+            self.addCleanup(cleanupDevs)
 
         m.execute("systemctl start NetworkManager")
 


### PR DESCRIPTION
Restarting NetworkManager and then immediately deleting network
devices via "ip link del dev" would sometimes not actually remove team
devices.

Thus let's first cleanly remove the devices via NM itself and then do
the restart.

The symptoms of this was a very flaky TestTeam.testBasic on rhel-8-6
when run after TestTeam.testActive on the same machine.
TestTeam.testActive would leave a unmanaged "tteam" device
behind (because of the bug fixed here), and the automatic activation
of the new connection object that TestTeam.testBasic would not happen
because of that, and "tteam" remained unmanaged.  (A explicit
actication would have put everything back in order.)