### PR TITLE
test: Relax expected D-Bus error message

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -894,7 +894,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
             do_test(alice_cert_key, ['HTTP/1.1 401 Authentication failed'])
 
         # sssd-dbus not available
-        self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.")
+        self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.*")
         self.allow_journal_messages("cockpit-session: Failed to map .* Unit sssd-ifp.service is masked.")
         m.execute("systemctl mask sssd-ifp && systemctl stop sssd-ifp")
         do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],


### PR DESCRIPTION
On Fedora Rawhide, the message now looks like this:

    cockpit-session: Failed to map certificate to user: [org.freedesktop.DBus.Error.NameHasNoOwner] Could not activate remote peer: activation request failed: unit is masked.

Relax the pattern to accept this as well.

---

Seen in #17384 in the failed [rawhide test](https://artifacts.dev.testing-farm.io/6edab079-87c6-42dc-9aff-4d74f2353e43/).