### PR TITLE
metrics: Disable on-demand install without PackageKit in PCP config dialog

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -46,7 +46,7 @@ import * as service from "service";
 import * as timeformat from "timeformat";
 import { superuser } from "superuser";
 import { journal } from "journal";
-import { useObject, useEvent } from "hooks.js";
+import { useObject, useEvent, useInit } from "hooks.js";
 import { WithDialogs, useDialogs } from "dialogs.jsx";
 
 import { EmptyStatePanel } from "../lib/cockpit-components-empty-state.jsx";
@@ -1124,6 +1124,9 @@ const PCPConfigDialog = ({
     const [dialogLoggerValue, setDialogLoggerValue] = useState(runningService(s_pmlogger));
     const [dialogProxyValue, setDialogProxyValue] = useState(dialogInitialProxyValue);
     const [pending, setPending] = useState(false);
+    const [packagekitExists, setPackagekitExists] = useState(null);
+
+    useInit(() => packagekit.detect().then(setPackagekitExists));
 
     const handleInstall = () => {
     // when enabling services, install missing packages on demand
@@ -1237,6 +1240,7 @@ const PCPConfigDialog = ({
 
             <Switch id="switch-pmlogger"
                         isChecked={dialogLoggerValue}
+                        isDisabled={!s_pmlogger.exists && !packagekitExists}
                         label={
                             <Flex spaceItems={{ modifier: 'spaceItemsXl' }}>
                                 <FlexItem>{ _("Collect metrics") }</FlexItem>

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1159,6 +1159,13 @@ class TestMetricsPackages(packagelib.PackageCase):
             self.login_and_go("/metrics")
             b.wait_in_text(".pf-c-empty-state", "cockpit-pcp is missing")
             b.wait_not_present(".pf-c-empty-state button.pf-m-primary")
+
+            b.click("#metrics-header-section button.pf-m-secondary")
+            b.wait_visible("#pcp-settings-modal")
+            b.wait_visible("#switch-pmlogger:not(:checked)")
+            # no packagekit, can't enable
+            b.wait_visible("#switch-pmlogger:disabled")
+            b.wait_visible("#switch-pmproxy:disabled")
             return
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):


### PR DESCRIPTION
So far we have only respected packagekit.exists() in the empty state
on-demand installation, but it was missing in the metrics config dialog.
Pass it on to that component as well, and disable the pmlogger switch if
packagekit is not available and pmlogger.service does not already exist.

Fixes #17693