### PR TITLE
cockpit.spec: drop RHEL build hanging workarounds

### DIFF
--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -172,7 +172,6 @@ Recommends: subscription-manager-cockpit
 %make_build
 
 %check
-exec 2>&1
 # HACK: RHEL i686 builders hang after running all tests; not a supported architecture, so don't bother
 %if 0%{?rhel} >= 8
 %ifarch i686

--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -172,13 +172,7 @@ Recommends: subscription-manager-cockpit
 %make_build
 
 %check
-# HACK: RHEL i686 builders hang after running all tests; not a supported architecture, so don't bother
-%if 0%{?rhel} >= 8
-%ifarch i686
-%define testsuite_skip #
-%endif
-%endif
-%{?testsuite_skip} make -j$(nproc) check
+make -j$(nproc) check
 
 %install
 %make_install


### PR DESCRIPTION
 - [x] #17315
 - [ ] manually test a i686 RHEL 8 build