### PR TITLE
storaged: Change VDO package installation alert to a helper text

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -837,7 +837,7 @@ export class VGroup extends React.Component {
                                   value: "block",
                                   choices: purposes
                               }),
-                    Message("info", cockpit.format(_("The $0 package will be installed to create VDO devices."), vdo_package),
+                    Message(cockpit.format(_("The $0 package will be installed to create VDO devices."), vdo_package),
                             {
                                 visible: vals => vals.purpose === 'vdo' && need_vdo_install,
                             }),

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -233,7 +233,7 @@ import {
     Popover,
     HelperText, HelperTextItem
 } from "@patternfly/react-core";
-import { ExclamationTriangleIcon, HelpIcon } from "@patternfly/react-icons";
+import { ExclamationTriangleIcon, InfoIcon, HelpIcon } from "@patternfly/react-icons";
 
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 
@@ -844,11 +844,11 @@ export const Skip = (className, options) => {
     };
 };
 
-export const Message = (variant, title, options) => {
+export const Message = (text, options) => {
     return {
         options: options,
 
-        render: () => <Alert variant={variant} isInline title={title}>{options.text}</Alert>
+        render: () => <HelperText><HelperTextItem icon={<InfoIcon />}>{text}</HelperTextItem></HelperText>,
     };
 };
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -431,11 +431,11 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
         b.click("button:contains(Create new logical volume)")
         self.dialog_wait_open()
         b._wait_present("[data-field='purpose'] select option[value='block']")
-        # no package installation (or any other) alert
-        self.assertFalse(b.is_present("#dialog .pf-c-alert"))
+        # no package installation helper text
+        self.assertFalse(b.is_present("#dialog .pf-c-helper-text"))
         self.dialog_set_val("purpose", "vdo")
         # shows the package installation note
-        b.wait_in_text("#dialog .pf-c-alert.pf-m-info", "vdo package will be installed")
+        b.wait_in_text("#dialog .pf-c-helper-text", "vdo package will be installed")
 
         # vdo package does not exist
         self.dialog_apply()


### PR DESCRIPTION
Leftover from https://github.com/cockpit-project/cockpit/pull/16623#issuecomment-976407637

Looks like this now:

![shot](https://user-images.githubusercontent.com/200109/143453507-163a0259-9c10-456e-b023-6f1a41831afc.png)

