### PR TITLE
ws: Avoid regular json_object_get_string_member assertion, catch unexpected messages

### DIFF
--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1502,9 +1502,9 @@ cockpit_auth_login_async (CockpitAuth *self,
 
   /* If the client sends a TLS certificate to cockpit-tls, treat this as a
    * definitive login type, and don't just silently fall back to other types */
-  const gchar *client_certificate;
+  const gchar *client_certificate = NULL;
   JsonObject *metadata = get_connection_metadata (connection);
-  if (metadata && (client_certificate = json_object_get_string_member (metadata, "client-certificate")))
+  if (metadata && cockpit_json_get_string (metadata, "client-certificate", NULL, &client_certificate) && client_certificate)
     {
       g_debug ("TLS connection has peer certificate, using tls-cert auth type");
       type = g_strdup ("tls-cert");

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1338,6 +1338,7 @@ class MachineCase(unittest.TestCase):
 
     def allow_restart_journal_messages(self):
         self.allow_journal_messages(".*Connection reset by peer.*",
+                                    "connection unexpectedly closed by peer",
                                     ".*Broken pipe.*",
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Underlying GIOStream returned 0 bytes on an async read \\(g-io-error-quark, 0\\). Exiting.",
                                     "connection unexpectedly closed by peer",
@@ -1380,11 +1381,17 @@ class MachineCase(unittest.TestCase):
             "SYSLOG_IDENTIFIER=cockpit-ws",
             "SYSLOG_IDENTIFIER=cockpit-bridge",
             "SYSLOG_IDENTIFIER=cockpit/ssh",
+            # also catch GLIB_DOMAIN=<library> which apply to cockpit-ws (but not to -bridge, too much random noise)
+            "_COMM=cockpit-ws",
             "GLIB_DOMAIN=cockpit-ws",
             "GLIB_DOMAIN=cockpit-bridge",
             "GLIB_DOMAIN=cockpit-ssh",
             "GLIB_DOMAIN=cockpit-pcp"
         ]
+
+        # older c-ws versions always log an assertion, fixed in PR #16765
+        if self.image == "rhel-8-5-distropkg":
+            self.allowed_messages.append("json_object_get_string_member: assertion 'node != NULL' failed")
 
         if not self.allow_core_dumps:
             matches += ["SYSLOG_IDENTIFIER=systemd-coredump"]

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -437,6 +437,7 @@ class TestConnection(MachineCase):
             ".*Peer failed to perform TLS handshake",
             ".*Peer sent fatal TLS alert:.*",
             ".*invalid base64 data in Basic header",
+            "Received unexpected TLS connection and no certificate was configured",
             ".*Error performing TLS handshake: No supported cipher suites have been found.",
             ".*Error performing TLS handshake: Could not negotiate a supported cipher suite.")
 
@@ -852,6 +853,7 @@ until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages(".*Peer failed to perform TLS handshake.*")
         self.allow_journal_messages(r".*cannot reauthorize identity\(s\): unix-user:.*")
+        self.allow_journal_messages("admin: Executing command .*COMMAND=/usr/bin/cockpit-bridge --privileged.*")
 
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -28,6 +28,7 @@ class KdumpHelpers(MachineCase):
         self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
         self.machine.execute("mkdir -p /var/crash")
         self.machine.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
+        self.allow_restart_journal_messages()
         self.machine.wait_reboot()
         self.machine.start_cockpit()
         self.browser.switch_to_top()
@@ -64,8 +65,6 @@ class TestKdump(KdumpHelpers):
         m = self.machine
 
         b.wait_timeout(120)
-        self.allow_restart_journal_messages()
-
         m.execute("systemctl enable kdump && systemctl start kdump || true")
 
         self.login_and_go("/kdump")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -530,6 +530,7 @@ class TestStorageLuks(StorageCase):
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
+        self.allow_restart_journal_messages()
         m.wait_reboot()
         m.start_cockpit()
         b.relogin()

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -361,6 +361,7 @@ class TestStorageStratis(StorageCase):
 
         # Reboot
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
+        self.allow_restart_journal_messages()
         m.wait_reboot()
         m.start_cockpit()
         b.relogin()

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -22,9 +22,11 @@ from testlib import *
 
 
 def allow_old_cockpit_ws_messsages(test):
-    # noisy debug message from old cockpit-ws
+    # noisy debug message from old cockpit-ws/polkit
     test.allow_journal_messages("logged in user session",
-                                "New connection to session from.*")
+                                "New connection to session from.*",
+                                "pam_unix(polkit-1:session): session opened for user root by .*uid=.*",
+                                "admin: Executing command .*COMMAND=/usr/bin/cockpit-bridge --privileged.*")
 
 
 @skipDistroPackage()


### PR DESCRIPTION
Whenever the login page was opened without a client certificate (i.e. in
the vast majority of cases), ws would log an error

    json_object_get_string_member: assertion 'node != NULL' failed

due to the sloppy way of checking for the existence of a client
certificate. Do this properly, and fail hard if tls sends a wrong data
type.

---

Spotted in #16764