### PR TITLE
systemd: Parse /proc/cpuinfo on s390x

### DIFF
--- a/pkg/lib/machine-info.js
+++ b/pkg/lib/machine-info.js
@@ -42,11 +42,13 @@ export const cpu_ram_info = address =>
                 let model_match = text.match(/^model name\s*:\s*(.*)$/m);
                 if (!model_match)
                     model_match = text.match(/^cpu\s*:\s*(.*)$/m); // PowerPC
+                if (!model_match)
+                    model_match = text.match(/^vendor_id\s*:\s*(.*)$/m); // s390x
                 if (model_match)
                     info.cpu_model = model_match[1];
 
                 info.cpus = 0;
-                const re = /^processor\s*:/gm;
+                const re = /^(processor|cpu number)\s*:/gm;
                 while (re.test(text))
                     info.cpus += 1;
                 return info;

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -512,6 +512,36 @@ revision\t: 2.3 (pvr 004e 1203)
         b.enter_page("/system")
         b.wait_in_text("#system-usage-cpu-progress + td", "of 2 CPUs")
 
+        # /proc/cpuinfo on s390x (reduced)
+        m.write("/tmp/cpuinfo", """vendor_id       : IBM/S390
+# processors    : 2
+bogomips per cpu: 3241.00
+max thread id   : 0
+features	: esan3 zarch stfle msa ldisp eimm dfp edat etf3eh highgprs te vx vxd vxe gs vxe2 vxp sort dflt sie
+processor 0: version = FF,  identification = 2EB428,  machine = 8561
+processor 1: version = FF,  identification = 2EB428,  machine = 8561
+
+cpu number      : 0
+cpu cores       : 1
+version         : FF
+identification  : 2EB428
+machine         : 8561
+
+cpu number      : 1
+cpu cores       : 1
+version         : FF
+identification  : 2EB428
+machine         : 8561
+""")
+
+        b.reload()
+        b.enter_page("/system")
+        b.wait_in_text("#system-usage-cpu-progress + td", "of 2 CPUs")
+
+        b.go('/system/hwinfo')
+        b.enter_page('/system/hwinfo')
+        b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(1) dd', "2x IBM/S390")
+
         # umount mocked /sys/class/dmi/id
         m.execute("umount /sys/class/dmi/id")
         m.execute("udevadm trigger --verbose /sys/devices/virtual/dmi/id")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -507,10 +507,16 @@ revision\t: 2.3 (pvr 004e 1203)
         b.enter_page('/system/hwinfo')
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(2) .pf-c-description-list__group:nth-of-type(1) dd', "2x POWER9 (architected), altivec supported")
 
+        # correct CPU count on overview
+        b.go("/system")
+        b.enter_page("/system")
+        b.wait_in_text("#system-usage-cpu-progress + td", "of 2 CPUs")
+
         # umount mocked /sys/class/dmi/id
         m.execute("umount /sys/class/dmi/id")
         m.execute("udevadm trigger --verbose /sys/devices/virtual/dmi/id")
         b.reload()
+        b.go("/system/hwinfo")
         b.enter_page('/system/hwinfo')
 
         # Memory details should be shown from our mocked DMI information from systemd's test files.


### PR DESCRIPTION
On this architecture, cpuinfo does not start processor blocks with
`processor:`, but it looks quite different. It also does not have a
per-cpu name, just a "vendor_id" in the header. Adjust the parsing
accordingly.

Test this with a real-life cpuinfo from a bug report.

https://bugzilla.redhat.com/show_bug.cgi?id=2069500
https://bugzilla.redhat.com/show_bug.cgi?id=2069552