### PR TITLE
test: Skip TestUpdatesSubscriptions on fedora-35

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1145,7 +1145,7 @@ class TestKpatchInstall(NoSubManCase):
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",
-           "fedora-34", "fedora-testing", "ubuntu-2004", "ubuntu-stable", "arch")
+           "fedora-34", "fedora-35", "fedora-testing", "ubuntu-2004", "ubuntu-stable", "arch")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},


### PR DESCRIPTION
This was only enabled by accident and doesn't work very well, see
#2323.  Also, at least testNoSubOsRepo is broken on any "*/devel" test
context since packagekit is not preloaded there.

Thus, let's disable these tests before making fedora-35 the default.