### PR TITLE
test: Fix pam_faillock configuration in Debian/Ubuntu

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -640,10 +640,11 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         if is_pam_tally2:
             self.sed_file("/common-auth/ { iauth required pam_tally2.so deny=4\n }", "/etc/pam.d/cockpit")
         elif m.image.startswith('debian-') or m.image.startswith('ubuntu'):
-            # enable pam_faillock.  see example in pam_faillock(8), adopted for sss
-            self.sed_file("""s/re.*pam_deny.so/[default=die] pam_faillock.so authfail deny=4/;
-                             s/re.*pam_permit.so/sufficient pam_faillock.so authsucc deny=4/;
-                          """, "/etc/pam.d/common-auth")
+            # enable pam_faillock.  see example in pam_faillock(8)
+            self.sed_file(r"/fallback if no module succeeds/ s/^/"
+                          r"auth [default=die] pam_faillock.so authfail deny=4\n"
+                          r"auth sufficient pam_faillock.so authsucc deny=4\n/",
+                          "/etc/pam.d/common-auth")
         elif m.image == "arch":
             self.sed_file("s/# deny = 3/deny = 4/", "/etc/security/faillock.conf")
         else:


### PR DESCRIPTION
Don't overwrite the standard pam_deny/pam_permit lines. They are there
for a very good reason, and we should keep the config changes to a
minimum.

In particular, `auth sufficient pam_faillock authsucc` does *not* fail
the login, so it needs the `pam_deny` fallback. Alternatively, the
module could be `required`, but let's stick to what the manpage says.

This resolves https://launchpad.net/bugs/1966416 and the corresponding
https://github.com/cockpit-project/bots/issues/3146

----

The previous PAM delta was:
```diff
--- /etc/pam.d/common-auth.orig 2022-03-25 10:41:29.088000000 +0000
+++ /etc/pam.d/common-auth 2022-03-25 10:48:48.913419254 +0000
@@ -17,11 +17,11 @@
 auth [success=2 default=ignore] pam_unix.so nullok
 auth [success=1 default=ignore] pam_sss.so use_first_pass
 # here's the fallback if no module succeeds
-auth requisite pam_deny.so
+auth [default=die] pam_faillock.so authfail deny=4
 # prime the stack with a positive return value if there isn't one already;
 # this avoids us returning an error just because nothing sets a success code
 # since the modules above will each just jump around
-auth required pam_permit.so
+auth sufficient pam_faillock.so authsucc deny=4
 # and here are more per-package modules (the "Additional" block)
 auth optional pam_cap.so
 # end of pam-auth-update config
```

With this PR, the delta is:
```diff
--- /tmp/common-auth.orig 2022-04-01 07:16:26.072608984 +0200
+++ /tmp/common-auth.faillock 2022-04-01 07:14:20.246707861 +0200
@@ -16,6 +16,8 @@
 # here are the per-package modules (the "Primary" block)
 auth [success=2 default=ignore] pam_unix.so nullok
 auth [success=1 default=ignore] pam_sss.so use_first_pass
+auth [default=die] pam_faillock.so authfail deny=4
+auth sufficient pam_faillock.so authsucc deny=4
 # here's the fallback if no module succeeds
 auth requisite pam_deny.so
 # prime the stack with a positive return value if there isn't one already;
```