### PR TITLE
containers/ws: Move os-release symlinking into run script

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -38,6 +38,3 @@ rm -rf /container/rpms || true
 # And the stuff that starts the container
 ln -s /host/proc/1 /container/target-namespace
 chmod -v +x /container/label-install /container/label-uninstall /container/label-run
-
-# Make the container think it's the host OS version
-rm -f /etc/os-release /usr/lib/os-release && ln -sv /host/etc/os-release /etc/os-release && ln -sv /host/usr/lib/os-release /usr/lib/os-release

--- a/containers/ws/label-run
+++ b/containers/ws/label-run
@@ -17,5 +17,12 @@ set +x
 /bin/mount --bind /host/var /var
 /bin/mount --bind /host/etc/ssh /etc/ssh
 
+# Make the container think it's the host OS version
+if ! mountpoint -q /etc/os-release; then
+    rm -f /etc/os-release /usr/lib/os-release
+    ln -sv /host/etc/os-release /etc/os-release
+    ln -sv /host/usr/lib/os-release /usr/lib/os-release
+fi
+
 # And run cockpit-ws
 exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws "$@"


### PR DESCRIPTION
This prepares the ws container for being able to run unprivileged.
Without /host, the branding will be completely broken, and trying to
run it with a customized /etc/os-release volume (aka bind mount) will
fail.

Only do the linking if /etc/os-release is not already mounted as a
volume.

---

The full support for unprivileged ws will come in a follow-up PR. But this particular bit is awkward to work around especially for our offline "update existing container" image-prepare, so I'd like to land this first, refresh the official container, and refresh our fedora-coreos image with that (although that step is blocked by https://github.com/cockpit-project/bots/pull/3437)