### PR TITLE
logs: Use utility for toolbar wrapping

### DIFF
--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -186,7 +186,7 @@ export const LogsPage = () => {
             <PageSection id="journal" padding={{ default: 'noPadding' }} className="ct-pagesection-mobile">
                 <Toolbar>
                     <ToolbarContent>
-                        <ToolbarToggleGroup toggleIcon={<><span className="pf-c-button__icon pf-m-start"><FilterIcon /></span>{_("Toggle filters")}</>} breakpoint="md">
+                        <ToolbarToggleGroup className="pf-u-flex-wrap pf-u-flex-grow-1" toggleIcon={<><span className="pf-c-button__icon pf-m-start"><FilterIcon /></span>{_("Toggle filters")}</>} breakpoint="md">
                             <ToolbarGroup>
                                 <ToolbarItem>
                                     <Select toggleId="logs-predefined-filters"

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -5,6 +5,7 @@
 @import "global-variables.scss";
 @import "@patternfly/patternfly/components/FormControl/form-control.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
+@import "@patternfly/patternfly/utilities/Flex/flex.scss";
 
 // https://github.com/patternfly/patternfly-react/issues/5993
 .pf-c-popover.pf-m-width-auto {
@@ -113,11 +114,6 @@
     // Make toolbar stretch to all the available space and wrap up to two lines
     --pf-c-toolbar--PaddingTop: 0;
     --pf-c-toolbar--PaddingBottom: 0;
-
-    .pf-c-toolbar__group.pf-m-toggle-group.pf-m-show-on-md {
-        flex-grow: 1;
-        flex-wrap: wrap;
-    }
 
     .pf-c-toolbar__group {
         padding-top: 0.5rem;


### PR DESCRIPTION
Name of this class has been changed in the recent PF update so it
stopped working. Using utility prevents such breakage in the future.

Fixes #17257