### PR TITLE
shell: Rewrite superuser dialogs 

### DIFF
--- a/pkg/systemd/superuser-alert.jsx
+++ b/pkg/systemd/superuser-alert.jsx
@@ -20,44 +20,24 @@
 import cockpit from "cockpit";
 import React from 'react';
 
-import {
-    Alert, Button
-} from '@patternfly/react-core';
+import { Alert } from '@patternfly/react-core';
 
 import { LockIcon } from '@patternfly/react-icons';
 
-import { SuperuserDialogs } from "../shell/superuser.jsx";
+import { SuperuserButton } from "../shell/superuser.jsx";
+import { superuser } from "superuser.js";
 
 const _ = cockpit.gettext;
 
 export class SuperuserAlert extends React.Component {
-    constructor () {
-        super();
-        this.superuser = cockpit.dbus(null, { bus: "internal" }).proxy("cockpit.Superuser", "/superuser");
-        this.superuser.addEventListener("changed", () => { this.setState({}) });
-    }
-
     render () {
-        const actions =
-            <SuperuserDialogs create_trigger={(unlocked, onclick) =>
-                <Button onClick={onclick}>{_("Turn on administrative access")}</Button>}
-                proxy={this.superuser}
-            />;
+        if (superuser.allowed)
+            return null;
 
-        // The SuperuserDialogs element above needs to be in the DOM
-        // regardless of the superuser level so that the dialogs are
-        // not closed unexpectedly.  Thus, we merely hide the Alert
-        // when it does not apply, instead of fully removing it.
-
-        return (
-            <>
-                <Alert className="ct-limited-access-alert"
-                       hidden={this.superuser.Current != "none"}
-                       variant="warning" isInline
-                       customIcon={<LockIcon />}
-                       actionClose={actions}
-                       title={_("Web console is running in limited access mode.")} />
-            </>
-        );
+        return <Alert className="ct-limited-access-alert"
+                      variant="warning" isInline
+                      customIcon={<LockIcon />}
+                      actionClose={<SuperuserButton />}
+        title={_("Web console is running in limited access mode.")} />;
     }
 }

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -239,7 +239,7 @@ session include system-auth
         b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
-        b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
+        b.wait_not_present(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
 
 @skipDistroPackage()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -230,7 +230,7 @@ class TestSystemInfo(MachineCase):
         b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
-        b.wait_not_visible(".pf-c-alert:contains('Web console is running in limited access mode.')")
+        b.wait_not_present(".pf-c-alert:contains('Web console is running in limited access mode.')")
 
         # Change the date
         b.click("#system_information_systime_button")


### PR DESCRIPTION
Now they use function components and the UnlockDialog maintains its
own state.

Most importantly, the new SuperuserButton is no longer tied to the
life-cycle of the dialogs and the SuperuserAlert component and its
parents do not need to do anything special to keep it alive.