### PR TITLE
selinux: Fix policy for pam_faillock

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -133,7 +133,8 @@ optional_policy(`
 #
 
 # cockpit-session changes to the actual logged in user
-allow cockpit_session_t self:capability { dac_override dac_read_search setgid setuid sys_admin sys_resource};
+# pam_faillock chowns the state file to the target user
+allow cockpit_session_t self:capability { chown dac_override dac_read_search setgid setuid sys_admin sys_resource };
 allow cockpit_session_t self:process { setexec setrlimit setsched signal_perms };
 
 read_files_pattern(cockpit_session_t, cockpit_var_lib_t, cockpit_var_lib_t)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -662,12 +662,6 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         m.start_cockpit()
 
-        # pam_faillock tries to chown the file to be owned by the user itself,
-        # which is currently an selinux fail on the following distros:
-        if m.image in ['centos-8-stream', 'fedora-testing', 'fedora-35', 'rhel-8-6', 'rhel-9-0']:
-            # https://bugzilla.redhat.com/show_bug.cgi?id=1836182
-            self.allow_journal_messages('.*type=1400.*avc:  denied  { chown }.*comm="cockpit-session".*')
-
         # start from a clean slate
         clean_cmd = f"rm -f {logfile('admin')}"
         self.addCleanup(m.execute, clean_cmd)


### PR DESCRIPTION
pam_faillock tries to chown its state files to the target user. That's
legit, so allow this in our policy. Drop the test hack that we've been
dragging around for a while.