### PR TITLE
css: Move some CSS imports to SCSS

### DIFF
--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -10,8 +10,6 @@ import 'polyfills';
 import { CockpitNav, CockpitNavItem } from "./nav.jsx";
 import { HostModal } from "./hosts_dialog.jsx";
 
-import "../../node_modules/@patternfly/patternfly/components/Select/select.css";
-
 const _ = cockpit.gettext;
 const hosts_sel = document.getElementById("nav-hosts");
 

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -22,6 +22,7 @@
 @use "page";
 @use "table";
 @use "nav";
+@import "@patternfly/patternfly/components/Select/select.css";
 
 :root {
   --ct-color-host-accent: var(--pf-global--active-color--100);

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -33,8 +33,6 @@ import { Overview } from "./overview.jsx";
 import { Details } from "./details.jsx";
 import { update_plot_state } from "./plot.jsx";
 
-import "table.css";
-import "journal.css";
 import "./storage.scss";
 
 const _ = cockpit.gettext;

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -33,8 +33,6 @@ import client from "./client.js";
 import { dialog_open } from "./dialog.jsx";
 import { fmt_to_fragments } from "utils.jsx";
 
-import '@patternfly/react-styles/css/components/Progress/progress.css';
-
 const _ = cockpit.gettext;
 
 /* StorageControl - a button or similar that triggers

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -18,8 +18,11 @@
  */
 @use "ct-card";
 @use "page";
+@use "table";
+@use "journal";
 @import "global-variables";
 @import "@patternfly/patternfly/components/Card/card.scss";
+@import "@patternfly/patternfly/components/Progress/progress.scss";
 @import "@patternfly/patternfly/utilities/Flex/flex.scss";
 @import "@patternfly/patternfly/utilities/Text/text.scss";
 


### PR DESCRIPTION
This prevents duplication and includes CSS in the correct place.