### PR TITLE
tools: replace usage of deprecated egrep

### DIFF
--- a/tools/git-utils.sh
+++ b/tools/git-utils.sh
@@ -43,7 +43,7 @@ git_cache() {
 # reads the named gitlink from the current state of the index
 # returns (ie: prints) a 40-character commit ID
 get_index_gitlink() {
-    if ! git ls-files -s "$1" | egrep -o '\<[[:xdigit:]]{40}\>'; then
+    if ! git ls-files -s "$1" | grep -E -o '\<[[:xdigit:]]{40}\>'; then
         echo "*** couldn't read gitlink for file $1 from the index" >&2
         exit 1
     fi


### PR DESCRIPTION
Since grep 3.8, there is now a warning about egrep being deprecated and users should switch to `grep -E`.

See https://lists.gnu.org/archive/html/info-gnu/2022-09/msg00001.html