### PR TITLE
test: replace pycodestyle and pyflakes with flake8

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -42,7 +42,7 @@ For running integration tests, the following dependencies are required:
 
     $ sudo dnf install curl expect xz rpm-build chromium-headless \
         libvirt-daemon-driver-storage-core libvirt-daemon-driver-qemu libvirt-client python3-libvirt \
-        python3-pyflakes python3-pycodestyle python3-pyyaml
+        python3-flake8 python3-pyyaml
 
 Creating VM images locally (not necessary for running tests) needs the
 following:

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -11,6 +11,7 @@ dependencies="\
     curl \
     dbus \
     firefox-esr \
+    flake8 \
     gcc-multilib \
     gdb \
     git \
@@ -39,9 +40,7 @@ dependencies="\
     npm \
     nodejs \
     pkg-config \
-    pyflakes3 \
     python3 \
-    python3-pycodestyle \
     sassc \
     ssh \
     strace \

--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -32,7 +32,7 @@ import textwrap
 gi.require_version("Gtk", "3.0")  # NOQA
 gi.require_version("WebKit2", "4.0")  # NOQA
 
-from gi.repository import GLib, Gio, Gtk, WebKit2
+from gi.repository import GLib, Gio, Gtk, WebKit2  # NOQA: E402
 
 try:
     gi.require_version("Handy", "1")

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -18,10 +18,10 @@ import importlib.util
 
 import parent
 parent.ensure_bots()  # NOQA: testvm lives in bots/
-import testlib
-import testvm
+import testlib   # NOQA: imported through parent.py
+import testvm   # NOQA: imported through parent.py
 
-from lcov import prepare_for_code_coverage, create_coverage_report
+from lcov import prepare_for_code_coverage, create_coverage_report  # NOQA: E402
 
 sys.dont_write_bytecode = True
 os.environ['PYTHONUNBUFFERED'] = '1'

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -27,9 +27,9 @@ import subprocess
 
 from common.parent import BASE_DIR, TEST_DIR, BOTS_DIR, ensure_bots
 ensure_bots()  # NOQA: testvm lives in bots/
-from lib import testmap
-from lib.constants import DEFAULT_IMAGE
-from machine.machine_core import machine_virtual
+from lib import testmap  # NOQA: imported through parent.py
+from lib.constants import DEFAULT_IMAGE  # NOQA: imported through parent.py
+from machine.machine_core import machine_virtual  # NOQA: imported through parent.py
 
 
 def build_rpms(dist_tar, image, verbose, quick):

--- a/test/static-code
+++ b/test/static-code
@@ -1,5 +1,5 @@
 #!/bin/bash
-# run static code checks like pyflakes and pycodestyle
+# run static code checks like flake8, pyvulture.
 
 set -eu
 
@@ -24,32 +24,10 @@ find_python_files() {
     find_scripts 'python3' '*.py'
 }
 
-test_pyflakes() {
-    # Run pyflakes on all Python files except those in test/verify/
-
-    python3 -c 'import pyflakes' 2>/dev/null || skip 'no pyflakes'
+test_flake8() {
+    python3 -c 'import flake8' 2>/dev/null || skip 'no flake8'
     filter="(undefined name '(Inotify|IN_[A-Z_]+)'|'parent' imported but unused)" # inotify.py get pasted together with other files
-    ! find_python_files | grep -zv '^test/verify' | xargs -r -0 python3 -m pyflakes 2>&1 | grep -Ev "${filter}"
-}
-
-test_pyflakes_test_verify() {
-    # Run pyflakes on all Python files in test/verify/
-
-    python3 -c 'import pyflakes' 2>/dev/null || skip 'no pyflakes'
-
-    # TODO: there are currently a lot of pyflakes errors like
-    #   'parent' imported but unused
-    #   'from testlib import *' used; unable to detect undefined names
-    # Filter these out until these get fixed properly.
-    filter="(unable to detect undefined names|'parent' imported but unused)"
-    ! find_python_files | grep -z '^test/verify' | xargs -r -0 python3 -m pyflakes 2>&1 | grep -Ev "${filter}"
-}
-
-test_pycodestyle() {
-    # pycodestyle python syntax check
-
-    python3 -c 'import pycodestyle' 2>/dev/null || skip 'no pycodestyle'
-    find_python_files | xargs -r -0 python3 -m pycodestyle --max-line-length=200 --ignore W504
+    ! find_python_files | xargs -r -0 python3 -m flake8 --max-line-length=200 --ignore W504 2>&1 | grep -Ev "${filter}"
 }
 
 test_pyvulture() {


### PR DESCRIPTION
flake8 is a wrapper over pyflakes and pycodestyle, and most importantly
supports ignoring specific lines with `noqa`. This allows us to drop our
custom grep filters. The last remaning grep is for inotify which is a
special case as it used by combined with other scripts and therefore
can't be imported.