### PR TITLE
test: Adjust expected sssd error message for missing CA

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -754,7 +754,9 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
             err = m.execute('! busctl call org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users '
                             'org.freedesktop.sssd.infopipe.Users FindByValidCertificate s -- '
                             '''"$(cat %s)" 2>&1''' % alice_cert)
-            self.assertIn("Invalid certificate provided", err)
+            # HACK: sssd 2.6.1 has a broken error message ("Invalid certificate provided"), accept that as well
+            # until 2.6.2 is available everywhere. https://github.com/SSSD/sssd/issues/5911
+            self.assertRegex(err, "Invalid certificate provided|Certificate authority file not found")
 
             m.execute("mkdir -p /etc/sssd/pki")
             # install our CA, so that sssd can validate

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -443,6 +443,7 @@ class CommonTests:
 
         # valid user certificate which fails CA validation; this requires sssd ≥ 2.6.1
         m.execute("mv /etc/sssd/pki/sssd_auth_ca_db.pem /etc/sssd/pki/sssd_auth_ca_db.pem.valid")
+        self.allow_journal_messages("cockpit-session: Failed to map certificate to user: .* Certificate authority file not found")
         with open("src/tls/ca/alice-expired.pem") as f:
             m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
         api = m.execute("busctl introspect org.freedesktop.sssd.infopipe /org/freedesktop/sssd/infopipe/Users")


### PR DESCRIPTION
sssd 2.6.1 has a broken error message ("Invalid certificate provided")
if sssd is missing a CA (https://github.com/SSSD/sssd/issues/5911)

sssd 2.6.2 fixes this and now says "Certificate authority file not
found". Adjust the expected error messages accordingly. This can be made
stricter once Fedora 35 and Debian testing both get the current version.

----

This broke [rawhide gating](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-pipeline/job/master/100353/testReport/(root)/tests/_test_verify/) in yesterday's release. We don't test upstream on rawhide, but let's be prepared for the new sssd.