### PR TITLE
bridge: remove "ssh-agent" internal address

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -773,7 +773,6 @@ this payload type:
    file path and arguments.
  * "internal": Open an internally defined stream.
    * "packages": A http-stream for serving package resources to cockpit-ws
-   * "ssh-agent": A connection to the session user's ssh-agent, if one is available.
 
 You can't specify both "unix" and "spawn" together. When "spawn" is set the
 following options can be specified:

--- a/src/bridge/cockpitconnect.c
+++ b/src/bridge/cockpitconnect.c
@@ -201,33 +201,14 @@ static gboolean
 lookup_internal (const gchar *name,
                  GSocketConnectable **connectable)
 {
-  const gchar *env;
-  gboolean ret = FALSE;
-  GSocketAddress *address;
-
   g_assert (name != NULL);
   g_assert (connectable != NULL);
 
-  if (internal_addresses)
-    {
-      ret = g_hash_table_lookup_extended (internal_addresses, name, NULL,
-                                          (gpointer *)connectable);
-    }
+  if (!internal_addresses)
+    return FALSE;
 
-  if (!ret && g_str_equal (name, "ssh-agent"))
-    {
-      *connectable = NULL;
-      env = g_getenv ("SSH_AUTH_SOCK");
-      if (env != NULL && env[0] != '\0')
-        {
-          address = g_unix_socket_address_new (env);
-          *connectable = G_SOCKET_CONNECTABLE (address);
-          cockpit_connect_add_internal_address ("ssh-agent", address);
-        }
-      ret = TRUE;
-    }
-
-  return ret;
+  return g_hash_table_lookup_extended (internal_addresses, name,
+                                       NULL, (gpointer *) connectable);
 }
 
 void


### PR DESCRIPTION
This used to be used when cockpit-ws originated ssh connections to other
hosts on behalf of the session, but that hasn't happened since
082da24a5a2a27d521e7b6d1beb2bbe094ffdc54.  Nowhere else in the code
refers to this anymore, so let's drop it.