### PR TITLE
bridge: Fix time_t format string in test_metrics_archive_timestamp_now()

### DIFF
--- a/src/bridge/test-pcp-archives.c
+++ b/src/bridge/test-pcp-archives.c
@@ -321,8 +321,8 @@ test_metrics_archive_timestamp_now (TestCase *tc,
   g_autofree gchar* json = g_strdup_printf("{ 'source': '" BUILDDIR "/mock-archives/3',"
                                            "  'metrics': [ { 'name': 'mock.now' } ],"
                                            "  'interval': 1000,"
-                                           "  'timestamp': %li000"
-                                           "}", now);
+                                           "  'timestamp': %lli000"
+                                           "}", (long long) now);
   JsonObject *options = json_obj(json);
 
   setup_metrics_channel_json (tc, options);


### PR DESCRIPTION
On 32 bit architectures, `time_t` can now be a 64 bit type, so that
printing a `long` (32 bit) is not sufficient. Print/cast the time_t into
a `long long` to ensure that it works on all architectures.

Fixes build failure on x32:

    src/bridge/test-pcp-archives.c: In function ‘test_metrics_archive_timestamp_now’:
    src/bridge/test-pcp-archives.c:321:44: error: format ‘%li’ expects argument of type ‘long int’,
        but argument 2 has type ‘time_t’ {aka ‘long long int’} [-Werror=format=]

----

This should fix the [Debian build failure on x32](https://buildd.debian.org/status/fetch.php?pkg=cockpit&arch=x32&ver=261-1&stamp=1643047857&raw=0).