### PR TITLE
http-stream2 unit tests and doc improvements

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -720,7 +720,10 @@ payload type:
 
 You may also specify these options:
 
- * "connection": A stable connection identifier.
+ * "connection": A stable identifier for connection sharing, i.e.
+   sending multiple requests to a single open connection.
+ * "method": "GET" (default if not specified), "POST", or other valid HTTP method
+ * "headers": JSON object with additional request headers
  * "tls": Set to a object to use an https connection.
 
 The TLS object can have the following options:

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -115,21 +115,20 @@ QUnit.test("not found", assert => {
 
 QUnit.test("streaming", assert => {
     const done = assert.async();
-    assert.expect(1);
+    assert.expect(3);
 
-    let at = 0;
+    let num_chunks = 0;
     let got = "";
     cockpit.http(test_server)
             .get("/mock/stream")
             .stream(resp => {
                 got += resp;
-                at++;
+                num_chunks++;
             })
             .finally(() => {
-                let expected = "";
-                for (let i = 0; i < at; i++)
-                    expected += String(i) + " ";
-                assert.equal(got, expected, "stream got right data");
+                assert.true(num_chunks > 1, "got at least two chunks");
+                assert.true(num_chunks <= 10, "got at most 10 chunks");
+                assert.equal(got, "0 1 2 3 4 5 6 7 8 9 ", "stream got right data");
                 done();
             });
 });

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -306,4 +306,17 @@ QUnit.test("address with params", assert => {
             .finally(done);
 });
 
+QUnit.test("wrong options", assert => {
+    assert.rejects(
+        cockpit.http({}).get("/"),
+        // unfortunately cockpit.js does not propagate the detailed error message
+        ex => ex.problem == "protocol-error" && ex.status == undefined,
+        "rejects request without port or unix option");
+
+    assert.rejects(
+        cockpit.http({ port: 1234, unix: "/nonexisting/socket" }).get("/"),
+        ex => ex.problem == "protocol-error" && ex.status == undefined,
+        "rejects request with both port and unix option");
+});
+
 QUnit.start();

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -306,6 +306,31 @@ QUnit.test("address with params", assert => {
             .finally(done);
 });
 
+QUnit.test("HEAD method", assert => {
+    const done = assert.async();
+    assert.expect(4);
+
+    assert.rejects(
+        cockpit.http(test_server).get("/mock/headonly"),
+        ex => ex.status == 400 && ex.reason == "Only HEAD allowed on this path",
+        "rejects GET request on /headonly path");
+
+    const InputData = "some chars";
+
+    cockpit.http(test_server).request({
+        path: "/mock/headonly",
+        method: "HEAD",
+        headers: { InputData },
+        body: "",
+    })
+            .response((status, headers) => {
+                assert.equal(status, 200);
+                assert.equal(headers.InputDataLength, InputData.length);
+            })
+            .then(data => assert.equal(data, ""))
+            .finally(done);
+});
+
 QUnit.test("wrong options", assert => {
     assert.rejects(
         cockpit.http({}).get("/"),


### PR DESCRIPTION
Noticed while I was working on the pybridge http channel. The JS unit tests don't run in our VMs, thus no-test.