### PR TITLE
Show dialog errors at the top

### DIFF
--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React from "react";
 import ReactDOM from "react-dom";
 import PropTypes from "prop-types";
-import { Alert, Button, Modal, Popover, Spinner } from "@patternfly/react-core";
+import { Alert, Button, Modal, Popover, Spinner, Stack } from "@patternfly/react-core";
 import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import "cockpit-components-dialog.scss";
@@ -43,7 +43,6 @@ const _ = cockpit.gettext;
  *      - caption optional, defaults to 'Ok'
  *      - disabled optional, defaults to false
  *      - style defaults to 'secondary', other options: 'primary', 'danger'
- *  - static_error optional, always show this error
  *  - idle_message optional, always show this message on the last row when idle
  *  - dialog_done optional, callback when dialog is finished (param true if success, false on cancel)
  */
@@ -167,11 +166,7 @@ class DialogFooter extends React.Component {
 
         // If we have an error message, display the error
         let error_element;
-        let error_message;
-        if (this.props.static_error !== undefined && this.props.static_error !== null)
-            error_message = this.props.static_error;
-        else
-            error_message = this.state.error_message;
+        const error_message = this.state.error_message;
         if (error_message)
             error_element = (
                 <Alert variant='danger' isInline title={React.isValidElement(error_message) ? error_message : error_message.toString() }>
@@ -194,7 +189,6 @@ DialogFooter.propTypes = {
     cancel_clicked: PropTypes.func,
     cancel_button: PropTypes.object,
     actions: PropTypes.array.isRequired,
-    static_error: PropTypes.string,
     dialog_done: PropTypes.func,
 };
 
@@ -209,6 +203,7 @@ DialogFooter.propTypes = {
  *      to the input components to the controller. That way, the controller can
  *      extract all necessary information (e.g. for input validation) when an
  *      action is triggered.
+ *  - static_error optional, always show this error after the body element
  *  - footer (react element, top element should be of class modal-footer)
  *  - id optional, id that is assigned to the top level dialog node, but not the backdrop
  *  - variant: See PF4 Modal component's 'variant' property
@@ -246,7 +241,10 @@ class Dialog extends React.Component {
                    isOpen
                    help={help}
                    footer={this.props.footer} title={this.props.title}>
-                { this.props.body }
+                <Stack hasGutter>
+                    { this.props.static_error}
+                    { this.props.body }
+                </Stack>
             </Modal>
         );
     }
@@ -255,6 +253,7 @@ Dialog.propTypes = {
     // TODO: fix following by refactoring the logic showing modal dialog (recently show_modal_dialog())
     title: PropTypes.string, // is effectively required, but show_modal_dialog() provides initially no props and resets them later.
     body: PropTypes.element, // is effectively required, see above
+    static_error: PropTypes.string,
     footer: PropTypes.element, // is effectively required, see above
     id: PropTypes.string
 };
@@ -308,9 +307,6 @@ export function show_modal_dialog(props, footerProps) {
         dialogObj.render();
     }
     dialogObj.setFooterProps = function(footerProps) {
-        /* Always log error messages to console for easier debugging */
-        if (footerProps.static_error)
-            console.warn(footerProps.static_error);
         dialogObj.footerProps = footerProps;
         if (dialogObj.footerProps.dialog_done != closeCallback) {
             origCallback = dialogObj.footerProps.dialog_done;

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -47,7 +47,7 @@ const _ = cockpit.gettext;
  *  - idle_message optional, always show this message on the last row when idle
  *  - dialog_done optional, callback when dialog is finished (param true if success, false on cancel)
  */
-export class DialogFooter extends React.Component {
+class DialogFooter extends React.Component {
     constructor(props) {
         super(props);
         this.state = {
@@ -214,7 +214,7 @@ DialogFooter.propTypes = {
  *  - variant: See PF4 Modal component's 'variant' property
  *  - titleIconVariant: See PF4 Modal component's 'titleIconVariant' property
  */
-export class Dialog extends React.Component {
+class Dialog extends React.Component {
     componentDidMount() {
         // if we used a button to open this, make sure it's not focused anymore
         if (document.activeElement)

--- a/pkg/lib/cockpit-components-install-dialog.jsx
+++ b/pkg/lib/cockpit-components-install-dialog.jsx
@@ -114,7 +114,8 @@ export function install_dialog(pkg, options) {
                     { remove_details }
                     { extra_details }
                 </div>
-            )
+            ),
+            static_error: error_message,
         };
 
         const footer = {
@@ -126,7 +127,6 @@ export function install_dialog(pkg, options) {
                     disabled: data == null
                 }
             ],
-            static_error: error_message,
             idle_message: footer_message,
             dialog_done: f => { if (!f && cancel) cancel(); done(f) }
         };

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -32,6 +32,7 @@ import {
     Popover,
     Progress, ProgressVariant,
     Select, SelectOption,
+    Stack, StackItem,
     Switch,
     Text, TextContent, TextVariants,
     Tooltip,
@@ -1270,8 +1271,6 @@ const PCPConfigDialog = ({
               </div>
           }
                    footer={<>
-                       { dialogError && <ModalError dialogError={ _("Failed to configure PCP") } dialogErrorDetail={dialogError} /> }
-
                        <Button variant='primary' onClick={handleSave} isDisabled={pending} isLoading={pending}>
                            { _("Save") }
                        </Button>
@@ -1281,36 +1280,41 @@ const PCPConfigDialog = ({
                    </>
                    }>
 
-            <Switch id="switch-pmlogger"
-                        isChecked={dialogLoggerValue}
-                        isDisabled={!s_pmlogger.exists && !packagekitExists}
-                        label={
-                            <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
-                                <FlexItem>{ _("Collect metrics") }</FlexItem>
-                                <TextContent>
-                                    <Text component={TextVariants.small}>(pmlogger.service)</Text>
-                                </TextContent>
-                            </Flex>
-                        }
-                        onChange={enable => {
-                            // pmproxy needs pmlogger, auto-disable it
-                            setDialogLoggerValue(enable);
-                            if (!enable)
-                                setDialogProxyValue(false);
-                        }} />
+            <Stack hasGutter>
+                { dialogError && <ModalError dialogError={ _("Failed to configure PCP") } dialogErrorDetail={dialogError} /> }
+                <StackItem>
+                    <Switch id="switch-pmlogger"
+                                isChecked={dialogLoggerValue}
+                                isDisabled={!s_pmlogger.exists && !packagekitExists}
+                                label={
+                                    <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
+                                        <FlexItem>{ _("Collect metrics") }</FlexItem>
+                                        <TextContent>
+                                            <Text component={TextVariants.small}>(pmlogger.service)</Text>
+                                        </TextContent>
+                                    </Flex>
+                                }
+                                onChange={enable => {
+                                    // pmproxy needs pmlogger, auto-disable it
+                                    setDialogLoggerValue(enable);
+                                    if (!enable)
+                                        setDialogProxyValue(false);
+                                }} />
 
-            <Switch id="switch-pmproxy"
-                        isChecked={dialogProxyValue}
-                        label={
-                            <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
-                                <FlexItem>{ _("Export to network") }</FlexItem>
-                                <TextContent>
-                                    <Text component={TextVariants.small}>(pmproxy.service)</Text>
-                                </TextContent>
-                            </Flex>
-                        }
-                        isDisabled={ !dialogLoggerValue }
-                        onChange={enable => setDialogProxyValue(enable)} />
+                    <Switch id="switch-pmproxy"
+                                isChecked={dialogProxyValue}
+                                label={
+                                    <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
+                                        <FlexItem>{ _("Export to network") }</FlexItem>
+                                        <TextContent>
+                                            <Text component={TextVariants.small}>(pmproxy.service)</Text>
+                                        </TextContent>
+                                    </Flex>
+                                }
+                                isDisabled={ !dialogLoggerValue }
+                            onChange={enable => setDialogProxyValue(enable)} />
+                </StackItem>
+            </Stack>
         </Modal>);
 };
 

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -591,9 +591,6 @@ class AddEditServicesModal extends React.Component {
                    onClose={Dialogs.close}
                    title={titleText}
                    footer={<>
-                       {
-                           this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
-                       }
                        { !this.state.custom ||
                            <Alert variant="warning"
                                isInline
@@ -608,6 +605,9 @@ class AddEditServicesModal extends React.Component {
                    </>}
             >
                 <Form isHorizontal onSubmit={this.props.custom_id ? this.edit : this.save}>
+                    {
+                        this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
+                    }
                     { !!this.props.custom_id ||
                         <FormGroup className="add-services-dialog-type" isInline>
                             <Radio name="type"
@@ -798,9 +798,6 @@ class ActivateZoneModal extends React.Component {
                    onClose={Dialogs.close}
                    title={_("Add zone")}
                    footer={<>
-                       {
-                           this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
-                       }
                        <Button variant="primary" onClick={this.save} isDisabled={this.state.zone === null ||
                                                                                (this.state.interfaces.size === 0 && this.state.ipRange === "ip-entire-subnet") ||
                                                                                (this.state.ipRange === "ip-range" && !this.state.ipRangeValue)}>
@@ -812,6 +809,9 @@ class ActivateZoneModal extends React.Component {
                    </>}
             >
                 <Form isHorizontal onSubmit={this.save}>
+                    {
+                        this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />
+                    }
                     <FormGroup label={ _("Trust level") } className="add-zone-zones">
                         <Flex>
                             <FlexItem className="add-zone-zones-firewalld">

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -515,7 +515,6 @@ class RestartServices extends React.Component {
                    title={_("Restart services")}
                    footer={
                        <>
-                           {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
                            {this.props.tracerPackages.daemons.includes("cockpit") &&
                                <Alert variant="warning"
                                    title={_("Web Console will restart")}
@@ -534,7 +533,10 @@ class RestartServices extends React.Component {
                            </Button>
                        </>
                    }>
-                {body}
+                <Stack hasGutter>
+                    {this.state.dialogError && <ModalError dialogError={this.state.dialogError} dialogErrorDetail={this.state.dialogErrorDetail} />}
+                    <StackItem>{body}</StackItem>
+                </Stack>
             </Modal>
         );
     }

--- a/pkg/playground/react-patterns.js
+++ b/pkg/playground/react-patterns.js
@@ -71,10 +71,11 @@ const onDialogDone = function(success) {
     document.getElementById("demo-dialog-result").textContent = "Dialog closed: " + result + "(" + action + ")";
 };
 
-const onStandardDemoClicked = function(staticError) {
+const onStandardDemoClicked = (staticError) => {
     const dialogProps = {
         title: "This shouldn't be seen",
         body: React.createElement(PatternDialogBody, { clickNested: onStandardDemoClicked }),
+        static_error: staticError,
     };
     // also test modifying properties in subsequent render calls
     const footerProps = {
@@ -94,7 +95,6 @@ const onStandardDemoClicked = function(staticError) {
                 caption: "Wait",
             },
         ],
-        static_error: staticError,
         dialog_done: onDialogDone,
     };
     const dialogObj = show_modal_dialog(dialogProps, footerProps);

--- a/pkg/shell/credentials.jsx
+++ b/pkg/shell/credentials.jsx
@@ -316,14 +316,12 @@ const UnlockKey = ({ keyName, load, onClose }) => {
                        <Button variant='link' onClick={onClose}>{_("Cancel")}</Button>
                    </>
                }>
-            <>
+            <Form onSubmit={e => { e.preventDefault(); return false }} isHorizontal>
                 {dialogError && <ModalError dialogError={dialogError} />}
-                <Form onSubmit={e => { e.preventDefault(); return false }} isHorizontal>
-                    <FormGroup label={_("Password")} fieldId={keyName + "-password"} type="password">
-                        <TextInput type="password" id={keyName + "-password"} value={password} onChange={setPassword} />
-                    </FormGroup>
-                </Form>
-            </>
+                <FormGroup label={_("Password")} fieldId={keyName + "-password"} type="password">
+                    <TextInput type="password" id={keyName + "-password"} value={password} onChange={setPassword} />
+                </FormGroup>
+            </Form>
         </Modal>
     );
 };

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -35,6 +35,7 @@ import {
     Form, FormGroup,
     Modal,
     Radio,
+    Stack,
     TextInput,
 } from '@patternfly/react-core';
 
@@ -76,13 +77,15 @@ class NotSupported extends React.Component {
                    onClose={this.props.onClose}
                    title={_("Cockpit is not installed")}
                    footer={<>
-                       { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                        <Button variant="link" className="btn-cancel" onClick={this.props.onClose}>
                            { _("Close") }
                        </Button>
                    </>}
             >
-                <p>{cockpit.format(_("A compatible version of Cockpit is not installed on $0."), this.props.full_address)}</p>
+                <Stack hasGutter>
+                    { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
+                    <p>{cockpit.format(_("A compatible version of Cockpit is not installed on $0."), this.props.full_address)}</p>
+                </Stack>
             </Modal>
         );
     }
@@ -268,7 +271,6 @@ class AddMachine extends React.Component {
                    onClose={this.props.onClose}
                    title={title}
                    footer={<>
-                       { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                        <Button variant="primary" onClick={callback} isLoading={this.state.inProgress}
                                isDisabled={this.state.address === "" || this.state.addressError !== "" || this.state.inProgress}>
                            { submitText }
@@ -278,7 +280,10 @@ class AddMachine extends React.Component {
                        </Button>
                    </>}
             >
-                {body}
+                <Stack hasGutter>
+                    { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
+                    {body}
+                </Stack>
             </Modal>
         );
     }
@@ -363,7 +368,6 @@ class MachinePort extends React.Component {
                    onClose={this.props.onClose}
                    title={title}
                    footer={<>
-                       { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                        <Button variant="primary" onClick={callback} isLoading={this.state.inProgress}
                                isDisabled={this.state.inProgress}>
                            { submitText }
@@ -373,7 +377,10 @@ class MachinePort extends React.Component {
                        </Button>
                    </>}
             >
-                {body}
+                <Stack hasGutter>
+                    { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
+                    {body}
+                </Stack>
             </Modal>
         );
     }
@@ -483,7 +490,6 @@ class HostKey extends React.Component {
                    onClose={this.props.onClose}
                    title={title}
                    footer={<>
-                       { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                        { unknown ||
                            <Button variant="primary" onClick={callback} isLoading={this.state.inProgress}
                                    isDisabled={this.state.inProgress}>
@@ -495,7 +501,10 @@ class HostKey extends React.Component {
                        </Button>
                    </>}
             >
-                {body}
+                <Stack hasGutter>
+                    { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
+                    {body}
+                </Stack>
             </Modal>
         );
     }
@@ -851,7 +860,6 @@ class ChangeAuth extends React.Component {
                    onClose={this.props.onClose}
                    title={title}
                    footer={<>
-                       { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
                        <Button variant="primary" onClick={callback} isLoading={this.state.inProgress}
                                isDisabled={this.state.inProgress || (!offer_login_password && !offer_key_password) || !this.state.default_ssh_key || !this.props.error_options}>
                            { submitText }
@@ -861,7 +869,10 @@ class ChangeAuth extends React.Component {
                        </Button>
                    </>}
             >
-                {body}
+                <Stack hasGutter>
+                    { this.props.dialogError && <ModalError dialogError={this.props.dialogError} />}
+                    {body}
+                </Stack>
             </Modal>
         );
     }

--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -21,7 +21,7 @@ import cockpit from "cockpit";
 import React, { useState } from "react";
 import { useObject, useInit, useEvent } from "hooks";
 import { useDialogs } from "dialogs.jsx";
-import { Alert, Button, Form, FormGroup, Modal, TextInput, FormSelect, FormSelectOption } from '@patternfly/react-core';
+import { Alert, Button, Form, FormGroup, Modal, TextInput, FormSelect, FormSelectOption, Stack, StackItem } from '@patternfly/react-core';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { host_superuser_storage_key } from './machines/machines';
 import { LockIcon } from '@patternfly/react-icons';
@@ -144,27 +144,25 @@ const UnlockDialog = ({ proxy, host }) => {
 
         title = _("Switch to administrative access");
         body = (
-            <>
-                { error && <><Alert variant={errorVariant || 'danger'} isInline title={error} /><br /></> }
-                <Form isHorizontal onSubmit={event => { apply(); event.preventDefault(); return false }}>
-                    { prompt.message && <span>{prompt.message}</span> }
-                    <FormGroup
-                        fieldId="switch-to-admin-access-password"
-                        label={prompt.prompt}
+            <Form isHorizontal onSubmit={event => { apply(); event.preventDefault(); return false }}>
+                { error && <Alert variant={errorVariant || 'danger'} isInline title={error} /> }
+                { prompt.message && <span>{prompt.message}</span> }
+                <FormGroup
+                    fieldId="switch-to-admin-access-password"
+                    label={prompt.prompt}
+                    validated={!error ? "default" : validated || "error"}
+                >
+                    <TextInput
+                        autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                        id="switch-to-admin-access-password"
+                        isDisabled={busy}
+                        onChange={setValue}
+                        type={!prompt.echo ? 'password' : 'text'}
                         validated={!error ? "default" : validated || "error"}
-                    >
-                        <TextInput
-                            autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-                            id="switch-to-admin-access-password"
-                            isDisabled={busy}
-                            onChange={setValue}
-                            type={!prompt.echo ? 'password' : 'text'}
-                            validated={!error ? "default" : validated || "error"}
-                            value={value}
-                        />
-                    </FormGroup>
-                </Form>
-            </>
+                        value={value}
+                    />
+                </FormGroup>
+            </Form>
         );
 
         footer = (
@@ -252,7 +250,6 @@ const LockDialog = ({ proxy, host }) => {
 
     const footer = (
         <>
-            {error && <ModalError dialogError={error} />}
             <Button variant='primary' onClick={apply}>
                 {_("Limit access")}
             </Button>
@@ -268,10 +265,13 @@ const LockDialog = ({ proxy, host }) => {
                onClose={D.close}
                footer={footer}
                title={_("Switch to limited access")}>
-            <>
-                <p>{_("Limited access mode restricts administrative privileges. Some parts of the web console will have reduced functionality.")}</p>
-                <p>{_("Your browser will remember your access level across sessions.")}</p>
-            </>
+            <Stack hasGutter>
+                {error && <ModalError dialogError={error} />}
+                <StackItem>
+                    <p>{_("Limited access mode restricts administrative privileges. Some parts of the web console will have reduced functionality.")}</p>
+                    <p>{_("Your browser will remember your access level across sessions.")}</p>
+                </StackItem>
+            </Stack>
         </Modal>
     );
 };

--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -167,7 +167,6 @@ const CryptoPolicyDialog = ({
                title={_("Change crypto policy")}
                footer={
                    <>
-                       {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
                        {inProgress &&
                        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
                            {_("Applying new policy... This may take a few minutes.")}
@@ -183,6 +182,7 @@ const CryptoPolicyDialog = ({
                    </>
                }
         >
+            {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
             {currentCryptoPolicy && <ProfilesMenuDialogBody active_profile={currentCryptoPolicy}
                                                      change_selected={setSelected}
                                                      isDisabled={inProgress}

--- a/pkg/systemd/overview-cards/motdCard.jsx
+++ b/pkg/systemd/overview-cards/motdCard.jsx
@@ -19,7 +19,13 @@
 
 import React, { useState } from 'react';
 
-import { Alert, AlertActionCloseButton, Button, Modal, TextArea } from '@patternfly/react-core';
+import {
+    Alert, AlertActionCloseButton,
+    Button,
+    Modal,
+    Stack,
+    TextArea
+} from '@patternfly/react-core';
 import { EditIcon } from '@patternfly/react-icons';
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { superuser } from "superuser";
@@ -46,9 +52,6 @@ const MotdEditDialog = ({ text }) => {
                title={_("Edit /etc/motd")}
                footer={
                    <>
-                       {error &&
-                       <ModalError dialogError={error}
-                                    dialogErrorDetail={errorDetail} />}
                        <Button variant='primary'
                                onClick={() => cockpit.file("/etc/motd", { superuser: "try", err: "message" })
                                        .replace(value)
@@ -65,9 +68,15 @@ const MotdEditDialog = ({ text }) => {
                        </Button>
                    </>
                }>
-            <TextArea resizeOrientation="vertical"
-                      value={value}
-                      onChange={setValue} />
+
+            <Stack hasGutter>
+                {error &&
+                <ModalError dialogError={error}
+                             dialogErrorDetail={errorDetail} />}
+                <TextArea resizeOrientation="vertical"
+                          value={value}
+                          onChange={setValue} />
+            </Stack>
         </Modal>);
 };
 

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -27,7 +27,7 @@ import {
     Tooltip, TooltipPosition,
     Card, CardBody, CardTitle, Text, TextVariants,
     List, ListItem,
-    Modal, Spinner, Switch
+    Modal, Spinner, Stack, Switch
 } from "@patternfly/react-core";
 import {
     AsleepIcon,
@@ -701,8 +701,10 @@ const DeleteModal = ({ reason, name, handleCancel, handleDelete }) => {
                    <Button variant="link" isDisabled={inProgress} onClick={handleCancel}>{_("Cancel")}</Button>
                </>}
         >
-            {dialogError && <ModalError dialogError={_("Timer deletion failed")} dialogErrorDetail={dialogError} />}
-            {reason}
+            <Stack hasGutter>
+                {dialogError && <ModalError dialogError={_("Timer deletion failed")} dialogErrorDetail={dialogError} />}
+                {reason}
+            </Stack>
         </Modal>
     );
 };

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -140,7 +140,6 @@ const CreateTimerDialogBody = ({ owner }) => {
            title={cockpit.format(_("Create timer"), name)}
            footer={
                <>
-                   {dialogError && <ModalError dialogError={_("Timer creation failed")} dialogErrorDetail={dialogError} />}
                    <Button variant='primary'
                            id="timer-save-button"
                            isLoading={inProgress}
@@ -153,6 +152,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                    </Button>
                </>
            }>
+            {dialogError && <ModalError dialogError={_("Timer creation failed")} dialogErrorDetail={dialogError} />}
             <Form isHorizontal onSubmit={onSubmit}>
                 <FormGroup label={_("Name")}
                            fieldId="servicename"

--- a/pkg/tuned/dialog.jsx
+++ b/pkg/tuned/dialog.jsx
@@ -304,7 +304,6 @@ const TunedDialog = ({
                title={_("Change performance profile")}
                footer={
                    <>
-                       {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
                        <Button variant='primary' isDisabled={!selected} onClick={setProfile}>
                            {_("Change profile")}
                        </Button>
@@ -314,6 +313,7 @@ const TunedDialog = ({
                    </>
                }
         >
+            {error && <ModalError dialogError={typeof error == 'string' ? error : error.message} />}
             {loading && <EmptyStatePanel loading />}
             {activeProfile && <ProfilesMenuDialogBody active_profile={activeProfile}
                                                change_selected={setSelected}

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -675,8 +675,8 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_visible("#restart-services-modal")
 
         # tracer updated the list of services which need a restart, so our service is no longer present
-        b.wait_not_in_text("#restart-services-modal .pf-c-modal-box__body", packageName)
-        b.wait_visible("#restart-services-modal footer .pf-c-alert")
+        b.wait_not_in_text("#restart-services-modal .pf-l-stack__item", packageName)
+        b.wait_visible("#restart-services-modal .pf-c-alert")
 
     @skipImage("No security changelog support in packagekit", "arch")
     def testInfoSecurity(self):

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -413,7 +413,7 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw1", new_password_2)
         b.set_input_text("#account-set-password-pw2", new_password_2)
         b.click('#account-set-password-dialog button.apply')
-        b.wait_in_text("#account-set-password-dialog .pf-c-modal-box__footer", "must wait longer")
+        b.wait_in_text("#account-set-password-dialog .pf-c-modal-box__body", "must wait longer")
 
     @skipImage("ssh root login not allowed", "fedora-coreos")
     def testRootLogin(self):


### PR DESCRIPTION
See @garrett's review in https://github.com/cockpit-project/cockpit/pull/17214#pullrequestreview-930307611 . This makes our dialogs comply with [PatternFly form validation design](https://www.patternfly.org/v4/components/form/design-guidelines/#error-validation-on-submission).

On main they look like this:

![kdump-main](https://user-images.githubusercontent.com/200109/161728671-86eefe07-e30e-4833-8aba-ce9b72f32d72.png)
![motd-edit-main](https://user-images.githubusercontent.com/200109/161728692-e29d0ebb-95d7-4d00-8d86-8b9efc4cf6b5.png)
![timer-main](https://user-images.githubusercontent.com/200109/161728704-302bf526-9c83-4c16-8372-0aab700b07ca.png)
![crypto-policies-main](https://user-images.githubusercontent.com/200109/161728718-71d50b9b-fc30-4610-9bcf-7f598aed6e08.png)

With this PR they look like this:
![kdump-pr](https://user-images.githubusercontent.com/200109/161728743-9821375a-d4e3-4319-9a8d-5ba308bc86d0.png)
![motd-edit-pr](https://user-images.githubusercontent.com/200109/161728766-0ad951e7-9bc7-4075-8794-3b6b112d434b.png)
![timer-pr](https://user-images.githubusercontent.com/200109/161728780-70b1a06f-1de2-4700-9f66-324ac34527b8.png)
![crypto-policies-pr png](https://user-images.githubusercontent.com/200109/161728788-c8a7b651-5c93-4a5a-975c-0c7523244b5e.png)

Initial draft which just converts cockpit-components-dialog and a few `<ModalError>` instances.

 - Builds on top of #17220 (spotted during this conversion)
 - [x] tuned
 - [x] shell superuser
 - [x] shell host dialog
 - [x] shell credentials
 - [x] Software Updates
 - [x] Firewall
 - [x] NetworkManager dialogs-common
 - [x] Metrics