### PR TITLE
test: Fix Firefox CDP driver

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -129,6 +129,7 @@ class Firefox(Browser):
                 user_pref("dom.navigation.locationChangeRateLimit.count", 9999);
                 // HACK: https://bugzilla.mozilla.org/show_bug.cgi?id=1746154
                 user_pref("fission.webContentIsolationStrategy", 0);
+                user_pref("fission.bfcacheInParent", false);
                 """.format(download_dir))
 
         with open(os.path.join(profile, "handlers.json"), "w") as f:


### PR DESCRIPTION
Firefox 96 enables Fission [1] by default to improve site isolation.
This broke DevTools Protocol's `Page` events [2]. Disable Fission to
work with current nightlies as well.

[1] https://wiki.mozilla.org/Project_Fission
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1746154