### PR TITLE
flatpak workflow: validate the generated metainfo

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Install required build and test dependencies
         run: |
           sudo apt update
-          sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto flatpak-builder xvfb cockpit-system
+          sudo apt install -y --no-install-recommends autoconf automake elfutils libglib2.0-dev libsystemd-dev xsltproc xmlto flatpak-builder xvfb cockpit-system appstream-util
 
       - name: Configure flathub remote
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
@@ -29,6 +29,9 @@ jobs:
 
       - name: Build and install flatpak
         run: sh -x containers/flatpak/install --user --install-deps-from=flathub
+
+      - name: Validate metainfo
+        run: appstream-util validate org.cockpit_project.CockpitClient.metainfo.xml
 
       - name: Smoke-test the installed flatpak
         run: |


### PR DESCRIPTION
flathub suggests running `appstream-util validate` on each upstream
commit.  Add it to the flatpak testing workflow.