### PR TITLE
fmf: Skip TestPages.testBasic on RHEL 9.0

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -105,6 +105,11 @@ if [ -n "$test_basic" ]; then
     if [ "$TEST_OS" = "fedora-36" ]; then
         TESTS="${TESTS/TestSOS/}"
     fi
+
+    # HACK: repeatedly fails on RHEL Testing Farm without error message, then corrupts VM
+    if [ "$TEST_OS" = "rhel-9-0" ]; then
+        EXCLUDES="$EXCLUDES TestPages.testBasic"
+    fi
 fi
 
 exclude_options=""


### PR DESCRIPTION
This test repeatedly fails on the RHEL testing farm without any error
message, and then corrupts the VM. Skip it for now, until we can
investigate what's going on. Leave it running on the public Testing Farm
to ensure it does not get broken further.

---

This test works fine in packit (public TF) and even [CentOS 9 Stream](https://gitlab.com/redhat/centos-stream/rpms/cockpit/-/merge_requests/19) (also public TF), but failed in [RHEL downstream packaging](https://src.osci.redhat.com/rpms/cockpit/pull-request/99)