### PR TITLE
test: Check pam_access denied logins

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -162,12 +162,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
             # test login with tcsh
             if not m.image.startswith("rhel") and not m.image.startswith("centos") and not m.image == "arch":  # no tcsh in RHEL and in Arch Linux (TODO: available in [community])
-                m.execute("sed -r -i.bak '/^admin:/ s_:[^:]+$_:/bin/tcsh_' /etc/passwd")
-                b.login_and_go()
-                b.enter_page('/system')
-                b.wait_visible('.system-information')
-                b.logout()
-                m.execute("mv /etc/passwd.bak /etc/passwd")
+                try:
+                    m.execute("sed -r -i.bak '/^admin:/ s_:[^:]+$_:/bin/tcsh_' /etc/passwd")
+                    b.login_and_go()
+                    b.enter_page('/system')
+                    b.wait_visible('.system-information')
+                    b.logout()
+                finally:
+                    m.execute("mv /etc/passwd.bak /etc/passwd")
 
             # login with user shell that prints some stdout/err noise
             # having stdout output in ~/.bashrc confuses docker, so don't run on OSTree

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -721,6 +721,22 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
         self.allow_journal_messages(".*minutes left to unlock.*")
 
+    @skipImage("root logins disabled by default with ssh", "fedora-coreos")
+    def testPamAccess(self):
+        b = self.browser
+
+        # root login works by default
+        self.login_and_go(user="root")
+        b.logout()
+
+        # disable root login with pam_access
+        self.write_file("/etc/security/access.conf", "- : root : ALL\n", append=True)
+        self.sed_file("1 aaccount required pam_access.so", "/etc/pam.d/cockpit")
+        b.try_login(user="root")
+        b.wait_in_text("#login-error-message", "Permission denied")
+
+        self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
+
     @skipImage("sssd not available", "fedora-coreos")
     def testClientCertAuthentication(self):
         m = self.machine


### PR DESCRIPTION
These should produce a proper error message. This was apparently broken
in the past: https://bugs.debian.org/859648

Skip this on OSTree, as root logins don't work there.
