### PR TITLE
session: Close shell's stdin in user_has_valid_login_shell()

### DIFF
--- a/src/session/session.c
+++ b/src/session/session.c
@@ -838,10 +838,17 @@ user_has_valid_login_shell (const char **envp)
    * <pitti> https://xkcd.com/221/
    */
   const char *argv[] = { pwd->pw_shell, "-c", "exit 71;", NULL };
-  const int remap_fds[] = { -1, 2, -1 }; /* send stdout to stderr */
+
+  int devnull = open ("/dev/null", O_RDONLY);
+  if (devnull < 0)
+      err (EX, "couldn't open /dev/null");
+
+  const int remap_fds[] = { devnull, 2, -1 }; /* send stdout to stderr */
   int wstatus;
 
   wstatus = spawn_and_wait (argv, envp, remap_fds, 3, pwd->pw_uid, pwd->pw_gid);
+  debug ("user_has_valid_login_shell: exited with status %x", wstatus);
+  close (devnull);
   return WIFEXITED(wstatus) && WEXITSTATUS(wstatus) == 71;
 }
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -399,7 +399,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         m = self.machine
         b = self.browser
 
-        m.execute("useradd user --shell /usr/bin/tlog-rec-session || true")
+        m.execute("useradd user --shell /usr/bin/tlog-rec-session")
         m.execute("echo user:abcdefg | chpasswd")
         # this doesn't actually record anything, but logging into cockpit should work
         m.start_cockpit()


### PR DESCRIPTION
tlog in RHEL/CentOS 9 now tries to read from its stdin even with `-c`.
While this is arguably a bug, it does not happen during VT or SSH logins
nor with `runas`. Let's just be robust against that and set stdin to
/dev/null.

----

This fixes the recent [c9s packit regression](http://artifacts.dev.testing-farm.io/96eec411-b0b0-49de-ae33-9778e853e7ad/). See https://github.com/cockpit-project/cockpit/pull/16718#issuecomment-995601497 for debugging notes.