### PR TITLE
selinux: fix onSelect callback for selinux page

### DIFF
--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -309,7 +309,7 @@ export class SETroubleshootPage extends React.Component {
 
     onSelect(_, isSelected, rowId) {
         const selected = Object.assign(this.state.selected);
-        selected[this.props.entries[rowId / 2].key] = isSelected;
+        selected[this.props.entries[rowId].key] = isSelected;
         this.setState({ selected });
     }
 


### PR DESCRIPTION
Commit 5108999badee3834fcc8e57222b5f9c82feae3a9 changed the
implementation of the ListingTable component and now the children rows
are not counting as extra rows, so the division by 2 is not needed.

Fixes #16640