### PR TITLE
test: Robustify executed commands

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -41,7 +41,7 @@ class NetworkHelpers:
         self.addCleanup(self.machine.execute, "rm /run/udev/rules.d/99-nm-veth-{0}-test.rules; ip link del dev {0}".format(name))
         if dhcp_cidr:
             # up the remote end, give it an IP, and start DHCP server
-            self.machine.execute("ip a add {0} dev v_{1} && ip link set v_{1} up".format(dhcp_cidr, name))
+            self.machine.execute("ip a add {0} dev v_{1}; ip link set v_{1} up".format(dhcp_cidr, name))
             server = self.machine.spawn("dnsmasq --keep-in-foreground --log-queries --log-facility=- "
                                         "--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{0} "
                                         "--bind-interfaces --except-interface=lo --interface=v_{0} --dhcp-range={1},{2},4h".format(name, dhcp_range[0], dhcp_range[1]),
@@ -138,7 +138,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
         # Wait for the interface to show up
         self.get_iface(m, mac)
         # Trigger udev to make sure that it has been renamed to its final name
-        m.execute("udevadm trigger && udevadm settle")
+        m.execute("udevadm trigger; udevadm settle")
         iface = self.get_iface(m, mac)
         if activate:
             self.nm_activate_eth(iface)

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -61,7 +61,7 @@ class PackageCase(MachineCase):
             self.restore_dir("/var/lib/apt", reboot_safe=True)
             self.restore_dir("/var/cache/apt", reboot_safe=True)
             self.restore_dir("/etc/apt", reboot_safe=True)
-            self.machine.execute("echo > /etc/apt/sources.list && rm -f /etc/apt/sources.list.d/* && apt-get clean && apt-get update")
+            self.machine.execute("echo > /etc/apt/sources.list; rm -f /etc/apt/sources.list.d/*; apt-get clean; apt-get update")
         elif self.backend == "alpm":
             self.restore_dir("/var/lib/pacman", reboot_safe=True)
             self.restore_dir("/var/cache/pacman", reboot_safe=True)
@@ -392,7 +392,7 @@ post_upgrade() {{
                                     O=$(apt-ftparchive -o APT::FTPArchive::Release::Origin=cockpittest release .); echo "$O" > Release
                                     echo 'Changelogs: http://localhost:12345/changelogs/@CHANGEPATH@' >> Release
                                     '''.format(self.repo_dir))
-            pid = self.machine.spawn(f"cd {self.repo_dir} && exec python3 -m http.server 12345", "changelog")
+            pid = self.machine.spawn(f"cd {self.repo_dir}; exec python3 -m http.server 12345", "changelog")
             # pid will not be present for rebooting tests
             self.addCleanup(self.machine.execute, "kill %i || true" % pid)
             self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1479,7 +1479,7 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(m.execute, "find /var/lib/systemd/coredump -type f -delete")
 
         # temporary directory in the VM
-        self.addCleanup(m.execute, "if [ -d {0} ]; then findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount && rm -r {0}; fi".format(self.vm_tmpdir))
+        self.addCleanup(m.execute, "if [ -d {0} ]; then findmnt --list --noheadings --output TARGET | grep ^{0} | xargs -r umount; rm -r {0}; fi".format(self.vm_tmpdir))
 
         # users/groups/home dirs
         self.restore_file("/etc/passwd")
@@ -1960,7 +1960,7 @@ class MachineCase(unittest.TestCase):
             return
 
         backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))
-        self.machine.execute("mkdir -p %(vm_tmpdir)s && cp -a %(path)s/ %(backup)s/" % {
+        self.machine.execute("mkdir -p %(vm_tmpdir)s; cp -a %(path)s/ %(backup)s/" % {
             "vm_tmpdir": self.vm_tmpdir, "path": path, "backup": backup})
 
         if not reboot_safe:
@@ -1971,7 +1971,7 @@ class MachineCase(unittest.TestCase):
             self.addCleanup(self.machine.execute, post_restore_action)
 
         if reboot_safe:
-            self.addCleanup(self.machine.execute, "rm -rf {0} && mv {1} {0}".format(path, backup))
+            self.addCleanup(self.machine.execute, "rm -rf {0}; mv {1} {0}".format(path, backup))
         else:
             self.addCleanup(self.machine.execute, "umount -lf " + path)
 
@@ -1988,7 +1988,7 @@ class MachineCase(unittest.TestCase):
         exists = self.machine.execute("if test -e %s; then echo yes; fi" % path).strip() != ""
         if exists:
             backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))
-            self.machine.execute("mkdir -p %(vm_tmpdir)s && cp -a %(path)s %(backup)s" % {
+            self.machine.execute("mkdir -p %(vm_tmpdir)s; cp -a %(path)s %(backup)s" % {
                 "vm_tmpdir": self.vm_tmpdir, "path": path, "backup": backup})
             if post_restore_action:
                 self.addCleanup(self.machine.execute, post_restore_action)

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -74,7 +74,7 @@ class TestApps(PackageCase):
             """,
             "/usr/share/app-info/icons/test/64x64/test.png": {"path": "/var/tmp/test.png"}})
         self.enableRepo()
-        self.machine.execute("systemctl stop packagekit && pkcon refresh force")
+        self.machine.execute("systemctl stop packagekit; pkcon refresh force")
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
@@ -94,7 +94,8 @@ class TestApps(PackageCase):
                 '{ "config": { "appstream_data_packages": [ "appstream-data-test" ] } }')
 
         if urlroot != "":
-            m.execute(f'mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot={urlroot}" > /etc/cockpit/cockpit.conf')
+            m.execute("mkdir -p /etc/cockpit")
+            m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         m.start_cockpit()
         b.login_and_go("/apps", urlroot=urlroot)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -58,8 +58,8 @@ class TestConnection(MachineCase):
         # on OSTree, also check with overlaid cockpit-ws rpm
         if m.ostree_image:
             def ws_start():
-                m.execute(r"""set -e;
-                    mkdir -p /etc/systemd/system/cockpit.service.d/ &&
+                m.execute(r"""
+                    mkdir -p /etc/systemd/system/cockpit.service.d/
                     printf "[Service]\nExecStart=\n%s --no-tls" `grep ExecStart= /lib/systemd/system/cockpit.service` \
                             > /etc/systemd/system/cockpit.service.d/notls.conf
                     systemctl daemon-reload
@@ -458,7 +458,8 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 301 Moved Permanently", output)
         self.assertIn("Location: https://172.27.0.15:9090/", output)
         # enable AllowUnencrypted, this disables redirect
-        m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nAllowUnencrypted=true" > /etc/cockpit/cockpit.conf')
+        m.execute("mkdir -p /etc/cockpit")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nAllowUnencrypted=true")
         m.restart_cockpit()
         # now it should not redirect
         self.assertIn("HTTP/1.1 200 OK", m.execute("curl --head http://127.0.0.1:9090"))
@@ -467,8 +468,8 @@ class TestConnection(MachineCase):
     @nondestructive
     def testConfigOrigins(self):
         m = self.machine
-        m.execute(
-            'mkdir -p /etc/cockpit/ && echo "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090" > /etc/cockpit/cockpit.conf')
+        m.execute("mkdir -p /etc/cockpit")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090")
         m.start_cockpit()
         headers = {
             'Connection': 'Upgrade',
@@ -577,8 +578,10 @@ class TestConnection(MachineCase):
 
         # Change port according to documentation: https://cockpit-project.org/guide/latest/listen.html
         m.execute('! selinuxenabled || semanage port -m -t websm_port_t -p tcp 443')
-        m.execute(
-            'mkdir -p /etc/systemd/system/cockpit.socket.d/ && printf "[Socket]\nListenStream=\nListenStream=/run/cockpit/sock\nListenStream=443" > /etc/systemd/system/cockpit.socket.d/listen.conf')
+        m.execute("""
+            mkdir -p /etc/systemd/system/cockpit.socket.d/
+            printf "[Socket]\nListenStream=\nListenStream=/run/cockpit/sock\nListenStream=443" > \
+                    /etc/systemd/system/cockpit.socket.d/listen.conf""")
 
         checkMotdContent('systemctl')
         checkMotdContent(':9090/', expected=False)
@@ -839,7 +842,7 @@ export XDG_CONFIG_DIRS=/usr/local
                     self.assertIn(a, out)
 
                 # should clean up processes
-                self.assertEqual(m.execute("! pgrep -a cockpit-ws && ! pgrep -a cockpit-bridge"), "")
+                self.assertEqual(m.execute("! pgrep -a cockpit-ws; ! pgrep -a cockpit-bridge"), "")
 
         # cockpit-desktop can start a privileged bridge through polkit
         # we don't have an agent, so just allow the privilege without interactive authentication

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -61,9 +61,9 @@ class TestXHRProxy(MachineCase):
 
         # set up served directory
         httpdir = self.vm_tmpdir + "/root"
-        m.execute("mkdir {0} && echo world > {0}/hello.txt".format(httpdir))
+        m.execute("mkdir {0}; echo world > {0}/hello.txt".format(httpdir))
         # start webserver
-        pid = m.spawn(f"cd {httpdir} && exec python3 -m http.server 12345", "httpserver")
+        pid = m.spawn(f"cd {httpdir}; exec python3 -m http.server 12345", "httpserver")
         self.addCleanup(m.execute, "kill %i" % pid)
         self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up
 
@@ -133,7 +133,7 @@ class TestLongRunning(MachineCase):
         self.assertEqual(m.execute("systemctl is-active cockpit-longrunning.service || true").strip(), "activating")
 
         # resume process
-        m.execute(f"mkdir -p {self.vm_tmpdir} && touch {ack_file}")
+        m.execute(f"mkdir -p {self.vm_tmpdir}; touch {ack_file}")
         b.wait_in_text("#output", "\nSTEP_B\n")
         # wait for completion
         b.wait_in_text("#output", "\nDONE\n")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -65,7 +65,7 @@ class TestKdump(KdumpHelpers):
         m = self.machine
 
         b.wait_timeout(120)
-        m.execute("systemctl enable kdump && systemctl start kdump || true")
+        m.execute("systemctl enable kdump; systemctl start kdump || true")
 
         self.login_and_go("/kdump")
 

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -254,7 +254,7 @@ class TestNetworkingBasic(NetworkCase):
             # remove the NM service file, test 'no-found' notification
             # This works for ND tests since there is a self.addCleanup(m.execute, "systemctl enable --now NetworkManager") in the start of the test
             self.restore_file('/usr/lib/systemd/system/NetworkManager.service')
-            m.execute("rm /usr/lib/systemd/system/NetworkManager.service && systemctl daemon-reload && systemctl stop NetworkManager")
+            m.execute("rm /usr/lib/systemd/system/NetworkManager.service; systemctl daemon-reload; systemctl stop NetworkManager")
             assert_not_found()
 
         self.allow_journal_messages(".*org.freedesktop.NetworkManager.*")

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -135,7 +135,7 @@ class TestBonding(NetworkCase):
         self.wait_for_iface(iface1)
         self.wait_for_iface(iface2)
 
-        m.execute("nmcli con mod TEST1 ipv4.method link-local && nmcli con up TEST1")
+        m.execute("nmcli con mod TEST1 ipv4.method link-local; nmcli con up TEST1")
         m.execute(f"nmcli dev dis {iface2}")
 
         b.wait_in_text(f"tr[data-interface='{iface1}'] td:nth-child(2)", "169.254.")
@@ -162,7 +162,7 @@ class TestBonding(NetworkCase):
 
         # Wait until the page is really ready by waiting for some ethernet interface
         # to show up in some row.
-        iface = m.execute("cd /sys/class/net && ls -d e* | head -n1").strip()
+        iface = m.execute("cd /sys/class/net; ls -d e* | head -n1").strip()
         b.wait_visible(f"tr[data-interface='{iface}']")
 
         # Make a simple bond without any members.  This is enough to

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -182,7 +182,7 @@ class TestFirewall(NetworkCase):
         self.assertNotIn('pop3', m.execute("firewall-cmd --list-services").split())
 
         # Test that service without name is shown properly
-        m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload && firewall-cmd --add-service=empty")
+        m.execute("firewall-cmd --permanent --new-service=empty; firewall-cmd --reload; firewall-cmd --add-service=empty")
         b.wait_visible(".zone-section[data-id='public'] tr[data-row-id='empty']")
 
         m.execute("firewall-cmd --add-port=9998/udp --add-port=9999/udp --add-port=6666/tcp")
@@ -275,7 +275,7 @@ class TestFirewall(NetworkCase):
         b.wait_visible(".zone-section[data-id='public'] tr[data-row-id='http']")
 
         # Service without name should appear in the dialog
-        m.execute("firewall-cmd --permanent --new-service=empty && firewall-cmd --reload")
+        m.execute("firewall-cmd --permanent --new-service=empty; firewall-cmd --reload")
         b.click(".zone-section[data-id='public'] .add-services-button")
         b.wait_visible(".pf-c-modal-box .service-list #firewall-service-empty")
         b.click("#add-services-dialog footer .btn-cancel")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -353,7 +353,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.enter_page("/updates")
 
         # old versions are still installed
-        m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
+        m.execute("test -f /stamp-vanilla-1.0-1; test -f /stamp-chocolate-2.0-1")
 
         # no update history yet
         self.assertFalse(b.is_present("table.updates-history"))
@@ -384,7 +384,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_not_present(".progress-main-view")
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
         self.assertFalse(b.is_present("table.updates-history"))
-        m.execute("test -f /stamp-vanilla-1.0-1 && test -f /stamp-chocolate-2.0-1")
+        m.execute("test -f /stamp-vanilla-1.0-1; test -f /stamp-chocolate-2.0-1")
 
         # update again; Cancel button should eventually disappear
         m.execute(f"umount {chocolate}")
@@ -415,7 +415,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.wait_not_present("#available-updates")
 
         # new versions are now installed
-        m.execute("test -f /stamp-vanilla-1.0-2 && test -f /stamp-chocolate-2.0-2")
+        m.execute("test -f /stamp-vanilla-1.0-2; test -f /stamp-chocolate-2.0-2")
 
         # history shows the two packages, expanded by default
         b.wait_text("table.updates-history tbody.pf-m-expanded td.history-pkgcount", "2 packages")
@@ -817,9 +817,9 @@ ExecStart=/usr/local/bin/{packageName}
         m.execute("systemctl stop packagekit; systemctl reset-failed packagekit || true")
 
         # new security versions are now installed
-        m.execute("test -f /stamp-secdeclare-3-4.b1 && test -f /stamp-secparse-4-2 && test -f /stamp-sevcritical-5-2")
+        m.execute("test -f /stamp-secdeclare-3-4.b1; test -f /stamp-secparse-4-2; test -f /stamp-sevcritical-5-2")
         # but the three others are untouched
-        m.execute("test -f /stamp-buggy-2-1 && test -f /stamp-norefs-bin-1-1 && test -f /stamp-norefs-doc-1-1")
+        m.execute("test -f /stamp-buggy-2-1; test -f /stamp-norefs-bin-1-1; test -f /stamp-norefs-doc-1-1")
 
         # should now only have one button (no security updates left)
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
@@ -857,7 +857,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.click("#ignore")
 
         # new versions are now installed
-        m.execute("test -f /stamp-norefs-bin-2-1 && test -f /stamp-norefs-doc-2-1")
+        m.execute("test -f /stamp-norefs-bin-2-1; test -f /stamp-norefs-doc-2-1")
 
         # no further updates
         b.wait_in_text("#status", "System is up to date")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -97,11 +97,11 @@ OnCalendar=daily
 
         # On Debian and Ubuntu we have to generate the other locales
         if "debian" in m.image:
-            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen && update-locale")
+            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen; locale-gen; update-locale")
         elif "arch" == m.image:
-            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen && locale-gen")
+            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen; locale-gen")
         elif "ubuntu" in m.image:
-            m.execute("locale-gen de_DE && locale-gen de_DE.UTF-8 && update-locale")
+            m.execute("locale-gen de_DE; locale-gen de_DE.UTF-8; update-locale")
 
         # login so that we have a cookie.
         self.login_and_go("/system/services#/test.service")
@@ -312,11 +312,11 @@ OnCalendar=daily
         m.execute('echo scruffy:foobar | chpasswd')
 
         if "debian" in m.image:
-            m.execute('echo \'pt_BR.UTF-8 UTF-8\' >> /etc/locale.gen && locale-gen && update-locale')
+            m.execute('echo \'pt_BR.UTF-8 UTF-8\' >> /etc/locale.gen; locale-gen; update-locale')
         elif "ubuntu" in m.image:
-            m.execute('locale-gen pt_BR && locale-gen pt_BR.UTF-8 && update-locale')
+            m.execute('locale-gen pt_BR; locale-gen pt_BR.UTF-8; update-locale')
         elif "arch" == m.image:
-            m.execute('echo \'pt_BR.UTF-8 UTF-8\' >> /etc/locale.gen && locale-gen')
+            m.execute('echo \'pt_BR.UTF-8 UTF-8\' >> /etc/locale.gen; locale-gen')
 
         self.login_and_go('/system')
         b.wait_visible('#overview')

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -271,7 +271,7 @@ class TestSelinux(MachineCase):
         b.wait_in_text(".xterm-accessibility-tree", "boolean -m -0 zebra_write_config")
         b.wait_in_text(".xterm-accessibility-tree", "fcontext -a -f a -t samba_share_t -r 's0' '/var/tmp/'")
 
-        m.execute("semanage boolean -D && semanage fcontext -D && semanage module -D")
+        m.execute("semanage boolean -D; semanage fcontext -D; semanage module -D")
         b.go("/selinux/setroubleshoot")
         b.enter_page("/selinux/setroubleshoot")
         b.reload()

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -129,7 +129,7 @@ class TestKeys(MachineCase):
         self.assertIn("other::---", perms)
 
         # Add invalid key directly
-        m.execute("(echo '' && echo 'bad') >> /home/user/.ssh/authorized_keys")
+        m.write("/home/user/.ssh/authorized_keys", "\nbad\n", append=True)
         b.wait_in_text("#account-authorized-keys-list li.pf-c-data-list__item:last-child", "Invalid key")
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list li.pf-c-data-list__item", 2)
 

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -33,7 +33,7 @@ class TestMenu(MachineCase):
         m = self.machine
 
         # Add a link with a hash in it to test that this works
-        m.execute("mkdir -p /usr/local/share/cockpit/systemd && cp -rp /usr/share/cockpit/systemd/* /usr/local/share/cockpit/systemd")
+        m.execute("mkdir -p /usr/local/share/cockpit/systemd; cp -rp /usr/share/cockpit/systemd/* /usr/local/share/cockpit/systemd")
         m.execute(
             """sed -i '/"menu"/a "memory": { "label": "Memory", "path": "#/memory" },' /usr/local/share/cockpit/systemd/manifest.json""")
         self.addCleanup(m.execute, "rm -r /usr/local/share/cockpit")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -390,7 +390,8 @@ class TestMultiMachine(MachineCase):
 
         hostname_selector = "#system_information_hostname_text"
 
-        m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot = cockpit-new" > /etc/cockpit/cockpit.conf')
+        m.execute("mkdir -p /etc/cockpit/")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nUrlRoot = cockpit-new")
         m.start_cockpit()
 
         # Make sure normal urls don't work.
@@ -434,7 +435,8 @@ class TestMultiMachine(MachineCase):
         b = self.browser
         m = self.machine
 
-        m.execute('mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot = cockpit-new" > /etc/cockpit/cockpit.conf')
+        m.execute("mkdir -p /etc/cockpit/")
+        m.write("/etc/cockpit/cockpit.conf", "[WebService]\nUrlRoot = cockpit-new")
         m.start_cockpit()
 
         b.open("/cockpit-new/system?access_token=XXXX")
@@ -796,7 +798,7 @@ class TestMultiMachine(MachineCase):
             b.wait_not_present('#hosts_setup_server_dialog')
 
         b.enter_page("/system", host="fred@10.111.113.2")
-        m1.execute("test -f /home/admin/.ssh/id_rsa && test -f /home/admin/.ssh/id_rsa.pub")
+        m1.execute("test -f /home/admin/.ssh/id_rsa; test -f /home/admin/.ssh/id_rsa.pub")
         self.assertEqual(m1.execute("cat /home/admin/.ssh/id_rsa.pub"),
                          m2.execute("cat /home/fred/.ssh/authorized_keys"))
 

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -48,7 +48,8 @@ only-plugins=release,date,host,cgroups,networking
 """)
 
         if urlroot != "":
-            m.execute(f'mkdir -p /etc/cockpit/ && echo "[WebService]\nUrlRoot={urlroot}" > /etc/cockpit/cockpit.conf')
+            m.execute("mkdir -p /etc/cockpit/")
+            m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         self.login_and_go("/sosreport", urlroot=urlroot, superuser=False)
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -727,7 +727,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         else:
             self.restore_dir("/etc/sssd", post_restore_action="systemctl try-restart sssd")
 
-        m.execute("useradd alice && echo alice:foobar123 | chpasswd")
+        m.execute("useradd alice; echo alice:foobar123 | chpasswd")
         m.upload(["alice.pem", "alice.key", "alice-expired.pem", "bob.pem", "bob.key"], self.vm_tmpdir,
                  relative_dir="src/tls/ca/")
         alice_cert = self.vm_tmpdir + "/alice.pem"
@@ -874,7 +874,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # sssd-dbus not available
         self.allow_journal_messages("cockpit-session: Failed to map .* Could not activate remote peer.*")
         self.allow_journal_messages("cockpit-session: Failed to map .* Unit sssd-ifp.service is masked.")
-        m.execute("systemctl mask sssd-ifp && systemctl stop sssd-ifp")
+        m.execute("systemctl mask sssd-ifp; systemctl stop sssd-ifp")
         do_test(alice_cert_key, ["HTTP/1.1 401 Authentication failed", '<h1>Authentication failed</h1>'],
                 not_expected=["crsf-token"])
         m.execute("systemctl unmask sssd-ifp")

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -32,7 +32,7 @@ class TestStorageISCSI(StorageCase):
         b.wait_timeout(120)
 
         # ensure that we generate a /etc/iscsi/initiatorname.iscsi
-        m.execute("systemctl start iscsid && systemctl stop iscsid")
+        m.execute("systemctl start iscsid; systemctl stop iscsid")
 
         target_iqn = "iqn.2015-09.cockpit.lan"
         initiator_iqn = "iqn.2015-10.cockpit.lan"

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -156,7 +156,7 @@ class TestStorageMdRaid(StorageCase):
 
         # Degrade and repair it
 
-        m.execute(f"mdadm --quiet {dev} --fail /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 && udevadm trigger")
+        m.execute(f"mdadm --quiet {dev} --fail /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1; udevadm trigger")
         wait_degraded_state(True)
 
         self.wait_states({"QEMU QEMU HARDDISK (DISK1)": "Failed"})

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -186,14 +186,14 @@ ExecStart=/usr/bin/sleep infinity
         # Move mount point externally, move back with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute("mkdir -p /run/bar && mount /dev/sda /run/bar")
+        m.execute("mkdir -p /run/bar; mount /dev/sda /run/bar")
         b.click(fsys_tab + " button:contains(Mount on /run/foo now)")
         b.wait_not_present(fsys_tab + " button:contains(Mount on /run/foo now)")
 
         # Move mount point externally, adjust fstab with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute("mkdir -p /run/bar && mount /dev/sda /run/bar")
+        m.execute("mkdir -p /run/bar; mount /dev/sda /run/bar")
         b.click(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
 
@@ -291,7 +291,7 @@ ExecStart=/usr/bin/sleep infinity
         # Quickly make two logical volumes
         m.add_disk("50M", serial="MYDISK")
         b.wait_in_text("#drives", "MYDISK")
-        m.execute("vgcreate test /dev/sda && lvcreate test -n one -L 20M && lvcreate test -n two -L 20M")
+        m.execute("vgcreate test /dev/sda; lvcreate test -n one -L 20M; lvcreate test -n two -L 20M")
         b.click('#devices .sidepanel-row:contains("test")')
         b.wait_visible("#storage-detail")
         self.content_row_wait_in_col(1, 1, "one")

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -339,13 +339,13 @@ class TestStoragePackagesNFS(PackageCase, StorageCase, StorageHelpers):
         # machinery and distribute the fluids evenly.
         #
         if "debian" in m.image or "ubuntu" in m.image:
-            m.execute("pkcon refresh && pkcon install -y dummy")
+            m.execute("pkcon refresh; pkcon install -y dummy")
 
         # HACK
         # Packagekit on Arch Linux does not deal well with detecting new repositories
         if m.image == "arch":
             m.execute("systemctl restart packagekit")
-            m.execute("pkcon refresh force && pkcon install -y dummy")
+            m.execute("pkcon refresh force; pkcon install -y dummy")
 
         b.reload()
         b.enter_page("/storage")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -308,7 +308,7 @@ class TestStorageStratis(StorageCase):
         b.wait_in_text("#detail-content", "fsys2")
 
         # Mount externally, adjust fstab with Cockpit
-        m.execute("mkdir /run/fsys1 && mount /dev/stratis/TEST1/fsys1 /run/fsys1")
+        m.execute("mkdir /run/fsys1; mount /dev/stratis/TEST1/fsys1 /run/fsys1")
         fsys_tab = self.content_tab_expand(1, 1)
         b.click(fsys_tab + " button:contains(Mount automatically on /run/fsys1 on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Mount automatically on /run/fsys1 on boot)")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -189,7 +189,7 @@ class TestStorageLegacyVDO(StorageCase):
         # Make a logical volume for use as the backing device.
         m.add_disk(SIZE_10G, serial="DISK1")
         b.wait_in_text("#drives", "DISK1")
-        m.execute("vgcreate vdo_vgroup /dev/sda && lvcreate -n lvol -L 5G vdo_vgroup")
+        m.execute("vgcreate vdo_vgroup /dev/sda; lvcreate -n lvol -L 5G vdo_vgroup")
         # Create VDO; this is not supported any more, thus no UI for it
         m.execute("vdo create --device /dev/vdo_vgroup/lvol --name vdo0 --vdoLogicalSize 5G")
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -81,7 +81,7 @@ class TestSystemInfo(MachineCase):
         #
         m.execute("rm /etc/os-release")
         m.write("/etc/os-release", os_release)
-        m.execute("chattr +i /etc/os-release && (systemctl restart systemd-hostnamed || systemctl restart hostnamed)")
+        m.execute("chattr +i /etc/os-release; (systemctl restart systemd-hostnamed || systemctl restart hostnamed)")
 
         self.login_and_go("/system")
 
@@ -172,7 +172,7 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text('#system_information_hostname_text', 'mydhcpname')
 
         b.logout()
-        m.execute("chattr -i /etc/os-release && rm /etc/os-release")
+        m.execute("chattr -i /etc/os-release; rm /etc/os-release")
         m.execute("rm /usr/lib/os-release || true")
 
         self.login_and_go("/system")
@@ -605,7 +605,7 @@ machine         : 8561
             if cmdline:
                 m.write('/run/cmdline', cmdline)
                 m.execute('if selinuxenabled 2>/dev/null; then chcon --reference /proc/cmdline /run/cmdline; fi')
-                m.execute('mount --bind /run/cmdline /proc/cmdline && rm /run/cmdline')
+                m.execute('mount --bind /run/cmdline /proc/cmdline; rm /run/cmdline')
 
             try:
                 b.login_and_go('/system/hwinfo')
@@ -705,7 +705,7 @@ fi
 
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
-        m.execute("/tmp/kernelopt.sh remove nosmt && /tmp/kernelopt.sh set mitigations=auto,nosmt")
+        m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
         m.reboot()
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -1160,7 +1160,7 @@ class TestPackageInstall(packagelib.PackageCase):
         m.execute("dpkg --purge realmd 2>/dev/null || rpm --erase realmd || yum remove -y realmd")
 
         # case 1: disable PackageKit
-        m.execute("systemctl mask packagekit && systemctl stop packagekit.service || true")
+        m.execute("systemctl mask packagekit; systemctl stop packagekit.service || true")
         self.login_and_go("/system")
         b.wait_text(self.domain_sel, "Join domain")
         b.wait_visible(self.domain_sel + "[disabled]")
@@ -1208,7 +1208,7 @@ class TestPackageInstall(packagelib.PackageCase):
 
         # disable the realmd package's service, so that we can restore it, but
         # the package install code path will be triggered
-        m.execute("systemctl stop realmd && systemctl mask realmd")
+        m.execute("systemctl stop realmd; systemctl mask realmd")
 
         self.login_and_go("/system")
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -38,8 +38,8 @@ class TestServices(MachineCase):
         # We manipulate with `/etc/systemd/system` so `daemon-reload` to keep it in proper state
         # Also `reset-failed` as failed units can be still listed with `systemctl` even when all files
         # were removed and daemon reloaded.
-        self.restore_dir("/etc/systemd/system", "systemctl daemon-reload && systemctl reset-failed", True)
-        user_post_restore = "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload && systemctl --user reset-failed'"
+        self.restore_dir("/etc/systemd/system", "systemctl daemon-reload; systemctl reset-failed", True)
+        user_post_restore = "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload; systemctl --user reset-failed'"
         self.restore_dir("/etc/systemd/user", user_post_restore, True)
         self.restore_dir("/etc/xdg/systemd/user", user_post_restore, True)
 

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -229,12 +229,12 @@ class TestTestlib(MachineCase):
         m.execute("echo data > /var/lib/cockpittest.txt")
 
         # existing dir
-        m.execute("mkdir -p /var/lib/existing_dir && echo hello > /var/lib/existing_dir/original")
+        m.execute("mkdir -p /var/lib/existing_dir; echo hello > /var/lib/existing_dir/original")
         self.restore_dir("/var/lib/existing_dir")
-        m.execute("rm /var/lib/existing_dir/original && echo pwned > /var/lib/existing_dir/new")
+        m.execute("rm /var/lib/existing_dir/original; echo pwned > /var/lib/existing_dir/new")
         # nonexisting dir
         self.restore_dir("/var/lib/cockpittestnew")
-        m.execute("mkdir -p /var/lib/cockpittestnew && echo hello > /var/lib/cockpittestnew/cruft")
+        m.execute("mkdir -p /var/lib/cockpittestnew; echo hello > /var/lib/cockpittestnew/cruft")
 
         # NSS is backed up by default
         m.execute("useradd cockpittest")

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -204,7 +204,7 @@ class TestWsBastionContainer(MachineCase):
         # authorize key
         p = "/home/admin/.ssh/authorized_keys.d/bastion"
         self.restore_dir(os.path.dirname(p))
-        m.execute(f"cp /root/id_bastion.pub {p} && chown admin:admin {p} && chmod 600 {p}")
+        m.execute(f"cp /root/id_bastion.pub {p}; chown admin:admin {p}; chmod 600 {p}")
 
         # fails with wrong key password
         b.set_val("#login-password-input", "notthispassword")
@@ -219,7 +219,7 @@ class TestWsBastionContainer(MachineCase):
 
         # now test with current OpenSSH format
         m.execute(f"yes | ssh-keygen -q -f /root/id_bastion -t rsa -N {KEY_PASSWORD}")
-        m.execute(f"cp /root/id_bastion.pub {p} && chown admin:admin {p} && chmod 600 {p}")
+        m.execute(f"cp /root/id_bastion.pub {p}; chown admin:admin {p}; chmod 600 {p}")
         b.set_val("#login-user-input", "admin")
         b.set_val("#server-field", HOST)
         b.set_val("#login-password-input", KEY_PASSWORD)


### PR DESCRIPTION
Most of the `a && b` constructs were wrong for our intent, as it will
silently succeed if `a` fails, and never run `b`. This can often cause
follow-up failures which are harder to investigate.

This was solved in in https://github.com/cockpit-project/bots/pull/3706
by running all Machine.execute() commands with `set -e`.

Replace `&&` with `;` where appropriate. There are still four places in
opportunistic cleanup commands which currently use `&&` in a broken way;
but keep them until we can get an agreement how to fix them.

Use Machine.write() to write files, instead of echo commands.

Drop the now redundant `set -e` from check-connection.

---

Similar to https://github.com/cockpit-project/cockpit-machines/pull/793 and https://github.com/cockpit-project/cockpit-podman/pull/1069