### PR TITLE
doc: Document how to connect to a non-standard D-Bus with giving an address

### DIFF
--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -112,9 +112,15 @@ client = cockpit.dbus(name, [options])
         <term><code>"bus"</code></term>
         <listitem><para>The DBus bus to connect to. Specifying <code>"session"</code> will
             connect to the DBus user session bus, <code>"user"</code> will connect to the
-            user bus (on some systems this is identical to the session bus), and <code>"system"</code>
-            will connect to the DBus system bus. This defaults to "system" if not
+            user bus (on some systems this is identical to the session bus), <code>"system"</code>
+            will connect to the DBus system bus, and <code>"none"</code> to the non-standard bus
+            specified with the <code>address</code> option. This defaults to "system" if not
             present.</para></listitem>
+      </varlistentry>
+      <varlistentry>
+        <term><code>"address"</code></term>
+        <listitem><para>The bus address to connect to in case <code>bus</code> is
+            <code>"none"</code>.</para></listitem>
       </varlistentry>
       <varlistentry>
         <term><code>"host"</code></term>


### PR DESCRIPTION
This is tested by pkg/base1/test-dbus-address.js.

---
Tested interactively:
```
❱❱❱ dbus-run-session sh -c 'echo $DBUS_SESSION_BUS_ADDRESS; sleep infinity'
unix:abstract=/tmp/dbus-7QHVXYWCbt,guid=c07a5a03839c596f3dddc18861af1525
```

Then in cockpit, open dev console:
```js
e = cockpit.dbus("org.freedesktop.DBus", { bus: "none", address: "unix:abstract=/tmp/dbus-7QHVXYWCbt,guid=c07a5a03839c596f3dddc18861af1525"})
❱❱ Object { options: {…}, unique_name: null, constructors: {…}, wait: wait(e), meta: meta(e, n), notify: v(e), close: close(e), call: call(e, t, o, i, r), signal: signal(e, n, t, o, i), subscribe: subscribe(e, n, t), … }

e.call("/org/freedesktop/DBus", "org.freedesktop.DBus", "ListNames", []).then(console.log, console.warn)
❱❱ Array [ (2) […] ]
```