### PR TITLE
workflows: clone flathub repository from flathub

### DIFF
--- a/.github/workflows/update-flathub.yml
+++ b/.github/workflows/update-flathub.yml
@@ -21,8 +21,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: flathub
-          repository: cockpit-project/org.cockpit_project.CockpitClient
+          repository: flathub/org.cockpit_project.CockpitClient
           ssh-key: ${{ secrets.DEPLOY_KEY }}
+          # this is needed so we can push to a different repository
+          fetch-depth: 0
 
       - name: Download latest tarball (hack)
         run: |
@@ -40,4 +42,4 @@ jobs:
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
           src/containers/flatpak/update-flathub "$(realpath *.tar.xz)" "$(realpath flathub)"
-          git -C flathub push origin HEAD
+          git -C flathub push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD


### PR DESCRIPTION
Instead of cloning our fork of the flathub repository, clone the
"official" one under the flathub project.  We still push the new branch
to our own repository, however.

This prevents us from having to keep our own repository up to date.  In
fact, our main branch now contains only a README telling you to look
elsewhere.

 - [x] test run: https://github.com/cockpit-project/cockpit/actions/runs/1555078984
 - [x] pushed branch: https://github.com/cockpit-project/org.cockpit_project.CockpitClient/commits/259
 - [x] empty main branch: https://github.com/cockpit-project/org.cockpit_project.CockpitClient/