### PR TITLE
logs: Don't navigate to log details when selecting details

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -40,10 +40,17 @@ export class JournalOutput {
         this.search_options = search_options || {};
     }
 
-    onEvent(ev, cursor) {
+    onEvent(ev, cursor, full_content) {
         // only consider primary mouse button for clicks
-        if (ev.type === 'click' && ev.button !== 0)
-            return;
+        if (ev.type === 'click') {
+            if (ev.button !== 0)
+                return;
+
+            // Ignore if text is being selected - less than 3 characters most likely means misclick
+            const selection = window.getSelection().toString();
+            if (selection && selection.length > 2 && full_content.indexOf(selection) >= 0)
+                return;
+        }
 
         // only consider enter button for keyboard events
         if (ev.type === 'keypress' && ev.key !== "Enter")
@@ -63,11 +70,13 @@ export class JournalOutput {
             warning = true;
         }
 
+        const full_content = [time, message, ident].join("\n");
+
         return (
             <div className="cockpit-logline" role="row" tabIndex="0" key={entry.__CURSOR}
                 data-cursor={entry.__CURSOR}
-                onClick={ev => this.onEvent(ev, entry.__CURSOR)}
-                onKeyPress={ev => this.onEvent(ev, entry.__CURSOR)}>
+                onClick={ev => this.onEvent(ev, entry.__CURSOR, full_content)}
+                onKeyPress={ev => this.onEvent(ev, entry.__CURSOR, full_content)}>
                 <div className="cockpit-log-warning" role="cell">
                     { warning
                         ? <ExclamationTriangleIcon className="ct-icon-exclamation-triangle" size="sm" />


### PR DESCRIPTION
Users might want to select log message or identifier to use it for
searching. We should not navigate in such case.

Fixes #14327

I tried to write tests but I am having no luck...
```
b.mouse(".cockpit-logline:nth-child(2) .cockpit-log-message", "mousedown", 0, 10)
b.mouse(".cockpit-logline:nth-child(2) .cockpit-log-message", "mousemove", 140, 10)
b.mouse(".cockpit-logline:nth-child(2) .cockpit-log-message", "mouseup", 140, 10)

```