### PR TITLE
test: Consider browser's time zone when checking service's next run

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -331,7 +331,8 @@ WantedBy=default.target
         self.run_systemctl(user, "start test-onboot.timer")
         # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
         today_stamp = int(m.execute("date +%s").strip())
-        today_plus_200min = m.execute(f"date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
+        time_zone = b.eval_js("Intl.DateTimeFormat().resolvedOptions().timeZone")  # get browser's time zone
+        today_plus_200min = m.execute(f"TZ='{time_zone}' date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
         self.run_systemctl(user, "stop test-onboot.timer")


### PR DESCRIPTION
This is especially visible during rhel's image refresh[1], which uses Eastern Time Zone.

[1] https://github.com/cockpit-project/bots/pull/3895