### PR TITLE
more static code cleanups

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -115,6 +115,10 @@ that will fail on trivial errors:
 
 This calls `test/static-code` for each commit you're trying to push.
 
+You can also set up a post-commit hook to do the same, after each commit:
+
+    $ ln -s ../../test/git-hook-post-commit .git/hooks/post-commit
+
 ## Running the integration test suite
 
 Refer to the [testing README](test/README.md) for details on running the Cockpit

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ nodist_noinst_DATA =
 nodist_noinst_SCRIPTS =
 
 TESTS = \
+	test/check-dist \
 	test/static-code \
 	$(NULL)
 

--- a/test/check-dist
+++ b/test/check-dist
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -eu
+
+echo '1..1'
+
+output="$(grep --color=auto -H -n "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" -r dist 2>&1)" || true
+
+printf "%s %d %s%s\n" "${output:+not }ok" '1' "/dist/patternfly-font-paths" "${skip:-}"
+if [ -n "${output:-}" ]; then
+    printf "%s\n" "${output}" | sed -e 's/^/# /'
+    exit 1
+fi

--- a/test/git-hook-post-commit
+++ b/test/git-hook-post-commit
@@ -30,3 +30,4 @@ fi
 
 # paranoia: make sure we delete what we think we will
 rm -rf "tmp/pre-push/${commit}"
+rmdir --ignore-fail-on-non-empty tmp/pre-push tmp

--- a/test/git-hook-post-commit
+++ b/test/git-hook-post-commit
@@ -21,9 +21,10 @@ fi
 # if any of the following commands fail, the function
 # will abort, leaving the temp directory in place
 (
+    unset -- $(env | sed -n '/^GIT_/{s/=.*//p}')
     cd "${tmpdir}"
-    env -i git init -qb main .
-    env -i git add .
+    git init -qb main .
+    git add .
     test/static-code
 )
 

--- a/test/git-hook-post-commit
+++ b/test/git-hook-post-commit
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+set -eu
+
+# resolve to a sha, ensure validity
+readonly commit="$(git rev-parse --verify "${1:-HEAD}^{commit}")"
+
+tmpdir="tmp/pre-push/${commit}"
+rm -rf "tmp/pre-push/${commit}"
+
+# unpack all of the changed files, plus the test/static-code from that commit
+files="$(git show --format='' --name-only "${commit}" --) test/static-code"
+git archive --prefix="${tmpdir}/" "${commit}" -- ${files} | tar x
+
+# check that node_modules always gets updated with package.json
+if [ -e "${tmpdir}/package.json" -a ! -e "${tmpdir}/node_modules" ]; then
+    echo 'not ok 0 /node-modules/update'
+    echo '# package.json changed, but node_modules not updated'
+fi
+
+# if any of the following commands fail, the function
+# will abort, leaving the temp directory in place
+(
+    cd "${tmpdir}"
+    env -i git init -qb main .
+    env -i git add .
+    test/static-code
+)
+
+# paranoia: make sure we delete what we think we will
+rm -rf "tmp/pre-push/${commit}"

--- a/test/git-hook-pre-push
+++ b/test/git-hook-pre-push
@@ -15,37 +15,35 @@ else
 fi
 
 post_commit_hook="$(realpath -m "$0"/../git-hook-post-commit)"
-nothing='0000000000000000000000000000000000000000'
 fail=''
 
 # cf. man 5 githooks
 # <local ref> SP <local object name> SP <remote ref> SP <remote object name> LF
 while read local_ref local_object_name remote_ref remote_object_name; do
+    # never check commits already on origin
+    opts='^origin'
+
+    # if we have the commit that the remote branch pointed to before, exclude it as well
+    opts="${opts} $(git rev-parse --not --quiet --verify "${remote_object_name}^{commit}" || true)"
+
+    # check the object being pushed (if it's not null)
+    opts="${opts} $(git rev-parse --quiet --verify "${local_object_name}^{commit}" || true)"
+
+    # compute the list of commits to check
+    commits="$(git rev-list ${opts})"
+    [ -z "${commits}" ] && continue
+
     printf "${blue}Performing pre-push checks for %s:${grey}\n" "${remote_ref}" >&2
-
-    if [ "${local_object_name}" = "${nothing}" ]; then
-        # deleting remote ref: no checks
-        continue
-    fi
-
-    if [ "${remote_object_name}" != "${nothing}" ]; then
-        reference="${remote_object_name}"
-    else
-        reference="origin" # matches any branch on origin
-    fi
-
-    for commit in $(git rev-list "${local_object_name}" --not "${reference}"); do
+    for commit in ${commits}; do
         subject="$(git show --no-patch --format='%h %s' "${commit}" --)"
-        out="$("${post_commit_hook}" "${commit}" | sed 's/^/    /')"
 
-        if [ -n "${out}" ]; then
-            fmt=" - ${red}%s${grey}:\n%s\n"
-            fail=1
+        if output="$("${post_commit_hook}" "${commit}")" && test -z "${output}"; then
+            printf " - ${green}%s${grey}\n" "${subject}"
         else
-            fmt=" - ${green}%s${grey}: ${green}pass${grey}%s\n"
+            printf " - ${red}%s${grey}${output:+:}\n" "${subject}"
+            printf "%s" "${output}" | sed 's/^/     /;$a\\'
+            fail=1
         fi
-
-        printf "${fmt}" "${subject}" "${out}" >&2
     done
 done
 

--- a/test/git-hook-pre-push
+++ b/test/git-hook-pre-push
@@ -35,7 +35,7 @@ check_commit() {
         cd "${tmpdir}"
         env -i git init -qb main .
         env -i git add .
-        ! test/static-code | grep '^[#n]'
+        test/static-code
     )
 
     # paranoia: make sure we delete what we think we will

--- a/test/git-hook-pre-push
+++ b/test/git-hook-pre-push
@@ -14,70 +14,39 @@ else
     grey=""
 fi
 
-# checks a single commit (ref name in $1) for validity
-check_commit() {
-    tmpdir="tmp/pre-push/${commit}"
-    rm -rf "tmp/pre-push/${commit}"
+post_commit_hook="$(realpath -m "$0"/../git-hook-post-commit)"
+nothing='0000000000000000000000000000000000000000'
+fail=''
 
-    # unpack all of the changed files, plus the test/static-code from that commit
-    files="$(git show --format='' --name-only "${commit}" --) test/static-code"
-    git archive --prefix="${tmpdir}/" "${commit}" -- ${files} | tar x
+# cf. man 5 githooks
+# <local ref> SP <local object name> SP <remote ref> SP <remote object name> LF
+while read local_ref local_object_name remote_ref remote_object_name; do
+    printf "${blue}Performing pre-push checks for %s:${grey}\n" "${remote_ref}" >&2
 
-    # check that node_modules always gets updated with package.json
-    if [ -e "${tmpdir}/package.json" -a ! -e "${tmpdir}/node_modules" ]; then
-        echo 'not ok 0 /node-modules/update'
-        echo '# package.json changed, but node_modules not updated'
+    if [ "${local_object_name}" = "${nothing}" ]; then
+        # deleting remote ref: no checks
+        continue
     fi
 
-    # if any of the following commands fail, the function
-    # will abort, leaving the temp directory in place
-    (
-        cd "${tmpdir}"
-        env -i git init -qb main .
-        env -i git add .
-        test/static-code
-    )
+    if [ "${remote_object_name}" != "${nothing}" ]; then
+        reference="${remote_object_name}"
+    else
+        reference="origin" # matches any branch on origin
+    fi
 
-    # paranoia: make sure we delete what we think we will
-    rm -rf "tmp/pre-push/${commit}"
-}
+    for commit in $(git rev-list "${local_object_name}" --not "${reference}"); do
+        subject="$(git show --no-patch --format='%h %s' "${commit}" --)"
+        out="$("${post_commit_hook}" "${commit}" | sed 's/^/    /')"
 
-main() {
-    nothing='0000000000000000000000000000000000000000'
-    fail=''
-
-    # cf. man 5 githooks
-    # <local ref> SP <local object name> SP <remote ref> SP <remote object name> LF
-    while read local_ref local_object_name remote_ref remote_object_name; do
-        printf "${blue}Performing pre-push checks for %s:${grey}\n" "${remote_ref}" >&2
-
-        if [ "${local_object_name}" = "${nothing}" ]; then
-            # deleting remote ref: no checks
-            continue
-        fi
-
-        if [ "${remote_object_name}" != "${nothing}" ]; then
-            reference="${remote_object_name}"
+        if [ -n "${out}" ]; then
+            fmt=" - ${red}%s${grey}:\n%s\n"
+            fail=1
         else
-            reference="origin" # matches any branch on origin
+            fmt=" - ${green}%s${grey}: ${green}pass${grey}%s\n"
         fi
 
-        for commit in $(git rev-list "${local_object_name}" --not "${reference}"); do
-            subject="$(git show --no-patch --format='%h %s' "${commit}" --)"
-            out="$(check_commit "${commit}" | sed 's/^/    /')"
-
-            if [ -n "${out}" ]; then
-                fmt=" - ${red}%s${grey}:\n%s\n"
-                fail=1
-            else
-                fmt=" - ${green}%s${grey}: ${green}pass${grey}%s\n"
-            fi
-
-            printf "${fmt}" "${subject}" "${out}" >&2
-        done
+        printf "${fmt}" "${subject}" "${out}" >&2
     done
+done
 
-    exit "${fail:-0}"
-}
-
-main
+exit "${fail:-0}"

--- a/test/static-code
+++ b/test/static-code
@@ -8,6 +8,8 @@ set -eu
 # exit with status 77 is a skip, with the message in the output
 # otherwise, any output is a failure, even if exit status is 0
 
+# note: `set -e` is not active during the tests.
+
 find_python_files() {
     # Helper to find all Python files in the tree
     (

--- a/test/static-code
+++ b/test/static-code
@@ -70,13 +70,6 @@ test_unsafe_security_policy() {
     done
 }
 
-test_patternfly_font_paths() {
-    # Bad paths or modifications in patternfly for fonts
-
-    test -d dist || skip 'dist/ not built'
-    ! grep --color=auto -H -n "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" -r dist
-}
-
 test_json_verify() {
     # Check all JSON files for validity
 

--- a/test/static-code
+++ b/test/static-code
@@ -103,6 +103,15 @@ skip() {
 }
 
 main() {
+    if [ $# = 0 ]; then
+        tap=''
+    elif [ $# = 1 -a "$1" = "--tap" ]; then
+        tap='1'
+    else
+        printf "usage: %s [--tap]\n" "$0" >&2
+        exit 1
+    fi
+
     cd "$(realpath -m "$0/../..")"
     if [ ! -e .git ]; then
         echo '1..0 # SKIP not in a git checkout'
@@ -113,8 +122,7 @@ main() {
     counter=0
 
     tests=($(compgen -A function 'test_'))
-    printf "1..%d\n" "${#tests[@]}"
-
+    [ -n "${tap}" ] && printf "1..%d\n" "${#tests[@]}"
 
     for test_function in ${tests[@]}; do
         path="/static-code/$(echo ${test_function} | tr '_' '-')"
@@ -133,6 +141,9 @@ main() {
             fail=1
         fi
 
+        # Only print output on failures or --tap mode
+        [ -n "${tap}" -o -n "${fail}" ] || continue
+
         # excluding the plan, this is the only output that we ever generate
         printf "%s %d %s%s\n" "${fail:+not }ok" "${counter}" "${path}" "${skip}"
         if [ -n "${output}" ]; then
@@ -143,4 +154,4 @@ main() {
     exit "${exit_status}"
 }
 
-main
+main "$@"


### PR DESCRIPTION
 - move the `dist/` checks to their own file and run it as part of `make check`
 - make sure to invoke the test script in an environment free from `GIT_` envvars
 - fix error handling due to unexpected `set -e` behaviour
 - add a commit hook
 - general cleanups