### PR TITLE
systemd: allow removal of cockpit created timers

### DIFF
--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -85,3 +85,11 @@
 .font-xs {
     font-size: var(--pf-global--FontSize--xs);
 }
+
+.pf-c-dropdown__menu-item.pf-m-danger {
+	    color: var(--pf-global--danger-color--200);
+}
+
+.pf-c-alert.pf-m-inline.pf-m-danger {
+    margin-bottom: var(--pf-global--spacer--sm);
+}

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1829,6 +1829,8 @@ class MachineCase(unittest.TestCase):
         '''
         m = self.machine
         self.restore_file(path, post_restore_action=post_restore_action)
+        dirname = os.path.dirname(path)
+        m.execute(f"mkdir -p {dirname}")
         m.write(path, content, append=append, owner=owner, perm=perm)
 
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -427,7 +427,6 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
             def prepare(self):
                 if self.rebootRequired:
                     # setting app as static in tracer's helper file will cause it to require a reboot
-                    m.execute("mkdir -p /etc/tracer")
                     self.testObj.write_file("/etc/tracer/applications.xml",
                                             """
 <applications>

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -35,9 +35,6 @@ class TestSOS(MachineCase):
         b = self.browser
         m = self.machine
 
-        # HACK: sos ships wrong sos.conf, we need to mkdir it, see https://bugzilla.redhat.com/show_bug.cgi?id=1903281
-        if m.image == "centos-8-stream":
-            m.execute("mkdir -p /etc/sos")
         self.write_file("/etc/sos/sos.conf",
                         """
 [global]

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -212,6 +212,33 @@ Description=Test OnBoot Timer
 OnBootSec=200min
 Unit=test.service
 """)
+        self.write_file("/usr/local/lib/systemd/system/cockpit-system.timer",
+                        """
+[Unit]
+Description=Not deleteable Timer
+
+[Timer]
+OnCalendar=*:1/2
+""")
+        self.write_file(f"{path}/deleteme.service",
+                        """
+[Unit]
+Description=Delete Me Service
+
+[Service]
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=default.target
+""")
+        self.write_file(f"{path}/deleteme.timer",
+                        """
+[Unit]
+Description=Delete Me Timer
+
+[Timer]
+OnCalendar=*:1/2
+""")
 
         self.make_test_service(path)
 
@@ -288,8 +315,23 @@ Unit=test.service
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
         self.run_systemctl(user, "stop test-onboot.timer")
 
-        # Selects Paths tab - the test VM does not have any user path units
         if not user:
+            self.goto_service("deleteme.timer")
+            self.do_action("Delete")
+            b.click("#delete-timer-modal-btn")
+            self.wait_page_load()
+            self.assertNotIn("deleteme", m.execute("systemctl list-timers"))
+            m.execute(f"! test -f {path}/deleteme.service")
+            m.execute(f"! test -f {path}/deleteme.timer")
+
+            # system timers are not allowed to be deleted
+            self.goto_service("cockpit-system.timer")
+            b.click(".service-top-panel .pf-c-dropdown button")
+            b.wait_in_text(".service-top-panel .pf-c-dropdown__menu", "Disallow running")
+            b.wait_not_in_text(".service-top-panel .pf-c-dropdown__menu", "Delete")
+            b.click(".pf-c-breadcrumb a:contains('Services')")
+
+            # Selects Paths tab - the test VM does not have any user path units
             self.pick_tab(5)
             b.wait_not_in_text("#services-list", "test")
             b.wait_not_in_text("#services-list", ".target")

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -54,7 +54,6 @@ class PackageCase(MachineCase):
             self.addCleanup(self.machine.execute, "nmcli con delete fake")
 
         # HACK: packagekit often hangs on shutdown; https://bugzilla.redhat.com/show_bug.cgi?id=1717185
-        self.machine.execute("mkdir -p /etc/systemd/system/packagekit.service.d")
         self.write_file("/etc/systemd/system/packagekit.service.d/timeout.conf", "[Service]\nTimeoutStopSec=5\n")
 
         # disable all existing repositories to avoid hitting the network


### PR DESCRIPTION
Cockpit allows for the creation of simple systemd system timers without
the option for deletion. This commit implements deletion for all timers
created in /etc/systemd/system/ by cockpit or by hand. The unit which is
triggered by the timer is also removed. Masked timers are not allowed to
be deleted as these are system timers in /etc/systemd/system symlinked
to /dev/null.

---

# Allow removal of user created timers

User created systemd timers in /etc/systemd/system can now be removed in cockpit.
 
![image](https://user-images.githubusercontent.com/67428/167916891-4d6c01eb-7fef-4178-971c-5d05e29df027.png)

![image](https://user-images.githubusercontent.com/67428/167917091-cd8acd07-cf8e-4ee1-9a6c-00b57ac748ac.png)
