### PR TITLE
client: Support WebKit 4.1 API

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -29,10 +29,15 @@ import sys
 import tempfile
 import textwrap
 
-gi.require_version("Gtk", "3.0")  # NOQA
-gi.require_version("WebKit2", "4.0")  # NOQA
+gi.require_version("Gtk", "3.0")
+from gi.repository import GLib, Gio, Gtk  # NOQA
 
-from gi.repository import GLib, Gio, Gtk, WebKit2  # NOQA: E402
+try:
+    gi.require_version("WebKit2", "4.1")
+    from gi.repository import WebKit2
+except (ValueError, ImportError):
+    gi.require_version("WebKit2", "4.0")
+    from gi.repository import WebKit2
 
 try:
     gi.require_version("Handy", "1")


### PR DESCRIPTION
Fedora 37 dropped webkit2gtk3 from their default desktop installation,
and only ships with webkit2gtk4.1 now. Confusingly, this is *not* GTK4,
but the GTK3 binding linked against libsoup 3.

-----

@M4rtinK, this should fix your woes. Quite possibly it'll also fix https://github.com/cockpit-project/bots/pull/3696

I tested that on a current Fedora rawhide workstation live system. Both with the default webkit2gtk4.1, and after installing webkit2gtk3 and damaging the gtk4.1 import code path.