### PR TITLE
handle http→https redirect from cockpit-tls

### DIFF
--- a/doc/man/cockpit-ws.xml
+++ b/doc/man/cockpit-ws.xml
@@ -151,16 +151,6 @@
         </listitem>
       </varlistentry>
       <varlistentry>
-        <term><option>--proxy-tls-redirect</option></term>
-        <listitem>
-          <para>
-            Enable redirection of unencrypted http requests to https (TLS) in <option>--no-tls</option> mode.
-            Use this when running <command>cockpit-ws</command> behind a reverse http proxy that also
-            supports https, but does no redirection from http to https by itself.
-          </para>
-        </listitem>
-      </varlistentry>
-      <varlistentry>
         <term><option>--local-ssh</option></term>
         <listitem>
           <para>

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -34,9 +34,7 @@ typedef enum {
   COCKPIT_WEB_SERVER_FOR_TLS_PROXY = 1 << 0,
   /* http → https redirection for non-localhost addresses */
   COCKPIT_WEB_SERVER_REDIRECT_TLS = 1 << 1,
-  /* http → https redirection for reverse proxy setups: Look at Host: header instead of connection IP */
-  COCKPIT_WEB_SERVER_REDIRECT_TLS_PROXY = 1 << 2,
-  COCKPIT_WEB_SERVER_FLAGS_MAX = 1 << 3
+  COCKPIT_WEB_SERVER_FLAGS_MAX = 1 << 2
 } CockpitWebServerFlags;
 
 

--- a/src/tls/Makefile-tls.am
+++ b/src/tls/Makefile-tls.am
@@ -27,6 +27,8 @@ cockpit_tls_SOURCES = \
 	src/tls/client-certificate.c \
 	src/tls/connection.h \
 	src/tls/connection.c \
+	src/tls/httpredirect.h \
+	src/tls/httpredirect.c \
 	src/tls/server.h \
 	src/tls/server.c \
 	src/tls/main.c \
@@ -94,6 +96,8 @@ test_tls_connection_SOURCES = \
 	src/tls/client-certificate.c \
 	src/tls/certificate.h \
 	src/tls/certificate.c \
+	src/tls/httpredirect.h \
+	src/tls/httpredirect.c \
 	src/tls/connection.c \
 	src/tls/test-connection.c \
 	$(NULL)
@@ -108,6 +112,8 @@ test_tls_server_SOURCES = \
 	src/tls/client-certificate.c \
 	src/tls/certificate.h \
 	src/tls/certificate.c \
+	src/tls/httpredirect.h \
+	src/tls/httpredirect.c \
 	src/tls/connection.c \
 	src/tls/server.c \
 	src/tls/test-server.c \

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -54,6 +54,7 @@
 
 #include "certificate.h"
 #include "client-certificate.h"
+#include "httpredirect.h"
 #include "socket-io.h"
 #include "utils.h"
 
@@ -61,6 +62,7 @@
 static struct {
   gnutls_certificate_request_t request_mode;
   Certificate *certificate;
+  bool require_https;
   int wsinstance_sockdir;
   int cert_session_dir;
 } parameters = {
@@ -463,30 +465,62 @@ connection_connect_to_dynamic_wsinstance (Connection *self)
 }
 
 static bool
-connection_connect_to_static_wsinstance (Connection *self)
+connection_is_to_localhost (Connection *self)
 {
-  const char *base;
+  struct sockaddr_storage address;
+  socklen_t address_len = sizeof address;
 
-  assert (self->tls == NULL);
+  /* NB: We check our own socket name, not the peer.  That lets us find
+   * out if the connection was made to 127.0.0.1, or some other address.
+   *
+   * In the case that the client connects to 127.0.0.2, for example, the
+   * peer socket is still 127.0.0.1.
+   */
+  if (getsockname (self->client_fd, (struct sockaddr *) &address, &address_len) != 0)
+    return false;
 
-  if (parameters.certificate)
-    base = "http-redirect.sock"; /* server is expecting https connections */
-  else
-    base = "http.sock"; /* server is expecting http connections */
-
-  if (af_unix_connectat (self->ws_fd, parameters.wsinstance_sockdir, base) != 0)
+  switch (address.ss_family)
     {
-      warn ("connect(%s) failed", base);
+    case AF_UNIX:
+      return true;
+
+    case AF_INET:
+        {
+          struct in_addr *addr4 = &((struct sockaddr_in *) &address)->sin_addr;
+          return addr4->s_addr == htonl (INADDR_LOOPBACK);
+        }
+
+    case AF_INET6:
+        {
+          struct in6_addr *addr6 = &((struct sockaddr_in6 *) &address)->sin6_addr;
+
+          /* Need to handle both ::ffff:127.0.0.1 as well as ::1
+           * This is ugly, but there doesn't seem to be a better (static) way... */
+          const struct in6_addr v4_loopback = { { { 0,0,0,0,0,0,0,0,0,0,0xff,0xff,127,0,0,1 } } };
+          return IN6_IS_ADDR_LOOPBACK (addr6) || IN6_ARE_ADDR_EQUAL(addr6, &v4_loopback);
+        }
+
+    default:
       return false;
     }
-
-  debug (CONNECTION, "  -> success!");
-  return true;
 }
 
 static bool
 connection_connect_to_wsinstance (Connection *self)
 {
+  if (self->tls == NULL && parameters.require_https && !connection_is_to_localhost (self))
+    {
+      /* server is expecting https connections */
+      self->ws_fd = http_redirect_connect ();
+      if (self->ws_fd == -1)
+        {
+          warn ("failed to connect to httpredirect");
+          return false;
+        }
+
+      return true;
+    }
+
   self->ws_fd = socket (AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0);
   if (self->ws_fd == -1)
     {
@@ -494,10 +528,19 @@ connection_connect_to_wsinstance (Connection *self)
       return false;
     }
 
-  if (self->tls)
-    return connection_connect_to_dynamic_wsinstance (self);
+  if (self->tls == NULL)
+    {
+      /* server is expecting http connections, or localhost is exempt */
+      if (af_unix_connectat (self->ws_fd, parameters.wsinstance_sockdir, "http.sock") != 0)
+        {
+          warn ("connect(http.sock) failed");
+          return false;
+        }
+
+      return true;
+    }
   else
-    return connection_connect_to_static_wsinstance (self);
+    return connection_connect_to_dynamic_wsinstance (self);
 }
 
 /**
@@ -814,10 +857,13 @@ connection_thread_main (int fd)
 void
 connection_crypto_init (const char *certificate_filename,
                         const char *key_filename,
+                        bool allow_unencrypted,
                         gnutls_certificate_request_t request_mode)
 {
   parameters.certificate = certificate_load (certificate_filename, key_filename);
   parameters.request_mode = request_mode;
+  /* If we aren't called, then require_https is false */
+  parameters.require_https = !allow_unencrypted;
 }
 
 void
@@ -859,6 +905,8 @@ connection_cleanup (void)
       certificate_unref (parameters.certificate);
       parameters.certificate = NULL;
     }
+
+  parameters.require_https = false;
 
   close (parameters.cert_session_dir);
   parameters.cert_session_dir = -1;

--- a/src/tls/httpredirect.c
+++ b/src/tls/httpredirect.c
@@ -1,0 +1,176 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2019 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+
+#include "httpredirect.h"
+
+#include <sys/socket.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <unistd.h>
+
+static char *
+read_line (FILE *stream,
+           char *buffer,
+           size_t sizeof_buffer,
+           size_t *offset)
+{
+  if (*offset >= sizeof_buffer)
+    return NULL;
+
+  char *line = fgets (buffer + *offset, sizeof_buffer - *offset, stream);
+
+  if (line == NULL)
+    return NULL;
+
+  /* Make sure we're terminated with \r\n or \n */
+  size_t line_length = strcspn (line, "\r\n");
+  const char *ending = line + line_length;
+  if (strcmp (ending, "\r\n") != 0 && strcmp (ending, "\n") != 0)
+    return NULL;
+
+  /* Discard the ending */
+  line[line_length++] = '\0';
+
+  *offset += line_length;
+
+  return line;
+}
+
+static bool
+write_error (FILE *output)
+{
+  fprintf (output, "HTTP/1.1 400 Client Error\r\n"
+                   "\r\n"
+                   "Incorrect request.\r\n");
+
+  return false;
+}
+
+static bool
+http_redirect (FILE *input,
+               FILE *output)
+{
+  char buffer[10000];
+  size_t offset = 0;
+
+  char *request_line = read_line (input, buffer, sizeof buffer, &offset);
+  if (request_line == NULL)
+    return write_error (output);
+
+  char *path = strchr (request_line, ' ');
+  if (path == NULL)
+    return write_error (output);
+  path++;
+
+  char *end_path = strchr (path, ' ');
+  if (end_path == NULL)
+    return write_error (output);
+  *end_path = '\0';
+
+  const char *host = NULL;
+  const char *header;
+  do
+    {
+      header = read_line (input, buffer, sizeof buffer, &offset);
+      if (header == NULL)
+        return write_error (output);
+
+#define HOST_HEADER "Host:"
+      if (strncmp (header, HOST_HEADER, strlen (HOST_HEADER)) == 0)
+        {
+          if (host != NULL)
+            return write_error (output);
+
+          host = header + strlen (HOST_HEADER);
+          host += strspn (host, " \t");
+        }
+    }
+  while (header[0] != '\0');
+
+  if (!host)
+    return write_error (output);
+
+  fprintf (output, "HTTP/1.1 301 Moved Permanently\r\n"
+                   "Content-Type: text/html\r\n"
+                   "Location: https://%s%s\r\n"
+                   "\r\n"
+                   "<html><head><title>Moved</title></head>"
+                   "<body>Please use TLS</body></html>\r\n", host, path);
+
+  return true;
+}
+
+static void *
+http_redirect_start (void *arg)
+{
+  FILE *stream = arg;
+
+  http_redirect (stream, stream);
+
+  fclose (stream);
+
+  return NULL;
+}
+
+int
+http_redirect_connect (void)
+{
+  int sv[2];
+  int r = socketpair (AF_UNIX, SOCK_STREAM, 0, sv);
+  if (r != 0)
+    return -1;
+
+  /* At this point we're going to succeed and return sv[1] to the
+   * caller.  We need to make sure that sv[0] gets closed one way or
+   * another:
+   *  - if we fail to create the stream, close()
+   *  - if we fail to spawn the thread, fclose()
+   *  - otherwise, the thread calls fclose()
+   */
+  FILE *stream = fdopen (sv[0], "r+");
+  if (stream == NULL)
+    close (sv[0]);
+  else
+    {
+      pthread_attr_t attr;
+      pthread_t thread;
+
+      pthread_attr_init (&attr);
+      pthread_attr_setdetachstate (&attr, PTHREAD_CREATE_DETACHED);
+
+      if (pthread_create (&thread, &attr, &http_redirect_start, stream))
+        fclose (stream);
+
+      pthread_attr_destroy (&attr);
+    }
+
+  return sv[1];
+}
+
+#ifdef HTTP_REDIRECT_STANDALONE
+int
+main (void)
+{
+  return http_redirect (stdin, stdout) ? 0 : 1;
+}
+#endif

--- a/src/tls/httpredirect.h
+++ b/src/tls/httpredirect.h
@@ -1,7 +1,7 @@
 /*
  * This file is part of Cockpit.
  *
- * Copyright (C) 2019 Red Hat, Inc.
+ * Copyright (C) 2021 Red Hat, Inc.
  *
  * Cockpit is free software; you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published by
@@ -19,25 +19,5 @@
 
 #pragma once
 
-#include <stdbool.h>
-#include <stdint.h>
-
-#include <gnutls/gnutls.h>
-
-/* init/teardown */
-void
-connection_set_directories (const char *wsinstance_sockdir,
-                            const char *runtime_directory);
-
-void
-connection_crypto_init (const char *certificate_filename,
-                        const char *key_filename,
-                        bool allow_unencrypted,
-                        gnutls_certificate_request_t request_mode);
-
-void
-connection_cleanup (void);
-
-/* handle a new connection */
-void
-connection_thread_main (int fd);
+int
+http_redirect_connect (void);

--- a/src/tls/main.c
+++ b/src/tls/main.c
@@ -120,9 +120,11 @@ main (int argc, char **argv)
       if (cockpit_conf_bool ("WebService", "ClientCertAuthentication", false))
         client_cert_mode = GNUTLS_CERT_REQUEST;
 
+      bool allow_unencrypted = cockpit_conf_bool ("WebService", "AllowUnencrypted", false);
+
       connection_crypto_init ("/run/cockpit/tls/server/cert",
                               "/run/cockpit/tls/server/key",
-                              client_cert_mode);
+                              allow_unencrypted, client_cert_mode);
 
       /* There's absolutely no need to keep these around */
       if (unlink ("/run/cockpit/tls/server/cert") != 0)

--- a/src/tls/socket-activation-helper.c
+++ b/src/tls/socket-activation-helper.c
@@ -48,7 +48,6 @@ static struct instance_type
   {"https@" SHA256_NIL ".sock", {"--for-tls-proxy", "--port=0"}},
   {"https@" CLIENT_CERT_FINGERPRINT ".sock", {"--for-tls-proxy", "--port=0"}},
   {"https@" ALTERNATE_FINGERPRINT ".sock", {}}, /* treated specially */
-  {"http-redirect.sock", {"--proxy-tls-redirect", "--no-tls", "--port=0"}},
   {"http.sock", {"--no-tls", "--port", "0"}},
 };
 

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -387,7 +387,7 @@ setup (TestCase *tc, gconstpointer data)
 
   server_init (tc->ws_socket_dir, tc->runtime_dir, fixture ? fixture->idle_timeout : 0, server_port);
   if (fixture && fixture->certfile)
-    connection_crypto_init (fixture->certfile, fixture->keyfile, fixture->cert_request_mode);
+    connection_crypto_init (fixture->certfile, fixture->keyfile, false, fixture->cert_request_mode);
 
   tc->server_addr.sin_family = AF_INET;
   tc->server_addr.sin_port = htons (server_port);

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -415,7 +415,6 @@ teardown (TestCase *tc, gconstpointer data)
   int socket_dir_fd = open (tc->ws_socket_dir, O_RDONLY | O_DIRECTORY);
   g_assert_cmpint (socket_dir_fd, >=, 0);
   g_assert_cmpint (unlinkat (socket_dir_fd, "http.sock", 0), ==, 0);
-  g_assert_cmpint (unlinkat (socket_dir_fd, "http-redirect.sock", 0), ==, 0);
   g_assert_cmpint (unlinkat (socket_dir_fd, "https-factory.sock", 0), ==, 0);
   g_assert_cmpint (unlinkat (socket_dir_fd, "https@" SHA256_NIL ".sock", 0), ==, 0);
   g_assert_cmpint (unlinkat (socket_dir_fd, "https@" CLIENT_CERT_FINGERPRINT ".sock", 0), ==, 0);

--- a/src/tls/test-server.c
+++ b/src/tls/test-server.c
@@ -554,6 +554,9 @@ test_no_tls_many_parallel (TestCase *tc, gconstpointer data)
 static void
 test_no_tls_redirect (TestCase *tc, gconstpointer data)
 {
+  /* Make sure we connect on something other than localhost */
+  tc->server_addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK + 1);
+
   /* without TLS support it should not redirect */
   const char *res = do_request (tc, "GET / HTTP/1.0\r\nHost: some.remote:1234\r\n\r\n");
   /* This succeeds (200 OK) when building in-tree, but fails with dist-check due to missing doc root */
@@ -580,6 +583,9 @@ test_tls_no_server_cert (TestCase *tc, gconstpointer data)
 static void
 test_tls_redirect (TestCase *tc, gconstpointer data)
 {
+  /* Make sure we connect on something other than localhost */
+  tc->server_addr.sin_addr.s_addr = htonl (INADDR_LOOPBACK + 1);
+
   /* with TLS support it should redirect */
   const char *res = do_request (tc, "GET / HTTP/1.0\r\nHost: some.remote:1234\r\n\r\n");
   cockpit_assert_strmatch (res, "HTTP/1.1 301 Moved Permanently*");

--- a/src/tls/test-socket-activation-helper.sh
+++ b/src/tls/test-socket-activation-helper.sh
@@ -6,7 +6,7 @@ if ! type curl >/dev/null 2>&1; then
     exit 0
 fi
 
-echo "1..6"
+echo "1..5"
 
 # start activation helper
 SOCKET_DIR=$(mktemp -d --tmpdir socks.XXXXXX)
@@ -56,14 +56,11 @@ expect_curl http.sock "$SUCCESS"
 echo "ok 1 http.sock"
 
 
-expect_curl http-redirect.sock "$REDIRECT"
-echo "ok 2 http-redirect.sock"
-
 expect_start $SHA256_NIL "^done$"
-echo "ok 3 https-factory/success"
+echo "ok 2 https-factory/success"
 
 expect_start "junk" "^fail$"
-echo "ok 4 https-factory/fail"
+echo "ok 3 https-factory/fail"
 
 expect_curl https@$SHA256_NIL.sock "$SUCCESS"
 # second call to existing instance
@@ -71,7 +68,7 @@ expect_curl https@$SHA256_NIL.sock "$SUCCESS"
 # wait for idle timeout
 sleep 2
 expect_curl https@$SHA256_NIL.sock "$SUCCESS"
-echo "ok 5 https@$SHA256_NIL.sock"
+echo "ok 4 https@$SHA256_NIL.sock"
 
 expect_curl https@$SHA256_CERT.sock "$SUCCESS"
-echo "ok 6 https@$SHA256_CERT.sock"
+echo "ok 5 https@$SHA256_CERT.sock"

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -74,8 +74,6 @@ systemd_units_in = \
 	src/ws/cockpit.socket.in \
 	src/ws/cockpit-wsinstance-http.service.in \
 	src/ws/cockpit-wsinstance-http.socket.in \
-	src/ws/cockpit-wsinstance-http-redirect.service.in \
-	src/ws/cockpit-wsinstance-http-redirect.socket.in \
 	src/ws/cockpit-wsinstance-https-factory@.service.in \
 	src/ws/cockpit-wsinstance-https-factory.socket.in \
 	src/ws/cockpit-wsinstance-https@.service.in \

--- a/src/ws/cockpit-wsinstance-http-redirect.service.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.service.in
@@ -1,9 +1,0 @@
-[Unit]
-Description=Cockpit Web Service http-redirect instance
-BindsTo=cockpit.service
-Documentation=man:cockpit-ws(8)
-
-[Service]
-ExecStart=@libexecdir@/cockpit-ws --proxy-tls-redirect --no-tls --port 0
-User=@wsinstanceuser@
-Group=@wsinstancegroup@

--- a/src/ws/cockpit-wsinstance-http-redirect.socket.in
+++ b/src/ws/cockpit-wsinstance-http-redirect.socket.in
@@ -1,9 +1,0 @@
-[Unit]
-Description=Socket for Cockpit Web Service http-redirect instance
-BindsTo=cockpit.service
-Documentation=man:cockpit-ws(8)
-
-[Socket]
-ListenStream=/run/cockpit/wsinstance/http-redirect.sock
-SocketUser=@user@
-SocketMode=0600

--- a/src/ws/cockpit.service.in
+++ b/src/ws/cockpit.service.in
@@ -2,8 +2,8 @@
 Description=Cockpit Web Service
 Documentation=man:cockpit-ws(8)
 Requires=cockpit.socket
-Requires=cockpit-wsinstance-http.socket cockpit-wsinstance-http-redirect.socket cockpit-wsinstance-https-factory.socket
-After=cockpit-wsinstance-http.socket cockpit-wsinstance-http-redirect.socket cockpit-wsinstance-https-factory.socket
+Requires=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
+After=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
 
 [Service]
 RuntimeDirectory=cockpit/tls

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -47,7 +47,6 @@ static gint      opt_port         = 9090;
 static gchar     *opt_address     = NULL;
 static gboolean  opt_no_tls       = FALSE;
 static gboolean  opt_for_tls_proxy    = FALSE;
-static gboolean  opt_proxy_tls_redirect = FALSE;
 static gboolean  opt_local_ssh    = FALSE;
 static gchar     *opt_local_session = NULL;
 static gboolean  opt_version      = FALSE;
@@ -58,9 +57,6 @@ static GOptionEntry cmd_entries[] = {
   {"no-tls", 0, 0, G_OPTION_ARG_NONE, &opt_no_tls, "Don't use TLS", NULL},
   {"for-tls-proxy", 0, 0, G_OPTION_ARG_NONE, &opt_for_tls_proxy,
       "Act behind a https-terminating proxy: accept only https:// origins by default",
-      NULL},
-  {"proxy-tls-redirect", 0, 0, G_OPTION_ARG_NONE, &opt_proxy_tls_redirect,
-      "Redirect http requests to https even with --no-tls (useful for running behind a http reverse proxy)",
       NULL},
   {"local-ssh", 0, 0, G_OPTION_ARG_NONE, &opt_local_ssh, "Log in locally via SSH", NULL },
   {"local-session", 0, 0, G_OPTION_ARG_STRING, &opt_local_session,
@@ -156,11 +152,6 @@ main (int argc,
       g_printerr ("--for-tls-proxy and --no-tls are mutually exclusive");
       goto out;
     }
-  if (opt_for_tls_proxy && opt_proxy_tls_redirect)
-    {
-      g_printerr ("--for-tls-proxy (running behind a https proxy) and --proxy-tls-redirect (running behind a http proxy) are mutually exclusive");
-      goto out;
-    }
 
   if (opt_version)
     {
@@ -214,8 +205,6 @@ main (int argc,
     {
       if (!opt_no_tls)
         server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS;
-      if (opt_proxy_tls_redirect)
-        server_flags |= COCKPIT_WEB_SERVER_REDIRECT_TLS | COCKPIT_WEB_SERVER_REDIRECT_TLS_PROXY;
     }
 
   server = cockpit_web_server_new (certificate, server_flags);

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -940,14 +940,6 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://172.27.0.15:9091"))
 
-        # ws with --proxy-tls-redirect redirects non-localhost to https
-        m.execute("pkill -e cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
-        m.spawn(f"su -s /bin/sh -c '{self.ws_executable} --proxy-tls-redirect --no-tls -p 9099 -a 127.0.0.1' cockpit-wsinstance",
-                "ws-proxy-tls-redirect.log")
-        m.wait_for_cockpit_running(tls=True)
-        self.assertIn("HTTP/1.1 301 Moved Permanently", m.execute("curl --silent --head http://172.27.0.15:9091"))
-        self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9091"))
-
     def testCaCert(self):
         m = self.machine
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -203,7 +203,7 @@ class TestConnection(MachineCase):
         def expect_actives(ws_socket, instance_sockets, http_instances, https_instances=0):
             expect_active("cockpit.socket", ws_socket)
             # http instances
-            for instance in ["http", "http-redirect"]:
+            for instance in ["http"]:
                 expect_active(f"cockpit-wsinstance-{instance}.socket", instance_sockets)
                 expect_active(f"cockpit-wsinstance-{instance}.service", instance in http_instances)
             # number of https instances
@@ -251,12 +251,12 @@ class TestConnection(MachineCase):
 
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
 
-        expect_actives(True, True, ["http-redirect"], 0)
+        expect_actives(True, True, ["http"], 0)
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent -k --head https://127.0.0.1:9090"))
-        expect_actives(True, True, ["http-redirect"], 1)
+        expect_actives(True, True, ["http"], 1)
 
         m.restart_cockpit()
-        expect_actives(True, True, ["http-redirect"], 1)
+        expect_actives(True, True, ["http"], 1)
 
         m.stop_cockpit()
         expect_actives(False, False, [], 0)
@@ -265,24 +265,24 @@ class TestConnection(MachineCase):
         expect_actives(True, False, [], 0)
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
 
-        expect_actives(True, True, ["http-redirect"], 0)
+        expect_actives(True, True, ["http"], 0)
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent -k --head https://127.0.0.1:9090"))
-        expect_actives(True, True, ["http-redirect"], 1)
+        expect_actives(True, True, ["http"], 1)
 
         # cleans up also when cockpit-tls crashes or idle-exits, not just by explicit stop request
         m.execute("pkill -e cockpit-tls")
         expect_actives(True, False, [], 0)
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --head http://127.0.0.1:9090"))
-        expect_actives(True, True, ["http-redirect"], 0)
+        expect_actives(True, True, ["http"], 0)
         # next https request after crash doesn't leak an instance
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent -k --head https://127.0.0.1:9090"))
-        expect_actives(True, True, ["http-redirect"], 1)
+        expect_actives(True, True, ["http"], 1)
 
         # instance service+socket going away does not confuse cockpit-tls' bookkeeping
         m.execute("systemctl stop cockpit-wsinstance-https@*.service cockpit-wsinstance-https@*.socket")
-        expect_actives(True, True, ["http-redirect"], 0)
+        expect_actives(True, True, ["http"], 0)
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --silent --show-error -k --head https://127.0.0.1:9090"))
-        expect_actives(True, True, ["http-redirect"], 1)
+        expect_actives(True, True, ["http"], 1)
 
         # sockets are inaccessible to users, only to cockpit-tls
         for s in ["http.sock", "https-factory.sock"]:

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -486,8 +486,6 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit.socket
 %{_unitdir}/cockpit-wsinstance-http.socket
 %{_unitdir}/cockpit-wsinstance-http.service
-%{_unitdir}/cockpit-wsinstance-http-redirect.socket
-%{_unitdir}/cockpit-wsinstance-http-redirect.service
 %{_unitdir}/cockpit-wsinstance-https-factory.socket
 %{_unitdir}/cockpit-wsinstance-https-factory@.service
 %{_unitdir}/cockpit-wsinstance-https@.socket

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -3,8 +3,6 @@ etc/pam.d/cockpit
 lib/systemd/system/cockpit.service
 lib/systemd/system/cockpit-motd.service
 lib/systemd/system/cockpit.socket
-lib/systemd/system/cockpit-wsinstance-http-redirect.service
-lib/systemd/system/cockpit-wsinstance-http-redirect.socket
 lib/systemd/system/cockpit-wsinstance-http.service
 lib/systemd/system/cockpit-wsinstance-http.socket
 lib/systemd/system/cockpit-wsinstance-https-factory@.service


### PR DESCRIPTION
This is a temporary increase in code size, since we still need to keep http→https redirection in `cockpit-ws` for the container case, but it's a precondition to removing it.

 * [ ] read the parser code very very very carefully