### PR TITLE
unit-tests: Enable -fanalyzer for gcc

### DIFF
--- a/containers/unit-tests/build.sh
+++ b/containers/unit-tests/build.sh
@@ -1,4 +1,9 @@
 #!/bin/sh -eux
 
+# run -fanalyzer for default gcc
+if [ -z "${CC:-}" ]; then
+    export CFLAGS="-fanalyzer"
+fi
+
 ./autogen.sh --prefix=/usr --enable-strict
 [ "${TEST_SCENARIO:-}" = "dist" ] || make


### PR DESCRIPTION
Commits b3e3b10fdae8 and 4193c1d96 fixed gcc -fanalyzer errors a while
ago. Now that we have a new enough gcc in the unit-tests container,
enable the analyzer permanently.