### PR TITLE
workflows: use merge instead of head for flatpak test

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           # need this to also fetch tags
           fetch-depth: 0
 


### PR DESCRIPTION
flatpak-test.yml checks out the head commit instead of the merge commit.
That was done to dodge a bug in webpack-jumpstart which caused it to
fail on merge commits.  That's been fixed, meanwhile, and we're also not
using jumpstart anymore anyway, and now this workaround is causing new
issues, like the failure in #16624.

TL;DR: let's just use the default and checkout the merge commit, since
that's what we're supposed to be testing anyway.