### PR TITLE
fmf: Drop cockpit packages from test dependencies

### DIFF
--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -1,12 +1,5 @@
 summary: Run browser integration tests on the host
 require:
-  - cockpit
-  - cockpit-kdump
-  - cockpit-networkmanager
-  - cockpit-packagekit
-  - cockpit-sosreport
-  - cockpit-storaged
-  - cockpit-tests
   # build/test infra dependencies
   - git
   - make


### PR DESCRIPTION
This causes the package to be (formally) upgraded in RHEL/CentOS 8:
there cockpit is already at version 264.1 (from the rhel-9.0 stable
branch), but our version on main is 264. Due to this it "upgrades" to an
actually older version, and does not test current changes.

---

This should fix [these failures](https://artifacts.dev.testing-farm.io/6db08ef5-15c4-4468-a98a-1b0c5aa465a9/) that we got for a few days (since https://github.com/cockpit-project/cockpit/releases/tag/264.1). You can see the bug in the log:

```
+ rpm -q cockpit-system
cockpit-system-264.1-1.el8.noarch
```

Same fix as in https://github.com/cockpit-project/cockpit-machines/pull/601 , specifically https://github.com/cockpit-project/cockpit-machines/commit/119d5b01bf5b1bf336683aaea50a8a7839aab4e7