### PR TITLE
shell: Add entry for Georgian

### DIFF
--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -12,6 +12,7 @@
         "he-il": "עברית",
         "it-it": "italiano",
         "ja-jp": "日本語",
+        "ka-ge" :"ქართული",
         "ko-kr": "한국어",
         "nb-no": "norsk bokmål",
         "nl-nl": "Nederlands",


### PR DESCRIPTION
This is supposed to happen automatically, but due to bug [1] it did not.

[1] https://github.com/cockpit-project/bots/pull/3226

Fixes #17233