### PR TITLE
tools: Drop SUSE section for removing 3rd party branding

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -275,13 +275,7 @@ rm -f %{buildroot}/%{_prefix}/share/metainfo/org.cockpit-project.cockpit-storage
 
 sed -i "s|%{buildroot}||" *.list
 
-%if 0%{?suse_version}
-# remove brandings with stale symlinks. Means they don't match
-# the distro.
-pushd %{buildroot}/%{_datadir}/cockpit/branding
-find -L * -type l -printf "%H\n" | sort -u | xargs rm -rv
-popd
-%else
+%if ! 0%{?suse_version}
 %global _debugsource_packages 1
 %global _debuginfo_subpackages 0
 


### PR DESCRIPTION
When we moved to install branding with relative symlinks in
ad74e9ba14c9748abcfcd9b5310738796172d7ef, this piece of code
is no longer applicable as it relies on absolute paths.