### PR TITLE
static: re-enable autologin if hostname was given

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -350,7 +350,7 @@
             }
         } else if (logout_intent) {
             show_login(logout_reason);
-        } else if (environment.page.require_host) {
+        } else if (need_host()) {
             show_login();
         } else {
             standard_auto_login();


### PR DESCRIPTION
We suppress auto-login in the case that a hostname is required, but we
don't consider that one may already have been pre-filled.

Use the need_host() function to take both into account.