### PR TITLE
test: Drop Machine.execute() calls with script=

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1214,7 +1214,7 @@ class TestUpdatesSubscriptions(PackageCase):
         self.sed_file("s/insecure = 0/insecure = 1/g", "/etc/rhsm/rhsm.conf")
 
         # Wait for the web service to be accessible
-        m.execute(script=WAIT_SCRIPT % {"addr": "10.111.112.100"})
+        m.execute(WAIT_SCRIPT % {"addr": "10.111.112.100"})
         self.update_icon = "#page_status_notification_updates svg"
         self.update_text = "#page_status_notification_updates"
         self.update_text_action = "#page_status_notification_updates a"

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -71,7 +71,7 @@ class TestSelinux(MachineCase):
         m = self.machine
 
         # fix audit events first
-        self.machine.execute(script=FIX_AUDITD)
+        self.machine.execute(FIX_AUDITD)
 
         # Do some local modifications
         m.execute("semanage fcontext --add -t samba_share_t /var/tmp/")
@@ -113,7 +113,7 @@ class TestSelinux(MachineCase):
         # trigger an sebool alert
         # this triggers two solutions -- the preferred sebool module, which can be applied automatically,
         # and the fallback "report a bug" ausearch one, which cannot be applied automatically
-        self.machine.execute(script=SELINUX_SEBOOL_ALERT_SCRIPT)
+        self.machine.execute(SELINUX_SEBOOL_ALERT_SCRIPT)
 
         row_selector = "tbody:contains('ls from read access on the directory')"
 
@@ -158,7 +158,7 @@ class TestSelinux(MachineCase):
 
         #########################################################
         # trigger a fixable restorecon alert
-        self.machine.execute(script=SELINUX_RESTORECON_ALERT_SCRIPT)
+        self.machine.execute(SELINUX_RESTORECON_ALERT_SCRIPT)
 
         row_selector = "tbody:contains('read access on the file /root/.ssh/authorized_keys')"
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -532,7 +532,7 @@ ExecStart=/bin/true
 
         # validate Kerberos setup for ws
         m.execute(f"echo {self.admin_password} | kinit -f {self.admin_user}@COCKPIT.LAN")
-        m.execute(script=WAIT_KRB_SCRIPT.format(f"{self.admin_user}@cockpit.lan"), timeout=300)
+        m.execute(WAIT_KRB_SCRIPT.format(f"{self.admin_user}@cockpit.lan"), timeout=300)
 
         # kerberos login should work
         output = m.execute(['curl', '-s', '--negotiate', '--delegation', 'always', '-u', ':', "-D", "-",
@@ -714,7 +714,7 @@ ipa-advise enable-admins-sudo | sh -ex
         persistent_ticket = m.execute(alice_klist_cmd)
 
         # enable sudo GSSAPI authentication
-        m.execute(script=r"""#!/bin/sh -eu
+        m.execute(r"""#!/bin/sh -eu
         sed -i '/\[domain\/cockpit.lan\]/ a pam_gssapi_services = sudo, sudo-i' /etc/sssd/sssd.conf
         sed -i '1 a auth sufficient pam_sss_gss.so' /etc/pam.d/sudo
         systemctl restart sssd
@@ -1020,8 +1020,8 @@ ExecStart=/bin/true
         if "ubuntu" in self.machine.image:
             # no nss-myhostname there
             self.machine.execute("echo '10.111.113.1 x0.cockpit.lan' >> /etc/hosts")
-        self.machine.execute(script=JOIN_SCRIPT % args, timeout=1800)
-        self.machine.execute(script=WAIT_KRB_SCRIPT.format("admin"), timeout=300)
+        self.machine.execute(JOIN_SCRIPT % args, timeout=1800)
+        self.machine.execute(WAIT_KRB_SCRIPT.format("admin"), timeout=300)
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testNegotiate(self):


### PR DESCRIPTION
The difference between "command" and "script" arguments is marginal,
insignificant, and confusing. Let's just always use command, and drop
the script= argument from machine_core at some point.