### PR TITLE
login: Use valid selectors when testing for :is() / :where() support.

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -225,7 +225,7 @@
                css("display", "flex") &&
                css("display", "grid") &&
                css("selector(test)") &&
-               css("selector(:is():where())");
+               css("selector(:is(*):where(*))");
     }
 
     function trim(s) {


### PR DESCRIPTION
Rejecting CSS.supports(":is()") is the correct thing to do per https://github.com/w3c/csswg-drafts/issues/7280

Fixes #17724.