### PR TITLE
tools: Suggest udisks2-lvm2 for Debian/Ubuntu

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -110,8 +110,11 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${source:Version}),
          python3,
          python3-dbus
+Suggests: udisks2-lvm2
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
+ .
+ Install udisks2-lvm2 if you use LVM and want to manage it with Cockpit.
 
 Package: cockpit-system
 Architecture: all


### PR DESCRIPTION
We don't want to add a "strong" dependency like "Recommends:" or even
"Depends:": We don't want to pull LVM packages onto a system just
because the admin installs Cockpit.

But let's at least show it as a suggested add-on and explain why you may
want it.

Fixes #17041