### PR TITLE
test: Drop focus from close button

### DIFF
--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -42,8 +42,12 @@ class TestNetworkingVLAN(NetworkCase):
 
         # wait until dialog initialized
         b.wait_visible("#network-vlan-settings-dialog > button[aria-label=Close]")
+        # Remove focus ring around the close button, which causes pixel tests retries.
+        b.blur("#network-vlan-settings-dialog > button[aria-label=Close]")
         b.wait_visible("#network-vlan-settings-interface-name-input")
-        b.assert_pixels("#network-vlan-settings-dialog", "networking-vlan-settings-dialog")
+        # Ignore flaky pixel issues with the select triangle
+        ignoredClasses = ["#network-vlan-settings-parent-select"] if self.browser.cdp.mobile else []
+        b.assert_pixels("#network-vlan-settings-dialog", "networking-vlan-settings-dialog", ignore=ignoredClasses)
 
         b.select_from_dropdown("#network-vlan-settings-parent-select", iface)
         b.set_input_text("#network-vlan-settings-interface-name-input", "tvlan")


### PR DESCRIPTION
The focus border around the close button of the dialog causes the pixel
tests to sometimes fail.