### PR TITLE
.github: always try to jumpstart node_modules

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -36,7 +36,7 @@ jobs:
         timeout-minutes: 30
         run: |
           containers/unit-tests/start \
-              --verbose --no-jumpstart \
+              --verbose \
               ${{ matrix.startarg.network }} \
               --env=CC='${{ matrix.startarg.cc }}' \
               --image-tag='${{ matrix.startarg.tag }}' \


### PR DESCRIPTION
For make check the base1 webpack is only required, this speeds up our
tests significantly.