### PR TITLE
python: Handle early errors during cockpit.spawn

### DIFF
--- a/pkg/base1/test-spawn-proc.js
+++ b/pkg/base1/test-spawn-proc.js
@@ -91,6 +91,16 @@ QUnit.test("error message fail", function (assert) {
             });
 });
 
+QUnit.test("nonexisting executable", assert => {
+    assert.rejects(cockpit.spawn(["/bin/nonexistent"]),
+                   ex => ex.problem == "not-found");
+});
+
+QUnit.test("permission denied", assert => {
+    assert.rejects(cockpit.spawn(["/etc/hostname"]),
+                   ex => ex.problem == "access-denied");
+});
+
 QUnit.test("write eof read", function (assert) {
     const done = assert.async();
     assert.expect(2);


### PR DESCRIPTION
- [x] #17758 
- [x] land #17763 and rebase