### PR TITLE
common: start using closefrom(), keeping our hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,10 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 AC_PROG_RANLIB
 
+AC_CHECK_FUNCS(
+    closefrom
+)
+
 AM_SILENT_RULES([yes])
 
 AC_MSG_CHECKING([whether to install to prefix only])

--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -38,7 +38,6 @@
 #include "cockpitwebsocketstream.h"
 
 #include "common/cockpitchannel.h"
-#include "common/cockpitcloserange.h"
 #include "common/cockpitfdpassing.h"
 #include "common/cockpithacks-glib.h"
 #include "common/cockpitjson.h"

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -39,8 +39,7 @@ noinst_LIBRARIES += libcockpit-common.a
 libcockpit_common_a_SOURCES = \
 	src/common/cockpitchannel.c \
 	src/common/cockpitchannel.h \
-	src/common/cockpitcloserange.c \
-	src/common/cockpitcloserange.h \
+	src/common/cockpitclosefrom.c \
 	src/common/cockpitcontrolmessages.c \
 	src/common/cockpitcontrolmessages.h \
 	src/common/cockpiterror.h src/common/cockpiterror.c \

--- a/src/common/cockpitcloserange.h
+++ b/src/common/cockpitcloserange.h
@@ -1,5 +1,0 @@
-#pragma once
-
-/* Added in Linux 5.9: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=278a5fbaed89dacd04e9d
- * will eventually be in glibc: https://sourceware.org/git/?p=glibc.git;a=commit;h=286286283e9bdc */
-int cockpit_close_range (int from, int max_fd, int flags);

--- a/src/common/cockpithacks.h
+++ b/src/common/cockpithacks.h
@@ -45,3 +45,8 @@
 #ifndef PACKAGE_VERSION
 #error config.h should be included from the top of every .c file
 #endif
+
+#ifndef HAVE_CLOSEFROM
+#define closefrom(lowfd) cockpit_closefrom(lowfd)
+void cockpit_closefrom (int lowfd);
+#endif

--- a/src/common/cockpitpipe.c
+++ b/src/common/cockpitpipe.c
@@ -21,8 +21,8 @@
 
 #include "cockpitpipe.h"
 
-#include "cockpitcloserange.h"
 #include "cockpitflow.h"
+#include "cockpithacks.h"
 #include "cockpitunicode.h"
 
 #include <glib-unix.h>
@@ -1407,11 +1407,8 @@ cockpit_pipe_pty (const gchar **argv,
   pid = forkpty (&fd, NULL, NULL, &winsz);
   if (pid == 0)
     {
-      if (cockpit_close_range (3, INT_MAX, 0) < 0)
-        {
-          g_printerr ("couldn't close file descriptors\n");
-          _exit (127);
-        }
+      closefrom (3);
+
       if (directory)
         {
           if (chdir (directory) < 0)

--- a/src/pam-ssh-add/Makefile.am
+++ b/src/pam-ssh-add/Makefile.am
@@ -1,8 +1,8 @@
 noinst_LIBRARIES += libpam_ssh_add.a
 
 libpam_ssh_add_a_SOURCES = \
-	src/common/cockpitcloserange.h \
-	src/common/cockpitcloserange.c \
+	src/common/cockpitclosefrom.c \
+	src/common/cockpithacks.h \
 	src/common/cockpitmemory.h \
 	src/common/cockpitmemory.c \
 	src/pam-ssh-add/pam-ssh-add.c \

--- a/src/pam-ssh-add/pam-ssh-add.c
+++ b/src/pam-ssh-add/pam-ssh-add.c
@@ -45,7 +45,7 @@
 
 #include "pam-ssh-add.h"
 
-#include "../common/cockpitcloserange.h"
+#include "../common/cockpithacks.h"
 #include "../common/cockpitmemory.h"
 
 /* programs that can be overwidden in tests */
@@ -343,11 +343,7 @@ setup_child (const char **args,
       exit (EXIT_FAILURE);
     }
 
-  if (cockpit_close_range (STDERR + 1, INT_MAX, 0) < 0)
-    {
-      error ("couldn't close all file descirptors");
-      exit (EXIT_FAILURE);
-    }
+  closefrom (STDERR + 1);
 
   /* Close unnecessary file descriptors */
   close (inp[READ_END]);

--- a/src/session/Makefile-session.am
+++ b/src/session/Makefile-session.am
@@ -1,8 +1,8 @@
 libexec_PROGRAMS += cockpit-session
 
 cockpit_session_SOURCES = \
-	src/common/cockpitcloserange.h \
-	src/common/cockpitcloserange.c \
+	src/common/cockpitclosefrom.c \
+	src/common/cockpithacks.h \
 	src/session/client-certificate.h \
 	src/session/client-certificate.c \
 	src/session/session-utils.c \

--- a/src/session/session-utils.c
+++ b/src/session/session-utils.c
@@ -21,9 +21,9 @@
 
 #include "session-utils.h"
 
-#include "common/cockpitcloserange.h"
 #include "common/cockpitframe.h"
 #include "common/cockpitjsonprint.h"
+#include "common/cockpithacks.h"
 
 #include <fcntl.h>
 #include <stdarg.h>
@@ -537,8 +537,7 @@ fd_remap (const int *remap_fds,
         abort_with_message ("dup2(%d, %d) failed: %m", fds[i], i);
 
   /* close everything else */
-  if (cockpit_close_range (n_remap_fds, INT_MAX, 0) < 0)
-    abort_with_message ("couldn't close all file descriptors");
+  closefrom (n_remap_fds);
 }
 
 int

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -27,8 +27,8 @@
 
 #include "common/cockpitauthorize.h"
 #include "common/cockpitconf.h"
-#include "common/cockpitcloserange.h"
 #include "common/cockpiterror.h"
+#include "common/cockpithacks.h"
 #include "common/cockpithex.h"
 #include "common/cockpitjson.h"
 #include "common/cockpitmemory.h"
@@ -514,11 +514,7 @@ session_child_setup (gpointer data)
 
   close (child->io);
 
-  if (cockpit_close_range (3, INT_MAX, 0) < 0)
-    {
-      g_printerr ("couldn't close file descriptors: %m\n");
-      _exit (127);
-    }
+  closefrom (3);
 }
 
 static CockpitTransport *


### PR DESCRIPTION
4cfc28a09dcf042b8091ca7739407a36f223ec6d introduced our own version of
close_range(), but this turned out to be the wrong API.  closefrom() is
meanwhile available on modern versions of glibc.  It features a
simplified API, with no chance of failure.

Rename cockpitcloserange.c to cockpitclosefrom.c and move the definition
into cockpithacks.h.  Introduce a configure check for closefrom() and
port all users to the closefrom() API.  In case that's not available, we
redirect those calls to our own cockpit_closefrom() (which is now only
conditionally-built).

Since neither the glibc API nor our own code have any chance of failure,
we can drop all the error checking we were doing before.

Incidentally, this should fix warnings we were occasionally seeing from
Valgrind that we were finding and attempting to close its log fd.
Modern Valgrind wraps closefrom() and prevents this from happening.