### PR TITLE
packagekit: Rename "Kernel patch" to "Kernel live patch"

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -237,7 +237,7 @@ export class KpatchSettings extends React.Component {
 
         const body = <Checkbox id="apply-kpatch"
                                isChecked={this.state.applyCheckbox}
-                               label={_("Apply kernel patches")}
+                               label={_("Apply kernel live patches")}
                                onChange={checked => this.setState({ applyCheckbox: checked })}
                                body={<>
                                    <Radio id="current-future"
@@ -258,7 +258,7 @@ export class KpatchSettings extends React.Component {
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     <Flex grow={{ default: 'grow' }} alignItems={{ default: 'alignItemsBaseline' }}>
                         <FlexItem>
-                            <b>{_("Kernel patching")}</b>
+                            <b>{_("Kernel live patching")}</b>
                         </FlexItem>
                         <FlexItem>
                             {state}
@@ -275,7 +275,7 @@ export class KpatchSettings extends React.Component {
                 </Flex>
             </div>
             <Modal position="top" variant="small" id="kpatch-setup" isOpen={this.state.showModal}
-                title={_("Kernel patch settings")}
+                title={_("Kernel live patch settings")}
                 onClose={ this.onClose }
                 footer={
                     <>
@@ -342,14 +342,14 @@ export class KpatchStatus extends React.Component {
         let text = [];
         text = this.state.loaded.map(i =>
             <Text key={i} component={TextVariants.p}>
-                { cockpit.format(_("Kernel patch $0 is active"), i) }
+                { cockpit.format(_("Kernel live patch $0 is active"), i) }
             </Text>
         );
 
         if (text.length === 0)
             text = this.state.installed.map(i =>
                 <Text key={i} component={TextVariants.p}>
-                    { cockpit.format(_("Kernel patch $0 is installed"), i) }
+                    { cockpit.format(_("Kernel live patch $0 is installed"), i) }
                 </Text>
             );
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -172,7 +172,7 @@ class TestUpdates(NoSubManCase):
         b.wait_in_text("#kpatch-settings", "Disabled")
         b.click("#kpatch-settings button:contains('Enable')")
 
-        # Apply kernel patches for current and future kernels
+        # Apply kernel live patches for current and future kernels
         b.click("#apply-kpatch")
         b.wait_visible("#apply-kpatch:checked")
         b.wait_visible("#current-future:checked")
@@ -206,7 +206,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_visible(".pf-c-badge:contains('patches')")
         b.click("button:contains('Install all updates')")
         b.click("button:contains('Continue')")
-        b.wait_in_text("#status", "Kernel patch kpatch_3_10_0_1062_1_1 is active")
+        b.wait_in_text("#status", "Kernel live patch kpatch_3_10_0_1062_1_1 is active")
 
         # Switch to 'for current kernel only'
         b.click("#kpatch-settings button:contains('Edit')")
@@ -254,7 +254,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_in_text("#kpatch-settings", "Disabled")
         b.click("#kpatch-settings button:contains('Enable')")
 
-        # Apply kernel patches for current and future kernels
+        # Apply kernel live patches for current and future kernels
         b.click("#apply-kpatch")
         b.wait_visible("#apply-kpatch:checked")
         b.click("#current-only")


### PR DESCRIPTION
This describes more precisely what this is about, and makes our UI
consistent with the RHEL documentation:
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_monitoring_and_updating_the_kernel/applying-patches-with-kernel-live-patching_managing-monitoring-and-updating-the-kernel