### PR TITLE
cockpituous: Add Fedora 36, drop 34

### DIFF
--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -28,8 +28,8 @@ job release-srpm
 
 # Do fedora builds for the tag, using tarball
 job release-koji -k rawhide
-job release-koji f34
 job release-koji f35
+job release-koji f36
 
 # Upload release to github, using tarball
 job release-github
@@ -41,8 +41,8 @@ job release-copr @cockpit/cockpit-preview
 job release-dockerhub cockpit-project/cockpit-container
 
 # Push out a Bodhi update
-job release-bodhi F34
 job release-bodhi F35
+# job release-bodhi F36  # enable after 2022-02-22
 
 # Upload documentation
 job tools/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
Fedora 36 got branched off and now needs its own koji builds. It does
not yet use bodhi. See
https://fedorapeople.org/groups/schedule/f-36/f-36-key-tasks.html

Drop Fedora 34, so that we keep the two latest releases, as usual.