### PR TITLE
cockpit-client: disable and hide forward/back

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -66,8 +66,8 @@ class CockpitClientWindow(Gtk.ApplicationWindow):
         self.webview.connect('decide-policy', self.decide_policy)
         self.webview.load_uri(uri)
 
-        history = self.webview.get_back_forward_list()
-        history.connect('changed', self.history_changed)
+        # history = self.webview.get_back_forward_list()
+        # history.connect('changed', self.history_changed)
         self.history_changed()
 
         if app.no_ui:

--- a/src/client/cockpit-client.ui
+++ b/src/client/cockpit-client.ui
@@ -28,7 +28,7 @@
         <property name="show-close-button">True</property>
         <child>
           <object class="GtkButtonBox">
-            <property name="visible">True</property>
+            <property name="visible">False</property>
             <property name="can-focus">False</property>
             <property name="homogeneous">True</property>
             <property name="layout-style">expand</property>


### PR DESCRIPTION
This is pretty seriously broken right now, particularly when navigating
back to the login screen.  Let's disable it until this works better.