### PR TITLE
test: Fix race condition with checking out pixel tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -885,7 +885,7 @@ class Browser:
 
         reference_dir = os.path.join(TEST_DIR, 'reference')
         if not os.path.exists(os.path.join(reference_dir, '.git')):
-            subprocess.check_call([f'{TEST_DIR}/common/pixel-tests', 'pull'])
+            raise SystemError("Pixel test references are missing, please run: test/common/pixel-tests pull")
 
         ignore_rects = relative_clips(list(map(lambda item: selector + " " + item, ignore)))
         base = self.pixels_label + "-" + key

--- a/test/run
+++ b/test/run
@@ -6,6 +6,7 @@
 set -eu
 
 tools/make-bots
+test/common/pixel-tests pull
 
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 TEST_OS_DEFAULT=$(PYTHONPATH=bots python3 -c 'from machine.machine_core.constants import TEST_OS_DEFAULT; print(TEST_OS_DEFAULT)')


### PR DESCRIPTION
With parallel tests it could happen that two pixel tests were running
around the same time. One would start the git clone, the other would see
the existing .git; but if the cloning was not done yet, the actual files
were missing, and the test failed with "New pixel test reference".

Let's avoid that by going back to pulling the reference images from
test/run; this reverts commit c20822b980b. In exchange, replace the 
on-demand checkout in testlib.py with an instructive error message.

----

[example 1](https://logs.cockpit-project.org/logs/pull-16942-20220209-124540-22d91db9-fedora-35/log.html#89), [example 2](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-16942-20220210-104937-a2b3c82a-fedora-35/log.html#267)

Now that we run 8 `@nd` tests in parallel instead of 2, this became a lot more apparent.