### PR TITLE
users: use superuser for `useradd -D`

### DIFF
--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -215,7 +215,7 @@ export function account_create_dialog(accounts) {
     }
 
     function create() {
-        return cockpit.spawn(["/usr/sbin/useradd", "-D"])
+        return cockpit.spawn(["/usr/sbin/useradd", "-D"], { superuser: "require" })
                 .catch(() => "")
                 .then(defaults => {
                     let shell = null;


### PR DESCRIPTION
On Arch Linux the useradd file `/etc/default/useradd` is only readable
by root, so any SHELL override is not picked up by `useradd -D`.