### PR TITLE
test: Adjust for rhel-8-7

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -103,6 +103,8 @@ You can set these environment variables to configure the test suite:
                   "fedora-testing"
                   "rhel-8-6"
                   "rhel-8-6-distropkg"
+                  "rhel-8-7"
+                  "rhel-8-7-distropkg"
                   "rhel-9-0"
                   "rhel-9-1"
                   "ubuntu-2204"

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -128,7 +128,7 @@ class TestApps(PackageCase):
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
 
-    @skipImage("language switching in Chrome not working (issue #8160, fixed in d9f88eb722f7a4)", "rhel-8-6-distropkg")
+    @skipImage("language switching in Chrome not working (issue #8160, fixed in d9f88eb722f7a4)", "rhel-8-6-distropkg", "rhel-8-7-distropkg")
     def testL10N(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -557,7 +557,7 @@ class TestConnection(MachineCase):
 
         def checkMotdContent(string, expected=True):
             # Needs https://github.com/linux-pam/linux-pam/pull/292 (or PAM 1.5.0)
-            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'debian-testing', 'ubuntu-2204', 'ubuntu-stable', 'rhel-8-6'])
+            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'debian-testing', 'ubuntu-2204', 'ubuntu-stable', 'rhel-8-6', 'rhel-8-7'])
 
             # check issue (should be exactly the same as motd)
             assertInOrNot(string, m.execute("cat /etc/issue.d/cockpit.issue"), expected)
@@ -1074,7 +1074,7 @@ ProtocolHeader = X-Forwarded-Proto
         b.logout()
 
     @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos",
-               "rhel-8-6", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2204", "arch")
+               "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2204", "arch")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxTLS(self):
         '''test proxying to Cockpit with TLS
@@ -1158,7 +1158,7 @@ server {
         b.wait_visible('article.system-health')
 
     @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos",
-               "rhel-8-6", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2204", "arch")
+               "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "ubuntu-stable", "ubuntu-2204", "arch")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxNoTLS(self):
         '''test proxying to Cockpit with plain HTTP

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -422,7 +422,7 @@ class TestHistoryMetrics(MachineCase):
         # Journal was recorded on Fedora 33 and when trying to use it with older systemd it fails with:
         # `Journal file /var/log/journal/*/journal.journal uses an unsupported feature, ignoring file.`
 
-        if self.machine.image in ["centos-8-stream", "rhel-8-6", "debian-stable"]:
+        if self.machine.image in ["centos-8-stream", "rhel-8-6", "rhel-8-7", "debian-stable"]:
             return
 
         m.upload(["verify/files/metrics-archives/journal.journal.gz"], "/tmp")
@@ -829,7 +829,7 @@ class TestCurrentMetrics(MachineCase):
 
         # Test link to user services
         # older releases don't have CPU accounting enabled for user services
-        if m.image not in ["rhel-8-6", "centos-8-stream"]:
+        if m.image not in ["rhel-8-6", "rhel-8-7", "centos-8-stream"]:
             m.execute("su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) systemd-run --user --collect --slice cockpittest -p CPUQuota=60% --unit cpu-userhog dd if=/dev/urandom of=/dev/null'")
             # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2
             b.wait_in_text("table[aria-label='Top 5 CPU services'] tbody", "cpu-userhog")
@@ -912,7 +912,7 @@ BEGIN {{
 
         # Test link to user services
         # older releases don't have memory accounting enabled for user services
-        if m.image not in ["rhel-8-6", "centos-8-stream"]:
+        if m.image not in ["rhel-8-6", "rhel-8-7", "centos-8-stream"]:
             m.execute("su - admin -c 'XDG_RUNTIME_DIR=/run/user/$(id -u admin) systemd-run --user --collect --slice cockpittest --unit mem-userhog memhog.sh'")
             m.execute("while [ ! -e /tmp/hogged ]; do sleep 1; done")
             # user services are always running underneath user@1000.service, so these two will compete for row 1 or 2

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -90,7 +90,7 @@ class TestPackages(MachineCase):
         check_nav_entry("Test", False)
 
         # The following override.json tests were enabled with PR #16884
-        if m.image == 'rhel-8-6-distropkg':
+        if m.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg']:
             return
 
         # Hide the terminal with a system override

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -387,7 +387,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_restart_journal_messages()
 
     @skipImage("No tlog", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204",
-               "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream", "fedora-coreos", "arch")
+               "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream", "fedora-coreos", "arch")
     def testSessionRecordingShell(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -168,7 +168,7 @@ class TestStorageLvm2(StorageCase):
         # remove disk2
         b.click(f'#detail-sidebar .sidepanel-row:contains({dev_2}) button.pf-m-secondary')
         b.wait_not_in_text("#detail-sidebar", dev_2)
-        if m.image == "rhel-8-6-distropkg":
+        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
             b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "48 MiB")
         else:
             b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "50.3 MB")
@@ -176,7 +176,7 @@ class TestStorageLvm2(StorageCase):
         # create thin pool and volume
         # the pool will be maximum size, 50.3 MB
         b.click("button:contains(Create new logical volume)")
-        self.dialog(expect={"size": 48 if m.image == "rhel-8-6-distropkg" else 50.3},
+        self.dialog(expect={"size": 48 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 50.3},
                     values={"purpose": "pool",
                             "name": "pool",
                             "size": 38})

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -87,15 +87,15 @@ class TestStoragePartitions(StorageCase):
         about_half_way = width / 2 + 1
 
         b.mouse(slider, "click", about_half_way, 0)
-        self.dialog_wait_val("size", 26 if m.image == "rhel-8-6-distropkg" else 27.3)
+        self.dialog_wait_val("size", 26 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 27.3)
         b.focus(slider + " + .pf-c-slider__thumb")
         b.key_press(chr(37), use_ord=True)  # arrow left
-        self.dialog_wait_val("size", 25.5 if m.image == "rhel-8-6-distropkg" else 26.7)
+        self.dialog_wait_val("size", 25.5 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 26.7)
 
         # Check that changing units affects the text input
-        unit = "1073741824" if m.image == "rhel-8-6-distropkg" else "1000000000"
+        unit = "1073741824" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "1000000000"
         b.select_from_dropdown(".size-unit", unit)
-        self.dialog_wait_val("size", "0.0249" if m.image == "rhel-8-6-distropkg" else "0.0267", unit)
+        self.dialog_wait_val("size", "0.0249" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "0.0267", unit)
 
         self.dialog_apply()
         self.dialog_wait_close()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -80,7 +80,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB" if m.image == "rhel-8-6-distropkg" else "398 MB")
+            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "398 MB")
             if grow_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
@@ -104,7 +104,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB" if m.image == "rhel-8-6-distropkg" else "201 MB")
+            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "201 MB")
             if shrink_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
@@ -124,7 +124,7 @@ class TestStorageResize(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @skipImage("No NTFS support installed", "rhel-8-6", "rhel-8-6-distropkg", "rhel-9-0", "rhel-9-1", "centos-8-stream")
+    @skipImage("No NTFS support installed", "rhel-8-6", "rhel-8-6-distropkg", "rhel-8-7", "rhel-8-7-distropkg", "rhel-9-0", "rhel-9-1", "centos-8-stream")
     def testResizeNtfs(self):
         self.checkResize("ntfs", False,
                          can_shrink=True, shrink_needs_unmount=True,

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -33,7 +33,7 @@ class TestStorageStratis(StorageCase):
 
         self.login_and_go("/storage")
 
-        if m.image == "rhel-8-6-distropkg":
+        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
             SIZE_4GB = 4 * 1024 * 1024 * 1024
         else:
             SIZE_4GB = 4 * 1000000000
@@ -65,7 +65,7 @@ class TestStorageStratis(StorageCase):
         self.dialog_wait_close()
 
         b.wait_in_text("#devices", "pool0")
-        if m.image == "rhel-8-6-distropkg":
+        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
             b.wait_in_text("#devices", "8 GiB Stratis pool")
         else:
             b.wait_in_text("#devices", "8 GB Stratis pool")
@@ -376,7 +376,7 @@ class TestStorageStratis(StorageCase):
 
 
 @skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
-@skipImage("No Stratis on demand", "rhel-9-0", "rhel-9-1", "rhel-8-6")
+@skipImage("No Stratis on demand", "rhel-9-0", "rhel-9-1", "rhel-8-6", "rhel-8-7")
 class TestStoragePackagesStratis(PackageCase, StorageCase):
 
     def testStratisOndemandInstallation(self):

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -30,7 +30,7 @@ import testvm
 SIZE_10G = "10000000000"
 
 
-@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
+@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg", "rhel-8-7-distropkg")
 class TestStorageVDO(StorageCase):
 
     def testVdo(self):
@@ -177,7 +177,7 @@ class TestStorageVDO(StorageCase):
 
 @unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel-8") or testvm.DEFAULT_IMAGE.startswith("centos-8"),
                      "legacy VDO API only supported on RHEL 8")
-@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg")
+@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg", "rhel-8-7-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -566,7 +566,7 @@ machine         : 8561
 
         b.reload()
         b.enter_page('/system/hwinfo')
-        distros_without_systemd_memory_dmi = ['rhel-8-6', 'centos-8-stream', 'debian-stable']
+        distros_without_systemd_memory_dmi = ['rhel-8-6', 'rhel-8-7', 'centos-8-stream', 'debian-stable']
 
         # Test more specific memory data with a fake dmidecode
         b.wait_in_text('#memory-listing tr:nth-of-type(1) td[data-label=ID]', "BANK 0: ChannelA-DIMM0")

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -522,7 +522,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible(journal_line_selector.format("INFO_MESSAGE"))
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtSegv(self):
@@ -556,7 +556,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-details .pf-c-accordion__expanded-content-body dt:contains('signal') + dd:contains('11')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtDelete(self):
@@ -588,7 +588,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_not_present("button.pf-m-danger:contains('Delete')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReport(self):
@@ -653,7 +653,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReportCancel(self):
@@ -689,7 +689,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') .pf-l-split__item:contains('Reporting was canceled')")
 
     @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-9-0", "rhel-9-1", "centos-8-stream",
+               "ubuntu-2204", "fedora-coreos", "rhel-8-6", "rhel-8-7", "rhel-9-0", "rhel-9-1", "centos-8-stream",
                "arch")
     @nondestructive
     def testAbrtReportNoReportd(self):

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -512,7 +512,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         self.goto_service("mem-hog.service")
         b.wait_not_present("#memory")
         # In some distros systemctl is showing memory current as [Not Set] for user units
-        if not user or m.image not in ["rhel-8-6", "centos-8-stream"]:
+        if not user or m.image not in ["rhel-8-6", "rhel-8-7", "centos-8-stream"]:
             self.run_systemctl(user, "start mem-hog.service")
             # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -76,7 +76,7 @@ class StorageHelpers:
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
         # PR#17163 moved units from base-2 to base-10
-        bs = 1048576 if self.image == 'rhel-8-6-distropkg' else 1000000
+        bs = 1048576 if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else 1000000
         dev = self.machine.execute("set -e; F=$(mktemp /var/tmp/loop.XXXX); "
                                    f"dd if=/dev/zero of=$F bs={bs} count=%s; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
@@ -263,7 +263,7 @@ class StorageHelpers:
                 self.browser.set_checked(f'{sel} :contains("{label}") input', val)
         elif ftype == "size-slider":
             # PR#17163 moved units from base-2 to base-10
-            self.browser.set_val(sel + " .size-unit", "1048576" if self.image == 'rhel-8-6-distropkg' else "1000000")
+            self.browser.set_val(sel + " .size-unit", "1048576" if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else "1000000")
             self.browser.set_input_text(sel + " .size-text", str(val))
         elif ftype == "select":
             self.browser.set_val(sel + " select", val)
@@ -298,7 +298,7 @@ class StorageHelpers:
     def dialog_wait_val(self, field, val, unit=None):
         if unit is None:
             # PR#17163 moved units from base-2 to base-10
-            unit = "1048576" if self.image == 'rhel-8-6-distropkg' else "1000000"
+            unit = "1048576" if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else "1000000"
 
         sel = self.dialog_field(field)
         ftype = self.browser.attr(sel, "data-field-type")


### PR DESCRIPTION
This temporarily makes the base-2 vs. base-10 special cases even more
ugly. But we'll be able to drop all of that soon after landing the first
update in RHEL 8.7, and dropping support for testing on 8.6.