### PR TITLE
packit: Enable tests on Fedora Rawhide, systemd: Cancel shutdown as root

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -20,6 +20,7 @@ jobs:
       targets:
       - fedora-35
       - fedora-36
+      - fedora-development
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
 

--- a/pkg/systemd/overview-cards/shutdownStatus.jsx
+++ b/pkg/systemd/overview-cards/shutdownStatus.jsx
@@ -40,7 +40,7 @@ const getScheduledShutdown = (setShutdownTime, setShutdownType) => {
 };
 
 const cancelShutdownAction = () => {
-    const client = cockpit.dbus("org.freedesktop.login1");
+    const client = cockpit.dbus("org.freedesktop.login1", { superuser: "try" });
     return client.call("/org/freedesktop/login1", "org.freedesktop.login1.Manager", "CancelScheduledShutdown")
             .then(([cancelled]) => {
                 if (!cancelled) {


### PR DESCRIPTION
These should be treated as advisory, but they will help us to spot
issues like https://bugzilla.redhat.com/show_bug.cgi?id=2081039

----

systemd 251 started to guard this as a privileged operation with polkit [1].
So call this as root if possible.
    
This is an incomplete fix: We should not even show the cancel action if
the session is not root and not allowed via a polkit rule, but that is
more intrusive -- let's fix the exploding gating test first.
    
https://bugzilla.redhat.com/show_bug.cgi?id=2081039
    
[1] https://github.com/systemd/systemd/commit/ec14fba91c94f38f3