### PR TITLE
lib: Let webpack rsync plugin rsync to /usr/local/share/cockpit/

### DIFF
--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -6,13 +6,17 @@ module.exports = class {
             options = {};
         this.dest = options.dest || "";
         this.source = options.source || "dist/";
+
+        // ensure the target directory exists
+        if (process.env.RSYNC)
+            child_process.spawnSync("ssh", [process.env.RSYNC, "mkdir", "-p", "/usr/local/share/cockpit/"], { stdio: "inherit" });
     }
 
     apply(compiler) {
         compiler.hooks.afterEmit.tapAsync('WebpackHookPlugin', (compilation, callback) => {
             if (process.env.RSYNC) {
                 const proc = child_process.spawn("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
-                    this.source, process.env.RSYNC + ":/usr/share/cockpit/" + this.dest], { stdio: "inherit" });
+                    this.source, process.env.RSYNC + ":/usr/local/share/cockpit/" + this.dest], { stdio: "inherit" });
                 proc.on('close', (code) => {
                     if (code !== 0) {
                         process.exit(1);


### PR DESCRIPTION
Scribbling over /usr/share/cockpit/ is evil: This is package manager
territory, and it might not even be writable (such as on Fedora CoreOS).
Sync to /usr/local/share/cockpit/ instead, which is meant for custom
built code. This also makes it possible to quickly go back to the distro
version.