### PR TITLE
tests: Some tweaks

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -695,11 +695,11 @@ class Browser:
 
         self.machine.allow_restart_journal_messages()
 
-    def relogin(self, path=None, user=None, superuser=None, wait_remote_session_machine=None):
+    def relogin(self, path=None, user=None, password=None, superuser=None, wait_remote_session_machine=None):
         self.logout()
         if wait_remote_session_machine:
             wait_remote_session_machine.execute("while pgrep -a cockpit-ssh; do sleep 1; done")
-        self.try_login(user, superuser=superuser)
+        self.try_login(user, password=password, superuser=superuser)
         self.expect_load()
         self._wait_present('#content')
         self.wait_visible('#content')

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1339,7 +1339,7 @@ class MachineCase(unittest.TestCase):
         def terminate_sessions():
             if self.machine.ostree_image:
                 # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH
-                self.machine.execute("loginctl kill-user admin 2>/dev/null|| true;"
+                self.machine.execute("loginctl kill-user admin 2>/dev/null || true;"
                                      "loginctl terminate-user admin 2>/dev/null || true")
                 return
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1341,6 +1341,7 @@ class MachineCase(unittest.TestCase):
                 # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH
                 self.machine.execute("loginctl kill-user admin 2>/dev/null || true;"
                                      "loginctl terminate-user admin 2>/dev/null || true")
+                self.machine.execute("while pgrep -u admin; do sleep 1; done;")
                 return
 
             sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -216,6 +216,8 @@ class TestNetworkingBasic(NetworkCase):
             assert_not_found()
 
         self.allow_journal_messages(".*org.freedesktop.NetworkManager.*")
+        # Killing NM affects realmd as well
+        self.allow_journal_messages(".*org.freedesktop.realmd.Service.*")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -272,14 +272,7 @@ class TestAccounts(MachineCase):
         b.wait_not_present('#account-set-password-dialog')
 
         # Logout and login with the new password
-        b.logout()
-        b.open("/users")
-        b.wait_visible("#login")
-        b.set_val("#login-user-input", "jussi")
-        b.set_val("#login-password-input", good_password_2)
-        b.click('#login-button')
-        b.expect_load()
-        b.wait_visible('#content')
+        b.relogin(path="/users", user="jussi", password=good_password_2)
 
         # incomplete passwd entry; fixed in PR #13384
         m.execute('echo "damaged:x:1234:1234:Damaged" >> /etc/passwd')


### PR DESCRIPTION
I am mostly focusing on coreos being busted on second retry for `TestAccounts.testBasic`. The pattern is always the same in any PR that forces this test to be retried.

Happend in this PR - [link](https://logs.cockpit-project.org/logs/pull-16959-20220212-070809-163abf03-fedora-coreos/log.html#300-2)
In #16957 (retried 3 times already) [link](https://logs.cockpit-project.org/logs/pull-16957-20220212-093355-c5c8f01e-fedora-coreos/log.html)
In #16981 - [link](https://logs.cockpit-project.org/logs/pull-16981-20220212-092125-57e3bb8a-fedora-coreos/log.html#300-1)

It was fine 4 days ago, see #16940.

It always says:
```
> warning: fatal: Authentication failed: Timeout
```
and then CDP is sad is no page is loaded.

Fixes #16970