### PR TITLE
package.json: drop explicit Red Hat font depend

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@patternfly/react-icons": "4.26.4",
     "@patternfly/react-styles": "4.25.4",
     "@patternfly/react-table": "4.44.4",
-    "@redhat/redhat-font": "git+https://github.com/RedHatOfficial/RedHatFont.git#2.2.0",
     "deep-equal": "2.0.5",
     "js-sha1": "0.6.0",
     "js-sha256": "0.9.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -322,7 +322,7 @@ const redhat_fonts = [
 ].map(name => {
     const subdir = 'RedHat' + name.split('-')[0];
     return {
-        from: path.resolve(nodedir, '@redhat/redhat-font/webfonts', subdir, 'RedHat' + name + '.woff2'),
+        from: path.resolve(nodedir, '@patternfly/patternfly/assets/fonts', subdir, 'RedHat' + name + '.woff2'),
         to: 'static/fonts/'
     };
 });


### PR DESCRIPTION
This should get pulled in by PatternFly, and lets us avoid npm requiring
git.