### PR TITLE
systemd: Updates for the Insights status

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -756,7 +756,6 @@ fi
                                     '.*warning: setlocale: LC_ALL: cannot change locale.*',
                                     'done')
 
-    @skipImage("Insights client not yet available on RHEL 9", "rhel-9-0", "rhel-9-1")
     def testInsightsStatus(self):
         m = self.machine
         b = self.browser
@@ -772,15 +771,15 @@ fi
         # TLS mock insights server certificate
         m.upload(["verify/files/mock-insights", "../src/tls/ca/alice.key", "../src/tls/ca/alice.pem"], "/var/tmp")
         m.spawn("/var/tmp/mock-insights", "mock-insights")
+
+        hostname = m.execute("hostname").rstrip()
         m.write("/etc/insights-client/insights-client.conf",
-                """
+                f"""
 [insights-client]
-gpg=False
 auto_config=False
-base_url=localhost:8888/r/insights
-# even if we would add tls/ca/ca.pem (the signer of alice.pem) to /etc/pki, some later part of insights still
-# does not respect that; so just give in, and disable validation
-cert_verify=False
+auto_update=False
+base_url={hostname}:8443/r/insights
+cert_verify=/var/lib/insights/mock-certs/ca.crt
 username=admin
 password=foobar
 """)
@@ -791,6 +790,15 @@ password=foobar
 
         # Enable insights, results should appear automatically
         m.execute("insights-client --register")
+        b.wait_in_text(".system-health-insights a", "3 hits, including important")
+        self.assertIn("123-nice-id", b.attr(".system-health-insights a", "href"))
+
+        # Switch to limited access, insights status will disappear completely
+        b.drop_superuser()
+        b.wait_not_present(".system-health-insights")
+
+        # Switch to admin access, insights status will re-appear
+        b.become_superuser()
         b.wait_in_text(".system-health-insights a", "3 hits, including important")
         self.assertIn("123-nice-id", b.attr(".system-health-insights a", "href"))
 

--- a/test/verify/files/mock-insights
+++ b/test/verify/files/mock-insights
@@ -10,17 +10,19 @@
 #
 # You need these in your insights-client.conf:
 #
-# gpg=False
 # auto_config=False
-# base_url=127.0.0.1:8888/r/insights
-# insecure_connection=True
+# auto_update=False
+# base_url=127.0.0.1:8443/r/insights
+# cert_verify=/var/lib/insights/mock-certs/ca.crt
 # username=admin
 # password=foobar
 
 from http.server import *
 import json
+import os
 import re
 import ssl
+import subprocess
 
 systems = {}
 
@@ -36,12 +38,6 @@ class handler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.end_headers()
             self.wfile.write(b"lub-dup")
-            return
-
-        m = self.match("/r/insights/v1/static/core/insights-core.egg")
-        if m:
-            self.send_response(304)
-            self.end_headers()
             return
 
         m = self.match("/r/insights/v1/static/uploader.v2.json")
@@ -138,9 +134,22 @@ class handler(BaseHTTPRequestHandler):
 
 
 def insights_server(port):
+    # Let's put the certs into /var/lib/insights so that SELinux
+    # allows insights-client to actually read ca.crt when running as a
+    # systemd service.
+    certdir = "/var/lib/insights/mock-certs"
+    if not os.path.exists(certdir):
+        os.makedirs(certdir)
+        subprocess.check_call(["sscg"], cwd=certdir)
+
     httpd = HTTPServer(('', port), handler)
-    httpd.socket = ssl.wrap_socket(httpd.socket, certfile='/var/tmp/alice.pem', keyfile='/var/tmp/alice.key', server_side=True)
+    ssl_args = {
+        'certfile': f'{certdir}/service.pem',
+        'keyfile': f'{certdir}/service-key.pem',
+        'server_side': True,
+    }
+    httpd.socket = ssl.wrap_socket(httpd.socket, **ssl_args)
     httpd.serve_forever()
 
 
-insights_server(8888)
+insights_server(8443)


### PR DESCRIPTION
The mock-insights server and the client config for it have been
updated from here:

   https://github.com/candlepin/subscription-manager/pull/2998
   https://github.com/candlepin/subscription-manager/pull/2996

The /var/lib/insights directory needs to be read as superuser, so the
InsightsStatus component needs to re-open its file watches
accordingly.