### PR TITLE
client: install metainfo file

### DIFF
--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -24,10 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build and install flatpak
-        run: sh -x containers/flatpak/install --user --install-deps-from=flathub
-
-      - name: Validate metainfo
-        run: appstream-util validate org.cockpit_project.CockpitClient.metainfo.xml
+        run: ELEMENT_TREE_NO_INDENT=1 sh -x containers/flatpak/install --user --install-deps-from=flathub
 
       - name: Smoke-test the installed flatpak
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ Makefile.in
 /dist/
 /frob-websocket
 /mock-*
-/org.cockpit_project.CockpitClient.*
+/org.cockpit_project.CockpitClient.yml
 /package-lock.json
 /socket-activation-helper
 /stamp-h1

--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ distdir: $(DISTFILES)
 
 dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball
+	$(srcdir)/src/client/add-metainfo-releases --version '$(VERSION)' '$(distdir)'/src/client/*.metainfo.xml
 	$(srcdir)/tools/create-spec --version '$(VERSION)' -o $(distdir)/tools/cockpit.spec $(srcdir)/tools/cockpit.spec.in
 	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/debian/changelog.in > $(distdir)/tools/debian/changelog
 	NODE_ENV=$(NODE_ENV) $(srcdir)/tools/build-debian-copyright > $(distdir)/tools/debian/copyright

--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -2,6 +2,7 @@ build-for-flatpak: cockpit-ws
 
 install-for-flatpak: \
 		install-cockpitwsPROGRAMS \
+		install-dist_client_metainfoDATA \
 		install-dist_defaultbrandingDATA \
 		install-dist_applicationsDATA \
 		install-dist_cockpitclientDATA \
@@ -10,6 +11,7 @@ install-for-flatpak: \
 		install-dist_scalableiconDATA \
 		install-dist_symboliciconDATA \
 		$(NULL)
+	appstream-util validate --nonet src/client/org.cockpit_project.CockpitClient.metainfo.xml
 	mkdir -p $(DESTDIR)/$(bindir)
 	ln -sfTv $(cockpitclientdir)/cockpit-client $(DESTDIR)/$(bindir)/cockpit-client
 	cp -rT dist/static $(pkgdatadir)/static

--- a/containers/flatpak/cockpit-client.yml.in
+++ b/containers/flatpak/cockpit-client.yml.in
@@ -26,13 +26,8 @@ modules:
     make-args:
       - build-for-flatpak
     install-rule: install-for-flatpak
-    post-install:
-      - install -Dt /app/share/metainfo ${FLATPAK_ID}.metainfo.xml
 
     sources:
       - type: archive
         @ARCHIVE_TYPE@: @ARCHIVE_LOCATION@
         sha256: @ARCHIVE_SHA256@
-
-      - type: file
-        path: @FLATPAK_ID@.metainfo.xml

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -18,30 +18,10 @@
 #
 # If the FLATPAK_ID environment variable is set, it overrides the
 # default value of org.cockpit_project.CockpitClient.
-#
-# If the PREVIOUS_RELEASES environment variable is set, it is written verbatim
-# into the metainfo xml after the current release info.
 
 set -eu
 
 FLATPAK_ID="${FLATPAK_ID:-org.cockpit_project.CockpitClient}"
-
-subst() {
-    ext="$1"
-
-    sed \
-        -e "s|@FLATPAK_ID@|${FLATPAK_ID}|" \
-        -e "s|@VERSION@|${VERSION}|" \
-        -e "s|@TODAY@|${TODAY}|" \
-        -e "s|@FLATPAK_BRANCH@|${FLATPAK_BRANCH}|" \
-        -e "s|@RELEASE_TYPE@|${RELEASE_TYPE}|" \
-        -e "s|@ARCHIVE_TYPE@|${ARCHIVE_TYPE}|" \
-        -e "s|@ARCHIVE_LOCATION@|${ARCHIVE_LOCATION}|" \
-        -e "s|@ARCHIVE_SHA256@|${ARCHIVE_SHA256}|" \
-        -e "s|@PREVIOUS_RELEASES@|${PREVIOUS_RELEASES:-}|" \
-        containers/flatpak/cockpit-client."${ext}".in > "${FLATPAK_ID}.${ext}.tmp"
-    mv "${FLATPAK_ID}.${ext}.tmp" "${FLATPAK_ID}.${ext}"
-}
 
 prepare() {
     TARBALL="${1:-}"
@@ -76,10 +56,15 @@ prepare() {
         FLATPAK_BRANCH=stable
     fi
 
-    TODAY="$(date +%F)"
-
-    subst metainfo.xml
-    subst yml
+    printf "  %-8s %s\n" GEN "${FLATPAK_ID}.yml" >&2
+    sed \
+        -e "s|@FLATPAK_ID@|${FLATPAK_ID}|" \
+        -e "s|@FLATPAK_BRANCH@|${FLATPAK_BRANCH}|" \
+        -e "s|@ARCHIVE_TYPE@|${ARCHIVE_TYPE}|" \
+        -e "s|@ARCHIVE_LOCATION@|${ARCHIVE_LOCATION}|" \
+        -e "s|@ARCHIVE_SHA256@|${ARCHIVE_SHA256}|" \
+        containers/flatpak/cockpit-client.yml.in > "${FLATPAK_ID}.yml.tmp"
+    mv "${FLATPAK_ID}.yml.tmp" "${FLATPAK_ID}.yml"
 }
 
 if [ $(basename -- "$0") = "prepare" ]; then

--- a/containers/flatpak/update-flathub
+++ b/containers/flatpak/update-flathub
@@ -26,20 +26,13 @@ test -f "${TARBALL}"
 test -d "${FLATHUB_REPO}"
 test -e "${FLATHUB_REPO}/.git"
 test -z "$(git -C "${FLATHUB_REPO}" status --porcelain)"
-test -f "${FLATHUB_REPO}/${FLATPAK_ID}.metainfo.xml"
 test -f "${FLATHUB_REPO}/${FLATPAK_ID}.yml"
-
-# Mine the previous versions out of the existing metainfo file
-PREVIOUS_RELEASES="$(sed -n 's/^\(    <release .*\)$/\1\\n/p' "${FLATHUB_REPO}/${FLATPAK_ID}.metainfo.xml" | tr -d '\n')"
 
 prepare "${TARBALL}" "${URLBASE}"
 
-cp "${FLATPAK_ID}".metainfo.xml "${FLATHUB_REPO}"/
 cp "${FLATPAK_ID}".yml "${FLATHUB_REPO}"/
 cd "${FLATHUB_REPO}"
 
 # Create a branch named after the version and push it to the origin
 git checkout -b "${VERSION}"
-git commit --message "Update to version ${VERSION}" --only \
-    "${FLATPAK_ID}".metainfo.xml \
-    "${FLATPAK_ID}".yml
+git commit --message "Update to version ${VERSION}" --only "${FLATPAK_ID}".yml

--- a/src/client/Makefile.am
+++ b/src/client/Makefile.am
@@ -32,4 +32,7 @@ dist_scalableicon_DATA = src/client/cockpit-client.svg
 symbolicicondir = $(datadir)/icons/hicolor/symbolic/apps
 dist_symbolicicon_DATA = src/client/cockpit-client-symbolic.svg
 
+client_metainfodir = $(datadir)/metainfo
+dist_client_metainfo_DATA = src/client/org.cockpit_project.CockpitClient.metainfo.xml
+
 endif

--- a/src/client/add-metainfo-releases
+++ b/src/client/add-metainfo-releases
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+import argparse
+import os
+import re
+import shlex
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+
+
+# Pretend like this is a little bit functional
+def element(tag, text=None, children=(), **kwargs):
+    tag = ET.Element(tag, kwargs)
+    tag.text = text
+    tag.extend(children)
+    return tag
+
+
+def points_from_body(body):
+    for text in re.split('^ *-', body, flags=re.MULTILINE):
+        if point := ' '.join(text.split()).strip():
+            yield element('li', point)
+
+
+def format_release(blob):
+    version, date, body = blob.split('|', 2)
+
+    return element('release', version=version, date=date, children=[
+        element('url', f'https://cockpit-project.org/blog/cockpit-{version}.html', type='details'),
+        element('description', children=[
+            element('p', f'Changes in Cockpit {version}:'),
+            element('ul', children=points_from_body(body))
+        ])
+    ])
+
+
+def get_releases():
+    # %(if)%(taggerdate) ensures we get only annotated tags.  258 was the first release
+    format = '%(if)%(taggerdate)%(then)%(refname:short)|%(taggerdate:short)|%(contents:body)%(end)'
+    output = subprocess.check_output(['git', 'for-each-ref', '--shell', '--sort=-taggerdate',
+                                      '--contains', '258', '--format', format, 'refs/tags'], text=True)
+    return shlex.split(output)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--version', help='Current version number', default='')
+    parser.add_argument('xml', help='Path to xml.in file in tree')
+    args = parser.parse_args()
+
+    tree = ET.parse(args.xml)
+    releases = tree.find('releases')
+
+    # Only update the file if it doesn't already contain releases.
+    if not releases.find('release'):
+        if 'g' in args.version:
+            today = time.strftime('%Y-%m-%d')
+            releases.append(element('release', version=args.version, date=today, type='development'))
+        releases.extend(format_release(r) for r in get_releases())
+        if 'ELEMENT_TREE_NO_INDENT' not in os.environ:
+            ET.indent(releases, space="  ", level=1)
+        tree.write(args.xml, encoding='utf-8', xml_declaration=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/client/org.cockpit_project.CockpitClient.metainfo.xml
+++ b/src/client/org.cockpit_project.CockpitClient.metainfo.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?>
-
+<?xml version='1.0' encoding='utf-8'?>
 <component type="desktop-application">
-  <id>@FLATPAK_ID@</id>
+  <id>org.cockpit_project.CockpitClient</id>
 
   <name>Cockpit Client</name>
   <summary>Connect via ssh to servers with Cockpit</summary>
@@ -14,7 +13,7 @@
       Cockpit Client provides a graphical interface to your servers, containers, and virtual machines.  Connections are made over SSH, using the SSH configuration of the local user (including aliases, known hosts, key files, hardware tokens, etc).
     </p>
     <p>
-      The server needs to have Cockpit installed, but the Cockpit webserver doesn&apos;t need to be enabled, and no extra ports need to be opened.
+      The server needs to have Cockpit installed, but the Cockpit webserver doesn't need to be enabled, and no extra ports need to be opened.
     </p>
   </description>
 
@@ -33,9 +32,7 @@
     </screenshot>
   </screenshots>
 
-  <releases>
-    <release date="@TODAY@" version="@VERSION@" type="@RELEASE_TYPE@"/>
-@PREVIOUS_RELEASES@  </releases>
+  <releases/>
 
   <launchable type="desktop-id">org.cockpit_project.CockpitClient.desktop</launchable>
 


### PR DESCRIPTION
Create a tool to turn the point form notes in our tags into a proper set
of `<release/>` tags for metainfo and fill this information in when
building a tarball.

Install the metainfo if building with --enable-client.

This will simplify the process of releasing the flatpak.