### PR TITLE
cockpit.js: Support different URL root for the websocket

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -49,50 +49,50 @@
   </refsect1>
 
   <refsect1 id="cockpit-conf-webservice">
-	  <title>WebService</title>
-	  <variablelist>
-	    <varlistentry>
-	      <term><option>Origins</option></term>
-	      <listitem>
-                <para>By default cockpit will not accept crossdomain websocket connections. Use this
-                  setting to allow access from alternate domains. Origins should include scheme, host
-                  and port, if necessary.</para>
+  <title>WebService</title>
+  <variablelist>
+    <varlistentry>
+      <term><option>Origins</option></term>
+      <listitem>
+        <para>By default cockpit will not accept crossdomain websocket connections. Use this
+            setting to allow access from alternate domains. Origins should include scheme, host
+            and port, if necessary.</para>
 
-          <informalexample>
+        <informalexample>
 <programlisting language="ini">
 [WebService]
 Origins = https://somedomain1.com https://somedomain2.com:9090
 </programlisting>
-          </informalexample>
-        </listitem>
-      </varlistentry>
-	    <varlistentry>
-	      <term><option>ProtocolHeader</option></term>
-	      <listitem>
-                <para>Configure cockpit to look at the contents of this header to determine if a connection
-                  is using tls. This should only be used when cockpit is behind a reverse proxy, and care
-                  should be taken to make sure that incoming requests cannot set this header.</para>
-          <informalexample>
+        </informalexample>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>ProtocolHeader</option></term>
+      <listitem>
+        <para>Configure cockpit to look at the contents of this header to determine if a connection
+          is using tls. This should only be used when cockpit is behind a reverse proxy, and care
+          should be taken to make sure that incoming requests cannot set this header.</para>
+        <informalexample>
 <programlisting language="ini">
 [WebService]
 ProtocolHeader = X-Forwarded-Proto
 </programlisting>
-          </informalexample>
-        </listitem>
-      </varlistentry>
-        <varlistentry>
-          <term><option>ForwardedForHeader</option></term>
-          <listitem>
-            <para>Configure cockpit to look at the contents of this header to determine the real origin of a
-              connection.  This should only be used when cockpit is behind a reverse proxy, and care
-              should be taken to make sure that incoming requests cannot set this header.</para>
-          <informalexample>
+        </informalexample>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>ForwardedForHeader</option></term>
+      <listitem>
+        <para>Configure cockpit to look at the contents of this header to determine the real origin of a
+          connection.  This should only be used when cockpit is behind a reverse proxy, and care
+          should be taken to make sure that incoming requests cannot set this header.</para>
+        <informalexample>
 <programlisting language="ini">
 [WebService]
 ForwardedForHeader = X-Forwarded-For
 </programlisting>
-          </informalexample>
-        </listitem>
+        </informalexample>
+      </listitem>
       </varlistentry>
       <varlistentry>
         <term><option>LoginTitle</option></term>

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -316,7 +316,10 @@ function calculate_url(suffix) {
     if (!suffix)
         suffix = "socket";
     const window_loc = window.location.toString();
-    let _url_root = url_root;
+    /* this is not set by anything right now, just a client-side stub; see
+     * https://github.com/cockpit-project/cockpit/pull/17473 for the server-side and complete solution */
+    const meta_websocket_root = document.head.querySelector("meta[name='websocket-root']");
+    let _url_root = meta_websocket_root ? meta_websocket_root.content.replace(/^\/+|\/+$/g, '') : url_root;
 
     if (window.mock && window.mock.url)
         return window.mock.url;

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1052,22 +1052,27 @@ ProtocolHeader = X-Forwarded-Proto
         m.execute("setsebool -P httpd_can_network_connect on")
         self.allow_journal_messages("audit.*bool=httpd_can_network_connect.*val=1.*")
 
+    def callProxyCurl(self, path, *args):
+        # should use nginx' certificate, not cockpit's; use --resolve so that SNI matches the certificate's CN
+        (https_host, https_port) = self.machine.forward["443"].split(':')
+        return subprocess.check_output(
+            ["curl", "--verbose",
+             "--resolve", f"alice:{https_port}:{https_host}",
+             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
+             *args,
+             f"https://alice:{https_port}{path}"],
+            stderr=subprocess.STDOUT)
+
     def checkCockpitOnProxy(self, urlroot="", login=True):
         b = self.new_browser()
 
-        # should use nginx' certificate, not cockpit's; use --resolve so that SNI matches the certificate's CN
-        (https_host, https_port) = self.machine.forward["443"].split(':')
-        out = subprocess.check_output(
-            ["curl", "--verbose", "--head",
-             "--resolve", f"alice:{https_port}:{https_host}",
-             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
-             f"https://alice:{https_port}{urlroot}/cockpit/static/login.html"],
-            stderr=subprocess.STDOUT)
+        out = self.callProxyCurl(f"{urlroot}/cockpit/static/login.html", "--head")
         self.assertIn(b"HTTP/1.1 200 OK", out)
         self.assertIn(b"subject: CN=alice; DC=COCKPIT", out)
 
         # works with browser (but we can't set our CA)
         b.ignore_ssl_certificate_errors(True)
+        (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}{urlroot}/system")
         if login:
             b.wait_visible("#login")
@@ -1140,19 +1145,14 @@ server {
                  "/srv/www/embed-cockpit/")
         m.execute("if selinuxenabled 2>&1; then chcon -R -t httpd_sys_content_t /srv/www; fi")
 
-        (https_host, https_port) = self.machine.forward["443"].split(':')
-        out = subprocess.check_output(
-            ["curl", "--verbose",
-             "--resolve", f"alice:{https_port}:{https_host}",
-             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
-             f"https://alice:{https_port}/embed-cockpit/embed.css"],
-            stderr=subprocess.STDOUT)
+        out = self.callProxyCurl("/embed-cockpit/embed.css")
         self.assertIn(b"HTTP/1.1 200 OK", out)
         self.assertIn(b"#embed-links", out)
 
         # embedding
         b = self.browser
         b.ignore_ssl_certificate_errors(True)
+        (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}/embed-cockpit/index.html")
         b.set_val("#embed-address", f"https://{https_host}:{https_port}/cockpit-root")
         b.click("#embed-full")


### PR DESCRIPTION
We eventually want to support running cockpit-ws behind https://www.3scale.net/.
This requires two different API paths: `/api/<service>-<port>/` for HTTP
traffic, and `/wss/<service>-<port>/` for websocket connections.

cockpit.js needs to know which URL/path to contact for the websocket, so this
cannot be done with path rewriting on the server side only, or even with
multiple UrlRoot= values.

Thus introduce support for reading a `websocket-root` meta tag from the 
webserver, similar to the existing `url-root` one. Nothing sets that tag 
right now, as we are still not entirely sure how we want to configure
this. See https://github.com/cockpit-project/cockpit/pull/17473 how all 
of this fits together.

This is the only part required on the client side (which is much harder
to change and get into distros than the ws container), so land this now.
It is harmless, and easy enough to revert if we won't use it after all.

 - [x] Re-test scenarios with COPR from this PR, to ensure that it suffices on the client side