### PR TITLE
bridge: Default "init-superuser" to "none"

### DIFF
--- a/src/bridge/cockpitpeer.c
+++ b/src/bridge/cockpitpeer.c
@@ -319,7 +319,7 @@ on_other_control (CockpitTransport *transport,
 
               if (explicit_superuser_capability)
                 {
-                  const gchar *superuser = "any";
+                  const gchar *superuser = "none";
                   if (self->init_superuser && *self->init_superuser)
                     superuser = self->init_superuser;
 

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -403,6 +403,12 @@ class TestSuperuserDashboard(MachineCase):
 
         # The superuser indicator in the Shell should apply to machine2
 
+        b.check_superuser_indicator("Limited access")
+        b.open_superuser_dialog()
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input[type=password]", "foobar")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.check_superuser_indicator("Administrative access")
         b.go("/@10.111.113.2/playground/test")
         b.enter_page("/playground/test", host="10.111.113.2")
@@ -418,18 +424,6 @@ class TestSuperuserDashboard(MachineCase):
         b.enter_page("/playground/test", host="10.111.113.2")
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'access-denied')
-
-        b.leave_page()
-        b.open_superuser_dialog()
-        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
-        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
-        b.click(".pf-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
-        b.check_superuser_indicator("Administrative access")
-        b.enter_page("/playground/test", host="10.111.113.2")
-        b.click(".super-channel button")
-        b.wait_in_text(".super-channel span", 'result: ')
-        self.assertIn('result: uid=0', b.text(".super-channel span"))
 
         self.allow_hostkey_messages()
 

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -86,6 +86,7 @@ class TestShutdownRestart(MachineCase):
         b2.wait_text("#system_information_hostname_text", "machine1")
 
         # Check auto reconnect on reboot
+        b2.become_superuser()
         b2.click("#reboot-button")
         b2.wait_popup("shutdown-dialog")
         b2.wait_in_text(f"#shutdown-dialog button{self.danger_btn_class}", 'Reboot')


### PR DESCRIPTION
This makes SSH logins use the same default as HTTP logins.  Running
"sudo" without explicit request from the user is problematic.

Fixes #17169