### PR TITLE
test: Ignore message on missing /run/systemd/coredump

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1525,6 +1525,8 @@ class MachineCase(unittest.TestCase):
         if not self.allow_core_dumps:
             matches += ["SYSLOG_IDENTIFIER=systemd-coredump"]
             self.allowed_messages.append("Resource limits disable core dumping for process.*")
+            # can happen on shutdown when /run/systemd/coredump is gone already
+            self.allowed_messages.append("Failed to connect to coredump service: No such file or directory")
 
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 


### PR DESCRIPTION
This can happen when something crashes during shutdown/reboot, when the
socket is already gone.

----

[example](https://logs.cockpit-project.org/logs/pull-16987-20220214-130456-74c31fa5-centos-8-stream/log.html#124)

This is rather rare, so it most likely won't happen in this PR.