### PR TITLE
metrics: Improve load average splitting for narrow layouts

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -216,7 +216,7 @@ class CurrentMetrics extends React.Component {
             swapUsed: null, // GiB
             cpuUsed: 0, // percentage
             cpuCoresUsed: [], // [ percentage ]
-            loadAvg: null, // string
+            loadAvg: null, // [ 1min, 5min, 15min ]
             disksRead: 0, // B/s
             disksWritten: 0, // B/s
             mounts: [], // [{ target (string), use (percent), avail (bytes) }]
@@ -322,8 +322,7 @@ class CurrentMetrics extends React.Component {
         cockpit.file("/proc/loadavg").read()
                 .then(content => {
                     // format: three load averages, then process counters; e.g.: 0.67 1.00 0.78 2/725 87151
-                    const load = content.split(' ').slice(0, 3);
-                    this.setState({ loadAvg: cockpit.format("$0: $1, $2: $3, $4: $5", _("1 min"), load[0], _("5 min"), load[1], _("15 min"), load[2]) });
+                    this.setState({ loadAvg: content.split(' ').slice(0, 3) });
                     // update it again regularly
                     window.setTimeout(this.updateLoad, 5000);
                 })
@@ -479,7 +478,13 @@ class CurrentMetrics extends React.Component {
                             <DescriptionList className="pf-m-horizontal-on-sm">
                                 <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Load") }</DescriptionListTerm>
-                                    <DescriptionListDescription id="load-avg">{this.state.loadAvg}</DescriptionListDescription>
+                                    <DescriptionListDescription id="load-avg">
+                                        <Flex spaceItems={{ default: 'spaceItemsXs' }}>
+                                            <FlexItem>{ _("1 min") }:&nbsp;{ this.state.loadAvg[0] },</FlexItem>
+                                            <FlexItem>{ _("5 min") }:&nbsp;{ this.state.loadAvg[1] },</FlexItem>
+                                            <FlexItem>{ _("15 min") }:&nbsp;{ this.state.loadAvg[2] }</FlexItem>
+                                        </Flex>
+                                    </DescriptionListDescription>
                                 </DescriptionListGroup>
                             </DescriptionList> }
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -730,17 +730,17 @@ class TestCurrentMetrics(MachineCase):
         b.wait_not_in_text("#current-metrics-card-cpu", "cpu-hog")
         b.wait_not_in_text("#current-metrics-card-cpu", "cpu-piglet")
 
-        # Load looks like "1 min: 1.41, 5 min: 1.47, 15 min: 2.30"
-        b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) < 5)
+        # Load is a flex, each part looks like "1 min: 1.41,"; wait until the 1min load is low
+        b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) < 5)
 
         m.execute("systemd-run --collect --slice cockpittest --unit load-hog sh -ec "
                   "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=10K count=500 status=none & done'")
-        b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) > 15)
+        b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) > 15)
         m.execute("systemctl stop load-hog 2>/dev/null || true")  # ok to fail, as the command exits by itself
 
         # this settles down slowly, don't wait for becoming really quiet
         with b.wait_timeout(180):
-            b.wait(lambda: float(b.text("#load-avg").split()[2].rstrip(',')) < 10)
+            b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) < 10)
 
     def testMemory(self):
         b = self.browser


### PR DESCRIPTION
Use Flex for a better layout, to avoid line breaks inside of the 1/5/15
minute fields.

---

## Current main:

Wide:
![image](https://user-images.githubusercontent.com/200109/150753225-d5349503-3127-4ae9-a4fe-400ef515e4a7.png)

Medium narrow:
![image](https://user-images.githubusercontent.com/200109/150753308-200b7c88-1f80-4383-b582-6a31f753db91.png)

Minimum width:
![image](https://user-images.githubusercontent.com/200109/150753361-9f374258-ffa0-4ffc-b8f4-b45104b9a680.png)

## This PR:
Wide:
![image](https://user-images.githubusercontent.com/200109/150753468-b6226e87-ea13-43a3-89e0-a8002ad06d72.png)

Medium narrow:
![image](https://user-images.githubusercontent.com/200109/150753557-058319bd-95e3-4138-adde-06cd0f515ffd.png)

Minimum width:
![image](https://user-images.githubusercontent.com/200109/150753635-27a13163-5e5e-4a13-8371-228278d41652.png)
