### PR TITLE
storage: Use mock values during some pixel tests

### DIFF
--- a/pkg/lib/hooks.js
+++ b/pkg/lib/hooks.js
@@ -44,6 +44,8 @@ import deep_equal from "deep-equal";
  * - useDeepEqualMemo: A utility hook that can help with things that
  * need deep equal comparisons in places where React only offers
  * Object identity comparisons, such as with useEffect.
+ *
+ * - useMock: For retrieving values injected during testing.
  */
 
 /* - usePageLocation()
@@ -325,4 +327,32 @@ export function useEvent(obj, event, handler) {
 
 export function useInit(func, deps, comps, destroy = null) {
     return useObject(func, destroy, deps || [], comps);
+}
+
+/* - useMock()
+ *
+ * function Component() {
+ *   const mock = useMock();
+ *   const now = Date.now();
+ *
+ *   return <div id="date">{mock?.date ?? now.toString()}</div>;
+ * }
+ *
+ * In the test:
+ *
+ *   b.assert_pixels('#date', mock={'date': "12. January"})
+ *
+ * Normally, "useMock()" will return undefined or null, but a test can
+ * cause it to return some other arbitrary value temporarily.  This is
+ * mostly useful for producing a stable layout for a pixel test.
+ *
+ * The value returned by useMock is typically a object with a few
+ * members. You don't need to worry about the member names; it is
+ * usually not a problem when two unrelated pieces of code happen to
+ * use the same names (like "date" in the example above).
+ */
+
+export function useMock() {
+    useEvent(window, "test_mock_changed");
+    return window.test_mock;
 }

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -240,6 +240,8 @@ import { ListingTable } from "cockpit-components-table.jsx";
 
 import { fmt_size, block_name, format_size_and_text, format_delay, for_each_async } from "./utils.js";
 import { fmt_to_fragments } from "utils.jsx";
+import { useMock } from "hooks.js";
+
 import client from "./client.js";
 
 const _ = cockpit.gettext;
@@ -1068,6 +1070,7 @@ export const BlockingMessage = (usage) => {
 };
 
 const UsersPopover = ({ users }) => {
+    const mock = useMock()?.busy;
     const max = 10;
     const services = users.filter(u => u.unit);
     const processes = users.filter(u => u.pid);
@@ -1094,7 +1097,7 @@ const UsersPopover = ({ users }) => {
                         ? <p>
                             <b>{_("Processes using the location")}</b>
                             <List>
-                                { processes.slice(0, max).map((u, i) => <ListItem key={i}>{u.comm} (user: {u.user}, pid: {u.pid})</ListItem>) }
+                                { processes.slice(0, max).map((u, i) => <ListItem key={i}>{u.comm} (user: {u.user}, pid: {mock?.pid ?? u.pid})</ListItem>) }
                                 { processes.length > max ? <ListItem key={max}>...</ListItem> : null }
                             </List>
                         </p>
@@ -1175,13 +1178,15 @@ export function init_active_usage_processes(client, usage) {
 }
 
 export const StopProcessesMessage = ({ mount_point, users }) => {
+    const mock = useMock()?.busy;
+
     const process_rows = users.filter(u => u.pid).map(u => {
         return {
             columns: [
-                u.pid,
+                mock?.pid ?? u.pid,
                 { title: u.cmd.substr(0, 100), props: { modifier: "breakWord" } },
                 u.user || "-",
-                { title: format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
+                { title: mock?.since ?? format_delay(-u.since * 1000), props: { modifier: "nowrap" } }
             ]
         };
     });

--- a/pkg/storaged/part-tab.jsx
+++ b/pkg/storaged/part-tab.jsx
@@ -22,35 +22,35 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
+import { useMock } from "hooks.js";
 
 const _ = cockpit.gettext;
 
-export class PartitionTab extends React.Component {
-    render() {
-        const block_part = this.props.client.blocks_part[this.props.block.path];
+export const PartitionTab = ({ client, block }) => {
+    const mock_UUID = useMock()?.part_UUID;
+    const block_part = client.blocks_part[block.path];
 
-        return (
-            <DescriptionList className="pf-m-horizontal-on-sm">
-                <DescriptionListGroup>
-                    <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
-                    <DescriptionListDescription>{block_part.Name || "-"}</DescriptionListDescription>
-                </DescriptionListGroup>
+    return (
+        <DescriptionList className="pf-m-horizontal-on-sm">
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
+                <DescriptionListDescription>{block_part.Name || "-"}</DescriptionListDescription>
+            </DescriptionListGroup>
 
-                <DescriptionListGroup>
-                    <DescriptionListTerm>{_("Size")}</DescriptionListTerm>
-                    <DescriptionListDescription>{utils.fmt_size(block_part.Size)}</DescriptionListDescription>
-                </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Size")}</DescriptionListTerm>
+                <DescriptionListDescription>{utils.fmt_size(block_part.Size)}</DescriptionListDescription>
+            </DescriptionListGroup>
 
-                <DescriptionListGroup>
-                    <DescriptionListTerm>{_("UUID")}</DescriptionListTerm>
-                    <DescriptionListDescription>{block_part.UUID}</DescriptionListDescription>
-                </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("UUID")}</DescriptionListTerm>
+                <DescriptionListDescription>{mock_UUID ?? block_part.UUID}</DescriptionListDescription>
+            </DescriptionListGroup>
 
-                <DescriptionListGroup>
-                    <DescriptionListTerm>{_("Type")}</DescriptionListTerm>
-                    <DescriptionListDescription>{block_part.Type}</DescriptionListDescription>
-                </DescriptionListGroup>
-            </DescriptionList>
-        );
-    }
-}
+            <DescriptionListGroup>
+                <DescriptionListTerm>{_("Type")}</DescriptionListTerm>
+                <DescriptionListDescription>{block_part.Type}</DescriptionListDescription>
+            </DescriptionListGroup>
+        </DescriptionList>
+    );
+};

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -315,3 +315,8 @@ function ph_element_clip(sel) {
 function ph_count_animations(sel) {
     return ph_find(sel).getAnimations({ subtree: true }).length;
 }
+
+function ph_set_test_mock(config) {
+    window.test_mock = config;
+    window.dispatchEvent(new Event("test_mock_changed"));
+}

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -551,6 +551,9 @@ class Browser:
 
         self.wait_val("{0} > div input[type=text]".format(group_identifier), location)
 
+    def set_test_mock(self, config):
+        self.call_js_func("ph_set_test_mock", config)
+
     def wait_timeout(self, timeout: int):
         browser = self
 
@@ -1022,12 +1025,16 @@ class Browser:
 
     def assert_pixels_in_current_layout(self, selector: str, key: str,
                                         ignore: List[str] = [],
+                                        mock=None,
                                         scroll_into_view: Optional[str] = None,
                                         wait_animations: bool = True):
         """Compare the given element with its reference in the current layout"""
 
         if not (Image and self.pixels_label):
             return
+
+        if mock:
+            self.set_test_mock(mock)
 
         self._adjust_window_for_fixed_content_size()
         self.call_js_func('ph_scrollIntoViewIfNeeded', scroll_into_view or selector)
@@ -1070,6 +1077,7 @@ class Browser:
             raise SystemError("Pixel test references are missing, please run: test/common/pixel-tests pull")
 
         ignore_rects = relative_clips(list(map(lambda item: selector + " " + item, ignore)))
+
         base = self.pixels_label + "-" + key
         if self.current_layout != self.layouts[0]:
             base += "-" + self.current_layout["name"]
@@ -1162,8 +1170,12 @@ class Browser:
                 print("Differences in pixel test " + base)
                 self.failed_pixel_tests += 1
 
+        if mock:
+            self.set_test_mock(None)
+
     def assert_pixels(self, selector: str, key: str,
                       ignore: List[str] = [],
+                      mock=None,
                       skip_layouts: List[str] = [],
                       scroll_into_view: Optional[str] = None,
                       wait_animations: bool = True,
@@ -1181,7 +1193,8 @@ class Browser:
                     time.sleep(wait_delay)
                     if "rtl" in self.current_layout["name"]:
                         self._set_direction("rtl")
-                    self.assert_pixels_in_current_layout(selector, key, ignore=ignore,
+                    self.assert_pixels_in_current_layout(selector, key,
+                                                         ignore=ignore, mock=mock,
                                                          scroll_into_view=scroll_into_view,
                                                          wait_animations=wait_animations)
 

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -61,12 +61,7 @@ class TestStorageBasic(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext2 filesystem")
 
         self.content_tab_expand(1, 1)
-        b.assert_pixels("#detail-content", "partition", ignore=[
-            # UUID is not stable
-            "dt:contains(UUID) + dd",
-            # browsers/harfbuzz don't render "ext2 filesystem" label reliably
-            "td[data-label='Type']",
-        ])
+        b.assert_pixels("#detail-content", "partition", mock={'part_UUID': "1234"})
         self.content_tab_expand(1, 2)
         b.assert_pixels("#detail-content", "filesystem")
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -100,7 +100,7 @@ class TestStorageLuks(StorageCase):
         self.content_tab_wait_in_info(1, 3, "Stored passphrase", f"Last modified: {date_no_mins}:")
 
         tab = self.content_tab_expand(1, 3)
-        b.assert_pixels(tab, "tab", ignore=["dt:contains(Stored passphrase) + dd",
+        b.assert_pixels(tab, "tab", ignore=["dt:contains(Stored passphrase) + dd", # contains date
                                             "dt:contains(Cleartext device) + dd"])
 
         # Unmount. This locks it

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -77,6 +77,7 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_in_text("#dialog", "Test Service")
         b.wait_in_text("#dialog", "/usr/bin/sleep infinity")
         b.wait_in_text("#dialog", "The listed processes and services will be forcefully stopped.")
+        b.assert_pixels("#dialog", "busy-unmount", mock={'busy': {'pid': 1234, 'since': "since 1m"}})
         self.confirm()
         self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -278,6 +278,7 @@ class TestStorageNfs(StorageCase):
         b.wait_in_text("#dialog", "sleep infinity")
         b.wait_in_text("#dialog", "The listed processes will be forcefully stopped.")
         b.wait_in_text("#dialog", "Stop and unmount")
+        b.assert_pixels("#dialog", "umount", mock={'busy': {'pid': 1234, 'since': "since 1m"}})
         self.dialog_apply()
         self.dialog_wait_close()
 

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -68,7 +68,7 @@ ExecStart=/usr/bin/sleep infinity
         b.click("#dialog button:contains(Currently in use)")
         b.wait_in_text(".pf-c-popover", str(sleep_pid))
         b.wait_in_text(".pf-c-popover", "keep-mnt-busy")
-        b.assert_pixels(".pf-c-popover", "popover", ignore=["li"],
+        b.assert_pixels(".pf-c-popover", "popover", mock={"busy": {"pid": 1234 }},
                         scroll_into_view="#dialog button:contains(Currently in use)")
         b.click(".pf-c-popover button")
         b.assert_pixels('#dialog', "format")


### PR DESCRIPTION
Instead of ignoring parts of the DOM that are unpredictable, we
replace them with some constant non-sense.  This gets rid of the
unpredictable content and also produces a predictable layout by
avoiding variable sized content.