### PR TITLE
tools: Build valid arch PKGBUILD and Debian changelog in dist tarballs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -84,6 +84,8 @@ endif
 		tar --format=posix -C $(srcdir) --exclude test/reference -cf - -T - | tar -C $(distdir) -xf -
 	echo $(VERSION) > $(distdir)/.tarball
 	tools/create-spec --version '$(VERSION)' -o $(distdir)/tools/cockpit.spec $(srcdir)/tools/cockpit.spec.in
+	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/debian/changelog.in > $(distdir)/tools/debian/changelog
+	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/arch/PKGBUILD.in > $(distdir)/tools/arch/PKGBUILD
 	tools/adjust-distdir-timestamps "$(distdir)"
 
 #

--- a/tools/arch/PKGBUILD.in
+++ b/tools/arch/PKGBUILD.in
@@ -13,7 +13,7 @@ url='https://cockpit-project.org/'
 license=(LGPL)
 makedepends=(krb5 libssh accountsservice perl-json perl-locale-po json-glib glib-networking
              git intltool gtk-doc gobject-introspection networkmanager libgsystem xmlto npm pcp)
-source=("SOURCE"
+source=("cockpit-VERSION.tar.xz"
         "cockpit.pam"
         "cockpit-ws.sysuser.conf"
         "cockpit-wsinstance.sysuser.conf")

--- a/tools/debian/changelog.in
+++ b/tools/debian/changelog.in
@@ -1,4 +1,4 @@
-cockpit (0-1) UNRELEASED; urgency=medium
+cockpit (VERSION-1) UNRELEASED; urgency=medium
 
   * Work in progress
 


### PR DESCRIPTION
Similarly how we already create a valid spec file, rename PKGBUILD and
debian/changelog to *.in and replace the VERSION and SOURCE macros at
`make dist` time.

This fixes `image-customize --build` for deb and arch.