### PR TITLE
test: Enable skipped timesyncd tests

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -553,12 +553,16 @@ class TestHistoryMetrics(MachineCase):
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
 
     @nondestructive
-    @skipImage("TODO: pm proxy alert doesn't show on Arch Linux", "arch")
     @skipImage("no PCP support", "fedora-coreos")
     @todoPybridge()
     def testPmProxySettings(self):
         b = self.browser
         m = self.machine
+
+        # Arch Linux has no active zone by default which the firewalld port alert test requires.
+        if m.image == "arch":
+            m.execute("firewall-cmd --zone=public --change-interface eth0 --permanent")
+            m.execute("firewall-cmd --reload")
 
         redis = redisService(m.image)
         hostname = m.execute("hostname").strip()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -201,7 +201,6 @@ class TestSystemInfo(MachineCase):
         b.click(f"#change_systime button:contains('{mode}')")
         b.wait_in_text("#system_information_change_systime .pf-c-form__group-label:contains('Set time') + div > .pf-c-select > button", mode)
 
-    @skipImage("TODO: systemd-timesyncd responds too slow on Arch Linux", "arch")
     @todoPybridge()
     def testTime(self):
         m = self.machine
@@ -282,13 +281,16 @@ class TestSystemInfo(MachineCase):
         self.assertIn("Mon Jun  4 06:34:", m.execute("date"))
         self.assertIn("EEST 2018\n", m.execute("date"))
 
-    @skipImage("TODO: systemd-timesyncd responds too slow on Arch Linux", "arch")
     def testTimeServers(self):
         m = self.machine
         b = self.browser
 
         # Fedora/RHEL/CentOS use chrony
         uses_timesyncd = m.image.startswith("debian") or m.image.startswith("ubuntu") or m.image == "arch"
+
+        # Enable ntp so setting specific timeservers becomes an option, as it is disabled by default.
+        if m.image == "arch":
+            m.execute("timedatectl set-ntp true")
 
         conf = "/etc/systemd/timesyncd.conf.d/50-cockpit.conf"
 


### PR DESCRIPTION
The testTime test works without skipping, for the testTimeServers test
enable the by default disabled ntp service in timesyncd so the test is
able to set specific time servers