### PR TITLE
tests: Stronger user/home directory cleanup between nondestructive tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1344,11 +1344,13 @@ class MachineCase(unittest.TestCase):
         def terminate_sessions():
             # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH; but also, some tests start
             # admin sessions without Cockpit
-            self.machine.execute("""for u in $(loginctl --no-legend list-users  | awk '{ if ($2 != "root") print $2 }'); do
+            self.machine.execute("""for u in $(loginctl --no-legend list-users  | awk '{ if ($2 != "root") print $1 }'); do
                                         loginctl terminate-user $u 2>/dev/null || true
                                         loginctl kill-user $u 2>/dev/null || true
                                         pkill -9 -u $u || true
                                         while pgrep -u $u; do sleep 1; done
+                                        umount /run/user/$u || true
+                                        rm -rf /run/user/$u
                                     done""")
 
             # Terminate all other Cockpit sessions

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1305,7 +1305,7 @@ class MachineCase(unittest.TestCase):
         def cleanup_home_dirs():
             for d in m.execute("ls /home").strip().split():
                 if d not in home_dirs:
-                    m.execute("rm -rf /home/" + d)
+                    m.execute("rm -r /home/" + d)
         self.addCleanup(cleanup_home_dirs)
 
         if m.image == "arch":

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1347,7 +1347,7 @@ class MachineCase(unittest.TestCase):
             self.machine.execute("""for u in $(loginctl --no-legend list-users  | awk '{ if ($2 != "root") print $2 }'); do
                                         loginctl terminate-user $u 2>/dev/null || true
                                         loginctl kill-user $u 2>/dev/null || true
-                                        pkill -u $u || true
+                                        pkill -9 -u $u || true
                                         while pgrep -u $u; do sleep 1; done
                                     done""")
 


### PR DESCRIPTION
This should fix failures like [this](https://logs.cockpit-project.org/logs/pull-16475-20220318-172950-02d7d82c-arch/log.html#265) and [this](https://logs.cockpit-project.org/logs/pull-16475-20220318-172950-02d7d82c-arch/log.html#265). I've also seen these countless times on c8s packit tests.