### PR TITLE
test: Allow restart messages in testClientCertAuthentication

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1462,7 +1462,6 @@ class MachineCase(unittest.TestCase):
                                     "connection unexpectedly closed by peer",
                                     ".*Broken pipe.*",
                                     "g_dbus_connection_real_closed: Remote peer vanished with error: Underlying GIOStream returned 0 bytes on an async read \\(g-io-error-quark, 0\\). Exiting.",
-                                    "connection unexpectedly closed by peer",
                                     "cockpit-session: .*timed out.*",
                                     "ignoring failure from session process:.*",
                                     "peer did not close io when expected",

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -834,6 +834,7 @@ ipa-advise enable-admins-sudo | sh -ex
             b.wait_in_text(".terminal .xterm-accessibility-tree", "root")
 
         # S4U proxy ticket gets cleaned up on logout
+        self.allow_restart_journal_messages()
         b.logout()
         m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
         m.execute(f"! su -c '{ccache_env} klist' alice")


### PR DESCRIPTION
Example: https://logs.cockpit-project.org/logs/pull-16959-20220209-131529-8148213f-rhel-8-6/log.html#245