### PR TITLE
Debug TestFirewall.testAddServices pixel test

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -975,8 +975,7 @@ class Browser:
     def assert_pixels_in_current_layout(self, selector: str, key: str,
                                         ignore: List[str] = [],
                                         scroll_into_view: Optional[str] = None,
-                                        wait_animations: bool = True,
-                                        wait_delay: float = 0.5):
+                                        wait_animations: bool = True):
         """Compare the given element with its reference in the current layout"""
 
         if not (Image and self.pixels_label):
@@ -1006,7 +1005,7 @@ class Browser:
         # But we know that tooltips fade in within 300ms, so we just
         # wait half a second to and side-step all that complexity.
 
-        time.sleep(wait_delay)
+        time.sleep(0.5)
         if wait_animations:
             self.wait_js_cond('ph_count_animations(%s) == 0' % jsquote(selector))
 
@@ -1120,8 +1119,7 @@ class Browser:
                       ignore: List[str] = [],
                       skip_layouts: List[str] = [],
                       scroll_into_view: Optional[str] = None,
-                      wait_animations: bool = True,
-                      wait_delay: float = 0.5):
+                      wait_animations: bool = True):
         """Compare the given element with its reference in all layouts"""
 
         if not (Image and self.pixels_label):
@@ -1133,8 +1131,7 @@ class Browser:
                 self.set_layout(layout["name"])
                 self.assert_pixels_in_current_layout(selector, key, ignore=ignore,
                                                      scroll_into_view=scroll_into_view,
-                                                     wait_animations=wait_animations,
-                                                     wait_delay=wait_delay)
+                                                     wait_animations=wait_animations)
         self.set_layout(previous_layout)
 
     def assert_no_unused_pixel_test_references(self):

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -243,6 +243,7 @@ class TestFirewall(NetworkCase):
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-pop3")
 
         b.assert_pixels(".pf-c-modal-box", "firewall-add-services-to-zone-modal")
+        assert False
 
         # don't select anything in the dialog
         b.click(f"#add-services-dialog footer .{self.btn_primary}")

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -242,8 +242,7 @@ class TestFirewall(NetworkCase):
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-imap")
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-pop3")
 
-        # HACK: the dialog needs some time to set up after resizing
-        b.assert_pixels(".pf-c-modal-box", "firewall-add-services-to-zone-modal", wait_delay=3)
+        b.assert_pixels(".pf-c-modal-box", "firewall-add-services-to-zone-modal")
 
         # don't select anything in the dialog
         b.click(f"#add-services-dialog footer .{self.btn_primary}")

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -304,6 +304,30 @@ class TestFirewall(NetworkCase):
         b.click(".zone-section[data-id='public'] a.pf-m-danger.pf-c-dropdown__menu-item")
         b.wait_not_present(".zone-section[data-id='public'] tr[data-row-id='pop3']")
 
+    def testAddServices2(self):
+        self.testAddServices()
+
+    def testAddServices3(self):
+        self.testAddServices()
+
+    def testAddServices4(self):
+        self.testAddServices()
+
+    def testAddServices5(self):
+        self.testAddServices()
+
+    def testAddServices6(self):
+        self.testAddServices()
+
+    def testAddServices7(self):
+        self.testAddServices()
+
+    def testAddServices8(self):
+        self.testAddServices()
+
+    def testAddServices9(self):
+        self.testAddServices()
+
     def testAddCustomServices(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Continuing my hunt for [this pixel test failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17614-20220803-052318-bdd91803-fedora-36/log.html#80). This completely resists to reproduce both [locally](https://github.com/cockpit-project/cockpit/pull/17616#issuecomment-1202691593) and [on our production infra](https://github.com/cockpit-project/cockpit/pull/17616#issuecomment-1203549152), so throwing some test PRs against the bots to investigate.