### PR TITLE
Revert "cockpit-client: disable and hide forward/back"

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -70,8 +70,8 @@ class CockpitClientWindow(Gtk.ApplicationWindow):
         self.webview.connect('decide-policy', self.decide_policy)
         self.webview.load_uri(uri)
 
-        # history = self.webview.get_back_forward_list()
-        # history.connect('changed', self.history_changed)
+        history = self.webview.get_back_forward_list()
+        history.connect('changed', self.history_changed)
         self.history_changed()
 
         if app.no_ui:

--- a/src/client/cockpit-client.ui
+++ b/src/client/cockpit-client.ui
@@ -27,7 +27,7 @@
         <property name="show-close-button">True</property>
         <child>
           <object class="GtkButtonBox">
-            <property name="visible">False</property>
+            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="homogeneous">True</property>
             <property name="layout-style">expand</property>


### PR DESCRIPTION
This reverts commit 6b716b1b87927ed4428a5514c27ed69242ce2fc4.

This is intended to land after #16938 and undo the temporary removal of back/forward in #16643.

 - [x] #16938 