### PR TITLE
flatpak: add screenshots to cockpit-client metainfo

### DIFF
--- a/containers/flatpak/cockpit-client.metainfo.xml.in
+++ b/containers/flatpak/cockpit-client.metainfo.xml.in
@@ -18,6 +18,21 @@
     </p>
   </description>
 
+  <screenshots>
+    <screenshot>
+      <caption>Cockpit Client login screen</caption>
+      <image>https://cockpit-project.org/images/flatpak/flatpak-screenshot-login.png</image>
+    </screenshot>
+    <screenshot type="default">
+      <caption>Cockpit overview</caption>
+      <image>https://cockpit-project.org/images/flatpak/flatpak-screenshot-overview.png</image>
+    </screenshot>
+    <screenshot>
+      <caption>Cockpit terminal</caption>
+      <image>https://cockpit-project.org/images/flatpak/flatpak-screenshot-terminal.png</image>
+    </screenshot>
+  </screenshots>
+
   <releases>
     <release date="@TODAY@" version="@VERSION@" type="@RELEASE_TYPE@"/>
 @PREVIOUS_RELEASES@  </releases>


### PR DESCRIPTION
These are required for flathub.