### PR TITLE
lib: Allow setting initial password for PasswordFormFields

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -48,10 +48,11 @@ export function password_quality(password, force) {
 export const PasswordFormFields = ({
     password_label, password_confirm_label,
     password_label_info,
+    initial_password,
     error_password, error_password_confirm,
     idPrefix, change
 }) => {
-    const [password, setPassword] = useState(undefined);
+    const [password, setPassword] = useState(initial_password);
     const [passwordConfirm, setConfirmPassword] = useState(undefined);
     const [passwordStrength, setPasswordStrength] = useState("");
     const [passwordMessage, setPasswordMessage] = useState("");

--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -62,7 +62,7 @@ export const PasswordFormFields = ({
 
         if (value) {
             password_quality(value)
-                    .catch(ex => {
+                    .catch(() => {
                         return { value: 0 };
                     })
                     .then(strength => {


### PR DESCRIPTION
This allows a user of PasswordFormFields to set the password value
from the outside, instead of the value being just initialized and stored
internally inside the component.

The motivation behind this change can be found at https://github.com/cockpit-project/cockpit-machines/pull/803 , which is blocked on this PR.