### PR TITLE
test: Clean up sudo privileges for test user in TestLogin.testNoAdminGroup, Drop alternative truths on user creation

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -299,7 +299,7 @@ OnCalendar=daily
         m = self.machine
         b = self.browser
 
-        m.execute('useradd scruffy -s /bin/bash -c \'Scruffy\' || true')
+        m.execute('useradd scruffy -s /bin/bash -c Scruffy')
         m.execute('echo scruffy:foobar | chpasswd')
 
         if "debian" in m.image:

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -90,7 +90,7 @@ class TestReauthorize(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd barney -s /bin/bash -c 'Barney' || true")
+        m.execute("useradd barney -s /bin/bash -c Barney")
         m.execute("echo barney:foobar | chpasswd")
 
         b.default_user = "barney"

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -90,10 +90,10 @@ class TestReauthorize(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd barney -s /bin/bash -c Barney")
-        m.execute("echo barney:foobar | chpasswd")
+        m.execute("useradd user -s /bin/bash -c Barney")
+        m.execute("echo user:foobar | chpasswd")
 
-        b.default_user = "barney"
+        b.default_user = "user"
         self.login_and_go("/playground/test")
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
@@ -101,7 +101,7 @@ class TestReauthorize(MachineCase):
         b.logout()
 
         # So first ask the user to retype their password
-        self.write_file("/etc/sudoers.d/barney-override", "barney ALL=(ALL) ALL", append=True)
+        self.write_file("/etc/sudoers.d/user-override", "user ALL=(ALL) ALL", append=True)
         self.login_and_go("/playground/test")
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')
@@ -116,7 +116,7 @@ class TestReauthorize(MachineCase):
         b.logout()
 
         # Even if sudo doesn't require a password, we shouldn't start a privileged bridge
-        self.write_file("/etc/sudoers.d/barney-override", "barney ALL=(ALL) NOPASSWD:ALL", append=True)
+        self.write_file("/etc/sudoers.d/user-override", "user ALL=(ALL) NOPASSWD:ALL", append=True)
         self.login_and_go("/playground/test", superuser=False)
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: ')

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -35,7 +35,7 @@ class TestKeys(MachineCase):
         b = self.browser
 
         # Create a user without any role
-        m.execute("useradd user -s /bin/bash -m -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -m -c User")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -101,7 +101,7 @@ class TestMultiMachineKeyAuth(MachineCase):
 
         # Add user
         self.machine2.disconnect()
-        self.machine2.execute("useradd user -c 'User' || true", direct=True)
+        self.machine2.execute("useradd user -c User", direct=True)
         self.machine2.execute(
             "sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)", direct=True)
         # HACK - Increase MaxAuthTries because of

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -502,7 +502,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
 
         # Create a user that is not in wheel but can sudo
-        m.execute("useradd user -s /bin/bash -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -c User")
         m.execute("echo user:foobar | chpasswd")
         m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
         self.password = "foobar"

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -504,7 +504,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # Create a user that is not in wheel but can sudo
         m.execute("useradd user -s /bin/bash -c User")
         m.execute("echo user:foobar | chpasswd")
-        m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
+        self.write_file("/etc/sudoers.d/user", "user ALL=(ALL) ALL")
         self.password = "foobar"
 
         self.login_and_go("/system", user="user")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -455,7 +455,7 @@ class TestAccounts(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd scruffy -s /bin/bash -c 'Scruffy' || true")
+        m.execute("useradd scruffy -s /bin/bash -c Scruffy")
         m.execute("echo scruffy:foobar | chpasswd")
 
         self.login_and_go("/users")

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -30,7 +30,7 @@ class TestRoles(MachineCase):
         b = self.browser
 
         # Create a user without any role
-        m.execute("useradd user -s /bin/bash -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -c User")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()


### PR DESCRIPTION
Better fix for #17128, plus some cleanup as repentence.

This ought to fix [this failure](https://artifacts.dev.testing-farm.io/c2bbcad3-d46a-45b3-b476-f1581912439c/), and similar ones that we had before: [example 1](https://logs.cockpit-project.org/logs/pull-17122-20220311-095551-5bc76534-fedora-coreos/log.html#76), [example 2](https://logs-https-frontdoor.apps.ocp.ci.centos.org/logs/pull-17122-20220311-095551-5bc76534-arch/log.html#76-2), [example 3](https://logs.cockpit-project.org/logs/pull-17122-20220311-131019-99f17013-rhel-8-6/log.html#76-2)