### PR TITLE
test: Relax expected memory plateau in TestPages.testPlots

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -688,11 +688,11 @@ OnCalendar=daily
 
         meminfo = read_mem_info(m)
         mem_avail = meminfo['MemAvailable']
-        b.wait_js_func("ph_plot_data_plateau", "direct", mem_avail * 0.95, mem_avail * 1.05, 15, "mem")
+        b.wait_js_func("ph_plot_data_plateau", "direct", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
         meminfo = read_mem_info(m)
         mem_avail = meminfo['MemAvailable']
-        b.wait_js_func("ph_plot_data_plateau", "pmcd", mem_avail * 0.95, mem_avail * 1.05, 15, "mem")
+        b.wait_js_func("ph_plot_data_plateau", "pmcd", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
     def testPageStatus(self):
         b = self.browser


### PR DESCRIPTION
Available memory changes very impredictably, not to the least as a
result of asynchronous Cockpit page actions. Also, the playground's plot
is very small, so one gets rounding errors. 5% error margin for the
expected available memory became too small at least on centos-8-stream
on CentOS CI.

---

[example failure](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-2761-20220101-081017-c533283e-centos-8-stream-cockpit-project-cockpit/log.html) -- over the holidays, with e2e being down, c8s has failed consistently on this issue. Locally the test works fine now.