### PR TITLE
client: enable dark mode if libhandy is available

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -34,6 +34,12 @@ gi.require_version("WebKit2", "4.0")  # NOQA
 
 from gi.repository import GLib, Gio, Gtk, WebKit2
 
+try:
+    gi.require_version("Handy", "1")
+    from gi.repository import Handy
+except (ValueError, ImportError):
+    Handy = None
+
 libexecdir = os.path.realpath(__file__ + '/..')
 
 libc6 = ctypes.cdll.LoadLibrary('libc.so.6')
@@ -183,6 +189,9 @@ class CockpitClient(Gtk.Application):
 
     def do_startup(self):
         Gtk.Application.do_startup(self)
+
+        if Handy:
+            Handy.StyleManager.get_default().set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
 
         # .add_action_entries() binding is broken for GApplication
         # https://gitlab.gnome.org/GNOME/pygobject/-/issues/426


### PR DESCRIPTION
Do a conditional import of libhandy, and if it's available, use it to
automatically set our colour scheme to match the system setting.

Notes:

I followed the implementation suggestions here: https://gitlab.gnome.org/GNOME/Initiatives/-/wikis/Dark-Style-Preference

We can't use the "GTK4+ libadwaita" route because WebKit isn't available for GTK4 yet: https://bugs.webkit.org/show_bug.cgi?id=210100


I've checked this, and it works from inside of the flatpak container as well.

I've also checked using the `--external-ws` commandline option to point the browser to external sites that support dark mode, and the setting is wired through automatically.

For example

```
src/client/cockpit-client --external-ws https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme
```

That suggests that once our own html/css support `prefers-color-scheme` this should work.

This needs review for both code, but also for if it makes sense at all to land this now, without having also implemented dark mode for at least the login screen.  It looks a bit silly to style only the headerbar dark while everything else stays light.