### PR TITLE
Add tools/make-rpms --build-in-place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,10 +42,6 @@ Makefile.in
 /frob-websocket
 /mock-*
 /org.cockpit_project.CockpitClient.*
-/tmp/
-/valgrind-suppressions
-/webpack-jumpstart.tar
-/wsinstance-start
 /package-lock.json
 /socket-activation-helper
 /stamp-h1
@@ -53,8 +49,12 @@ Makefile.in
 /test-*
 /test-*.log
 /test-*.trs
-/tmp-dist
 /test_rsa_key
+/tmp-dist
+/tmp/
+/valgrind-suppressions
+/webpack-jumpstart.tar
+/wsinstance-start
 
 # subdirs (/subdir/...)
 /doc/guide/version

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Makefile
 Makefile.in
 
 # toplevel (/...)
+/*.list
 /.flatpak-builder
 /aclocal.m4
 /bots
@@ -33,10 +34,9 @@ Makefile.in
 /cockpit-tls
 /cockpit-ws
 /cockpit-wsinstance-factory
-/config.h
-/config.h.in
-/config.log
-/config.status
+/cockpit.lang
+/cockpit.pp.bz2
+/config.*
 /configure
 /dist/
 /frob-websocket

--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -14,7 +14,7 @@ type cockpit_tmp_t;
 files_tmp_file(cockpit_tmp_t)
 
 type cockpit_tmpfs_t;
-userdom_user_tmpfs_file(cockpit_tmpfs_t)
+userdom_user_tmp_file(cockpit_tmpfs_t)
 
 type cockpit_var_run_t;
 files_pid_file(cockpit_var_run_t)

--- a/src/branding/arch/Makefile.am
+++ b/src/branding/arch/Makefile.am
@@ -7,6 +7,6 @@ archbranding_DATA = \
 EXTRA_DIST += $(archbranding_DATA)
 
 install-data-hook::
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico

--- a/src/branding/centos/Makefile.am
+++ b/src/branding/centos/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(centosbranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico

--- a/src/branding/debian/Makefile.am
+++ b/src/branding/debian/Makefile.am
@@ -8,5 +8,5 @@ EXTRA_DIST += $(debianbranding_DATA)
 
 # Opportunistically use debconf debian logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico

--- a/src/branding/fedora/Makefile.am
+++ b/src/branding/fedora/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(fedorabranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico

--- a/src/branding/opensuse/Makefile.am
+++ b/src/branding/opensuse/Makefile.am
@@ -7,6 +7,6 @@ opensusebranding_DATA = \
 EXTRA_DIST += $(opensusebranding_DATA)
 
 install-data-hook::
-	ln -sf /usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
-	ln -sf /usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
-	ln -sf /usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico

--- a/src/branding/rhel/Makefile.am
+++ b/src/branding/rhel/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(rhelbranding_DATA)
 
 # Opportunistically use redhat-logos ... yes they're called 'fedora'
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico

--- a/src/branding/scientific/Makefile.am
+++ b/src/branding/scientific/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST += $(scientificbranding_DATA)
 
 # Opportunistically use Scientific Linux logos. 
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
 

--- a/src/branding/ubuntu/Makefile.am
+++ b/src/branding/ubuntu/Makefile.am
@@ -9,4 +9,4 @@ EXTRA_DIST += $(ubuntubranding_DATA)
 
 # Opportunistically use plymouth ubuntu logo
 install-data-hook::
-	ln -sf /usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png

--- a/src/common/test-jsonfds.c
+++ b/src/common/test-jsonfds.c
@@ -767,7 +767,7 @@ test_unix_socket_simple (void)
 
   /* try multiple fds */
   send_fds (one, (gint []){ 0, 1, 2}, 3);
-  gint n_fds;
+  gint n_fds = 0; /* gcc is unhappy without this... */
   gint *fds = receive_fds (two, &n_fds, &error);
   g_assert_no_error (error);
   g_assert (fds != NULL);

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -23,9 +23,9 @@ dist_motd_SCRIPTS = src/systemd/update-motd
 # Automake: 'Variables using ... ‘sysconf’ ... are installed by install-exec.'
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/motd.d
-	ln -snf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
+	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
 	mkdir -p $(DESTDIR)$(sysconfdir)/issue.d
-	ln -snf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
+	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/systemd/cockpit-tempfiles.conf

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -629,13 +629,13 @@ class TestConnection(MachineCase):
                 m.execute("rpm --erase cockpit cockpit-ws")
 
         # upgrade from distro version (our images have cockpit-ws preinstalled) sets up dynamic motd/issue symlink
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
+        self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
 
         # package upgrade keeps them
         install()
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
+        self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
 
         # HACK: On Arch Linux the symlink is overwritten, bug?
         if m.image != "arch":
@@ -652,8 +652,9 @@ class TestConnection(MachineCase):
 
         # fresh install (most of our test images have cockpit-ws preinstalled, so the first test above does not cover that)
         install()
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        # verify that we installed relative links in the new package
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "../../run/cockpit/motd")
+        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "../../run/cockpit/motd")
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     def testCommandline(self):

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -174,7 +174,7 @@ exec 2>&1
     --disable-ssh \
 %endif
 
-make -j4 %{?extra_flags} all
+make -j$(nproc) %{?extra_flags} all
 
 %if 0%{?with_selinux}
     make -f /usr/share/selinux/devel/Makefile cockpit.pp

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -178,6 +178,7 @@ make -j$(nproc) %{?extra_flags} all
 
 %if 0%{?with_selinux}
     make -f /usr/share/selinux/devel/Makefile cockpit.pp
+    rm -f cockpit.pp.bz2
     bzip2 -9 cockpit.pp
 %endif
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -231,10 +231,10 @@ echo '%dir %{_datadir}/cockpit/ssh' >> base.list
 find %{buildroot}%{_datadir}/cockpit/ssh -type f >> base.list
 echo '%{_libexecdir}/cockpit-ssh' >> base.list
 
-echo '%dir %{_datadir}/cockpit/pcp' >> pcp.list
+echo '%dir %{_datadir}/cockpit/pcp' > pcp.list
 find %{buildroot}%{_datadir}/cockpit/pcp -type f >> pcp.list
 
-echo '%dir %{_datadir}/cockpit/tuned' >> system.list
+echo '%dir %{_datadir}/cockpit/tuned' > system.list
 find %{buildroot}%{_datadir}/cockpit/tuned -type f >> system.list
 
 echo '%dir %{_datadir}/cockpit/shell' >> system.list
@@ -249,7 +249,7 @@ find %{buildroot}%{_datadir}/cockpit/users -type f >> system.list
 echo '%dir %{_datadir}/cockpit/metrics' >> system.list
 find %{buildroot}%{_datadir}/cockpit/metrics -type f >> system.list
 
-echo '%dir %{_datadir}/cockpit/kdump' >> kdump.list
+echo '%dir %{_datadir}/cockpit/kdump' > kdump.list
 find %{buildroot}%{_datadir}/cockpit/kdump -type f >> kdump.list
 
 echo '%dir %{_datadir}/cockpit/sosreport' > sosreport.list
@@ -261,7 +261,7 @@ find %{buildroot}%{_datadir}/cockpit/storaged -type f >> storaged.list
 echo '%dir %{_datadir}/cockpit/networkmanager' > networkmanager.list
 find %{buildroot}%{_datadir}/cockpit/networkmanager -type f >> networkmanager.list
 
-echo '%dir %{_datadir}/cockpit/packagekit' >> packagekit.list
+echo '%dir %{_datadir}/cockpit/packagekit' > packagekit.list
 find %{buildroot}%{_datadir}/cockpit/packagekit -type f >> packagekit.list
 
 echo '%dir %{_datadir}/cockpit/apps' >> packagekit.list

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -534,8 +534,8 @@ fi
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
 if [ "$1" = 1 ]; then
     mkdir -p /etc/motd.d /etc/issue.d
-    ln -s /run/cockpit/motd /etc/motd.d/cockpit
-    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+    ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
+    ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
 fi
 
 %tmpfiles_create cockpit-tempfiles.conf

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -161,7 +161,6 @@ Recommends: subscription-manager-cockpit
 %setup -q -n cockpit-%{version}
 
 %build
-exec 2>&1
 %configure \
     --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -24,8 +24,8 @@ fi
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
 if [ "$1" = "configure" ] && [ -z "$2" ]; then
     mkdir -p /etc/motd.d /etc/issue.d
-    ln -s /run/cockpit/motd /etc/motd.d/cockpit
-    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+    ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
+    ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
 fi
 
 # check for deprecated PAM config

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -58,14 +58,14 @@ fi
 srpm="$($base/tools/make-srpm ${1-})"
 
 tmpdir=$(mktemp -d $PWD/rpm-build.XXXXXX)
-rpmbuild --rebuild $check $quiet \
+rpmbuild $check $quiet \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
     --define "_builddir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \
     --define "_rpmdir $tmpdir/output" \
     --define "_buildrootdir $tmpdir/build" \
-    $srpm
+    -rb $srpm
 
 find $tmpdir/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 rm -r $tmpdir

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -22,7 +22,7 @@ base=$(cd $(dirname $0)/../; pwd -P)
 
 usage()
 {
-	echo "usage: make-rpms [--quick] [--verbose] [tarball]"
+    echo "usage: make-rpms [--quick] [--verbose] [tarball]"
 }
 
 quiet="--quiet"
@@ -31,28 +31,28 @@ check=""
 args=$(getopt -o "h,q,v" -l "help,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
-	case $1 in
-	-v|--verbose)
-		quiet=""
-		;;
+    case $1 in
+    -v|--verbose)
+        quiet=""
+        ;;
     -q|--quick)
         check="--nocheck"
         ;;
-	-h|--help)
-		usage
-		exit 0
-		;;
-	--)
-		shift
-		break
-		;;
-	esac
-	shift
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
 done
 
 if [ $# -gt 1 ]; then
-	usage
-	exit 2
+    usage
+    exit 2
 fi
 
 srpm="$($base/tools/make-srpm ${1-})"

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -22,16 +22,20 @@ base=$(cd $(dirname $0)/../; pwd -P)
 
 usage()
 {
-    echo "usage: make-rpms [--quick] [--verbose] [tarball]"
+    echo "usage: make-rpms [--quick] [--verbose] [--build-in-place | tarball]"
 }
 
+build_in_place=""
 quiet="--quiet"
 check=""
 
-args=$(getopt -o "h,q,v" -l "help,quick,verbose" -- "$@")
+args=$(getopt -o "h,i,q,v" -l "help,build-in-place,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
     case $1 in
+    -i|--build-in-place)
+        build_in_place=1
+        ;;
     -v|--verbose)
         quiet=""
         ;;
@@ -50,22 +54,59 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [ $# -gt 1 ]; then
+if [ $# -gt 1 -o $# = 1 -a -n "${build_in_place}" ]; then
     usage
     exit 2
 fi
 
-srpm="$($base/tools/make-srpm ${1-})"
-
 tmpdir=$(mktemp -d $PWD/rpm-build.XXXXXX)
+
+if [ -n "${build_in_place}" ]; then
+    test -f "${base}/configure" || NOCONFIGURE=1 "${base}/autogen.sh"
+    version="$(sed -n "s/^PACKAGE_VERSION='\(.*\)'\$/\1/p" "${base}/configure")"
+    test -n "${version}"
+
+    spec="${tmpdir}/cockpit.spec"
+    sed "s/^Version:.*$/Version: ${version}/" "${base}/tools/cockpit.spec" > "${spec}"
+    "${base}/tools/gen-spec-dependencies" "${spec}"
+
+    # unfortunately, this can't contain newlines
+    ensure_configured='ensure_configured() { \
+        args_checksum="$(echo "$*" | sha256sum - | cut -c1-64)"; \
+        test -f Makefile -a config.checksum -nt Makefile && \
+            test "$(cat config.checksum)" = "${args_checksum}" && \
+                return; \
+        test -f Makefile && make distclean; \
+        ./configure "$@"; \
+        echo "${args_checksum}" > config.checksum; \
+    }; \
+    ensure_configured'
+
+    defines=(
+        --define "_build_in_place 1"
+        --define "_builddir $base"
+        # the gnuconfig hack doesn't apply to Cockpit and is broken with our configure tricks
+        --define "_configure_gnuconfig_hack 0"
+        --define "_configure ${ensure_configured}"
+        # add 'wip' to version number
+        --define "wip wip"
+    )
+    cmd="-bb ${spec}"
+else
+    defines=(
+        --define "_builddir $tmpdir"
+    )
+    srpm="$($base/tools/make-srpm ${1-})"
+    cmd="-rb ${srpm}"
+fi
+
 rpmbuild $check $quiet \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
-    --define "_builddir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \
     --define "_rpmdir $tmpdir/output" \
     --define "_buildrootdir $tmpdir/build" \
-    -rb $srpm
+    "${defines[@]}" ${cmd}
 
 find $tmpdir/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 rm -r $tmpdir

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -101,6 +101,7 @@ else
 fi
 
 rpmbuild $check $quiet \
+    --define "_topdir $tmpdir" \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \


### PR DESCRIPTION
This allows for incremental building of the binary `.rpm` packages, which takes ~4 seconds.

Include a bunch of RPM-packaging-related fixups.

 - [x] #16838 