### PR TITLE
test: change minimum filesystem sizes to 320MB

### DIFF
--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -52,7 +52,7 @@ class TestStorageFormat(StorageCase):
 
         self.login_and_go("/storage")
 
-        m.add_disk("50M", serial="DISK1")
+        m.add_disk("320M", serial="DISK1")  # xfs minimum size is ~300MB.
         b.wait_in_text("#drives", "DISK1")
         b.click('#drives .sidepanel-row:contains("DISK1")')
         b.wait_visible('#storage-detail')

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -47,7 +47,7 @@ class TestStorageResize(StorageCase):
         b.wait_in_text("#drives", "DISK1")
 
         m.execute("vgcreate TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1")
-        m.execute("lvcreate TEST -n vol -L 200m")
+        m.execute("lvcreate TEST -n vol -L 320m")  # minimum xfs size is ~300MB
         b.wait_in_text("#devices", "TEST")
         b.click('#devices .sidepanel-row:contains("TEST")')
         b.wait_visible("#storage-detail")


### PR DESCRIPTION
Newer versions of xfsprogs (5.19) refuse to create XFS filesystems on
devices that are smaller than 300MB.

See cockpit-project/bots#3769.