### PR TITLE
test: Do not create kmod-kvdo package

### DIFF
--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -415,10 +415,6 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
             self.skipTest("No vdo available")
 
         m.execute("pkcon remove -y vdo")
-
-        # do *not* create vdo package yet
-        self.createPackage("kmod-kvdo", "999", "1")
-        self.enableRepo()
         m.execute("pkcon refresh")
 
         self.login_and_go("/storage")


### PR DESCRIPTION
It is already present from distribution.

It might be possible that some distros still need it, then I'll wrap it into `if !(rpm -q kmod-kvdo)...`