### PR TITLE
Test fixes, fix kdump crash

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -375,7 +375,7 @@ export class KdumpPage extends React.Component {
                 <span>{ _("Loading...") }</span>
             </div>
         );
-        let targetCanChange = true;
+        let targetCanChange = false;
         if (this.props.kdumpStatus && this.props.kdumpStatus.target) {
             // if we have multiple targets defined, the config is invalid
             const target = this.props.kdumpStatus.target;
@@ -387,26 +387,26 @@ export class KdumpPage extends React.Component {
                         kdumpLocation = cockpit.format(_("locally in $0"), target.path);
                     else
                         kdumpLocation = cockpit.format(_("locally in $0"), "/var/crash");
+                    targetCanChange = true;
                 } else if (target.target == "ssh") {
                     kdumpLocation = _("Remote over SSH");
+                    targetCanChange = true;
                 } else if (target.target == "nfs") {
                     kdumpLocation = _("Remote over NFS");
+                    targetCanChange = true;
                 } else if (target.target == "raw") {
                     kdumpLocation = _("Raw to a device");
-                    targetCanChange = false;
                 } else if (target.target == "mount") {
                     /* mount targets outside of nfs are too complex for the
                      * current target dialog */
                     kdumpLocation = _("On a mounted device");
-                    targetCanChange = false;
                 } else {
                     kdumpLocation = _("No configuration found");
-                    targetCanChange = false;
                 }
             }
         }
         // this.storeLocation(this.props.kdumpStatus.config);
-        const settingsLink = (targetCanChange && !!this.props.kdumpStatus)
+        const settingsLink = targetCanChange
             ? <Button variant="link" isInline id="kdump-change-target" onClick={this.handleSettingsClick}>{ kdumpLocation }</Button>
             : <span>{ kdumpLocation }</span>;
         let reservedMemory;

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -45,7 +45,7 @@ class TestConnection(MachineCase):
         # uninstall cockpit/ws container startup script
         m.execute("rm /etc/systemd/system/cockpit.service")
         # overlay cockpit-ws rpm
-        m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm")
+        m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm", timeout=180)
         m.reboot()
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -364,6 +364,9 @@ OnCalendar=daily
         b.logout()
         b.wait_text('#password-group > label', 'Senha')
 
+        # translated variants of standard messages in testlib.py
+        self.allow_journal_messages("xargs: basename: .*13.*")
+
     def testFrameReload(self):
         b = self.browser
         frame = "cockpit1:localhost/playground/test"

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -133,9 +133,9 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
 @skipDistroPackage()
 class TestMultiMachineAdd(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
-        "machine3": {"address": "10.111.113.3/20", "memory_mb": 512},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
+        "machine3": {"address": "10.111.113.3/20", "memory_mb": 660},
     }
 
     def setup_ssh_auth(self):
@@ -247,9 +247,9 @@ class TestMultiMachineAdd(MachineCase):
 @skipDistroPackage()
 class TestMultiMachine(MachineCase):
     provision = {
-        "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},
-        "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
-        "machine3": {"address": "10.111.113.3/20", "memory_mb": 512},
+        "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
+        "machine2": {"address": "10.111.113.2/20", "memory_mb": 660},
+        "machine3": {"address": "10.111.113.3/20", "memory_mb": 660},
     }
 
     def setUp(self):


### PR DESCRIPTION
`tesTroubleshooting` [example 1](https://logs.cockpit-project.org/logs/pull-17133-20220313-193136-26d7dc1a-rhel-9-0/log.html#147), [example 2](https://logs.cockpit-project.org/logs/pull-17132-20220313-191222-c6c81578-centos-8-stream/log.html#147)

[rpm-ostree failure](https://logs.cockpit-project.org/logs/pull-17133-20220313-193136-26d7dc1a-fedora-coreos/log.html#13)