### PR TITLE
test: Disable FreeIPA tests on debian-testing

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -497,7 +497,7 @@ class TestRealms(MachineCase):
         self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
 
 
-@skipImage("freeipa not currently available", "debian-stable", "arch")
+@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
@@ -997,7 +997,7 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 
 @skipImage("No realmd available", "fedora-coreos", "arch")
-@skipImage("freeipa not currently available", "debian-stable", "arch")
+@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestKerberos(MachineCase):


### PR DESCRIPTION
This package was again dropped.

This reverts commit ef04f8b9398dcac6f0c63e459cc0eb84859459b9.