### PR TITLE
metrics: Show top CPU core usage

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -444,6 +444,8 @@ class CurrentMetrics extends React.Component {
         }
 
         let cores = null;
+        let topCore = null;
+        let cpu_label = null;
         if (this.state.cpuCoresUsed.length > 1) {
             const top_cores = this.state.cpuCoresUsed.map((v, i) => [i, v]).sort((a, b) => b[1] - a[1])
                     .slice(0, 16);
@@ -451,6 +453,22 @@ class CurrentMetrics extends React.Component {
                 <FlexItem>{ cockpit.format(_("Core $0"), c[0]) }</FlexItem>
                 <FlexItem>{c[1]}%</FlexItem></Flex>
             );
+
+            cpu_label = (
+                <Flex spaceItems={{ default: 'spaceItemsNone' }} justifyContent={{ default: 'justifyContentFlexEnd' }}>
+                    <FlexItem>&nbsp;{ cockpit.format(_("average: $0%"), this.state.cpuUsed) }</FlexItem>
+                    <FlexItem>&nbsp;{ cockpit.format(_("max: $0%"), top_cores[0][1]) }</FlexItem>
+                </Flex>);
+
+            topCore = <Progress
+                           id="current-top-cpu-usage"
+                           value={top_cores[0][1]}
+                           className="pf-m-sm"
+                           min={0} max={100}
+                           variant={ top_cores[0][1] > 90 ? ProgressVariant.danger : ProgressVariant.info }
+                           measureLocation="none" />;
+        } else {
+            cpu_label = this.state.cpuUsed + '%';
         }
 
         const cpu_usage = (
@@ -461,17 +479,18 @@ class CurrentMetrics extends React.Component {
                 min={0} max={100}
                 variant={ this.state.cpuUsed > 90 ? ProgressVariant.danger : null }
                 title={ num_cpu_str }
-                label={ this.state.cpuUsed + '% ' } />);
+                label={ cpu_label } />);
 
         return (
             <Gallery className="current-metrics" hasGutter>
                 <Card id="current-metrics-card-cpu">
                     <CardTitle>{ _("CPU") }</CardTitle>
                     <CardBody>
-                        <div className="progress-stack">
+                        <div className="progress-stack-no-space">
                             {cores !== null ? <Tooltip content={ cores } position="bottom">
                                 {cpu_usage}
                             </Tooltip> : cpu_usage }
+                            {topCore}
                         </div>
 
                         { this.state.loadAvg &&

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -26,8 +26,10 @@ import {
     Card, CardTitle, CardBody, Gallery,
     DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
     Flex, FlexItem,
+    Grid, GridItem,
     Modal,
     Page, PageSection, PageSectionVariants,
+    Popover,
     Progress, ProgressVariant,
     Select, SelectOption,
     Switch,
@@ -445,14 +447,19 @@ class CurrentMetrics extends React.Component {
 
         let cores = null;
         let topCore = null;
+        let allCpus = null;
         let cpu_label = null;
         if (this.state.cpuCoresUsed.length > 1) {
             const top_cores = this.state.cpuCoresUsed.map((v, i) => [i, v]).sort((a, b) => b[1] - a[1])
                     .slice(0, 16);
-            cores = top_cores.map(c => <Flex key={c[0]} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-                <FlexItem>{ cockpit.format(_("Core $0"), c[0]) }</FlexItem>
-                <FlexItem>{c[1]}%</FlexItem></Flex>
-            );
+            cores = (<Grid className='cpu-all' component='dl'>
+                {top_cores.map(c =>
+                    <React.Fragment key={c[0]}>
+                        <GridItem component='dt'>{ cockpit.format(_("Core $0"), c[0]) }</GridItem>
+                        <GridItem component='dd'>{c[1]}%</GridItem>
+                    </React.Fragment>)
+                }
+            </Grid>);
 
             cpu_label = (
                 <Flex spaceItems={{ default: 'spaceItemsNone' }} justifyContent={{ default: 'justifyContentFlexEnd' }}>
@@ -467,19 +474,14 @@ class CurrentMetrics extends React.Component {
                            min={0} max={100}
                            variant={ top_cores[0][1] > 90 ? ProgressVariant.danger : ProgressVariant.info }
                            measureLocation="none" />;
+
+            allCpus = (
+                <Popover minWidth={0} aria-label={ _("View all CPUs") } bodyContent={cores}>
+                    <Button variant="link" className='pf-u-font-size-sm'>{ _("View all CPUs") }</Button>
+                </Popover>);
         } else {
             cpu_label = this.state.cpuUsed + '%';
         }
-
-        const cpu_usage = (
-            <Progress
-                id="current-cpu-usage"
-                value={this.state.cpuUsed}
-                className="pf-m-sm"
-                min={0} max={100}
-                variant={ this.state.cpuUsed > 90 ? ProgressVariant.danger : null }
-                title={ num_cpu_str }
-                label={ cpu_label } />);
 
         return (
             <Gallery className="current-metrics" hasGutter>
@@ -487,10 +489,16 @@ class CurrentMetrics extends React.Component {
                     <CardTitle>{ _("CPU") }</CardTitle>
                     <CardBody>
                         <div className="progress-stack-no-space">
-                            {cores !== null ? <Tooltip content={ cores } position="bottom">
-                                {cpu_usage}
-                            </Tooltip> : cpu_usage }
+                            <Progress
+                                id="current-cpu-usage"
+                                value={this.state.cpuUsed}
+                                className="pf-m-sm"
+                                min={0} max={100}
+                                variant={ this.state.cpuUsed > 90 ? ProgressVariant.danger : null }
+                                title={ num_cpu_str }
+                                label={ cpu_label } />
                             {topCore}
+                            {allCpus}
                         </div>
 
                         { this.state.loadAvg &&

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -73,6 +73,21 @@
           }
       }
 
+      .progress-stack-no-space {
+          display: grid;
+          padding-bottom: var(--pf-global--spacer--lg);
+          grid-gap: 0;
+
+          &:not(:first-child) {
+            padding-top: var(--pf-global--spacer--lg);
+          }
+
+          // avoid the "x" icon on high CPU usage
+          .pf-c-progress__status-icon {
+              display: none;
+          }
+      }
+
       // Stretch the progress stack and description list so they fill up remaining space.
       // This pushes the (unflexing) tables to the bottom.
       .progress-stack,

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -4,6 +4,7 @@
 @import "global-variables";
 @import "@patternfly/patternfly/components/Table/table.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
+@import "@patternfly/patternfly/utilities/Text/text.scss";
 
 #app {
     section.pf-c-page__main-breadcrumb {
@@ -85,6 +86,12 @@
           // avoid the "x" icon on high CPU usage
           .pf-c-progress__status-icon {
               display: none;
+          }
+
+          // don't center the "View all CPUs" button
+          button {
+            padding-left: 0;
+            width: fit-content;
           }
       }
 
@@ -541,5 +548,27 @@
     // leave some space for the focus rings
     .pf-c-switch {
         margin-bottom: 10px;
+    }
+}
+
+.cpu-all {
+    --pf-l-grid--m-gutter--GridGap: var(--pf-global--spacer--xs) var(--pf-global--spacer--md);
+    // Mixing font families need to be aligned properly (to the baseline)
+    align-items: baseline;
+    // In monospaced text, "100%" is 4 characters
+    grid-template-columns: 1fr minmax(4ch, auto);
+
+    > .pf-l-grid__item {
+        // Don't use PF's hardcoded 12-column grid
+        grid-column: auto;
+    }
+
+    > dd {
+        // TODO: Use tabular numbers instead of monospace,
+        // after new font usage is enabled
+        font-family: var(--pf-global--FontFamily--monospace);
+        // Aligning percentages to the right, especially when monospaced,
+        // makes  it easier to see high percentages
+        text-align: right;
     }
 }

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1064,10 +1064,12 @@ class TestMultiCPU(MachineCase):
         b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
-        b.wait(lambda: progressValue(self, "#current-cpu-usage") > 40)
-        b.mouse("#current-cpu-usage", "mouseenter")
-        b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:first-child div:nth-child(2)")[:-1]) > 50)
-        b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:nth-child(2) div:nth-child(2)")[:-1]) > 20)
+        # View all CPUs
+        b.click("#current-metrics-card-cpu button")
+        b.wait(lambda: int(b.text(".pf-c-popover .cpu-all dd:nth-of-type(1)")[:-1]) > 50)
+        b.wait(lambda: int(b.text(".pf-c-popover .cpu-all dd:nth-of-type(2)")[:-1]) > 20)
+        b.click(".pf-c-popover button")
+        b.wait_not_present(".pf-c-popover")
 
         # the top CPU core runs cpu-hog
         b.wait(lambda: progressValue(self, "#current-top-cpu-usage") >= 58)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -708,6 +708,14 @@ class TestCurrentMetrics(MachineCase):
 
         nproc = m.execute("nproc").strip()
         b.wait_in_text("#current-cpu-usage", nproc + " CPU")
+        # top CPU core is not visible with just 1 core; our upstream test VMs have only 1 core,
+        # but let's not just assume this for downstream gating/custom VMs
+        if nproc == '1':
+            self.assertFalse(b.is_present("#current-top-cpu-usage"))
+            b.wait_text("#current-cpu-usage-description", "1 CPU")
+        else:
+            b.wait_visible("#current-top-cpu-usage")
+
         # wait until system settles down
         b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
@@ -1052,6 +1060,7 @@ class TestMultiCPU(MachineCase):
         self.assertLessEqual(getMaximumSpike(self, "cpu", False, 1598968800000, 45), 1.0)
 
         # Test current usage of cores
+        b.wait_text("#current-cpu-usage-description", "2 CPUs")
         b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
         m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
@@ -1059,6 +1068,13 @@ class TestMultiCPU(MachineCase):
         b.mouse("#current-cpu-usage", "mouseenter")
         b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:first-child div:nth-child(2)")[:-1]) > 50)
         b.wait(lambda: int(b.text(".pf-c-tooltip .pf-l-flex:nth-child(2) div:nth-child(2)")[:-1]) > 20)
+
+        # the top CPU core runs cpu-hog
+        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") >= 58)
+        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") <= 70)
+        # looks like "average: 45% max: 60%"
+        b.wait(lambda: int(b.text("#current-cpu-usage .pf-c-progress__status").split()[-1].rstrip('%')) >= 58)
+        b.wait(lambda: int(b.text("#current-cpu-usage .pf-c-progress__status").split()[-1].rstrip('%')) <= 70)
 
 
 @skipImage("no PCP support", "fedora-coreos")


### PR DESCRIPTION
Often some application maxes out and gets bottle-necked on a single CPU
core. On systems with a lot of CPUs this is not visible in the average
CPU progress though. It is visible in the tooltip, but first this is not
very discoverable, and second there is no indication for the user to
actually check this, as there might be dozens of idle cores next to the
single 100% one.

On multi-core systems, show a second CPU progress bar for the currently
busiest CPU core. This provides a good balance between pointing out the
problem and avoiding cluttered UI with showing all of them all the time
(which is not even all that interesting).

Also add an info icon to the "n CPUs" progress if there are multiple
cores, so that users get a hint that there is a tooltip.

## Metrics: Show busiest CPU core

On multi-core systems, the Metrics page now shows an additional usage bar for the CPU core with the highest usage. This points out bottlenecks and performance problems which happen because only a few cores (or even a single one) get fully used, while many others are mostly idle. In that case, the average CPU usage will be low.

![image](https://user-images.githubusercontent.com/200109/155984196-c58bf1dd-3771-4591-8b47-080ec19719a3.png)