### PR TITLE
The prompt text "Permission denied" should display internationalized text when the login failed

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -888,7 +888,7 @@
                     }
                 }
             } else if (xhr.status == 403) {
-                login_failure(decodeURIComponent(xhr.statusText) || _("Permission denied"));
+                login_failure(_(decodeURIComponent(xhr.statusText)) || _("Permission denied"));
             } else if (xhr.statusText) {
                 fatal(decodeURIComponent(xhr.statusText));
             } else {


### PR DESCRIPTION
Our browser is in Chinese. When a user login to cockpit-ws and uses a wrong password, it always displays "Permission denied", but the user actually wants to see the prompt text in Chinese.

I found the prompt text passed by a .c file is always fetched first in login.js, and the internationalized "Permission denied" is used only when the decoding fails.
![english_permission_denied](https://user-images.githubusercontent.com/57792210/156287929-a8653fce-4ec1-4c7c-965a-09c5008b7dae.png)

When we can confirm that the returned text is "Permission denied", using internationalized text directly will meet the needs of users.
![chinese_permission_denied](https://user-images.githubusercontent.com/57792210/156287938-c200b198-b9e5-4513-aaac-7a5aaca7e934.png)
 