### PR TITLE
metrics: fix missing aria-label on progress element

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -474,6 +474,7 @@ class CurrentMetrics extends React.Component {
                 </Flex>);
 
             topCore = <Progress
+                           aria-label={_("Current top CPU usage")}
                            id="current-top-cpu-usage"
                            value={top_cores[0][1]}
                            className="pf-m-sm"


### PR DESCRIPTION
Without specifying an aria-label the console logs the following message
on every metrics update:
"One of aria-label or aria-labelledby properties should be passed when
using the progress component without a title"