### PR TITLE
Password component cleanups

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -47,20 +47,40 @@ export function password_quality(password, force) {
 
 export const PasswordFormFields = ({
     password_label, password_confirm_label,
-    password_strength, password_message,
     password_label_info,
     error_password, error_password_confirm,
     idPrefix, change
 }) => {
     const [password, setPassword] = useState(undefined);
     const [passwordConfirm, setConfirmPassword] = useState(undefined);
+    const [passwordStrength, setPasswordStrength] = useState("");
+    const [passwordMessage, setPasswordMessage] = useState("");
+
+    function onPasswordChanged(value) {
+        setPassword(value);
+        change("password", value);
+
+        if (value) {
+            password_quality(value)
+                    .catch(ex => {
+                        return { value: 0 };
+                    })
+                    .then(strength => {
+                        setPasswordStrength(strength.value);
+                        setPasswordMessage(strength.message);
+                    });
+        } else {
+            setPasswordStrength("");
+            setPasswordMessage("");
+        }
+    }
 
     let variant;
-    if (password_strength === "")
+    if (passwordStrength === "")
         variant = "default";
-    else if (password_strength > 66)
+    else if (passwordStrength > 66)
         variant = "success";
-    else if (password_strength > 33)
+    else if (passwordStrength > 33)
         variant = "warning";
     else
         variant = "danger";
@@ -80,7 +100,7 @@ export const PasswordFormFields = ({
                        validated={error_password ? "error" : "default"}
                        fieldId={idPrefix + "-pw1"}>
                 <TextInput className="check-passwords" type="password" id={idPrefix + "-pw1"}
-                           autocomplete="new-password" value={password} onChange={value => { setPassword(value); change("password", value) }} />
+                           autocomplete="new-password" value={password} onChange={onPasswordChanged} />
                 <div>
                     <Progress id={idPrefix + "-meter"}
                               className={"ct-password-strength-meter " + variant}
@@ -88,8 +108,8 @@ export const PasswordFormFields = ({
                               size={ProgressSize.sm}
                               measureLocation={ProgressMeasureLocation.none}
                               variant={variant}
-                              value={Number.isInteger(password_strength) ? password_strength : 0} />
-                    <div id={idPrefix + "-password-meter-message"} className="pf-c-form__helper-text" aria-live="polite">{password_message}</div>
+                              value={Number.isInteger(passwordStrength) ? passwordStrength : 0} />
+                    <div id={idPrefix + "-password-meter-message"} className="pf-c-form__helper-text" aria-live="polite">{passwordMessage}</div>
                 </div>
             </FormGroup>
 

--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -17,7 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 import cockpit from 'cockpit';
-import React from 'react';
+import React, { useState } from 'react';
 import { FormGroup, Popover, Progress, ProgressSize, ProgressMeasureLocation, TextInput } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 
@@ -46,13 +46,15 @@ export function password_quality(password, force) {
 }
 
 export const PasswordFormFields = ({
-    password, password_confirm,
     password_label, password_confirm_label,
     password_strength, password_message,
     password_label_info,
     error_password, error_password_confirm,
     idPrefix, change
 }) => {
+    const [password, setPassword] = useState(undefined);
+    const [passwordConfirm, setConfirmPassword] = useState(undefined);
+
     let variant;
     if (password_strength === "")
         variant = "default";
@@ -78,7 +80,7 @@ export const PasswordFormFields = ({
                        validated={error_password ? "error" : "default"}
                        fieldId={idPrefix + "-pw1"}>
                 <TextInput className="check-passwords" type="password" id={idPrefix + "-pw1"}
-                           autocomplete="new-password" value={password} onChange={value => change("password", value)} />
+                           autocomplete="new-password" value={password} onChange={value => { setPassword(value); change("password", value) }} />
                 <div>
                     <Progress id={idPrefix + "-meter"}
                               className={"ct-password-strength-meter " + variant}
@@ -96,7 +98,7 @@ export const PasswordFormFields = ({
                        validated={error_password_confirm ? "error" : "default"}
                        fieldId={idPrefix + "-pw2"}>
                 <TextInput type="password" id={idPrefix + "-pw2"} autocomplete="new-password"
-                           value={password_confirm} onChange={value => change("password_confirm", value)} />
+                           value={passwordConfirm} onChange={value => { setConfirmPassword(value); change("password_confirm", value) }} />
             </FormGroup>}
         </>
     );

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -32,7 +32,6 @@ const _ = cockpit.gettext;
 function AccountCreateBody({ state, errors, change }) {
     const {
         real_name, user_name,
-        password_strength, password_message,
         locked
     } = state;
 
@@ -58,8 +57,6 @@ function AccountCreateBody({ state, errors, change }) {
 
             <PasswordFormFields password_label={_("Password")}
                                 password_confirm_label={_("Confirm")}
-                                password_strength={password_strength}
-                                password_message={password_message}
                                 error_password={errors && errors.password}
                                 error_password_confirm={errors && errors.password_confirm}
                                 idPrefix="accounts-create-password"
@@ -156,8 +153,6 @@ export function account_create_dialog(accounts) {
         user_name: "",
         password: "",
         password_confirm: "",
-        password_strength: "",
-        password_message: "",
         locked: false,
         confirm_weak: false,
     };
@@ -179,20 +174,6 @@ export function account_create_dialog(accounts) {
         if (state.password != old_password) {
             state.confirm_weak = false;
             old_password = state.password;
-            if (state.password) {
-                password_quality(state.password)
-                        .catch(ex => {
-                            return { value: 0 };
-                        })
-                        .then(strength => {
-                            state.password_strength = strength.value;
-                            state.password_message = strength.message;
-                            update();
-                        });
-            } else {
-                state.password_strength = "";
-                state.password_message = "";
-            }
         }
 
         update();

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -32,7 +32,7 @@ const _ = cockpit.gettext;
 function AccountCreateBody({ state, errors, change }) {
     const {
         real_name, user_name,
-        password, password_confirm, password_strength, password_message,
+        password_strength, password_message,
         locked
     } = state;
 
@@ -56,9 +56,7 @@ function AccountCreateBody({ state, errors, change }) {
                            value={user_name} onChange={value => change("user_name", value)} />
             </FormGroup>
 
-            <PasswordFormFields password={password}
-                                password_confirm={password_confirm}
-                                password_label={_("Password")}
+            <PasswordFormFields password_label={_("Password")}
                                 password_confirm_label={_("Confirm")}
                                 password_strength={password_strength}
                                 password_message={password_message}

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -128,7 +128,7 @@ export function passwd_change(user, new_pass) {
 }
 
 function SetPasswordDialogBody({ state, errors, change }) {
-    const { need_old, password_old, password_strength, password_message, current_user } = state;
+    const { need_old, password_old, current_user } = state;
 
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
@@ -145,8 +145,6 @@ function SetPasswordDialogBody({ state, errors, change }) {
             </> }
             <PasswordFormFields password_label={_("New password")}
                                 password_confirm_label={_("Confirm new password")}
-                                password_strength={password_strength}
-                                password_message={password_message}
                                 error_password={errors && errors.password}
                                 error_password_confirm={errors && errors.password_confirm}
                                 idPrefix="account-set-password"
@@ -166,7 +164,6 @@ export function set_password_dialog(account, current_user) {
         password_old: "",
         password: "",
         password_confirm: "",
-        password_strength: "",
         confirm_weak: false,
     };
 
@@ -181,19 +178,6 @@ export function set_password_dialog(account, current_user) {
             state.confirm_weak = false;
             old_password = state.password;
             errors = { };
-            if (state.password) {
-                password_quality(state.password)
-                        .catch(ex => {
-                            return { value: 0 };
-                        })
-                        .then(strength => {
-                            state.password_strength = strength.value;
-                            state.password_message = strength.message;
-                            update();
-                        });
-            } else {
-                state.password_strength = "";
-            }
         }
 
         update();

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -128,10 +128,7 @@ export function passwd_change(user, new_pass) {
 }
 
 function SetPasswordDialogBody({ state, errors, change }) {
-    const {
-        need_old, password_old, password, password_confirm,
-        password_strength, password_message, current_user,
-    } = state;
+    const { need_old, password_old, password_strength, password_message, current_user } = state;
 
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
@@ -146,9 +143,7 @@ function SetPasswordDialogBody({ state, errors, change }) {
                                autocomplete="current-password" value={password_old} onChange={value => change("password_old", value)} />
                 </FormGroup>
             </> }
-            <PasswordFormFields password={password}
-                                password_confirm={password_confirm}
-                                password_label={_("New password")}
+            <PasswordFormFields password_label={_("New password")}
                                 password_confirm_label={_("Confirm new password")}
                                 password_strength={password_strength}
                                 password_message={password_message}


### PR DESCRIPTION
I am trying to add password hints but for that I need some preparation work. Only visible change is dropping of password confirmation, now looks like this:
![Screenshot from 2022-02-11 07-55-32](https://user-images.githubusercontent.com/12330670/153548984-95ceed63-acaa-443c-9413-fafac22feef6.png)


One disadvantage is, that now the value of password input is held by two components separately. That is not ideal, but once component needs it for setting it eventually up and other to run checks on it. 