### PR TITLE
packagekit: Show current package when reattaching to running update

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import re
 import time
 
 import parent
@@ -1104,7 +1105,6 @@ class TestWsUpdate(NoSubManCase):
         # restarts the service and terminates the connection. As we can't
         # (efficiently) build a newer working cockpit-ws package, test the two
         # parts (reconnect and warning about disconnect) separately.
-        # This test is destructive and thus must run last.
 
         # no security updates, no changelogs
         b = self.browser
@@ -1131,7 +1131,13 @@ class TestWsUpdate(NoSubManCase):
         m.restart_cockpit()
         b.login_and_go("/updates")
 
-        b.wait_in_text(".pf-c-empty-state .pf-c-title", "Initializing")
+        b.wait_in_text("#app div.progress-description", "slow 1-2")
+        # progress bar has some reasonable value
+        b.wait_attr_contains(".progress-main-view .pf-c-progress__indicator", "style", "width:")
+        rm = re.search(r"width: (\d+)%;", b.attr(".progress-main-view .pf-c-progress__indicator", "style"))
+        progress = int(rm.group(1))
+        self.assertGreater(progress, 20)
+        self.assertLess(progress, 80)
 
         # finish the package installation
         m.execute(f"touch {install_lockfile}")


### PR DESCRIPTION
So far, watchTransaction() only updated the state on "Package" signals.
When reattaching to an already running transaction (on page reload, or
after relogin), this kept the "Initializing.." empty state until the
next Package signal arrived.

We can do better: The transaction object has `LastPackage` and `Status`
properties which we can read to get the data for the package which is
currently being updated. So factor out the code for reading the D-Bus
object properties and computing the state, and call it for both the
"Package" signal and the state of the transaction when attaching to it.

This will also make it easier for us to work on the "Applying updates"
page, as our tests create packages which hang forever -- and thus we
couldn't use page reloads to check the effect of code changes.

----

Also do some code modernization.