### PR TITLE
shell: Re-include cross-package translations

### DIFF
--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -7,9 +7,8 @@
     <link href="index.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
-    <script src="../base1/po.js"></script>
     <script src="../manifests.js"></script>
-    <script src="po.js"></script>
+    <script src="../*/po.js"></script>
   </head>
   <body class="pf-m-redhat-font" hidden>
     <div id="main" class="page">


### PR DESCRIPTION
Revert the shell part of commit af5678b0be5. This broke translation of
menu entries for external pages like starter-kit.

----

See https://github.com/cockpit-project/starter-kit/pull/542#issuecomment-1070472816 for details. I am actually not sure how this worked for our internal pages -- do we somehow bundle all manifest translations into shell's po file?

I built this locally, installed it into a VM, and validated that this makes starter-kit menu translation and tests happy again. We obviously need a better solution for this, but for now let's fix the regression.