### PR TITLE
containers: Update flatpak to GNOME runtime version 42

### DIFF
--- a/containers/flatpak/cockpit-client.yml.in
+++ b/containers/flatpak/cockpit-client.yml.in
@@ -1,6 +1,6 @@
 app-id: @FLATPAK_ID@
 runtime: org.gnome.Platform
-runtime-version: '41'
+runtime-version: '42'
 sdk: org.gnome.Sdk
 default-branch: @FLATPAK_BRANCH@
 command: cockpit-client


### PR DESCRIPTION
Thanks to BigmenPixel! Originally proposed in
https://github.com/flathub/org.cockpit_project.CockpitClient/pull/6