### PR TITLE
fmf: Fix $TEST_OS for centos-9-stream

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -32,8 +32,8 @@ if [ "$TEST_OS" = "fedora-36" ]; then
     export TEST_OS=fedora-35
 fi
 
-if [ "$TEST_OS" = "centos-8" ]; then
-    TEST_OS=centos-8-stream
+if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
+    TEST_OS="${TEST_OS}-stream"
 fi
 
 if [ "$ID" = "fedora" ]; then


### PR DESCRIPTION
Generalize the `$TEST_OS` transformation for stream to apply to any
major version. Taken from corresponding script in cockpit-podman.

----

This should make https://github.com/cockpit-project/bots/pull/2704 actually effective, and fix the [c9s failure](http://artifacts.dev.testing-farm.io/27845049-5918-402b-985e-596423232e2e/).