### PR TITLE
flatpak: update desktop file in metainfo

### DIFF
--- a/containers/flatpak/cockpit-client.metainfo.xml.in
+++ b/containers/flatpak/cockpit-client.metainfo.xml.in
@@ -37,7 +37,7 @@
     <release date="@TODAY@" version="@VERSION@" type="@RELEASE_TYPE@"/>
 @PREVIOUS_RELEASES@  </releases>
 
-  <launchable type="desktop-id">cockpit-client.desktop</launchable>
+  <launchable type="desktop-id">org.cockpit_project.CockpitClient.desktop</launchable>
 
   <categories>
     <category>Network</category>


### PR DESCRIPTION
We renamed the desktop file but forgot to update it in the metainfo.
This was flagged by @flathubbot when we attempted to push the update.


We won't have to re-do the release or anything.  I've just manually patched it into the bot-written commit for the time being.  This kind of thing is part of the reason why we keep the metainfo outside of the tarball.