### PR TITLE
test: Minimize scope of "seq" in firefox-cdp-driver.js

### DIFF
--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -363,7 +363,6 @@ CDP(options)
             // TODO: Security handling not yet supported in Firefox
 
             let input_buf = '';
-            let seq = 0;
             process.stdin
                     .on('data', chunk => {
                         input_buf += chunk;
@@ -378,7 +377,7 @@ CDP(options)
                                 command = command.substring(12);
 
                             // run the command
-                            seq = ++cur_cmd_seq;
+                            const seq = ++cur_cmd_seq;
                             eval(command).then(reply => { // eslint-disable-line no-eval
                                 currentExecId = null;
                                 if (unhandledExceptions.length === 0) {


### PR DESCRIPTION
It is captured by the promise closures and if there ever are
overlapping command evaluations, each needs to keep their own number.