### PR TITLE
test: Reduce packagekit.service stop time

### DIFF
--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -52,6 +52,10 @@ class PackageCase(MachineCase):
             self.machine.execute("nmcli con add type dummy con-name fake ifname fake0 ip4 1.2.3.4/24 gw4 1.2.3.1")
             self.addCleanup(self.machine.execute, "nmcli con delete fake")
 
+        # HACK: packagekit often hangs on shutdown; https://bugzilla.redhat.com/show_bug.cgi?id=1717185
+        self.machine.execute("mkdir -p /etc/systemd/system/packagekit.service.d")
+        self.write_file("/etc/systemd/system/packagekit.service.d/timeout.conf", "[Service]\nTimeoutStopSec=5\n")
+
         # disable all existing repositories to avoid hitting the network
         if self.backend == "apt":
             self.restore_dir("/var/lib/apt", reboot_safe=True)


### PR DESCRIPTION
packagekit.service tends to hang on shutdown. This bug [1] is ancient,
and we kept working around it in bots' *.install files; but we keep
losing that hack with newer images, and it's also missing on
rhel-9-0.install.

So centralize the hack here for all PackageKit related tests.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1717185

----

This ought to help a bit with the ridiculous [testTracer](https://logs.cockpit-project.org/logs/pull-16891-20220201-165621-7b1e6dcf-rhel-9-0/log.html) runtime of > 5 minutes on our infra. Locally it was ~ 170 seconds on main, and now around 90.