### PR TITLE
test: Retry unmounting user runtime directory

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1349,7 +1349,7 @@ class MachineCase(unittest.TestCase):
                                         loginctl kill-user $u 2>/dev/null || true
                                         pkill -9 -u $u || true
                                         while pgrep -u $u; do sleep 1; done
-                                        umount /run/user/$u || true
+                                        while mountpoint -q /run/user/$u && ! umount /run/user/$u; do sleep 1; done
                                         rm -rf /run/user/$u
                                     done""")
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -27,12 +27,6 @@ from testlib import *
 @skipDistroPackage()
 class TestAccounts(MachineCase):
 
-    def tearDown(self):
-        # ensure that there are no lingering processes after the test which prevent userdel
-        self.machine.execute("pkill -e -u anton 2>/dev/null; pkill -e -u scruffy 2>/dev/null ; pkill -e -u jussi 2>/dev/null || true")
-        self.machine.execute("while pgrep -u anton; do sleep 1; done; while pgrep -u scruffy; do sleep 1; done; while pgrep -u jussi; do sleep 1; done;")
-        super().tearDown()
-
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This should fix situations where the directory is still busy, so that it
cannot be removed.

---

This should hopefully fix [this kind of failure](https://logs.cockpit-project.org/logs/pull-17143-20220321-062402-200e1966-arch/log.html#302-2). I also added a cleanup to check-users to make its tests "affected", so that we get a more thorough run.