### PR TITLE
test: Restore complete /etc/ for each test (version 2)

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1293,13 +1293,10 @@ class MachineCase(unittest.TestCase):
         # temporary directory in the VM
         self.addCleanup(m.execute, "if [ -d {0} ]; then findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount && rm -r {0}; fi".format(self.vm_tmpdir))
 
-        # users/groups/home dirs
-        self.restore_file("/etc/passwd")
-        self.restore_file("/etc/group")
-        self.restore_file("/etc/shadow")
-        self.restore_file("/etc/gshadow")
-        self.restore_file("/etc/subuid")
-        self.restore_file("/etc/subgid")
+        # configuration (including users) and home dirs
+        self.addCleanup(m.execute, "systemctl daemon-reload; systemctl reset-failed")
+        # don't use bind-mounts here, it breaks inotify of running services like udisks
+        self.restore_dir("/etc", reboot_safe=True)
         home_dirs = m.execute("ls /home").strip().split()
 
         def cleanup_home_dirs():
@@ -1308,14 +1305,7 @@ class MachineCase(unittest.TestCase):
                     m.execute("rm -rf /home/" + d)
         self.addCleanup(cleanup_home_dirs)
 
-        # cockpit configuration
-        self.addCleanup(m.execute, "rm -f /etc/cockpit/cockpit.conf /etc/cockpit/machines.d/* /etc/cockpit/*.override.json")
-
         if not m.ostree_image:
-            # for storage tests
-            self.restore_file("/etc/fstab")
-            self.restore_file("/etc/crypttab")
-
             # tests expect cockpit.service to not run at start; also, avoid log leakage into the next test
             self.addCleanup(m.execute, "systemctl stop --quiet cockpit")
 
@@ -1806,7 +1796,9 @@ class MachineCase(unittest.TestCase):
         @perm is the desired file permission as chmod shell string (e.g. "0600")
         '''
         m = self.machine
-        self.restore_file(path)
+        # /etc already gets restored wholesale
+        if not path.startswith("/etc/"):
+            self.restore_file(path)
         m.write(path, content, append=append, owner=owner, perm=perm)
 
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -671,7 +671,6 @@ class TestConnection(MachineCase):
         self.assertIn('id="login"', m.curl('-k', 'https://localhost:9090/', headers=large_headers))
         m.stop_cockpit()
 
-        self.restore_dir("/etc/cockpit")
         m.execute("rm -f /etc/cockpit/ws-certs.d/* /etc/cockpit/cockpit.conf")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nLoginTitle = A Custom Title\n")
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -177,8 +177,6 @@ class TestKdump(KdumpHelpers):
         b = self.browser
         m = self.machine
 
-        self.restore_file("/etc/kdump.conf")
-
         m.execute("systemctl disable --now kdump")
 
         self.login_and_go("/kdump")

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -72,7 +72,7 @@ class TestBonding(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
 
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbond'] button")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -63,7 +63,7 @@ class TestBridge(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
 
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbridge'] button")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -67,7 +67,7 @@ class TestTeam(NetworkCase):
         # Check that the configuration file has the expected sane name
         # on systems that use "network-scripts".
         if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
+            m.execute("! test -d /etc/sysconfig/network-scripts || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
 
         # Check that the members are displayed
         self.select_iface('tteam')

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -159,7 +159,6 @@ class TestUpdates(NoSubManCase):
                            provides=f"kpatch-patch = {kernel_ver_arch}")
         self.enableRepo()
 
-        self.restore_file("/etc/dnf/plugins/kpatch.conf")
         m.execute("systemctl disable --now kpatch")
 
         m.start_cockpit()

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -94,7 +94,6 @@ class TestPackages(MachineCase):
             return
 
         # Hide the terminal with a system override
-        self.restore_dir("/etc/cockpit")
         m.write("/etc/cockpit/systemd.override.json", """{
     "tools": {
         "terminal": null

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -343,7 +343,6 @@ class TestSystemInfo(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.restore_file("/etc/motd")
         m.execute("rm -f /etc/motd")
 
         self.login_and_go("/system")

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -609,13 +609,11 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.addCleanup(m.execute, "pkill -f '[m]ock-.*-server' || true")
         m.upload(["verify/files/mock-bugzilla-server.py"], "/tmp/")
         m.spawn("setsid /tmp/mock-bugzilla-server.py", "mock-bugzilla.log")
-        self.restore_file("/etc/libreport/plugins/bugzilla.conf")
         m.execute("echo 'BugzillaURL=http://localhost:8080' > /etc/libreport/plugins/bugzilla.conf")
 
         # start mock FAF server
         m.upload(["verify/files/mock-faf-server.py"], "/tmp/")
         m.spawn("setsid /tmp/mock-faf-server.py", "mock-faf.log")
-        self.restore_file("/etc/libreport/plugins/ureport.conf")
         m.execute("echo 'URL=http://localhost:12345' > /etc/libreport/plugins/ureport.conf")
 
         m.upload(["verify/files/cockpit_event.conf"], "/etc/libreport/events.d/")
@@ -673,13 +671,11 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.addCleanup(m.execute, "pkill -f '[m]ock-.*-server' || true")
         m.upload(["verify/files/mock-bugzilla-server.py"], "/tmp/")
         m.spawn("setsid /tmp/mock-bugzilla-server.py", "mock-bugzilla.log")
-        self.restore_file("/etc/libreport/plugins/bugzilla.conf")
         m.execute("echo 'BugzillaURL=http://localhost:8080' > /etc/libreport/plugins/bugzilla.conf")
 
         # start mock FAF server
         m.upload(["verify/files/mock-faf-server.py"], "/tmp/")
         m.spawn("setsid /tmp/mock-faf-server.py", "mock-faf.log")
-        self.restore_file("/etc/libreport/plugins/ureport.conf")
         m.execute("echo 'URL=http://localhost:12345' > /etc/libreport/plugins/ureport.conf")
 
         m.upload(["verify/files/cockpit_event.conf"], "/etc/libreport/events.d/")
@@ -712,7 +708,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         self.addCleanup(m.execute, "pkill -f '[m]ock-.*-server' || true")
         m.upload(["verify/files/mock-faf-server.py"], "/tmp/")
         m.execute("setsid /tmp/mock-faf-server.py >/tmp/mock-faf.log 2>&1 &")
-        self.restore_file("/etc/libreport/plugins/ureport.conf")
         m.execute("echo 'URL=http://localhost:12345' > /etc/libreport/plugins/ureport.conf")
 
         m.execute("systemctl mask --now reportd")

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -190,10 +190,12 @@ class TestTestlib(MachineCase):
         m = self.machine
 
         self.assertEqual(m.execute("whoami").strip(), "root")
+        # /etc gets restored wholesale
+        m.execute("echo spam > /etc/spam; mkdir /etc/spamdir")
         # existing file
-        m.execute("echo original > /etc/someconfig")
-        self.restore_file("/etc/someconfig")
-        m.execute("echo changed > /etc/someconfig")
+        m.execute("echo original > /var/somefile")
+        self.restore_file("/var/somefile")
+        m.execute("echo changed > /var/somefile")
         # nonexisting file
         self.restore_file("/var/lib/cockpittest.txt")
         m.execute("echo data > /var/lib/cockpittest.txt")
@@ -206,15 +208,19 @@ class TestTestlib(MachineCase):
         self.restore_dir("/var/lib/cockpittestnew")
         m.execute("mkdir -p /var/lib/cockpittestnew && echo hello > /var/lib/cockpittestnew/cruft")
 
-        # NSS is backed up by default
+        # NSS is backed up by default (as part of /etc)
         m.execute("useradd cockpittest")
 
         # now pretend the test ends here
         self.doCleanups()
 
+        # restored /etc
+        m.execute("test ! -e /etc/spam")
+        m.execute("test ! -e /etc/spamdir")
+
         # correctly restored existing file
-        self.assertEqual("original", m.execute("cat /etc/someconfig").strip())
-        m.execute("rm /etc/someconfig")
+        self.assertEqual("original", m.execute("cat /var/somefile").strip())
+        m.execute("rm /var/somefile")
         # correctly cleaned up nonexisting file
         m.execute("test ! -e /var/lib/cockpittest.txt")
 

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -82,11 +82,9 @@ class NetworkCase(MachineCase, NetworkHelpers):
                 self.machine.execute(f"for d in {' '.join(new)}; do nmcli dev del $d; done")
 
             self.orig_devs = devs()
-            self.restore_dir("/etc/NetworkManager", post_restore_action="systemctl try-restart NetworkManager")
-            self.restore_dir("/etc/sysconfig/network-scripts")
             self.addCleanup(cleanupDevs)
 
-        m.execute("systemctl start NetworkManager")
+        m.execute("systemctl restart NetworkManager")
 
         # Ensure a clean and consistent state.  We remove rogue
         # connections that might still be here from the time of

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -60,15 +60,11 @@ class PackageCase(MachineCase):
         if self.backend == "apt":
             self.restore_dir("/var/lib/apt", reboot_safe=True)
             self.restore_dir("/var/cache/apt", reboot_safe=True)
-            self.restore_dir("/etc/apt", reboot_safe=True)
             self.machine.execute("echo > /etc/apt/sources.list && rm -f /etc/apt/sources.list.d/* && apt-get clean && apt-get update")
         elif self.backend == "alpm":
             self.restore_dir("/var/lib/pacman", reboot_safe=True)
             self.restore_dir("/var/cache/pacman", reboot_safe=True)
-            self.restore_dir("/etc/pacman.d", reboot_safe=True)
             self.restore_dir("/var/lib/PackageKit/alpm", reboot_safe=True)
-            self.restore_file("/etc/pacman.conf")
-            self.restore_file("/etc/pacman.d/mirrorlist")
             self.restore_file("/usr/share/libalpm/hooks/90-packagekit-refresh.hook")
             self.machine.execute("rm /etc/pacman.conf /etc/pacman.d/mirrorlist /var/lib/pacman/sync/* /usr/share/libalpm/hooks/90-packagekit-refresh.hook")
             # Initial config for installation
@@ -88,7 +84,6 @@ Server = file://{empty_repo_dir}
             self.machine.write("/etc/pacman.conf", config)
             self.machine.execute("pacman -Sy")
         else:
-            self.restore_dir("/etc/yum.repos.d", reboot_safe=True)
             self.restore_dir("/var/cache/dnf", reboot_safe=True)
             self.machine.execute("rm -rf /etc/yum.repos.d/* /var/cache/yum/* /var/cache/dnf/*")
 


### PR DESCRIPTION
Instead of hand-picking config files in /etc, let's just backup/restore
all files there. It's cheap enough, and avoids bugs like the one fixed
in commit ec24d029076b4.
    
Drop some redundant restoration of files/directories inside /etc.

-----

Alternate version of PR #17137. It should be more robust, e.g. it doesn't need the udisks reloading hack (which would introduce new ways to shoot ourselves into the foot). Let's get me a parallel test run.
