### PR TITLE
storaged: Properly represent LVM VDO pools

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -171,6 +171,7 @@ function init_proxies () {
     client.blocks_crypto = proxies("Encrypted");
     client.blocks_swap = proxies("Swapspace");
     client.iscsi_sessions = proxies("ISCSI.Session");
+    client.vdo_vols = proxies("VDOVolume");
     client.jobs = proxies("Job");
 
     return client.storaged_client.watch({ path_namespace: "/org/freedesktop/UDisks2" });

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -47,7 +47,10 @@ class TestStorageVDO(StorageCase):
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
-        b.wait_in_text("#devices", "vdo_vgroup")
+        # wait until UI knows about lvol
+        b.click("#devices .sidepanel-row:contains(vdo_vgroup)")
+        b.wait_in_text("#storage-detail", "/dev/vdo_vgroup/lvol")
+        b.go("#/")
 
         # Create VDO
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -28,7 +28,7 @@ SUPPORTED_OS = ["centos-8-stream", "rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5",
 
 
 @skipImage("no vdo package yet on RHEL 9, https://bugzilla.redhat.com/show_bug.cgi?id=1916216", "rhel-9-0", "rhel-9-0-distropkg")
-class TestStorageVDO(StorageCase):
+class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):
         m = self.machine

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -18,6 +18,8 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent
+import re
+
 from packagelib import *
 from storagelib import *
 from testlib import *
@@ -27,7 +29,111 @@ from testlib import *
 SUPPORTED_OS = ["centos-8-stream", "rhel-8-4", "rhel-8-4-distropkg", "rhel-8-5", "rhel-8-6", "rhel-8-5-distropkg"]
 
 
-@skipImage("no vdo package yet on RHEL 9, https://bugzilla.redhat.com/show_bug.cgi?id=1916216", "rhel-9-0", "rhel-9-0-distropkg")
+@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
+class TestStorageVDO(StorageCase):
+
+    def testVdo(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Make a logical volume for use as the backing device.
+        m.add_disk("10G", serial="DISK1")
+        b.wait_in_text("#drives", "DISK1")
+        m.execute("vgcreate vdo_vgroup /dev/sda")
+        b.wait_in_text("#devices", "vdo_vgroup")
+
+        b.click('.sidepanel-row:contains("vdo_vgroup")')
+        b.wait_in_text("#detail-content", "No logical volumes")
+
+        b.click("button:contains(Create new logical volume)")
+        self.dialog_wait_open()
+        b._wait_present("[data-field='purpose'] select option[value='block']")
+
+        if m.image not in SUPPORTED_OS:
+            # FIXME: This is looking into the future, the UI can't create LVM VDO volumes yet
+            b.wait_not_present("[data-field='purpose'] select option[value='vdo']")
+            return
+
+        # FIXME: use the dialog to create the VDO volume once it can; for now, do CLI call
+        self.dialog_cancel()
+        self.dialog_wait_close()
+        m.execute("lvcreate --type vdo --size 6g --virtualsize 10g --name vdo0 vdo_vgroup")
+
+        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo0")
+        # the pool does not appear as a top-level volume
+        b.wait_not_in_text("#detail-content", "vpool0")
+        # Volume tab
+        self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
+        self.content_tab_wait_in_info(1, 1, "Size", "10 GiB")
+        # VDO Pool tab
+        self.content_tab_wait_in_info(1, 2, "Name", "vpool0")
+        self.content_tab_wait_in_info(1, 2, "Size", "6 GiB")
+        # initial physical usage is 4 GiB, overhead for the deduplication index
+        self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
+        self.content_tab_wait_in_info(1, 2, "Metadata used", "0%")
+        b.wait_visible("input[aria-label='Use compression']:checked")
+        b.wait_visible("input[aria-label='Use deduplication']:checked")
+
+        # create a file system
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "xfs",
+                     "name": "vdofs",
+                     "mount_point": "/run/data"})
+        self.content_row_wait_in_col(1, 1, "xfs file system")
+
+        # compressible data should affect logical usage
+        m.execute("dd if=/dev/zero of=/run/data/empty bs=1M count=1000")
+        self.content_tab_wait_in_info(1, 3, "Used", "1.08 GiB of 9.99 GiB")
+        # but not physical usage
+        self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
+
+        # incompressible data
+        m.execute("dd if=/dev/urandom of=/run/data/gibberish bs=1M count=1000")
+        self.content_tab_wait_in_info(1, 3, "Used", "2.05 GiB of 9.99 GiB")
+        # equal amount of physical space (not completely predictable due to random data)
+        self.content_tab_wait_in_info(1, 2, "Data used", "4.8", "4.9")
+        self.content_tab_wait_in_info(1, 2, "Data used", cond=lambda sel: re.search(r"\(8[1234]%\)", b.text(sel)))
+
+        def wait_prop(device, prop, value):
+            m.execute(f"until lvdisplay --noheadings -Co {prop} /dev/vdo_vgroup/{device} | grep -q '{value}'; do sleep 0.1; done")
+
+        # change compression/deduplication
+        b.click("input[aria-label='Use compression']")
+        b.wait_visible("input[aria-label='Use compression']:not(checked):not([disabled])")
+        wait_prop("vpool0", "vdo_compression_state", "offline")
+        b.click("input[aria-label='Use compression']")
+        b.wait_visible("input[aria-label='Use compression']:checked:not([disabled])")
+        wait_prop("vpool0", "vdo_compression_state", "online")
+
+        b.click("input[aria-label='Use deduplication']")
+        b.wait_visible("input[aria-label='Use deduplication']:not(checked):not([disabled])")
+        wait_prop("vpool0", "vdo_index_state", "offline")
+        b.click("input[aria-label='Use deduplication']")
+        b.wait_visible("input[aria-label='Use deduplication']:checked:not([disabled])")
+        wait_prop("vpool0", "vdo_index_state", "online")
+
+        # grow volume
+        self.content_tab_action(1, 1, "Grow")
+        self.dialog({"size": 12 * 1024})
+        self.content_tab_wait_in_info(1, 1, "Size", "12 GiB")
+        wait_prop("vdo0", "lv_size", "12.00g")
+
+        # grow pool
+        self.content_tab_action(1, 2, "Grow")
+        self.dialog({"size": 8 * 1024})
+        self.content_tab_wait_in_info(1, 2, "Size", "8 GiB")
+        wait_prop("vpool0", "lv_size", "8.00g")
+
+        # deleting the vdo0 volume deletes the pool as well
+        self.content_dropdown_action(1, "Delete")
+        self.confirm()
+        b.wait_in_text("#detail-content", "No logical volumes")
+        self.assertEqual(m.execute("lvs --noheadings").strip(), "")
+
+
+@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):


### PR DESCRIPTION
The `vdo cli` API and standalone "vdo" block device type has been deprecated a while ago, in favor of the LVM/udisks-lvm2 API. The latter is the officially documented one [1].

The official VDO API is a particular "VDO" type of LVM volume, similar
to a thin pool volume or a normal LVM block LV. These consist of two
LVs:

 (1) The physical "pool" volume which holds the compressed data; from
     the user's point of view these are an internal implementation detail
     and have no sensible actions other than growing. In particular,
     these should not be (de)activated [2]. The `lvcreate` CLI also does
     not require specifying them, it will just make up a new name.

 (2) The virtual block volume which gets formatted, mounted, and used.

Stop showing type (1) as standalone top-level LV volumes.  Instead, add a
"VDO Pool" tab to the type (2) volumes, show the pool size (including
Grow button) there, and also show information and toggles from the
`org.freedesktop.UDisks2.VDOVolume` interface.

The Storage page cannot yet create this kind of VDO volume, this only
fixes the presentation of existing ones.

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deduplicating_and_compressing_logical_volumes_on_rhel/creating-a-deduplicated-and-compressed-logical-volume_deduplicating-and-compressing-logical-volumes

[2] udisks currently also represents them wrongly: https://github.com/storaged-project/udisks/issues/934

----

On current main, these "new-style" VDO devices look like this; the pool is a top-level thing with a broken (or even dangerous?) Activate/Deactivate button (it times out eventually, but does change the status in LVM), it has no logical connection to the actually interesting volume, and does not show any interesting properties other than the size:


![main](https://user-images.githubusercontent.com/200109/141945513-0446ea0b-c9fd-475e-a15f-3049ea7c9e10.png)

Now the pool is a tab inside the vdo0 volume ("Volume" tab is the same as before):

![pr-vdo](https://user-images.githubusercontent.com/200109/141945558-ba4b69ce-7271-4899-8a33-03a2d823d415.png)

The "Grow" buttons on both tabs work. I did not yet add a "Rename" button for the pool; it works, but it causes a page crash, and it's also not interesting. I don't even plan to expose the pool name on UI creation, it can just be `<volname>_pool`.

The "Filesystem" tab is also unchanged, but for reference:

![pr-fs](https://user-images.githubusercontent.com/200109/141945609-02bd2856-6bc5-4d49-954c-5c7a9dff9fbb.png)

 - [ ] Agree on design
 - [x] Use `lvcreate` instead of raw D-Bus call
 - [x] Show correct/precise physical size
 - [x] Add On/Off buttons for compression and deduplication
 - [x] Add missing tests for the actions (grow volume, grow pool)

Follow-ups:
 - [ ] Show overhead (Requires polling VDOVolume.GetStatistics)
 - [ ] Add creation dialog
 - [ ] Drop creation of old-style VDO volumes