### PR TITLE
storaged: add Arch Linux nfs-utils/stratisd packages

### DIFF
--- a/pkg/storaged/manifest.json
+++ b/pkg/storaged/manifest.json
@@ -54,11 +54,13 @@
         "nfs_client_package": {
             "rhel": "nfs-utils", "fedora": "nfs-utils",
             "opensuse": "nfs-client", "opensuse-leap": "nfs-client",
-            "debian": "nfs-common", "ubuntu": "nfs-common"
+            "debian": "nfs-common", "ubuntu": "nfs-common",
+            "arch": "nfs-utils"
         },
         "vdo_package": { "rhel": "vdo", "centos": "vdo" },
         "stratis_package": { "fedora": "stratisd",
-                             "centos": "stratisd"
+                             "centos": "stratisd",
+                             "arch": "stratisd"
                            }
     },
     "content-security-policy": "img-src 'self' data:"

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -279,7 +279,6 @@ class TestStorageNfs(StorageCase):
 
 # Re-use allowed journal messages from StorageCase
 @skipImage("No udisks/cockpit-storaged on OSTree images", "fedora-coreos")
-@skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
 @nondestructive
 class TestStoragePackagesNFS(PackageCase, StorageCase, StorageHelpers):
 

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -323,7 +323,7 @@ post_upgrade() {{
         if postinst:
             cmd += f"rm /tmp/{name}.install"
         self.machine.execute(cmd)
-        self.addCleanup(self.machine.execute, f"pacman -R --noconfirm {name} 2>/dev/null || true")
+        self.addCleanup(self.machine.execute, f"pacman -Rdd --noconfirm {name} 2>/dev/null || true")
 
     def createAptChangelogs(self):
         # apt metadata has no formal field for bugs/CVEs, they are parsed from the changelog

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -71,6 +71,7 @@ class PackageCase(MachineCase):
             self.restore_file("/etc/pacman.d/mirrorlist")
             self.restore_file("/usr/share/libalpm/hooks/90-packagekit-refresh.hook")
             self.machine.execute("rm /etc/pacman.conf /etc/pacman.d/mirrorlist /var/lib/pacman/sync/* /usr/share/libalpm/hooks/90-packagekit-refresh.hook")
+            self.machine.execute("test -d /var/lib/PackageKit/alpm && rm -r /var/lib/PackageKit/alpm || true")  # Drop alpm state directory as it interferes with running offline
             # Initial config for installation
             empty_repo_dir = '/var/lib/cockpittest/empty'
             config = f"""


### PR DESCRIPTION
Make it possible to install optional NFS/Stratis support using
PackageKit.