### PR TITLE
systemd: display the scheduled reboot/shutdown time

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -23,6 +23,7 @@ import { Card, CardBody, CardFooter, CardTitle } from '@patternfly/react-core';
 import cockpit from "cockpit";
 import { PageStatusNotifications } from "../page-status.jsx";
 import { InsightsStatus } from "./insights.jsx";
+import { ShutDownStatus } from "./shutdownStatus.jsx";
 import LastLogin from "./lastLogin.jsx";
 
 import "./healthCard.scss";
@@ -38,6 +39,7 @@ export class HealthCard extends React.Component {
                     <ul className="system-health-events">
                         <PageStatusNotifications />
                         <InsightsStatus />
+                        <ShutDownStatus />
                         <LastLogin />
                     </ul>
                 </CardBody>

--- a/pkg/systemd/overview-cards/shutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/shutdownStatus.jsx
@@ -1,0 +1,111 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+import React, { useState, useEffect } from 'react';
+import { Button, Flex, FlexItem } from '@patternfly/react-core';
+import { PowerOffIcon, RedoIcon } from "@patternfly/react-icons";
+
+import * as timeformat from "timeformat";
+
+import cockpit from "cockpit";
+
+const _ = cockpit.gettext;
+
+const getScheduledShutdown = (setShutdownTime, setShutdownType) => {
+    const client = cockpit.dbus("org.freedesktop.login1");
+    return client.call("/org/freedesktop/login1", "org.freedesktop.DBus.Properties", "Get",
+                       ["org.freedesktop.login1.Manager", "ScheduledShutdown"], { type: "ss" })
+            .then(([result]) => {
+                setShutdownType(result.v[0]);
+                setShutdownTime(result.v[1]);
+            })
+            .catch(err => console.warn("Failed to get ScheduledShutdown property", err.toString()));
+};
+
+const cancelShutdownAction = () => {
+    const client = cockpit.dbus("org.freedesktop.login1");
+    return client.call("/org/freedesktop/login1", "org.freedesktop.login1.Manager", "CancelScheduledShutdown")
+            .then(([cancelled]) => {
+                if (!cancelled) {
+                    console.warn("Unable to cancel shutdown");
+                }
+            })
+            .catch(err => console.warn("Failed to cancel shutdown", err.toString()));
+};
+
+export const ShutDownStatus = () => {
+    const [shutdownType, setShutdownType] = useState(null);
+    const [shutdownTime, setShutdownTime] = useState(0);
+
+    useEffect(() => {
+        getScheduledShutdown(setShutdownTime, setShutdownType);
+        // logind does not have a propertieschanged mechanism https://github.com/systemd/systemd/issues/22244
+        cockpit.file("/run/systemd/shutdown/scheduled").watch(() => {
+            getScheduledShutdown(setShutdownTime, setShutdownType);
+        });
+    }, []);
+
+    // We only care about these two types
+    if (shutdownType !== "poweroff" && shutdownType !== "reboot") {
+        // don't log undefined
+        if (shutdownType !== null && shutdownType !== "") {
+            console.log(`unsupported shutdown type ${shutdownType}`);
+        }
+        return null;
+    }
+
+    const date = new Date(shutdownTime / 1000);
+    const now = new Date();
+    let displayDate = null;
+    if (date.getFullYear() == now.getFullYear()) {
+        displayDate = timeformat.dateTimeNoYear(date);
+    } else {
+        displayDate = timeformat.dateTime(date);
+    }
+
+    let text;
+    let cancelText;
+    let icon;
+    if (shutdownType === "poweroff") {
+        icon = <PowerOffIcon />;
+        text = _("Scheduled poweroff at $0");
+        cancelText = _("Cancel poweroff");
+    } else {
+        icon = <RedoIcon />;
+        text = _("Scheduled reboot at $0");
+        cancelText = _("Cancel reboot");
+    }
+
+    return (
+        <li id="system-health-shutdown-status">
+            <Flex flexWrap={{ default: 'nowrap' }}>
+                <FlexItem spacer={{ default: 'spacerSm' }}>{icon}</FlexItem>
+                <Flex id="system-health-shutdown-status-text" direction={{ default: 'column' }}>
+                    {cockpit.format(text, displayDate)}
+                    <FlexItem>
+                        <Button variant="link" isInline
+                                id="system-health-shutdown-status-cancel-btn"
+                                className="pf-u-font-size-sm"
+                                onClick={cancelShutdownAction}>
+                            {cancelText}
+                        </Button>
+                    </FlexItem>
+                </Flex>
+            </Flex>
+        </li>);
+};

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -822,6 +822,38 @@ password=foobar
         wait(lambda: progressValue(2) <= hog_usage - 15)
         self.assertGreater(progressValue(2), 10)
 
+    def testShutdownStatus(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/system")
+        b.wait_not_present("#system-health-shutdown-status")
+
+        # Schedule a reboot
+        m.execute("shutdown --reboot +10")
+        self.addCleanup(m.execute, "shutdown -c")
+
+        b.wait_in_text('#system-health-shutdown-status-text', "Scheduled reboot")
+
+        # Check that reloading still shows the reboot text
+        b.reload()
+        b.enter_page("/system")
+        b.wait_in_text('#system-health-shutdown-status-text', "Scheduled reboot")
+
+        # Cancel
+        b.click("#system-health-shutdown-status-cancel-btn")
+        b.wait_not_present('#system-health-shutdown-status')
+
+        # Schedule a poweroff
+        m.execute("shutdown --poweroff +10")
+        b.wait_in_text('#system-health-shutdown-status-text', "Scheduled poweroff")
+
+        # Cancel
+        b.click("#system-health-shutdown-status-cancel-btn")
+        b.wait_not_present('#system-health-shutdown-status')
+        dbus_call = 'busctl get-property org.freedesktop.login1 /org/freedesktop/login1  org.freedesktop.login1.Manager ScheduledShutdown'
+        self.assertEqual('(st) "" 0', m.execute(dbus_call).strip())
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
In the health card in the system overview page we now show a scheduled
reboot/poweroff with the option to cancel it. The implementation does
not watch dbus property changes on org.freedesktop.login1.Manager as
they are not emitted when using `shutdown --reboot $timestamp`. For now
the file (/run/systemd/shutdown/poweroff) systemd creates when
requesting a shutdown is watched to detect scheduled shutdowns. The
systemd issue for dbus property changes is tracked here:

https://github.com/systemd/systemd/issues/22244

---

# Overview: Show scheduled shutdowns

The Health card shows a scheduled reboot or poweroff. This can also be cancelled.

![image](https://user-images.githubusercontent.com/67428/151211645-9eec9b4a-421a-4a75-a2dc-bcbb3d423fa6.png)
