### PR TITLE
test: Ignore "ext2 filesystem" label in TestStorageBasic pixel test

### DIFF
--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -61,7 +61,12 @@ class TestStorageBasic(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext2 filesystem")
 
         self.content_tab_expand(1, 1)
-        b.assert_pixels("#detail-content", "partition", ignore=["dt:contains(UUID) + dd"])
+        b.assert_pixels("#detail-content", "partition", ignore=[
+            # UUID is not stable
+            "dt:contains(UUID) + dd",
+            # browsers/harfbuzz don't render "ext2 filesystem" label reliably
+            "td[data-label='Type']",
+        ])
         self.content_tab_expand(1, 2)
         b.assert_pixels("#detail-content", "filesystem")
 


### PR DESCRIPTION
There is something spethial about this label, and browsers/harfbuzz just
keep rendering it with some slight noise. Ignore the column. The check
above already ensures that the label appears in the expected column.

---

I see [this failure](https://logs.cockpit-project.org/logs/pull-17063-20220301-052940-903213ae-fedora-35/log.html#154) time and again. It is perfectly reproducible locally for me, it fails in about half of the runs.