### PR TITLE
Add a cockpit rsync webpack plugin for cockpit plugins

### DIFF
--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -1,0 +1,28 @@
+const child_process = require("child_process");
+
+module.exports = class {
+    constructor(options) {
+        if (!options)
+            options = {};
+        this.dest = options.dest || "";
+        this.source = options.source || "dist/";
+    }
+
+    apply(compiler) {
+        compiler.hooks.afterEmit.tapAsync('WebpackHookPlugin', (compilation, callback) => {
+            if (process.env.RSYNC) {
+                const proc = child_process.spawn("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
+                    this.source, process.env.RSYNC + ":/usr/share/cockpit/" + this.dest], { stdio: "inherit" });
+                proc.on('close', (code) => {
+                    if (code !== 0) {
+                        process.exit(1);
+                    } else {
+                        callback();
+                    }
+                });
+            } else {
+                callback();
+            }
+        });
+    }
+};

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -10,6 +10,7 @@ const path = require("path");
 const argparse = require("argparse");
 const fs = require("fs");
 const child_process = require("child_process");
+const CockpitRsyncPlugin = require("../pkg/lib/cockpit-rsync-plugin");
 
 // argv0 is node
 const webpack_watch = process.argv[1].includes('webpack-watch');
@@ -38,6 +39,11 @@ const srcdir = (process.env.SRCDIR || ".").replace(/\/$/, '');
 const cwd = process.cwd();
 const config_path = path.resolve(cwd, args.config);
 const config = require(config_path);
+
+if (args.rsync) {
+  process.env["RSYNC"] = args.rsync;
+  config.plugins.push(new CockpitRsyncPlugin({source: path.dirname(makefile)}));
+}
 
 const compiler = webpack(config);
 
@@ -75,9 +81,6 @@ function process_result(err, stats) {
             process.exit(1);
         return;
     }
-
-    if (args.rsync)
-        rsync();
 
     generateDeps(makefile, stats);
 }
@@ -184,12 +187,4 @@ function generateDeps(makefile, stats) {
     lines.push(prefix + ": " + stampfile);
 
     fs.writeFileSync(makefile, lines.join("\n") + "\n");
-}
-
-function rsync() {
-    const ret = child_process.spawnSync("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
-                                        path.dirname(makefile), args.rsync + ":/usr/share/cockpit/"],
-                                        { stdio: "inherit" });
-    if (ret.status !== 0)
-        process.exit(1);
 }


### PR DESCRIPTION
Currently it is not possible to easily run `npm run watch` and upload
artifacts using rsync as `./tools/webpack-make -r c` does. A webpack
plugin has some limitations no custom cli arguments can be passed,
either use env variables or --env.foo=1. Apart from that the plugin is
fairly simply but requires the `webpack.config.js` file to provide a
valid `packagename` for example `cockpit-machines` for the machines
plugin to the instantiated plugin.