### PR TITLE
test: Call super().tearDown() as appropriate, test fixes

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1308,6 +1308,10 @@ class MachineCase(unittest.TestCase):
                     m.execute("rm -rf /home/" + d)
         self.addCleanup(cleanup_home_dirs)
 
+        if m.image == "arch":
+            # arch configures pam_faillock by default
+            self.addCleanup(m.execute, "rm -rf /run/faillock")
+
         # cockpit configuration
         self.addCleanup(m.execute, "rm -f /etc/cockpit/cockpit.conf /etc/cockpit/machines.d/* /etc/cockpit/*.override.json")
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -29,12 +29,6 @@ from testlib import *
 @nondestructive
 @skipDistroPackage()
 class TestLogin(MachineCase):
-    def tearDown(self):
-        # arch configures pam_faillock by default, and tests here do a lot of failed login attempts
-        if self.machine.image == "arch":
-            self.machine.execute("rm -rf /run/faillock")
-        super().tearDown()
-
     def check_shell(self):
         b = self.browser
         b.wait_visible("#content")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -33,6 +33,7 @@ class TestLogin(MachineCase):
         # arch configures pam_faillock by default, and tests here do a lot of failed login attempts
         if self.machine.image == "arch":
             self.machine.execute("rm -rf /run/faillock")
+        super().tearDown()
 
     def check_shell(self):
         b = self.browser
@@ -469,6 +470,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages('.*type=1400.*avc:  denied  { map }.*comm="cockpit-pcp".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="sudo".*')
         self.allow_journal_messages('.*type=1400.*avc:  denied .* comm="systemd".*')
+        self.allow_journal_messages('.*type=1400.*avc:  denied  { watch } .* comm="cockpit-bridge".*')
         # https://bugzilla.redhat.com/show_bug.cgi?id=1727887
         self.allow_journal_messages('.*type=1400.*avc:  denied  { connectto } .* path="/run/user/.*/bus" scontext=user_u:user_r:user_t:s0.*')
 
@@ -719,7 +721,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                 expect_failed_login("root", "bad", n)
             expect_successful_login("root", "foobar")
 
-        self.allow_journal_messages(".*Account locked due to .* failed logins")
+        self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
+        self.allow_journal_messages(".*minutes left to unlock.*")
 
     @skipImage("sssd not available", "fedora-coreos")
     def testClientCertAuthentication(self):
@@ -873,6 +876,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         if has_validate_api:
             m.execute("rm /etc/sssd/pki/sssd_auth_ca_db.pem")
             self.allow_journal_messages("cockpit-session: Failed to map .* Invalid certificate provided")
+            self.allow_journal_messages("cockpit-session: Failed to map .* Certificate authority file not found")
             do_test(alice_cert_key, ['HTTP/1.1 401 Authentication failed'])
 
         # sssd-dbus not available

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -34,7 +34,7 @@ class TestStorageNfs(StorageCase):
 
         m.execute("mkdir /home/foo /home/bar /mnt/test")
         # Removing the nfs mount removes the target dir.
-        self.addCleanup(m.execute, "! test -e /mnt/test || rm -r /mnt/test")
+        self.addCleanup(m.execute, "if [ -e /mnt/test ]; then umount /mnt/test 2>/dev/null || true; rm -r /mnt/test; fi")
         self.write_file("/etc/exports", "/home/foo 127.0.0.0/24(rw)\n/home/bar 127.0.0.0/24(rw)\n",
                         post_restore_action="systemctl restart nfs-server")
         m.execute("systemctl restart nfs-server")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -132,14 +132,10 @@ session include system-auth
 
     def testWrongPasswd(self):
         b = self.browser
-        m = self.machine
 
         # Log in with limited access
         self.login_and_go(superuser=False)
         b.check_superuser_indicator("Limited access")
-
-        if m.image == "arch":
-            self.addCleanup(m.execute, "rm -f /var/run/faillock/admin")
 
         b.open_superuser_dialog()
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -31,6 +31,7 @@ class TestAccounts(MachineCase):
         # ensure that there are no lingering processes after the test which prevent userdel
         self.machine.execute("pkill -e -u anton 2>/dev/null; pkill -e -u scruffy 2>/dev/null ; pkill -e -u jussi 2>/dev/null || true")
         self.machine.execute("while pgrep -u anton; do sleep 1; done; while pgrep -u scruffy; do sleep 1; done; while pgrep -u jussi; do sleep 1; done;")
+        super().tearDown()
 
     def testBasic(self):
         b = self.browser
@@ -363,7 +364,10 @@ class TestAccounts(MachineCase):
         self.allow_journal_messages("Password quality check failed:")
         self.allow_journal_messages("The password is a palindrome")
         self.allow_journal_messages("passwd: user.*does not exist")
+        self.allow_journal_messages("passwd: Unknown user name 'anton'.")
         self.allow_journal_messages("lastlog: Unknown user or range: anton")
+        self.allow_journal_messages(".*required to change your password immediately.*")
+        self.allow_journal_messages(".*user account or password has expired.*")
 
     def testUnprivileged(self):
         m = self.machine


### PR DESCRIPTION
So that the usual tearDown actions will run, such as journal checking
and code coverage processing.

 - Requires https://github.com/cockpit-project/bots/pull/3097
 - Requires https://github.com/cockpit-project/bots/pull/3098