### PR TITLE
containers/ws: Fix pulling in packages from COPR

### DIFF
--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -24,7 +24,7 @@ if [ -n "$rpm" ]; then
     $INSTALL /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm
 else
     # pull packages from https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/
-    echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview owned by @cockpit\nbaseurl=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/fedora-$releasever-$basearch/\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg\nrepo_gpgcheck=0\nenabled=1\nenabled_metadata=1' > /etc/yum.repos.d/cockpit.repo
+    echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview owned by @cockpit\nbaseurl=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/fedora-$releasever-$basearch/\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg\nrepo_gpgcheck=0\nenabled=1\nenabled_metadata=1' > /build/etc/yum.repos.d/cockpit.repo
     ws=$(package_name "cockpit-ws")
     bridge=$(package_name "cockpit-bridge")
     $INSTALL "$ws" "$bridge"


### PR DESCRIPTION
Commit 76da7b7fc29 broke building the official container against COPR:
`dnf --installroot` only considers the repos in the target tree, not on
the host. So create cockpit.repo in /build.

---

I noticed that when I [synced the recent changes](https://github.com/cockpit-project/cockpit-container/commit/ff6df9118190b4aca436591d37fdea274c38c58e) to cockpit-container, and bumped the release to 272. I [added the fix](https://github.com/cockpit-project/cockpit-container/commit/92a0ec596c10ed186c1ce1b139a3b404c2e409ef)  to cockpit-containers directly, built the container, validated it, and pushed it to quay.

I didn't notice that in my earlier testing as I was building the container against local rpms. Sorry for the blunder!