### PR TITLE
containers: Explicitly install util-linux-core into cockpit/ws

### DIFF
--- a/containers/Makefile.am
+++ b/containers/Makefile.am
@@ -3,10 +3,9 @@ WS_DIR = $(srcdir)/containers/ws
 CLEANFILES += $(WS_DIR)/rpms
 
 ws-container:
-	rm -rf $(WS_DIR)/rpms && mkdir -p $(WS_DIR)/rpms
-	cd $(WS_DIR)/rpms && $(abs_srcdir)/tools/make-rpms
-	sudo docker build -t cockpit/ws $(WS_DIR)
+	rm -rf $(WS_DIR)/rpms
+	if [ -e cockpit-bridge-*.rpm ]; then mkdir -p $(WS_DIR)/rpms; cp *.rpm $(WS_DIR)/rpms; fi
+	podman build -t quay.io/cockpit/ws $(WS_DIR)
 
 ws-container-shell:
-	sudo docker run -ti --rm --publish=9001:9090 \
-		cockpit/ws /bin/bash
+	podman run -ti --rm --publish=9001:9090 quay.io/cockpit/ws /bin/bash

--- a/containers/ws/install-package.sh
+++ b/containers/ws/install-package.sh
@@ -18,7 +18,7 @@ if [ -z "$INSTALLER" ]; then
 fi
 
 "$INSTALLER" -y update
-"$INSTALLER" install -y sed
+"$INSTALLER" install -y util-linux-core sed
 
 arch=`uname -p`
 rpm=$(ls /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm || true)


### PR DESCRIPTION
The install scripts require `mount`, but that fell out of the default
fedora:35 container recently. This caused the latest container refresh
to fail to install:

    # podman container runlabel INSTALL cockpit/ws
    + /bin/mount --bind /host/etc/cockpit /etc/cockpit
    /container/atomic-install: line 67: /bin/mount: No such file or directory

We need to land this, and immediately do a new official container build, as the current official one is just broken.

Spotted by https://github.com/cockpit-project/bots/pull/2950