### PR TITLE
unit-tests: remove amd64 arch from i386 container

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -34,5 +34,5 @@ jobs:
           fi
 
       - name: Run unit-tests container
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: containers/unit-tests/start ${{ matrix.startarg }}

--- a/containers/unit-tests/run.sh
+++ b/containers/unit-tests/run.sh
@@ -23,12 +23,14 @@ export MAKEFLAGS="-j $(nproc)"
 # information about the running processes in order to give us a better chance
 # of tracking down problems.
 ( set +x
-  sleep 18m
-  echo ===== 18 mins ====================
-  ps auxwfe
+  sleep 28m
+  echo ===== 28 mins ====================
+  ps auxwe
+  echo
+  ps auxwf
   echo
   top -b -n1
-  echo ===== 18 mins ====================
+  echo ===== 28 mins ====================
 )&
 
 # copy host's source tree to avoid changing that, and make sure we have a clean tree

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -68,8 +68,6 @@ chmod +x /entrypoint
 
 echo "deb http://deb.debian.org/debian-debug/ testing-debug main" > /etc/apt/sources.list.d/ddebs.list
 echo "deb http://deb.debian.org/debian-debug/ testing-proposed-updates-debug main" >> /etc/apt/sources.list.d/ddebs.list
-# always install amd64 nodejs version; there is e.g. no i386 version for node-sass available
-dpkg --add-architecture amd64
 apt-get update
 apt-get install -y --no-install-recommends eatmydata
 DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recommends ${dependencies}

--- a/pkg/base1/test-dbus-common.js
+++ b/pkg/base1/test-dbus-common.js
@@ -932,12 +932,12 @@ export function common_dbus_tests(channel_options, bus_name) { // eslint-disable
                             "com.redhat.Cockpit.DBusTests.Hidden": { Name: name }
                         }, "got data before signal");
                         dbus.removeEventListener("notify", onnotify);
-                        done();
                     });
                     dbus.call("/otree/frobber", "com.redhat.Cockpit.DBusTests.Frobber",
                               "EmitHidden", [name])
                             .always(function() {
                                 assert.equal(this.state(), "resolved", "method called");
+                                done();
                             });
                 });
     });


### PR DESCRIPTION
This was originally used to install amd64 nodejs because there was no
binary version of node-sass for i386.  That stopped being a problem a
long time ago and we've since dropped installing nodejs:amd64, but we
forgot to remove adding the architecture for it.

 - [ ] Rebuild here: https://github.com/cockpit-project/cockpit/actions/runs/1576746588