### PR TITLE
tools: Recommend cockpit-ostree on OSTree systems

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -147,6 +147,8 @@ Suggests: cockpit-pcp
 
 %if 0%{?rhel} == 0
 Recommends: (cockpit-networkmanager if NetworkManager)
+# c-ostree is not in RHEL 8/9
+Recommends: (cockpit-ostree if rpm-ostree)
 Suggests: cockpit-selinux
 %endif
 %if 0%{?rhel} && 0%{?centos} == 0


### PR DESCRIPTION
Similarly how we recommend cockpit-packagekit if dnf is installed, recommend cockpit-ostree if rpm-ostree is installed. That will make the package more discoverable, and provide an OOTB "Software Updates" page.

cockpit-ostree is not in RHEL 8/9 at the moment, so only generate this
dependency on non-RHEL (i.e. Fedora) for the time being.
