### PR TITLE
review and clean up base-2 vs. base-10 unit inconsistencies

### DIFF
--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -76,14 +76,14 @@ const initStore = function(rootElement) {
                 const value = parseInt(content, 10);
                 if (!isNaN(value)) {
                 // if it's only a number, guess from the size what units we should use
-                // https://access.redhat.com/solutions/59432 states limit to be 896M and the auto at 768M max
-                // default unit is M
-                    if (value >= 1000000)
-                        dataStore.kdumpMemory = cockpit.format_bytes(value);
-                    else if (value >= 1000)
-                        dataStore.kdumpMemory = cockpit.format_bytes(value * 1024);
+                // https://access.redhat.com/solutions/59432 states limit to be 896MiB and the auto at 768MiB max
+                // default unit is MiB
+                    if (value >= 1024 * 1024)
+                        dataStore.kdumpMemory = cockpit.format_bytes(value, 1024);
+                    else if (value >= 1024)
+                        dataStore.kdumpMemory = cockpit.format_bytes(value * 1024, 1024);
                     else
-                        dataStore.kdumpMemory = cockpit.format_bytes(value * 1024 * 1024);
+                        dataStore.kdumpMemory = cockpit.format_bytes(value * 1024 * 1024, 1024);
                 } else {
                     dataStore.kdumpMemory = content.trim();
                 }

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -71,10 +71,7 @@ const initStore = function(rootElement) {
 
     // read memory reserved for kdump from system
     dataStore.kdumpMemory = undefined;
-    // HACK cockpit.file() can't be used for /sys yet, since those files can't be mapped
-    // https://github.com/cockpit-project/cockpit/issues/5597
-    // cockpit.file("/sys/kernel/kexec_crash_size").read()
-    cockpit.spawn(["cat", "/sys/kernel/kexec_crash_size"])
+    cockpit.file("/sys/kernel/kexec_crash_size").read()
             .then(content => {
                 const value = parseInt(content, 10);
                 if (!isNaN(value)) {

--- a/pkg/kdump/manifest.json
+++ b/pkg/kdump/manifest.json
@@ -1,6 +1,6 @@
 {
     "requires": {
-        "cockpit": "122"
+        "cockpit": "130"
     },
 
     "tools": {

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -112,8 +112,8 @@ const RESOURCES = {
         name: _("Memory usage"),
         event_description: _("Memory spike"),
         // assume used == total - available
-        normalize: ([total, avail]) => 1 - (avail / total),
-        format: ([total, avail]) => `${cockpit.format_bytes((total - avail) * 1024)} / ${cockpit.format_bytes(total * 1024)}`,
+        normalize: ([totalKiB, availKiB]) => 1 - (availKiB / totalKiB),
+        format: ([totalKiB, availKiB]) => `${cockpit.format_bytes((totalKiB - availKiB) * 1024)} / ${cockpit.format_bytes(totalKiB * 1024)}`,
     },
     sat_memory: {
         name: _("Swap out"),
@@ -126,9 +126,9 @@ const RESOURCES = {
     use_disks: {
         name: _("Disk I/O"),
         event_description: _("Disk I/O spike"),
-        // kB/s, unbounded, dynamic scaling for normalization
-        normalize: kBps => kBps / scaleUseDisks,
-        format: kBps => cockpit.format_bytes_per_sec(kBps * 1024),
+        // KiB/s, unbounded, dynamic scaling for normalization
+        normalize: KiBps => KiBps / scaleUseDisks,
+        format: KiBps => cockpit.format_bytes_per_sec(KiBps * 1024),
     },
     use_network: {
         name: _("Network I/O"),
@@ -165,15 +165,15 @@ const HISTORY_METRICS = [
     // CPU saturation
     { name: "kernel.all.load" },
 
-    // memory utilization
+    // memory utilization (unit: KiB)
     { name: "mem.physmem" },
-    // mem.util.used is useless, it includes cache
+    // mem.util.used is useless, it includes cache (unit: KiB)
     { name: "mem.util.available" },
 
     // memory saturation
     { name: "swap.pagesout", derive: "rate" },
 
-    // disk utilization
+    // disk utilization; despite the name, the unit is in KiB! (pminfo -d -F disk.all.total_bytes)
     { name: "disk.all.total_bytes", derive: "rate" },
 
     // network utilization

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -201,7 +201,7 @@ export const StorageUsageBar = ({ stats, critical, block, offset, total, small }
     const fraction = stats[0] / stats[1];
     const off_fraction = offset / stats[1];
     const total_fraction = total / stats[1];
-    const labelText = small ? cockpit.format_bytes(stats[0], 1024) : utils.format_fsys_usage(stats[0], stats[1]);
+    const labelText = small ? cockpit.format_bytes(stats[0]) : utils.format_fsys_usage(stats[0], stats[1]);
 
     return (
         <div className={"pf-c-progress pf-m-outside pf-m-singleline" + (fraction > critical ? " pf-m-danger" : "") + (small ? " pf-m-sm" : "")}>

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -85,7 +85,7 @@ export function encode_filename(decoded) {
 }
 
 export function fmt_size(bytes) {
-    return cockpit.format_bytes(bytes, 1024);
+    return cockpit.format_bytes(bytes);
 }
 
 export function fmt_size_long(bytes) {
@@ -96,7 +96,7 @@ export function fmt_size_long(bytes) {
 }
 
 export function fmt_rate(bytes_per_sec) {
-    return cockpit.format_bytes_per_sec(bytes_per_sec, 1024);
+    return cockpit.format_bytes_per_sec(bytes_per_sec);
 }
 
 export function format_temperature(kelvin) {
@@ -107,12 +107,11 @@ export function format_temperature(kelvin) {
 
 export function format_fsys_usage(used, total) {
     let text = "";
-    let units = 1024;
-    let parts = cockpit.format_bytes(total, units, true);
+    let parts = cockpit.format_bytes(total, undefined, true);
     text = " / " + parts.join(" ");
-    units = parts[1];
+    const unit = parts[1];
 
-    parts = cockpit.format_bytes(used, units, true);
+    parts = cockpit.format_bytes(used, unit, true);
     if (parts[0].indexOf("0.") == 0)
         parts[0] = parts[0].substring(0, 4);
     return parts[0] + text;

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -537,7 +537,7 @@ export class ServiceDetails extends React.Component {
                                 </DescriptionListGroup>
                                 {unit.MemoryCurrent ? <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Memory") }</DescriptionListTerm>
-                                    <DescriptionListDescription id="memory">{cockpit.format_bytes(unit.MemoryCurrent, 1024)}</DescriptionListDescription>
+                                    <DescriptionListDescription id="memory">{cockpit.format_bytes(unit.MemoryCurrent)}</DescriptionListDescription>
                                 </DescriptionListGroup> : null}
                                 {this.props.unit.Listen && this.props.unit.Listen.length && <DescriptionListGroup>
                                     <DescriptionListTerm>{ _("Listen") }</DescriptionListTerm>

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -27,9 +27,8 @@ class KdumpHelpers(MachineCase):
         # all current Fedora/CentOS/RHEL images use BootLoaderSpec
         self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
         self.machine.execute("mkdir -p /var/crash")
-        self.machine.spawn("sync && sync && sync && sleep 0.1 && reboot", "reboot")
+        self.machine.reboot()
         self.allow_restart_journal_messages()
-        self.machine.wait_reboot()
         self.machine.start_cockpit()
         self.browser.switch_to_top()
         self.browser.relogin("/kdump")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -776,14 +776,14 @@ class TestCurrentMetrics(MachineCase):
         # wait until RAM usage is initialized
         b.wait(lambda: progressValue(self, "#current-memory-usage") > 10)
 
-        # our test machines have ~ 1 GiB of memory, a reasonable chunk of it should be used
-        b.wait_in_text("#current-memory-usage", " GiB")
+        # our test machines should use a reasonable chunk of available memory
         initial_usage = progressValue(self, "#current-memory-usage")
         self.assertGreater(initial_usage, 10)
         self.assertLess(initial_usage, 80)
         # allocate a chunk of memory; this may cause other stuff to get unmapped,
         # thus not exact addition, but usage should go up
-        size = 300 if have_swap else 200
+        size = 300 if have_swap else 200  # MB
+        size_MiB = size / 1.024 / 1.024
         self.write_file("/usr/local/bin/memhog.sh", f"""#!/usr/bin/awk -f
 BEGIN {{
     x = sprintf("%{size}000000s","");
@@ -798,12 +798,12 @@ BEGIN {{
         self.assertGreater(hog_usage, initial_usage + 8)
 
         b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
-        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) > size)
-        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) < size + 50)
+        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) > size_MiB)
+        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) < size_MiB + 50)
 
         # total memory is shown as tooltip
         b.mouse("#current-memory-usage", "mouseenter")
-        b.wait_in_text(".pf-c-tooltip", "GiB total")
+        b.wait_in_text(".pf-c-tooltip", "iB total")
         b.mouse("#current-memory-usage", "mouseleave")
 
         # table entries are links to Services page
@@ -833,7 +833,7 @@ BEGIN {{
 
             # total swap is shown as tooltip
             b.mouse("#current-swap-usage", "mouseenter")
-            b.wait_in_text(".pf-c-tooltip", "GiB total")
+            b.wait_in_text(".pf-c-tooltip", "iB total")
             b.mouse("#current-swap-usage", "mouseleave")
         else:
             m.execute("systemctl stop mem-hog")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -390,8 +390,7 @@ class TestMultiMachine(MachineCase):
         # enable FIPS: RHEL has and needs a convenience script for that
         # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/using-the-system-wide-cryptographic-policies_security-hardening#switching-the-system-to-fips-mode_using-the-system-wide-cryptographic-policies
         self.machine.execute('set -e; fips-mode-setup --enable', timeout=300)
-        self.machine.spawn('sync && sync && sync && sleep 0.1 && reboot', 'reboot')
-        self.machine.wait_reboot()
+        self.machine.reboot()
         # ensure it's really enabled
         self.assertEqual(self.machine.execute('cat /proc/sys/crypto/fips_enabled').strip(), "1")
 


### PR DESCRIPTION
This prepares us to switch to base-10 units globally. See individual commits for details.

The main apparent change here is on the Metrics page. It used to look like this:

![mem-vr-main](https://user-images.githubusercontent.com/200109/158995812-83c12f34-55d0-40a7-9237-7e9b23649244.png)
 
and now looks like this:

![mem-vm-pr](https://user-images.githubusercontent.com/200109/158995851-78d05d8c-3612-4f41-935a-70dc265753db.png)
