### PR TITLE
abrt: Only navigate once problem is deleted

### DIFF
--- a/pkg/systemd/abrtLog.jsx
+++ b/pkg/systemd/abrtLog.jsx
@@ -225,8 +225,7 @@ export class AbrtLogDetails extends React.Component {
     }
 
     onDelete(ev) {
-        this.props.service.DeleteProblems([this.props.problem.path]);
-        this.props.reloadProblems(ev);
+        this.props.service.DeleteProblems([this.props.problem.path]).then(() => this.props.reloadProblems(ev));
     }
 
     renderBacktrace(val) {


### PR DESCRIPTION
While this should be pretty much immediate, every now and then bots are
too fast to navigate back to this item before the problem has been
deleted resulting in still seeing the report.

Note: I am not super sure if this waits for the report to be deleted or not. If it does not, then I will add direct wait into test.

Example: https://logs.cockpit-project.org/logs/pull-17012-20220223-065011-732ceefd-fedora-35/log.html#232