### PR TITLE
test: sudo with cert auth now works on RHEL 8.6/C8S

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -780,7 +780,7 @@ ipa-advise enable-admins-sudo | sh -ex
         # now sudo works with the delegated ticket
         # this requires https://github.com/sudo-project/sudo/commit/3b7977a42c0 (see https://bugzilla.redhat.com/show_bug.cgi?id=1917379)
         # to actually work, so on older distros it fails
-        supports_sudo_krb = m.image not in ["rhel-8-5", "rhel-8-6", "centos-8-stream", "ubuntu-2004"]
+        supports_sudo_krb = m.image not in ["rhel-8-5", "ubuntu-2004"]
         b.open_superuser_dialog()
 
         if supports_sudo_krb:

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -26,7 +26,7 @@ from testlib import *
 @skipImage("freeipa not currently available", "debian-stable", "debian-testing", "ubuntu-2004", "arch")
 @skipImage("Skip these for now, unsure what's broken", "ubuntu-stable")
 @skipDistroPackage()
-@skipImage("Needs sssd >=2.4.1", "rhel-8-4", "rhel-8-5", "rhel-8-6", "centos-8-stream")
+@skipImage("Needs sssd >=2.4.1", "rhel-8-4", "rhel-8-5")
 class TestS4USsh(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},


### PR DESCRIPTION
The sudo fix made it into RHEL 8.6 nightly and CentOS 8 Stream. Adjust
the test special case accordingly.

----

This needs to land in lockstep with https://github.com/cockpit-project/bots/pull/2729