### PR TITLE
fmf: Trim tests to only exercise external APIs and be faster

### DIFF
--- a/test/run-verify-host-user.sh
+++ b/test/run-verify-host-user.sh
@@ -62,12 +62,12 @@ if [ -n "$test_optional" ]; then
          TestUpdates
          TestAutoUpdates
          TestStorage"
+
+    # Testing Farm machines often have pending restarts/reboot
+    EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart"
 fi
 
 if [ -n "$test_basic" ]; then
-    # Testing Farm machines often have pending restarts/reboot
-    EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart"
-
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"
 

--- a/test/verify.fmf
+++ b/test/verify.fmf
@@ -23,4 +23,4 @@ require:
   - tuned
 
 test: ./run-verify-host.sh
-duration: 4h
+duration: 1h


### PR DESCRIPTION
packit tests currently take ~ 1.5 hours, which is way too long for our
"max. 1 hour" goal. Many of them are also not that useful in downstream
gating, as they only exercise cockpit-internal functionality -- it's
enough to do that in upstream CI where we have a lot more performance
(due to parallelization).

So trim the list to those tests which exercise external APIs, and are
thus useful for reverse dependency gating.

This also eliminates all the excludes. Still keep the mechanism in
place, as we are surely going to have more of them in the future
(especially for development releases).

Adjust the test timeout to 1 hour to match our goal.

---

See the [log of a current test](https://artifacts.dev.testing-farm.io/bca39cdc-ee44-40bd-96a4-8d6b3afcea1f//work-allJ0Tz_d/log.txt) for current timings:
```
07:08:14 /var/ARTIFACTS/work-allJ0Tz_d
[...]
08:31:31 total: 1 test passed
```