### PR TITLE
kdump: Use close with cockpit.file, not remove

### DIFF
--- a/pkg/kdump/config-client.js
+++ b/pkg/kdump/config-client.js
@@ -47,7 +47,7 @@ export class ConfigFile {
 
     close() {
         if (this._fileHandle) {
-            this._fileHandle.remove();
+            this._fileHandle.close();
             this._fileHandle = undefined;
         }
     }


### PR DESCRIPTION
There is no remove, and the intention is to close the watch channel.
