### PR TITLE
build: add `make rsync` target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,6 +2,7 @@ NULL =
 man_MANS =
 BUILT_SOURCES =
 bin_PROGRAMS =
+check_DATA =
 check_SCRIPTS =
 check_PROGRAMS =
 noinst_SCRIPTS =

--- a/Makefile.am
+++ b/Makefile.am
@@ -63,6 +63,7 @@ install-data-local:: $(WEBPACK_INSTALL) $(MANIFESTS)
 install-data-local:: $(WEBPACK_GZ_INSTALL)
 	@for file in $^; do \
 		target="$(DESTDIR)$(pkgdatadir)/$${file##*dist/}.gz"; \
+		[ -n "$(DESTDIR)" -a "$${target}" -nt "$${file}" ] && continue; \
 		mkdir -p "$${target%/*}"; \
 		echo "$${file} → $${target}"; \
 		gzip -9 < "$${file}" > "$${target}"; \

--- a/Makefile.am
+++ b/Makefile.am
@@ -209,6 +209,14 @@ multi-word: po/cockpit.pot
 title2sentence: multi-word
 	tools/title2sentence.py -i titles -o t2s.sh
 
+.PHONY: rsync
+RSYNC_HOST ?= c
+RSYNC_DEST ?= $(RSYNC_HOST):/
+rsync:
+	$(MAKE)
+	$(MAKE) install DESTDIR=tmp/rsync >/dev/null
+	rsync --recursive --links --checksum --verbose --inplace tmp/rsync/ $(RSYNC_DEST)
+
 include containers/Makefile.am
 include containers/flatpak/Makefile.am
 include doc/Makefile-doc.am

--- a/pkg/build
+++ b/pkg/build
@@ -52,7 +52,7 @@ WEBPACK_INSTALL =
 WEBPACK_GZ_INSTALL =
 WEBPACK_DEPS = $(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/Makefile.deps)
 
-noinst_SCRIPTS += $(MANIFESTS)
+noinst_DATA += $(MANIFESTS)
 EXTRA_DIST += $(MANIFESTS) $(WEBPACK_DEPS) webpack.config.js
 
 # Nothing generates this directly, but it's included as a dependency in

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -238,7 +238,7 @@ test_websocketstream_SOURCES = \
 test_websocketstream_CFLAGS = $(libcockpit_bridge_a_CFLAGS)
 test_websocketstream_LDADD = $(libcockpit_bridge_LIBS) -ldl
 
-noinst_PROGRAMS += $(BRIDGE_CHECKS) mock-bridge
+check_PROGRAMS += $(BRIDGE_CHECKS) mock-bridge
 TESTS += $(BRIDGE_CHECKS)
 
 EXTRA_DIST += \
@@ -323,7 +323,7 @@ BRIDGE_CHECKS += \
 	test-pcp-archives \
 	$(NULL)
 
-noinst_PROGRAMS += mock-pmda.so
+check_PROGRAMS += mock-pmda.so
 mock_pmda_so_SOURCES = src/bridge/mock-pmda.c
 mock_pmda_so_CFLAGS = -fPIC
 mock_pmda_so_LDFLAGS = -shared

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -323,20 +323,13 @@ BRIDGE_CHECKS += \
 	test-pcp-archives \
 	$(NULL)
 
-noinst_DATA += mock-pmda.so
+noinst_PROGRAMS += mock-pmda.so
+mock_pmda_so_SOURCES = src/bridge/mock-pmda.c
+mock_pmda_so_CFLAGS = -fPIC
+mock_pmda_so_LDFLAGS = -shared
+mock_pmda_so_LDADD = -lpcp_pmda -lpcp
 
-CLEANFILES += \
-	mock-pmda.so \
-	mock-archives/* \
-	$(NULL)
-
-# This is non-portable, but I don't feel like dragging in libtool just
-# for this.
-#
-mock-pmda.so: src/bridge/mock-pmda.c
-	$(AM_V_CCLD) $(CC) $(AM_CPPFLAGS) $(CFLAGS) -fPIC -shared \
-		-DSRCDIR=\"$(abs_srcdir)\" \
-		-o mock-pmda.so $(srcdir)/src/bridge/mock-pmda.c -lpcp_pmda -lpcp
+CLEANFILES += mock-archives/*
 
 test_pcp_SOURCES = \
 	src/bridge/test-pcp.c \

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -175,6 +175,7 @@ test_locale_PO = \
 	$(NULL)
 
 test_locale_MO = $(test_locale_PO:.po=.mo)
+CLEANFILES += $(test_locale_MO)
 
 test_locale_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_locale_SOURCES = src/common/test-locale.c
@@ -238,14 +239,7 @@ nodist_noinst_SCRIPTS += \
 	$(NULL)
 
 # preload wrapper library for unit tests that need a temp home dir
-# we don't use libtool, so build this manually
-nodist_noinst_DATA += libpreload-temp-home.so
-EXTRA_DIST += src/common/preload-temp-home.c
-
-libpreload-temp-home.so: src/common/preload-temp-home.c
-	$(AM_V_CCLD) $(CC) $(AM_CPPFLAGS) $(CFLAGS) -fPIC -shared -o $@ $^
-
-CLEANFILES += \
-	$(test_locale_MO) \
-	libpreload-temp-home.so \
-	$(NULL)
+noinst_PROGRAMS += libpreload-temp-home.so
+libpreload_temp_home_so_SOURCES = src/common/preload-temp-home.c
+libpreload_temp_home_so_CFLAGS = -fPIC
+libpreload_temp_home_so_LDFLAGS = -shared

--- a/src/common/Makefile-common.am
+++ b/src/common/Makefile-common.am
@@ -229,7 +229,7 @@ test_config_CFLAGS = $(libcockpit_common_a_CFLAGS)
 test_config_SOURCES = src/common/test-config.c
 test_config_LDADD = $(libcockpit_common_a_LIBS)
 
-noinst_PROGRAMS += $(COCKPIT_CHECKS)
+check_PROGRAMS += $(COCKPIT_CHECKS)
 TESTS += $(COCKPIT_CHECKS)
 
 # For the test-locale test
@@ -239,7 +239,7 @@ nodist_noinst_SCRIPTS += \
 	$(NULL)
 
 # preload wrapper library for unit tests that need a temp home dir
-noinst_PROGRAMS += libpreload-temp-home.so
+check_PROGRAMS += libpreload-temp-home.so
 libpreload_temp_home_so_SOURCES = src/common/preload-temp-home.c
 libpreload_temp_home_so_CFLAGS = -fPIC
 libpreload_temp_home_so_LDFLAGS = -shared

--- a/src/pam-ssh-add/Makefile.am
+++ b/src/pam-ssh-add/Makefile.am
@@ -31,7 +31,7 @@ PAM_SSH_ADD_CHECKS = \
 test_ssh_add_SOURCES = src/pam-ssh-add/test-ssh-add.c
 test_ssh_add_LDADD = $(libpam_ssh_add_a_LIBS) libretest.a
 
-noinst_PROGRAMS += $(PAM_SSH_ADD_CHECKS)
+check_PROGRAMS += $(PAM_SSH_ADD_CHECKS)
 TESTS += $(PAM_SSH_ADD_CHECKS)
 
 EXTRA_DIST += \

--- a/src/pam-ssh-add/Makefile.am
+++ b/src/pam-ssh-add/Makefile.am
@@ -15,24 +15,11 @@ libpam_ssh_add_a_LIBS = \
 	libpam_ssh_add.a \
 	$(PAM_LIBS)
 
-pam_ssh_add_FILES = src/pam-ssh-add/pam-ssh-add.c
-pam_ssh_add.so: libpam_ssh_add.a $(pam_ssh_add_FILES)
-	$(AM_V_CCLD) $(CC) -fPIC -shared $(AM_CPPFLAGS) $(CFLAGS) $(libpam_ssh_add_a_CFLAGS) -I$(builddir) \
-		-o $@ $^ $(libpam_ssh_add_a_LIBS) $(LDFLAGS)
-
-all-local:: pam_ssh_add.so
-
-EXTRA_DIST += \
-	$(pam_ssh_add_FILES) \
-	$(NULL)
-
-CLEANFILES += pam_ssh_add.so
-
-install-exec-local::
-	mkdir -p $(DESTDIR)$(pamdir)
-	$(INSTALL) pam_ssh_add.so $(DESTDIR)$(pamdir)
-uninstall-local::
-	$(RM) -f $(DESTDIR)$(pamdir)/pam_ssh_add.so
+pam_PROGRAMS = pam_ssh_add.so
+pam_ssh_add_so_SOURCES = src/pam-ssh-add/pam-ssh-add.c
+pam_ssh_add_so_CFLAGS = -fPIC
+pam_ssh_add_so_LDFLAGS = -shared
+pam_ssh_add_so_LDADD = $(libpam_ssh_add_a_LIBS)
 
 # -----------------------------------------------------------------------------
 # Tests
@@ -42,7 +29,6 @@ PAM_SSH_ADD_CHECKS = \
 	$(NULL)
 
 test_ssh_add_SOURCES = src/pam-ssh-add/test-ssh-add.c
-test_ssh_add_CFLAGS = $(libpam_ssh_add_a_CFLAGS)
 test_ssh_add_LDADD = $(libpam_ssh_add_a_LIBS) libretest.a
 
 noinst_PROGRAMS += $(PAM_SSH_ADD_CHECKS)

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -83,11 +83,6 @@ CLEANFILES += \
 	test_rsa_key \
 	$(NULL)
 
-noinst_SCRIPTS += \
-	src/ssh/mock-pid-cat \
-	src/ssh/mock-bin/sss_ssh_knownhostsproxy \
-	$(NULL)
-
 noinst_PROGRAMS += $(SSH_CHECKS)
 
 TESTS += $(SSH_CHECKS)

--- a/src/ssh/Makefile-ssh.am
+++ b/src/ssh/Makefile-ssh.am
@@ -50,7 +50,7 @@ cockpit_ssh_CFLAGS = \
 	$(COCKPIT_SSH_SESSION_CFLAGS) \
 	$(NULL)
 
-noinst_PROGRAMS += mock-sshd
+check_PROGRAMS += mock-sshd
 
 mock_sshd_SOURCES = src/ssh/mock-sshd.c
 
@@ -77,13 +77,13 @@ test_sshbridge_LDADD = libcockpit-ssh.a $(cockpit_ssh_LDADD)
 
 test_rsa_key: src/ssh/test_rsa
 	$(AM_V_GEN) cp $< $@ && chmod 600 $@
-noinst_DATA += test_rsa_key
+check_DATA += test_rsa_key
 
 CLEANFILES += \
 	test_rsa_key \
 	$(NULL)
 
-noinst_PROGRAMS += $(SSH_CHECKS)
+check_PROGRAMS += $(SSH_CHECKS)
 
 TESTS += $(SSH_CHECKS)
 

--- a/src/tls/Makefile-tls.am
+++ b/src/tls/Makefile-tls.am
@@ -1,6 +1,6 @@
 libexec_PROGRAMS += cockpit-tls cockpit-wsinstance-factory cockpit-certificate-ensure
 libexec_SCRIPTS += src/tls/cockpit-certificate-helper
-noinst_PROGRAMS += wsinstance-start
+check_PROGRAMS += wsinstance-start
 
 wsinstance_start_SOURCES = \
 	src/tls/utils.h \
@@ -132,7 +132,7 @@ socket_activation_helper_SOURCES = \
 	src/tls/socket-activation-helper.c \
 	$(NULL)
 
-noinst_PROGRAMS += $(TLS_TESTS) socket-activation-helper
+check_PROGRAMS += $(TLS_TESTS) socket-activation-helper
 EXTRA_DIST += \
 	src/tls/ca/alice-expired.pem \
 	src/tls/ca/alice.key \

--- a/src/websocket/Makefile-websocket.am
+++ b/src/websocket/Makefile-websocket.am
@@ -16,7 +16,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 noinst_LIBRARIES += libwebsocket.a
-noinst_PROGRAMS += \
+check_PROGRAMS += \
 	frob-websocket \
 	test-websocket \
 	$(NULL)

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -68,20 +68,11 @@ cockpit_ws_LDADD = 					\
 	$(COCKPIT_WS_LIBS)					\
 	$(NULL)
 
-noinst_PROGRAMS += pam_cockpit_cert.so
-pam_cockpit_cert_so_SOURCES = \
-	src/ws/pam_cockpit_cert.c
-pam_cockpit_cert.so$(EXEEXT): $(pam_cockpit_cert_so_SOURCES)
-	$(AM_V_CCLD) $(CC) -fPIC -shared $(PAM_COCKPIT_CERT_CFLAGS) $(AM_CPPFLAGS) $(CFLAGS) $(DEFS) -I$(builddir) -o $@ $^ $(LDFLAGS) $(PAM_COCKPIT_CERT_LIBS)
-
-CLEANFILES += pam_cockpit_cert.so
-
-install-exec-local::
-	mkdir -p $(DESTDIR)$(pamdir)
-	$(INSTALL) pam_cockpit_cert.so $(DESTDIR)$(pamdir)
-
-uninstall-local::
-	$(RM) -f $(DESTDIR)$(pamdir)/pam_cockpit_cert.so
+pam_PROGRAMS += pam_cockpit_cert.so
+pam_cockpit_cert_so_SOURCES = src/ws/pam_cockpit_cert.c
+pam_cockpit_cert_so_CFLAGS = -fPIC
+pam_cockpit_cert_so_LDFLAGS = -shared
+pam_cockpit_cert_so_LDADD = $(PAM_COCKPIT_CERT_LIBS)
 
 libexec_SCRIPTS += src/ws/cockpit-desktop
 
@@ -270,13 +261,11 @@ endif
 
 TESTS += $(WS_CHECKS)
 
-mock_pam_conv_mod_so_SOURCES = src/ws/mock-pam-conv-mod.c
-mock-pam-conv-mod.so$(EXEEXT): $(mock_pam_conv_mod_so_SOURCES)
-	$(AM_V_CCLD) $(CC) -fPIC -shared $(AM_CPPFLAGS) $(CFLAGS) -I$(builddir) \
-		-o $@ $^ $(PAM_LIBS) $(LDFLAGS)
-
 noinst_PROGRAMS += mock-pam-conv-mod.so
-CLEANFILES += mock-pam-conv-mod.so
+mock_pam_conv_mod_so_SOURCES = src/ws/mock-pam-conv-mod.c
+mock_pam_conv_mod_so_CFLAGS = -fPIC
+mock_pam_conv_mod_so_LDFLAGS = -shared
+mock_pam_conv_mod_so_LDADD = $(PAM_LIBS)
 
 testassetsdir = $(prefix)/lib/cockpit-test-assets
 testserviceddir = $(systemdunitdir)/cockpit.service.d

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -97,7 +97,6 @@ EXTRA_DIST += \
 
 # ----------------------------------------------------------------------------------------------------
 
-noinst_PROGRAMS += test-server
 check_PROGRAMS += test-server
 
 GDBUS_CODEGEN_XML = $(srcdir)/src/ws/com.redhat.Cockpit.DBusTests.xml
@@ -231,13 +230,13 @@ mock_echo_LDADD = $(COCKPIT_WS_LIBS)
 mock_auth_command_SOURCES = src/ws/mock-auth-command.c
 mock_auth_command_LDADD = libcockpit-common-nodeps.a
 
-noinst_PROGRAMS += \
+check_PROGRAMS += \
 	$(WS_CHECKS) \
 	mock-echo \
 	mock-auth-command \
 	$(NULL)
 
-noinst_SCRIPTS += \
+check_SCRIPTS += \
 	src/ws/mock-cat-with-init \
 	$(NULL)
 


### PR DESCRIPTION
This builds the tree, runs `make install` into a temporary DESTDIR, and then rsyncs the result to another host (default: `c`).

This is intended to be used with the recently-added ./autogen.sh rpm feature in order to live-apply changes to a running VM image.

An incremental `make rsync` after no changes takes less than one second.


### How to use this / manual testing:

 - check out the branch
 - `./autogen.sh rpm`
 - `test/image-prepare -q fedora-35`
 - `vm-run -q fedora-35&`
 - `make -j8 rsync`
 - `ssh c systemctl enable --now cockpit.socket`
 - open web browser, login
 - break some stuff
 - `ssh c systemctl stop cockpit.socket`   # needed because of "Text file busy"
 - `make rsync`
 - `ssh c systemctl start cockpit.socket`
 - open web browser, watch stuff fail

### Future directions
 - automatic cockpit restart to avoid the `ETXTBUSY` thing
 - ability to install directly into a downloaded image, without first preparing it