### PR TITLE
test: Don't expect only one item on dashboard

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1140,7 +1140,7 @@ class TestGrafanaClient(MachineCase):
 
             # Switch to "Dashboards" tab, import "Host Overview"
             bg.click(".page-header__tabs a[href$='/dashboards']")
-            bg.click("table:contains('PCP Redis: Host Overview') button")
+            bg.click("tr:contains('PCP Redis: Host Overview') button")
 
             # .. and the dashboard name becomes clickable
             bg.click("a:contains('PCP Redis: Host Overview')")


### PR DESCRIPTION
This page consists of one `table` element with more `tr` elements, where
each has a button. Previous selector was not unique if there were more
than one item in the table.