### PR TITLE
use DynamicUser=yes for all cockpit components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,7 +76,7 @@ Makefile.in
 /src/cockpit.egg-info/
 /src/common/fail-html.c
 /src/systemd/cockpit*.service
-/src/systemd/cockpit*.socket
+/src/systemd/cockpit.socket
 /src/systemd/tmpfiles.d/cockpit-ws.conf
 /src/tls/cockpit-certificate-helper
 /src/ws/cockpit-desktop

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -60,11 +60,6 @@ systemdgenerated += $(nodist_tmpfilesconf_DATA)
 nodist_tmpfilesconf_DATA = src/systemd/tmpfiles.d/cockpit-ws.conf
 
 # -----------------
-# sysusers
-sysusersconfdir = $(prefix)/lib/sysusers.d
-dist_sysusersconf_DATA = src/systemd/sysusers.d/cockpit-wsinstance.conf
-
-# -----------------
 # Policykit
 polkitdir = $(datadir)/polkit-1/actions
 systemdgenerated += $(nodist_polkit_DATA)

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -31,6 +31,7 @@ nodist_systemdunit_DATA = \
 
 dist_systemdunit_DATA = \
 	src/systemd/cockpit-session.socket \
+	src/systemd/cockpit-session-socket-user.service \
 	src/systemd/cockpit-ws-user.service \
 	src/systemd/system-cockpithttps.slice \
 	src/systemd/cockpit-wsinstance-http.socket \

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -37,6 +37,7 @@ dist_systemdunit_DATA = \
 	src/systemd/cockpit-wsinstance-http.socket \
 	src/systemd/cockpit-wsinstance-https-factory.socket \
 	src/systemd/cockpit-wsinstance-https@.socket \
+	src/systemd/cockpit-wsinstance-socket-user.service \
 	$(NULL)
 
 # -----------------

--- a/src/systemd/cockpit-session-socket-user.service
+++ b/src/systemd/cockpit-session-socket-user.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dynamic user for /run/cockpit/session socket
+BindsTo=cockpit-session.socket
+
+[Service]
+DynamicUser=yes
+User=cockpit-session-socket
+Group=cockpit-session-socket
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/src/systemd/cockpit-session.socket
+++ b/src/systemd/cockpit-session.socket
@@ -1,10 +1,13 @@
 [Unit]
 Description=Initiator socket for Cockpit sessions
+PartOf=cockpit.service
+Requires=cockpit-session-socket-user.service
+After=cockpit-session-socket-user.service
 
 [Socket]
 ListenStream=/run/cockpit/session
 SocketUser=root
-SocketGroup=cockpit-wsinstance
+SocketGroup=cockpit-session-socket
 SocketMode=0660
 RemoveOnStop=yes
 Accept=yes

--- a/src/systemd/cockpit-wsinstance-http.service.in
+++ b/src/systemd/cockpit-wsinstance-http.service.in
@@ -7,6 +7,6 @@ After=cockpit-session.socket cockpit-session-socket-user.service
 
 [Service]
 ExecStart=@libexecdir@/cockpit-ws --no-tls --port=0
-User=cockpit-wsinstance
-Group=cockpit-wsinstance
+User=cockpit-wsinstance-socket
+Group=cockpit-wsinstance-socket
 SupplementaryGroups=cockpit-session-socket

--- a/src/systemd/cockpit-wsinstance-http.service.in
+++ b/src/systemd/cockpit-wsinstance-http.service.in
@@ -2,10 +2,11 @@
 Description=Cockpit Web Service http instance
 Documentation=man:cockpit-ws(8)
 BindsTo=cockpit.service
-Requires=cockpit-session.socket
-After=cockpit-session.socket
+Requires=cockpit-session.socket cockpit-session-socket-user.service
+After=cockpit-session.socket cockpit-session-socket-user.service
 
 [Service]
 ExecStart=@libexecdir@/cockpit-ws --no-tls --port=0
 User=cockpit-wsinstance
 Group=cockpit-wsinstance
+SupplementaryGroups=cockpit-session-socket

--- a/src/systemd/cockpit-wsinstance-http.socket
+++ b/src/systemd/cockpit-wsinstance-http.socket
@@ -3,11 +3,12 @@ Description=Socket for Cockpit Web Service http instance
 Documentation=man:cockpit-ws(8)
 BindsTo=cockpit.service
 # ensure our DynamicUser exists
-Requires=cockpit-ws-user.service
-After=cockpit-ws-user.service
+Requires=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
+After=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/http.sock
-SocketUser=cockpit-ws
-SocketMode=0600
+SocketUser=root
+SocketGroup=cockpit-wsinstance-socket
+SocketMode=0660
 RemoveOnStop=yes

--- a/src/systemd/cockpit-wsinstance-https-factory.socket
+++ b/src/systemd/cockpit-wsinstance-https-factory.socket
@@ -3,12 +3,13 @@ Description=Socket for Cockpit Web Service https instance factory
 Documentation=man:cockpit-ws(8)
 BindsTo=cockpit.service
 # ensure our DynamicUser exists
-Requires=cockpit-ws-user.service
-After=cockpit-ws-user.service
+Requires=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
+After=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https-factory.sock
 Accept=yes
-SocketUser=cockpit-ws
-SocketMode=0600
+SocketUser=root
+SocketGroup=cockpit-wsinstance-socket
+SocketMode=0660
 RemoveOnStop=yes

--- a/src/systemd/cockpit-wsinstance-https@.service.in
+++ b/src/systemd/cockpit-wsinstance-https@.service.in
@@ -8,6 +8,6 @@ After=cockpit-session.socket cockpit-session-socket-user.service
 [Service]
 Slice=system-cockpithttps.slice
 ExecStart=@libexecdir@/cockpit-ws --for-tls-proxy --port=0
-User=cockpit-wsinstance
-Group=cockpit-wsinstance
+User=cockpit-wsinstance-socket
+Group=cockpit-wsinstance-socket
 SupplementaryGroups=cockpit-session-socket

--- a/src/systemd/cockpit-wsinstance-https@.service.in
+++ b/src/systemd/cockpit-wsinstance-https@.service.in
@@ -2,11 +2,12 @@
 Description=Cockpit Web Service https instance %I
 Documentation=man:cockpit-ws(8)
 BindsTo=cockpit.service
-Requires=cockpit-session.socket
-After=cockpit-session.socket
+Requires=cockpit-session.socket cockpit-session-socket-user.service
+After=cockpit-session.socket cockpit-session-socket-user.service
 
 [Service]
 Slice=system-cockpithttps.slice
 ExecStart=@libexecdir@/cockpit-ws --for-tls-proxy --port=0
 User=cockpit-wsinstance
 Group=cockpit-wsinstance
+SupplementaryGroups=cockpit-session-socket

--- a/src/systemd/cockpit-wsinstance-https@.socket
+++ b/src/systemd/cockpit-wsinstance-https@.socket
@@ -7,11 +7,12 @@ BindsTo=cockpit.service
 # the services are resource-limited by system-cockpithttps.slice
 BindsTo=cockpit-wsinstance-https@%i.service
 # ensure our DynamicUser exists
-Requires=cockpit-ws-user.service
-After=cockpit-ws-user.service
+Requires=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
+After=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
 
 [Socket]
 ListenStream=/run/cockpit/wsinstance/https@%i.sock
-SocketUser=cockpit-ws
-SocketMode=0600
+SocketUser=root
+SocketGroup=cockpit-wsinstance-socket
+SocketMode=0660
 RemoveOnStop=yes

--- a/src/systemd/cockpit-wsinstance-socket-user.service
+++ b/src/systemd/cockpit-wsinstance-socket-user.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Dynamic user for /run/cockpit/wsinstance/ sockets
+BindsTo=cockpit.service
+
+[Service]
+DynamicUser=yes
+User=cockpit-wsinstance-socket
+Group=cockpit-wsinstance-socket
+Type=oneshot
+ExecStart=/bin/true
+RemainAfterExit=yes

--- a/src/systemd/cockpit.service.in
+++ b/src/systemd/cockpit.service.in
@@ -4,8 +4,8 @@ Documentation=man:cockpit-ws(8)
 Requires=cockpit.socket
 Requires=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
 # ensure our DynamicUser exists
-Requires=cockpit-ws-user.service
-After=cockpit-ws-user.service
+Requires=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
+After=cockpit-ws-user.service cockpit-wsinstance-socket-user.service
 # we need to start after the sockets so that we can instantly forward incoming requests
 After=cockpit-wsinstance-http.socket cockpit-wsinstance-https-factory.socket
 
@@ -17,6 +17,7 @@ ExecStartPre=+@libexecdir@/cockpit-certificate-ensure --for-cockpit-tls
 ExecStart=@libexecdir@/cockpit-tls
 User=cockpit-ws
 Group=cockpit-ws
+SupplementaryGroups=cockpit-wsinstance-socket
 NoNewPrivileges=true
 ProtectSystem=strict
 ProtectHome=true

--- a/src/systemd/sysusers.d/cockpit-wsinstance.conf
+++ b/src/systemd/sysusers.d/cockpit-wsinstance.conf
@@ -1,1 +1,0 @@
-u cockpit-wsinstance - "User for cockpit-ws instances" -

--- a/src/tls/README.md
+++ b/src/tls/README.md
@@ -73,8 +73,8 @@ use of systemd features.
      reads the fingerprint from stdin, and asks systemd to start a new
      [cockpit-wsinstance-https@fingerprint.socket](../src/ws/cockpit-wsinstance-https@.socket.in)
      and .service pair.
- * Each instance runs in its own systemd cgroup, as another unprivileged system
-   user `cockpit-wsinstance`.
+ * Each instance runs in its own systemd cgroup, as another unprivileged
+   dynamic system user `cockpit-wsinstance-socket`.
  * cockpit-tls exports the client certificates to `/run/cockpit/tls/<fingerprint>`
    while there is at least one open connection with that certificate, i. e. as
    long as there is an active Cockpit session.

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -332,7 +332,7 @@ class TestConnection(testlib.MachineCase):
         # number of https instances is bounded (DoS prevention)
         # with MaxTasks=200 und 2 threads per ws instance we should have a
         # rough limit of 100 instances, so at some point curl should start failing
-        m.execute("runuser -u cockpit-ws -- sh -ec 'RC=1; for i in `seq 120`; do "
+        m.execute("runuser -u cockpit-wsinstance-socket -- sh -ec 'RC=1; for i in `seq 120`; do "
                   "  echo -n $i | nc %s -U /run/cockpit/wsinstance/https-factory.sock;"
                   "  curl --silent --head --max-time 5 --unix-socket /run/cockpit/wsinstance/https@$i.sock http://dummy > /dev/null || RC=0; "
                   "done; exit $RC'" % n_opt)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1005,7 +1005,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
 
         # ws with plain --no-tls should fail after login with mismatching Origin (expected http, got https)
         m.execute("systemctl start cockpit-session.socket")
-        m.spawn(f"runuser -u cockpit-wsinstance -- {self.ws_executable} --no-tls -p 9099",
+        m.spawn(f"runuser -u cockpit-session-socket -- {self.ws_executable} --no-tls -p 9099",
                 "ws-notls.log")
         m.wait_for_cockpit_running(tls=True)
 
@@ -1038,7 +1038,7 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         self.allow_browser_errors("Error reading machine id")
 
         # ws with --for-tls-proxy accepts only https origins, thus should work
-        m.spawn(f"runuser -u cockpit-wsinstance -- {self.ws_executable} --for-tls-proxy -p 9099 -a 127.0.0.1",
+        m.spawn(f"runuser -u cockpit-session-socket -- {self.ws_executable} --for-tls-proxy -p 9099 -a 127.0.0.1",
                 "ws-fortlsproxy.log")
         m.wait_for_cockpit_running(tls=True)
         b.open(f"https://{b.address}:{b.port}/system")
@@ -1441,7 +1441,7 @@ server {
 
         def run_ws(extra_opts=""):
             m.spawn(
-                f"runuser -u cockpit-wsinstance -- {self.libexecdir}/cockpit-ws "
+                f"runuser -u cockpit-session-socket -- {self.libexecdir}/cockpit-ws "
                 f"--address=127.0.0.1 --for-tls-proxy {extra_opts}", "ws.log")
             m.wait_for_cockpit_running()
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -387,6 +387,7 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit-wsinstance-https-factory@.service
 %{_unitdir}/cockpit-wsinstance-https@.socket
 %{_unitdir}/cockpit-wsinstance-https@.service
+%{_unitdir}/cockpit-wsinstance-socket-user.service
 %{_unitdir}/system-cockpithttps.slice
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-ws.conf
 %{_sysusersdir}/cockpit-wsinstance.conf

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -390,7 +390,6 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit-wsinstance-socket-user.service
 %{_unitdir}/system-cockpithttps.slice
 %{_prefix}/%{__lib}/tmpfiles.d/cockpit-ws.conf
-%{_sysusersdir}/cockpit-wsinstance.conf
 %{pamdir}/pam_ssh_add.so
 %{pamdir}/pam_cockpit_cert.so
 %{_libexecdir}/cockpit-ws
@@ -409,11 +408,6 @@ authentication via sssd/FreeIPA.
 %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
-# HACK: old RPM and even Fedora's current RPM don't properly support sysusers
-# https://github.com/rpm-software-management/rpm/issues/3073
-getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
-getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
-
 if %{_sbindir}/selinuxenabled 2>/dev/null; then
     %selinux_relabel_pre -s %{selinuxtype}
 fi
@@ -446,6 +440,11 @@ if test -f %{_sysconfdir}/pam.d/cockpit &&  grep -q pam_cockpit_cert %{_sysconfd
     echo '**** WARNING: pam_cockpit_cert is a no-op and will be removed in a'
     echo '**** WARNING: future release; remove it from your /etc/pam.d/cockpit.'
     echo '**** WARNING:'
+fi
+
+# remove obsolete system user on upgrade (replaced with DynamicUser in version 330)
+if getent passwd cockpit-wsinstance >/dev/null; then
+    userdel cockpit-wsinstance
 fi
 
 %preun ws

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -378,6 +378,7 @@ authentication via sssd/FreeIPA.
 %{_unitdir}/cockpit-motd.service
 %{_unitdir}/cockpit.socket
 %{_unitdir}/cockpit-ws-user.service
+%{_unitdir}/cockpit-session-socket-user.service
 %{_unitdir}/cockpit-session.socket
 %{_unitdir}/cockpit-session@.service
 %{_unitdir}/cockpit-wsinstance-http.socket

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -18,7 +18,6 @@ ${env:deb_systemdsystemunitdir}/system-cockpithttps.slice
 ${env:deb_pamlibdir}/security/pam_ssh_add.so
 ${env:deb_pamlibdir}/security/pam_cockpit_cert.so
 usr/lib/tmpfiles.d/cockpit-ws.conf
-usr/lib/sysusers.d/cockpit-wsinstance.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws
 usr/lib/cockpit/cockpit-wsinstance-factory

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -13,6 +13,7 @@ ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https-factory@.service
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https-factory.socket
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https@.service
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-https@.socket
+${env:deb_systemdsystemunitdir}/cockpit-wsinstance-socket-user.service
 ${env:deb_systemdsystemunitdir}/system-cockpithttps.slice
 ${env:deb_pamlibdir}/security/pam_ssh_add.so
 ${env:deb_pamlibdir}/security/pam_cockpit_cert.so

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -5,6 +5,7 @@ ${env:deb_systemdsystemunitdir}/cockpit-motd.service
 ${env:deb_systemdsystemunitdir}/cockpit.socket
 ${env:deb_systemdsystemunitdir}/cockpit-session.socket
 ${env:deb_systemdsystemunitdir}/cockpit-session@.service
+${env:deb_systemdsystemunitdir}/cockpit-session-socket-user.service
 ${env:deb_systemdsystemunitdir}/cockpit-ws-user.service
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-http.service
 ${env:deb_systemdsystemunitdir}/cockpit-wsinstance-http.socket

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -4,7 +4,7 @@ set -e
 #DEBHELPER#
 
 # remove dpkg-statoverride on upgrade
-if dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
+if [ "$1" = "configure" ] && dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
     chmod 755 /usr/lib/cockpit/cockpit-session
     chgrp root /usr/lib/cockpit/cockpit-session

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -10,6 +10,12 @@ if [ "$1" = "configure" ] && dpkg-statoverride --list /usr/lib/cockpit/cockpit-s
     chgrp root /usr/lib/cockpit/cockpit-session
 fi
 
+# remove obsolete system user on upgrade (replaced with DynamicUser in version 330)
+if [ "$1" = "configure" ] && getent passwd cockpit-wsinstance >/dev/null; then
+    echo "Cleaning up obsolete static cockpit-wsinstance user"
+    deluser --system cockpit-wsinstance
+fi
+
 # restart cockpit.service on package upgrades, if it's already running
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then
     deb-systemd-invoke try-restart cockpit.service >/dev/null || true

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -87,7 +87,3 @@ else
 	NO_QUNIT=1 pytest -vv -k 'not linter and not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
 endif
 endif
-
-# dh compat 14 does that automatically, remove when upgrading
-execute_before_dh_installtmpfiles:
-	dh_installsysusers


### PR DESCRIPTION
Switch over to systemd allocating user IDs for us dynamically, dropping our static users.

We create these users dynamically:
 - `cockpit-session-socket` is the group owner of `/run/cockpit/session`
 - `cockpit-wsinstance-socket` is the group owner of all sockets in `/run/cockpit/wsinstance/`
 - `cockpit-tls` gets its own user
 - `cockpit-wsinstance-http{,s@}.service` each get a user.  In this case, I think the separate https instances even each get a separate user.

This is a bit complicated due to https://github.com/systemd/systemd/issues/23067

 - [x] #16808
 - [x] Clean up obsolete cockpit-wsinstance user in spec and debian packaging on upgrade