### PR TITLE
tests: Fix for Machine.execute() enabling `set -e`

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -772,7 +772,7 @@ class TestConnection(MachineCase):
         self.assertIn('id="overview"', out)
 
         # shut it down, wait until it is gone
-        m.execute("pkill -ef cockpit-ws")
+        m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
 
         # start ws with --local-session and existing running bridge
         script = '''#!/bin/bash -eu
@@ -788,6 +788,9 @@ G_MESSAGES_DEBUG=all XDG_CONFIG_DIRS=/usr/local %s -p 9999 -a 127.0.0.90 --local
         # System frame should work directly, no login page
         out = m.execute("curl --compressed http://127.0.0.90:9999/cockpit/@localhost/system/index.html")
         self.assertIn('id="overview"', out)
+
+        # shut it down, wait until it is gone
+        m.execute("pkill cockpit-ws; while pgrep -a cockpit-ws; do sleep 1; done")
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1320,7 +1320,7 @@ class TestGrafanaClient(MachineCase):
         mg = self.machines['services']
 
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
-        m.execute("""systemctl stop pmlogger
+        m.execute("""systemctl stop pmlogger || true
                      systemctl reset-failed pmlogger
                      rm -rf /var/log/pcp/pmlogger
                      hostnamectl set-hostname grafana-client""")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -814,7 +814,7 @@ password=foobar
         wait(lambda: progressValue(1) < 20)
         m.spawn("for i in $(seq $(nproc)); do cat /dev/urandom > /dev/null & done", "cpu_hog.log")
         wait(lambda: progressValue(1) > 75)
-        m.execute("pkill -e -f cat.*urandom")
+        m.execute("pkill -e -f [c]at.*urandom")
         # should go back to idle usage
         wait(lambda: progressValue(1) < 20)
 

--- a/test/verify/packagelib.py
+++ b/test/verify/packagelib.py
@@ -95,7 +95,7 @@ Server = file://{empty_repo_dir}
 
         # have PackageKit start from a clean slate
         self.machine.execute("systemctl stop packagekit")
-        self.machine.execute("systemctl kill --signal=SIGKILL packagekit; rm -rf /var/cache/PackageKit")
+        self.machine.execute("systemctl kill --signal=SIGKILL packagekit || true; rm -rf /var/cache/PackageKit")
         self.machine.execute("systemctl reset-failed packagekit || true")
         self.restore_file("/var/lib/PackageKit/transactions.db")
 

--- a/test/verify/storagelib.py
+++ b/test/verify/storagelib.py
@@ -79,7 +79,7 @@ class StorageHelpers:
                                    "dd if=/dev/zero of=$F bs=1000000 count=%s; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # right after unmounting the device is often still busy, so retry a few times
-        self.addCleanup(self.machine.execute, "umount {0}; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
+        self.addCleanup(self.machine.execute, "umount {0} || true; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
         return dev
 
     def force_remove_disk(self, device):


### PR DESCRIPTION
This actually spotted two bugs. Blocks https://github.com/cockpit-project/bots/pull/3706

 - https://github.com/cockpit-project/cockpit/pull/17625