### PR TITLE
apps: packagekit with apt backend reports backward percentages for th…

### DIFF
--- a/pkg/apps/packagekit.js
+++ b/pkg/apps/packagekit.js
@@ -23,8 +23,11 @@ import * as PK from "packagekit.js";
 function progress_reporter(base, range, callback) {
     if (callback) {
         return function (data) {
-            if (data.absolute_percentage >= 0)
-                data.percentage = base + data.absolute_percentage / 100 * range;
+            if (data.absolute_percentage >= 0) {
+                const newPercentage = base + data.absolute_percentage / 100 * range;
+                if (data.percentage == undefined || newPercentage >= data.percentage)
+                    data.percentage = newPercentage;
+            }
             callback(data);
         };
     }


### PR DESCRIPTION
…e refresh operation

Guard these wrong values that the packagekit API returns by making sure
these are corresponding to an increasing percentage value.

Fixes #16564