### PR TITLE
sass: Reduce duplication in variables import

### DIFF
--- a/pkg/lib/_global-variables.scss
+++ b/pkg/lib/_global-variables.scss
@@ -1,4 +1,4 @@
-@import "@patternfly/patternfly/base/patternfly-variables.scss";
+@import "@patternfly/patternfly/sass-utilities/all";
 
 /*
  * PatternFly 4 adapting the lists too early.


### PR DESCRIPTION
Contents of `@patternfly/patternfly/base/patternfly-variables.scss` currently includes two imports:

```scss
@import "../sass-utilities/all";
@import "variables";
```

The `sass-utilties/all` import does not render into CSS; it only includes SASS-specific contents (that is: variables and mixins). However, the `variables` import _does_ render to CSS, which means that we wind up with CSS-rendered outputs of PatternFly variables every time our `_global-variables.scss` file is included anywhere... and this file of ours is included in `page.scss`, so this is a problem with every single page.

Changing the import in our `_global-variables.scss` to only use the sass-utilities file means that we're not accidentally redefining the CSS variables on the page. (The `@import "variables";` is included elsewhere already as a base part of PatternFly.)