### PR TITLE
lib: drop duplicate patternfly-variables include

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -1,4 +1,3 @@
-@use "@patternfly/patternfly/base/patternfly-variables.scss";
 @import "global-variables";
 @import "@patternfly/patternfly/components/Table/table.scss";
 @import "@patternfly/patternfly/components/Table/table-grid.scss";


### PR DESCRIPTION
We already include the breakpoints via "global-variables" so due to the
nature of SASS we end up with duplicated --pf-global--font-path
declaration in :root {}. Before this commit:

$ grep -cr "\-\-pf-global--font-path" dist/networkmanager/*.css
dist/networkmanager/firewall.css:2

After:
$ grep -cr "\-\-pf-global--font-path" dist/networkmanager/*.css
dist/networkmanager/firewall.css:1


See also for more context:
https://github.com/cockpit-project/cockpit/issues/17556#issuecomment-1184518556

Let's hope the pixel tests agree this is a good idea.