### PR TITLE
test: change browser locale to C.UTF-8

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -278,7 +278,7 @@ class CDP:
             self._browser_home = tempfile.mkdtemp()
             environ = os.environ.copy()
             environ["HOME"] = self._browser_home
-            environ["LC_ALL"] = "en_US.UTF-8"
+            environ["LC_ALL"] = "C.UTF-8"
             # this might be set for the tests themselves, but we must isolate caching between tests
             try:
                 del environ["XDG_CACHE_HOME"]


### PR DESCRIPTION
We used to use en_US.UTF-8 as our "always available" English locale, but
it's not always available.  Use C.UTF-8 instead.

This fixes the many warnings from firefox that can be seen when running
unit-tests:

(firefox-esr:16949): Gtk-WARNING **: 14:46:06.423: Locale not supported by C library.
	Using the fallback 'C' locale.