### PR TITLE
flatpak: stop suggesting to install cockpit-bridge

### DIFF
--- a/containers/flatpak/cockpit-client.metainfo.xml.in
+++ b/containers/flatpak/cockpit-client.metainfo.xml.in
@@ -14,7 +14,7 @@
       Cockpit Client provides a graphical interface to your servers, containers, and virtual machines.  Connections are made over SSH, using the SSH configuration of the local user (including aliases, known hosts, key files, hardware tokens, etc).
     </p>
     <p>
-      The server needs only to have cockpit-bridge installed.  The Cockpit webserver doesn&apos;t need to be enabled, and no extra ports need to be opened.
+      The server needs to have Cockpit installed, but the Cockpit webserver doesn&apos;t need to be enabled, and no extra ports need to be opened.
     </p>
   </description>
 


### PR DESCRIPTION
This language ends up being extremely visible on our flathub page and in
GNOME Software, and it's possibly leading to people running `dnf install
cockpit-bridge` and expecting that to work.

Drop the language and just say that the server needs to have Cockpit
installed, but not enabled.

See also #16775