### PR TITLE
users: Clear password errors when password is changed

### DIFF
--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -181,6 +181,7 @@ export function set_password_dialog(account, current_user) {
         if (state.password != old_password) {
             state.confirm_weak = false;
             old_password = state.password;
+            errors = { };
             if (state.password) {
                 password_quality(state.password)
                         .catch(ex => {

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -126,6 +126,10 @@ class TestAccounts(MachineCase):
         b.click('#accounts-create-dialog button.apply')
         b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "Password is longer than 256 characters")
 
+        # changing input clears the error message
+        b.set_input_text('#accounts-create-password-pw1', "test")
+        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error")
+
         # correct password confirmation
         b.set_input_text('#accounts-create-password-pw1', good_password)
         b.set_input_text('#accounts-create-password-pw2', good_password)


### PR DESCRIPTION
When a user types a bad password and tries to set a weak password
errors are shown underneath the password field. Changing the password
then again does not clear the password.