### PR TITLE
login: Use × icon as input clear; show when needed

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -75,13 +75,13 @@ img {
 
 #option-group,
 .pf-c-button,
-.cross,
+.input-clear,
 button {
   cursor: pointer;
 }
 
 #option-group svg,
-.cross {
+.input-clear {
   opacity: .7;
 }
 
@@ -520,7 +520,7 @@ label.checkbox {
   text-decoration: underline;
 }
 
-.cross,
+.input-clear,
 .inline .container .help-block {
   color: #000;
 }
@@ -593,21 +593,32 @@ label.checkbox {
   transform-origin: 0.5rem;
 }
 
-.cross {
-  align-items: center;
-  bottom: 0;
+.input-clear {
   display: flex;
-  font-size: 1rem;
-  font-weight: 700;
-  justify-content: center;
+  padding: 0.5rem 0.75rem;
   position: absolute;
-  right: 2rem;
   top: 0;
-  width: 2rem;
+  right: 0;
+  bottom: 0;
+}
+
+.input-clear > svg {
+  height: 1rem;
+  width: auto;
+}
+
+/* Only show clear icon when the field has text */
+.form-control:placeholder-shown + .input-clear {
+  display: none;
+}
+
+/* Reserve a little space for the clear icon in the input */
+.server-box > .form-control {
+  padding-right: 2rem;
 }
 
 #option-group:hover svg,
-.cross:hover {
+.input-clear:hover {
   opacity: 1;
 }
 
@@ -771,10 +782,6 @@ a:hover {
 
 .caret polygon {
   fill: #06c;
-}
-
-.cross {
-  right: 0;
 }
 
 /* Mobile-specific */

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -102,8 +102,10 @@
         <div id="server-group" class="form-group" hidden>
           <label title="Log in to another system. Leave blank to log in to the local system." for="server-field" class="control-label" translate>Connect to</label>
           <div class="server-box">
-            <input type="text" class="form-control" id="server-field">
-            <span class="cross" id="server-clear" aria-hidden="true">&#x274c;</span>
+            <input type="text" class="form-control" id="server-field" placeholder="">
+            <span class="input-clear" id="server-clear" aria-hidden="true">
+              <svg fill="currentColor" viewBox="0 0 352 512"><path d="m242.72 256 100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.29 12.28-32.19 0-44.48z"/></svg>
+            </span>
           </div>
         </div>
 


### PR DESCRIPTION
This changes the red emoji &#x274c; to an actual SVG icon from PatternFly. It also only shows when there's something typed into the field, thanks to the (empty) placeholder attribute.

![Screenshot 2021-11-17 at 17-29-04 bolt](https://user-images.githubusercontent.com/10246/142241050-e469c740-0f50-4e77-bf3a-be39449817cc.png)
![Screenshot 2021-11-17 at 17-28-53 bolt](https://user-images.githubusercontent.com/10246/142241052-cfe5681b-7604-4878-a0a4-fafa17e8fde9.png)
