### PR TITLE
client: Fix crash on absent Handy.StyleManager

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -190,7 +190,7 @@ class CockpitClient(Gtk.Application):
     def do_startup(self):
         Gtk.Application.do_startup(self)
 
-        if Handy:
+        if Handy and hasattr(Handy, 'StyleManager'):
             Handy.StyleManager.get_default().set_color_scheme(Handy.ColorScheme.PREFER_LIGHT)
 
         # .add_action_entries() binding is broken for GApplication


### PR DESCRIPTION
Current RHEL 9 has libhandy 1.2.3, which does not yet have the
`StyleManager` API. This causes client to crash with an AttributeError
since commit 9d9b1f8e5c04.

https://bugzilla.redhat.com/show_bug.cgi?id=2106096

---

See bz for how I tested this.