### PR TITLE
test: make Fedora-37 Fedora-36

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -32,6 +32,11 @@ if [ "$TEST_OS" = "fedora-38" ]; then
     export TEST_OS=fedora-36
 fi
 
+# HACK: 37 is beta
+if [ "$TEST_OS" = "fedora-37" ]; then
+    export TEST_OS=fedora-36
+fi
+
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi


### PR DESCRIPTION
Use the same skip/naughties as Fedora-36 for Fedora-37.

Maybe we should stop doing this and explicitly add fedora-37 to our naughties/skips for packit and rawhide.

I think we might also want to stop using `fedora-development` as it's an alias to rawhide OR the beta when available which means your PR will randomly start failing as Fedora-37 is added.