### PR TITLE
shell: Don't show "Oops" for silent errors

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -4519,7 +4519,10 @@ function factory() {
 
     const old_onerror = window.onerror;
     window.onerror = function(msg, url, line) {
-        cockpit.oops();
+        // Errors with url == "" are not logged apparently, so let's
+        // not show the "Oops" for them either.
+        if (url != "")
+            cockpit.oops();
         if (old_onerror)
             return old_onerror(msg, url, line);
         return false;

--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -596,7 +596,10 @@ function Index() {
 
     const old_onerror = window.onerror;
     window.onerror = function cockpit_error_handler(msg, url, line) {
-        self.show_oops();
+        // Errors with url == "" are not logged apparently, so let's
+        // not show the "Oops" for them either.
+        if (url != "")
+            self.show_oops();
         if (old_onerror)
             return old_onerror(msg, url, line);
         return false;


### PR DESCRIPTION
Fixes #17288