### PR TITLE
Fix user test races

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -260,6 +260,7 @@ class TestAccounts(MachineCase):
         long_password = "2a02-x!h4a" * 30
         b.set_input_text('#account-set-password-pw1', long_password)
         b.set_input_text('#account-set-password-pw2', long_password)
+        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error")
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error", "Password is longer than 256 characters")
 
@@ -268,6 +269,7 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw1", good_password_2)
         b.set_input_text("#account-set-password-pw2", good_password_2)
         b.wait_visible("#account-set-password-meter.success")
+        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error")
         b.click('#account-set-password-dialog button.apply')
         b.wait_not_present('#account-set-password-dialog')
 


### PR DESCRIPTION
1. Enter long password (we enter 300 characters long)
2. Click on 'Set password' button - that triggers `validate()`
3. `validate()` sets `errors.password` to "Password is longer than 256 characters" and it is shown in the UI
4. Then `validate()` calls `password_quality()`. This takes longer because it checks 300 characters long password
5. But since the UI is updated with the error, bots type in new correct password
6. `change()` function that is invoked when inputs change clears the `errors` object
7. Now that `password_quality()` finally resolved, it checks if there are errors
   in `errors` object, but that was already cleared. So it succeeds.
8. `validate()` succeeded, we get back to step 2, the promise resolved,
   so it calls `passwd_change(account.name, state.password)`
9. `state.password` is the already new typed in password, so it also
   succeeds as it is not the long one anymore.
10. We set up password from step 5 while checking password from step 1