### PR TITLE
test: Disable HTTP/3 in Firefox

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -132,6 +132,8 @@ class Firefox(Browser):
                 user_pref("dom.navigation.locationChangeRateLimit.count", 9999);
                 // HACK: https://bugzilla.mozilla.org/show_bug.cgi?id=1746154
                 user_pref("fission.webContentIsolationStrategy", 0);
+                // HACK: https://bugzilla.mozilla.org/show_bug.cgi?id=1749908
+                user_pref("network.http.http3.enabled", false);
                 """.format(download_dir))
 
         with open(os.path.join(profile, "handlers.json"), "w") as f:


### PR DESCRIPTION
Since today this has caused a major firefox screw-up [1]. We don't need
HTTP/3 for testing Cockpit, as that only supports 1.1 anyway.

This fixes broken tests on the Testing Farm, which run with Firefox.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1749908

----

This curiously does not seem to break cockpit itself, at least not that hard. But it [caused a disaster](http://artifacts.dev.testing-farm.io/7f256f0c-3e6e-47d1-bb63-1db6619347ee/) for cockpit-machines, and applying this hack locally in https://github.com/cockpit-project/cockpit-machines/pull/520 proved that this works.