### PR TITLE
Install kpatches only

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -21,6 +21,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import {
     Alert, Button, Checkbox,
+    Form,
     Flex, FlexItem,
     Modal, Radio,
     Popover,
@@ -254,7 +255,7 @@ export class KpatchSettings extends React.Component {
         const kernel_name = this.state.kernelName ? " (" + this.state.kernelName + ")" : "";
         const error = this.state.error ? <Alert variant='danger' isInline title={this.state.error} /> : null;
 
-        const body = <Checkbox id="apply-kpatch"
+        const body = <Form><Checkbox id="apply-kpatch"
                                isChecked={this.state.applyCheckbox}
                                label={_("Apply kernel live patches")}
                                onChange={checked => this.setState({ applyCheckbox: checked })}
@@ -270,7 +271,7 @@ export class KpatchSettings extends React.Component {
                                           isDisabled={!this.state.applyCheckbox}
                                           isChecked={this.state.justCurrent} />
                                </>}
-        />;
+        /></Form>;
 
         return (<>
             <div id="kpatch-settings">

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -284,7 +284,7 @@ function updateItem(info, pkgNames, key) {
         pkgsTruncated.push(<span key="more">…</span>);
 
     if (pkgNames.some(p => p.name.startsWith("kpatch-patch")))
-        pkgsTruncated.push(<>{" "}<Badge>{_("patches")}</Badge></>);
+        pkgsTruncated.push(<React.Fragment key={`${key}-kpatches-spacer`}>{" "}<Badge>{_("patches")}</Badge></React.Fragment>);
 
     let descriptionFirstLine = (info.description || "").trim();
     if (descriptionFirstLine.indexOf("\n") >= 0)

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -29,11 +29,13 @@ import {
     DescriptionList, DescriptionListTerm, DescriptionListGroup, DescriptionListDescription,
     ExpandableSection,
     Flex, FlexItem,
+    LabelGroup,
     Spinner,
     Stack, StackItem,
     Page, PageSection, PageSectionVariants,
     Text, TextContent, TextListItem, TextList, TextVariants,
 } from '@patternfly/react-core';
+
 import {
     BugIcon,
     CheckIcon,
@@ -284,7 +286,11 @@ function updateItem(info, pkgNames, key) {
         pkgsTruncated.push(<span key="more">…</span>);
 
     if (pkgNames.some(p => p.name.startsWith("kpatch-patch")))
-        pkgsTruncated.push(<React.Fragment key={`${key}-kpatches-spacer`}>{" "}<Badge>{_("patches")}</Badge></React.Fragment>);
+        pkgsTruncated.push(
+            <LabelGroup key={`${key}-kpatches-labelgroup`} className="kpatches-labelgroup">
+                {" "}<Badge color="blue" variant="filled">{_("patches")}</Badge>
+            </LabelGroup>
+        );
 
     let descriptionFirstLine = (info.description || "").trim();
     if (descriptionFirstLine.indexOf("\n") >= 0)

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -15,6 +15,12 @@
     }
 }
 
+.kpatches-labelgroup ul.pf-c-label-group__list,
+.kpatches-labelgroup li.pf-c-label-group__list-item:last-child,
+{
+    margin-bottom: 0px;
+}
+
 .pk-updates--header {
     display: flex;
     flex-wrap: wrap;

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -196,14 +196,25 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
                            provides=f"kpatch-patch = {kernel_ver_arch}",
                            content={"/usr/local/bin/kpatch": kpatch},
                            postinst="chmod +x /usr/local/bin/kpatch; mount -o bind /usr/local/bin/kpatch /usr/sbin/kpatch")
+        # Mix in an normal update and ensure it's not updated
+        self.createPackage("vanilla", "1.0", "1", install=True)
+        self.createPackage("vanilla", "1.0", "2")
+        self.createPackage("secdeclare", "3", "4.a1", install=True)
+        self.createPackage("secdeclare", "3", "4.b1", severity="security",
+                           changes="Will crash your data center", cves=["CVE-2014-123456"])
         self.enableRepo()
         self.addCleanup(m.execute, "umount /usr/sbin/kpatch")
 
         b.click("#status .pf-c-card__actions button")
         b.wait_visible(".pf-c-badge:contains('patches')")
-        b.click("button:contains('Install all updates')")
+        b.click("button:contains('Install kpatch updates')")
         b.click("button:contains('Continue')")
         b.wait_in_text("#status", "Kernel live patch kpatch_3_10_0_1062_1_1 is active")
+        # Other updates are not installed
+        self.check_nth_update(1, "secdeclare", "3-4.b1", "security", 1,
+                              desc_matches=["Will crash your data center"], cves=["CVE-2014-123456"])
+        self.check_nth_update(2, "vanilla", "1.0-2")
+        self.assertEqual(m.execute("rpm -q vanilla").strip(), "vanilla-1.0-1.noarch")
 
         # Switch to 'for current kernel only'
         b.click("#kpatch-settings button:contains('Edit')")
@@ -748,6 +759,7 @@ ExecStart=/usr/local/bin/{packageName}
 
         # install only security updates
         self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
+        b.wait_not_present("#available-updates button#install-kpatches")
         b.click("#available-updates button#install-security")
         b.wait_visible(".pf-c-empty-state .pf-c-title:contains('Update was successful')")
 
@@ -844,6 +856,7 @@ ExecStart=/usr/local/bin/{packageName}
 
         # should only have one button (only security updates)
         b.wait_not_present("#available-updates button#install-all")
+        b.wait_not_present("#available-updates button#install-kpatches")
         self.assertEqual(b.text("#available-updates button#install-security"), "Install security updates")
 
         # security fix without CVE URLs


### PR DESCRIPTION
A new option to only install kpatches.

---

# Software Updates: Install kpatches only

It is now possible to only install kpatch updates. This is useful at times when a reboot or service restarts are not acceptable, to at least fix kernel vulnerabilities.

![image](https://user-images.githubusercontent.com/67428/162717087-e4f05cac-89ff-4086-b3ec-41d39b11fc72.png)
