### PR TITLE
test: Fix TypeError crash with --trace

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -219,7 +219,7 @@ function setupFrameTracking(client) {
 function setupLocalFunctions(client) {
     client.reloadPageAndWait = (args) => {
         return new Promise((resolve, reject) => {
-            pageLoadHandler = () => { pageLoadHandler = null; resolve(); };
+            pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
             client.Page.reload(args);
         });
     };

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -287,7 +287,7 @@ function setupFrameTracking(client) {
 function setupLocalFunctions(client) {
     client.reloadPageAndWait = (args) => {
         return new Promise((resolve, reject) => {
-            pageLoadHandler = () => { pageLoadHandler = null; resolve(); };
+            pageLoadHandler = () => { pageLoadHandler = null; resolve({}) };
             client.Page.reload(args);
         });
     };


### PR DESCRIPTION
This was previously crashing with

```
  File "/var/home/martin/upstream/c3/test/verify/check-shell-menu", line 75, in testBasic
    b.reload()
  File "/var/home/martin/upstream/c3/test/common/testlib.py", line 216, in reload
    self.cdp.invoke("reloadPageAndWait", ignoreCache=ignore_cache)
  File "/var/home/martin/upstream/c3/test/common/cdp.py", line 201, in invoke
    if "result" in res:
TypeError: argument of type 'NoneType' is not iterable
```

as client.reloadPageAndWait() did not return anything, but our cdp.py
driver expect an object. We could make the driver tolerate that, but 
let's be strict here to avoid unexpected empty results from DevTools API 
calls.
