### PR TITLE
kdump: Show current journal when (re)starting service fails

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -24,6 +24,7 @@ import React from "react";
 import {
     Button, Checkbox,
     Card, CardBody,
+    CodeBlockCode,
     Flex,
     Form, FormGroup, FormSection,
     FormSelect, FormSelectOption,
@@ -281,7 +282,18 @@ export class KdumpPage extends React.Component {
 
     handleSaveClick() {
         return this.props.onSaveSettings(this.state.dialogSettings)
-                .catch(error => Promise.reject(cockpit.format(_("Unable to save settings: $0"), String(error))));
+                .catch(error => {
+                    if (error.details) {
+                        // avoid bad summary like "systemd job RestartUnit ["kdump.service","replace"] failed with result failed"
+                        // if we have a more concrete journal
+                        error.message = _("Unable to save settings");
+                        error.details = <CodeBlockCode>{ error.details }</CodeBlockCode>;
+                    } else {
+                        // without a journal, show the error as-is
+                        error = new Error(cockpit.format(_("Unable to save settings: $0"), String(error)));
+                    }
+                    return Promise.reject(error);
+                });
     }
 
     handleTestSettingsClick(e) {

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -280,11 +280,8 @@ export class KdumpPage extends React.Component {
     }
 
     handleSaveClick() {
-        return new Promise((resolve, reject) => {
-            this.props.onSaveSettings(this.state.dialogSettings)
-                    .then(resolve)
-                    .catch(error => reject(cockpit.format(_("Unable to save settings: $0"), String(error))));
-        });
+        return this.props.onSaveSettings(this.state.dialogSettings)
+                .catch(error => Promise.reject(cockpit.format(_("Unable to save settings: $0"), String(error))));
     }
 
     handleTestSettingsClick(e) {

--- a/pkg/kdump/kdump.scss
+++ b/pkg/kdump/kdump.scss
@@ -22,3 +22,9 @@
 #kdump-settings-location {
     width: 100%;
 }
+
+// error details
+#kdump-settings-dialog .pf-c-code-block__pre {
+  max-height: 200px;
+  overflow-y: auto;
+}

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -173,7 +173,11 @@ export class DialogFooter extends React.Component {
         else
             error_message = this.state.error_message;
         if (error_message)
-            error_element = <Alert variant='danger' isInline title={React.isValidElement(error_message) ? error_message : error_message.toString() } />;
+            error_element = (
+                <Alert variant='danger' isInline title={React.isValidElement(error_message) ? error_message : error_message.toString() }>
+                    { error_message.details }
+                </Alert>
+            );
         return (
             <>
                 { error_element }

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -109,10 +109,12 @@ class TestKdump(KdumpHelpers):
         mountInput = "#kdump-settings-nfs-mount"
         b.set_input_text(mountInput, ":/var/crash")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_visible(".pf-c-alert__title:contains('Unable to save settings')")
+        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs dump target isn't formatted as server:path")
+        # no further details/journal
+        self.assertFalse(b.is_present("#kdump-settings-dialog .pf-c-code-block__code"))
         b.set_input_text(mountInput, "localhost:")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_visible(".pf-c-alert__title:contains('Unable to save settings')")
+        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs dump target isn't formatted as server:path")
         b.click("#kdump-settings-dialog button.cancel")
         b.wait_not_present("#kdump-settings-dialog")
 
@@ -152,7 +154,8 @@ class TestKdump(KdumpHelpers):
         b.set_input_text(pathInput, customPath)
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         # we should get an error
-        b.wait_visible("h4.pf-c-alert__title:contains('Unable to save settings')")
+        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title",
+                       "Unable to save settings: Directory /var/crash2 isn't writable or doesn't exist")
         # also allow the journal message about failed touch
         self.allow_journal_messages(".*mktemp: failed to create file via template.*")
         # create the directory and try again
@@ -303,7 +306,9 @@ class TestKdumpNFS(KdumpHelpers):
         b.set_input_text("#kdump-settings-nfs-directory", "dumps")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         # dumps directory does not exist, error
-        b.wait_visible("h4.pf-c-alert__title:contains('Unable to save settings')")
+        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings")
+        # also shows error details
+        b.wait_in_text("#kdump-settings-dialog .pf-c-code-block__code", 'does not exist in dump target "10.111.113.2:/srv/kdump"')
         # create the directory on the NFS server
         self.machines["nfs"].execute("mkdir /srv/kdump/dumps")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")


### PR DESCRIPTION
This is often due to some mis-configuration, such as an NFS remote
directory not existing on the server. There is currently no better
machine-readable API for showing the root cause of the error, so
show the journal of the recently failed kdump.service run.

Use the same `<CodeBlockCode>` formatting and size as the realmd
overview card.

If the dialog is able to read the journal, then don't show the original
exception. That often reads "systemd job RestartUnit
["kdump.service","replace"] failed with result failed" which is not very
useful. Only show that if reading the journal failed (which "should not
happen™").

Assert the error formatting more precisely in the integration tests.

https://bugzilla.redhat.com/show_bug.cgi?id=2062297

----
Wide window, NFS error:
![image](https://user-images.githubusercontent.com/200109/161899942-e83b8efc-8e86-48d1-a1c4-a73f76df6503.png)

Narrow window, same NFS error:
![image](https://user-images.githubusercontent.com/200109/161900040-b9788c5c-7815-4f9e-9241-d22faf476792.png)

The error message is still a bit confusing, I reported this in https://bugzilla.redhat.com/show_bug.cgi?id=2071529. After that gets fixed, it'll be okay. But showing the journal is still better than just "it failed".

Another example failure when having wrong SSH parameters:
![image](https://user-images.githubusercontent.com/200109/161900191-7fd50bab-2e2d-40fd-8168-774a22466093.png)
