### PR TITLE
packit: Drop Fedora 35, add Fedora 37; fix tests for fedora-37

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,8 +24,8 @@ jobs:
   - job: tests
     trigger: pull_request
     targets:
-      - fedora-35
       - fedora-36
+      - fedora-37
       - fedora-development
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
@@ -48,9 +48,8 @@ jobs:
     # should just use the existing config for permanent COPRs;
     # https://github.com/packit/packit-service/issues/1499
     targets:
-      - fedora-35
       - fedora-36
-      - fedora-development
+      - fedora-37
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
     actions:
@@ -69,19 +68,19 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-35
       - fedora-36
+      - fedora-37
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-35
       - fedora-36
+      - fedora-37

--- a/test/README.md
+++ b/test/README.md
@@ -97,8 +97,8 @@ You can set these environment variables to configure the test suite:
                   "centos-8-stream"
                   "debian-stable"
                   "debian-testing"
-                  "fedora-35"
                   "fedora-36"
+                  "fedora-37"
                   "fedora-coreos"
                   "fedora-testing"
                   "rhel-8-7"
@@ -151,7 +151,7 @@ the target machine -- so only do this with the ones marked with
 In particular, you can use our standard test VMs with this mode:
 
     $ test/image-prepare
-    $ bots/vm-run fedora-35
+    $ bots/vm-run fedora-37
 
 Note the SSH and cockpit ports. If this is the only running VM, it will have
 the addresses in the example below, otherwise the port will be different.

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -39,7 +39,7 @@ done
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos"]
 OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable",
-                     "fedora-coreos", "fedora-35", "fedora-36", "fedora-testing", "centos-8-stream", "arch"]
+                     "fedora-coreos", "fedora-35", "fedora-36", "fedora-37", "fedora-testing", "centos-8-stream", "arch"]
 
 
 class NoSubManCase(PackageCase):
@@ -1253,7 +1253,7 @@ class TestKpatchInstall(NoSubManCase):
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",
-           "fedora-35", "fedora-36", "fedora-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+           "fedora-35", "fedora-36", "fedora-37", "fedora-testing", "ubuntu-2204", "ubuntu-stable", "arch")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -489,8 +489,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # This should work, but it will not because of
         # https://bugzilla.redhat.com/show_bug.cgi?id=1814569
-        working_images = ["fedora-35", "fedora-36", "fedora-testing"]
-        if m.image in working_images:
+        if m.image.startswith("fedora"):
             self.assertIn('result: uid=0', b.text(".super-channel span"))
         else:
             self.assertIn('result: access-denied', b.text(".super-channel span"))
@@ -764,7 +763,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # we don't want to completely pinpoint the OS list to avoid lockstep image refreshes+cockpit PRs
         # and spontaneous packit test failures as sssd 2.6.1 goes into more distros; but make sure we hit
         # this code path on some known-good ones
-        if m.image in ["fedora-35", "fedora-36", "debian-testing"]:
+        if m.image.startswith("fedora") or m.image in ["debian-testing"]:
             self.assertTrue(has_validate_api)
 
         if has_validate_api:

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -219,6 +219,8 @@ class TestSystemInfo(MachineCase):
             "org.freedesktop.systemd1: couldn't get property org.freedesktop.systemd1.Service ExecMain "
             "at /org/freedesktop/systemd1/unit/systemd_2dtimedated_2eservice: "
             "GDBus.Error:org.freedesktop.DBus.Error.UnknownProperty.*")
+        # journal gets confused with time jumps
+        self.allow_journal_messages(r"Journal file .*\.journal corrupted, ignoring file.*")
 
         self.login_and_go("/system", superuser=False)
         b.wait_text_not("#system_information_systime_button", "")


### PR DESCRIPTION
As usual, keep supporting the two most recent branched versions.

Also drop Rawhide from our cockpit-preview COPR build: We directly upload new releases to Rawhide anyway, so this is redundant.

Adjust test special cases.

This also needs some naughties first, I found [at least one new SELinux regression](https://bugzilla.redhat.com/show_bug.cgi?id=2083900) locally already.

 - https://github.com/cockpit-project/bots/pull/3797
 - https://github.com/cockpit-project/bots/pull/3801
 - https://github.com/cockpit-project/bots/pull/3804