### PR TITLE
fmf fixes

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -14,7 +14,6 @@ jobs:
     trigger: pull_request
     metadata:
       targets:
-      - fedora-34
       - fedora-35
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64

--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -66,7 +66,7 @@ fi
 
 if [ -n "$test_basic" ]; then
     # Testing Farm machines often have pending restarts/reboot
-    EXCLUDES="$EXCLUDES TestUpdates.testBasic"
+    EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart"
 
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"

--- a/test/run-verify-host.sh
+++ b/test/run-verify-host.sh
@@ -9,7 +9,8 @@ if [ -d source ]; then
 else
     SOURCE="$(realpath $TESTS/..)"
 fi
-LOGS="$(pwd)/logs"
+# https://tmt.readthedocs.io/en/stable/overview.html#variables
+LOGS="${TMT_TEST_DATA:-logs}"
 mkdir -p "$LOGS"
 chmod a+w "$LOGS"
 


### PR DESCRIPTION
This will fix the [fedora 35 failure](http://artifacts.dev.testing-farm.io/bf9e81a9-e3f7-4ceb-89ba-4ffe8de5dd8e/) which started yesterday or today. It will also bring us artifacts, finally!

Broken out from PR #17017, adding F36 will take some more work.