### PR TITLE
doc: Fix getcert invocation in cockpit-tls manpage

### DIFF
--- a/doc/man/cockpit-tls.xml
+++ b/doc/man/cockpit-tls.xml
@@ -97,12 +97,12 @@ $ sudo /usr/lib/cockpit/cockpit-certificate-ensure --check
 </programlisting>
 
     <para>If using <literal>certmonger</literal> to manage certificates, following command can
-      be used to automatically prepare concatenated <literal>.cert</literal> file:</para>
+      be used to generate a certificate/key pair:</para>
 <programlisting>
-CERT_FILE=/etc/pki/tls/certs/$(hostname).pem
-KEY_FILE=/etc/pki/tls/private/$(hostname).key
+CERT_FILE=/etc/cockpit/ws-certs.d/50-certmonger.crt
+KEY_FILE=/etc/cockpit/ws-certs.d/50-certmonger.key
 
-getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn) -C "sed -n w/etc/cockpit/ws-certs.d/50-from-certmonger.cert ${CERT_FILE} ${KEY_FILE}"
+getcert request -f ${CERT_FILE} -k ${KEY_FILE} -D $(hostname --fqdn)
 </programlisting>
 
   </refsect1>


### PR DESCRIPTION
Since supporting (and prefering) split key files, and reading
certificates as root, we don't need the "merge/copy" dance any more. Use
the clean approach of cockpit-certificate-helper. doc/guide/https.xml
already documents it that way, and check-connection ensures that it
works.

Fixes #17358