### PR TITLE
packagekit: order kpatches before security updates

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -924,8 +924,8 @@ class CardsPage extends React.Component {
                                 </Popover>
                             </FlexItem>
                         </Flex>}
-                    {this.props.applySecurity}
                     {this.props.applyKpatches}
+                    {this.props.applySecurity}
                     {this.props.applyAll}
                 </div>),
                 containsList: true,


### PR DESCRIPTION
Order the install updates buttons based on amount of updates with
kpatches being the fewest.

![image](https://user-images.githubusercontent.com/67428/165708575-312835e4-ffa3-4492-85d9-a365510bf289.png)
