### PR TITLE
test: sudo and socketpair() now work properly on fedora-35

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -493,7 +493,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = ["fedora-34", "fedora-testing"]
+        working_images = ["fedora-34", "fedora-35", "fedora-testing"]
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:


### PR DESCRIPTION
The fix made it to Fedora 35 stable as well. Similar to what commit
d9eda6d263 did for Fedora 34.

---

Blocks and needs to land in lockstep with a fedora-35 image refresh that includes [selinux-policy-35.11-1.fc35 ](https://bodhi.fedoraproject.org/updates/FEDORA-2022-87a0b7e8d0): https://github.com/cockpit-project/bots/pull/2839

This has caused [f35 packit failures](http://artifacts.dev.testing-farm.io/6ef24b96-630c-4044-b24a-d4509c34b4f4/) a few days ago when the new SELinux landed. This PR should make them green again.