### PR TITLE
test: Clean up rhel-8-6 and rhel-8-7-distropkg for storage tests

### DIFF
--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -168,15 +168,12 @@ class TestStorageLvm2(StorageCase):
         # remove disk2
         b.click(f'#detail-sidebar .sidepanel-row:contains({dev_2}) button.pf-m-secondary')
         b.wait_not_in_text("#detail-sidebar", dev_2)
-        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
-            b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "48 MiB")
-        else:
-            b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "50.3 MB")
+        b.wait_in_text("#detail-header dt:contains(Capacity) + dd", "50.3 MB")
 
         # create thin pool and volume
         # the pool will be maximum size, 50.3 MB
         b.click("button:contains(Create new logical volume)")
-        self.dialog(expect={"size": 48 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 50.3},
+        self.dialog(expect={"size": 50.3},
                     values={"purpose": "pool",
                             "name": "pool",
                             "size": 38})

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -87,15 +87,15 @@ class TestStoragePartitions(StorageCase):
         about_half_way = width / 2 + 1
 
         b.mouse(slider, "click", about_half_way, 0)
-        self.dialog_wait_val("size", 26 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 27.3)
+        self.dialog_wait_val("size", 27.3)
         b.focus(slider + " + .pf-c-slider__thumb")
         b.key_press(chr(37), use_ord=True)  # arrow left
-        self.dialog_wait_val("size", 25.5 if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else 26.7)
+        self.dialog_wait_val("size", 26.7)
 
         # Check that changing units affects the text input
-        unit = "1073741824" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "1000000000"
+        unit = "1000000000"
         b.select_from_dropdown(".size-unit", unit)
-        self.dialog_wait_val("size", "0.0249" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "0.0267", unit)
+        self.dialog_wait_val("size", "0.0267", unit)
 
         self.dialog_apply()
         self.dialog_wait_close()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -80,7 +80,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "400 MiB" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "398 MB")
+            self.content_tab_wait_in_info(1, 1, "Size", "398 MB")
             if grow_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
@@ -104,7 +104,7 @@ class TestStorageResize(StorageCase):
             self.dialog_wait_close()
             # HACK - https://github.com/storaged-project/udisks/pull/631
             m.execute("udevadm trigger")
-            self.content_tab_wait_in_info(1, 1, "Size", "200 MiB" if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"] else "201 MB")
+            self.content_tab_wait_in_info(1, 1, "Size", "201 MB")
             if shrink_needs_unmount:
                 self.content_row_action(fsys_row, "Mount")
                 self.confirm()
@@ -124,7 +124,7 @@ class TestStorageResize(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @skipImage("No NTFS support installed", "rhel-8-6", "rhel-8-6-distropkg", "rhel-8-7", "rhel-8-7-distropkg", "rhel-9-0", "rhel-9-1", "centos-8-stream")
+    @skipImage("No NTFS support installed", "rhel-8-7", "rhel-8-7-distropkg", "rhel-9-0", "rhel-9-1", "centos-8-stream")
     def testResizeNtfs(self):
         self.checkResize("ntfs", False,
                          can_shrink=True, shrink_needs_unmount=True,

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -33,10 +33,7 @@ class TestStorageStratis(StorageCase):
 
         self.login_and_go("/storage")
 
-        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
-            SIZE_4GB = 4 * 1024 * 1024 * 1024
-        else:
-            SIZE_4GB = 4 * 1000000000
+        SIZE_4GB = 4 * 1000000000
 
         dev_1 = "/dev/sda"
         m.add_disk(SIZE_4GB, serial="DISK1")
@@ -65,10 +62,7 @@ class TestStorageStratis(StorageCase):
         self.dialog_wait_close()
 
         b.wait_in_text("#devices", "pool0")
-        if m.image in ["rhel-8-6-distropkg", "rhel-8-7-distropkg"]:
-            b.wait_in_text("#devices", "8 GiB Stratis pool")
-        else:
-            b.wait_in_text("#devices", "8 GB Stratis pool")
+        b.wait_in_text("#devices", "8 GB Stratis pool")
         b.assert_pixels("#devices", "pool-row")
 
         # Check that the next name is "pool1"
@@ -376,7 +370,7 @@ class TestStorageStratis(StorageCase):
 
 
 @skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
-@skipImage("No Stratis on demand", "rhel-9-0", "rhel-9-1", "rhel-8-6", "rhel-8-7")
+@skipImage("No Stratis on demand", "rhel-9-0", "rhel-9-1", "rhel-8-7")
 class TestStoragePackagesStratis(PackageCase, StorageCase):
 
     def testStratisOndemandInstallation(self):

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -30,7 +30,6 @@ import testvm
 SIZE_10G = "10000000000"
 
 
-@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg", "rhel-8-7-distropkg")
 class TestStorageVDO(StorageCase):
 
     def testVdo(self):
@@ -177,7 +176,6 @@ class TestStorageVDO(StorageCase):
 
 @unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel-8") or testvm.DEFAULT_IMAGE.startswith("centos-8"),
                      "legacy VDO API only supported on RHEL 8")
-@skipImage("cockpit 266 changed base-2 to base-10 units, too much hassle to make this work for both", "rhel-8-6-distropkg", "rhel-8-7-distropkg")
 class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -75,10 +75,8 @@ class StorageHelpers:
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1969408
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
-        # PR#17163 moved units from base-2 to base-10
-        bs = 1048576 if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else 1000000
         dev = self.machine.execute("set -e; F=$(mktemp /var/tmp/loop.XXXX); "
-                                   f"dd if=/dev/zero of=$F bs={bs} count=%s; "
+                                   "dd if=/dev/zero of=$F bs=1000000 count=%s; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # right after unmounting the device is often still busy, so retry a few times
         self.addCleanup(self.machine.execute, "umount {0}; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
@@ -262,8 +260,7 @@ class StorageHelpers:
             for label in val:
                 self.browser.set_checked(f'{sel} :contains("{label}") input', val)
         elif ftype == "size-slider":
-            # PR#17163 moved units from base-2 to base-10
-            self.browser.set_val(sel + " .size-unit", "1048576" if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else "1000000")
+            self.browser.set_val(sel + " .size-unit", "1000000")
             self.browser.set_input_text(sel + " .size-text", str(val))
         elif ftype == "select":
             self.browser.set_val(sel + " select", val)
@@ -297,8 +294,7 @@ class StorageHelpers:
 
     def dialog_wait_val(self, field, val, unit=None):
         if unit is None:
-            # PR#17163 moved units from base-2 to base-10
-            unit = "1048576" if self.image in ['rhel-8-6-distropkg', 'rhel-8-7-distropkg'] else "1000000"
+            unit = "1000000"
 
         sel = self.dialog_field(field)
         ftype = self.browser.attr(sel, "data-field-type")


### PR DESCRIPTION
rhel-8-6 is no longer supported, and rhel-8-7-distropkg now uses
base-10 units.