### PR TITLE
shell: Fix rendering of access level indicator

### DIFF
--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -61,8 +61,8 @@ export class TopNav extends React.Component {
             osRelease: {},
         };
 
-        this.superuser_connection = cockpit.dbus(null, { bus: "internal", host: props.machine.connection_string });
-        this.superuser = this.superuser_connection.proxy("cockpit.Superuser", "/superuser");
+        this.superuser_connection = null;
+        this.superuser = null;
 
         read_os_release().then(os => this.setState({ osRelease: os || {} }));
     }
@@ -87,21 +87,20 @@ export class TopNav extends React.Component {
         return null;
     }
 
-    componentDidUpdate(prevProps) {
-        if (prevProps.machine.connection_string !== this.props.machine.connection_string) {
+    render() {
+        const Dialogs = this.context;
+        const connected = this.props.machine.state === "connected";
+
+        let docs = [];
+
+        if (!this.superuser_connection || (this.superuser_connection.options.host !=
+                                           this.props.machine.connection_string)) {
             if (this.superuser_connection)
                 this.superuser_connection.close();
 
             this.superuser_connection = cockpit.dbus(null, { bus: "internal", host: this.props.machine.connection_string });
             this.superuser = this.superuser_connection.proxy("cockpit.Superuser", "/superuser");
         }
-    }
-
-    render() {
-        const Dialogs = this.context;
-        const connected = this.props.machine.state === "connected";
-
-        let docs = [];
 
         const item = this.props.compiled.items[this.props.state.component];
         if (item && item.docs)


### PR DESCRIPTION
The "proxy" property of the SuperuserIndicator was not updated in time
with a change to the "host" property since "componentDidUpdate" runs
after render.  Let's just keep the proxy up-to-date in "render"
itself.

Fixes #17467