### PR TITLE
package.json: Update chrome-remote-interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "argparse": "^2.0.1",
     "axe-core": "^3.5.2",
     "babel-loader": "^8.1.0",
-    "chrome-remote-interface": "^0.28.1",
+    "chrome-remote-interface": "^0.31.2",
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -24,6 +24,9 @@ git clone --depth=1 https://github.com/cockpit-project/bots
 # support running from clean git tree
 if [ ! -d node_modules/chrome-remote-interface ]; then
     npm install chrome-remote-interface sizzle
+else
+    # make sure we use the correct node_modules
+    ./tools/node-modules checkout
 fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"


### PR DESCRIPTION
This release contains a fix for nodejs to prefer ipv4 resolving which
is needed as Firefox the CDP runs only on ipv4 on Fedora rawhide on
packit.