### PR TITLE
test: add firefox-developer to firefox binaries

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -102,7 +102,7 @@ class Chromium(Browser):
 
 class Firefox(Browser):
     NAME = "firefox"
-    EXECUTABLES = ["firefox-nightly", "firefox"]
+    EXECUTABLES = ["firefox-developer-edition", "firefox-nightly", "firefox"]
     CDP_DRIVER_FILENAME = "firefox-cdp-driver.js"
 
     def _path(self, show_browser):


### PR DESCRIPTION
On Arch Linux there is a seperate package for the firefox developer
edition which can be installed alongside firefox. Add this as useable
firefox binary.