### PR TITLE
systemd: Show timer creation errors

### DIFF
--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -116,12 +116,12 @@ const CreateTimerDialogBody = ({ setIsOpen, owner }) => {
         cockpit.spawn(["test", "-f", command_parts[0]], { err: "ignore" })
                 .then(() => {
                     create_timer({ name, description, command, delay, delayUnit, delayNumber, repeat, specificTime, repeatPatterns, owner })
-                            .then(setIsOpen(false), exc => {
+                            .then(() => setIsOpen(false), exc => {
                                 setDialogError(exc.message);
                                 setInProgress(false);
                             });
                 })
-                .fail(() => {
+                .catch(() => {
                     setCommandNotFound(true);
                     setInProgress(false);
                 });

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1047,6 +1047,16 @@ class TestTimers(MachineCase):
         b.set_input_text("[data-index=0] .pf-c-date-picker:nth-child(2) input", "16:00")
         b.set_input_text("[data-index=1] .pf-c-date-picker:nth-child(1) input", "2037-01-01")
         b.set_input_text("[data-index=1] .pf-c-date-picker:nth-child(2) input", "01:22")
+
+        # shows creation errors
+        m.execute("chattr +i /etc/systemd/system")
+        try:
+            b.click("#timer-save-button")
+            b.wait_in_text("#timer-dialog .pf-c-alert", "Timer creation failed")
+            b.wait_in_text("#timer-dialog .pf-c-alert", "Not permitted")
+        finally:
+            m.execute("chattr -i /etc/systemd/system")
+
         b.click("#timer-save-button")
         b.wait_not_present("#timer-dialog")
         b.wait_visible(self.svc_sel('yearly_timer.timer'))


### PR DESCRIPTION
Fix the setOpen() call to actually happen *after* `create_timer()`
promise finishes and succeeds. Otherwise the dialog closes immediately.

Fix the promise chaining in create_timer_file() to actually return
errors from creating the .service file, by dropping the parallel catch
handler (which was just logging). Instead, chain it up to creating the
.timer file as well.

Fix chaining of the Reload call.

There is not a lot of opportunity for this to actually fail, but it can
happen on inaccessible or even non-existing directories. Do that in the
test.