### PR TITLE
test: Fix SELinux message matching

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -459,7 +459,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="systemd".*')
         # https://bugzilla.redhat.com/show_bug.cgi?id=1727887
-        self.allow_journal_messages('.*type=1400.*avc:  denied  { connect_to } .* path="/run/user/.*/bus" scontext=user_u:user_r:user_t:s0.*')
+        self.allow_journal_messages('.*type=1400.*avc:  denied  { connectto } .* path="/run/user/.*/bus" scontext=user_u:user_r:user_t:s0.*')
 
         # sysadm_u
         m.execute("semanage login -a -s sysadm_u admin")


### PR DESCRIPTION
Commit 745f978a19e51579 typoed the operation name.

----

Still [happened](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-2623-20211112-023032-91f70e17-fedora-testing-cockpit-project-cockpit/log.html#166) in https://github.com/cockpit-project/bots/pull/2623 -- Sorry, brown paperpag.. :cry: I can't for my life reproduce this failure locally.