### PR TITLE
updates: Use better key

### DIFF
--- a/pkg/packagekit/history.jsx
+++ b/pkg/packagekit/history.jsx
@@ -89,7 +89,7 @@ export class History extends React.Component {
             const expandedContent = <PackageList packages={update.packages} />;
 
             return ({
-                props: { key: index },
+                props: { key: update.time },
                 columns: [
                     { title: timeformat.dateTime(update.time), props: { className: "history-time" } },
                     { title: pkgcount, props: { className: "history-pkgcount" } },


### PR DESCRIPTION
When new item would get added, the existing ones would get re-keyed.
Timestamp is unique enough.