### PR TITLE
test: Close port 8765 to update the pixel tests

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -64,6 +64,14 @@ class TestFirewall(NetworkCase):
         if m.image not in ["ubuntu-2004"]:
             m.execute("if virsh net-list --name | grep -q default; then until firewall-cmd --get-active-zones | grep -q libvirt; do sleep 1; done; fi")
 
+        # Temporary remove the test Dbus port 8765, this workaround can be
+        # removed once the pixel tests are merged and the image updated to not
+        # open port 8765
+        if m.image.startswith("fedora"):
+            m.execute("firewall-cmd --permanent --remove-port=8765/tcp")
+            m.execute("firewall-cmd --remove-port=8765/tcp")
+            m.execute("firewall-cmd --reload")
+
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
The tests no longer require port 8765 to be opened as the dbus tests now
run locally in the virtual machine. The port is closed in cockpit, so
the pixel tests can be updated and not opening the ports is an easier
change in bots.