### PR TITLE
fmf: Fix TEST_OS mappings

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -28,8 +28,12 @@ fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
-if [ "$TEST_OS" = "fedora-35" ]; then
-    export TEST_OS=fedora-34
+if [ "$TEST_OS" = "fedora-36" ]; then
+    export TEST_OS=fedora-35
+fi
+
+if [ "$TEST_OS" = "centos-8" ]; then
+    TEST_OS=centos-8-stream
 fi
 
 if [ "$ID" = "fedora" ]; then


### PR DESCRIPTION
Map os-release detected "centos-8" to "centos-8-stream", which fixes
TestServices.testBasicSession (regression from commit 154da47d94).

Our tests do know about "fedora-35" now, and rawhide is now fedora-36.

----

packit centos 8 has [failed](http://artifacts.dev.testing-farm.io/749216f5-0781-43d0-ba61-ba4ba105ea42/) for a few days now, this should fix it.