### PR TITLE
webserver: expose and emit CockpitWebRequest

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -826,6 +826,7 @@ cockpit_packages_resolve (CockpitPackages *packages,
 
 static gboolean
 handle_package_checksum (CockpitWebServer *server,
+                         CockpitWebRequest *request,
                          const gchar *path,
                          GHashTable *headers,
                          CockpitWebResponse *response,
@@ -874,6 +875,7 @@ set_manifest_headers (CockpitWebResponse *response,
 
 static gboolean
 handle_package_manifests_js (CockpitWebServer *server,
+                             CockpitWebRequest *request,
                              const gchar *path,
                              GHashTable *headers,
                              CockpitWebResponse *response,
@@ -906,6 +908,7 @@ handle_package_manifests_js (CockpitWebServer *server,
 
 static gboolean
 handle_package_manifests_json (CockpitWebServer *server,
+                               CockpitWebRequest *request,
                                const gchar *path,
                                GHashTable *headers,
                                CockpitWebResponse *response,
@@ -1114,6 +1117,7 @@ out:
 
 static gboolean
 handle_packages (CockpitWebServer *server,
+                 CockpitWebRequest *request,
                  const gchar *unused,
                  GHashTable *headers,
                  CockpitWebResponse *response,

--- a/src/bridge/test-httpstream.c
+++ b/src/bridge/test-httpstream.c
@@ -93,6 +93,7 @@ teardown_general (TestGeneral *tt,
 
 static gboolean
 handle_host_header (CockpitWebServer *server,
+                    CockpitWebRequest *request,
                     const gchar *path,
                     GHashTable *headers,
                     CockpitWebResponse *response,
@@ -185,6 +186,7 @@ test_host_header (TestGeneral *tt,
 
 static gboolean
 handle_default (CockpitWebServer *server,
+                CockpitWebRequest *request,
                 const gchar *path,
                 GHashTable *headers,
                 CockpitWebResponse *response,
@@ -311,6 +313,7 @@ const gint MAGIC_NUMBER = 3068;
 
 static gboolean
 handle_chunked (CockpitWebServer *server,
+                CockpitWebRequest *request,
                 const gchar *path,
                 GHashTable *headers,
                 CockpitWebResponse *response,
@@ -467,6 +470,7 @@ typedef struct {
 
 static gboolean
 handle_test (CockpitWebServer *server,
+             CockpitWebRequest *request,
              const gchar *path,
              GHashTable *headers,
              CockpitWebResponse *response,

--- a/src/bridge/test-websocketstream.c
+++ b/src/bridge/test-websocketstream.c
@@ -84,14 +84,15 @@ on_socket_close (WebSocketConnection *ws,
 
 static gboolean
 handle_socket (CockpitWebServer *server,
-               const gchar *original_path,
-               const gchar *path,
-               const gchar *method,
-               GIOStream *io_stream,
-               GHashTable *headers,
-               GByteArray *input,
+               CockpitWebRequest *request,
                gpointer data)
 {
+  const gchar *path = cockpit_web_request_get_path (request);
+  const gchar *method = cockpit_web_request_get_method (request);
+  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
+  GByteArray *input = cockpit_web_request_get_buffer (request);
+  GHashTable *headers = cockpit_web_request_get_headers (request);
+
   const gchar *origins[] = { NULL, NULL };
   const gchar *protocols[] = { "one", "two", "three", NULL };
   WebSocketConnection *ws = NULL;

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -84,6 +84,7 @@ libcockpit_common_a_SOURCES = \
 	src/common/cockpitwebinject.c \
 	src/common/cockpitwebresponse.h \
 	src/common/cockpitwebresponse.c \
+	src/common/cockpitwebrequest-private.h \
 	src/common/cockpitwebserver.h \
 	src/common/cockpitwebserver.c \
 	$(NULL)

--- a/src/common/cockpitwebrequest-private.h
+++ b/src/common/cockpitwebrequest-private.h
@@ -16,6 +16,7 @@ struct _CockpitWebRequest {
   GHashTable *headers;
   const gchar *original_path;
   const gchar *path;
+  const gchar *host;
   const gchar *query;
   const gchar *method;
 };

--- a/src/common/cockpitwebrequest-private.h
+++ b/src/common/cockpitwebrequest-private.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "cockpitwebserver.h"
+
+struct _CockpitWebRequest {
+  int state;
+  GIOStream *io;
+  GByteArray *buffer;
+  gint delayed_reply;
+  CockpitWebServer *web_server;
+  gboolean eof_okay;
+  GSource *source;
+  GSource *timeout;
+  gboolean check_tls_redirect;
+
+  GHashTable *headers;
+  const gchar *original_path;
+  const gchar *path;
+  const gchar *method;
+};
+
+#define WebRequest(...) (&(CockpitWebRequest) {__VA_ARGS__})

--- a/src/common/cockpitwebrequest-private.h
+++ b/src/common/cockpitwebrequest-private.h
@@ -16,6 +16,7 @@ struct _CockpitWebRequest {
   GHashTable *headers;
   const gchar *original_path;
   const gchar *path;
+  const gchar *query;
   const gchar *method;
 };
 

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -60,7 +60,7 @@ struct _CockpitWebResponse {
   gchar *method;
   gchar *origin;
 
-  CockpitWebResponseFlags flags;
+  gchar *protocol;
   CockpitCacheType cache_type;
 
   /* The output queue */
@@ -155,6 +155,7 @@ cockpit_web_response_finalize (GObject *object)
 {
   CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (object);
 
+  g_free (self->protocol);
   g_free (self->full_path);
   g_free (self->url_root);
   g_free (self->method);
@@ -202,12 +203,11 @@ cockpit_web_response_new (GIOStream *io,
                           const gchar *original_path,
                           const gchar *path,
                           GHashTable *in_headers,
-                          CockpitWebResponseFlags flags)
+                          const gchar *protocol)
 {
   CockpitWebResponse *self;
   GOutputStream *out;
   const gchar *connection;
-  const gchar *protocol = NULL;
   const gchar *host = NULL;
   gint offset;
 
@@ -255,10 +255,9 @@ cockpit_web_response_new (GIOStream *io,
       host = g_hash_table_lookup (in_headers, "Host");
     }
 
-  self->flags = flags;
-  protocol = cockpit_web_response_get_protocol (self, in_headers);
-  if (protocol && host)
-    self->origin = g_strdup_printf ("%s://%s", protocol, host);
+  self->protocol = g_strdup (protocol ?: "http");
+  if (host)
+    self->origin = g_strdup_printf ("%s://%s", self->protocol, host);
 
   return self;
 }
@@ -1899,36 +1898,13 @@ cockpit_web_response_get_origin (CockpitWebResponse *self)
 }
 
 const gchar *
-cockpit_web_response_get_protocol (CockpitWebResponse *self,
-                                   GHashTable *headers)
+cockpit_web_response_get_protocol (CockpitWebResponse *self)
 {
-  return cockpit_connection_get_protocol (self->io, headers, self->flags & COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY);
+  return self->protocol;
 }
 
 static void
 cockpit_web_response_flow_iface_init (CockpitFlowInterface *iface)
 {
   /* No implementation */
-}
-
-const gchar *
-cockpit_connection_get_protocol (GIOStream *connection,
-                                 GHashTable *headers,
-                                 gboolean for_tls_proxy)
-{
-  const gchar *protocol = NULL;
-  const gchar *protocol_header;
-
-  if (connection && G_IS_TLS_CONNECTION (connection))
-    {
-      protocol = "https";
-    }
-  else
-    {
-      protocol_header = cockpit_conf_string ("WebService", "ProtocolHeader");
-      if (protocol_header && headers)
-         protocol = g_hash_table_lookup (headers, protocol_header);
-    }
-
-  return protocol ?: (for_tls_proxy ? "https" : "http");
 }

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -56,7 +56,6 @@ struct _CockpitWebResponse {
   const gchar *logname;
   const gchar *path;
   gchar *full_path;
-  gchar *query;
   gchar *url_root;
   gchar *method;
   gchar *origin;
@@ -157,7 +156,6 @@ cockpit_web_response_finalize (GObject *object)
   CockpitWebResponse *self = COCKPIT_WEB_RESPONSE (object);
 
   g_free (self->full_path);
-  g_free (self->query);
   g_free (self->url_root);
   g_free (self->method);
   g_free (self->origin);
@@ -187,7 +185,6 @@ cockpit_web_response_class_init (CockpitWebResponseClass *klass)
  * cockpit_web_response_new:
  * @io: the stream to send on
  * @path: the path resource or NULL
- * @query: the query string or NULL
  * @in_headers: input headers or NULL
  * @flags: in #COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY mode, the origin is assumed to
  *         be https://<host> even for a non-HTTPS connection.
@@ -204,7 +201,6 @@ CockpitWebResponse *
 cockpit_web_response_new (GIOStream *io,
                           const gchar *original_path,
                           const gchar *path,
-                          const gchar *query,
                           GHashTable *in_headers,
                           CockpitWebResponseFlags flags)
 {
@@ -245,7 +241,6 @@ cockpit_web_response_new (GIOStream *io,
         self->url_root = g_strndup (original_path, offset);
     }
 
-  self->query = g_strdup (query);
   if (self->path)
     self->logname = self->path;
   else
@@ -298,19 +293,6 @@ cockpit_web_response_get_path (CockpitWebResponse *self)
 const gchar *
 cockpit_web_response_get_url_root (CockpitWebResponse *self) {
   return self->url_root;
-}
-
-/**
- * cockpit_web_response_get_query:
- * @self: the response
- *
- * Returns: the resource path for response
- */
-const gchar *
-cockpit_web_response_get_query (CockpitWebResponse *self)
-{
-  g_return_val_if_fail (COCKPIT_IS_WEB_RESPONSE (self), NULL);
-  return self->query;
 }
 
 /**

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -60,7 +60,6 @@ extern const gchar *  cockpit_web_exception_escape_root;
 CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           const gchar *original_path,
                                                           const gchar *path,
-                                                          const gchar *query,
                                                           GHashTable *in_headers,
                                                           CockpitWebResponseFlags flags);
 void                  cockpit_web_response_set_method    (CockpitWebResponse *response,
@@ -68,8 +67,6 @@ void                  cockpit_web_response_set_method    (CockpitWebResponse *re
 
 
 const gchar *         cockpit_web_response_get_path      (CockpitWebResponse *self);
-
-const gchar *         cockpit_web_response_get_query     (CockpitWebResponse *self);
 
 GIOStream *           cockpit_web_response_get_stream    (CockpitWebResponse *self);
 

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -32,12 +32,6 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(CockpitWebResponse, cockpit_web_response, COCKPIT, WEB_RESPONSE, GObject)
 
 typedef enum {
-  COCKPIT_WEB_RESPONSE_NONE = 0,
-  COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY = 1 << 0,
-  COCKPIT_WEB_RESPONSE_MAX = 1 << 1
-} CockpitWebResponseFlags;
-
-typedef enum {
   COCKPIT_WEB_RESPONSE_READY = 1,
   COCKPIT_WEB_RESPONSE_QUEUING,
   COCKPIT_WEB_RESPONSE_COMPLETE,
@@ -61,7 +55,7 @@ CockpitWebResponse *  cockpit_web_response_new           (GIOStream *io,
                                                           const gchar *original_path,
                                                           const gchar *path,
                                                           GHashTable *in_headers,
-                                                          CockpitWebResponseFlags flags);
+                                                          const gchar *protocol);
 void                  cockpit_web_response_set_method    (CockpitWebResponse *response,
                                                           const gchar *method);
 
@@ -144,8 +138,7 @@ const gchar *  cockpit_web_response_get_url_root         (CockpitWebResponse *re
 
 const gchar *  cockpit_web_response_get_origin           (CockpitWebResponse *response);
 
-const gchar *  cockpit_web_response_get_protocol         (CockpitWebResponse *response,
-                                                          GHashTable *headers);
+const gchar *  cockpit_web_response_get_protocol         (CockpitWebResponse *response);
 
 void           cockpit_web_response_template             (CockpitWebResponse *response,
                                                           const gchar *escaped,
@@ -154,11 +147,6 @@ void           cockpit_web_response_template             (CockpitWebResponse *re
 
 gchar *      cockpit_web_response_security_policy        (const gchar *content_security_policy,
                                                           const gchar *self_origin);
-
-
-const gchar *  cockpit_connection_get_protocol           (GIOStream *connection,
-                                                          GHashTable *headers,
-                                                          gboolean for_tls_proxy);
 
 G_END_DECLS
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -835,6 +835,7 @@ cockpit_web_request_process (CockpitWebRequest *self,
   self->path = path_copy + self->web_server->url_root->len;
   self->method = method;
   self->headers = headers;
+  self->host = host;
 
   gchar *query = strchr (path_copy, '?');
   if (query)
@@ -1343,6 +1344,12 @@ GIOStream *
 cockpit_web_request_get_io_stream (CockpitWebRequest *self)
 {
   return self->io;
+}
+
+const gchar *
+cockpit_web_request_get_host (CockpitWebRequest *self)
+{
+  return self->host;
 }
 
 const gchar *

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -1276,12 +1276,8 @@ cockpit_web_request_start (CockpitWebServer *web_server,
 CockpitWebResponse *
 cockpit_web_request_respond (CockpitWebRequest *self)
 {
-  CockpitWebResponseFlags flags = COCKPIT_WEB_RESPONSE_NONE;
-
-  if (self->web_server->flags & COCKPIT_WEB_SERVER_FOR_TLS_PROXY)
-    flags |= COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY;
-
-  return cockpit_web_response_new (self->io, self->original_path, self->path, self->headers, flags);
+  return cockpit_web_response_new (self->io, self->original_path, self->path, self->headers,
+                                   cockpit_web_request_get_protocol (self));
 }
 
 const gchar *

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -39,6 +39,9 @@ const gchar *
 cockpit_web_request_get_path (CockpitWebRequest *self);
 
 const gchar *
+cockpit_web_request_get_query (CockpitWebRequest *self);
+
+const gchar *
 cockpit_web_request_get_method (CockpitWebRequest *self);
 
 GHashTable *

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -32,6 +32,9 @@ typedef struct _CockpitWebRequest CockpitWebRequest;
 GType
 cockpit_web_request_get_type (void);
 
+CockpitWebResponse *
+cockpit_web_request_respond (CockpitWebRequest *self);
+
 const gchar *
 cockpit_web_request_get_original_path (CockpitWebRequest *self);
 

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -68,6 +68,9 @@ GByteArray *
 cockpit_web_request_get_buffer (CockpitWebRequest *self);
 
 const gchar *
+cockpit_web_request_get_host (CockpitWebRequest *self);
+
+const gchar *
 cockpit_web_request_get_protocol (CockpitWebRequest *self);
 
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -73,6 +73,12 @@ cockpit_web_request_get_host (CockpitWebRequest *self);
 const gchar *
 cockpit_web_request_get_protocol (CockpitWebRequest *self);
 
+gchar *
+cockpit_web_request_get_remote_address (CockpitWebRequest *self);
+
+const gchar *
+cockpit_web_request_get_client_certificate (CockpitWebRequest *self);
+
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
 G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)
 

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -44,6 +44,14 @@ cockpit_web_request_get_method (CockpitWebRequest *self);
 GHashTable *
 cockpit_web_request_get_headers (CockpitWebRequest *self);
 
+const gchar *
+cockpit_web_request_lookup_header (CockpitWebRequest *self,
+                                   const gchar *header);
+
+gchar *
+cockpit_web_request_parse_cookie (CockpitWebRequest *self,
+                                  const gchar *name);
+
 GIOStream *
 cockpit_web_request_get_io_stream (CockpitWebRequest *self);
 

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -67,6 +67,9 @@ cockpit_web_request_get_headers (CockpitWebRequest *self);
 GByteArray *
 cockpit_web_request_get_buffer (CockpitWebRequest *self);
 
+const gchar *
+cockpit_web_request_get_protocol (CockpitWebRequest *self);
+
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
 G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)
 
@@ -109,6 +112,10 @@ cockpit_web_server_add_fd_listener (CockpitWebServer *self,
 
 GIOStream *
 cockpit_web_server_connect (CockpitWebServer *self);
+
+void
+cockpit_web_server_set_protocol_header (CockpitWebServer *self,
+                                        const gchar *protocol_header);
 
 G_END_DECLS
 

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -22,7 +22,36 @@
 
 #include <gio/gio.h>
 
+#include "cockpitwebresponse.h"
+
 G_BEGIN_DECLS
+
+#define COCKPIT_TYPE_WEB_REQUEST (cockpit_web_request_get_type ())
+typedef struct _CockpitWebRequest CockpitWebRequest;
+
+GType
+cockpit_web_request_get_type (void);
+
+const gchar *
+cockpit_web_request_get_original_path (CockpitWebRequest *self);
+
+const gchar *
+cockpit_web_request_get_path (CockpitWebRequest *self);
+
+const gchar *
+cockpit_web_request_get_method (CockpitWebRequest *self);
+
+GHashTable *
+cockpit_web_request_get_headers (CockpitWebRequest *self);
+
+GIOStream *
+cockpit_web_request_get_io_stream (CockpitWebRequest *self);
+
+GHashTable *
+cockpit_web_request_get_headers (CockpitWebRequest *self);
+
+GByteArray *
+cockpit_web_request_get_buffer (CockpitWebRequest *self);
 
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
 G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -88,7 +88,7 @@ setup (TestCase *tc,
       g_hash_table_insert (headers, g_strdup (fixture->header), g_strdup (fixture->value));
     }
 
-  tc->response = cockpit_web_response_new (io, path, path, NULL, headers,
+  tc->response = cockpit_web_response_new (io, path, path, headers,
                                            (fixture && fixture->for_tls_proxy) ? COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY : COCKPIT_WEB_RESPONSE_NONE);
 
   if (headers)
@@ -1109,7 +1109,7 @@ test_pop_path (TestPlain *tc,
   gchar *part;
   const gchar *start = "/cockpit/@localhost/another/test.html";
 
-  response = cockpit_web_response_new (tc->io, start, start, NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, start, start, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, start);
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
 
@@ -1149,7 +1149,7 @@ test_pop_path_root (TestPlain *tc,
   CockpitWebResponse *response;
   gchar *part;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
 
   part = cockpit_web_response_pop_path (response);
@@ -1168,7 +1168,7 @@ test_skip_path (TestPlain *tc,
   CockpitWebResponse *response;
   const gchar *start = "/cockpit/@localhost/another/test.html";
 
-  response = cockpit_web_response_new (tc->io, start, start, NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, start, start, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/cockpit/@localhost/another/test.html");
 
   g_assert (cockpit_web_response_skip_path (response) == TRUE);
@@ -1196,7 +1196,7 @@ test_skip_path_root (TestPlain *tc,
 {
   CockpitWebResponse *response;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
 
   g_assert (cockpit_web_response_skip_path (response) == FALSE);
@@ -1212,31 +1212,31 @@ test_removed_prefix (TestPlain *tc,
 {
   CockpitWebResponse *response;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/path/", "/path/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/path/", "/path/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/path/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/path/path2/", "/path2/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/path/path2/", "/path2/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/path2/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, "/path");
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/mis/", "/match/", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/mis/", "/match/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/match/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, NULL, NULL, NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, NULL, NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, NULL);
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);

--- a/src/common/test-webresponse.c
+++ b/src/common/test-webresponse.c
@@ -89,7 +89,7 @@ setup (TestCase *tc,
     }
 
   tc->response = cockpit_web_response_new (io, path, path, headers,
-                                           (fixture && fixture->for_tls_proxy) ? COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY : COCKPIT_WEB_RESPONSE_NONE);
+                                           (fixture && fixture->for_tls_proxy) ? "https" : "http");
 
   if (headers)
     g_hash_table_unref (headers);
@@ -1109,7 +1109,7 @@ test_pop_path (TestPlain *tc,
   gchar *part;
   const gchar *start = "/cockpit/@localhost/another/test.html";
 
-  response = cockpit_web_response_new (tc->io, start, start, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, start, start, tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, start);
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
 
@@ -1149,7 +1149,7 @@ test_pop_path_root (TestPlain *tc,
   CockpitWebResponse *response;
   gchar *part;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
 
   part = cockpit_web_response_pop_path (response);
@@ -1168,7 +1168,7 @@ test_skip_path (TestPlain *tc,
   CockpitWebResponse *response;
   const gchar *start = "/cockpit/@localhost/another/test.html";
 
-  response = cockpit_web_response_new (tc->io, start, start, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, start, start, tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/cockpit/@localhost/another/test.html");
 
   g_assert (cockpit_web_response_skip_path (response) == TRUE);
@@ -1196,7 +1196,7 @@ test_skip_path_root (TestPlain *tc,
 {
   CockpitWebResponse *response;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
 
   g_assert (cockpit_web_response_skip_path (response) == FALSE);
@@ -1212,31 +1212,31 @@ test_removed_prefix (TestPlain *tc,
 {
   CockpitWebResponse *response;
 
-  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/", "/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/path/", "/path/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/path/", "/path/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/path/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/path/path2/", "/path2/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/path/path2/", "/path2/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/path2/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, "/path");
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, "/mis/", "/match/", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/mis/", "/match/", tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, "/match/");
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);
   g_clear_object (&response);
 
-  response = cockpit_web_response_new (tc->io, NULL, NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, NULL, NULL, tc->headers, NULL);
   g_assert_cmpstr (cockpit_web_response_get_path (response), ==, NULL);
   g_assert_cmpstr (cockpit_web_response_get_url_root (response), ==, NULL);
   cockpit_web_response_abort (response);

--- a/src/common/test-webserver.c
+++ b/src/common/test-webserver.c
@@ -436,6 +436,7 @@ perform_https_request (const gchar *hostport,
 
 static gboolean
 on_shell_index_html (CockpitWebServer *server,
+                     CockpitWebRequest *request,
                      const gchar *path,
                      GHashTable *headers,
                      CockpitWebResponse *response,
@@ -507,6 +508,7 @@ test_webserver_tls (TestCase *tc,
 
 static gboolean
 on_big_header (CockpitWebServer *server,
+               CockpitWebRequest *request,
                const gchar *path,
                GHashTable *headers,
                CockpitWebResponse *response,
@@ -634,6 +636,7 @@ test_webserver_noredirect_override (TestCase *tc,
 
 static gboolean
 on_oh_resource (CockpitWebServer *server,
+                CockpitWebRequest *request,
                 const gchar *path,
                 GHashTable *headers,
                 CockpitWebResponse *response,
@@ -654,6 +657,7 @@ on_oh_resource (CockpitWebServer *server,
 
 static gboolean
 on_scruffy_resource (CockpitWebServer *server,
+                     CockpitWebRequest *request,
                      const gchar *path,
                      GHashTable *headers,
                      CockpitWebResponse *response,
@@ -674,6 +678,7 @@ on_scruffy_resource (CockpitWebServer *server,
 
 static gboolean
 on_index_resource (CockpitWebServer *server,
+                   CockpitWebRequest *request,
                    const gchar *path,
                    GHashTable *headers,
                    CockpitWebResponse *response,
@@ -694,6 +699,7 @@ on_index_resource (CockpitWebServer *server,
 
 static gboolean
 on_default_resource (CockpitWebServer *server,
+                     CockpitWebRequest *request,
                      const gchar *path,
                      GHashTable *headers,
                      CockpitWebResponse *response,

--- a/src/ws/cockpitauth.h
+++ b/src/ws/cockpitauth.h
@@ -28,6 +28,7 @@
 
 #include "common/cockpitpipe.h"
 #include "common/cockpittransport.h"
+#include "common/cockpitwebserver.h"
 
 G_BEGIN_DECLS
 
@@ -78,9 +79,7 @@ CockpitAuth *   cockpit_auth_new             (gboolean login_loopback, CockpitAu
 gchar *         cockpit_auth_nonce           (CockpitAuth *self);
 
 void            cockpit_auth_login_async     (CockpitAuth *self,
-                                              const gchar *path,
-                                              GIOStream *connection,
-                                              GHashTable *headers,
+                                              CockpitWebRequest *request,
                                               GAsyncReadyCallback callback,
                                               gpointer user_data);
 
@@ -101,16 +100,10 @@ gboolean        cockpit_auth_local_finish    (CockpitAuth *self,
                                               GError **error);
 
 CockpitWebService *  cockpit_auth_check_cookie    (CockpitAuth *self,
-                                                   const gchar *path,
-                                                   GHashTable *in_headers);
+                                                   CockpitWebRequest *request);
 
 gchar *         cockpit_auth_parse_application    (const gchar *path,
                                                    gboolean *is_host);
-
-gchar *         cockpit_auth_steal_authorization      (GHashTable *headers,
-                                                       GIOStream *connection,
-                                                       gchar **ret_type,
-                                                       gchar **ret_conversation);
 
 gchar *         cockpit_auth_empty_cookie_value       (const gchar *path,
                                                        gboolean secure);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -682,7 +682,7 @@ cockpit_channel_response_serve (CockpitWebService *service,
     }
 
   /* Send along the HTTP scheme the package should assume is accessing things */
-  protocol = cockpit_web_response_get_protocol (response, in_headers);
+  protocol = cockpit_web_response_get_protocol (response);
 
   json_object_set_string_member (heads, "Host", host);
   json_object_set_string_member (heads, "X-Forwarded-Proto", protocol);

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -721,8 +721,7 @@ out:
 
 void
 cockpit_channel_response_open (CockpitWebService *service,
-                               GHashTable *in_headers,
-                               CockpitWebResponse *response,
+                               CockpitWebRequest *request,
                                JsonObject *open)
 {
   CockpitChannelResponse *self;
@@ -732,6 +731,8 @@ cockpit_channel_response_open (CockpitWebService *service,
   const gchar *content_type;
   const gchar *content_encoding;
   const gchar *content_disposition;
+
+  g_autoptr(CockpitWebResponse) response = cockpit_web_request_respond (request);
 
   /* Parse the external */
   if (!cockpit_web_service_parse_external (open, &content_type, &content_encoding, &content_disposition, NULL))

--- a/src/ws/cockpitchannelresponse.h
+++ b/src/ws/cockpitchannelresponse.h
@@ -20,6 +20,7 @@
 #ifndef __COCKPIT_CHANNEL_RESPONSE_H__
 #define __COCKPIT_CHANNEL_RESPONSE_H__
 
+#include "common/cockpitwebserver.h"
 #include "cockpitwebservice.h"
 
 G_BEGIN_DECLS
@@ -32,8 +33,7 @@ void             cockpit_channel_response_serve       (CockpitWebService *servic
                                                        const gchar *path);
 
 void             cockpit_channel_response_open        (CockpitWebService *service,
-                                                       GHashTable *headers,
-                                                       CockpitWebResponse *response,
+                                                       CockpitWebRequest *request,
                                                        JsonObject *open);
 
 G_END_DECLS

--- a/src/ws/cockpitchannelsocket.c
+++ b/src/ws/cockpitchannelsocket.c
@@ -168,7 +168,7 @@ respond_with_error (const gchar *original_path,
 {
   CockpitWebResponse *response;
 
-  response = cockpit_web_response_new (io_stream, original_path, path, NULL, headers,
+  response = cockpit_web_response_new (io_stream, original_path, path, headers,
                                        for_tls_proxy ? COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY : COCKPIT_WEB_RESPONSE_NONE);
   cockpit_web_response_error (response, status, NULL, "%s", message);
   g_object_unref (response);

--- a/src/ws/cockpitchannelsocket.h
+++ b/src/ws/cockpitchannelsocket.h
@@ -20,6 +20,8 @@
 #ifndef __COCKPIT_CHANNEL_SOCKET_H__
 #define __COCKPIT_CHANNEL_SOCKET_H__
 
+#include "common/cockpitwebserver.h"
+
 #include "cockpitwebservice.h"
 
 G_BEGIN_DECLS
@@ -27,12 +29,7 @@ G_BEGIN_DECLS
 
 void                 cockpit_channel_socket_open     (CockpitWebService *service,
                                                       JsonObject *open,
-                                                      const gchar *original_path,
-                                                      const gchar *path,
-                                                      GIOStream *io_stream,
-                                                      GHashTable *headers,
-                                                      GByteArray *input_buffer,
-                                                      gboolean for_tls_proxy);
+                                                      CockpitWebRequest *request);
 
 G_END_DECLS
 

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -443,7 +443,7 @@ send_login_html (CockpitWebResponse *response,
   else
     {
       /* The login Content-Security-Policy allows the page to have inline <script> and <style> tags. */
-      gboolean secure = g_strcmp0 (cockpit_web_response_get_protocol (response, headers), "https") == 0;
+      gboolean secure = g_strcmp0 (cockpit_web_response_get_protocol (response), "https") == 0;
       cookie_line = cockpit_auth_empty_cookie_value (path, secure);
       content_security_policy = cockpit_web_response_security_policy ("default-src 'self' 'unsafe-inline'",
                                                                       cockpit_web_response_get_origin (response));

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -134,7 +134,7 @@ cockpit_handler_socket (CockpitWebServer *server,
   if (g_strcmp0 (method, "GET") != 0)
       return FALSE;
 
-  if (headers)
+  if (headers && ws)
     service = cockpit_auth_check_cookie (ws->auth, request);
   if (service)
     {

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -158,7 +158,6 @@ cockpit_handler_external (CockpitWebServer *server,
 {
   const gchar *original_path = cockpit_web_request_get_original_path (request);
   const gchar *path = cockpit_web_request_get_path (request);
-  const gchar *method = cockpit_web_request_get_method (request);
   GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
   GByteArray *input = cockpit_web_request_get_buffer (request);
   GHashTable *headers = cockpit_web_request_get_headers (request);
@@ -229,12 +228,7 @@ cockpit_handler_external (CockpitWebServer *server,
         }
       else
         {
-          response = cockpit_web_response_new (io_stream, original_path, path, headers,
-                                               (cockpit_web_server_get_flags (server) & COCKPIT_WEB_SERVER_FOR_TLS_PROXY) ?
-                                                 COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY : COCKPIT_WEB_RESPONSE_NONE);
-          cockpit_web_response_set_method (response, method);
-          cockpit_channel_response_open (service, headers, response, open);
-          g_object_unref (response);
+          cockpit_channel_response_open (service, request, open);
         }
       json_object_unref (open);
     }

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -105,14 +105,15 @@ handle_noauth_socket (GIOStream *io_stream,
 /* Called by @server when handling HTTP requests to /cockpit/socket */
 gboolean
 cockpit_handler_socket (CockpitWebServer *server,
-                        const gchar *original_path,
-                        const gchar *path,
-                        const gchar *method,
-                        GIOStream *io_stream,
-                        GHashTable *headers,
-                        GByteArray *input,
+                        CockpitWebRequest *request,
                         CockpitHandlerData *ws)
 {
+  const gchar *path = cockpit_web_request_get_path (request);
+  const gchar *method = cockpit_web_request_get_method (request);
+  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
+  GByteArray *input = cockpit_web_request_get_buffer (request);
+  GHashTable *headers = cockpit_web_request_get_headers (request);
+
   CockpitWebService *service = NULL;
   const gchar *segment = NULL;
 
@@ -152,14 +153,16 @@ cockpit_handler_socket (CockpitWebServer *server,
 
 gboolean
 cockpit_handler_external (CockpitWebServer *server,
-                          const gchar *original_path,
-                          const gchar *path,
-                          const gchar *method,
-                          GIOStream *io_stream,
-                          GHashTable *headers,
-                          GByteArray *input,
+                          CockpitWebRequest *request,
                           CockpitHandlerData *ws)
 {
+  const gchar *original_path = cockpit_web_request_get_original_path (request);
+  const gchar *path = cockpit_web_request_get_path (request);
+  const gchar *method = cockpit_web_request_get_method (request);
+  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
+  GByteArray *input = cockpit_web_request_get_buffer (request);
+  GHashTable *headers = cockpit_web_request_get_headers (request);
+
   CockpitWebResponse *response = NULL;
   CockpitWebService *service = NULL;
   const gchar *segment = NULL;
@@ -665,6 +668,7 @@ handle_shell (CockpitHandlerData *data,
 
 gboolean
 cockpit_handler_default (CockpitWebServer *server,
+                         CockpitWebRequest *request,
                          const gchar *path,
                          GHashTable *headers,
                          CockpitWebResponse *response,
@@ -726,6 +730,7 @@ cockpit_handler_default (CockpitWebServer *server,
 
 gboolean
 cockpit_handler_root (CockpitWebServer *server,
+                      CockpitWebRequest *request,
                       const gchar *path,
                       GHashTable *headers,
                       CockpitWebResponse *response,
@@ -738,6 +743,7 @@ cockpit_handler_root (CockpitWebServer *server,
 
 gboolean
 cockpit_handler_ping (CockpitWebServer *server,
+                      CockpitWebRequest *request,
                       const gchar *path,
                       GHashTable *headers,
                       CockpitWebResponse *response,
@@ -773,6 +779,7 @@ cockpit_handler_ping (CockpitWebServer *server,
 
 gboolean
 cockpit_handler_ca_cert (CockpitWebServer *server,
+                         CockpitWebRequest *request,
                          const gchar *path,
                          GHashTable *headers,
                          CockpitWebResponse *response,

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -215,10 +215,7 @@ cockpit_handler_external (CockpitWebServer *server,
 
   if (!open)
     {
-      response = cockpit_web_response_new (io_stream, original_path, path, headers,
-                                           (cockpit_web_server_get_flags (server) & COCKPIT_WEB_SERVER_FOR_TLS_PROXY) ?
-                                             COCKPIT_WEB_RESPONSE_FOR_TLS_PROXY : COCKPIT_WEB_RESPONSE_NONE);
-
+      response = cockpit_web_request_respond (request);
       cockpit_web_response_error (response, 400, NULL, NULL);
       g_object_unref (response);
     }

--- a/src/ws/cockpithandlers.h
+++ b/src/ws/cockpithandlers.h
@@ -36,42 +36,36 @@ typedef struct {
 } CockpitHandlerData;
 
 gboolean       cockpit_handler_socket            (CockpitWebServer *server,
-                                                  const gchar *original_path,
-                                                  const gchar *path,
-                                                  const gchar *method,
-                                                  GIOStream *io_stream,
-                                                  GHashTable *headers,
-                                                  GByteArray *input,
+                                                  CockpitWebRequest *request,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_external          (CockpitWebServer *server,
-                                                  const gchar *original_path,
-                                                  const gchar *path,
-                                                  const gchar *method,
-                                                  GIOStream *io_stream,
-                                                  GHashTable *headers,
-                                                  GByteArray *input,
+                                                  CockpitWebRequest *request,
                                                   CockpitHandlerData *data);
 
 gboolean       cockpit_handler_root              (CockpitWebServer *server,
+                                                  CockpitWebRequest *request,
                                                   const gchar *path,
                                                   GHashTable *headers,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
 gboolean       cockpit_handler_default           (CockpitWebServer *server,
+                                                  CockpitWebRequest *request,
                                                   const gchar *path,
                                                   GHashTable *headers,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
 gboolean       cockpit_handler_ping              (CockpitWebServer *server,
+                                                  CockpitWebRequest *request,
                                                   const gchar *path,
                                                   GHashTable *headers,
                                                   CockpitWebResponse *response,
                                                   CockpitHandlerData *ws);
 
 gboolean       cockpit_handler_ca_cert           (CockpitWebServer *server,
+                                                  CockpitWebRequest *request,
                                                   const gchar *path,
                                                   GHashTable *headers,
                                                   CockpitWebResponse *response,

--- a/src/ws/cockpitwebservice.c
+++ b/src/ws/cockpitwebservice.c
@@ -44,11 +44,6 @@
 
 #include <stdlib.h>
 
-const gchar *cockpit_ws_default_host_header =
-    "0.0.0.0:0"; /* Must be something invalid */
-
-const gchar *cockpit_ws_default_protocol_header = NULL;
-
 guint cockpit_ws_ping_interval = 5;
 
 /* ----------------------------------------------------------------------------
@@ -1315,21 +1310,8 @@ cockpit_web_service_create_socket (const gchar **protocols,
 
   g_return_val_if_fail (path != NULL, NULL);
 
-  if (headers)
-    host = g_hash_table_lookup (headers, "Host");
-  if (!host)
-    host = cockpit_ws_default_host_header;
-
-  /* No headers case for tests */
-  if (cockpit_ws_default_protocol_header && !headers &&
-      cockpit_conf_string ("WebService", "ProtocolHeader"))
-    {
-      protocol = cockpit_ws_default_protocol_header;
-    }
-  else
-    {
-      protocol = cockpit_connection_get_protocol (io_stream, headers, for_tls_proxy);
-    }
+  host = g_hash_table_lookup (headers, "Host");
+  protocol = cockpit_connection_get_protocol (io_stream, headers, for_tls_proxy);
 
   g_debug("cockpit_web_service_create_socket: host %s, protocol %s, for_tls_proxy %i", host, protocol, for_tls_proxy);
 

--- a/src/ws/cockpitwebservice.h
+++ b/src/ws/cockpitwebservice.h
@@ -25,6 +25,7 @@
 #include "common/cockpitjson.h"
 #include "common/cockpittransport.h"
 #include "common/cockpitwebresponse.h"
+#include "common/cockpitwebserver.h"
 
 #include "websocket/websocket.h"
 
@@ -44,11 +45,7 @@ CockpitWebService *  cockpit_web_service_new         (CockpitCreds *creds,
 void                 cockpit_web_service_disconnect  (CockpitWebService *self);
 
 void                 cockpit_web_service_socket      (CockpitWebService *self,
-                                                      const gchar *path,
-                                                      GIOStream *io_stream,
-                                                      GHashTable *headers,
-                                                      GByteArray *input_buffer,
-                                                      gboolean for_tls_proxy);
+                                                      CockpitWebRequest *request);
 
 CockpitCreds *       cockpit_web_service_get_creds   (CockpitWebService *self);
 const gchar *        cockpit_web_service_get_id      (CockpitWebService *self);
@@ -58,11 +55,7 @@ void                 cockpit_web_service_set_id      (CockpitWebService *self,
 gboolean             cockpit_web_service_get_idling  (CockpitWebService *self);
 
 WebSocketConnection *   cockpit_web_service_create_socket    (const gchar **protocols,
-                                                              const gchar *path,
-                                                              GIOStream *io_stream,
-                                                              GHashTable *headers,
-                                                              GByteArray *input_buffer,
-                                                              gboolean for_tls_proxy);
+                                                              CockpitWebRequest *request);
 
 gchar *                 cockpit_web_service_unique_channel   (CockpitWebService *self);
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -232,6 +232,8 @@ main (int argc,
                     NULL);
     }
 
+  cockpit_web_server_set_protocol_header (server, cockpit_conf_string ("WebService", "ProtocolHeader"));
+
   /* Ignores stuff it shouldn't handle */
   g_signal_connect (server, "handle-stream",
                     G_CALLBACK (cockpit_handler_socket), &data);

--- a/src/ws/test-authssh.c
+++ b/src/ws/test-authssh.c
@@ -28,6 +28,8 @@
 #include "common/cockpitwebserver.h"
 #include "common/cockpiterror.h"
 
+#include "common/cockpitwebrequest-private.h"
+
 #include <sys/wait.h>
 #include <errno.h>
 #include <stdlib.h>
@@ -175,7 +177,7 @@ test_basic_good (TestCase *test,
   cookie = g_strdup_printf ("machine-cockpit+127.0.0.1:%d", test->ssh_port);
   path = g_strdup_printf ("/%s", application);
 
-  cockpit_auth_login_async (test->auth, path, NULL, in_headers, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, WebRequest(.path=path, .headers=in_headers), on_ready_get_result, &result);
   g_hash_table_unref (in_headers);
 
   while (result == NULL)
@@ -188,7 +190,7 @@ test_basic_good (TestCase *test,
   json_object_unref (response);
 
   mock_auth_include_cookie_as_if_client (out_headers, out_headers, cookie);
-  service = cockpit_auth_check_cookie (test->auth, path, out_headers);
+  service = cockpit_auth_check_cookie (test->auth, WebRequest(.path=path, .headers=out_headers));
   g_assert (service != NULL);
 
   creds = cockpit_web_service_get_creds (service);
@@ -232,7 +234,9 @@ test_basic_fail (TestCase *test,
   application = g_strdup_printf ("cockpit+=127.0.0.1:%d", test->ssh_port);
   path = g_strdup_printf ("/%s", application);
 
-  cockpit_auth_login_async (test->auth, path, NULL, headers, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth,
+                            WebRequest(.path=path, .headers=headers),
+                            on_ready_get_result, &result);
   g_hash_table_unref (headers);
   headers = cockpit_web_server_new_table ();
 

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -217,7 +217,7 @@ test_resource_simple (TestResourceCase *tc,
     "0\r\n\r\n";
 
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
@@ -276,7 +276,7 @@ test_resource_simple_host (TestResourceCase *tc,
     "0\r\n\r\n";
 
   g_hash_table_insert (tc->headers, g_strdup ("Host"), g_strdup ("my.host"));
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
@@ -333,7 +333,7 @@ test_resource_language (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("pig, blah"));
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
@@ -390,7 +390,7 @@ test_resource_cookie (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   g_hash_table_insert (tc->headers, g_strdup ("Cookie"), g_strdup ("CockpitLang=pig"));
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
@@ -439,7 +439,7 @@ test_resource_not_found (TestResourceCase *tc,
     "Not Found\r\nf\r\n"
     "</body></html>\n\r\n0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "another@localhost", "/not-exist");
 
@@ -484,7 +484,7 @@ test_resource_no_path (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing path after package */
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "another@localhost", "");
 
@@ -532,7 +532,7 @@ test_resource_failure (TestResourceCase *tc,
   while (kill (pid, 0) >= 0)
     g_usleep (1000);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -573,7 +573,7 @@ request_checksum (TestResourceCase *tc)
   g_object_unref (input);
 
   /* Start the connection up, and poke it a bit */
-  response = cockpit_web_response_new (io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (io, "/unused", "/unused", NULL, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/checksum");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -617,7 +617,7 @@ test_resource_checksum (TestResourceCase *tc,
 
   request_checksum (tc);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -659,7 +659,7 @@ test_resource_not_modified (TestResourceCase *tc,
   g_hash_table_insert (tc->headers, g_strdup ("If-None-Match"),
                        g_strdup ("\"" CHECKSUM "-c\""));
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -703,7 +703,7 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
                        g_strdup ("\"" CHECKSUM "-c\""));
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("de"));
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -757,7 +757,7 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   cookie = g_strdup_printf ("%s; CockpitLang=fr", (gchar *)g_hash_table_lookup (tc->headers, "Cookie"));
   g_hash_table_insert (tc->headers, g_strdup ("Cookie"), cookie);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, NULL);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -802,7 +802,7 @@ test_resource_no_checksum (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "xxx", "/test");
 
@@ -847,7 +847,7 @@ test_resource_bad_checksum (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "09323094823029348", "/path");
 
@@ -899,7 +899,7 @@ test_resource_language_suffix (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.de.html");
 
@@ -955,7 +955,7 @@ test_resource_language_fallback (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
 
   /* Language cookie overrides */
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.fi.html");
@@ -1007,7 +1007,7 @@ test_resource_gzip_encoding (TestResourceCase *tc,
     ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A"
     "0\x0D\x0A\x0D\x0A";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test-file.txt");
 
@@ -1051,7 +1051,7 @@ test_resource_head (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL);
   cockpit_web_response_set_method (response, "HEAD");
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");

--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -217,7 +217,7 @@ test_resource_simple (TestResourceCase *tc,
     "0\r\n\r\n";
 
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
@@ -276,7 +276,7 @@ test_resource_simple_host (TestResourceCase *tc,
     "0\r\n\r\n";
 
   g_hash_table_insert (tc->headers, g_strdup ("Host"), g_strdup ("my.host"));
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
@@ -333,7 +333,7 @@ test_resource_language (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("pig, blah"));
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
@@ -390,7 +390,7 @@ test_resource_cookie (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   g_hash_table_insert (tc->headers, g_strdup ("Cookie"), g_strdup ("CockpitLang=pig"));
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
@@ -439,7 +439,7 @@ test_resource_not_found (TestResourceCase *tc,
     "Not Found\r\nf\r\n"
     "</body></html>\n\r\n0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "another@localhost", "/not-exist");
 
@@ -484,7 +484,7 @@ test_resource_no_path (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing path after package */
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "another@localhost", "");
 
@@ -532,7 +532,7 @@ test_resource_failure (TestResourceCase *tc,
   while (kill (pid, 0) >= 0)
     g_usleep (1000);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -573,7 +573,7 @@ request_checksum (TestResourceCase *tc)
   g_object_unref (input);
 
   /* Start the connection up, and poke it a bit */
-  response = cockpit_web_response_new (io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/checksum");
 
   while (cockpit_web_response_get_state (response) != COCKPIT_WEB_RESPONSE_SENT)
@@ -617,7 +617,7 @@ test_resource_checksum (TestResourceCase *tc,
 
   request_checksum (tc);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -659,7 +659,7 @@ test_resource_not_modified (TestResourceCase *tc,
   g_hash_table_insert (tc->headers, g_strdup ("If-None-Match"),
                        g_strdup ("\"" CHECKSUM "-c\""));
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -703,7 +703,7 @@ test_resource_not_modified_new_language (TestResourceCase *tc,
                        g_strdup ("\"" CHECKSUM "-c\""));
   g_hash_table_insert (tc->headers, g_strdup ("Accept-Language"), g_strdup ("de"));
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -757,7 +757,7 @@ test_resource_not_modified_cookie_language (TestResourceCase *tc,
   cookie = g_strdup_printf ("%s; CockpitLang=fr", (gchar *)g_hash_table_lookup (tc->headers, "Cookie"));
   g_hash_table_insert (tc->headers, g_strdup ("Cookie"), cookie);
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, tc->headers, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", tc->headers, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_channel_response_serve (tc->service, tc->headers, response,
                                 CHECKSUM,
                                 "/test/sub/file.ext");
@@ -802,7 +802,7 @@ test_resource_no_checksum (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "xxx", "/test");
 
@@ -847,7 +847,7 @@ test_resource_bad_checksum (TestResourceCase *tc,
     "</body></html>\n\r\n0\r\n\r\n";
 
   /* Missing checksum */
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "09323094823029348", "/path");
 
@@ -899,7 +899,7 @@ test_resource_language_suffix (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.de.html");
 
@@ -955,7 +955,7 @@ test_resource_language_fallback (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   /* Language cookie overrides */
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.fi.html");
@@ -1007,7 +1007,7 @@ test_resource_gzip_encoding (TestResourceCase *tc,
     ".QH\xCB\xCCI\xE5\x02\x00>PjG\x12\x00\x00\x00\x0D\x0A"
     "0\x0D\x0A\x0D\x0A";
 
-  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, "/unused", "/unused", NULL, COCKPIT_WEB_RESPONSE_NONE);
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test-file.txt");
 
@@ -1051,7 +1051,7 @@ test_resource_head (TestResourceCase *tc,
     "\r\n"
     "0\r\n\r\n";
 
-  response = cockpit_web_response_new (tc->io, url, url, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (tc->io, url, url, NULL, COCKPIT_WEB_RESPONSE_NONE);
   cockpit_web_response_set_method (response, "HEAD");
 
   cockpit_channel_response_serve (tc->service, tc->headers, response, "@localhost", "/another/test.html");

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -125,7 +125,7 @@ setup (Test *test,
        gconstpointer path)
 {
   base_setup (test);
-  test->response = cockpit_web_response_new (test->io, path, path, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  test->response = cockpit_web_response_new (test->io, path, path, NULL, COCKPIT_WEB_RESPONSE_NONE);
   g_signal_connect (test->response, "done",
                     G_CALLBACK (on_web_response_done_set_flag),
                     &test->response_done);
@@ -396,7 +396,7 @@ setup_default (Test *test,
   base_setup (test);
   test->response = cockpit_web_response_new (test->io,
                                             fixture->org_path ? fixture->org_path : fixture->path,
-                                            fixture->path, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+                                            fixture->path, NULL, COCKPIT_WEB_RESPONSE_NONE);
   g_signal_connect (test->response, "done",
                     G_CALLBACK (on_web_response_done_set_flag),
                     &test->response_done);
@@ -480,7 +480,7 @@ test_resource_checksum (Test *test,
   input = g_memory_input_stream_new ();
   io = g_simple_io_stream_new (input, output);
   path = "/cockpit/@localhost/checksum";
-  response = cockpit_web_response_new (io, path, path, NULL, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (io, path, path, NULL, COCKPIT_WEB_RESPONSE_NONE);
   g_signal_connect (response, "done", G_CALLBACK (on_web_response_done_set_flag), &response_done);
   g_assert (cockpit_handler_default (test->server, WebRequest(.path=path, .headers=test->headers),
                                      path, test->headers, response, &test->data));

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -203,7 +203,9 @@ test_login_with_cookie (Test *test,
 
   headers = mock_auth_basic_header ("me", PASSWORD);
 
-  cockpit_auth_login_async (test->auth, path, NULL, headers, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth,
+                            WebRequest(.path=path, .headers=headers),
+                            on_ready_get_result, &result);
   g_hash_table_unref (headers);
   while (result == NULL)
     g_main_context_iteration (NULL, TRUE);
@@ -308,7 +310,7 @@ test_login_accept (Test *test,
   headers = split_headers (output);
   include_cookie_as_if_client (headers, test->headers);
 
-  service = cockpit_auth_check_cookie (test->auth, "/cockpit", test->headers);
+  service = cockpit_auth_check_cookie (test->auth, WebRequest(.path="/cockpit", .headers=test->headers));
   g_assert (service != NULL);
   creds = cockpit_web_service_get_creds (service);
   g_assert_cmpstr (cockpit_creds_get_user (creds), ==, "me");
@@ -403,7 +405,9 @@ setup_default (Test *test,
     {
       headers = mock_auth_basic_header ("bridge-user", PASSWORD);
 
-      cockpit_auth_login_async (test->auth, fixture->auth, NULL, headers, on_ready_get_result, &result);
+      cockpit_auth_login_async (test->auth,
+                                WebRequest(.path=fixture->auth, .headers=headers),
+                                on_ready_get_result, &result);
       g_hash_table_unref (headers);
       while (result == NULL)
         g_main_context_iteration (NULL, TRUE);

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -125,7 +125,7 @@ setup (Test *test,
        gconstpointer path)
 {
   base_setup (test);
-  test->response = cockpit_web_response_new (test->io, path, path, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  test->response = cockpit_web_response_new (test->io, path, path, NULL, NULL);
   g_signal_connect (test->response, "done",
                     G_CALLBACK (on_web_response_done_set_flag),
                     &test->response_done);
@@ -396,7 +396,7 @@ setup_default (Test *test,
   base_setup (test);
   test->response = cockpit_web_response_new (test->io,
                                             fixture->org_path ? fixture->org_path : fixture->path,
-                                            fixture->path, NULL, COCKPIT_WEB_RESPONSE_NONE);
+                                            fixture->path, NULL, NULL);
   g_signal_connect (test->response, "done",
                     G_CALLBACK (on_web_response_done_set_flag),
                     &test->response_done);
@@ -480,7 +480,7 @@ test_resource_checksum (Test *test,
   input = g_memory_input_stream_new ();
   io = g_simple_io_stream_new (input, output);
   path = "/cockpit/@localhost/checksum";
-  response = cockpit_web_response_new (io, path, path, NULL, COCKPIT_WEB_RESPONSE_NONE);
+  response = cockpit_web_response_new (io, path, path, NULL, NULL);
   g_signal_connect (response, "done", G_CALLBACK (on_web_response_done_set_flag), &response_done);
   g_assert (cockpit_handler_default (test->server, WebRequest(.path=path, .headers=test->headers),
                                      path, test->headers, response, &test->data));

--- a/src/ws/test-kerberos.c
+++ b/src/ws/test-kerberos.c
@@ -26,6 +26,8 @@
 #include "common/cockpittest.h"
 #include "common/cockpitwebserver.h"
 
+#include "common/cockpitwebrequest-private.h"
+
 #include <krb5/krb5.h>
 #include <gssapi/gssapi_krb5.h>
 
@@ -304,7 +306,7 @@ test_authenticate (TestCase *test,
   build_authorization_header (in_headers, &output);
   gss_release_buffer (&minor, &output);
 
-  cockpit_auth_login_async (test->auth, "/cockpit+test", NULL, in_headers, on_ready_get_result, &result);
+  cockpit_auth_login_async (test->auth, WebRequest(.path="/cockpit+test", .headers=in_headers), on_ready_get_result, &result);
   g_hash_table_unref (in_headers);
 
   while (result == NULL)
@@ -321,7 +323,7 @@ test_authenticate (TestCase *test,
 
   include_cookie_as_if_client (out_headers, out_headers);
 
-  service = cockpit_auth_check_cookie (test->auth, "/cockpit+test", out_headers);
+  service = cockpit_auth_check_cookie (test->auth, WebRequest(.path="/cockpit+test", .headers=out_headers));
   g_assert (service != NULL);
 
   creds = cockpit_web_service_get_creds (service);

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -247,6 +247,7 @@ mock_http_expect_warnings (CockpitWebResponse *response,
 
 static gboolean
 on_handle_mock (CockpitWebServer *server,
+                CockpitWebRequest *request,
                 const gchar *path,
                 GHashTable *headers,
                 CockpitWebResponse *response,
@@ -301,14 +302,14 @@ on_transport_control (CockpitTransport *transport,
 
 static gboolean
 on_handle_stream_socket (CockpitWebServer *server,
-                         const gchar *original_path,
-                         const gchar *path,
-                         const gchar *method,
-                         GIOStream *io_stream,
-                         GHashTable *headers,
-                         GByteArray *input,
+                         CockpitWebRequest *request,
                          gpointer user_data)
 {
+  const gchar *path = cockpit_web_request_get_path (request);
+  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
+  GByteArray *input = cockpit_web_request_get_buffer (request);
+  GHashTable *headers = cockpit_web_request_get_headers (request);
+
   CockpitTransport *transport;
   const gchar *query = NULL;
   CockpitCreds *creds;
@@ -426,14 +427,15 @@ on_echo_socket_close (WebSocketConnection *ws,
 
 static gboolean
 on_handle_stream_external (CockpitWebServer *server,
-                           const gchar *original_path,
-                           const gchar *path,
-                           const gchar *method,
-                           GIOStream *io_stream,
-                           GHashTable *headers,
-                           GByteArray *input,
+                           CockpitWebRequest *request,
                            gpointer user_data)
 {
+  const gchar *path = cockpit_web_request_get_path (request);
+  const gchar *method = cockpit_web_request_get_method (request);
+  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
+  GByteArray *input = cockpit_web_request_get_buffer (request);
+  GHashTable *headers = cockpit_web_request_get_headers (request);
+
   CockpitWebResponse *response;
   gboolean handled = FALSE;
   const gchar *upgrade;
@@ -607,6 +609,7 @@ handle_package_file (CockpitWebServer *server,
 
 static gboolean
 on_handle_resource (CockpitWebServer *server,
+                    CockpitWebRequest *request,
                     const gchar *path,
                     GHashTable *headers,
                     CockpitWebResponse *response,
@@ -632,6 +635,7 @@ on_handle_resource (CockpitWebServer *server,
 
 static gboolean
 on_handle_source (CockpitWebServer *server,
+                  CockpitWebRequest *request,
                   const gchar *path,
                   GHashTable *headers,
                   CockpitWebResponse *response,
@@ -649,10 +653,11 @@ on_handle_source (CockpitWebServer *server,
 
 static gboolean
 on_handle_favicon (CockpitWebServer *server,
-                  const gchar *path,
-                  GHashTable *headers,
-                  CockpitWebResponse *response,
-                  gpointer user_data)
+                   CockpitWebRequest *request,
+                   const gchar *path,
+                   GHashTable *headers,
+                   CockpitWebResponse *response,
+                   gpointer user_data)
 {
   const char* roots[] = { SRCDIR "/src/branding/default", NULL };
   cockpit_web_response_file (response, NULL, roots);

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -432,12 +432,10 @@ on_handle_stream_external (CockpitWebServer *server,
                            gpointer user_data)
 {
   const gchar *path = cockpit_web_request_get_path (request);
-  const gchar *method = cockpit_web_request_get_method (request);
   GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
   GByteArray *input = cockpit_web_request_get_buffer (request);
   GHashTable *headers = cockpit_web_request_get_headers (request);
 
-  CockpitWebResponse *response;
   gboolean handled = FALSE;
   const gchar *upgrade;
   CockpitCreds *creds;
@@ -506,10 +504,7 @@ on_handle_stream_external (CockpitWebServer *server,
             }
           else
             {
-              response = cockpit_web_response_new (io_stream, path, path, headers, COCKPIT_WEB_RESPONSE_NONE);
-              cockpit_web_response_set_method (response, method);
-              cockpit_channel_response_open (service, headers, response, open);
-              g_object_unref (response);
+              cockpit_channel_response_open (service, request, open);
               handled = TRUE;
             }
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -307,9 +307,6 @@ on_handle_stream_socket (CockpitWebServer *server,
                          gpointer user_data)
 {
   const gchar *path = cockpit_web_request_get_path (request);
-  GIOStream *io_stream = cockpit_web_request_get_io_stream (request);
-  GByteArray *input = cockpit_web_request_get_buffer (request);
-  GHashTable *headers = cockpit_web_request_get_headers (request);
 
   CockpitTransport *transport;
   const gchar *query = NULL;
@@ -392,7 +389,7 @@ on_handle_stream_socket (CockpitWebServer *server,
       g_signal_handler_disconnect (transport, handler);
     }
 
-  cockpit_web_service_socket (service, path, io_stream, headers, input, FALSE /* for_tls_proxy */);
+  cockpit_web_service_socket (service, request);
 
   /* Keeps ref on itself until it closes */
   g_object_unref (service);
@@ -499,7 +496,7 @@ on_handle_stream_external (CockpitWebServer *server,
           upgrade = g_hash_table_lookup (headers, "Upgrade");
           if (upgrade && g_ascii_strcasecmp (upgrade, "websocket") == 0)
             {
-              cockpit_channel_socket_open (service, open, path, path, io_stream, headers, input, FALSE /* for_tls_proxy */);
+              cockpit_channel_socket_open (service, open, request);
               handled = TRUE;
             }
           else

--- a/src/ws/test-webservice.c
+++ b/src/ws/test-webservice.c
@@ -137,12 +137,7 @@ handle_stream (CockpitWebServer *web_server,
   TestCase *test = user_data;
 
   g_assert (test->web_server == web_server);
-  cockpit_web_service_socket (test->service,
-                              cockpit_web_request_get_path (request),
-                              cockpit_web_request_get_io_stream (request),
-                              cockpit_web_request_get_headers (request),
-                              cockpit_web_request_get_buffer (request),
-                              cockpit_web_server_get_flags (test->web_server) & COCKPIT_WEB_SERVER_FOR_TLS_PROXY);
+  cockpit_web_service_socket (test->service, request);
   g_signal_handler_disconnect (web_server, test->request_handler);
   test->request_handler = 0;
 


### PR DESCRIPTION
The handle-stream signal on CockpitWebServer has a veritable grab-bag of parameters.  I've wanted to extend it several times in the past, but have always shied away.
    
Let's start to clean this up.
    
Expose our internal CockpitRequest as a public type named CockpitWebRequest.  Instead of emitting six separate parameters on the handle-stream function, we now emit this single object.

We also push this object down through our stack of functions designed for responding to web requests, allowing for a large number of cleanups to move various bits of webserver implementation detail from the consumers of this API to be accessible via new accessors on CockpitWebRequest.
