### PR TITLE
ws: only spawn cockpit-session on known auth types

### DIFF
--- a/src/common/cockpitconf.c
+++ b/src/common/cockpitconf.c
@@ -327,7 +327,7 @@ cockpit_conf_bool (const char *section,
   return defawlt;
 }
 
-const char **
+const char * const *
 cockpit_conf_strv (const char *section,
                    const char *field,
                    char delimiter)

--- a/src/common/cockpitconf.h
+++ b/src/common/cockpitconf.h
@@ -29,7 +29,8 @@ const char *   cockpit_conf_string           (const char *section,
                                               const char *field);
 
 
-const char **  cockpit_conf_strv             (const char *section,
+const char * const *
+               cockpit_conf_strv             (const char *section,
                                               const char *field,
                                               char delimiter);
 

--- a/src/common/test-config.c
+++ b/src/common/test-config.c
@@ -86,7 +86,7 @@ test_get_uint (void)
 static void
 test_get_strvs (void)
 {
-  const gchar **list = NULL;
+  const gchar * const *list = NULL;
 
   cockpit_config_file = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf";
 

--- a/src/websocket/websocketserver.c
+++ b/src/websocket/websocketserver.c
@@ -476,8 +476,8 @@ web_socket_server_class_init (WebSocketServerClass *klass)
  */
 WebSocketConnection *
 web_socket_server_new_for_stream (const gchar *url,
-                                  const gchar **origins,
-                                  const gchar **protocols,
+                                  const gchar * const *origins,
+                                  const gchar * const *protocols,
                                   GIOStream *io_stream,
                                   GHashTable *request_headers,
                                   GByteArray *input_buffer)

--- a/src/websocket/websocketserver.h
+++ b/src/websocket/websocketserver.h
@@ -35,8 +35,8 @@ G_BEGIN_DECLS
 GType                 web_socket_server_get_type           (void) G_GNUC_CONST;
 
 WebSocketConnection * web_socket_server_new_for_stream     (const gchar *url,
-                                                            const gchar **origins,
-                                                            const gchar **protocols,
+                                                            const gchar * const *origins,
+                                                            const gchar * const *protocols,
                                                             GIOStream *io_stream,
                                                             GHashTable *request_headers,
                                                             GByteArray *input_buffer);

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -1306,7 +1306,7 @@ cockpit_web_service_create_socket (const gchar **protocols,
   WebSocketConnection *connection;
   const gchar *host = NULL;
   const gchar *protocol = NULL;
-  const gchar **origins;
+  const gchar * const *origins;
   gchar *allocated = NULL;
   gchar *origin = NULL;
   gchar *defaults[2];

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -232,7 +232,7 @@ test_login_bad (Test *test,
   g_hash_table_unref (headers);
 
   g_assert (ret == TRUE);
-  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Authentication failed\r\n*");
+  cockpit_assert_strmatch (output_as_string (test), "HTTP/1.1 401 Authentication disabled\r\n*");
 }
 
 static void


### PR DESCRIPTION
If we receive requests for exotic authentication types from the client like:
         
``` 
Authorization: Random xyz
```
    
and those types are not explicitly disabled in cockpit.conf with a stanza like:
                                                                      
```             
[Random]
action = none
```
   
then by default we'll try to spawn cockpit-session to respond to them.

This doesn't make a lot of sense, as cockpit-session doesn't support any types other than "basic", "negotiate" and "tls-cert" (which is only ever used internally, and already blocked when received from clients).                                                 
                                                                           
Modify the check to only spawn cockpit-session for the recognised types.  In case another type is specified, then the command to handle that type needs to be explicitly specified:
                                                                            
```                                                                        
[Random]                             
command = /path/to/my/handler
```
   
as we already have for several cases in the unit tests.
