### PR TITLE
storaged: Create VDO devices as LVM LV type

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -844,6 +844,14 @@ export const Skip = (className, options) => {
     };
 };
 
+export const Message = (variant, title, options) => {
+    return {
+        options: options,
+
+        render: () => <Alert variant={variant} isInline title={title}>{options.text}</Alert>
+    };
+};
+
 function size_slider_round(value, round) {
     if (round) {
         if (typeof round == "function")

--- a/pkg/storaged/things-panel.jsx
+++ b/pkg/storaged/things-panel.jsx
@@ -24,7 +24,7 @@ import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import { SidePanel } from "./side-panel.jsx";
 import { create_mdraid, mdraid_rows } from "./mdraids-panel.jsx";
 import { create_vgroup, vgroup_rows } from "./vgroups-panel.jsx";
-import { vdo_feature, create_vdo, vdo_rows } from "./vdos-panel.jsx";
+import { vdo_rows } from "./vdos-panel.jsx";
 import { StorageBarMenu, StorageMenuItem } from "./storage-controls.jsx";
 import { stratis_feature, create_stratis_pool, stratis_rows } from "./stratis-panel.jsx";
 import { dialog_open } from "./dialog.jsx";
@@ -77,7 +77,6 @@ export class ThingsPanel extends React.Component {
             <StorageBarMenu id="devices-menu" label={_("Create devices")} menuItems={[
                 menu_item(null, _("Create RAID device"), () => create_mdraid(client)),
                 menu_item(lvm2_feature, _("Create LVM2 volume group"), () => create_vgroup(client)),
-                menu_item(vdo_feature(client), _("Create VDO device"), () => create_vdo(client)),
                 menu_item(stratis_feature(client), _("Create Stratis pool"), () => create_stratis_pool(client))].filter(item => item !== null)} />
         );
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -38,7 +38,7 @@ class TestStorageVDO(StorageCase):
 
         self.login_and_go("/storage")
 
-        # Make a logical volume for use as the backing device.
+        # Make a volume group in which to create the VDO LV
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda")
@@ -52,23 +52,27 @@ class TestStorageVDO(StorageCase):
         b._wait_present("[data-field='purpose'] select option[value='block']")
 
         if m.image not in SUPPORTED_OS:
-            # FIXME: This is looking into the future, the UI can't create LVM VDO volumes yet
             b.wait_not_present("[data-field='purpose'] select option[value='vdo']")
             return
 
-        # FIXME: use the dialog to create the VDO volume once it can; for now, do CLI call
-        self.dialog_cancel()
+        # create VDO LV with default options and default virtual size
+        self.dialog_set_val("name", "vdo0")
+        self.dialog_set_val("purpose", "vdo")
+        self.dialog_set_val("vdo_psize", 6 * 1024)
+        self.dialog_apply()
         self.dialog_wait_close()
-        m.execute("lvcreate --type vdo --size 6g --virtualsize 10g --name vdo0 vdo_vgroup")
+
+        # pool name gets auto-generated
+        pool_name = "vpool0"
 
         self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo0")
         # the pool does not appear as a top-level volume
-        b.wait_not_in_text("#detail-content", "vpool0")
+        b.wait_not_in_text("#detail-content", pool_name)
         # Volume tab
         self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
-        self.content_tab_wait_in_info(1, 1, "Size", "10 GiB")
+        self.content_tab_wait_in_info(1, 1, "Size", "10 GiB", "10.0 GiB")
         # VDO Pool tab
-        self.content_tab_wait_in_info(1, 2, "Name", "vpool0")
+        self.content_tab_wait_in_info(1, 2, "Name", pool_name)
         self.content_tab_wait_in_info(1, 2, "Size", "6 GiB")
         # initial physical usage is 4 GiB, overhead for the deduplication index
         self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
@@ -102,17 +106,17 @@ class TestStorageVDO(StorageCase):
         # change compression/deduplication
         b.click("input[aria-label='Use compression']")
         b.wait_visible("input[aria-label='Use compression']:not(checked):not([disabled])")
-        wait_prop("vpool0", "vdo_compression_state", "offline")
+        wait_prop(pool_name, "vdo_compression_state", "offline")
         b.click("input[aria-label='Use compression']")
         b.wait_visible("input[aria-label='Use compression']:checked:not([disabled])")
-        wait_prop("vpool0", "vdo_compression_state", "online")
+        wait_prop(pool_name, "vdo_compression_state", "online")
 
         b.click("input[aria-label='Use deduplication']")
         b.wait_visible("input[aria-label='Use deduplication']:not(checked):not([disabled])")
-        wait_prop("vpool0", "vdo_index_state", "offline")
+        wait_prop(pool_name, "vdo_index_state", "offline")
         b.click("input[aria-label='Use deduplication']")
         b.wait_visible("input[aria-label='Use deduplication']:checked:not([disabled])")
-        wait_prop("vpool0", "vdo_index_state", "online")
+        wait_prop(pool_name, "vdo_index_state", "online")
 
         # grow volume
         self.content_tab_action(1, 1, "Grow")
@@ -124,13 +128,49 @@ class TestStorageVDO(StorageCase):
         self.content_tab_action(1, 2, "Grow")
         self.dialog({"size": 8 * 1024})
         self.content_tab_wait_in_info(1, 2, "Size", "8 GiB")
-        wait_prop("vpool0", "lv_size", "8.00g")
+        wait_prop(pool_name, "lv_size", "8.00g")
 
         # deleting the vdo0 volume deletes the pool as well
         self.content_dropdown_action(1, "Delete")
         self.confirm()
         b.wait_in_text("#detail-content", "No logical volumes")
         self.assertEqual(m.execute("lvs --noheadings").strip(), "")
+
+        # create VDO LV with customized options
+        b.click("button:contains(Create new logical volume)")
+        self.dialog_wait_open()
+        b._wait_present("[data-field='purpose'] select option[value='block']")
+        self.dialog_set_val("name", "vdo0")
+        self.dialog_set_val("purpose", "vdo")
+        self.dialog_set_val("vdo_psize", 6 * 1024)
+        # grossly overcommitted
+        self.dialog_set_val("vdo_lsize", 20 * 1024)
+        self.dialog_set_val("vdo_options.compression", False)
+        self.dialog_apply()
+        self.dialog_wait_close()
+
+        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo0")
+        # Volume tab
+        self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
+        self.content_tab_wait_in_info(1, 1, "Size", "20 GiB")
+        # VDO Pool tab
+        self.content_tab_wait_in_info(1, 2, "Size", "6 GiB")
+        b.wait_visible("input[aria-label='Use compression']:not(:checked)")
+        b.wait_visible("input[aria-label='Use deduplication']:checked")
+        wait_prop(pool_name, "vdo_compression_state", "offline")
+        wait_prop(pool_name, "vdo_index_state", "online")
+
+        # delete again
+        self.content_dropdown_action(1, "Delete")
+        self.confirm()
+        b.wait_in_text("#detail-content", "No logical volumes")
+        self.assertEqual(m.execute("lvs --noheadings").strip(), "")
+
+        # react to CLI
+        m.execute("lvcreate --type vdo --size 6g --virtualsize 10g --name vdo1 --yes vdo_vgroup")
+        self.content_row_wait_in_col(1, 2, "/dev/vdo_vgroup/vdo1")
+        m.execute("lvremove --yes /dev/vdo_vgroup/vdo1")
+        b.wait_in_text("#detail-content", "No logical volumes")
 
 
 @skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
@@ -143,8 +183,6 @@ class TestStorageLegacyVDO(StorageCase):
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
-            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")
@@ -153,19 +191,8 @@ class TestStorageLegacyVDO(StorageCase):
         m.add_disk("10G", serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
-        # wait until UI knows about lvol
-        b.click("#devices .sidepanel-row:contains(vdo_vgroup)")
-        b.wait_in_text("#storage-detail", "/dev/vdo_vgroup/lvol")
-        b.go("#/")
-
-        # Create VDO
-
-        self.devices_dropdown("Create VDO device")
-        self.dialog_wait_open()
-        self.dialog_wait_val("name", "vdo0")
-        self.dialog_set_val("space", {"/dev/vdo_vgroup/lvol": True})
-        self.dialog_apply()
-        self.dialog_wait_close()
+        # Create VDO; this is not supported any more, thus no UI for it
+        m.execute("vdo create --device /dev/vdo_vgroup/lvol --name vdo0 --vdoLogicalSize 5G")
 
         b.wait_in_text("#devices", "vdo0")
         b.click("#devices .sidepanel-row:contains(vdo0)")
@@ -236,8 +263,6 @@ class TestStorageLegacyVDO(StorageCase):
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
-            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")
@@ -293,8 +318,6 @@ config: !Configuration
         self.login_and_go("/storage")
 
         if m.image not in SUPPORTED_OS:
-            b.click("#devices .pf-c-dropdown button.pf-c-dropdown__toggle")
-            b.wait_not_present("#devices .pf-c-dropdown a:contains('VDO')")
             return
 
         b.wait_visible("#devices")
@@ -393,19 +416,42 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
 
         m.execute("pkcon remove -y vdo")
 
-        self.createPackage("vdo", "999", "1")
+        # do *not* create vdo package yet
+        self.createPackage("kmod-kvdo", "999", "1")
         self.enableRepo()
         m.execute("pkcon refresh")
 
         self.login_and_go("/storage")
+        m.add_disk("10G", serial="DISK1")
+        b.wait_in_text("#drives", "DISK1")
+        m.execute("vgcreate vdo_vgroup /dev/sda")
+        b.wait_in_text("#devices", "vdo_vgroup")
 
-        self.devices_dropdown("Create VDO device")
+        b.click('.sidepanel-row:contains("vdo_vgroup")')
+        b.click("button:contains(Create new logical volume)")
         self.dialog_wait_open()
-        b.wait_in_text("#dialog", "The vdo package must be installed")
-        b.wait_in_text("#dialog", "Total size:")
+        b._wait_present("[data-field='purpose'] select option[value='block']")
+        # no package installation (or any other) alert
+        self.assertFalse(b.is_present("#dialog .pf-c-alert"))
+        self.dialog_set_val("purpose", "vdo")
+        # shows the package installation note
+        b.wait_in_text("#dialog .pf-c-alert.pf-m-info", "vdo package will be installed")
+
+        # vdo package does not exist
         self.dialog_apply()
-        # A new dialog opens immediately
-        b.wait_in_text("#dialog", "Create VDO device")
+        b.wait_in_text("#dialog .pf-c-alert.pf-m-danger", "vdo is not available from any repository")
+
+        self.createPackage("vdo", "999", "1")
+        self.enableRepo()
+
+        self.dialog_apply()
+        # gets over package installation now, but it's a mock package
+        b.wait_in_text("#dialog .pf-c-alert.pf-m-danger", "vdoformat")
+        b.wait_in_text("#dialog .pf-c-alert.pf-m-danger", "No such file or directory")
+        # but it got past package installation
+        self.assertIn("999", m.execute("rpm -q vdo"))
+
+        self.dialog_cancel()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is the officially documented and supported API [1], both on the
command line and in UDisks. Add them as a new type to the "Create
logical volume" dialog and drop the standalone one from the things
panel.

Drop the "Use 512 byte emulation", this is not a thing with LVM VDO.

Also drop the "index memory" slider. This is a bit dubious, not even
exposed by `lvcreate` or the documentation, and can only be done via
changing the config file. The UDisks2 D-Bus API does support setting it,
but this is probably not something that the admin should customize
lightly (and if so, they can still set it in the config file). Also,
neither `lvdisplay` nor UDisks2 have an API to get the current value.

The pool name is rather uninteresting -- in fact, lvcreate does not even
need it. udisks2 does not currently support automatic name creation
(https://github.com/storaged-project/udisks/issues/939), so do the same
thing as lvcreate and use the next available `vpoolN`.

Rework the on-demand package installation: As it is only necessary when
selecting "vdo" in the "create LV" dialog, it can't happen before
opening the dialog. Also, we don't want (or even can) have the standard
install dialog on top of the create dialog; instead, just show an info
alert that the vdo package is going to be installed, and build the
progress and installation into the "Create" button. The vdo+kmod-kvdo
packages are small enough that this won't take an inordinate amount of
time anyway. We also don't expect any package removals there, so abort
if they would happen.

Adjust the tests to use the new dialog to create the VDO. But also
validate that the API properly reacts to CLI creation/removal.

[1] https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/deduplicating_and_compressing_logical_volumes_on_rhel/creating-a-deduplicated-and-compressed-logical-volume_deduplicating-and-compressing-logical-volumes


----

New choice in the dialog if `vdo` package is installed:

![vdo-create](https://user-images.githubusercontent.com/200109/142415866-997c21e2-b9b9-4435-bd67-a8c5c1b99f91.png)

If it is not installed, but available, you get an info alert, and the progress status. The "Cancel" link works until packagekit is into installing the package. I tested that manually.

![vdo-create-installing](https://user-images.githubusercontent.com/200109/142415967-89c03513-25b7-47c9-b842-57658210268a.png)

The whole process takes just a few seconds even with the real vdo package (not just our test suite mock), so I think that's okay with just the spinner.