### PR TITLE
git-hook-post-commit: add some colour

### DIFF
--- a/test/git-hook-post-commit
+++ b/test/git-hook-post-commit
@@ -2,6 +2,12 @@
 
 set -eu
 
+# if being run directly, add a dash of red
+if [ -t 1 ]; then
+    trap 'printf "\e[0m"' EXIT
+    printf "\e[1;31m"
+fi
+
 # resolve to a sha, ensure validity
 readonly commit="$(git rev-parse --verify "${1:-HEAD}^{commit}")"
 


### PR DESCRIPTION
If this is used as a post-commit hook (and not run from the pre-commit
hook) then the output often blends in a little too well with the normal
post-commit messages like

```
  [branch 2523c98cf] subject: made a change
   1 file changed, 192 insertions(+), 88 deletions(-)
```

Detect if we are being run directly and make the output red in that
case.



I've been using this locally for a week or so and it's a big usability improvement for me.