### PR TITLE
hacking: update to use tools/create-spec

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -33,12 +33,12 @@ files and other components. The following should work in a fresh Git clone:
 
     $ sudo dnf install dnf-utils python-srpm-macros
     $ TEMPFILE=$(mktemp -u --suffix=.spec) && \
-      sed 's/%{npm-version:.*}/0/' tools/cockpit.spec >$TEMPFILE && \
-      sudo dnf builddep --spec $TEMPFILE && \
-      rm $TEMPFILE
+      ./tools/create-spec --version 1 -o "$TEMPFILE" tools/cockpit.spec.in && \
+      sudo dnf builddep --spec "$TEMPFILE" &&
+      rm "$TEMPFILE"
 
-Note that `tools/cockpit.spec` is a template filled in by
-`tools/gen-spec-dependencies` when building RPMs, and cannot be directly parsed
+Note that `tools/cockpit.spec.in` is a template filled in by
+`tools/create-spec` when building RPMs, and cannot be directly parsed
 by dnf.
 
 For running the browser unit tests, the following dependencies are required:


### PR DESCRIPTION
The hacking guide points to non-existing `tools/gen-spec-dependencies`, thus replaced that with `tools/create-spec`. Also adding the command makes it run cleanly, instead of failing to find `tools/cockpit.spec`.

Not sure about `--version 1`, let me know if that needs to be changed.