### PR TITLE
tests: Unify usage of `allow_restart_journal_messages()`

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -217,6 +217,8 @@ class Browser:
         self.cdp.invoke("Page.reload", ignoreCache=ignore_cache)
         self.expect_load()
 
+        self.machine.allow_restart_journal_messages()
+
     def expect_load(self):
         if opts.trace:
             print("-> expect_load")
@@ -690,6 +692,8 @@ class Browser:
                 self.open_session_menu()
                 self.click('#logout')
         self.expect_load()
+
+        self.machine.allow_restart_journal_messages()
 
     def relogin(self, path=None, user=None, superuser=None, wait_remote_session_machine=None):
         self.logout()

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -135,9 +135,6 @@ class TestApps(PackageCase):
         self.allow_journal_messages("invalid or unusable locale.*",
                                     "Error .* data: Connection reset by peer")
 
-        # Because of the reloading done by set_lang
-        self.allow_restart_journal_messages()
-
         # Reset everything
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -169,8 +169,6 @@ class TestConnection(MachineCase):
             b.wait_text('#login-fatal-message', "The cockpit package is not installed")
             m.execute("mv /usr/bin/cockpit-bridge.disabled /usr/bin/cockpit-bridge")
 
-        self.allow_restart_journal_messages()
-
         # Lets crash a systemd-crontrolled process and see if we get a proper backtrace in the logs
         # This helps with debugging failures in the tests elsewhere
         m.execute("""mkdir -p /run/systemd/system/systemd-hostnamed.service.d
@@ -924,7 +922,6 @@ until pgrep -f '^/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
 
         m.execute("pkill -e cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
         # this page failure is reeally noisy
-        self.allow_restart_journal_messages()
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
         self.allow_journal_messages("received request from bad Origin.*")
@@ -1079,8 +1076,6 @@ ProtocolHeader = X-Forwarded-Proto
         b.expect_load()
         b.wait_visible('#content')
         b.logout()
-
-        self.allow_restart_journal_messages()
 
     @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos",
                "rhel-8-4", "rhel-8-5", "rhel-8-6", "rhel-9-0", "ubuntu-stable", "ubuntu-2004", "arch")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -581,8 +581,6 @@ ExecStart=/usr/local/bin/{self.packageName}
             testStatusCard=True,
         ).execute()
 
-        self.allow_restart_journal_messages()
-
     @skipImage("Arch Linux does not start services by default", "arch")
     @skipImage("tracer not available", *OSesWithoutTracer)
     @nondestructive
@@ -831,8 +829,6 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertHistory("table.updates-history tbody.pf-m-expanded ul", ["buggy", "norefs-bin", "norefs-doc"])
         # and the previous one, not expaned
         b.wait_visible("table.updates-history tbody:not(.pf-m-expanded)")
-
-        self.allow_restart_journal_messages()
 
     @skipImage("No security changelog support in packagekit", "arch")
     @nondestructive

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -94,7 +94,6 @@ OnCalendar=daily
 
         m.execute("systemctl start test.timer")
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages("Failed to get realtime timestamp: Cannot assign requested address")
 
         # On Debian and Ubuntu we have to generate the other locales
@@ -313,8 +312,6 @@ OnCalendar=daily
         m.execute('useradd scruffy -s /bin/bash -c \'Scruffy\' || true')
         m.execute('echo scruffy:foobar | chpasswd')
 
-        self.allow_restart_journal_messages()
-
         if "debian" in m.image:
             m.execute('echo \'pt_BR.UTF-8 UTF-8\' >> /etc/locale.gen && locale-gen && update-locale')
         elif "ubuntu" in m.image:
@@ -414,8 +411,6 @@ OnCalendar=daily
                 '{ "menu": { "index": { "label": "FOO!" } } }')
         b.reload()
         self.check_system_menu("FOO!", True)
-
-        self.allow_restart_journal_messages()
 
     def testMenuSearch(self):
         b = self.browser

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -29,9 +29,6 @@ class TestSession(MachineCase):
         m = self.machine
         b = self.browser
 
-        # Might happen when killing the bridge.
-        self.allow_restart_journal_messages()
-
         def wait_session(should_exist):
             def cond():
                 return should_exist == ("admin" in m.execute("loginctl list-sessions"))

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -152,7 +152,6 @@ class TestKeys(MachineCase):
         b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:first-child", "no authorized public keys")
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 1)
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages('authorized_keys is not a public key file.')
         self.allow_journal_messages('Missing callback called fullpath = /home/user/.ssh/authorized_keys')
         self.allow_journal_messages('')

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -566,7 +566,6 @@ class TestMultiMachine(MachineCase):
         b.wait_text(".curtains-ct h1", "Not connected to host")
         self.assertEqual(b.text(".curtains-ct .pf-c-empty-state__body"), "Cannot connect to an unknown host")
 
-        self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
         # Might happen when killing the bridge.
         self.allow_journal_messages("localhost: dropping message while waiting for child to exit",
@@ -818,7 +817,6 @@ class TestMultiMachine(MachineCase):
 
         # Relogin.  This should now work seamlessly.
         b.relogin(None, wait_remote_session_machine=m1)
-        self.allow_restart_journal_messages()
         b.enter_page("/system", host="fred@10.111.113.2")
 
         # De-authorize key and relogin, then re-authorize.

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -217,7 +217,6 @@ class TestMultiMachineKeyAuth(MachineCase):
         b.wait_visible("a[href='/@10.111.113.2']")
         b.enter_page("/system", host="user@10.111.113.2")
 
-        self.allow_restart_journal_messages()
         self.allow_hostkey_messages()
         # Might happen when killing the bridge.
         self.allow_journal_messages("localhost: dropping message while waiting for child to exit",

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -187,8 +187,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "noise-rc-.*")
 
-        self.allow_restart_journal_messages()
-
     @skipImage("logs in via ssh, not cockpit-session", "fedora-coreos")
     def testLogging(self):
         m = self.machine
@@ -246,8 +244,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # But after that login, they should be gone again
         verify_correct(True, 0)
-
-        self.allow_restart_journal_messages()
 
     @skipImage("Arch Linux has no pwquality by default", "arch")
     def testExpired(self):
@@ -696,7 +692,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 expect_failed_login("root", "bad", n)
             expect_successful_login("root", "foobar")
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages(".*Account locked due to .* failed logins")
 
     @skipImage("sssd not available", "fedora-coreos")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -536,7 +536,6 @@ class TestStorageLuks(StorageCase):
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
-        self.allow_restart_journal_messages()
         m.wait_reboot()
         m.start_cockpit()
         b.relogin()

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -362,7 +362,6 @@ class TestStorageStratis(StorageCase):
 
         # Reboot
         m.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
-        self.allow_restart_journal_messages()
         m.wait_reboot()
         m.start_cockpit()
         b.relogin()

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -77,8 +77,6 @@ class TestSuperuser(MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
-        self.allow_restart_journal_messages()
-
     def testNoPasswd(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -428,9 +428,6 @@ class TestSystemInfo(MachineCase):
         b.wait_text('#motd', "Hello cockpit team")
         self.assertEqual("Hello cockpit team", self.machine.execute("cat /etc/motd").rstrip())
 
-        # because of the reload
-        self.allow_restart_journal_messages()
-
     @nondestructive
     def testHardwareInfo(self):
         b = self.browser
@@ -755,7 +752,6 @@ fi
                                     'Found initrd image.*',
                                     '.*warning: setlocale: LC_ALL: cannot change locale.*',
                                     'done')
-        self.allow_restart_journal_messages()
 
     @skipImage("Insights client not yet available on RHEL 9", "rhel-9-0")
     def testInsightsStatus(self):

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -331,7 +331,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b = self.browser
         m = self.machine
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages(".*Failed to get realtime timestamp: Cannot assign requested address.*")
 
         # HACK: pmie and pmlogger take a looooong time to shutdown (https://bugzilla.redhat.com/show_bug.cgi?id=1703348)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -263,7 +263,6 @@ class CommonTests:
         wait_number_domains(1)
 
         self.allow_journal_messages(".*No authentication agent found.*")
-        self.allow_restart_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 
@@ -834,7 +833,6 @@ ipa-advise enable-admins-sudo | sh -ex
             b.wait_in_text(".terminal .xterm-accessibility-tree", "root")
 
         # S4U proxy ticket gets cleaned up on logout
-        self.allow_restart_journal_messages()
         b.logout()
         m.execute("while ls /run/user/$(id -u alice)/*.ccache; do sleep 1; done")
         m.execute(f"! su -c '{ccache_env} klist' alice")
@@ -1121,7 +1119,6 @@ ExecStart=/bin/true
                             'http://x0.cockpit.lan:9090/cockpit/login'])
         self.assertIn("HTTP/1.1 200 OK", output)
         self.assertIn('"csrf-token"', output)
-        self.allow_restart_journal_messages()
 
         m.write("/etc/cockpit/cockpit.conf", "[Negotiate]\naction = none\n", append=True)
         m.restart_cockpit()

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -27,8 +27,6 @@ from testlib import *
 class TestTuned(MachineCase):
 
     def testBasic(self):
-        self.allow_restart_journal_messages()
-
         b = self.browser
         m = self.machine
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -273,7 +273,6 @@ class TestAccounts(MachineCase):
 
         # Logout and login with the new password
         b.logout()
-        self.allow_restart_journal_messages()
         b.open("/users")
         b.wait_visible("#login")
         b.set_val("#login-user-input", "jussi")
@@ -364,8 +363,6 @@ class TestAccounts(MachineCase):
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .pf-c-modal-box__footer", "must wait longer")
 
-        self.allow_restart_journal_messages()
-
     @skipImage("ssh root login not allowed", "fedora-coreos")
     def testRootLogin(self):
         m = self.machine
@@ -403,8 +400,6 @@ class TestAccounts(MachineCase):
             b.click('#login-button')
             b.expect_load()
             b.wait_visible('#content')
-
-        self.allow_restart_journal_messages()
 
     def accountExpiryInfo(self, account, field):
         for line in self.machine.execute(f"LC_ALL=C chage -l {account}").split("\n"):

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -102,8 +102,6 @@ class TestRoles(MachineCase):
         b.wait_visible(admin_role_sel + ":not([disabled])")
         b.wait_visible(admin_role_sel + ":checked")
 
-        self.allow_restart_journal_messages()
-
     @nondestructive
     def testDynamic(self):
         m = self.machine


### PR DESCRIPTION
When it is used due to `relogin()`, `reload()` or `logout()` don't
always specify it but let these methods to do it.

There are still 11 cases where `allow_restart_journal_messages()` is used - these are due to different reasons than us logging out or relaoding (like killing cockpit, restarting the machine, removing host...)

Lets see if there are some flaky messages