### PR TITLE
test: Fix Firefox CDP driver for version 97 nightlies

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -130,6 +130,8 @@ class Firefox(Browser):
                 user_pref("browser.download.folderList", 2);
                 user_pref("signon.rememberSignons", false);
                 user_pref("dom.navigation.locationChangeRateLimit.count", 9999);
+                // HACK: https://bugzilla.mozilla.org/show_bug.cgi?id=1746154
+                user_pref("fission.webContentIsolationStrategy", 0);
                 """.format(download_dir))
 
         with open(os.path.join(profile, "handlers.json"), "w") as f:


### PR DESCRIPTION
Firefox 97 enables Fission [1] by default to improve site isolation.
This broke DevTools Protocol's `Page` events [2]. Disable Fission to
work with current nightlies as well.

This bug hopefully gets fixed at some point, but this workaround will
not break.

[1] https://wiki.mozilla.org/Project_Fission
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1746154

----

We don't have that Firefox nightly in our tasks container (and won't have, as we can go back to the distro version), but I verified it locally against a current nighty. For easy comparison:

```
mkdir /tmp/fn; curl --location 'https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US' | tar -C /tmp/fn -xj
sudo ln -sfn /tmp/fn/firefox/firefox /usr/local/bin/firefox
```

and you can go back to the older one from the tasks container with
```
sudo ln -sfn /usr/local/lib/firefox/firefox /usr/local/bin/firefox
```