### PR TITLE
pam-ssh-add: drop two uses of libcockpit-common APIs

### DIFF
--- a/src/pam-ssh-add/Makefile.am
+++ b/src/pam-ssh-add/Makefile.am
@@ -1,8 +1,6 @@
 noinst_LIBRARIES += libpam_ssh_add.a
 
 libpam_ssh_add_a_SOURCES = \
-	src/common/cockpitmemory.h \
-	src/common/cockpitmemory.c \
 	src/pam-ssh-add/pam-ssh-add.c \
 	src/pam-ssh-add/pam-ssh-add.h \
 	$(NULL)

--- a/src/pam-ssh-add/Makefile.am
+++ b/src/pam-ssh-add/Makefile.am
@@ -1,8 +1,6 @@
 noinst_LIBRARIES += libpam_ssh_add.a
 
 libpam_ssh_add_a_SOURCES = \
-	src/common/cockpitclosefrom.c \
-	src/common/cockpithacks.h \
 	src/common/cockpitmemory.h \
 	src/common/cockpitmemory.c \
 	src/pam-ssh-add/pam-ssh-add.c \

--- a/src/pam-ssh-add/pam-ssh-add.c
+++ b/src/pam-ssh-add/pam-ssh-add.c
@@ -29,6 +29,7 @@
 #include <sys/wait.h>
 #include <signal.h>
 #include <assert.h>
+#include <err.h>
 #include <errno.h>
 #include <limits.h>
 #include <stdio.h>
@@ -45,8 +46,6 @@
 #include <security/pam_modutil.h>
 
 #include "pam-ssh-add.h"
-
-#include "../common/cockpitmemory.h"
 
 /* programs that can be overwidden in tests */
 const char *pam_ssh_agent_program = PATH_SSH_AGENT;
@@ -807,6 +806,17 @@ cleanup_free_password (pam_handle_t *pamh,
                        int pam_end_status)
 {
   free_password (data);
+}
+
+static char *
+strdupx (const char *string)
+{
+  char *copy = strdup (string);
+  if (copy != NULL)
+    return copy;
+
+  warn ("failed to allocate memory for strdup");
+  abort ();
 }
 
 static int

--- a/src/pam-ssh-add/pam-ssh-add.h
+++ b/src/pam-ssh-add/pam-ssh-add.h
@@ -20,6 +20,7 @@
 #ifndef PAM_SSH_ADD_H__
 #define PAM_SSH_ADD_H__
 
+#include <security/pam_modules.h>
 #include "pwd.h"
 
 #define N_ELEMENTS(x) (sizeof(x) / sizeof (x)[0])
@@ -33,12 +34,14 @@ extern int pam_ssh_add_verbose_mode;
 typedef void (*pam_ssh_add_logger) (int level, const char *data);
 extern pam_ssh_add_logger pam_ssh_add_log_handler;
 
-int     pam_ssh_add_start_agent     (struct passwd *pwd,
+int     pam_ssh_add_start_agent     (pam_handle_t *pamh,
+                                     struct passwd *pwd,
                                      const char *xdg_runtime_overide,
                                      char **out_auth_sock_var,
                                      char **out_agent_pid_var);
 
-int     pam_ssh_add_load            (struct passwd *pwd,
+int     pam_ssh_add_load            (pam_handle_t *pamh,
+                                     struct passwd *pwd,
                                      const char *agent_socket,
                                      const char *password);
 

--- a/src/pam-ssh-add/test-ssh-add.c
+++ b/src/pam-ssh-add/test-ssh-add.c
@@ -204,7 +204,7 @@ run_test_agent_environment (void *data,
   expect_message ("NO SSH_AUTH_SOCK");
   expect_message ("Failed to start ssh-agent");
 
-  ret = pam_ssh_add_start_agent (fix->pw, xdg_runtime, NULL, NULL);
+  ret = pam_ssh_add_start_agent (NULL, fix->pw, xdg_runtime, NULL, NULL);
 
   assert_num_eq (0, ret);
 
@@ -248,7 +248,7 @@ test_failed_agent (void *data)
 
   expect_message ("Bad things");
   expect_message ("Failed to start ssh-agent");
-  ret = pam_ssh_add_start_agent (fix->pw, NULL, &sock, &pid);
+  ret = pam_ssh_add_start_agent (NULL, fix->pw, NULL, &sock, &pid);
 
   assert_num_eq (0, ret);
   assert_ptr_eq (sock, NULL);
@@ -271,7 +271,7 @@ test_bad_agent_vars (void *data)
   int ret;
 
   expect_message ("Expected agent environment variables not found");
-  ret = pam_ssh_add_start_agent (fix->pw, NULL, &sock, &pid);
+  ret = pam_ssh_add_start_agent (NULL, fix->pw, NULL, &sock, &pid);
 
   assert_num_eq (0, ret);
   assert_ptr_eq (sock, NULL);
@@ -293,7 +293,7 @@ test_good_agent_vars (void *data)
   char *pid = NULL;
   int ret;
 
-  ret = pam_ssh_add_start_agent (fix->pw, NULL, &sock, &pid);
+  ret = pam_ssh_add_start_agent (NULL, fix->pw, NULL, &sock, &pid);
 
   assert_num_eq (1, ret);
   assert_str_cmp (sock, ==, "SSH_AUTH_SOCKET=socket");
@@ -344,7 +344,7 @@ test_keys (void *data)
   if (expect)
     expect_message ("Failed adding some keys");
 
-  ret = pam_ssh_add_load (fix->pw, "mock-socket", fix->password);
+  ret = pam_ssh_add_load (NULL, fix->pw, "mock-socket", fix->password);
 
   assert_num_eq (1, ret);
 }
@@ -362,7 +362,7 @@ test_key_environment (void *data)
   char *home_expect = NULL;
 
   expect_message ("ssh-add requires an agent socket");
-  ret = pam_ssh_add_load (fix->pw, NULL, NULL);
+  ret = pam_ssh_add_load (NULL, fix->pw, NULL, NULL);
   assert_num_eq (0, ret);
 
   if (asprintf (&home_expect, "HOME=%s", fix->pw->pw_dir) < 0)
@@ -378,7 +378,7 @@ test_key_environment (void *data)
   expect_message ("SSH_AUTH_SOCK=mock-socket");
   expect_message ("Failed adding some keys");
 
-  ret = pam_ssh_add_load (fix->pw, "mock-socket", NULL);
+  ret = pam_ssh_add_load (NULL, fix->pw, "mock-socket", NULL);
 
   assert_num_eq (1, ret);
 


### PR DESCRIPTION
This prevents us from recompiling libcockpit-common files as -fPIC.