### PR TITLE
 Disable release-dockerhub, use deploy key for release website update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,14 @@ jobs:
           # override GitHub's bind mount from host, we don't want anything from there and it interferes with ssh
           export HOME=$(getent passwd $(id -u) | cut -f6 -d:)
 
-          # This uses the shared cockpit-project organization secrets:
-          # https://github.com/organizations/cockpit-project/settings/secrets
-          echo '${{ secrets.SSH_KNOWN_HOSTS }}' > ~/.ssh/known_hosts
-          echo '${{ secrets.FEDPKG_SSH_PUBLIC }}' > ~/.ssh/id_rsa.pub
-          echo '${{ secrets.FEDPKG_SSH_PRIVATE }}' > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
+          git config user.name "GitHub Workflow"
+          git config user.email "cockpituous@cockpit-project.org"
+
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
+
+          # deploy key for updating the website repo, via tools/release-guide
+          eval $(ssh-agent)
+          ssh-add - <<< '${{ secrets.WEBSITE_DEPLOY_KEY }}'
 
       - name: Run cockpituous
         run: |

--- a/tools/cockpituous-release
+++ b/tools/cockpituous-release
@@ -26,7 +26,9 @@ job release-srpm
 job release-github
 
 # Update the Github repo that Docker Hub is tracking
-job release-dockerhub cockpit-project/cockpit-container
+# FIXME: this broke with releasing to COPR via packit, needs to be triggered
+# manually for now and automated as a separate workflow
+# job release-dockerhub cockpit-project/cockpit-container
 
 # Upload documentation
 job tools/release-guide dist/guide cockpit-project/cockpit-project.github.io


### PR DESCRIPTION
As a follow-up to #17337, let's get rid of our SSH key release secret as well. See the individual commits for details.

 - Builds on top of PR #17337 
 - Requires new deploy key: https://github.com/cockpit-project/bots/pull/3410