### PR TITLE
fmf: Fix syntax error in node_modules checkout

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -22,7 +22,7 @@ fi
 git clone --depth=1 https://github.com/cockpit-project/bots
 
 # support running from clean git tree; this doesn't work from release tarballs
-if [ ! -d node_modules/chrome-remote-interface ] && [ -d . git ]; then
+if [ ! -d node_modules/chrome-remote-interface ] && [ -d .git ]; then
     ./tools/node-modules checkout
 fi
 


### PR DESCRIPTION
Introduced in commit 70de12208c4

----

Should fix [this failure](https://artifacts.dev.testing-farm.io/8c35e8cb-73e0-4894-b642-96f153b322bc/), seen in PR #17544.