### PR TITLE
pkg/build: sort webpack packages by build time

### DIFF
--- a/pkg/build
+++ b/pkg/build
@@ -5,28 +5,34 @@ srcdir ?= .
 AM_DEFAULT_VERBOSITY ?= 0
 NODE_ENV ?= production
 
+# Sorted by build time.  See webpack-benchmark rule below.
 WEBPACK_PACKAGES = \
-	base1 \
-	apps \
-	kdump \
-	metrics \
-	networkmanager \
-	packagekit \
-	playground \
-	selinux \
-	shell \
-	sosreport \
-	static \
 	storaged \
 	systemd \
-	tuned \
+	networkmanager \
+	base1 \
+	packagekit \
+	shell \
+	metrics \
+	playground \
 	users \
+	selinux \
+	kdump \
+	apps \
+	tuned \
+	sosreport \
+	static \
 	$(NULL)
 
 MANIFESTS = $(WEBPACK_PACKAGES:%=$(srcdir)/dist/%/manifest.json)
 
 .PHONY: all-webpack
 all-webpack: $(MANIFESTS)
+
+webpack-benchmark:
+	@hyperfine --export-markdown $@ --warmup 5 --prepare 'rm -rf dist' \
+		--parameter-list pkg "$$(echo '$(WEBPACK_PACKAGES)' | sed -E 's/\>\s+\</,/g;s/\s//g')" \
+		'pkg/build dist/{pkg}/manifest.json'
 
 V_TAR = $(V_TAR_$(V))
 V_TAR_ = $(V_TAR_$(AM_DEFAULT_VERBOSITY))


### PR DESCRIPTION
Add a rule to invoke hyperfine to measure the length of individual
webpack builds and write the output to a markdown file.

Use this output to sort the list of the packages by build time.  This
should allow better use of multiple CPUs when doing parallel builds.

I ran this over lunch and it produced the following:

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pkg/build dist/storaged/manifest.json` | 28.962 ± 0.253 | 28.651 | 29.432 | 7.49 ± 0.19 |
| `pkg/build dist/systemd/manifest.json` | 28.615 ± 0.257 | 28.276 | 29.175 | 7.40 ± 0.19 |
| `pkg/build dist/networkmanager/manifest.json` | 23.818 ± 0.400 | 23.411 | 24.821 | 6.16 ± 0.18 |
| `pkg/build dist/base1/manifest.json` | 21.686 ± 0.378 | 21.260 | 22.627 | 5.60 ± 0.16 |
| `pkg/build dist/packagekit/manifest.json` | 18.706 ± 0.147 | 18.395 | 18.894 | 4.83 ± 0.12 |
| `pkg/build dist/shell/manifest.json` | 17.591 ± 0.232 | 17.303 | 18.017 | 4.55 ± 0.12 |
| `pkg/build dist/metrics/manifest.json` | 16.702 ± 0.222 | 16.285 | 17.053 | 4.32 ± 0.12 |
| `pkg/build dist/playground/manifest.json` | 15.171 ± 0.184 | 14.849 | 15.428 | 3.92 ± 0.10 |
| `pkg/build dist/users/manifest.json` | 14.992 ± 0.205 | 14.745 | 15.416 | 3.87 ± 0.11 |
| `pkg/build dist/selinux/manifest.json` | 13.767 ± 0.219 | 13.433 | 14.104 | 3.56 ± 0.10 |
| `pkg/build dist/kdump/manifest.json` | 11.897 ± 0.182 | 11.512 | 12.134 | 3.07 ± 0.09 |
| `pkg/build dist/apps/manifest.json` | 11.739 ± 0.150 | 11.553 | 11.931 | 3.03 ± 0.08 |
| `pkg/build dist/tuned/manifest.json` | 10.064 ± 0.141 | 9.871 | 10.256 | 2.60 ± 0.07 |
| `pkg/build dist/sosreport/manifest.json` | 9.495 ± 0.175 | 9.254 | 9.801 | 2.45 ± 0.07 |
| `pkg/build dist/static/manifest.json` | 3.869 ± 0.092 | 3.731 | 3.992 | 1.00 |
