### PR TITLE
login: Fix username/password autofill

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -50,12 +50,6 @@
     <div id="login" class="login-area" hidden>
       <form onsubmit="return false">
 
-        <div id="conversation-group" class="form-group" hidden>
-          <div id="conversation-message"></div>
-          <label id="conversation-prompt" for="conversation-input"></label>
-          <input type="password" class="form-control" id="conversation-input">
-        </div>
-
         <div id="hostkey-group" class="form-group" hidden>
           <h1 id="hostkey-title"></h1>
           <div id="hostkey-warning-group" class="pf-c-alert pf-m-warning pf-m-inline dialog-error" aria-label="inline warning alert" hidden>
@@ -88,6 +82,12 @@
               </svg>
             </button>
           </div>
+        </div>
+
+        <div id="conversation-group" class="form-group" hidden>
+          <div id="conversation-message"></div>
+          <label id="conversation-prompt" for="conversation-input"></label>
+          <input type="password" class="form-control" id="conversation-input">
         </div>
 
         <div id="option-group">

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -619,7 +619,8 @@
         hideToggle("#hostkey-group", form != "hostkey");
 
         id("login-button-text").textContent = (form == "hostkey") ? _("Accept key and log in") : _("Log in");
-        id("login-password-input").value = '';
+        if (form != "login")
+            id("login-password-input").value = '';
 
         if (environment.page.require_host) {
             hide("#option-group");


### PR DESCRIPTION
Some browsers get confused when there is some type="password" field before the username field. Re-ordering mutually exclusive parts of the login page should not have any visible impact but fixes automatic filling of credentials saved in browser's password manager.

The password field was also explicitly cleared in all auth scenarios while it should be only for conversations.