### PR TITLE
packit: Drop obsolete FMF plan bumping

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -5,21 +5,12 @@ actions:
   post-upstream-clone:
     # HACK: spec must be next to the generated tarball; https://github.com/packit/packit/issues/1621
     - cp tools/cockpit.spec .
-    # HACK: until FMF uses tests from dist-git source tarball: https://github.com/teemtee/tmt/issues/585
-    - sh -exc 'mkdir -p tmp; curl --silent --fail https://src.fedoraproject.org/rpms/cockpit/raw/rawhide/f/plans/upstream.fmf | sed -r "/ref:/ s/[0-9.]+/$(git describe --abbrev=0)/" > tmp/upstream.fmf'
 
   create-archive:
     # The sandcastle doesn't have enough ram to run webpack, so wait
     # until the webpack-jumpstart workflow has run and grab the result.
     - tools/webpack-jumpstart --wait --rebase
     - tools/make-dist
-
-# HACK: packit.yml and spec get synced by default; drop this when the plans/upstream.fmf HACK above gets dropped
-files_to_sync:
-  - packit.yaml
-  - cockpit.spec
-  - src: tmp/upstream.fmf
-    dest: plans/upstream.fmf
 
 srpm_build_deps:
   - automake


### PR DESCRIPTION
tmt got fixed to be able to run the tests from the dist-git tarball
instead of checking it out from git, and this PR enabled that:
https://src.fedoraproject.org/rpms/cockpit/pull-request/76