### PR TITLE
tools: Fix SELinux module installation in non-SELinux environments

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -521,7 +521,7 @@ fi
 
 %post ws
 %if 0%{?with_selinux}
-if %{_sbindir}/selinuxenabled 2>/dev/null; then
+if [ -x %{_sbindir}/selinuxenabled ]; then
     %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
     %selinux_relabel_post -s %{selinuxtype}
 fi
@@ -552,7 +552,7 @@ fi
 
 %postun ws
 %if 0%{?with_selinux}
-if %{_sbindir}/selinuxenabled 2>/dev/null; then
+if [ -x %{_sbindir}/selinuxenabled ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{name}
     %selinux_relabel_post -s %{selinuxtype}
 fi


### PR DESCRIPTION
`%selinux_modules_{,un}install` works fine in environments like guestfs,
which don't run with SELinux enabled. Adjust the condition so that
module installation happens there as well. The relabeling still won't
work there, but that has its own guard with calling `selinuxenabled`.

https://bugzilla.redhat.com/show_bug.cgi?id=2023579