### PR TITLE
bridge: Don't 404 on "po.js"

### DIFF
--- a/src/bridge/cockpitpackages.c
+++ b/src/bridge/cockpitpackages.c
@@ -1020,6 +1020,18 @@ package_content (CockpitPackages *packages,
 
       bytes = cockpit_web_response_negotiation (filename, package ? package->paths : NULL, language, &is_language_specific, &gzipped, &error);
 
+      /* HACK: if a translation file is missing, just return empty
+       * content. This saves a whole lot of 404s in the developer
+       * console when trying to fetch po.js for English, for example.
+       * Note that error == NULL only in the 'not found' case.
+       */
+      if (bytes == NULL && error == NULL && g_str_has_suffix (filename, "/po.js"))
+        {
+          bytes = g_bytes_new_static ("", 0);
+          is_language_specific = TRUE;
+          gzipped = FALSE;
+        }
+
       /* When globbing most errors result in a zero length block */
       if (globbing)
         {


### PR DESCRIPTION
If we can't find a file called "po.js", return an empty document rather
than an error.  This matches what happens in the globbing case, and
avoids filling the debugging console with messages about incorrect
content type when requesting po.js in English (due to our HTML 404
page).