### PR TITLE
workflows: Adjust unit-tests-refresh to recent container changes

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -13,9 +13,6 @@ jobs:
       contents: read
       packages: write
     timeout-minutes: 180
-    env:
-      # current podman backport falls over as non-root, and completely breaks down with :i386 image
-      docker: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -39,9 +36,9 @@ jobs:
         run: containers/unit-tests/start :i386 distcheck
 
       - name: Log into container registry
-        run: docker login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+        run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
 
       - name: Push containers to registry
         run: |
-          docker push ghcr.io/cockpit-project/unit-tests:latest
-          docker push ghcr.io/cockpit-project/unit-tests:i386
+          podman push ghcr.io/cockpit-project/unit-tests:latest
+          podman push ghcr.io/cockpit-project/unit-tests:i386

--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -24,16 +24,16 @@ jobs:
         run: containers/unit-tests/build
 
       - name: Run amd64 gcc check-memory test
-        run: containers/unit-tests/start check-memory
+        run: containers/unit-tests/start --verbose --env=CC=gcc --image-tag=latest --make check-memory
 
       - name: Run i386 clang check-memory test
-        run: containers/unit-tests/start :i386 CC=clang check-memory
+        run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=i386 --make check-memory
 
       - name: Run amd64 clang distcheck test
-        run: containers/unit-tests/start CC=clang distcheck
+        run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=latest --make distcheck
 
       - name: Run i386 gcc distcheck test
-        run: containers/unit-tests/start :i386 distcheck
+        run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=i386 --make distcheck
 
       - name: Log into container registry
         run: podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,9 +12,6 @@ jobs:
           - { make: 'distcheck', cc: 'gcc', tag: 'i386' }
       fail-fast: false
     timeout-minutes: 60
-    env:
-      # current podman backport falls over as non-root, and completely breaks down with :i386 image
-      docker: docker
     steps:
       - name: Clone repository
         uses: actions/checkout@v2

--- a/containers/unit-tests/build
+++ b/containers/unit-tests/build
@@ -3,15 +3,10 @@ set -eu
 
 dir=$(dirname "$0")
 
-if test -z "${docker:=$(which podman || which docker || true)}"; then
-  echo 'Neither podman nor docker are installed'
-  exit 1
-fi
-
 if [ -z "${1:-}" ] || [ "${1:-}" = amd64 ]; then
-    $docker build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t ghcr.io/cockpit-project/unit-tests ${dir}
+    podman build --build-arg debian_arch=amd64 --build-arg personality=linux64 -t ghcr.io/cockpit-project/unit-tests ${dir}
 fi
 
 if [ -z "${1:-}" ] || [ "${1:-}" = i386 ]; then
-    $docker build --build-arg debian_arch=i386 --build-arg personality=linux32 -t ghcr.io/cockpit-project/unit-tests:i386 ${dir}
+    podman build --build-arg debian_arch=i386 --build-arg personality=linux32 -t ghcr.io/cockpit-project/unit-tests:i386 ${dir}
 fi


### PR DESCRIPTION
Commit b746f5aef3671446 changed the unit-tests workflow, but not the
-refresh one.

---

See last night's [failure](https://github.com/cockpit-project/cockpit/actions/runs/2525468187)

[run against this branch](https://github.com/cockpit-project/cockpit/actions/runs/2526902198)