### PR TITLE
test: Kill admin sessions after nondestructive tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1335,15 +1335,15 @@ class MachineCase(unittest.TestCase):
                         "    umount /dev/$dev 2>/dev/null || true; "
                         "done; until rmmod scsi_debug; do sleep 1; done")
 
-        # Terminate all lingering Cockpit sessions
         def terminate_sessions():
-            if self.machine.ostree_image:
-                # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH
-                self.machine.execute("loginctl kill-user admin 2>/dev/null || true;"
-                                     "loginctl terminate-user admin 2>/dev/null || true")
-                self.machine.execute("while pgrep -u admin; do sleep 1; done;")
-                return
+            # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH; but also, some tests start
+            # admin sessions without Cockpit
+            self.machine.execute("loginctl kill-user admin 2>/dev/null || true;"
+                                 "loginctl terminate-user admin 2>/dev/null || true;"
+                                 "pkill -u admin || true")
+            self.machine.execute("while pgrep -u admin; do sleep 1; done;")
 
+            # Terminate all other Cockpit sessions
             sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
             for s in sessions:
                 # Don't insist that terminating works, the session might be gone by now.


### PR DESCRIPTION
Some tests seem to leak an "admin" session which is not started by
Cockpit. This causes TestSession.testBasic to fail its initial "no
running admin sessions" check.

Clean up more thoroughly, and just always kill leftover admin sessions
also on OSes other than OSTree.

---

Fixes [this failure](https://logs.cockpit-project.org/logs/pull-17080-20220303-065131-4ef167f5-rhel-8-6/log.html#130-2)