### PR TITLE
test: Allow more variations of "Unknown metric name" messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1324,7 +1324,7 @@ class MachineCase(unittest.TestCase):
         r"#3\) With great power comes great responsibility.",
 
         # starting out with empty PCP logs and pmlogger not running causes these metrics channel messages
-        "pcp-archive: no such metric: kernel.all.cpu.nice: Unknown metric name",
+        "pcp-archive: no such metric: kernel.all.cpu..*: Unknown metric name",
         "pcp-archive: instance name lookup failed:.*",
         "pcp-archive: couldn't create pcp archive context for.*",
     ]


### PR DESCRIPTION
This can also happen for `kernel.all.cpu.user`.

----

Seen [here](https://logs.cockpit-project.org/logs/pull-16798-20220110-064948-be591291-ubuntu-2004/log.html#58)