### PR TITLE
base1: tweak error message check in test-dbus.js

### DIFF
--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -662,7 +662,7 @@ QUnit.test("publish object replaces", function (assert) {
 
 QUnit.test("publish object unpublish", function (assert) {
     const done = assert.async();
-    assert.expect(5);
+    assert.expect(4);
 
     const info = {
         "org.Interface": {
@@ -695,8 +695,9 @@ QUnit.test("publish object unpublish", function (assert) {
                             }, function(ex) {
                                 assert.strictEqual(ex.name, "org.freedesktop.DBus.Error.UnknownMethod",
                                                    "got right error name");
-                                assert.ok(ex.message.indexOf("No such interface") == 0, "unexpected error: " + ex.message);
-                                assert.ok(ex.message.indexOf("org.Interface") > 0, "unexpected error: " + ex.message);
+                                assert.ok(ex.message.includes("No such interface") ||
+                                          ex.message.includes("Object does not exist"),
+                                          "unexpected error: " + ex.message);
                                 assert.ok(ex.message.indexOf("/a/path") > 0, "unexpected error: " + ex.message);
                             })
                             .always(function() {


### PR DESCRIPTION
Fedora 35 now gives an error message about "Object does not exist" vs.
previous versions saying "No such interface".  Accept both messages.


We don't actually run unit tests in Fedora 35 at the moment (although perhaps we should) but I can confirm that this fixes `make check` for me locally.