### PR TITLE
common: Fix unused assignment in test_memfd_json_error_cases()

### DIFF
--- a/src/common/test-jsonfds.c
+++ b/src/common/test-jsonfds.c
@@ -537,6 +537,7 @@ test_memfd_json_error_cases (void)
   r = fcntl (fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE);
   g_assert (r == 0);
   object = cockpit_memfd_read_json (fd, &error);
+  g_assert (object == NULL);
   cockpit_assert_error_matches (error, JSON_PARSER_ERROR, JSON_PARSER_ERROR_INVALID_BAREWORD, "*unexpected identifier*");
   g_clear_error (&error);
   close (fd);
@@ -547,6 +548,7 @@ test_memfd_json_error_cases (void)
   r = fcntl (fd, F_ADD_SEALS, F_SEAL_SHRINK | F_SEAL_GROW | F_SEAL_WRITE);
   g_assert (r == 0);
   object = cockpit_memfd_read_json (fd, &error);
+  g_assert (object == NULL);
   cockpit_assert_error_matches (error, JSON_PARSER_ERROR, -1, "*Not a JSON object*");
   close (fd);
 


### PR DESCRIPTION
Fixes build failure with current clang:

    src/common/test-jsonfds.c:530:25: error: variable 'object' set but not used [-Werror,-Wunused-but-set-variable]
      g_autoptr(JsonObject) object = NULL;
                            ^

----

This is the [second reason](https://github.com/cockpit-project/cockpit/runs/4762043181?check_suite_focus=true) after PR #16799 that broke the unit-tests container refresh. This time I actually did a clang build in a debian sid container locally, to ensure that this is the last bit. I'll also [trigger a refresh on this branch](https://github.com/cockpit-project/cockpit/actions/runs/1677848023).