### PR TITLE
test: Don't retry failed pixel tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -137,8 +137,9 @@ def finish_test(opts, test, affected_tests):
     if not affected and not retry_reason:
         retry_reason = "be robust against unstable tests"
 
-    unexpected_message = testlib.UNEXPECTED_MESSAGE.encode() in test.output
-    if test.retries < 2 and not unexpected_message and retry_reason:
+    has_unexpected_message = testlib.UNEXPECTED_MESSAGE.encode() in test.output
+    has_pixel_test_message = testlib.PIXEL_TEST_MESSAGE.encode() in test.output
+    if test.retries < 2 and not (has_unexpected_message or has_pixel_test_message) and retry_reason:
         test.retries += 1
         print_test(test, retry_reason="# RETRY {0} ({1})".format(test.retries, retry_reason))
         return retry_reason, 0

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -56,6 +56,7 @@ os.environ["PATH"] = "{0}:{1}:{2}".format(os.environ.get("PATH"), BOTS_DIR, TEST
 
 # Be careful when changing this string, check in cockpit-project/bots where it is being used
 UNEXPECTED_MESSAGE = "FAIL: Test completed, but found unexpected "
+PIXEL_TEST_MESSAGE = "Some pixel tests have failed"
 
 __all__ = (
     # Test definitions
@@ -79,6 +80,7 @@ __all__ = (
     'opts',
     'TEST_DIR',
     'UNEXPECTED_MESSAGE',
+    'PIXEL_TEST_MESSAGE'
 )
 
 # Command line options
@@ -1473,7 +1475,7 @@ class MachineCase(unittest.TestCase):
 
     def check_pixel_tests(self):
         if self.browser and self.browser.failed_pixel_tests > 0:
-            raise Error("Some pixel tests have failed")
+            raise Error(PIXEL_TEST_MESSAGE)
 
     def check_axe(self, label=None, suffix=""):
         """Run aXe check on the currently active frame


### PR DESCRIPTION
We expect pixel test failures to be deterministic, expecially since we
wait for all animations to have stopped.  Often, failed pixel tests
are even expected since we update the references only late in the life
of a pull request.