### PR TITLE
cockpit-po-plugin: stop including base1/ in all packages

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -68,8 +68,6 @@ module.exports = class {
         const patterns = [
             // all translations for that page, including manifest.json and *.html
             `pkg/${this.subdir}.*`,
-            // FIXME: https://github.com/cockpit-project/cockpit/issues/13906
-            'pkg/base1/cockpit.js'
         ];
 
         // add translations from libraries outside of page directory


### PR DESCRIPTION
Each package already includes base1/po.js, so including the base1/
translations in each webpack is redundant.

Fixes #13906