### PR TITLE
packit: Use upstream tarball for release COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -49,6 +49,15 @@ jobs:
       - fedora-development
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
+    actions:
+      post-upstream-clone:
+        # packit will overwrite the version in its "fix spec file" stage
+        - tools/create-spec --version 0 --build-all -o cockpit.spec tools/cockpit.spec.in
+      # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
+      # really should be the default, see https://github.com/packit/packit-service/issues/1505
+      create-archive:
+        - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
+        - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
 
   - job: propose_downstream
     trigger: release


### PR DESCRIPTION
Current packit defaults to runing the `create-archive:` action for
release copr_builds. It should rather behave like `propose_downstream:`
and download the official release tarball from the spec's `Source0:`, as
this is conceptually much closer to releasing to Fedora than building a
temporary COPR for a PR.

This is currently being discussed in
https://github.com/packit/packit-service/issues/1505 , and this is the
recommended workaround until this becomes the default.

----

Same hack as in https://github.com/cockpit-project/cockpit-podman/pull/978