### PR TITLE
Fix DatePicker's start of week for most cases

### DIFF
--- a/pkg/lib/cockpit-components-shutdown.jsx
+++ b/pkg/lib/cockpit-components-shutdown.jsx
@@ -197,6 +197,7 @@ export class ShutdownModal extends React.Component {
                                                 invalidFormatText=""
                                                 isDisabled={!this.state.formFilled}
                                                 locale={cockpit.language}
+                                                weekStart={timeformat.firstDayOfWeek()}
                                                 onBlur={this.calculate}
                                                 onChange={(d, ds) => this.updateDate(d, ds)}
                                                 placeholder={timeformat.dateShortFormat()}

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -520,6 +520,7 @@ function ChangeSystimeBody({ state, errors, change }) {
                                     dateParse={timeformat.parseShortDate}
                                     invalidFormatText=""
                                     locale={cockpit.language}
+                                    weekStart={timeformat.firstDayOfWeek()}
                                     placeholder={timeformat.dateShortFormat()}
                                     onChange={d => change("manual_date", d)}
                                     value={manual_date} />

--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -48,3 +48,17 @@ export function parseShortDate(dateStr) {
     const timePortion = parsed.getTime() % (3600 * 1000 * 24);
     return new Date(parsed - timePortion);
 }
+
+/***
+ * sorely missing from Intl: https://github.com/tc39/ecma402/issues/6
+ * based on https://github.com/unicode-cldr/cldr-core/blob/master/supplemental/weekData.json#L59
+ * However, we don't have translations for most locales, and cockpit.language does not even contain
+ * the country in most cases, so this is just an approximation.
+ * Most locales start the week on Monday (day 1), so default to that and enumerate the others.
+ */
+
+const first_dow_sun = ['en', 'ja', 'ko', 'pt', 'pt_BR', 'sv', 'zh_CN', 'zh_TW'];
+
+export function firstDayOfWeek() {
+    return first_dow_sun.indexOf(cockpit.language) >= 0 ? 0 : 1;
+}

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -37,6 +37,7 @@ import { ModalError } from 'cockpit-components-inline-notification.jsx';
 
 import { updateTime } from './services.jsx';
 import { create_timer } from './timer-dialog-helpers.js';
+import * as timeformat from "timeformat.js";
 
 import "./timers.scss";
 
@@ -309,11 +310,15 @@ const CreateTimerDialogBody = ({ setIsOpen, owner }) => {
                                             {timePicker(idx)}
                                         </>}
                                         {repeat == "yearly" && <>
-                                            <DatePicker onChange={(str, data) => {
-                                                const arr = [...repeatPatterns];
-                                                arr[idx].date = str;
-                                                setRepeatPatterns(arr);
-                                            }} />
+                                            <DatePicker aria-label={_("Pick date")}
+                                                        buttonAriaLabel={_("Toggle date picker")}
+                                                        locale={cockpit.language}
+                                                        weekStart={timeformat.firstDayOfWeek()}
+                                                        onChange={(str, data) => {
+                                                            const arr = [...repeatPatterns];
+                                                            arr[idx].date = str;
+                                                            setRepeatPatterns(arr);
+                                                        }} />
                                             {timePicker(idx)}
                                         </>}
                                         {repeat !== "no" && <FlexItem align={{ default: 'alignRight' }}>

--- a/pkg/users/expiration-dialogs.js
+++ b/pkg/users/expiration-dialogs.js
@@ -23,6 +23,7 @@ import { Flex, Form, FormGroup, FormHelperText, Radio, TextInput, DatePicker } f
 
 import { has_errors } from "./dialog-utils.js";
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
+import * as timeformat from "timeformat.js";
 
 const _ = cockpit.gettext;
 
@@ -39,7 +40,11 @@ function AccountExpirationDialogBody({ state, errors, change }) {
                        label={
                            <Flex>
                                <span>{before}</span>
-                               <DatePicker onChange={str => change("date", str)}
+                               <DatePicker aria-label={_("Pick date")}
+                                           buttonAriaLabel={_("Toggle date picker")}
+                                           locale={cockpit.language}
+                                           weekStart={timeformat.firstDayOfWeek()}
+                                           onChange={str => change("date", str)}
                                            invalidFormatText=""
                                            id="account-expiration-input"
                                            value={date}


### PR DESCRIPTION
PF's DatePicker defaults to Sunday as the start of the week instead of
the given locale's convention. There is currently no official JS API
which exposes that piece of locale information [1], and
`cockpit.language` does not even contain the country in most cases. So
add a `timefirmat.firstDayOfWeek()` approximation by language, which at
least gets it right for most of our supported languages *except*
English-speaking countries in Europe (in particular, en-GB and en-IE).

Add missing aria and localization to the timer creation and user account
expiration dialogs, so that their month names are properly translated.

[1] https://github.com/tc39/ecma402/issues/6

---

English looks as before:

![date-picker-en](https://user-images.githubusercontent.com/200109/141076566-b5eef07e-0c9a-4ce5-bc42-bc261488dcaa.png)

In German, the week now starts on Monday:

![date-picker-de](https://user-images.githubusercontent.com/200109/141076614-05b5838d-2d39-459f-93b4-2ff900a928f2.png)