### PR TITLE
bridge: give hints for missing cockpit-system package

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -990,7 +990,17 @@ package_content (CockpitPackages *packages,
         {
           /* On the first round */
           if (l == names)
-            cockpit_web_response_error (response, 404, NULL, NULL);
+            {
+              /* cockpit_packages_resolve() only fails if the entire
+               * package is missing.  Check if that's a package that
+               * ought to have been available and issue a more helpful
+               * message.
+               */
+              if (g_str_equal (name, "shell") || g_str_equal (name, "systemd"))
+                cockpit_web_response_error (response, 404, NULL, _("Server is missing the cockpit-system package"));
+              else
+                cockpit_web_response_error (response, 404, NULL, NULL);
+            }
           else
             cockpit_web_response_abort (response);
           goto out;


### PR DESCRIPTION
We've had a few users get confused about the generic "Not found" error
that we throw when trying to login to a system that's missing the
cockpit-system package.

Issue a better error message for that case.

# bridge: Warning on missing cockpit-system package

Previously, when attempting to connect to a system which had `cockpit-bridge` installed, but not `cockpit-system`, you'd get a generic "Not found" error, with no hints about how to fix that.

cockpit-bridge now detects this problem and issues a more helpful message.

![image](https://user-images.githubusercontent.com/36541154/148196914-de4718d5-7b9c-432f-84cb-b7c87ba9512a.png)

