### PR TITLE
branding: fix symlink installation

### DIFF
--- a/src/branding/arch/Makefile.am
+++ b/src/branding/arch/Makefile.am
@@ -7,6 +7,6 @@ archbranding_DATA = \
 EXTRA_DIST += $(archbranding_DATA)
 
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/archlinux-logo.png $(DESTDIR)$(archbrandingdir)/favicon.ico

--- a/src/branding/centos/Makefile.am
+++ b/src/branding/centos/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(centosbranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
-	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(centosbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(centosbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/etc/favicon.png $(DESTDIR)$(centosbrandingdir)/favicon.ico

--- a/src/branding/debian/Makefile.am
+++ b/src/branding/debian/Makefile.am
@@ -8,5 +8,5 @@ EXTRA_DIST += $(debianbranding_DATA)
 
 # Opportunistically use debconf debian logos
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/debian-logo.png $(DESTDIR)$(debianbrandingdir)/favicon.ico

--- a/src/branding/fedora/Makefile.am
+++ b/src/branding/fedora/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(fedorabranding_DATA)
 
 # Opportunistically use fedora-logos
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
-	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(fedorabrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(fedorabrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/etc/favicon.png $(DESTDIR)$(fedorabrandingdir)/favicon.ico

--- a/src/branding/opensuse/Makefile.am
+++ b/src/branding/opensuse/Makefile.am
@@ -7,6 +7,6 @@ opensusebranding_DATA = \
 EXTRA_DIST += $(opensusebranding_DATA)
 
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/wallpapers/default-1920x1200.jpg $(DESTDIR)$(opensusebrandingdir)/default-1920x1200.jpg
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/distribution-logos/square-hicolor.svg $(DESTDIR)$(opensusebrandingdir)/square-hicolor.svg
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/distribution-logos/favicon.ico $(DESTDIR)$(opensusebrandingdir)/favicon.ico

--- a/src/branding/rhel/Makefile.am
+++ b/src/branding/rhel/Makefile.am
@@ -8,6 +8,6 @@ EXTRA_DIST += $(rhelbranding_DATA)
 
 # Opportunistically use redhat-logos ... yes they're called 'fedora'
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
-	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(rhelbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(rhelbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/etc/favicon.png $(DESTDIR)$(rhelbrandingdir)/favicon.ico

--- a/src/branding/scientific/Makefile.am
+++ b/src/branding/scientific/Makefile.am
@@ -8,7 +8,7 @@ EXTRA_DIST += $(scientificbranding_DATA)
 
 # Opportunistically use Scientific Linux logos. 
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
-	ln -sTfr $(DESTDIR)usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
-	ln -sTfr $(DESTDIR)etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/system-logo-white.png $(DESTDIR)$(scientificbrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/pixmaps/fedora-logo-sprite.png $(DESTDIR)$(scientificbrandingdir)/apple-touch-icon.png
+	ln -sTfr $(DESTDIR)/etc/favicon.png $(DESTDIR)$(scientificbrandingdir)/favicon.ico
 

--- a/src/branding/ubuntu/Makefile.am
+++ b/src/branding/ubuntu/Makefile.am
@@ -9,4 +9,4 @@ EXTRA_DIST += $(ubuntubranding_DATA)
 
 # Opportunistically use plymouth ubuntu logo
 install-data-hook::
-	ln -sTfr $(DESTDIR)usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png
+	ln -sTfr $(DESTDIR)/usr/share/plymouth/ubuntu-logo.png $(DESTDIR)$(ubuntubrandingdir)/logo.png


### PR DESCRIPTION
We need to add an extra / after the $(DESTDIR) and before /usr in order
to get the correct path.


...but the real scandal here is that not a single test failed :(