### PR TITLE
git-hook-post-commit: deal with deleted files

### DIFF
--- a/test/git-hook-post-commit
+++ b/test/git-hook-post-commit
@@ -9,7 +9,7 @@ tmpdir="tmp/pre-push/${commit}"
 rm -rf "tmp/pre-push/${commit}"
 
 # unpack all of the changed files, plus the test/static-code from that commit
-files="$(git show --format='' --name-only "${commit}" --) test/static-code"
+files="$(git diff-tree --no-commit-id --no-renames --diff-filter=d --name-only -r "${commit}" --) test/static-code"
 git archive --prefix="${tmpdir}/" "${commit}" -- ${files} | tar x
 
 # check that node_modules always gets updated with package.json


### PR DESCRIPTION
Deleting files will currently fail the post-commit hook (and therefore
the pre-push hook) with a message like

  fatal: pathspec 'tools/gen-spec-dependencies' did not match any files
  tar: This does not look like a tar archive
  tar: Exiting with failure status due to previous errors
   - 3f6fecd00 build: produce static cockpit.spec for release

This is caused by the fact that the filename shows up in the list of
changed files, but can't be extracted from the commit via git-archive,
because it doesn't exist anymore.

Replace our use of git-show with git-diff-tree, which is a better fit
anyway).  It also has a very nice feature to filter certain types of
events (eg. --diff-filter=d for deletes).