### PR TITLE
packagekit: Add "Reboot after completion" switch to update progress page

### DIFF
--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -1,6 +1,8 @@
 @use "ct-card";
 @use "page";
 
+@import "@patternfly/patternfly/utilities/Spacing/spacing.css";
+
 /* Style the list cards as ct-cards */
 .pf-c-page__main-section .pf-c-card {
     @extend .ct-card;
@@ -112,17 +114,15 @@ div.changelog {
 .progress-main-view {
     max-width: 60rem;
     margin: 10ex auto 0;
+
+    .pf-l-grid {
+        align-items: end;
+    }
 }
 
 /* workaround font not supporting tabular numbers yet https://github.com/cockpit-project/cockpit/issues/15090 */
 .pf-c-progress__status {
     min-width: 3ch;
-}
-
-/* don't let the install progress bar get too wide */
-.progress-cancel {
-    display: flex;
-    margin: 1em auto;
 }
 
 /* Add some space between the spinner and the text */
@@ -154,8 +154,6 @@ div.changelog {
 }
 
 .update-log {
-    margin: 0 auto;
-    max-width: 69rem;
     text-align: center;
 
     th {

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -360,13 +360,35 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
 
         # should only have one button (no security updates)
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
+
+        # stall the download of chocolate by replacing the package with a pipe, so that we can test cancelling
+        chocolate = m.execute(f"""set -eux;
+            p=$(ls {self.vm_tmpdir}/repo/chocolate*2.0*2*)
+            f={self.vm_tmpdir}/fifo
+            mkfifo $f
+            mount -o bind $f $p
+            echo $p""").strip()
+
         b.click("#available-updates button#install-all")
 
         # applying updates panel present
         b.wait_visible("#app div.pf-c-progress__bar")
 
+        # cancel the installation
         b.wait_in_text(".progress-main-view button.progress-cancel", "Cancel")
-        # Cancel button should eventually get disabled
+        b.click(".progress-main-view button.progress-cancel")
+        # abort the current download, so that read calls don't hang indefinitely
+        m.spawn(f"echo > {self.vm_tmpdir}/fifo", "fifo")
+
+        # going back to overview, nothing happened just yet
+        b.wait_not_present(".progress-main-view")
+        self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
+        self.assertFalse(b.is_present("table.updates-history"))
+        m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
+
+        # update again; Cancel button should eventually get disabled
+        m.execute(f"umount {chocolate}")
+        b.click("#available-updates button#install-all")
         b.wait_visible(".progress-main-view button.progress-cancel:disabled")
 
         # update log only exists in the expander, collapsed by default

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -375,8 +375,8 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_visible("#app div.pf-c-progress__bar")
 
         # cancel the installation
-        b.wait_in_text(".progress-main-view button.progress-cancel", "Cancel")
-        b.click(".progress-main-view button.progress-cancel")
+        b.wait_in_text(".progress-main-view button.pf-m-secondary", "Cancel")
+        b.click(".progress-main-view button.pf-m-secondary")
         # abort the current download, so that read calls don't hang indefinitely
         m.spawn(f"echo > {self.vm_tmpdir}/fifo", "fifo")
 
@@ -386,10 +386,11 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         self.assertFalse(b.is_present("table.updates-history"))
         m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
 
-        # update again; Cancel button should eventually get disabled
+        # update again; Cancel button should eventually disappear
         m.execute(f"umount {chocolate}")
         b.click("#available-updates button#install-all")
-        b.wait_visible(".progress-main-view button.progress-cancel:disabled")
+        b.wait_visible(".progress-main-view")
+        b.wait_not_present(".progress-main-view button.pf-m-secondary")
 
         # update log only exists in the expander, collapsed by default
         self.assertFalse(b.is_visible("#update-log"))
@@ -975,6 +976,37 @@ ExecStart=/usr/local/bin/{packageName}
                               desc_matches=["Things change #00", "Things change #29"])
 
         # seems we can't verify that the description has a scrollbar
+
+    def testRebootAfterSuccess(self):
+        b = self.browser
+        m = self.machine
+
+        install_lockfile = "/tmp/finish-pk"
+        # create two updates; force installing chocolate before vanilla
+        self.createPackage("vanilla", "1.0", "1", install=True)
+        self.createPackage("vanilla", "1.0", "2",
+                           postinst="while [ ! -e {0} ]; do sleep 1; done; rm -f {0}".format(install_lockfile))
+        self.enableRepo()
+        m.execute("pkcon refresh")
+
+        m.start_cockpit()
+        b.login_and_go("/updates")
+        with b.wait_timeout(30):
+            b.wait_visible("#available-updates")
+        b.click("#available-updates button#install-all")
+
+        b.wait_visible("#app div.pf-c-progress__bar")
+        # auto-reboot is off by default
+        b.wait_visible("#reboot-after:not(:checked)")
+        b.click("#reboot-after")
+        b.wait_visible("#reboot-after:checked")
+
+        m.execute(f"touch {install_lockfile}")
+        # reboots automatically
+        b.switch_to_top()
+        b.wait_in_text(".curtains-ct h1", "Disconnected")
+        m.wait_reboot()
+        self.allow_restart_journal_messages()
 
     @nondestructive
     def testUpdateError(self):


### PR DESCRIPTION
This allows users to start a manual update and queue a reboot without
having to babysit the progress.

Rework the progress page layout a bit:

 - Use a Grid layout, so that the update log has the same alignment than
   the progress bar.

 - Stop centering the "Cancel" button, which was a bit dubious wrt. PF
   recommendations anyway. Show it to the right of the progress bar
   instead.

 - Hide the cancel button instead of disabling it, once cancellation is
   not allowed any more.

 - Rename "Update log" to "View update log" to clarify what the action
   means.

 - Increase the spinner size, to make it easier to see.

https://bugzilla.redhat.com/show_bug.cgi?id=2056786

-----

 - Builds on top of PR #17517

## Software Updates: Reboot after applying updates

The update progress page offers you to reboot the machine after applying updates succeeded. If the machine can be rebooted without careful planning, this avoids having to wait and do another interactive step.

![Screen Shot 2022-07-13 at 13 33 36](https://user-images.githubusercontent.com/200109/178724483-dccfdde2-2e43-4366-b013-890f22ef69fd.png)

