### PR TITLE
packagekit: handle timeSinceRefresh unitialized

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -738,7 +738,8 @@ const UpdatesStatus = ({ updates, highestSeverity, timeSinceRefresh, tracerPacka
     const numManualSoftware = tracerPackages.manual.length;
     const numRebootPackages = tracerPackages.reboot.length;
     let lastChecked;
-    if (timeSinceRefresh !== null)
+    // PackageKit returns G_MAXUINT if the db was never checked.
+    if (timeSinceRefresh !== null && timeSinceRefresh !== 2 ** 32 - 1)
         lastChecked = cockpit.format(_("Last checked: $0"), timeformat.distanceToNow(new Date().valueOf() - timeSinceRefresh * 1000, true));
 
     const notifications = [];


### PR DESCRIPTION
When the packagekit service has not refreshed yet PackageKit returns
G_MAXUINT which on Linux corresponds to 2^32-1 and shows as last checked
136 years ago.

PackageKit code https://github.com/PackageKit/PackageKit/blob/dadea5f987d7f86baff9abf42f9462d7f76a0e0e/src/pk-transaction-db.c#L219

![image](https://user-images.githubusercontent.com/67428/162779725-e5d0ca25-b21c-4997-9884-a260740ae252.png)
