### PR TITLE
test: assume motd permissions work on debian-testing

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -557,7 +557,7 @@ class TestConnection(MachineCase):
 
         def checkMotdContent(string, expected=True):
             # Needs https://github.com/linux-pam/linux-pam/pull/292 (or PAM 1.5.0)
-            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'debian-testing', 'ubuntu-2204', 'ubuntu-stable', 'rhel-8-7'])
+            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'ubuntu-2204', 'ubuntu-stable', 'rhel-8-7'])
 
             # check issue (should be exactly the same as motd)
             assertInOrNot(string, m.execute("cat /etc/issue.d/cockpit.issue"), expected)


### PR DESCRIPTION
Our incoming debian-testing update has a new pam (1.4.0-13 -> 1.5.2-2)
which now supports checking the permissions of the motd files, and thus
properly elides displaying the message about how to enable cockpit for
non-administrator users.