### PR TITLE
test: Increase timeout for sos report building

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -74,7 +74,7 @@ only-plugins=release,date,host,cgroups,networking
         if urlroot == "":
             b.assert_pixels("#sos-dialog", "dialog")
         b.click("#sos-dialog button:contains(Run report)")
-        with b.wait_timeout(120):
+        with b.wait_timeout(180):
             b.wait_not_present("#sos-dialog")
 
         b.wait_visible("tr:contains(mylabel) button:contains(Download)")


### PR DESCRIPTION
Despite only runnning 5 plugins, the sos report command now still takes
some non-trivial time due to the obfuscation and encryption. It
times out in RHEL 8.7 gating, so let's bump the timeout some more.