### PR TITLE
bridge: Disallow TLS connections to Unix socket, http parallel stress test

### DIFF
--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -342,6 +342,11 @@ QUnit.test("wrong options", assert => {
         cockpit.http({ port: 1234, unix: "/nonexisting/socket" }).get("/"),
         ex => ex.problem == "protocol-error" && ex.status == undefined,
         "rejects request with both port and unix option");
+
+    assert.rejects(
+        cockpit.http({ unix: "/nonexisting/socket", tls: {} }).get("/"),
+        ex => ex.problem == "protocol-error" && ex.status == undefined,
+        "rejects request with both unix and tls option");
 });
 
 QUnit.start();

--- a/src/bridge/cockpitconnect.c
+++ b/src/bridge/cockpitconnect.c
@@ -220,6 +220,13 @@ parse_address (CockpitChannel *channel,
       goto out;
     }
 
+  if (unix_path && json_object_has_member (options, "tls"))
+    {
+      cockpit_channel_fail (channel, "protocol-error",
+                            "TLS on Unix socket is not supported");
+      goto out;
+    }
+
   if (port != G_MAXINT64 && unix_path)
     {
       cockpit_channel_fail (channel, "protocol-error", "cannot specify both \"port\" and \"unix\" options");
@@ -654,4 +661,3 @@ cockpit_connect_parse_stream (CockpitChannel *channel)
 
   return connectable;
 }
-


### PR DESCRIPTION
We don't test or use TLS connections in channels, and a lot of TLS modes
are even just plain broken with the C bridge.

It's hard to imagine for what we'd ever need TLS to connect to a local
Unix socket (the main use cases are REST calls to docker, podman, or
weldr). Explicitly disallow this, so that we don't have to implement all
these corner cases in the Python bridge.

----

Also add a parallel stress test for http-stream2. This will be useful for validating the py bridge.

For the record: We use cockpit.http() exactly twice in all our projects: in [podman](https://github.com/cockpit-project/cockpit-podman/blob/main/src/rest.js#L18) (connect to podman Unix socket) and [composer](https://github.com/osbuild/cockpit-composer/blob/main/core/composer.js#L4) (connect to weldr Unix socket).