### PR TITLE
cmmon: Fix memory allocation in cockpit_hex_decode()

### DIFF
--- a/src/common/cockpithex.c
+++ b/src/common/cockpithex.c
@@ -64,7 +64,7 @@ cockpit_hex_decode (const char *hex,
   if (hexlen % 2 != 0)
     return NULL;
 
-  out = mallocx (hexlen * 2 + 1);
+  out = mallocx (hexlen / 2 + 1);
   for (i = 0; i < hexlen / 2; i++)
     {
       hpos = strchr (HEX, hex[i * 2]);


### PR DESCRIPTION
Dear Maintainer,
        There is a coding err at ```src/common/cockpithex.c:cockpit_hex_decode```, which leads a over-size-malloc issue.
         Could U please review this PR?