### PR TITLE
PoC: All the changes we need to support 3scale/clouddot

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -150,6 +150,14 @@ ForwardedForHeader = X-Forwarded-For
         </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>WebsocketRoot</option></term>
+        <listitem>
+          <para>The root URL where you will be serving cockpit's web socket. This defaults to
+            <code>UrlRoot</code>, but some reverse proxies like <ulink url="https://www.3scale.net/">3scale</ulink>
+            route websocket requests through a different path.</para>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>ClientCertAuthentication</option></term>
         <listitem>
           <para>If true, enable TLS client certificates for authenticating users. Commonly

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -95,6 +95,21 @@ ForwardedForHeader = X-Forwarded-For
       </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>AuthorizationHeader</option></term>
+        <listitem>
+          <para>Cockpit normally uses the <code>Authorization:</code> header for sending credentials from
+            the login page to the web server. In some cases, this header is already being used for
+            authenticating to a reverse proxy. Then you can tell cockpit's web server to use a different header
+            header for itself. It is recommended to use <code>X-Cockpit-Authorization</code>.</para>
+        <informalexample>
+<programlisting language="ini">
+[WebService]
+AuthorizationHeader = X-Cockpit-Authorization
+</programlisting>
+        </informalexample>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>LoginTitle</option></term>
         <listitem><para>Set the browser title for the login screen.</para></listitem>
       </varlistentry>

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -316,8 +316,6 @@ function calculate_url(suffix) {
     if (!suffix)
         suffix = "socket";
     const window_loc = window.location.toString();
-    /* this is not set by anything right now, just a client-side stub; see
-     * https://github.com/cockpit-project/cockpit/pull/17473 for the server-side and complete solution */
     const meta_websocket_root = document.head.querySelector("meta[name='websocket-root']");
     let _url_root = meta_websocket_root ? meta_websocket_root.content.replace(/^\/+|\/+$/g, '') : url_root;
 

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -21,6 +21,8 @@
             oauth.ErrorParam = "error_description";
     }
 
+    const authorization_header = environment.authorization_header || "Authorization";
+
     const fmt_re = /\$\{([^}]+)\}|\$([a-zA-Z0-9_]+)/g;
     function format(fmt /* ... */) {
         const args = Array.prototype.slice.call(arguments, 1);
@@ -422,7 +424,7 @@
             show("#login-wait-validating");
             const xhr = new XMLHttpRequest();
             xhr.open("GET", login_path, true);
-            xhr.setRequestHeader("Authorization", "Bearer " + token_val);
+            xhr.setRequestHeader(authorization_header, "Bearer " + token_val);
             xhr.onreadystatechange = function () {
                 if (xhr.readyState == 4) {
                     if (xhr.status == 200) {
@@ -555,7 +557,7 @@
             localStorage.setItem('standard-login', true);
 
             const headers = {
-                Authorization: "Basic " + window.btoa(utf8(user + ":" + password)),
+                [authorization_header]: "Basic " + window.btoa(utf8(user + ":" + password)),
                 "X-Superuser": superuser,
             };
             // allow unknown remote hosts with interactive logins with "Connect to:"
@@ -894,7 +896,7 @@
 
     function converse(id, msg) {
         const headers = {
-            Authorization: "X-Conversation " + id + " " + window.btoa(utf8(msg))
+            [authorization_header]: "X-Conversation " + id + " " + window.btoa(utf8(msg))
         };
         send_login_request("GET", headers, true);
     }

--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -22,6 +22,7 @@
 #include "cockpitchannelresponse.h"
 
 #include "common/cockpitchannel.h"
+#include "common/cockpitconf.h"
 #include "common/cockpitflow.h"
 #include "common/cockpitwebinject.h"
 #include "common/cockpitwebserver.h"
@@ -85,12 +86,17 @@ cockpit_channel_inject_perform (CockpitChannelInject *inject,
   g_autofree gchar *prefixed_application = NULL;
 
   const gchar *url_root = cockpit_web_response_get_url_root (response);
+  const gchar *websocket_root = cockpit_conf_string ("WebService", "WebsocketRoot");
 
-  if (!url_root && !inject->base_path)
+  if (!url_root && !websocket_root && !inject->base_path)
     return;
 
   g_autoptr(GString) str = g_string_new ("");
   CockpitCreds *creds = cockpit_web_service_get_creds (inject->service);
+
+  if (websocket_root)
+      g_string_append_printf (str, "\n    <meta name=\"websocket-root\" content=\"%s\">", websocket_root);
+
   if (url_root)
     {
       g_string_append_printf (str, "\n    <meta name=\"url-root\" content=\"%s\">", url_root);

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -347,6 +347,10 @@ build_environment (GHashTable *os_release)
         json_object_set_string_member (object, "banner", contents);
     }
 
+  const gchar *authorization_header = cockpit_conf_string ("Webservice", "AuthorizationHeader");
+  if (authorization_header)
+      json_object_set_string_member (object, "authorization_header", authorization_header);
+
   bytes = cockpit_json_write_bytes (object);
   json_object_unref (object);
 

--- a/src/ws/main.c
+++ b/src/ws/main.c
@@ -230,6 +230,12 @@ main (int argc,
                     cockpit_conf_string ("WebService", "UrlRoot"),
                     NULL);
     }
+  if (cockpit_conf_string ("WebService", "WebsocketRoot"))
+    {
+      g_object_set (server, "websocket-root",
+                    cockpit_conf_string ("WebService", "WebsocketRoot"),
+                    NULL);
+    }
 
   cockpit_web_server_set_protocol_header (server, cockpit_conf_string ("WebService", "ProtocolHeader"));
   cockpit_web_server_set_forwarded_for_header (server, cockpit_conf_string ("WebService", "ForwardedForHeader"));

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1235,6 +1235,15 @@ server {
         self.checkCockpitOnProxy(urlroot="/myroot", login=False)
         kill_ws()
 
+        # separate websocket URL root like on 3scale
+        # reject /api path to websocket with distinct error 418
+        self.sed_file('s_/myroot_~ ^/(api|wss)/myroot/_; /location/i location ~ ^/api/myroot/cockpit/socket { return 418 "wrong path"; }',
+                      "/etc/nginx/conf.d/cockpit.conf", "systemctl restart nginx")
+        m.write("/etc/cockpit/cockpit.conf", "UrlRoot = /api/myroot\nWebsocketRoot = /wss/myroot\n", append=True)
+        run_ws("--local-session=cockpit-bridge")
+        self.checkCockpitOnProxy(urlroot="/api/myroot", login=False)
+        kill_ws()
+
         self.allow_restart_journal_messages()
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
         self.allow_journal_messages("couldn't change to runtime dir.*Permission denied")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1196,6 +1196,8 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 
+        #HOOK
+
         # Pass ETag header from Cockpit to clients.
         # See: https://github.com/cockpit-project/cockpit/issues/5239
         gzip off;
@@ -1233,6 +1235,25 @@ server {
         # UrlRoot without login page
         run_ws("--local-session=cockpit-bridge")
         self.checkCockpitOnProxy(urlroot="/myroot", login=False)
+        kill_ws()
+
+        # custom authorization header; block standard Authorization: header in the proxy
+        self.sed_file('s/#HOOK/proxy_set_header Authorization "";/', "/etc/nginx/conf.d/cockpit.conf",
+                      "systemctl restart nginx")
+        m.write("/etc/cockpit/cockpit.conf", "AuthorizationHeader = X-Cockpit-Authorization\n", append=True)
+        run_ws()
+        self.checkCockpitOnProxy(urlroot="/myroot")
+        # does not accept standard header
+        basic_auth = base64.b64encode(b"admin:foobar").decode()
+        (https_host, https_port) = self.machine.forward["443"].split(':')
+        out = self.callProxyCurl("/myroot/cockpit/login", "--head",
+                                 "--header", f"Authorization: Basic {basic_auth}")
+        self.assertRegex(out, b"HTTP/1.1 (401 Authentication failed|403 Permission denied).*")
+        # accepts custom header
+        out = self.callProxyCurl("/myroot/cockpit/login", "--head",
+                                 "--header", f"X-Cockpit-Authorization: Basic {basic_auth}")
+        self.assertIn(b"HTTP/1.1 200 OK", out)
+        self.assertIn(b"\nSet-Cookie:", out)
         kill_ws()
 
         # separate websocket URL root like on 3scale


### PR DESCRIPTION
We want to support running cockpit-ws behind https://www.3scale.net/. This PR subsumes all the changes that we need for this on the cockpit side, so that we can easily build a container and packages out of them. We will land these in individual PRs, though.

Dependencies:
 - PR #17469
 - PR #17640 

With the extra commit for hacking the container, I published this as https://quay.io/repository/rhn_engineering_mpitt/ws with:

    podman build -t quay.io/rhn_engineering_mpitt/ws containers/ws/
    podman push quay.io/rhn_engineering_mpitt/ws

 - [x] Finally decide whether we can do everything through /wss on 3scale and ignore the /app route -- then drop the WebsocketRoot= commit

Superseded by https://github.com/jelly/console.dot/pull/47