### PR TITLE
reposchutz: use fetch-depth: 0

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Clone target branch
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Fetch PR commits
         run: git fetch origin "${BASE_SHA}" "${HEAD_SHA}"


### PR DESCRIPTION
We use `--not` with `git log` to find the merge base of the base branch
with the proposed branch, which doesn't work if we fetched them shallow.

I had thought that `git fetch` would fix this, but it turns out not to
sufficiently de-shallow the already-checked-out target branch.

Just do `fetch-depth: 0` from the start to avoid this non-sense.


I didn't test this, but it certainly won't make anything *worse* :)