### PR TITLE
DBG: test/verify/check-shell-multi-machine TestMultiMachine.testSshKe…

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -653,7 +653,7 @@ class Browser:
     def relogin(self, path=None, user=None, superuser=None, wait_remote_session_machine=None):
         self.logout()
         if wait_remote_session_machine:
-            wait_remote_session_machine.execute("while pgrep -a cockpit-ssh; do sleep 1; done")
+            wait_remote_session_machine.execute("while pgrep -a cockpit-ssh || pgrep -a cockpit-bridge || pgrep -a cockpit-session; do sleep 1; done")
         self.try_login(user, superuser=superuser)
         self.expect_load()
         self._wait_present('#content')

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -840,15 +840,8 @@ class TestMultiMachine(MachineCase):
         # Put a 'better' passphrase on the key and relogin, then
         # change the passphrase back to the login password
         m1.execute("ssh-keygen -q -f /home/admin/.ssh/id_rsa -p -P foobar -N foobarfoo")
-        b.logout()
-        m1.execute("while pgrep -a cockpit-ssh || pgrep -a cockpit-bridge || pgrep -a cockpit-session; do sleep 1; done")
-        m2.execute("while pgrep -a cockpit-bridge; do sleep 1; done")
-        b.try_login()
-        b.expect_load()
-        b._wait_present('#content')
-        b.wait_visible('#content')
-        b.adjust_window_for_fixed_content_size()
-
+        time.sleep(10)
+        b.relogin(None, wait_remote_session_machine=m1)
         b.wait_visible("#machine-troubleshoot")
         b.click('#machine-troubleshoot')
         b.wait_visible('#hosts_setup_server_dialog')

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -777,6 +777,7 @@ class TestMultiMachine(MachineCase):
         m1 = self.machine
         m2 = self.machine2
 
+        # RETRY
         # Let's not use "admin" on the remote machine.  Creating a
         # dedicated user gives us a guaranteed clean slate and also
         # tests more code paths.
@@ -839,7 +840,15 @@ class TestMultiMachine(MachineCase):
         # Put a 'better' passphrase on the key and relogin, then
         # change the passphrase back to the login password
         m1.execute("ssh-keygen -q -f /home/admin/.ssh/id_rsa -p -P foobar -N foobarfoo")
-        b.relogin(None, wait_remote_session_machine=m1)
+        b.logout()
+        m1.execute("while pgrep -a cockpit-ssh || pgrep -a cockpit-bridge || pgrep -a cockpit-session; do sleep 1; done")
+        m2.execute("while pgrep -a cockpit-bridge; do sleep 1; done")
+        b.try_login()
+        b.expect_load()
+        b._wait_present('#content')
+        b.wait_visible('#content')
+        b.adjust_window_for_fixed_content_size()
+
         b.wait_visible("#machine-troubleshoot")
         b.click('#machine-troubleshoot')
         b.wait_visible('#hosts_setup_server_dialog')


### PR DESCRIPTION
…ySetup

File "/work/bots/make-checkout-workdir/test/verify/check-shell-multi-machine", line 843, in testSshKeySetup
    b.wait_visible("#machine-troubleshoot")

Example: https://logs.cockpit-project.org/logs/pull-16793-20220110-065937-630ab4f4-fedora-coreos/log.html#139-2