### PR TITLE
test: Reinstate offline builds for rpms/debs

### DIFF
--- a/test/fedora-coreos.install
+++ b/test/fedora-coreos.install
@@ -4,7 +4,7 @@ set -eu
 # install/upgrade RPMs that apply to Fedora CoreOS
 # Note: cockpit-selinux would be desirable, but needs setroubleshoot-server which isn't installed
 cd /var/tmp/
-rpm-ostree install cockpit-bridge-*.rpm \
+rpm-ostree install --cache-only cockpit-bridge-*.rpm \
     cockpit-networkmanager-*.rpm cockpit-system-*.rpm cockpit-tests-*.rpm
 
 # update cockpit-ws and install scripts in the container

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -187,6 +187,10 @@ def main():
     if args.quick:
         customize.append("--quick")
 
+    # rpms/debs can be built offline; arch can't yet
+    if args.image != 'arch':
+        customize.append("--no-network")
+
     # HACK: freeze the repository so we don't pull a newer GLIBC; until we refresh the arch image (https://github.com/cockpit-project/bots/pull/2796)
     if args.image == 'arch':
         customize += ['--run-command',


### PR DESCRIPTION
This ensures that we stay independent from any changes that go on in
online repositories, and our mock/pbuilders are sufficiently pre-cached.

This got lost in the move to image-customize in commit e060058027fecc83.