### PR TITLE
Fully automatic npm-update

### DIFF
--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -64,3 +64,11 @@ deploy_env node-cache
 # https://github.com/cockpit-project/org.cockpit_project.CockpitClient
 #   - update-flathub.yml
 deploy_env flathub cockpit-project/org.cockpit_project.CockpitClient
+
+# https://github.com/cockpit-project/cockpit (COCKPIT_DEPLOY_KEY)
+# https://github.com/cockpit-project/node-cache (NODE_CACHE_DEPLOY_KEY)
+#   - npm-update.yml
+#   - npm-update-pf.yml
+# Installed additionally to the above keys (+).
+deploy_env npm-update +cockpit-project/cockpit COCKPIT_DEPLOY_KEY
+deploy_env npm-update +cockpit-project/node-cache NODE_CACHE_DEPLOY_KEY

--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -31,11 +31,12 @@ fi
 deploy_env() {
     ENVIRONMENT="$1"
     DEPLOY_TO="${2:-${ORG}/${ENVIRONMENT}}"
+    SECRET_NAME="${3:-DEPLOY_KEY}"
 
     bots/github-upload-secrets $DRY_RUN \
         --receiver "${ORG}/${THIS}" \
         --env "${ENVIRONMENT}" \
-        --ssh-keygen DEPLOY_KEY \
+        --ssh-keygen "${SECRET_NAME}" \
         --deploy-to "${DEPLOY_TO}"
 }
 

--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -3,6 +3,9 @@
 # (Re-)generate all deploy keys on
 #   https://github.com/cockpit-project/cockpit/settings/environments
 #
+# Your personal access token needs `public_repo` for this to work:
+#   https://github.com/settings/tokens
+#
 # You might want this first:
 #   dnf install python3-pynacl
 #

--- a/.github/deploy-keys.sh
+++ b/.github/deploy-keys.sh
@@ -30,11 +30,7 @@ fi
 
 deploy_env() {
     ENVIRONMENT="$1"
-    if [ -n "${2:-}" ]; then
-        DEPLOY_TO="${ORG}/$2"
-    else
-        DEPLOY_TO="${ORG}/${ENVIRONMENT}"
-    fi
+    DEPLOY_TO="${2:-${ORG}/${ENVIRONMENT}}"
 
     bots/github-upload-secrets $DRY_RUN \
         --receiver "${ORG}/${THIS}" \
@@ -49,7 +45,7 @@ deploy_env() {
 # https://github.com/cockpit-project/cockpit
 #   - npm-update.yml
 #   - weblate-sync-po.yml
-deploy_env self cockpit
+deploy_env self cockpit-project/cockpit
 
 # https://github.com/cockpit-project/cockpit-weblate
 #   - weblate-sync-pot.yml
@@ -66,4 +62,4 @@ deploy_env node-cache
 
 # https://github.com/cockpit-project/org.cockpit_project.CockpitClient
 #   - update-flathub.yml
-deploy_env flathub org.cockpit_project.CockpitClient
+deploy_env flathub cockpit-project/org.cockpit_project.CockpitClient

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    environment: node-cache
+    environment: npm-update
     permissions:
       pull-requests: write
       contents: write
@@ -28,8 +28,17 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo ${{ github.token }} >> ~/.config/cockpit-dev/github-token
           eval $(ssh-agent)
-          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          ssh-add - <<< '${{ secrets.NODE_CACHE_DEPLOY_KEY }}'
           bots/npm-update @patternfly >&2
           ssh-add -D
           ssh-agent -k
 
+      - name: Force push the change to trigger testing workflows
+        run: |
+          sleep 1 # make sure the timestamp changes
+          git commit --amend --no-edit
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.COCKPIT_DEPLOY_KEY }}'
+          git push --force 'git@github.com:${{ github.repository }}' HEAD
+          ssh-add -D
+          ssh-agent -k

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 jobs:
   npm-update:
-    environment: node-cache
+    environment: npm-update
     permissions:
       pull-requests: write
       contents: write
@@ -28,7 +28,17 @@ jobs:
           mkdir -p ~/.config/cockpit-dev
           echo ${{ github.token }} >> ~/.config/cockpit-dev/github-token
           eval $(ssh-agent)
-          ssh-add - <<< '${{ secrets.DEPLOY_KEY }}'
+          ssh-add - <<< '${{ secrets.NODE_CACHE_DEPLOY_KEY }}'
           bots/npm-update ~@patternfly >&2
+          ssh-add -D
+          ssh-agent -k
+
+      - name: Force push the change to trigger testing workflows
+        run: |
+          sleep 1 # make sure the timestamp changes
+          git commit --amend --no-edit
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.COCKPIT_DEPLOY_KEY }}'
+          git push --force 'git@github.com:${{ github.repository }}' HEAD
           ssh-add -D
           ssh-agent -k


### PR DESCRIPTION
Do an extra force-push via SSH after opening the PR to trigger the tests to run.

See a test workflow run here:

https://github.com/cockpit-project/cockpit/actions/runs/2160854103

which opened this PR here:

https://github.com/cockpit-project/cockpit/pull/17252

and which reposchutz was able to successfully reproduce `npm install` for here:

https://github.com/cockpit-project/cockpit/runs/6006502062?check_suite_focus=true