### PR TITLE
test: Drop brittle sysconfig name check in NetworkManager tests

### DIFF
--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -69,11 +69,6 @@ class TestBonding(NetworkCase):
         b.wait_not_present("#network-bond-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbond']")
 
-        # Check that the configuration file has the expected sane name
-        # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbond")
-
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbond'] button")
         b.wait_visible("#network-interface")

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -60,11 +60,6 @@ class TestBridge(NetworkCase):
         b.wait_not_present("#network-bridge-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
 
-        # Check that the configuration file has the expected sane name
-        # on systems that use "network-scripts".
-        if "ubuntu" not in m.image and "debian" not in m.image and m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tbridge")
-
         # Check that the members are displayed and both On
         b.click("#networking-interfaces tr[data-interface='tbridge'] button")
         b.wait_visible("#network-interface")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -64,11 +64,6 @@ class TestTeam(NetworkCase):
         b.wait(lambda: 'nmcli con show | grep tteam')
         b.wait_visible("#networking-interfaces tr[data-interface='tteam']")
 
-        # Check that the configuration file has the expected sane name
-        # on systems that use "network-scripts".
-        if m.image not in ["fedora-coreos", "fedora-testing", "fedora-36"]:
-            m.execute("! test -d /etc/sysconfig || test -f /etc/sysconfig/network-scripts/ifcfg-tteam")
-
         # Check that the members are displayed
         self.select_iface('tteam')
         b.wait_visible("#network-interface")


### PR DESCRIPTION
Fedora and RHEL 9 phase out /etc/sysconfig/network-scripts support, see
/etc/sysconfig/network-scripts/readme-ifcfg-rh.txt.  Writing this file
is between that and NetworkManager, cockpit does not trigger or
influence it. That check already had some non-trivial skip conditions,
and now starts to fail on RHEL 9.1 as well now.

---

This broke downstream gating. If you are in the RH network, the [log is here](http://artifacts.osci.redhat.com/testing-farm/5d3f0d0f-e191-4588-93f4-ce10f7f436c3/work-upstreammF6XmB/plans/upstream/execute/data/test/browser/output.txt).