### PR TITLE
flatpak: tweak our manifest to match downstream

### DIFF
--- a/containers/flatpak/cockpit-client.yml.in
+++ b/containers/flatpak/cockpit-client.yml.in
@@ -6,6 +6,12 @@ default-branch: @FLATPAK_BRANCH@
 command: cockpit-client
 rename-desktop-file: cockpit-client.desktop
 rename-icon: cockpit-client
+finish-args:
+  - --talk-name=org.freedesktop.Flatpak
+  - --socket=wayland
+  - --socket=fallback-x11
+  - --device=dri
+  - --share=ipc
 modules:
   - name: cockpit-client
     buildsystem: autotools
@@ -31,8 +37,3 @@ modules:
 
       - type: file
         path: @FLATPAK_ID@.metainfo.xml
-finish-args:
-  - --talk-name=org.freedesktop.Flatpak
-  - --socket=wayland
-  - --socket=fallback-x11
-  - --device=dri


### PR DESCRIPTION
When proposing cockpit-client to flathub, we received some review
comments requesting some minor tweaks to the manifest.  Merge those back
upstream so that they're not undone again during the next release.

--share=ipc was added because X11 apparently requires it.

See https://github.com/flathub/flathub/pull/2655