### PR TITLE
storaged: Set cockpit.format_bytes() precision instead of string hacking

### DIFF
--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "storage",
     "requires": {
-        "cockpit": "186"
+        "cockpit": "266"
     },
 
     "menu": {

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -107,13 +107,11 @@ export function format_temperature(kelvin) {
 
 export function format_fsys_usage(used, total) {
     let text = "";
-    let parts = cockpit.format_bytes(total, undefined, { separate: true });
+    let parts = cockpit.format_bytes(total, undefined, { separate: true, precision: 2 });
     text = " / " + parts.join(" ");
     const unit = parts[1];
 
-    parts = cockpit.format_bytes(used, unit, { separate: true });
-    if (parts[0].indexOf("0.") == 0)
-        parts[0] = parts[0].substring(0, 4);
+    parts = cockpit.format_bytes(used, unit, { separate: true, precision: 2 });
     return parts[0] + text;
 }
 

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -90,13 +90,13 @@ class TestStorageVDO(StorageCase):
 
         # compressible data should affect logical usage
         m.execute("dd if=/dev/zero of=/run/data/empty bs=1M count=1000")
-        self.content_row_wait_in_col(1, 4, "1.15 / 9.98 GB")
+        self.content_row_wait_in_col(1, 4, "1.2 / 10 GB")
         # but not physical usage
         self.content_tab_wait_in_info(1, 2, "Data used", "3.86 GB (64%)")
 
         # incompressible data
         m.execute("dd if=/dev/urandom of=/run/data/gibberish bs=1M count=1000")
-        self.content_row_wait_in_col(1, 4, "2.20 / 9.98 GB")
+        self.content_row_wait_in_col(1, 4, "2.2 / 10 GB")
         # equal amount of physical space (not completely predictable due to random data)
         self.content_tab_wait_in_info(1, 2, "Data used", "4.8", "4.9", "5.0")
         self.content_tab_wait_in_info(1, 2, "Data used", cond=lambda sel: re.search(r"\(8[1234]%\)", b.text(sel)))
@@ -220,7 +220,7 @@ class TestStorageLegacyVDO(StorageCase):
         self.content_tab_wait_in_info(1, 1, "Mount point", "_netdev")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.device-timeout=0")
         self.content_tab_wait_in_info(1, 1, "Mount point", "x-systemd.requires=vdo.service")
-        self.content_row_wait_in_col(1, 4, "/ 5.36 GB", alternate_val="/ 5.37 GB")
+        self.content_row_wait_in_col(1, 4, "/ 5.4 GB")
 
         # Grow physical
 
@@ -235,7 +235,7 @@ class TestStorageLegacyVDO(StorageCase):
         b.click(detail(4) + " button:contains(Grow)")
         self.dialog({"lsize": 10000})
         b.wait_in_text(detail(4), "used of 10.0 GB")
-        self.content_row_wait_in_col(1, 4, "/ 9.99 GB", alternate_val="/ 10.0 GB")
+        self.content_row_wait_in_col(1, 4, "/ 10 GB")
 
         # Stop
 


### PR DESCRIPTION
That string hacking was only working in locales with `.` as decimal
separator, but e.g. not German or Portugese.

Use the new precision option from commit 083f889c0a47 (released in
Cockpit 266). Adjust the VDO tests accordingly.