### PR TITLE
firewall: Prefer zone name when given

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -175,7 +175,7 @@ function ZoneSection(props) {
             <CardTitle>
                 <Flex alignItems={{ default: 'alignSelfBaseline' }} spaceItems={{ default: 'spaceItemsXl' }}>
                     <Title headingLevel="h2" size="xl">
-                        { cockpit.format(_("$0 Zone"), upperCaseFirstLetter(props.zone.id)) }
+                        { cockpit.format(_("$0 zone"), upperCaseFirstLetter(props.zone.name || props.zone.id)) }
                     </Title>
                     <Flex>
                         { props.zone.interfaces.length > 0 &&

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -58,7 +58,7 @@ class TestFirewall(NetworkCase):
         m.execute("systemctl restart firewalld")
         self.btn_danger = "pf-m-danger"
         self.btn_primary = "pf-m-primary"
-        self.default_zone = "Public Zone"
+        self.default_zone = "Public zone"
 
         # Temporary remove the test Dbus port 8765, this workaround can be
         # removed once the pixel tests are merged and the image updated to not


### PR DESCRIPTION
Zone name may be defined so we should use that when possible.

Before:
![Screenshot from 2022-06-06 14-48-06](https://user-images.githubusercontent.com/12330670/172163958-6acc5d81-8cda-4089-aa59-82c6202ba7c7.png)

After:
![Screenshot from 2022-06-06 14-52-08](https://user-images.githubusercontent.com/12330670/172164270-5cafdce9-b5b8-4938-8330-fa1cc7b718f2.png)

