### PR TITLE
networking: Fix return value of CheckpointCreate method - FIX COMMIT MESSAGE ON MERGING

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1169,6 +1169,7 @@ export function NetworkManagerModel() {
                                           devices.map(objpath),
                                           timeout,
                                           0)
+                        .then(results => results[0])
                         .catch(function (error) {
                             if (error.name != "org.freedesktop.DBus.Error.UnknownMethod")
                                 console.warn(error.message || error);

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -134,6 +134,44 @@ class TestNetworkingCheckpoints(NetworkCase):
             b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
             b.wait_not_present("#confirm-breaking-change-popup")
 
+    def testNoRollback(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/network")
+        self.nm_checkpoints_enable()
+        b.wait_visible("#networking")
+
+        iface = 'cockpit1'
+        self.add_veth(iface, dhcp_cidr="10.111.113.2/20")
+        self.nm_activate_eth(iface)
+        self.wait_for_iface(iface)
+
+        self.select_iface(iface)
+        b.wait_visible("#network-interface")
+
+        # Disconnect
+        self.wait_onoff(f".pf-c-card__header:contains('{iface}')", True)
+        self.toggle_onoff(f".pf-c-card__header:contains('{iface}')")
+
+        # The checkpoint should be destroyed before it is being rolled
+        # back.
+
+        def checkpoint_was_destroyed():
+            lines = m.execute("journalctl -n 1000 -u NetworkManager | grep op=").split("\n")
+            last_checkpoint = None
+            for line in lines:
+                match = re.search('op="checkpoint-create" arg="([^"]*)"', line)
+                if match:
+                    last_checkpoint = match[1]
+            if last_checkpoint:
+                for line in lines:
+                    if f'op="checkpoint-destroy" arg="{last_checkpoint}"' in line:
+                        return True
+            return False
+
+        wait(checkpoint_was_destroyed)
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
The call_object_method function used to pass all return values as
individual arguments to the "then" function, but this got accidentally
changed in e4093f5e6ab3125de96aca0db403313a5962ccde to pass them all
in an array.

Thus, checkpoint_create would return an array containing the
checkpoint object path instead of the object path directly.  When this
got passed to checkpoint_destroy later on, this would fail with an
"invalid arguments" error.  Cockpit doesn't look closely at the exact
error, interpretes a failed checkpoint_destroy call always as "we got
disconnected", assumes that the checkpoint has been rolled back, and
brings up the "Connection will be lost" dialog.

This was missed by the tests because we switch off checkpoints during
those tests that dont expect them.

This is fixed here just for CheckpointCreate.  Other calls to
call_object_method need to be checked and corrected accordingly as
well.