### PR TITLE
[r79] Fix build in Fedora 36 tasks container

### DIFF
--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -14,7 +14,7 @@ class TestPinger(MachineCase):
     def setUp(self):
         super(TestPinger, self).setUp()
         self.machine.execute("mkdir -p ~admin/.local/share/cockpit")
-        self.machine.upload([os.path.join(EXAMPLES_DIR, "pinger")], "~admin/.local/share/cockpit/")
+        self.machine.upload([os.path.join(EXAMPLES_DIR, "pinger")], "/home/admin/.local/share/cockpit/")
 
     def testBasic(self):
         b = self.browser

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -255,6 +255,11 @@ var externals = {
  * Implementation
  */
 
+// HACK: OpenSSL 3 does not support md4 any more, but webpack hardcodes it all over the place: https://github.com/webpack/webpack/issues/13572
+const crypto = require("crypto");
+const crypto_orig_createHash = crypto.createHash;
+crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);
+
 var webpack = require("webpack");
 var copy = require("copy-webpack-plugin");
 var html = require('html-webpack-plugin');


### PR DESCRIPTION
Fedora-36/CentOS/RHEL 9 switched to OpenSSL 3, which does not support
the `md4` hash any more. webpack hardcodes that in a lot of places, so
monkey-patch `crypto.createHash()` to substitute sha256 for md4.

Hack to work around https://github.com/webpack/webpack/issues/13572

Cherry-picked from https://github.com/cockpit-project/starter-kit/commit/3220617fec508

This is solved in current webpack 5 versions, but we don't want to
update this old stable branch to that.

---

Seen in https://github.com/cockpit-project/bots/pull/3637 , fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3637-20220720-230754-25322310-rhel-7-9-cockpit-project-cockpit-rhel-7.9/log.html)