### PR TITLE
python: Send expected 'ping' during flow control

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,6 +31,7 @@ pyTESTS_PASSING = \
 	dist/base1/test-protocol.html \
 	dist/base1/test-series.html \
 	dist/base1/test-spawn.html \
+	dist/base1/test-spawn-proc.html \
 	dist/base1/test-user.html \
 	dist/base1/test-utf8.html \
 	dist/kdump/test-config-client.html \
@@ -45,7 +46,6 @@ pyTESTS_FAILING = \
 pyTESTS_HANGING = \
 	dist/base1/test-dbus-address.html \
 	dist/base1/test-dbus.html \
-	dist/base1/test-spawn-proc.html \
 	$(NULL)
 
 pyTESTS = $(pyTESTS_PASSING) $(pyTESTS_FAILING)

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -165,7 +165,11 @@ class AsyncChannel(Channel):
     async def write(self, data):
         if self.flow_control:
             assert len(data) <= AsyncChannel.CHANNEL_FLOW_WINDOW
-            self.out_sequence += len(data)
+
+            out_sequence = self.out_sequence + len(data)
+            if self.out_sequence // AsyncChannel.CHANNEL_FLOW_PING != out_sequence // AsyncChannel.CHANNEL_FLOW_PING:
+                self.send_control(command='ping', sequence=out_sequence)
+            self.out_sequence = out_sequence
 
             while self.out_window < self.out_sequence:
                 self.write_waiter = asyncio.get_running_loop().create_future()


### PR DESCRIPTION
Otherwise we never get the 'pong' that will allow us to write more data.