### PR TITLE
ws: Support non-standard Authorization: header

### DIFF
--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -95,6 +95,21 @@ ForwardedForHeader = X-Forwarded-For
       </listitem>
       </varlistentry>
       <varlistentry>
+        <term><option>AuthorizationHeader</option></term>
+        <listitem>
+          <para>Cockpit normally uses the <code>Authorization:</code> header for sending credentials from
+            the login page to the web server. In some cases, this header is already being used for
+            authenticating to a reverse proxy. Then you can tell cockpit's web server to use a different header
+            header for itself. It is recommended to use <code>X-Cockpit-Authorization</code>.</para>
+        <informalexample>
+<programlisting language="ini">
+[WebService]
+AuthorizationHeader = X-Cockpit-Authorization
+</programlisting>
+        </informalexample>
+        </listitem>
+      </varlistentry>
+      <varlistentry>
         <term><option>LoginTitle</option></term>
         <listitem><para>Set the browser title for the login screen.</para></listitem>
       </varlistentry>

--- a/doc/man/cockpit.conf.xml
+++ b/doc/man/cockpit.conf.xml
@@ -49,50 +49,50 @@
   </refsect1>
 
   <refsect1 id="cockpit-conf-webservice">
-	  <title>WebService</title>
-	  <variablelist>
-	    <varlistentry>
-	      <term><option>Origins</option></term>
-	      <listitem>
-                <para>By default cockpit will not accept crossdomain websocket connections. Use this
-                  setting to allow access from alternate domains. Origins should include scheme, host
-                  and port, if necessary.</para>
+  <title>WebService</title>
+  <variablelist>
+    <varlistentry>
+      <term><option>Origins</option></term>
+      <listitem>
+      <para>By default cockpit will not accept crossdomain websocket connections. Use this
+          setting to allow access from alternate domains. Origins should include scheme, host
+          and port, if necessary.</para>
 
-          <informalexample>
+      <informalexample>
 <programlisting language="ini">
 [WebService]
 Origins = https://somedomain1.com https://somedomain2.com:9090
 </programlisting>
-          </informalexample>
-        </listitem>
-      </varlistentry>
-	    <varlistentry>
-	      <term><option>ProtocolHeader</option></term>
-	      <listitem>
-                <para>Configure cockpit to look at the contents of this header to determine if a connection
-                  is using tls. This should only be used when cockpit is behind a reverse proxy, and care
-                  should be taken to make sure that incoming requests cannot set this header.</para>
-          <informalexample>
+      </informalexample>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>ProtocolHeader</option></term>
+      <listitem>
+        <para>Configure cockpit to look at the contents of this header to determine if a connection
+          is using tls. This should only be used when cockpit is behind a reverse proxy, and care
+          should be taken to make sure that incoming requests cannot set this header.</para>
+        <informalexample>
 <programlisting language="ini">
 [WebService]
 ProtocolHeader = X-Forwarded-Proto
 </programlisting>
-          </informalexample>
-        </listitem>
-      </varlistentry>
-        <varlistentry>
-          <term><option>ForwardedForHeader</option></term>
-          <listitem>
-            <para>Configure cockpit to look at the contents of this header to determine the real origin of a
-              connection.  This should only be used when cockpit is behind a reverse proxy, and care
-              should be taken to make sure that incoming requests cannot set this header.</para>
-          <informalexample>
+        </informalexample>
+      </listitem>
+    </varlistentry>
+    <varlistentry>
+      <term><option>ForwardedForHeader</option></term>
+      <listitem>
+        <para>Configure cockpit to look at the contents of this header to determine the real origin of a
+          connection.  This should only be used when cockpit is behind a reverse proxy, and care
+          should be taken to make sure that incoming requests cannot set this header.</para>
+        <informalexample>
 <programlisting language="ini">
 [WebService]
 ForwardedForHeader = X-Forwarded-For
 </programlisting>
-          </informalexample>
-        </listitem>
+        </informalexample>
+      </listitem>
       </varlistentry>
       <varlistentry>
         <term><option>LoginTitle</option></term>

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -21,6 +21,8 @@
             oauth.ErrorParam = "error_description";
     }
 
+    const authorization_header = environment.authorization_header || "Authorization";
+
     const fmt_re = /\$\{([^}]+)\}|\$([a-zA-Z0-9_]+)/g;
     function format(fmt /* ... */) {
         const args = Array.prototype.slice.call(arguments, 1);
@@ -422,7 +424,7 @@
             show("#login-wait-validating");
             const xhr = new XMLHttpRequest();
             xhr.open("GET", login_path, true);
-            xhr.setRequestHeader("Authorization", "Bearer " + token_val);
+            xhr.setRequestHeader(authorization_header, "Bearer " + token_val);
             xhr.onreadystatechange = function () {
                 if (xhr.readyState == 4) {
                     if (xhr.status == 200) {
@@ -555,7 +557,7 @@
             localStorage.setItem('standard-login', true);
 
             const headers = {
-                Authorization: "Basic " + window.btoa(utf8(user + ":" + password)),
+                [authorization_header]: "Basic " + window.btoa(utf8(user + ":" + password)),
                 "X-Superuser": superuser,
             };
             // allow unknown remote hosts with interactive logins with "Connect to:"
@@ -894,7 +896,7 @@
 
     function converse(id, msg) {
         const headers = {
-            Authorization: "X-Conversation " + id + " " + window.btoa(utf8(msg))
+            [authorization_header]: "X-Conversation " + id + " " + window.btoa(utf8(msg))
         };
         send_login_request("GET", headers, true);
     }

--- a/src/ws/cockpithandlers.c
+++ b/src/ws/cockpithandlers.c
@@ -347,6 +347,10 @@ build_environment (GHashTable *os_release)
         json_object_set_string_member (object, "banner", contents);
     }
 
+  const gchar *authorization_header = cockpit_conf_string ("Webservice", "AuthorizationHeader");
+  if (authorization_header)
+      json_object_set_string_member (object, "authorization_header", authorization_header);
+
   bytes = cockpit_json_write_bytes (object);
   json_object_unref (object);
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1052,22 +1052,27 @@ ProtocolHeader = X-Forwarded-Proto
         m.execute("setsebool -P httpd_can_network_connect on")
         self.allow_journal_messages("audit.*bool=httpd_can_network_connect.*val=1.*")
 
+    def callProxyCurl(self, path, *args):
+        # should use nginx' certificate, not cockpit's; use --resolve so that SNI matches the certificate's CN
+        (https_host, https_port) = self.machine.forward["443"].split(':')
+        return subprocess.check_output(
+            ["curl", "--verbose",
+             "--resolve", f"alice:{https_port}:{https_host}",
+             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
+             *args,
+             f"https://alice:{https_port}{path}"],
+            stderr=subprocess.STDOUT)
+
     def checkCockpitOnProxy(self, urlroot="", login=True):
         b = self.new_browser()
 
-        # should use nginx' certificate, not cockpit's; use --resolve so that SNI matches the certificate's CN
-        (https_host, https_port) = self.machine.forward["443"].split(':')
-        out = subprocess.check_output(
-            ["curl", "--verbose", "--head",
-             "--resolve", f"alice:{https_port}:{https_host}",
-             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
-             f"https://alice:{https_port}{urlroot}/cockpit/static/login.html"],
-            stderr=subprocess.STDOUT)
+        out = self.callProxyCurl(f"{urlroot}/cockpit/static/login.html", "--head")
         self.assertIn(b"HTTP/1.1 200 OK", out)
         self.assertIn(b"subject: CN=alice; DC=COCKPIT", out)
 
         # works with browser (but we can't set our CA)
         b.ignore_ssl_certificate_errors(True)
+        (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}{urlroot}/system")
         if login:
             b.wait_visible("#login")
@@ -1140,19 +1145,14 @@ server {
                  "/srv/www/embed-cockpit/")
         m.execute("if selinuxenabled 2>&1; then chcon -R -t httpd_sys_content_t /srv/www; fi")
 
-        (https_host, https_port) = self.machine.forward["443"].split(':')
-        out = subprocess.check_output(
-            ["curl", "--verbose",
-             "--resolve", f"alice:{https_port}:{https_host}",
-             "--cacert", os.path.join(TEST_DIR, "../src/tls/ca/ca.pem"),
-             f"https://alice:{https_port}/embed-cockpit/embed.css"],
-            stderr=subprocess.STDOUT)
+        out = self.callProxyCurl("/embed-cockpit/embed.css")
         self.assertIn(b"HTTP/1.1 200 OK", out)
         self.assertIn(b"#embed-links", out)
 
         # embedding
         b = self.browser
         b.ignore_ssl_certificate_errors(True)
+        (https_host, https_port) = self.machine.forward["443"].split(':')
         b.open(f"https://{https_host}:{https_port}/embed-cockpit/index.html")
         b.set_val("#embed-address", f"https://{https_host}:{https_port}/cockpit-root")
         b.click("#embed-full")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1196,6 +1196,8 @@ server {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
 
+        #HOOK
+
         # Pass ETag header from Cockpit to clients.
         # See: https://github.com/cockpit-project/cockpit/issues/5239
         gzip off;
@@ -1233,6 +1235,25 @@ server {
         # UrlRoot without login page
         run_ws("--local-session=cockpit-bridge")
         self.checkCockpitOnProxy(urlroot="/myroot", login=False)
+        kill_ws()
+
+        # custom authorization header; block standard Authorization: header in the proxy
+        self.sed_file('s/#HOOK/proxy_set_header Authorization "";/', "/etc/nginx/conf.d/cockpit.conf",
+                      "systemctl restart nginx")
+        m.write("/etc/cockpit/cockpit.conf", "AuthorizationHeader = X-Cockpit-Authorization\n", append=True)
+        run_ws()
+        self.checkCockpitOnProxy(urlroot="/myroot")
+        # does not accept standard header
+        basic_auth = base64.b64encode(b"admin:foobar").decode()
+        (https_host, https_port) = self.machine.forward["443"].split(':')
+        out = self.callProxyCurl("/myroot/cockpit/login", "--head",
+                                 "--header", f"Authorization: Basic {basic_auth}")
+        self.assertRegex(out, b"HTTP/1.1 (401 Authentication failed|403 Permission denied).*")
+        # accepts custom header
+        out = self.callProxyCurl("/myroot/cockpit/login", "--head",
+                                 "--header", f"X-Cockpit-Authorization: Basic {basic_auth}")
+        self.assertIn(b"HTTP/1.1 200 OK", out)
+        self.assertIn(b"\nSet-Cookie:", out)
         kill_ws()
 
         self.allow_restart_journal_messages()


### PR DESCRIPTION
In some scenarios, the normal `Authorization:` header is already being
used for something else, like authenticating to console.redhat.com's
3scale proxy. So we can't use that for authentication between the login
page and the managed machine.

Introduce a new `AuthorizationHeader` cockpit.config option to use
another header instead. Recommended value is `X-Cockpit-Authorization`.

---

See PR #17473, which pulls this into a bigger context.