### PR TITLE
webpack-jumpstart: look past merge commit for --rebase

### DIFF
--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -49,7 +49,14 @@ if ! git diff --quiet -- ':^test' ':^packit.yaml' ':^.github'; then
     exit 1
 fi
 
-tag="sha-$(git rev-parse HEAD)"
+# If we are rebasing and the HEAD commit is a merge, use the merged
+# commit ID to find the cached data, instead of the merge itself.
+if test -n "${rebase}" && git rev-parse --verify HEAD^2 >/dev/null; then
+    tag="sha-$(git rev-parse HEAD^2)"
+else
+    tag="sha-$(git rev-parse HEAD)"
+fi
+
 for try in $(seq 50 -1 0); do
     if fetch_to_cache tag "${tag}"; then
         break


### PR DESCRIPTION
If we are rebasing and the HEAD commit is a merge, use the merged commit
ID to find the cached data, instead of the merge itself.  The subsequent
rebase will result in the merge commit itself being removed.
