### PR TITLE
packit: build SRPM in Copr

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -9,6 +9,17 @@ actions:
     - tools/webpack-jumpstart --wait --rebase
     - make XZ_OPT=-0 dist
     - sh -c 'echo cockpit-*.tar.xz'
+srpm_build_deps:
+  - npm
+  - selinux-policy
+  - autogen
+  - autoconf
+  - automake
+  - make
+  - gcc
+  - glib2-devel
+  - systemd-devel
+  - xmlto
 jobs:
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
...and be able to specify the precise list of deps needed to create the SRPM

TODO:
* [x] resolve the problem that specfile_path is needed

The SRPM is also created in a fresh VM instead of a locked-down openshift pod.

Please bear in mind this feature made it to production just today :)