### PR TITLE
cockpit-bridge: add Recommends and Suggests

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -366,6 +366,14 @@ troubleshooting, interactive command-line sessions, and more.
 %package bridge
 Summary: Cockpit bridge server-side component
 Requires: glib-networking
+Recommends: cockpit-system
+Suggests: cockpit-kdump
+Suggests: cockpit-networkmanager
+Suggests: cockpit-packagekit
+Suggests: cockpit-pcp
+Suggests: cockpit-selinux
+Suggests: cockpit-sosreport
+Suggests: cockpit-storaged
 Provides: cockpit-ssh = %{version}-%{release}
 # PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
 Conflicts: cockpit-ws < 181.x

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -57,6 +57,12 @@ Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
          glib-networking
+Recommends: cockpit-system (>= ${source_Version}),
+Suggests: cockpit-networkmanager (>= ${source_Version}),
+          cockpit-packagekit (>= ${source_Version}),
+          cockpit-pcp (>= ${source_Version}),
+          cockpit-sosreport (>= ${source_Version}),
+          cockpit-storaged (>= ${source_Version}),
 Provides: cockpit-ssh
 Breaks: cockpit-ws (<< 181.x),
 # 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)


### PR DESCRIPTION
We've seen users getting confused by trying to use cockpit-client to log
in to servers where they've installed cockpit-bridge, and not being able
to due to missing cockpit-system.

Add cockpit-system as a recommend from the cockpit-bridge package for
both dpkg and rpm.

Additionally, list networkmanager, packagekit, pcp, sosreport, and
storaged as suggested packages on both distros, and additionally
kdump and selinux for rpm.