### PR TITLE
containers/ws: Accept $container == podman, test ws install script, pycodestyle fix

### DIFF
--- a/containers/ws/label-install
+++ b/containers/ws/label-install
@@ -44,7 +44,7 @@ chown root:root /host/etc/cockpit/ws-certs.d /host/etc/cockpit/machines.d
 mkdir -p /etc/ssh
 
 # For podman, generate a systemd unit for starting on boot
-if [ "${container:-}" = oci ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
+if [ "${container:-}" = oci -o "${container:-}" = podman ] && [ -n "$IMAGE" ] && [ ! -e /host/etc/systemd/system/cockpit.service ]; then
     mkdir -p /host/etc/systemd/system/
     cat << EOF > /host/etc/systemd/system/cockpit.service
 [Unit]

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -30,7 +30,6 @@ from machine_core.constants import TEST_OS_DEFAULT
 class TestBonding(NetworkCase):
     def testBasic(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -28,7 +28,6 @@ from testlib import *
 class TestBridge(NetworkCase):
     def testBasic(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
         b.wait_visible("#networking")

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -30,7 +30,6 @@ from testlib import *
 class TestTeam(NetworkCase):
     def testBasic(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/network")
 

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -217,5 +217,40 @@ class TestWsBastionContainer(MachineCase):
         b.wait_visible('#content')
 
 
+@unittest.skipUnless(DEFAULT_IMAGE == "fedora-coreos", "no cockpit/ws container on this image")
+@nondestructive
+class TestWsPrivileged(MachineCase):
+    def testService(self):
+        # the install script should have created a cockpit.service, but not started it
+        m = self.machine
+
+        self.assertEqual(m.execute("! systemctl is-enabled cockpit.service").strip(), "disabled")
+        self.assertEqual(m.execute("! systemctl is-active cockpit.service").strip(), "inactive")
+        # stop ws container from previous test runs
+        self.machine.stop_cockpit()
+        self.assertEqual(m.execute("podman ps --noheading"), "")
+        self.addCleanup(m.execute, "systemctl disable --now cockpit.service")
+
+        m.execute("systemctl start cockpit.service")
+        self.assertEqual(m.execute("systemctl is-active cockpit.service").strip(), "active")
+        firstStartTime = m.execute("podman inspect cockpit-ws| jq '.[0].Created'")
+        m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
+
+        m.execute("systemctl restart cockpit.service")
+        self.assertEqual(m.execute("systemctl is-active cockpit.service").strip(), "active")
+        secondStartTime = m.execute("podman inspect cockpit-ws| jq '.[0].Created'")
+        m.execute("until curl --fail --head -k https://localhost:9090/; do sleep 1; done")
+
+        self.assertNotEqual(firstStartTime, secondStartTime)
+
+        m.execute("systemctl stop cockpit.service")
+        self.assertEqual(m.execute("! systemctl is-enabled cockpit.service").strip(), "disabled")
+        self.assertEqual(m.execute("! systemctl is-active cockpit.service").strip(), "inactive")
+        self.assertEqual(m.execute("podman ps --noheading"), "")
+
+        # current container has `set -x` in its startup script, which ends up in the journal
+        self.allow_journal_messages("^[/+'].*")
+
+
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
This changed on the most recent Fedora CoreOS refresh [1] and thus breaks the install script.
    
[1] https://github.com/cockpit-project/bots/pull/3562

After this lands, refresh the official container, then refresh the image.
