### PR TITLE
tools: Adjust RHEL dependencies

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -607,8 +607,8 @@ class TestConnection(MachineCase):
             # clean up debug symbols, they get in the way of upgrading
             m.execute("dpkg --purge cockpit-ws-dbgsym")
         elif m.image.startswith("rhel"):
-            # subscription-manager-cockpit depends on cockpit-ws
-            m.execute("rpm --erase subscription-manager-cockpit")
+            # subscription-manager-cockpit depends on cockpit-ws, and cockpit.rpm metapackage depends on sub-man on RHEL
+            m.execute("rpm --erase cockpit subscription-manager-cockpit")
 
         def install():
             if m.image.startswith("debian") or m.image.startswith("ubuntu"):
@@ -625,6 +625,8 @@ class TestConnection(MachineCase):
                 m.execute("dpkg --purge cockpit cockpit-ws")
             elif m.image == "arch":
                 m.execute("pacman -Rdd --noconfirm cockpit")
+            elif m.image.startswith("rhel"):
+                m.execute("rpm --erase cockpit-ws")
             else:
                 m.execute("rpm --erase cockpit cockpit-ws")
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -363,6 +363,8 @@ class TestAccounts(MachineCase):
         self.allow_journal_messages("lastlog: Unknown user or range: anton")
         self.allow_journal_messages(".*required to change your password immediately.*")
         self.allow_journal_messages(".*user account or password has expired.*")
+        # when sed'ing, there is a short time when the config file does not exist
+        self.allow_journal_messages(".*libuser initialization error: .*/etc/default/useradd.*: No such file or directory")
 
     def testUnprivileged(self):
         m = self.machine

--- a/tools/cockpit.spec.in
+++ b/tools/cockpit.spec.in
@@ -150,7 +150,7 @@ Recommends: (cockpit-networkmanager if NetworkManager)
 Suggests: cockpit-selinux
 %endif
 %if 0%{?rhel} && 0%{?centos} == 0
-Recommends: subscription-manager-cockpit
+Requires: subscription-manager-cockpit
 %endif
 
 %prep
@@ -388,17 +388,17 @@ Provides: cockpit-tuned = %{version}-%{release}
 Provides: cockpit-users = %{version}-%{release}
 Obsoletes: cockpit-dashboard < %{version}-%{release}
 %if 0%{?rhel}
-Provides: cockpit-networkmanager = %{version}-%{release}
 Requires: NetworkManager >= 1.6
-Provides: cockpit-kdump = %{version}-%{release}
 Requires: kexec-tools
-Recommends: (sudo or polkit)
+Requires: sos
+Requires: sudo
 Recommends: PackageKit
-Recommends: NetworkManager-team
 Recommends: setroubleshoot-server >= 3.3.3
+Suggests: NetworkManager-team
+Provides: cockpit-kdump = %{version}-%{release}
+Provides: cockpit-networkmanager = %{version}-%{release}
 Provides: cockpit-selinux = %{version}-%{release}
 Provides: cockpit-sosreport = %{version}-%{release}
-Requires: sos
 %endif
 %if 0%{?fedora}
 Recommends: (reportd if abrt)


### PR DESCRIPTION
Avoid some "Recommends", as they are discouraged:

- Lift subscription-manager-cockpit to Requires, it's an essential part
  on RHEL.
- Require sudo, that's our main UI for getting administrative
  privileges.
- Demote NetworkManager-team to Suggests.

Shuffle the Requires:, Provides:, and Suggests: lines a bit to keep the
same kind together in a single block.

https://bugzilla.redhat.com/show_bug.cgi?id=2093231

---

This also fixes an [unexpected error message](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17426-20220603-183752-19c4b4ea-fedora-35/log.html#304), which seems really unlucky, but let's just deal with it.