### PR TITLE
fmf: Don't install weak firefox dependencies

### DIFF
--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -20,7 +20,7 @@ rpm -q cockpit-system
 
 # install firefox (available everywhere in Fedora and RHEL)
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
-dnf install --disablerepo=fedora-cisco-openh264 -y firefox
+dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd


### PR DESCRIPTION
firefox pulls in half a desktop, we don't need any of these for a
headless test. This reduces the number packages from 133 (459 MB) to 66
(365 MB).