### PR TITLE
test: Factorize and strengthen disabling of virbr0

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -32,7 +32,7 @@ class TestNetworkingBasic(NetworkCase):
 
         if not m.ostree_image:
             # screenshot assumes running firewalld and absent virbr0 (in particular, *3* interfaces)
-            m.execute("systemctl start firewalld; virsh net-destroy default 2>/dev/null || true")
+            m.execute("systemctl start firewalld")
 
         self.login_and_go("/network")
         b.wait_visible("#networking")

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -32,9 +32,6 @@ class TestBonding(NetworkCase):
         b = self.browser
         m = self.machine
 
-        # screenshot assumes absent virbr0
-        m.execute("virsh net-destroy default 2>/dev/null || true")
-
         self.login_and_go("/network")
 
         b.wait_visible("#networking")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -30,9 +30,6 @@ class TestBridge(NetworkCase):
         b = self.browser
         m = self.machine
 
-        # screenshot assumes absent virbr0
-        m.execute("virsh net-destroy default 2>/dev/null || true")
-
         self.login_and_go("/network")
         b.wait_visible("#networking")
 

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -32,9 +32,6 @@ class TestTeam(NetworkCase):
         b = self.browser
         m = self.machine
 
-        # screenshot assumes absent virbr0
-        m.execute("virsh net-destroy default 2>/dev/null || true")
-
         self.login_and_go("/network")
 
         b.wait_visible("button:contains('Add team')")

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -108,11 +108,15 @@ class NetworkCase(MachineCase, NetworkHelpers):
         m.write("/etc/NetworkManager/conf.d/99-test.conf", "[main]\nno-auto-default=*\n")
         m.execute("systemctl reload-or-restart NetworkManager")
 
+        # our assertions and pixel tests assume that virbr0 is absent
+        if 'default' in m.execute("virsh net-list --name || true"):
+            m.execute("virsh net-autostart --disable default; virsh net-destroy default")
+
         ver = self.machine.execute(
             "busctl --system get-property org.freedesktop.NetworkManager /org/freedesktop/NetworkManager org.freedesktop.NetworkManager Version || true")
-        m = re.match('s "(.*)"', ver)
-        if m:
-            self.networkmanager_version = [int(x) for x in m.group(1).split(".")]
+        ver_match = re.match('s "(.*)"', ver)
+        if ver_match:
+            self.networkmanager_version = [int(x) for x in ver_match.group(1).split(".")]
         else:
             self.networkmanager_version = [0]
 


### PR DESCRIPTION
Commit e3802c02407 was not strong enough -- sometimes, virbr0 still came
online in the middle of a test. This also sometimes disrupts the
Firewall tests when they count the expected zones at the beginning, but
a second one (for virbr0) suddenly springs into existence.

Stop this harder by also disabling autostart. Also centralized it in
NetworkCase.setUp().

Avoid clobbering the `m` machine alias in setUp with a regexp match,
rename the variable.

---

[example failure](https://logs.cockpit-project.org/logs/pull-16993-20220214-162516-f665c18d-fedora-35/log.html#55)