### PR TITLE
kdump: use correct base for translations

### DIFF
--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -27,7 +27,7 @@ along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
     <link rel="stylesheet" href="kdump.css">
 
     <script type="text/javascript" src="kdump.js"></script>
-    <script type="text/javascript" src="../base/po.js"></script>
+    <script type="text/javascript" src="../base1/po.js"></script>
     <script type="text/javascript" src="po.js"></script>
 </head>
 


### PR DESCRIPTION
Introduced in af5678b0be55474ccf523 as a typo most likely.

This breaks the new Python bridge with KeyError 'base', do we need to fix it in there?

The old bridge handles it here:

```
src/bridge/cockpitpackages.c:  if (!cockpit_json_get_string (manifest, "base", NULL, &base))
```