### PR TITLE
Fix Build against Go 1.16

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -52,7 +52,7 @@ am__v_GO_ = $(am__v_GO_@AM_DEFAULT_V@)
 am__v_GO_0 = @echo "  GO      " $@;
 
 GO_BUILD_RULE = \
-	GOPATH=$(abs_srcdir)/pkg/kubernetes/standalone $(GOLANG) build \
+	GO111MODULE=auto GOPATH=$(abs_srcdir)/pkg/kubernetes/standalone $(GOLANG) build \
 		-ldflags "-B 0x"`head -c20 /dev/urandom|od -An -tx1|tr -d ' \n'` "$@"
 
 COCKPIT_KUBE_HELPERS =	\


### PR DESCRIPTION
Go 1.16 now defaults to `GO111MODULE=on` [1], which breaks our build, with a
*really* unhelpful error message, too:

    package cockpit-kube-auth is not in GOROOT (/usr/lib/golang/src/cockpit-kube-auth)

Switch back to the old behaviour.

[1] https://go.dev/doc/go1.16

Fixes #16920
See https://bugzilla.redhat.com/show_bug.cgi?id=2050088