### PR TITLE
session: Validate client certificates against sssd's trusted CA

### DIFF
--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -35,12 +35,11 @@ openssl req -new -newkey rsa:2048 -days 365 \
 
     <para>Now get this certificate request signed by the Certificate Authority of your Identity
     Management domain, to get a PEM certificate. Browsers and smart cart utilities accept PKCS#12 format
-    for importing/transfer, so convert the certificate/key pair, and protect it with a transfer
-    password:</para>
+    for importing/transfer, so convert the certificate/key pair; it will ask for and protect it
+    with a transfer password:</para>
 
 <programlisting>
-openssl pkcs12 -export -password pass:somepassword \
-    -in alice.pem -inkey alice.key -out alice.p12
+openssl pkcs12 -export -in alice.pem -inkey alice.key -out alice.p12
 </programlisting>
 
     <para>Don't forget to clean up the key file when you do not need it any more:</para>

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -29,7 +29,7 @@
       This command generates a simple key and certificate request for the "alice" user:</para>
 
 <programlisting>
-openssl req -new -newkey rsa:2048 -days 365 -nodes \
+openssl req -new -newkey rsa:2048 -days 365 \
     -keyout alice.key -out alice.csr -subj "/CN=alice"
 </programlisting>
 
@@ -41,6 +41,12 @@ openssl req -new -newkey rsa:2048 -days 365 -nodes \
 <programlisting>
 openssl pkcs12 -export -password pass:somepassword \
     -in alice.pem -inkey alice.key -out alice.p12
+</programlisting>
+
+    <para>Don't forget to clean up the key file when you do not need it any more:</para>
+
+<programlisting>
+shred -u alice.key
 </programlisting>
 
   <para>You can now import <code>alice.p12</code> directly into your browser,

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -144,6 +144,16 @@ maprule = LDAP:(userCertificate={cert!base64})
   <section id="certauth-server-cockpitconf">
     <title>Cockpit web server configuration</title>
 
+    <para>Set the trusted Certificate Authority of your user certificates in <command>sssd</command>,
+    either by copying the CA PEM file to <code>/etc/sssd/pki/sssd_auth_ca_db.pem</code> or setting the
+    <ulink url="https://www.mankier.com/5/sssd.conf#Services_Sections-PAM_configuration_options">
+    <command>pam_cert_db_path</command></ulink> configuration option to the path of the CA.
+    If you use FreeIPA and its CA:</para>
+
+<programlisting>
+cp /etc/ipa/ca.crt /etc/sssd/pki/sssd_auth_ca_db.pem
+</programlisting>
+
     <para>Certificate authentication needs to be enabled in
       <ulink url="./cockpit.conf.5.html">cockpit.conf</ulink> explicitly:</para>
 
@@ -155,12 +165,17 @@ ClientCertAuthentication = yes
   <warning>
     <para>Any client can generate certificates with arbitrary information, thus
       the client certificates must be checked for validity. Cockpit currently
-      accepts any client certificate and relies on sssd to verify their validity.
-      This is secure only when the entire certificate gets matched, i.e. when
-      importing the complete certificates into Identity Management as shown above.
-      <emphasis>Do not use this with local sssd <code>certmap</code> rules</emphasis>
-      which only match on Subject/Issuer properties!
-  </para>
+      accepts any client certificate and relies on sssd to verify their validity.</para>
+
+    <para>Check if your <command>sssd</command> version is at least 2.6.1, as earlier
+      versions did not validate the user certificate against the configured CA with
+      Cockpit logins. With earlier versions, this is secure only when the
+      entire certificate gets matched, i.e. when importing the complete
+      certificates into Identity Management as shown above. Also, certificate
+      revocations are <emphasis>not checked with earlier sssd versions</emphasis>.</para>
+
+    <para><emphasis>Do not use this with local sssd <code>certmap</code> rules</emphasis>
+      which only match on Subject/Issuer properties, if you run sssd earlier than 2.6.1!</para>
  </warning>
 
   <para>When enabling this mode,

--- a/doc/guide/cert-authentication.xml
+++ b/doc/guide/cert-authentication.xml
@@ -26,19 +26,19 @@
     <para>Generating the certificates for users is usually done with a certificate management system like
       <ulink url="https://pagure.io/certmonger">certmonger</ulink> or
       <ulink url="https://www.freeipa.org/page/PKI">FreeIPA</ulink>, which are not documented here.
-      For testing purposes, these commands will generate a self-signed certificate/key for the "alice" user:</para>
+      This command generates a simple key and certificate request for the "alice" user:</para>
 
 <programlisting>
-# create self-signed certificate and key
-# some browsers insist on specifying key usage, so it needs a config file
-printf '[req]\ndistinguished_name=dn\nextensions=v3_req\n[dn]\n
-    [v3_req]\nkeyUsage=digitalSignature,keyEncipherment,keyAgreement\n' > /tmp/openssl.cnf
+openssl req -new -newkey rsa:2048 -days 365 -nodes \
+    -keyout alice.key -out alice.csr -subj "/CN=alice"
+</programlisting>
 
-openssl req -x509 -newkey rsa:2048 -days 365 -nodes -keyout alice.key \
-    -out alice.pem -subj "/CN=alice" -config /tmp/openssl.cnf -extensions v3_req
+    <para>Now get this certificate request signed by the Certificate Authority of your Identity
+    Management domain, to get a PEM certificate. Browsers and smart cart utilities accept PKCS#12 format
+    for importing/transfer, so convert the certificate/key pair, and protect it with a transfer
+    password:</para>
 
-# browsers and smart cart utilities accept PKCS#12 format, convert it
-# this needs to set a transfer/import password
+<programlisting>
 openssl pkcs12 -export -password pass:somepassword \
     -in alice.pem -inkey alice.key -out alice.p12
 </programlisting>
@@ -55,16 +55,24 @@ pkcs15-init --store-private-key alice.p12 --format pkcs12 --auth-id 01
 
   <section id="certauth-server-ipa">
     <title>Certificate mapping with FreeIPA</title>
+    <para>The recommended method to sign a user certificate request and associate it to a user is
+      <command>ipa cert-request</command>: </para>
 
-    <para>The domain's users get associated to certificates with
-      the <command>ipa user-add-cert</command> command. This expects PEM format, but without the
-      <code>-----BEGIN</code>/<code>-----END</code> markers.  See the
-      <ulink url="https://www.freeipa.org/page/V4/User_Certificates#Feature_Management">
-      FreeIPA User Certificates documentation</ulink>:</para>
+<programlisting>
+ipa cert-request alice.csr --principal=alice --certificate-out=alice.pem
+</programlisting>
+
+    <para>Alternatively, if you are using a different CA, you can use
+    <command>ipa user-add-cert</command> to associate the signed certificate to the user.
+    This expects PEM format, but without the <code>-----BEGIN</code>/<code>-----END</code>
+    markers:</para>
 
 <programlisting>
 ipa user-add-cert alice --certificate="$(grep -v ^---- alice.pem)"
 </programlisting>
+
+    <para>See the <ulink url="https://www.freeipa.org/page/V4/User_Certificates#Feature_Management">
+      FreeIPA User Certificates documentation</ulink> for details.</para>
 
   </section>
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -692,10 +692,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
     @skipImage("sssd not available", "fedora-coreos")
     def testClientCertAuthentication(self):
-        # This only tests the cockpit ←→ sssd API, but this is completely unsafe!
-        # Nothing currently checks whether the client certificate is signed by
-        # a trusted CA, or is in a revocation list. But it is convenient as a downstream
-        # gating test and as a basis to properly supporting certmap rules in the future.
         m = self.machine
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
@@ -714,7 +710,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         alice_cert_key = ['--cert', alice_cert, '--key', alice_key]
 
         # set up local (NIS) sssd provider and certificate mapping
-        m.write("/etc/sssd/sssd.conf", """
+        self.write_file("/etc/sssd/sssd.conf", """
 [sssd]
 domains = local
 
@@ -722,18 +718,43 @@ domains = local
 id_provider = files
 
 [certmap/local/alice]
-# WARNING: interface testing only, this is insecure! Nothing validates the cert signer
+# WARNING: Requires sssd >= 2.6.1 and installing sssd_auth_ca_db.pem; with earlier sssd this is completely unsafe
 matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
 """, perm="0600")
         m.execute("systemctl restart sssd")
 
-        # ensure sssd certificate lookup works
+        # ensure sssd certificate lookup without validation works
         user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
                              'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
                              '''"$(cat %s)" | sed 's/^o "//; s/"$//' ''' % alice_cert)
         self.assertEqual(m.execute('busctl get-property org.freedesktop.sssd.infopipe ' + user_obj.strip() +
                                    ' org.freedesktop.sssd.infopipe.Users.User name').strip(),
                          's "alice"')
+
+        # sssd 2.6.1 introduces FindByValidCertificate() method which validates the given certificate
+        # against the configured CA. Without this, certmap rules are completely unsafe!
+        api = m.execute("busctl introspect org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users")
+        has_validate_api = 'FindByValidCertificate' in api
+        # we don't want to completely pinpoint the OS list to avoid lockstep image refreshes+cockpit PRs
+        # and spontaneous packit test failures as sssd 2.6.1 goes into more distros; but make sure we hit
+        # this code path on some known-good ones
+        if m.image in ["fedora-35", "debian-testing"]:
+            self.assertTrue(has_validate_api)
+
+        if has_validate_api:
+            err = m.execute('! busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                            'org.freedesktop.sssd.infopipe.Users FindByValidCertificate s -- '
+                            '''"$(cat %s)" 2>&1''' % alice_cert)
+            self.assertIn("Invalid certificate provided", err)
+
+            m.execute("mkdir -p /etc/sssd/pki")
+            # install our CA, so that sssd can validate
+            with open("src/tls/ca/ca.pem") as f:
+                m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
+            u = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
+                          'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
+                          '''"$(cat %s)" | sed 's/^o "//; s/"$//' ''' % alice_cert)
+            self.assertEqual(u, user_obj)
 
         # These tests have to be run with curl, as chromium-headless does not support selecting/handling client-side
         # certificates; it just rejects cert requests. For interactive tests, grab src/tls/ca/alice.p12 and import
@@ -814,6 +835,12 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         do_test(['-u', 'alice:foobar123'],
                 ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
+
+        # with validation API and without a CA, alice's cert fails
+        if has_validate_api:
+            m.execute("rm /etc/sssd/pki/sssd_auth_ca_db.pem")
+            self.allow_journal_messages("cockpit-session: Failed to map .* Invalid certificate provided")
+            do_test(alice_cert_key, ['HTTP/1.1 401 Authentication failed'])
 
         # sssd-dbus not available
         self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -29,6 +29,10 @@ from testlib import *
 @nondestructive
 @skipDistroPackage()
 class TestLogin(MachineCase):
+    def tearDown(self):
+        # arch configures pam_faillock by default, and tests here do a lot of failed login attempts
+        if self.machine.image == "arch":
+            self.machine.execute("rm -rf /run/faillock")
 
     def check_shell(self):
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -740,6 +740,10 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # it into the browser.
 
         def do_test(authopts, expected, not_expected=[], session_leader=None):
+            if m.image in ["debian-testing"]:
+                # HACK: works around https://bugs.debian.org/1001377
+                m.execute("rm -f /var/log/sssd/*")
+
             m.start_cockpit(tls=True)
             output = m.execute(['curl', '-ksS', '-D-'] + authopts + ['https://localhost:9090/cockpit/login'])
             for s in expected:

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -493,6 +493,9 @@ ExecStart=/bin/true
         # during image creation the /var/cache directory gets cleaned up, recreate the krb5rcache
         self.machine.execute("mkdir -pZ /var/cache/krb5rcache")
 
+        # IPA CA cert has OCSP entry with that host name, make it available
+        self.machine.execute("echo '10.111.112.100 ipa-ca.cockpit.lan' >> /etc/hosts")
+
         # HACK: Figure out why this happens
         self.allow_journal_messages('''.*didn't receive expected "authorize" message''',
                                     'cockpit-session:$')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -355,12 +355,9 @@ class CommonTests:
         b.logout()
         m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
 
-        # upload certificates to client machine
-        m.upload(["alice.pem", "alice.key", "bob.pem", "bob.key"], "/var/tmp",
-                 relative_dir="src/tls/ca/")
+        # alice's certificate was written by testClientCertAuthentication()
         alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]
         alice_user_pass = ['-u', 'alice:' + self.alice_password]
-        bob_cert_key = ['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"]
 
         # ensure sssd certificate lookup works
         user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
@@ -426,7 +423,9 @@ class CommonTests:
         # another certificate gets rejected
         self.allow_journal_messages("cockpit-session: .*User not found")
         self.allow_journal_messages("cockpit-session: No matching user for certificate")
-        do_test(bob_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
+        m.upload(["bob.pem", "bob.key"], "/var/tmp", relative_dir="src/tls/ca/")
+        do_test(['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"],
+                ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
                 not_expected=["crsf-token"])
 
         # disallow password auth
@@ -665,20 +664,23 @@ ExecStart=/bin/true
         b = self.browser
 
         ipa_machine = self.machines['services']
-        with open("src/tls/ca/alice.pem") as f:
-            alice_cert = f.read().strip()
-        # IPA does not like the ---BEGIN/END lines
-        alice_cert = '\n'.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
         # set up an IPA user with a TLS certificate; can't use "admin" due to https://pagure.io/freeipa/issue/6683
-        ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
+        ipa_machine.execute(f"""podman exec -i freeipa sh -exc '
 ipa user-add --first=Alice --last="Developer" --shell=/bin/bash alice
-yes "%(password)s" | ipa user-mod --password alice
-ipa user-mod --password-expiration='2030-01-01T00:00:00Z' alice
-ipa user-add-cert alice --certificate="%(cert)s"
+yes "{self.alice_password}" | ipa user-mod --password alice
+ipa user-mod --password-expiration=2030-01-01T00:00:00Z alice' """)
+
+        ipa_machine.execute(r"""podman exec -i freeipa sh -exc '
+# generate IPA CA signed certificate for alice
+openssl req -new -newkey rsa:2048 -days 365 -nodes -keyout /tmp/alice.key -out /tmp/alice.csr -subj "/CN=alice"
+ipa cert-request /tmp/alice.csr --principal=alice --certificate-out=/tmp/alice.pem
 # make alice an admin
 ipa group-add-member admins --users=alice
 ipa-advise enable-admins-sudo | sh -ex
-' """ % {"cert": alice_cert, "password": self.alice_password})
+' """)
+        # download certificate to cockpit machine
+        m.write("/var/tmp/alice.pem", ipa_machine.execute("podman exec -i freeipa cat /tmp/alice.pem").strip())
+        m.write("/var/tmp/alice.key", ipa_machine.execute("podman exec -i freeipa cat /tmp/alice.key").strip())
 
         self.checkClientCertAuthentication()
 
@@ -865,6 +867,9 @@ class TestAD(TestRealms, CommonTests):
         m = self.machine
 
         services_machine = self.machines['services']
+        # samba has no default CA and no helpers, so just re-use our completely independent cockpit-tls unit test one
+        m.upload(["alice.pem", "alice.key"], "/var/tmp", relative_dir="src/tls/ca/")
+
         with open("src/tls/ca/alice.pem") as f:
             alice_cert = f.read().strip()
         # mangle into form palatable for LDAP

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -359,6 +359,12 @@ class CommonTests:
         alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]
         alice_user_pass = ['-u', 'alice:' + self.alice_password]
 
+        if self.__class__ == TestIPA:
+            # `realm join` does not automatically configure sssd to be able to validate certificates;
+            # it needs to be explicitly told the CA to trust. Use the IPA's CA. (That would be an
+            # excellent default, but oh well, we can't have all nice things.)
+            m.execute("mkdir -p /etc/sssd/pki/; cp /etc/ipa/ca.crt /etc/sssd/pki/sssd_auth_ca_db.pem")
+
         # ensure sssd certificate lookup works
         user_obj = m.execute('busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
                              'org.freedesktop.sssd.infopipe.Users FindByCertificate s -- '
@@ -427,12 +433,26 @@ class CommonTests:
         do_test(['--cert', "/var/tmp/bob.pem", '--key', "/var/tmp/bob.key"],
                 ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
                 not_expected=["crsf-token"])
+        self.allow_journal_messages("cockpit-session: Failed to map certificate to user: .* Invalid certificate provided")
 
         # disallow password auth
         m.write("/etc/cockpit/cockpit.conf", "[Basic]\naction = none\n", append=True)
         do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
         do_test(alice_user_pass, ['HTTP/1.1 401 Authentication disabled', '<h1>Authentication disabled</h1>'],
                 not_expected=["crsf-token"])
+
+        # valid user certificate which fails CA validation; this requires sssd ≥ 2.6.1
+        m.execute("mv /etc/sssd/pki/sssd_auth_ca_db.pem /etc/sssd/pki/sssd_auth_ca_db.pem.valid")
+        with open("src/tls/ca/alice-expired.pem") as f:
+            m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
+        api = m.execute("busctl introspect org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users")
+        has_validate_api = 'FindByValidCertificate' in api
+        if has_validate_api:
+            do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed"])
+        else:
+            # earlier sssd just matches the certificate verbatim, without CA validation
+            do_test(alice_cert_key, ['HTTP/1.1 200 OK', '"csrf-token"'])
+        m.execute("mv /etc/sssd/pki/sssd_auth_ca_db.pem.valid /etc/sssd/pki/sssd_auth_ca_db.pem")
 
 
 @skipImage("No realmd available", "fedora-coreos", "arch")
@@ -898,6 +918,10 @@ maprule = LDAP:(userCertificate={cert!base64})
 # this also requires CA validation in cockpit-tls or sssd, which we don't have yet
 # maprule = (|(userPrincipalName={subject_principal})(sAMAccountName={subject_principal.short_name}))
 """, perm="0600")
+        # tell sssd about our CA for validating certs
+        m.execute("mkdir -p /etc/sssd/pki")
+        with open("src/tls/ca/ca.pem") as f:
+            m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
 
         self.checkClientCertAuthentication()
 

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -95,6 +95,11 @@ class TestS4USsh(MachineCase):
         """
         ipa_machine.execute(f"podman exec freeipa bash -ec '{script}'")
 
+        # tell sssd about our CA for validating certs
+        client_machine.execute("mkdir -p /etc/sssd/pki")
+        with open("src/tls/ca/ca.pem") as f:
+            client_machine.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
+
         # enable gssapiauth for ssh
         sshd_machine.execute("sed -ri 's/#GSSAPIAuthentication (yes|no)/GSSAPIAuthentication yes/' /etc/ssh/sshd_config")
         sshd_machine.execute("systemctl restart sshd")


### PR DESCRIPTION
sssd 2.6.1 introduces a new FindByValidCertificate() method which
validates the given certificate against the configured CA. Use this API
if available, and fall back to FindByCertificate() to keep compatibility
with older distributions.

This enables OCSP/CRL checks, and enables certmap rules in a safe way.
Update TestLogin.testClientCertAuthentication() to adjust the scary
comments, and make sure that certificates without a valid CA are
rejected if the new API is available.

Similarly, adjust check-system-realms to tell sssd about a valid CA, and
test valid/invalid cases.

Update the client certificate docs to show how to set up the CA in sssd,
and adjust the warning: certmap rules are now actually okay with sssd
2.6.1.

https://bugzilla.redhat.com/show_bug.cgi?id=1992149
CVE-2021-3698

-----

TODO:
 - [x] update FreeIPA cert login docs to use `ipa cert-request`
 - [x] add integration test for matching cert with invalid sig (works on older OSes, fails with sssd 2.6.1)
 - [x] update `TestLogin.testClientCertAuthentication` for CA validation, certmap rules are safe with this new API
 - [x] update documentation: Preview (without CSS) at https://piware.de/tmp/cert-authentication.html
 - [x] add release note: in particular, point out sssd CA installation requirement on updates

## Certificate login validation: Action required on updates

Earlier Cockpit/sssd versions did not check trust or revocation status of a presented client certificate, and thus certificate/smart card login was secure and supported only when matching the entire binary certificate against the Identity Management's database. With sssd 2.6.1 and Cockpit 260, the certificate signature and revocation status is now validated against the CA [configured in sssd](https://www.mankier.com/5/sssd.conf#Services_Sections-PAM_configuration_options), and any non-trusted certificate is rejected. This includes the case when the local sssd has *no* configured CA, which may break certificate logins after updating cockpit and sssd.

Thus if you use certificate login, you need to set up the trusted CA in sssd. Please see the [certificate authentication documentation](https://cockpit-project.org/guide/latest/cert-authentication.html#certauth-server-cockpitconf) for details.

This issue was assigned [CVE-2021-3698](https://access.redhat.com/security/cve/CVE-2021-3698).