### PR TITLE
metrics: Use `setUTC*` functions to work across all timezones

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -665,12 +665,12 @@ class MetricsMinute extends React.Component {
         const end_second = (end - (end_minute * SAMPLES_PER_MIN)) * (60 / SAMPLES_PER_MIN);
 
         const time = new Date(timestamp);
-        time.setMinutes(start_minute);
-        time.setSeconds(start_second);
+        time.setUTCMinutes(start_minute);
+        time.setUTCSeconds(start_second);
         const since = formatUTC_ISO(time);
 
-        time.setMinutes(end_minute);
-        time.setSeconds(end_second);
+        time.setUTCMinutes(end_minute);
+        time.setUTCSeconds(end_second);
         const until = formatUTC_ISO(time);
 
         const match = { priority: "info", since: since, until: until, follow: false, count: 10 };


### PR DESCRIPTION
If timezone is shifted by 30 minutes compared to UTC, then `setMinutes`
does not behave as expected.

Example:
`time` in UTC is "10:34" which in some timezone is "3:04". We then want
to round the time by one minute down, so we do `setMinutes(33)` which
works for all timezones that are shifted by full hours but it completely
breaks some timezones as they now would not be "3:03" but "3:33" which
in UTC would be "11:03".

Fixes #16492

Before:
Same timezone:
![Screenshot from 2022-02-07 12-42-24](https://user-images.githubusercontent.com/12330670/152781902-22192a0f-3c17-4838-8a90-633a94ece307.png)

Different timezone:
![Screenshot from 2022-02-07 15-36-18](https://user-images.githubusercontent.com/12330670/152781634-238f5808-b357-4057-ae20-b13b2aabd48a.png)

With this PR different timezone:
![newminutes](https://user-images.githubusercontent.com/12330670/152781708-5335f55e-25d9-44b1-8b40-c59cbbc3e6f4.png)

@ testing https://github.com/cockpit-project/cockpit/pull/15626
