### PR TITLE
git: add git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,1 @@
+c33285c2cad23636c5a8a86d63609f9bf7462b0e # stylelint indentation


### PR DESCRIPTION
Since Git 2.37.2 there is a new option in Git to configure revisions to
be ignored by git blame. This can be used to ignore re-styling commits
automatically by setting a git config option:

git config --global blame.ignoreRevsFile .git-blame-ignore-revs

As example I added the stylelint re-indentation commit, the configuration file name comes from https://www.michaelheap.com/git-ignore-rev/