### PR TITLE
Test flake fixes

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -117,6 +117,10 @@ class TestHistoryMetrics(MachineCase):
         super().setUp()
         # start with a clean slate and avoid running into restart limits
         self.machine.execute("systemctl stop pmlogger pmproxy; systemctl reset-failed pmlogger pmproxy 2>/dev/null || true")
+        if self.machine.image == 'debian-stable':
+            # HACK: work around pcp breaking permissions: https://bugzilla.redhat.com/show_bug.cgi?id=2013937
+            # This is failing in too many ways to meaningfully cover with naughty
+            self.machine.execute("chown -R pcp:pcp /var/log/pcp/pmlogger/")
 
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -818,6 +818,7 @@ class TestMultiMachine(MachineCase):
 
         # Relogin.  This should now work seamlessly.
         b.relogin(None, wait_remote_session_machine=m1)
+        self.allow_restart_journal_messages()
         b.enter_page("/system", host="fred@10.111.113.2")
 
         # De-authorize key and relogin, then re-authorize.


### PR DESCRIPTION
This addresses more of the discovered flakes from PR #16942. The big remaining one is #16970, but that's a "tomorrow" thing.

[example for the multi-machine failure](https://logs.cockpit-project.org/logs/pull-16973-20220210-151712-c7a966fe-fedora-35-firefox/log.html#142)

Issue #16974 has the details for the second commit.