### PR TITLE
client: add win.pwn action

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -62,6 +62,7 @@ class CockpitClientWindow(Gtk.ApplicationWindow):
             ('go-forward', self.go_forward),
             ('zoom', self.zoom, 's'),
             ('open-inspector', self.open_inspector),
+            ('pwn', self.pwn, 's', '""'),
         ])
 
         self.webview.get_settings().set_enable_developer_extras(True)
@@ -113,6 +114,11 @@ class CockpitClientWindow(Gtk.ApplicationWindow):
 
     def open_inspector(self, *unused):
         self.webview.get_inspector().show()
+
+    def pwn(self, action, param, *args):
+        js = param.get_string()
+        result = repr(eval(js))
+        action.set_state(GLib.Variant.new_string(result))
 
 
 class CockpitClient(Gtk.Application):


### PR DESCRIPTION
Add a "pwn" action on the window that will execute arbitrary code and
set the state of the action to the result.

You can use it like this:

```
  gdbus monitor --session --dest=org.cockpit_project.CockpitClient &

  gdbus call --session --dest=org.cockpit_project.CockpitClient \
        -o /org/cockpit_project/CockpitClient/window/1
        -m org.gtk.Actions.Activate \
        '"pwn"' '[<"2+2">]' '[]'
```

and see

```
  /org/cockpit_project/CockpitClient/window/1: org.gtk.Actions.Changed (@as [], @a{sb} {}, {'pwn': <'4'>}, @a{s(bgav)} {})
```

Right now it runs Python, but obviously it should run Javascript in the
future.