### PR TITLE
clean up "internal" endpoints

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -771,8 +771,6 @@ this payload type:
  * "spawn": Spawn a process and connect standard input and standard output
    to the channel. Should be an array of strings which is the process
    file path and arguments.
- * "internal": Open an internally defined stream.
-   * none of these are currently defined
 
 You can't specify both "unix" and "spawn" together. When "spawn" is set the
 following options can be specified:

--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -772,7 +772,7 @@ this payload type:
    to the channel. Should be an array of strings which is the process
    file path and arguments.
  * "internal": Open an internally defined stream.
-   * "packages": A http-stream for serving package resources to cockpit-ws
+   * none of these are currently defined
 
 You can't specify both "unix" and "spawn" together. When "spawn" is set the
 following options can be specified:

--- a/src/bridge/cockpitconnect.h
+++ b/src/bridge/cockpitconnect.h
@@ -44,6 +44,7 @@ typedef struct {
 CockpitConnectable *    cockpit_connectable_ref    (CockpitConnectable *connectable);
 
 void                    cockpit_connectable_unref  (gpointer data);
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CockpitConnectable, cockpit_connectable_unref)
 
 void                    cockpit_connect_stream        (GSocketConnectable *address,
                                                        GCancellable *cancellable,

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -1214,12 +1214,7 @@ cockpit_packages_new (void)
 
   packages = g_new0 (CockpitPackages, 1);
 
-  packages->web_server = cockpit_web_server_new (NULL, -1, NULL, COCKPIT_WEB_SERVER_NONE, NULL, &error);
-  if (!packages->web_server)
-    {
-      g_warning ("couldn't initialize bridge package server: %s", error->message);
-      goto out;
-    }
+  packages->web_server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
 
   if (!cockpit_web_server_add_socket (packages->web_server, socket, &error))
     {

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -45,8 +45,6 @@
 /* Overridable from tests */
 const gchar **cockpit_bridge_data_dirs = NULL; /* default */
 
-gint cockpit_bridge_packages_port = 0;
-
 static CockpitPackages *packages_singleton = NULL;
 
 /* Packages might change while the bridge is running, and we support
@@ -1220,18 +1218,6 @@ cockpit_packages_new (void)
 
   packages->web_server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
 
-  if (!cockpit_web_server_add_socket (packages->web_server, socket, &error))
-    {
-      g_warning ("couldn't add socket to package server: %s", error->message);
-      goto out;
-    }
-
-  cockpit_bridge_packages_port = (gint)g_inet_socket_address_get_port (G_INET_SOCKET_ADDRESS (address));
-  cockpit_connect_add_internal_address ("packages", address);
-
-  g_debug ("package server port: %d", cockpit_bridge_packages_port);
-
-
   g_signal_connect (packages->web_server, "handle-resource::/checksum",
                     G_CALLBACK (handle_package_checksum), packages);
   g_signal_connect (packages->web_server, "handle-resource::/manifests.js",
@@ -1240,8 +1226,6 @@ cockpit_packages_new (void)
                     G_CALLBACK (handle_package_manifests_json), packages);
   g_signal_connect (packages->web_server, "handle-resource",
                     G_CALLBACK (handle_packages), packages);
-
-  cockpit_web_server_start (packages->web_server);
 
   build_packages (packages);
   ret = TRUE;

--- a/src/bridge/cockpitpackages.h
+++ b/src/bridge/cockpitpackages.h
@@ -28,6 +28,8 @@ typedef struct _CockpitPackages CockpitPackages;
 
 CockpitPackages * cockpit_packages_new              (void);
 
+GIOStream *       cockpit_packages_connect          (void);
+
 const gchar *     cockpit_packages_get_checksum     (CockpitPackages *packages);
 
 gchar **          cockpit_packages_get_names        (CockpitPackages *packages);

--- a/src/bridge/cockpitpipechannel.c
+++ b/src/bridge/cockpitpipechannel.c
@@ -472,8 +472,14 @@ cockpit_pipe_channel_prepare (CockpitChannel *channel)
           self->pipe = cockpit_pipe_spawn ((const gchar **)argv, (const gchar **)env, dir, flags);
         }
     }
-  else if (internal && steal_internal_fd (internal, &fd))
+  else if (internal)
     {
+      if (!steal_internal_fd (internal, &fd))
+        {
+          cockpit_channel_close (channel, "not-found");
+          goto out;
+        }
+
       self->pipe = cockpit_pipe_new_user_fd (internal, fd);
     }
   else

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -941,9 +941,6 @@ static void
 cockpit_router_class_init (CockpitRouterClass *class)
 {
   GObjectClass *object_class;
-  GSocketAddress *address;
-  GInetAddress *inet;
-  const gchar *port;
 
   object_class = G_OBJECT_CLASS (class);
   object_class->set_property = cockpit_router_set_property;
@@ -957,21 +954,6 @@ cockpit_router_class_init (CockpitRouterClass *class)
                                                         G_PARAM_WRITABLE |
                                                         G_PARAM_CONSTRUCT_ONLY |
                                                         G_PARAM_STATIC_STRINGS));
-
-  /*
-   * If we're running under a test server, register that server's HTTP address
-   * as an internal address, available for use in cockpit channels.
-   */
-
-  port = g_getenv ("COCKPIT_TEST_SERVER_PORT");
-  if (port)
-    {
-      inet = g_inet_address_new_loopback (G_SOCKET_FAMILY_IPV4);
-      address = g_inet_socket_address_new (inet, atoi (port));
-      cockpit_connect_add_internal_address ("/test-server", address);
-      g_object_unref (address);
-      g_object_unref (inet);
-    }
 }
 
 /**

--- a/src/bridge/test-connect.c
+++ b/src/bridge/test-connect.c
@@ -347,81 +347,6 @@ test_fail_access_denied (void)
 }
 
 static void
-test_internal_not_registered (void)
-{
-  CockpitConnectable *connectable;
-  JsonObject *options;
-  MockTransport *transport;
-  CockpitChannel *channel;
-  JsonObject *sent;
-
-  cockpit_expect_log ("cockpit-protocol", G_LOG_LEVEL_MESSAGE, "55: couldn't find internal address: test");
-  cockpit_connect_add_internal_address ("other", NULL);
-
-  options = json_object_new ();
-  json_object_set_string_member (options, "internal", "test");
-  transport = g_object_new (mock_transport_get_type (), NULL);
-
-  channel = g_object_new (mock_echo_channel_get_type (),
-                          "transport", transport,
-                          "id", "55",
-                          "options", options,
-                          NULL);
-  json_object_unref (options);
-  connectable = cockpit_connect_parse_stream (channel);
-  g_assert (connectable == NULL);
-  while (g_main_context_iteration (NULL, FALSE));
-
-  sent = mock_transport_pop_control (transport);
-  g_assert (sent != NULL);
-
-  cockpit_assert_json_eq (sent,
-                  "{ \"command\": \"close\", \"channel\": \"55\", \"problem\": \"not-found\", \"message\":\"couldn't find internal address: test\"}");
-  g_object_unref (channel);
-  g_object_unref (transport);
-  cockpit_assert_expected ();
-
-  cockpit_connect_remove_internal_address ("other");
-}
-
-static void
-test_internal_null_registered (void)
-{
-  CockpitConnectable *connectable;
-  JsonObject *options;
-  MockTransport *transport;
-  CockpitChannel *channel;
-  JsonObject *sent;
-
-  cockpit_connect_add_internal_address ("test", NULL);
-
-  options = json_object_new ();
-  json_object_set_string_member (options, "internal", "test");
-  transport = g_object_new (mock_transport_get_type (), NULL);
-
-  channel = g_object_new (mock_echo_channel_get_type (),
-                          "transport", transport,
-                          "id", "55",
-                          "options", options,
-                          NULL);
-  json_object_unref (options);
-  connectable = cockpit_connect_parse_stream (channel);
-  g_assert (connectable == NULL);
-  while (g_main_context_iteration (NULL, FALSE));
-
-  sent = mock_transport_pop_control (transport);
-  g_assert (sent != NULL);
-
-  cockpit_assert_json_eq (sent,
-                  "{ \"command\": \"close\", \"channel\": \"55\", \"problem\": \"not-found\"}");
-  g_object_unref (channel);
-  g_object_unref (transport);
-  cockpit_assert_expected ();
-
-  cockpit_connect_remove_internal_address ("test");
-}
-
-static void
 test_parse_port (void)
 {
   JsonObject *options;
@@ -531,11 +456,6 @@ main (int argc,
 
   g_test_add_func ("/connect/not-found", test_fail_not_found);
   g_test_add_func ("/connect/access-denied", test_fail_access_denied);
-
-  g_test_add_func ("/channel/internal-null-registered",
-                   test_internal_null_registered);
-  g_test_add_func ("/channel/internal-not-registered",
-                   test_internal_not_registered);
 
   g_test_add_func ("/channel/parse-port", test_parse_port);
   g_test_add_func ("/channel/parse-address", test_parse_address);

--- a/src/bridge/test-fs.c
+++ b/src/bridge/test-fs.c
@@ -438,11 +438,10 @@ static void
 test_read_non_mmappable (TestCase *tc,
                          gconstpointer unused)
 {
-  gchar *tag;
   JsonObject *control;
   const gchar *path = "/sys/power/state";
 
-  tag = cockpit_get_file_tag (path);
+  g_autofree gchar *tag = cockpit_get_file_tag (path);
 
   if (g_strcmp0 (tag, "-") == 0)
     {
@@ -462,7 +461,6 @@ test_read_non_mmappable (TestCase *tc,
   control = mock_transport_pop_control (tc->transport);
   g_assert (json_object_get_member (control, "problem") == NULL);
   g_assert_cmpstr (json_object_get_string_member (control, "tag"), ==, tag);
-  g_free (tag);
 }
 
 static void

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -74,9 +74,9 @@ static void
 setup_general (TestGeneral *tt,
                gconstpointer host_fixture)
 {
-  tt->web_server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, NULL);
+  tt->web_server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  tt->port = cockpit_web_server_add_inet_listener (tt->web_server, NULL, 0, NULL);
   cockpit_web_server_start (tt->web_server);
-  tt->port = cockpit_web_server_get_port (tt->web_server);
   tt->transport = mock_transport_new ();
   tt->host = host_fixture;
 }
@@ -364,11 +364,10 @@ test_http_chunked (void)
   GBytes *bytes = NULL;
 
   const gchar *control;
-  guint port;
 
-  web_server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, NULL);
-  g_assert (web_server);
-  port = cockpit_web_server_get_port (web_server);
+  web_server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  guint16 port = cockpit_web_server_add_inet_listener (web_server, NULL, 0, NULL);
+  g_assert (port != 0);
   g_signal_connect (web_server, "handle-resource::/",
                     G_CALLBACK (handle_chunked), NULL);
 
@@ -505,10 +504,11 @@ setup_tls (TestTls *test,
                                                         SRCDIR "/src/bridge/mock-server.key", &error);
   g_assert_no_error (error);
 
-  test->web_server = cockpit_web_server_new (NULL, 0, test->certificate, COCKPIT_WEB_SERVER_NONE, NULL, &error);
+  test->web_server = cockpit_web_server_new (test->certificate, COCKPIT_WEB_SERVER_NONE);
+  test->port = cockpit_web_server_add_inet_listener (test->web_server, NULL, 0, &error);
   g_assert_no_error (error);
+  g_assert (test->port != 0);
 
-  test->port = cockpit_web_server_get_port (test->web_server);
   g_signal_connect (test->web_server, "handle-resource::/test", G_CALLBACK (handle_test), test);
 
   cockpit_web_server_start (test->web_server);

--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -52,7 +52,6 @@
 
 extern const gchar **cockpit_bridge_data_dirs;
 extern const gchar *cockpit_bridge_local_address;
-extern gint cockpit_bridge_packages_port;
 
 typedef struct {
   CockpitPackages *packages;
@@ -125,7 +124,7 @@ setup (TestCase *tc,
   g_signal_connect (tc->transport, "closed", G_CALLBACK (on_transport_closed), NULL);
 
   options = json_object_new ();
-  json_object_set_int_member (options, "port", cockpit_bridge_packages_port);
+  json_object_set_string_member (options, "internal", "packages");
   json_object_set_string_member (options, "payload", "http-stream1");
   json_object_set_string_member (options, "method", "GET");
   json_object_set_string_member (options, "path", fixture->path);

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -116,8 +116,8 @@ static void
 setup (TestCase *test,
        gconstpointer data)
 {
-  test->server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, NULL);
-  test->port = cockpit_web_server_get_port (test->server);
+  test->server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  test->port = cockpit_web_server_add_inet_listener (test->server, NULL, 0, NULL);
   cockpit_web_server_start (test->server);
   test->transport = mock_transport_new ();
   test->ws_closed = FALSE;
@@ -258,12 +258,13 @@ setup_tls (TestTls *test,
   test->certificate = g_tls_certificate_new_from_files (SRCDIR "/src/bridge/mock-server.crt",
                                                         SRCDIR "/src/bridge/mock-server.key", &error);
   g_assert_no_error (error);
-  test->server = cockpit_web_server_new (NULL, 0, test->certificate, COCKPIT_WEB_SERVER_NONE, NULL, &error);
+  test->server = cockpit_web_server_new (test->certificate, COCKPIT_WEB_SERVER_NONE);
+  test->port = cockpit_web_server_add_inet_listener (test->server, NULL, 0, &error);
   g_assert_no_error (error);
+  g_assert (test->port != 0);
 
   cockpit_web_server_start (test->server);
 
-  test->port = cockpit_web_server_get_port (test->server);
   test->transport = mock_transport_new ();
   test->ws_closed = FALSE;
   test->origin = g_strdup_printf ("https://localhost:%u", test->port);

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -22,9 +22,10 @@
 #include "cockpitwebserver.h"
 
 #include "cockpithash.h"
-#include "cockpitmemory.h"
-#include "cockpitwebresponse.h"
 #include "cockpitmemfdread.h"
+#include "cockpitmemory.h"
+#include "cockpitsocket.h"
+#include "cockpitwebresponse.h"
 
 #include "websocket/websocket.h"
 
@@ -1293,6 +1294,21 @@ cockpit_web_server_start (CockpitWebServer *self)
 {
   g_return_if_fail (COCKPIT_IS_WEB_SERVER (self));
   g_socket_service_start (self->socket_service);
+}
+
+GIOStream *
+cockpit_web_server_connect (CockpitWebServer *self)
+{
+  g_return_val_if_fail (COCKPIT_IS_WEB_SERVER (self), NULL);
+
+  g_autoptr(GIOStream) server = NULL;
+  g_autoptr(GIOStream) client = NULL;
+
+  cockpit_socket_streampair (&client, &server);
+
+  cockpit_request_start (self, server, TRUE);
+
+  return g_steal_pointer (&client);
 }
 
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -1221,14 +1221,6 @@ on_incoming (GSocketService *service,
 
 /* ---------------------------------------------------------------------------------------------------- */
 
-gboolean
-cockpit_web_server_add_socket (CockpitWebServer *self,
-                               GSocket *socket,
-                               GError **error)
-{
-  return g_socket_listener_add_socket (G_SOCKET_LISTENER (self->socket_service), socket, NULL, error);
-}
-
 guint16
 cockpit_web_server_add_inet_listener (CockpitWebServer *self,
                                       const gchar *address,

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -70,6 +70,9 @@ cockpit_web_server_add_fd_listener (CockpitWebServer *self,
                                     int fd,
                                     GError **error);
 
+GIOStream *
+cockpit_web_server_connect (CockpitWebServer *self);
+
 G_END_DECLS
 
 #endif /* __COCKPIT_WEB_SERVER_H__ */

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -40,12 +40,8 @@ typedef enum {
 } CockpitWebServerFlags;
 
 
-CockpitWebServer * cockpit_web_server_new           (const gchar *address,
-                                                     gint port,
-                                                     GTlsCertificate *certificate,
-                                                     CockpitWebServerFlags flags,
-                                                     GCancellable *cancellable,
-                                                     GError **error);
+CockpitWebServer * cockpit_web_server_new           (GTlsCertificate *certificate,
+                                                     CockpitWebServerFlags flags);
 
 void               cockpit_web_server_start         (CockpitWebServer *self);
 
@@ -61,11 +57,18 @@ gchar *            cockpit_web_server_parse_cookie    (GHashTable *headers,
 gchar **           cockpit_web_server_parse_accept_list   (const gchar *accept,
                                                            const gchar *first);
 
-gboolean           cockpit_web_server_get_socket_activated (CockpitWebServer *self);
-
-gint               cockpit_web_server_get_port             (CockpitWebServer *self);
-
 CockpitWebServerFlags cockpit_web_server_get_flags         (CockpitWebServer *self);
+
+guint16
+cockpit_web_server_add_inet_listener (CockpitWebServer *self,
+                                      const gchar *address,
+                                      guint16 port,
+                                      GError **error);
+
+gboolean
+cockpit_web_server_add_fd_listener (CockpitWebServer *self,
+                                    int fd,
+                                    GError **error);
 
 G_END_DECLS
 

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -45,10 +45,6 @@ CockpitWebServer * cockpit_web_server_new           (GTlsCertificate *certificat
 
 void               cockpit_web_server_start         (CockpitWebServer *self);
 
-gboolean           cockpit_web_server_add_socket    (CockpitWebServer *self,
-                                                     GSocket *socket,
-                                                     GError **error);
-
 GHashTable *       cockpit_web_server_new_table     (void);
 
 gchar *            cockpit_web_server_parse_cookie    (GHashTable *headers,

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -91,7 +91,8 @@ base_setup (Test *test)
   const gchar *static_roots[] = { SRCDIR "/src/ws", SRCDIR "/src/branding/default", NULL };
   GError *error = NULL;
 
-  test->server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, &error);
+  test->server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  cockpit_web_server_add_inet_listener (test->server, NULL, 0, &error);
   g_assert_no_error (error);
 
   cockpit_web_server_start (test->server);
@@ -759,7 +760,8 @@ test_socket_unauthenticated (void)
 
   cockpit_socket_streampair (&io_a, &io_b);
 
-  server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, &error);
+  server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  cockpit_web_server_add_inet_listener (server, NULL, 0, NULL);
   g_assert_no_error (error);
 
   client = g_object_new (WEB_SOCKET_TYPE_CLIENT,

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -320,7 +320,6 @@ on_handle_stream_socket (CockpitWebServer *server,
   GPid pid = 0;
 
   gchar *value;
-  gchar **env;
   gchar **argv;
 
   if (!g_str_has_prefix (path, "/cockpit/socket"))
@@ -344,17 +343,15 @@ on_handle_stream_socket (CockpitWebServer *server,
       g_clear_object (&bridge);
 
       value = g_strdup_printf ("%d", server_port);
-      env = g_environ_setenv (g_get_environ (), "COCKPIT_TEST_SERVER_PORT", value, TRUE);
 
       argv = g_strdupv (bridge_argv);
       if (query)
         argv[g_strv_length (argv) - 1] = g_strdup (query);
 
-      g_spawn_async_with_pipes (NULL, argv, env,
+      g_spawn_async_with_pipes (NULL, argv, NULL,
                                 G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD,
                                 NULL, NULL, &pid, &session_stdin, &session_stdout, NULL, &error);
 
-      g_strfreev (env);
       g_free (argv);
       g_free (value);
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -665,16 +665,12 @@ server_ready (void)
     server_port = 8765;
 
   server_roots = cockpit_web_response_resolve_roots (roots);
-  server = cockpit_web_server_new (NULL, server_port, /* TCP port to listen to */
-                                   NULL, /* TLS cert */
-                                   COCKPIT_WEB_SERVER_NONE,
-                                   NULL, /* GCancellable* */
-                                   &error);
-  if (server == NULL)
-    {
-      g_critical ("Error setting up web server: %s (%s, %d)",
-                  error->message, g_quark_to_string (error->domain), error->code);
-    }
+  server = cockpit_web_server_new (NULL, /* TLS cert */
+                                   COCKPIT_WEB_SERVER_NONE);
+  server_port = cockpit_web_server_add_inet_listener (server, NULL, server_port, &error);
+  g_assert_no_error (error);
+  g_assert (server_port != 0);
+
 
   g_signal_connect (server, "handle-stream",
                     G_CALLBACK (on_handle_stream_socket), NULL);
@@ -687,7 +683,6 @@ server_ready (void)
   g_signal_connect (server, "handle-resource::/mock/",
                     G_CALLBACK (on_handle_mock), NULL);
 
-  server_port = cockpit_web_server_get_port (server);
   url = g_strdup_printf("http://localhost:%d", server_port);
 
   cockpit_web_server_start (server);

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -143,7 +143,8 @@ setup_mock_webserver (TestCase *test,
   GBytes *password;
 
   /* Zero port makes server choose its own */
-  test->web_server = cockpit_web_server_new (NULL, 0, NULL, COCKPIT_WEB_SERVER_NONE, NULL, &error);
+  test->web_server = cockpit_web_server_new (NULL, COCKPIT_WEB_SERVER_NONE);
+  cockpit_web_server_add_inet_listener (test->web_server, NULL, 0, &error);
   g_assert_no_error (error);
 
   cockpit_web_server_start (test->web_server);


### PR DESCRIPTION
Major changes:
 * cockpit-bridge no longer opens a TCP port for serving packages
 * we no longer have the `internal` connection option
 * `internal: "packages"` is preserved as a one-off exception on HTTP streams for reasons of cockpit-ws/cockpit-bridge compatibility
 * cleanup of listening options on cockpitwebserver, ~and cockpit-ws gains a -U option to listen on a unix socket~ (from #16650)