### PR TITLE
build: fix `make dist` from tarball

### DIFF
--- a/tools/adjust-distdir-timestamps
+++ b/tools/adjust-distdir-timestamps
@@ -13,7 +13,7 @@ distdir="$1"
 # so producing a tarball from a tarball should also create the exact same
 # output.
 
-stamp="$(git show --format=%ct --no-patch 2>&1 || stat -c %Y .tarball)"
+stamp="$(git show --format=%ct --no-patch 2>/dev/null || stat -c %Y .tarball)"
 
 test -n "${stamp}"
 


### PR DESCRIPTION
The recently-introduced adjust-distdir-timestamps script attempts to
determine the correct base timestamp for the distribution by checking
first git, and then falling back to stat on the .tarball file, if git
fails.

The logic there is broken due to a typo, though: we anticipate the git
check may fail and redirect its stderr to avoid seeing the error, but it
ought to be redirected to /dev/null, not to stdout, where it is captured
and treated as a (completely invalid) timestamp.