### PR TITLE
packit.yaml: reduce the srpm depends

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -10,16 +10,11 @@ actions:
     - make XZ_OPT=-0 dist
     - sh -c 'echo cockpit-*.tar.xz'
 srpm_build_deps:
-  - npm
-  - selinux-policy
-  - autogen
-  - autoconf
   - automake
-  - make
   - gcc
   - glib2-devel
+  - make
   - systemd-devel
-  - xmlto
 jobs:
   - job: tests
     trigger: pull_request


### PR DESCRIPTION
The list here contains very many dependencies that are either no longer
required by this project to build an SRPM (xmlto, selinux-policy, npm)
or never were (the unrelated "autogen" package).

automake pulls in autoconf as a hard dependency central to its
functionality, but gcc's dependency on make seems a bit less central, so
list it explicitly.