### PR TITLE
storage: Don't use Patternfly table actions

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -549,7 +549,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object) {
                 : utils.fmt_size(desc.size),
             props: { className: "ct-text-align-right" }
         },
-        { title: <>{actions}{menu}</>, props: { className: "pf-c-table__action content-action" } },
+        { title: <div className="content-action">{actions}{menu}</div> },
     ];
 
     rows.push({
@@ -588,7 +588,7 @@ function append_partitions(client, rows, level, block) {
             { },
             { },
             { title: utils.fmt_size(size), props: { className: "ct-text-align-right" } },
-            { title: btn, props: { className: "pf-c-table__action content-action" } },
+            { title: <div className="content-action">{btn}</div> },
         ];
 
         rows.push({
@@ -724,9 +724,10 @@ const BlockContent = ({ client, block, allow_partitions }) => {
                 <CardActions>{format_disk_btn}</CardActions>
             </CardHeader>
             <CardBody className="contains-list">
-                <ListingTable rows={ block_rows(client, block) }
+                <ListingTable variant="compact"
+                              rows={ block_rows(client, block) }
                               aria-label={_("Content")}
-                              columns={[_("Name"), _("Type"), _("Used for"), _("Size")]}
+                              columns={[_("Name"), _("Type"), _("Used for"), _("Size"), ""]}
                               showHeader={false} />
             </CardBody>
         </Card>
@@ -974,9 +975,10 @@ export class VGroup extends React.Component {
                     <CardActions>{new_volume_link}</CardActions>
                 </CardHeader>
                 <CardBody className="contains-list">
-                    <ListingTable emptyCaption={_("No logical volumes")}
+                    <ListingTable variant="compact"
+                                  emptyCaption={_("No logical volumes")}
                                   aria-label={_("Logical volumes")}
-                                  columns={[_("Name"), _("Type"), _("Used for"), _("Size")]}
+                                  columns={[_("Name"), _("Type"), _("Used for"), _("Size"), ""]}
                                   showHeader={false}
                                   rows={vgroup_rows(client, vgroup)} />
                 </CardBody>

--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -76,6 +76,7 @@ export class LockedCryptoPanel extends React.Component {
             <OptionalPanel id="locked-cryptos"
                 title={_("Locked devices")}>
                 <ListingTable
+                    variant="compact"
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Locked devices")}
                     className={locked_cryptos.length ? 'table-hover' : ''}

--- a/pkg/storaged/fsys-panel.jsx
+++ b/pkg/storaged/fsys-panel.jsx
@@ -163,6 +163,7 @@ export class FilesystemsPanel extends React.Component {
             <OptionalPanel id="mounts" className="storage-mounts"
                 title={_("Filesystems")}>
                 <ListingTable
+                    variant="compact"
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Filesystems")}
                     className={mounts.length ? 'table-hover' : ''}

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -93,6 +93,7 @@ export class NFSPanel extends React.Component {
                        not_installed_text={_("NFS support not installed")}
                        install_title={_("Install NFS support")}>
                 <ListingTable
+                    variant="compact"
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("NFS mounts")}
                     onRowClick={onRowClick}

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -165,8 +165,13 @@ td.job-action {
 }
 
 .content-action {
-    text-align: right;
-    white-space: nowrap !important;
+    display: flex;
+    justify-content: flex-end;
+    margin: -0.25rem 0;
+}
+
+.content-action > button {
+    margin: 0.25rem 0 0.25rem 0.5rem;
 }
 
 .dialog-item-tooltip {

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -620,8 +620,7 @@ export const StratisPoolDetails = ({ client, pool }) => {
                 props: { className: "ct-text-align-right" }
             },
             {
-                title: <>{actions}<StorageBarMenu key="menu" menuItems={menuitems} isKebab /></>,
-                props: { className: "pf-c-table__action content-action" }
+                title: <div className="content-action">{actions}<StorageBarMenu key="menu" menuItems={menuitems} isKebab /></div>
             }
         ];
 
@@ -650,9 +649,10 @@ export const StratisPoolDetails = ({ client, pool }) => {
                 </CardActions>
             </CardHeader>
             <CardBody className="contains-list">
-                <ListingTable emptyCaption={_("No filesystems")}
+                <ListingTable variant="compact"
+                              emptyCaption={_("No filesystems")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), _("Used for"), _("Size")]}
+                              columns={[_("Name"), _("Used for"), _("Size"), ""]}
                               showHeader={false}
                               rows={rows.filter(row => !!row)} />
             </CardBody>
@@ -787,9 +787,10 @@ export const StratisLockedPoolDetails = ({ client, uuid }) => {
                 <CardTitle><Text component={TextVariants.h2}>{_("Filesystems")}</Text></CardTitle>
             </CardHeader>
             <CardBody className="contains-list">
-                <ListingTable emptyCaption={_("Unlock pool to see filesystems.")}
+                <ListingTable variant="compact"
+                              emptyCaption={_("Unlock pool to see filesystems.")}
                               aria-label={_("Filesystems")}
-                              columns={[_("Name"), _("Used for"), _("Size")]}
+                              columns={[_("Name"), _("Used for"), _("Size"), ""]}
                               showHeader={false}
                               rows={[]} />
             </CardBody>


### PR DESCRIPTION
They have a broken layout in mobile mode, see https://github.com/patternfly/patternfly/issues/4547

Instead, move them to their own unlabeled row at the bottom.