### PR TITLE
metrics: Compress space a bit

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -123,7 +123,7 @@
   // Shrink progress bars and their gap a little
   .pf-c-progress {
       grid-gap: 0;
-      --pf-c-progress__bar--Height: var(--pf-global--spacer--sm);
+      --pf-c-progress__bar--Height: var(--pf-global--spacer--xs);
       // PF4 uses end; it probably should arguably use last baseline.
       // (perhaps end may work better for non-text content?)
       align-items: last baseline;

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -66,21 +66,21 @@
 
       .progress-stack {
           display: grid;
-          padding-bottom: var(--pf-global--spacer--md);
-          grid-gap: var(--pf-global--spacer--md) var(--pf-global--spacer--lg);
+          padding-bottom: var(--pf-global--spacer--sm);
+          grid-gap: var(--pf-global--spacer--sm) var(--pf-global--spacer--md);
 
           &:not(:first-child) {
-            padding-top: var(--pf-global--spacer--md);
+            padding-top: var(--pf-global--spacer--sm);
           }
       }
 
       .progress-stack-no-space {
           display: grid;
-          padding-bottom: var(--pf-global--spacer--lg);
+          padding-bottom: var(--pf-global--spacer--sm);
           grid-gap: 0;
 
           &:not(:first-child) {
-            padding-top: var(--pf-global--spacer--lg);
+            padding-top: var(--pf-global--spacer--sm);
           }
 
           // avoid the "x" icon on high CPU usage

--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -127,6 +127,11 @@
       // PF4 uses end; it probably should arguably use last baseline.
       // (perhaps end may work better for non-text content?)
       align-items: last baseline;
+
+      + .pf-c-progress {
+          // Add a tiny gap for sandwiched usage bars (as in CPU)
+          padding-top: 1px;
+      }
   }
 
   // Only underline the description

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -750,7 +750,7 @@ class TestCurrentMetrics(MachineCase):
         b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) < 5)
 
         m.execute("systemd-run --collect --slice cockpittest --unit load-hog sh -ec "
-                  "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=10K count=500 status=none & done'")
+                  "  'for i in `seq 500`; do dd if=/dev/urandom of=/dev/zero bs=100K count=500 status=none & done'")
         b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) > 15)
         m.execute("systemctl stop load-hog 2>/dev/null || true")  # ok to fail, as the command exits by itself
 


### PR DESCRIPTION
I adjusted the extra spacing between the CPU bars & load and then decided to adjust all the spacing in the current metrics area.

The extra spacing between the CPU bars & load _definitely_ needs to be adjusted, but the rest are mostly subjective changes and I'm still not fully sold on it. I'd like feedback.

Before:

![Screenshot 2022-03-02 at 13-19-52 Overview - garrett Bolt](https://user-images.githubusercontent.com/10246/156366081-910d5472-7083-4958-b39e-43c3bc911070.png)

After:

![Screenshot 2022-03-02 at 13-19-40 Overview - garrett Bolt](https://user-images.githubusercontent.com/10246/156366078-0ad91cc8-0f4d-47b0-acb0-aadfee445812.png)