### PR TITLE
make tools/make-dist (and therefore image-prepare) a bit prettier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,6 +34,7 @@ dist-hook:
 	NODE_ENV=$(NODE_ENV) $(srcdir)/tools/build-debian-copyright > $(distdir)/tools/debian/copyright
 	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/arch/PKGBUILD.in > $(distdir)/tools/arch/PKGBUILD
 	$(srcdir)/tools/adjust-distdir-timestamps "$(distdir)"
+	@echo '  DIST     $(DIST_ARCHIVES)'
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-prefix-only
 

--- a/tools/make-dist
+++ b/tools/make-dist
@@ -3,6 +3,8 @@
 set -eu
 cd "$(realpath -m "$0"/../..)"
 
+message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
+
 jumpstart_flags=''
 download_only=''
 while [ $# != 0 ] ; do
@@ -32,7 +34,11 @@ if [ ! -d dist ]; then
 fi
 
 # autogen, if not already done
-test configure -nt configure.ac || NOCONFIGURE=1 ./autogen.sh >&2
+if [ ! configure -nt configure.ac ]; then
+    message AUTOGEN 'configure, Makefile.in'
+    # Unfortunately there's no better way to silence this
+    NOCONFIGURE=1 ./autogen.sh >/dev/null 2>&1
+fi
 
 # If we have a configured tree, use it to build the tarball.  Otherwise, create
 # a temporary directory and configure it with a minimal config to build the
@@ -44,6 +50,7 @@ else
     rm -rf "${builddir}"
     mkdir -p "${builddir}"
     cd "${builddir}"
+    message CONFIG "${builddir}/Makefile"
     ../../configure \
         CPPFLAGS=-I../../tools/mock-build-env \
         PKG_CONFIG_PATH=../../tools/mock-build-env \

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -129,7 +129,6 @@ for try in $(seq 50 -1 0); do
         break
     fi
     if [ -z "${wait}" -o "$try" = '0' ]; then
-        echo "There is no cache entry ${tag}" >&2
         exit 1
     fi
     message WAIT 30s


### PR DESCRIPTION
This is silly, but I like it :)

```
  FETCH    dist  [ref: tag sha-a5a0b87f6da0eb78c20319c8f449f2d1f3f6bf5a]
fatal: couldn't find remote ref refs/tags/sha-a5a0b87f6da0eb78c20319c8f449f2d1f3f6bf5a
  AUTOGEN  configure, Makefile.in
  CONFIG   tmp/build-dist/Makefile
  WEBPACK  base1
  WEBPACK  apps
  WEBPACK  kdump
  WEBPACK  metrics
  WEBPACK  networkmanager
  WEBPACK  packagekit
  WEBPACK  playground
  WEBPACK  selinux
  WEBPACK  sosreport
  WEBPACK  shell
  WEBPACK  static
  WEBPACK  storaged
  WEBPACK  systemd
  WEBPACK  tuned
  WEBPACK  users
  DIST     cockpit-264.112.g2e441db12.tar.xz
```