### PR TITLE
Fix TestConnection.testCockpitDesktop arch test, and race condition

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -842,7 +842,7 @@ ResultActive=yes""")
         m.write(r"/tmp/browser.sh", """#!/bin/sh -e
 curl --silent --compressed -o /tmp/out.html "$@"
 # wait until privileged bridge starts
-until pgrep -f cockpit-bridge.*--privileged; do sleep 1; done
+until pgrep -f '^/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
 """)
         m.execute("chmod 755 /tmp/browser.sh")
         m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -831,14 +831,21 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
 
         # cockpit-desktop can start a privileged bridge through polkit
         # we don't have an agent, so just allow the privilege without interactive authentication
-        polkit_loc = "/etc/polkit-1/rules.d" if m.image == "arch" else "/etc/polkit-1/localauthority/50-local.d"
-        m.write(f"{polkit_loc}/test.pkla", r"""
+        if m.image == "arch":
+            m.write("/etc/polkit-1/rules.d/test.rules", r"""
+polkit.addRule(function(action, subject) {
+    if (action.id == "org.cockpit-project.cockpit.root-bridge" && subject.user == "admin")
+        return polkit.Result.YES;
+}); """)
+        else:
+            m.write("/etc/polkit-1/localauthority/50-local.d/test.pkla", r"""
 [Testing without an agent]
 Identity=unix-user:admin
 Action=org.cockpit-project.cockpit.root-bridge
 ResultAny=yes
 ResultInactive=yes
 ResultActive=yes""")
+
         m.write(r"/tmp/browser.sh", """#!/bin/sh -e
 curl --silent --compressed -o /tmp/out.html "$@"
 # wait until privileged bridge starts


### PR DESCRIPTION
Fixes [this top flake](https://logs.cockpit-project.org/logs/pull-16795-20220107-134435-a1131daf-arch/log.html#15-2)

On [arch it fails most of the time](https://logs-https-frontdoor.apps.ocp.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=14&test=test%2Fverify%2Fcheck-connection+TestConnection.testCockpitDesktop#)