### PR TITLE
urls-check: Ignore patternfly redirects

### DIFF
--- a/tools/urls-check
+++ b/tools/urls-check
@@ -101,7 +101,7 @@ def check_urls(verbose):
             # Specify agent as some websites otherwise block requests
             req = Request(url=url, headers={"User-Agent": "Mozilla/5.0 (X11; Fedora; Linux x86_64; rv:90.0) Gecko/20100101 Firefox/90.0"})
             resp = urlopen(req)
-            if resp.geturl() != url and url not in known_redirects:
+            if resp.geturl() != url and url not in known_redirects and not url.startswith("https://github.com/patternfly/"):
                 redirects.append(url)
             if resp.getcode() >= 400:
                 failed.append(url)


### PR DESCRIPTION
PF maintainers often transfer issues between their repositories. This is
nothing we need to worry about.

Such reports can be seen in:
https://github.com/cockpit-project/cockpit/issues/16607
https://github.com/cockpit-project/cockpit/issues/16221
https://github.com/cockpit-project/cockpit/issues/14752