### PR TITLE
shell: Translate documentation links

### DIFF
--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -130,7 +130,7 @@ export class TopNav extends React.Component {
 
         docs.forEach(e => {
             docItems.push(<DropdownItem key={e.label} href={e.url} target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>
-                {e.label}
+                {_(e.label)}
             </DropdownItem>);
         });
 


### PR DESCRIPTION
We already pick these items from manifest and translate them. We just
never told Cockpit to show them in the target language.