### PR TITLE
test: Ignore realmd disconnect message on idle timeout for property updates

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -475,6 +475,9 @@ class TestRealms(MachineCase):
         self.domain_sel = "#system_information_domain_button"
         self.machine.execute("hostnamectl set-hostname x0.cockpit.lan")
 
+        # realmd times out on inactivity, which occasionally races with the proxy
+        self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
+
 
 @skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
 @skipDistroPackage()


### PR DESCRIPTION
Occasionally the realmd tests run into a race condition of our service
proxy with realmd's idle timeout:

    realmd[2202]: quitting realmd service after timeout
    realmd[2202]: stopping service
    cockpit-bridge[4480]: org.freedesktop.realmd: couldn't get all properties of org.freedesktop.realmd.Service at /org/freedesktop/realmd: GDBus.Error:org.freedesktop.DBus.Error.NoReply: Remote peer disconnected

The proxy causes the service to immediately start again, so there is no
harm done.

---

Spotted in [this test flake](https://logs.cockpit-project.org/logs/pull-16831-20220113-160722-5c62c8e9-fedora-35-devel/log.html#261). The corresponding [journal](https://logs.cockpit-project.org/logs/pull-16831-20220113-160722-5c62c8e9-fedora-35-devel/TestIPA-testClientCertAuthentication-fedora-35-127.0.0.2-2401-FAIL.log.gz) makes it pretty clear that this is harmless.