### PR TITLE
more test fixes for Machine.execute() with set -e by default

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1321,7 +1321,7 @@ class TestGrafanaClient(MachineCase):
 
         # avoid dynamic host name changes during PCP data collection, and start from clean slate
         m.execute("""systemctl stop pmlogger || true
-                     systemctl reset-failed pmlogger
+                     systemctl reset-failed pmlogger || true
                      rm -rf /var/log/pcp/pmlogger
                      hostnamectl set-hostname grafana-client""")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1408,7 +1408,8 @@ class TestAutoUpdates(NoSubManCase):
         super().setUp()
         # not implemented for yum and apt yet, only dnf
         self.supported_backend = self.backend in ["dnf"]
-        self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
+        if self.backend == 'dnf':
+            self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
 
     def closeSettings(self, browser):
         browser.click("#automatic-updates-dialog button:contains('Save changes')")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -67,7 +67,8 @@ class TestPages(MachineCase):
     def testBasic(self):
         m = self.machine
         b = self.browser
-        self.restore_dir("/etc/systemd/system", post_restore_action="systemctl stop test.timer test.service; systemctl daemon-reload")
+        self.restore_dir("/etc/systemd/system", post_restore_action="systemctl daemon-reload")
+        self.addCleanup(m.execute, "systemctl stop test.timer test.service")
         m.write("/etc/systemd/system/test.service",
                 """
 [Unit]


### PR DESCRIPTION
Fixes [these failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-3706-20220808-163657-549403cf-rhel-8-7-cockpit-project-cockpit/log.html) from https://github.com/cockpit-project/bots/pull/3706