### PR TITLE
bridge: Block signals initially for the default CockpitDBusCache

### DIFF
--- a/src/bridge/cockpitdbusjson.c
+++ b/src/bridge/cockpitdbusjson.c
@@ -2792,6 +2792,13 @@ process_connection (CockpitDBusJson *self,
                                                                 self, NULL);
           self->default_watched = TRUE;
           subscribe_and_cache (self);
+
+          /* Stop the cache from processing signals until we know its
+             bus name.
+           */
+          CockpitDBusPeer *peer = g_hash_table_lookup (self->peers, self->default_name);
+          if (peer)
+            cockpit_dbus_cache_set_name_owner (peer->cache, "");
         }
       else
         {


### PR DESCRIPTION
The CockpitDBusCache for the default name of a dbus channel is already
careful not to process signals from other sources than the default
name, but it starts doing that only as soon as the unique name is
known (or known to not exist).  Before that, it will accept all
signals, which might still lead to journal messages like

    org.storage.stratis3: couldn't get managed objects at /org/freedesktop/UDisks2: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name org.storage.stratis3 was not provided by any .service files

Thus, we block signals initially as well, until the unique name is
known.