### PR TITLE
tls: avoid static port in test-tls-server

### DIFF
--- a/src/tls/server.c
+++ b/src/tls/server.c
@@ -272,6 +272,13 @@ server_init (const char *wsinstance_sockdir,
     }
 }
 
+int
+server_get_listener (void)
+{
+  assert (server.first_listener == server.last_listener);
+  return server.first_listener;
+}
+
 /**
  * server_cleanup: Free all resources to the cockpit TLS proxy server
  *

--- a/src/tls/server.h
+++ b/src/tls/server.h
@@ -36,6 +36,9 @@ server_run (void);
 void
 server_cleanup (void);
 
+int
+server_get_listener (void);
+
 /* these are for unit tests only */
 bool
 server_poll_event (int timeout);


### PR DESCRIPTION
We've run into issues where port 9123 isn't available on the builder
we're using, so let's use a dynamically allocated port instead.

We accomplish this by passing 0 as the port number (which already
worked) but we need to have a way to figure out what port we actually
used.  We add a minimal accessor to the server code to let us get the
listener socket fd, which we can call getsockname() on to determine to
where we ought to connect.