### PR TITLE
Partly revert dc2f5125a5fd74c30cb47779733e84aae925c15d

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ Makefile.in
 /src/ws/cockpit.appdata.xml
 /src/ws/mock-dbus-tests.[ch]
 /test/images/
+/tools/ar-lib
 /tools/compile
 /tools/debian/copyright
 /tools/depcomp

--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,7 @@ am__tar='tar --format=ustar --sort=name --owner=root:0 --group=root:0 -chf - "$$
 
 AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
+AM_PROG_AR
 AC_PROG_RANLIB
 
 AC_CHECK_FUNCS(


### PR DESCRIPTION
AM_PROG_AR is still required on linux, see https://github.com/cockpit-project/cockpit/pull/2183. Not sure about the `.gitignore` stuff but it got added back then as well in https://github.com/cockpit-project/cockpit/commit/293d8ce1e6cd21970dfb73ea5a8667d5fc78b39d.

**Before**:

```
[...]
checking for x86_64-pc-linux-gnu-ranlib... x86_64-pc-linux-gnu-ranlib
[...]
```

```
[...]
rm -f libcockpit-bridge.a
ar cru libcockpit-bridge.a src/bridge/libcockpit_bridge_a-cockpitconnect.o src/bridge/libcockpit_bridge_a-cockpitdbuscache.o src/bridge/libcockpit_bridge_a-cockpitdbusconfig.o src/bridge/libcockpit_bridge_a-cockpitdbusinternal.o src/bridge/libcockpit_bridge_a-cockpitdbusjson.o src/bridge/libcockpit_bridge_a-cockpitdbusloginmessages.o src/bridge/libcockpit_bridge_a-cockpitdbusmachines.o src/bridge/libcockpit_bridge_a-cockpitdbusmeta.o src/bridge/libcockpit_bridge_a-cockpitdbusprocess.o src/bridge/libcockpit_bridge_a-cockpitdbusrules.o src/bridge/libcockpit_bridge_a-cockpitdbususer.o src/bridge/libcockpit_bridge_a-cockpitechochannel.o src/bridge/libcockpit_bridge_a-cockpitfslist.o src/bridge/libcockpit_bridge_a-cockpitfsread.o src/bridge/libcockpit_bridge_a-cockpitfsreplace.o src/bridge/libcockpit_bridge_a-cockpitfswatch.o src/bridge/libcockpit_bridge_a-cockpithttpstream.o src/bridge/libcockpit_bridge_a-cockpitinteracttransport.o src/bridge/libcockpit_bridge_a-cockpitnullchannel.o src/bridge/libcockpit_bridge_a-cockpitpackages.o src/bridge/libcockpit_bridge_a-cockpitpacketchannel.o src/bridge/libcockpit_bridge_a-cockpitpaths.o src/bridge/libcockpit_bridge_a-cockpitpeer.o src/bridge/libcockpit_bridge_a-cockpitpipechannel.o src/bridge/libcockpit_bridge_a-cockpitrouter.o src/bridge/libcockpit_bridge_a-cockpitstream.o src/bridge/libcockpit_bridge_a-cockpitwebsocketstream.o   
rm -f libcockpit-metrics.a
ar cru libcockpit-metrics.a src/bridge/libcockpit_metrics_a-cockpitblocksamples.o src/bridge/libcockpit_metrics_a-cockpitcgroupsamples.o src/bridge/libcockpit_metrics_a-cockpitcpusamples.o src/bridge/libcockpit_metrics_a-cockpitdisksamples.o src/bridge/libcockpit_metrics_a-cockpitinternalmetrics.o src/bridge/libcockpit_metrics_a-cockpitmemorysamples.o src/bridge/libcockpit_metrics_a-cockpitmetrics.o src/bridge/libcockpit_metrics_a-cockpitmountsamples.o src/bridge/libcockpit_metrics_a-cockpitnetworksamples.o src/bridge/libcockpit_metrics_a-cockpitsamples.o  
make[1]: *** [Makefile:3149: libcockpit-bridge.a] Error 123
make[1]: *** Waiting for unfinished jobs....
make[1]: *** [Makefile:3294: libcockpit-metrics.a] Error 123
[...]
```


**After**:

```
[...]
checking for x86_64-pc-linux-gnu-ar... x86_64-pc-linux-gnu-ar
checking the archiver (x86_64-pc-linux-gnu-ar) interface... ar
checking for x86_64-pc-linux-gnu-ranlib... x86_64-pc-linux-gnu-ranlib
[...]
```

```
[...]
rm -f libcockpit-bridge.a
x86_64-pc-linux-gnu-ar cru libcockpit-bridge.a src/bridge/libcockpit_bridge_a-cockpitconnect.o src/bridge/libcockpit_bridge_a-cockpitdbuscache.o src/bridge/libcockpit_bridge_a-cockpitdbusconfig.o src/bridge/libcockpit_bridge_a-cockpitdbusinternal.o src/bridge/libcockpit_bridge_a-cockpitdbusjson.o src/bridge/libcockpit_bridge_a-cockpitdbusloginmessages.o src/bridge/libcockpit_bridge_a-cockpitdbusmachines.o src/bridge/libcockpit_bridge_a-cockpitdbusmeta.o src/bridge/libcockpit_bridge_a-cockpitdbusprocess.o src/bridge/libcockpit_bridge_a-cockpitdbusrules.o src/bridge/libcockpit_bridge_a-cockpitdbususer.o src/bridge/libcockpit_bridge_a-cockpitechochannel.o src/bridge/libcockpit_bridge_a-cockpitfslist.o src/bridge/libcockpit_bridge_a-cockpitfsread.o src/bridge/libcockpit_bridge_a-cockpitfsreplace.o src/bridge/libcockpit_bridge_a-cockpitfswatch.o src/bridge/libcockpit_bridge_a-cockpithttpstream.o src/bridge/libcockpit_bridge_a-cockpitinteracttransport.o src/bridge/libcockpit_bridge_a-cockpitnullchannel.o src/bridge/libcockpit_bridge_a-cockpitpackages.o src/bridge/libcockpit_bridge_a-cockpitpacketchannel.o src/bridge/libcockpit_bridge_a-cockpitpaths.o src/bridge/libcockpit_bridge_a-cockpitpeer.o src/bridge/libcockpit_bridge_a-cockpitpipechannel.o src/bridge/libcockpit_bridge_a-cockpitrouter.o src/bridge/libcockpit_bridge_a-cockpitstream.o src/bridge/libcockpit_bridge_a-cockpitwebsocketstream.o   
rm -f libcockpit-metrics.a
x86_64-pc-linux-gnu-ar cru libcockpit-metrics.a src/bridge/libcockpit_metrics_a-cockpitblocksamples.o src/bridge/libcockpit_metrics_a-cockpitcgroupsamples.o src/bridge/libcockpit_metrics_a-cockpitcpusamples.o src/bridge/libcockpit_metrics_a-cockpitdisksamples.o src/bridge/libcockpit_metrics_a-cockpitinternalmetrics.o src/bridge/libcockpit_metrics_a-cockpitmemorysamples.o src/bridge/libcockpit_metrics_a-cockpitmetrics.o src/bridge/libcockpit_metrics_a-cockpitmountsamples.o src/bridge/libcockpit_metrics_a-cockpitnetworksamples.o src/bridge/libcockpit_metrics_a-cockpitsamples.o
[...]
```