### PR TITLE
packagekit: Show "Web Console restart" for Arch and derivates

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -501,3 +501,11 @@ export function install_missing_packages(data, progress_cb) {
                                       }
                                   });
 }
+
+/**
+ * Get the used backendName in PackageKit.
+ */
+export function getBackendName() {
+    return call("/org/freedesktop/PackageKit", "org.freedesktop.DBus.Properties",
+                "Get", ["org.freedesktop.PackageKit", "BackendName"]);
+}

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -944,6 +944,7 @@ class OsUpdates extends React.Component {
             tracerRunning: false,
             showRestartServicesDialog: false,
             showRebootSystemDialog: false,
+            backend: "",
         };
         this.handleLoadError = this.handleLoadError.bind(this);
         this.handleRefresh = this.handleRefresh.bind(this);
@@ -965,6 +966,10 @@ class OsUpdates extends React.Component {
     componentDidMount() {
         this._mounted = true;
         this.callTracer(null);
+
+        PK.getBackendName().then(reply => {
+            this.setState({ backend: reply[0].v });
+        });
 
         // check if there is an upgrade in progress already; if so, switch to "applying" state right away
         PK.call("/org/freedesktop/PackageKit", "org.freedesktop.PackageKit", "GetTransactionList", [])
@@ -1119,6 +1124,9 @@ class OsUpdates extends React.Component {
                                 info = PK.Enum.INFO_NORMAL;
                             updates[packageId] = { name: id_fields[0], version: id_fields[1], severity: info, arch: id_fields[2] };
                             if (id_fields[0] == "cockpit-ws")
+                                cockpitUpdate = true;
+                            // Arch Linux has no cockpit-ws package
+                            if (id_fields[0] == "cockpit" && this.state.backend === "alpm")
                                 cockpitUpdate = true;
                         },
                     }))


### PR DESCRIPTION
On Arch Linux and derivates cockpit-ws is included in the cockpit
package which makes users miss out on the "Web Console restart" warning
message. As these distriubtions all use the "alpm" backend, the
component now on load fetches the configured backend (can only be one)
to determine which package to check. Using packagekit was chosen over
parsing /etc/os-release or checking if pacman is installed on the
system as we already interact with packagekit over Dbus.