### PR TITLE
test: workaround python3-linux-procfs and networkmanager being broken

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -34,6 +34,9 @@ if grep -q 'ID=.*fedora' /etc/os-release; then
     dnf install -y tcsh
 fi
 
+# HACK: python3-linux-procfs can't be installed on rawhide
+dnf install -y --skip-broken tuned
+
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -20,7 +20,8 @@ require:
   - sssd-dbus
   - targetcli
   - tlog
-  - tuned
+# HACK this should be in require, but Fedora-rawhide's python3-linux-procfs package is broken
+#  - tuned
 
 test: ./browser.sh
 duration: 1h

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -87,23 +87,24 @@ if [ -n "$test_basic" ]; then
     # Don't run TestPages, TestPackages, and TestTerminal at all -- not testing external APIs
     TESTS="$TESTS
         TestAccounts
-        TestBonding
-        TestBridge
         TestFirewall
         TestKdump
         TestJournal
         TestLogin
-        TestNetworking
         TestServices
         TestSOS
         TestSystemInfo
-        TestTeam
         "
 
     # HACK: python3-linux-procfs can't be installed on rawhide
+    # HACK: NetworkManager 1.39.8 IpConfig.Addresses is an empty list
     if [ -z "$RAWHIDE" ]; then
          TESTS="$TESTS
+            TestBonding
+            TestBridge
+            TestNetworking
             TestTuned
+            TestTeam
             "
     fi
 

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -27,8 +27,10 @@ if [ ! -d node_modules/chrome-remote-interface ] && [ -d . git ]; then
 fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"
+export RAWHIDE=
 # HACK: upstream does not yet know about rawhide
 if [ "$TEST_OS" = "fedora-37" ]; then
+    export RAWHIDE=1
     export TEST_OS=fedora-36
 fi
 
@@ -96,8 +98,14 @@ if [ -n "$test_basic" ]; then
         TestSOS
         TestSystemInfo
         TestTeam
-        TestTuned
         "
+
+    # HACK: python3-linux-procfs can't be installed on rawhide
+    if [ -z "$RAWHIDE" ]; then
+         TESTS="$TESTS
+            TestTuned
+            "
+    fi
 
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"


### PR DESCRIPTION
In rawhide python3-linux-procfs can't be installed after the Python 3.11
rebuild. The package was not rebuild yet, the maintainer has been made
aware of the breakage. To keep our rawhide CI running allow the
installation of tuned to fail and skip the test on rawhide.