### PR TITLE
kdump: show tooltip when crashkernel is not configured

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -504,6 +504,17 @@ export class KdumpPage extends React.Component {
             );
         }
         const tooltip_info = _("This will test the kdump configuration by crashing the kernel.");
+
+        let kdumpSwitch = (<Switch isChecked={!!serviceRunning}
+                              onChange={this.props.onSetServiceState}
+                              aria-label={_("kdump status")}
+                              isDisabled={this.props.stateChanging || !this.props.kdumpCmdlineEnabled} />);
+        if (!this.props.kdumpCmdlineEnabled) {
+            kdumpSwitch = (
+                <Tooltip content={_("crashkernel not configured in the kernel command line")} position={TooltipPosition.right}>
+                    {kdumpSwitch}
+                </Tooltip>);
+        }
         return (
             <Page>
                 <PageSection variant={PageSectionVariants.light}>
@@ -511,10 +522,7 @@ export class KdumpPage extends React.Component {
                         <Title headingLevel="h2" size="3xl">
                             {_("Kernel crash dump")}
                         </Title>
-                        <Switch isChecked={!!serviceRunning}
-                                onChange={this.props.onSetServiceState}
-                                aria-label={_("kdump status")}
-                                isDisabled={this.props.stateChanging} />
+                        {kdumpSwitch}
                     </Flex>
                 </PageSection>
                 <PageSection className="ct-pagesection-mobile">

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -63,11 +63,20 @@ const initStore = function(rootElement) {
             stateChanging: dataStore.stateChanging,
             reservedMemory: dataStore.kdumpMemory,
             kdumpStatus: dataStore.kdumpStatus,
+            kdumpCmdlineEnabled: dataStore.crashkernel || false,
             onSaveSettings: dataStore.saveSettings,
             onCrashKernel: dataStore.kdumpClient.crashKernel,
         }), rootElement);
     };
     dataStore.render = render;
+
+    cockpit.file("/proc/cmdline").read()
+            .then(content => {
+                if (content !== null) {
+                    dataStore.crashkernel = content.indexOf('crashkernel=') !== -1;
+                }
+            })
+            .catch(err => console.error("cannot read /proc/cmdline", err));
 
     // read memory reserved for kdump from system
     dataStore.kdumpMemory = undefined;

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -79,6 +79,8 @@ class TestKdump(KdumpHelpers):
             b.wait_in_text("#app", "Service is running")
             assertActive(True)
         else:
+            # crashkernel command line not set
+            b.wait_visible(".pf-c-switch__input:disabled")
             # right now we have no memory reserved
             b.mouse("span + .popover-ct-kdump", "mouseenter")
             b.wait_in_text(".pf-c-tooltip", "No memory reserved.")


### PR DESCRIPTION
Disable the service switch and show a tooltip when the kernel's command
line lacks the crashkernel option. Without this change a user can try to
enable the service which will instantly fail without an indication that
crashkernel has to be configured upfront.