### PR TITLE
packit: Run tests on i386 and s390x (alternative to #16875)

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -16,5 +16,14 @@ jobs:
       targets:
       - fedora-34
       - fedora-35
+        # 32 bit
+      - fedora-stable-i386
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
+
+  - job: copr_build
+    trigger: pull_request
+    metadata:
+      targets:
+        # big-endian (emulated, no integration tests)
+        - fedora-development-s390x


### PR DESCRIPTION
This introduces some architecture variety; so far we have only tested on
x86_64, and thus were missing issues about `int` size, endianess, or RPM
builds on different architectures.

Run build and browser integration test on i386 to cover a 32 bit
architecture. Run package build (and thus unit tests) on s390x to cover
a big-endian architecture; but as that is emulated, it is way too slow
for running browser tests.

----

This is a more ambitious alternative to #16875, to run the integration tests on i386 as well. Let's see how this works.