### PR TITLE
ws: add support for connecting to unix sockets

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -29,6 +29,9 @@ Authentication commands are called with a single argument which is the host that
 is connecting to. They communicate with their parent process using the cockpit protocol on
 stdin and stdout.
 
+Instead of `Command`, it's also possible to specify `UnixPath` to connect to a unix socket at a
+given path.  The protocol is the same.
+
 Credentials can then be retrieved by issuing a authorize command with a challenge. The challenge
 should correspond to the authorization type in header (ei: Basic or Bearer). For example:
 

--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -46,6 +46,9 @@ kernel_read_system_state(cockpit_ws_t)
 # cockpit-tls can execute cockpit-ws
 can_exec(cockpit_ws_t,cockpit_ws_exec_t)
 
+# systemd can execute cockpit-session
+can_exec(init_t,cockpit_session_exec_t)
+
 # cockpit-ws can execute cockpit-session
 can_exec(cockpit_ws_t,cockpit_session_exec_t)
 

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -5,6 +5,8 @@ nodist_systemdunit_DATA = \
 	src/systemd/cockpit-motd.service \
 	src/systemd/cockpit.service \
 	src/systemd/cockpit.socket \
+	src/systemd/cockpit-session@.service \
+	src/systemd/cockpit-session.socket \
 	src/systemd/cockpit-wsinstance-http.service \
 	src/systemd/cockpit-wsinstance-http.socket \
 	src/systemd/cockpit-wsinstance-https-factory@.service \

--- a/src/systemd/cockpit-session.socket.in
+++ b/src/systemd/cockpit-session.socket.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Initiator socket for Cockpit sessions
+
+[Socket]
+ListenStream=/run/cockpit/session
+SocketUser=root
+SocketGroup=@wsinstancegroup@
+SocketMode=0660
+Accept=yes

--- a/src/systemd/cockpit-session@.service.in
+++ b/src/systemd/cockpit-session@.service.in
@@ -1,0 +1,9 @@
+[Unit]
+Description=Cockpit session %I
+
+[Service]
+ExecStart=@libexecdir@/cockpit-session
+StandardInput=socket
+StandardOutput=inherit
+StandardError=journal
+User=root

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1045,8 +1045,10 @@ cockpit_session_launch (CockpitAuth *self,
                         const gchar *application,
                         GError **error)
 {
+  g_return_val_if_fail (type != NULL, NULL);
+
   const gchar *host = application_parse_host (application);
-  const gchar *action = type_option (type, "action", "localhost");
+  const gchar *action = cockpit_conf_string (type, "action");
   if (g_strcmp0 (action, ACTION_NONE) == 0)
     {
       g_set_error (error, COCKPIT_ERROR, COCKPIT_ERROR_AUTHENTICATION_FAILED,
@@ -1060,7 +1062,7 @@ cockpit_session_launch (CockpitAuth *self,
   const gchar *section;
   if (host)
     section = COCKPIT_CONF_SSH_SECTION;
-  else if (self->login_loopback && g_strcmp0 (type, "basic") == 0)
+  else if (self->login_loopback && g_str_equal (type, "basic"))
     section = COCKPIT_CONF_SSH_SECTION;
   else if (g_strcmp0 (action, ACTION_SSH) == 0)
     section = COCKPIT_CONF_SSH_SECTION;
@@ -1069,7 +1071,7 @@ cockpit_session_launch (CockpitAuth *self,
 
   const gchar *program_default = NULL;
   gboolean capture_stderr = FALSE;
-  if (g_strcmp0 (section, COCKPIT_CONF_SSH_SECTION) == 0)
+  if (g_str_equal (section, COCKPIT_CONF_SSH_SECTION))
     {
       if (!host)
         host = type_option (COCKPIT_CONF_SSH_SECTION, "host", "127.0.0.1");
@@ -1080,9 +1082,9 @@ cockpit_session_launch (CockpitAuth *self,
       capture_stderr = cockpit_conf_bool ("WebService", "X-For-CockpitClient", FALSE);
       program_default = cockpit_ws_ssh_program;
     }
-  else if (type && (g_str_equal (type, "basic") ||
-                    g_str_equal (type, "negotiate") ||
-                    g_str_equal (type, "tls-cert")))
+  else if (g_str_equal (type, "basic") ||
+           g_str_equal (type, "negotiate") ||
+           g_str_equal (type, "tls-cert"))
     {
       program_default = cockpit_ws_session_program;
     }

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -402,17 +402,6 @@ out:
   return ret;
 }
 
-static const gchar *
-type_option (const gchar *type,
-             const gchar *option,
-             const gchar *default_str)
-{
-  if (type && cockpit_conf_string (type, option))
-    return cockpit_conf_string (type, option);
-
-  return default_str;
-}
-
 static guint
 timeout_option (const gchar *name,
                 const gchar *type,
@@ -1075,7 +1064,7 @@ cockpit_session_launch (CockpitAuth *self,
   if (g_str_equal (section, COCKPIT_CONF_SSH_SECTION))
     {
       if (!host)
-        host = type_option (COCKPIT_CONF_SSH_SECTION, "host", "127.0.0.1");
+        host = cockpit_conf_string (COCKPIT_CONF_SSH_SECTION, "host") ?: "127.0.0.1";
 
       /* We capture stderr only for Cockpit Client; we don't want to
        * send log messages to potential remote attackers.

--- a/src/ws/cockpitauth.c
+++ b/src/ws/cockpitauth.c
@@ -1069,7 +1069,8 @@ cockpit_session_launch (CockpitAuth *self,
   else
     section = type;
 
-  const gchar *program_default = NULL;
+  const gchar *command = cockpit_conf_string (section, "Command");
+
   gboolean capture_stderr = FALSE;
   if (g_str_equal (section, COCKPIT_CONF_SSH_SECTION))
     {
@@ -1080,16 +1081,17 @@ cockpit_session_launch (CockpitAuth *self,
        * send log messages to potential remote attackers.
        */
       capture_stderr = cockpit_conf_bool ("WebService", "X-For-CockpitClient", FALSE);
-      program_default = cockpit_ws_ssh_program;
+
+      if (command == NULL)
+        command = cockpit_ws_ssh_program;
     }
   else if (g_str_equal (type, "basic") ||
            g_str_equal (type, "negotiate") ||
            g_str_equal (type, "tls-cert"))
     {
-      program_default = cockpit_ws_session_program;
+      if (command == NULL)
+        command = cockpit_ws_session_program;
     }
-
-  const gchar *command = type_option (section, "command", program_default);
 
   if (!command)
     {

--- a/src/ws/cockpitcreds.h
+++ b/src/ws/cockpitcreds.h
@@ -73,6 +73,7 @@ JsonObject *    cockpit_creds_get_login_data             (CockpitCreds *creds);
 
 JsonObject *    cockpit_creds_to_json                    (CockpitCreds *creds);
 
+G_DEFINE_AUTOPTR_CLEANUP_FUNC(CockpitCreds, cockpit_creds_unref)
 
 G_END_DECLS
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1045,6 +1045,26 @@ until pgrep -f '^/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
         b.wait_visible("#login")
         b.assert_pixels("body", "login-screen")
 
+    @skipImage("no cockpit-ws package", "fedora-coreos")
+    def testAuthUnixPath(self):
+        '''test UnixPath for auth method in cockpit.conf'''
+        m = self.machine
+
+        m.execute(['systemctl', 'start', 'cockpit-session.socket'])
+        m.write('/etc/cockpit/cockpit.conf', '''
+[Negotiate]
+Action=none
+
+[Basic]
+UnixPath=/run/cockpit/session
+''')
+
+        # make sure this isn't being run via spawning
+        m.execute(['chmod', '700', f'{self.libexecdir}/cockpit-session'])
+
+        m.start_cockpit()
+        self.login_and_go("/system")
+
 
 @skipDistroPackage()
 class TestReverseProxy(MachineCase):

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -257,9 +257,8 @@ done
 for data in doc man pixmaps polkit-1; do
     rm -r %{buildroot}/%{_datadir}/$data
 done
-for lib in systemd tmpfiles.d; do
-    rm -r %{buildroot}/%{_prefix}/%{__lib}/$lib
-done
+rm -r %{buildroot}/%{_prefix}/%{__lib}/tmpfiles.d
+find %{buildroot}/%{_unitdir}/ -type f ! -name 'cockpit-session*' -delete
 for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-client cockpit-client.ui cockpit-desktop cockpit-certificate-helper cockpit-certificate-ensure; do
     rm %{buildroot}/%{_libexecdir}/$libexec
 done
@@ -277,6 +276,8 @@ for pkg in apps packagekit pcp playground storaged; do
 done
 # files from -tests
 rm -f %{buildroot}/%{pamdir}/mock-pam-conv-mod.so
+rm -f %{buildroot}/%{_unitdir}/cockpit-session.socket
+rm -f %{buildroot}/%{_unitdir}/cockpit-session@.service
 # files from -pcp
 rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib/pcp/
 # files from -storaged
@@ -636,6 +637,8 @@ These files are not required for running Cockpit.
 
 %files -n cockpit-tests -f tests.list
 %{pamdir}/mock-pam-conv-mod.so
+%{_unitdir}/cockpit-session.socket
+%{_unitdir}/cockpit-session@.service
 
 %package -n cockpit-pcp
 Summary: Cockpit PCP integration

--- a/tools/debian/cockpit-tests.install
+++ b/tools/debian/cockpit-tests.install
@@ -1,1 +1,3 @@
 usr/share/cockpit/playground
+lib/systemd/system/cockpit-session.socket
+lib/systemd/system/cockpit-session@.service


### PR DESCRIPTION
cockpit.conf can now specify a unix socket address in the ConnectTo= field of a given authentication method.  If this is provided, and no Command= is present, then a connection will be opened to that address instead of spawning a command.                        

This is the "easy stuff" split out from #16808, and is already enough to help us with cockpit-cloud-connector.