### PR TITLE
PF: Work around flex; make it use gap

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -179,3 +179,29 @@ svg {
 .pf-c-masthead .pf-c-dropdown:not(.pf-m-expanded) > .pf-c-dropdown__toggle:focus:not(:focus-visible):not(:hover):not(:active)::before {
     border-color: transparent;
 }
+
+// Flex should use gap, not a margin hack
+// https://github.com/patternfly/patternfly/issues/4523
+.pf-l-flex {
+    gap: var(--pf-l-flex--spacer-base);
+
+    // Negate the margin hack used by immediate flex children
+    > * {
+        --pf-l-flex--spacer-base: 0;
+    }
+
+    // Undo all spacer modification adjustments
+    &[class*=pf-m-space-items-] {
+        > * {
+            --pf-l-flex--spacer: 0;
+        }
+    }
+
+    // Re-add spacer modification adjustments on the flex layout widget
+    // (using class attribute matching for handling breakpoint -on- also)
+    @each $size in (none, sm, md, lg, xl, 2xl, 3xl, 4xl) {
+        &[class*=pf-m-space-items-#{$size}] {
+            --pf-l-flex--spacer-base: var(--pf-l-flex--spacer--#{$size});
+        }
+    }
+}

--- a/pkg/systemd/overview-cards/lastLogin.jsx
+++ b/pkg/systemd/overview-cards/lastLogin.jsx
@@ -110,8 +110,8 @@ const LastLogin = () => {
 
     return (
         <li className="last-login" id="page_status_last_login">
-            <Flex flexWrap={{ default: 'nowrap' }}>
-                <FlexItem spacer={{ default: 'spacerSm' }}>{icon}</FlexItem>
+            <Flex spacer={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+                <FlexItem>{icon}</FlexItem>
                 <div>
                     <div id="system_last_login"
                             className={headerClass}

--- a/pkg/systemd/overview-cards/shutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/shutdownStatus.jsx
@@ -95,8 +95,8 @@ export const ShutDownStatus = () => {
 
     return (
         <li id="system-health-shutdown-status">
-            <Flex flexWrap={{ default: 'nowrap' }}>
-                <FlexItem spacer={{ default: 'spacerSm' }}>{icon}</FlexItem>
+            <Flex spacer={{ default: 'spaceItemsSm' }} flexWrap={{ default: 'nowrap' }}>
+                <FlexItem>{icon}</FlexItem>
                 <Flex id="system-health-shutdown-status-text" direction={{ default: 'column' }}>
                     {cockpit.format(text, displayDate)}
                     <FlexItem>


### PR DESCRIPTION
Local workaround to use flex properly with a gap instead of having a right margin.

Upstream issue: https://github.com/patternfly/patternfly/issues/4523