### PR TITLE
test: Assume that fstab and crypttab updates are synchronous now

### DIFF
--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -68,11 +68,11 @@ class TestStorageHidden(StorageCase):
                      "mount_point": mount_point_1,
                      "mount_options.auto": False,
                      "crypto_options": "my-crypto-tag"})
+        self.assert_in_configuration("/dev/TEST/lvol", "crypttab", "options", "my-crypto-tag")
+        self.assert_in_child_configuration("/dev/TEST/lvol", "fstab", "dir", mount_point_1)
+        self.assert_in_lvol_child_configuration("lvol", "crypttab", "options", "my-crypto-tag")
+        self.assert_in_lvol_child_configuration("lvol", "fstab", "dir", mount_point_1)
         self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
-        self.wait_in_configuration("/dev/TEST/lvol", "crypttab", "options", "my-crypto-tag")
-        self.wait_in_child_configuration("/dev/TEST/lvol", "fstab", "dir", mount_point_1)
-        self.wait_in_lvol_child_configuration("lvol", "crypttab", "options", "my-crypto-tag")
-        self.wait_in_lvol_child_configuration("lvol", "fstab", "dir", mount_point_1)
 
         # Now the filesystem is hidden because the LUKS device is
         # locked.  Doubly hide it by deactivating /dev/TEST/lvol
@@ -115,8 +115,8 @@ class TestStorageHidden(StorageCase):
         self.dialog({"type": "ext4",
                      "name": "FS2",
                      "mount_point": mount_point_2})
+        self.assert_in_configuration("/dev/md127", "fstab", "dir", mount_point_2)
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_in_configuration("/dev/md127", "fstab", "dir", mount_point_2)
 
         # we need to wait for mdadm --monitor to stop using the device before delete
         m.execute("while fuser -s /dev/md127; do sleep 0.2; done", timeout=20)

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -79,13 +79,13 @@ class TestStorageLuks(StorageCase):
         cleartext_dev = "/dev/mapper/luks-" + uuid
         passphrase_path = "/etc/luks-keys/luks-" + uuid
 
-        self.wait_in_configuration(dev, "crypttab", "options", "crypto,options")
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_configuration(dev, "crypttab", "passphrase-path", passphrase_path)
+        self.assert_in_configuration(dev, "crypttab", "options", "crypto,options")
+        self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_configuration(dev, "crypttab", "passphrase-path", passphrase_path)
         self.assertEqual(m.execute(f"cat {passphrase_path}"), "vainu-reku-toma-rolle-kaja")
 
-        self.wait_in_configuration(cleartext_dev, "fstab", "dir", mount_point_secret)
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
+        self.assert_in_configuration(cleartext_dev, "fstab", "dir", mount_point_secret)
+        self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
         # cut off minutes, to avoid a too wide race condition in the test
         date_no_mins = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium', timeStyle: 'short' }).format()").split(':')[0]
@@ -98,9 +98,9 @@ class TestStorageLuks(StorageCase):
         # Unmount. This locks it
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
+        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_child_configuration(dev, "fstab", "opts", "noauto")
         self.content_tab_wait_in_info(1, 2, "Mount point", "The filesystem is not mounted")
-        self.wait_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
 
         # It should be listed on the Overview. Click it to come back
         # here.
@@ -114,26 +114,26 @@ class TestStorageLuks(StorageCase):
         self.dialog_wait_val("mount_point", mount_point_secret)
         self.dialog_apply()
         self.dialog_wait_close()
+        self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
         self.content_tab_info_action(1, 3, "Options")
         self.dialog({"options": "weird,options"})
-        self.wait_in_configuration(dev, "crypttab", "options", "weird,options")
+        self.assert_in_configuration(dev, "crypttab", "options", "weird,options")
 
         # Change stored passphrase
         b.click(self.content_tab_info_label(1, 3, "Stored passphrase") + " + dd button")
         self.dialog({"passphrase": "wrong-passphrase"})
-        self.wait_in_configuration(dev, "crypttab", "passphrase-path", passphrase_path)
+        self.assert_in_configuration(dev, "crypttab", "passphrase-path", passphrase_path)
         self.assertEqual(m.execute(f"cat {passphrase_path}"), "wrong-passphrase")
 
         # Unmount it
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
+        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_child_configuration(dev, "fstab", "opts", "noauto")
         b.wait_not_in_text("#detail-content", "ext4 filesystem")
-        self.wait_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
 
         # Mount, this tries the wrong passphrase but eventually prompts.
         self.content_row_action(1, "Mount")
@@ -143,23 +143,23 @@ class TestStorageLuks(StorageCase):
         self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
         self.dialog_wait_close()
+        self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
 
         self.wait_mounted(1, 2)
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
         # Remove passphrase
         b.click(self.content_tab_info_label(1, 3, "Stored passphrase") + " + dd button")
         self.dialog({"passphrase": ""})
-        self.wait_in_configuration(dev, "crypttab", "passphrase-path", "")
+        self.assert_in_configuration(dev, "crypttab", "passphrase-path", "")
 
         # Unmount it
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
         b.wait_not_in_text("#detail-content", "ext4 filesystem")
-        self.wait_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
+        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_child_configuration(dev, "fstab", "opts", "noauto")
 
         # Mount it readonly.  This asks for a passphrase.
         self.content_row_action(1, "Mount")
@@ -168,8 +168,8 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.wait_mounted(1, 2)
         self.assertIn("ro", m.execute(f"findmnt -s -n -o OPTIONS {mount_point_secret}"))
-        self.wait_in_configuration(dev, "crypttab", "options", "readonly")
-        self.wait_in_configuration(cleartext_dev, "fstab", "opts", "ro")
+        self.assert_in_configuration(dev, "crypttab", "options", "readonly")
+        self.assert_in_configuration(cleartext_dev, "fstab", "opts", "ro")
 
         # Delete the partition.
         self.content_dropdown_action(1, "Delete")
@@ -330,19 +330,19 @@ class TestStorageLuks(StorageCase):
         self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja"})
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
+        self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         # unlock with second passphrase
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
+        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_child_configuration(dev, "fstab", "opts", "noauto")
         b.wait_not_in_text("#detail-content", "ext4 filesystem")
-        self.wait_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
         self.content_row_action(1, "Mount")
         self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-1"})
+        self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
         # delete second key slot
         b.click(panel + "li:nth-child(2) button[aria-label=Remove]")
         # do not accept the same passphrase
@@ -357,8 +357,8 @@ class TestStorageLuks(StorageCase):
         # check that it is not possible to unlock with deleted passphrase
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
-        self.wait_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_in_child_configuration(dev, "fstab", "opts", "noauto")
+        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_child_configuration(dev, "fstab", "opts", "noauto")
         b.wait_not_in_text("#detail-content", "ext4 filesystem")
         self.content_row_action(1, "Mount")
         self.dialog_wait_open()
@@ -420,13 +420,13 @@ class TestStorageLuks(StorageCase):
             self.dialog_set_val("new_passphrase2", "vainu-reku-toma-rolle-kaja-8")
             self.dialog_apply()
             self.dialog_wait_close()
-            # unlock volume with the newly created passphrase
+            # unlock volume with the negwly created passphrase
             self.content_row_action(1, "Mount")
             self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
             self.content_row_wait_in_col(1, 2, "ext4 filesystem")
             self.wait_mounted(1, 1)
-            self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-            self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
+            self.assert_not_in_configuration(dev, "crypttab", "options", "noauto")
+            self.assert_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
     def testNoFsys(self):
         m = self.machine

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -147,7 +147,7 @@ class TestStorageLvm2(StorageCase):
         self.dialog({"type": "ext4",
                      "mount_point": mount_point_one})
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
+        self.assert_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
         self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_one)
 
         # unmount it
@@ -211,8 +211,8 @@ class TestStorageLvm2(StorageCase):
         self.dialog({"erase.on": True,
                      "type": "ext4",
                      "mount_point": mount_point_thin})
+        self.assert_in_configuration("/dev/vgroup0/thin", "fstab", "dir", mount_point_thin)
         self.content_row_wait_in_col(2, 2, "ext4 filesystem")
-        self.wait_in_configuration("/dev/vgroup0/thin", "fstab", "dir", mount_point_thin)
 
         # remove pool
         self.content_dropdown_action(1, "Delete")
@@ -230,8 +230,8 @@ class TestStorageLvm2(StorageCase):
         self.content_row_action(1, "Format")
         self.dialog({"type": "ext4",
                      "mount_point": mount_point_one})
+        self.assert_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_in_configuration("/dev/vgroup0/lvol0", "fstab", "dir", mount_point_one)
         self.content_tab_wait_in_info(1, 2, "Mount point", mount_point_one)
 
         # remove volume group

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -51,9 +51,9 @@ class TestStorageMounting(StorageCase):
         self.dialog_set_val("mount_point", mount_point_foo)
         self.dialog_apply()
         self.dialog_wait_close()
+        self.assert_in_configuration("/dev/sda", "fstab", "dir", mount_point_foo)
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 1, "Name", "FILESYSTEM")
-        self.wait_in_configuration("/dev/sda", "fstab", "dir", mount_point_foo)
 
         self.content_tab_wait_in_info(1, 1, "Mount point", mount_point_foo)
 
@@ -83,10 +83,10 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog({"name": "filesystem"})
         self.content_tab_wait_in_info(1, 1, "Name", "filesystem")
 
-        self.dialog_with_retry(trigger=lambda: self.content_tab_info_action(1, 1, "Mount point"),
-                               expect={"mount_point": mount_point_foo},
-                               values={"mount_point": mount_point_bar})
-        self.wait_in_configuration("/dev/sda", "fstab", "dir", mount_point_bar)
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog(expect={"mount_point": mount_point_foo},
+                    values={"mount_point": mount_point_bar})
+        self.assert_in_configuration("/dev/sda", "fstab", "dir", mount_point_bar)
         self.content_tab_wait_in_info(1, 1, "Mount point", mount_point_bar)
 
         self.content_row_action(1, "Mount")

--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -620,9 +620,9 @@ Dummy package from building optional packages only; never install or publish me.
 %package -n cockpit-storaged
 Summary: Cockpit user interface for storage, using udisks
 Requires: cockpit-shell >= @REQUIRED_BASE@
-Requires: udisks2 >= 2.6
-Recommends: udisks2-lvm2 >= 2.6
-Recommends: udisks2-iscsi >= 2.6
+Requires: udisks2 >= 2.9
+Recommends: udisks2-lvm2 >= 2.9
+Recommends: udisks2-iscsi >= 2.9
 Recommends: device-mapper-multipath
 Recommends: clevis-luks
 Requires: %{__python3}

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -106,7 +106,7 @@ Package: cockpit-storaged
 Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
-         udisks2 (>= 2.7),
+         udisks2 (>= 2.9),
          libblockdev-mdraid2,
          cockpit-bridge (>= ${source:Version}),
          python3,


### PR DESCRIPTION
UDisks2 used to return from methods calls like AddConfigurationItem
before the requested changes have been reflected in the Configuration
properties.  This has been fixed in 2.9.0.