### PR TITLE
shell: Fix locale provided to DatePicker

### DIFF
--- a/pkg/lib/cockpit-components-shutdown.jsx
+++ b/pkg/lib/cockpit-components-shutdown.jsx
@@ -206,7 +206,7 @@ export class ShutdownModal extends React.Component {
                                                 dateParse={timeformat.parseShortDate}
                                                 invalidFormatText=""
                                                 isDisabled={!this.state.formFilled}
-                                                locale={cockpit.language}
+                                                locale={timeformat.dateFormatLang()}
                                                 weekStart={timeformat.firstDayOfWeek()}
                                                 onBlur={this.calculate}
                                                 onChange={(d, ds) => this.updateDate(d, ds)}

--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -527,7 +527,7 @@ function ChangeSystimeBody({ state, errors, change }) {
                                         dateFormat={timeformat.dateShort}
                                         dateParse={timeformat.parseShortDate}
                                         invalidFormatText=""
-                                        locale={cockpit.language}
+                                        locale={timeformat.dateFormatLang()}
                                         weekStart={timeformat.firstDayOfWeek()}
                                         placeholder={timeformat.dateShortFormat()}
                                         onChange={d => change("manual_date", d)}

--- a/pkg/lib/timeformat.js
+++ b/pkg/lib/timeformat.js
@@ -6,7 +6,7 @@ import { parse, formatDistanceToNow } from 'date-fns';
 import * as locales from 'date-fns/locale';
 
 // this needs to be dynamic, as some pages don't initialize cockpit.language right away
-const dateFormatLang = () => cockpit.language.replace('_', '-');
+export const dateFormatLang = () => cockpit.language.replace('_', '-');
 
 const dateFormatLangDateFns = () => {
     if (cockpit.language == "en") return "enUS";

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -312,7 +312,7 @@ const CreateTimerDialogBody = ({ setIsOpen, owner }) => {
                                         {repeat == "yearly" && <>
                                             <DatePicker aria-label={_("Pick date")}
                                                         buttonAriaLabel={_("Toggle date picker")}
-                                                        locale={cockpit.language}
+                                                        locale={timeformat.dateFormatLang()}
                                                         weekStart={timeformat.firstDayOfWeek()}
                                                         onChange={(str, data) => {
                                                             const arr = [...repeatPatterns];

--- a/pkg/users/expiration-dialogs.js
+++ b/pkg/users/expiration-dialogs.js
@@ -42,7 +42,7 @@ function AccountExpirationDialogBody({ state, errors, change }) {
                                <span>{before}</span>
                                <DatePicker aria-label={_("Pick date")}
                                            buttonAriaLabel={_("Toggle date picker")}
-                                           locale={cockpit.language}
+                                           locale={timeformat.dateFormatLang()}
                                            weekStart={timeformat.firstDayOfWeek()}
                                            onChange={str => change("date", str)}
                                            invalidFormatText=""


### PR DESCRIPTION
When using locale that contains country code (such as pt_BR or zh_TW) and
clicking on calendar icon oopses the page.

[1] mentions that hyphens should be used as separators. With this fix it
behaves as expected, that `pt_BR` has starting day Sunday but `pt` Monday.

[1] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl#Locale_identification_and_negotiation