### PR TITLE
test: disable NetworkManager pixel test on mobile

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -55,7 +55,8 @@ class TestNetworkingBasic(NetworkCase):
                 "#networking-graphs .pf-l-grid",
                 ".cockpit-log-panel .pf-c-card__body",
                 "#networking-firewall-summary .pf-c-card__body",
-            ]
+            ],
+            skip_layouts=['mobile']
         )
 
         # Details of test iface


### PR DESCRIPTION
We have an issue with the IPv6 address sometimes wrapping which seems to
happen more frequently with changes in the latest `fedora-36` image to
how the IPv6 address is chosen.

Disable this test on mobile, for now.