### PR TITLE
.gitignore: ignore *.log and *.trs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@
 .deps/
 Makefile
 Makefile.in
+test-*.log
+test-*.trs
 
 # toplevel (/...)
 /.flatpak-builder


### PR DESCRIPTION
These are generated by `make check`.