### PR TITLE
flatpak: Wait for application to stop during test

### DIFF
--- a/containers/flatpak/test/test-ssh
+++ b/containers/flatpak/test/test-ssh
@@ -54,4 +54,5 @@ gapplication action "${FLATPAK_ID}" open-path '"=cockpit-client-test"'
 until test -f cockpit-client-test-"${USER}"-cockpit-client-test-22; do sleep 0.5; done
 
 gapplication action "${FLATPAK_ID}" quit
+while flatpak ps | grep org.cockpit_project.CockpitClient; do sleep 1; done
 rm cockpit-client-test-*-*-*


### PR DESCRIPTION
`test-ssh` send a `quit` command to Client, but did not previously wait
for the application to actually quit. Let's make sure this actually
works properly.

This also fixes a race condition with the flatpak-test workflow:
Starting test-browser immediately after test-ssh often failed with funny
errors like

    error: Environment variable must be given in the form VARIABLE=VALUE, not ��

as the test tried to talk to the dying instance which then went away.

-----

Failed test run [example 1](https://github.com/cockpit-project/cockpit/runs/4760838344?check_suite_focus=true), [example 2](https://github.com/cockpit-project/cockpit/runs/4805942961?check_suite_focus=true)

These always go along with

    error: Environment variable must be given in the form VARIABLE=VALUE, not �

or some other broken string, like `not j`. 

This is coming from flatpak, [here](https://github.com/flatpak/flatpak/blob/master/common/flatpak-context.c#L1208) or [here](https://github.com/flatpak/flatpak-xdg-utils/blob/master/src/flatpak-spawn.c#L730) and smells like a race condition in flatpak itself.