### PR TITLE
test: Enable FreeIPA tests on debian-testing

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -619,8 +619,11 @@ class TestIPA(TestRealms, CommonTests):
         super().testUnqualifiedUsers()
 
         # now try 2FA with OTP
-        # This does not yet work with sssd < 2.2.2-1 on Ubuntu
-        if m.image in ["ubuntu-2004", "ubuntu-stable"]:
+        if m.image == "ubuntu-2004":
+            # This does not yet work with sssd < 2.2.2-1
+            return
+        if "debian" in m.image or "ubuntu" in m.image:
+            # FIXME: needs some additional setup on Debian to actually work
             return
 
         # set up "alice" user with HOTP; that won't affect existing users (admin)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -491,7 +491,7 @@ class TestRealms(MachineCase):
         self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
 
 
-@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
+@skipImage("freeipa not currently available", "debian-stable", "arch")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
@@ -996,7 +996,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 
 @skipImage("No realmd available", "fedora-coreos", "arch")
-@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
+@skipImage("freeipa not currently available", "debian-stable", "arch")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestKerberos(MachineCase):

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -71,6 +71,22 @@ def hotp_token(secret, counter, digits=6, hash_alg=hashlib.sha1):
     return numbers[-digits:].rjust(digits, '0')
 
 
+def setup_fake_chrony(machine):
+    # Our Debian/Ubuntu VM images have systemd-timesyncd installed, which conflicts with chrony.
+    # Set up a mock chrony.service to make ipa-client-install happy
+    machine.write("/run/systemd/system/chrony.service", """
+[Service]
+Type=oneshot
+ExecStart=/bin/true
+""")
+    machine.execute("ln -s /bin/true /usr/bin/chronyc")
+    machine.execute("systemctl unmask chrony")
+
+    if machine.image == 'ubuntu-2004':
+        # HACK: https://launchpad.net/bugs/1890786
+        machine.execute("ln -s chrony.service /run/systemd/system/chronyd.service")
+
+
 @skipImage("No realmd available", "arch")
 @skipDistroPackage()
 class CommonTests:
@@ -490,18 +506,8 @@ class TestIPA(TestRealms, CommonTests):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
         wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
 
-        # HACK: ipa-client-install fails on restarting absent chronyd.service: https://launchpad.net/bugs/1890786
-        if self.machine.image in ["ubuntu-2004", "ubuntu-stable"]:
-            self.write_file("/run/systemd/system/chronyd.service", """
-[Service]
-Type=oneshot
-ExecStart=/bin/true
-""")
-            self.machine.execute("ln -s /bin/true /usr/bin/chronyc")
-
-            # HACK: It now expects chrony.service and not chronyd.service: https://bugs.debian.org/968428
-            # Not to be attached to a specific version of a testing image, support both for now
-            self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
+        if "ubuntu" in self.machine.image or "debian" in self.machine.image:
+            setup_fake_chrony(self.machine)
 
         # wait until FreeIPA started up
         self.machines['services'].execute("""podman exec -i freeipa sh -ec '
@@ -998,18 +1004,8 @@ class TestKerberos(MachineCase):
 
     def setUp(self):
         super().setUp()
-        # HACK: ipa-client-install fails on restarting absent chronyd.service: https://launchpad.net/bugs/1890786
-        if self.machine.image in ["ubuntu-2004", "ubuntu-stable"]:
-            self.write_file("/run/systemd/system/chronyd.service", """
-[Service]
-Type=oneshot
-ExecStart=/bin/true
-""")
-            self.machine.execute("ln -s /bin/true /usr/bin/chronyc")
-
-            # HACK: It now expects chrony.service and not chronyd.service: https://bugs.debian.org/968428
-            # Not to be attached to a specific version of a testing image, support both for now
-            self.machine.execute("ln -s /run/systemd/system/chronyd.service /run/systemd/system/chrony.service")
+        if "ubuntu" in self.machine.image or "debian" in self.machine.image:
+            setup_fake_chrony(self.machine)
 
     def configure_kerberos(self, keytab):
         self.machines["services"].execute("/root/run-freeipa")


### PR DESCRIPTION
The package is finally available again, and got added to the image in [1].

Adjust the mock chrony.service hack a bit -- this bug is still around,
and I filed [2][3] about it. chrony.service is now masked by default, so
unmask it. And systemd does not accept symlinks to other units any more,
so replace that with a copy.

[1] https://github.com/cockpit-project/bots/pull/3132
[2] https://launchpad.net/bugs/1966181
[3] https://bugs.debian.org/1008195

 - Requires https://github.com/cockpit-project/bots/pull/3139