### PR TITLE
services: Add pinning services

### DIFF
--- a/pkg/systemd/services/service-details.scss
+++ b/pkg/systemd/services/service-details.scss
@@ -40,11 +40,17 @@
 }
 
 .service-top-panel > .service-name {
-    margin: 0 1.5rem 0 0;
+    margin: 0 0.75rem 0 0;
 }
 
 .service-top-panel .pf-c-switch {
     vertical-align: text-bottom;
+    margin: 0 0 0 0.75rem;
+}
+
+.service-top-panel > .service-thumbtack-icon {
+    color: var(--pf-global--icon--Color--light);
+    margin: 0 0.5rem 0 0;
 }
 
 /* Make the kebab wrapper flex to parents for proper alignment */

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -62,7 +62,9 @@ export class Service extends React.Component {
                                 owner={this.props.owner}
                                 permitted={superuser.allowed}
                                 loadingUnits={this.props.loadingUnits}
-                                isValid={this.props.unitIsValid} />;
+                                isValid={this.props.unitIsValid}
+                                isPinned={this.props.isPinned}
+        />;
 
         const cur_unit_id = this.props.unit.Id;
         const match = [

--- a/pkg/systemd/services/services-list.jsx
+++ b/pkg/systemd/services/services-list.jsx
@@ -25,7 +25,7 @@ import {
     Tooltip, TooltipPosition, Badge,
 } from '@patternfly/react-core';
 import { ListingTable } from 'cockpit-components-table.jsx';
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, ThumbtackIcon } from '@patternfly/react-icons';
 
 import cockpit from "cockpit";
 
@@ -55,7 +55,7 @@ export const ServicesList = ({ units, isTimer }) => {
     );
 };
 
-const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadState, HasFailed, CombinedState, LastTriggerTime, NextRunTime, Description, isTimer }) => {
+const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadState, HasFailed, IsPinned, CombinedState, LastTriggerTime, NextRunTime, Description, isTimer }) => {
     let displayName = shortId;
     // Remove ".service" from services as this is not necessary
     if (shortId.endsWith(".service"))
@@ -85,13 +85,19 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
         {
             title: (
                 <div className='service-unit-first-column'>
-                    <Button className='service-unit-id'
+                    <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                        <Button className='service-unit-id'
                             isInline
                             component="a"
                             onClick={() => cockpit.location.go([shortId], cockpit.location.options)}
                             variant='link'>
-                        {props.displayName}
-                    </Button>
+                            {props.displayName}
+                        </Button>
+                        {IsPinned &&
+                            <Tooltip content={_("Pinned unit")}>
+                                <ThumbtackIcon className='service-thumbtack-icon-color' />
+                            </Tooltip>}
+                    </Flex>
                     {props.Description != shortId && <div className='service-unit-description'>{props.Description}</div>}
                 </div>
             )

--- a/pkg/systemd/services/services.scss
+++ b/pkg/systemd/services/services.scss
@@ -80,6 +80,10 @@
     }
 }
 
+.service-thumbtack-icon-color {
+    color: var(--pf-global--icon--Color--light);
+}
+
 .pf-c-table .pf-c-table__action.service-unit-second-column {
     --pf-c-table--cell--Width: 20%;
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -371,13 +371,13 @@ WantedBy=default.target
         self.wait_service_present("test.service")
         m.execute("udevadm trigger; udevadm settle")
         self.goto_service("test.service")
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
+        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], True)
 
         # Stop and disable and back again
         self.toggle_onoff()
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
         self.toggle_onoff()
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
+        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], True)
 
         testUrl = f'/system/services#/test.service{suffix}'
         # Check without permissions
@@ -387,14 +387,14 @@ WantedBy=default.target
         b.relogin(testUrl, superuser=True)
         self.wait_page_load()
         self.toggle_onoff()  # later on we need some disabled test
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
 
         # Check service that fails to start
         b.go(f'/system/services#/{suffix}')
         self.goto_service("test-fail.service")
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
         self.toggle_onoff()
-        self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
+        self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"], True)
         if not user:
             b.assert_pixels("#service-details", "details-test-fail",
                             # in medium layout we sometimes get a scrollbar depending on how many test-fail logs exist
@@ -407,7 +407,7 @@ WantedBy=default.target
 
         # Check static service
         self.goto_service("systemd-exit.service")
-        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)"], True, onoff=False)
+        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)", "Pin unit"], True, onoff=False)
 
         # Mask and unmask
         self.do_action("Disallow running (mask)")
@@ -418,7 +418,41 @@ WantedBy=default.target
         b.wait_not_present("#service-details-show-relationships")
 
         self.do_action("Allow running (unmask)")
-        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)"], True, onoff=False)
+        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)", "Pin unit"], True, onoff=False)
+
+        # Pin unit
+        b.go(f'/system/services#/{suffix}')
+        b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
+
+        self.goto_service("test.service")
+        b.wait_not_present('#service-details-unit > article > div > svg.service-thumbtack-icon')
+        self.do_action("Pin unit")
+        b.is_present('#service-details-unit > article > div > svg.service-thumbtack-icon')
+        b.go(f'/system/services#/{suffix}')
+
+        # returns index of first unit that isn't failed
+        b.inject_js("""
+                    function firstWorkingUnitPos() {
+                        const arr = document.getElementById('services-list').firstChild;
+                        for (var i = 0; i < arr.childElementCount; i++) {
+                            const child = arr.children[i];
+                            if (!child.classList.contains('service-unit-failed')) {
+                                return i + 1;
+                            }
+                        }
+                    }
+                  """)
+        pos = b.eval_js('firstWorkingUnitPos();')
+        b.wait_text(f'#services-list > tbody > tr:nth-child({pos}) > th > div > div > a', 'test')
+        b.is_present('#test.service > svg.service-thumbtack-icon-color')
+
+        # Unpin unit
+        self.goto_service("test.service")
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Unpin unit"], False)
+        self.do_action("Unpin unit")
+        b.wait_not_present('#service-details-unit > article > div > svg.service-thumbtack-icon')
+        b.go(f'/system/services#/{suffix}')
+        b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
 
         def init_filter_state():
             if not b.is_visible("#services-text-filter"):
@@ -610,9 +644,9 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
 
         # Check test.service and then start it
         self.goto_service("test.service")
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
         self.toggle_onoff()
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)"], True)
+        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], True)
         b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "START")
         b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "WORKING")
         b.click(".cockpit-log-panel .pf-c-card__header button")
@@ -700,7 +734,7 @@ WantedBy=multi-user.target
 
         self.wait_service_in_panel("condtest.service", "Enabled")
         self.goto_service("condtest.service")
-        self.check_service_details(["Not running", "Automatically starts"], ["Start", "Disallow running (mask)"], True)
+        self.check_service_details(["Not running", "Automatically starts"], ["Start", "Disallow running (mask)", "Pin unit"], True)
         self.do_action("Start")
         b.wait_text("#condition", "Condition ConditionDirectoryNotEmpty=/var/tmp/empty was not met")
 
@@ -708,7 +742,7 @@ WantedBy=multi-user.target
         m.execute("touch /var/tmp/empty/non-empty")
         self.addCleanup(m.execute, "rm /var/tmp/empty/non-empty")
         self.do_action("Start")
-        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Stop", "Disallow running (mask)"], True)
+        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Stop", "Disallow running (mask)", "Pin unit"], True)
         b.wait_not_present("#condition")
 
     def testRelationships(self):
@@ -856,35 +890,35 @@ WantedBy=default.target
         self.goto_service("test-fail.service")
         b.wait_js_cond('window.location.hash === "#/test-fail.service"')
 
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
 
         self.wait_onoff(False)
         self.toggle_onoff()
 
         self.check_service_details(["Failed to start", "Automatically starts"],
-                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
+                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"], True)
 
         # Disabling should reset the "Failed to start" status
         self.wait_onoff(True)
         self.toggle_onoff()
 
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)"], False)
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
 
         self.wait_onoff(False)
         self.toggle_onoff()
 
         self.check_service_details(["Failed to start", "Automatically starts"],
-                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
+                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"], True)
 
         # Just reset the failed status, but leave it enabled
         self.do_action("Clear")
 
         self.check_service_details(["Not running", "Automatically starts"],
-                                   ["Start", "Disallow running (mask)"], True)
+                                   ["Start", "Disallow running (mask)", "Pin unit"], True)
 
         self.do_action("Start")
         self.check_service_details(["Failed to start", "Automatically starts"],
-                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)"], True)
+                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"], True)
 
         # Masking should also clear the failed status
         self.do_action("Disallow running (mask)")
@@ -1040,7 +1074,7 @@ Where=/fail
         self.addCleanup(m.execute, "systemctl stop test-transient.service || true")
         self.wait_service_present("test-transient.service")
         self.goto_service("test-transient.service")
-        self.check_service_details(["Static", "Running"], ["Restart", "Stop", "Disallow running (mask)"], False, onoff=False)
+        self.check_service_details(["Static", "Running"], ["Restart", "Stop", "Disallow running (mask)", "Pin unit"], False, onoff=False)
 
         self.do_action("Stop")
 


### PR DESCRIPTION
Fixes: #16780

This uses localStorage to store paths of every pinned unit.
There is no way to tell appart unit aliases because stored objects
are identical so as a side effect all aliases refering to the same
path end up being pinned.

Pinning unit:
![pin_unit_pin](https://user-images.githubusercontent.com/74668142/171144695-a2b4eeae-5331-424f-807f-98176fd52435.png)

Unpinning unit:
![pin_unit_unpin](https://user-images.githubusercontent.com/74668142/172914604-126a20d7-0588-497a-843f-0a294c01f607.png)

Pinned unit is on the top of the list:
![pin_unit](https://user-images.githubusercontent.com/74668142/172632715-b8305393-4d0f-4294-96ad-a03b0b59ac3c.png)

Failed units are above pinned units:
![pin_unit_with_failed](https://user-images.githubusercontent.com/74668142/172632671-7c395046-434f-4ba0-bb45-3f5a319ee17d.png)

Tooltip:
![pin_unit_tooltip](https://user-images.githubusercontent.com/74668142/172632612-61e9cff6-f85d-449d-9607-9b5f73f420bd.png)
