### PR TITLE
test: sudo and socketpair() now work properly on fedora-34

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -493,7 +493,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = ["fedora-testing"]
+        working_images = ["fedora-34", "fedora-testing"]
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:


### PR DESCRIPTION
The fix made it to Fedora 34 stable, see commit 9ea3b2fe7f2.

---

Blocks https://github.com/cockpit-project/bots/pull/2800 but should fix the fedora-34 test on Testing Farm.