### PR TITLE
configure.ac: use AC_CHECK_TOOL to find ar

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,9 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_SYS_LARGEFILE
 AC_PROG_RANLIB
 
+# This is required to find the correct `ar` for cross-compiling
+AC_CHECK_TOOL(AR, ar)
+
 AC_CHECK_FUNCS(
     closefrom
 )


### PR DESCRIPTION
This makes sure we get the executable with the correct `--host` prefix,
allowing us to successfully cross-compile.  Without this, `AR` gets
hard-coded to `ar`.