### PR TITLE
tools: unset git envvars in git-utils.sh

### DIFF
--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -7,6 +7,9 @@
 [ -n "${GITHUB_REPO}" ]
 [ -n "${SUBDIR}" ]
 
+# Set by git-rebase for spawned actions
+unset GIT_DIR GIT_EXEC_PATH GIT_PREFIX GIT_REFLOG_ACTION GIT_WORK_TREE
+
 GITHUB_BASE="${GITHUB_BASE:-cockpit-project/cockpit}"
 GITHUB_REPOSITORY="${GITHUB_BASE%/*}/${GITHUB_REPO}"
 HTTPS_REMOTE="https://github.com/${GITHUB_REPOSITORY}"


### PR DESCRIPTION
It would be nice to be able to jumpstart from a known point in the git
history by doing an interactive rebase and adding

```
x tools/webpack-jumpstart
```

at the desired point.  Up until now that has been broken by git-rebase
setting a bunch of environment variables in the spawned command.  This
interferes with our use of git to work on the cache repository.

Unset those variables to fix the issue.