### PR TITLE
static: lib: drop MozWebSocket fallback

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -479,8 +479,6 @@ function Transport() {
         if (ws_loc) {
             if ("WebSocket" in window) {
                 ws = new window.WebSocket(ws_loc, "cockpit1");
-            } else if ("MozWebSocket" in window) { // Firefox 6
-                ws = new window.MozWebSocket(ws_loc);
             } else {
                 console.error("WebSocket not supported, application will not work!");
             }

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -211,7 +211,7 @@
             return true;
         }
 
-        return ("MozWebSocket" in window || req("WebSocket", window)) &&
+        return req("WebSocket", window) &&
                req("XMLHttpRequest", window) &&
                req("sessionStorage", window) &&
                req("JSON", window) &&


### PR DESCRIPTION
10 years ago in Firefox 11 MozWebSocket was replaced by Websocket.
https://bugzilla.mozilla.org/show_bug.cgi?id=695635