### PR TITLE
tools: Use our own SELinux policy on RHEL/CentOS 8 as well

### DIFF
--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -108,18 +108,8 @@ cmd_ipa_request() {
     klist -k "${KEYTAB}" | grep -qF "${SERVICE}" || \
         ipa-getkeytab -p "HTTP/${HOST}" -k "${KEYTAB}"
 
-    # request the certificate and put it into our certificate directory
-    if ! selinuxenabled || [ "$(stat -c %C /etc/cockpit/ws-certs.d/ | cut -f3 -d:)" = cert_t ]; then
-        # the prefered way is to let certmonger write the certificate directly, so that auto-refresh works
-        ipa-getcert request -f "${COCKPIT_WS_CERTS_D}/10-ipa.cert" -k "${COCKPIT_WS_CERTS_D}/10-ipa.key" -K "HTTP/${HOST}" -m 640 -o root:${COCKPIT_GROUP:-root} -M 644 -w -v
-    else
-        # ... but that does not work on RHEL 8 or customized SELinux policies, so copy it ourselves
-        # request the certificate (into the working directory)
-        ipa-getcert request -f 10-ipa.cert -k 10-ipa.key -K "HTTP/${HOST}" -w -v
-        # install it into /etc
-        install_cert 10-ipa.cert
-        install_key 10-ipa.key
-    fi
+    # request the certificate and put it into our certificate directory, so that auto-refresh works
+    ipa-getcert request -f "${COCKPIT_WS_CERTS_D}/10-ipa.cert" -k "${COCKPIT_WS_CERTS_D}/10-ipa.key" -K "HTTP/${HOST}" -m 640 -o root:${COCKPIT_GROUP:-root} -M 644 -w -v
 }
 
 cmd_ipa_cleanup() {

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -407,9 +407,6 @@ class TestConnection(MachineCase):
         # certmonger generated certificate; asciibetically later than the above
         # not all images have certmonger
         if m.image not in ["debian-stable", "debian-testing", "fedora-coreos"]:
-            # on RHEL 8 we need to fix the context as that does not have our own SELinux policy
-            if m.image.startswith("rhel-8") or m.image in ["centos-8-stream"]:
-                m.execute(r"semanage fcontext -a -t cert_t '/etc/cockpit/ws-certs\.d(/.*)?' && restorecon -v /etc/cockpit/ws-certs.d")
             hostname = m.execute("hostname --fqdn").strip()
             m.execute(f"getcert request -f /etc/cockpit/ws-certs.d/monger.cert -k /etc/cockpit/ws-certs.d/monger.key -D {hostname} -m 640 -o root:cockpit-ws -M 644 --ca=local --wait")
             # cert generation succeeded, and it is being tracked

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -535,17 +535,13 @@ ExecStart=/bin/true
         # cert is being tracked
         out = m.execute("ipa-getcert list")
         self.assertIn("MONITORING", out)
-        if m.image.startswith("rhel-8") or m.image in ["centos-8-stream"]:
-            # fall back to certificate copy mode (with broken refresh), due to missing SELinux policy
-            self.assertIn("/run/cockpit/certificate-helper/10-ipa.key", out)
-        else:
-            # on most OSes certmonger can directly write and auto-refresh the certificates
-            self.assertIn("/etc/cockpit/ws-certs.d/10-ipa.key", out)
-            # ensure that refreshing works
-            old_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
-            m.execute("ipa-getcert rekey --verbose --wait -f /etc/cockpit/ws-certs.d/10-ipa.cert")
-            new_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
-            self.assertNotEqual(old_cert, new_cert)
+        # certmonger must be able to directly write and auto-refresh the certificates
+        self.assertIn("/etc/cockpit/ws-certs.d/10-ipa.key", out)
+        # ensure that refreshing works
+        old_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
+        m.execute("ipa-getcert rekey --verbose --wait -f /etc/cockpit/ws-certs.d/10-ipa.cert")
+        new_cert = m.execute("cat /etc/cockpit/ws-certs.d/10-ipa.cert").strip()
+        self.assertNotEqual(old_cert, new_cert)
 
         # Restart without SSL (IPA certificate is not on the testing host)
         m.stop_cockpit()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -81,8 +81,8 @@ Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{v
 %define build_optional 1
 %endif
 
-# Ship custom SELinux policy only in Fedora and RHEL-9 onward
-%if 0%{?rhel} >= 9 || 0%{?fedora}
+# Ship custom SELinux policy (but not for cockpit-appstream)
+%if "%{name}" == "cockpit"
 %define selinuxtype targeted
 %define with_selinux 1
 %define selinux_policy_version %(rpm --quiet -q selinux-policy && rpm -q --queryformat "%{V}-%{R}" selinux-policy || echo 1)


### PR DESCRIPTION
tools: Use our own SELinux policy on RHEL/CentOS 8 as well

This will fix the SELinux type of /etc/cockpit/ws-certs.d (from commit
6ec488185), and is going to fix systemd's cleanup of /run/cockpit in
PR #16572.

Drop the distribution test from the .spec, as this is actually also
being used in OpenSUSE. As this now builds on RHEL 8,  add a `name == "cockpit"`
guard, as we don't want to build this for cockpit-appstream.

This allows us to drop the fallback from cockpit-certificate-helper, as
certmonger can now finally write directly into ws-certs.d/ everywhere.
This will fix certificate auto-refresh on RHEL 8. Drop the corresponding
hacks/special cases from the integration tests.

-----

I asked @zpytela and @vmojzis  and got their blessing for this. It will also help with getting rid of that hack in linux-system-roles eventually: https://github.com/linux-system-roles/cockpit/#certificate-setup

 - [x] https://github.com/cockpit-project/bots/pull/2611