### PR TITLE
cockpit.spec: drop --with-selinux-config-type

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -166,7 +166,6 @@ exec 2>&1
     --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
-    --with-selinux-config-type=etc_t \
 %if 0%{?suse_version}
     --docdir=%_defaultdocdir/%{name} \
 %endif


### PR DESCRIPTION
This option doesn't exist anymore.