### PR TITLE
pf4: Properly handled nested PF Flex

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -186,7 +186,8 @@ svg {
     gap: var(--pf-l-flex--spacer-base);
 
     // Negate the margin hack used by immediate flex children
-    > * {
+    // (except for nested flex, as we want to mind the gap)
+    > :not(.pf-l-flex) {
         --pf-l-flex--spacer-base: 0;
     }
 


### PR DESCRIPTION
Fix for https://github.com/cockpit-project/cockpit-podman/pull/943, where there's a PF Flex nested immediately inside another PF Flex.