### PR TITLE
test: Ignore unexpected certificate message in TestIPA.testQualifiedUsers

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -589,6 +589,9 @@ ExecStart=/bin/true
         b.wait_visible("a[href='/@x0.cockpit.lan']")
         b.logout()
 
+        # FIXME: Something above triggers this error message
+        self.allow_journal_messages("Received unexpected TLS connection and no certificate was configured")
+
     def checkBackendSpecificCleanup(self):
         '''Check domain backend specific integration after leaving domain'''
 


### PR DESCRIPTION
These have happened for a long time, but tests did not notice these
until commit ade6e81943d5.

It is not immediately clear why that happens, but for now let's not ruin
most our PRs with this.

----

[example](https://logs.cockpit-project.org/logs/pull-16794-20220107-113510-fda46253-rhel-8-5/log.html#263)

I've seen this quite a lot in the recent days.