### PR TITLE
webpack: replace our gzip tricks with compression-webpack-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ Makefile.in
 /aclocal.m4
 /autom4te.cache
 /bots
+/cockpit
 /cockpit-*.tar*
 /cockpit-*.xz
 /cockpit-askpass

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "axe-core": "^3.5.2",
     "babel-loader": "^8.1.0",
     "chrome-remote-interface": "^0.28.1",
+    "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",
     "css-minimizer-webpack-plugin": "^3.0.1",

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -25,22 +25,19 @@ EXTRA_DIST += \
 	$(pixmaps_DATA) \
 	$(NULL)
 
+pcpmanifestdir = $(datadir)/cockpit/pcp
+dist_pcpmanifest_DATA = pkg/pcp/manifest.json
+
+sshmanifestdir = $(datadir)/cockpit/ssh
+dist_sshmanifest_DATA = pkg/ssh/manifest.json
+
 include pkg/build
 
-INSTALL_DATA_LOCAL_TARGETS += install-webpack
-install-webpack: $(WEBPACK_INSTALL) $(MANIFESTS)
-	mkdir -p $(DESTDIR)$(pkgdatadir)
-	$(V_TAR) tar --format=posix -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
+# automake doesn't support stripping initial path components (ie: `dist`) with
+# `nobase_`, so we create a cockpit/ symlink and use that instead.
+# That way, the files land in $(datadir)/cockpit/ and `dist` is avoided.
+all-local:: cockpit
+cockpit:
+	$(AM_V_GEN) ln -sf $(srcdir)/dist $@
 
-INSTALL_DATA_LOCAL_TARGETS += install-webpack-map
-install-webpack-map: $(wildcard $(top_srcdir)/dist/*/*.map)
-	$(V_TAR) tar --format=posix -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
-
-UNINSTALL_LOCAL_TARGETS += uninstall-webpack
-uninstall-webpack:
-	test ! -d $(DESTDIR)$(pkgdatadir) || \
-	  (find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type f -exec rm -f {} \; && \
-	   find $(DESTDIR)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
-	test ! -d $(DESTDIR)$(debugdir)$(pkgdatadir) || \
-	  (find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type f -delete && \
-	   find $(DESTDIR)$(debugdir)$(pkgdatadir) -ignore_readdir_race -type d -empty -delete)
+nobase_data_DATA = $(patsubst dist/%,cockpit/%,$(WEBPACK_INSTALL))

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -32,16 +32,6 @@ install-webpack: $(WEBPACK_INSTALL) $(MANIFESTS)
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	$(V_TAR) tar --format=posix -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
 
-INSTALL_DATA_LOCAL_TARGETS += install-webpack-gz
-install-webpack-gz: $(WEBPACK_GZ_INSTALL)
-	@for file in $^; do \
-		target="$(DESTDIR)$(pkgdatadir)/$${file##*dist/}.gz"; \
-		[ -n "$(DESTDIR)" -a "$${target}" -nt "$${file}" ] && continue; \
-		mkdir -p "$${target%/*}"; \
-		echo "$${file} → $${target}"; \
-		gzip -9 < "$${file}" > "$${target}"; \
-	done
-
 INSTALL_DATA_LOCAL_TARGETS += install-webpack-map
 install-webpack-map: $(wildcard $(top_srcdir)/dist/*/*.map)
 	$(V_TAR) tar --format=posix -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv

--- a/pkg/build
+++ b/pkg/build
@@ -23,11 +23,7 @@ WEBPACK_PACKAGES = \
 	users \
 	$(NULL)
 
-MANIFESTS = \
-	$(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/manifest.json) \
-	pkg/pcp/manifest.json \
-	pkg/ssh/manifest.json \
-	$(NULL)
+MANIFESTS = $(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/manifest.json)
 
 .PHONY: all-webpack
 all-webpack: $(MANIFESTS)

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -959,7 +959,6 @@ package_content (CockpitPackages *packages,
   GBytes *uncompressed = NULL;
   CockpitPackage *package;
   gboolean result = FALSE;
-  GList *l, *names = NULL;
   gchar *filename = NULL;
   GError *error = NULL;
   GBytes *bytes = NULL;
@@ -973,17 +972,19 @@ package_content (CockpitPackages *packages,
   if (!self_origin)
     self_origin = cockpit_web_response_get_origin (response);
 
+  GList *names;
   globbing = g_str_equal (name, "*");
   if (globbing)
     {
       names = g_hash_table_get_keys (packages->listing);
+      names = g_list_sort (names, (GCompareFunc) g_strcmp0);
 
       /* When globbing files together no gzip encoding is possible */
       allow_gzipped = FALSE;
     }
   else
     {
-      names = g_list_append (names, (gchar *)name);
+      names = g_list_prepend (NULL, (gchar *)name);
 
       /* Check if client allows us to send gzipped content */
       for (gint i = 0; encodings[i] != NULL; i++)
@@ -994,9 +995,8 @@ package_content (CockpitPackages *packages,
         }
     }
 
-  names = g_list_sort (names, (GCompareFunc)g_strcmp0);
 
-  for (l = names; l != NULL; l = g_list_next (l))
+  for (GList *l = names; l != NULL; l = g_list_next (l))
     {
       name = l->data;
       g_free (filename);

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1265,16 +1265,8 @@ web_response_file (CockpitWebResponse *response,
                    gpointer user_data)
 {
   const gchar *default_policy = "default-src 'self' 'unsafe-inline';";
-
   const gchar *headers[5] = { NULL };
-  GError *error = NULL;
-  gchar *unescaped = NULL;
-  gchar *path = NULL;
-  gchar *alloc = NULL;
-  GMappedFile *file = NULL;
-  const gchar *root;
-  GBytes *body;
-  GList *output = NULL;
+  g_autofree gchar *alloc = NULL;
   GList *l = NULL;
   gint content_length = -1;
   gint at = 0;
@@ -1287,60 +1279,62 @@ web_response_file (CockpitWebResponse *response,
   g_return_if_fail (escaped != NULL);
 
   /* Someone is trying to escape the root directory, or access hidden files? */
-  unescaped = g_uri_unescape_string (escaped, "/");
+  g_autofree gchar *unescaped = g_uri_unescape_string (escaped, "/");
   if (!unescaped || strstr (unescaped, "/.") || strstr (unescaped, "../") || strstr (unescaped, "//"))
     {
       g_debug ("%s: invalid path request", escaped);
       cockpit_web_response_error (response, 404, NULL, "Not Found");
-      goto out;
+      return;
     }
 
-again:
-  root = *(roots++);
-  if (root == NULL)
+  g_autoptr(GMappedFile) file = NULL;
+  for (gint i = 0; roots[i]; i++)
     {
-      cockpit_web_response_error (response, 404, NULL, "Not Found");
-      goto out;
-    }
+      const gchar *root = roots[i];
+      g_autofree gchar *path = g_build_filename (root, unescaped, NULL);
 
-  g_free (path);
-  path = g_build_filename (root, unescaped, NULL);
+      if (g_file_test (path, G_FILE_TEST_IS_DIR))
+        {
+          cockpit_web_response_error (response, 403, NULL, "Directory Listing Denied");
+          return;
+        }
 
-  if (g_file_test (path, G_FILE_TEST_IS_DIR))
-    {
-      cockpit_web_response_error (response, 403, NULL, "Directory Listing Denied");
-      goto out;
-    }
+      /* As a double check of above behavior */
+      g_assert (path_has_prefix (path, root));
 
-  /* As a double check of above behavior */
-  g_assert (path_has_prefix (path, root));
+      g_autoptr(GError) error = NULL;
+      file = g_mapped_file_new (path, FALSE, &error);
+      if (file != NULL)
+        break;
 
-  g_clear_error (&error);
-  file = g_mapped_file_new (path, FALSE, &error);
-  if (file == NULL)
-    {
       if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT) ||
           g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NAMETOOLONG))
         {
           g_debug ("%s: file not found in root: %s", escaped, root);
-          goto again;
         }
       else if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_PERM) ||
                g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_ACCES) ||
                g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_ISDIR))
         {
           cockpit_web_response_error (response, 403, NULL, "Access denied");
-          goto out;
+          return;
         }
       else
         {
           g_warning ("%s: %s", path, error->message);
           cockpit_web_response_error (response, 500, NULL, "Internal server error");
-          goto out;
+          return;
         }
     }
 
-  body = g_mapped_file_get_bytes (file);
+  if (file == NULL)
+    {
+      cockpit_web_response_error (response, 404, NULL, "Not Found");
+      return;
+    }
+
+  g_autoptr(GBytes) body = g_mapped_file_get_bytes (file);
+  GList *output = NULL;
   if (template_func)
     {
       output = cockpit_template_expand (body, "${", "}", template_func, user_data);
@@ -1380,16 +1374,7 @@ again:
   if (l == NULL)
     cockpit_web_response_complete (response);
 
-out:
-  g_free (alloc);
-  g_free (unescaped);
-  g_clear_error (&error);
-  g_free (path);
-  if (file)
-    g_mapped_file_unref (file);
-
-  if (output)
-    g_list_free_full (output, (GDestroyNotify)g_bytes_unref);
+  g_list_free_full (output, (GDestroyNotify)g_bytes_unref);
 }
 
 /**

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1261,6 +1261,8 @@ static void
 web_response_file (CockpitWebResponse *response,
                    const gchar *escaped,
                    const gchar **roots,
+                   gboolean search_gzip,
+                   gboolean accept_gzip,
                    CockpitTemplateFunc template_func,
                    gpointer user_data)
 {
@@ -1280,6 +1282,7 @@ web_response_file (CockpitWebResponse *response,
       return;
     }
 
+  gboolean is_gzip = FALSE;
   g_autoptr(GMappedFile) file = NULL;
   for (gint i = 0; roots[i]; i++)
     {
@@ -1297,6 +1300,18 @@ web_response_file (CockpitWebResponse *response,
 
       g_autoptr(GError) error = NULL;
       file = g_mapped_file_new (path, FALSE, &error);
+
+      if (file == NULL && search_gzip &&
+          g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+        {
+          g_debug ("%s: file not found in root: %s, looking for .gz", escaped, root);
+          g_clear_error (&error);
+          g_autofree gchar *old_path = g_steal_pointer (&path);
+          path = g_strconcat (old_path, ".gz", NULL);
+          file = g_mapped_file_new (path, FALSE, &error);
+          is_gzip = file != NULL;
+        }
+
       if (file != NULL)
         break;
 
@@ -1328,6 +1343,23 @@ web_response_file (CockpitWebResponse *response,
 
   g_autoptr(GBytes) body = g_mapped_file_get_bytes (file);
 
+  if (is_gzip && (!accept_gzip || template_func))
+    {
+      /* We have gzipped content, but the client won't accept it, or
+       * template expansion was requested.  Decompress.
+       */
+      g_autoptr(GError) error = NULL;
+      g_autoptr(GBytes) body_gz = g_steal_pointer (&body);
+      body = cockpit_web_response_gunzip (body_gz, &error);
+      if (body == NULL)
+        {
+          g_warning ("%s", error->message);
+          cockpit_web_response_error (response, 500, NULL, "Internal server error");
+          return;
+        }
+      is_gzip = FALSE;
+    }
+
   GList *output;
   gint content_length = -1;
   if (template_func)
@@ -1358,6 +1390,9 @@ web_response_file (CockpitWebResponse *response,
       seen |= append_header (string, "Content-Security-Policy", policy);
     }
 
+  if (is_gzip)
+    seen |= append_header (string, "Content-Encoding", "gzip");
+
   g_autoptr(GBytes) headers_block = finish_headers (response, string, content_length, 200, seen);
   queue_bytes (response, headers_block);
 
@@ -1386,7 +1421,7 @@ cockpit_web_response_file (CockpitWebResponse *response,
                            const gchar *escaped,
                            const gchar **roots)
 {
-  web_response_file (response, escaped, roots, NULL, NULL);
+  web_response_file (response, escaped, roots, FALSE, FALSE, NULL, NULL);
 }
 
 void
@@ -1395,7 +1430,16 @@ cockpit_web_response_template (CockpitWebResponse *response,
                                    const gchar **roots,
                                    GHashTable *values)
 {
-  web_response_file (response, escaped, roots, substitute_hash_value, values);
+  web_response_file (response, escaped, roots, FALSE, FALSE, substitute_hash_value, values);
+}
+
+void
+cockpit_web_response_file_or_gz (CockpitWebResponse *response,
+                                 gboolean accepts_gzip,
+                                 const gchar *escaped,
+                                 const gchar **roots)
+{
+  web_response_file (response, escaped, roots, TRUE, accepts_gzip, NULL, NULL);
 }
 
 static gboolean

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -112,6 +112,11 @@ void                  cockpit_web_response_file          (CockpitWebResponse *re
                                                           const gchar *escaped,
                                                           const gchar **roots);
 
+void                  cockpit_web_response_file_or_gz    (CockpitWebResponse *response,
+                                                          gboolean accepts_gz,
+                                                          const gchar *escaped,
+                                                          const gchar **roots);
+
 GBytes *              cockpit_web_response_gunzip        (GBytes *bytes,
                                                           GError **error);
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -1441,4 +1441,16 @@ cockpit_web_request_get_client_certificate (CockpitWebRequest *self)
   return client_certificate;
 }
 
+gboolean
+cockpit_web_request_accepts_encoding (CockpitWebRequest *self,
+                                      const gchar *encoding)
+{
+  const gchar *accept = g_hash_table_lookup (self->headers, "Accept-Encoding");
+  if (!accept)
+    return TRUE;
+  g_auto(GStrv) encodings = cockpit_web_server_parse_accept_list (accept, NULL);
+  return g_strv_contains ((const gchar **) encodings, encoding) ||
+         g_strv_contains ((const gchar **) encodings, "*");
+}
+
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -79,6 +79,10 @@ cockpit_web_request_get_remote_address (CockpitWebRequest *self);
 const gchar *
 cockpit_web_request_get_client_certificate (CockpitWebRequest *self);
 
+gboolean
+cockpit_web_request_accepts_encoding (CockpitWebRequest *self,
+                                      const gchar *encoding);
+
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
 G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -632,7 +632,7 @@ on_handle_source (CockpitWebServer *server,
       inject_address (response, "bus_address", bus_address);
       inject_address (response, "direct_address", direct_address);
     }
-  cockpit_web_response_file (response, path, (const gchar **)server_roots);
+  cockpit_web_response_file_or_gz (response, TRUE, path, (const gchar **)server_roots);
   return TRUE;
 }
 

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -473,10 +473,15 @@ class TestMultiMachine(MachineCase):
         m2 = self.machine2
 
         # Modify the terminals to be different on the two machines.
-        m1.execute("zcat /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m1-token</body>|' | gzip"
-                   " > /tmp/terminal.html.gz && mount -o bind /tmp/terminal.html.gz /usr/share/cockpit/systemd/terminal.html.gz")
-        m2.execute("zcat /usr/share/cockpit/systemd/terminal.html.gz | sed -e 's|</body>|magic-m2-token</body>|' | gzip"
-                   " > /tmp/terminal.html.gz && mount -o bind /tmp/terminal.html.gz /usr/share/cockpit/systemd/terminal.html.gz")
+        for machine, name in zip((m1, m2), ('m1', 'm2')):
+            # This page may be either compressed or uncompressed
+            machine.execute(f"""
+                FILENAME=/usr/share/cockpit/systemd/terminal.html*
+                cp $FILENAME /tmp
+                test -f /tmp/terminal.html || gzip -d /tmp/terminal.html.gz
+                sed -ie 's|</body>|magic-{name}-token</body>|' /tmp/terminal.html
+                gzip < /tmp/terminal.html > /tmp/terminal.html.gz
+                mount -o bind /tmp/"$(basename $FILENAME)" $FILENAME""")
 
         self.login_and_go("/system")
         add_machine(b, "10.111.113.2")

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -4,6 +4,7 @@
 #         Allison Karlitskaya <allison.karlitskaya@redhat.com>
 
 import argparse
+import gzip
 import os
 import re
 import sys
@@ -81,10 +82,10 @@ dist_licenses = {}  # Files: dirglob → set(licenses)
 
 for directory, _subdirs, files in os.walk(f'{BASE_DIR}/dist'):
     for file in files:
-        if not file.endswith('.LICENSE.txt'):
+        if not file.endswith('.LICENSE.txt.gz'):
             continue
 
-        with open(os.path.join(directory, file)) as license_file:
+        with gzip.open(os.path.join(directory, file), 'rt') as license_file:
             comments = license_file.read().split('\n\n')
 
         for comment in comments:

--- a/tools/check-dist
+++ b/tools/check-dist
@@ -2,13 +2,6 @@
 
 # Check for mistakes in tarball distribution
 
-# Make sure we don't distribute gz files
-find $1/dist -name '*.gz' -print | sort | while read file; do
-        find $1/dist -name '*.gz' -print >&2
-        echo "Refusing to distribute gzip files" >&2
-        exit 1
-done
-
 # Make sure all po files are valid
 find $1/po -name '*.po' -print | while read file; do
     if ! msgfmt "$file" -o /dev/null; then

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -111,16 +111,8 @@ function generateDeps(makefile, stats) {
         inputs.add(input);
     }
 
-    const uncompressed_patterns = [
-        '/manifest.json$', '/override.json$',
-        '^dist/static/', // cockpit-ws cannot currently serve compressed login page
-        '^dist/shell/index.html$',  // COMPAT: Support older cockpit-ws binaries. See #14673
-        '\.png$', '\.woff$', '\.woff2$', '\.gif$'
-    ].map((r) => new RegExp(r));
-
     const outputs = new Set();
     const installs = new Set();
-    const gz_installs = new Set();
     const tests = new Set();
     for (const asset in stats.compilation.assets) {
         const output = path.join(dir, asset);
@@ -139,11 +131,7 @@ function generateDeps(makefile, stats) {
         if (output.endsWith(".map") || output.endsWith(".LICENSE.txt"))
             continue;
 
-        if (uncompressed_patterns.some((s) => output.match(s))) {
-            installs.add(output);
-        } else {
-            gz_installs.add(output);
-        }
+        installs.add(output);
     }
 
     const lines = [ "# Generated Makefile data for " + prefix ];
@@ -161,7 +149,6 @@ function generateDeps(makefile, stats) {
     makeArray(prefix + "_OUTPUTS", outputs);
 
     makeArray(prefix + "_INSTALL", installs);
-    makeArray(prefix + "_GZ_INSTALL", gz_installs);
     makeArray(prefix + "_TESTS", tests);
 
     lines.push(stampfile + ": $(" + prefix + "_INPUTS)");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,6 +244,7 @@ const fs = require("fs");
 const copy = require("copy-webpack-plugin");
 const html = require('html-webpack-plugin');
 const miniCssExtractPlugin = require('mini-css-extract-plugin');
+const CompressionPlugin = require("compression-webpack-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
@@ -349,6 +350,18 @@ const plugins = [
         wrapper: (section === 'static/') ? 'window.cockpit_po = PO_DATA;' : undefined,
     }),
 ];
+
+if (production) {
+    plugins.push(new CompressionPlugin({
+        test: /\.(css|html|js|txt)$/,
+        deleteOriginalAssets: true,
+        exclude: [
+            '/test-[^/]+.$', // don't compress test cases
+            '^static/[^/]+$', // cockpit-ws cannot currently serve compressed login page
+            '^shell/index.html$', // COMPAT: Support older cockpit-ws binaries. See #14673
+        ].map(r => new RegExp(r)),
+    }));
+}
 
 if (eslint) {
     plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"] }));


### PR DESCRIPTION
Our build system does quite some tricks to compress our assets on the
fly during the `make install` phase.  Let's just do the compression as
part of the webpack.

 - [x] wait for #17105 
 - [x] #17120 