### PR TITLE
Login: Dark mode

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -87,20 +87,17 @@ button {
 }
 
 a {
-  color: inherit;
+  color: #06c;
   text-decoration: none;
 }
 
 .pf-c-button:focus,
+.host-remove:focus,
+button:focus,
 a:focus {
   outline: -webkit-focus-ring-color auto 5px;
   outline: dotted thin;
   outline-offset: -2px;
-}
-
-a:active,
-a:hover {
-  outline: 0;
 }
 
 a:focus,
@@ -272,7 +269,7 @@ label.checkbox {
   display: inline-block;
 }
 
-#login-button[spinning] .spinner {
+.pf-c-button[spinning] .spinner {
   display: inline-flex;
 }
 
@@ -299,7 +296,6 @@ label.checkbox {
 
 .pf-c-button:focus,
 .pf-c-button:hover {
-  color: #4d5258;
   text-decoration: none;
 }
 
@@ -319,8 +315,8 @@ label.checkbox {
 }
 
 .pf-m-primary:active,
-.pf-m-primary:focus,
-.pf-m-primary:hover {
+.pf-m-primary:not([disabled]):focus,
+.pf-m-primary:not([disabled]):hover {
   background-color: #004080;
   border-color: #004080;
   color: #fff;
@@ -523,14 +519,12 @@ label.checkbox {
 }
 
 .unsupported-browser ul {
-  color: #aaa;
   display: inline-block;
   margin: 0 auto;
   text-align: left;
 }
 
 .unsupported-browser a {
-  color: #fff;
   font-weight: 700;
   text-decoration: underline;
 }
@@ -561,7 +555,7 @@ label.checkbox {
 #hostkey-fingerprint {
   font-size: large;
   font-weight: bold;
-  margin-bottom: 0px
+  margin-bottom: 0;
 }
 
 #hostkey-type {
@@ -574,8 +568,8 @@ label.checkbox {
   background: #ddd;
 }
 
-#login-button .spinner,
-#login-button[spinning] #login-button-text,
+.pf-c-button .spinner,
+.pf-c-button[spinning] .button-text,
 .hide-before:before {
   display: none;
 }
@@ -643,7 +637,7 @@ label.checkbox {
   margin-bottom: 1rem;
 }
 
-#login-button {
+.login-button {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -651,14 +645,15 @@ label.checkbox {
   flex-basis: 100%;
 }
 
-#hostkey-group:not([hidden]) ~ .login-actions > #login-button {
+#hostkey-group:not([hidden]) ~ .login-actions > .login-button {
   flex-basis: max-content;
 }
 
-#login-button[disabled] {
+.pf-c-button[disabled] {
   background-color: #333;
   background-image: none;
   border-color: #555;
+  cursor: default;
 }
 
 /*** Media breakpoints ***/
@@ -796,15 +791,9 @@ body.login-pf {
 
 .login-pf #brand.text-brand {
   width: auto;
+  background: none;
 }
 
-.unsupported-browser a,
-a {
-  color: #06c;
-}
-
-.unsupported-browser a:focus,
-.unsupported-browser a:hover,
 a:focus,
 a:hover {
   color: #004080;
@@ -840,14 +829,32 @@ a:hover {
 }
 
 .host-remove {
+  background: transparent;
   margin-right: 1.5rem;
-  background: center / contain no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 352 512'%3E%3Cpath d='m242.7 256 100-100a31.5 31.5 0 0 0 0-44.5l-22.2-22.3a31.5 31.5 0 0 0-44.4 0L176 189.2 76 89.3a31.5 31.5 0 0 0-44.5 0L9.2 111.5a31.5 31.5 0 0 0 0 44.4l100 100.1-100 100a31.5 31.5 0 0 0 0 44.5l22.3 22.3a31.5 31.5 0 0 0 44.4 0l100.1-100 100 100a31.5 31.5 0 0 0 44.5 0l22.3-22.2a31.5 31.5 0 0 0 0-44.5L242.8 256z'/%3E%3C/svg%3E");
-  background-size: 1rem 1rem;
+  padding: 0.375rem 1rem;
+  /* Allow ::before to size relative to .host-remove */
+  position: relative;
+}
+
+/* As masking would hide outline, use ::before for the × SVG  */
+.host-remove::before {
+  /* ::before pseudoelement needs special CSS to be visible */
+  content: "";
+  display: block;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background-color: #151515;
   border: none;
+  mask: center / contain no-repeat url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='currentColor' viewBox='0 0 352 512'%3E%3Cpath d='m242.7 256 100-100a31.5 31.5 0 0 0 0-44.5l-22.2-22.3a31.5 31.5 0 0 0-44.4 0L176 189.2 76 89.3a31.5 31.5 0 0 0-44.5 0L9.2 111.5a31.5 31.5 0 0 0 0 44.4l100 100.1-100 100a31.5 31.5 0 0 0 0 44.5l22.3 22.3a31.5 31.5 0 0 0 44.4 0l100.1-100 100 100a31.5 31.5 0 0 0 44.5 0l22.3-22.2a31.5 31.5 0 0 0 0-44.5L242.8 256z'/%3E%3C/svg%3E");
+  mask-size: 1rem 1rem;
   opacity: 0.6;
 }
 
-.host-remove:hover {
+.host-remove:focus::before,
+.host-remove:hover::before {
   opacity: 1;
 }
 
@@ -897,7 +904,7 @@ a:hover {
 
 #login-again {
   display: block;
-  margin-bottom: 1rem;
+  margin-top: 1rem;
 }
 
 .password-with-toggle {
@@ -920,6 +927,118 @@ a:hover {
 input[type=text] + .login-password-toggle .password-show,
 input[type=password] + .login-password-toggle .password-hide {
   display: none;
+}
+
+/* Dark */
+@media (prefers-color-scheme: dark) {
+  .login-pf .container,
+  .login-pf .details {
+    z-index: 2;
+  }
+
+  .login-pf .container {
+    background: #26292d;
+    color: #f0f0f0;
+  }
+
+  .login-pf .details {
+    background: #151515;
+    color: #f0f0f0;
+  }
+
+  .pf-c-button.pf-m-control,
+  .form-control[type=password],
+  .form-control[type=text] {
+    background: #393f44;
+    border-color: #393f44;
+    border-bottom-color: #6c6f72;
+    color: #f0f0f0;
+  }
+
+  a,
+  a:active,
+  a:focus,
+  a:hover {
+    color: #8ac0f6;
+  }
+
+  .pf-m-primary {
+    background-color: #06c;
+  }
+
+  .pf-m-primary:hover {
+    background-color: #004080;
+  }
+
+  .pf-m-tertiary {
+    background-color: transparent;
+    border-color: #8ac0f6;
+    color: #8ac0f6;
+  }
+
+  .pf-m-tertiary:active,
+  .pf-m-tertiary:focus,
+  .pf-m-tertiary:hover {
+    background-color: transparent;
+    border-color: #c5e0fb;
+    outline-color: #c5e0fb;
+    color: #c5e0fb;
+  }
+
+  .input-clear,
+  .inline .container .help-block {
+    color: #f0f0f0;
+  }
+
+  .host-line {
+    border-color: #34373b;
+  }
+
+  /* The × icon's focus ring */
+  .host-remove:focus {
+    outline-color: #f1f1f1;
+  }
+
+  /* The × icon */
+  .host-remove::before {
+    background-color: #f1f1f1;
+  }
+
+  .unsupported-browser ul {
+    color: #999;
+  }
+
+  .pf-c-alert.pf-m-inline.pf-m-danger {
+    background: #1e2125;
+    border-color: #fe5142;
+  }
+
+  .pf-c-alert.pf-m-danger > svg,
+  .pf-c-alert.pf-m-danger .pf-c-alert__title {
+    color: #fe5142;
+  }
+
+  .pf-c-button[disabled] {
+    background-color: #444548;
+    border-color: #444548;
+    color: #c6c7c8
+  }
+
+  /* Screen the background and logo darker */
+  .login-pf::after {
+    /* Pass through mouse events */
+    pointer-events: none;
+    background: #000;
+    opacity: 0.66;
+    display: block;
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
+  }
 }
 
 /* Animation */

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -112,7 +112,7 @@
         <div class="form-group login-actions">
           <button class="pf-c-button pf-m-primary login-button" id="login-button" type="submit">
             <span class="spinner"></span>
-            <span id="login-button-text" translate>Log in</span>
+            <span id="login-button-text" class="button-text" translate>Log in</span>
           </button>
           <a id="get-out-link" href="/" translate>Cancel</a>
         </div>
@@ -126,7 +126,7 @@
 
     <div id="login-fatal" hidden>
       <div id="login-fatal-message"></div>
-      <a id="login-again" href="#" translate hidden>Try again</a>
+      <a id="login-again" class="pf-c-button pf-m-primary" href="#" translate hidden>Try again</a>
     </div>
 
     <div class="unsupported-browser" id="unsupported-browser" hidden>

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -584,7 +584,7 @@
             const b2 = document.createElement("button");
             b2.title = _("Remove host");
             b2.ariaLabel = b2.title;
-            b2.classList.add("pf-c-button", "pf-m-tertiary", "host-remove");
+            b2.classList.add("host-remove");
             b2.addEventListener("click", () => {
                 const i = hosts.indexOf(host);
                 hosts.splice(i, 1);


### PR DESCRIPTION
The login page now has a dark mode which changes with your system's dark settings. Most desktops have a setting for this in "appearance" area in system settings, including GNOME, KDE, Windows, macOS, Android, and iOS/iPadOS.

Here's [Cockpit Client](https://flathub.org/apps/details/org.cockpit_project.CockpitClient), which [also recently got dark mode a few releases ago](https://cockpit-project.org/blog/cockpit-269.html), in the standard light mode:

![Screenshot from 2022-06-22 18-42-47](https://user-images.githubusercontent.com/10246/175091972-223986a2-2116-4e76-a734-5e51e36dce5d.png)

And after switching to dark settings, it looks like this:

![Screenshot from 2022-06-22 18-42-59](https://user-images.githubusercontent.com/10246/175091974-7a740111-008d-4679-bea0-7e4d1fd583c4.png)

We’re still working on adding dark mode for Cockpit once you've logged in, in the near future.