### PR TITLE
two changes for webpack-jumpstart

### DIFF
--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -17,11 +17,14 @@ set -eu
 cd "$(realpath -m "$0"/../..)"
 . tools/git-utils.sh
 
+force=''
 wait=''
 rebase=''
 partial=''
 while [ $# != 0 ] ; do
     case "$1" in
+        --force)
+            force=1;;
         --wait)
             wait=1;;
         --rebase)
@@ -37,7 +40,7 @@ done
 
 [ -n "${quiet}" ] || set -x
 
-if [ -e dist ]; then
+if [ -e dist -a -z "${force}" ]; then
     echo "jumpstart: dist/ already exists, skipping" >&2
     exit 1
 fi
@@ -155,6 +158,12 @@ if [ -n "${changed_files}" -a -z "${partial}" ]; then
 fi
 
 tools/node-modules make_package_lock_json
+
+if [ -d dist -a -n "${force}" ]; then
+    message 'REMOVE' dist
+    rm -rf dist
+fi
+
 unpack_from_cache "${tag}"
 
 if [ -n "${changed_files}" ]; then

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -166,7 +166,11 @@ fi
 
 unpack_from_cache "${tag}"
 
-if [ -n "${changed_files}" ]; then
-    printf "\nTouching the following changed files:\n%s\n\n" "${changed_files}" >&2
-    touch -- ${changed_files}
-fi
+# "${changed_files}" is empty unless --partial was given
+for file in ${changed_files}; do
+    # don't touch files that have nothing to do with webpack
+    if grep -q -F ${file} dist/*/Makefile.deps; then
+        message TOUCH "${file}"
+        touch "${file}"
+    fi
+done


### PR DESCRIPTION
 - `--force` will delete `dist/` if it already exists (should be uncontroversial)
 - in `--partial` mode, only touch related files (this appeared in an earlier iteration of jumpstart work, but @martinpitt expressed misgivings about how it was duplicating the logic of the build system: let's discuss).