### PR TITLE
tools: add git-hook-pre-rebase

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -119,6 +119,11 @@ You can also set up a post-commit hook to do the same, after each commit:
 
     $ ln -s ../../test/git-hook-post-commit .git/hooks/post-commit
 
+We also have a hook to ameliorate one of the more annoying drawbacks of using
+git submodules:
+
+    $ ln -s ../../tools/git-hook-pre-rebase .git/tools/pre-rebase
+
 ## Running the integration test suite
 
 Refer to the [testing README](test/README.md) for details on running the Cockpit

--- a/tools/git-hook-pre-rebase
+++ b/tools/git-hook-pre-rebase
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+rebase_onto="$1"
+
+for dir in node_modules test/reference; do
+    # If a particular submodule is...
+    if test -e "${dir}/.git" &&                         # ...checked out...
+       test -z "$(git status --porcelain "${dir}")" &&  # ...clean...
+       ! git diff --quiet "${rebase_onto}" -- "${dir}"  # ...and changed on origin...
+    then
+        # then save ourselves the trouble of it being wrong post-rebase.
+        echo "Removing soon-to-be out-of-date ${dir}..."
+        rm -rf "${dir}"
+        mkdir "${dir}"
+    fi
+done


### PR DESCRIPTION
One of the more annoying things about the use of submodules is rebasing.
If the submodule was updated upstream and you have a copy if it checked
out in your working directory, then after the rebase, the old version
will still be checked out, and now it's the incorrect version.

More than once I've accidentally committed the old version again, as a
result of subsequent careless use of `commit -a`.  Even if you notice
the problem, it's an unnecessary nuisance.

Add a script to delete submodules before performing a rebase if:

 - the submodule is checked out
 - it contains no local changes
 - it will be out of date after the rebase

Add a note to HACKING.md, suggesting to install the hook.