### PR TITLE
autogen.sh: add 'rpm' option

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Minimum configuration for building dist tarball
         run: |
-          ./autogen.sh --disable-polkit --disable-ssh --disable-pcp --with-systemdunitdir=/invalid CPPFLAGS=-Itools/mock-build-env PKG_CONFIG_PATH=tools/mock-build-env
+          ./autogen.sh mock
 
       - name: Build and install flatpak
         run: sh -x containers/flatpak/install --user --install-deps-from=flathub

--- a/autogen.sh
+++ b/autogen.sh
@@ -8,6 +8,18 @@ srcdir="$(realpath -m "$0"/..)"
 [ -n "${NOCONFIGURE:-}" ] && exit
 
 case "${1:-}" in
+    mock)
+        # broken configuration with as few deps as possible
+        # mostly only useful for running `make dep`
+        exec ./autogen.sh \
+            CPPFLAGS=-Itools/mock-build-env \
+            PKG_CONFIG_PATH=tools/mock-build-env \
+            --enable-prefix-only \
+            --disable-pcp \
+            --disable-polkit \
+            --disable-ssh \
+        ;;
+
     rpm)
         # configure with the same flags as when building an RPM
         mkdir -p tmp/rpmbuild/SPECS

--- a/autogen.sh
+++ b/autogen.sh
@@ -5,5 +5,16 @@ set -eu
 srcdir="$(realpath -m "$0"/..)"
 
 (cd "${srcdir}" && autoreconf -is --warnings obsolete)
+[ -n "${NOCONFIGURE:-}" ] && exit
 
-[ -n "${NOCONFIGURE:-}" ] || exec "${srcdir}/configure" "$@"
+case "${1:-}" in
+    rpm)
+        # configure with the same flags as when building an RPM
+        mkdir -p tmp/rpmbuild/SPECS
+        tools/create-spec -v 0 -o tmp/rpmbuild/SPECS/cockpit.spec tools/cockpit.spec.in
+        exec rpmbuild -D '_topdir tmp/rpmbuild' -D 'make_build #' \
+            --build-in-place -bc tmp/rpmbuild/SPECS/cockpit.spec ;;
+
+    *)
+        exec "${srcdir}/configure" "$@" ;;
+esac

--- a/packit.yaml
+++ b/packit.yaml
@@ -3,7 +3,7 @@ actions:
     # packit will overwrite the version in its "fix spec file" stage
     - tools/create-spec --version 0 --build-all -o cockpit.spec tools/cockpit.spec.in
   create-archive:
-    - ./autogen.sh --disable-polkit --disable-ssh --disable-pcp --enable-prefix-only CPPFLAGS=-Itools/mock-build-env PKG_CONFIG_PATH=tools/mock-build-env
+    - ./autogen.sh mock
     # The sandcastle doesn't have enough ram to run webpack, so wait
     # until the webpack-jumpstart workflow has run and grab the result.
     - tools/webpack-jumpstart --wait --rebase


### PR DESCRIPTION
When run as `./autogen.sh rpm` then configure the package in exactly the same way as it would be configured by RPM for a build on this system.


@martinpitt mentioned wanting to have something like this.  To be honest, I'm not crazy about putting this in `./autogen.sh` and would like to find a better place for it.

 - [x] #16870 