### PR TITLE
make-compile-commands: avoid including makefiles

### DIFF
--- a/tools/make-compile-commands
+++ b/tools/make-compile-commands
@@ -20,7 +20,11 @@ with tempfile.NamedTemporaryFile() as makefile_copy:
     # to run the whole configure machinery, so copy the Makefile to a temporary
     # path to short-circuit the exception.
     with open('Makefile', 'rb') as original_makefile:
-        makefile_copy.write(original_makefile.read())
+        original = original_makefile.readlines()
+
+    # Also remove include lines to prevent included makefiles from being rebuilt
+    patched = [line for line in original if not re.search(b'^-?include', line)]
+    makefile_copy.write(b''.join(patched))
 
     # get the build commands
     output = subprocess.check_output(['make',


### PR DESCRIPTION
We try hard to avoid the "except in certain circumstances" exception to
`make --dry-run` that the manpage talks about, making a renamed copy of
the Makefile to avoid it being regenerated, but we forgot that these
exceptions also apply to regenerating included Makefiles.

In particular, our current approach causes the "dummy" .deps/*.Po files
to be generated as a side-effect of running tools/make-compile-commands.
If that process races with the actual compilation (as it often does), it
can lead to incorrect results.

Let's up our game a bit and also try to remove "include" lines from the
Makefile that we're processing.

Removing these files from consideration (and sometimes rebuilding) also
reduces the time to create `compile-commands.json` from just under 1s to
just under 100ms.