### PR TITLE
webpack: Fix regexp for unit test files

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -125,17 +125,17 @@ function generateDeps(makefile, stats) {
         const output = path.join(dir, asset);
         fs.utimesSync(output, now, now);
 
-        if (!output.endsWith("/manifest.json") && !output.endsWith(".map"))
+        if (!asset.endsWith("/manifest.json") && !asset.endsWith(".map"))
             outputs.add(output);
 
-        if (output.includes("/test-")) {
-            if (output.endsWith(".html")) {
+        if (asset.includes("/test-")) {
+            if (asset.endsWith(".html")) {
                 tests.add(output);
             }
             continue;
         }
 
-        if (output.endsWith(".map") || output.endsWith(".LICENSE.txt"))
+        if (asset.endsWith(".map") || asset.endsWith(".LICENSE.txt"))
             continue;
 
         installs.add(output);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -444,7 +444,7 @@ module.exports = {
                 test: /\.(js|jsx)$/,
                 // exclude external dependencies; it's too slow, and they are already plain JS except the above
                 // also exclude unit tests, we don't need it for them, just a waste and makes failures harder to read
-                exclude: /\/node_modules|\/test-/,
+                exclude: /\/node_modules|\/test-[^/]*\.js/,
                 use: "babel-loader"
             },
             {


### PR DESCRIPTION
`exclude:` matches on the complete absolute path. This broke when
cockpit was checked out into a directory (e.g. a branch worktree) that
started with "test-".

To avoid that, tighten the regular expression to only match on test-*.js
files.

Fixes #16829