### PR TITLE
ws: Go back to assuming GChildWatch on mips in test-channelresponse

### DIFF
--- a/src/ws/test-channelresponse.c
+++ b/src/ws/test-channelresponse.c
@@ -530,7 +530,7 @@ test_resource_failure (TestResourceCase *tc,
   g_assert_cmpint (pid, >, 0);
   g_assert_cmpint (kill (pid, SIGTERM), ==, 0);
   /* Wait until it's gone */
-#if GLIB_CHECK_VERSION(2,73,2)
+#if GLIB_CHECK_VERSION(2,73,2) && !defined(__MIPSEL)
   /* https://gitlab.gnome.org/GNOME/glib/-/commit/f615eef4bafaa2f dropped global GChildWatch, we need to wait ourselves */
   g_assert_cmpint (waitpid (pid, NULL, 0), ==, pid);
 #else


### PR DESCRIPTION
Commit 0c7793da868cc adjusted the "wait for killed bridge" behaviour for glib 2.73.2: that dropped the global GChildWatch waiting in favor of pidfds. But on mips{,64}el, glib now went back to the old behaviour, so adjust the condition.

See https://buildd.debian.org/status/fetch.php?pkg=cockpit&arch=mipsel&ver=276-1&stamp=1662541707&file=log

----

I can't say I like this hack, but I don't really have a good idea how to predict the behaviour otherwise.

I tested this on a Debian mips porter box, and it makes the test happy. I keep the build environment around for a day or so.

See https://buildd.debian.org/status/package.php?p=cockpit for an overview of all build logs (current and older)