### PR TITLE
build: build deterministic tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -111,6 +111,7 @@ endif
 		tar --format=posix -C $(srcdir) --exclude test/reference -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
+	tools/adjust-distdir-timestamps "$(distdir)"
 
 #
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -101,8 +101,16 @@ uninstall-local::
 	  (find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete && \
 	   find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
 dist-hook:: $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS) $(WEBPACK_TEST_DEPS) $(MANIFESTS)
+if !ENABLE_DOC
+	@echo "*** doc must be enabled (ie: --enable-doc) in order to make dist or distcheck"
+	@false
+endif
 	$(V_TAR) tar --format=posix -cf - $^ | tar -C $(distdir) -xf -
 	cp $(srcdir)/tools/README.node_modules $(distdir)/node_modules/README
+	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
+		tar --format=posix -C $(srcdir) --exclude test/reference -cf - -T - | tar -C $(distdir) -xf -
+	echo $(VERSION) > $(distdir)/.tarball
+	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 #
 
@@ -188,14 +196,6 @@ else
 	@true
 endif
 
-dist-hook::
-if ENABLE_DOC
-	@true
-else
-	@echo "*** doc must be enabled (ie: --enable-doc) in order to make dist or distcheck"
-	@false
-endif
-
 # See test/image-prepare
 dump-dist:
 	@echo "$(abs_builddir)/$(distdir).tar.xz"
@@ -215,14 +215,6 @@ tools/debian/copyright: tools/debian/copyright.template $(MANIFESTS)
 # https://git.savannah.gnu.org/cgit/automake.git/commit/?id=13659a7385
 distdir:
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am
-
-# Build up the distribution using $COMMITTED_DIST and include node_modules licenses
-# also automatically update minimum base dependency in RPM spec file
-dist-hook:: $(MANIFESTS)
-	( cd $(srcdir); git ls-tree HEAD --name-only -r $(COMMITTED_DIST) || (echo $(COMMITTED_DIST) | tr ' ' '\n' ) ) | \
-		tar --format=posix -C $(srcdir) --exclude test/reference -cf - -T - | tar -C $(distdir) -xf -
-	echo $(VERSION) > $(distdir)/.tarball
-	[ ! -e $(distdir)/tools/cockpit.spec ] || $(srcdir)/tools/gen-spec-dependencies $(distdir)/tools/cockpit.spec
 
 distcheck-hook::
 	$(srcdir)/tools/check-dist $(distdir)

--- a/configure.ac
+++ b/configure.ac
@@ -39,7 +39,7 @@ AC_CONFIG_MACRO_DIR([tools])
 AM_INIT_AUTOMAKE([1.11 foreign dist-xz no-dist-gzip subdir-objects])
 # we want tar-ustar to avoid introducing extra metadata (ctime, atime) which
 # only adds useless non-determinism to the result.  we also want to sort.
-am__tar='tar --format=ustar --sort=name -chf - "$$tardir"'
+am__tar='tar --format=ustar --sort=name --owner=root:0 --group=root:0 -chf - "$$tardir"'
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_RANLIB

--- a/configure.ac
+++ b/configure.ac
@@ -37,7 +37,9 @@ AC_CONFIG_AUX_DIR([tools])
 AC_CONFIG_MACRO_DIR([tools])
 
 AM_INIT_AUTOMAKE([1.11 foreign dist-xz no-dist-gzip subdir-objects])
-am__tar='tools/tar-create "$$tardir"'
+# we want tar-ustar to avoid introducing extra metadata (ctime, atime) which
+# only adds useless non-determinism to the result.  we also want to sort.
+am__tar='tar --format=ustar --sort=name -chf - "$$tardir"'
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_RANLIB

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,8 @@ AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_AUX_DIR([tools])
 AC_CONFIG_MACRO_DIR([tools])
 
-AM_INIT_AUTOMAKE([1.11 foreign dist-xz no-dist-gzip subdir-objects tar-pax])
+AM_INIT_AUTOMAKE([1.11 foreign dist-xz no-dist-gzip subdir-objects])
+am__tar='tools/tar-create "$$tardir"'
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_RANLIB

--- a/containers/flatpak/install
+++ b/containers/flatpak/install
@@ -20,6 +20,5 @@ prepare "${TARBALL:-}" "${URLBASE:-}"
 flatpak-builder \
     "$@" \
     --disable-rofiles-fuse \
-    --disable-cache \
     --force-clean \
     --install flatpak-build-dir "${FLATPAK_ID}".yml

--- a/tools/adjust-distdir-timestamps
+++ b/tools/adjust-distdir-timestamps
@@ -1,11 +1,11 @@
 #!/bin/sh
 
-# Create a deterministic distribution tarball with timestamps
+# Help create a deterministic distribution tarball with timestamps
 # based on the time of the latest git commit.
 
 set -eu
 
-tardir="$1"
+distdir="$1"
 
 # This will work for .git or for .tarball
 #
@@ -23,32 +23,28 @@ timestamp() {
 }
 
 # all files get the same timestamp as the commit date
-timestamp "${tardir}"
+timestamp "${distdir}"
 
 # aclocal.m4 comes next
-timestamp "${tardir}/aclocal.m4"
+timestamp "${distdir}/aclocal.m4"
 
 # then the other automake generated files
 timestamp \
-    "${tardir}/config.h.in" \
-    "${tardir}/configure" \
-    "${tardir}/Makefile.in"
+    "${distdir}/config.h.in" \
+    "${distdir}/configure" \
+    "${distdir}/Makefile.in"
 
 # package-lock.json needs to be newer than package.json
-timestamp "${tardir}/package-lock.json"
+timestamp "${distdir}/package-lock.json"
 
 # and dist/ needs to be newer than that
-timestamp "${tardir}/dist"
+timestamp "${distdir}/dist"
 
 # we generate these files during `make dist`
 timestamp \
-    "${tardir}/.tarball" \
-    "${tardir}/tools/debian/copyright" \
-    "${tardir}/tools/cockpit.spec"
+    "${distdir}/.tarball" \
+    "${distdir}/tools/debian/copyright" \
+    "${distdir}/tools/cockpit.spec"
 
 # finally, the directories should be newer than everything else
-timestamp "${tardir}" -type d
-
-# and now we can produce the archive
-# we use ustar because it excludes atime/ctime
-exec tar --format=ustar --sort=name -chf - "${tardir}"
+timestamp "${distdir}" -type d

--- a/tools/tar-create
+++ b/tools/tar-create
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Create a deterministic distribution tarball with timestamps
+# based on the time of the latest git commit.
+
+set -eu
+
+tardir="$1"
+
+# This will work for .git or for .tarball
+#
+# Note: we give the .tarball file the exact same timestamp as the git commit,
+# so producing a tarball from a tarball should also create the exact same
+# output.
+
+stamp="$(git show --format=%ct --no-patch 2>&1 || stat -c %Y .tarball)"
+
+test -n "${stamp}"
+
+timestamp() {
+    find "$@" -exec touch -d "@${stamp}" '{}' '+'
+    stamp="$((stamp + 1))"
+}
+
+# all files get the same timestamp as the commit date
+timestamp "${tardir}"
+
+# aclocal.m4 comes next
+timestamp "${tardir}/aclocal.m4"
+
+# then the other automake generated files
+timestamp \
+    "${tardir}/config.h.in" \
+    "${tardir}/configure" \
+    "${tardir}/Makefile.in"
+
+# package-lock.json needs to be newer than package.json
+timestamp "${tardir}/package-lock.json"
+
+# and dist/ needs to be newer than that
+timestamp "${tardir}/dist"
+
+# we generate these files during `make dist`
+timestamp \
+    "${tardir}/.tarball" \
+    "${tardir}/tools/debian/copyright" \
+    "${tardir}/tools/cockpit.spec"
+
+# finally, the directories should be newer than everything else
+timestamp "${tardir}" -type d
+
+# and now we can produce the archive
+# we use ustar because it excludes atime/ctime
+exec tar --format=ustar --sort=name -chf - "${tardir}"


### PR DESCRIPTION
The goal is for a given git commit ID to always give the exact same `.tar.xz` output.