### PR TITLE
cockpit.spec: fix RHEL 8 check

### DIFF
--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -184,7 +184,7 @@ rm -f %{buildroot}/%{_libdir}/cockpit/*.so
 install -D -p -m 644 AUTHORS COPYING README.md %{buildroot}%{_docdir}/cockpit/
 
 # only ship deprecated PatternFly API for stable releases
-%if 0%{?rhel} <= 8
+%if 0%{?rhel} == 8
     ln -s cockpit.css.gz %{buildroot}/%{_datadir}/cockpit/base1/patternfly.css.gz
 %endif
 


### PR DESCRIPTION
We currently install a symlink for compatibility purposes with the
intention of only installing it on RHEL <= 8, but the way the test is
written:

```
%if 0%{?rhel} <= 8
```

We install it on RHEL 8 plus every non-RHEL system, because if %{rhel}
is not defined, then it's equivalent to `%if 0 <= 8`, which is true.

Since we don't care about RHEL 7 on this branch anymore, change the
comparison to exactly 8.