### PR TITLE
networkmanager: show Wireguard device type

### DIFF
--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -180,6 +180,8 @@ export const NetworkInterfacePage = ({
                 desc = _("VLAN");
             } else if (dev.DeviceType == 'bridge') {
                 desc = _("Bridge");
+            } else if (dev.Driver == 'wireguard') {
+                desc = "WireGuard";
             } else
                 desc = cockpit.format(_("Unknown \"$0\""), dev.DeviceType);
         } else if (iface) {
@@ -192,6 +194,8 @@ export const NetworkInterfacePage = ({
                 desc = _("VLAN");
             else if (cs.type == "bridge")
                 desc = _("Bridge");
+            else if (cs.type == "wireguard")
+                desc = "WireGuard";
             else if (cs.type)
                 desc = cockpit.format(_("Unknown \"$0\""), cs.type);
             else


### PR DESCRIPTION
Interestingly networkmanager's dbus API does not set a DeviceType for a
WireGuard device but sets the Driver property.

Know it shows like:

![image](https://user-images.githubusercontent.com/67428/184659505-97ff21ca-5de1-4389-b9e9-4ef1bd2f9228.png)
