### PR TITLE
static: show login form onpageshow

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -301,8 +301,6 @@
     }
 
     function boot() {
-        window.onload = null;
-
         translate();
         if (window.cockpit_po && window.cockpit_po[""])
             document.documentElement.lang = window.cockpit_po[""].language || "en-us";
@@ -348,7 +346,9 @@
         const os_release = environment["os-release"];
         if (os_release)
             localStorage.setItem('os-release', JSON.stringify(os_release));
+    }
 
+    function page_show() {
         const logout_intent = window.sessionStorage.getItem("logout-intent") == "explicit";
         if (logout_intent)
             window.sessionStorage.removeItem("logout-intent");
@@ -937,5 +937,6 @@
         login_reload(wanted);
     }
 
+    window.onpageshow = page_show;
     window.onload = boot;
 })(window.console);


### PR DESCRIPTION
Currently, the login form is shown from the onload event, from a
function which immediately removes itself from running again.

This means that when we navigate backwards to the login page, we'll find
it in exactly the state we left it: with the spinner active and all
controls effectively dead.

Move the code for showing the login page to the pageshow event.