### PR TITLE
package.json: Update chrome-remote-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "argparse": "^2.0.1",
     "axe-core": "^3.5.2",
     "babel-loader": "^8.1.0",
-    "chrome-remote-interface": "^0.28.1",
+    "chrome-remote-interface": "^0.31.2",
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",


### PR DESCRIPTION
This release contains a fix for nodejs to prefer ipv4 resolving which
is needed as Firefox the CDP runs only on ipv4.