### PR TITLE
test: Stop marking rebooting TestUpdates tests as nondestructive

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -49,12 +49,10 @@ TESTS=""
 EXCLUDES=""
 RC=0
 if [ -n "$test_optional" ]; then
-    # TestUpdates: we can't run rebooting tests
     TESTS="$TESTS
+         TestUpdates
          TestAutoUpdates
-         TestStorage
-         TestUpdates.testBasic
-         TestUpdates.testSecurityOnly"
+         TestStorage"
 fi
 
 if [ -n "$test_basic" ]; then

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -62,14 +62,25 @@ if [ -n "$test_basic" ]; then
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"
 
+    # No ABRT in CentOS/RHEL, thus not a test dependency
+    EXCLUDES="$EXCLUDES
+              TestJournal.testAbrtDelete
+              TestJournal.testAbrtReportCancel
+              TestJournal.testAbrtReport
+              TestJournal.testAbrtReportNoReportd
+              TestJournal.testAbrtSegv"
+
     TESTS="$TESTS
         TestAccounts
         TestBonding
         TestBridge
         TestFirewall
         TestKdump
+        TestJournal
         TestLogin
         TestNetworking
+        TestPackages
+        TestPages
         TestServices
         TestSOS
         TestSystemInfo

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -49,10 +49,6 @@ TESTS=""
 EXCLUDES=""
 RC=0
 if [ -n "$test_optional" ]; then
-    # not investigated yet
-    EXCLUDES="$EXCLUDES
-        TestAutoUpdates.testPrivilegeChange"
-
     # TestUpdates: we can't run rebooting tests
     TESTS="$TESTS
          TestAutoUpdates
@@ -62,10 +58,6 @@ if [ -n "$test_optional" ]; then
 fi
 
 if [ -n "$test_basic" ]; then
-    # TODO: fix for CI environment
-    EXCLUDES="$EXCLUDES TestAccounts.testBasic"
-    EXCLUDES="$EXCLUDES TestLogin.testServer"
-
     # Testing Farm machines often have pending restarts/reboot
     EXCLUDES="$EXCLUDES TestUpdates.testBasic"
 

--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -20,6 +20,7 @@ require:
   - firewalld
   - libvirt-daemon-config-network
   - libvirt-python3
+  - python3-tracer
   - rpm-build
   - sssd-dbus
   - targetcli

--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -17,6 +17,7 @@ require:
   - createrepo_c
   - cryptsetup
   - dnf-automatic
+  - glibc-all-langpacks
   - firewalld
   - libvirt-daemon-config-network
   - libvirt-python3

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -58,7 +58,6 @@ class NoSubManCase(PackageCase):
 
 @skipImage("TODO: Fails with 401 on our test runners", "arch")
 @skipImage("Image uses OSTree", "fedora-coreos")
-@nondestructive
 class TestUpdates(NoSubManCase):
 
     def setUp(self):
@@ -146,6 +145,7 @@ class TestUpdates(NoSubManCase):
         else:
             self.fail("Timed out waiting for updates spinner to go away")
 
+    @nondestructive
     @skipImage("kpatch is not available", *OSesWithoutKpatch)
     def testKpatch(self):
         b = self.browser
@@ -270,6 +270,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         # Patches should be installed
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
 
+    @nondestructive
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -584,6 +585,7 @@ ExecStart=/usr/local/bin/{self.packageName}
 
     @skipImage("Arch Linux does not start services by default", "arch")
     @skipImage("tracer not available", *OSesWithoutTracer)
+    @nondestructive
     def testFailServiceRestart(self):
         b = self.browser
         m = self.machine
@@ -833,6 +835,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.allow_restart_journal_messages()
 
     @skipImage("No security changelog support in packagekit", "arch")
+    @nondestructive
     def testSecurityOnly(self):
         b = self.browser
         m = self.machine
@@ -870,6 +873,7 @@ ExecStart=/usr/local/bin/{packageName}
             self.check_nth_update(2, "secnocve", "1-2", "security", desc_matches=["Fix leak"])
 
     @skipImage("No changelog support in Arch Linux", "arch")
+    @nondestructive
     def testInfoTruncation(self):
         b = self.browser
         m = self.machine
@@ -936,6 +940,7 @@ ExecStart=/usr/local/bin/{packageName}
 
         # seems we can't verify that the description has a scrollbar
 
+    @nondestructive
     def testUpdateError(self):
         b = self.browser
         m = self.machine
@@ -965,6 +970,7 @@ ExecStart=/usr/local/bin/{packageName}
         # not expecting any buttons
         self.assertFalse(b.is_present("#app button"))
 
+    @nondestructive
     def testPackageKitCrash(self):
         b = self.browser
         m = self.machine
@@ -998,6 +1004,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.allow_journal_messages("Stack trace of thread.*")
         self.allow_journal_messages("#[0-9].*")
 
+    @nondestructive
     def testNoPackageKit(self):
         b = self.browser
         m = self.machine
@@ -1026,6 +1033,7 @@ ExecStart=/usr/local/bin/{packageName}
             self.assertIn("exclamation", b.attr(self.update_icon, "class"))
 
     @skipDistroPackage()
+    @nondestructive
     def testUnprivileged(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
testInfoSecurity and testTracer reboot, so they can't run on the Testing
Farm. Mark all other tests as nondestructive, and drop the special
treatment in the FMF tests. This will run a few more tests in FMF.

----

Also do some FMF test adjustments. The first round is experimental to get some details if the excluded tests work now, and if not, why exactly.