### PR TITLE
test: Increase session cleanup hammer size on Fedora 34

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1348,6 +1348,10 @@ class MachineCase(unittest.TestCase):
             for s in sessions:
                 # Don't insist that terminating works, the session might be gone by now.
                 self.machine.execute(f"loginctl kill-session {s}; loginctl terminate-session {s} || true")
+                # HACK: fedora 34's systemd has dangling empty session scopes
+                if self.machine.image in ["fedora-34"]:
+                    self.machine.execute(f"if scope=$(loginctl show-session --property Scope --value {s} 2>/dev/null); then systemctl stop $scope; fi")
+
                 # Wait for it to be gone
                 try:
                     m.execute(f"while loginctl show-session {s}; do sleep 1; done", timeout=30)


### PR DESCRIPTION
Fedora 34's logind/systemd often leaves "closing" state logind sessions
around with *zero* processes. Explicitly kill the scope units to clean
up the session.

This is an utter hack, but as long as it does not happen any more on
newer versions, it will go away soon (as we just stopped updating Fedora
34 anyway).

---

Validated locally with

    for i in `seq 10`; do TEST_OS=fedora-34 test/verify/check-users TestAccounts.testAccountLogs $RUNC -stv || break; done

Before, this reproduced the broken situation in the first or second run.

[example 1](https://logs.cockpit-project.org/logs/pull-16908-20220215-104929-2ca6371e-fedora-34/log.html#298), [example 2](https://logs.cockpit-project.org/logs/pull-16379-20220215-094728-1630e9de-fedora-34/log.html#300)

If we see this anywhere else, I'll report it to bugzilla, but let's save us the effort if it only happens there.