### PR TITLE
shell: Fix browser history

### DIFF
--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -137,10 +137,6 @@ export const Application = ({ metainfo_db, id, progress, progress_title, action 
         );
     }
 
-    function navigate_up() {
-        cockpit.location.go("/");
-    }
-
     return (
         <Page groupProps={{ sticky: 'top' }}
               id="app-page"
@@ -148,7 +144,7 @@ export const Application = ({ metainfo_db, id, progress, progress_title, action 
               isBreadcrumbGrouped
               breadcrumb={
                   <Breadcrumb>
-                      <BreadcrumbItem className="pf-c-breadcrumb__link" onClick={navigate_up} to="#">{_("Applications")}</BreadcrumbItem>
+                      <BreadcrumbItem to="#/">{_("Applications")}</BreadcrumbItem>
                       <BreadcrumbItem isActive>{comp ? comp.name : id}</BreadcrumbItem>
                   </Breadcrumb>
               }>

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -394,7 +394,7 @@ class CurrentMetrics extends React.Component {
         }
 
         function serviceRow(name, value) {
-            const name_text = <Button variant="link" isInline component="a" key={name} href="#" onClick={ e => cockpit.jump("/system/services#/" + name + ".service") }><TableText wrapModifier="truncate">{name}</TableText></Button>;
+            const name_text = <Button variant="link" isInline component="a" key={name} onClick={ e => cockpit.jump("/system/services#/" + name + ".service") }><TableText wrapModifier="truncate">{name}</TableText></Button>;
             const value_text = <TableText wrapModifier="nowrap">{value}</TableText>;
             return {
                 cells: [{ title: name_text }, { title: value_text }]

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1426,7 +1426,7 @@ export const Application = () => {
                   <Flex>
                       <FlexItem>
                           <Breadcrumb>
-                              <BreadcrumbItem onClick={() => cockpit.jump("/system")} to="#">{_("Overview")}</BreadcrumbItem>
+                              <BreadcrumbItem onClick={() => cockpit.jump("/system")} className="pf-c-breadcrumb__link">{_("Overview")}</BreadcrumbItem>
                               <BreadcrumbItem isActive>{_("Performance Metrics")}</BreadcrumbItem>
                           </Breadcrumb>
                       </FlexItem>

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -939,7 +939,7 @@ export class Firewall extends React.Component {
                   isBreadcrumbGrouped
                   breadcrumb={
                       <Breadcrumb>
-                          <BreadcrumbItem onClick={go_up} className="pf-c-breadcrumb__item" to="#">{_("Networking")}</BreadcrumbItem>
+                          <BreadcrumbItem onClick={go_up} className="pf-c-breadcrumb__link">{_("Networking")}</BreadcrumbItem>
                           <BreadcrumbItem isActive>{_("Firewall")}</BreadcrumbItem>
                       </Breadcrumb>}
                   additionalGroupedContent={

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -691,10 +691,10 @@ export const NetworkInterfacePage = ({
               data-test-wait={operationInProgress}
               breadcrumb={
                   <Breadcrumb>
-                      <BreadcrumbItem to='#'>
+                      <BreadcrumbItem to='#/'>
                           {_("Networking")}
                       </BreadcrumbItem>
-                      <BreadcrumbItem to="." isActive>
+                      <BreadcrumbItem isActive>
                           {dev_name}
                       </BreadcrumbItem>
                   </Breadcrumb>}>

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -82,12 +82,6 @@ export class Details extends React.Component {
     render() {
         const client = this.props.client;
 
-        function go_up(event) {
-            if (!event || event.button !== 0)
-                return;
-            cockpit.location.go("/");
-        }
-
         let body = null;
         let name = this.props.name;
         if (this.props.type == "block") {
@@ -143,7 +137,7 @@ export class Details extends React.Component {
                   id="storage-detail"
                   breadcrumb={
                       <Breadcrumb>
-                          <BreadcrumbItem onClick={go_up} to="#">{_("Storage")}</BreadcrumbItem>
+                          <BreadcrumbItem to="#/">{_("Storage")}</BreadcrumbItem>
                           <BreadcrumbItem isActive>{name}</BreadcrumbItem>
                       </Breadcrumb>}>
                 <PageSection>

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -323,7 +323,7 @@ class HardwareInfo extends React.Component {
                   isBreadcrumbGrouped
                   breadcrumb={
                       <Breadcrumb>
-                          <BreadcrumbItem onClick={ () => cockpit.jump("/system", cockpit.transport.host)} className="pf-c-breadcrumb__item" to="#">{ _("Overview") }</BreadcrumbItem>
+                          <BreadcrumbItem onClick={ () => cockpit.jump("/system", cockpit.transport.host)} className="pf-c-breadcrumb__link">{ _("Overview") }</BreadcrumbItem>
                           <BreadcrumbItem isActive>{ _("Hardware information") }</BreadcrumbItem>
                       </Breadcrumb>}>
                 <CPUSecurityMitigationsDialog show={this.state.showCpuSecurityDialog} onClose={ () => this.setState({ showCpuSecurityDialog: false }) } />

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -172,7 +172,7 @@ export class LogEntry extends React.Component {
                   id="log-details"
                   breadcrumb={
                       <Breadcrumb>
-                          <BreadcrumbItem onClick={this.goHome} to="#">{_("Logs")}</BreadcrumbItem>
+                          <BreadcrumbItem onClick={this.goHome} className="pf-c-breadcrumb__link">{_("Logs")}</BreadcrumbItem>
                           <BreadcrumbItem isActive>
                               {breadcrumb}
                           </BreadcrumbItem>

--- a/pkg/systemd/overview-cards/insights.jsx
+++ b/pkg/systemd/overview-cards/insights.jsx
@@ -123,7 +123,7 @@ export class InsightsStatus extends React.Component {
                     <li className="system-health-insights">
                         <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
                             <ExclamationTriangleIcon className="ct-exclamation-triangle" />
-                            <Button isInline variant="link" component="a" href="#" onClick={ev => { ev.preventDefault(); cockpit.jump("/subscriptions") }}>
+                            <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/subscriptions") }}>
                                 {_("Not connected to Insights")}
                             </Button>
                         </Flex>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -141,7 +141,7 @@ export class SystemInfomationCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <Button isInline variant="link" component="a" href="#" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
+                    <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/system/hwinfo", cockpit.transport.host) }}>
                         {_("View hardware details")}
                     </Button>
                 </CardFooter>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -146,7 +146,7 @@ export class UsageCard extends React.Component {
                     </table>
                 </CardBody>
                 <CardFooter>
-                    <Button isInline variant="link" component="a" href="#" onClick={ev => { ev.preventDefault(); cockpit.jump("/metrics", cockpit.transport.host) }}>
+                    <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/metrics", cockpit.transport.host) }}>
                         {_("View details and history")}
                     </Button>
                 </CardFooter>

--- a/pkg/systemd/page-status.jsx
+++ b/pkg/systemd/page-status.jsx
@@ -83,12 +83,12 @@ export class PageStatusNotifications extends React.Component {
                 let action;
                 if (status.details && status.details.link !== undefined) {
                     if (status.details.link)
-                        action = <Button variant="link" isInline component="a" href="#"
+                        action = <Button variant="link" isInline component="a"
                                          onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + status.details.link) } }>{status.title}</Button>;
                     else
                         action = <span>{status.title}</span>; // no link
                 } else {
-                    action = <Button variant="link" isInline component="a" href="#"
+                    action = <Button variant="link" isInline component="a"
                                      onClick={ ev => { ev.preventDefault(); cockpit.jump("/" + page) } }>{status.title}</Button>;
                 }
 

--- a/pkg/systemd/services/service-tabs.jsx
+++ b/pkg/systemd/services/service-tabs.jsx
@@ -55,7 +55,7 @@ export function ServiceTabs({ onChange, activeTab, tabErrors }) {
                                  key={key}
                                  preventDefault
                                  isActive={activeItem == key}>
-                            <Button variant="link" component="a" href="#" style={{ "--pf-c-button--m-link--Color": "var(--pf-global--Color--200)", "--pf-c-nav__link--m-current--Color": "var(--pf-global--Color--100)", "--pf-c-nav__link--hover--Color": "var(--pf-global--Color--200)" }}>
+                            <Button variant="link" component="a" style={{ "--pf-c-button--m-link--Color": "var(--pf-global--Color--200)", "--pf-c-nav__link--m-current--Color": "var(--pf-global--Color--100)", "--pf-c-nav__link--hover--Color": "var(--pf-global--Color--200)" }}>
                                 {service_tabs[key]}
                                 {tabErrors[key] ? <ExclamationCircleIcon className="ct-exclamation-circle" /> : null}
                             </Button>

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -226,7 +226,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                 </Title>
                 <EmptyStateSecondaryActions>
                     <Breadcrumb>
-                        <BreadcrumbItem onClick={() => cockpit.location.go("/")} to="#">{_("Back to accounts")}</BreadcrumbItem>
+                        <BreadcrumbItem to="#/">{_("Back to accounts")}</BreadcrumbItem>
                     </Breadcrumb>
                 </EmptyStateSecondaryActions>
             </EmptyState>
@@ -258,7 +258,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
               id="account"
               breadcrumb={
                   <Breadcrumb>
-                      <BreadcrumbItem onClick={() => cockpit.location.go("/")} to="#">{_("Accounts")}</BreadcrumbItem>
+                      <BreadcrumbItem to="#/">{_("Accounts")}</BreadcrumbItem>
                       <BreadcrumbItem isActive>{title_name}</BreadcrumbItem>
                   </Breadcrumb>}>
             <PageSection>

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -188,7 +188,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_text(".pf-c-empty-state", "No data available")
 
         # Breadcrumb back to Overview page
-        b.click(".pf-c-breadcrumb li:first-child a")
+        b.click(".pf-c-breadcrumb li:first-child")
         b.enter_page("/system")
         b.wait_visible('.system-information')
 
@@ -408,7 +408,7 @@ class TestHistoryMetrics(MachineCase):
         b.click(".cockpit-logline:first-child .cockpit-log-message")
         b.enter_page("/system/logs")
         b.wait_in_text(".pf-c-card__title", "cpu-piglet")
-        b.click("a:contains('Logs')")
+        b.click("li:contains('Logs')")
         b.wait_visible(".cockpit-log-message:contains('Created slice cockpittest.slice.')")
 
         b.go("/metrics")

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -124,7 +124,7 @@ class TestFirewall(NetworkCase):
         b.click("#networking-firewall-link")
         b.enter_page("/network/firewall")
 
-        b.click(".pf-c-breadcrumb li:first a")
+        b.click(".pf-c-breadcrumb li:first")
 
         b.enter_page("/network")
 

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -721,6 +721,95 @@ OnCalendar=daily
         b.wait_text("#received-type", "-")
         b.wait_text("#received-title", "-")
 
+    def testHistory(self):
+
+        b = self.browser
+
+        def assert_location(path_hash):
+            self.assertEqual(path_hash,
+                             self.browser.eval_js("window.location.pathname + window.location.hash"))
+
+        self.login_and_go("/system")
+
+        # Create a login entry so that the "View last login" button appears
+        b.logout()
+        self.login_and_go("/system")
+
+        b.switch_to_top()
+        assert_location("/system")
+
+        b.click('#nav-system a[href="/users"]')
+        b.enter_page("/users")
+        b.switch_to_top()
+        assert_location("/users")
+
+        b.enter_page("/users")
+        b.click('a[href="#/root"]')
+        b.wait_text("#account-title", "root")
+        b.switch_to_top()
+        assert_location("/users#/root")
+
+        b.enter_page("/users")
+        b.click("nav a:contains(Accounts)")
+        b.wait_visible("button:contains('Create new account')")
+        b.switch_to_top()
+        assert_location("/users")
+
+        b.eval_js("window.history.back()")
+        b.enter_page("/users")
+        b.wait_text("#account-title", "root")
+        b.switch_to_top()
+        assert_location("/users#/root")
+
+        b.eval_js("window.history.forward()")
+        b.enter_page("/users")
+        b.wait_visible("button:contains('Create new account')")
+        b.switch_to_top()
+        assert_location("/users")
+
+        b.eval_js("window.history.back()")
+        b.enter_page("/users")
+        b.wait_text("#account-title", "root")
+        b.switch_to_top()
+        assert_location("/users#/root")
+
+        b.eval_js("window.history.back()")
+        b.enter_page("/users")
+        b.wait_visible("button:contains('Create new account')")
+        b.switch_to_top()
+        assert_location("/users")
+
+        b.click('#nav-system a[href="/system/terminal"]')
+        b.enter_page("/system/terminal")
+        b.switch_to_top()
+        assert_location("/system/terminal")
+
+        b.eval_js("window.history.back()")
+        b.enter_page("/users")
+        b.wait_visible("button:contains('Create new account')")
+        b.switch_to_top()
+        assert_location("/users")
+
+        b.eval_js("window.history.back()")
+        b.enter_page("/system")
+        b.switch_to_top()
+        assert_location("/system")
+
+        # CoreOS does not keep login history
+        if self.machine.image not in ["fedora-coreos"]:
+
+            b.enter_page("/system")
+            b.click("button:contains(View login history)")
+            b.enter_page("/users")
+            b.wait_text("#account-title", "Administrator")
+            b.switch_to_top()
+            assert_location("/users#/admin")
+
+            b.eval_js("window.history.back()")
+            b.enter_page("/system")
+            b.switch_to_top()
+            assert_location("/system")
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -247,7 +247,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.wait_text_not("#system_information_systime_button", "")
         b.click(".system-information a")  # View hardware details
         b.enter_page("/system/hwinfo", "10.111.113.3")
-        b.click(".pf-c-breadcrumb li:first-child a")
+        b.click(".pf-c-breadcrumb li:first-child")
         b.enter_page("/system", "10.111.113.3")
         b.wait_in_text(".ct-overview-header-hostname", "machine3")
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -471,7 +471,7 @@ class TestSystemInfo(MachineCase):
         b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
 
         # go back to system page
-        b.click('.pf-c-breadcrumb li:first a')
+        b.click('.pf-c-breadcrumb li:first')
 
         b.enter_page("/system")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -481,7 +481,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         wait_field("FOO", "bar")
         wait_field("BIN", "[6 bytes of binary data]")
 
-        b.click('.pf-c-breadcrumb li:first a')
+        b.click('.pf-c-breadcrumb li:first')
         b.wait_visible("#journal-box .cockpit-logline .cockpit-log-message:contains('[13 bytes of binary data]')")
 
     @nondestructive

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -547,7 +547,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.click(".cockpit-logline:nth-child(2)")
         b.enter_page("/system/logs")
         b.wait_text(".pf-c-card__title", "WORKING")
-        b.click(".pf-c-breadcrumb a:contains('Logs')")
+        b.click(".pf-c-breadcrumb li:contains('Logs')")
         b.wait_val("#journal-grep input", "priority:debug service:test.service ")
         b.go("/system/services#test.service")
         b.enter_page("/system/services")


### PR DESCRIPTION
The browser creates an entry in the history whenever an iframe changes
its "window.location" (which is how our pages implement
in-page-navigation).  The shell did not expect this and would add
another entry whenever the location of the current iframe changes.

---

### The back and forward buttons in your browser now work as expected

Cockpit used to interfere with the browser history, and hitting the back button would frequently get into a loop, for example. This has been fixed.