### PR TITLE
systemd: Fix Service details crash on disappearing units

### DIFF
--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -737,8 +737,9 @@ class ServicesPageBody extends React.Component {
             const unit_id = path[0];
             const get_unit_path = (unit_id) => this.path_by_id[unit_id];
             const unit_path = get_unit_path(unit_id);
+            const unit = this.state.unit_by_path[unit_path];
 
-            if (unit_path === undefined) {
+            if (unit_path === undefined || unit === undefined || unit.LoadState === 'not-found') {
                 const path = "/system/services" + (this.props.owner === "user" ? "#/?owner=user" : "");
                 return <EmptyStatePanel
                             icon={ExclamationCircleIcon}
@@ -753,7 +754,6 @@ class ServicesPageBody extends React.Component {
                 />;
             }
 
-            const unit = this.state.unit_by_path[unit_path];
             return <Service unitIsValid={unitId => { const path = get_unit_path(unitId); return path !== undefined && this.state.unit_by_path[path].LoadState != 'not-found' }}
                             owner={this.props.owner}
                             key={unit_id}

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -942,12 +942,15 @@ Where=/fail
 
         self.allow_journal_messages(".*type=1400 audit(.*): avc:  denied  { create } .* comm=\"systemd\" name=\"fail\".*")
 
-    def testTransientFailingUnits(self):
+    def testTransientUnits(self):
+        m = self.machine
+        b = self.browser
+
         self.login_and_go("/system/services")
         self.wait_page_load()
 
-        self.machine.execute("systemd-run --collect --unit test-autocollect@1.service sh -c 'sleep 10; false'")
-        self.machine.execute("systemd-run --unit test-manual-collect@1.service sh -c 'sleep 3; false'")
+        m.execute("systemd-run --collect --unit test-autocollect@1.service sh -c 'sleep 10; false'")
+        m.execute("systemd-run --unit test-manual-collect@1.service sh -c 'sleep 3; false'")
 
         self.wait_service_present("test-autocollect@1.service")
         self.wait_service_present("test-manual-collect@1.service")
@@ -957,8 +960,22 @@ Where=/fail
         self.wait_service_not_present("test-autocollect@1.service")
         self.wait_service_present("test-manual-collect@1.service")
 
-        self.machine.execute("systemctl reset-failed")
+        m.execute("systemctl reset-failed")
         self.wait_service_not_present("test-manual-collect@1.service")
+
+        # details page handles units going away
+        m.execute("systemd-run --collect --unit test-transient.service sleep infinity")
+        self.addCleanup(m.execute, "systemctl stop test-transient.service || true")
+        self.wait_service_present("test-transient.service")
+        self.goto_service("test-transient.service")
+        self.check_service_details(["Static", "Running"], ["Restart", "Stop", "Disallow running (mask)"], False, onoff=False)
+
+        self.do_action("Stop")
+
+        b.wait_in_text(".pf-c-empty-state", "Unit not found")
+        b.click("a:contains('View all services')")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname == "/system/services"')
 
 
 @skipDistroPackage()


### PR DESCRIPTION
These happen after `systemctl daemon-reload` when changing unit files,
or when stopping transient units (systemd-run). Then the page would
crash with

    Cannot read properties of undefined (reading 'Names')

Intercept this condition and show the "Unit not found" empty state.

---

This can be seen in current logs, e.g. [here](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-17082-20220303-091332-1070fb01-fedora-35/log) in `TestCurrentMetrics.testCPU`. 