### PR TITLE
fmf: Fix node_modules/ handling for tarballs

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -21,11 +21,8 @@ fi
 # tests need cockpit's bots/ libraries
 git clone --depth=1 https://github.com/cockpit-project/bots
 
-# support running from clean git tree
-if [ ! -d node_modules/chrome-remote-interface ]; then
-    npm install chrome-remote-interface sizzle
-else
-    # make sure we use the correct node_modules
+# support running from clean git tree; this doesn't work from release tarballs
+if [ ! -d node_modules/chrome-remote-interface ] && [ -d . git ]; then
     ./tools/node-modules checkout
 fi
 


### PR DESCRIPTION
Commit 121e770ab9a regressed running tests from tarballs: As there is no
.git directory, tools/node_modules fails to run. So add a check for .git.

We can also simplify this: Since commit c00710475274a, our tarballs
include the NPM modules necessary for testing, so we never need to run
npm.

----

See [this failure](https://artifacts.dev.testing-farm.io/03a6bbff-9b47-4212-a38d-7842673bf82e/) from https://src.fedoraproject.org/rpms/cockpit/pull-request/72