### PR TITLE
python: send EOF on AsyncChannel close

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -187,6 +187,10 @@ class AsyncChannel(Channel):
     def do_done(self):
         self.receive_queue.put_nowait(b'')
 
+    def do_close(self):
+        # we might have already sent EOF for done, but two EOFs won't hurt anyone
+        self.receive_queue.put_nowait(b'')
+
     def do_ping(self, message):
         self.receive_queue.put_nowait(message)
 


### PR DESCRIPTION
If an AsyncChannel gets `close` from the other side without having first
received `done` then the EOF will never get delivered to the reader in
the `run()` function.

Add an extra EOF on `close`, as well.