### PR TITLE
test: Fix run-tests scheduling with little or no parallelism

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -441,8 +441,8 @@ def run(opts, image):
         def running_cost():
             return functools.reduce(lambda cost, test: cost + test.cost, running_tests, 0)
 
-        # fill the remaining available job slots with parallel tests
-        while parallel_tests and running_cost() + parallel_tests[0].cost <= opts.jobs:
+        # fill the remaining available job slots with parallel tests; run tests with a cost higher than #jobs by themselves
+        while parallel_tests and (running_cost() + parallel_tests[0].cost <= opts.jobs or len(running_tests) == 0):
             test = parallel_tests.pop(0)
             logging.debug(f"{len(running_tests)} running tests with total cost {running_cost()}, starting next parallel test {test}")
             test.start()


### PR DESCRIPTION
Commit 49a7122df introduced a regression when the number of parallel
jobs was smaller than the cost of a test: These tests would never be
scheduled, and at the end the scheduler failed the "parallel_tests
should be empty" assertion.

Fix that by also scheduling the next parallel test if the number of
running tests is empty. That will cause the costly ones to run serially,
as intended.

---

Tested with
```
test/common/run-tests -j2 --test-dir test/verify/ -v TestNondestructiveExample TestExample TestMultiMachineAdd.testBasic
```
which reproduces @ptoscano 's [reported crash/problem](https://pastebin.com/Pyr1jz5K), and confirms the fix.