### PR TITLE
pkg/lib: add required property rowIndex

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -156,7 +156,7 @@ export const ListingTable = ({
                     {isExpandable
                         ? (row.expandedContent
                             ? <Td expand={{
-                                rowKey,
+                                rowIndex: rowKey,
                                 isExpanded,
                                 onToggle: () => {
                                     if (afterToggle)


### PR DESCRIPTION
The TdExpandType requires a rowIndex to be provided as property.