### PR TITLE
shell: Clean up PatternFly 3 leftover

### DIFF
--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -7,10 +7,7 @@
     <link rel="stylesheet" href="index.css">
 </head>
 <body class="pf-m-redhat-font">
-    <div class="blank-slate-pf curtains-ct">
-        <div class="blank-slate-pf-icon">
-            <span class="fa fa-meh-o"></span>
-        </div>
+    <div class="curtains-ct">
         <h1>Things have moved</h1>
         <p>This old version of Cockpit doesn't know where to find default pages. Use the navigation menus to help it find its way.</p>
     </div>


### PR DESCRIPTION
blank-slate-pf and the FontAwesome icon both don't work any more in the
PF4-only shell. No real-life user should ever see this fallback any more
these days, having an icon there is really not important. So just drop
the icon and blank-slate style.