### PR TITLE
git-utils.sh: pre-init the cache directory for untar

### DIFF
--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -120,6 +120,9 @@ unpack_from_cache() {
 # This stores a .tar file from stdin into the cache as a tree object.
 # Returns the ID.  Opposite of `git archive`, basically.
 tar_to_cache() {
+    # Need to do this before we set the GIT_* variables
+    init_cache
+
     # Use a sub-shell to enable cleanup of the temporary directory
     (
         tmpdir="$(mktemp --tmpdir --directory cockpit-tar-to-git.XXXXXX)"


### PR DESCRIPTION
Trying to call `git init` with the GIT_WORK_TREE variable set gives the
following error:

  fatal: GIT_WORK_TREE (or --work-tree=<directory>) not allowed without specifying GIT_DIR (or --git-dir=<directory>)

So call init_cache before we set the variables to make sure the
directory already exists.