### PR TITLE
networkmanager: Watch the D-Bus ObjectManager

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -158,10 +158,6 @@ export function NetworkManagerModel() {
      * resources for maintaining the unused proxies, avoids some code
      * complexity, and allows to do the right thing with the
      * peculiarities of the NetworkManager API.
-     *
-     * However, we do use a fake object manager since that allows us
-     * to avoid a lot of 'GetAll' round trips during initialization
-     * and helps with removing obsolete objects.
      */
 
     const self = this;
@@ -404,8 +400,8 @@ export function NetworkManagerModel() {
 
     self.preinit.then(() => {
         subscription = client.subscribe({ }, signal_emitted);
-        watch = client.watch({ });
         client.addEventListener("notify", onNotifyEventHandler);
+        watch = client.watch({ path_namespace: "/org/freedesktop" });
     });
 
     self.close = function close() {


### PR DESCRIPTION
The NetworkManager daemon now has a standard ObjectManager at
/org/freedesktop.  By using this as the "path_namespace" in our D-Bus
watch, cockpit-bridge will recognize it immediately.

Also, register the "notify" handler before starting the watch so as to
not miss any events.

Previously, The Network page was asking cockpit-bridge to emulate an
object manager at "/" by introspecting the whole tree.  This is less
efficient, and also seems to trigger bugs in cockpit-bridge if a real
ObjectManager is detected while that introspection is going on.

Even if there is no real ObjectManager at /org/freedesktop, this
change is still correct.  In that case, cockpit-bridge will continue
to emulate one via introspection.