### PR TITLE
workflows: Add missing apt update to flatpak-test

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -10,7 +10,9 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Install required build and test dependencies
-        run: sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto flatpak-builder xvfb cockpit-system
+        run: |
+          sudo apt update
+          sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto flatpak-builder xvfb cockpit-system
 
       - name: Configure flathub remote
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
Some package versions in the GitHub workflow machine's old package index
got cleaned up and are not available any more.

----

Fixes [this failure](https://github.com/cockpit-project/cockpit/runs/4543993599?check_suite_focus=true)