### PR TITLE
test: Stop resizing the browser by default with TEST_SHOW_BROWSER

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -120,7 +120,9 @@ You can set these environment variables to configure the test suite:
                   "chromium" is the default.
 
     TEST_SHOW_BROWSER  Set to run browser interactively. When not specified,
-                       browser is run in headless mode.
+                       browser is run in headless mode. When set to "pixels",
+                       the browser will be resized to the exact dimensions that
+                       are used for pixel tests.
 
     TEST_TIMEOUT_FACTOR Scale normal timeouts by given integer. Useful for
                         slow/busy testbeds or architectures.

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -204,7 +204,7 @@ class Browser:
             schema = tls and "https" or "http"
             href = "%s://%s:%s%s" % (schema, self.address, self.port, href)
 
-        if not self.current_layout:
+        if not self.current_layout and os.environ.get("TEST_SHOW_BROWSER") in [None, "pixels"]:
             self.current_layout = self.layouts[0]
             size = self.current_layout["shell_size"]
             self._set_window_size(size[0], size[1])


### PR DESCRIPTION
Iterating page code and test development or doing screenshots  with
TEST_SHOW_BROWSER is rather unnerving, as most of the page isn't
visible/scrollable due to the fixed sizing. Stop this, and go back to
the old behavior where the browser uses its actual window size.

The only corner case is to watch the browser while doing assert_pixels()
development. Support that with `TEST_SHOW_BROWSER=pixels`.