### PR TITLE
test: Restart reportd after installing custom configuration

### DIFF
--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -620,6 +620,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         m.upload(["verify/files/cockpit_event.conf"], "/etc/libreport/events.d/")
         m.upload(["verify/files/workflow_Cockpit.xml"], "/usr/share/libreport/workflows/")
+        m.execute("systemctl try-restart reportd")
 
         self.crash()
 
@@ -676,6 +677,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
 
         m.upload(["verify/files/cockpit_event.conf"], "/etc/libreport/events.d/")
         m.upload(["verify/files/workflow_Cockpit.xml"], "/usr/share/libreport/workflows/")
+        m.execute("systemctl try-restart reportd")
 
         self.crash()
 


### PR DESCRIPTION
If the daemon is already running when installing the mock
config/workflow, it will not pick it up.

---

[example](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-16999-20220214-194134-4b331678-fedora-35/log.html#253-2), [example](https://logs.cockpit-project.org/logs/pull-16999-20220214-194134-4b331678-fedora-34/log.html#253-2)

[debugging notes](https://github.com/cockpit-project/cockpit/pull/16999#issuecomment-1039858186)