### PR TITLE
test: Give content iframes a fixed size

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -159,7 +159,7 @@ def jsquote(str):
 
 
 class CDP:
-    def __init__(self, lang=None, verbose=False, trace=False, inject_helpers=[]):
+    def __init__(self, lang=None, verbose=False, trace=False, fixed_content_size=False, inject_helpers=[]):
         self.lang = lang
         self.timeout = 60
         self.valid = False
@@ -174,12 +174,40 @@ class CDP:
         self._browser = None
         self._browser_home = None
         self._cdp_port_lockfile = None
-        if not self.mobile:
-            self.window_width = "1920"
-            self.window_height = "1200"
+
+        if fixed_content_size:
+
+            # We fix the size of the content iframe and then make the
+            # window large enough to fit the shell around it.  The
+            # content iframe size will be set later with
+            # "adjust_window_for_fixed_content_size" in testlib.py,
+            # after the shell has been loaded and we know how big it
+            # really is.
+            #
+            # The browser window needs to be big enough for the final
+            # adjusted size of shell plus content, but it also needs to be
+            # tight enough to trigger the right layout mode (desktop or
+            # mobile) from the start.
+
+            if not self.mobile:
+                self.content_width = 1680
+                self.content_height = 1130
+                self.window_width = self.content_width + 300
+                self.window_height = self.content_height + 300
+            else:
+                self.content_width = 414
+                self.content_height = 1856
+                self.window_width = self.content_width
+                self.window_height = self.content_height + 300
+
         else:
-            self.window_width = "414"
-            self.window_height = "1920"
+
+            if not self.mobile:
+                self.window_width = 1920
+                self.window_height = 1200
+            else:
+                self.window_width = 414
+                self.window_height = 1920
 
     def invoke(self, fn, **kwargs):
         """Call a particular CDP method such as Runtime.evaluate

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -320,3 +320,23 @@ function ph_element_clip(sel) {
 function ph_count_animations(sel) {
     return ph_find(sel).getAnimations({subtree:true}).length;
 }
+
+function ph_adjust_content_size(w, h) {
+    const body = document.body;
+    const content = document.getElementById("content");
+    const dx = w - content.offsetWidth;
+    const dy = h - content.offsetHeight;
+
+    // Making the body bigger doesn't really work.  It already fills
+    // the whole browser window and making it bigger would cause parts
+    // of it to stick out and we couldn't take snapshots of them.
+    // Let's just warn about this here and hope it doesn't matter.
+
+    if (dx > 0 || dy > 0) {
+        console.warn("Can't adjust content iframe size.  Browser window is too small.");
+        return;
+    }
+
+    body.style.width = (body.offsetWidth + dx) + "px";
+    body.style.height = (body.offsetHeight + dy) + "px";
+}


### PR DESCRIPTION
This isolates pixel tests for the pages from changes in the shell
layout.