### PR TITLE
Fix ESLint errors in test/common/

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/*
+test/common/sizzle.js

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -30,7 +30,7 @@
 
 const CDP = require('chrome-remote-interface');
 
-var enable_debug = false;
+let enable_debug = false;
 
 function debug(msg) {
     if (enable_debug)
@@ -49,24 +49,24 @@ function fatal() {
 function fail(err) {
     if (typeof err === 'undefined')
         err = null;
-    process.stdout.write(JSON.stringify({"error": err}) + '\n');
+    process.stdout.write(JSON.stringify({ error: err }) + '\n');
 }
 
 function success(result) {
     if (typeof result === 'undefined')
         result = null;
-    process.stdout.write(JSON.stringify({"result": result}) + '\n');
+    process.stdout.write(JSON.stringify({ result: result }) + '\n');
 }
 
 /**
  * Record console.*() calls and Log messages so that we can forward them to
  * stderr and dump them on test failure
  */
-var messages = [];
-var logPromiseResolver;
-var nReportedLogMessages = 0;
-var unhandledExceptions = [];
-var shownMessages = []; // Show every message just once, keep here seen messages
+const messages = [];
+let logPromiseResolver;
+let nReportedLogMessages = 0;
+const unhandledExceptions = [];
+const shownMessages = []; // Show every message just once, keep here seen messages
 
 function clearExceptions() {
     unhandledExceptions.length = 0;
@@ -77,27 +77,27 @@ function setupLogging(client) {
     client.Runtime.enable();
 
     client.Runtime.consoleAPICalled(info => {
-        let msg = info.args.map(v => (v.value || "").toString()).join(" ");
+        const msg = info.args.map(v => (v.value || "").toString()).join(" ");
 
-        messages.push([ info.type, msg ]);
+        messages.push([info.type, msg]);
         if (shownMessages.indexOf(msg) == -1) {
             if (!enable_debug) // disable message de-duplication in --trace mode
                 shownMessages.push(msg);
-            process.stderr.write("> " + info.type + ": " + msg + "\n")
+            process.stderr.write("> " + info.type + ": " + msg + "\n");
         }
 
         resolveLogPromise();
     });
 
     client.Runtime.exceptionThrown(info => {
-        let details = info.exceptionDetails;
+        const details = info.exceptionDetails;
         // don't log test timeouts, they already get handled
         if (details.exception && details.exception.className === "PhWaitCondTimeout")
             return;
 
         // HACK: https://github.com/cockpit-project/cockpit/issues/14871
         if (details.description && details.description.indexOf("Rendering components directly into document.body is discouraged") > -1)
-            return
+            return;
 
         process.stderr.write(details.description || JSON.stringify(details) + "\n");
 
@@ -109,7 +109,7 @@ function setupLogging(client) {
 
     client.Log.enable();
     client.Log.entryAdded(entry => {
-        let msg = entry["entry"];
+        const msg = entry.entry;
         /* Ignore unsafe-inline messages from PatternFly's usage of Emotion
          * (https://github.com/patternfly/patternfly-react/issues/2919) */
         if ((msg.text || "").indexOf("Refused to apply inline style") >= 0) {
@@ -121,10 +121,10 @@ function setupLogging(client) {
                 msg.stackTrace = "(minified)";
         }
 
-        messages.push([ "cdp", msg ]);
+        messages.push(["cdp", msg]);
         /* Ignore authentication failure log lines that don't denote failures */
         if (!(msg.url || "").endsWith("/login") || (msg.text || "").indexOf("401") === -1) {
-            const orig = {...msg};
+            const orig = { ...msg };
             delete msg.timestamp;
             delete msg.args;
             const msgstr = JSON.stringify(msg);
@@ -168,7 +168,6 @@ function waitLog() {
     });
 }
 
-
 /**
  * Frame tracking
  *
@@ -180,10 +179,10 @@ function waitLog() {
  * to load. This is very laborious, see this issue for discussing improvements:
  * https://github.com/ChromeDevTools/devtools-protocol/issues/72
  */
-var frameIdToContextId = {};
-var frameNameToFrameId = {};
+const frameIdToContextId = {};
+const frameNameToFrameId = {};
 
-var pageLoadHandler = null;
+let pageLoadHandler = null;
 
 function setupFrameTracking(client) {
     client.Page.enable();
@@ -207,7 +206,7 @@ function setupFrameTracking(client) {
 
     client.Runtime.executionContextDestroyed(info => {
         debug("executionContextDestroyed " + info.executionContextId);
-        for (let frameId in frameIdToContextId) {
+        for (const frameId in frameIdToContextId) {
             if (frameIdToContextId[frameId] == info.executionContextId) {
                 delete frameIdToContextId[frameId];
                 break;
@@ -229,10 +228,10 @@ function setupLocalFunctions(client) {
 function getFrameExecId(frame) {
     if (frame === null)
         frame = "cockpit1";
-    var frameId = frameNameToFrameId[frame];
+    const frameId = frameNameToFrameId[frame];
     if (!frameId)
         return -1;
-    var execId = frameIdToContextId[frameId];
+    const execId = frameIdToContextId[frameId];
     if (!execId)
         return -1;
     return execId;
@@ -249,17 +248,17 @@ var ssl_bad_certificate_action = "cancel";
 function setupSSLCertHandling(client) {
     client.Security.enable();
 
-    client.Security.setOverrideCertificateErrors({override: true});
+    client.Security.setOverrideCertificateErrors({ override: true });
     client.Security.certificateError(info => {
         process.stderr.write(`CDP: Security.certificateError ${JSON.stringify(info)}; action: ${ssl_bad_certificate_action}\n`);
         client.Security.handleCertificateError({ eventId: info.eventId, action: ssl_bad_certificate_action })
-            .catch(ex => {
+                .catch(ex => {
                 // some race condition in Chromium, ok if the event is already gone
-                if (ex.response && ex.response.message && ex.response.message.indexOf("Unknown event id") >= 0)
-                    debug(`setupSSLCertHandling for event ${info.eventId} failed, ignoring: ${JSON.stringify(ex.response)}`);
-                else
-                    throw ex;
-            });
+                    if (ex.response && ex.response.message && ex.response.message.indexOf("Unknown event id") >= 0)
+                        debug(`setupSSLCertHandling for event ${info.eventId} failed, ignoring: ${JSON.stringify(ex.response)}`);
+                    else
+                        throw ex;
+                });
     });
 }
 
@@ -273,7 +272,7 @@ function setupSSLCertHandling(client) {
  */
 process.stdin.setEncoding('utf8');
 
-if (process.env["TEST_CDP_DEBUG"])
+if (process.env.TEST_CDP_DEBUG)
     enable_debug = true;
 
 options = { };
@@ -286,46 +285,45 @@ if (process.argv.length >= 3) {
 }
 
 CDP.New(options)
-    .then(target => {
-        target.port = options.port;
-        CDP({target: target})
-            .then(client => {
-                setupLogging(client);
-                setupFrameTracking(client);
-                setupSSLCertHandling(client);
-                setupLocalFunctions(client);
+        .then(target => {
+            target.port = options.port;
+            CDP({ target: target })
+                    .then(client => {
+                        setupLogging(client);
+                        setupFrameTracking(client);
+                        setupSSLCertHandling(client);
+                        setupLocalFunctions(client);
 
-                let input_buf = '';
-                process.stdin
-                    .on('data', chunk => {
-                        input_buf += chunk;
-                        while (true) {
-                            let i = input_buf.indexOf('\n');
-                            if (i < 0)
-                                break;
-                            let command = input_buf.slice(0, i);
+                        let input_buf = '';
+                        process.stdin
+                                .on('data', chunk => {
+                                    input_buf += chunk;
+                                    while (true) {
+                                        const i = input_buf.indexOf('\n');
+                                        if (i < 0)
+                                            break;
+                                        const command = input_buf.slice(0, i);
 
-                            // run the command
-                            eval(command).then(reply => {
-                                if (unhandledExceptions.length === 0) {
-                                    success(reply);
-                                } else {
-                                    let message = unhandledExceptions[0];
-                                    fail(message.split("\n")[0]);
-                                    clearExceptions();
-                                }
-                            }, fail);
+                                        // run the command
+                                        eval(command).then(reply => {
+                                            if (unhandledExceptions.length === 0) {
+                                                success(reply);
+                                            } else {
+                                                const message = unhandledExceptions[0];
+                                                fail(message.split("\n")[0]);
+                                                clearExceptions();
+                                            }
+                                        }, fail);
 
-                            input_buf = input_buf.slice(i+1);
-                        }
-
+                                        input_buf = input_buf.slice(i + 1);
+                                    }
+                                })
+                                .on('end', () => {
+                                    CDP.Close(target)
+                                            .then(() => process.exit(0))
+                                            .catch(fatal);
+                                });
                     })
-                   .on('end', () => {
-                       CDP.Close(target)
-                           .then(() => process.exit(0))
-                           .catch(fatal);
-                   });
-            })
-            .catch(fatal);
-    })
-    .catch(fatal);
+                    .catch(fatal);
+        })
+        .catch(fatal);

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -314,7 +314,7 @@ CDP.New(options)
                                         const command = input_buf.slice(0, i);
 
                                         // run the command
-                                        eval(command).then(reply => {
+                                        eval(command).then(reply => { // eslint-disable-line no-eval
                                             if (unhandledExceptions.length === 0) {
                                                 success(reply);
                                             } else {

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -157,7 +157,7 @@ function resolveLogPromise() {
  * Only one such promise can be active at a given time. Once the promise is
  * resolved, this function can be called again to wait for further messages.
  */
-function waitLog() {
+function waitLog() { // eslint-disable-line no-unused-vars
     console.assert(logPromiseResolver === undefined);
 
     return new Promise((resolve, reject) => {
@@ -225,7 +225,7 @@ function setupLocalFunctions(client) {
 }
 
 // helper functions for testlib.py which are too unwieldy to be poked in from Python
-function getFrameExecId(frame) {
+function getFrameExecId(frame) { // eslint-disable-line no-unused-vars
     if (frame === null)
         frame = "cockpit1";
     const frameId = frameNameToFrameId[frame];

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -243,7 +243,16 @@ function getFrameExecId(frame) {
 
 // secure by default; tests can override to "continue"
 // https://chromedevtools.github.io/devtools-protocol/1-3/Security/#type-CertificateErrorAction
-var ssl_bad_certificate_action = "cancel";
+let ssl_bad_certificate_action = "cancel";
+
+/**
+ * Change what happens when the browser opens a page with an invalid SSL certificate.
+ * Defaults to "cancel", can be set to "continue".
+ */
+function setSSLBadCertificateAction(action) { // eslint-disable-line no-unused-vars
+    ssl_bad_certificate_action = action;
+    return Promise.resolve();
+}
 
 function setupSSLCertHandling(client) {
     client.Security.enable();

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -284,7 +284,7 @@ process.stdin.setEncoding('utf8');
 if (process.env.TEST_CDP_DEBUG)
     enable_debug = true;
 
-options = { };
+const options = { };
 if (process.argv.length >= 3) {
     options.port = parseInt(process.argv[2]);
     if (!options.port) {

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -379,7 +379,7 @@ CDP(options)
 
                             // run the command
                             seq = ++cur_cmd_seq;
-                            eval(command).then(reply => {
+                            eval(command).then(reply => { // eslint-disable-line no-eval
                                 currentExecId = null;
                                 if (unhandledExceptions.length === 0) {
                                     success(seq, reply);

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -145,7 +145,7 @@ function setupLogging(client) {
         if (msg.stackTrace !== undefined &&
             typeof text === "string" &&
             text.indexOf("Error: ") !== -1) {
-            trace = text.split(": ", 1);
+            const trace = text.split(": ", 1);
             processException({
                 exceptionDetails: {
                     exception: {
@@ -320,7 +320,7 @@ process.stdin.setEncoding('utf8');
 if (process.env.TEST_CDP_DEBUG)
     enable_debug = true;
 
-options = { };
+const options = { };
 if (process.argv.length >= 3) {
     options.port = parseInt(process.argv[2]);
     if (!options.port) {

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -31,7 +31,6 @@
 const CDP = require('chrome-remote-interface');
 
 let enable_debug = false;
-let the_client = null;
 
 function debug(msg) {
     if (enable_debug)
@@ -195,7 +194,7 @@ function resolveLogPromise() {
  * Only one such promise can be active at a given time. Once the promise is
  * resolved, this function can be called again to wait for further messages.
  */
-function waitLog() {
+function waitLog() { // eslint-disable-line no-unused-vars
     console.assert(logPromiseResolver === undefined);
 
     return new Promise((resolve, reject) => {
@@ -295,7 +294,7 @@ function setupLocalFunctions(client) {
 }
 
 // helper functions for testlib.py which are too unwieldy to be poked in from Python
-function getFrameExecId(frame) {
+function getFrameExecId(frame) { // eslint-disable-line no-unused-vars
     if (frame === null)
         frame = "cockpit1";
     const frameId = frameNameToFrameId[frame];
@@ -334,7 +333,7 @@ if (process.argv.length >= 3) {
 // thus save all scripts in array and on each new context just execute these
 // scripts in them
 // https://bugzilla.mozilla.org/show_bug.cgi?id=1549465
-function addScriptToEvaluateOnNewDocument(script) {
+function addScriptToEvaluateOnNewDocument(script) { // eslint-disable-line no-unused-vars
     return new Promise((resolve, reject) => {
         scriptsOnNewContext.push(script.source);
         resolve();
@@ -358,7 +357,6 @@ function addScriptToEvaluateOnNewDocument(script) {
 // should be fine
 CDP(options)
         .then(client => {
-            the_client = client;
             setupLogging(client);
             setupFrameTracking(client);
             setupLocalFunctions(client);

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -1,3 +1,5 @@
+/* eslint no-unused-vars: 0 */
+
 /*
  * These are routines used by our testing code.
  *
@@ -7,15 +9,15 @@
 
 function ph_select(sel) {
     if (!window.Sizzle)
-        throw "Sizzle was not properly loaded";
+        throw new Error("Sizzle was not properly loaded");
     return window.Sizzle(sel);
 }
 
 function ph_only(els, sel) {
     if (els.length === 0)
-        throw sel + " not found";
+        throw new Error(sel + " not found");
     if (els.length > 1)
-        throw sel + " is ambiguous";
+        throw new Error(sel + " is ambiguous");
     return els[0];
 }
 
@@ -36,14 +38,14 @@ function ph_count_check(sel, expected_num) {
 function ph_val (sel) {
     const el = ph_find(sel);
     if (el.value === undefined)
-        throw sel + " does not have a value";
+        throw new Error(sel + " does not have a value");
     return el.value;
 }
 
 function ph_set_val (sel, val) {
     const el = ph_find(sel);
     if (el.value === undefined)
-        throw sel + " does not have a value";
+        throw new Error(sel + " does not have a value");
     el.value = val;
     const ev = new Event("change", { bubbles: true, cancelable: false });
     el.dispatchEvent(ev);
@@ -57,7 +59,7 @@ function ph_collected_text_is (sel, val) {
     const els = ph_select(sel);
     const rest = els.map(el => {
         if (el.textContent === undefined)
-            throw sel + " can not have text";
+            throw new Error(sel + " can not have text");
         return el.textContent.replace(/\xa0/g, " ");
     }).join("");
     return rest === val;
@@ -66,7 +68,7 @@ function ph_collected_text_is (sel, val) {
 function ph_text (sel) {
     const el = ph_find(sel);
     if (el.textContent === undefined)
-        throw sel + " can not have text";
+        throw new Error(sel + " can not have text");
     // 0xa0 is a non-breakable space, which is a rendering detail of Chromium
     // and awkward to handle in tests; turn it into normal spaces
     return el.textContent.replace(/\xa0/g, " ");
@@ -101,7 +103,7 @@ function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
 
     /* The element has to be visible, and not collapsed */
     if (el.offsetWidth <= 0 && el.offsetHeight <= 0 && el.tagName != 'svg')
-        throw sel + " is not visible";
+        throw new Error(sel + " is not visible");
 
     /* The event has to actually work */
     let processed = false;
@@ -148,13 +150,13 @@ function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
 
     /* It really had to work */
     if (!processed)
-        throw sel + " is disabled or somehow doesn't process events";
+        throw new Error(sel + " is disabled or somehow doesn't process events");
 }
 
 function ph_get_checked (sel) {
     const el = ph_find(sel);
     if (el.checked === undefined)
-        throw sel + " is not checkable";
+        throw new Error(sel + " is not checkable");
 
     return el.checked;
 }
@@ -162,7 +164,7 @@ function ph_get_checked (sel) {
 function ph_set_checked (sel, val) {
     const el = ph_find(sel);
     if (el.checked === undefined)
-        throw sel + " is not checkable";
+        throw new Error(sel + " is not checkable");
 
     if (el.checked != val)
         ph_mouse(sel, "click", 0, 0, 0);
@@ -195,7 +197,7 @@ function ph_go(href) {
         window.location.hash = href;
     } else {
         if (window.name.indexOf("cockpit1") !== 0)
-            throw "ph_go() called in non cockpit window";
+            throw new Error("ph_go() called in non cockpit window");
         const control = {
             command: "jump",
             location: href

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -7,12 +7,11 @@
 
 function ph_select(sel) {
     if (!window.Sizzle)
-        throw "Sizzle was not properly loaded"
+        throw "Sizzle was not properly loaded";
     return window.Sizzle(sel);
 }
 
-function ph_only(els, sel)
-{
+function ph_only(els, sel) {
     if (els.length === 0)
         throw sel + " not found";
     if (els.length > 1)
@@ -20,14 +19,13 @@ function ph_only(els, sel)
     return els[0];
 }
 
-function ph_find (sel)
-{
-    var els = ph_select(sel);
+function ph_find (sel) {
+    const els = ph_select(sel);
     return ph_only(els, sel);
 }
 
 function ph_count(sel) {
-    var els = ph_select(sel);
+    const els = ph_select(sel);
     return els.length;
 }
 
@@ -35,87 +33,78 @@ function ph_count_check(sel, expected_num) {
     return (ph_count(sel) == expected_num);
 }
 
-function ph_val (sel)
-{
-    var el = ph_find(sel);
+function ph_val (sel) {
+    const el = ph_find(sel);
     if (el.value === undefined)
         throw sel + " does not have a value";
     return el.value;
 }
 
-function ph_set_val (sel, val)
-{
-    var el = ph_find(sel);
+function ph_set_val (sel, val) {
+    const el = ph_find(sel);
     if (el.value === undefined)
         throw sel + " does not have a value";
     el.value = val;
-    var ev = new Event("change", { bubbles: true, cancelable: false });
+    const ev = new Event("change", { bubbles: true, cancelable: false });
     el.dispatchEvent(ev);
 }
 
-function ph_has_val (sel, val)
-{
+function ph_has_val (sel, val) {
     return ph_val(sel) == val;
 }
 
-function ph_collected_text_is (sel, val)
-{
-    var els = ph_select(sel);
-    var rest = els.map(el => {
+function ph_collected_text_is (sel, val) {
+    const els = ph_select(sel);
+    const rest = els.map(el => {
         if (el.textContent === undefined)
             throw sel + " can not have text";
-        return el.textContent.replace(/\xa0/g, " ")
+        return el.textContent.replace(/\xa0/g, " ");
     }).join("");
     return rest === val;
 }
 
-function ph_text (sel)
-{
-    var el = ph_find(sel);
+function ph_text (sel) {
+    const el = ph_find(sel);
     if (el.textContent === undefined)
         throw sel + " can not have text";
     // 0xa0 is a non-breakable space, which is a rendering detail of Chromium
     // and awkward to handle in tests; turn it into normal spaces
-    return el.textContent.replace(/\xa0/g, " ")
+    return el.textContent.replace(/\xa0/g, " ");
 }
 
-function ph_attr (sel, attr)
-{
+function ph_attr (sel, attr) {
     return ph_find(sel).getAttribute(attr);
 }
 
-function ph_set_attr (sel, attr, val)
-{
-    var el = ph_find(sel);
+function ph_set_attr (sel, attr, val) {
+    const el = ph_find(sel);
     if (val === null || val === undefined)
         el.removeAttribute(attr);
     else
         el.setAttribute(attr, val);
 
-    var ev = new Event("change", { bubbles: true, cancelable: false });
+    const ev = new Event("change", { bubbles: true, cancelable: false });
     el.dispatchEvent(ev);
 }
 
-function ph_has_attr (sel, attr, val)
-{
+function ph_has_attr (sel, attr, val) {
     return ph_attr(sel, attr) == val;
 }
 
-function ph_attr_contains (sel, attr, val)
-{
-    var a = ph_attr(sel, attr);
+function ph_attr_contains (sel, attr, val) {
+    const a = ph_attr(sel, attr);
     return a && a.indexOf(val) > -1;
 }
 
 function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
-    let el = ph_find(sel);
+    const el = ph_find(sel);
 
     /* The element has to be visible, and not collapsed */
     if (el.offsetWidth <= 0 && el.offsetHeight <= 0 && el.tagName != 'svg')
         throw sel + " is not visible";
 
     /* The event has to actually work */
-    var processed = false;
+    let processed = false;
     function handler() {
         processed = true;
     }
@@ -131,13 +120,13 @@ function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
         top += elp.offsetTop;
     }
 
-    var detail = 0;
+    let detail = 0;
     if (["click", "mousedown", "mouseup"].indexOf(type) > -1)
         detail = 1;
     else if (type === "dblclick")
         detail = 2;
 
-    var ev = new MouseEvent(type, {
+    const ev = new MouseEvent(type, {
         bubbles: true,
         cancelable: true,
         view: window,
@@ -162,18 +151,16 @@ function ph_mouse(sel, type, x, y, btn, ctrlKey, shiftKey, altKey, metaKey) {
         throw sel + " is disabled or somehow doesn't process events";
 }
 
-function ph_get_checked (sel)
-{
-    var el = ph_find(sel);
+function ph_get_checked (sel) {
+    const el = ph_find(sel);
     if (el.checked === undefined)
         throw sel + " is not checkable";
 
     return el.checked;
 }
 
-function ph_set_checked (sel, val)
-{
-    var el = ph_find(sel);
+function ph_set_checked (sel, val) {
+    const el = ph_find(sel);
     if (el.checked === undefined)
         throw sel + " is not checkable";
 
@@ -181,41 +168,35 @@ function ph_set_checked (sel, val)
         ph_mouse(sel, "click", 0, 0, 0);
 }
 
-function ph_is_visible (sel)
-{
-    var el = ph_find(sel);
+function ph_is_visible (sel) {
+    const el = ph_find(sel);
     return el.tagName == "svg" || ((el.offsetWidth > 0 || el.offsetHeight > 0) && !(el.style.visibility == "hidden" || el.style.display == "none"));
 }
 
-function ph_is_present(sel)
-{
-    var els = ph_select(sel);
+function ph_is_present(sel) {
+    const els = ph_select(sel);
     return els.length > 0;
 }
 
-function ph_in_text (sel, text)
-{
+function ph_in_text (sel, text) {
     return ph_text(sel).indexOf(text) != -1;
 }
 
-function ph_text_is (sel, text)
-{
+function ph_text_is (sel, text) {
     return ph_text(sel) == text;
 }
 
-function ph_text_matches (sel, pattern)
-{
+function ph_text_matches (sel, pattern) {
     return ph_text(sel).match(pattern);
 }
 
 function ph_go(href) {
     if (href.indexOf("#") === 0) {
         window.location.hash = href;
-
     } else {
         if (window.name.indexOf("cockpit1") !== 0)
             throw "ph_go() called in non cockpit window";
-        var control = {
+        const control = {
             command: "jump",
             location: href
         };
@@ -223,23 +204,19 @@ function ph_go(href) {
     }
 }
 
-function ph_focus(sel)
-{
+function ph_focus(sel) {
     ph_find(sel).focus();
 }
 
-function ph_scrollIntoViewIfNeeded(sel)
-{
+function ph_scrollIntoViewIfNeeded(sel) {
     ph_find(sel).scrollIntoViewIfNeeded();
 }
 
-function ph_blur(sel)
-{
+function ph_blur(sel) {
     ph_find(sel).blur();
 }
 
-function ph_blur_active()
-{
+function ph_blur_active() {
     const elt = window.document.activeElement;
     if (elt)
         elt.blur();
@@ -262,11 +239,11 @@ function ph_wait_cond(cond, timeout, error_description) {
         // https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
         let stepTimer = null;
         let last_err = null;
-        let tm = window.setTimeout( () => {
-                if (stepTimer)
-                    window.clearTimeout(stepTimer);
-                reject(last_err || new PhWaitCondTimeout(error_description));
-            }, timeout);
+        const tm = window.setTimeout(() => {
+            if (stepTimer)
+                window.clearTimeout(stepTimer);
+            reject(last_err || new PhWaitCondTimeout(error_description));
+        }, timeout);
         function step() {
             try {
                 if (cond()) {
@@ -286,17 +263,17 @@ function ph_wait_cond(cond, timeout, error_description) {
 function currentFrameAbsolutePosition() {
     let currentWindow = window;
     let currentParentWindow;
-    let positions = [];
+    const positions = [];
     let rect;
 
     while (currentWindow !== window.top) {
         currentParentWindow = currentWindow.parent;
         for (let idx = 0; idx < currentParentWindow.frames.length; idx++)
             if (currentParentWindow.frames[idx] === currentWindow) {
-                for (let frameElement of currentParentWindow.document.getElementsByTagName('iframe')) {
+                for (const frameElement of currentParentWindow.document.getElementsByTagName('iframe')) {
                     if (frameElement.contentWindow === currentWindow) {
                         rect = frameElement.getBoundingClientRect();
-                        positions.push({x: rect.x, y: rect.y});
+                        positions.push({ x: rect.x, y: rect.y });
                     }
                 }
                 currentWindow = currentParentWindow;
@@ -320,8 +297,8 @@ function flatten(array_of_arrays) {
 }
 
 function ph_selector_clips(sels) {
-    var f = currentFrameAbsolutePosition();
-    var elts = flatten(sels.map(ph_select))
+    const f = currentFrameAbsolutePosition();
+    const elts = flatten(sels.map(ph_select));
     return elts.map(e => {
         const r = e.getBoundingClientRect();
         return { x: r.x + f.x, y: r.y + f.y, width: r.width, height: r.height, scale: 1 };
@@ -334,5 +311,5 @@ function ph_element_clip(sel) {
 }
 
 function ph_count_animations(sel) {
-    return ph_find(sel).getAnimations({subtree:true}).length;
+    return ph_find(sel).getAnimations({ subtree:true }).length;
 }

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -774,7 +774,7 @@ class Browser:
         action = ignore and "continue" or "cancel"
         if opts.trace:
             print("-> Setting SSL certificate error policy to %s" % action)
-        self.cdp.command("new Promise((resolve, _) => { ssl_bad_certificate_action = '%s'; resolve() })" % action)
+        self.cdp.command(f"setSSLBadCertificateAction('{action}')")
 
     def grant_permissions(self, *args):
         """Grant permissions to the browser"""


### PR DESCRIPTION
Now it's almost clean:
```
❱❱❱ node_modules/.bin/eslint test/common/

/var/home/martin/upstream/c3/test/common/chromium-cdp-driver.js
  221:72  error  Extra semicolon  semi

/var/home/martin/upstream/c3/test/common/firefox-cdp-driver.js
  290:72  error  Extra semicolon  semi

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.
```

That remaining error is fixed in PR #17062, and I want to avoid colliding.

Once these two land, I'll add it to the `npm run eslint` rules in package.json. But that will also incur a node_modules/ refresh, so let's do that separately.