### PR TITLE
test: Drop alternative truths on user creation

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -299,7 +299,7 @@ OnCalendar=daily
         m = self.machine
         b = self.browser
 
-        m.execute('useradd scruffy -s /bin/bash -c \'Scruffy\' || true')
+        m.execute('useradd scruffy -s /bin/bash -c Scruffy')
         m.execute('echo scruffy:foobar | chpasswd')
 
         if "debian" in m.image:

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -90,7 +90,7 @@ class TestReauthorize(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd barney -s /bin/bash -c 'Barney' || true")
+        m.execute("useradd barney -s /bin/bash -c Barney")
         m.execute("echo barney:foobar | chpasswd")
 
         b.default_user = "barney"

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -35,7 +35,7 @@ class TestKeys(MachineCase):
         b = self.browser
 
         # Create a user without any role
-        m.execute("useradd user -s /bin/bash -m -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -m -c User")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -101,7 +101,7 @@ class TestMultiMachineKeyAuth(MachineCase):
 
         # Add user
         self.machine2.disconnect()
-        self.machine2.execute("useradd user -c 'User' || true", direct=True)
+        self.machine2.execute("useradd user -c User", direct=True)
         self.machine2.execute(
             "sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)", direct=True)
         # HACK - Increase MaxAuthTries because of

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -502,7 +502,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
 
         # Create a user that is not in wheel but can sudo
-        m.execute("useradd user -s /bin/bash -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -c User")
         m.execute("echo user:foobar | chpasswd")
         m.execute("echo 'user ALL=(ALL) ALL' > /etc/sudoers.d/user")
         self.password = "foobar"

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -455,7 +455,7 @@ class TestAccounts(MachineCase):
         m = self.machine
         b = self.browser
 
-        m.execute("useradd scruffy -s /bin/bash -c 'Scruffy' || true")
+        m.execute("useradd scruffy -s /bin/bash -c Scruffy")
         m.execute("echo scruffy:foobar | chpasswd")
 
         self.login_and_go("/users")

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -30,7 +30,7 @@ class TestRoles(MachineCase):
         b = self.browser
 
         # Create a user without any role
-        m.execute("useradd user -s /bin/bash -c 'User' || true")
+        m.execute("useradd user -s /bin/bash -c User")
         m.execute("echo user:foobar | chpasswd")
 
         m.start_cockpit()


### PR DESCRIPTION
We don't expect this to fail -- if it does, it points out a bug in our
testbed setup/cleanup, and we very much want to know.