### PR TITLE
test: Drop obsolete mkdir -p calls

### DIFF
--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -161,7 +161,7 @@ Server = file://{empty_repo_dir}
                     m.execute(f"cp '{data['path']}' '{dest}'")
                 else:
                     m.write(dest, data)
-        m.execute(f"mkdir -p /tmp/b/DEBIAN {self.repo_dir}")
+        m.execute(f"mkdir -p {self.repo_dir}")
         m.write("/tmp/b/DEBIAN/control", textwrap.dedent(f"""
             Package: {name}
             Version: {version}

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2008,8 +2008,6 @@ class MachineCase(unittest.TestCase):
         """
         m = self.machine
         self.restore_file(path, post_restore_action=post_restore_action)
-        dirname = os.path.dirname(path)
-        m.execute(f"mkdir -p {dirname}")
         m.write(path, content, append=append, owner=owner, perm=perm)
 
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -94,7 +94,6 @@ class TestApps(PackageCase):
                 '{ "config": { "appstream_data_packages": [ "appstream-data-test" ] } }')
 
         if urlroot != "":
-            m.execute("mkdir -p /etc/cockpit")
             m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         m.start_cockpit()
@@ -144,7 +143,6 @@ class TestApps(PackageCase):
         b.login_and_go("/apps")
         b.wait_visible(".pf-c-empty-state")
 
-        m.execute("mkdir -p /usr/share/app-info/xmls")
         m.write("/usr/share/app-info/xmls/test.xml", """
 <components origin="test">
   <component type="addon">
@@ -202,8 +200,6 @@ class TestApps(PackageCase):
         m.start_cockpit()
         b.login_and_go("/apps")
         b.wait_visible(".pf-c-empty-state")
-
-        m.execute("mkdir -p /usr/share/app-info/xmls")
 
         self.allow_journal_messages(".*/usr/share/app-info/xmls/test.xml.*",
                                     ".*xml.etree.ElementTree.ParseError.*")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -163,11 +163,11 @@ class TestConnection(MachineCase):
             b.wait_text('#login-fatal-message', "The cockpit package is not installed")
             m.execute("mv /usr/bin/cockpit-bridge.disabled /usr/bin/cockpit-bridge")
 
-        # Lets crash a systemd-crontrolled process and see if we get a proper backtrace in the logs
+        # Lets crash a systemd-controlled process and see if we get a proper backtrace in the logs
         # This helps with debugging failures in the tests elsewhere
-        m.execute("""mkdir -p /run/systemd/system/systemd-hostnamed.service.d
-                     printf '[Service]\nLimitCORE=infinity\n' > /run/systemd/system/systemd-hostnamed.service.d/core.conf
-                     systemctl daemon-reload
+        m.write("/run/systemd/system/systemd-hostnamed.service.d/core.conf",
+                "[Service]\nLimitCORE=infinity\n")
+        m.execute("""systemctl daemon-reload
                      systemctl restart systemd-hostnamed
                      pkill -e -SEGV systemd-hostnam""")
         wait(lambda: m.execute("journalctl -b | grep 'Process.*systemd-hostnam.*of user.*dumped core.'"))
@@ -458,7 +458,6 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 301 Moved Permanently", output)
         self.assertIn("Location: https://172.27.0.15:9090/", output)
         # enable AllowUnencrypted, this disables redirect
-        m.execute("mkdir -p /etc/cockpit")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nAllowUnencrypted=true")
         m.restart_cockpit()
         # now it should not redirect
@@ -468,7 +467,6 @@ class TestConnection(MachineCase):
     @nondestructive
     def testConfigOrigins(self):
         m = self.machine
-        m.execute("mkdir -p /etc/cockpit")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nOrigins = http://other-origin:9090 http://localhost:9090")
         m.start_cockpit()
         headers = {

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -61,7 +61,7 @@ class TestXHRProxy(MachineCase):
 
         # set up served directory
         httpdir = self.vm_tmpdir + "/root"
-        m.execute("mkdir {0}; echo world > {0}/hello.txt".format(httpdir))
+        m.write(f"{httpdir}/hello.txt", "world\n")
         # start webserver
         pid = m.spawn(f"cd {httpdir}; exec python3 -m http.server 12345", "httpserver")
         self.addCleanup(m.execute, "kill %i" % pid)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -494,9 +494,8 @@ class TestHistoryMetrics(MachineCase):
         b = self.browser
         m = self.machine
 
+        m.write("/run/systemd/system/pmlogger.service.d/break.conf", "[Service]\nExecStart=\nExecStart=/bin/false")
         m.execute(r"""mount -t tmpfs tmpfs /var/log/pcp/pmlogger
-                      mkdir -p /run/systemd/system/pmlogger.service.d/
-                      printf '[Service]\nExecStart=\nExecStart=/bin/false\n' > /run/systemd/system/pmlogger.service.d/break.conf
                       systemctl daemon-reload
                       systemctl start pmlogger || true""")
         self.addCleanup(m.execute,
@@ -839,7 +838,6 @@ podman save quay.io/libpod/busybox | sudo -i -u admin podman load
         b.wait_not_present("#current-metrics-card-cpu .temperature")
 
         # No matching type
-        m.execute("mkdir -p /tmp/sensor-sys-class/hwmon/hwmon0")
         self.addCleanup(m.execute, "rm -rf /tmp/sensor-sys-class")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon0/name", "BAT0")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon0/temp1_input", "40000")
@@ -852,7 +850,6 @@ podman save quay.io/libpod/busybox | sudo -i -u admin podman load
 
         # create files that contain CPU temperature
         # ARM
-        m.execute("mkdir -p /tmp/sensor-sys-class/hwmon/hwmon1")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/name", "cpu_thermal")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_input", "30000")
 
@@ -929,7 +926,6 @@ podman save quay.io/libpod/busybox | sudo -i -u admin podman load
         b.wait_in_text("#current-metrics-card-cpu", "70 °C")
 
         # add second CPU
-        m.execute("mkdir -p /tmp/sensor-sys-class/hwmon/hwmon2")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon2/name", "coretemp")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon2/temp1_label", "Package id 0")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon2/temp1_input", "60000")

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -74,7 +74,6 @@ class TestPackages(MachineCase):
 
         check_nav_entry("Terminal", True)
 
-        m.execute("mkdir -p /usr/local/share/cockpit/test")
         m.write("/usr/local/share/cockpit/test/manifest.json", test_manifest)
         m.write("/usr/local/share/cockpit/test/test.html", test_html)
         reload_packages()
@@ -101,7 +100,6 @@ class TestPackages(MachineCase):
 
         # user override on top which renames the services label
         self.restore_dir("/home/admin")
-        m.execute("mkdir -p /home/admin/.config/cockpit")
         m.write("/home/admin/.config/cockpit/systemd.override.json", """{
     "menu": {
         "services": { "label": "Hackices" }

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -97,9 +97,11 @@ OnCalendar=daily
 
         # On Debian and Ubuntu we have to generate the other locales
         if "debian" in m.image:
-            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen; locale-gen; update-locale")
+            m.write("/etc/locale.gen", "de_DE.UTF-8 UTF-8\n", append=True)
+            m.execute("locale-gen; update-locale")
         elif "arch" == m.image:
-            m.execute("echo 'de_DE.UTF-8 UTF-8' >> /etc/locale.gen; locale-gen")
+            m.write("/etc/locale.gen", "de_DE.UTF-8 UTF-8\n", append=True)
+            m.execute("locale-gen")
         elif "ubuntu" in m.image:
             m.execute("locale-gen de_DE; locale-gen de_DE.UTF-8; update-locale")
 
@@ -406,7 +408,6 @@ OnCalendar=daily
 
         self.check_system_menu("Overview", True)
         self.restore_dir("/home/admin")
-        m.execute("mkdir -p /home/admin/.local/share/cockpit/foo")
         m.write("/home/admin/.local/share/cockpit/foo/manifest.json",
                 '{ "menu": { "index": { "label": "FOO!" } } }')
         b.reload()
@@ -563,7 +564,8 @@ OnCalendar=daily
 
         stuff = os.path.join(self.vm_tmpdir, "stuff")
         # prepare a directory for testing file autocomplete widget
-        m.execute("mkdir -p {0}/dir1; touch {0}/file1.txt".format(stuff))
+        m.execute(f"mkdir -p {stuff}/dir1")
+        m.write(f"{stuff}/file1.txt", "")
 
         self.login_and_go("/playground/react-patterns")
 

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -229,7 +229,6 @@ class TestSelinux(MachineCase):
 
         ansible_m = self.machines["ansible_machine"]
         ansible_m.execute("semanage module -D")
-        ansible_m.execute("mkdir -p roles/selinux/tasks/")
         ansible_m.write("roles/selinux/tasks/main.yml", b.text(ansible_script_sel))
         se_before = normalize(ansible_m.execute("semanage export"))
         ansible_m.execute("ansible -m include_role -a name=selinux localhost")

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -390,7 +390,6 @@ class TestMultiMachine(MachineCase):
 
         hostname_selector = "#system_information_hostname_text"
 
-        m.execute("mkdir -p /etc/cockpit/")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nUrlRoot = cockpit-new")
         m.start_cockpit()
 
@@ -435,7 +434,6 @@ class TestMultiMachine(MachineCase):
         b = self.browser
         m = self.machine
 
-        m.execute("mkdir -p /etc/cockpit/")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nUrlRoot = cockpit-new")
         m.start_cockpit()
 

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -239,15 +239,14 @@ class TestMultiMachineKeyAuth(MachineCase):
         m2 = self.machine2
 
         # upload id_ed25519 (password: locked)
-        m1.execute("mkdir -p /home/admin/.ssh")
-        m1.upload(["verify/files/ssh/id_ed25519", "verify/files/ssh/id_ed25519.pub",
-                   "verify/files/ssh/id_rsa", "verify/files/ssh/id_rsa.pub"],
-                  "/home/admin/.ssh/")
         m1.write("/home/admin/.ssh/config", """
 Host 10.111.113.2
     User user
     IdentityFile /home/admin/.ssh/id_ed25519
 """)
+        m1.upload(["verify/files/ssh/id_ed25519", "verify/files/ssh/id_ed25519.pub",
+                   "verify/files/ssh/id_rsa", "verify/files/ssh/id_rsa.pub"],
+                  "/home/admin/.ssh/")
         m1.execute("chmod 400 /home/admin/.ssh/*")
         m1.execute("chown -R admin:admin /home/admin/.ssh")
         authorize_user(m2, "user", ["verify/files/ssh/id_ed25519.pub"])

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -48,7 +48,6 @@ only-plugins=release,date,host,cgroups,networking
 """)
 
         if urlroot != "":
-            m.execute("mkdir -p /etc/cockpit/")
             m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         self.login_and_go("/sosreport", urlroot=urlroot, superuser=False)

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -774,7 +774,6 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
             # until 2.6.2 is available everywhere. https://github.com/SSSD/sssd/issues/5911
             self.assertRegex(err, "Invalid certificate provided|Certificate authority file not found")
 
-            m.execute("mkdir -p /etc/sssd/pki")
             # install our CA, so that sssd can validate
             with open("src/tls/ca/ca.pem") as f:
                 m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())

--- a/test/verify/check-storage-ignored
+++ b/test/verify/check-storage-ignored
@@ -38,7 +38,6 @@ class TestStorageIgnored(StorageCase):
             b.wait_in_text("#mounts", disk + " (TESTLABEL)")
 
         # Hide it via a udev rule
-        m.execute("mkdir -p /run/udev/rules.d")
         m.write("/run/udev/rules.d/99-ignore.rules",
                 'SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="TESTLABEL", ENV{UDISKS_IGNORE}="1"\n')
         self.addCleanup(m.execute, "rm /run/udev/rules.d/99-ignore.rules; udevadm control --reload; udevadm trigger")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -934,7 +934,6 @@ maprule = LDAP:(userCertificate={cert!base64})
 # maprule = (|(userPrincipalName={subject_principal})(sAMAccountName={subject_principal.short_name}))
 """, perm="0600")
         # tell sssd about our CA for validating certs
-        m.execute("mkdir -p /etc/sssd/pki")
         with open("src/tls/ca/ca.pem") as f:
             m.write("/etc/sssd/pki/sssd_auth_ca_db.pem", f.read())
 


### PR DESCRIPTION
Since https://github.com/cockpit-project/bots/commit/e84a589781a3fa ,
SSHConnection.write() creates the target directory by itself.

---

Follow-ups from https://github.com/cockpit-project/cockpit/pull/17645#pullrequestreview-1092152421