### PR TITLE
workflows/npm-update{,-pf}.yml: don't force push main

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Force push the change to trigger testing workflows
         run: |
+          # Don't force-push if no branch was created
+          test "$(git symbolic-ref HEAD)" = '${{ github.ref }}' && exit
+
           sleep 1 # make sure the timestamp changes
           git commit --amend --no-edit
           eval $(ssh-agent)

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -35,6 +35,9 @@ jobs:
 
       - name: Force push the change to trigger testing workflows
         run: |
+          # Don't force-push if no branch was created
+          test "$(git symbolic-ref HEAD)" = '${{ github.ref }}' && exit
+
           sleep 1 # make sure the timestamp changes
           git commit --amend --no-edit
           eval $(ssh-agent)


### PR DESCRIPTION
In case no update happened, we really ought to be skipping the
force-push.  Check the current branch name, and don't do a force push if
it's main.