### PR TITLE
storage: Remove some pixel tests for complex tables

### DIFF
--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -72,8 +72,11 @@ ExecStart=/usr/bin/sleep infinity
 
         self.content_dropdown_action(1, "Unmount")
         b.wait_in_text("#dialog", str(sleep_pid))
+        b.wait_in_text("#dialog", "sleep infinity")
         b.wait_in_text("#dialog", "keep-mnt-busy")
-        b.assert_pixels("#dialog", "busy-unmount", ignore=["td:nth-child(1)", "td:nth-child(4)"])
+        b.wait_in_text("#dialog", "Test Service")
+        b.wait_in_text("#dialog", "/usr/bin/sleep infinity")
+        b.wait_in_text("#dialog", "The listed processes and services will be forcefully stopped.")
         self.confirm()
         self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -271,7 +271,9 @@ class TestStorageNfs(StorageCase):
         b.click("#detail-header button:contains(Unmount)")
         self.dialog_wait_open()
         b.wait_in_text("#dialog", str(sleep_pid))
-        b.assert_pixels("#dialog", "umount", ignore=["td:nth-child(1)", "td:nth-child(4)"])
+        b.wait_in_text("#dialog", "sleep infinity")
+        b.wait_in_text("#dialog", "The listed processes will be forcefully stopped.")
+        b.wait_in_text("#dialog", "Stop and unmount")
         self.dialog_apply()
 
         b.wait_visible("#detail-header button:contains(Mount)")


### PR DESCRIPTION
The tables can change layout completely "at random".  When the width
of a PID changes, for example, the Command column might wrap
differently and increase the height of the whole dialog.