### PR TITLE
overview: Adjust modals & select lists

### DIFF
--- a/pkg/lib/menu-select-widget.scss
+++ b/pkg/lib/menu-select-widget.scss
@@ -4,19 +4,19 @@
 // Therefore, we're changing the visuals here locally.
 // PF4 upstream request for multi-select @ https://github.com/patternfly/patternfly/issues/4027
 .ct-menu-select-widget.pf-c-menu {
-  // It's  not really a menu, so it shouldn't have a shadow
-  box-shadow: none;
-
   // Divider is silly between the widgets in this context
   .pf-c-divider {
     display: none;
+
+    + .pf-c-menu__content {
+      // There should be minimal space between the widgets (replacing the divider)
+      margin-top: var(--pf-global--spacer--sm);
+    }
   }
 
   .pf-c-menu__content {
     // An overflow multi-select widget needs an outline
     border: 1px solid var(--pf-global--BorderColor--100);
-    // There should be minimal space between the widgets (replacing the divider)
-    margin-top: var(--pf-global--spacer--sm);
   }
 
   // Search should not be inset when there's no border containing it

--- a/pkg/shell/shell-modals.jsx
+++ b/pkg/shell/shell-modals.jsx
@@ -117,6 +117,8 @@ export const LangModal = () => {
             <Flex direction={{ default: 'column' }}>
                 <p>{_("Choose the language to be used in the application")}</p>
                 <Menu id="display-language-list"
+                      isPlain
+                      isScrollable
                       className="ct-menu-select-widget"
                       onSelect={(_, selected) => setSelected(selected)}
                       activeItemId={selected}

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -159,6 +159,7 @@ const CryptoPolicyDialog = ({
 
     return (
         <Modal position="top" variant="medium"
+               className="ct-m-stretch-body"
                isOpen
                help={help}
                onClose={Dialogs.close}

--- a/pkg/systemd/overview-cards/profiles-menu-dialog-body.jsx
+++ b/pkg/systemd/overview-cards/profiles-menu-dialog-body.jsx
@@ -67,6 +67,8 @@ export class ProfilesMenuDialogBody extends React.Component {
         });
         return (
             <Menu className="ct-menu-select-widget"
+                  isPlain
+                  isScrollable
                   onSelect={(_, selected) => {
                       this.setState({ selected_profile: selected });
                       this.props.change_selected(selected);

--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -265,3 +265,26 @@
 .pf-c-alert .pf-c-alert__description a {
   padding-left: 15px;
 }
+
+// Stretch modal content to fill body
+// This redirects scrolling from the modal body to the select widget
+.ct-m-stretch-body {
+  // Use flex to let children fully expand to the content
+  .pf-c-modal-box__body {
+    &, > :only-child {
+      // Let children fully stretch to content
+      display: flex;
+    }
+
+    > :only-child,
+    .pf-c-menu__content {
+      // Get squishy with children and the menu content
+      flex: auto;
+    }
+
+    .pf-c-menu__content {
+      // Relax the height constraint
+      --pf-c-menu__content--MaxHeight: 100%;
+    }
+  }
+}

--- a/pkg/tuned/dialog.jsx
+++ b/pkg/tuned/dialog.jsx
@@ -297,6 +297,7 @@ const TunedDialog = ({
 
     return (
         <Modal position="top" variant="medium"
+               className="ct-m-stretch-body"
                isOpen
                help={help}
                onClose={Dialogs.close}


### PR DESCRIPTION
- Using updated PF menus lets us drop a little bit of overrides
- Moving the scrollbar from the modal to the menu makes sense here, but it needs some fixups