### PR TITLE
test: More user.pref magic for Firefox

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -128,6 +128,7 @@ class Firefox(Browser):
                 user_pref("signon.rememberSignons", false);
                 user_pref("dom.navigation.locationChangeRateLimit.count", 9999);
                 // HACK: https://bugzilla.mozilla.org/show_bug.cgi?id=1746154
+                user_pref("fission.bfcacheInParent", false);
                 user_pref("fission.webContentIsolationStrategy", 0);
                 """.format(download_dir))
 


### PR DESCRIPTION
The bug report also recommends this new user preference, and indeed it
seems to help with TestGrafanaClient, which recently started to get
stuck due to missing CDP events.