### PR TITLE
Hardware information improvements

### DIFF
--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -126,7 +126,7 @@ export default function detect() {
 
     tasks.push(machine_info.cpu_ram_info()
             .then(result => {
-                info.system.cpu_model = result.cpu_model;
+                info.system.cpu_model = result.cpu_model || _("unknown");
                 info.system.nproc = result.cpus;
                 return true;
             }));

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -36,6 +36,7 @@ import {
     DataListItemCells,
     DataListAction,
     DescriptionList, DescriptionListGroup, DescriptionListTerm, DescriptionListDescription,
+    EmptyState,
     Flex, FlexItem,
     Gallery,
     Page, PageSection,
@@ -50,6 +51,7 @@ import { ListingTable } from "cockpit-components-table.jsx";
 import kernelopt_sh from "raw-loader!./kernelopt.sh";
 import detect from "./hw-detect.js";
 
+import { superuser } from "superuser";
 import { PrivilegedButton } from "cockpit-components-privileged.jsx";
 
 const _ = cockpit.gettext;
@@ -311,6 +313,10 @@ class HardwareInfo extends React.Component {
                         columns: [dimm.locator, dimm.technology, dimm.type, dimm.size, dimm.state, dimm.rank, dimm.speed]
                     })) } />
             );
+        } else if (!superuser.allowed) {
+            memory = (<EmptyState>
+                {_("Viewing memory information requires administrative access.")}
+            </EmptyState>);
         }
 
         return (


### PR DESCRIPTION
This PR improves the hardware information shown on ARM devices such as the Raspberry Pi and shows why there is no memory information shown for normal users.

![image](https://user-images.githubusercontent.com/67428/153903856-2514caa4-0f1d-4183-bf75-efa2253a363a.png)
