### PR TITLE
test: Debug hanging logind sessions

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1349,7 +1349,12 @@ class MachineCase(unittest.TestCase):
                 # Don't insist that terminating works, the session might be gone by now.
                 self.machine.execute(f"loginctl kill-session {s}; loginctl terminate-session {s} || true")
                 # Wait for it to be gone
-                m.execute(f"while loginctl show-session {s}; do sleep 1; done")
+                try:
+                    m.execute(f"while loginctl show-session {s}; do sleep 1; done", timeout=30)
+                except RuntimeError:
+                    # show the status in debug logs, to see what's wrong
+                    m.execute(f"loginctl session-status {s} >&2")
+                    raise
 
         self.addCleanup(terminate_sessions)
 


### PR DESCRIPTION
If a session does not go away after killing and terminating it, show the
session-status on stderr (i.e. the test log), so that we see what's
going on.

---

[This flake](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-16938-20220214-145222-37e948c0-fedora-34/log.html#39) currently happens rather often, let's see what's going on. I'll rebase this after landing PR #16993, as that fixes the far more important race. But maybe in the meantime it catches this case, and I can investigate it already.