### PR TITLE
metrics: Consistent page title and Overview link

### DIFF
--- a/doc/guide/feature-pcp.xml
+++ b/doc/guide/feature-pcp.xml
@@ -7,7 +7,7 @@
   <para>If available, Cockpit uses the
     <ulink url="https://pcp.io/">Performance Co-Pilot</ulink> framework to
     gather metrics data about the system. This data is used to display the history
-    graphs on the "Performance Metrics" page.
+    graphs on the "Metrics and history" page.
     Cockpit can use the PCP logging feature to display archived data about the
     system from a different point in time. If PCP is not available, then Cockpit
     gathers the metrics data itself, but archival features are not available.</para>
@@ -15,7 +15,7 @@
   <para>Whether or not metrics are archived depends on whether the
     <ulink url="https://linux.die.net/man/1/pmlogger"><code>pmlogger.service</code></ulink>
     systemd unit is running or not. The "Enable PCP metrics collector" button on the
-    "Performance Metrics" page will enable and start this service.</para>
+    Metrics page will enable and start this service.</para>
 
   <para>To see similar metrics data from the command line, you can use tools like
     <ulink url="https://linux.die.net/man/1/pmstat"><code>pmstat</code></ulink>

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -17,7 +17,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
 -->
 <html lang="en">
 <head>
-    <title translate>Performance Metrics</title>
+    <title translate>Metrics and history</title>
     <meta charset="utf-8">
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1476,7 +1476,7 @@ export const Application = () => {
                 <FlexItem>
                     <Breadcrumb>
                         <BreadcrumbItem onClick={() => cockpit.jump("/system")} className="pf-c-breadcrumb__link">{_("Overview")}</BreadcrumbItem>
-                        <BreadcrumbItem isActive>{_("Performance Metrics")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{_("Metrics and history")}</BreadcrumbItem>
                     </Breadcrumb>
                 </FlexItem>
                 <FlexItem align={{ default: 'alignRight' }}>

--- a/pkg/systemd/overview-cards/usageCard.jsx
+++ b/pkg/systemd/overview-cards/usageCard.jsx
@@ -159,7 +159,7 @@ export class UsageCard extends React.Component {
                 </CardBody>
                 <CardFooter>
                     <Button isInline variant="link" component="a" onClick={ev => { ev.preventDefault(); cockpit.jump("/metrics", cockpit.transport.host) }}>
-                        {_("View details and history")}
+                        {_("View metrics and history")}
                     </Button>
                 </CardFooter>
             </Card>

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -105,7 +105,7 @@ def login(self):
                     });
                 });
             })"""))
-        self.browser.click("a:contains('View details and history')")
+        self.browser.click("a:contains('View metrics and history')")
         self.browser.enter_page("/metrics")
     else:
         self.login_and_go("/metrics")


### PR DESCRIPTION
We got a report about a confusing mental disconnection between the Usage
card's link ("View details and history") and the metrics page title
("Performance Metrics"). There is no overlap, and additionally
"Performance profile" on the Overview refers to tuned (which is
completely different).

Rename both to "metrics and history" for consistency, and avoiding the
"performance" overlap. Also move to sentence case for the breadcrumb, to
comply to [1] and be consistent with e.g. the "Kernel crash dump" page
tile.

[1] https://www.patternfly.org/v4/ux-writing/capitalization/#capitalization-across-patternfly

---

[pixel diff link](https://github.com/cockpit-project/pixel-test-reference/compare/fa3e8b66637ce0815d01915779b5906b98245f4d..54401adf76a823142cd2a1061fcb2d545342051b)