### PR TITLE
login: Make fonts path relative, so prefixes work

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -4,14 +4,14 @@
   font-family: RedHatText;
   font-style: normal;
   font-weight: 400;
-  src: url(/cockpit/static/fonts/RedHatText-Regular.woff2) format('woff2');
+  src: url(fonts/RedHatText-Regular.woff2) format('woff2');
 }
 
 @font-face {
   font-family: RedHatText;
   font-style: normal;
   font-weight: 700;
-  src: url(/cockpit/static/fonts/RedHatText-Medium.woff2) format('woff2');
+  src: url(fonts/RedHatText-Medium.woff2) format('woff2');
 }
 
 *,


### PR DESCRIPTION
Fixes #17388