### PR TITLE
test: Don't let our dnsmasq instances read /etc/resolv.conf

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -43,7 +43,7 @@ class NetworkHelpers:
             # up the remote end, give it an IP, and start DHCP server
             self.machine.execute("ip a add {0} dev v_{1}; ip link set v_{1} up".format(dhcp_cidr, name))
             server = self.machine.spawn("dnsmasq --keep-in-foreground --log-queries --log-facility=- "
-                                        "--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{0} "
+                                        "--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{0} --no-resolv "
                                         "--bind-interfaces --except-interface=lo --interface=v_{0} --dhcp-range={1},{2},4h".format(name, dhcp_range[0], dhcp_range[1]),
                                         f"dhcp-{name}.log")
             self.addCleanup(self.machine.execute, "kill %i" % server)


### PR DESCRIPTION
They are not supposed to resolve DNS queries and thus don't need any
upstream servers.  Also, NetworkManager puts the interfaces added via
add_veth into /etc/resolv.conf on Debian, and if there are two of
these, they will forward queries to each other endlessly.  This seems
to slow down the test enough to sometimes cause timeouts elsewhere.