### PR TITLE
test: Rework pixel testing and mobile layout logic

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -108,8 +108,6 @@ You can set these environment variables to configure the test suite:
     TEST_SHOW_BROWSER  Set to run browser interactively. When not specified,
                        browser is run in headless mode.
 
-    TEST_MOBILE  Set to run browser with mobile screen window size.
-
     TEST_TIMEOUT_FACTOR Scale normal timeouts by given integer. Useful for
                         slow/busy testbeds or architectures.
 

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -335,23 +335,3 @@ function ph_element_clip(sel) {
 function ph_count_animations(sel) {
     return ph_find(sel).getAnimations({subtree:true}).length;
 }
-
-function ph_adjust_content_size(w, h) {
-    const body = document.body;
-    const content = document.getElementById("content");
-    const dx = w - content.offsetWidth;
-    const dy = h - content.offsetHeight;
-
-    // Making the body bigger doesn't really work.  It already fills
-    // the whole browser window and making it bigger would cause parts
-    // of it to stick out and we couldn't take snapshots of them.
-    // Let's just warn about this here and hope it doesn't matter.
-
-    if (dx > 0 || dy > 0) {
-        console.warn("Can't adjust content iframe size.  Browser window is too small.");
-        return;
-    }
-
-    body.style.width = (body.offsetWidth + dx) + "px";
-    body.style.height = (body.offsetHeight + dy) + "px";
-}

--- a/test/run
+++ b/test/run
@@ -11,10 +11,9 @@ TEST_SCENARIO=${TEST_SCENARIO:-verify}
 TEST_OS_DEFAULT=$(PYTHONPATH=bots python3 -c 'from machine.machine_core.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')
 
 case $TEST_SCENARIO in
-    verify|mobile|devel|firefox|firefox-devel)
+    verify|devel|firefox|firefox-devel)
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || export NODE_ENV=development
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
-        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##mobile}" ] || export TEST_MOBILE=true
         test/image-prepare --verbose $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify
         ;;

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -45,9 +45,7 @@ class TestNetworkingVLAN(NetworkCase):
         # Remove focus ring around the close button, which causes pixel tests retries.
         b.blur("#network-vlan-settings-dialog > button[aria-label=Close]")
         b.wait_visible("#network-vlan-settings-interface-name-input")
-        # Ignore flaky pixel issues with the select triangle
-        ignoredClasses = ["#network-vlan-settings-parent-select"] if self.browser.cdp.mobile else []
-        b.assert_pixels("#network-vlan-settings-dialog", "networking-vlan-settings-dialog", ignore=ignoredClasses)
+        b.assert_pixels("#network-vlan-settings-dialog", "networking-vlan-settings-dialog")
 
         b.select_from_dropdown("#network-vlan-settings-parent-select", iface)
         b.set_input_text("#network-vlan-settings-interface-name-input", "tvlan")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -728,15 +728,18 @@ ExecStart=/usr/local/bin/{packageName}
         # norefs: just changelog, show both binary packages
         sel = self.check_nth_update(5, ["norefs-bin", "norefs-doc"], "2-1", self.enhancement_severity,
                                     desc_matches=["Now 10% more unicorns"])
-        # verify Markdown formatting in table cell - only present in large window sizes
-        if not b.cdp.mobile:
-            self.assertEqual(b.text(sel + " td.changelog em"), "more")  # *more*
-            self.assertEqual(b.attr(sel + " td.changelog a", "href"), "http://unicorn.example.com")
-            # verify Markdown formatting in details
-            self.assertEqual(b.text(sel + " .pf-m-expanded em"), "more")  # *more*
-            self.assertEqual(b.attr(sel + " .pf-m-expanded a:first-of-type", "href"), "http://unicorn.example.com")
-        else:
-            b.wait_not_visible(sel + " td.changelog em")
+        # verify Markdown formatting in table cell
+        self.assertEqual(b.text(sel + " td.changelog em"), "more")  # *more*
+        self.assertEqual(b.attr(sel + " td.changelog a", "href"), "http://unicorn.example.com")
+        # verify Markdown formatting in details
+        self.assertEqual(b.text(sel + " .pf-m-expanded em"), "more")  # *more*
+        self.assertEqual(b.attr(sel + " .pf-m-expanded a:first-of-type", "href"), "http://unicorn.example.com")
+
+        # verify that changelog is absent in mobile
+        b.set_layout("mobile")
+        b.wait_not_visible(sel + " td.changelog em")
+        b.set_layout("desktop")
+        b.wait_visible(sel + " td.changelog em")
 
         # updates are shown on system page
         b.go("/system")
@@ -911,16 +914,26 @@ ExecStart=/usr/local/bin/{packageName}
         self.check_nth_update(2, ["fine00", "fine01", "fine02", "fine03"], "1-2",
                               desc_matches=["fine07", "fine09"])
 
-        # verbose changelog should be truncated
-        if not b.cdp.mobile:
-            desc = b.text("#app .ct-table tbody:nth-of-type(3) [data-label=Details]")
-            self.assertIn("Things change #00", desc)
-            self.assertNotIn("#01", desc)
-        else:
-            b.wait_not_visible("#app .ct-table tbody:nth-of-type(3) [data-label=Details]")
+        # changelog should be truncated
+        desc = b.text("#app .ct-table tbody:nth-of-type(3) [data-label=Details]")
+        self.assertIn("Things change #00", desc)
+        self.assertNotIn("#01", desc)
+
+        # and not visible on mobile
+        b.set_layout("mobile")
+        b.wait_not_visible("#app .ct-table tbody:nth-of-type(3) [data-label=Details]")
         # but complete in the details
         self.check_nth_update(3, "verbose", "1-2",
                               desc_matches=["Things change #00", "Things change #29"])
+
+        # also on desktop
+        b.set_layout("desktop")
+        b.wait_visible("#app .ct-table tbody:nth-of-type(3) [data-label=Details]")
+        # collapse it so that check_nth_update is happy
+        b.click("#available-updates table[aria-label='Available updates'] > tbody:nth-of-type(3) td.pf-c-table__toggle button")
+        self.check_nth_update(3, "verbose", "1-2",
+                              desc_matches=["Things change #00", "Things change #29"])
+
         # seems we can't verify that the description has a scrollbar
 
     def testUpdateError(self):

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -61,12 +61,7 @@ class TestPackages(MachineCase):
         self.login_and_go("/playground/pkgs")
 
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.wait_visible("#nav-system li:contains(Terminal)")
-        if b.cdp.mobile:
-            # close menu again
-            b.click("#nav-system-item")
 
         m.execute("mkdir /usr/share/cockpit/test")
         m.write("/usr/share/cockpit/test/manifest.json", test_manifest)
@@ -75,8 +70,6 @@ class TestPackages(MachineCase):
         b.click("#reload")
 
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.click("#nav-system a:contains(Test)")
 
         b.enter_page("/test/test")
@@ -88,12 +81,7 @@ class TestPackages(MachineCase):
         b.click("#reload")
 
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.wait_not_present("#nav-system a:contains(Test)")
-        if b.cdp.mobile:
-            # close menu again
-            b.click("#nav-system-item")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -54,17 +54,10 @@ class TestPages(MachineCase):
 
     def check_system_menu(self, label, present):
         b = self.browser
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
-
         if present:
             b.wait_visible(f"#host-apps li a:contains('{label}')")
         else:
             b.wait_not_present(f"#host-apps li a:contains('{label}')")
-
-        if b.cdp.mobile:
-            # close menu again
-            b.click("#nav-system-item")
 
     def open_lang_modal(self):
         self.browser.switch_to_top()
@@ -432,8 +425,6 @@ OnCalendar=daily
         self.allow_journal_messages("invalid or unusable locale: de_DE.UTF-8")
 
         self.login_and_go()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
 
         filter_sel = ".pf-c-search-input__text-input"
 
@@ -466,7 +457,12 @@ OnCalendar=daily
         # Clean up failed services for screenshots
         m.execute("systemctl reset-failed")
         b.wait_not_present("#services-error")
-        b.assert_pixels("#nav-system", "menu-search")
+        b.assert_pixels("#nav-system", "menu-search", skip_layouts=["mobile"])
+        b.set_layout("mobile")
+        b.click("#nav-system-item")
+        b.assert_pixels_in_current_layout("#nav-system", "menu-search")
+        b.click("#nav-system-item")
+        b.set_layout("desktop")
 
         # Check that enter activates first result
         b.focus(filter_sel)
@@ -480,9 +476,6 @@ OnCalendar=daily
 
         # Visited page, search should be cleaned up
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
-            b.focus(filter_sel)
         b.wait_val(filter_sel, "")
 
         # Check that escape cleans the search
@@ -517,8 +510,6 @@ OnCalendar=daily
 
         # Check we jump into subpage when defined in manifest
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.focus(filter_sel)
         b.key_press("firew")
         b.wait_visible("#host-apps li a:contains('Networking')")
@@ -547,8 +538,6 @@ OnCalendar=daily
         b.wait_in_text(".ct-overview-header", "Neustart")
 
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.wait_visible("#host-apps li a:contains('Dienste')")
         b.wait_visible("#host-apps li a:contains('Protokolle')")
         b.focus(filter_sel)
@@ -709,8 +698,6 @@ OnCalendar=daily
         b.click("#set-status")
 
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.wait_visible("#development-info")
         b.mouse("#development-info", "mouseenter")
         b.wait_in_text(".pf-c-tooltip", "My Little Page Status")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -142,17 +142,14 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         # This should all work without being admin on machine1
         self.login_and_go(superuser=False)
 
-        if b.cdp.mobile:
-            # system menu not visible in mobile mode
-            b.click("#nav-system-item")
-            b.wait_visible("#nav-system.interact")
-
-        b.assert_pixels("#nav-system", "nav-system")
-
-        if b.cdp.mobile:
-            # close system menu again in mobile mode
-            b.click("#nav-system-item")
-            b.wait_not_present("#nav-system.interact")
+        b.assert_pixels("#nav-system", "nav-system", skip_layouts=["mobile"])
+        b.set_layout("mobile")
+        b.click("#nav-system-item")
+        b.wait_visible("#nav-system.interact")
+        b.assert_pixels_in_current_layout("#nav-system", "nav-system")
+        b.click("#nav-system-item")
+        b.wait_not_present("#nav-system.interact")
+        b.set_layout("desktop")
 
         b.assert_pixels("#hosts-sel", "hosts-sel-closed")
 
@@ -415,8 +412,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3']")
         b.wait_visible("iframe.container-frame[name='cockpit1:franz@10.111.113.3/system']")
 
-        if not b.cdp.mobile:
-            b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "franz@machine3")
+        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "franz@machine3")
         b.click("#hosts-sel button")
         b.wait_text(".nav-item a[href='/@10.111.113.3']", "franz @machine3")
         b.click("button:contains('Edit hosts')")
@@ -435,8 +431,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click('#hosts_setup_server_dialog .pf-m-primary')
         b.wait_not_present('#hosts_setup_server_dialog')
 
-        if not b.cdp.mobile:
-            b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@machine2")
+        b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@machine2")
 
         # Changing the address of a host will navigate to that host,
         # and that will close the host switcher.  Let's open it again

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -89,12 +89,7 @@ class TestMenu(MachineCase):
         b.go("/playground/exception")
 
         # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         b.wait_in_text("#host-apps .pf-m-current", "Development")
-        if b.cdp.mobile:
-            # close menu again
-            b.click("#nav-system-item")
 
         b.enter_page("/playground/exception")
         b.wait_visible("button")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -37,12 +37,12 @@ class TestLogin(MachineCase):
     def check_shell(self):
         b = self.browser
         b.wait_visible("#content")
-        if b.cdp.mobile:
-            b.click("#hosts-sel button")
-            b.wait_in_text(".view-hosts .pf-m-current", "admin @")
-            b.click("#hosts-sel button")
-        else:
-            b.wait_text('#current-username', 'admin')
+        b.wait_text('#current-username', 'admin')
+        b.set_layout("mobile")
+        b.click("#hosts-sel button")
+        b.wait_in_text(".view-hosts .pf-m-current", "admin @")
+        b.click("#hosts-sel button")
+        b.set_layout("desktop")
 
     def testBasic(self):
         m = self.machine

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -57,7 +57,8 @@ class TestSuperuser(MachineCase):
         # We want to be lectured again
         m.execute("rm -rf /var/{db,lib}/sudo/lectured/admin")
 
-        # Get the privileges back
+        # Get the privileges back, this time in the mobile layout
+        b.set_layout("mobile")
         b.open_superuser_dialog()
         if "ubuntu" not in m.image:
             b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')",
@@ -69,6 +70,7 @@ class TestSuperuser(MachineCase):
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.check_superuser_indicator("Administrative access")
+        b.set_layout("desktop")
 
         # Check we still have them after logout
         b.relogin()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -282,12 +282,7 @@ class TestSystemInfo(MachineCase):
         # wait until icon settles down
         b.wait_visible("#systime-time-input-input[aria-invalid='false']")
         b.wait_not_present("#systime-manual-row .dialog-error")
-        if b.cdp.mobile:
-            # HACK: the clock icon in the <input> has too much jitter on mobile
-            ignore = ["#systime-time-input-input"]
-        else:
-            ignore = []
-        b.assert_pixels("#system_information_change_systime", "systime-manual-time", ignore=ignore)
+        b.assert_pixels("#system_information_change_systime", "systime-manual-time")
         b.click("#system_information_change_systime .apply")
         b.wait_not_present("#system_information_change_systime")
 
@@ -454,12 +449,11 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Class]', "Bridge")
         b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Class]', "Unclassified")
 
-        # sort by model (no sort buttons in mobile mode)
-        if not b.cdp.mobile:
-            b.click(pci_selector + ' thead th:nth-child(2) button')
-            b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Model]', "440")
-            b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Virtio SCSI")
-            b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
+        # sort by model
+        b.click(pci_selector + ' thead th:nth-child(2) button')
+        b.wait_in_text(pci_selector + ' tbody tr:first-of-type td[data-label=Model]', "440")
+        b.wait_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Virtio SCSI")
+        b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
 
         # go back to system page
         b.click('.pf-c-breadcrumb li:first a')

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -212,9 +212,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_log_present("THE SERVICE")
         wait_log_present("JUST ERROR")
 
-        if b.cdp.mobile:
-            b.click(".pf-c-toolbar__toggle button")
-
         # We cannot open this select with tests but we need to wait until it gets loaded
         b.select_PF4("#journal-identifier-menu .pf-c-select__toggle", "just-a-service")
         wait_log_not_present("JUST ERROR")
@@ -447,8 +444,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                         ["", "Reboot", ""],
                         ["check-journal", "BEFORE BOOT", ""]
                         ])
-        if b.cdp.mobile:
-            b.click(".pf-c-toolbar__toggle button")
 
         b.focus("#journal-grep input")
         b.key_press("until:2037-01-01\\ 00:03")
@@ -513,9 +508,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         journal_line_selector = "#journal-box .cockpit-logline:has(span:contains({0}))"
 
-        if b.cdp.mobile:
-            b.click(".pf-c-toolbar__toggle button")
-
         self.browser.select_PF4("#journal-prio-menu", "Only emergency")
         b.wait_visible(journal_line_selector.format("EMERGENCY_MESSAGE"))
         b.wait_not_present(journal_line_selector.format("WARNING_MESSAGE"))
@@ -543,8 +535,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.crash()
 
         self.login_and_go("/system/logs#/?since=@" + self.test_start_time)
-        if b.cdp.mobile:
-            b.click(".pf-c-toolbar__toggle button")
 
         self.browser.select_PF4("#journal-prio-menu", "Critical and above")
         b.wait_visible(sleep_crash_list_sel)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -18,7 +18,6 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import time
-
 import parent
 import testvm
 from testlib import *
@@ -390,17 +389,20 @@ Unit=test.service
         b.set_input_text("#services-text-filter input", "Test Service")
         self.wait_service_present("test.service")
         self.wait_service_present("test-fail.service")
-        if b.cdp.mobile:
-            # close the expanded toolbar again to see the whole list
-            b.click("#services-page .pf-c-toolbar__toggle button")
-            b.wait_not_visible("#services-page .pf-m-search-filter")
-            # scroll the menu navbar all the way to the left
-            nav_scroll_btn = ".services-header button[aria-label='Scroll left']"
-            while b.call_js_func("ph_attr", nav_scroll_btn, "disabled") is None:
-                b.click(nav_scroll_btn)
-                time.sleep(0.5)
         if not user:
-            b.assert_pixels("#services-page", "text-filter-test")
+            b.assert_pixels("#services-page", "text-filter-test", skip_layouts=["mobile"])
+        b.set_layout("mobile")
+        # Waiting a bit for the layout to stabilize.  The scrolling of
+        # the header happens asynchronously with an animation.
+        time.sleep(2)
+        # Now scroll the header all the way to the left to get a conistent pixel test result
+        nav_scroll_btn = ".services-header button[aria-label='Scroll left']"
+        while b.call_js_func("ph_attr", nav_scroll_btn, "disabled") is None:
+            b.click(nav_scroll_btn)
+            time.sleep(0.5)
+        if not user:
+            b.assert_pixels_in_current_layout("#services-page", "text-filter-test")
+        b.set_layout("desktop")
 
         # Filter by description capitalization not matching the unit description
         init_filter_state()
@@ -537,8 +539,6 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
         t = b.text("#journal-box .cockpit-log-panel > div:nth-child(3)") + b.text("#journal-box .cockpit-log-panel > div:nth-child(4)")
         self.assertIn("START", t)
-        if b.cdp.mobile:
-            b.click("button[aria-label='Show Filters']")
         b.wait_val("#journal-grep input", "priority:debug service:test.service ")
         b.go("/system/services#test.service")
         b.enter_page("/system/services")
@@ -548,8 +548,6 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.enter_page("/system/logs")
         b.wait_text(".pf-c-card__title", "WORKING")
         b.click(".pf-c-breadcrumb a:contains('Logs')")
-        if b.cdp.mobile:
-            b.click("button[aria-label='Show Filters']")
         b.wait_val("#journal-grep input", "priority:debug service:test.service ")
         b.go("/system/services#test.service")
         b.enter_page("/system/services")
@@ -806,18 +804,18 @@ WantedBy=default.target
     def check_system_menu_services_error(self, expected, pixel_label=None):
         b = self.browser
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#nav-system-item")
         if expected:
             b.wait_visible("#services-error")
         else:
             b.wait_not_present("#services-error")
-        if pixel_label:
-            b.assert_pixels("#nav-system", pixel_label)
 
-        if b.cdp.mobile:
-            # close menu again
+        if pixel_label:
+            b.assert_pixels("#nav-system", pixel_label, skip_layouts=["mobile"])
+            b.set_layout("mobile")
             b.click("#nav-system-item")
+            b.assert_pixels_in_current_layout("#nav-system", pixel_label)
+            b.click("#nav-system-item")
+            b.set_layout("desktop")
 
     def testNotifyFailed(self):
         m = self.machine

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -46,12 +46,12 @@ class TestRoles(MachineCase):
         b.expect_load()
         b.enter_page("/system")
         b.switch_to_top()
-        if b.cdp.mobile:
-            b.click("#hosts-sel button")
-            b.wait_in_text(".view-hosts .pf-m-current", "user @")
-            b.click("#hosts-sel button")
-        else:
-            b.wait_text('#current-username', 'user')
+        b.wait_text('#current-username', 'user')
+        b.set_layout("mobile")
+        b.click("#hosts-sel button")
+        b.wait_in_text(".view-hosts .pf-m-current", "user @")
+        b.click("#hosts-sel button")
+        b.set_layout("desktop")
 
         b.go("/users#/user")
         b.enter_page("/users")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -107,15 +107,11 @@ class StorageHelpers:
             b.wait_visible(tbody + ".pf-m-expanded")
 
     def content_row_action(self, index, title, isExpandable=True):
-        if self.browser.cdp.mobile:
-            # in mobile layout, we expect all actions to be in the dropdown
-            self.content_dropdown_action(index, title, isExpandable)
+        if isExpandable:
+            btn = self.content_row_tbody(index) + f" tr:first-child td button:contains({title})"
         else:
-            if isExpandable:
-                btn = self.content_row_tbody(index) + f" tr:first-child td button:contains({title})"
-            else:
-                btn = "#detail-content > article > div > table > :nth-child(%d)" % index + f" td button:contains({title})"
-            self.browser.click(btn)
+            btn = "#detail-content > article > div > table > :nth-child(%d)" % index + f" td button:contains({title})"
+        self.browser.click(btn)
 
     # The row might come and go a couple of times until it has the
     # expected content.  However, wait_in_text can not deal with a


### PR DESCRIPTION
test/common/testlib.py has a set of layouts and test code can switch a
Browser into one via Browser.set_layout.  Right now there is only
"desktop" and "mobile", but more can be easily added.
    
Browser.assert_pixels cycles through all the defined layouts and does
a pixel test for each.

 - [ ] merge change to testmap at the same time, https://github.com/cockpit-project/bots/pull/2848
