### PR TITLE
test: Enable some NetworkManager tests on Arch

### DIFF
--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -72,7 +72,7 @@ class TestBonding(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbond'] button")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -63,7 +63,7 @@ class TestBridge(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbridge'] button")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -24,8 +24,8 @@ from testlib import *
 
 @nondestructive
 @skipDistroPackage()
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestBridge(NetworkCase):
+    @skipImage("TODO: fails on Arch Linux", "arch")
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -22,8 +22,7 @@ from netlib import *
 from testlib import *
 
 
-@skipImage("No network checkpoint support", "ubuntu-2004", "ubuntu-2204", "ubuntu-stable")
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
+@skipImage("No network checkpoint support", "ubuntu-2004", "ubuntu-2204", "ubuntu-stable", "arch")
 @skipDistroPackage()
 class TestNetworkingCheckpoints(NetworkCase):
     def testCheckpoint(self):

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -25,13 +25,13 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestNetworkingMAC(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
+    @skipImage("TODO: fails on Arch Linux", "arch")
     def testMac(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -25,13 +25,13 @@ from machine_core.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
-@skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 class TestNetworkingMTU(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
+    @skipImage("TODO: fails on Arch Linux", "arch")
     def testMtu(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -34,6 +34,7 @@ class TestNetworkingOther(NetworkCase):
 
         # Create a tun device and let NetworkManager manage it
         m.execute(f"ip tuntap add mode tun dev {iface}")
+        self.addCleanup(m.execute, f"ip link del dev {iface}")
         wait(lambda: m.execute(f'nmcli device | grep {iface} | grep -v unavailable'))
         m.execute(f"nmcli dev set {iface} managed yes")
 

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -23,7 +23,6 @@ from testlib import *
 
 
 @skipDistroPackage()
-@skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 @nondestructive
 class TestNetworkingOther(NetworkCase):
     def testOther(self):

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -67,7 +67,7 @@ class TestTeam(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed
         self.select_iface('tteam')

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -24,7 +24,7 @@ from testlib import *
 
 
 @skipImage("NetworkManager-team not installed", "fedora-coreos")
-@skipImage("TODO: networkmanager fails on Arch Linux", "arch")
+@skipImage("TODO: team capability not detected on Arch Linux", "arch")
 @skipDistroPackage()
 @nondestructive
 class TestTeam(NetworkCase):


### PR DESCRIPTION
A recent Arch image fix [1] now allows the NetworkManager tests to run.

Some are still broken, like TestBridge.testBasic(); skip only the
affected test instead of the whole class.

Adjust the reason in check-networkmanager-checkpoints and -teams.

[1] https://github.com/cockpit-project/bots/pull/2987