### PR TITLE
build selinux policy as part of main build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ test-*.trs
 /cockpit-ws
 /cockpit-wsinstance-factory
 /cockpit.lang
+/cockpit.pp
 /cockpit.pp.bz2
 /cockpit.spec
 /config.*

--- a/Makefile.am
+++ b/Makefile.am
@@ -25,7 +25,6 @@ CLEANFILES = \
 	$(NULL)
 
 EXTRA_DIST = \
-	selinux \
 	package.json \
 	package-lock.json \
 	README.md \
@@ -215,6 +214,7 @@ include doc/guide/Makefile-guide.am
 include doc/man/Makefile-man.am
 include pkg/Makefile.am
 include po/Makefile.am
+include selinux/Makefile.am
 include src/branding/arch/Makefile.am
 include src/branding/centos/Makefile.am
 include src/branding/debian/Makefile.am

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,18 @@ AC_ARG_ENABLE([prefix-only],
               [], [enable_prefix_only=no])
 AC_MSG_RESULT($enable_prefix_only)
 
+
+# --enable-selinux-policy=[type]
+AC_MSG_CHECKING([whether to build selinux policy, and which])
+AC_ARG_ENABLE([selinux-policy], [AS_HELP_STRING([--enable-selinux-policy=type], [Whether to build selinux policy])])
+if test "${enable_selinux_policy:=no}" = 'yes'; then
+    AC_MSG_ERROR([--enable-selinux-policy requires a type (eg: targeted)])
+fi
+AM_CONDITIONAL(SELINUX_POLICY_ENABLED, test "$enable_selinux_policy" != "no")
+AC_SUBST(SELINUX_POLICY_TYPE, [${enable_selinux_policy}])
+AC_MSG_RESULT($enable_selinux_policy)
+
+
 # Initialization
 #
 
@@ -517,6 +529,7 @@ echo "
         With address sanitizer:     ${asan_status}
         With PCP:                   ${enable_pcp}
         With polkit:                ${enable_polkit}
+        SELinux Policy:             ${enable_selinux_policy}
 
         cockpit-client:             ${enable_cockpit_client}
         cockpit-ssh:                ${enable_ssh}

--- a/configure.ac
+++ b/configure.ac
@@ -139,7 +139,6 @@ if test "$enable_ssh" != "no"; then
   AC_SUBST(COCKPIT_SSH_SESSION_CFLAGS)
 else
   enable_ssh="no"
-  key_auth="no"
   AC_MSG_RESULT([$enable_ssh])
 fi
 
@@ -518,11 +517,9 @@ echo "
         With address sanitizer:     ${asan_status}
         With PCP:                   ${enable_pcp}
         With polkit:                ${enable_polkit}
-        Branding:                   ${BRAND}
 
         cockpit-client:             ${enable_cockpit_client}
         cockpit-ssh:                ${enable_ssh}
-        Supports key auth:          ${key_auth}
 
         ssh-add:                    ${SSH_ADD}
         ssh-agent:                  ${SSH_AGENT}

--- a/selinux/Makefile.am
+++ b/selinux/Makefile.am
@@ -1,0 +1,32 @@
+SELINUX_POLICY_FILES = \
+	selinux/cockpit.fc \
+	selinux/cockpit.if \
+	selinux/cockpit.te \
+	$(NULL)
+
+SELINUX_POLICY_MANPAGES = \
+	selinux/cockpit_session_selinux.8cockpit \
+	selinux/cockpit_ws_selinux.8cockpit \
+	$(NULL)
+
+EXTRA_DIST += \
+	$(SELINUX_POLICY_FILES) \
+	$(SELINUX_POLICY_MANPAGES) \
+	$(NULL)
+
+cockpit.pp: $(SELINUX_POLICY_FILES)
+	$(AM_V_GEN) make -sf /usr/share/selinux/devel/Makefile cockpit.pp
+
+cockpit.pp.bz2: cockpit.pp
+	$(AM_V_GEN) bzip2 -9 < $< > $@.tmp && mv $@.tmp $@
+
+selinuxpackagesdir = $(datadir)/selinux/packages/$(SELINUX_POLICY_TYPE)/
+selinuxactivedir = $(sharedstatedir)/selinux/$(SELINUX_POLICY_TYPE)/active/modules/200/cockpit
+
+install-data-hook::
+if SELINUX_POLICY_ENABLED
+	$(INSTALL) -d -m 700 $(DESTDIR)$(selinuxactivedir)
+
+selinuxpackages_DATA = cockpit.pp.bz2
+man_MANS += $(SELINUX_POLICY_MANPAGES)
+endif

--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -77,8 +77,7 @@ Source0:        @PATH@cockpit-@VERSION@.tar.xz
 # Ship custom SELinux policy (but not for cockpit-appstream)
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
-%define with_selinux 1
-%define selinux_policy_version %(rpm --quiet -q selinux-policy && rpm -q --queryformat "%{V}-%{R}" selinux-policy || echo 1)
+%define selinux_configure_arg --enable-selinux-policy=%{selinuxtype}
 %endif
 
 BuildRequires: gcc
@@ -125,10 +124,8 @@ BuildRequires: gdb
 # For documentation
 BuildRequires: xmlto
 
-%if 0%{?with_selinux}
 BuildRequires:  selinux-policy
 BuildRequires:  selinux-policy-devel
-%endif
 
 # This is the "cockpit" metapackage. It should only
 # Require, Suggest or Recommend other cockpit-xxx subpackages
@@ -155,6 +152,7 @@ Recommends: subscription-manager-cockpit
 
 %build
 %configure \
+    %{?selinux_configure_arg} \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
 %if 0%{?suse_version}
@@ -166,12 +164,6 @@ Recommends: subscription-manager-cockpit
 %endif
 
 %make_build
-
-%if 0%{?with_selinux}
-    make -f /usr/share/selinux/devel/Makefile cockpit.pp
-    rm -f cockpit.pp.bz2
-    bzip2 -9 cockpit.pp
-%endif
 
 %check
 exec 2>&1
@@ -196,14 +188,6 @@ mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/pam.d
 install -p -m 644 tools/cockpit.pam $RPM_BUILD_ROOT%{_sysconfdir}/pam.d/cockpit
 rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
-
-%if 0%{?with_selinux}
-    install -D -m 644 %{name}.pp.bz2 %{buildroot}%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
-    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_session_selinux.8cockpit
-    install -D -m 644 -t %{buildroot}%{_mandir}/man8 selinux/%{name}_ws_selinux.8cockpit
-    # create this directory in the build root so that %ghost sees the desired mode
-    install -d -m 700 %{buildroot}%{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
-%endif
 
 # only ship deprecated PatternFly API for stable releases
 %if 0%{?rhel} <= 8
@@ -437,10 +421,8 @@ Summary: Cockpit Web Service
 Requires: glib-networking
 Requires: openssl
 Requires: glib2 >= 2.50.0
-%if 0%{?with_selinux}
-Requires: (selinux-policy >= %{selinux_policy_version} if selinux-policy-%{selinuxtype})
+Requires: (selinux-policy >= %{_selinux_policy_version} if selinux-policy-%{selinuxtype})
 Requires(post): (policycoreutils if selinux-policy-%{selinuxtype})
-%endif
 Conflicts: firewalld < 0.6.0-1
 Recommends: sscg >= 2.3
 Recommends: system-logos
@@ -495,13 +477,10 @@ authentication via sssd/FreeIPA.
 %{_libexecdir}/cockpit-certificate-helper
 %attr(4750, root, cockpit-wsinstance) %{_libexecdir}/cockpit-session
 %{_datadir}/cockpit/branding
-
-%if 0%{?with_selinux}
-    %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
-    %{_mandir}/man8/%{name}_session_selinux.8cockpit.*
-    %{_mandir}/man8/%{name}_ws_selinux.8cockpit.*
-    %ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
-%endif
+%{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
+%{_mandir}/man8/%{name}_session_selinux.8cockpit.*
+%{_mandir}/man8/%{name}_ws_selinux.8cockpit.*
+%ghost %{_sharedstatedir}/selinux/%{selinuxtype}/active/modules/200/%{name}
 
 %pre ws
 getent group cockpit-ws >/dev/null || groupadd -r cockpit-ws
@@ -509,19 +488,15 @@ getent passwd cockpit-ws >/dev/null || useradd -r -g cockpit-ws -d /nonexisting 
 getent group cockpit-wsinstance >/dev/null || groupadd -r cockpit-wsinstance
 getent passwd cockpit-wsinstance >/dev/null || useradd -r -g cockpit-wsinstance -d /nonexisting -s /sbin/nologin -c "User for cockpit-ws instances" cockpit-wsinstance
 
-%if 0%{?with_selinux}
 if %{_sbindir}/selinuxenabled 2>/dev/null; then
     %selinux_relabel_pre -s %{selinuxtype}
 fi
-%endif
 
 %post ws
-%if 0%{?with_selinux}
 if [ -x %{_sbindir}/selinuxenabled ]; then
     %selinux_modules_install -s %{selinuxtype} %{_datadir}/selinux/packages/%{selinuxtype}/%{name}.pp.bz2
     %selinux_relabel_post -s %{selinuxtype}
 fi
-%endif
 
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
 if [ "$1" = 1 ]; then
@@ -547,12 +522,10 @@ fi
 %systemd_preun cockpit.socket cockpit.service
 
 %postun ws
-%if 0%{?with_selinux}
 if [ -x %{_sbindir}/selinuxenabled ]; then
     %selinux_modules_uninstall -s %{selinuxtype} %{name}
     %selinux_relabel_post -s %{selinuxtype}
 fi
-%endif
 %systemd_postun_with_restart cockpit.socket cockpit.service
 
 # -------------------------------------------------------------------------------

--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -155,7 +155,6 @@ Recommends: subscription-manager-cockpit
 
 %build
 %configure \
-    --disable-silent-rules \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance \
 %if 0%{?suse_version}
@@ -166,7 +165,7 @@ Recommends: subscription-manager-cockpit
     --disable-ssh \
 %endif
 
-make -j$(nproc) %{?extra_flags} all
+%make_build
 
 %if 0%{?with_selinux}
     make -f /usr/share/selinux/devel/Makefile cockpit.pp


### PR DESCRIPTION
 - adds a `Makefile.am` to `selinux/` and a `--enable-selinux-policy` option
 - removes the rules for building this stuff from the spec file

 - [x] packit/sandcastle#156