### PR TITLE
test: Add known journal message to logouts

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -650,6 +650,9 @@ class Browser:
                 self.click('#logout')
         self.expect_load()
 
+        # Log out can cause race with polkit request
+        self.allow_journal_messages(".*couldn't create polkit session subject: No session for pid.*")
+
     def relogin(self, path=None, user=None, superuser=None, wait_remote_session_machine=None):
         self.logout()
         if wait_remote_session_machine:


### PR DESCRIPTION
Right now we have this pattern in `allow_restart_journal_messages` but
it is documented in `src/bridge/cockpitpolkitagent.c` as:
```
This can happen if there's a race between the polkit request and closing of
Cockpit. So it's not unheard of. We can complain, but not too loudly.
```

Logout causes closing of Cockpit as well.

As seen [here (twice)](https://logs.cockpit-project.org/logs/pull-2825-20220119-022917-6b8f29bd-rhel-8-5-cockpit-project-cockpit/log.html#128)