### PR TITLE
shell: Immediately close superuser dialog when cancelling

### DIFF
--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -54,8 +54,7 @@ const UnlockDialog = ({ proxy, host }) => {
         setBusy(true);
         setCancel(() => () => {
             proxy.Stop();
-            setBusy(true);
-            setCancel(null);
+            D.close();
         });
 
         let did_prompt = false;


### PR DESCRIPTION
Sudo sometimes takes a bit to terminate, but having the dialog stay
open is confusing.  People might think that they have clicked the
"Authenticate" button by accident, maybe.
    
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2073263