### PR TITLE
test: Robustify TestCurrentMetrics.testMemory

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -784,6 +784,8 @@ class TestCurrentMetrics(MachineCase):
         b.wait_visible("table[aria-label='Top 5 memory services']")
 
         if have_swap:
+            usage_hog1 = progressValue(self, "#current-memory-usage")
+
             # use even more memory to trigger swap
             m.execute("systemd-run --collect --slice cockpittest --unit mem-hog2 awk "
                       """'BEGIN { x = sprintf("%700000000s",""); system("sleep infinity") }'""")
@@ -791,8 +793,8 @@ class TestCurrentMetrics(MachineCase):
 
             m.execute("systemctl stop mem-hog mem-hog2")
 
-            # should go back to initial_usage; often below, due to paged out stuff
-            b.wait(lambda: progressValue(self, "#current-memory-usage") <= initial_usage)
+            # after stopping both hogs, usage should go down
+            b.wait(lambda: progressValue(self, "#current-memory-usage") < usage_hog1)
             self.assertGreater(progressValue(self, "#current-memory-usage"), 10)
             b.wait_not_in_text("table[aria-label='Top 5 memory services'] tbody", "mem-hog")
 


### PR DESCRIPTION
In the "have swap" code path of this test it often happens that the
memory usage after killing both memhogs does not go back quite to the
same number as at the start of the test. In our noisy test VM this could
have any number of reasons. So make the check less strict by measuring
against the usage before starting mem-hog2 (which is higher, as memhog
is already running). The point of the check is that current memory usage
goes down after stopping the services, but we can't pinpoint an exact
number.

----

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-16686-20211206-123627-ca37ceaf-fedora-35/log.html#291-1), which pretty much always happens on Fedora 35 in tests which touch metrics (and thus have to survive 3x affected retries)