### PR TITLE
ws: serve gzipped files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -58,14 +58,6 @@ clean-local::
 install-data-local:: $(WEBPACK_INSTALL) $(MANIFESTS)
 	mkdir -p $(DESTDIR)$(pkgdatadir)
 	$(V_TAR) tar --format=posix -cf - $^ | tar --no-same-owner -C $(DESTDIR)$(pkgdatadir) --strip-components=1 -xvf -
-install-data-local:: $(WEBPACK_GZ_INSTALL)
-	@for file in $^; do \
-		target="$(DESTDIR)$(pkgdatadir)/$${file##*dist/}.gz"; \
-		[ -n "$(DESTDIR)" -a "$${target}" -nt "$${file}" ] && continue; \
-		mkdir -p "$${target%/*}"; \
-		echo "$${file} → $${target}"; \
-		gzip -9 < "$${file}" > "$${target}"; \
-	done
 install-data-local:: $(wildcard $(top_srcdir)/dist/*/*.map)
 	$(V_TAR) tar --format=posix -c --transform="s@.*dist/@$(debugdir)$(pkgdatadir)/@" -T/dev/null $^ | tar --no-same-owner -C $(DESTDIR)/ -xv
 uninstall-local::

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "axe-core": "^3.5.2",
     "babel-loader": "^8.1.0",
     "chrome-remote-interface": "^0.28.1",
+    "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",
     "css-minimizer-webpack-plugin": "^3.0.1",

--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -943,7 +943,6 @@ package_content (CockpitPackages *packages,
   GBytes *uncompressed = NULL;
   CockpitPackage *package;
   gboolean result = FALSE;
-  GList *l, *names = NULL;
   gchar *filename = NULL;
   GError *error = NULL;
   GBytes *bytes = NULL;
@@ -957,17 +956,19 @@ package_content (CockpitPackages *packages,
   if (!self_origin)
     self_origin = cockpit_web_response_get_origin (response);
 
+  GList *names;
   globbing = g_str_equal (name, "*");
   if (globbing)
     {
       names = g_hash_table_get_keys (packages->listing);
+      names = g_list_sort (names, (GCompareFunc) g_strcmp0);
 
       /* When globbing files together no gzip encoding is possible */
       allow_gzipped = FALSE;
     }
   else
     {
-      names = g_list_append (names, (gchar *)name);
+      names = g_list_prepend (NULL, (gchar *)name);
 
       /* Check if client allows us to send gzipped content */
       for (gint i = 0; encodings[i] != NULL; i++)
@@ -978,9 +979,8 @@ package_content (CockpitPackages *packages,
         }
     }
 
-  names = g_list_sort (names, (GCompareFunc)g_strcmp0);
 
-  for (l = names; l != NULL; l = g_list_next (l))
+  for (GList *l = names; l != NULL; l = g_list_next (l))
     {
       name = l->data;
       g_free (filename);

--- a/src/common/cockpitwebresponse.c
+++ b/src/common/cockpitwebresponse.c
@@ -1266,13 +1266,6 @@ web_response_file (CockpitWebResponse *response,
                    CockpitTemplateFunc template_func,
                    gpointer user_data)
 {
-  const gchar *default_policy = "default-src 'self' 'unsafe-inline';";
-  const gchar *headers[5] = { NULL };
-  g_autofree gchar *alloc = NULL;
-  GList *l = NULL;
-  gint content_length = -1;
-  gint at = 0;
-
   g_return_if_fail (COCKPIT_IS_WEB_RESPONSE (response));
 
   if (!escaped)
@@ -1336,23 +1329,24 @@ web_response_file (CockpitWebResponse *response,
     }
 
   g_autoptr(GBytes) body = g_mapped_file_get_bytes (file);
-  GList *output = NULL;
+
+  GList *output;
+  gint content_length = -1;
   if (template_func)
     {
       output = cockpit_template_expand (body, "${", "}", template_func, user_data);
     }
   else
     {
-      output = g_list_prepend (output, g_bytes_ref (body));
+      output = g_list_prepend (NULL, g_bytes_ref (body));
       content_length = g_bytes_get_size (body);
     }
-  g_bytes_unref (body);
+
+  GString *string = begin_headers (response, 200, "OK");
+  guint seen = 0;
 
   if (response->origin)
-    {
-      headers[at++] = "Access-Control-Allow-Origin";
-      headers[at++] = response->origin;
-    }
+    seen |= append_header (string, "Access-Control-Allow-Origin", response->origin);
 
   /*
    * The default Content-Security-Policy for .html files allows
@@ -1361,13 +1355,15 @@ web_response_file (CockpitWebResponse *response,
    */
   if (g_str_has_suffix (unescaped, ".html"))
     {
-      headers[at++] = "Content-Security-Policy";
-      headers[at++] = alloc = cockpit_web_response_security_policy (default_policy, response->origin);
+      const gchar *default_policy = "default-src 'self' 'unsafe-inline';";
+      g_autofree gchar *policy = cockpit_web_response_security_policy (default_policy, response->origin);
+      seen |= append_header (string, "Content-Security-Policy", policy);
     }
 
-  cockpit_web_response_headers (response, 200, "OK", content_length,
-                                headers[0], headers[1], headers[2], headers[3], NULL);
+  g_autoptr(GBytes) headers_block = finish_headers (response, string, content_length, 200, seen);
+  queue_bytes (response, headers_block);
 
+  GList *l;
   for (l = output; l != NULL; l = g_list_next (l))
     {
       if (!cockpit_web_response_queue (response, l->data))

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -113,6 +113,11 @@ void                  cockpit_web_response_file          (CockpitWebResponse *re
                                                           const gchar *escaped,
                                                           const gchar **roots);
 
+void                  cockpit_web_response_file_or_gz    (CockpitWebResponse *response,
+                                                          gboolean accepts_gz,
+                                                          const gchar *escaped,
+                                                          const gchar **roots);
+
 GBytes *              cockpit_web_response_gunzip        (GBytes *bytes,
                                                           GError **error);
 

--- a/src/common/cockpitwebserver.c
+++ b/src/common/cockpitwebserver.c
@@ -1420,4 +1420,16 @@ cockpit_web_request_get_client_certificate (CockpitWebRequest *self)
   return client_certificate;
 }
 
+gboolean
+cockpit_web_request_accepts_encoding (CockpitWebRequest *self,
+                                      const gchar *encoding)
+{
+  const gchar *accept = g_hash_table_lookup (self->headers, "Accept-Encoding");
+  if (!accept)
+    return TRUE;
+  g_auto(GStrv) encodings = cockpit_web_server_parse_accept_list (accept, NULL);
+  return g_strv_contains ((const gchar **) encodings, encoding) ||
+         g_strv_contains ((const gchar **) encodings, "*");
+}
+
 /* ---------------------------------------------------------------------------------------------------- */

--- a/src/common/cockpitwebserver.h
+++ b/src/common/cockpitwebserver.h
@@ -79,6 +79,10 @@ cockpit_web_request_get_remote_address (CockpitWebRequest *self);
 const gchar *
 cockpit_web_request_get_client_certificate (CockpitWebRequest *self);
 
+gboolean
+cockpit_web_request_accepts_encoding (CockpitWebRequest *self,
+                                      const gchar *encoding);
+
 #define COCKPIT_TYPE_WEB_SERVER  (cockpit_web_server_get_type ())
 G_DECLARE_FINAL_TYPE(CockpitWebServer, cockpit_web_server, COCKPIT, WEB_SERVER, GObject)
 

--- a/src/ws/cockpitbranding.c
+++ b/src/ws/cockpitbranding.c
@@ -97,7 +97,8 @@ cockpit_branding_calculate_static_roots (const gchar *os_id,
 }
 
 static void
-serve_branding_css_file (CockpitWebResponse *response,
+serve_branding_css_file (CockpitWebRequest *request,
+                         CockpitWebResponse *response,
                          const gchar *path,
                          const gchar **roots,
                          GHashTable *os_release)
@@ -116,6 +117,7 @@ typedef struct {
 
 static void
 serve_branding_css_with_init_data (CockpitWebService *service,
+                                   CockpitWebRequest *request,
                                    CockpitWebResponse *response,
                                    const gchar *path)
 {
@@ -162,7 +164,7 @@ serve_branding_css_with_init_data (CockpitWebService *service,
       os_release = g_object_get_data (G_OBJECT (transport), "os-release");
     }
 
-  serve_branding_css_file (response, path, (const gchar **)roots, os_release);
+  serve_branding_css_file (request, response, path, (const gchar **)roots, os_release);
   responded = TRUE;
 
 out:
@@ -172,6 +174,7 @@ out:
 
 void
 cockpit_branding_serve (CockpitWebService *service,
+                        CockpitWebRequest *request,
                         CockpitWebResponse *response,
                         const gchar *full_path,
                         const gchar *static_path,
@@ -197,11 +200,11 @@ cockpit_branding_serve (CockpitWebService *service,
     {
       if (!is_host)
         {
-          serve_branding_css_file (response, static_path, local_roots, local_os_release);
+          serve_branding_css_file (request, response, static_path, local_roots, local_os_release);
         }
       else
         {
-          serve_branding_css_with_init_data (service, response, static_path);
+          serve_branding_css_with_init_data (service, request, response, static_path);
         }
     }
   else

--- a/src/ws/cockpitbranding.h
+++ b/src/ws/cockpitbranding.h
@@ -30,6 +30,7 @@ gchar **        cockpit_branding_calculate_static_roots     (const gchar *os_id,
                                                              gboolean is_local);
 
 void            cockpit_branding_serve                      (CockpitWebService *service,
+                                                             CockpitWebRequest *request,
                                                              CockpitWebResponse *response,
                                                              const gchar *full_path,
                                                              const gchar *static_path,

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -660,7 +660,7 @@ cockpit_handler_default (CockpitWebServer *server,
         }
       else if (g_str_has_prefix (remainder, "/static/"))
         {
-          cockpit_branding_serve (service, response, path, remainder + 8,
+          cockpit_branding_serve (service, request, response, path, remainder + 8,
                                   data->os_release, data->branding_roots);
           return TRUE;
         }

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -632,7 +632,7 @@ on_handle_source (CockpitWebServer *server,
       inject_address (response, "bus_address", bus_address);
       inject_address (response, "direct_address", direct_address);
     }
-  cockpit_web_response_file (response, path, (const gchar **)server_roots);
+  cockpit_web_response_file_or_gz (response, TRUE, path, (const gchar **)server_roots);
   return TRUE;
 }
 

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -111,16 +111,8 @@ function generateDeps(makefile, stats) {
         inputs.add(input);
     }
 
-    const uncompressed_patterns = [
-        '/manifest.json$', '/override.json$',
-        '^dist/static/', // cockpit-ws cannot currently serve compressed login page
-        '^dist/shell/index.html$',  // COMPAT: Support older cockpit-ws binaries. See #14673
-        '\.png$', '\.woff$', '\.woff2$', '\.gif$'
-    ].map((r) => new RegExp(r));
-
     const outputs = new Set();
     const installs = new Set();
-    const gz_installs = new Set();
     const tests = new Set();
     for (const asset in stats.compilation.assets) {
         const output = path.join(dir, asset);
@@ -139,11 +131,7 @@ function generateDeps(makefile, stats) {
         if (output.endsWith(".map") || output.endsWith(".LICENSE.txt"))
             continue;
 
-        if (uncompressed_patterns.some((s) => output.match(s))) {
-            installs.add(output);
-        } else {
-            gz_installs.add(output);
-        }
+        installs.add(output);
     }
 
     const lines = [ "# Generated Makefile data for " + prefix ];
@@ -161,7 +149,6 @@ function generateDeps(makefile, stats) {
     makeArray(prefix + "_OUTPUTS", outputs);
 
     makeArray(prefix + "_INSTALL", installs);
-    makeArray(prefix + "_GZ_INSTALL", gz_installs);
     makeArray(prefix + "_TESTS", tests);
 
     lines.push(stampfile + ": $(" + prefix + "_INPUTS)");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -244,6 +244,7 @@ const fs = require("fs");
 const copy = require("copy-webpack-plugin");
 const html = require('html-webpack-plugin');
 const miniCssExtractPlugin = require('mini-css-extract-plugin');
+const CompressionPlugin = require("compression-webpack-plugin");
 const TerserJSPlugin = require('terser-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const ESLintPlugin = require('eslint-webpack-plugin');
@@ -349,6 +350,18 @@ const plugins = [
         wrapper: (section === 'static/') ? 'window.cockpit_po = PO_DATA;' : undefined,
     }),
 ];
+
+if (production) {
+    plugins.push(new CompressionPlugin({
+        test: /\.(css|html|js)$/,
+        deleteOriginalAssets: true,
+        exclude: [
+            '/test-[^/]+.$', // don't compress test cases
+            '^static/[^/]+$', // cockpit-ws cannot currently serve compressed login page
+            '^shell/index.html$', // COMPAT: Support older cockpit-ws binaries. See #14673
+        ].map((r) => new RegExp(r)),
+    }));
+}
 
 if (eslint) {
     plugins.push(new ESLintPlugin({ extensions: ["js", "jsx"] }));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -357,7 +357,6 @@ if (production) {
         deleteOriginalAssets: true,
         exclude: [
             '/test-[^/]+.$', // don't compress test cases
-            '^static/[^/]+$', // cockpit-ws cannot currently serve compressed login page
             '^shell/index.html$', // COMPAT: Support older cockpit-ws binaries. See #14673
         ].map((r) => new RegExp(r)),
     }));


### PR DESCRIPTION
Teach cockpit-ws how to serve .gz files out of static/, and remove the exception that was preventing those files from being compressed.

I'm not sure we want this, but let's put it here as not to lose it.

The changes to the test-server (which are part of #16982) absolutely make sense as:

 - they facilitate using `compress-webpack-plugin`
 - they're not a security risk — it's just the test server

but the branding code is super complicated, and this only makes it more complicated.  I think I'd rather take a dramatic simplification/improvement of that code as a precondition to doing something here.

One thought for the branding makeover: we could take a page from `cockpit-bridge` and build a hashtable of all branding files and use that to resolve the exact filename behind a given URL without spamming the kernel with a bunch of `open()` attempts on missing file.  That's a TODO for another day, though.

 - [ ] de-complicate branding code