### PR TITLE
test: rawhide is now Fedora-38

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -28,7 +28,7 @@ fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"
 # HACK: upstream does not yet know about rawhide
-if [ "$TEST_OS" = "fedora-37" ]; then
+if [ "$TEST_OS" = "fedora-38" ]; then
     export TEST_OS=fedora-36
 fi
 


### PR DESCRIPTION
Fedora-37 has been branched off
https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/message/OLJ7BBFJEW4SDNQ2J2VTT5R4K6UV4ZQO/

Noticed this by looking at my PR and noticing that rawhide executes kpatch tests which it should not as Fedora does not have kpatch.

https://artifacts.dev.testing-farm.io/7f66bfc0-e1e4-4930-b6bb-6198dbebe35a/