### PR TITLE
networking: Fix IP Settings dialog

### DIFF
--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -65,9 +65,9 @@ export const IpSettingsDialog = ({ topic, connection, dev, setIsOpen, settings }
     const [addresses, setAddresses] = useState(params.addresses ? params.addresses.map(addr => ({ address: addr[0], netmask: addr[1], gateway: addr[2] })) : []);
     const [dialogError, setDialogError] = useState(undefined);
     const [dns, setDns] = useState(params.dns || []);
-    const [dnsSearch, setDnsSearch] = useState(params.dns || []);
-    const [ignoreAutoDns, setIgnoreAutoDns] = useState();
-    const [ignoreAutoRoutes, setIgnoreAutoRoutes] = useState();
+    const [dnsSearch, setDnsSearch] = useState(params.dns_search || []);
+    const [ignoreAutoDns, setIgnoreAutoDns] = useState(params.ignore_auto_dns);
+    const [ignoreAutoRoutes, setIgnoreAutoRoutes] = useState(params.ignore_auto_routes);
     const [method, setMethod] = useState(params.method);
     const [routes, setRoutes] = useState(params.routes ? params.routes.map(addr => ({ address: addr[0], netmask: addr[1], gateway: addr[2], metric: addr[3] })) : []);
 
@@ -106,7 +106,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, setIsOpen, settings }
                 method,
                 addresses: addresses.map(addr => [addr.address, addr.netmask, addr.gateway]),
                 dns,
-                dnsSearch,
+                dns_search: dnsSearch,
                 routes: routes.map(route => [route.address, route.netmask, route.gateway, route.metric]),
                 ignore_auto_dns: ignoreAutoDns,
                 ignore_auto_routes: ignoreAutoRoutes,
@@ -262,7 +262,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, setIsOpen, settings }
                                 <Button variant="secondary"
                                         isDisabled={!canHaveExtra}
                                         onClick={() => setDnsSearch([...dnsSearch, ""])}
-                                        id={idPrefix + "-dnf-search-add"}
+                                        id={idPrefix + "-dns-search-add"}
                                         aria-label={_("Add item")}
                                         icon={<PlusIcon />} />
                             </Flex>
@@ -273,8 +273,8 @@ export const IpSettingsDialog = ({ topic, connection, dev, setIsOpen, settings }
                 {dnsSearch.map((domain, i) => {
                     return (
                         <Grid key={i} hasGutter>
-                            <FormGroup fieldId={idPrefix + "-search-domain"} label={_("Search domain")}>
-                                <TextInput id={idPrefix + "-search-domain"} value={domain} onChange={value => setDnsSearch(
+                            <FormGroup fieldId={idPrefix + "-search-domain-" + i} label={_("Search domain")}>
+                                <TextInput id={idPrefix + "-search-domain-" + i} value={domain} onChange={value => setDnsSearch(
                                     dnsSearch.map((item, index) =>
                                         i === index
                                             ? value

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -61,10 +61,13 @@ class TestNetworkingSettings(NetworkCase):
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('IPv4', 'Address 1.2.3.4/24')
 
+        def assert_connection_setting(con_id, field, value):
+            self.assertEqual(m.execute(f'nmcli -m tabular -t -f {field} con show "{con_id}"').strip(),
+                             value)
+
         # Check that we now have connection settings
         con_id = wait(lambda: self.iface_con_id(iface))
-        self.assertEqual(m.execute(f'nmcli -m tabular -t -f ipv4.method con show "{con_id}"').strip(),
-                         "manual")
+        assert_connection_setting(con_id, "ipv4.method", "manual")
 
         # The interface will be activated. Deactivate it.
         self.wait_for_iface_setting('Status', '1.2.3.4/24')
@@ -82,8 +85,34 @@ class TestNetworkingSettings(NetworkCase):
 
         # Check again that we now have connection settings
         con_id = wait(lambda: self.iface_con_id(iface))
-        self.assertEqual(m.execute(f'nmcli -m tabular -t -f ipv4.method con show "{con_id}"').strip(),
-                         "auto")
+        assert_connection_setting(con_id, "ipv4.method", "auto")
+
+        # Change some more settins and check that the actual config
+        # and dialog reflects the change
+
+        self.configure_iface_setting('IPv4')
+        b.wait_visible("#network-ip-settings-dialog")
+        self.wait_onoff("[data-field=dns]", True)
+        self.toggle_onoff("[data-field=dns]")
+        self.wait_onoff("[data-field=dns_search]", False)
+        b.click("#network-ip-settings-dns-add")
+        b.set_input_text("#network-ip-settings-dns-server-0", "1.2.3.4")
+        b.click("#network-ip-settings-dns-search-add")
+        b.set_input_text("#network-ip-settings-search-domain-0", "foo.com")
+        b.click("#network-ip-settings-apply")
+        b.wait_not_present("#network-ip-settings-dialog")
+
+        assert_connection_setting(con_id, "ipv4.ignore-auto-dns", "yes")
+        assert_connection_setting(con_id, "ipv4.dns", "1.2.3.4")
+        assert_connection_setting(con_id, "ipv4.dns-search", "foo.com")
+
+        self.configure_iface_setting('IPv4')
+        self.wait_onoff("[data-field=dns]", False)
+        self.wait_onoff("[data-field=dns_search]", False)
+        b.wait_val("#network-ip-settings-dns-server-0", "1.2.3.4")
+        b.wait_val("#network-ip-settings-search-domain-0", "foo.com")
+        b.click("#network-ip-settings-cancel")
+        b.wait_not_present("#network-ip-settings-dialog")
 
         self.configure_iface_setting('IPv6')
         b.wait_visible("#network-ip-settings-dialog")
@@ -91,9 +120,7 @@ class TestNetworkingSettings(NetworkCase):
         b.click("#network-ip-settings-apply")
         b.wait_not_present("#network-ip-settings-dialog")
 
-        con_id = wait(lambda: self.iface_con_id(iface))
-        self.assertEqual(m.execute(f'nmcli -m tabular -t -f ipv6.method con show "{con_id}"').strip(),
-                         "disabled")
+        assert_connection_setting(con_id, "ipv6.method", "disabled")
 
     def testOtherSettings(self):
         b = self.browser

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -197,7 +197,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
         self.addCleanup(self.machine.execute, "umount /usr/sbin/dhclient")
 
     def wait_onoff(self, sel, val):
-        self.browser.wait_visible(sel + " input" + (":checked" if val else ":not(:checked)"))
+        self.browser.wait_visible(sel + " input[type=checkbox]" + (":checked" if val else ":not(:checked)"))
 
     def toggle_onoff(self, sel):
         self.browser.click(sel + " input[type=checkbox]")


### PR DESCRIPTION
Initializion of the dialog was wrong for ignore-auto-dns,
ignore-auto-routes, and dns-search.  Taking values out of the dialog
was wrong for dns-search.