### PR TITLE
Revert "build: add -ffile-prefix-map to CFLAGS"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,14 +247,6 @@ AC_DEFINE_UNQUOTED([PATH_SSH_AGENT], ["$SSH_AGENT"], [Location of ssh-agent bina
 
 changequote(,)dnl
 if test "x$GCC" = "xyes"; then
-  if  grep -q platform:el8 /usr/lib/os-release; then
-    # /usr/lib/rpm/find-debuginfo.sh on RHEL 8 gets confused by
-    # -fdebug-prefix-map, so disable it if we're building there
-    strip_sourcefile_prefix="."
-  else
-    strip_sourcefile_prefix="$(realpath -s "${PWD}/${srcdir}")"
-  fi
-
   CFLAGS="-Wall \
           -Werror=strict-prototypes -Werror=missing-prototypes \
           -Werror=implicit-function-declaration \
@@ -262,7 +254,6 @@ if test "x$GCC" = "xyes"; then
           -Werror=format=2 \
           -Werror=return-type \
           -Werror=missing-include-dirs \
-          -ffile-prefix-map=${strip_sourcefile_prefix}=. \
           $CFLAGS"
 fi
 changequote([,])dnl

--- a/containers/unit-tests/scenario/distcheck
+++ b/containers/unit-tests/scenario/distcheck
@@ -27,21 +27,7 @@ cd _distcleancheck/cockpit-*
 ./configure
 make distclean
 ./configure
-make -j$(nproc)
-make install DESTDIR=destdir
 make check 2>&1 || {
     find -name test-suite.log | xargs cat
     exit 1
 }
-cd ../..
-
-# do another build in a different directory and ensure that it produces the
-# same output (in the name of reproducible builds)
-mkdir _otherdir
-tar -C _otherdir -xf cockpit-[0-9]*.tar.xz
-cd _otherdir/cockpit-*
-./configure
-make -j$(nproc)
-make install DESTDIR=destdir
-cd ../..
-diff --no-dereference -ur _distcleancheck/*/destdir _otherdir/*/destdir


### PR DESCRIPTION
Commit c66a65feacf4 caused Fedora koji builds to break on finding the 
debug symbols. Revert it for now. Let's figure this out after the 
release: Debian builds probably already supply the flag as part of their
reproducible build efforts, and we can put it back into the .spec file
when/where needed.

Also revert the corresponding unit test from commit 59e173100.

---

Supposed to fix [these koji failures](https://kojipkgs.fedoraproject.org//work/tasks/5249/81755249/build.log) which broke the release. I did a [scratch build with a clean revert](https://koji.fedoraproject.org/koji/taskinfo?taskID=81758410) which succeeded.

We don't see this upstream because this only fails on all arches in [Rawhide](https://koji.fedoraproject.org/koji/taskinfo?taskID=81754804) but in [Fedora 34](https://koji.fedoraproject.org/koji/taskinfo?taskID=81755150) it works on x86_64, i686, and aarch64, but fails on the three others.