### PR TITLE
containers/ws: Support running as unprivileged user

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -12,7 +12,7 @@ RUN /container/install.sh
 
 LABEL INSTALL="docker run --rm --privileged -v /:/host -e IMAGE=\${IMAGE} \${IMAGE} /container/label-install \${IMAGE}"
 LABEL UNINSTALL="docker run --rm --privileged -v /:/host -e IMAGE=\${IMAGE} \${IMAGE} /container/label-uninstall"
-LABEL RUN="docker run -d --name \${NAME} --privileged --pid=host -v /:/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} /container/label-run --local-ssh"
+LABEL RUN="docker run -d --name \${NAME} --privileged --pid=host -v /:/host -e NAME=\${NAME} -e IMAGE=\${IMAGE} \${IMAGE} /container/label-run"
 
 # Look ma, no EXPOSE
 

--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -18,26 +18,62 @@ Cockpit packages.
 
 Steps 1 and 2 are enough when the CoreOS machine is only connected to through another host running Cockpit.
 
-If you want to also run a web server to log in directly on the CoreOS host:
+If you want to also run a web server to log in directly on the CoreOS host, you
+can use this container in two modes.
 
-3. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html):
+## Privileged ws container
+
+Privileged mode provides tight integration with the host: You can use the
+host's users and their passwords to log in, and Cockpit's branding will adjust
+to the host operating system.
+
+1. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html):
    ```
    echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/02-enable-passwords.conf
    sudo systemctl try-restart sshd
    ```
 
-4. Run the Cockpit web service with a privileged container (as root):
+2. Run the Cockpit web service with a privileged container (as root):
    ```
    podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws
    ```
 
-5. Make Cockpit start on boot:
+3. Make Cockpit start on boot:
    ```
    podman container runlabel INSTALL quay.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 
 Afterward, use a web browser to log into port `9090` on your host IP address as usual.
+
+## Unprivileged bastion container
+
+When you run the container without `--privileged`, it presents an unbranded
+login page. The user always has to specify a host name, and it connects to that
+host with SSH.
+
+```
+podman run -d --name cockpit-bastion -p 9090:9090 quay.io/cockit/ws
+```
+
+This mode is suitable for deploying to e.g. Kubernetes or similar environments
+where you cannot have or want privileged containers. In this "bastion host
+mode", you can get a Cockpit for servers in your data center without opening an
+extra port for cockpit-ws on them.
+
+You can still log into the ws container's host if you specify its *public*
+address. [podman](https://podman.io/) provides the special name
+`host.containers.internal` for that.
+
+By default, the container uses an internal
+[cockpit.conf](https://cockpit-project.org/guide/latest/cockpit.conf.5.html)
+which sets `RequireHost = true` and a neutral login title. You can customize
+this by passing your own configuration as a volume:
+
+    -v /path/to/your/cockpit.conf:/etc/cockpit/cockpit.conf:ro,Z
+
+Similarly you can also provide a custom `/etc/os-release` to change the
+branding.
 
 ## More Info
 

--- a/containers/ws/default-bastion.conf
+++ b/containers/ws/default-bastion.conf
@@ -1,0 +1,7 @@
+[WebService]
+ProtocolHeader = X-Forwarded-Proto
+LoginTitle = Cockpit Bastion
+RequireHost = true
+
+[Negotiate]
+action = none

--- a/containers/ws/label-run
+++ b/containers/ws/label-run
@@ -25,4 +25,4 @@ if ! mountpoint -q /etc/os-release; then
 fi
 
 # And run cockpit-ws
-exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws "$@"
+exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws --local-ssh "$@"

--- a/containers/ws/label-run
+++ b/containers/ws/label-run
@@ -1,28 +1,43 @@
-#!/bin/sh -eu
+#!/bin/sh
+set -eu
 
-# This is the startup script for cockpit-ws when run in a privileged container
-#
-# The host file system must be mounted at /host
-#
+# This is the startup script for cockpit-ws.
 
 cd /
 PATH="/bin:/sbin"
 
-# Run the install command just to be sure
-/container/label-install || exit $?
+# When run in a privileged container, the host file system must be mounted at /host.
+if [ -d /host ]; then
+    # Run the install command just to be sure
+    /container/label-install || exit $?
 
-set +x
+    set +x
 
-/bin/mount --bind /host/usr/share/pixmaps /usr/share/pixmaps
-/bin/mount --bind /host/var /var
-/bin/mount --bind /host/etc/ssh /etc/ssh
+    /bin/mount --bind /host/usr/share/pixmaps /usr/share/pixmaps
+    /bin/mount --bind /host/var /var
+    /bin/mount --bind /host/etc/ssh /etc/ssh
 
-# Make the container think it's the host OS version
-if ! mountpoint -q /etc/os-release; then
-    rm -f /etc/os-release /usr/lib/os-release
-    ln -sv /host/etc/os-release /etc/os-release
-    ln -sv /host/usr/lib/os-release /usr/lib/os-release
+    # Make the container think it's the host OS version
+    if ! mountpoint -q /etc/os-release; then
+        rm -f /etc/os-release /usr/lib/os-release
+        ln -sv /host/etc/os-release /etc/os-release
+        ln -sv /host/usr/lib/os-release /usr/lib/os-release
+    fi
+
+    # And run cockpit-ws
+    exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws --local-ssh "$@"
+else
+    # unprivileged mode
+
+    # branding can be set from outside; if it's not, don't show any branding
+    if ! mountpoint --quiet /etc/os-release; then
+        rm /etc/os-release
+        printf 'NAME=default\nID=default\n' > /etc/os-release
+    fi
+
+    # config can be customized, but provide a default suitable for a bastion host
+    mountpoint --quiet /etc/cockpit/cockpit.conf || ln -s /container/default-bastion.conf /etc/cockpit/cockpit.conf
+
+    /usr/libexec/cockpit-certificate-ensure
+    exec /usr/libexec/cockpit-ws --local-ssh "$@"
 fi
-
-# And run cockpit-ws
-exec /usr/bin/nsenter --net=/container/target-namespace/ns/net --uts=/container/target-namespace/ns/uts -- /usr/libexec/cockpit-ws --local-ssh "$@"

--- a/test/fedora-coreos.install
+++ b/test/fedora-coreos.install
@@ -12,7 +12,7 @@ podman run --name build-cockpit -i \
     -v /var/tmp/:/run/build:Z \
     quay.io/cockpit/ws sh -exc '
 rpm --freshen --verbose /run/build/cockpit-ws-*.rpm /run/build/cockpit-bridge-*.rpm
-cp /run/build/containers/ws/label-* /container/
+cp /run/build/containers/ws/label-* /run/build/containers/ws/default-bastion.conf /container/
 '
 podman commit --change CMD=/container/label-run build-cockpit localhost/cockpit/ws
 podman rm -f build-cockpit

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -1,0 +1,133 @@
+#!/usr/bin/python3
+
+# This file is part of Cockpit.
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# Cockpit is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation; either version 2.1 of the License, or
+# (at your option) any later version.
+#
+# Cockpit is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+import parent
+from testlib import *
+from testvm import DEFAULT_IMAGE
+
+HOST = "host.containers.internal"
+
+
+@unittest.skipUnless(DEFAULT_IMAGE == "fedora-coreos", "no cockpit/ws container on this image")
+@nondestructive
+class TestWsBastionContainer(MachineCase):
+    def setUp(self):
+        super().setUp()
+        # stop ws container from previous runs
+        self.machine.stop_cockpit()
+        # undo cockpit/ws install steps
+        self.restore_file("/etc/systemd/system/cockpit.service")
+        self.machine.execute("rm /etc/systemd/system/cockpit.service")
+        self.addCleanup(self.machine.execute, "podman rm -f --all")
+
+    def approve_key(self, b, hostname):
+        b.wait_visible("#hostkey-group")
+        b.wait_in_text("#hostkey-message-1", f"You are connecting to {hostname} for the first time.")
+        b.click("#login-button")
+
+    def testPasswordLogin(self):
+        m = self.machine
+        b = self.browser
+        m.execute("podman run -d --name cockpit-bastion -p 9090:9090 localhost/cockpit/ws")
+        m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
+
+        b.ignore_ssl_certificate_errors(True)
+        b.open("/", tls=True)
+
+        b.wait_visible("#login")
+        # should be pre-configured to RequireHost
+        b.wait_not_visible("#option-group")
+        b.wait_visible("#server-field")
+        # LoginTitle from default-bastion.conf
+        b.wait_text("#server-name", "Cockpit Bastion")
+        # No branding by default
+        b.wait_text("#brand", "")
+
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+
+        # Requires a host
+        b.click("#login-button")
+        b.wait_in_text("#login-error-message", "host to connect")
+        # so connect to our own container host
+        b.set_val("#server-field", HOST)
+        b.set_val("#login-password-input", "foobar")
+        # key is unknown
+        b.click("#login-button")
+        self.approve_key(b, HOST)
+
+        b.wait_visible('#content')
+        b.wait_text('#current-username', 'admin')
+        b.logout()
+
+        # remembers the last host via URL, server field should be pre-filled
+        self.assertEqual(b.eval_js("window.location.pathname"), f"/={HOST}/system")
+        # FIXME: login page does not really set this in the DOM? DOM has empty value, but browser shows the value
+        # b.wait_text("#server-field", host)
+        # this is only for Cockpit Client
+        b.wait_not_visible("#recent-hosts")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+        # second time SSH key is known
+        b.click("#login-button")
+        b.wait_visible('#content')
+        b.logout()
+
+    def testCustomConf(self):
+        m = self.machine
+        b = self.browser
+
+        # custom cockpit.conf and pretend we are Fedora CoreOS
+        self.write_file("/root/cockpit.conf", """[WebService]
+            LoginTitle = My Walden
+""")
+        m.execute("cp /etc/os-release /root; "
+                  "podman run -d --name cockpit-bastion -p 9090:9090 "
+                  "-v /root/cockpit.conf:/etc/cockpit/cockpit.conf:ro,Z "
+                  "-v /root/os-release:/etc/os-release:ro,Z "
+                  "localhost/cockpit/ws")
+        m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
+
+        b.ignore_ssl_certificate_errors(True)
+        b.open("/", tls=True)
+
+        b.wait_visible("#login")
+        b.wait_text("#server-name", "My Walden")
+        # custom conf does not have RequireHost
+        b.wait_visible("#option-group")
+        # Shows os-release branding
+        b.wait_in_text("#brand", "Fedora")
+
+        # pre-fill target host
+        b.open(f"/={HOST}/", tls=True)
+        b.wait_visible("#login")
+        b.set_val("#login-user-input", "admin")
+        b.set_val("#login-password-input", "foobar")
+
+        b.click("#login-button")
+        self.approve_key(b, HOST)
+
+        b.wait_visible('#content')
+        b.wait_text('#current-username', 'admin')
+
+
+if __name__ == '__main__':
+    test_main()


### PR DESCRIPTION
This provides the basic functionality of the ./containers/bastion demo
container. You can already customize cockpit.conf and the branding, but
it does not support SSH key logins yet. This will be added in a
follow-up.

## Unprivileged cockpit/ws container mode

The [cockpit/ws container](https://quay.io/repository/cockpit/ws) can now also be run in unprivileged mode. It then presents an unbranded login page. The user always has to specify a host name, and it connects to that host with SSH.

This mode is suitable for deploying to e.g. Kubernetes or similar environments where you cannot have or want privileged containers. In this "bastion host mode", you can get a Cockpit for servers in your data center without opening an extra port for cockpit-ws on them.

For now this only supports password authentication. Support for SSH key authentication will be added soon.