### PR TITLE
tools/release-guide: adjust to build system changes

### DIFF
--- a/tools/release-guide
+++ b/tools/release-guide
@@ -93,7 +93,7 @@ prepare()
     mkdir build
     cd build
     "../extract/${subdir}/configure"
-    make "$DIRECTORY/html"
+    make "$DIRECTORY/html/index.html"
     cd ..
 
     trace "Committing documentation for version $version"


### PR DESCRIPTION
9efc2e016e7544adbb99415e7527117587d35c09 dropped the rule for making
dist/guide/html, which was a seemingly-unused alias for
dist/guide/html/index.html, but it was actually in use from
tools/release-guide.

Update tools/release-guide to just build dist/guide/html/index.html
directly.