### PR TITLE
test: Make venvs happy

### DIFF
--- a/src/client/add-metainfo-releases
+++ b/src/client/add-metainfo-releases
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import argparse
 import os

--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/src/client/cockpit-client-ssh
+++ b/src/client/cockpit-client-ssh
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import base64
 import json

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-bots-api
+++ b/test/verify/check-bots-api
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-embed
+++ b/test/verify/check-embed
@@ -1,4 +1,4 @@
-#! /usr/bin/python3
+#! /usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Run this with --help to see available options for tracing and debugging
 # See https://github.com/cockpit-project/cockpit/blob/main/test/common/testlib.py
 # "class Browser" and "class MachineCase" for the available API.

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-session
+++ b/test/verify/check-session
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-scaling
+++ b/test/verify/check-storage-scaling
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #
@@ -197,7 +197,7 @@ class TestRunTest(MachineCase):
 
         # create affected test for systemd changes
         affected_testfile = os.path.join(VERIFY_DIR, "check-system-testlib")
-        writeFile(affected_testfile, """#!/usr/bin/python3
+        writeFile(affected_testfile, """#!/usr/bin/env python3
 import unittest
 class TestSystemd(unittest.TestCase):
     def testBasic(self):

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-users-roles
+++ b/test/verify/check-users-roles
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # This file is part of Cockpit.
 #


### PR DESCRIPTION
When running `test/image-prepare` using python virtualenv, some scripts were still using system-wide python3.