### PR TITLE
test: stop using deprecated machine_core import

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, timeout
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 class KdumpHelpers(MachineCase):

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -13,7 +13,7 @@ from testlib import (Browser, Error, MachineCase, nondestructive, skipDistroPack
                      skipMobile, test_main, wait)
 
 from machine_core import ssh_connection
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 def getMaximumSpike(test, g_type, saturation, hour, minute):

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -21,7 +21,7 @@ import parent  # noqa: F401
 from netlib import NetworkCase
 from testlib import nondestructive, skipDistroPackage, skipImage, test_main, wait
 
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 @nondestructive

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -21,7 +21,7 @@ import parent  # noqa: F401
 from netlib import NetworkCase
 from testlib import skipDistroPackage, skipImage, test_main
 
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -21,7 +21,7 @@ import parent  # noqa: F401
 from netlib import NetworkCase
 from testlib import skipDistroPackage, skipImage, test_main, wait
 
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -21,7 +21,7 @@ import parent  # noqa: F401
 from netlib import NetworkCase
 from testlib import skipDistroPackage, skipImage, test_main, wait
 
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -21,7 +21,7 @@ import parent  # noqa: F401
 from netlib import NetworkCase
 from testlib import skipDistroPackage, test_main
 
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from testlib import Error, MachineCase, skipBrowser, skipDistroPackage, skipImage, test_main
-from machine_core.constants import TEST_OS_DEFAULT
+from lib.constants import TEST_OS_DEFAULT
 
 import time
 


### PR DESCRIPTION
Cockpit bots deprecated machine_core.constants import in b9d9b67e.