### PR TITLE
workflows: Add build-ws-container

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -1,0 +1,36 @@
+name: build-ws-container
+on:
+  # can be run manually on https://github.com/cockpit-project/cockpit/actions
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    environment: quay.io
+    permissions: {}
+    timeout-minutes: 20
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - name: Log into container registry
+        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+
+      - name: Build and push ws container
+        run: |
+          TAG=$(date +%Y-%m-%d)
+          docker build -t quay.io/cockpit/ws:$TAG containers/ws
+
+          # smoke test
+          docker run --name ws -p 9090:9090 -d quay.io/cockpit/ws:$TAG
+          until curl --fail --show-error -k --head https://localhost:9090; do
+              sleep 1
+          done
+          docker rm -f ws
+
+          docker tag quay.io/cockpit/ws:$TAG quay.io/cockpit/ws:latest
+
+          # push both tags
+          docker push quay.io/cockpit/ws:$TAG
+          docker push quay.io/cockpit/ws:latest


### PR DESCRIPTION
Building container images on quay.io has been broken for more than half
a year now, so stop holding our breath (and doing builds manually).
Instead, let's build the image on GitHub and push it to quay.io.

This also gets rid of the
https://github.com/cockpit-project/cockpit-container/ repository. That
was used as a quay.io build trigger, but it needed manual syncing
whenever we changed anything in the container definition (and we often
forgot to do that).

The internal CI secrets repo was updated to create a "quay.io"
environment on cockpit, similar to the one in cockpituous.

Start with a manual trigger: For now this should be run:

 - When we do an upstream release, and something significant changed in
   ws; this needs to wait until our cockpit-preview COPR finished
   building

 - When we changed anything in containers/ws/ that does *not* assume
   functionality changes since the last release

We can automate this in the future, but this already makes container
releases a lot simpler again.

----

I tested this on my fork's `main` branch, with changing `:latest` to `:testtest`. The [workflow succeeded](https://github.com/martinpitt/cockpit/actions/runs/2689189797), and https://quay.io/repository/cockpit/ws?tab=tags shows the 2022-07-18 and testtest tags. You can run it:

    podman run --name ws -p 9999:9090 -d quay.io/cockpit/ws:testtest

and open http://localhost:9999 and connect to `host.containers.internal` to start a session on your machine.

 - [x] Create [quay.io environment](https://github.com/cockpit-project/cockpit/settings/environments) and adjust the internal CI secrets repo documentation 
 - [x] This found a bug in the secrets upload script, land https://github.com/cockpit-project/bots/pull/3633
 - [x] Close/transfer all https://github.com/cockpit-project/cockpit-container/ issues, and disable issues
 - [x] Adjust [release process](https://github.com/cockpit-project/cockpit/wiki/ReleaseProcess); [text diff](https://github.com/cockpit-project/cockpit/wiki/ReleaseProcess/_compare/2766ddbb806f98a3d25c28a1f4d2678b28023c06...da6623ec5e791114c3de091cb4e20c99809e49e1)

After this lands:
 - [ ] Delete the "testtest" tag
 - [ ] Run the workflow on cockpit main, to ensure it all works
 - [ ] Delete https://github.com/cockpit-project/cockpit-container/ project
