### PR TITLE
shell: Support for alternatives to sudo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -278,6 +278,28 @@ AC_ARG_WITH([admin-group],
             ])
 AC_SUBST(admin_group)
 
+# Default PATH for cockpit-session
+AC_ARG_WITH([default-session-path],
+            [AS_HELP_STRING([--with-default-session-path=PATH],
+                            [The value for the PATH environment variable in a session started by cockpit-session])],
+            [default_session_path=$withval],
+            [
+              AC_MSG_CHECKING([for cockpit-session PATH value])
+              if test "$(readlink /sbin)" == "usr/bin"; then
+                 # This is Arch where "sbin" is symlinked to "bin" and
+                 # "/bin" is symlinked to "/usr/bin".  We use the
+                 # normal Arch PATH which omits "sbin" and "/bin" for
+                 # those reasons.  Otherwise "pkexec" will find
+                 # cockpit-bridge in "/usr/sbin" and our rule wont
+                 # match.
+                 default_session_path=/usr/local/sbin:/usr/local/bin:/usr/bin
+              else
+                 default_session_path=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+              fi
+              AC_MSG_RESULT([$default_session_path])
+            ])
+AC_DEFINE_UNQUOTED([DEFAULT_SESSION_PATH], ["$default_session_path"], [Default value of PATH for cockpit-session])
+
 # Documentation
 
 AC_MSG_CHECKING([whether to build documentation])
@@ -430,6 +452,7 @@ echo "
         cockpit-ws instance user:   ${COCKPIT_WSINSTANCE_USER}
         cockpit-ws instance group:  ${COCKPIT_WSINSTANCE_GROUP}
         admin group:                ${admin_group}
+        cockpit-session PATH:       ${default_session_path}
 
         Building docs:              ${enable_doc}
         Debug mode:                 ${debug_status}

--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,9 @@ AC_MSG_RESULT($enable_selinux_policy)
 AC_MSG_CHECKING([whether to build polkit support])
 AC_ARG_ENABLE(polkit, AS_HELP_STRING([--disable-polkit], [Disable usage of polkit]))
 AM_CONDITIONAL(WITH_POLKIT, test "$enable_polkit" != 'no')
+if test "$enable_polkit" != 'no'; then
+  AC_DEFINE([WITH_POLKIT], 1, [Whether to build with polkit support])
+fi
 AC_MSG_RESULT(${enable_polkit:=yes})
 
 # --disable-ssh

--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -400,6 +400,25 @@ mypackage/test.min.js.gz
         <listitem><para>If set to <code>true</code>, this marks the bridge as a superuser bridge.  Cockpit will start one of these explicitly when trying to escalate the privileges of a session.  A privileged bridge can not have a <code>"match"</code> property.</para></listitem>
       </varlistentry>
       <varlistentry>
+        <term>label</term>
+        <listitem><para>Setting this enables selection of privileged
+        bridges in the UI.  When no privileged bridge has a
+        <code>label</code>, then Cockpit will start the bridge that
+        runs <code>sudo</code>.  This is the case in a default Cockpit
+        installation.  When at least one privileged bridge has a
+        <code>label</code> then the user can select one of them when
+        escalating privileges.  As a special case, if only one bridge
+        has a <code>label</code>, then the step of selecting a bridge
+        is omitted in the UI and that one bridge is always started.</para>
+        <para>Thus, if you add a privileged bridge with a
+        <code>label</code> in a new manifest, Cockpit will use that
+        bridge the next time a user opens the "Administrative access"
+        dialog. If you want the user to choose between the
+        <code>sudo</code> method and your new one, you need to
+        duplicate the <code>sudo</code> bridge definition in your
+        manifest and give it a label.</para></listitem>
+      </varlistentry>
+      <varlistentry>
         <term>problem</term>
         <listitem><para>If a problem is specified, and this bridge fails to start up then
             channels will be closed with this problem code. Otherwise later bridges or internal

--- a/pkg/lib/manifest2po
+++ b/pkg/lib/manifest2po
@@ -62,6 +62,8 @@ function process_manifest(manifest) {
         process_menu(manifest.menu);
     if (manifest.tools)
         process_menu(manifest.tools);
+    if (manifest.bridges)
+        process_bridges(manifest.bridges);
 }
 
 function process_keywords(keywords) {
@@ -96,6 +98,17 @@ function process_menu(menu) {
             process_keywords(menu[m].keywords);
         if (menu[m].docs)
             process_docs(menu[m].docs);
+    }
+}
+
+function process_bridges(bridges) {
+    for (const b in bridges) {
+        if (bridges[b].label) {
+            push({
+                msgid: bridges[b].label,
+                locations: [filename + ":0"]
+            });
+        }
     }
 }
 

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -34,6 +34,7 @@
             ],
             "spawn": [
                 "sudo",
+                "-k",
                 "-A",
                 "cockpit-bridge",
                 "--privileged"

--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -206,12 +206,10 @@ const LockDialog = ({ proxy, host }) => {
         setError(null);
         proxy.Stop()
                 .then(() => {
-                    return cockpit.spawn(["sudo", "-k"], { host: host }).always(() => {
-                        const key = host_superuser_storage_key(host);
-                        if (key)
-                            window.localStorage.setItem(key, "none");
-                        D.close();
-                    });
+                    const key = host_superuser_storage_key(host);
+                    if (key)
+                        window.localStorage.setItem(key, "none");
+                    D.close();
                 })
                 .catch(err => {
                     setError(err.toString());

--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -1640,6 +1640,9 @@ cockpit_router_prompt (CockpitRouter *self,
   if (prompt == NULL)
     prompt = "";
 
+  if (previous_error == NULL)
+    previous_error = "";
+
   if (self->superuser_answer_function)
     {
       g_warning ("Overlapping prompts");

--- a/src/session/session-utils.h
+++ b/src/session/session-utils.h
@@ -50,7 +50,6 @@
 #endif
 
 #define EX 127
-#define DEFAULT_PATH "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 extern const char *program_name;
 extern struct passwd *pwd;

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -867,7 +867,7 @@ save_environment (void)
 
   /* Force save our default path */
   if (!getenv ("COCKPIT_TEST_KEEP_PATH"))
-    setenv ("PATH", DEFAULT_PATH, 1);
+    setenv ("PATH", DEFAULT_SESSION_PATH, 1);
 
   for (i = 0, j = 0; env_names[i] != NULL; i++)
     {
@@ -928,7 +928,7 @@ main (int argc,
         err (1, "couldn't clear environment");
 
       /* set a minimal environment */
-      setenv ("PATH", DEFAULT_PATH, 1);
+      setenv ("PATH", DEFAULT_SESSION_PATH, 1);
 
       if (setgid (0) != 0 || setuid (0) != 0)
         err (1, "couldn't switch permissions correctly");

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -181,13 +181,14 @@ session include system-auth
         b = self.browser
         m = self.machine
 
-        m.write("/etc/cockpit/shell.override.json", """
+        self.write_file("/etc/cockpit/shell.override.json", """
 {
   "bridges": [
     {
       "privileged": true,
       "spawn": [
         "sudo",
+        "-k",
         "-A",
         "cockpit-bridge",
         "--privileged"
@@ -212,13 +213,12 @@ session include system-auth
 
     def testRemoveBridgeConfig(self):
         b = self.browser
-        m = self.machine
 
         self.login_and_go("/playground/pkgs", superuser=True)
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
-        m.write("/etc/cockpit/shell.override.json", """
+        self.write_file("/etc/cockpit/shell.override.json", """
 {
   "bridges": [ ]
 }
@@ -228,6 +228,99 @@ session include system-auth
         b.click("#reload")
         b.leave_page()
         b.check_superuser_indicator("Limited access")
+
+    def testSingleLabelBridgeConfig(self):
+        b = self.browser
+
+        # When there is a single labeled privileged bridge, Cockit will start it automatically.
+
+        self.write_file("/etc/cockpit/shell.override.json", """
+{
+  "bridges": [
+    {
+      "privileged": true,
+      "label": "Always fails",
+      "spawn": [
+        "/bin/bash", "-c", "echo >&2 'Hello from the bash method'; exit 1"
+      ]
+    }
+  ]
+}
+""")
+
+        self.login_and_go("/playground/pkgs", superuser=False)
+        b.leave_page()
+        b.check_superuser_indicator("Limited access")
+        b.open_superuser_dialog()
+        b.wait_in_text(".pf-c-modal-box:contains('Problem becoming administrator')", "Hello from the bash method")
+        b.click(".pf-c-modal-box button:contains('Close')")
+        b.check_superuser_indicator("Limited access")
+
+    def testMultipleBridgeConfig(self):
+        b = self.browser
+
+        self.write_file("/etc/cockpit/shell.override.json", """
+{
+  "bridges": [
+    {
+      "privileged": true,
+      "label": "Sudo",
+      "environ": [
+        "SUDO_ASKPASS=${libexecdir}/cockpit-askpass"
+      ],
+      "spawn": [
+        "sudo",
+        "-k",
+        "-A",
+        "cockpit-bridge",
+        "--privileged"
+      ]
+    },
+    {
+        "privileged": true,
+        "label": "Polkit",
+        "spawn": [
+            "pkexec",
+            "--disable-internal-agent",
+            "cockpit-bridge",
+            "--privileged"
+        ]
+    }
+  ]
+}
+""")
+
+        self.login_and_go("/playground/pkgs", superuser=False)
+        b.leave_page()
+        b.check_superuser_indicator("Limited access")
+
+        # Get admin rights with "pkexec" method
+        b.open_superuser_dialog()
+        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "pkexec")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access') select", "Polkit")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Please authenticate")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
+        b.check_superuser_indicator("Administrative access")
+
+        # Drop them
+        b.open_superuser_dialog()
+        b.click(".pf-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to limited access')")
+        b.check_superuser_indicator("Limited access")
+
+        # Run the regular sudo method, which should work as always
+        b.open_superuser_dialog()
+        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "sudo")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access') select", "Sudo")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
+        b.click(".pf-c-modal-box button:contains('Authenticate')")
+        b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
+        b.check_superuser_indicator("Administrative access")
 
     def testOverview(self):
         b = self.browser

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -193,6 +193,8 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         path = m.execute("cat /tmp/path").strip()
         if m.ostree_image:
             self.assertIn("/usr/local/bin:/usr/bin", path)
+        elif m.image == "arch":
+            self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/bin", path)
         else:
             self.assertIn("/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", path)
         self.assertNotIn(":/.local", path)  # would happen with empty $HOME


### PR DESCRIPTION
Demo: https://www.youtube.com/watch?v=ET5w39M3HIw

------

### Shell: Support for alternatives to sudo

Cockpit always had the ability to run arbitrary programs to gain administrative access, by adding them to a package manifest.  However, the UI would always use "sudo". Now the UI lets you select which program to use when multiple are defined in the manifests.

By default, Cockpit will still only use "sudo", so unless you actually add more programs via a manifest, there will be no visible change in the UI.

