### PR TITLE
[r8.5] test: sudo with cert auth now works on RHEL 8.6/C8S

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -720,7 +720,7 @@ ipa-advise enable-admins-sudo | sh -ex
         # now sudo works with the delegated ticket
         # this requires https://github.com/sudo-project/sudo/commit/3b7977a42c0 (see https://bugzilla.redhat.com/show_bug.cgi?id=1917379)
         # to actually work, so on older distros it fails
-        supports_sudo_krb = m.image not in ["rhel-8-5", "centos-8-stream", "debian-stable", "ubuntu-2004", "ubuntu-stable"]
+        supports_sudo_krb = m.image not in ["rhel-8-5", "ubuntu-2004"]
         b.click("#super-user-indicator button")
 
         if supports_sudo_krb:

--- a/test/verify/check-system-s4u
+++ b/test/verify/check-system-s4u
@@ -26,7 +26,7 @@ from testlib import *
 @skipImage("freeipa not currently in testing", "debian-testing", "ubuntu-2004")
 @skipImage("Skip these for now, unsure what's broken", "ubuntu-stable", "debian-stable")
 @skipDistroPackage()
-@skipImage("Needs sssd >=2.4.1", "rhel-8-4", "rhel-8-5", "centos-8-stream")
+@skipImage("Needs sssd >=2.4.1", "rhel-8-4", "rhel-8-5")
 class TestS4USsh(MachineCase):
     provision = {
         "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},


### PR DESCRIPTION
The sudo fix made it into RHEL 8.6 nightly and CentOS 8 Stream. Adjust
the test special case accordingly.

Cherry-picked from main commit fd9e6a09fd20c.

----

Should fix [this failure](https://logs.cockpit-project.org/logs/pull-16849-20220119-090844-ce19f66c-centos-8-stream/log.html#170-2) which I ignored in #16849.