### PR TITLE
tools: add tool to create compile_commands.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ Makefile.in
 /cockpit.pp.bz2
 /cockpit.spec
 /config.*
+/compile_commands.json
 /configure
 /dist/
 /frob-websocket

--- a/Makefile.am
+++ b/Makefile.am
@@ -128,6 +128,11 @@ rsync:
 	$(MAKE) install DESTDIR=tmp/rsync >/dev/null
 	rsync --recursive --links --checksum --verbose --inplace tmp/rsync/ $(RSYNC_DEST)
 
+CLEANFILES += compile_commands.json
+noinst_DATA += compile_commands.json
+compile_commands.json: Makefile
+	$(AM_V_GEN) $(srcdir)/tools/make-compile-commands
+
 
 # We use these to add conditionally-enabled extra rules
 # automake doesn't like mixing `::` and `if`

--- a/tools/make-compile-commands
+++ b/tools/make-compile-commands
@@ -1,0 +1,59 @@
+#!/usr/bin/python3
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import tempfile
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output', '-o', default='compile_commands.json',
+                    help='The output file [default: compile_commands.json]')
+args = parser.parse_args()
+
+directory = os.getcwd()
+
+with tempfile.NamedTemporaryFile() as makefile_copy:
+    # rebuilding the makefile is an exception to --dry-run, and we don't want
+    # to run the whole configure machinery, so copy the Makefile to a temporary
+    # path to short-circuit the exception.
+    with open('Makefile', 'rb') as original_makefile:
+        makefile_copy.write(original_makefile.read())
+
+    # get the build commands
+    output = subprocess.check_output(['make',
+                                      '-f', makefile_copy.name,
+                                      'MAKE=false',   # block recursive make
+                                      'V=1',          # simplify the output
+                                      '--always-make', '--dry-run', 'all-am'],
+                                     universal_newlines=True)
+
+# This assumes a very specific output format.  We can change it or add more in
+# the future, if necessary.
+cc_pattern = re.compile(r'([a-z]+) (.*?) -o ([^ ]*) (`test .[^`]*`)?([^ ]+\.c)')
+
+result = []
+for line in output.splitlines():
+    match = cc_pattern.fullmatch(line)
+    if not match:
+        continue
+
+    cc = match.group(1)
+    flags = shlex.split(match.group(2))
+    output = match.group(3)
+    # match group 4 is the `test ...` VPATH stuff (discard it)
+    source = match.group(5)
+
+    result.append({
+        'directory': directory,
+        'output': output,
+        'file': source,
+        'arguments': ['cc', *flags, '-o', output, source]
+    })
+
+result.sort(key=lambda d: (d['file'], d['output']))
+
+with open(args.output, 'w+') as output_file:
+    json.dump(result, output_file, sort_keys=True, indent=4)


### PR DESCRIPTION
Add a new script, tools/make-compile-commands, which can generate the
compile_commands.json script used by many static analysis tools.