### PR TITLE
test: Give starting kdump.service more time in TestKDumpNFS

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -274,12 +274,15 @@ class TestKdumpNFS(KdumpHelpers):
         b.set_val("#kdump-settings-location", "nfs")
         b.set_input_text("#kdump-settings-nfs-mount", "10.111.113.2:/srv/kdump")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_not_present("#kdump-settings-dialog")
+        # rebuilding initrd might take a while on busy CI machines
+        with b.wait_timeout(300):
+            b.wait_not_present("#kdump-settings-dialog")
 
         # enable service, regenerates initrd and tests NFS settings
         b.wait_visible(".pf-c-switch__input:not(:checked)")
         b.click(".pf-c-switch__input")
-        b.wait_visible(".pf-c-switch__input:checked")
+        with b.wait_timeout(300):
+            b.wait_visible(".pf-c-switch__input:checked")
         b.wait_in_text("#app", "Service is running")
 
         # explicit nfs option, unset path
@@ -305,7 +308,8 @@ class TestKdumpNFS(KdumpHelpers):
         # create the directory on the NFS server
         self.machines["nfs"].execute("mkdir /srv/kdump/dumps")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_not_present("#kdump-settings-dialog")
+        with b.wait_timeout(300):
+            b.wait_not_present("#kdump-settings-dialog")
         conf = m.execute("cat /etc/kdump.conf")
         self.assertIn("\nnfs 10.111.113.2:/srv/kdump\n", conf)
         self.assertIn("\npath dumps\n", conf)


### PR DESCRIPTION
Enabling kdump for the first time rebuilds the initrd, which is
inherently slow. On busy CI machines it sometimes takes more than a
minute.

The `TestKDump` class already does this by bumping the global timeout.
Be more specific here, to avoid hiding UI issues for operations that
should be fast.

----

[example 1](https://logs.cockpit-project.org/logs/pull-16686-20220125-102735-bf8b3591-rhel-8-6/log.html), [example 2](https://logs.cockpit-project.org/logs/pull-16826-20220113-155723-e5f39086-rhel-8-6/log.html#48), [example 3](https://logs.cockpit-project.org/logs/pull-16779-20220105-090740-28f20c62-centos-8-stream/log.html#48). I found some more on our logs server, but these should be sufficient to prove the issue. :grinning: 