### PR TITLE
test: Reduce multi-VM test memory

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -249,8 +249,8 @@ class TestKdump(KdumpHelpers):
 @skipDistroPackage()
 class TestKdumpNFS(KdumpHelpers):
     provision = {
-        "0": {"address": "10.111.113.1/24"},
-        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24"}
+        "0": {"address": "10.111.113.1/24", "memory_mb": 1024},
+        "nfs": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/24", "memory_mb": 512}
     }
 
     def testBasic(self):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1117,9 +1117,9 @@ class TestMultiCPU(MachineCase):
 class TestGrafanaClient(MachineCase):
 
     provision = {
-        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
+        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},
         # forward Grafana port, so that a developer can connect to it with local browser
-        "services": {"image": "services", "forward": {"3000": 3000}}
+        "services": {"image": "services", "forward": {"3000": 3000}, "memory_mb": 512}
     }
 
     def testBasic(self):

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -274,8 +274,8 @@ class TestBonding(NetworkCase):
 @skipDistroPackage()
 class TestBondingVirt(NetworkCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
     @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-2004", "ubuntu-stable")

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -28,8 +28,8 @@ from machine_core.constants import TEST_OS_DEFAULT
 @skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestNetworkingMAC(NetworkCase):
     provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
+        "machine1": {"memory_mb": 512},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
     def testMac(self):

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -28,8 +28,8 @@ from machine_core.constants import TEST_OS_DEFAULT
 @skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 class TestNetworkingMTU(NetworkCase):
     provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
+        "machine1": {"memory_mb": 512},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
     def testMtu(self):

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -28,8 +28,8 @@ from machine_core.constants import TEST_OS_DEFAULT
 @skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 class TestNetworkingSettings(NetworkCase):
     provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
+        "machine1": {"memory_mb": 512},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
     def testNoConnectionSettings(self):

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -27,8 +27,8 @@ from machine_core.constants import TEST_OS_DEFAULT
 @skipDistroPackage()
 class TestNetworkingUnmanaged(NetworkCase):
     provision = {
-        "machine1": {},
-        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True}
+        "machine1": {"memory_mb": 512},
+        "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
     def testUnmanaged(self):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1173,8 +1173,8 @@ class TestKpatchInstall(NoSubManCase):
            "fedora-35", "fedora-36", "fedora-testing", "ubuntu-2004", "ubuntu-stable", "arch")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
-        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1"},
-        "services": {"image": "services"}
+        "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},
+        "services": {"image": "services", "memory_mb": 1024}
     }
 
     def register(self):

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -60,8 +60,8 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 @skipDistroPackage()
 class TestSelinux(MachineCase):
     provision = {
-        "0": {},
-        "ansible_machine": {"image": TEST_OS_DEFAULT}
+        "0": {"memory_mb": 768},
+        "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 512}
     }
 
     @skipImage("No setroubleshoot", "debian-stable", "debian-testing", "fedora-coreos", "ubuntu-2004", "ubuntu-stable", "arch")

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -103,9 +103,9 @@ class HostSwitcherHelpers:
 @skipDistroPackage()
 class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     provision = {
-        'machine1': {"address": "10.111.113.1/20"},
-        'machine2': {"address": "10.111.113.2/20"},
-        'machine3': {"address": "10.111.113.3/20"}
+        'machine1': {"address": "10.111.113.1/20", "memory_mb": 512},
+        'machine2': {"address": "10.111.113.2/20", "memory_mb": 512},
+        'machine3': {"address": "10.111.113.3/20", "memory_mb": 512}
     }
 
     def setUp(self):

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -133,9 +133,9 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
 @skipDistroPackage()
 class TestMultiMachineAdd(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20"},
-        "machine3": {"address": "10.111.113.3/20"},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
+        "machine3": {"address": "10.111.113.3/20", "memory_mb": 512},
     }
 
     def setup_ssh_auth(self):
@@ -247,9 +247,9 @@ class TestMultiMachineAdd(MachineCase):
 @skipDistroPackage()
 class TestMultiMachine(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20"},
-        "machine3": {"address": "10.111.113.3/20"},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
+        "machine3": {"address": "10.111.113.3/20", "memory_mb": 512},
     }
 
     def setUp(self):

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -62,8 +62,8 @@ KEY_IDS_MD5 = [
 @skipDistroPackage()
 class TestMultiMachineKeyAuth(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20"},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
     def load_key(self, name, password):

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -72,8 +72,8 @@ def add_stock_machine(b, address, password):
 @skipDistroPackage()
 class TestMultiOS(MachineCase):
     provision = {
-        "0": {"address": "10.111.113.1/20"},
-        "centos-7": {"address": "10.111.113.5/20", "image": "centos-7"}
+        "0": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "centos-7": {"address": "10.111.113.5/20", "image": "centos-7", "memory_mb": 512}
     }
 
     def check_spawn(self, b, address):
@@ -162,8 +162,8 @@ class TestMultiOS(MachineCase):
 @skipDistroPackage()
 class TestMultiOSDirect(MachineCase):
     provision = {
-        "0": {"address": "10.111.113.1/20"},
-        "centos-7": {"address": "10.111.113.5/20", "image": "centos-7"}
+        "0": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "centos-7": {"address": "10.111.113.5/20", "image": "centos-7", "memory_mb": 512}
     }
 
     def testCentos7Direct(self):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -497,6 +497,37 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         else:
             self.assertIn('result: access-denied', b.text(".super-channel span"))
 
+    def testNoAdminGroup(self):
+        m = self.machine
+        b = self.browser
+
+        # Create a user that is not in wheel but can sudo
+        m.execute("useradd user -s /bin/bash -c 'User' || true")
+        m.execute("echo user:foobar | chpasswd")
+        m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
+        self.password = "foobar"
+
+        self.login_and_go("/system", user="user")
+
+        # session is privileged
+        b.switch_to_top()
+        b.check_superuser_indicator("Administrative access")
+        b.enter_page('/system')
+
+        # shutdown button should be enabled and working
+        b.click("#reboot-button")
+        b.wait_popup("shutdown-dialog")
+        b.wait_in_text(f"#shutdown-dialog button{self.danger_btn_class}", 'Reboot')
+        b.click("#delay")
+        b.click("button:contains('5 minutes')")
+        b.wait_text("#delay .pf-c-select__toggle-text", "5 minutes")
+        b.click(f"#shutdown-dialog button{self.danger_btn_class}")
+
+        # cancel reboot
+        b.wait_in_text('#system-health-shutdown-status-text', "Scheduled reboot")
+        b.click("#system-health-shutdown-status-cancel-btn")
+        b.wait_not_present('#system-health-shutdown-status')
+
     def testUnsupportedBrowser(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -249,8 +249,8 @@ session include system-auth
 @skipDistroPackage()
 class TestSuperuserOldShell(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20", "image": "centos-7"},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "image": "centos-7", "memory_mb": 512},
     }
 
     def test(self):
@@ -286,8 +286,8 @@ class TestSuperuserOldShell(MachineCase):
 @skipDistroPackage()
 class TestSuperuserOldWebserver(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
-        "machine2": {"address": "10.111.113.2/20"},
+        "machine1": {"address": "10.111.113.1/20", "image": "centos-7", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
     def test(self):
@@ -376,8 +376,8 @@ class TestSuperuserOldWebserver(MachineCase):
 @skipDistroPackage()
 class TestSuperuserDashboard(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20"},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
     def test(self):
@@ -441,8 +441,8 @@ class TestSuperuserDashboard(MachineCase):
 @skipDistroPackage()
 class TestSuperuserOldDashboard(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "image": "centos-7"},
-        "machine2": {"address": "10.111.113.2/20"},
+        "machine1": {"address": "10.111.113.1/20", "image": "centos-7", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
     def test(self):

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -459,8 +459,8 @@ class TestRealms(MachineCase):
     '''Common variables and tests for all supported domain backends'''
 
     provision = {
-        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
-        "services": {"image": "services", "memory_mb": 2048}
+        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100", "memory_mb": 700},
+        "services": {"image": "services", "memory_mb": 1500}
     }
 
     def setUp(self):
@@ -992,8 +992,8 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 @no_retry_when_changed
 class TestKerberos(MachineCase):
     provision = {
-        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100"},
-        "services": {"image": "services", "memory_mb": 2048}
+        "0": {"address": "10.111.113.1/20", "dns": "10.111.112.100", "memory_mb": 512},
+        "services": {"image": "services", "memory_mb": 1500}
     }
 
     def setUp(self):

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -24,8 +24,8 @@ from testlib import *
 @skipDistroPackage()
 class TestShutdownRestart(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20"},
-        "machine2": {"address": "10.111.113.2/20"}
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512}
     }
 
     def setUp(self):

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -33,34 +33,6 @@ class TestShutdownRestart(MachineCase):
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machines['machine2'].execute("hostnamectl set-hostname machine2")
 
-    def testNoAdminGroup(self):
-        m = self.machine
-        b = self.browser
-
-        self.allow_restart_journal_messages()
-
-        # Create a user that is not in wheel but can sudo
-        m.execute("useradd user -s /bin/bash -c 'User' || true")
-        m.execute("echo user:foobar | chpasswd")
-        m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
-        self.password = "foobar"
-
-        self.login_and_go("/system", user="user")
-
-        # shutdown button should be enabled and working
-        b.click("#reboot-button")
-        b.wait_popup("shutdown-dialog")
-        b.wait_in_text(f"#shutdown-dialog button{self.danger_btn_class}", 'Reboot')
-        b.click("#delay")
-        b.click("button:contains('No delay')")
-        b.wait_text("#delay .pf-c-select__toggle-text", "No delay")
-        b.click(f"#shutdown-dialog button{self.danger_btn_class}")
-        b.switch_to_top()
-
-        b.wait_in_text(".curtains-ct h1", "Disconnected")
-
-        m.wait_reboot()
-
     def testBasic(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Our test VMs get 1.1 GiB of RAM by default, which is enough to fit more
complex tests. However, this demands a lot of unnecessary RAM in tests
which provision multiple VMs.

Explicitly specify the RAM for these tests; strive for making the sum of
all VMs not exceed 1.1 GiB. For example, the networking tests only start
a second machine to provide a DHCP server -- that its completely happy
with just 256 MiB. This isn't always possible -- e.g. candlepin or
FreeIPA on the services image need a lot of RAM, and the host
switching/multi-machine tests run three cockpit machines, which can only
be made that small. But at least severely reduce their size, so that
they don't exceed 2 GiB in total.

This makes it easier to plan capacity for our infrastructure (for
calculating maximum allowable parallelism), and also makes it easier for
developers to run these tests on laptops which don't have tons of RAM.

----

This should allow us to go ahead with https://github.com/cockpit-project/cockpituous/pull/459 to pack our tests on machines in a more predictable/less inefficient manner. It may also help with PRs like #16930 -- as soon as the multi-host tests are "affected" and thus retried, they fail rather reliably.