### PR TITLE
test: Drop rhel-8-5 from documented supported OSes

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -101,7 +101,6 @@ You can set these environment variables to configure the test suite:
                   "fedora-36"
                   "fedora-coreos"
                   "fedora-testing"
-                  "rhel-8-5"
                   "rhel-8-6"
                   "rhel-8-6-distropkg"
                   "rhel-9-0"


### PR DESCRIPTION
We dropped this from bots' testmap a while ago.

---

This is a first test for the increased test parallelization in https://github.com/cockpit-project/cockpituous/pull/459