### PR TITLE
HACKING.md fix formatting

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -259,6 +259,7 @@ units, cockpit-tls, etc.) use that:
     $ sudo mount -o bind cockpit-ws /usr/libexec/cockpit-ws
 
 On Debian based OSes, the path will be `/usr/lib/cockpit/cockpit-ws` instead.
+
 You need to disable SELinux with
 
     $ sudo setenforce 0


### PR DESCRIPTION
Add newline between special path of cockpit-ws on Debiand and disable SELinux as these two steps should be visibly separated.