### PR TITLE
Various http stream test improvements, doc update

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -717,12 +717,12 @@ payload type:
    host name. To use this option you must also specify a port.
    This option should be used to communicate with external
    apis and not as a synonym for the host parameter.
+ * "method": "GET", "POST", or other valid HTTP method
 
 You may also specify these options:
 
  * "connection": A stable identifier for connection sharing, i.e.
    sending multiple requests to a single open connection.
- * "method": "GET" (default if not specified), "POST", or other valid HTTP method
  * "headers": JSON object with additional request headers
  * "tls": Set to a object to use an https connection.
 

--- a/pkg/base1/test-echo.js
+++ b/pkg/base1/test-echo.js
@@ -79,10 +79,18 @@ QUnit.test("binary", function (assert) {
     channel.send(buffer);
 });
 
-// This is implemented in the C bridge, but not in Python.
-// Nobody uses it, so skip the test for now.
-QUnit.test.skip("fence", function (assert) {
+QUnit.test("fence", async assert => {
     const done = assert.async();
+
+    const response = await fetch(`http://${window.location.hostname}:${window.location.port}/mock/info`);
+    const info = await response.json();
+    // This is implemented in the C bridge, but not in Python.
+    if (info.bridge == "cockpit-bridge.pyz") {
+        assert.ok(true, "skipping on python bridge, not implemented");
+        done();
+        return;
+    }
+
     assert.expect(2);
 
     const before = cockpit.channel({ payload: "echo" });


### PR DESCRIPTION
Splitting this out from PR #17631 as the /mock/info stuff might be useful for @jelly and @mvollmer to adjust their parts of the unit test for py vs. C bridge differences.