### PR TITLE
users: Use `autocomplete` property for password inputs

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -78,7 +78,7 @@ export const PasswordFormFields = ({
                        validated={error_password ? "error" : "default"}
                        fieldId={idPrefix + "-pw1"}>
                 <TextInput className="check-passwords" type="password" id={idPrefix + "-pw1"}
-                           value={password} onChange={value => change("password", value)} />
+                           autocomplete="new-password" value={password} onChange={value => change("password", value)} />
                 <div>
                     <Progress id={idPrefix + "-meter"}
                               className={"ct-password-strength-meter " + variant}
@@ -95,7 +95,7 @@ export const PasswordFormFields = ({
                        helperTextInvalid={error_password_confirm}
                        validated={error_password_confirm ? "error" : "default"}
                        fieldId={idPrefix + "-pw2"}>
-                <TextInput type="password" id={idPrefix + "-pw2"}
+                <TextInput type="password" id={idPrefix + "-pw2"} autocomplete="new-password"
                            value={password_confirm} onChange={value => change("password_confirm", value)} />
             </FormGroup>}
         </>

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -130,19 +130,22 @@ export function passwd_change(user, new_pass) {
 function SetPasswordDialogBody({ state, errors, change }) {
     const {
         need_old, password_old, password, password_confirm,
-        password_strength, password_message
+        password_strength, password_message, current_user,
     } = state;
 
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
             { need_old &&
-            <FormGroup label={_("Old password")}
-                       helperTextInvalid={errors && errors.password_old}
-                       validated={(errors && errors.password_old) ? "error" : "default"}
-                       fieldId="account-set-password-old">
-                <TextInput className="check-passwords" type="password" id="account-set-password-old"
-                           autocomplete="current-password" value={password_old} onChange={value => change("password_old", value)} />
-            </FormGroup> }
+            <>
+                <input hidden disabled value={current_user} />
+                <FormGroup label={_("Old password")}
+                           helperTextInvalid={errors && errors.password_old}
+                           validated={(errors && errors.password_old) ? "error" : "default"}
+                           fieldId="account-set-password-old">
+                    <TextInput className="check-passwords" type="password" id="account-set-password-old"
+                               autocomplete="current-password" value={password_old} onChange={value => change("password_old", value)} />
+                </FormGroup>
+            </> }
             <PasswordFormFields password={password}
                                 password_confirm={password_confirm}
                                 password_label={_("New password")}
@@ -164,6 +167,7 @@ export function set_password_dialog(account, current_user) {
 
     const state = {
         need_old: change_self,
+        current_user: current_user,
         password_old: "",
         password: "",
         password_confirm: "",

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -141,7 +141,7 @@ function SetPasswordDialogBody({ state, errors, change }) {
                        validated={(errors && errors.password_old) ? "error" : "default"}
                        fieldId="account-set-password-old">
                 <TextInput className="check-passwords" type="password" id="account-set-password-old"
-                           value={password_old} onChange={value => change("password_old", value)} />
+                           autocomplete="current-password" value={password_old} onChange={value => change("password_old", value)} />
             </FormGroup> }
             <PasswordFormFields password={password}
                                 password_confirm={password_confirm}


### PR DESCRIPTION
Mark fields that need new passwords so that browser does not try to
input remembered passwords but rather offers to generate a new one.
Also mark old password so in that case browser tries to offer remembered one.

Before when I tried to create new user it auto filled my current password and username:
![Screenshot from 2022-02-08 09-25-52](https://user-images.githubusercontent.com/12330670/152951281-4fa62f0a-85da-4043-96bb-1300d84b4dd0.png)

Now it does not do that:
![Screenshot from 2022-02-08 09-47-02](https://user-images.githubusercontent.com/12330670/152951326-6e39b6f7-f497-4fa6-aeae-986cc78d75d7.png)

And it offers to create a new one that is then filled in both fields:
![Screenshot from 2022-02-08 09-47-22](https://user-images.githubusercontent.com/12330670/152951392-f99a6d10-9f15-4727-bf99-9d6599fba52a.png)

And when old one is needed it is still correctly auto set:
![Screenshot from 2022-02-08 09-46-38](https://user-images.githubusercontent.com/12330670/152951443-acddc9f3-7bb6-49eb-9111-c440f4a27197.png)
