### PR TITLE
selinux: Allow cockpit-session to access LDAP port

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -155,13 +155,15 @@ kernel_read_network_state(cockpit_session_t)
 
 # cockpit-session runs a full pam stack, including pam_selinux.so
 auth_login_pgm_domain(cockpit_session_t)
-# cockpit-session resseting expired passwords
+# cockpit-session resetting expired passwords
 auth_manage_passwd(cockpit_session_t)
 auth_manage_shadow(cockpit_session_t)
 auth_write_login_records(cockpit_session_t)
 
 corenet_tcp_bind_ssh_port(cockpit_session_t)
 corenet_tcp_connect_ssh_port(cockpit_session_t)
+# query identity management domain users
+corenet_tcp_connect_ldap_port(cockpit_session_t)
 
 # cockpit-session can execute cockpit-agent as the user
 userdom_spec_domtrans_all_users(cockpit_session_t)


### PR DESCRIPTION
This is now required on RHEL 8.6 for authenticating identity domain
managed users:

    avc:  denied  { name_connect } for comm="cockpit-session"
      dest=389 scontext=system_u:system_r:cockpit_session_t:s0
      tcontext=system_u:object_r:ldap_port_t:s0 tclass=tcp_socket

----

Will fix two of the issues in https://github.com/cockpit-project/bots/pull/2794

 - [ ] Decide if this is actually desired: https://bugzilla.redhat.com/show_bug.cgi?id=2039892