### PR TITLE
systemd: Fix link in BreadcrumbItem

### DIFF
--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -79,7 +79,7 @@ export class Service extends React.Component {
                       id="service-details"
                       breadcrumb={
                           <Breadcrumb>
-                              <BreadcrumbItem to={"#" + cockpit.location.href.replace(cockpit.location.path[0], '')}>{_("Services")}</BreadcrumbItem>
+                              <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
                               <BreadcrumbItem isActive>
                                   {this.props.unit.Id}
                               </BreadcrumbItem>

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -239,6 +239,17 @@ Description=Delete Me Timer
 [Timer]
 OnCalendar=*:1/2
 """)
+        self.write_file(f"{path}/special@:-characters.service",
+                        """
+[Unit]
+Description=Service With Special Characters in Id
+
+[Service]
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=default.target
+""")
 
         self.make_test_service(path)
 
@@ -265,6 +276,16 @@ OnCalendar=*:1/2
         self.run_systemctl(user, "start test.service")
 
         b.wait_attr("#services-toolbar", "data-loading", "false")
+
+        self.wait_service_present("special@:-characters.service")
+        self.wait_service_in_panel("special@:-characters.service", "Disabled")
+        self.wait_service_state("special@:-characters.service", "inactive")
+
+        # Test breadcrumb link when service id contains special characters
+        self.goto_service("special@:-characters.service")
+        b.wait_in_text(".pf-c-breadcrumb", "special@:-characters.service")
+        b.click(".pf-c-breadcrumb a:contains('Services')")
+        b.wait_visible("#services-list")
 
         # Selects Targets tab
         self.pick_tab(2)


### PR DESCRIPTION
Fixes issue on service details page where 'Services' link doesn't lead back
to the services overview page when service Id containts special characters.