### PR TITLE
test: add pixel tests for our custom progress implementation

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -94,6 +94,7 @@ class TestStorageStratis(StorageCase):
         self.dialog({'name': 'fsys2',
                      'mount_point': '/run/fsys2'})
         b.wait_in_text("#detail-content", "fsys2")
+        b.assert_pixels("#detail-content", "fsys-rows")
         self.assertEqual(self.inode(m.execute("findmnt -n -o SOURCE /run/fsys2").strip()),
                          self.inode("/dev/stratis/pool0/fsys2"))
         m.write("/run/fsys2/FILE", "Hello Stratis!")


### PR DESCRIPTION
For stratis if you have multiple filesystems we show the space one
filesystem takes up relative to the other. As this uses our own written
usagebar let's make sure PF doesn't break it on updates.