### PR TITLE
Revert "test: Improve run-tests scheduling of multi-provision tests"

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -12,7 +12,6 @@ import socket
 import tempfile
 import binascii
 import logging
-import functools
 
 import importlib.machinery
 import importlib.util
@@ -38,7 +37,7 @@ def flush_stdout():
 
 
 class Test:
-    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, cost=1):
+    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected):
         self.process = None
         self.retries = 0
         self.test_id = test_id
@@ -47,7 +46,6 @@ class Test:
         self.nondestructive = nondestructive
         self.machine_id = None
         self.retry_when_affected = retry_when_affected
-        self.cost = cost
         self.returncode = None
 
     def assign_machine(self, machine_id, ssh_address, web_address):
@@ -145,9 +143,12 @@ class Test:
     # internal methods
 
     def __str__(self):
-        cost = "" if self.cost == 1 else f" ${self.cost}"
-        nd = f" [ND@{self.machine_id}]" if self.nondestructive else ""
-        return f"{self.test_id} {self.command[0]} {self.command[-1]}{cost}{nd}"
+        return "{0} {1} {2}{3}".format(
+            self.test_id,
+            self.command[0],
+            self.command[-1],
+            " [ND@{0}]".format(self.machine_id) if self.nondestructive else "",
+        )
 
     def _print_test(self, print_tap=True, retry_reason="", skip_reason=""):
         def write_line(line):
@@ -317,12 +318,7 @@ def detect_tests(test_files, image, opts):
                     continue
                 nd = getattr(test_method, "_testlib__non_destructive", False)
                 rwa = getattr(test_method, "_testlib__retry_when_affected", True)
-                if getattr(test.__class__, "provision", None):
-                    # each additionally provisioned VM costs parallel test capacity
-                    cost = len(test.__class__.provision)
-                else:
-                    cost = 1
-                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, cost=cost)
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa)
                 if nd:
                     serial_tests.append(test)
                 else:
@@ -438,13 +434,10 @@ def run(opts, image):
 
                     made_progress = True
 
-        def running_cost():
-            return functools.reduce(lambda cost, test: cost + test.cost, running_tests, 0)
-
         # fill the remaining available job slots with parallel tests
-        while parallel_tests and running_cost() + parallel_tests[0].cost <= opts.jobs:
+        while parallel_tests and len(running_tests) < opts.jobs:
             test = parallel_tests.pop(0)
-            logging.debug(f"{len(running_tests)} running tests with total cost {running_cost()}, starting next parallel test {test}")
+            logging.debug(f"{len(running_tests)} running tests, starting next parallel test {test}")
             test.start()
             running_tests.append(test)
             made_progress = True


### PR DESCRIPTION
The underlying reason for the slow/failed boots got fixed in
https://github.com/cockpit-project/bots/pull/3668

The cost code regressed running tests with very few parallel slots: any
test whose cost was higher than `-jN` would never run. This is fixable,
but let's instead make the code simpler again.

This reverts commits 49a7122df205ab43 and f4b44198f462d4.

---

@ptoscano: If this works, that will solve [your woes](https://pastebin.com/Pyr1jz5K). I'll run this a couple of times on our new infra to ensure it's stable. If not, I'll fix it properly.