### PR TITLE
TestMenu improvements

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1307,8 +1307,7 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(cleanup_home_dirs)
 
         # cockpit configuration
-        self.addCleanup(m.execute, "rm -f /etc/cockpit/cockpit.conf")
-        self.addCleanup(m.execute, "rm -f /etc/cockpit/machines.d/*")
+        self.addCleanup(m.execute, "rm -f /etc/cockpit/cockpit.conf /etc/cockpit/machines.d/* /etc/cockpit/*.override.json")
 
         if not m.ostree_image:
             # for storage tests

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -117,7 +117,7 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         if self.is_devel_build():
             for machine in ["machine2", "machine3"]:
                 for pkg in ["packagekit", "systemd", "playground"]:
-                    self.machines[machine].write(f"/usr/share/cockpit/{pkg}/override.json", '{ "preload": [ ] }')
+                    self.machines[machine].write(f"/etc/cockpit/{pkg}.override.json", '{ "preload": [ ] }')
         # Also, quick logouts cause async preloads to run into "ReferenceError: cockpit is not defined"
         self.disable_preload("packagekit", "playground", "systemd")
 

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -23,6 +23,7 @@ import parent
 from testlib import *
 
 
+@nondestructive
 @skipDistroPackage()
 class TestMenu(MachineCase):
 
@@ -35,7 +36,7 @@ class TestMenu(MachineCase):
         m.execute("mkdir -p /usr/local/share/cockpit/systemd && cp -rp /usr/share/cockpit/systemd/* /usr/local/share/cockpit/systemd")
         m.execute(
             """sed -i '/"menu"/a "memory": { "label": "Memory", "path": "#/memory" },' /usr/local/share/cockpit/systemd/manifest.json""")
-        m.execute("printf '[Session]\nIdleTimeout = 1\n' >> /etc/cockpit/cockpit.conf")
+        self.addCleanup(m.execute, "rm -r /usr/local/share/cockpit")
 
         self.login_and_go("/system")
 
@@ -49,7 +50,38 @@ class TestMenu(MachineCase):
         b.click('.pf-c-about-modal-box__close button')
         b.wait_not_present('#about-cockpit-modal')
 
-        # Test session timeout
+        self.check_axe("Test-navigation")
+
+        # Check that we can use a link with a hash in it
+        b.click_system_menu("/system/#/memory")
+
+        # Ensure that our tests pick up unhandled JS exceptions
+        b.switch_to_top()
+        b.go("/playground/exception")
+
+        # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
+        b.wait_in_text("#host-apps .pf-m-current", "Development")
+
+        b.enter_page("/playground/exception")
+        b.wait_visible("button")
+        with self.assertRaisesRegex(RuntimeError, "TypeError:.*undefined"):
+            b.click("button")
+            # Some round trips, one of which should update the deferred exception
+            for i in range(0, 5):
+                b.wait_visible("button")
+                time.sleep(2)
+
+        # UI should also show the crash
+        b.switch_to_top()
+        b.wait_visible("#navbar-oops")
+
+    def testSessionTimeout(self):
+        b = self.browser
+        m = self.machine
+
+        m.execute("printf '[Session]\nIdleTimeout = 1\n' >> /etc/cockpit/cockpit.conf")
+
+        self.login_and_go()
         time.sleep(20)
         b.wait_not_present("#session-timeout-modal")
         b.wait_visible("#hosts-sel")
@@ -78,31 +110,6 @@ class TestMenu(MachineCase):
         time.sleep(75)
         b.wait_not_present("#session-timeout-modal")
         b.wait_visible("#hosts-sel")
-
-        self.check_axe("Test-navigation")
-
-        # Check that we can use a link with a hash in it
-        b.click_system_menu("/system/#/memory")
-
-        # Ensure that our tests pick up unhandled JS exceptions
-        b.switch_to_top()
-        b.go("/playground/exception")
-
-        # Test that subpages are correctly shown in the navigation (twice - once that only one page is shown as active)
-        b.wait_in_text("#host-apps .pf-m-current", "Development")
-
-        b.enter_page("/playground/exception")
-        b.wait_visible("button")
-        with self.assertRaisesRegex(RuntimeError, "TypeError:.*undefined"):
-            b.click("button")
-            # Some round trips, one of which should update the deferred exception
-            for i in range(0, 5):
-                b.wait_visible("button")
-                time.sleep(2)
-
-        # UI should also show the crash
-        b.switch_to_top()
-        b.wait_visible("#navbar-oops")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -81,35 +81,37 @@ class TestMenu(MachineCase):
 
         m.execute("printf '[Session]\nIdleTimeout = 1\n' >> /etc/cockpit/cockpit.conf")
 
+        # does not time out immediately
         self.login_and_go()
         time.sleep(20)
-        b.wait_not_present("#session-timeout-modal")
+        self.assertFalse(b.is_present("#session-timeout-modal"))
         b.wait_visible("#hosts-sel")
+
+        # a mouse event resets the timer
         b.enter_page("/system")
         b.mouse("#system_information_hardware_text", "mousemove", 24, 24)
         b.switch_to_top()
+
+        # 30s before the 1 min timeout the dialog pops up
         time.sleep(35)
         with b.wait_timeout(3):
             b.wait_visible("#session-timeout-modal")
             self.assertGreater(int(b.text("#session-timeout-modal .pf-c-modal-box__body").split()[-2]), 15)
+        # click on "Continue session"
         b.click("#session-timeout-modal footer button")
         b.wait_not_present("#session-timeout-modal")
+
+        # now wait for timeout dialog again, but don't click; instead, wait for the full minute
         time.sleep(30)
         with b.wait_timeout(8):
             b.wait_popup("session-timeout-modal")
             self.assertGreater(int(b.text("#session-timeout-modal .pf-c-modal-box__body").split()[-2]), 20)
+
         time.sleep(30)
+        # that logs you out
         b.wait_visible("#login")
         b.wait_visible("#login-info-message")
         b.wait_text("#login-info-message", "You have been logged out due to inactivity.")
-        m.execute("sed -i '/IdleTimeout/d' /etc/cockpit/cockpit.conf")
-        m.restart_cockpit()
-        b.reload()
-        self.login_and_go("/system")
-        b.switch_to_top()
-        time.sleep(75)
-        b.wait_not_present("#session-timeout-modal")
-        b.wait_visible("#hosts-sel")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -152,18 +152,18 @@ class TestMultiMachineAdd(MachineCase):
     def setUp(self):
         super().setUp()
         self.machine2 = self.machines['machine2']
-        self.machine2.execute("hostnamectl set-hostname machine2")
         self.machine3 = self.machines['machine3']
-        self.machine3.execute("hostnamectl set-hostname machine3")
 
-        # Disable preloading on all machines ("machine1" is done in testlib.py)
-        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-        # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.is_devel_build():
-            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+        for name in ['machine2', 'machine3']:
+            m = self.machines[name]
+            m.execute(f"hostnamectl set-hostname {name}")
+
+            # Disable preloading on all machines ("machine1" is done in testlib.py)
+            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+            # In these tests we actually switch between machines in quick succession which can make things even worse
+            if self.is_devel_build():
+                m.write("/etc/cockpit/packagekit.override.json", '{ "preload": [ ] }')
+                m.write("/etc/cockpit/systemd.override.json", '{ "preload": [ ] }')
 
         self.setup_ssh_auth()
 
@@ -254,20 +254,23 @@ class TestMultiMachine(MachineCase):
 
     def setUp(self):
         super().setUp()
+
         self.machine.execute("hostnamectl set-hostname machine1")
-        self.machine2 = self.machines['machine2']
-        self.machine2.execute("hostnamectl set-hostname machine2")
-        self.machines['machine3'].execute("hostnamectl set-hostname machine3")
         self.allow_journal_messages("sudo: unable to resolve host machine1: .*")
 
-        # Disable preloading on all machines ("machine1" is done in testlib.py)
-        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-        # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.is_devel_build():
-            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine3"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+        self.machine2 = self.machines['machine2']
+        self.machine3 = self.machines['machine3']
+
+        for name in ['machine2', 'machine3']:
+            m = self.machines[name]
+            m.execute(f"hostnamectl set-hostname {name}")
+
+            # Disable preloading on all machines ("machine1" is done in testlib.py)
+            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+            # In these tests we actually switch between machines in quick succession which can make things even worse
+            if self.is_devel_build():
+                m.write("/etc/cockpit/packagekit.override.json", '{ "preload": [ ] }')
+                m.write("/etc/cockpit/systemd.override.json", '{ "preload": [ ] }')
 
     def checkDirectLogin(self, root='/', known_host=False):
         b = self.browser

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -116,8 +116,8 @@ class TestMultiMachineKeyAuth(MachineCase):
         # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
         # In these tests we actually switch between machines in quick succession which can make things even worse
         if self.is_devel_build():
-            self.machines["machine2"].write("/usr/share/cockpit/packagekit/override.json", '{ "preload": [ ] }')
-            self.machines["machine2"].write("/usr/share/cockpit/systemd/override.json", '{ "preload": [ ] }')
+            self.machine2.write("/etc/cockpit/packagekit.override.json", '{ "preload": [ ] }')
+            self.machine2.write("/etc/cockpit/systemd.override.json", '{ "preload": [ ] }')
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -179,8 +179,7 @@ session include system-auth
         b = self.browser
         m = self.machine
 
-        m.needs_writable_usr()
-        m.write("/usr/share/cockpit/shell/override.json", """
+        m.write("/etc/cockpit/shell.override.json", """
 {
   "bridges": [
     {
@@ -213,13 +212,11 @@ session include system-auth
         b = self.browser
         m = self.machine
 
-        m.needs_writable_usr()
-
         self.login_and_go("/playground/pkgs", superuser=True)
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
-        m.write("/usr/share/cockpit/shell/override.json", """
+        m.write("/etc/cockpit/shell.override.json", """
 {
   "bridges": [ ]
 }

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -762,7 +762,7 @@ fi
             self.skipTest("insights-client is only on RHEL")
 
         # Pretend that the Subscriptions page can do Insights stuff
-        m.write("/usr/share/cockpit/subscription-manager/override.json", '{ "features": { "insights": true } }')
+        m.write("/etc/cockpit/subscription-manager.override.json", '{ "features": { "insights": true } }')
 
         # Run a mock version of the Insights API locally and configure
         # insights-client to access it. That requires a good enough


### PR DESCRIPTION
I'm trying to get to the bottom of the [TestMenu.testBasic failure](https://logs.cockpit-project.org/logs/pull-17043-20220224-094403-fd5a366e-rhel-8-6/log.html#138-2) which happens very often. It's our current [top flake](https://logs-https-frontdoor.apps.ocp.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7) -- it fails in [2 out of 3 cases on centos-8-stream](https://logs-https-frontdoor.apps.ocp.ci.centos.org/tests.html?repo=cockpit-project%2Fcockpit&days=7&test=test%2Fverify%2Fcheck-shell-menu+TestMenu.testBasic)!

[example 2](https://logs.cockpit-project.org/logs/pull-17043-20220224-094403-fd5a366e-centos-8-stream/log.html#138-2), [example 3](https://logs.cockpit-project.org/logs/pull-17059-20220228-131339-7b5d1203-centos-8-stream/log.html)