### PR TITLE
systemd: style the shutdown/reboot icon grey

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.scss
+++ b/pkg/systemd/overview-cards/healthCard.scss
@@ -15,6 +15,12 @@
           margin-left: 0;
       }
 
+      .pf-c-spinner {
+          // PF's spinner is 18px while the icons are 16px,
+          // so redefine it here to make text to the right line up
+          --pf-c-spinner--m-md--diameter: 16px;
+      }
+
       > :not(a):last-child {
         flex: auto;
       }

--- a/pkg/systemd/overview-cards/shutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/shutdownStatus.jsx
@@ -24,6 +24,8 @@ import * as timeformat from "timeformat";
 
 import cockpit from "cockpit";
 
+import "./shutdownStatus.scss";
+
 const _ = cockpit.gettext;
 
 const getScheduledShutdown = (setShutdownTime, setShutdownType) => {
@@ -82,11 +84,11 @@ export const ShutDownStatus = () => {
     let cancelText;
     let icon;
     if (shutdownType === "poweroff") {
-        icon = <PowerOffIcon />;
+        icon = <PowerOffIcon className="shutdown-status-poweroff-icon" />;
         text = _("Scheduled poweroff at $0");
         cancelText = _("Cancel poweroff");
     } else {
-        icon = <RedoIcon />;
+        icon = <RedoIcon className="reboot-status-poweroff-icon" />;
         text = _("Scheduled reboot at $0");
         cancelText = _("Cancel reboot");
     }

--- a/pkg/systemd/overview-cards/shutdownStatus.scss
+++ b/pkg/systemd/overview-cards/shutdownStatus.scss
@@ -1,0 +1,3 @@
+.shutdown-status-poweroff-icon, .reboot-status-poweroff-icon {
+	color: var(--pf-global--Color--200);
+}

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -55,7 +55,7 @@ function get_pficon(name) {
     if (name == "check")
         return <CheckIcon color="green" data-pficon={name} />;
     if (name == "spinner")
-        return <Spinner isSVG size="sm" data-pficon={name} />;
+        return <Spinner isSVG size="md" data-pficon={name} />;
 
     throw new Error(`get_pficon(): unknown icon name ${name}`);
 }

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -28,7 +28,7 @@ import {
     ExclamationCircleIcon,
     InfoCircleIcon,
     SecurityIcon,
-    WarningTriangleIcon,
+    ExclamationTriangleIcon,
 } from '@patternfly/react-icons';
 
 import "./page-status.scss";
@@ -39,7 +39,7 @@ function icon_for_type(type) {
     if (type == "error")
         return <ExclamationCircleIcon className="ct-exclamation-circle" />;
     else if (type == "warning")
-        return <WarningTriangleIcon className="ct-exclamation-triangle" />;
+        return <ExclamationTriangleIcon className="ct-exclamation-triangle" />;
     else
         return <InfoCircleIcon className="ct-info-circle" />;
 }


### PR DESCRIPTION
Apply the same change as was applied to the "bug fix" icon, so the
scheduled reboot icon does not stand out.

This makes everything look the same:

![image](https://user-images.githubusercontent.com/67428/152010402-37a6a27e-bf22-4d33-a00e-d29f7643a99f.png)


Required for https://github.com/cockpit-project/cockpit/pull/16885