### PR TITLE
test: Drop obsolete container test documentation and scenario

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -159,14 +159,6 @@ mode), copy it into the VM, and run the test against it:
 
     $ test/verify/check-connection --machine 127.0.0.2:2201 --browser 127.0.0.2:9091
 
-# Container tests
-
-The `test/containers/` tests use the same VMs as the above `test/verify/` ones.
-But they don't have a separate "prepare" step/script; instead, the first time
-you run `test/containers/run-tests` you need to use the `-i` option to
-build/install cockpit into the test VM. This needs to be done with a compatible
-`TEST_OS` (usually a recent `fedora-*`).
-
 ## Debugging tests
 
 If you pass the `-s` ("sit on failure") option to a test program, it

--- a/test/run
+++ b/test/run
@@ -19,9 +19,6 @@ case $TEST_SCENARIO in
         test/image-prepare --verbose $TEST_OS
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify ${OPTS}
         ;;
-    container-bastion)
-        echo "Obsolete, absorbed by test/verify/check-ws-bastion"
-        ;;
     dnf-copr*)
         bots/image-customize -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y --setopt=install_weak_deps=False update' $TEST_OS
         test/image-prepare --verbose --overlay $TEST_OS


### PR DESCRIPTION
These were dropped in commit d81735ca198 and
https://github.com/cockpit-project/bots/pull/3526