### PR TITLE
lib: allow setting initial value in FileAutoComplete

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -32,7 +32,7 @@ export class FileAutoComplete extends React.Component {
             directory: '', // The current directory we list files/dirs from
             displayFiles: [],
             isOpen: false,
-            value: null,
+            value: this.props.value || null,
         };
         this.updateFiles(props.value || '/');
         this.typeaheadInputValue = "";
@@ -196,6 +196,7 @@ FileAutoComplete.propTypes = {
     superuser: PropTypes.string,
     isOptionCreatable: PropTypes.bool,
     onChange: PropTypes.func,
+    value: PropTypes.string,
 };
 FileAutoComplete.defaultProps = {
     isOptionCreatable: false,


### PR DESCRIPTION
Allows setting initial value in FileAutoComplete component. This use case
is needed in c-podman to prefill ImageRunModal when editing/recreating containers.