### PR TITLE
test: Call `tuned-adm recommend` with running tuned

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -89,13 +89,15 @@ if [ -n "$test_basic" ]; then
         "
 fi
 
+TESTS=TestTuned.testBasic
+
 exclude_options=""
 for t in $EXCLUDES; do
     exclude_options="$exclude_options --exclude $t"
 done
 
 # execute run-tests
-test/common/run-tests --test-dir test/verify --nondestructive $exclude_options \
+test/common/run-tests -tv --test-dir test/verify --nondestructive $exclude_options \
     --machine localhost:22 --browser localhost:9090 $TESTS || RC=$?
 
 echo $RC > "$LOGS/exitcode"

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -32,8 +32,6 @@ class TestTuned(MachineCase):
         b = self.browser
         m = self.machine
 
-        recommended_profile = m.execute("tuned-adm recommend").strip()
-
         # Stop tuned in case it is running by default, as on RHEL.
 
         m.execute("systemctl stop tuned")
@@ -56,6 +54,7 @@ class TestTuned(MachineCase):
 
         # Start tuned manually. The recommended profile will be activated automatically.
         m.execute("systemctl start tuned")
+        recommended_profile = m.execute("tuned-adm recommend").strip()
         b.wait_text('#tuned-status-button', recommended_profile)
         check_status_tooltip("This system is using the recommended profile")
 


### PR DESCRIPTION
This avoids the "Cannot talk to TuneD daemon via DBus. Is TuneD daemon
running?" warning, and gives more accurate results. In particular,
tuned in CentOS 9 Stream started to recommend "atomic-guest" on the
testing farm.

----

[c9s packit](http://artifacts.dev.testing-farm.io/07c9b635-19fc-4802-90c7-1cf1985773bb/) spontaneously broke two days ago, let's see if that fixes it.

First version still has some debugging stuff.