### PR TITLE
test: drop DEFAULT_TEST_OS from locale tests

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -22,7 +22,6 @@ import os
 
 import parent
 from testlib import *
-from machine_core.constants import TEST_OS_DEFAULT
 
 
 @nondestructive
@@ -246,7 +245,7 @@ OnCalendar=daily
         # Test all languages
         # Test that pages do not oops and that locale is valid
 
-        if m.image not in [TEST_OS_DEFAULT] and not m.image.startswith("rhel-"):
+        if not m.image.startswith("rhel-"):
             return
 
         def line_sel(i):


### PR DESCRIPTION
Only test locales on RHEL as our default image also does pixel tests
which take longer and the locale tests take up a significant time (~ 5 min.)