### PR TITLE
nosmt code and test cleanup, work around kernel-install bugs

### DIFF
--- a/pkg/systemd/kernelopt.sh
+++ b/pkg/systemd/kernelopt.sh
@@ -29,21 +29,8 @@ grub() {
     if type grubby >/dev/null 2>&1; then
         if [ "$1" = set ]; then
             grubby --args="$2" --update-kernel=ALL
-            # HACK: grubby on RHEL 8.0 does not change default kernel args (https://bugzilla.redhat.com/show_bug.cgi?id=1690765)
-            envopts=$(grub2-editenv - list | grep ^kernelopts) || envopts=""
-            if [ -n "$envopts" ]; then
-                newenvopts=$(echo "$envopts" | sed -r "s/$key(=[^[:space:]\"]*)?/$2/g; t; s/$/ $2/")
-            fi
         else
             grubby --remove-args="$2" --update-kernel=ALL
-            envopts=$(grub2-editenv - list | grep ^kernelopts) || envopts=""
-            if [ -n "$envopts" ]; then
-                newenvopts=$(echo "$envopts" | sed -r "s/$key(=[^[:space:]\"]*)?//g")
-            fi
-        fi
-
-        if [ -n "$envopts" ] && [ "$newenvopts" != "$envopts" ]; then
-            grub2-editenv - set "$newenvopts"
         fi
 
     # on Debian/Ubuntu, use update-grub, which reads from /etc/default/grub

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -666,16 +666,11 @@ machine         : 8561
         # - BLS, entries use $kernelopt, that is defined in grubenv (newest)
         if not m.ostree_image:
             m.execute(r"""set -e
-. /etc/os-release
 touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
 else
-    if [ "$ID" = rhel -o "$ID" = centos ] && [ "${VERSION_ID#7}" != "$VERSION_ID" ]; then
-        new-kernel-pkg --package kernel --install 42.0.0  # RHEL/CentOS 7
-    else
-        kernel-install add 42.0.0 /boot/vmlinuz-42.0.0 2>/dev/null # Fedora/RHEL >= 8
-    fi
+    kernel-install add 42.0.0 /boot/vmlinuz-42.0.0 2>/dev/null
 fi
 grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
   grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
@@ -684,16 +679,11 @@ grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
 """)
             # clean up so that next reboot works
             m.execute(r"""set -e
-. /etc/os-release
 rm /boot/vmlinuz-42.0.0
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
 else
-    if [ "$ID" = rhel -o "$ID" = centos ] && [ "${VERSION_ID#7}" != "$VERSION_ID" ]; then
-        new-kernel-pkg --package kernel --remove 42.0.0  # RHEL/CentOS 7
-    else
-        kernel-install remove 42.0.0 /boot/vmlinuz-42.0.0  # Fedora/RHEL >= 8
-    fi
+    kernel-install remove 42.0.0 /boot/vmlinuz-42.0.0
 fi
 """)
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -658,24 +658,21 @@ machine         : 8561
         else:
             self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
 
-        # Ensure that future kernel upgrades also retain the option; various
-        # Fedora and RHEL version are in different stages of the BLS
-        # transition, so there are three cases:
-        # - no BLS, options go into /etc/default/grub and grub.cfg (oldest)
-        # - BLS, options go directly into entries (RHEL 8.0)
-        # - BLS, entries use $kernelopt, that is defined in grubenv (newest)
+        # Ensure that future kernel upgrades also retain the option
+        # - Debian: no BLS, options go into /etc/default/grub and grub.cfg
+        # - BLS, options go directly into entries, or entries use $kernelopt (defined in grubenv)
         if not m.ostree_image:
             m.execute(r"""set -e
 touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
+    grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg
 else
     kernel-install add 42.0.0 /boot/vmlinuz-42.0.0 2>/dev/null
+    grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
+    ( grub2-editenv list | grep -q kernelopts.*nosmt &&
+      grep -q '^options.*$kernelopts' /boot/loader/entries/*42.0.0*.conf )
 fi
-grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg ||
-  grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
-  ( grub2-editenv list | grep -q kernelopts.*nosmt &&
-    grep -q '^options.*$kernelopts' /boot/loader/entries/*42.0.0*.conf )
 """)
             # clean up so that next reboot works
             m.execute(r"""set -e

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -668,6 +668,7 @@ if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
     grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg
 else
+    cp -a /boot/grub2/grubenv /boot/grub2/grubenv.prev
     kernel-install add 42.0.0 /boot/vmlinuz-42.0.0 2>/dev/null
     grep -q '^options.*\bnosmt\b' /boot/loader/entries/*42.0.0*.conf ||
     ( grub2-editenv list | grep -q kernelopts.*nosmt &&
@@ -681,6 +682,8 @@ if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
 else
     kernel-install remove 42.0.0 /boot/vmlinuz-42.0.0
+    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2078359 and https://bugzilla.redhat.com/show_bug.cgi?id=2078379
+    mv /boot/grub2/grubenv.prev /boot/grub2/grubenv
 fi
 """)
 


### PR DESCRIPTION
Removing a kernel leaves behind its BLS entry [1], and `kernel-install remove`
leaves GRUB's default kernel setting to the just removed kernel [2].
Both bugs together cause a boot failure when removing old kernels [3].
Work around that by restoring grub's defaults after the fake kernel
install/removal.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2078379
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2078359
[3] https://github.com/cockpit-project/bots/pull/3293

 - Requires https://github.com/cockpit-project/bots/pull/3296