### PR TITLE
unit-tests: explicitly create the home directory

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -39,5 +39,6 @@ jobs:
               --verbose \
               ${{ matrix.startarg.network }} \
               --env=CC='${{ matrix.startarg.cc }}' \
+              --env=CFLAGS='-O2 -gdwarf-4' \
               --image-tag='${{ matrix.startarg.tag }}' \
               --make '${{ matrix.startarg.make }}'

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -56,7 +56,7 @@ apt-get update
 apt-get install -y --no-install-recommends eatmydata
 DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recommends ${dependencies}
 
-adduser --system --gecos "Builder" builder
+adduser --gecos "Builder" builder
 
 # minimize image
 # useful command: dpkg-query --show -f '${package} ${installed-size}\n' | sort -k2n


### PR DESCRIPTION
`adduser` recently changed its behaviour for system users, not to create
the home directory.  We expect the home directory to be created, though
(since we build in it), so explicitly specify `--create-home`.