### PR TITLE
containers: Move cockpit/ws to Fedora 35

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:34
+FROM registry.fedoraproject.org/fedora:35
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 

--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -28,12 +28,12 @@ If you want to also run a web server to log in directly on the CoreOS host:
 
 4. Run the Cockpit web service with a privileged container (as root):
    ```
-   podman container runlabel --name cockpit-ws RUN docker.io/cockpit/ws
+   podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws
    ```
 
 5. Make Cockpit start on boot:
    ```
-   podman container runlabel INSTALL docker.io/cockpit/ws
+   podman container runlabel INSTALL quay.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 
@@ -43,4 +43,4 @@ Afterward, use a web browser to log into port `9090` on your host IP address as 
 
  * [Cockpit Project](https://cockpit-project.org)
  * [Cockpit Development](https://github.com/cockpit-project/cockpit)
- * [cockpit/ws Docker hub page](https://hub.docker.com/r/cockpit/ws)
+ * [cockpit/ws quay.io page](https://quay.io/repository/cockpit/ws)


### PR DESCRIPTION
This will unblock https://github.com/cockpit-project/bots/pull/2907 .

Blockers:
 - [x] Do a manual build and confirm it works
 - [x] Update https://quay.io/repository/cockpit/ws for changed repository

Post landing:
 - [ ] Apply this to https://github.com/cockpit-project/cockpit-container/ and refresh the official image (through autobuild)
 - [ ] Refresh/land https://github.com/cockpit-project/bots/pull/2907