### PR TITLE
lib: cockpit-po-plugin: add support for file prefixes in pattern creation

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -11,6 +11,7 @@ module.exports = class {
     constructor(options) {
         if (!options)
             options = {};
+        this.filenamePrefixPattern = options.filenamePrefixPattern || '';
         this.subdir = options.subdir || '';
         this.reference_patterns = options.reference_patterns;
         this.wrapper = options.wrapper || 'cockpit.locale(PO_DATA);';
@@ -80,7 +81,7 @@ module.exports = class {
 
         Array.prototype.push.apply(patterns, extras);
 
-        return patterns.map((p) => new RegExp(`^${p}:[0-9]+$`));
+        return patterns.map((p) => new RegExp(`^${this.filenamePrefixPattern}${p}:[0-9]+$`));
     }
 
     check_reference_patterns(patterns, references) {


### PR DESCRIPTION
This is necessary in the case that translations are not generated in the same directory
where webpack lives.

This happens in the new anaconda webui cockpit based plugin.

See more https://github.com/rhinstaller/anaconda/pull/3785