### PR TITLE
workflows: Restore issues write permissions to reposchutz

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     timeout-minutes: 5
     env:
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
Commit 0ce651fc7a dropped all write permissions. But deleting the label
requires writing to the issues API.

----

See [current workflow failure](https://github.com/cockpit-project/cockpit/runs/6001588717?check_suite_focus=true). *This* PR will fail also in any case, as reposchutz runs from main.

I temporarily removed reposchutz as a required check.