### PR TITLE
test: Increase scheduling cost of provisioned VMs, speed up build

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -318,8 +318,8 @@ def detect_tests(test_files, image, opts):
                 nd = getattr(test_method, "_testlib__non_destructive", False)
                 rwa = getattr(test_method, "_testlib__retry_when_affected", True)
                 if getattr(test.__class__, "provision", None):
-                    # each additionally provisioned VM costs half a parallel test capacity
-                    cost = 1 + (len(test.__class__.provision) - 1) / 2
+                    # each additionally provisioned VM costs parallel test capacity
+                    cost = len(test.__class__.provision)
                 else:
                     cost = 1
                 test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, cost=cost)

--- a/test/run
+++ b/test/run
@@ -7,6 +7,7 @@ set -eu
 
 tools/make-bots
 test/common/pixel-tests pull
+tools/webpack-jumpstart --partial || true
 
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 


### PR DESCRIPTION
We are still getting a lot of VM boot failures on PSI, so let's reduce
the amount of parallel VMs more.

---

See e.g. [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17594-20220726-100137-69b3f677-ubuntu-stable/log.html) or [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17594-20220726-130123-69b3f677-ubuntu-stable/log.html) run (I cancelled the latter)