### PR TITLE
packagekit: Show a spinner while checking for kpatch support on RHEL

### DIFF
--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -246,3 +246,7 @@ table.header-buttons {
 .autoupdates-card-error {
     margin-bottom: var(--pf-global--spacer--md);
 }
+
+.ct-info-circle {
+    color: var(--pf-global--info-color--100);
+}

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1121,8 +1121,13 @@ class TestKpatchInstall(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
         b.wait_visible("#status")
-        time.sleep(5)
-        b.wait_not_present("#kpatch-settings")
+        b.wait_in_text("#kpatch-settings", "Not available")
+        # show unavailable packages in popover
+        b.click("#kpatch-settings .ct-info-circle")
+        b.wait_in_text(".pf-c-popover", "Unavailable packages")
+        b.wait_in_text(".pf-c-popover", "kpatch-dnf")
+        b.click("#kpatch-settings .ct-info-circle")
+        b.wait_not_present(".pf-c-popover")
 
         dummy_service = "[Service]\nExecStart=/bin/sleep infinity\n[Install]\nWantedBy=multi-user.target\n"
         self.createPackage("kpatch", "999", "1", content={"/lib/systemd/system/kpatch.service": dummy_service})


### PR DESCRIPTION
Testing for kpatch support can take quite long (UX review reported 8
seconds), and it is apparently confusing/not discoverable for users to
wait that long until they see the status of kpatch.

During detection of kpatch support on RHEL (the only OS where we
actually expect this to succeed), show a spinner as status. Also show a
disabled "Edit" button to avoid the layout jumping around once it gets
enabled.

Don't show the spinner on other OSes, as we expect it to fail there, and 
it is both confusing and also changing the page layout when the "Kernel
live patching" entry entirely disappears from the Settings card.

------
 - Depends on PR #16833

On RHEL while loading:
![image](https://user-images.githubusercontent.com/200109/149490664-73e84a32-0357-42c7-8eb8-c70ffaec82a9.png)

On RHEL when loading is done (no change compared to main):

![image](https://user-images.githubusercontent.com/200109/149721625-12b35140-32a4-4a2b-b724-b7d521348ae9.png)

On RHEL when kpatch package is not available (done synthetically, this is rather unlikely):

![image](https://user-images.githubusercontent.com/200109/149721291-68b88b20-0af9-4150-a82f-1b2e29bc04d2.png)
![image](https://user-images.githubusercontent.com/200109/149721386-636334a6-c65e-4584-b9a7-5774f29cff20.png)

On Fedora nothing ever gets displayed.