### PR TITLE
build: change approach to versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         run: ./autogen.sh
 
       - name: Build release
-        run: make dist -j$(nproc)
+        run: make dist -j$(nproc) VERSION='${{ github.ref_name }}'
 
       - id: publish
         name: Publish GitHub release

--- a/.gitignore
+++ b/.gitignore
@@ -14,14 +14,15 @@
 *.pyc
 *.so
 *.trs
-.dirstamp
 .deps/
+.dirstamp
 .extra_dist
 Makefile
 Makefile.in
 
 # toplevel (/...)
 /*.list
+/Coverage
 /aclocal.m4
 /autom4te.cache
 /bots
@@ -41,11 +42,12 @@ Makefile.in
 /cockpit.pp
 /cockpit.pp.bz2
 /cockpit.spec
-/config.*
 /compile_commands.json
+/config.*
 /configure
 /dist/
 /frob-websocket
+/lcov/
 /mock-*
 /package-lock.json
 /socket-activation-helper
@@ -58,8 +60,6 @@ Makefile.in
 /valgrind-suppressions
 /webpack-jumpstart.tar
 /wsinstance-start
-/lcov/
-/Coverage
 
 # subdirs (/subdir/...)
 /doc/guide/html

--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ Makefile.in
 /Coverage
 
 # subdirs (/subdir/...)
+/doc/guide/html
 /doc/guide/version
 /doc/man/*.[1-8]
 /doc/version

--- a/Makefile.am
+++ b/Makefile.am
@@ -26,16 +26,27 @@ distdir: $(DISTFILES)
 		git -C '$(srcdir)' ls-files -x test/reference test tools > .extra_dist.tmp && \
 		mv .extra_dist.tmp '$(srcdir)/.extra_dist'; fi
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am EXTRA_FILES="$$(tr '\n' ' ' < $(srcdir)/.extra_dist) .extra_dist"
-
-dist-hook:
 	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/src/client/add-metainfo-releases --version '$(VERSION)' '$(distdir)'/src/client/*.metainfo.xml
-	$(srcdir)/tools/create-spec --version '$(VERSION)' -o $(distdir)/tools/cockpit.spec $(srcdir)/tools/cockpit.spec.in
-	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/debian/changelog.in > $(distdir)/tools/debian/changelog
-	NODE_ENV=$(NODE_ENV) $(srcdir)/tools/build-debian-copyright > $(distdir)/tools/debian/copyright
-	sed 's/VERSION/$(VERSION)/' $(srcdir)/tools/arch/PKGBUILD.in > $(distdir)/tools/arch/PKGBUILD
 	$(srcdir)/tools/adjust-distdir-timestamps "$(distdir)"
 	@echo '  DIST     $(DIST_ARCHIVES)'
+
+# Various downstream packaging assets
+dist-hook: $(distdir)/tools/arch/PKGBUILD
+$(distdir)/tools/arch/PKGBUILD: $(distdir)/tools/arch/PKGBUILD.in
+	$(AM_V_GEN) sed "s/VERSION/$(VERSION)/" $< > $@
+
+dist-hook: $(distdir)/tools/cockpit.spec
+$(distdir)/tools/cockpit.spec: $(distdir)/tools/cockpit.spec.in
+	$(AM_V_GEN) $(srcdir)/tools/create-spec --version "$(VERSION)" -o $@ $<
+
+dist-hook: $(distdir)/tools/debian/changelog
+$(distdir)/tools/debian/changelog: $(distdir)/tools/debian/changelog.in
+	$(AM_V_GEN) sed "s/VERSION/$(VERSION)/" $< > $@
+
+dist-hook: $(distdir)/tools/debian/copyright
+$(distdir)/tools/debian/copyright:
+	$(AM_V_GEN) NODE_ENV=$(NODE_ENV) $(srcdir)/tools/build-debian-copyright > $@
 
 DISTCHECK_CONFIGURE_FLAGS = --enable-prefix-only
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -15,6 +15,7 @@ sbin_PROGRAMS =
 #  make dist
 
 EXTRA_DIST = README.md
+CLEANFILES += cockpit-*.tar.xz
 
 # We override distdir for two reasons:
 #  - we need to make sure DISTFILES is built before calling `make distdir-am`
@@ -26,10 +27,19 @@ distdir: $(DISTFILES)
 		git -C '$(srcdir)' ls-files -x test/reference test tools > .extra_dist.tmp && \
 		mv .extra_dist.tmp '$(srcdir)/.extra_dist'; fi
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am EXTRA_FILES="$$(tr '\n' ' ' < $(srcdir)/.extra_dist) .extra_dist"
-	echo $(VERSION) > $(distdir)/.tarball
 	$(srcdir)/src/client/add-metainfo-releases --version '$(VERSION)' '$(distdir)'/src/client/*.metainfo.xml
 	$(srcdir)/tools/adjust-distdir-timestamps "$(distdir)"
 	@echo '  DIST     $(DIST_ARCHIVES)'
+
+# Needed to ensure the tarball is correct for $(VERSION) override
+$(distdir)/version.m4: FORCE
+	@rm -f $(distdir)/version.m4
+	$(AM_V_GEN) echo 'm4_define(VERSION_NUMBER, [$(VERSION)])' > $@
+
+dist-hook: $(distdir)/configure
+$(distdir)/configure: $(distdir)/version.m4
+	@rm -f $(distdir)/configure
+	$(AM_V_GEN) autoreconf $(distdir)
 
 # Various downstream packaging assets
 dist-hook: $(distdir)/tools/arch/PKGBUILD
@@ -52,9 +62,6 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-prefix-only
 
 distcheck-hook:
 	$(srcdir)/tools/check-dist $(distdir)
-
-dump-dist:
-	@echo "$(abs_builddir)/$(distdir).tar.xz"
 
 # -----------------------------------------------------------------------------
 

--- a/autogen.sh
+++ b/autogen.sh
@@ -4,7 +4,12 @@ set -eu
 
 srcdir="${0%/*}"
 
-(cd "${srcdir}" && autoreconf -is --warnings obsolete)
+(
+    cd "${srcdir}"
+    echo "m4_define(VERSION_NUMBER, [$(git describe --tags --abbrev=0)+git])" > version.m4
+    autoreconf -is --warnings obsolete
+)
+
 [ -n "${NOCONFIGURE:-}" ] && exit
 
 case "${1:-}" in

--- a/configure.ac
+++ b/configure.ac
@@ -15,21 +15,12 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+m4_include([version.m4])
 AC_INIT([Cockpit],
-        [m4_esyscmd_s([if [ -f .tarball ]; then cat .tarball; else echo $(git describe | tr - . ); fi])],
+        [VERSION_NUMBER],
         [devel@lists.cockpit-project.org],
         [cockpit],
         [https://cockpit-project.org/])
-
-# The above command needs to run in a git repository or `.tarball` file needs to be
-# present. If that didn't work bail early. Cockpit needs to know its own version number
-AC_MSG_CHECKING(that PACKAGE_VERSION is properly set)
-if test -z "$PACKAGE_VERSION"; then
-  AC_MSG_RESULT(no)
-  AC_MSG_ERROR(Please build from a .git checkout or .tar.xz tarball)
-else
-  AC_MSG_RESULT(yes)
-fi
 
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_HEADERS([config.h])

--- a/tools/make-dist
+++ b/tools/make-dist
@@ -5,6 +5,9 @@ cd "$(realpath -m "$0"/../..)"
 
 message() { printf "  %-8s %s\n" "$1" "$2" >&2; }
 
+# Set the version number from the state at the time the build was requested
+VERSION="$(git describe --tags --long --dirty | tr '-' '.')"
+
 jumpstart_flags=''
 download_only=''
 while [ $# != 0 ] ; do
@@ -63,5 +66,5 @@ else
 fi
 
 # Do the actual build
-make -s -j"$(nproc)" XZ_OPT='-0' "$@" dist >&2
-make dump-dist
+make -s -j"$(nproc)" XZ_OPT='-0' VERSION="${VERSION}" "$@" dist >&2
+realpath cockpit-${VERSION}.tar.xz  # (only) result to stdout


### PR DESCRIPTION
Currently, we choose the version number that we use at the time that ./autogen.sh is first run.  That means that if you configure your tree and hack on it for a while, making commits as you go, the overly-specific version number will soon be out of date.  This version number is the number used when building tarballs for testing.  Even switching to old branches on previous versions can result in the version number not being updated.

Let's move to automake's suggested approach[1] to dynamic versioning by introducing a `version.m4` file.  We write that file from two places:

- `./autogen.sh` writes an approximate version number (the last release) appended by +git (eg. "270+git")

- from `make dist` we write the value we find in `$(VERSION)` and call autoreconf to update the configure script accordingly

The expectation is now that anyone who calls `make dist` should specify the VERSION explicitly.  That's two places:

- from `tools/make-dist` we specify the full `git describe` style version

- from the release workflow we specify the tag name

Since the only thing that uses `make dump-dist` anymore is `tools/make-dist`, and since it now provides its own version number, we can drop the rule and print the filename directly.

Since we move to `version.m4`-style versioning, our tarballs will no longer contain the `.tarball` file.

Finally, since we're going to end up having more tarballs created, with various version numbers, add `cockpit-*.tar.xz` to `CLEANFILES` to help keep things under control.

[1] https://www.gnu.org/software/automake/manual/html_node/Rebuilding.html
