### PR TITLE
networking: Remove redundant imports

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -1,9 +1,6 @@
 @use "ct-card";
 @use "page";
 @import "global-variables";
-@import "@patternfly/patternfly/components/Table/table.scss";
-@import "@patternfly/patternfly/components/Table/table-grid.scss";
-@import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 #firewall,
 #network-page {


### PR DESCRIPTION
Networking uses Cockpit's ListingTable, which already has these imports.