### PR TITLE
test: Lower default CDP timeout to 15s

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -163,7 +163,7 @@ def jsquote(str):
 class CDP:
     def __init__(self, lang=None, verbose=False, trace=False, inject_helpers=[], start_profile=False):
         self.lang = lang
-        self.timeout = 60
+        self.timeout = 15
         self.valid = False
         self.verbose = verbose
         self.trace = trace

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -106,7 +106,8 @@ class TestApps(PackageCase):
         # Refresh package info
         b.click("#refresh")
 
-        b.click(".app-list #app-1")
+        with b.wait_timeout(30):
+            b.click(".app-list #app-1")
         b.wait_visible('a[href="https://app-1.com"]')
         b.wait_visible(f'#app-page img[src^="{urlroot}/cockpit/channel/"]')
         b.click(".pf-c-breadcrumb a:contains('Applications')")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -115,8 +115,7 @@ class TestConnection(MachineCase):
         # sever the connection on the login page
         m.execute("iptables -w -I INPUT -p tcp --dport 9090 -j REJECT --reject-with tcp-reset")
         b.click('#login-button')
-        with b.wait_timeout(20):
-            b.wait_text_not('#login-fatal-message', "")
+        b.wait_text_not('#login-fatal-message', "")
         m.execute("iptables -w -D INPUT -p tcp --dport 9090 -j REJECT --reject-with tcp-reset")
         b.reload()
         b.wait_visible("#login")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -43,7 +43,8 @@ class KdumpHelpers(MachineCase):
 
         # wait for disconnect and then try connecting again
         b.switch_to_top()
-        b.wait_in_text("div.curtains-ct h1", "Disconnected")
+        with b.wait_timeout(60):
+            b.wait_in_text("div.curtains-ct h1", "Disconnected")
         self.machine.disconnect()
         self.machine.wait_boot(timeout_sec=300)
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -81,6 +81,11 @@ def redisService(image):
     return "redis"
 
 
+def applySettings(browser):
+    browser.click("#pcp-settings-modal button.pf-m-primary")
+    browser.wait_not_present("#pcp-settings-modal")
+
+
 def login(self):
     # HACK: Ubuntu and Debian need some time until metrics channel is available
     # Really no idea what it needs to wait for, so let's just try channel until it succeeds
@@ -443,8 +448,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_visible("#switch-pmlogger:not(:checked)")
         b.click("#switch-pmlogger")
         b.wait_visible("#switch-pmlogger:checked")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
 
         m.execute("until systemctl is-active pmlogger; do sleep 1; done")
 
@@ -501,8 +505,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_visible("#switch-pmlogger:checked")
         b.click("#switch-pmlogger")
         b.wait_visible("#switch-pmlogger:not(:checked)")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
 
         self.assertEqual(m.execute("systemctl is-active pmlogger || true").strip(), "inactive")
         self.assertEqual(m.execute("systemctl is-enabled pmlogger || true").strip(), "disabled")
@@ -513,8 +516,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_visible("#switch-pmlogger:not(:checked)")
         b.click("#switch-pmlogger")
         b.wait_visible("#switch-pmlogger:checked")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
 
         m.execute("until systemctl is-active pmlogger; do sleep 1; done")
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
@@ -537,8 +539,7 @@ class TestHistoryMetrics(MachineCase):
             b.wait_visible("#switch-pmproxy:not(:checked)")
             b.click('#switch-pmproxy')
             b.wait_visible('#switch-pmproxy:checked')
-            b.click("#pcp-settings-modal button.pf-m-primary")
-            b.wait_not_present("#pcp-settings-modal")
+            applySettings(b)
             if firewalld_alert:
                 b.wait_visible(".pf-c-alert:contains(pmproxy)")
             else:
@@ -556,8 +557,7 @@ class TestHistoryMetrics(MachineCase):
             b.wait_visible('#switch-pmproxy:checked')
             b.click('#switch-pmproxy')
             b.wait_visible("#switch-pmproxy:not(:checked)")
-            b.click("#pcp-settings-modal button.pf-m-primary")
-            b.wait_not_present("#pcp-settings-modal")
+            applySettings(b)
             # always clears the firewalld alert
             b.wait_not_present(".pf-c-alert:contains(pmproxy)")
             self.assertEqual(m.execute("! systemctl is-active pmproxy").strip(), "inactive")
@@ -585,8 +585,7 @@ class TestHistoryMetrics(MachineCase):
         # enable pmlogger
         b.click('#switch-pmlogger')
         b.wait_visible('#switch-pmlogger:checked')
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
         m.execute('while [ $(systemctl is-active pmlogger) = activating ]; do sleep 1; done')
         self.assertEqual(m.execute("systemctl is-active pmlogger").strip(), "active")
         b.wait_not_present(".pf-c-alert:contains(pmproxy)")
@@ -1028,8 +1027,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         b.wait_visible("#switch-pmlogger:not(:checked)")
         b.click("#switch-pmlogger")
         b.wait_visible("#switch-pmlogger:checked")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
         # install dialog
         b.click("#dialog button:contains('Install')")
         b.wait_not_present("#dialog")
@@ -1055,8 +1053,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         b.wait_visible("#switch-pmproxy:not(:checked)")
         b.click("#switch-pmproxy")
         b.wait_visible("#switch-pmproxy:checked")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
         # install dialog
         b.click("#dialog button:contains('Install')")
         b.wait_not_present("#dialog")
@@ -1147,8 +1144,7 @@ class TestGrafanaClient(MachineCase):
         b.wait_visible("#switch-pmlogger:not(:checked)")
         b.click("#switch-pmlogger")
         b.wait_visible("#switch-pmlogger:checked")
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
 
         # enable pmproxy+redis (none of our test OSes have both of them running by default)
         b.click("#metrics-header-section button.pf-m-secondary")
@@ -1156,8 +1152,7 @@ class TestGrafanaClient(MachineCase):
         b.wait_visible("#switch-pmproxy:not(:checked)")
         b.click('#switch-pmproxy')
         b.wait_visible('#switch-pmproxy:checked')
-        b.click("#pcp-settings-modal button.pf-m-primary")
-        b.wait_not_present("#pcp-settings-modal")
+        applySettings(b)
 
         # enable pmproxy service in firewalld in the alert
         b.wait_visible("#firewalld-request-pmproxy")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -83,7 +83,8 @@ def redisService(image):
 
 def applySettings(browser):
     browser.click("#pcp-settings-modal button.pf-m-primary")
-    browser.wait_not_present("#pcp-settings-modal")
+    with browser.wait_timeout(30):
+        browser.wait_not_present("#pcp-settings-modal")
 
 
 def login(self):
@@ -205,6 +206,8 @@ class TestHistoryMetrics(MachineCase):
     def testEvents(self):
         b = self.browser
         m = self.machine
+
+        b.wait_timeout(60)
 
         def events_at(hour, minute):
             return b.text(f"#metrics-hour-{hour} div.metrics-minute[data-minute={minute}] .metrics-events")
@@ -484,8 +487,10 @@ class TestHistoryMetrics(MachineCase):
 
         # Troubleshoot
         b.click(".pf-c-empty-state button.pf-m-link")
-        b.enter_page("/system/services")
-        b.wait_in_text("#service-details", "pmlogger.service")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.enter_page("/system/services")
+            b.wait_in_text("#service-details", "pmlogger.service")
 
     @nondestructive
     @skipImage("no PCP support", "fedora-coreos")
@@ -707,6 +712,8 @@ class TestCurrentMetrics(MachineCase):
         b = self.browser
         m = self.machine
 
+        b.wait_timeout(60)
+
         nproc = m.execute("nproc").strip()
         b.wait_in_text("#current-cpu-usage", nproc + " CPU")
         # top CPU core is not visible with just 1 core; our upstream test VMs have only 1 core,
@@ -807,7 +814,9 @@ BEGIN {{
         # table entries are links to Services page
         b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a span")
         b.enter_page("/system/services")
-        b.wait_in_text("#path", "/mem-hog.service")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.wait_in_text("#path", "/mem-hog.service")
         b.wait_in_text(".service-name", "memhog.sh")
 
         b.go("/metrics")
@@ -853,6 +862,8 @@ BEGIN {{
         b = self.browser
         m = self.machine
         login(self)
+
+        b.wait_timeout(60)
 
         # test env should be quiet enough to not transmit MB/s
         b.wait(lambda: re.match(r'^(0|[0-9.]+ (kB|B)/s)$', b.text("#current-disks-read")))
@@ -1087,6 +1098,8 @@ class TestMultiCPU(MachineCase):
         self.assertGreaterEqual(getMaximumSpike(self, "cpu", False, 1598968800000, 45), 0.5)
         self.assertLessEqual(getMaximumSpike(self, "cpu", False, 1598968800000, 45), 1.0)
 
+        b.wait_timeout(60)
+
         # Test current usage of cores
         b.wait_text("#current-cpu-usage-description", "2 CPUs")
         b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
@@ -1172,10 +1185,11 @@ class TestGrafanaClient(MachineCase):
             # HACK Unsigned plugin needs to be enabled manually
             # See https://github.com/performancecopilot/grafana-pcp/issues/94
             bg.open("/plugins/performancecopilot-pcp-app")
-            bg.wait_visible(".gf-form-button-row button")
-            if bg.text(".gf-form-button-row button") == "Enable":
-                bg.click(".gf-form-button-row button")
-                bg.wait_text(".gf-form-button-row button", "Disable")
+            with bg.wait_timeout(30):
+                bg.wait_visible(".gf-form-button-row button")
+                if bg.text(".gf-form-button-row button") == "Enable":
+                    bg.click(".gf-form-button-row button")
+                    bg.wait_text(".gf-form-button-row button", "Disable")
 
             # Add the PCP redis data source for our client machine
             # Cog (Configuration) menu → Data Sources → Add

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -180,7 +180,9 @@ class TestNetworkingBasic(NetworkCase):
         assert_stopped(True)
         b.click("#networking-nm-crashed a")
         b.enter_page("/system/services")
-        b.wait_text(".service-name", "Network Manager")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.wait_text(".service-name", "Network Manager")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -49,7 +49,8 @@ class TestNetworkingCheckpoints(NetworkCase):
         self.toggle_onoff(f".pf-c-card__header:contains('{iface}')")
 
         # Wait for dialog to appear and dismiss it
-        b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
+        with b.wait_timeout(60):
+            b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
         b.wait_not_present("#confirm-breaking-change-popup")
 
         if m.image not in ["debian-testing", "debian-stable"]:
@@ -60,7 +61,8 @@ class TestNetworkingCheckpoints(NetworkCase):
             b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
             b.set_input_text('#network-ip-settings-netmask-0', "24")
             b.click("#network-ip-settings-save")
-            b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
+            with b.wait_timeout(60):
+                b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
             b.wait_not_present("#confirm-breaking-change-popup")
 
     @skipImage("Main interface settings are read-only", "debian-stable", "debian-testing")

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -43,7 +43,8 @@ class TestNetworkingUnmanaged(NetworkCase):
 
         self.login_and_go("/network")
 
-        b.wait_visible("#networking-unmanaged-interfaces tr[data-interface='" + iface + "']")
+        with b.wait_timeout(60):
+            b.wait_visible("#networking-unmanaged-interfaces tr[data-interface='" + iface + "']")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1346,6 +1346,7 @@ class TestAutoUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
+        b.wait_visible("#status")
 
         if not self.supported_backend:
             self.assertFalse(b.is_present("#automatic"))

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -166,7 +166,8 @@ class TestUpdates(NoSubManCase):
         b.login_and_go("/updates")
 
         # Enable and install kpatch
-        b.wait_in_text("#kpatch-settings", "Disabled")
+        with b.wait_timeout(30):
+            b.wait_in_text("#kpatch-settings", "Disabled")
         b.click("#kpatch-settings button:contains('Enable')")
 
         # Apply kernel live patches for current and future kernels
@@ -332,7 +333,8 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         # check again
         b.click("#status .pf-c-card__header button")
 
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         b.wait_in_text("#status", "2 updates available")
 
         b.wait_in_text("table[aria-label='Available updates']", "vanilla")
@@ -454,14 +456,16 @@ ExecStart=/usr/local/bin/{self.packageName}
                 b.login_and_go("/updates")
 
                 # check update is present
-                b.wait_in_text("#status", "1 update available")
+                with b.wait_timeout(30):
+                    b.wait_in_text("#status", "1 update available")
                 b.wait_in_text("#available-updates table", self.packageName)
 
                 # install updates
                 b.wait_visible("#install-all")
                 b.wait_in_text("#install-all", "Install all updates")
                 b.click("#install-all")
-                b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+                with b.wait_timeout(60):
+                    b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
 
                 b.wait_visible("#ignore")
                 b.wait_visible(".updates-success-table")
@@ -620,14 +624,16 @@ ExecStart=/usr/local/bin/{packageName}
         b.login_and_go("/updates")
 
         # check update is present
-        b.wait_in_text("#status", "1 update available")
+        with b.wait_timeout(30):
+            b.wait_in_text("#status", "1 update available")
         b.wait_in_text("#available-updates table", packageName)
 
         # install updates
         b.wait_visible("#install-all")
         b.wait_in_text("#install-all", "Install all updates")
         b.click("#install-all")
-        b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+        with b.wait_timeout(60):
+            b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
 
         b.wait_visible("#ignore")
         b.wait_visible(".updates-success-table")
@@ -682,7 +688,8 @@ ExecStart=/usr/local/bin/{packageName}
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         b.wait_in_text("#status", "6 updates available, including 3 security fixes")
 
         b.wait_in_text("table[aria-label='Available updates']", "sevcritical")
@@ -761,7 +768,8 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
         b.wait_not_present("#available-updates button#install-kpatches")
         b.click("#available-updates button#install-security")
-        b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+        with b.wait_timeout(60):
+            b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
 
         # history on restart page should show the three security updates
         b.click(".pf-c-expandable-section__toggle")
@@ -798,7 +806,8 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("#app div.pf-c-progress__bar")
 
         # should have succeeded and show restart
-        b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+        with b.wait_timeout(60):
+            b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
         b.wait_visible("#ignore")
 
         # history on restart page should show the three non-security updates
@@ -851,7 +860,8 @@ ExecStart=/usr/local/bin/{packageName}
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         b.wait_in_text("#status", "1 security fix available")
 
         # should only have one button (only security updates)
@@ -866,7 +876,8 @@ ExecStart=/usr/local/bin/{packageName}
             self.enableRepo()
             # check for updates
             b.click("#status .pf-c-card__header button")
-            b.wait_visible("#available-updates")
+            with b.wait_timeout(30):
+                b.wait_visible("#available-updates")
             b.wait_in_text("#status", "2")
 
             b.wait_in_text("table[aria-label='Available updates']", "secnocve")
@@ -902,7 +913,8 @@ ExecStart=/usr/local/bin/{packageName}
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_in_text("table[aria-label='Available updates']", "Things change")
+        with b.wait_timeout(30):
+            b.wait_in_text("table[aria-label='Available updates']", "Things change")
 
         # "coarse" package list should be complete
         t = b.text("#app .ct-table tbody:nth-of-type(1) tr:first-child [data-label=Name]")
@@ -958,7 +970,8 @@ ExecStart=/usr/local/bin/{packageName}
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         b.wait_in_text("#status", "1 update available")
 
         b.click("#available-updates button#install-all")
@@ -996,7 +1009,8 @@ ExecStart=/usr/local/bin/{packageName}
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.click("#available-updates button#install-all")
+        with b.wait_timeout(30):
+            b.click("#available-updates button#install-all")
 
         # let updates start and zap PackageKit
         b.wait_visible("#app div.pf-c-progress__bar")
@@ -1057,7 +1071,8 @@ ExecStart=/usr/local/bin/{packageName}
 
         # getting update info is allowed to all users
         self.login_and_go("/updates", superuser=False)
-        b.wait_in_text("#status", "1 update available")
+        with b.wait_timeout(30):
+            b.wait_in_text("#status", "1 update available")
         b.wait_visible("#available-updates")
 
         # but applying updates is not; FIXME: this is a crappy UX
@@ -1073,7 +1088,8 @@ ExecStart=/usr/local/bin/{packageName}
         # applying updates works now
         b.click("#available-updates button#install-all")
 
-        b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+        with b.wait_timeout(60):
+            b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
         b.click("#ignore")
 
         # should go back to updates overview, nothing pending any more
@@ -1106,7 +1122,8 @@ class TestWsUpdate(NoSubManCase):
         m.start_cockpit()
         b.login_and_go("/updates")
 
-        b.click("#available-updates button#install-all")
+        with b.wait_timeout(30):
+            b.click("#available-updates button#install-all")
 
         # applying updates panel present
         b.wait_in_text("#app div.progress-description", "slow")
@@ -1133,7 +1150,8 @@ class TestWsUpdate(NoSubManCase):
         self.enableRepo()
         b.click("#status .pf-c-card__header button")
 
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         b.wait_in_text("#status", "2 updates available")
         b.wait_in_text("table[aria-label='Available updates']", "cockpit-ws")
 
@@ -1153,7 +1171,8 @@ class TestKpatchInstall(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#status")
+        with b.wait_timeout(30):
+            b.wait_visible("#status")
         b.wait_in_text("#kpatch-settings", "Not available")
         # show unavailable packages in popover
         b.click("#kpatch-settings .ct-info-circle")
@@ -1232,7 +1251,8 @@ class TestUpdatesSubscriptions(PackageCase):
         m.start_cockpit()
         b.login_and_go("/system")
         # show unregistered status on system front page
-        b.wait_in_text(self.update_text, "Not registered")
+        with b.wait_timeout(30):
+            b.wait_in_text(self.update_text, "Not registered")
         self.assertIn("triangle", b.attr(self.update_icon, "class"))
 
         # software updates page also shows unregistered
@@ -1274,7 +1294,8 @@ class TestUpdatesSubscriptions(PackageCase):
 
         b.login_and_go("/system")
         # by default our rhel-* images are not registered; show warning on system page
-        b.wait_in_text(self.update_text, "Not registered")
+        with b.wait_timeout(30):
+            b.wait_in_text(self.update_text, "Not registered")
         self.assertIn("triangle", b.attr(self.update_icon, "class"))
         # should be a link leading to subscriptions page
         b.click(self.update_text_action)
@@ -1293,7 +1314,8 @@ class TestUpdatesSubscriptions(PackageCase):
         b.go("/updates")
         b.enter_page("/updates")
         b.wait_not_present(".pf-c-empty-state")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
         # no update history yet
         self.assertFalse(b.is_present("table.updates-history"))
 
@@ -1318,7 +1340,8 @@ class TestUpdatesSubscriptions(PackageCase):
 
         m.start_cockpit()
         b.login_and_go("/system")
-        b.wait_text(self.update_text, "System is up to date")
+        with b.wait_timeout(30):
+            b.wait_text(self.update_text, "System is up to date")
 
         b.go("/updates")
         b.enter_page("/updates")
@@ -1338,7 +1361,8 @@ class TestAutoUpdates(NoSubManCase):
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")
-        browser.wait_not_present("#automatic-updates-dialog")
+        with browser.wait_timeout(30):
+            browser.wait_not_present("#automatic-updates-dialog")
 
     def testBasic(self):
         b = self.browser
@@ -1346,7 +1370,8 @@ class TestAutoUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#status")
+        with b.wait_timeout(30):
+            b.wait_visible("#status")
 
         if not self.supported_backend:
             self.assertFalse(b.is_present("#automatic"))
@@ -1452,7 +1477,8 @@ class TestAutoUpdates(NoSubManCase):
         # page should parse it correctly from the timer
         b.logout()
         b.login_and_go("/updates")
-        b.wait_in_text("#autoupdates-settings", "Updates will be applied every Thursday at 21:00")
+        with b.wait_timeout(30):
+            b.wait_in_text("#autoupdates-settings", "Updates will be applied every Thursday at 21:00")
 
         # change back to daily
         b.click("#autoupdates-settings button:contains('Edit')")
@@ -1522,7 +1548,8 @@ class TestAutoUpdates(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
 
         if not self.supported_backend:
             return
@@ -1554,7 +1581,8 @@ class TestAutoUpdates(NoSubManCase):
             return
 
         # detecting auto updates configuration works unprivileged, but changing does not
-        b.wait_visible("#autoupdates-settings button:disabled")
+        with b.wait_timeout(30):
+            b.wait_visible("#autoupdates-settings button:disabled")
 
         # become superuser, enable auto-updates
         b.become_superuser()
@@ -1615,12 +1643,14 @@ class TestAutoUpdatesInstall(NoSubManCase):
 
         m.start_cockpit()
         b.login_and_go("/updates")
-        b.wait_visible("#available-updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
 
         # apply updates
         b.click("#available-updates button#install-all")
         # wait until installation is finished
-        b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
+        with b.wait_timeout(60):
+            b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
         b.click("#ignore")
 
         if self.backend == 'dnf':
@@ -1664,7 +1694,8 @@ WantedBy=basic.target
         b.login_and_go('/updates')
 
         # click through install dialog
-        b.wait_in_text("#autoupdates-settings", "Not set up")
+        with b.wait_timeout(30):
+            b.wait_in_text("#autoupdates-settings", "Not set up")
         b.wait_not_present("#settings .pf-c-alert")
         b.click("#autoupdates-settings button:contains('Enable')")
         b.wait_popup('dialog')

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1336,6 +1336,10 @@ class TestAutoUpdates(NoSubManCase):
         self.supported_backend = self.backend in ["dnf"]
         self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
 
+    def closeSettings(self, browser):
+        browser.click("#automatic-updates-dialog button:contains('Save changes')")
+        browser.wait_not_present("#automatic-updates-dialog")
+
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -1403,7 +1407,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#all-updates")
         b.wait_val("#auto-update-time-input", "06:00")
         b.wait_in_text("#auto-update-day", "every day")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
         assertTimer("06")
         assertType("all")
@@ -1412,7 +1416,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.click("#security-updates")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Security updates will be applied every day at 06:00")
         assertType("security")
         assertTimer("06")
@@ -1421,7 +1425,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.click("#all-updates")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
         assertType("all")
         assertTimer("06")
@@ -1430,7 +1434,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.select_from_dropdown("#auto-update-day", "thu")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every Thursday at 06:00")
         assertType("all")
         assertTimer("06", "Thu")
@@ -1439,7 +1443,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.set_input_text("#auto-update-time-input", "21:00")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every Thursday at 21:00")
         assertType("all")
         assertTimer("21", "Thu")
@@ -1453,7 +1457,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.select_from_dropdown("#auto-update-day", "everyday")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 21:00")
         assertType("all")
         assertTimer("21")
@@ -1462,7 +1466,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.click("#no-updates")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Disabled")
         assertTimer(None)
 
@@ -1470,8 +1474,7 @@ class TestAutoUpdates(NoSubManCase):
             b.click("#autoupdates-settings button:contains('Edit')")
             b.wait_visible("#automatic-updates-dialog")
             b.click("#all-updates")
-            b.click("#automatic-updates-dialog button:contains('Save changes')")
-            b.wait_not_present("#automatic-updates-dialog")
+            self.closeSettings(b)
             # OnCalendar= parsing: only time
             m.execute("mkdir -p /etc/systemd/system/dnf-automatic.timer.d")
             m.execute(r'printf "[Timer]\nOnUnitInactiveSec=\nOnCalendar=08:00\n" > '
@@ -1529,7 +1532,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.click("#all-updates")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
 
         if self.backend == 'dnf':
@@ -1558,7 +1561,7 @@ class TestAutoUpdates(NoSubManCase):
         b.click("#autoupdates-settings button:contains('Edit')")
         b.wait_visible("#automatic-updates-dialog")
         b.click("#all-updates")
-        b.click("#automatic-updates-dialog button:contains('Save changes')")
+        self.closeSettings(b)
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
 
         # without superuser, auto-update status still visible, but disabled

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -109,7 +109,9 @@ OnCalendar=daily
         b.enter_page("/system/services")
         b.reload()
         b.enter_page("/system/services")
-        b.wait_text(".service-name", "Test Service")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.wait_text(".service-name", "Test Service")
         b.switch_to_top()
         self.checkDocs(["Managing services"])
         b.click("#toggle-docs")
@@ -125,7 +127,9 @@ OnCalendar=daily
 
         m.restart_cockpit()
         b.relogin("/system/services")
-        b.wait_text(".service-name", "Test Service")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.wait_text(".service-name", "Test Service")
 
         # check that navigating away and back preserves place
         b.click_system_menu("/system")
@@ -668,11 +672,13 @@ OnCalendar=daily
 
         meminfo = read_mem_info(m)
         mem_avail = meminfo['MemAvailable']
-        b.wait_js_func("ph_plot_data_plateau", "direct", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
+        with b.wait_timeout(60):
+            b.wait_js_func("ph_plot_data_plateau", "direct", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
         meminfo = read_mem_info(m)
         mem_avail = meminfo['MemAvailable']
-        b.wait_js_func("ph_plot_data_plateau", "pmcd", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
+        with b.wait_timeout(60):
+            b.wait_js_func("ph_plot_data_plateau", "pmcd", mem_avail * 0.85, mem_avail * 1.15, 15, "mem")
 
     def testPageStatus(self):
         b = self.browser

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -84,7 +84,8 @@ class TestSelinux(MachineCase):
         # Starting Cockpit might produce some alerts (e.g. from
         # starting rhsm.service), so let's give them some time to
         # appear before cleaning it all out.
-        b.wait_js_cond("ph_in_text('body', 'No SELinux alerts.') || ph_is_present('tbody .pf-c-table__toggle')")
+        with b.wait_timeout(60):
+            b.wait_js_cond("ph_in_text('body', 'No SELinux alerts.') || ph_is_present('tbody .pf-c-table__toggle')")
         time.sleep(30)
 
         dismiss_sel = ".selinux-alert-dismiss"
@@ -118,7 +119,8 @@ class TestSelinux(MachineCase):
         row_selector = "tbody:contains('ls from read access on the directory')"
 
         # wait for the alert to appear
-        b.wait_visible(row_selector)
+        with b.wait_timeout(60):
+            b.wait_visible(row_selector)
 
         # expand it to see details
         toggle_selector = row_selector + " .pf-c-table__toggle button"
@@ -163,7 +165,8 @@ class TestSelinux(MachineCase):
         row_selector = "tbody:contains('read access on the file /root/.ssh/authorized_keys')"
 
         # wait for the alert to appear
-        b.wait_visible(row_selector)
+        with b.wait_timeout(60):
+            b.wait_visible(row_selector)
 
         # expand it to see details
         toggle_selector = row_selector + " .pf-c-table__toggle button"
@@ -240,7 +243,8 @@ class TestSelinux(MachineCase):
         m.execute("semanage boolean --modify --off zebra_write_config")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_visible(".pf-c-data-list__cell:contains(Disallow zebra)")
+        with b.wait_timeout(30):
+            b.wait_visible(".pf-c-data-list__cell:contains(Disallow zebra)")
         b.click("button:contains('View automation script')")
         b.click("button:contains('Ansible')")
         ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
@@ -272,7 +276,8 @@ class TestSelinux(MachineCase):
         b.enter_page("/selinux/setroubleshoot")
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
-        b.wait_text("ul[aria-label='System modifications']", "No system modifications")
+        with b.wait_timeout(30):
+            b.wait_text("ul[aria-label='System modifications']", "No system modifications")
         b.relogin("/selinux/setroubleshoot", "admin", superuser=False)
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 
@@ -288,7 +293,9 @@ class TestSelinux(MachineCase):
         b.wait_in_text("body", "SELinux policy")
 
         def assertEnforce(active):
-            b.wait_visible(".pf-c-switch__input" + (active and ":checked" or ":not(:checked)"))
+            # polled every 10s
+            with b.wait_timeout(20):
+                b.wait_visible(".pf-c-switch__input" + (active and ":checked" or ":not(:checked)"))
 
         # SELinux should be enabled and enforcing at the beginning
         assertEnforce(True)

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -72,7 +72,8 @@ class HostSwitcherHelpers:
         if not known_host:
             b.wait_in_text('#hosts_setup_server_dialog', f"You are connecting to {address} for the first time")
             b.click('#hosts_setup_server_dialog .pf-m-primary')
-        b.wait_not_present('#hosts_setup_server_dialog')
+        with b.wait_timeout(30):
+            b.wait_not_present('#hosts_setup_server_dialog')
 
     def connect_and_wait(self, b, address):
         b.click(f"a[href='/@{address}']")
@@ -404,7 +405,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
             enter()
 
         b.click('#hosts_setup_server_dialog .pf-m-primary')
-        b.wait_not_present('#hosts_setup_server_dialog')
+        with b.wait_timeout(30):
+            b.wait_not_present('#hosts_setup_server_dialog')
 
         b.wait_text(".nav-item a[href='/@10.111.113.3']", "franz @machine3")
 
@@ -429,7 +431,8 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click('#hosts_setup_server_dialog .pf-m-primary')
         b.wait_in_text('#hosts_setup_server_dialog', "You are connecting to 10.111.113.2 for the first time.")
         b.click('#hosts_setup_server_dialog .pf-m-primary')
-        b.wait_not_present('#hosts_setup_server_dialog')
+        with b.wait_timeout(30):
+            b.wait_not_present('#hosts_setup_server_dialog')
 
         b.wait_text("#hosts-sel button .pf-c-select__toggle-text", "admin@machine2")
 

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -184,10 +184,12 @@ class TestMultiMachineAdd(MachineCase):
         b.click("#hosts-sel button")
 
         kill_user_admin(m2)
-        b.wait_visible("#machine2-error")
+        with b.wait_timeout(30):
+            b.wait_visible("#machine2-error")
 
         kill_user_admin(m3)
-        b.wait_visible("#machine3-error")
+        with b.wait_timeout(30):
+            b.wait_visible("#machine3-error")
 
         # Navigating reconnects
         b.click("a[href='/@10.111.113.2']")
@@ -495,7 +497,8 @@ class TestMultiMachine(MachineCase):
         m2.execute('passwd -l admin')
         kill_user_admin(m2)
 
-        b.wait_text(".curtains-ct h1", "Not connected to host")
+        with b.wait_timeout(30):
+            b.wait_text(".curtains-ct h1", "Not connected to host")
         b.wait_text("#machine-reconnect", "Reconnect")
 
         b.click("#hosts-sel button")
@@ -508,7 +511,8 @@ class TestMultiMachine(MachineCase):
 
         # navigating there again will fail
         b.go(m2_path)
-        b.wait_text(".curtains-ct h1", "Not connected to host")
+        with b.wait_timeout(30):
+            b.wait_text(".curtains-ct h1", "Not connected to host")
         b.wait_text("#machine-troubleshoot", "Log in")
 
         # wait for system to load
@@ -523,7 +527,8 @@ class TestMultiMachine(MachineCase):
         # path should reconnect at this point
         b.reload()
         b.go(m2_path)
-        b.wait_text(".curtains-ct h1", "Not connected to host")
+        with b.wait_timeout(30):
+            b.wait_text(".curtains-ct h1", "Not connected to host")
         b.click("#machine-troubleshoot")
         b.wait_visible('#hosts_setup_server_dialog')
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
@@ -543,7 +548,8 @@ class TestMultiMachine(MachineCase):
 
         # Bad host also bounces
         b.go("/@10.0.0.0/playground/test")
-        b.wait_text(".curtains-ct h1", "Not connected to host")
+        with b.wait_timeout(30):
+            b.wait_text(".curtains-ct h1", "Not connected to host")
         self.assertEqual(b.text(".curtains-ct .pf-c-empty-state__body"), "Cannot connect to an unknown host")
 
         self.allow_hostkey_messages()
@@ -786,7 +792,8 @@ class TestMultiMachine(MachineCase):
             b.set_input_text('#hosts_setup_server_dialog #login-setup-new-key-password', "foobar")
             b.set_input_text('#hosts_setup_server_dialog #login-setup-new-key-password2', "foobar")
         b.click('#hosts_setup_server_dialog button:contains(Log in)')
-        b.wait_not_present('#hosts_setup_server_dialog')
+        with b.wait_timeout(30):
+            b.wait_not_present('#hosts_setup_server_dialog')
 
         b.enter_page("/system", host="fred@10.111.113.2")
         m1.execute("test -f /home/admin/.ssh/id_rsa && test -f /home/admin/.ssh/id_rsa.pub")

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -56,7 +56,8 @@ only-plugins=release,date,host,cgroups,networking
         b.wait_visible("#sos-dialog")
 
         b.wait(lambda: b.eval_js('ph_find("#sos-progress .pf-c-progress__bar").offsetWidth') > 0)
-        b.wait_visible("#sos-download")
+        with b.wait_timeout(60):
+            b.wait_visible("#sos-download")
 
         if b.cdp.browser.name == "chromium":
             b.cdp.invoke("Page.setDownloadBehavior", behavior="allow", downloadPath=b.cdp.download_dir)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -726,7 +726,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
 
         # root login works by default
-        self.login_and_go(user="root")
+        self.login_and_go("/system", user="root")
+        b.wait_visible('.system-information')
         b.logout()
 
         # disable root login with pam_access

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -109,7 +109,8 @@ class TestStorageFormat(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val("mount_point", "/foo")
         self.dialog_apply()
-        b.wait_in_text("footer", "Creating filesystem on /dev/mapper/superslow")
+        with b.wait_timeout(60):
+            b.wait_in_text("footer", "Creating filesystem on /dev/mapper/superslow")
         self.dialog_cancel()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 2, "Unrecognized data")
@@ -119,7 +120,8 @@ class TestStorageFormat(StorageCase):
         self.dialog_set_val("erase.on", True)
         self.dialog_set_val("mount_point", "/foo")
         self.dialog_apply()
-        b.wait_in_text("footer", "Erasing /dev/mapper/superslow")
+        with b.wait_timeout(60):
+            b.wait_in_text("footer", "Erasing /dev/mapper/superslow")
         self.dialog_cancel()
         self.dialog_wait_close()
         self.content_row_wait_in_col(1, 2, "Unrecognized data")

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -34,7 +34,8 @@ class TestStorageIgnored(StorageCase):
         b.wait_in_text("#drives", disk)
 
         m.execute(f"yes | mke2fs -q -L TEST {disk}")
-        b.wait_in_text("#mounts", disk)
+        with b.wait_timeout(30):
+            b.wait_in_text("#mounts", disk)
 
         # Hide it via a udev rule
         m.execute("mkdir -p /run/udev/rules.d")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -352,7 +352,8 @@ class TestStorageLuks(StorageCase):
         # delete with passphrase from slot 0
         b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja")
         b.click("button:contains('Remove')")
-        b.wait_not_present("#remove-passphrase")
+        with b.wait_timeout(30):
+            b.wait_not_present("#remove-passphrase")
         # check that it is not possible to unlock with deleted passphrase
         self.content_dropdown_action(1, "Unmount")
         self.confirm()
@@ -390,7 +391,8 @@ class TestStorageLuks(StorageCase):
         b.click(slots_list + "li:last-child button[aria-label=Remove]")
         b.set_input_text("#remove-passphrase", "vainu-reku-toma-rolle-kaja-6")
         b.click("button:contains('Remove')")
-        b.wait_not_present("#remove-passphrase")
+        with b.wait_timeout(30):
+            b.wait_not_present("#remove-passphrase")
         # check if buttons have become enabled after removing last slot
         b.wait_not_present(slots_list + ":disabled")
         b.wait_not_present(panel + ":disabled")
@@ -398,32 +400,33 @@ class TestStorageLuks(StorageCase):
         b.click(slots_list + "li:nth-child(1) button[aria-label=Remove]")
         b.click("#force-remove-passphrase")
         b.click("button:contains('Remove')")
-        b.wait_not_present("#remove-passphrase")
-        # check that it is not possible to unlock with deleted passphrase
-        self.content_row_action(1, "Mount")
-        self.dialog_wait_open()
-        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
-        self.dialog_apply()
-        b.wait_visible(".pf-c-alert")
-        self.assertIn(b.text("h4.pf-c-alert__title:not(span)").split("Danger alert:", 1).pop(), error_messages)
-        self.dialog_cancel()
-        # change one of the passphrases
-        b.wait_visible(slots_list + "li:last-child [aria-label=Edit]")
-        b.click(slots_list + "li:last-child [aria-label=Edit]")
-        self.dialog_wait_open()
-        self.dialog_wait_apply_enabled()
-        self.dialog_set_val("old_passphrase", "vainu-reku-toma-rolle-kaja-6")
-        self.dialog_set_val("new_passphrase", "vainu-reku-toma-rolle-kaja-8")
-        self.dialog_set_val("new_passphrase2", "vainu-reku-toma-rolle-kaja-8")
-        self.dialog_apply()
-        self.dialog_wait_close()
-        # unlock volume with the newly created passphrase
-        self.content_row_action(1, "Mount")
-        self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
-        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.wait_mounted(1, 1)
-        self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
-        self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
+        with b.wait_timeout(30):
+            b.wait_not_present("#remove-passphrase")
+            # check that it is not possible to unlock with deleted passphrase
+            self.content_row_action(1, "Mount")
+            self.dialog_wait_open()
+            self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+            self.dialog_apply()
+            b.wait_visible(".pf-c-alert")
+            self.assertIn(b.text("h4.pf-c-alert__title:not(span)").split("Danger alert:", 1).pop(), error_messages)
+            self.dialog_cancel()
+            # change one of the passphrases
+            b.wait_visible(slots_list + "li:last-child [aria-label=Edit]")
+            b.click(slots_list + "li:last-child [aria-label=Edit]")
+            self.dialog_wait_open()
+            self.dialog_wait_apply_enabled()
+            self.dialog_set_val("old_passphrase", "vainu-reku-toma-rolle-kaja-6")
+            self.dialog_set_val("new_passphrase", "vainu-reku-toma-rolle-kaja-8")
+            self.dialog_set_val("new_passphrase2", "vainu-reku-toma-rolle-kaja-8")
+            self.dialog_apply()
+            self.dialog_wait_close()
+            # unlock volume with the newly created passphrase
+            self.content_row_action(1, "Mount")
+            self.dialog({"passphrase": "vainu-reku-toma-rolle-kaja-8"})
+            self.content_row_wait_in_col(1, 2, "ext4 filesystem")
+            self.wait_mounted(1, 1)
+            self.wait_not_in_configuration(dev, "crypttab", "options", "noauto")
+            self.wait_not_in_configuration(cleartext_dev, "fstab", "opts", "noauto")
 
     def testNoFsys(self):
         m = self.machine

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -171,10 +171,11 @@ class TestStorageMdRaid(StorageCase):
         wait_degraded_state(False)
 
         # Turn it off and on again
-        self.raid_default_action("Stop")
-        b.wait_in_text(info_field("State"), "Not running")
-        self.raid_default_action("Start")
-        b.wait_in_text(info_field("State"), "Running")
+        with b.wait_timeout(30):
+            self.raid_default_action("Stop")
+            b.wait_in_text(info_field("State"), "Not running")
+            self.raid_default_action("Start")
+            b.wait_in_text(info_field("State"), "Running")
 
         # Stopping and starting the array will create the expected
         # symlink in /dev/md/.
@@ -282,6 +283,9 @@ class TestStorageMdRaid(StorageCase):
 
         self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "In sync",
                           "QEMU QEMU HARDDISK (DISK2)": "In sync"})
+
+        # event processing is a bit slow for these
+        b.wait_timeout(60)
 
         # All buttons should be disabled when the array is stopped
 

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -84,7 +84,8 @@ class TestStorageResize(StorageCase):
             if grow_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
-            self.wait_mounted(fsys_row, fsys_tab)
+            with b.wait_timeout(30):
+                self.wait_mounted(fsys_row, fsys_tab)
             size = int(m.execute("df -k --output=size /run/foo | tail -1").strip())
             self.assertGreater(size, 300000)
         else:

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -31,9 +31,10 @@ class TestStorageScaling(StorageCase):
         m.execute("modprobe scsi_debug num_tgts=200")
 
         self.login_and_go("/storage")
-        b.click("#drives button:contains(Show all 202 drives)")
-        b.wait_not_in_text("#drives", "Show all")
-        b.wait_js_cond('ph_select("#drives .sidepanel-row").length == 202')
+        with b.wait_timeout(60):
+            b.click("#drives button:contains(Show all 202 drives)")
+            b.wait_not_in_text("#drives", "Show all")
+            b.wait_js_cond('ph_select("#drives .sidepanel-row").length == 202')
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -399,7 +399,8 @@ class TestStoragePackagesStratis(PackageCase, StorageCase):
         self.devices_dropdown("Create Stratis pool")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "The fake-stratisd package must be installed")
-        self.dialog_apply()
+        with b.wait_timeout(60):
+            self.dialog_apply()
         self.dialog_wait_val("name", "pool0")
         self.dialog_set_val("disks", {dev_1: True})
         self.dialog_apply()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -163,7 +163,9 @@ class CommonTests:
 
         # log in as domain admin and check that we can do privileged operations
         b.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user=f'{self.admin_user}@cockpit.lan', password=self.admin_password)
-        b.wait_in_text("#statuses", "Running")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(60):
+            b.wait_in_text("#statuses", "Running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
@@ -176,7 +178,9 @@ class CommonTests:
         b.login_and_go('/system', user=f'{self.admin_user.lower()}@COCKPIT.LAN', password=self.admin_password)
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
-        b.wait_in_text("#statuses", "Not running")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(60):
+            b.wait_in_text("#statuses", "Not running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")
@@ -205,7 +209,8 @@ class CommonTests:
         b.assert_pixels("#realms-leave-dialog", "realm-leave", [".pf-c-expandable-section__toggle-icon"])
         b.click("#realms-op-leave")
 
-        b.wait_not_present("#realms-leave-dialog")
+        with b.wait_timeout(30):
+            b.wait_not_present("#realms-leave-dialog")
         wait_number_domains(0)
         # re-enables hostname changing
         b.wait_visible("#system_information_hostname_button:not([disabled])")
@@ -226,7 +231,8 @@ class CommonTests:
             b.wait_val(self.op_admin, self.admin_user)
             b.set_input_text(self.op_admin_password, "foo")
             b.click(f"#realms-join-dialog button{self.primary_btn_class}")
-            b.wait_text_not(".realms-op-error", "")
+            with b.wait_timeout(60):
+                b.wait_text_not(".realms-op-error", "")
             error = b.text(".realms-op-error")
             if "Already running another action" not in error:
                 # "More" link is part of the message component, so this looks a little funny here
@@ -259,7 +265,8 @@ class CommonTests:
         # wait for auto-detection
         set_address()
         b.set_input_text(self.op_address, "NOPE")
-        b.wait_text("#realms-op-address-helper", "Domain could not be contacted")
+        with b.wait_timeout(30):
+            b.wait_text("#realms-op-address-helper", "Domain could not be contacted")
         b.wait_visible(f"#realms-join-dialog button{self.primary_btn_class}:disabled")
         b.click("#realms-join-dialog button.pf-m-link")
         b.wait_not_present("#realms-join-dialog")
@@ -311,13 +318,16 @@ class CommonTests:
         b.wait_text("#realms-op-info-server-sw", self.expected_server_software)
         b.wait_text("#realms-op-info-client-sw", "sssd")
         b.click(f"#realms-leave-dialog button{self.default_btn_class}")
-        b.wait_not_present("#realms-leave-dialog")
+        with b.wait_timeout(30):
+            b.wait_not_present("#realms-leave-dialog")
 
         # should be able to run admin operations
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
 
-        b.wait_in_text("#statuses", "Running")
+        # FIXME: Services page is too slow
+        with b.wait_timeout(30):
+            b.wait_in_text("#statuses", "Running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
@@ -1186,7 +1196,8 @@ class TestPackageInstall(packagelib.PackageCase):
         self.waitTooltip("requires installation of realmd")
 
         b.click(self.domain_sel)
-        b.wait_in_text(".pf-c-modal-box:contains('Install software')", "realmd is not available")
+        with b.wait_timeout(30):
+            b.wait_in_text(".pf-c-modal-box:contains('Install software')", "realmd is not available")
         b.wait_visible(".pf-c-modal-box:contains('Install software') .pf-c-modal-box__footer button:contains(Install):disabled")
         b.click(".pf-c-modal-box:contains('Install software') .pf-c-modal-box__footer button.cancel")
         b.wait_not_present(".pf-c-modal-box:contains('Install software')")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -43,6 +43,9 @@ class TestServices(MachineCase):
         self.restore_dir("/etc/systemd/user", user_post_restore, True)
         self.restore_dir("/etc/xdg/systemd/user", user_post_restore, True)
 
+        # FIXME: this page is too slow
+        self.browser.wait_timeout(60)
+
     def run_systemctl(self, user, cmd):
         if user:
             self.machine.execute(f"su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user {cmd}'")
@@ -517,8 +520,9 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             self.assertGreater(initial_memory, 0.5)
             m.execute(f"touch /tmp/continue{params}")
             self.addCleanup(m.execute, f"rm /tmp/continue{params}")
-            # MemoryCurrent auto-updates every 30s - default timeout is 60s - when it updates the memory used should be ~50MiB
-            b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)
+            # MemoryCurrent auto-updates every 30s - when it updates the memory used should be ~50MiB
+            with b.wait_timeout(60):
+                b.wait(lambda: float(b.text("#memory .pf-c-description-list__text").split(" ")[0]) > 40)
             self.run_systemctl(user, "stop mem-hog.service")
             b.wait_not_present("#memory")
         # Check that listen is not shown for .service units
@@ -1013,6 +1017,9 @@ class TestTimers(MachineCase):
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
         m.reboot()
+
+        # FIXME: this page is too slow
+        b.wait_timeout(30)
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -71,7 +71,8 @@ class TestShutdownRestart(MachineCase):
         # Add machine with static IP to m2
         b2.switch_to_top()
         b2.go("/@10.111.113.1")
-        b2.wait_visible("#machine-troubleshoot")
+        with b2.wait_timeout(30):
+            b2.wait_visible("#machine-troubleshoot")
         b2.click('#machine-troubleshoot')
         b2.wait_visible('#hosts_setup_server_dialog')
         b2.wait_text(f'#hosts_setup_server_dialog {self.primary_btn_class}', "Add")
@@ -102,7 +103,8 @@ class TestShutdownRestart(MachineCase):
 
         m.wait_reboot()
 
-        b2.wait_visible("#machine-troubleshoot")
+        with b2.wait_timeout(30):
+            b2.wait_visible("#machine-troubleshoot")
         b2.click('#machine-troubleshoot')
         b2.wait_visible('#hosts_setup_server_dialog')
         b2.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -36,7 +36,8 @@ class TestAccounts(MachineCase):
         # Add a user externally
         m.execute("useradd anton")
         m.execute("echo anton:foobar | chpasswd")
-        b.wait_in_text('#accounts-list', "anton")
+        with b.wait_timeout(30):
+            b.wait_in_text('#accounts-list', "anton")
 
         # There is only one badge and it is for admin
         b.wait_text('.cockpit-account-badge', 'Your account')

--- a/test/verify/netlib.py
+++ b/test/verify/netlib.py
@@ -155,7 +155,8 @@ class NetworkCase(MachineCase, NetworkHelpers):
             text = "Inactive"
 
         try:
-            self.browser.wait_in_text(sel, text)
+            with self.browser.wait_timeout(20):
+                self.browser.wait_in_text(sel, text)
         except Error as e:
             print(f"Interface {iface} didn't show up.")
             print(self.machine.execute(f"grep . /sys/class/net/*/address; nmcli con; nmcli dev; nmcli dev show {iface} || true"))

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -327,7 +327,9 @@ class StorageHelpers:
         self.browser.click('#dialog button.cancel')
 
     def dialog_wait_close(self):
-        self.browser.wait_not_present('#dialog')
+        # file system operations often take longer than 10s
+        with self.browser.wait_timeout(60):
+            self.browser.wait_not_present('#dialog')
 
     def dialog_check(self, expect):
         for f in expect:
@@ -509,8 +511,9 @@ class StorageHelpers:
         self.browser.wait(lambda: text in self.lvol_child_configuration_field(lvol, tab, field))
 
     def wait_mounted(self, row, col):
-        self.content_tab_wait_in_info(row, col, "Mount point",
-                                      cond=lambda cell: "The filesystem is not mounted" not in self.browser.text(cell))
+        with self.browser.wait_timeout(30):
+            self.content_tab_wait_in_info(row, col, "Mount point",
+                                          cond=lambda cell: "The filesystem is not mounted" not in self.browser.text(cell))
 
     def setup_systemd_password_agent(self, password):
         # This sets up a systemd password agent that replies to all


### PR DESCRIPTION
One full minute is way too long for our UI to react for our UI
standards. In general, our UI should react very fast even on loaded CI
machines. The main exception are waiting for OS APIs that genuinely take
a lot of time (such as formatting a drive or joining a FreeIPA domain),
but these should (and often already do) have an explicit wait_timeout().

This also makes development of tests less annoying, and speeds up
known-failing tests (with naughty matching).

Lower the default timeout to 15s, drop the redundant low timeout in
TestConnection, and add explicit timeouts for legitimately long-running
steps. This makes it easy for us to grep the tests for things that are
slow, and worth looking into.

The biggest offender is the Services page, which is known to be dog
slow. Until we fix this properly, liberally and widely sprinkle
increased timeouts over the tests.