### PR TITLE
Metrics spacing

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -53,11 +53,12 @@
 
       .progress-stack {
           display: grid;
-          padding-bottom: var(--pf-global--spacer--lg);
-          grid-gap: var(--pf-global--spacer--xl) var(--pf-global--spacer--2xl);
+          padding-bottom: var(--pf-global--spacer--md);
+          grid-gap: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
+
 
           &:not(:first-child) {
-            padding-top: var(--pf-global--spacer--lg);
+            padding-top: var(--pf-global--spacer--md);
           }
       }
 
@@ -184,11 +185,6 @@
   .current-metrics .pf-c-card__body {
     overflow-y: auto;
     max-height: 50vw;
-  }
-
-  // Reduce the space between progress items
-  .current-metrics .pf-c-card .progress-stack {
-      grid-gap: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
   }
 
   // Trim down the gutter space between cards

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -122,7 +122,6 @@
   .pf-c-description-list {
       --pf-c-description-list--m-horizontal__term--width: minmax(0, auto);
       --pf-c-description-list--m-horizontal__description--width: minmax(0, auto);
-      --pf-c-description-list__group--ColumnGap: 0;
   }
 
   // Don't wrap network in / out data


### PR DESCRIPTION
I realized we have a bit too much spacing in the metrics cards by default, especially when adding a maximum CPU and when there are several storage devices.

## Before

![Screenshot 2021-12-07 at 10-55-28 Overview - garrett Bolt](https://user-images.githubusercontent.com/10246/145007341-08a04829-8ae3-4c68-bd02-62e120ae141d.png)

## After

![Screenshot 2021-12-07 at 10-53-40 Overview - garrett Bolt](https://user-images.githubusercontent.com/10246/145007361-c274e864-afa8-4eba-8f02-f17f7d2978df.png)
