### PR TITLE
image-prepare --build-in-place

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,10 +42,6 @@ Makefile.in
 /frob-websocket
 /mock-*
 /org.cockpit_project.CockpitClient.*
-/tmp/
-/valgrind-suppressions
-/webpack-jumpstart.tar
-/wsinstance-start
 /package-lock.json
 /socket-activation-helper
 /stamp-h1
@@ -53,8 +49,12 @@ Makefile.in
 /test-*
 /test-*.log
 /test-*.trs
-/tmp-dist
 /test_rsa_key
+/tmp-dist
+/tmp/
+/valgrind-suppressions
+/webpack-jumpstart.tar
+/wsinstance-start
 
 # subdirs (/subdir/...)
 /doc/guide/version

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Makefile
 Makefile.in
 
 # toplevel (/...)
+/*.list
 /.flatpak-builder
 /aclocal.m4
 /bots
@@ -33,10 +34,9 @@ Makefile.in
 /cockpit-tls
 /cockpit-ws
 /cockpit-wsinstance-factory
-/config.h
-/config.h.in
-/config.log
-/config.status
+/cockpit.lang
+/cockpit.pp.bz2
+/config.*
 /configure
 /dist/
 /frob-websocket

--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -14,7 +14,7 @@ type cockpit_tmp_t;
 files_tmp_file(cockpit_tmp_t)
 
 type cockpit_tmpfs_t;
-userdom_user_tmpfs_file(cockpit_tmpfs_t)
+userdom_user_tmp_file(cockpit_tmpfs_t)
 
 type cockpit_var_run_t;
 files_pid_file(cockpit_var_run_t)

--- a/src/branding/arch/Makefile.am
+++ b/src/branding/arch/Makefile.am
@@ -7,6 +7,6 @@ archbranding_DATA = \
 EXTRA_DIST += $(archbranding_DATA)
 
 install-data-hook::
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
-	ln -sf /usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico

--- a/src/branding/centos/Makefile.am
+++ b/src/branding/centos/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(centosbranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico

--- a/src/branding/debian/Makefile.am
+++ b/src/branding/debian/Makefile.am
@@ -8,5 +8,5 @@ EXTRA_DIST += $(debianbranding_DATA)
 
 # Opportunistically use debconf debian logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico

--- a/src/branding/fedora/Makefile.am
+++ b/src/branding/fedora/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(fedorabranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico

--- a/src/branding/opensuse/Makefile.am
+++ b/src/branding/opensuse/Makefile.am
@@ -7,6 +7,6 @@ opensusebranding_DATA = \
 EXTRA_DIST += $(opensusebranding_DATA)
 
 install-data-hook::
-	ln -sf /usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
-	ln -sf /usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
-	ln -sf /usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico

--- a/src/branding/rhel/Makefile.am
+++ b/src/branding/rhel/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(rhelbranding_DATA)
 
 # Opportunistically use redhat-logos ... yes they're called 'fedora'
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico

--- a/src/branding/scientific/Makefile.am
+++ b/src/branding/scientific/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST += $(scientificbranding_DATA)
 
 # Opportunistically use Scientific Linux logos. 
 install-data-hook::
-	ln -sf /usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
-	ln -sf /usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
-	ln -sf /etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
 

--- a/src/branding/ubuntu/Makefile.am
+++ b/src/branding/ubuntu/Makefile.am
@@ -9,4 +9,4 @@ EXTRA_DIST += $(ubuntubranding_DATA)
 
 # Opportunistically use plymouth ubuntu logo
 install-data-hook::
-	ln -sf /usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png

--- a/src/common/test-jsonfds.c
+++ b/src/common/test-jsonfds.c
@@ -767,7 +767,7 @@ test_unix_socket_simple (void)
 
   /* try multiple fds */
   send_fds (one, (gint []){ 0, 1, 2}, 3);
-  gint n_fds;
+  gint n_fds = 0; /* gcc is unhappy without this... */
   gint *fds = receive_fds (two, &n_fds, &error);
   g_assert_no_error (error);
   g_assert (fds != NULL);

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -23,9 +23,9 @@ dist_motd_SCRIPTS = src/systemd/update-motd
 # Automake: 'Variables using ... ‘sysconf’ ... are installed by install-exec.'
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/motd.d
-	ln -snf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
+	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
 	mkdir -p $(DESTDIR)$(sysconfdir)/issue.d
-	ln -snf /run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
+	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/systemd/cockpit-tempfiles.conf

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -45,6 +45,7 @@ def main():
     parser.add_argument('-b', '--build-image', action='store', help='Build in this image')
     parser.add_argument('-B', '--build-only', action='store_true', help='Only build and download results')
     parser.add_argument('-I', '--install-only', action='store_true', help='Only upload and install')
+    parser.add_argument('-i', '--build-in-place', action='store_true', help='Build in the current working directory (experimental, rpm-only)')
     parser.add_argument('-c', '--containers', action='store_true', help='Install container images')
     parser.add_argument('--address', help='Address of already running machine, implies --install-only')
     parser.add_argument('image', nargs='?', default=testvm.DEFAULT_IMAGE, help='The image to use')
@@ -61,7 +62,7 @@ def main():
 
     # The image we're going to build in. This image is never written to
     build_image = None
-    if not args.install_only and not args.incremental:
+    if not args.install_only and not args.build_in_place:
         build_image = testvm.get_build_image(args.build_image or base_image)
 
     if args.install_only and args.build_only:
@@ -87,7 +88,9 @@ def main():
         return 1
 
     try:
-        if not args.install_only:
+        if args.build_in_place:
+            build_in_place(results, args)
+        elif not args.install_only:
             build_and_install(build_image, results, skips, args)
 
         if args.address:
@@ -99,6 +102,15 @@ def main():
         return 2
 
     return 0
+
+
+def build_in_place(results, args):
+    cmd = [f'{BASE_DIR}/tools/make-rpms', '--build-in-place']
+    if args.quick:
+        cmd.append('--quick')
+    if args.verbose:
+        cmd.append('--verbose')
+    subprocess.check_call(cmd, cwd=results, stdout=subprocess.DEVNULL)
 
 
 def upload_scripts(machine, args):

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -52,16 +52,16 @@ def main():
     # The basic operating system we're preparing on top of. Never written to
     base_image = args.image
 
-    # The image we're going to build in. This image is never written to
-    build_image = None
-    if not args.install_only:
-        build_image = testvm.get_build_image(args.build_image or base_image)
-
     # Depending on the operating system ignore some things
     skips = []
     if args.address:
         skips.append("cockpit-tests")
         args.install_only = True
+
+    # The image we're going to build in. This image is never written to
+    build_image = None
+    if not args.install_only and not args.incremental:
+        build_image = testvm.get_build_image(args.build_image or base_image)
 
     if args.install_only and args.build_only:
         sys.stderr.write("image-prepare: use of --install-only with --build-only is incompatible\n")
@@ -86,8 +86,11 @@ def main():
     try:
         if not args.install_only:
             build_and_install(build_image, results, skips, args)
-        if not args.build_only and build_image != base_image:
-            only_install(base_image, results, skips, args)
+
+        if args.address:
+            install_into_existing(base_image, results, skips, args)
+        elif not args.build_only and build_image != base_image:
+            create_and_install(base_image, results, skips, args)
     except (RuntimeError, testvm.Failure) as ex:
         sys.stderr.write("image-prepare: {0}\n".format(str(ex)))
         return 2
@@ -188,32 +191,37 @@ def build_and_install(build_image, build_results, skips, args):
             machine.stop()
 
 
-def only_install(image, build_results, skips, args):
-    """Install Cockpit into a test image"""
-    started = False
-    if args.address:
-        machine = testvm.Machine(address=args.address, verbose=args.verbose, image=image)
-    else:
-        target, overlay = prepare_install_image(image, args.overlay)
-        machine = testvm.VirtMachine(verbose=args.verbose, image=(overlay or target), networking=networking, maintain=True)
-        machine.start()
-        started = True
-    completed = False
+def do_install(machine, build_results, skips, args):
     try:
-        if started:
-            machine.wait_boot()
         upload_scripts(machine, args=args)
         machine.execute("rm -rf /var/tmp/build-results")
         machine.upload([build_results], "/var/tmp/build-results")
         run_install_script(machine, False, True, skips, None, args)
-        finalize_image(target, overlay)
-        completed = True
-    finally:
-        if not completed and args.sit:
+    except Exception:
+        if args.sit:
             sys.stderr.write(machine.diagnose())
             input("Press RET to continue... ")
-        if started:
-            machine.stop()
+        raise
+
+
+def install_into_existing(image, build_results, skips, args):
+    """Install Cockpit into an already-running VM"""
+    machine = testvm.Machine(address=args.address, verbose=args.verbose, image=image)
+    do_install(machine, build_results, skips, args)
+
+
+def create_and_install(image, build_results, skips, args):
+    """Create a new test image, with Cockpit installed"""
+    target, overlay = prepare_install_image(image, args.overlay)
+    machine = testvm.VirtMachine(verbose=args.verbose, image=(overlay or target), networking=networking, maintain=True)
+    try:
+        machine.start()
+        machine.wait_boot()
+        do_install(machine, build_results, skips, args)
+    finally:
+        machine.stop()
+
+    finalize_image(target, overlay)
 
 
 if __name__ == "__main__":

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -19,8 +19,9 @@
 import argparse
 import errno
 import os
-import sys
+import shutil
 import subprocess
+import sys
 
 import make_dist
 
@@ -68,6 +69,8 @@ def main():
         return 2
 
     results = os.path.abspath("tmp/build-results")
+    shutil.rmtree(results, ignore_errors=True)
+    os.makedirs(results)  # throws if rm failed
 
     # Make sure any images are downloaded
     try:
@@ -183,9 +186,6 @@ def build_and_install(build_image, build_results, skips, args):
             sys.stderr.write(machine.diagnose())
             input("Press RET to continue... ")
         try:
-            if os.path.exists(build_results):
-                subprocess.check_call(["rm", "-rf", build_results])
-            os.makedirs(build_results)
             machine.download("/var/tmp/build-results/*", build_results)
         finally:
             machine.stop()

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -629,13 +629,13 @@ class TestConnection(MachineCase):
                 m.execute("rpm --erase cockpit cockpit-ws")
 
         # upgrade from distro version (our images have cockpit-ws preinstalled) sets up dynamic motd/issue symlink
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
+        self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
 
         # package upgrade keeps them
         install()
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
+        self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
 
         # HACK: On Arch Linux the symlink is overwritten, bug?
         if m.image != "arch":
@@ -652,8 +652,12 @@ class TestConnection(MachineCase):
 
         # fresh install (most of our test images have cockpit-ws preinstalled, so the first test above does not cover that)
         install()
-        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "/run/cockpit/motd")
-        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "/run/cockpit/motd")
+        self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
+        self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
+
+        # verify that we installed relative links in the new package
+        self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "../../run/cockpit/motd")
+        self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "../../run/cockpit/motd")
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     def testCommandline(self):

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -174,7 +174,7 @@ exec 2>&1
     --disable-ssh \
 %endif
 
-make -j4 %{?extra_flags} all
+make -j$(nproc) %{?extra_flags} all
 
 %if 0%{?with_selinux}
     make -f /usr/share/selinux/devel/Makefile cockpit.pp

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -178,6 +178,7 @@ make -j$(nproc) %{?extra_flags} all
 
 %if 0%{?with_selinux}
     make -f /usr/share/selinux/devel/Makefile cockpit.pp
+    rm -f cockpit.pp.bz2
     bzip2 -9 cockpit.pp
 %endif
 

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -231,10 +231,10 @@ echo '%dir %{_datadir}/cockpit/ssh' >> base.list
 find %{buildroot}%{_datadir}/cockpit/ssh -type f >> base.list
 echo '%{_libexecdir}/cockpit-ssh' >> base.list
 
-echo '%dir %{_datadir}/cockpit/pcp' >> pcp.list
+echo '%dir %{_datadir}/cockpit/pcp' > pcp.list
 find %{buildroot}%{_datadir}/cockpit/pcp -type f >> pcp.list
 
-echo '%dir %{_datadir}/cockpit/tuned' >> system.list
+echo '%dir %{_datadir}/cockpit/tuned' > system.list
 find %{buildroot}%{_datadir}/cockpit/tuned -type f >> system.list
 
 echo '%dir %{_datadir}/cockpit/shell' >> system.list
@@ -249,7 +249,7 @@ find %{buildroot}%{_datadir}/cockpit/users -type f >> system.list
 echo '%dir %{_datadir}/cockpit/metrics' >> system.list
 find %{buildroot}%{_datadir}/cockpit/metrics -type f >> system.list
 
-echo '%dir %{_datadir}/cockpit/kdump' >> kdump.list
+echo '%dir %{_datadir}/cockpit/kdump' > kdump.list
 find %{buildroot}%{_datadir}/cockpit/kdump -type f >> kdump.list
 
 echo '%dir %{_datadir}/cockpit/sosreport' > sosreport.list
@@ -261,7 +261,7 @@ find %{buildroot}%{_datadir}/cockpit/storaged -type f >> storaged.list
 echo '%dir %{_datadir}/cockpit/networkmanager' > networkmanager.list
 find %{buildroot}%{_datadir}/cockpit/networkmanager -type f >> networkmanager.list
 
-echo '%dir %{_datadir}/cockpit/packagekit' >> packagekit.list
+echo '%dir %{_datadir}/cockpit/packagekit' > packagekit.list
 find %{buildroot}%{_datadir}/cockpit/packagekit -type f >> packagekit.list
 
 echo '%dir %{_datadir}/cockpit/apps' >> packagekit.list

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -534,8 +534,8 @@ fi
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
 if [ "$1" = 1 ]; then
     mkdir -p /etc/motd.d /etc/issue.d
-    ln -s /run/cockpit/motd /etc/motd.d/cockpit
-    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+    ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
+    ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
 fi
 
 %tmpfiles_create cockpit-tempfiles.conf

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -161,7 +161,6 @@ Recommends: subscription-manager-cockpit
 %setup -q -n cockpit-%{version}
 
 %build
-exec 2>&1
 %configure \
     --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -24,8 +24,8 @@ fi
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
 if [ "$1" = "configure" ] && [ -z "$2" ]; then
     mkdir -p /etc/motd.d /etc/issue.d
-    ln -s /run/cockpit/motd /etc/motd.d/cockpit
-    ln -s /run/cockpit/motd /etc/issue.d/cockpit.issue
+    ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
+    ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
 fi
 
 # check for deprecated PAM config

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -58,14 +58,14 @@ fi
 srpm="$($base/tools/make-srpm ${1-})"
 
 tmpdir=$(mktemp -d $PWD/rpm-build.XXXXXX)
-rpmbuild --rebuild $check $quiet \
+rpmbuild $check $quiet \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
     --define "_builddir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \
     --define "_rpmdir $tmpdir/output" \
     --define "_buildrootdir $tmpdir/build" \
-    $srpm
+    -rb $srpm
 
 find $tmpdir/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 rm -r $tmpdir

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -22,7 +22,7 @@ base=$(cd $(dirname $0)/../; pwd -P)
 
 usage()
 {
-	echo "usage: make-rpms [--quick] [--verbose] [tarball]"
+    echo "usage: make-rpms [--quick] [--verbose] [tarball]"
 }
 
 quiet="--quiet"
@@ -31,28 +31,28 @@ check=""
 args=$(getopt -o "h,q,v" -l "help,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
-	case $1 in
-	-v|--verbose)
-		quiet=""
-		;;
+    case $1 in
+    -v|--verbose)
+        quiet=""
+        ;;
     -q|--quick)
         check="--nocheck"
         ;;
-	-h|--help)
-		usage
-		exit 0
-		;;
-	--)
-		shift
-		break
-		;;
-	esac
-	shift
+    -h|--help)
+        usage
+        exit 0
+        ;;
+    --)
+        shift
+        break
+        ;;
+    esac
+    shift
 done
 
 if [ $# -gt 1 ]; then
-	usage
-	exit 2
+    usage
+    exit 2
 fi
 
 srpm="$($base/tools/make-srpm ${1-})"

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -22,16 +22,20 @@ base=$(cd $(dirname $0)/../; pwd -P)
 
 usage()
 {
-    echo "usage: make-rpms [--quick] [--verbose] [tarball]"
+    echo "usage: make-rpms [--quick] [--verbose] [--build-in-place | tarball]"
 }
 
+build_in_place=""
 quiet="--quiet"
 check=""
 
-args=$(getopt -o "h,q,v" -l "help,quick,verbose" -- "$@")
+args=$(getopt -o "h,i,q,v" -l "help,build-in-place,quick,verbose" -- "$@")
 eval set -- "$args"
 while [ $# -gt 0 ]; do
     case $1 in
+    -i|--build-in-place)
+        build_in_place=1
+        ;;
     -v|--verbose)
         quiet=""
         ;;
@@ -50,22 +54,59 @@ while [ $# -gt 0 ]; do
     shift
 done
 
-if [ $# -gt 1 ]; then
+if [ $# -gt 1 -o $# = 1 -a -n "${build_in_place}" ]; then
     usage
     exit 2
 fi
 
-srpm="$($base/tools/make-srpm ${1-})"
-
 tmpdir=$(mktemp -d $PWD/rpm-build.XXXXXX)
+
+if [ -n "${build_in_place}" ]; then
+    test -f "${base}/configure" || NOCONFIGURE=1 "${base}/autogen.sh"
+    version="$(sed -n "s/^PACKAGE_VERSION='\(.*\)'\$/\1/p" "${base}/configure")"
+    test -n "${version}"
+
+    spec="${tmpdir}/cockpit.spec"
+    sed "s/^Version:.*$/Version: ${version}/" "${base}/tools/cockpit.spec" > "${spec}"
+    "${base}/tools/gen-spec-dependencies" "${spec}"
+
+    # unfortunately, this can't contain newlines
+    ensure_configured='ensure_configured() { \
+        args_checksum="$(echo "$*" | sha256sum - | cut -c1-64)"; \
+        test -f Makefile -a config.checksum -nt Makefile && \
+            test "$(cat config.checksum)" = "${args_checksum}" && \
+                return; \
+        test -f Makefile && make distclean; \
+        ./configure "$@"; \
+        echo "${args_checksum}" > config.checksum; \
+    }; \
+    ensure_configured'
+
+    defines=(
+        --define "_build_in_place 1"
+        --define "_builddir $base"
+        # the gnuconfig hack doesn't apply to Cockpit and is broken with our configure tricks
+        --define "_configure_gnuconfig_hack 0"
+        --define "_configure ${ensure_configured}"
+        # add 'wip' to version number
+        --define "wip wip"
+    )
+    cmd="-bb ${spec}"
+else
+    defines=(
+        --define "_builddir $tmpdir"
+    )
+    srpm="$($base/tools/make-srpm ${1-})"
+    cmd="-rb ${srpm}"
+fi
+
 rpmbuild $check $quiet \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
-    --define "_builddir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \
     --define "_rpmdir $tmpdir/output" \
     --define "_buildrootdir $tmpdir/build" \
-    -rb $srpm
+    "${defines[@]}" ${cmd}
 
 find $tmpdir/output -name '*.rpm' -printf '%f\n' -exec mv {} . \;
 rm -r $tmpdir

--- a/tools/make-rpms
+++ b/tools/make-rpms
@@ -101,6 +101,7 @@ else
 fi
 
 rpmbuild $check $quiet \
+    --define "_topdir $tmpdir" \
     --define "_sourcedir $tmpdir" \
     --define "_specdir $tmpdir" \
     --define "_srcrpmdir $tmpdir" \


### PR DESCRIPTION
Add a `--build-in-place` option to `image-prepare`.

Uses the `--build-in-place` option of `tools/make-rpms` added in #16839.

 - [ ] #16839 