### PR TITLE
packit: Run package build and unit tests on i386 and s390x

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -18,3 +18,13 @@ jobs:
       - fedora-35
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
+
+  # run build/unit tests on some interesting architectures
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        # 32 bit
+        - fedora-development-i386
+        # big-endian
+        - fedora-development-s390x


### PR DESCRIPTION
This introduces some architecture variety; so far we have only tested on
x86_64, and thus were missing issues about `int` size, endianess, or RPM
builds on different architectures.

----

This should hopefully prevent issues like yesterday's release failure -- see PPR #16872