### PR TITLE
Fix /etc/os-release handling

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -31,6 +31,7 @@ import {
 import { RebootingIcon } from "@patternfly/react-icons";
 
 import * as PackageKit from "./packagekit.js";
+import { read_os_release } from "os-release.js";
 import { icon_url, show_error, launch, ProgressBar, CancelButton } from "./utils.jsx";
 import { ActionButton } from "./application.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -108,12 +109,11 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
     }
 
     function refresh() {
-        const distro_id = JSON.parse(window.localStorage['os-release'] || "{}").ID;
-
-        PackageKit.refresh(metainfo_db.origin_files,
-                           get_config('appstream_config_packages', distro_id, []),
-                           get_config('appstream_data_packages', distro_id, []),
-                           setProgress)
+        read_os_release().then(os_release =>
+            PackageKit.refresh(metainfo_db.origin_files,
+                               get_config('appstream_config_packages', os_release.ID, []),
+                               get_config('appstream_data_packages', os_release.ID, []),
+                               setProgress))
                 .finally(() => setProgress(false))
                 .catch(show_error);
     }

--- a/pkg/lib/os-release.js
+++ b/pkg/lib/os-release.js
@@ -1,0 +1,38 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+
+function parse_simple_vars(text) {
+    const res = { };
+    for (const l of text.split('\n')) {
+        const pos = l.indexOf('=');
+        if (pos > 0) {
+            const name = l.substring(0, pos);
+            let val = l.substring(pos + 1);
+            if (val[0] == '"' && val[val.length - 1] == '"')
+                val = val.substring(1, val.length - 1);
+            res[name] = val;
+        }
+    }
+    return res;
+}
+
+/* Return /etc/os-release as object */
+export const read_os_release = () => cockpit.file("/etc/os-release", { syntax: { parse: parse_simple_vars } }).read();

--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -31,6 +31,7 @@ import { ActivePagesDialog } from "./active-pages-modal.jsx";
 import { CredentialsModal } from './credentials.jsx';
 import { AboutCockpitModal, LangModal, OopsModal } from "./shell-modals.jsx";
 import { SuperuserIndicator } from "./superuser.jsx";
+import { read_os_release } from "os-release.js";
 
 const _ = cockpit.gettext;
 
@@ -58,10 +59,13 @@ export class TopNav extends React.Component {
             docsOpened: false,
             menuOpened: false,
             showActivePages: false,
+            osRelease: {},
         };
 
         this.superuser_connection = cockpit.dbus(null, { bus: "internal", host: props.machine.connection_string });
         this.superuser = this.superuser_connection.proxy("cockpit.Superuser", "/superuser");
+
+        read_os_release().then(os => this.setState({ osRelease: os || {} }));
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
@@ -112,10 +116,9 @@ export class TopNav extends React.Component {
 
         const docItems = [];
 
-        const os_release = JSON.parse(window.localStorage['os-release'] || "{}");
-        if (os_release.DOCUMENTATION_URL)
-            docItems.push(<DropdownItem key="os-doc" href={os_release.DOCUMENTATION_URL} target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>
-                {cockpit.format(_("$0 documentation"), os_release.NAME)}
+        if (this.state.osRelease.DOCUMENTATION_URL)
+            docItems.push(<DropdownItem key="os-doc" href={this.state.osRelease.DOCUMENTATION_URL} target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>
+                {cockpit.format(_("$0 documentation"), this.state.osRelease.NAME)}
             </DropdownItem>);
 
         docItems.push(<DropdownItem key="cockpit-doc" href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/index" target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -345,10 +345,6 @@
             el.focus();
         });
 
-        const os_release = environment["os-release"];
-        if (os_release)
-            localStorage.setItem('os-release', JSON.stringify(os_release));
-
         const logout_intent = window.sessionStorage.getItem("logout-intent") == "explicit";
         if (logout_intent)
             window.sessionStorage.removeItem("logout-intent");


### PR DESCRIPTION
The most obvious confusion is with remote logins:

![image](https://user-images.githubusercontent.com/200109/149488120-aa1d53a9-7ffd-464f-860c-afb24594d3a4.png)

It's more subtle with the Applications page, the refresh would simply fail if you e.g. logging into a remote Debian machine from a Fedora host.