### PR TITLE
workflows/npm-update(-pf).yml: change the environment

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -58,7 +58,6 @@ deploy_env "${THIS}-weblate"
 deploy_env "${THIS}-dist"
 
 # https://github.com/cockpit-project/node-cache
-#   - npm-install.yml
 #   - release.yml
 deploy_env node-cache
 

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -6,9 +6,10 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    environment: self
+    environment: node-cache
     permissions:
       pull-requests: write
+      contents: write
     runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
@@ -18,8 +19,6 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v2
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run npm-update bot
         run: |
@@ -28,4 +27,9 @@ jobs:
           git config --global user.email "cockpituous@cockpit-project.org"
           mkdir -p ~/.config/cockpit-dev
           echo ${{ github.token }} >> ~/.config/cockpit-dev/github-token
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
           bots/npm-update @patternfly >&2
+          ssh-add -D
+          ssh-agent -k
+

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,9 +6,10 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    environment: self
+    environment: node-cache
     permissions:
       pull-requests: write
+      contents: write
     runs-on: ubuntu-20.04
     steps:
       - name: Set up dependencies
@@ -18,8 +19,6 @@ jobs:
 
       - name: Clone repository
         uses: actions/checkout@v2
-        with:
-          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Run npm-update bot
         run: |
@@ -28,4 +27,8 @@ jobs:
           git config --global user.email "cockpituous@cockpit-project.org"
           mkdir -p ~/.config/cockpit-dev
           echo ${{ github.token }} >> ~/.config/cockpit-dev/github-token
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
           bots/npm-update ~@patternfly >&2
+          ssh-add -D
+          ssh-agent -k


### PR DESCRIPTION
Instead of running the npm-update workflow in the `self` environment and    
using SSH to push, push via HTTPS (with the `contents: write` permission    
now granted).    
    
This frees us to use the `node-cache` environment, which lets use use    
the `DEPLOY_KEY` secret from there with `tools/node-modules push`.    
    
Eventually we may want to create an environment with both deploy keys    
inside of it so that we can force-push the commit after we create the    
PR, in order to trigger the testing workflows to run.  Since we're not    
actually doing this force-push at the moment anyway, let's take this    
approach as the easier one.


Take a look at the branch here: 

https://github.com/cockpit-project/cockpit/commits/npm-update-workflow

It has the changes from this PR, plus a bogus commit to revert to old PF versions.  It had this workflow run:

https://github.com/cockpit-project/cockpit/runs/5993739199?check_suite_focus=true

which filed this PR:

https://github.com/cockpit-project/cockpit/pull/17242