### PR TITLE
ws: add option to report cockpit-ssh stderr

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -108,6 +108,23 @@
         hideToggle(arguments, true);
     }
 
+    function show_captured_stderr(msg) {
+        if (window.console)
+            console.warn("stderr:", msg);
+
+        hide("#login-wait-validating");
+
+        hide("#login", "#login-details");
+        show("#login-fatal");
+
+        id("login-again").onclick = () => { hide('#login-fatal'); show_login() };
+        show("#login-again");
+
+        const el = id("login-fatal-message");
+        el.textContent = "";
+        el.appendChild(document.createTextNode(msg));
+    }
+
     function fatal(msg) {
         if (window.console)
             console.warn("fatal:", msg);
@@ -785,7 +802,9 @@
                 } else {
                     if (window.console)
                         console.log(xhr.statusText);
-                    if (xhr.statusText.indexOf("authentication-not-supported") > -1) {
+                    if (xhr.statusText.startsWith("captured-stderr:")) {
+                        show_captured_stderr(decodeURIComponent(xhr.statusText.replace(/^captured-stderr:/, '')));
+                    } else if (xhr.statusText.indexOf("authentication-not-supported") > -1) {
                         const user = trim(id("login-user-input").value);
                         fatal(format(_("The server refused to authenticate '$0' using password authentication, and no other supported authentication methods are available."), user));
                     } else if (xhr.statusText.indexOf("terminated") > -1) {

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -525,7 +525,8 @@ session_child_setup (gpointer data)
 
 static CockpitTransport *
 session_start_process (const gchar **argv,
-                       const gchar **env)
+                       const gchar **env,
+                       gboolean capture_stderr)
 {
   CockpitTransport *transport = NULL;
   CockpitPipe *pipe = NULL;
@@ -544,11 +545,12 @@ session_start_process (const gchar **argv,
       return NULL;
     }
 
+  int stderr_fd = -1;
   child.io = fds[0];
   ret = g_spawn_async_with_pipes (NULL, (gchar **)argv, (gchar **)env,
                                   G_SPAWN_DO_NOT_REAP_CHILD | G_SPAWN_LEAVE_DESCRIPTORS_OPEN,
                                   session_child_setup, &child,
-                                  &pid, NULL, NULL, NULL, &error);
+                                  &pid, NULL, NULL, capture_stderr ? &stderr_fd : NULL, &error);
 
   close (fds[0]);
 
@@ -563,6 +565,7 @@ session_start_process (const gchar **argv,
   pipe = g_object_new (COCKPIT_TYPE_PIPE,
                        "in-fd", fds[1],
                        "out-fd", fds[1],
+                       "err-fd", stderr_fd,
                        "pid", pid,
                        "name", argv[0],
                        NULL);
@@ -892,13 +895,20 @@ on_transport_closed (CockpitTransport *transport,
   else if (!session->initialized)
     {
       pipe = cockpit_pipe_transport_get_pipe (COCKPIT_PIPE_TRANSPORT (transport));
+      g_autofree gchar *captured_error = cockpit_pipe_take_stderr_as_utf8 (pipe);
+
       if (cockpit_pipe_get_pid (pipe, NULL))
         status = cockpit_pipe_exit_status (pipe);
       g_debug ("%s: authentication process exited: %d; problem %s", session->name, status, problem);
 
+      if (captured_error)
+        {
+          g_set_error (&error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED,
+                       "captured-stderr:%s", captured_error);
+        }
       /* we get "access-denied" both if cockpit-session cannot execute cockpit-bridge (common case)
        * and if cockpit-session itself is not executable (corner case, messed up install) */
-      if (problem && (!session->authorize || g_strcmp0 (problem, "access-denied") != 0))
+      else if (problem && (!session->authorize || g_strcmp0 (problem, "access-denied") != 0))
         {
           g_set_error (&error, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,
                        g_strcmp0 (problem, "no-cockpit") == 0
@@ -1105,6 +1115,7 @@ cockpit_session_launch (CockpitAuth *self,
   CockpitTransport *transport = NULL;
   CockpitSession *session = NULL;
   CockpitCreds *creds = NULL;
+  gboolean capture_stderr = FALSE;
 
   const gchar *host;
   const gchar *action;
@@ -1147,6 +1158,7 @@ cockpit_session_launch (CockpitAuth *self,
       if (!host)
         host = type_option (COCKPIT_CONF_SSH_SECTION, "host", "127.0.0.1");
 
+      capture_stderr = cockpit_conf_bool (COCKPIT_CONF_SSH_SECTION, "reportstderr", FALSE);
       program_default = cockpit_ws_ssh_program;
     }
   else
@@ -1172,7 +1184,7 @@ cockpit_session_launch (CockpitAuth *self,
   argv[0] = command;
   argv[1] = host ? host : "localhost";
 
-  transport = session_start_process (argv, (const gchar **)env);
+  transport = session_start_process (argv, (const gchar **)env, capture_stderr);
   if (!transport)
     {
       g_set_error (error, COCKPIT_ERROR, COCKPIT_ERROR_FAILED,


### PR DESCRIPTION
Add a "ReportStderr" option to the [Ssh-Login] session which sends the
stderr output from cockpit-ssh to the client as part of the error
message.

This is only intended for use with the Cockpit Client flatpak.  Sending
logging information to random remote users might be a security problem.

On the login page we reuse the fatal error message and the "Try again"
link.