### PR TITLE
run-tests code cleanup

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -25,18 +25,33 @@ os.environ['PYTHONUNBUFFERED'] = '1'
 
 
 class Test:
-    process = None
-    retries = 0
-    retry_when_affected = True
-    output = b""
-
     def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected):
+        self.process = None
+        self.retries = 0
         self.test_id = test_id
         self.command = command
         self.timeout = timeout
         self.nondestructive = nondestructive
         self.serial_machine = None
         self.retry_when_affected = retry_when_affected
+        self.returncode = None
+
+    def start(self):
+        self.outfile = tempfile.TemporaryFile()
+        self.process = subprocess.Popen(["timeout", str(self.timeout)] + self.command,
+                                        stdout=self.outfile, stderr=subprocess.STDOUT)
+
+    def poll(self):
+        poll_result = self.process.poll()
+        if poll_result is not None:
+            self.outfile.flush()
+            self.outfile.seek(0)
+            self.output = self.outfile.read()
+            self.outfile.close()
+            self.outfile = None
+            self.returncode = self.process.returncode
+
+        return poll_result
 
 
 class GlobalMachine:
@@ -100,7 +115,7 @@ def print_test(test, print_tap=True, retry_reason="", skip_reason=""):
         return
 
     print()  # Tap needs to start on a separate line
-    if test.process.returncode == 0:
+    if test.returncode == 0:
         print("ok {0}{1}".format(test_name(test), retry_reason))
     elif skip_reason:
         print("ok {0}{1}".format(test_name(test), skip_reason))
@@ -122,19 +137,19 @@ def finish_test(opts, test, affected_tests):
     skip_reason = ""
 
     # Try affected tests 3 times
-    if test.process.returncode == 0 and affected and test.retry_when_affected and test.retries < 2:
+    if test.returncode == 0 and affected and test.retry_when_affected and test.retries < 2:
         retry_reason = "test affected tests 3 times"
         test.retries += 1
         print_test(test, not opts.list, "# RETRY {0} ({1})".format(test.retries, retry_reason))
         return retry_reason, 0
 
     # If test is being skipped pick up the reason
-    if test.process.returncode == 77:
+    if test.returncode == 77:
         lines = test.output.splitlines()
         skip_reason = lines[-1].strip().decode("utf-8")
         test.output = b"\n".join(lines[:-1])
 
-    if test.process.returncode in [0, 77]:
+    if test.returncode in [0, 77]:
         print_test(test, not opts.list, skip_reason=skip_reason)
         return None, 0
 
@@ -363,19 +378,13 @@ def run(opts, image):
 
             if test:
                 made_progress = True
-                test.outfile = tempfile.TemporaryFile()
-                test.process = subprocess.Popen(["timeout", str(test.timeout)] + test.command,
-                                                stdout=test.outfile, stderr=subprocess.STDOUT)
+                test.start()
                 running_tests.append(test)
 
         for test in running_tests.copy():
-            poll_result = test.process.poll()
+            poll_result = test.poll()
             if poll_result is not None:
                 made_progress = True
-                test.outfile.flush()
-                test.outfile.seek(0)
-                test.output = test.outfile.read()
-                test.outfile.close()
                 running_tests.remove(test)
                 retry_reason, test_result = finish_test(opts, test, changed_tests)
                 result += test_result
@@ -394,8 +403,6 @@ def run(opts, image):
 
                 # run again if needed
                 if retry_reason:
-                    test.output = None
-                    test.process = None
                     if test.serial_machine is not None:
                         batch_tests[test.serial_machine]["tests"].insert(0, test)
                         serial_remaining = sum([len(batch_tests[x]["tests"]) for x in batch_tests])

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -193,55 +193,46 @@ def build_command(filename, test, opts):
     return cmd
 
 
-def run(opts, image):
-    # Build the list of tests we'll parallelize and the ones we'll run serially
-    test_loader = unittest.TestLoader()
+def get_affected_tests(test_dir, base_branch, test_files):
+    if not base_branch:
+        return []
+
+    changed_tests = []
+
+    # Detect affected tests from changed test files
+    diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + base_branch, test_dir])
+    # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
+    # This file provides only examples, there is no place for it being flaky, no need to retry
+    changed_tests = [test.decode("utf-8") for test in diff_out.strip().splitlines() if not test.endswith(b"check-example")]
+
+    # If more than 3 test files were changed don't consider any of them as affected
+    # as it might be a PR that changes more unrelated things.
+    if len(changed_tests) > 3:
+        # If 'test/verify/check-testlib' is affected, keep just that one - our tests for tests count on that
+        if "test/verify/check-testlib" in changed_tests:
+            changed_tests = ["test/verify/check-testlib"]
+        else:
+            changed_tests = []
+
+    # Detect affected tests from changed pkg/* subdirectories in cockpit
+    # If affected tests get detected from pkg/* changes, don't apply the
+    # "only do this for max. 3 check-* changes" (even if the PR also changes ≥ 3 check-*)
+    # (this does not apply to other projects)
+    diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + base_branch, "--", "pkg/"])
+    changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in diff_out.strip().splitlines())
+    changed_tests.extend([test for test in test_files if any(pkg in test for pkg in changed_pkgs)])
+
+    return changed_tests
+
+
+def detect_tests(test_files, image, opts):
+    '''Build the list of tests we'll parallelize and the ones we'll run serially'''
+
     parallel_tests = []
     serial_tests = []
-    test_id = 1
-    result = 0
-    jobs = 1 if opts.list else opts.jobs
-    start_time = time.time()
-
-    # Map of batches of serial tests. Key is the batch name, value is a map with 3 keys:
-    # - "working" - None if the machine is idle
-    # - "tests"   - Array of tests to run
-    # - "time"    - Combined time all tests took
-    # - "machine" - A GlobalMachine instance for running the tests
-    batch_tests = {}
-
-    # Make sure tests can make relative imports
-    sys.path.append(os.path.realpath(opts.test_dir))
-
-    # Build list of affected tests
-    # If file from `test-dir` was changed in the PR, all tests from it are considered affected
-    changed_tests = []
-    test_files = glob.glob(os.path.join(opts.test_dir, "check-*"))
-    if opts.base:
-        # Detect affected tests from changed test files
-        diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + opts.base, opts.test_dir])
-        # Never consider 'test/verify/check-example' to be affected - our tests for tests count on that
-        # This file provides only examples, there is no place for it being flaky, no need to retry
-        changed_tests = [test.decode("utf-8") for test in diff_out.strip().splitlines() if not test.endswith(b"check-example")]
-
-        # If more than 3 test files were changed don't consider any of them as affected
-        # as it might be a PR that changes more unrelated things.
-        if len(changed_tests) > 3:
-            # If 'test/verify/check-testlib' is affected, keep just that one - our tests for tests count on that
-            if "test/verify/check-testlib" in changed_tests:
-                changed_tests = ["test/verify/check-testlib"]
-            else:
-                changed_tests = []
-
-        # Detect affected tests from changed pkg/* subdirectories in cockpit
-        # If affected tests get detected from pkg/* changes, don't apply the
-        # "only do this for max. 3 check-* changes" (even if the PR also changes ≥ 3 check-*)
-        # (this does not apply to other projects)
-        diff_out = subprocess.check_output(["git", "diff", "--name-only", "origin/" + opts.base, "--", "pkg/"])
-        changed_pkgs = set(pkg.decode("utf-8").split('/')[1] for pkg in diff_out.strip().splitlines())
-        changed_tests.extend([test for test in test_files if any(pkg in test for pkg in changed_pkgs)])
-
     seen_classes = {}
+    test_id = 1
+
     for filename in test_files:
         name = check_valid(filename)
         if not name or not os.path.isfile(filename):
@@ -249,7 +240,7 @@ def run(opts, image):
         loader = importlib.machinery.SourceFileLoader(name, filename)
         module = importlib.util.module_from_spec(importlib.util.spec_from_loader(loader.name, loader))
         loader.exec_module(module)
-        for test_suite in test_loader.loadTestsFromModule(module):
+        for test_suite in unittest.TestLoader().loadTestsFromModule(module):
             for test in test_suite:
                 # ensure that test classes are unique, so that they can be selected properly
                 cls = test.__class__.__name__
@@ -277,10 +268,32 @@ def run(opts, image):
                         parallel_tests.append(test)
                 test_id += 1
 
-    # sort serial tests by class/test name, to avoid spurious errors where failures depend on the order of execution
-    # but let's make sure we always test them both ways around; hash the image name, which is robust, reproducible, and provides
-    # an even distribution of both directions
+    # sort serial tests by class/test name, to avoid spurious errors where failures depend on the order of
+    # execution but let's make sure we always test them both ways around; hash the image name, which is
+    # robust, reproducible, and provides an even distribution of both directions
     serial_tests.sort(key=lambda t: t.command[-1], reverse=bool(binascii.crc32(image.encode()) & 1))
+
+    return (serial_tests, parallel_tests)
+
+
+def run(opts, image):
+    result = 0
+    jobs = 1 if opts.list else opts.jobs
+    start_time = time.time()
+
+    # Map of batches of serial tests. Key is the batch name, value is a map with 3 keys:
+    # - "working" - None if the machine is idle
+    # - "tests"   - Array of tests to run
+    # - "time"    - Combined time all tests took
+    # - "machine" - A GlobalMachine instance for running the tests
+    batch_tests = {}
+
+    # Make sure tests can make relative imports
+    sys.path.append(os.path.realpath(opts.test_dir))
+
+    test_files = glob.glob(os.path.join(opts.test_dir, "check-*"))
+    changed_tests = get_affected_tests(opts.test_dir, opts.base, test_files)
+    (serial_tests, parallel_tests) = detect_tests(test_files, image, opts)
 
     print("1..{0}".format(len(parallel_tests) + len(serial_tests)))
     flush_stdout()

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -39,6 +39,28 @@ class Test:
         self.retry_when_affected = retry_when_affected
 
 
+class GlobalMachine:
+    def __init__(self, restrict=True, cpus=None, memory_mb=None):
+        self.image = testvm.DEFAULT_IMAGE
+        self.network = testvm.VirtNetwork(image=self.image)
+        self.networking = self.network.host(restrict=restrict)
+        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image, cpus=cpus, memory_mb=memory_mb)
+        if not os.path.exists(self.machine.image_file):
+            self.machine.pull(self.machine.image_file)
+        self.machine.start()
+
+    def reset(self):
+        # It is important to re-use self.networking here, so that the
+        # machine keeps its browser and control port.
+        self.machine.kill()
+        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image)
+        self.machine.start()
+
+    def kill(self):
+        self.machine.kill()
+        self.network.kill()
+
+
 def test_name(test):
     return "{0} {1} {2}{3}".format(
         test.test_id,
@@ -169,28 +191,6 @@ def build_command(filename, test, opts):
         cmd.append("-l")
     cmd.append(test)
     return cmd
-
-
-class GlobalMachine:
-    def __init__(self, restrict=True, cpus=None, memory_mb=None):
-        self.image = testvm.DEFAULT_IMAGE
-        self.network = testvm.VirtNetwork(image=self.image)
-        self.networking = self.network.host(restrict=restrict)
-        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image, cpus=cpus, memory_mb=memory_mb)
-        if not os.path.exists(self.machine.image_file):
-            self.machine.pull(self.machine.image_file)
-        self.machine.start()
-
-    def reset(self):
-        # It is important to re-use self.networking here, so that the
-        # machine keeps its browser and control port.
-        self.machine.kill()
-        self.machine = testvm.VirtMachine(verbose=True, networking=self.networking, image=self.image)
-        self.machine.start()
-
-    def kill(self):
-        self.machine.kill()
-        self.network.kill()
 
 
 def run(opts, image):

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -420,10 +420,9 @@ def run(opts, image):
 
 
 def main():
-    jobs = int(os.environ.get("TEST_JOBS", 1))
     parser = testlib.arg_parser(enable_sit=False)
     parser.add_argument('-j', '--jobs', type=int,
-                        default=jobs, help="Number of concurrent jobs")
+                        default=int(os.environ.get("TEST_JOBS", 1)), help="Number of concurrent jobs")
     parser.add_argument('--thorough', action='store_true',
                         help='Thorough mode, no skipping known issues')
     parser.add_argument('-n', '--nondestructive', action='store_true',
@@ -437,7 +436,7 @@ def main():
     parser.add_argument('--exclude', action="append", default=[], metavar="TestClass.testName",
                         help="Exclude test (exact match only); can be specified multiple times")
     parser.add_argument('-b', '--batches', type=int,
-                        default=max(jobs // 2, 1), help="Number of concurrent batches of nondestructive tests")
+                        help="Number of concurrent batches of nondestructive tests")
     parser.add_argument('--nondestructive-cpus', type=int, default=None,
                         help="Number of CPUs for nondestructive test global machines")
     parser.add_argument('--nondestructive-memory-mb', type=int, default=None,
@@ -450,6 +449,9 @@ def main():
         if opts.jobs > 1:
             parser.error("--machine cannot be used with concurrent jobs")
         opts.nondestructive = True
+
+    if not opts.batches:
+        opts.batches = max(opts.jobs // 2, 1)
 
     # Tell any subprocesses what we are testing
     if "TEST_REVISION" not in os.environ:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -24,6 +24,15 @@ sys.dont_write_bytecode = True
 os.environ['PYTHONUNBUFFERED'] = '1'
 
 
+def flush_stdout():
+    while True:
+        try:
+            sys.stdout.flush()
+            break
+        except BlockingIOError:
+            time.sleep(0.1)
+
+
 class Test:
     def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected):
         self.process = None
@@ -35,14 +44,6 @@ class Test:
         self.serial_machine = None
         self.retry_when_affected = retry_when_affected
         self.returncode = None
-
-    def get_title(self):
-        return "{0} {1} {2}{3}".format(
-            self.test_id,
-            self.command[0],
-            self.command[-1],
-            " [ND@{0}]".format(self.serial_machine) if self.nondestructive else "",
-        )
 
     def start(self):
         self.outfile = tempfile.TemporaryFile()
@@ -60,6 +61,106 @@ class Test:
             self.returncode = self.process.returncode
 
         return poll_result
+
+    def finish(self, affected_tests, print_tap=True, thorough=False):
+        """Returns if a test should retry or not
+
+        Call test-failure-policy on the test's output, print if needed.
+
+        Return (retry_reason, exit_code). retry_reason can be None or a string.
+        """
+
+        affected = any([self.command[0].endswith(t) for t in affected_tests])
+        retry_reason = ""
+        skip_reason = ""
+
+        # Try affected tests 3 times
+        if self.returncode == 0 and affected and self.retry_when_affected and self.retries < 2:
+            retry_reason = "test affected tests 3 times"
+            self.retries += 1
+            self._print_test(print_tap, "# RETRY {0} ({1})".format(self.retries, retry_reason))
+            return retry_reason, 0
+
+        # If test is being skipped pick up the reason
+        if self.returncode == 77:
+            lines = self.output.splitlines()
+            skip_reason = lines[-1].strip().decode("utf-8")
+            self.output = b"\n".join(lines[:-1])
+
+        if self.returncode in [0, 77]:
+            self._print_test(print_tap, skip_reason=skip_reason)
+            return None, 0
+
+        if not thorough:
+            cmd = ["test-failure-policy", testvm.DEFAULT_IMAGE]
+            try:
+                proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+                reason = proc.communicate(self.output + ("not ok " + self._get_title()).encode())[0].strip()
+
+                if proc.returncode == 77:
+                    self._print_test(skip_reason="# SKIP {0}".format(reason.decode("utf-8")))
+                    return None, 0
+
+                if proc.returncode == 1:
+                    retry_reason = reason.decode("utf-8")
+
+            except OSError as ex:
+                if ex.errno != errno.ENOENT:
+                    sys.stderr.write("\nCouldn't run test-failure-policy: {0}\n".format(str(ex)))
+
+        # HACK: many tests are unstable, always retry them 3 times unless affected
+        if not affected and not retry_reason:
+            retry_reason = "be robust against unstable tests"
+
+        has_unexpected_message = testlib.UNEXPECTED_MESSAGE.encode() in self.output
+        has_pixel_test_message = testlib.PIXEL_TEST_MESSAGE.encode() in self.output
+        if self.retries < 2 and not (has_unexpected_message or has_pixel_test_message) and retry_reason:
+            self.retries += 1
+            self._print_test(retry_reason="# RETRY {0} ({1})".format(self.retries, retry_reason))
+            return retry_reason, 0
+
+        self.output += b"\n"
+        self._print_test()
+        return None, 1
+
+    # internal methods
+
+    def _get_title(self):
+        return "{0} {1} {2}{3}".format(
+            self.test_id,
+            self.command[0],
+            self.command[-1],
+            " [ND@{0}]".format(self.serial_machine) if self.nondestructive else "",
+        )
+
+    def _print_test(self, print_tap=True, retry_reason="", skip_reason=""):
+        for line in self.output.strip().splitlines(keepends=True):
+            while line:
+                try:
+                    sys.stdout.buffer.write(line)
+                    break
+                except BlockingIOError as e:
+                    line = line[e.characters_written:]
+                    time.sleep(0.1)
+
+        if retry_reason:
+            retry_reason = " " + retry_reason
+        if skip_reason:
+            skip_reason = " " + skip_reason
+
+        if not print_tap:
+            print(retry_reason + skip_reason)
+            flush_stdout()
+            return
+
+        print()  # Tap needs to start on a separate line
+        if self.returncode == 0:
+            print(f"ok {self._get_title()}{retry_reason}")
+        elif skip_reason:
+            print(f"ok {self._get_title()}{skip_reason}")
+        else:
+            print(f"not ok {self._get_title()}{retry_reason}")
+        flush_stdout()
 
 
 class GlobalMachine:
@@ -82,107 +183,6 @@ class GlobalMachine:
     def kill(self):
         self.machine.kill()
         self.network.kill()
-
-
-def flush_stdout():
-    while True:
-        try:
-            sys.stdout.flush()
-            break
-        except BlockingIOError:
-            time.sleep(0.1)
-
-
-def print_test(test, print_tap=True, retry_reason="", skip_reason=""):
-    for line in test.output.strip().splitlines(keepends=True):
-        while line:
-            try:
-                sys.stdout.buffer.write(line)
-                break
-            except BlockingIOError as e:
-                line = line[e.characters_written:]
-                time.sleep(0.1)
-
-    if retry_reason:
-        retry_reason = " " + retry_reason
-    if skip_reason:
-        skip_reason = " " + skip_reason
-
-    if not print_tap:
-        print(retry_reason + skip_reason)
-        flush_stdout()
-        return
-
-    print()  # Tap needs to start on a separate line
-    if test.returncode == 0:
-        print(f"ok {test.get_title()}{retry_reason}")
-    elif skip_reason:
-        print(f"ok {test.get_title()}{skip_reason}")
-    else:
-        print("not ok {test.get_title()}{retry_reason}")
-    flush_stdout()
-
-
-def finish_test(opts, test, affected_tests):
-    """Returns if a test should retry or not
-
-    Call test-failure-policy on the test's output, print if needed.
-
-    Return (retry_reason, exit_code). retry_reason can be None or a string.
-    """
-
-    affected = any([test.command[0].endswith(t) for t in affected_tests])
-    retry_reason = ""
-    skip_reason = ""
-
-    # Try affected tests 3 times
-    if test.returncode == 0 and affected and test.retry_when_affected and test.retries < 2:
-        retry_reason = "test affected tests 3 times"
-        test.retries += 1
-        print_test(test, not opts.list, "# RETRY {0} ({1})".format(test.retries, retry_reason))
-        return retry_reason, 0
-
-    # If test is being skipped pick up the reason
-    if test.returncode == 77:
-        lines = test.output.splitlines()
-        skip_reason = lines[-1].strip().decode("utf-8")
-        test.output = b"\n".join(lines[:-1])
-
-    if test.returncode in [0, 77]:
-        print_test(test, not opts.list, skip_reason=skip_reason)
-        return None, 0
-
-    if not opts.thorough:
-        cmd = ["test-failure-policy", testvm.DEFAULT_IMAGE]
-        try:
-            proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            reason = proc.communicate(test.output + ("not ok " + test.get_title()).encode())[0].strip()
-
-            if proc.returncode == 77:
-                print_test(test, skip_reason="# SKIP {0}".format(reason.decode("utf-8")))
-                return None, 0
-
-            if proc.returncode == 1:
-                retry_reason = reason.decode("utf-8")
-
-        except OSError as ex:
-            if ex.errno != errno.ENOENT:
-                sys.stderr.write("\nCouldn't run test-failure-policy: {0}\n".format(str(ex)))
-
-    # HACK: many tests are unstable, always retry them 3 times unless affected
-    if not affected and not retry_reason:
-        retry_reason = "be robust against unstable tests"
-
-    has_unexpected_message = testlib.UNEXPECTED_MESSAGE.encode() in test.output
-    has_pixel_test_message = testlib.PIXEL_TEST_MESSAGE.encode() in test.output
-    if test.retries < 2 and not (has_unexpected_message or has_pixel_test_message) and retry_reason:
-        test.retries += 1
-        print_test(test, retry_reason="# RETRY {0} ({1})".format(test.retries, retry_reason))
-        return retry_reason, 0
-
-    test.output += b"\n"
-    print_test(test)
-    return None, 1
 
 
 def check_valid(filename):
@@ -385,7 +385,7 @@ def run(opts, image):
             if poll_result is not None:
                 made_progress = True
                 running_tests.remove(test)
-                retry_reason, test_result = finish_test(opts, test, changed_tests)
+                retry_reason, test_result = test.finish(changed_tests, print_tap=not opts.list, thorough=opts.thorough)
                 result += test_result
 
                 if test.serial_machine is not None:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -41,11 +41,21 @@ class Test:
         self.command = command
         self.timeout = timeout
         self.nondestructive = nondestructive
-        self.serial_machine = None
+        self.machine_id = None
         self.retry_when_affected = retry_when_affected
         self.returncode = None
 
+    def assign_machine(self, machine_id, ssh_address, web_address):
+        assert self.nondestructive, "assigning a machine only works for nondestructive test"
+        self.machine_id = machine_id
+        self.command.insert(-2, "--machine")
+        self.command.insert(-2, ssh_address)
+        self.command.insert(-2, "--browser")
+        self.command.insert(-2, web_address)
+
     def start(self):
+        if self.nondestructive:
+            assert self.machine_id is not None, f"need to assign nondestructive test {self.test_id} {self.command} to a machine"
         self.outfile = tempfile.TemporaryFile()
         self.process = subprocess.Popen(["timeout", str(self.timeout)] + self.command,
                                         stdout=self.outfile, stderr=subprocess.STDOUT)
@@ -130,7 +140,7 @@ class Test:
             self.test_id,
             self.command[0],
             self.command[-1],
-            " [ND@{0}]".format(self.serial_machine) if self.nondestructive else "",
+            " [ND@{0}]".format(self.machine_id) if self.nondestructive else "",
         )
 
     def _print_test(self, print_tap=True, retry_reason="", skip_reason=""):
@@ -316,32 +326,23 @@ def run(opts, image):
         # Just build one batch for listing
         batch_tests[0] = {"working": None, "tests": [], "time": 0}
         for test in serial_tests:
-            test.serial_machine = 0
+            test.assign_machine(0, "listdummy", "listdummy")
             batch_tests[0]["tests"].append(test)
 
     if serial_tests and not opts.list:
         if opts.machine:
             batch_tests[0] = {"working": None, "tests": [], "time": 0}
-            ssh_address = opts.machine
-            web_address = opts.browser
-
             for test in serial_tests:
                 batch_tests[0]["tests"].append(test)
-                test.command.insert(-2, "--machine")
-                test.command.insert(-2, ssh_address)
-                test.command.insert(-2, "--browser")
-                test.command.insert(-2, web_address)
-                test.serial_machine = 0
+                test.assign_machine(0, opts.machine, opts.browser)
         else:
             batch_size = len(serial_tests) // opts.batches
 
             for i in range(opts.batches):
                 m = GlobalMachine(restrict=not opts.enable_network, cpus=opts.nondestructive_cpus, memory_mb=opts.nondestructive_memory_mb)
                 batch_tests[i] = {"working": None, "tests": [], "time": 0, "machine": m}
-                ssh_address = "{0}:{1}".format(m.machine.ssh_address,
-                                               m.machine.ssh_port)
-                web_address = "{0}:{1}".format(m.machine.web_address,
-                                               m.machine.web_port)
+                ssh_address = f"{m.machine.ssh_address}:{m.machine.ssh_port}"
+                web_address = f"{m.machine.web_address}:{m.machine.web_port}"
 
                 if i == opts.batches - 1:  # Last machine needs to resolve the rest
                     batch = serial_tests[batch_size * i:]
@@ -350,11 +351,7 @@ def run(opts, image):
 
                 for test in batch:
                     batch_tests[i]["tests"].append(test)
-                    test.command.insert(-2, "--machine")
-                    test.command.insert(-2, ssh_address)
-                    test.command.insert(-2, "--browser")
-                    test.command.insert(-2, web_address)
-                    test.serial_machine = i
+                    test.assign_machine(i, ssh_address, web_address)
 
     running_tests = []
     serial_tests_len = len(serial_tests)
@@ -388,28 +385,28 @@ def run(opts, image):
                 retry_reason, test_result = test.finish(changed_tests, print_tap=not opts.list, thorough=opts.thorough)
                 result += test_result
 
-                if test.serial_machine is not None:
-                    tests_duration = (time.time() - batch_tests[test.serial_machine]["started"])
-                    batch_tests[test.serial_machine]["time"] += tests_duration
+                if test.machine_id is not None:
+                    tests_duration = (time.time() - batch_tests[test.machine_id]["started"])
+                    batch_tests[test.machine_id]["time"] += tests_duration
 
                     # sometimes our global machine gets messed up; also, tests that time out don't run cleanup handlers
                     # restart it to avoid an unbounded number of test retries and follow-up errors
                     if not opts.machine and (poll_result == 124 or (retry_reason and "test harness" in retry_reason)):
                         # try hard to keep the test output consistent
-                        sys.stderr.write("\nRestarting global machine %s\n" % test.serial_machine)
+                        sys.stderr.write("\nRestarting global machine %s\n" % test.machine_id)
                         sys.stderr.flush()
-                        batch_tests[test.serial_machine]["machine"].reset()
+                        batch_tests[test.machine_id]["machine"].reset()
 
                 # run again if needed
                 if retry_reason:
-                    if test.serial_machine is not None:
-                        batch_tests[test.serial_machine]["tests"].insert(0, test)
+                    if test.machine_id is not None:
+                        batch_tests[test.machine_id]["tests"].insert(0, test)
                         serial_remaining = sum([len(batch_tests[x]["tests"]) for x in batch_tests])
                     else:
                         parallel_tests.insert(0, test)
 
-                if test.serial_machine is not None:
-                    batch_tests[test.serial_machine]["working"] = None
+                if test.machine_id is not None:
+                    batch_tests[test.machine_id]["working"] = None
 
         # Sleep if we didn't make progress
         if not made_progress and not opts.list:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -36,6 +36,14 @@ class Test:
         self.retry_when_affected = retry_when_affected
         self.returncode = None
 
+    def get_title(self):
+        return "{0} {1} {2}{3}".format(
+            self.test_id,
+            self.command[0],
+            self.command[-1],
+            " [ND@{0}]".format(self.serial_machine) if self.nondestructive else "",
+        )
+
     def start(self):
         self.outfile = tempfile.TemporaryFile()
         self.process = subprocess.Popen(["timeout", str(self.timeout)] + self.command,
@@ -76,15 +84,6 @@ class GlobalMachine:
         self.network.kill()
 
 
-def test_name(test):
-    return "{0} {1} {2}{3}".format(
-        test.test_id,
-        test.command[0],
-        test.command[-1],
-        " [ND@{0}]".format(test.serial_machine) if test.nondestructive else "",
-    )
-
-
 def flush_stdout():
     while True:
         try:
@@ -116,11 +115,11 @@ def print_test(test, print_tap=True, retry_reason="", skip_reason=""):
 
     print()  # Tap needs to start on a separate line
     if test.returncode == 0:
-        print("ok {0}{1}".format(test_name(test), retry_reason))
+        print(f"ok {test.get_title()}{retry_reason}")
     elif skip_reason:
-        print("ok {0}{1}".format(test_name(test), skip_reason))
+        print(f"ok {test.get_title()}{skip_reason}")
     else:
-        print("not ok {0}{1}".format(test_name(test), retry_reason))
+        print("not ok {test.get_title()}{retry_reason}")
     flush_stdout()
 
 
@@ -157,7 +156,7 @@ def finish_test(opts, test, affected_tests):
         cmd = ["test-failure-policy", testvm.DEFAULT_IMAGE]
         try:
             proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-            reason = proc.communicate(test.output + ("not ok " + test_name(test)).encode())[0].strip()
+            reason = proc.communicate(test.output + ("not ok " + test.get_title()).encode())[0].strip()
 
             if proc.returncode == 77:
                 print_test(test, skip_reason="# SKIP {0}".format(reason.decode("utf-8")))


### PR DESCRIPTION
This does not change the logic much yet, just shifts around a lot of code to reduce the scope of variables/members, and make the structure easier to understand. It's a prerequisite for changing the scheduling.