### PR TITLE
system: Improve terminal toolbar on mobile

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -5,7 +5,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 import {
     FormSelect, FormSelectOption, NumberInput,
-    Toolbar, ToolbarContent, ToolbarItem
+    Toolbar, ToolbarContent, ToolbarItem, ToolbarGroup
 } from "@patternfly/react-core";
 
 import { Terminal } from "cockpit-components-terminal.jsx";
@@ -123,36 +123,40 @@ const _ = cockpit.gettext;
                         <tt className="terminal-title">{this.state.title}</tt>
                         <Toolbar id="toolbar">
                             <ToolbarContent>
-                                <ToolbarItem variant="label" id="size-select">
-                                    {_("Font size")}
-                                </ToolbarItem>
-                                <ToolbarItem>
-                                    <NumberInput
-                                        className="font-size"
-                                        value={this.state.size}
-                                        min={this.minSize}
-                                        max={this.maxSize}
-                                        onMinus={this.onMinus}
-                                        onPlus={this.onPlus}
-                                        inputAriaLabel={_("Font size")}
-                                        minusBtnAriaLabel={_("Decrease by one")}
-                                        plusBtnAriaLabel={_("Increase by one")}
-                                        widthChars={2}
-                                    />
-                                </ToolbarItem>
-                                <ToolbarItem variant="label" id="theme-select">
-                                    {_("Appearance")}
-                                </ToolbarItem>
-                                <ToolbarItem>
-                                    <FormSelect onChange={this.onThemeChanged}
-                                                aria-labelledby="theme-select"
-                                                value={this.state.theme}>
-                                        <FormSelectOption value='black-theme' label={_("Black")} />
-                                        <FormSelectOption value='dark-theme' label={_("Dark")} />
-                                        <FormSelectOption value='light-theme' label={_("Light")} />
-                                        <FormSelectOption value='white-theme' label={_("White")} />
-                                    </FormSelect>
-                                </ToolbarItem>
+                                <ToolbarGroup>
+                                    <ToolbarItem variant="label" id="size-select">
+                                        {_("Font size")}
+                                    </ToolbarItem>
+                                    <ToolbarItem>
+                                        <NumberInput
+                                            className="font-size"
+                                            value={this.state.size}
+                                            min={this.minSize}
+                                            max={this.maxSize}
+                                            onMinus={this.onMinus}
+                                            onPlus={this.onPlus}
+                                            inputAriaLabel={_("Font size")}
+                                            minusBtnAriaLabel={_("Decrease by one")}
+                                            plusBtnAriaLabel={_("Increase by one")}
+                                            widthChars={2}
+                                        />
+                                    </ToolbarItem>
+                                </ToolbarGroup>
+                                <ToolbarGroup>
+                                    <ToolbarItem variant="label" id="theme-select">
+                                        {_("Appearance")}
+                                    </ToolbarItem>
+                                    <ToolbarItem>
+                                        <FormSelect onChange={this.onThemeChanged}
+                                                    aria-labelledby="theme-select"
+                                                    value={this.state.theme}>
+                                            <FormSelectOption value='black-theme' label={_("Black")} />
+                                            <FormSelectOption value='dark-theme' label={_("Dark")} />
+                                            <FormSelectOption value='light-theme' label={_("Light")} />
+                                            <FormSelectOption value='white-theme' label={_("White")} />
+                                        </FormSelect>
+                                    </ToolbarItem>
+                                </ToolbarGroup>
                                 <ToolbarItem>
                                     <button ref={this.resetButtonRef}
                                             className="pf-c-button pf-m-secondary terminal-reset"

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -104,7 +104,8 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         with b.wait_timeout(300):
             b.wait_in_text(".terminal .xterm-accessibility-tree", "9999989999991000000admin@")
 
-        b.assert_pixels("#terminal", "terminal", ignore=[".xterm-cursor-layer", ".terminal-title"])
+        b.assert_pixels("#terminal .terminal-group", "header", ignore=[".terminal-title"])
+        b.assert_pixels("#terminal .xterm-text-layer", "text")
 
         # now reset terminal
         b.click('button:contains("Reset")')


### PR DESCRIPTION
The existing test ignores almost everything and is thus not very
useful.  The ".xterm-cursor-layer" is probably intended to catch the
cursor only, but does in fact covers the whole terminal area.

Also, the exact scrollbar position seems to vary, which has started to
cause random failures.

Thus, let's test the header and actual text area (without scrollbar)
separately.