### PR TITLE
test: Increase timeout for load to drop

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -755,7 +755,7 @@ class TestCurrentMetrics(MachineCase):
         m.execute("systemctl stop load-hog 2>/dev/null || true")  # ok to fail, as the command exits by itself
 
         # this settles down slowly, don't wait for becoming really quiet
-        with b.wait_timeout(180):
+        with b.wait_timeout(300):
             b.wait(lambda: float(b.text("#load-avg .pf-l-flex div:first-child").split()[-1].rstrip(',')) < 10)
 
         # Test link to user services


### PR DESCRIPTION
On some busy CI machines, 3 minutes is not enough for the load to drop
below 10, so wait a little more.

---

I've seen this [fail a lot](https://logs.cockpit-project.org/logs/pull-17087-20220307-095055-49c7fcef-centos-8-stream/log.html#51-2) today, and it's getting annoying. I can't reproduce the long wait times locally, it's usually done after ~ 1.5 minutes. But our CI machines are a lot more busy.