### PR TITLE
test: Go back to fewer global machines

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -345,8 +345,9 @@ def run(opts, image):
     if not opts.machine:
         # Create appropriate number of serial machines; prioritize the nondestructive (serial) tests, to get
         # them out of the way as fast as possible, then let the destructive (parallel) ones start as soon as
-        # a given serial runner is done.
-        num_global = min(serial_tests_len, opts.jobs)
+        # a given serial runner is done. However, limit the number of parallel nondestructive tests, as they
+        # are currently too flaky to run with full parallelism.
+        num_global = min(serial_tests_len, opts.jobs // 2)
 
         for i in range(num_global):
             global_machines.append(GlobalMachine(restrict=not opts.enable_network, cpus=opts.nondestructive_cpus,


### PR DESCRIPTION
Commit 4999a18a increased the number of parallel nondestructive tests
(global machines) to the full number of `$TEST_JOBS`. Since around that
time we have no end of test flakes and browser timeouts. While a lot of
the failures are real, they are a bit much to keep up with all at once.
The increased number of random white screens and timeouts are likely due 
to a lot more browsers being started and stopped in parallel, which
happens much faster with nondestructive tests. This clogs our infra's
tasks containers too much.

So for now, go back to the old distribution of destructive vs. 
nondestructive tests. This still retains the better balancing between
the nondestructive runners and the more efficient packing of the 
destructive tests, thus does not actually increase the wallclock test
runtime.


---

This is an emergency measure. But first I want to see some results here whether this actually helps.