### PR TITLE
packit: Start testing on Fedora 36

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -15,6 +15,7 @@ jobs:
     metadata:
       targets:
       - fedora-35
+      - fedora-36
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
 

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -28,8 +28,8 @@ fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
-if [ "$TEST_OS" = "fedora-36" ]; then
-    export TEST_OS=fedora-35
+if [ "$TEST_OS" = "fedora-37" ]; then
+    export TEST_OS=fedora-36
 fi
 
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -100,6 +100,11 @@ if [ -n "$test_basic" ]; then
         TestTerminal
         TestTuned
         "
+
+    # HACK: check-sos fails 100% on Testing Farm Fedora 36 without any error message; works in local tmt VM
+    if [ "$TEST_OS" = "fedora-36" ]; then
+        TESTS="${TESTS/TestSOS/}"
+    fi
 fi
 
 exclude_options=""

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -38,7 +38,7 @@ done
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable", "fedora-coreos"]
 OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable",
-                     "fedora-coreos", "fedora-34", "fedora-35", "fedora-testing", "centos-8-stream", "arch"]
+                     "fedora-coreos", "fedora-34", "fedora-35", "fedora-36", "fedora-testing", "centos-8-stream", "arch"]
 
 
 class NoSubManCase(PackageCase):
@@ -1167,7 +1167,7 @@ class TestKpatchInstall(NoSubManCase):
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",
-           "fedora-34", "fedora-35", "fedora-testing", "ubuntu-2004", "ubuntu-stable", "arch")
+           "fedora-34", "fedora-35", "fedora-36", "fedora-testing", "ubuntu-2004", "ubuntu-stable", "arch")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -489,7 +489,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = ["fedora-34", "fedora-35", "fedora-testing"]
+        working_images = ["fedora-34", "fedora-35", "fedora-36", "fedora-testing"]
         if m.image in working_images:
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:
@@ -743,7 +743,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # we don't want to completely pinpoint the OS list to avoid lockstep image refreshes+cockpit PRs
         # and spontaneous packit test failures as sssd 2.6.1 goes into more distros; but make sure we hit
         # this code path on some known-good ones
-        if m.image in ["fedora-35", "debian-testing"]:
+        if m.image in ["fedora-35", "fedora-36", "debian-testing"]:
             self.assertTrue(has_validate_api)
 
         if has_validate_api:


### PR DESCRIPTION
Corresponding to cockpituous release targets in commit c9eadef1a0

----

Yesterday's [fedora-36 release](https://bodhi.fedoraproject.org/updates/FEDORA-2022-7b7b2119dc) [failed several tests](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-pipeline/job/master/112990/testReport/(root)/tests/_test_verify/). I waived it, let's walk through them here.

 - Builds on top of PR #17021
 - Needs https://github.com/cockpit-project/bots/pull/2956
 - Needs https://github.com/cockpit-project/bots/pull/2970