### PR TITLE
Eliminate obsolete cockpit.extend()

### DIFF
--- a/doc/guide/cockpit-util.xml
+++ b/doc/guide/cockpit-util.xml
@@ -140,14 +140,4 @@ cockpit.event_target(object, [handlers])
       if its specified.</para>
   </refsection>
 
-  <refsection id="cockpit-extend">
-    <title>cockpit.extend</title>
-<programlisting>
-cockpit.extend(target, src, ...)
-</programlisting>
-    <para>This function is used to copy the values of all enumerable own properties
-      from one or more source objects to a target object. It will return the target object. This
-      is similar to <code>Object.assign()</code>.</para>
-  </refsection>
-
 </refentry>

--- a/pkg/kdump/config-client.js
+++ b/pkg/kdump/config-client.js
@@ -114,7 +114,7 @@ export class ConfigFile {
         // make sure we copy the original keys so we overwrite the correct lines when saving
         this._originalSettings = { };
         Object.keys(this.settings).forEach((key) => {
-            this._originalSettings[key] = cockpit.extend({}, this.settings[key]);
+            this._originalSettings[key] = { ...this.settings[key] };
         });
         if (!skipNotify)
             this.dispatchEvent("kdumpConfigChanged", this.settings);

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -240,7 +240,7 @@ export class KdumpPage extends React.Component {
              * with a target so no conflicting settings remain */
             settings = {};
             Object.keys(this.props.kdumpStatus.config).forEach((key) => {
-                settings[key] = cockpit.extend({}, this.props.kdumpStatus.config[key]);
+                settings[key] = { ...this.props.kdumpStatus.config[key] };
             });
             Object.keys(this.props.kdumpStatus.target).forEach((key) => {
                 if (settings[key])
@@ -336,7 +336,7 @@ export class KdumpPage extends React.Component {
         const self = this;
         const settings = { };
         Object.keys(self.props.kdumpStatus.config).forEach((key) => {
-            settings[key] = cockpit.extend({}, self.props.kdumpStatus.config[key]);
+            settings[key] = { ...self.props.kdumpStatus.config[key] };
         });
         // open the settings dialog
         const dialogProps = {

--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -77,7 +77,7 @@ journal.build_cmd = function build_cmd(/* ... */) {
             if (arg instanceof Array) {
                 matches.push.apply(matches, arg);
             } else {
-                cockpit.extend(options, arg);
+                Object.assign(options, arg);
                 break;
             }
         } else {

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -406,9 +406,10 @@ function Router(index) {
                     source = register(child);
                 }
                 if (source) {
-                    const reply = cockpit.extend({ }, cockpit.transport.options,
-                                                 { command: "init", host: source.default_host, "channel-seed": source.channel_seed }
-                    );
+                    const reply = {
+                        ...cockpit.transport.options,
+                        command: "init", host: source.default_host, "channel-seed": source.channel_seed,
+                    };
                     child.postMessage("\n" + JSON.stringify(reply), origin);
                     source.inited = true;
 

--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -106,7 +106,7 @@ function Machines() {
     let timeout = null;
 
     function sync(machine, values, overlay) {
-        const desired = cockpit.extend({ }, values || { }, overlay || { });
+        const desired = { ...values, ...overlay };
         for (const prop in desired) {
             if (machine[prop] !== desired[prop])
                 machine[prop] = desired[prop];
@@ -200,7 +200,7 @@ function Machines() {
     function update_session_machine(machine, host, values) {
         /* We don't save the whole machine object */
         const skey = generate_session_key(host);
-        const data = cockpit.extend({}, machine, values);
+        const data = { ...machine, ...values };
         window.sessionStorage.setItem(skey, JSON.stringify(data));
         self.overlay(host, values);
         return cockpit.when([]);
@@ -248,10 +248,11 @@ function Machines() {
         let values = self.split_connection_string(connection_string);
         const host = values.address;
 
-        values = cockpit.extend({
+        values = {
             visible: true,
             color: color || self.unused_color(),
-        }, values);
+            ...values
+        };
 
         const machine = self.lookup(host);
         if (machine)
@@ -301,7 +302,7 @@ function Machines() {
         const changes = {};
 
         for (const host in content) {
-            changes[host] = cockpit.extend({ }, last.overlay[host] || { });
+            changes[host] = { ...last.overlay[host] };
             merge(changes[host], { on_disk: true });
         }
 
@@ -310,25 +311,25 @@ function Machines() {
          */
         for (const host in machines) {
             if (content && !content[host]) {
-                changes[host] = cockpit.extend({ }, last.overlay[host] || { });
+                changes[host] = { ...last.overlay[host] };
                 merge(changes[host], { on_disk: null });
             }
         }
 
         refresh({
             content: content,
-            overlay: cockpit.extend({ }, last.overlay, changes)
+            overlay: { ...last.overlay, ...changes },
         }, true);
     };
 
     self.overlay = function overlay(host, values) {
         const address = self.split_connection_string(host).address;
         const changes = { };
-        changes[address] = cockpit.extend({ }, last.overlay[address] || { });
+        changes[address] = { ...last.overlay[address] };
         merge(changes[address], values);
         refresh({
             content: last.content,
-            overlay: cockpit.extend({ }, last.overlay, changes)
+            overlay: { ...last.overlay, ...changes }
         }, true);
     };
 


### PR DESCRIPTION
This was an ages old compatibility shim for a time when Object.assign()
was not yet a standard browser API. Replace it with Object.assign() for
updating existing objects, and the spread operator for creating new
ones.

Drop the documentation as well. Keep cockpit.extend() as alias for
Object.assign() to keep the current API.