### PR TITLE
base1: Default to base-10 units in cockpit.format_bytes*()

### DIFF
--- a/pkg/base1/cockpit.js
+++ b/pkg/base1/cockpit.js
@@ -1554,13 +1554,13 @@ function factory() {
 
     cockpit.format_bytes = function format_bytes(number, factor, options) {
         if (factor === undefined)
-            factor = 1024;
+            factor = 1000;
         return format_units(number, byte_suffixes, factor, options);
     };
 
     cockpit.get_byte_units = function get_byte_units(guide_value, factor) {
         if (factor === undefined || !(factor in byte_suffixes))
-            factor = 1024;
+            factor = 1000;
 
         function unit(index) {
             return {
@@ -1591,7 +1591,7 @@ function factory() {
 
     cockpit.format_bytes_per_sec = function format_bytes_per_sec(number, factor, options) {
         if (factor === undefined)
-            factor = 1024;
+            factor = 1000;
         return format_units(number, byte_sec_suffixes, factor, options);
     };
 

--- a/pkg/base1/test-format.js
+++ b/pkg/base1/test-format.js
@@ -153,32 +153,37 @@ QUnit.test("get_byte_units", function (assert) {
 
 QUnit.test("format_bytes_per_sec", function (assert) {
     const checks = [
-        [2555, "2.50 KiB/s"]
+        // default unit
+        [5, undefined, undefined, "5 B/s"],
+        [2555, undefined, undefined, "2.50 KiB/s"],
+        [12345678, undefined, undefined, "11.8 MiB/s"],
+        // explicit base-2 unit
+        [2555, 1024, undefined, "2.50 KiB/s"],
+        // explicit base-10 unit
+        [2555, 1000, undefined, "2.56 kB/s"],
+        [12345678, 1000, undefined, "12.3 MB/s"],
+        // explicit unit
+        [12345678, "kB/s", undefined, "12346 kB/s"],
+        [12345678, "MiB/s", undefined, "11.8 MiB/s"],
+        // custom precision
+        [2555, 1000, { precision: 2 }, "2.6 kB/s"],
+        [25555, "MB/s", { precision: 2 }, "0.026 MB/s"],
+        // significant integer digits exceed custom precision
+        [25555000, "kB/s", { precision: 2 }, "25555 kB/s"],
+        [25555678, "kB/s", { precision: 2 }, "25556 kB/s"],
     ];
 
-    assert.expect(checks.length + 9);
+    assert.expect(checks.length + 2);
     for (let i = 0; i < checks.length; i++) {
-        assert.strictEqual(cockpit.format_bytes_per_sec(checks[i][0]), checks[i][1],
-                           "format_bytes_per_sec(" + checks[i][0] + ") = " + checks[i][1]);
+        assert.strictEqual(cockpit.format_bytes_per_sec(checks[i][0], checks[i][1], checks[i][2]), checks[i][3],
+                           `format_bytes_per_sec(${checks[i][0]}, ${checks[i][1]}, ${checks[i][2]}) = ${checks[i][3]}`);
     }
 
-    // base-10 units
-    assert.strictEqual(cockpit.format_bytes_per_sec(2555, 1000), "2.56 kB/s");
-    assert.strictEqual(cockpit.format_bytes_per_sec(12345678, 1000), "12.3 MB/s");
-    assert.strictEqual(cockpit.format_bytes_per_sec(12345678, "kB/s"), "12346 kB/s");
-
-    // custom precision
-    assert.strictEqual(cockpit.format_bytes_per_sec(2555, 1000, { precision: 2 }), "2.6 kB/s");
-    assert.strictEqual(cockpit.format_bytes_per_sec(25555, "MB/s", { precision: 2 }), "0.026 MB/s");
-    // significant integer digits exceed custom precision
-    assert.strictEqual(cockpit.format_bytes_per_sec(25555000, "kB/s", { precision: 2 }), "25555 kB/s");
-    assert.strictEqual(cockpit.format_bytes_per_sec(25555678, "kB/s", { precision: 2 }), "25556 kB/s");
-
     // separate unit
-    assert.deepEqual(cockpit.format_bytes_per_sec(2555, undefined, { separate: true }),
+    assert.deepEqual(cockpit.format_bytes_per_sec(2555, 1024, { separate: true }),
                      ["2.50", "KiB/s"]);
     // backwards compatible API for separate flag
-    assert.deepEqual(cockpit.format_bytes_per_sec(2555, undefined, true),
+    assert.deepEqual(cockpit.format_bytes_per_sec(2555, 1024, true),
                      ["2.50", "KiB/s"]);
 });
 

--- a/pkg/base1/test-format.js
+++ b/pkg/base1/test-format.js
@@ -82,7 +82,7 @@ QUnit.test("format_number", function (assert) {
 QUnit.test("format_bytes", function (assert) {
     const checks = [
         [999, 1000, "999"],
-        [1934, undefined, "1.89 KiB"],
+        [1934, undefined, "1.93 KB"],
         [1934, 1000, "1.93 KB"],
         [2000, 1024, "1.95 KiB"],
         [1999, 1000, "2.00 KB"],
@@ -155,8 +155,8 @@ QUnit.test("format_bytes_per_sec", function (assert) {
     const checks = [
         // default unit
         [5, undefined, undefined, "5 B/s"],
-        [2555, undefined, undefined, "2.50 KiB/s"],
-        [12345678, undefined, undefined, "11.8 MiB/s"],
+        [2555, undefined, undefined, "2.56 kB/s"],
+        [12345678, undefined, undefined, "12.3 MB/s"],
         // explicit base-2 unit
         [2555, 1024, undefined, "2.50 KiB/s"],
         // explicit base-10 unit

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -89,10 +89,10 @@ export function fmt_size(bytes) {
 }
 
 export function fmt_size_long(bytes) {
-    const with_binary_unit = cockpit.format_bytes(bytes, 1024);
     const with_decimal_unit = cockpit.format_bytes(bytes, 1000);
+    const with_binary_unit = cockpit.format_bytes(bytes, 1024);
     /* Translators: Used in "..." */
-    return with_binary_unit + ", " + with_decimal_unit + ", " + bytes + " " + C_("format-bytes", "bytes");
+    return with_decimal_unit + ", " + with_binary_unit + ", " + bytes + " " + C_("format-bytes", "bytes");
 }
 
 export function fmt_rate(bytes_per_sec) {

--- a/pkg/systemd/hw-detect.js
+++ b/pkg/systemd/hw-detect.js
@@ -80,7 +80,7 @@ function findMemoryDevices(udevdb, info) {
     for (let slot = 0; slot < devices; slot++) {
         let memorySize = parseInt(props[`MEMORY_DEVICE_${slot}_SIZE`], 10);
         if (memorySize) {
-            memorySize = cockpit.format_bytes(memorySize);
+            memorySize = cockpit.format_bytes(memorySize, 1024);
         } else {
             memorySize = _("Unknown");
         }

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -783,7 +783,6 @@ class TestCurrentMetrics(MachineCase):
         # allocate a chunk of memory; this may cause other stuff to get unmapped,
         # thus not exact addition, but usage should go up
         size = 300 if have_swap else 200  # MB
-        size_MiB = size / 1.024 / 1.024
         self.write_file("/usr/local/bin/memhog.sh", f"""#!/usr/bin/awk -f
 BEGIN {{
     x = sprintf("%{size}000000s","");
@@ -798,12 +797,12 @@ BEGIN {{
         self.assertGreater(hog_usage, initial_usage + 8)
 
         b.wait_text("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service']", "mem-hog")
-        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) > size_MiB)
-        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) < size_MiB + 50)
+        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) > size)
+        b.wait(lambda: topServiceValue(self, "Top 5 memory services", "Used", 1) < size + 50)
 
         # total memory is shown as tooltip
         b.mouse("#current-memory-usage", "mouseenter")
-        b.wait_in_text(".pf-c-tooltip", "iB total")
+        b.wait_in_text(".pf-c-tooltip", "B total")
         b.mouse("#current-memory-usage", "mouseleave")
 
         # table entries are links to Services page
@@ -833,7 +832,7 @@ BEGIN {{
 
             # total swap is shown as tooltip
             b.mouse("#current-swap-usage", "mouseenter")
-            b.wait_in_text(".pf-c-tooltip", "iB total")
+            b.wait_in_text(".pf-c-tooltip", "B total")
             b.mouse("#current-swap-usage", "mouseleave")
         else:
             m.execute("systemctl stop mem-hog")
@@ -857,22 +856,22 @@ BEGIN {{
         login(self)
 
         # test env should be quiet enough to not transmit MB/s
-        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-read")))
-        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-write")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("#current-disks-read")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("#current-disks-write")))
         # reading lots of data
         m.execute("systemd-run --collect --slice cockpittest --unit disk-read-hog sh -ec 'while true; do echo 3 > /proc/sys/vm/drop_caches; grep -r . /usr >/dev/null; done'")
-        b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-read")))
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-write")))  # this should stay calm
+        b.wait(lambda: re.match(r'^[0-9.]+ (MB|GB)/s$', b.text("#current-disks-read")))
+        b.wait(lambda: re.match(r'^[0-9.]+ (kB|B)/s$', b.text("#current-disks-write")))  # this should stay calm
         m.execute("systemctl stop disk-read-hog")
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))  # back to quiet
+        b.wait(lambda: re.match(r'^[0-9.]+ (kB|B)/s$', b.text("#current-disks-read")))  # back to quiet
         # writing lots of data
         m.execute("systemd-run --collect --slice cockpittest --unit disk-write-hog sh -ec "
                   " 'while true; do dd if=/dev/zero of=/var/tmp/blob bs=1M count=100; done'")
         self.addCleanup(m.execute, "rm -f /var/tmp/blob")
-        b.wait(lambda: re.match(r'^[0-9.]+ (MiB|GiB)/s$', b.text("#current-disks-write")))
-        b.wait(lambda: re.match(r'^[0-9.]+ (KiB|B)/s$', b.text("#current-disks-read")))  # this should stay calm
+        b.wait(lambda: re.match(r'^[0-9.]+ (MB|GB)/s$', b.text("#current-disks-write")))
+        b.wait(lambda: re.match(r'^[0-9.]+ (kB|B)/s$', b.text("#current-disks-read")))  # this should stay calm
         m.execute("systemctl stop disk-write-hog")
-        b.wait(lambda: re.match(r'^(0|[0-9.]+ (KiB|B)/s)$', b.text("#current-disks-write")))
+        b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("#current-disks-write")))
 
         # Disk usage
 
@@ -946,13 +945,13 @@ BEGIN {{
             return re.match(regexp, text) is not None
 
         # loopback is quiet enough to not transmit MB/s
-        b.wait(lambda: rateMatches("In", r'^(0|[0-9.]+ (KiB|B)/s)$'))
-        b.wait(lambda: rateMatches("Out", r'^(0|[0-9.]+ (KiB|B)/s)$'))
+        b.wait(lambda: rateMatches("In", r'^(0|[0-9.]+ (kB|B)/s)$'))
+        b.wait(lambda: rateMatches("Out", r'^(0|[0-9.]+ (kB|B)/s)$'))
         # pipe lots of data through lo
         m.execute("systemd-run --collect --slice cockpittest --unit lo-hog sh -ec "
                   " 'nc -n -vv -l 2000 > /dev/null & sleep 1; nc -vv localhost 2000 </dev/zero'")
-        b.wait(lambda: rateMatches("In", r'^[0-9.]+ (MiB|GiB)/s$'))
-        b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (MiB|GiB)/s$'))
+        b.wait(lambda: rateMatches("In", r'^[0-9.]+ (MB|GB)/s$'))
+        b.wait(lambda: rateMatches("Out", r'^[0-9.]+ (MB|GB)/s$'))
         m.execute("systemctl stop lo-hog")
 
         # nothing happens on cockpittest1

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -195,9 +195,9 @@ class TestStorageLvm2(StorageCase):
         self.dialog_apply()
         self.dialog_wait_close()
         b.wait_in_text("#detail-sidebar", dev_2)
-        # this is sometimes 92, sometimes 96 MiB
-        b.wait_js_cond("Number(ph_text('#detail-header dt:contains(Capacity) + dd').split(' ')[0]) >= 92")
-        b.wait_js_cond("Number(ph_text('#detail-header dt:contains(Capacity) + dd').split(' ')[0]) <= 96")
+        # this is sometimes 96, sometimes 100 MB
+        b.wait_js_cond("Number(ph_text('#detail-header dt:contains(Capacity) + dd').split(' ')[0]) >= 96")
+        b.wait_js_cond("Number(ph_text('#detail-header dt:contains(Capacity) + dd').split(' ')[0]) <= 101")
 
         self.content_tab_action(1, 1, "Grow")
         self.dialog({"size": 70})

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -168,12 +168,15 @@ class TestStorageLvm2(StorageCase):
         # remove disk2
         b.click(f'#detail-sidebar .sidepanel-row:contains({dev_2}) button.pf-m-secondary')
         b.wait_not_in_text("#detail-sidebar", dev_2)
-        b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "48 MiB")
+        if m.image == "rhel-8-6-distropkg":
+            b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "48 MiB")
+        else:
+            b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "50.3 MB")
 
         # create thin pool and volume
-        # the pool will be maximum size, 48 MiB
+        # the pool will be maximum size, 50.3 MB
         b.click("button:contains(Create new logical volume)")
-        self.dialog(expect={"size": 48},
+        self.dialog(expect={"size": 48 if m.image == "rhel-8-6-distropkg" else 50.3},
                     values={"purpose": "pool",
                             "name": "pool",
                             "size": 38})

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -87,14 +87,15 @@ class TestStoragePartitions(StorageCase):
         about_half_way = width / 2 + 1
 
         b.mouse(slider, "click", about_half_way, 0)
-        self.dialog_wait_val("size", 26)
+        self.dialog_wait_val("size", 26 if m.image == "rhel-8-6-distropkg" else 27.3)
         b.focus(slider + " + .pf-c-slider__thumb")
         b.key_press(chr(37), use_ord=True)  # arrow left
-        self.dialog_wait_val("size", 25.5)
+        self.dialog_wait_val("size", 25.5 if m.image == "rhel-8-6-distropkg" else 26.7)
 
         # Check that changing units affects the text input
-        b.select_from_dropdown(".size-unit", "1073741824")
-        self.dialog_wait_val("size", "0.0249", "1073741824")
+        unit = "1073741824" if m.image == "rhel-8-6-distropkg" else "1000000000"
+        b.select_from_dropdown(".size-unit", unit)
+        self.dialog_wait_val("size", "0.0249" if m.image == "rhel-8-6-distropkg" else "0.0267", unit)
 
         self.dialog_apply()
         self.dialog_wait_close()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -80,7 +80,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB")
+            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB" if m.image == "rhel-8-6-distropkg" else "398 MB")
             if grow_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
@@ -103,7 +103,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB")
+            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB" if m.image == "rhel-8-6-distropkg" else "201 MB")
             if shrink_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -33,20 +33,25 @@ class TestStorageStratis(StorageCase):
 
         self.login_and_go("/storage")
 
+        if m.image == "rhel-8-6-distropkg":
+            SIZE_4GB = 4 * 1024 * 1024 * 1024
+        else:
+            SIZE_4GB = 4 * 1000000000
+
         dev_1 = "/dev/sda"
-        m.add_disk("4G", serial="DISK1")
+        m.add_disk(SIZE_4GB, serial="DISK1")
         b.wait_in_text("#drives", dev_1)
 
         dev_2 = "/dev/sdb"
-        m.add_disk("4G", serial="DISK2")
+        m.add_disk(SIZE_4GB, serial="DISK2")
         b.wait_in_text("#drives", dev_2)
 
         dev_3 = "/dev/sdc"
-        m.add_disk("4G", serial="DISK3")
+        m.add_disk(SIZE_4GB, serial="DISK3")
         b.wait_in_text("#drives", dev_3)
 
         dev_4 = "/dev/sdd"
-        m.add_disk("4G", serial="DISK4")
+        m.add_disk(SIZE_4GB, serial="DISK4")
         b.wait_in_text("#drives", dev_4)
 
         # Create a pool
@@ -60,7 +65,10 @@ class TestStorageStratis(StorageCase):
         self.dialog_wait_close()
 
         b.wait_in_text("#devices", "pool0")
-        b.wait_in_text("#devices", "8 GiB Stratis pool")
+        if m.image == "rhel-8-6-distropkg":
+            b.wait_in_text("#devices", "8 GiB Stratis pool")
+        else:
+            b.wait_in_text("#devices", "8 GB Stratis pool")
         b.assert_pixels("#devices", "pool-row")
 
         # Check that the next name is "pool1"

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -28,8 +28,11 @@ from testlib import *
 # vdo only exists on RHEL
 SUPPORTED_OS = ["centos-8-stream", "rhel-8-6", "rhel-8-6-distropkg"]
 
+SIZE_10G = "10000000000"
+
 
 @skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
+@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageVDO(StorageCase):
 
     def testVdo(self):
@@ -39,7 +42,7 @@ class TestStorageVDO(StorageCase):
         self.login_and_go("/storage")
 
         # Make a volume group in which to create the VDO LV
-        m.add_disk("10G", serial="DISK1")
+        m.add_disk(SIZE_10G, serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda")
         b.wait_in_text("#devices", "vdo_vgroup")
@@ -58,7 +61,7 @@ class TestStorageVDO(StorageCase):
         # create VDO LV with default options and default virtual size
         self.dialog_set_val("name", "vdo0")
         self.dialog_set_val("purpose", "vdo")
-        self.dialog_set_val("vdo_psize", 6 * 1024)
+        self.dialog_set_val("vdo_psize", 6000)
         self.dialog_apply()
         self.dialog_wait_close()
 
@@ -70,12 +73,12 @@ class TestStorageVDO(StorageCase):
         b.wait_not_in_text("#detail-content", pool_name)
         # Volume tab
         self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
-        self.content_tab_wait_in_info(1, 1, "Size", "10 GiB", "10.0 GiB")
+        self.content_tab_wait_in_info(1, 1, "Size", "10 GB", "10.0 GB")
         # VDO Pool tab
         self.content_tab_wait_in_info(1, 2, "Name", pool_name)
-        self.content_tab_wait_in_info(1, 2, "Size", "6 GiB")
-        # initial physical usage is 4 GiB, overhead for the deduplication index
-        self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
+        self.content_tab_wait_in_info(1, 2, "Size", "6.00 GB")
+        # initial physical usage is ~ 4 GB, overhead for the deduplication index
+        self.content_tab_wait_in_info(1, 2, "Data used", "3.86 GB (64%)")
         self.content_tab_wait_in_info(1, 2, "Metadata used", "0%")
         b.wait_visible("input[aria-label='Use compression']:checked")
         b.wait_visible("input[aria-label='Use deduplication']:checked")
@@ -89,15 +92,15 @@ class TestStorageVDO(StorageCase):
 
         # compressible data should affect logical usage
         m.execute("dd if=/dev/zero of=/run/data/empty bs=1M count=1000")
-        self.content_row_wait_in_col(1, 4, "1.08 / 9.99 GiB")
+        self.content_row_wait_in_col(1, 4, "1.15 / 9.98 GB")
         # but not physical usage
-        self.content_tab_wait_in_info(1, 2, "Data used", "4.00 GiB (67%)")
+        self.content_tab_wait_in_info(1, 2, "Data used", "3.86 GB (64%)")
 
         # incompressible data
         m.execute("dd if=/dev/urandom of=/run/data/gibberish bs=1M count=1000")
-        self.content_row_wait_in_col(1, 4, "2.05 / 9.99 GiB")
+        self.content_row_wait_in_col(1, 4, "2.20 / 9.98 GB")
         # equal amount of physical space (not completely predictable due to random data)
-        self.content_tab_wait_in_info(1, 2, "Data used", "4.8", "4.9")
+        self.content_tab_wait_in_info(1, 2, "Data used", "4.8", "4.9", "5.0")
         self.content_tab_wait_in_info(1, 2, "Data used", cond=lambda sel: re.search(r"\(8[1234]%\)", b.text(sel)))
 
         def wait_prop(device, prop, value):
@@ -120,15 +123,15 @@ class TestStorageVDO(StorageCase):
 
         # grow volume
         self.content_tab_action(1, 1, "Grow")
-        self.dialog({"size": 12 * 1024})
-        self.content_tab_wait_in_info(1, 1, "Size", "12 GiB")
-        wait_prop("vdo0", "lv_size", "12.00g")
+        self.dialog({"size": 12000})
+        self.content_tab_wait_in_info(1, 1, "Size", "12.0 GB")
+        wait_prop("vdo0", "lv_size", "11.18g")
 
         # grow pool
         self.content_tab_action(1, 2, "Grow")
-        self.dialog({"size": 8 * 1024})
-        self.content_tab_wait_in_info(1, 2, "Size", "8 GiB")
-        wait_prop(pool_name, "lv_size", "8.00g")
+        self.dialog({"size": 8000})
+        self.content_tab_wait_in_info(1, 2, "Size", "8.15 GB")
+        wait_prop(pool_name, "lv_size", "7.59g")
 
         # deleting the vdo0 volume deletes the pool as well
         self.content_dropdown_action(1, "Delete")
@@ -142,9 +145,9 @@ class TestStorageVDO(StorageCase):
         b._wait_present("[data-field='purpose'] select option[value='block']")
         self.dialog_set_val("name", "vdo0")
         self.dialog_set_val("purpose", "vdo")
-        self.dialog_set_val("vdo_psize", 6 * 1024)
+        self.dialog_set_val("vdo_psize", 6000)
         # grossly overcommitted
-        self.dialog_set_val("vdo_lsize", 20 * 1024)
+        self.dialog_set_val("vdo_lsize", 20000)
         self.dialog_set_val("vdo_options.compression", False)
         self.dialog_apply()
         self.dialog_wait_close()
@@ -152,9 +155,9 @@ class TestStorageVDO(StorageCase):
         self.content_row_wait_in_col(1, 1, "vdo0")
         # Volume tab
         self.content_tab_wait_in_info(1, 1, "Name", "vdo0")
-        self.content_tab_wait_in_info(1, 1, "Size", "20 GiB")
+        self.content_tab_wait_in_info(1, 1, "Size", "20.0 GB")
         # VDO Pool tab
-        self.content_tab_wait_in_info(1, 2, "Size", "6 GiB")
+        self.content_tab_wait_in_info(1, 2, "Size", "6.0 GB", "6.00 GB")
         b.wait_visible("input[aria-label='Use compression']:not(:checked)")
         b.wait_visible("input[aria-label='Use deduplication']:checked")
         wait_prop(pool_name, "vdo_compression_state", "offline")
@@ -174,6 +177,7 @@ class TestStorageVDO(StorageCase):
 
 
 @skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
+@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):
@@ -188,7 +192,7 @@ class TestStorageLegacyVDO(StorageCase):
         b.wait_visible("#devices")
 
         # Make a logical volume for use as the backing device.
-        m.add_disk("10G", serial="DISK1")
+        m.add_disk(SIZE_10G, serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
         # Create VDO; this is not supported any more, thus no UI for it
@@ -203,9 +207,9 @@ class TestStorageLegacyVDO(StorageCase):
 
         b.wait_text(detail(1), "/dev/mapper/vdo0")
         b.wait_in_text(detail(2), "vdo_vgroup")
-        b.wait_in_text(detail(3), "used of 5 GiB")
-        b.wait_in_text(detail(4), "used of 5 GiB")
-        b.wait_text(detail(5), "256 MiB")
+        b.wait_in_text(detail(3), "used of 5.37 GB")
+        b.wait_in_text(detail(4), "used of 5.37 GB")
+        b.wait_text(detail(5), "268 MB")
         b.wait_visible(detail(6) + " input:checked")
         b.wait_visible(detail(7) + " input:checked")
 
@@ -221,22 +225,22 @@ class TestStorageLegacyVDO(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Mount point", "_netdev")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.device-timeout=0")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.requires=vdo.service")
-        self.content_row_wait_in_col(1, 4, "/ 4.99 GiB", alternate_val="/ 5.0 GiB")
+        self.content_row_wait_in_col(1, 4, "/ 5.36 GB", alternate_val="/ 5.37 GB")
 
         # Grow physical
 
         m.execute("lvresize vdo_vgroup/lvol -L 9G")
-        b.wait_in_text(".pf-c-alert__description", '5 GiB of 9 GiB')
+        b.wait_in_text(".pf-c-alert__description", 'Only 5.37 GB of 9')
         b.click("button:contains('Grow to take all space')")
         b.wait_not_present(".pf-c-alert")
-        b.wait_in_text(detail(3), "used of 9 GiB")
+        b.wait_in_text(detail(3), "used of 9.66 GB")
 
         # Grow logical
 
         b.click(detail(4) + " button:contains(Grow)")
-        self.dialog({"lsize": 10 * 1024})
-        b.wait_in_text(detail(4), "used of 10 GiB")
-        self.content_row_wait_in_col(1, 4, "/ 9.99 GiB", alternate_val="/ 10.0 GiB")
+        self.dialog({"lsize": 10000})
+        b.wait_in_text(detail(4), "used of 10.0 GB")
+        self.content_row_wait_in_col(1, 4, "/ 9.99 GB", alternate_val="/ 10.0 GB")
 
         # Stop
 
@@ -267,7 +271,7 @@ class TestStorageLegacyVDO(StorageCase):
 
         b.wait_visible("#devices")
 
-        m.add_disk("10G", serial="DISK1")
+        m.add_disk(SIZE_10G, serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
 
         # Install a valid configuration file that describes a broken VDO
@@ -418,7 +422,7 @@ class TestStoragePackagesVDO(PackageCase, StorageHelpers):
         m.execute("pkcon refresh")
 
         self.login_and_go("/storage")
-        m.add_disk("10G", serial="DISK1")
+        m.add_disk(SIZE_10G, serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda")
         b.wait_in_text("#devices", "vdo_vgroup")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -74,8 +74,10 @@ class StorageHelpers:
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1969408
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
+        # PR#17163 moved units from base-2 to base-10
+        bs = 1048576 if self.image == 'rhel-8-6-distropkg' else 1000000
         dev = self.machine.execute("set -e; F=$(mktemp /var/tmp/loop.XXXX); "
-                                   "dd if=/dev/zero of=$F bs=1M count=%s; "
+                                   f"dd if=/dev/zero of=$F bs={bs} count=%s; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # right after unmounting the device is often still busy, so retry a few times
         self.addCleanup(self.machine.execute, "umount {0}; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
@@ -259,7 +261,8 @@ class StorageHelpers:
             for label in val:
                 self.browser.set_checked(f'{sel} :contains("{label}") input', val)
         elif ftype == "size-slider":
-            self.browser.set_val(sel + " .size-unit", "1048576")
+            # PR#17163 moved units from base-2 to base-10
+            self.browser.set_val(sel + " .size-unit", "1048576" if self.image == 'rhel-8-6-distropkg' else "1000000")
             self.browser.set_input_text(sel + " .size-text", str(val))
         elif ftype == "select":
             self.browser.set_val(sel + " select", val)
@@ -291,7 +294,11 @@ class StorageHelpers:
     def dialog_is_present(self, field, label):
         return self.browser.is_present(f'{self.dialog_field(field)} :contains("{label}") input')
 
-    def dialog_wait_val(self, field, val, unit="1048576"):
+    def dialog_wait_val(self, field, val, unit=None):
+        if unit is None:
+            # PR#17163 moved units from base-2 to base-10
+            unit = "1048576" if self.image == 'rhel-8-6-distropkg' else "1000000"
+
         sel = self.dialog_field(field)
         ftype = self.browser.attr(sel, "data-field-type")
         if ftype == "size-slider":


### PR DESCRIPTION
This makes more sense as a default now. Storage and network devices,
network transmission speeds etc. have all been base-10 for decades. The
only place which is inherently/physically base-2 is total RAM size, and
reserved kdump memory because that's just its API. But these special
cases have all been explicitly moved to format as base-2 recently.

https://bugzilla.redhat.com/show_bug.cgi?id=1970119

---

[pixel diff review](https://github.com/cockpit-project/pixel-test-reference/compare/ac6d9ad037ca8939d6795834abf82b35c4039836..fa3e8b66637ce0815d01915779b5906b98245f4d)


This is most apparent on the Metrics, Storage, and Networking pages:
![image](https://user-images.githubusercontent.com/200109/159422467-a5c56e1a-044a-44a0-8f8a-538067f61646.png)
![image](https://user-images.githubusercontent.com/200109/159422560-89875873-4acb-4e15-aa39-27a93e6f5ea2.png)
![image](https://user-images.githubusercontent.com/200109/159422595-b87c33f2-50df-428a-ae2f-ccf86b1b9050.png)


## Show disk/memory/network sizes and rates in decimal units

All sizes and rates are now shown in decimal units, such as "MB" or "kB/s". Physical storage, network devices,
and network transmission speeds have all been sold and used in decimal units for a long time. This also avoids some inconsistencies, such as the Metrics page showing available/used RAM in decimal units, but the memory usage of individual services in binary units.

Only total RAM size on the Overview, the size of individual RAM modules on the Hardware Details page, and the size of KDump memory are shown in binary units such as MiB or GiB, as these are all natively based on these.

![image](https://user-images.githubusercontent.com/200109/159422467-a5c56e1a-044a-44a0-8f8a-538067f61646.png)
