### PR TITLE
workflows: Prefix node-cache tags with project name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,8 @@ jobs:
       - name: Tag node-cache
         run: |
           set -eux
-          TAG="$(basename $GITHUB_REF)"
+          # this is a shared repo, prefix with project name
+          TAG="${GITHUB_REPOSITORY#*/}-$(basename $GITHUB_REF)"
 
           tools/node-modules checkout
           cd node_modules


### PR DESCRIPTION
This is a shared repository, and e.g. cockpit-machines is using that as
well now. We want to tag c-machines releases in this as well. To avoid
version number collisions, prefix the tag with the project name.