### PR TITLE
storaged: Fix VDO for RHEL 9

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -463,6 +463,12 @@ function init_model(callback) {
             });
     }
 
+    function enable_lvm_create_vdo_feature() {
+        return cockpit.spawn(["vdoformat", "--version"], { err: "ignore" })
+                .then(() => { client.features.lvm_create_vdo = true; return Promise.resolve() })
+                .catch(() => Promise.resolve());
+    }
+
     function enable_legacy_vdo_features() {
         return client.legacy_vdo_overlay.start().then(
             function (success) {
@@ -521,6 +527,7 @@ function init_model(callback) {
                 .then(enable_nfs_features)
                 .then(enable_pk_features)
                 .then(enable_stratis_feature)
+                .then(enable_lvm_create_vdo_feature)
                 .then(enable_legacy_vdo_features));
     }
 

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -463,10 +463,11 @@ function init_model(callback) {
             });
     }
 
-    function enable_vdo_features() {
-        return client.vdo_overlay.start().then(
+    function enable_legacy_vdo_features() {
+        return client.legacy_vdo_overlay.start().then(
             function (success) {
-                client.features.vdo = success;
+                // hack here
+                client.features.legacy_vdo = success;
                 return cockpit.resolve();
             },
             function () {
@@ -520,7 +521,7 @@ function init_model(callback) {
                 .then(enable_nfs_features)
                 .then(enable_pk_features)
                 .then(enable_stratis_feature)
-                .then(enable_vdo_features));
+                .then(enable_legacy_vdo_features));
     }
 
     function query_fsys_info() {
@@ -723,9 +724,9 @@ function nfs_mounts() {
 
 client.nfs = nfs_mounts();
 
-/* VDO */
+/* Legacy VDO CLI (RHEL 8), unsupported; newer versions use VDO through LVM API */
 
-function vdo_overlay() {
+function legacy_vdo_overlay() {
     const self = {
         start: start,
 
@@ -889,7 +890,7 @@ function vdo_overlay() {
     return self;
 }
 
-client.vdo_overlay = vdo_overlay();
+client.legacy_vdo_overlay = legacy_vdo_overlay();
 
 /* Stratis */
 

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -222,7 +222,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     if (is_filesystem) {
         add_tab(_("Filesystem"), FilesystemTab, true, ["mismounted-fsys"]);
     } else if (content_block && (content_block.IdUsage == "raid" ||
-                                 client.vdo_overlay.find_by_backing_block(content_block))) {
+                                 client.legacy_vdo_overlay.find_by_backing_block(content_block))) {
         // no tab for these
     } else if (content_block && content_block.IdUsage == "other" && content_block.IdType == "swap") {
         add_tab(_("Swap"), SwapTab, true);
@@ -428,7 +428,7 @@ function block_description(client, block) {
     let type, used_for, link, size, critical_size;
     const block_stratis_blockdev = client.blocks_stratis_blockdev[block.path];
     const block_stratis_locked_pool = client.blocks_stratis_locked_pool[block.path];
-    const vdo = client.vdo_overlay.find_by_backing_block(block);
+    const vdo = client.legacy_vdo_overlay.find_by_backing_block(block);
     const cleartext = client.blocks_cleartext[block.path];
     if (cleartext)
         block = cleartext;
@@ -858,9 +858,9 @@ export class VGroup extends React.Component {
             ];
 
             const vdo_package = client.get_config("vdo_package", null);
-            const need_vdo_install = vdo_package && !client.features.vdo;
+            const need_vdo_install = vdo_package && !client.features.legacy_vdo;
 
-            if (client.features.vdo || vdo_package)
+            if (client.features.legacy_vdo || vdo_package)
                 purposes.push({ value: "vdo", title: _("VDO filesystem volume (compression/deduplication)") });
 
             dialog_open({

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -858,9 +858,9 @@ export class VGroup extends React.Component {
             ];
 
             const vdo_package = client.get_config("vdo_package", null);
-            const need_vdo_install = vdo_package && !client.features.legacy_vdo;
+            const need_vdo_install = vdo_package && !(client.features.lvm_create_vdo || client.features.legacy_vdo);
 
-            if (client.features.legacy_vdo || vdo_package)
+            if (client.features.lvm_create_vdo || client.features.legacy_vdo || vdo_package)
                 purposes.push({ value: "vdo", title: _("VDO filesystem volume (compression/deduplication)") });
 
             dialog_open({

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -108,7 +108,7 @@ export class Details extends React.Component {
                 body = <MDRaidDetails client={client} mdraid={mdraid} />;
             }
         } else if (this.props.type == "vdo") {
-            const vdo = client.vdo_overlay.by_name[this.props.name];
+            const vdo = client.legacy_vdo_overlay.by_name[this.props.name];
             if (vdo) {
                 name = vdo.name;
                 body = <VDODetails client={client} vdo={vdo} />;

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -65,7 +65,7 @@ export function initial_tab_options(client, block, for_fstab) {
             options._netdev = true;
         }
         // HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1589541
-        if (client.vdo_overlay.find_by_block(client.blocks[p])) {
+        if (client.legacy_vdo_overlay.find_by_block(client.blocks[p])) {
             options._netdev = true;
             options["x-systemd.device-timeout=0"] = true;
             if (for_fstab)
@@ -319,7 +319,7 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                     options.label = { t: 's', v: vals.name };
 
                 // HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1516041
-                if (client.vdo_overlay.find_by_block(block)) {
+                if (client.legacy_vdo_overlay.find_by_block(block)) {
                     options['no-discard'] = { t: 'b', v: true };
                 }
 

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -73,14 +73,14 @@ function lvol_and_fsys_resize(client, lvol, size, offline, passphrase) {
         if (!cleartext)
             return;
         fsys = client.blocks_fsys[cleartext.path];
-        vdo = client.vdo_overlay.find_by_backing_block(cleartext);
+        vdo = client.legacy_vdo_overlay.find_by_backing_block(cleartext);
         if (crypto.MetadataSize !== undefined)
             crypto_overhead = crypto.MetadataSize;
         else
             crypto_overhead = block.Size - cleartext.Size;
     } else {
         fsys = client.blocks_fsys[block.path];
-        vdo = client.vdo_overlay.find_by_backing_block(block);
+        vdo = client.legacy_vdo_overlay.find_by_backing_block(block);
         crypto_overhead = 0;
     }
 
@@ -193,7 +193,7 @@ function get_resize_info(client, block, to_fit) {
         } else if (block.IdUsage == 'raid') {
             info = { };
             shrink_excuse = grow_excuse = _("Physical volumes can not be resized here.");
-        } else if (client.vdo_overlay.find_by_backing_block(block)) {
+        } else if (client.legacy_vdo_overlay.find_by_backing_block(block)) {
             info = {
                 can_shrink: false,
                 can_grow: true,
@@ -332,7 +332,7 @@ function lvol_shrink(client, lvol, info, to_fit) {
         if (fsys)
             shrink_size = fsys.Size + crypto_overhead;
 
-        const vdo = client.vdo_overlay.find_by_backing_block(client.blocks[content_path]);
+        const vdo = client.legacy_vdo_overlay.find_by_backing_block(client.blocks[content_path]);
         if (vdo)
             shrink_size = vdo.physical_size + crypto_overhead;
 

--- a/pkg/storaged/pvol-tabs.jsx
+++ b/pkg/storaged/pvol-tabs.jsx
@@ -80,7 +80,7 @@ export class MDRaidMemberTab extends React.Component {
 
 export class VDOBackingTab extends React.Component {
     render() {
-        const vdo = this.props.client.vdo_overlay.find_by_backing_block(this.props.block);
+        const vdo = this.props.client.legacy_vdo_overlay.find_by_backing_block(this.props.block);
 
         return (
             <DescriptionList className="pf-m-horizontal-on-sm">

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -256,7 +256,7 @@ export function get_block_link_parts(client, path) {
         location = ["vg", target];
         link = cockpit.format(_("LVM2 volume group $0"), target);
     } else {
-        const vdo = client.vdo_overlay.find_by_block(block);
+        const vdo = client.legacy_vdo_overlay.find_by_block(block);
         if (vdo) {
             location = ["vdo", vdo.name];
             link = cockpit.format(_("VDO device $0"), vdo.name);
@@ -404,7 +404,7 @@ export function get_available_spaces(client) {
         }
 
         function is_vdo_backing_dev() {
-            return !!client.vdo_overlay.find_by_backing_block(block);
+            return !!client.legacy_vdo_overlay.find_by_backing_block(block);
         }
 
         return (!block.HintIgnore &&
@@ -480,7 +480,7 @@ export function get_other_devices(client) {
                 (!block_lvm2 || block_lvm2.LogicalVolume == "/") &&
                 !block.HintIgnore &&
                 block.Size > 0 &&
-                !client.vdo_overlay.find_by_block(block) &&
+                !client.legacy_vdo_overlay.find_by_block(block) &&
                 !client.blocks_stratis_fsys[block.path] &&
                 !is_snap(client, block));
     });
@@ -623,7 +623,7 @@ export function get_active_usage(client, path, top_action, child_action) {
         const mdraid = block && client.mdraids[block.MDRaidMember];
         const pvol = client.blocks_pvol[path];
         const vgroup = pvol && client.vgroups[pvol.VolumeGroup];
-        const vdo = block && client.vdo_overlay.find_by_backing_block(block);
+        const vdo = block && client.legacy_vdo_overlay.find_by_backing_block(block);
         const stratis_blockdev = block && client.blocks_stratis_blockdev[path];
         const stratis_pool = stratis_blockdev && client.stratis_pools[stratis_blockdev.Pool];
 

--- a/pkg/storaged/vdo-details.jsx
+++ b/pkg/storaged/vdo-details.jsx
@@ -64,7 +64,7 @@ export class VDODetails extends React.Component {
         }
 
         if (path)
-            this.poll_process = cockpit.spawn([client.vdo_overlay.python, "--", "-", path], { superuser: true })
+            this.poll_process = cockpit.spawn([client.legacy_vdo_overlay.python, "--", "-", path], { superuser: true })
                     .input(inotify_py + vdo_monitor_py)
                     .stream((data) => {
                         buf += data;

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -39,6 +39,6 @@ export function vdo_rows(client) {
     function cmp_vdo(a, b) {
         return a.name.localeCompare(b.Name);
     }
-    return client.vdo_overlay.volumes.sort(cmp_vdo)
+    return client.legacy_vdo_overlay.volumes.sort(cmp_vdo)
             .map(vdo => vdo_row(client, vdo));
 }

--- a/pkg/storaged/warnings.jsx
+++ b/pkg/storaged/warnings.jsx
@@ -71,7 +71,7 @@ export function find_warnings(client) {
 
         const fsys = client.blocks_fsys[content_path];
         const content_block = client.blocks[content_path];
-        const vdo = content_block ? client.vdo_overlay.find_by_backing_block(content_block) : null;
+        const vdo = content_block ? client.legacy_vdo_overlay.find_by_backing_block(content_block) : null;
 
         if (fsys && fsys.Size && (lvol.Size - fsys.Size - crypto_overhead) > vgroup.ExtentSize && fsys.Resize) {
             enter_warning(path, {

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -30,7 +30,6 @@ import testvm
 SIZE_10G = "10000000000"
 
 
-@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-1")
 @skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageVDO(StorageCase):
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -19,14 +19,13 @@
 
 import parent
 import re
+import unittest
 
 from packagelib import *
 from storagelib import *
 from testlib import *
+import testvm
 
-
-# vdo only exists on RHEL
-SUPPORTED_OS = ["centos-8-stream", "rhel-8-6", "rhel-8-6-distropkg"]
 
 SIZE_10G = "10000000000"
 
@@ -54,7 +53,8 @@ class TestStorageVDO(StorageCase):
         self.dialog_wait_open()
         b._wait_present("[data-field='purpose'] select option[value='block']")
 
-        if m.image not in SUPPORTED_OS:
+        # vdo only exists on RHEL
+        if not m.image.startswith("rhel") and not m.image.startswith("centos"):
             b.wait_not_present("[data-field='purpose'] select option[value='vdo']")
             return
 
@@ -176,7 +176,8 @@ class TestStorageVDO(StorageCase):
         b.wait_in_text("#detail-content", "No logical volumes")
 
 
-@skipImage("no matching kmod-kvdo package yet on RHEL 9", "rhel-9-0", "rhel-9-1")
+@unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel-8") or testvm.DEFAULT_IMAGE.startswith("centos-8"),
+                     "legacy VDO API only supported on RHEL 8")
 @skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 
@@ -185,9 +186,6 @@ class TestStorageLegacyVDO(StorageCase):
         b = self.browser
 
         self.login_and_go("/storage")
-
-        if m.image not in SUPPORTED_OS:
-            return
 
         b.wait_visible("#devices")
 
@@ -266,9 +264,6 @@ class TestStorageLegacyVDO(StorageCase):
 
         self.login_and_go("/storage")
 
-        if m.image not in SUPPORTED_OS:
-            return
-
         b.wait_visible("#devices")
 
         m.add_disk(SIZE_10G, serial="DISK1")
@@ -320,9 +315,6 @@ config: !Configuration
         b = self.browser
 
         self.login_and_go("/storage")
-
-        if m.image not in SUPPORTED_OS:
-            return
 
         b.wait_visible("#devices")
 
@@ -409,14 +401,13 @@ config: !Configuration
         b.wait_in_text("#devices", "vdo1")
 
 
+@unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel") or testvm.DEFAULT_IMAGE.startswith("centos"),
+                     "VDO API only supported on RHEL")
 class TestStoragePackagesVDO(PackageCase, StorageHelpers):
 
     def testVdoMissingPackages(self):
         m = self.machine
         b = self.browser
-
-        if m.image not in SUPPORTED_OS:
-            self.skipTest("No vdo available")
 
         m.execute("pkcon remove -y vdo")
         m.execute("pkcon refresh")


### PR DESCRIPTION
RHEL 9 dropped the legacy API and the `vdo` command line tool. This
caused the "Create LV" dialog to falsely claim that the "vdo" package
needs to be installed, even though it was already -- and then fail the
creation as the `vdo` program was not available.

This was hidden by the obsolete test skips from the times when RHEL 9
images really didn't have a kmod-kvdo yet, but that has existed for a
long time already.

The `vdo` package is only necessary for creating a new volume (the rest
is built into the kernel and LVM itself), so define a new
`lvm_create_vdo` feature which checks the availability of `vdoformat`.
Check this in the "Create LV" dialog as well.