### PR TITLE
lib: remove listingActions property from ListingPanel component

### DIFF
--- a/pkg/lib/cockpit-components-listing-panel.jsx
+++ b/pkg/lib/cockpit-components-listing-panel.jsx
@@ -26,7 +26,6 @@ import './cockpit-components-listing-panel.scss';
  *     - name tab name (has to be unique in the entry, used as react key)
  *     - renderer react component
  *     - data render data passed to the tab renderer
- * listingActions optional: buttons that are presented as actions for the expanded item
  */
 export class ListingPanel extends React.Component {
     constructor(props) {
@@ -56,9 +55,8 @@ export class ListingPanel extends React.Component {
 
         return (
             <div className="ct-listing-panel">
-                {(listingDetail || this.props.listingActions) && <div className="ct-listing-panel-actions pf-c-tabs">
+                {listingDetail && <div className="ct-listing-panel-actions pf-c-tabs">
                     {listingDetail}
-                    {this.props.listingActions}
                 </div>}
                 {this.props.tabRenderers.length && <Tabs activeKey={this.state.activeTab} className="ct-listing-panel-tabs" mountOnEnter onSelect={this.handleTabClick}>
                     {this.props.tabRenderers.map((itm, tabIdx) => {
@@ -85,6 +83,5 @@ ListingPanel.defaultProps = {
 ListingPanel.propTypes = {
     tabRenderers: PropTypes.array,
     listingDetail: PropTypes.node,
-    listingActions: PropTypes.node,
     initiallyActiveTab: PropTypes.number,
 };


### PR DESCRIPTION
This was serving a design that cockpit was using heavily till now, and
namely the actions of table rows being placed next to the expanded row tabs selector.

However, the suggested design from patternfly is to put actions behind a
kebab in table rows.

So, let's remove this option, so that we don't promote it's future usage.

Note: Last consumer is cockpit-machines and I am working on the porting right now. 