### PR TITLE
RFC: add theming support (via CSS overrides)

### DIFF
--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -23,6 +23,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <title translate="yes">Applications</title>
     <meta charset="utf-8">
     <link href="apps.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -25,6 +25,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="kdump.css">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
     <script type="text/javascript" src="kdump.js"></script>
     <script type="text/javascript" src="../base/po.js"></script>

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -23,6 +23,7 @@ along with this package; If not, see <http://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="index.css">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../manifests.js"></script>

--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -23,6 +23,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta charset="utf-8">
 
     <link href="firewall.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -24,6 +24,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="network.css" type="text/css" rel="stylesheet">
+  <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
   <script src="../base1/cockpit.js"></script>
   <script src="../manifests.js"></script>
   <script src="../base1/po.js"></script>

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -24,6 +24,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <meta charset="utf-8">
 
   <link href="updates.css" rel="stylesheet">
+  <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
   <script src="../base1/cockpit.js"></script>
   <script src="../base1/po.js"></script>

--- a/pkg/playground/index.html
+++ b/pkg/playground/index.html
@@ -5,6 +5,7 @@
     <title>Cockpit Development Playground</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="index.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="index.js"></script>

--- a/pkg/playground/journal.html
+++ b/pkg/playground/journal.html
@@ -5,6 +5,7 @@
     <title>Cockpit Journal Box</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="journal.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="journal.js"></script>
 </head>

--- a/pkg/playground/metrics.html
+++ b/pkg/playground/metrics.html
@@ -5,6 +5,7 @@
     <title>Cockpit Monitoring</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="metrics.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="metrics.js"></script>
 </head>

--- a/pkg/playground/plot.html
+++ b/pkg/playground/plot.html
@@ -5,6 +5,7 @@
     <title>Cockpit Plots</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="plot.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="plot.js"></script>
 </head>

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -5,6 +5,7 @@
     <title>Cockpit React Patterns Usage</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="react-patterns.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="react-patterns.js"></script>
 </head>

--- a/pkg/playground/speed.html
+++ b/pkg/playground/speed.html
@@ -5,6 +5,7 @@
     <title>Cockpit Speed Tests</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="speed.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="speed.js"></script>
 </head>

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -5,6 +5,7 @@
     <title>Cockpit playground</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="test.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="test.js"></script>
 </head>

--- a/pkg/selinux/setroubleshoot.html
+++ b/pkg/selinux/setroubleshoot.html
@@ -25,6 +25,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
     <link rel="stylesheet" href="selinux.css">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="index.css" rel="stylesheet">
     <link href="../../static/branding.css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
     <script src="../*/po.js"></script>

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -5,6 +5,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="index.css">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 </head>
 <body class="pf-m-redhat-font">
     <div class="curtains-ct">

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -22,6 +22,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <title translate="yes">Diagnostic reports</title>
     <meta charset="utf-8">
     <link href="sosreport.css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script type="text/javascript" src="../base1/cockpit.js"></script>
     <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -16,6 +16,7 @@
   <script type="text/javascript" src="cockpit/static/login.js"></script>
   <link href="cockpit/static/login.css" type="text/css" rel="stylesheet">
   <link href="cockpit/static/branding.css" type="text/css" rel="stylesheet">
+  <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 </head>
 
 <body class="login-pf">

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -24,6 +24,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="storage.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="../manifests.js"></script>

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -4,6 +4,7 @@
     <title translate="yes">Hardware information</title>
     <meta charset="utf-8">
     <link href="hwinfo.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="po.js"></script>

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -7,6 +7,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
   <link rel="stylesheet" href="overview.css">
+  <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
 
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script type="text/javascript" src="../base1/po.js"></script>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -23,6 +23,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
   <title translate>Journal</title>
   <meta charset="utf-8">
   <link href="logs.css" rel="stylesheet">
+  <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script src="../base1/po.js"></script>
   <script src="po.js"></script>

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="services.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="services.js"></script>

--- a/pkg/systemd/terminal.html
+++ b/pkg/systemd/terminal.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="terminal.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="po.js"></script>

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -24,6 +24,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link href="users.css" type="text/css" rel="stylesheet">
+    <link href="../../static/theme-overrides.css" type="text/css" rel="stylesheet">
     <script src="../base1/cockpit.js"></script>
     <script src="../base1/po.js"></script>
     <script src="po.js"></script>


### PR DESCRIPTION
This PoC is just a proposal to help with https://github.com/cockpit-project/cockpit/issues/16359. There might be a lot of details that need to be considered, which is why I am opening the PR as a RFC. Regardless, it's the cleanest method I've found after trying [ others](https://gist.github.com/dgdavid/ec2648c61f63f49a8aa8d9871d2b70f9). Read more at https://github.com/cockpit-project/cockpit/discussions/16256#discussioncomment-2834640

Basically, _the trick_ is to load a new _theme-overrides.css_ file in every HTML page. For overrides to take effect, this file must be the last to be applied.

Since the load of this file mimic how [_branding.css_ is included](https://github.com/cockpit-project/cockpit/blob/75c33b347ae80115241f058c196ec25ffbc9d274/pkg/shell/index.html#L8), Cockpit look&feel could be customized without having to patch it (once changes are merged, of course). Just using an external package to provide needed resources. That package must include those files following the same rules as [branding](https://github.com/cockpit-project/cockpit/blob/27cb665b5c135481f900dafac0c1b754ab91b5a0/doc/branding.md#how-cockpit-selects-branding).

For illustrative purposes, I have [created a simple package](https://build.opensuse.org/package/show/home:dgdavid/carbon-cockpit-theme) using a few bits (colors, spacing, typeface) from [Carbon Design System](https://carbondesignsystem.com) and patched Cockpit before using it. See how it looks:

|| Before | After |
|-|-|-|
| Overview | ![overview_before_theming](https://user-images.githubusercontent.com/1691872/172424196-20b84afc-49d3-4ebc-b4d3-64d6e79c7ec5.png) | ![overview_after_theming](https://user-images.githubusercontent.com/1691872/172424318-acf2f4d0-cc25-4694-8be9-dc468a82d00d.png) |
| Logs | ![logs_before_theming](https://user-images.githubusercontent.com/1691872/172424545-427797a1-a03d-44ab-bb5c-d501b8f45b41.png) | ![logs_after_theming](https://user-images.githubusercontent.com/1691872/172424719-0553bb82-a072-4371-a1a7-ec8a0b946d67.png) |
| Storage | ![storage_before_theming](https://user-images.githubusercontent.com/1691872/172425091-46d9ea53-3152-4247-a901-fa6dccd7c220.png) | ![storage_after_theming](https://user-images.githubusercontent.com/1691872/172425028-cb64916f-3f08-4531-93db-c22c47cca09e.png) |
| Network | ![network_before_theming](https://user-images.githubusercontent.com/1691872/172425278-f40452c8-5ffa-4ad2-9b3e-013e1475d409.png) | ![network_after_theming](https://user-images.githubusercontent.com/1691872/172425247-d9afe2da-4cec-411e-8350-6d76d6836193.png) |

:point_right: Note: the package uses the _/usr/share/cockpit/branding/default_ directory just for the sake of simplicity.

## Caveats

With this approach, you can never be sure that every Cockpit module, like [cockpit-podman](https://github.com/cockpit-project/cockpit-podman) or [cockpit-wicked](https://github.com/openSUSE/cockpit-wicked), will be themed as you wish. They can be adapted to load the file as well, and even patching the [starter-kit](https://github.com/cockpit-project/starter-kit) can help with upcoming modules, but would still be subject to oversights.

So having the option of always _injecting_ or _applying_ the overrides after each iframe has been loaded seems like a better idea. Yet I haven't begun looking into this (I would appreciate any guidance).

## Pending stuff

_Only if this approach will be adopted_

* to choose a better name for that file
* to think about the convenience of adding an empty one by default (or with an explanatory comment pointed to the documentation).
* to check if worth reusing _branding.css_ instead (?) (maybe there could some _CSS collisions_ (??))

---

CC: @gabrielefronze