### PR TITLE
services: Swap timer order: specific & after boot

### DIFF
--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -176,18 +176,18 @@ const CreateTimerDialogBody = ({ owner }) => {
                 </FormGroup>
                 <FormGroup label={_("Trigger")} hasNoPaddingTop>
                     <Flex>
-                        <Radio value="system-boot"
-                               id="system-boot"
-                               name="boot-or-specific-time"
-                               onChange={() => setDelay("system-boot")}
-                               isChecked={delay == "system-boot"}
-                               label={_("After system boot")} />
                         <Radio value="specific-time"
                                id="specific-time"
                                name="boot-or-specific-time"
                                onChange={() => setDelay("specific-time")}
                                isChecked={delay == "specific-time"}
                                label={_("At specific time")} />
+                        <Radio value="system-boot"
+                               id="system-boot"
+                               name="boot-or-specific-time"
+                               onChange={() => setDelay("system-boot")}
+                               isChecked={delay == "system-boot"}
+                               label={_("After system boot")} />
                     </Flex>
                     { delay == "system-boot" &&
                     <FormGroup className="delay-group"


### PR DESCRIPTION
Change order to prefer the more-commonly-used and default choice "at specific time" instead of "after system boot".

As spotted in #17592.