### PR TITLE
test: Wait a bit longer for Candlepin to start

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1289,7 +1289,7 @@ class TestUpdatesSubscriptions(PackageCase):
         self.sed_file("s/insecure = 0/insecure = 1/g", "/etc/rhsm/rhsm.conf")
 
         # Wait for the web service to be accessible
-        m.execute(WAIT_SCRIPT % {"addr": "10.111.112.100"})
+        m.execute(WAIT_SCRIPT % {"addr": "10.111.112.100"}, timeout=360)
         self.update_icon = "#page_status_notification_updates svg"
         self.update_text = "#page_status_notification_updates"
         self.update_text_action = "#page_status_notification_updates a"


### PR DESCRIPTION
The default of 120 seconds seems to be too short now.

https://cockpit-logs.us-east-1.linodeobjects.com/pull-17668-20220829-074839-431e6065-rhel-8-7/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-17668-20220829-074839-431e6065-rhel-8-7-distropkg/log.html
https://cockpit-logs.us-east-1.linodeobjects.com/pull-17668-20220829-074839-431e6065-rhel-9-1/log.html
