### PR TITLE
test: Improve run-tests scheduling of multi-provision tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -12,6 +12,7 @@ import socket
 import tempfile
 import binascii
 import logging
+import functools
 
 import importlib.machinery
 import importlib.util
@@ -37,7 +38,7 @@ def flush_stdout():
 
 
 class Test:
-    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected):
+    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, cost=1):
         self.process = None
         self.retries = 0
         self.test_id = test_id
@@ -46,6 +47,7 @@ class Test:
         self.nondestructive = nondestructive
         self.machine_id = None
         self.retry_when_affected = retry_when_affected
+        self.cost = cost
         self.returncode = None
 
     def assign_machine(self, machine_id, ssh_address, web_address):
@@ -143,12 +145,9 @@ class Test:
     # internal methods
 
     def __str__(self):
-        return "{0} {1} {2}{3}".format(
-            self.test_id,
-            self.command[0],
-            self.command[-1],
-            " [ND@{0}]".format(self.machine_id) if self.nondestructive else "",
-        )
+        cost = "" if self.cost == 1 else f" ${self.cost}"
+        nd = f" [ND@{self.machine_id}]" if self.nondestructive else ""
+        return f"{self.test_id} {self.command[0]} {self.command[-1]}{cost}{nd}"
 
     def _print_test(self, print_tap=True, retry_reason="", skip_reason=""):
         def write_line(line):
@@ -318,7 +317,12 @@ def detect_tests(test_files, image, opts):
                     continue
                 nd = getattr(test_method, "_testlib__non_destructive", False)
                 rwa = getattr(test_method, "_testlib__retry_when_affected", True)
-                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa)
+                if getattr(test.__class__, "provision", None):
+                    # each additionally provisioned VM costs half a parallel test capacity
+                    cost = 1 + (len(test.__class__.provision) - 1) / 2
+                else:
+                    cost = 1
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, cost=cost)
                 if nd:
                     serial_tests.append(test)
                 else:
@@ -434,10 +438,13 @@ def run(opts, image):
 
                     made_progress = True
 
+        def running_cost():
+            return functools.reduce(lambda cost, test: cost + test.cost, running_tests, 0)
+
         # fill the remaining available job slots with parallel tests
-        while parallel_tests and len(running_tests) < opts.jobs:
+        while parallel_tests and running_cost() + parallel_tests[0].cost <= opts.jobs:
             test = parallel_tests.pop(0)
-            logging.debug(f"{len(running_tests)} running tests, starting next parallel test {test}")
+            logging.debug(f"{len(running_tests)} running tests with total cost {running_cost()}, starting next parallel test {test}")
             test.start()
             running_tests.append(test)
             made_progress = True


### PR DESCRIPTION
Due to sorting our tests, the expensive ones like TestMultiMachine tend
to run in parallel, which causes the number of parallel VMs to be up to
three times as high as `$TEST_JOBS`. This leads to overly long VM boot
times and timeouts [1].

Improve this by scheduling fewer of them in parallel. Introduce a notion
of "cost" to a Test object and measure it in terms of how may VMs it
will boot -- each additional VM costs an extra ½ TEST_JOBS.

Schedule tests until their total cost (instead of just their number)
hits `$TEST_JOBS`.

[1] https://github.com/cockpit-project/cockpituous/issues/506

---

I tested this locally with enabling debug loggging (the commented out basicConfig). It now behaves as expected, it lets all other tests finish first:

```
❱❱❱ test/common/run-tests -j3 --test-dir test/verify/ -v TestNondestructiveExample TestExample TestMultiMachineAdd.testBasic
1..9
qemu-img create -q -f qcow2 -b /var/home/martin/upstream/cockpit/main/test/images/fedora-36 -F qcow2 /tmp/cockpit-l98gbyt_.qcow2
qemu-img create -q -f qcow2 -b /var/home/martin/upstream/cockpit/main/test/images/fedora-36 -F qcow2 /tmp/cockpit-de8cbq4e.qcow2
qemu-img create -q -f qcow2 -b /var/home/martin/upstream/cockpit/main/test/images/fedora-36 -F qcow2 /tmp/cockpit-az_td7d_.qcow2
DEBUG:root:Global machine 0 is free, assigning next test 8 test/verify/check-example TestNondestructiveExample.testTwo [ND@None]
DEBUG:root:Global machine 1 is free, assigning next test 7 test/verify/check-example TestNondestructiveExample.testOne [ND@None]
DEBUG:root:Global machine 2 is free, assigning next test 4 test/verify/check-example TestExample.testNondestructive [ND@None]
# 1 TEST PASSED [27s on cockpit-toolbox]
ok 8 test/verify/check-example TestNondestructiveExample.testTwo [ND@0]
DEBUG:root:test 8 test/verify/check-example TestNondestructiveExample.testTwo [ND@0] finished; result 0 retry reason None
# 1 TEST PASSED [27s on cockpit-toolbox]
ok 7 test/verify/check-example TestNondestructiveExample.testOne [ND@1]
DEBUG:root:test 7 test/verify/check-example TestNondestructiveExample.testOne [ND@1] finished; result 0 retry reason None
DEBUG:root:Global machine 0 is free, and no more serial tests; killing
DEBUG:root:Global machine 1 is free, and no more serial tests; killing
DEBUG:root:1 running tests with total cost 1, starting next parallel test 1 test/verify/check-example TestExample.testBasic
DEBUG:root:2 running tests with total cost 2, starting next parallel test 2 test/verify/check-example TestExample.testExpectedFail
# 1 TEST PASSED [34s on cockpit-toolbox]
ok 4 test/verify/check-example TestExample.testNondestructive [ND@2]
DEBUG:root:test 4 test/verify/check-example TestExample.testNondestructive [ND@2] finished; result 0 retry reason None
DEBUG:root:Global machine 2 is free, and no more serial tests; killing
DEBUG:root:2 running tests with total cost 2, starting next parallel test 3 test/verify/check-example TestExample.testFail
# 1 TEST PASSED [33s on cockpit-toolbox]
ok 1 test/verify/check-example TestExample.testBasic
DEBUG:root:test 1 test/verify/check-example TestExample.testBasic finished; result 0 retry reason None
DEBUG:root:2 running tests with total cost 2, starting next parallel test 5 test/verify/check-example TestExample.testRaiseSkip
# 1 TEST PASSED [33s on cockpit-toolbox]
ok 2 test/verify/check-example TestExample.testExpectedFail
DEBUG:root:test 2 test/verify/check-example TestExample.testExpectedFail finished; result 0 retry reason None
DEBUG:root:2 running tests with total cost 2, starting next parallel test 6 test/verify/check-example TestExample.testSkip
# ----------------------------------------------------------------------
# testSkip (__main__.TestExample)
# Result testSkip (__main__.TestExample) skipped:
ok 6 test/verify/check-example TestExample.testSkip # SKIP testSkip (__main__.TestExample)
DEBUG:root:test 6 test/verify/check-example TestExample.testSkip finished; result 0 retry reason None
# 1 TEST PASSED [34s on cockpit-toolbox]
ok 3 test/verify/check-example TestExample.testFail
DEBUG:root:test 3 test/verify/check-example TestExample.testFail finished; result 0 retry reason None
# ----------------------------------------------------------------------
# testRaiseSkip (__main__.TestExample)
# Result testRaiseSkip (__main__.TestExample) skipped: dynamic skip
ok 5 test/verify/check-example TestExample.testRaiseSkip # SKIP testRaiseSkip (__main__.TestExample) dynamic skip
DEBUG:root:test 5 test/verify/check-example TestExample.testRaiseSkip finished; result 0 retry reason None
DEBUG:root:0 running tests with total cost 0, starting next parallel test 9 test/verify/check-shell-multi-machine TestMultiMachineAdd.testBasic 🏋 3
# 1 TEST PASSED [43s on cockpit-toolbox]
ok 9 test/verify/check-shell-multi-machine TestMultiMachineAdd.testBasic 🏋 3
DEBUG:root:test 9 test/verify/check-shell-multi-machine TestMultiMachineAdd.testBasic 🏋 3 finished; result 0 retry reason None

# TESTS PASSED [127s on cockpit-toolbox, 6 parallel tests, 3 serial tests: 0: 28s, 1: 28s, 2: 36s]

```