### PR TITLE
css: Remove unused PF component imports

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -1,8 +1,6 @@
 @use "page";
 @use "ct-card";
 @import "global-variables";
-@import "@patternfly/patternfly/components/Table/table.scss";
-@import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 @import "@patternfly/patternfly/utilities/Text/text.scss";
 
 // utilities for `pf-u...` classes

--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -1,5 +1,5 @@
 @import "global-variables";
-@import "../../node_modules/@patternfly/patternfly/components/Toolbar/toolbar.scss";
+@import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 /* Navigation base, used for both desktop & mobile navigation */
 

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -22,7 +22,6 @@
 @use "page";
 @use "../lib/table.css";
 @use "nav.scss";
-@import "@patternfly/patternfly/components/Button/button.css";
 
 :root {
     --ct-color-host-accent: var(--pf-global--active-color--100);

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -2,7 +2,6 @@
 @use "../lib/journal.css";
 @use "./system-global.scss";
 @import "global-variables.scss";
-@import "@patternfly/patternfly/components/FormControl/form-control.scss";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 @import "@patternfly/patternfly/utilities/Flex/flex.scss";
 

--- a/pkg/systemd/terminal.scss
+++ b/pkg/systemd/terminal.scss
@@ -1,7 +1,6 @@
 @use "../lib/console.css";
 @use "page";
 @import "global-variables";
-@import "@patternfly/patternfly/components/Button/button.css";
 @import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 .console-ct-container {

--- a/pkg/users/users.scss
+++ b/pkg/users/users.scss
@@ -5,7 +5,6 @@
 @import "@patternfly/patternfly/utilities/Spacing/spacing.css";
 @import "global-variables.scss";
 @import "@patternfly/patternfly/components/DataList/data-list.scss";
-@import "@patternfly/patternfly/components/Form/form.scss";
 
 #account .pf-c-card {
     @extend .ct-card;


### PR DESCRIPTION
I removed as many `@import`s as I could and re-added the imports where things were broken.

I'm adding this as a draft to see what the tests (especially pixel tests) do.