### PR TITLE
systemd: Implement crypto policies support

### DIFF
--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -55,11 +55,6 @@ import { PrivilegedButton } from "cockpit-components-privileged.jsx";
 const _ = cockpit.gettext;
 
 class SystemInfo extends React.Component {
-    constructor(props) {
-        super(props);
-        this.permission = cockpit.permission({ admin: true });
-    }
-
     render() {
         const info = this.props.info;
         if ((!info.name || !info.version) && info.alt_name && info.alt_version) {
@@ -71,7 +66,7 @@ class SystemInfo extends React.Component {
         const mitigations = (
             <PrivilegedButton variant="link" buttonId="cpu_mitigations" tooltipId="tip-cpu-security"
                         excuse={ _("The user $0 is not permitted to change cpu security mitigations") }
-                        permission={ this.permission } onClick={ onSecurityClick }>
+                        onClick={ onSecurityClick }>
                 { _("Mitigations") }
             </PrivilegedButton>
         );

--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -30,6 +30,7 @@ import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { ServerTimeConfig } from 'serverTime.js';
 import { RealmdClient, RealmButton } from "./realmd.jsx";
 import { TunedPerformanceProfile } from '../../tuned/dialog.jsx';
+import { CryptoPolicyRow } from './cryptoPolicies.jsx';
 
 import "./configurationCard.scss";
 
@@ -82,6 +83,8 @@ export const ConfigurationCard = ({ hostname }) => {
                                 <th scope="row">{_("Performance profile")}</th>
                                 <td><TunedPerformanceProfile /></td>
                             </tr>
+
+                            <CryptoPolicyRow />
 
                             <tr>
                                 <th scope="row">{_("Secure shell keys")}</th>

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -1,0 +1,210 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from "cockpit";
+import React, { useState, useEffect } from 'react';
+import { Button, Flex, Modal, Popover } from "@patternfly/react-core";
+import { ExternalLinkSquareAltIcon, HelpIcon, InProgressIcon } from '@patternfly/react-icons';
+
+import { ModalError } from 'cockpit-components-inline-notification.jsx';
+import { ShutdownModal } from 'cockpit-components-shutdown.jsx';
+import { PrivilegedButton } from "cockpit-components-privileged.jsx";
+import { TunedDialogBody } from '../../../pkg/tuned/change-profile.jsx';
+
+import "./cryptoPolicies.scss";
+
+const _ = cockpit.gettext;
+
+// Found in /usr/share/crypto-policies/policies/
+const cryptopolicies = {
+    DEFAULT: _("Recommended, secure settings for current threat models."),
+    FUTURE: _("Protects from anticipated near-term future attacks at the expense of interoperability."),
+    LEGACY: _("Higher interoperability at the cost of an increased attack surface."),
+};
+const applyNeedRebootStamp = "/run/cockpit/crypto-policies-reboot-stamp";
+const displayProfileText = profile => profile.charAt(0) + profile.slice(1, profile.length).toLowerCase();
+
+export const CryptoPolicyRow = () => {
+    const [currentCryptoPolicy, setCurrentCryptoPolicy] = useState(null);
+    const [isOpen, setIsOpen] = useState(false);
+
+    useEffect(() => {
+        // Avoid cockpit.spawn every re-render from parent
+        if (currentCryptoPolicy === null) {
+            cockpit.spawn(["update-crypto-policies", "--show"], { err: "message" })
+                    .then(output => setCurrentCryptoPolicy(output.trim()))
+                    .catch(err => {
+                        console.debug("no crypto policies support: ", err.toString());
+                        setCurrentCryptoPolicy(undefined);
+                    });
+            // When users run `update-crypto-policies` manually.
+            cockpit.file("/etc/crypto-policies/state/current")
+                    .watch(content => setCurrentCryptoPolicy(content ? content.trim() : null));
+        }
+    }, [currentCryptoPolicy]);
+
+    if (!currentCryptoPolicy) {
+        return null;
+    }
+
+    return (
+        <tr>
+            <th scope="row">{_("Crypto policy")}</th>
+            <td>
+                <PrivilegedButton variant="link" buttonId="crypto-policy-button" tooltipId="tip-crypto-policy"
+                                  excuse={ _("The user $0 is not permitted to change crypto policies") }
+                                  onClick={() => setIsOpen(true)}>
+                    {displayProfileText(currentCryptoPolicy)}
+                </PrivilegedButton>
+                {isOpen &&
+                <CryptoPolicyDialog close={() => setIsOpen(false)}
+                                    currentCryptoPolicy={currentCryptoPolicy}
+                                    setCurrentCryptoPolicy={setCurrentCryptoPolicy}
+                />
+                }
+            </td>
+        </tr>
+    );
+};
+
+const CryptoPolicyDialog = ({
+    close,
+    currentCryptoPolicy,
+    setCurrentCryptoPolicy,
+}) => {
+    const [error, setError] = useState();
+    const [selected, setSelected] = useState(currentCryptoPolicy);
+
+    const setPolicy = (reboot) => {
+        cockpit.spawn(["update-crypto-policies", "--set", selected], { superuser: "require", err: "message" })
+                .then(() => {
+                    setCurrentCryptoPolicy(selected);
+                    if (reboot) {
+                        cockpit.spawn(["shutdown", "--reboot", "now"], { superuser: "require", err: "message" })
+                                .catch(error => setError(error));
+                    } else {
+                        cockpit.file(applyNeedRebootStamp, { superuser: "require" }).replace("\n")
+                                .then(() => close());
+                    }
+                })
+                .catch(error => setError(error));
+    };
+
+    const policies = Object.keys(cryptopolicies).map(policy => ({
+        name: policy,
+        title: displayProfileText(policy),
+        description: cryptopolicies[policy],
+        active: policy === currentCryptoPolicy,
+        recommended: false,
+    }));
+
+    // Custom profile
+    if (!(currentCryptoPolicy in cryptopolicies)) {
+        policies.push({
+            name: currentCryptoPolicy,
+            title: displayProfileText(currentCryptoPolicy),
+            description: _("Custom crypto policy"),
+            active: true,
+            recommended: false,
+        });
+    }
+
+    const help = (
+        <Popover
+            id="crypto-policies-help"
+            bodyContent={
+                <div>
+                    {_("Crypto Policies is a system component that configures the core cryptographic subsystems, covering the TLS, IPSec, SSH, DNSSec, and Kerberos protocols.")}
+                </div>
+            }
+            footerContent={
+                <Button component='a'
+                        rel="noopener noreferrer" target="_blank"
+                        variant='link'
+                        isInline
+                        icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
+                        href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening">
+                    {_("Learn more")}
+                </Button>
+            }
+        >
+            <Button variant="plain" aria-label={_("Help")}>
+                <HelpIcon />
+            </Button>
+        </Popover>
+    );
+
+    return (
+        <Modal position="top" variant="medium"
+               isOpen
+               help={help}
+               onClose={close}
+               id="crypto-policy-dialog"
+               title={_("Change crypto policy")}
+               footer={
+                   <>
+                       {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
+                       <Button id="crypto-policy-apply-reboot" variant='primary' onClick={() => setPolicy(true)}>
+                           {_("Apply and reboot")}
+                       </Button>
+                       <Button id="crypto-policy-apply-reboot-later" variant='secondary' onClick={() => setPolicy(false)}>
+                           {_("Apply only")}
+                       </Button>
+                       <Button variant='link' onClick={close}>
+                           {_("Cancel")}
+                       </Button>
+                   </>
+               }
+        >
+            {currentCryptoPolicy && <TunedDialogBody active_profile={currentCryptoPolicy}
+                                                     change_selected={setSelected}
+                                                     profiles={policies} />}
+        </Modal>
+    );
+};
+
+export const CryptoPolicyStatus = () => {
+    const [requiresReboot, setRequiresReboot] = useState(false);
+    const [showShutdownModal, setShowShutDownModal] = useState(false);
+
+    useEffect(() => {
+        if (!requiresReboot) {
+            // For when we change the setting
+            cockpit.file(applyNeedRebootStamp).watch(content => setRequiresReboot(content !== null));
+        }
+    }, [requiresReboot]);
+
+    if (!requiresReboot) {
+        return null;
+    }
+
+    return (
+        <li className="system-health-crypto-policies">
+            <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                <InProgressIcon size="sm" className="crypto-policies-health-card-icon" />
+                <Button isInline variant="link" onClick={() => setShowShutDownModal(true)}>
+                    {_("Reboot to apply new crypto policy")}
+                </Button>
+            </Flex>
+            {showShutdownModal &&
+            <ShutdownModal onClose={() => setShowShutDownModal(false)} />
+            }
+        </li>
+    );
+};

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -25,7 +25,7 @@ import { ExternalLinkSquareAltIcon, HelpIcon, InProgressIcon } from '@patternfly
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { ShutdownModal } from 'cockpit-components-shutdown.jsx';
 import { PrivilegedButton } from "cockpit-components-privileged.jsx";
-import { TunedDialogBody } from '../../../pkg/tuned/change-profile.jsx';
+import { ProfilesMenuDialogBody } from "./profiles-menu-dialog-body.jsx";
 
 import "./cryptoPolicies.scss";
 
@@ -172,7 +172,7 @@ const CryptoPolicyDialog = ({
                    </>
                }
         >
-            {currentCryptoPolicy && <TunedDialogBody active_profile={currentCryptoPolicy}
+            {currentCryptoPolicy && <ProfilesMenuDialogBody active_profile={currentCryptoPolicy}
                                                      change_selected={setSelected}
                                                      profiles={policies} />}
         </Modal>

--- a/pkg/systemd/overview-cards/cryptoPolicies.scss
+++ b/pkg/systemd/overview-cards/cryptoPolicies.scss
@@ -1,0 +1,3 @@
+.crypto-policies-health-card-icon {
+	color: var(--pf-global--Color--200);
+}

--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -25,6 +25,7 @@ import { PageStatusNotifications } from "../page-status.jsx";
 import { InsightsStatus } from "./insights.jsx";
 import { ShutDownStatus } from "./shutdownStatus.jsx";
 import LastLogin from "./lastLogin.jsx";
+import { CryptoPolicyStatus } from "./cryptoPolicies.jsx";
 
 import "./healthCard.scss";
 
@@ -39,6 +40,7 @@ export class HealthCard extends React.Component {
                     <ul className="system-health-events">
                         <PageStatusNotifications />
                         <InsightsStatus />
+                        <CryptoPolicyStatus />
                         <ShutDownStatus />
                         <LastLogin />
                     </ul>

--- a/pkg/systemd/overview-cards/profiles-menu-dialog-body.jsx
+++ b/pkg/systemd/overview-cards/profiles-menu-dialog-body.jsx
@@ -27,18 +27,18 @@ import "menu-select-widget.scss";
 
 const _ = cockpit.gettext;
 
-/* dialog body with list of performance profiles
+/* dialog body with list of profiles
  * Expected props:
  *  - active_profile (key of the active profile)
  *  - change_selected callback, called with profile name each time the selected entry changes
- *  - profiles (array of entries passed to TunedDialogProfile)
+ *  - profiles (array of entries)
  *    - name (string, key)
  *    - recommended (boolean)
  *    - active (boolean)
  *    - title (string)
  *    - description (string)
  */
-export class TunedDialogBody extends React.Component {
+export class ProfilesMenuDialogBody extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -81,7 +81,7 @@ export class TunedDialogBody extends React.Component {
         );
     }
 }
-TunedDialogBody.propTypes = {
+ProfilesMenuDialogBody.propTypes = {
     active_profile: PropTypes.string.isRequired,
     change_selected: PropTypes.func.isRequired,
     profiles: PropTypes.array.isRequired,

--- a/pkg/tuned/change-profile.jsx
+++ b/pkg/tuned/change-profile.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Label, Menu, MenuItem, MenuContent, MenuList, Flex, FlexItem } from '@patternfly/react-core';
+import { Label, LabelGroup, Menu, MenuItem, MenuContent, MenuList, Flex, FlexItem } from '@patternfly/react-core';
 
 import "menu-select-widget.scss";
 
@@ -52,12 +52,13 @@ export class TunedDialogBody extends React.Component {
 
             return (
                 <MenuItem itemId={itm.name} key={itm.name} data-value={itm.name} description={itm.description}>
-                    <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                    <Flex alignItems={{ default: 'alignItemsCenter' }}>
                         <p>{ itm.title }</p>
                         <FlexItem>
-                            {itm.recommended && <Label color="blue" variant='filled'>{_("recommended")}</Label>}
-                            {" "}
-                            {active && <Label color="blue" variant='filled'>{_("active")}</Label>}
+                            <LabelGroup>
+                                {itm.recommended && <Label color="green" variant='filled'>{_("recommended")}</Label>}
+                                {active && <Label color="blue" variant='filled'>{_("active")}</Label>}
+                            </LabelGroup>
                         </FlexItem>
                     </Flex>
                 </MenuItem>

--- a/pkg/tuned/dialog.jsx
+++ b/pkg/tuned/dialog.jsx
@@ -26,7 +26,7 @@ import { ExternalLinkSquareAltIcon, HelpIcon } from '@patternfly/react-icons';
 import * as service from "service";
 import { EmptyStatePanel } from 'cockpit-components-empty-state.jsx';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
-import { TunedDialogBody } from './change-profile.jsx';
+import { ProfilesMenuDialogBody } from '../systemd/overview-cards/profiles-menu-dialog-body.jsx';
 import { superuser } from 'superuser';
 import { useObject, useEvent } from "hooks";
 
@@ -312,7 +312,7 @@ const TunedDialog = ({
                }
         >
             {loading && <EmptyStatePanel loading />}
-            {activeProfile && <TunedDialogBody active_profile={activeProfile}
+            {activeProfile && <ProfilesMenuDialogBody active_profile={activeProfile}
                                                change_selected={setSelected}
                                                profiles={profiles} />}
         </Modal>

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -835,6 +835,66 @@ password=foobar
         dbus_call = 'busctl get-property org.freedesktop.login1 /org/freedesktop/login1  org.freedesktop.login1.Manager ScheduledShutdown'
         self.assertEqual('(st) "" 0', m.execute(dbus_call).strip())
 
+    @skipImage("crypto-policies not avaiable", "fedora-coreos", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "arch")
+    def testCryptoPolicies(self):
+        def shown_profile_text(profile):
+            return profile[0] + profile[1:].lower()
+
+        def change_profile(profile, new_profile, reboot=False):
+            b.click("#crypto-policy-button")
+            b.wait_in_text(".pf-c-menu__item.pf-m-selected", shown_profile_text(profile))
+            profile_button_name = shown_profile_text(new_profile)
+            b.click(f".pf-c-menu__item-main .pf-c-menu__item-text:contains('{profile_button_name}')")
+            if reboot:
+                b.click("#crypto-policy-apply-reboot")
+            else:
+                b.click("#crypto-policy-apply-reboot-later")
+                b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
+                profile = m.execute(cmd + " --show").strip()
+                self.assertEqual(new_profile, profile)
+
+        m = self.machine
+        b = self.browser
+        cmd = "update-crypto-policies"
+
+        self.login_and_go("/system")
+
+        profile = m.execute(cmd + " --show").strip()
+        b.wait_text("#crypto-policy-button", shown_profile_text(profile))
+
+        # Select a different profile and reboot later, verify health card status.
+        new_profile = "LEGACY"
+        change_profile(profile, new_profile)
+
+        b.wait_text(".system-health-crypto-policies", "Reboot to apply new crypto policy")
+        # Check that reloading still shows the reboot text
+        b.reload()
+        b.enter_page("/system")
+        b.wait_text(".system-health-crypto-policies", "Reboot to apply new crypto policy")
+
+        b.click(".system-health-crypto-policies button")
+        b.wait_text("#shutdown-dialog .pf-c-modal-box__header .pf-c-modal-box__title-text", "Reboot")
+        # Cancel reboot
+        b.click("#shutdown-dialog button.pf-c-button.pf-m-link")
+
+        # Select a new profile and reboot
+        profile = new_profile
+        new_profile = "FUTURE"
+        change_profile(profile, new_profile, True)
+        m.wait_reboot()
+        self.login_and_go('/system')
+        b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
+
+        # Select a custom policy (non-selectable option)
+        profile = "EMPTY"
+        m.execute(cmd + f" --set {profile}")
+        b.enter_page("/system")
+        b.wait_text("#crypto-policy-button", shown_profile_text(profile))
+        b.click("#crypto-policy-button")
+        b.wait_in_text(".pf-c-menu__item.pf-m-selected", shown_profile_text(profile))
+        b.wait_in_text(".pf-c-menu__item.pf-m-selected", "Custom crypto policy")
+        b.click("#crypto-policy-dialog button.pf-c-button.pf-m-link")
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This implements the ability to set and show crypto policies from within
the cockpit system overview. The current implementation is limited to
three hardcoded policies and `update-security-policies` does not have an
option to list all existing policies. When a crypto policy is applied
but a user chooses to not reboot a notification is shown in the health
card overview.

---

# Crypto policies support

Cockpit now has basic support for displaying and changing a subset of crypto policies (default, future, legacy). The current configured crypto policy is shown in the `configuration` card.

![image](https://user-images.githubusercontent.com/67428/158211328-fd8936be-5127-4e30-9c4b-5ba251c7d60a.png)

Crypto policy changes can be applied directly or later, when later is selected the health card shows that a reboot is required to fully apply the changed crypto policy.

![image](https://user-images.githubusercontent.com/67428/158211149-36822bc4-a47e-4501-a01a-a82f7bbf3ec2.png)
