### PR TITLE
login: Add toggle button to view password

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -189,6 +189,7 @@ form .control-label {
   color: #151515;
 }
 
+.pf-c-button.pf-m-control,
 .form-control[type=password],
 .form-control[type=text] {
   display: block;
@@ -203,6 +204,7 @@ form .control-label {
   color: #151515;
 }
 
+.pf-c-button.pf-m-control:hover,
 .form-control[type=password]:hover,
 .form-control[type=text]:hover,
 .form-control[type=password]:focus,
@@ -210,12 +212,14 @@ form .control-label {
   border-bottom-color: #06c;
 }
 
+.pf-c-button.pf-m-control:focus,
 .form-control[type=password]:focus,
 .form-control[type=text]:focus {
   padding-bottom: calc(0.25rem - 1px);
   border-bottom-width: 2px;
 }
 
+.pf-c-button.pf-m-control:focus,
 .form-control:focus {
   outline: 0;
 }
@@ -819,6 +823,28 @@ a:hover {
 #login-again {
   display: block;
   margin-bottom: 1rem;
+}
+
+.password-with-toggle {
+  display: grid;
+  grid-template-columns: 1fr auto;
+}
+
+.pf-c-button.login-password-toggle {
+  display: flex;
+  align-items: center;
+  border-left-width: 0;
+}
+
+.login-password-toggle > svg {
+  height: 1rem;
+  width: auto;
+}
+
+/* Show the appropriate eye icon based on the password text status */
+input[type=text] + .login-password-toggle .password-show,
+input[type=password] + .login-password-toggle .password-hide {
+  display: none;
 }
 
 /* Animation */

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -79,7 +79,15 @@
 
         <div id="password-group" class="form-group">
           <label for="login-password-input" class="control-label" translate>Password</label>
-          <input type="password" class="form-control" id="login-password-input">
+          <div class="password-with-toggle">
+            <input type="password" class="form-control" id="login-password-input">
+            <button type="button" id="login-password-toggle" class="pf-c-button pf-m-control login-password-toggle" aria-label="Show password">
+              <svg fill="currentColor" aria-hidden="true" viewBox="0 0 640 512">
+                <path class="password-show" d="M572.52 241.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400a144 144 0 1 1 144-144 143.93 143.93 0 0 1-144 144zm0-240a95.31 95.31 0 0 0-25.31 3.79 47.85 47.85 0 0 1-66.9 66.9A95.78 95.78 0 1 0 288 160z"/>
+                <path class="password-hide" d="M320 400c-75.85 0-137.25-58.71-142.9-133.11L72.2 185.82c-13.79 17.3-26.48 35.59-36.72 55.59a32.35 32.35 0 0 0 0 29.19C89.71 376.41 197.07 448 320 448c26.91 0 52.87-4 77.89-10.46L346 397.39a144.13 144.13 0 0 1-26 2.61zm313.82 58.1-110.55-85.44a331.25 331.25 0 0 0 81.25-102.07 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64a308.15 308.15 0 0 0-147.32 37.7L45.46 3.37A16 16 0 0 0 23 6.18L3.37 31.45A16 16 0 0 0 6.18 53.9l588.36 454.73a16 16 0 0 0 22.46-2.81l19.64-25.27a16 16 0 0 0-2.82-22.45zm-183.72-142-39.3-30.38A94.75 94.75 0 0 0 416 256a94.76 94.76 0 0 0-121.31-92.21A47.65 47.65 0 0 1 304 192a46.64 46.64 0 0 1-1.54 10l-73.61-56.89A142.31 142.31 0 0 1 320 112a143.92 143.92 0 0 1 144 144c0 21.63-5.29 41.79-13.9 60.11z"/>
+              </svg>
+            </button>
+          </div>
         </div>
 
         <div id="option-group">

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -276,6 +276,13 @@
         }
     }
 
+    function toggle_password(event) {
+        const input = id("login-password-input");
+
+        input.setAttribute("type", (input.getAttribute("type") === "password") ? "text" : "password");
+        event.stopPropagation();
+    }
+
     function boot() {
         window.onload = null;
 
@@ -591,6 +598,7 @@
         };
 
         id("login-password-input").addEventListener("keydown", do_login);
+        id("login-password-toggle").addEventListener("click", toggle_password);
 
         show_form("login");
         id("login-user-input").focus();


### PR DESCRIPTION
Based on https://www.patternfly.org/v4/components/login-page

This adds a toggle to switch text input types from "password" to "text",
to make it cleartext for viewing and back. SVG icons are inlined and
chosen based on the state of the input. Minimal JavaScript is used to
swap the attribute.

Allowing one to choose to swap to clear text lets people use complex
passwords and not have to second guess what they typed. It's a usability
and accessibility feature. (And it shouldn't be used when someone is
actively looking at their computer, but otherwise should be fine.)

The form still defaults to hiding the password by default.