### PR TITLE
debian/control: pin pages to the same bridge version

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -78,7 +78,7 @@ Package: cockpit-networkmanager
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          network-manager (>= 1.6)
 Description: Cockpit user interface for networking
  The Cockpit components for interacting with networking configuration.
@@ -87,7 +87,7 @@ Package: cockpit-pcp
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          pcp
 Description: Cockpit PCP integration
  Cockpit support for reading PCP metrics and loading PCP archives.
@@ -96,7 +96,7 @@ Package: cockpit-packagekit
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          packagekit
 Description: Cockpit user interface for packages
  The Cockpit component for installing packages, via PackageKit.
@@ -107,7 +107,7 @@ Multi-Arch: foreign
 Depends: ${misc:Depends},
          udisks2 (>= 2.7),
          libblockdev-mdraid2,
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          python3,
          python3-dbus
 Description: Cockpit user interface for storage
@@ -117,7 +117,7 @@ Package: cockpit-system
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          libpwquality-tools,
          openssl,
 Recommends: sudo | policykit-1
@@ -167,7 +167,7 @@ Package: cockpit-sosreport
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         cockpit-bridge (>= ${bridge:minversion}),
+         cockpit-bridge (>= ${source:Version}),
          sosreport
 Description: Cockpit user interface for diagnostic reports
  The Cockpit component for creating diagnostic reports with the

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -59,13 +59,6 @@ Depends: ${misc:Depends},
          glib-networking
 Provides: cockpit-ssh
 Breaks: cockpit-ws (<< 181.x),
-# 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)
- cockpit-dashboard (<< 233),
- cockpit-networkmanager (<< 233),
- cockpit-storaged (<< 233),
- cockpit-system (<< 233),
- cockpit-tests (<< 233),
- cockpit-docker (<< 233),
 Replaces: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)
 Description: Cockpit bridge server-side component
  The Cockpit bridge component installed server side and runs commands on

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -50,6 +50,3 @@ endif
 
 	dh_install --fail-missing -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
-
-override_dh_gencontrol:
-	dh_gencontrol -- -Vbridge:minversion="$(shell tools/min-base-version)"


### PR DESCRIPTION
At Debian package build time, we run a Python script which scans all of our manifest.json files and returns a single number representing the highest version of the bridge that any of the packages depends on, and then we add this as a dependency for all of the pages packages.                                       

It's a bit arbitrary that we take the highest version and apply it as a dependency for every single pages package, when we could scan the individual manifest for the page in question and generate the dependency more precisely.
                                                                           
On the other hand, however, we gain very little value from any of this: the new versions of the binary packages are all released at the same time.                                                  
                                                                       
Let's drop this and just pin the pages to the same cockpit-bridge version.  This also lets us drop our `override_dh_gencontrol:` rule from debian/rules.                                           
