### PR TITLE
tools: simplify cockpit-appstream trickery

### DIFF
--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -43,7 +43,11 @@
 %define pamdir %{_libdir}/security
 %endif
 
+%if %{defined appstream_srpm}
+Name:           cockpit-appstream
+%else
 Name:           cockpit
+%endif
 Summary:        Web Console for Linux servers
 
 License:        LGPLv2+

--- a/tools/make-srpm
+++ b/tools/make-srpm
@@ -51,12 +51,7 @@ rpmbuild "${rpmbuild_args[@]}" -ts ${source} | sed -n 's@^Wrote:.*/@@p'
 # "cockpit" with build_basic=1, and "cockpit-appstream" with build_optional=1
 # the spec has proper build_* defaults depending on the Name:
 if grep -q 'platform:el8' /usr/lib/os-release; then
-    appstream_spec="${tmpdir}/cockpit-appstream.spec"
-    tar xf "$source" -O '*/tools/cockpit.spec' |
-        sed '/^Name:/ s/$/-appstream/' > "${appstream_spec}"
-
-    rpmbuild "${rpmbuild_args[@]}" --define "_sourcedir $(dirname $source)" \
-        -bs "${appstream_spec}" | sed -n 's@^Wrote:.*/@@p'
+    rpmbuild "${rpmbuild_args[@]}" -D 'appstream_srpm 1' -ts ${source} | sed -n 's@^Wrote:.*/@@p'
 fi
 
 rm -rf "${tmpdir}"


### PR DESCRIPTION
Instead of extracting the spec file from the tarball and patching it
before manually passing it to rpmbuild (and ensuring that we set
_sourcedir properly so that it can still find the tarball), let's just
add a macro which changes the package name if it's defined.