### PR TITLE
test: Use add_loopback_disk() to create loopback disks

### DIFF
--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -26,7 +26,6 @@ from testlib import *
 class TestStoragePartitions(StorageCase):
 
     def testPartitions(self):
-        m = self.machine
         b = self.browser
 
         self.login_and_go("/storage")
@@ -41,10 +40,7 @@ class TestStoragePartitions(StorageCase):
         #
         # https://github.com/storaged-project/storaged/issues/97
 
-        dev = m.execute("set -e; dd if=/dev/zero of=/var/tmp/disk1 bs=1M count=10; "
-                        "losetup --show loop12 /var/tmp/disk1; "
-                        "rm /var/tmp/disk1").strip()
-        self.addCleanup(m.execute, "losetup -d " + dev)
+        dev = self.add_loopback_disk(10, "loop12")
 
         b.wait_visible('.sidepanel-row:contains("%s")' % dev)
         b.click('.sidepanel-row:contains("%s")' % dev)

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -60,7 +60,7 @@ class StorageHelpers:
 
         return dev
 
-    def add_loopback_disk(self, size=50):
+    def add_loopback_disk(self, size=50, name=None):
         '''Add per-test loopback disk
 
         The disk gets removed automatically when the test ends. This is safe for @nondestructive tests.
@@ -76,7 +76,7 @@ class StorageHelpers:
         # losetup, but that will break some versions of lvm2.
         dev = self.machine.execute("set -e; F=$(mktemp /var/tmp/loop.XXXX); "
                                    "dd if=/dev/zero of=$F bs=1M count=%s; "
-                                   "losetup --find --show $F" % size).strip()
+                                   "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # right after unmounting the device is often still busy, so retry a few times
         self.addCleanup(self.machine.execute, "umount {0}; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
         return dev


### PR DESCRIPTION
This method has proper cleanup defined.

This is easily reproducible:
```diff
diff --git test/verify/check-storage-partitions test/verify/check-storage-partitions
index b0c783dd4..c58789744 100755
--- test/verify/check-storage-partitions
+++ test/verify/check-storage-partitions
@@ -58,6 +58,7 @@ class TestStoragePartitions(StorageCase):
         self.content_row_wait_in_col(1, 1, "ext4 file system")
 
         self.content_dropdown_action(1, "Delete")
+        b.wait_visible("#foobar")
         self.confirm()
         self.content_row_wait_in_col(1, 0, "Free space")
```

and then run `./test/common/run-tests --test-dir test/verify TestStoragePartitions.testPartitions`. Without this patch it fails for the first time on this new `wait_visible` and then quickly fails on `dev = m.execute("set -e; dd if=/dev/zero of=/var/tmp/disk1 bs=1M count=10; "` as seen [here](https://logs.cockpit-project.org/logs/pull-16572-20211110-131547-9d5ddabf-ubuntu-2004/log.html#186). With this patch it fails every time on the new `wait_visible`. Also works just fine 3 successful times in a row.