### PR TITLE
ws: Don't cache po.js files forever

### DIFF
--- a/src/bridge/test-packages.c
+++ b/src/bridge/test-packages.c
@@ -826,7 +826,7 @@ test_glob (TestCase *tc,
   message = mock_transport_pop_channel (tc->transport, "444");
   object = cockpit_json_parse_bytes (message, &error);
   g_assert_no_error (error);
-  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{" STATIC_HEADERS ",\"X-Cockpit-Pkg-Checksum\":\"" CHECKSUM_GLOB "\",\"Content-Type\":\"text/plain\"}}");
+  cockpit_assert_json_eq (object, "{\"status\":200,\"reason\":\"OK\",\"headers\":{" STATIC_HEADERS_CACHECONTROL ",\"X-Cockpit-Pkg-Checksum\":\"" CHECKSUM_GLOB "\",\"Content-Type\":\"text/plain\"}}");
   json_object_unref (object);
 
   message = mock_transport_pop_channel (tc->transport, "444");

--- a/src/common/cockpitwebresponse.h
+++ b/src/common/cockpitwebresponse.h
@@ -118,7 +118,8 @@ GBytes *              cockpit_web_response_gunzip        (GBytes *bytes,
 GBytes *              cockpit_web_response_negotiation   (const gchar *path,
                                                           GHashTable *existing,
                                                           const gchar *language,
-                                                          gchar **actual,
+                                                          gboolean *out_is_language_specific,
+                                                          gboolean *out_is_compressed,
                                                           GError **error);
 
 const gchar *         cockpit_web_response_content_type  (const gchar *path);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -414,7 +414,7 @@ send_login_html (CockpitWebResponse *response,
           language = languages[0];
         }
 
-      po_bytes = cockpit_web_response_negotiation (ws->login_po_js, NULL, language, NULL, &error);
+      po_bytes = cockpit_web_response_negotiation (ws->login_po_js, NULL, language, NULL, NULL, &error);
       if (error)
         {
           g_message ("%s", error->message);
@@ -429,7 +429,7 @@ send_login_html (CockpitWebResponse *response,
         }
     }
 
-  bytes = cockpit_web_response_negotiation (ws->login_html, NULL, NULL, NULL, &error);
+  bytes = cockpit_web_response_negotiation (ws->login_html, NULL, NULL, NULL, NULL, &error);
   if (error)
     {
       g_message ("%s", error->message);

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -180,7 +180,7 @@ class TestApps(PackageCase):
             else:
                 b.click(f'#display-language-modal li[data-value={lang}] button')
             b.click("#display-language-modal footer button.pf-m-primary")
-            if b.cdp.browser.name == "chromium":
+            if m.image == "rhel-8-6-distropkg" and b.cdp.browser.name == "chromium":
                 # HACK: work around language switching in Chrome not working in current session (issue #8160)
                 b.reload(ignore_cache=True)
             b.wait_language(lang)

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -178,9 +178,6 @@ OnCalendar=daily
         self.open_lang_modal()
         b.click('#display-language-modal li[data-value=de-de] button')
         b.click("#display-language-modal footer button.pf-m-primary")
-        if b.cdp.browser.name == "chromium":
-            # HACK: work around language switching in Chrome not working in current session (issue #8160)
-            b.reload(ignore_cache=True)
         b.wait_language("de-de")
 
         # Check that the system page is translated
@@ -272,9 +269,6 @@ OnCalendar=daily
             self.open_lang_modal()
             b.click(f"#display-language-modal li[data-value={language}] button")
             b.click("#display-language-modal footer button.pf-m-primary")
-            if b.cdp.browser.name == "chromium":
-                # HACK: work around language switching in Chrome not working in current session (issue #8160)
-                b.reload(ignore_cache=True)
             b.wait_language(language)
 
             # Test some pages, end up in terminal
@@ -324,9 +318,6 @@ OnCalendar=daily
         self.open_lang_modal()
         b.click('#display-language-modal li[data-value=pt-br] button')
         b.click('#display-language-modal footer button.pf-m-primary')
-        if b.cdp.browser.name == "chromium":
-            # HACK: work around language switching in Chrome not working in current session (issue #8160)
-            b.reload(ignore_cache=True)
         b.wait_language("pt-br")
 
         # Check that the system page is translated
@@ -524,9 +515,6 @@ OnCalendar=daily
 
         b.click('#display-language-modal li[data-value=de-de] button')
         b.click("#display-language-modal footer button.pf-m-primary")
-        if b.cdp.browser.name == "chromium":
-            # HACK: work around language switching in Chrome not working in current session (issue #8160)
-            b.reload(ignore_cache=True)
         b.wait_language("de-de")
         b.go("/system")
         b.enter_page("/system")


### PR DESCRIPTION
This causes at least Chromium to not ever re-request the file from the
webserver, so that switching languages does not have any effect.

This is a very heavy hammer, as it generally disables caching po.js even
when not switching languages (the common case). So this should be
replaced with a better design at some point.

Note that caching is already disabled if any Cockpit package is present
in the user's home directory, so this is not something completely new.

Fixes #8160

----

Draft for now. I want a full test run, and possibly also use it to test #16930