### PR TITLE
hack metainfo releases a bit more

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,7 +27,7 @@ distdir: $(DISTFILES)
 		git -C '$(srcdir)' ls-files -x test/reference .fmf plans test tools > .extra_dist.tmp && \
 		mv .extra_dist.tmp '$(srcdir)/.extra_dist'; fi
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am EXTRA_FILES="$$(tr '\n' ' ' < $(srcdir)/.extra_dist) .extra_dist"
-	$(srcdir)/src/client/add-metainfo-releases --version '$(VERSION)' '$(distdir)'/src/client/*.metainfo.xml
+	test ! -x $(srcdir)/src/client/add-metainfo-releases || $(srcdir)/src/client/add-metainfo-releases --version '$(VERSION)' '$(distdir)'/src/client/*.metainfo.xml
 	$(srcdir)/tools/adjust-distdir-timestamps "$(distdir)"
 	@echo '  DIST     $(DIST_ARCHIVES)'
 

--- a/src/client/add-metainfo-releases
+++ b/src/client/add-metainfo-releases
@@ -57,7 +57,7 @@ def main():
         if 'g' in args.version:
             today = time.strftime('%Y-%m-%d')
             releases.append(element('release', version=args.version, date=today, type='development'))
-        releases.extend(format_release(r) for r in get_releases())
+        releases.extend(format_release(r) for r in get_releases() if r)
         if 'ELEMENT_TREE_NO_INDENT' not in os.environ:
             ET.indent(releases, space="  ", level=1)
         tree.write(args.xml, encoding='utf-8', xml_declaration=True)


### PR DESCRIPTION
I wanted to get all of this stuff out of the process of building a tarball, but
 - managing this externally is (really) hard.  At some point you find yourself writing XSL and ask yourself "...what am I doing?".
 - ximion/appstream#354 will hopefully provide a proper fix for this eventually
 - the current approach is working well enough

Instead of trying to create some new thing which we'll just have to replace a little bit later anyway, let's just make the current stuff work.

This fixes `make distcheck`.