### PR TITLE
storage: Also show "other devices" in plots

### DIFF
--- a/pkg/storaged/others-panel.jsx
+++ b/pkg/storaged/others-panel.jsx
@@ -21,29 +21,13 @@ import cockpit from "cockpit";
 import React from "react";
 
 import { SidePanel, SidePanelRow } from "./side-panel.jsx";
-import { block_name, fmt_size, make_block_path_cmp } from "./utils.js";
+import { block_name, fmt_size, make_block_path_cmp, get_other_devices } from "./utils.js";
 
 const _ = cockpit.gettext;
 
 export class OthersPanel extends React.Component {
     render() {
         const client = this.props.client;
-
-        function is_other(path) {
-            const block = client.blocks[path];
-            const block_part = client.blocks_part[path];
-            const block_lvm2 = client.blocks_lvm2[path];
-
-            return ((!block_part || block_part.Table == "/") &&
-                    block.Drive == "/" &&
-                    block.CryptoBackingDevice == "/" &&
-                    block.MDRaid == "/" &&
-                    (!block_lvm2 || block_lvm2.LogicalVolume == "/") &&
-                    !block.HintIgnore &&
-                    block.Size > 0 &&
-                    !client.vdo_overlay.find_by_block(block) &&
-                    !client.blocks_stratis_fsys[block.path]);
-        }
 
         function make_other(path) {
             const block = client.blocks[path];
@@ -62,7 +46,7 @@ export class OthersPanel extends React.Component {
             );
         }
 
-        const others = Object.keys(client.blocks).filter(is_other)
+        const others = get_other_devices(client)
                 .sort(make_block_path_cmp(client))
                 .map(make_other);
 

--- a/pkg/storaged/plot.jsx
+++ b/pkg/storaged/plot.jsx
@@ -22,7 +22,7 @@ import React from "react";
 import { Split, SplitItem, Grid, GridItem } from '@patternfly/react-core';
 import { ZoomControls, SvgPlot, bytes_per_sec_config } from "cockpit-components-plot.jsx";
 
-import { decode_filename } from "./utils.js";
+import { decode_filename, get_other_devices } from "./utils.js";
 
 const single_read_metric = {
     direct: ["disk.all.read_bytes"],
@@ -58,12 +58,16 @@ const instances_write_metric = {
 
 export function update_plot_state(ps, client) {
     const devs = [];
-    for (const p in client.drives) {
-        const block = client.drives_block[p];
+
+    // show all top-level block objects: Drives and Other devices
+    const blocks = Object.keys(client.drives).map(p => client.drives_block[p])
+            .concat(get_other_devices(client).map(p => client.blocks[p]));
+
+    blocks.forEach(block => {
         const dev = block && decode_filename(block.Device).replace(/^\/dev\//, "");
         if (dev)
             devs.push(dev);
-    }
+    });
 
     if (devs.length > 10) {
         ps.plot_single('read', single_read_metric);

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -463,6 +463,24 @@ export function prepare_available_spaces(client, spcs) {
     return Promise.all(spcs.map(prepare));
 }
 
+export function get_other_devices(client) {
+    return Object.keys(client.blocks).filter(path => {
+        const block = client.blocks[path];
+        const block_part = client.blocks_part[path];
+        const block_lvm2 = client.blocks_lvm2[path];
+
+        return ((!block_part || block_part.Table == "/") &&
+                block.Drive == "/" &&
+                block.CryptoBackingDevice == "/" &&
+                block.MDRaid == "/" &&
+                (!block_lvm2 || block_lvm2.LogicalVolume == "/") &&
+                !block.HintIgnore &&
+                block.Size > 0 &&
+                !client.vdo_overlay.find_by_block(block) &&
+                !client.blocks_stratis_fsys[block.path]);
+    });
+}
+
 /* Comparison function for sorting lists of block devices.
 
    We sort by major:minor numbers to get the expected order when


### PR DESCRIPTION
Some virtual block devices, in particular not EC2 EBS volumes
(/dev/xvd*), do not appear as physical drive, so on EC2 instances there
were previously no storage graphs.

Show the "other devices" in the plot as well, as these are also
top-level objects. Factor the logic into utils, so that it can be used
in both the panel and the plot code.

Fixes #16493

----

I tested this on an EC2 instance (graphs now appearing) and my laptop (no difference). See #16493 for screenshots and debugging details.