### PR TITLE
pybridge: Add http-stream2 channel

### DIFF
--- a/pkg/base1/test-echo.js
+++ b/pkg/base1/test-echo.js
@@ -82,10 +82,8 @@ QUnit.test("binary", function (assert) {
 QUnit.test("fence", async assert => {
     const done = assert.async();
 
-    const response = await fetch(`http://${window.location.hostname}:${window.location.port}/mock/info`);
-    const info = await response.json();
     // This is implemented in the C bridge, but not in Python.
-    if (info.bridge == "cockpit-bridge.pyz") {
+    if (await QUnit.mock_info("bridge") == "cockpit-bridge.pyz") {
         assert.ok(true, "skipping on python bridge, not implemented");
         done();
         return;

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -347,10 +347,8 @@ QUnit.test("wrong options", assert => {
 });
 
 QUnit.test("parallel stress test", async assert => {
-    const response = await fetch(`http://${window.location.hostname}:${window.location.port}/mock/info`);
-    const info = await response.json();
     // This is way too slow under valgrind
-    if (info.skip_slow_tests) {
+    if (await QUnit.mock_info("skip_slow_tests")) {
         assert.ok(true, "skipping on python bridge, not implemented");
         return;
     }

--- a/pkg/lib/qunit-tests.js
+++ b/pkg/lib/qunit-tests.js
@@ -30,4 +30,9 @@ require("./qunit-config.js");
 
 require("qunit/qunit/qunit.css");
 
+QUnit.mock_info = async key => {
+    const response = await fetch(`http://${window.location.hostname}:${window.location.port}/mock/info`);
+    return (await response.json())[key];
+};
+
 export default QUnit;

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -20,6 +20,7 @@ pyTESTS_PASSING = \
 	dist/base1/test-format.html \
 	dist/base1/test-framed-cache.html \
 	dist/base1/test-framed.html \
+	dist/base1/test-http.html \
 	dist/base1/test-journal-renderer.html \
 	dist/base1/test-locale.html \
 	dist/base1/test-location.html \
@@ -38,7 +39,6 @@ pyTESTS_PASSING = \
 	$(NULL)
 
 pyTESTS_FAILING = \
-	dist/base1/test-http.html \
 	dist/base1/test-websocket.html \
 	$(NULL)
 
@@ -62,6 +62,7 @@ PYTHON_BRIDGE_FILES = \
 	src/cockpit/channels/dbus.py \
 	src/cockpit/channels/dbus_internal.py \
 	src/cockpit/channels/filesystem.py \
+	src/cockpit/channels/http.py \
 	src/cockpit/channels/metrics.py \
 	src/cockpit/channels/packages.py \
 	src/cockpit/channels/stream.py \

--- a/src/cockpit/channels/__init__.py
+++ b/src/cockpit/channels/__init__.py
@@ -18,6 +18,7 @@
 from .dbus import DBusChannel
 from .dbus_internal import DBusInternalChannel
 from .filesystem import FsListChannel, FsReadChannel, FsReplaceChannel, FsWatchChannel
+from .http import HttpChannel
 from .metrics import MetricsChannel
 from .packages import PackagesChannel
 from .stream import StreamChannel
@@ -32,6 +33,7 @@ CHANNEL_TYPES = [
     FsReadChannel,
     FsReplaceChannel,
     FsWatchChannel,
+    HttpChannel,
     MetricsChannel,
     NullChannel,
     PackagesChannel,

--- a/src/cockpit/channels/http.py
+++ b/src/cockpit/channels/http.py
@@ -1,0 +1,154 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import asyncio
+import http.client
+import logging
+import ssl
+import socket
+import threading
+
+from ..channel import Channel
+
+logger = logging.getLogger(__name__)
+
+
+class HttpChannel(Channel):
+    payload = 'http-stream2'
+
+    def create_connection(self):
+        opt_address = self.options.get('address') or 'localhost'
+        opt_port = self.options.get('port')
+        opt_unix = self.options.get('unix')
+        opt_tls = self.options.get('tls')
+        logger.debug('connecting to %s:%s; tls: %s', opt_address, opt_port or opt_unix, opt_tls)
+
+        if opt_tls is not None:
+            if 'authority' in opt_tls:
+                if 'data' in opt_tls['authority']:
+                    context = ssl.create_default_context(cadata=opt_tls['authority']['data'])
+                else:
+                    context = ssl.create_default_context(cafile=opt_tls['authority']['file'])
+            else:
+                context = ssl.create_default_context()
+
+            if 'validate' in opt_tls and not opt_tls['validate']:
+                context.check_hostname = False
+                context.verify_mode = ssl.VerifyMode.CERT_NONE
+
+            connection = http.client.HTTPSConnection(opt_address, opt_port, context=context)
+        else:
+            connection = http.client.HTTPConnection(opt_address, opt_port)
+
+        try:
+            if opt_unix:
+                # create the connection's socket so that it won't call .connect() internally (which only supports TCP)
+                connection.sock = socket.socket(socket.AF_UNIX)
+                connection.sock.connect(opt_unix)
+            else:
+                # explicitly call connect(), so that we can do proper error handling
+                connection.connect()
+        except (OSError, IOError) as e:
+            logger.error('Failed to open %s:%s: %s %s', opt_address, opt_port or opt_unix, type(e), e)
+            problem = 'unknown-hostkey' if isinstance(e, ssl.SSLCertVerificationError) else 'not-found'
+            self.close(problem=problem, message=str(e))
+            return None
+
+        return connection
+
+    def read_send_response(self, response):
+        '''Completely read the response and send it to the channel'''
+
+        while True:
+            # we want to stream data blocks as soon as they come in
+            block = response.read1(4096)
+            if not block:
+                logger.debug('reading response done')
+                # this returns immediately and does not read anything more, but updates the http.client's
+                # internal state machine to "response done"
+                block = response.read()
+                assert block == b''
+                break
+            logger.debug('read block of size %i', len(block))
+            self.loop.call_soon_threadsafe(self.send_data, block)
+
+    def parse_headers(self, http_msg):
+        headers = dict(http_msg)
+        remove = ['Connection', 'Transfer-Encoding']
+        if self.options.get('binary'):
+            remove = ['Content-Length', 'Range']
+        for h in remove:
+            try:
+                del headers[h]
+            except KeyError:
+                pass
+        return headers
+
+    def request(self):
+        connection = self.create_connection()
+        if not connection:
+            # make_connection does the error reporting
+            return
+
+        connection.request(self.options.get('method'),
+                           self.options.get('path'),
+                           headers=self.options.get('headers') or {},
+                           body=self.body)
+        response = connection.getresponse()
+        self.loop.call_soon_threadsafe(lambda: self.send_control(
+            command='response', status=response.status, reason=response.reason,
+            headers=self.parse_headers(response.headers)))
+        self.read_send_response(response)
+        connection.close()
+
+        self.loop.call_soon_threadsafe(self.done)
+        self.loop.call_soon_threadsafe(self.close)
+        logger.debug('closed')
+
+    def do_open(self, options):
+        logger.debug('open %s', options)
+        if not options.get('method'):
+            self.close(problem='protocol-error', message='missing or empty "method" field in HTTP stream request')
+            return
+        if options.get('path') is None:
+            self.close(problem='protocol-error', message='missing "path" field in HTTP stream request')
+            return
+        if options.get('tls') is not None and options.get('unix'):
+            self.close(problem='protocol-error', message='TLS on Unix socket is not supported')
+            return
+        if options.get('connection') is not None:
+            self.close(problem='protocol-error', message='connection sharing is not implemented on this bridge')
+            return
+
+        opt_port = options.get('port')
+        opt_unix = options.get('unix')
+        if opt_port is None and opt_unix is None:
+            self.close(problem='protocol-error', message='no "port" or "unix" option for channel')
+            return
+        if opt_port is not None and opt_unix is not None:
+            self.close(problem='protocol-error', message='cannot specify both "port" and "unix" options')
+            return
+
+        self.options = options
+        self.body = b''
+
+    def do_data(self, data):
+        self.body += data
+
+    def do_done(self):
+        self.loop = asyncio.get_event_loop()
+        threading.Thread(target=self.request, daemon=True).start()


### PR DESCRIPTION
This is sufficient to pass pkg/base1/test-http.js, but is still missing a lot:

 - [x] needs to not block other channels:
     *  [aiohttp](https://github.com/aio-libs/aiohttp/) would be nice, but it's an external module and we only want to use included batteries
     * we might be able to poll() the `response.fileno()` for at least asynchronously reading the response data, but that still leaves the connection handshake and sending the request; all of that can block as well
     * we might spawn `curl`, but that's ugly and not always installed either
     * :heavy_check_mark: our best bet might be to run the whole thing in a thread
  - [x] add smoke test with lots of parallel channels, to validate correct serialization in threading: also split out to PR #17639
  - [x] add support for Unix sockets (not covered by unit tests)
  - [x] correct problem key for SSL certificate validation errors ("unknown-hostkey")
  - [x] add support for TLS options (not covered by unit tests)
  - [x] ~check if C bridge supports TLS on Unix socket~ we'd rather not support this weird case, so forbid + unit test
  - [ ] ~Understand C bridge's `Keep-Alive:` header handling, write a test for it, implement in py bridge~ (see below)
  - [ ] ~Understand C bridge's connection sharing with serial requests and with server-side timeouts/closes; write a test for it, implement in py bridge~ (disabled the feature, see below)
  - [x] Fix POST data; validate with cockpit-podman
  - [x] Goes on top of PR #17702

## manual tests for async stream

These require the hack from PR #17599 to run the py bridge interactively.

Interleaved spawn and http channel with C bridge:

```
(printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "piware.de", "port": 443, "method": "GET", "path": "/tmp/x.txt", "tls": {} }\n---\n\n{ "command": "done", "channel": "h" }\n---\n\n{ "command": "open", "channel": "s", "payload": "stream", "spawn": ["ping", "-c3", "piware.de"] }\n---\n'; sleep 5;) | cockpit-bridge --interact=---
```
This works fine. If you change the port to "444", the `h` channel hangs forever (my server doesn't send REJECT, the firewall just blocks it). But the `s` channel responds fine.

A similar command with the py bridge:

```
make cockpit-bridge.pyz && (printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "piware.de", "port": 443, "method": "GET", "path": "/tmp/x.txt", "tls": {} }\n---\n\n{ "command": "done", "channel": "h" }\n---\n\n{ "command": "open", "channel": "s", "payload": "stream", "spawn": ["ping", "-c3", "piware.de"] }\n---\n'; sleep 5;) | ./cockpit-bridge.pyz
```
~That works reasonably as well, and the blocking isn't visible here. But if you change port to 444, it currently hangs in "creating new connection for None to piware.de:444; tls: {}", as that never returns and has no timeout either.~ This works similar to the C bridge now.

## manual test for Unix socket

Server:
```
python3 -m http.server & socat unix-listen:/tmp/sock,,reuseaddr,fork tcp-connect:localhost:8000
```
C bridge:
```
(printf '\n{ "command": "open", "channel": "m", "payload": "http-stream2", "unix": "/tmp/sock", "method": "GET", "path": "/.bashrc" }\n---\n\n{ "command": "done", "channel": "m" }\n---\n'; sleep 2;) | cockpit-bridge --interact=---
```
py bridge:
```
make cockpit-bridge.pyz && (printf '\n{ "command": "open", "channel": "m", "payload": "http-stream2", "unix": "/tmp/sock", "method": "GET", "path": "/.bashrc" }\n---\n\n{ "command": "done", "channel": "m" }\n---\n'; sleep 2;) | ./cockpit-bridge.pyz
```

## manual tests for TLS

Simple, no options (using publicly known certificate):
```
(printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "piware.de", "port": 443, "method": "GET", "path": "/tmp/x.txt", "tls": {} }\n---\n'; sleep 2;) | ...
```

Custom certificate, failing:
```
(printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "cockpit-11.apps.cnfdb2.e2e.bos.redhat.com", "port": 443, "method": "GET", "path": "/images/", "tls": {} }\n---\n'; sleep 2;) | ...
```
C bridge fails with `"problem":"unknown-hostkey"`, current py bridge ~with "not-found"~ fixed, same behaviour now.

Custom certificate with CA:
```
(printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "cockpit-11.apps.cnfdb2.e2e.bos.redhat.com", "port": 443, "method": "GET", "path": "/images/", "tls": { "authority": { "file": "/home/martin/upstream/bots/images/files/ca.pem" } } }\n---\n\n{ "command": "done", "channel": "m" }\n---\n'; sleep 5;)
```

Likewise, disabling CA validation:
```
(printf '\n{ "command": "open", "channel": "h", "payload": "http-stream2", "address": "cockpit-11.apps.cnfdb2.e2e.bos.redhat.com", "port": 443, "method": "GET", "path": "/images/", "tls": { "validate": false } }\n---\n\n{ "command": "done", "channel": "m" }\n---\n'; sleep 5;)
```
These two fail on the C bridge, it never responds with anything. These work on the py bridge (but no automatic test.)