### PR TITLE
test: remove already handled restart messages

### DIFF
--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -122,10 +122,6 @@ class TestBonding(NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
-        # Due to above reload
-        self.allow_journal_messages(".*Connection reset by peer.*",
-                                    "connection unexpectedly closed by peer")
-
     def testNonDefaultSettings(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -96,10 +96,6 @@ class TestTeam(NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
-        # Due to above reload
-        self.allow_journal_messages(".*Connection reset by peer.*",
-                                    "connection unexpectedly closed by peer")
-
     def testActive(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -64,8 +64,6 @@ class TestReauthorize(MachineCase):
 
     @skipImage("ssh root login not allowed", "fedora-coreos")
     def testSuper(self):
-        self.allow_journal_messages("Error receiving data: Connection reset by peer")
-        self.allow_journal_messages("connection unexpectedly closed by peer")
         b = self.browser
 
         self.login_and_go("/playground/test")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -376,9 +376,7 @@ class TestMultiMachine(MachineCase):
 
         # Might happen when we switch away.
         self.allow_hostkey_messages()
-        self.allow_journal_messages(".*: Connection reset by peer",
-                                    "connection unexpectedly closed by peer",
-                                    ".* Failed to resolve hostname bad .*")
+        self.allow_journal_messages(".* Failed to resolve hostname bad .*")
 
     def testDirectLogin(self):
         self.machine.start_cockpit()
@@ -754,7 +752,6 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
         self.allow_journal_messages('.* couldn\'t connect: .*',
-                                    '.*: Connection reset by peer',
                                     '.* failed to retrieve resource: invalid-hostkey',
                                     '.* host key for server has changed to: .*',
                                     '.* spawning remote bridge failed .*',


### PR DESCRIPTION
In testlib reload(), logout() already calls
allow_restart_journal_messages().