### PR TITLE
cockpit-client: add support for :port

### DIFF
--- a/src/client/cockpit-client-ssh
+++ b/src/client/cockpit-client-ssh
@@ -52,14 +52,20 @@ def cockpit_client_ssh():
     askpass = os.path.join(xdg_data_home, 'cockpit-client-askpass')
     shutil.copy(__file__, askpass, follow_symlinks=False)
 
-    host = sys.argv[1]
-
-    if host == 'localhost':
+    connect_to = sys.argv[1]
+    if connect_to == 'localhost':
         cmd = ['flatpak-spawn', '--host', 'cockpit-bridge']
     else:
+        host, _, port = connect_to.rpartition(':')
+        # catch cases like `host:123` but not cases like `[2001:abcd::1]`
+        if port.isdigit():
+            host_args = ['-p', port, host]
+        else:
+            host_args = [connect_to]
+
         cmd = ['flatpak-spawn', '--host', '/usr/bin/env',
                'SSH_ASKPASS_REQUIRE=force', f'SSH_ASKPASS={askpass}',
-               '/usr/bin/ssh', host, 'cockpit-bridge']
+               '/usr/bin/ssh'] + host_args + ['cockpit-bridge']
 
     os.execvp(cmd[0], cmd)
 

--- a/test/README.md
+++ b/test/README.md
@@ -212,21 +212,23 @@ ad-hoc when doing incremental development.
 If you add a snippet like this to your `~/.ssh/config` then you'll be able to
 log in to test machines without authentication:
 
-    Host 127.0.0.2
+    Match final host 127.0.0.2
         User root
-        Port 2201
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
+        CheckHostIp no
         IdentityFile ~/src/cockpit/bots/machine/identity
         IdentitiesOnly yes
 
 Many cockpit developers take it a step further, and add an alias to
 allow typing `ssh c`:
 
-    Host 127.0.0.2 c
+    Host c
         Hostname 127.0.0.2
-        User root
-        ... etc
+        Port 2201
+
+The `final` keyword in the first rule will cause it to be checked (and matched)
+after the `Hostname` substitution in the `c` rule.
 
 For web access, if you'd like to avoid Chromium (or Chrome) prompting
 about certificate errors while connecting to localhost, you can change


### PR DESCRIPTION
Connecting to an address like
```
root@127.0.0.2:2201
```
doesn't currently work because ssh(1) doesn't under the port number. Break it out to a -p parameter, if it's present.
