### PR TITLE
test: sudo and socketpair() now work properly on fedora-testing

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -493,7 +493,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = []  # none yet :-(
+        working_images = ["fedora-testing"]
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:


### PR DESCRIPTION
The fix for https://bugzilla.redhat.com/show_bug.cgi?id=1814569 is now
present in fedora-testing
This PR should unblock https://github.com/cockpit-project/bots/pull/2785