### PR TITLE
tap-cdp: return non-zero if we see 'not ok' lines

### DIFF
--- a/test/common/tap-cdp
+++ b/test/common/tap-cdp
@@ -111,6 +111,8 @@ for t, message in cdp.read_log():
 
     # TAP lines go to stdout, everything else to stderr
     if tap_line_re.match(message):
+        if message.startswith('not ok'):
+            success = False
         print(message)
     else:
         print(message, file=sys.stderr)


### PR DESCRIPTION
This used to be handled by the tap driver, but since we don't use that
anymore, we need to add a check for it here.

Fortunately, we didn't break anything in the meantime.