### PR TITLE
lib: Ensure empty expander in ListingTable cell has right class

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -154,18 +154,19 @@ export const ListingTable = ({
             <React.Fragment key={rowKey + "-inner-row"}>
                 <Tr {...rowProps}>
                     {isExpandable
-                        ? <Td expand={
-                            row.expandedContent
-                                ? {
-                                    rowKey,
-                                    isExpanded,
-                                    onToggle: () => {
-                                        if (afterToggle)
-                                            afterToggle(!expanded[rowKey]);
-                                        setExpanded({ ...expanded, [rowKey]: !expanded[rowKey] });
-                                    }
-                                } : null} />
-                        : null}
+                        ? (row.expandedContent
+                            ? <Td expand={{
+                                rowKey,
+                                isExpanded,
+                                onToggle: () => {
+                                    if (afterToggle)
+                                        afterToggle(!expanded[rowKey]);
+                                    setExpanded({ ...expanded, [rowKey]: !expanded[rowKey] });
+                                }
+                            }} />
+                            : <Td className="pf-c-table__toggle" />)
+                        : null
+                    }
                     {onSelect &&
                         <Td select={{
                             rowIndex,


### PR DESCRIPTION
Otherwise the mobile layout is has a unexpected empty row at the top.

Before:

![image](https://user-images.githubusercontent.com/3228183/144259075-3f8b2673-425a-46e0-b73e-62442c808d9b.png)

After:

![image](https://user-images.githubusercontent.com/3228183/144259127-1b909fae-80c7-42e1-8281-4cfdbf211bce.png)
