### PR TITLE
cockpit-client: fix assertion in cockpit-client-ssh

### DIFF
--- a/src/client/cockpit-client-ssh
+++ b/src/client/cockpit-client-ssh
@@ -31,7 +31,7 @@ def do_authorize(challenge='*', **kwargs):
     cookie = str(uuid.uuid4())
     send_control(command='authorize', challenge=challenge, cookie=cookie, **kwargs)
     response = recv_control()
-    assert response.cookie == cookie
+    assert response['cookie'] == cookie
     logging.debug(response)
     if 'response' not in response:
         raise ValueError('invalid authorize response')


### PR DESCRIPTION
When run in askpass mode, we attempt to access the cookie in the
response from cockpit-ws by way of response.cookie instead of the
(correct) syntax of response['cookie'].  Fix that.