### PR TITLE
pkg: stop including cross-package translations

### DIFF
--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -24,7 +24,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta charset="utf-8">
     <link href="apps.css" type="text/css" rel="stylesheet">
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="../manifests.js"></script>
     <script type="text/javascript" src="apps.js"></script>
   </head>

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -27,7 +27,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="kdump.css">
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="../base/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="kdump.js"></script>
 </head>
 

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -26,7 +26,8 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../manifests.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="index.js"></script>
 </head>
 

--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -25,7 +25,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link href="firewall.css" type="text/css" rel="stylesheet">
 
     <script src="../base1/cockpit.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="po.js"></script>
     <script src="firewall.js"></script>
   </head>
 

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -26,7 +26,8 @@
   <link href="network.css" type="text/css" rel="stylesheet">
   <script src="../base1/cockpit.js"></script>
   <script src="../manifests.js"></script>
-  <script src="../*/po.js"></script>
+  <script src="../base1/po.js"></script>
+  <script src="po.js"></script>
   <script src="network.js"></script>
 </head>
 <body class="pf-m-redhat-font">

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -26,8 +26,9 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <link href="updates.css" rel="stylesheet">
 
   <script src="../base1/cockpit.js"></script>
+  <script src="../base1/po.js"></script>
   <script src="updates.js"></script>
-  <script src="../*/po.js"></script>
+  <script src="po.js"></script>
 </head>
 <body class="pf-m-redhat-font">
     <div class="ct-page-fill" id="app"></div>

--- a/pkg/playground/translate.html
+++ b/pkg/playground/translate.html
@@ -130,7 +130,8 @@
     </div>
     <script src="translate.js"></script>
     <!-- Bring in initial translations -->
-    <script src="../*/po.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="po.js"></script>
     <!-- Override translations from here -->
     <script src="po.extra.js"></script>
 </body>

--- a/pkg/selinux/setroubleshoot.html
+++ b/pkg/selinux/setroubleshoot.html
@@ -27,7 +27,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="selinux.css">
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="selinux.js"></script>
 </head>
 

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -7,8 +7,9 @@
     <link href="index.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
+    <script src="../base1/po.js"></script>
     <script src="../manifests.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="po.js"></script>
   </head>
   <body class="pf-m-redhat-font" hidden>
     <div id="main" class="page">

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -23,7 +23,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta charset="utf-8">
     <link href="sosreport.css" rel="stylesheet">
     <script type="text/javascript" src="../base1/cockpit.js"></script>
-    <script type="text/javascript" src="../*/po.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
+    <script type="text/javascript" src="po.js"></script>
     <script type="text/javascript" src="sosreport.js"></script>
   </head>
   <body class="pf-m-redhat-font">

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -25,8 +25,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="storage.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
+    <script src="../base1/po.js"></script>
     <script src="../manifests.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="po.js"></script>
     <script src="storage.js"></script>
 </head>
 <body class="pf-m-redhat-font">

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -5,7 +5,8 @@
     <meta charset="utf-8">
     <link href="hwinfo.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="po.js"></script>
 </head>
 <body class="pf-m-redhat-font">
     <div class="ct-page-fill" id="hwinfo"></div>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -9,8 +9,9 @@
   <link rel="stylesheet" href="overview.css">
 
   <script type="text/javascript" src="../base1/cockpit.js"></script>
+  <script type="text/javascript" src="../base1/po.js"></script>
   <script type="text/javascript" src="overview.js"></script>
-  <script type="text/javascript" src="../*/po.js"></script>
+  <script type="text/javascript" src="po.js"></script>
   <script src="../manifests.js"></script>
 </head>
 <body class="pf-m-redhat-font">

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -24,7 +24,8 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta charset="utf-8">
   <link href="logs.css" rel="stylesheet">
   <script type="text/javascript" src="../base1/cockpit.js"></script>
-  <script src="../*/po.js"></script>
+  <script src="../base1/po.js"></script>
+  <script src="po.js"></script>
 </head>
 
 <body class="pf-m-redhat-font">

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -6,8 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="services.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
+    <script src="../base1/po.js"></script>
     <script src="services.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="po.js"></script>
 </head>
 
 <body class="pf-m-redhat-font" id="services-page">

--- a/pkg/systemd/terminal.html
+++ b/pkg/systemd/terminal.html
@@ -6,7 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="terminal.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="po.js"></script>
 </head>
 <body class="pf-m-redhat-font" hidden>
     <div class="ct-page-fill" id="terminal"></div>

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -25,7 +25,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="users.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
-    <script src="../*/po.js"></script>
+    <script src="../base1/po.js"></script>
+    <script src="po.js"></script>
     <script src="users.js"></script>
 </head>
 <body class="pf-m-redhat-font">

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -127,6 +127,7 @@ class TestApps(PackageCase):
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
 
+    @skipImage("language switching in Chrome not working (issue #8160, fixed in d9f88eb722f7a4)", "rhel-8-6-distropkg")
     def testL10N(self):
         b = self.browser
         m = self.machine
@@ -176,9 +177,6 @@ class TestApps(PackageCase):
             else:
                 b.click(f'#display-language-modal li[data-value={lang}] button')
             b.click("#display-language-modal footer button.pf-m-primary")
-            if m.image == "rhel-8-6-distropkg" and b.cdp.browser.name == "chromium":
-                # HACK: work around language switching in Chrome not working in current session (issue #8160)
-                b.reload(ignore_cache=True)
             b.wait_language(lang)
             b.enter_page("/apps")
 


### PR DESCRIPTION
A great number of our pages contain this:

```
  <script type="text/javascript" src="../*/po.js"></script>
```

in their .html files.  The effect is that the page pulls in the
translations for every package that the bridge knows about, including
those that may have come from a different source package.

This was introduced in #5898, but unfortunately the PR is a bit thin on
rationale for why this was done.

Each page really only needs it own translations, plus the translations
for base1.  Adjust accordingly.

See also discussion in #13906.

 - Blocked on fixing #8160

Fixes #13906