### PR TITLE
test: Adjust special cases for rhel-9-1

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -104,7 +104,9 @@ You can set these environment variables to configure the test suite:
                   "rhel-8-6"
                   "rhel-8-6-distropkg"
                   "rhel-9-0"
+                  "rhel-9-1"
                   "ubuntu-2004"
+                  "ubuntu-2204"
                   "ubuntu-stable"
                "fedora-35" is the default (bots/machine/machine_core/constants.py)
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1075,7 +1075,7 @@ ProtocolHeader = X-Forwarded-Proto
         b.logout()
 
     @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos",
-               "rhel-8-6", "rhel-9-0", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204", "arch")
+               "rhel-8-6", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204", "arch")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxTLS(self):
         '''test proxying to Cockpit with TLS
@@ -1159,7 +1159,7 @@ server {
         b.wait_visible('article.system-health')
 
     @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos",
-               "rhel-8-6", "rhel-9-0", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204", "arch")
+               "rhel-8-6", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204", "arch")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxNoTLS(self):
         '''test proxying to Cockpit with plain HTTP

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -387,7 +387,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_restart_journal_messages()
 
     @skipImage("No tlog", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204",
-               "rhel-8-6", "rhel-9-0", "rhel-9-0-distropkg", "centos-8-stream", "fedora-coreos", "arch")
+               "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream", "fedora-coreos", "arch")
     def testSessionRecordingShell(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -123,7 +123,7 @@ class TestStorageResize(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @skipImage("No NTFS support installed", "rhel-8-6", "rhel-8-6-distropkg", "rhel-9-0", "rhel-9-0-distropkg", "centos-8-stream")
+    @skipImage("No NTFS support installed", "rhel-8-6", "rhel-8-6-distropkg", "rhel-9-0", "rhel-9-1", "centos-8-stream")
     def testResizeNtfs(self):
         self.checkResize("ntfs", False,
                          can_shrink=True, shrink_needs_unmount=True,

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -376,7 +376,7 @@ class TestStorageStratis(StorageCase):
 
 
 @skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2004", "ubuntu-2204", "arch")
-@skipImage("No Stratis on demand", "rhel-9-0", "rhel-8-6")
+@skipImage("No Stratis on demand", "rhel-9-0", "rhel-9-1", "rhel-8-6")
 class TestStoragePackagesStratis(PackageCase, StorageCase):
 
     def testStratisOndemandInstallation(self):

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -31,7 +31,7 @@ SUPPORTED_OS = ["centos-8-stream", "rhel-8-6", "rhel-8-6-distropkg"]
 SIZE_10G = "10000000000"
 
 
-@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
+@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-1")
 @skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageVDO(StorageCase):
 
@@ -176,7 +176,7 @@ class TestStorageVDO(StorageCase):
         b.wait_in_text("#detail-content", "No logical volumes")
 
 
-@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-0-distropkg")
+@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-1")
 @skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -754,7 +754,7 @@ fi
                                     '.*warning: setlocale: LC_ALL: cannot change locale.*',
                                     'done')
 
-    @skipImage("Insights client not yet available on RHEL 9", "rhel-9-0")
+    @skipImage("Insights client not yet available on RHEL 9", "rhel-9-0", "rhel-9-1")
     def testInsightsStatus(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -522,7 +522,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible(journal_line_selector.format("INFO_MESSAGE"))
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtSegv(self):
@@ -556,7 +556,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-details .pf-c-accordion__expanded-content-body dt:contains('signal') + dd:contains('11')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtDelete(self):
@@ -588,7 +588,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_not_present("button.pf-m-danger:contains('Delete')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReport(self):
@@ -653,7 +653,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReportCancel(self):
@@ -689,7 +689,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') .pf-l-split__item:contains('Reporting was canceled')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "centos-8-stream",
+               "ubuntu-2004", "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReportNoReportd(self):


### PR DESCRIPTION
Also drop unused rhel-9-0-distropkg skips. We never set that up and
don't plan to, as there is just a single cockpit srpm in RHEL 9.