### PR TITLE
test: Skip TestStoragePackagesNFS.testNfsMissingPackages on arch

### DIFF
--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -264,6 +264,7 @@ class TestStorageNfs(StorageCase):
 
 # Re-use allowed journal messages from StorageCase
 @skipImage("No udisks/cockpit-storaged on OSTree images", "fedora-coreos")
+@skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
 @nondestructive
 class TestStoragePackagesNFS(PackageCase, StorageCase, StorageHelpers):
 


### PR DESCRIPTION
All the other PackageKit related tests are skipped on arch
(check-packagekit, check-apps, TestMetricsPackages, etc.) as the current
mechanism of creating, installing, and cleaning up fake packages is
buggy.

Skip this test as well, as it runs into similar issues.

---

[example 1](https://logs.cockpit-project.org/logs/pull-15626-20220209-203633-a56677da-arch/log.html#153), [example 2](https://logs.cockpit-project.org/logs/pull-2987-20220222-125942-c6c8d0f1-arch-cockpit-project-cockpit/log.html)

I promise, I'll re-enable lots of tests after https://github.com/cockpit-project/bots/pull/2987 lands (in particular, the networkmanager ones) for a net positive balance :wink: 