### PR TITLE
test: Adjust expected Fedora documentation name for fedora-testing

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -39,10 +39,10 @@ class TestPages(MachineCase):
         expected += "About Web Console"
         # DOCUMENTATION_URL is only in Fedora, RHEL and Arch
         if "fedora" in m.image:
-            if m.image in ["fedora-35", "fedora-coreos"]:
-                expected = "Fedora Linux documentation" + expected
-            else:
+            if m.image in ["fedora-34"]:
                 expected = "Fedora documentation" + expected
+            else:
+                expected = "Fedora Linux documentation" + expected
         elif m.image.startswith("rhel-"):
             expected = "Red Hat Enterprise Linux documentation" + expected
         elif m.image == "arch":


### PR DESCRIPTION
Our fedora-testing image is moving to Fedora 35. Adjust
TestPages.testBasic for the changed name. Invert the condition to do the
right thing for future Fedora versions.

---

Blocks https://github.com/cockpit-project/bots/pull/2841