### PR TITLE
workflows: Fix race between flatpak tests

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Smoke-test the installed flatpak
         run: |
           . /etc/profile.d/flatpak.sh
-          xvfb-run dbus-run-session sh -ec '
-            containers/flatpak/test/test-ssh
-            containers/flatpak/test/test-browser
+          xvfb-run sh -ec '
+            dbus-run-session containers/flatpak/test/test-ssh
+            dbus-run-session containers/flatpak/test/test-browser
           '

--- a/containers/flatpak/test/test-ssh
+++ b/containers/flatpak/test/test-ssh
@@ -12,6 +12,7 @@ FLATPAK_ID="${1:-org.cockpit_project.CockpitClient}"
 if mkdir ~/.ssh; then
     # ~/.ssh didn't exist yet.  Assume that we're safe to configure this.
     echo 'Include cockpit-client-test.config' > ~/.ssh/config
+    trap 'rm -rf ~/.ssh' EXIT INT QUIT PIPE
 else
     # There's already a ~/.ssh directory.  Don't modify that, but check it.
     if ! grep -q 'Include cockpit-client-test.config' ~/.ssh/config; then


### PR DESCRIPTION
Even after commit 91854c8cc7b492, test-browser still sometimes tries to
talk to an allegedly existing instance, and then fails on talking into
the void. There are no related processes any more, apparently the
session D-Bus does not recognize the disappeared process fast enough.

Let's avoid that by running each test in its own D-Bus session.

Note: Keep sharing a single Xvfb server, as xvfb-run does not like being
run multiple times in a row without waiting.

-----

The flatpak test [fails](https://github.com/cockpit-project/cockpit/runs/5596465518?check_suite_focus=true) annoyingly often again:
```
+ flatpak ps
+ grep org.cockpit_project.CockpitClient
429308595	9871	org.cockpit_project.CockpitClient	org.gnome.Platform
12201561	9891	org.cockpit_project.CockpitClient	org.gnome.Platform
+ sleep 1
+ flatpak ps
+ grep org.cockpit_project.CockpitClient
+ rm cockpit-client-test-runner-cockpit-client-test-22

(cockpit-client:2): dbind-WARNING **: 06:10:29.601: AT-SPI: Error retrieving accessibility bus address: org.freedesktop.DBus.Error.ServiceUnknown: org.freedesktop.DBus.Error.ServiceUnknown
error: Environment variable must be given in the form VARIABLE=VALUE, not �
F
======================================================================
FAIL: testBasic (__main__.BrowserTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "containers/flatpak/test/test-browser", line 100, in testBasic
    self.assertIn(self.run_js("test-browser-wait-init.js"), ["found", "page-load"])
AssertionError: 'timed out waiting for JavaScript result' not found in ['found', 'page-load']
```

This is clearly test-browser talking to an old instance of the client from test-ssh still. I fixed that previously in commit 91854c8cc7b492fa96b , but something changed some two weeks ago.