### PR TITLE
test: drop sizzle.js symlink

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 cockpit/*
 dist/*
 node_modules/*
-test/common/sizzle.js

--- a/test/common/sizzle.js
+++ b/test/common/sizzle.js
@@ -1,1 +1,0 @@
-../../node_modules/sizzle/dist/sizzle.js

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -172,8 +172,9 @@ class Browser:
         self.coverage_label = coverage_label
         self.machine = machine
         path = os.path.dirname(__file__)
+        sizzle_js = os.path.join(path, "../../node_modules/sizzle/dist/sizzle.js")
         self.cdp = cdp.CDP("C.utf8", verbose=opts.trace, trace=opts.trace,
-                           inject_helpers=[os.path.join(path, "test-functions.js"), os.path.join(path, "sizzle.js")],
+                           inject_helpers=[os.path.join(path, "test-functions.js"), sizzle_js],
                            start_profile=coverage_label is not None)
         self.password = "foobar"
         self.timeout_factor = int(os.getenv("TEST_TIMEOUT_FACTOR", "1"))


### PR DESCRIPTION
This symlink always points to the same place (inside `node_modules/`), so we may as well just resolve that location directly.

This avoids all kinds of problems we've seen, such as `tar -h` failing on this file, or https://github.com/packit/packit/issues/1560

Fixes #17370