### PR TITLE
git-hook-pre-push: bring back realpath -m

### DIFF
--- a/test/git-hook-pre-push
+++ b/test/git-hook-pre-push
@@ -14,7 +14,7 @@ else
     grey=""
 fi
 
-post_commit_hook="${0%/*}/git-hook-post-commit"
+post_commit_hook="$(realpath -m "$0"/../git-hook-post-commit)"
 fail=''
 
 # cf. man 5 githooks


### PR DESCRIPTION
This reverts a tiny piece of d126de6a642f1ddac1fedd31adb5268c1f561a67.

This script is typically run by git from a symlink located in the
~/.git/hooks/ directory, which results in `$0` pointing to that link, and
not to the original file.  In order to make sure we resolve the path
relative to the location of the original file, go back to using
realpath, as before.