### PR TITLE
Give more time for candlepin

### DIFF
--- a/test/verify/check-subscriptions
+++ b/test/verify/check-subscriptions
@@ -109,7 +109,7 @@ class SubscriptionsCase(MachineCase):
 
         # Wait for the web service to be accessible
         args = {"addr": "services.cockpit.lan"}
-        m.execute(WAIT_SCRIPT % args)
+        m.execute(WAIT_SCRIPT % args, timeout=360)
 
         if m.image != "rhel-atomic":  # insights-client not installed there
             m.write("/etc/insights-client/insights-client.conf",


### PR DESCRIPTION
In recent rhel-7-9 image refresh[1], it seems candlepin began to timeout:
+ curl -s https://services.cockpit.lan:8443/candlepin --verbose
*   Trying 10.111.112.100...
[timeout]

[1] https://github.com/cockpit-project/bots/pull/3866