### PR TITLE
storage: Hide table buttons in narrow layouts

### DIFF
--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -96,7 +96,7 @@ function checked(callback) {
     };
 }
 
-export const StorageButton = ({ id, kind, excuse, onClick, children, ariaLabel }) => (
+export const StorageButton = ({ id, kind, excuse, onClick, children, ariaLabel, onlyWide }) => (
     <StorageControl excuse={excuse}
                     content={excuse => (
                         <Button id={id}
@@ -104,6 +104,7 @@ export const StorageButton = ({ id, kind, excuse, onClick, children, ariaLabel }
                                 onClick={checked(onClick)}
                                 variant={kind || "secondary"}
                                 isDisabled={!!excuse}
+                                className={onlyWide ? "show-only-when-wide" : null}
                                 style={excuse ? { pointerEvents: 'none' } : null}>
                             {children}
                         </Button>
@@ -217,11 +218,15 @@ export const StorageUsageBar = ({ stats, critical, block, offset, total, small }
         </div>);
 };
 
-export const StorageMenuItem = ({ onClick, children }) => (
-    <DropdownItem onKeyPress={checked(onClick)} onClick={checked(onClick)}>{children}</DropdownItem>
+export const StorageMenuItem = ({ onClick, onlyNarrow, children }) => (
+    <DropdownItem className={onlyNarrow ? "show-only-when-narrow" : null}
+                  onKeyPress={checked(onClick)}
+                  onClick={checked(onClick)}>
+        {children}
+    </DropdownItem>
 );
 
-export const StorageBarMenu = ({ label, isKebab, menuItems }) => {
+export const StorageBarMenu = ({ label, isKebab, onlyNarrow, menuItems }) => {
     const [isOpen, setIsOpen] = useState(false);
 
     if (!client.superuser.allowed)
@@ -237,7 +242,8 @@ export const StorageBarMenu = ({ label, isKebab, menuItems }) => {
         </DropdownToggle>;
 
     return (
-        <Dropdown onSelect={() => setIsOpen(!isOpen)}
+        <Dropdown className={onlyNarrow ? "show-only-when-narrow" : null}
+                  onSelect={() => setIsOpen(!isOpen)}
                   toggle={toggle}
                   isOpen={isOpen}
                   isPlain

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -425,3 +425,15 @@ td.ct-text-align-right {
 td button.pf-m-link {
     padding: 0px;
 }
+
+@media ( max-width: $pf-global--breakpoint--md - 1 ) {
+    .show-only-when-wide {
+        display: none;
+    }
+}
+
+@media ( min-width: $pf-global--breakpoint--md ) {
+    .show-only-when-narrow {
+        display: none;
+    }
+}

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -591,10 +591,13 @@ export const StratisPoolDetails = ({ client, pool }) => {
         ];
 
         const actions = [];
-        if (!fs_is_mounted)
-            actions.push(<StorageButton key="mount" onClick={mount}>{_("Mount")}</StorageButton>);
-
         const menuitems = [];
+
+        if (!fs_is_mounted) {
+            actions.push(<StorageButton onlyWide key="mount" onClick={mount}>{_("Mount")}</StorageButton>);
+            menuitems.push(<StorageMenuItem onlyNarrow key="mount" onClick={mount}>{_("Mount")}</StorageMenuItem>);
+        }
+
         if (fs_is_mounted)
             menuitems.push(<StorageMenuItem key="unmount" onClick={unmount}>{_("Unmount")}</StorageMenuItem>);
         menuitems.push(<StorageMenuItem key="rename" onClick={rename_fsys}>{_("Rename")}</StorageMenuItem>);

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -107,11 +107,15 @@ class StorageHelpers:
             b.wait_visible(tbody + ".pf-m-expanded")
 
     def content_row_action(self, index, title, isExpandable=True):
-        if isExpandable:
-            btn = self.content_row_tbody(index) + f" tr:first-child td button:contains({title})"
+        if self.browser.cdp.mobile:
+            # in mobile layout, we expect all actions to be in the dropdown
+            self.content_dropdown_action(index, title, isExpandable)
         else:
-            btn = "#detail-content > article > div > table > :nth-child(%d)" % index + f" td button:contains({title})"
-        self.browser.click(btn)
+            if isExpandable:
+                btn = self.content_row_tbody(index) + f" tr:first-child td button:contains({title})"
+            else:
+                btn = "#detail-content > article > div > table > :nth-child(%d)" % index + f" td button:contains({title})"
+            self.browser.click(btn)
 
     # The row might come and go a couple of times until it has the
     # expected content.  However, wait_in_text can not deal with a
@@ -124,8 +128,11 @@ class StorageHelpers:
             col = "#detail-content > article > div > table > :nth-child(%d)" % row_index + " > :nth-child(%d)" % (col_index + 1)
         wait(lambda: self.browser.is_present(col) and (val in self.browser.text(col) or (alternate_val and alternate_val in self.browser.text(col))))
 
-    def content_dropdown_action(self, index, title):
-        dropdown = self.content_row_tbody(index) + " tr td:last-child .pf-c-dropdown"
+    def content_dropdown_action(self, index, title, isExpandable=True):
+        if isExpandable:
+            dropdown = self.content_row_tbody(index) + " tr td:last-child .pf-c-dropdown"
+        else:
+            dropdown = "#detail-content > article > div > table > :nth-child(%d)" % index + " td:last-child .pf-c-dropdown"
         self.browser.click(dropdown + " button.pf-c-dropdown__toggle")
         self.browser.click(dropdown + f" a:contains('{title}')")
 


### PR DESCRIPTION
The main goal is to avoid https://github.com/patternfly/patternfly/issues/4547 by not having buttons in the mobile mode in the top right corner. We (almost) always have an expander on the row, which already takes space, and thus having a menu in mobile mode is free for us. And I like it in the top right corner. :-)

Demo: https://www.youtube.com/watch?v=-BSB-DN4yBM