### PR TITLE
testlib: allow nondestructive tests runs against global machines with custom machine_class

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1103,7 +1103,7 @@ class MachineCase(unittest.TestCase):
     def new_machine(self, image=None, forward={}, restrict=True, cleanup=True, **kwargs):
         machine_class = self.machine_class
         if opts.address:
-            if machine_class or forward:
+            if forward:
                 raise unittest.SkipTest("Cannot run this test when specific machine address is specified")
             machine = testvm.Machine(address=opts.address, image=image or self.image, verbose=opts.trace, browser=opts.browser)
             if cleanup:


### PR DESCRIPTION
Leave it up to the user to make these tests destructive instead, in the case
the `machine_class` a test defines, is different than the class
`test/common/run-tests` script global machine uses for VM creation.

Background:

The `anaconda-webui` tests, do not use the `VirtMachine` class for the test VM
creation. For the purpose of overriding `Machine` class, `machine_class` property is
used, for the whole test suite.

The condition removed by this commit was blocking `anaconda-webui` tests
to have non-destructive tests running against the same global machine.

The only other obvious user of the `machine_class`, that could have been
affected by this change is `test/containers/check-bastion`, but that test
is destructive and therefore not affected.