### PR TITLE
Don't use `data-label` for selectors in CSS

### DIFF
--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -88,7 +88,7 @@ th {
 }
 
 #networking-interfaces, #networking-unmanaged-interfaces {
-  th[data-label="Name"] button {
+  th > .pf-m-link {
     font-weight: var(--pf-global--FontWeight--bold);
 
     // Preserve the same baseline as other elements, so items align

--- a/pkg/shell/credentials.scss
+++ b/pkg/shell/credentials.scss
@@ -4,11 +4,11 @@
     word-wrap: anywhere;
   }
 
-  th[data-label="Name"] {
+  .pf-c-table__toggle + th {
     font-weight: var(--pf-global--FontWeight--bold);
   }
 
-  td[data-label="Toggle"] {
+  td:last-child {
     width: 1%;
   }
 


### PR DESCRIPTION
As spotted at https://github.com/cockpit-project/cockpit/pull/17657#pullrequestreview-1086711740, we shouldn't use data-label in CSS for selectors. Doing so ties it to the language specified.