### PR TITLE
tests: return true (not undefined) from a filter

### DIFF
--- a/pkg/base1/test-chan.js
+++ b/pkg/base1/test-chan.js
@@ -682,6 +682,7 @@ QUnit.test("filter message in", function (assert) {
             assert.strictEqual(channelid, "", "control message channel");
             assert.equal(typeof control, "object", "control is a JSON object");
             assert.equal(typeof control.command, "string", "control has a command");
+            return true;
         } else {
             assert.strictEqual(channelid, channel.id, "cockpit channel id");
             assert.equal(control, undefined, "control is undefined");


### PR DESCRIPTION
The filter function should always return a boolean, and in one case we
were missing a return statement.  That seems to have worked out okay on
Chromium, but sometimes Firefox doesn't like it, leading to fails like

> log: not ok 154 - Expected 11 assertions, but 14 were run...

Make it explicit.


I have no idea if this is actually the problem from https://github.com/cockpit-project/cockpit/runs/4517621520?check_suite_focus=true#step:4:3391 but this fix certainly won't make things worse...