### PR TITLE
systemd: Don't call updateTime() for every property change ever

### DIFF
--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -322,6 +322,7 @@ class ServicesPageBody extends React.Component {
         });
 
         this.timedated_subscription = timedate_client.subscribe({
+            path_namespace: "/org/freedesktop/timedate1",
             interface: "org.freedesktop.DBus.Properties",
             member: "PropertiesChanged"
         }, updateTime);


### PR DESCRIPTION
A D-Bus signal subscription will get all signals from all services,
not just from the service that the client was created for.