### PR TITLE
test: drop script= kwarg to Machine.execute()

### DIFF
--- a/test/avocado/run-tests
+++ b/test/avocado/run-tests
@@ -113,7 +113,7 @@ def run_avocado_tests(machine, avocado_tests, print_failed=True, env={}, timeout
 
     # HACK override env for LC_ALL to utf, python3 avocado fails with LANG set to C
     try:
-        machine.execute(script=" ".join(cmd_parts), timeout=timeout, environment=env)
+        machine.execute(" ".join(cmd_parts), timeout=timeout, environment=env)
     except subprocess.CalledProcessError:
         if print_failed:
             # try to get the list of failed tests
@@ -164,13 +164,13 @@ def copy_avocado_logs(machine, title):
 
 
 def wait_for_selenium_running(machine, host, port=4444):
-    WAIT_SELENIUM_RUNNING = """#!/bin/sh
+    WAIT_SELENIUM_RUNNING = """
 until curl -s --connect-timeout 3 http://%s:%d >/dev/null; do
 sleep 0.5;
 done;
 """ % (host, port)
     with testvm.Timeout(seconds=300, error_message="Timeout while waiting for selenium to start"):
-        machine.execute(script=WAIT_SELENIUM_RUNNING)
+        machine.execute(WAIT_SELENIUM_RUNNING)
 
 
 def prepare_machines_test_env(avocado_tests, machine):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -27,7 +27,7 @@ from testlib import *
 
 
 WAIT_SCRIPT = """
-set -ex
+set -x
 for x in $(seq 1 200); do
     if curl --insecure -s https://%(addr)s:8443/candlepin; then
         break
@@ -683,7 +683,7 @@ class TestUpdatesSubscriptions(PackageCase):
         m.execute("sed -i -e 's/insecure = 0/insecure = 1/g' /etc/rhsm/rhsm.conf")
 
         # Wait for the web service to be accessible
-        m.execute(script=WAIT_SCRIPT % {"addr": "10.111.112.100"})
+        m.execute(WAIT_SCRIPT % {"addr": "10.111.112.100"})
 
     def testNoUpdates(self):
         m = self.machine

--- a/test/verify/check-realms
+++ b/test/verify/check-realms
@@ -28,7 +28,7 @@ from testlib import *
 
 
 WAIT_KRB_SCRIPT = """
-set -ex
+set -x
 # HACK: This needs to work, but may take a minute
 for x in $(seq 1 60); do
     if getent passwd {0}; then
@@ -135,7 +135,7 @@ class TestRealms(MachineCase):
 
         # validate Kerberos setup for ws
         m.execute("echo foobarfoo | kinit -f admin@COCKPIT.LAN")
-        m.execute(script=WAIT_KRB_SCRIPT.format("admin@cockpit.lan"), timeout=300)
+        m.execute(WAIT_KRB_SCRIPT.format("admin@cockpit.lan"), timeout=300)
 
         # should have added SPN to ws keytab
         output = m.execute(['klist', '-k', '/etc/cockpit/krb5.keytab'])
@@ -461,8 +461,8 @@ class TestKerberos(MachineCase):
         if "ubuntu" in self.machine.image:
             # no nss-myhostname there
             self.machine.execute("echo '10.111.113.1 x0.cockpit.lan' >> /etc/hosts")
-        self.machine.execute(script=JOIN_SCRIPT % args, timeout=1800)
-        self.machine.execute(script=WAIT_KRB_SCRIPT.format("admin"), timeout=300)
+        self.machine.execute(JOIN_SCRIPT % args, timeout=1800)
+        self.machine.execute(WAIT_KRB_SCRIPT.format("admin"), timeout=300)
 
     def testNegotiate(self):
         self.allow_authorize_journal_messages()

--- a/test/verify/check-setroubleshoot
+++ b/test/verify/check-setroubleshoot
@@ -23,7 +23,6 @@ from testlib import *
 
 
 FIX_AUDITD = """
-set -e
 mkdir -p /var/log/audit
 touch /var/log/audit.log
 restorecon -r /var/log/audit
@@ -31,7 +30,6 @@ systemctl start auditd
 """
 
 SELINUX_ALERT_SCRIPT = """
-set -e
 mkdir -p ~/selinux_temp
 cd ~/selinux_temp
 cp /bin/ls ls
@@ -41,7 +39,6 @@ runcon -u system_u -r system_r -t httpd_t -- ./ls  /home/* || true
 """
 
 SELINUX_FIXABLE_ALERT_SCRIPT = """
-set -e
 mkdir -p ~/.ssh
 ssh-keygen -t rsa -f ~/.ssh/test-avc-rsa -N ""
 mv -f ~/.ssh/authorized_keys ~/.ssh/authorized_keys.test-avc
@@ -68,11 +65,11 @@ class TestSelinux(MachineCase):
         b.wait_in_text("body", "No SELinux alerts.")
 
         # fix audit events first
-        self.machine.execute(script=FIX_AUDITD)
+        self.machine.execute(FIX_AUDITD)
 
         #########################################################
         # trigger an alert
-        self.machine.execute(script=SELINUX_ALERT_SCRIPT)
+        self.machine.execute(SELINUX_ALERT_SCRIPT)
 
         row_selector = "tbody:contains('ls from read access on the directory')"
 
@@ -117,7 +114,7 @@ class TestSelinux(MachineCase):
 
         #########################################################
         # trigger a fixable alert
-        self.machine.execute(script=SELINUX_FIXABLE_ALERT_SCRIPT)
+        self.machine.execute(SELINUX_FIXABLE_ALERT_SCRIPT)
 
         row_selector = "tbody:contains('read access on the file /root/.ssh/authorized_keys')"
 

--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -52,7 +52,7 @@ from testlib import *
 # in order to get the right ids for the activation key and pool, see ACTIVATION_KEY_COMMAND and POOL_COMMAND
 
 WAIT_SCRIPT = """
-set -ex
+set -x
 for x in $(seq 1 200); do
     if curl -s https://%(addr)s:8443/candlepin; then
         break
@@ -109,7 +109,7 @@ class SubscriptionsCase(MachineCase):
 
         # Wait for the web service to be accessible
         args = {"addr": "services.cockpit.lan"}
-        m.execute(script=WAIT_SCRIPT % args)
+        m.execute(WAIT_SCRIPT % args)
 
         if m.image != "rhel-atomic":  # insights-client not installed there
             m.write("/etc/insights-client/insights-client.conf",

--- a/test/verify/kubelib.py
+++ b/test/verify/kubelib.py
@@ -102,7 +102,7 @@ systemctl try-restart docker""")
         echo "Timed out waiting for service/kubernetes to appear" >&2
         exit 1
         """.format(**locals())
-        self.machine.execute(script=waiter)
+        self.machine.execute(waiter)
 
 
 class VolumeTests(object):


### PR DESCRIPTION
Scripts can now be handed directly to the command positional argument.

Remove some redundant cases of `#!/bin/sh` or `set -e`.