### PR TITLE
Fix unit-test container refresh, fix valgrind invocation for HTML tests

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -12,7 +12,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    timeout-minutes: 180
+    timeout-minutes: 60
     steps:
       - name: Clone repository
         uses: actions/checkout@v2
@@ -21,18 +21,23 @@ jobs:
           fetch-depth: 0
 
       - name: Build fresh containers
+        timeout-minutes: 10
         run: containers/unit-tests/build
 
       - name: Run amd64 gcc check-memory test
+        timeout-minutes: 20
         run: containers/unit-tests/start --verbose --env=CC=gcc --image-tag=latest --make check-memory
 
       - name: Run i386 clang check-memory test
+        timeout-minutes: 20
         run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=i386 --make check-memory
 
       - name: Run amd64 clang distcheck test
+        timeout-minutes: 15
         run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=latest --make distcheck
 
       - name: Run i386 gcc distcheck test
+        timeout-minutes: 15
         run: containers/unit-tests/start --verbose --env=CC=clang --image-tag=i386 --make distcheck
 
       - name: Log into container registry

--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   # we do both builds and all tests in a single run, so that we only upload the containers on success
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -2,7 +2,7 @@ name: unit-tests
 on: [pull_request, workflow_dispatch]
 jobs:
   unit-tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         startarg:

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,21 +75,21 @@ EXTRA_DIST += \
 check: export VERBOSE=1
 
 TEST_EXTENSIONS = .html .sh
-HTML_LOG_COMPILER = $(top_srcdir)/test/common/tap-cdp --strip=$(abs_top_srcdir)/ ./test-server $(COCKPIT_BRIDGE)
+HTML_LOG_COMPILER = $(top_srcdir)/test/common/tap-cdp --strip=$(abs_top_srcdir)/ $(HTML_TEST_WRAPPER) ./test-server $(COCKPIT_BRIDGE)
 
-VALGRIND_ARGS = --trace-children=yes --quiet --error-exitcode=33 --gen-suppressions=all \
+VALGRIND = valgrind --trace-children=yes --quiet --error-exitcode=33 --gen-suppressions=all \
 	$(foreach file,$(wildcard $(srcdir)/tools/*.supp),--suppressions=$(file)) \
 	--num-callers=16 --leak-check=yes --show-leak-kinds=definite \
 	--errors-for-leak-kinds=definite --trace-children-skip='*mock*,/bin*,/usr/bin/*,/usr/local/bin'
 
 check-memory:
-	$(MAKE) LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
-	        HTML_LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
+	$(MAKE) LOG_FLAGS="$(VALGRIND)" \
+	        HTML_TEST_WRAPPER="$(VALGRIND)" \
 		COCKPIT_SKIP_SLOW_TESTS=1 \
 		$(AM_MAKEFLAGS) check TESTS="$(filter-out test/% bots/%,$(TESTS))"
 recheck-memory:
-	$(MAKE) LOG_FLAGS="-- valgrind $(VALGRIND_ARGS)" \
-	        HTML_LOG_FLAGS="valgrind $(VALGRIND_ARGS)" \
+	$(MAKE) LOG_FLAGS="$(VALGRIND_ARGS)" \
+	        HTML_TEST_WRAPPER="$(VALGRIND)" \
 		$(AM_MAKEFLAGS) recheck
 
 # checkout Cockpit's bots for standard test VM images and API to launch them


### PR DESCRIPTION
Refreshing our unit-tests container has recently [started to fail](https://github.com/cockpit-project/cockpit/actions/runs/2646144001) both on the scheduled runs on main, and in PR #17549. See [this comment](https://github.com/cockpit-project/cockpit/pull/17549#issuecomment-1182741018) for details of the debugging.

I [triggered a run](https://github.com/cockpit-project/cockpit/actions/runs/2661693623) against this branch, but with an extra commit that avoids pushing the container to the registry -- for now I just want to see if the tests work. And they did! :partying_face: 