### PR TITLE
test: In the year 2037...

### DIFF
--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -347,7 +347,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                      fi""")
         # this is asynchronous; must wait until timesyncd stops before the time can be set
         m.execute("while systemctl is-active systemd-timesyncd; do sleep 1; done")
-        m.execute("timedatectl set-time 2038-01-01")
+        m.execute("timedatectl set-time 2037-01-01")
 
         def wait_log_lines(expected):
             b.wait_visible(".cockpit-log-panel")
@@ -385,8 +385,8 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                 return month_names[d.getMonth()] + ' ' + d.getDate().toFixed() + ', ' + d.getFullYear().toFixed();
             }
         """)
-        # January 1, 2038 00:00:00Z in browser time
-        expected_date = b.eval_js("localTime(2145916800000)")
+        # January 1, 2037 00:00:00Z in browser time
+        expected_date = b.eval_js("localTime(2114380800000)")
 
         # insert messages as errors because we know these will be shown by default
         m.execute("systemctl start systemd-journald.service")
@@ -398,7 +398,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         # Now reboot things
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
         m.wait_reboot()
-        m.execute("timedatectl set-time '2038-01-01 00:05:00'")
+        m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 
         m.start_cockpit()
@@ -451,7 +451,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
             b.click(".pf-c-toolbar__toggle button")
 
         b.focus("#journal-grep input")
-        b.key_press("until:2038-01-01\\ 00:03")
+        b.key_press("until:2037-01-01\\ 00:03")
         b.click("#journal-grep button[aria-label=Search]")
         wait_log_lines([expected_date,
                         ["check-journal", "BEFORE BOOT", ""],


### PR DESCRIPTION
This is some very odd problem with new systemd that it does not list
boots after 14. January 2037.

See https://github.com/cockpit-project/bots/pull/2828#issuecomment-1019929426