### PR TITLE
networkmanager: Improved firewall permission check

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -335,6 +335,19 @@ cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all
             firewall.readonly = false;
             firewall.debouncedEvent('changed');
             firewall.debouncedGetZones();
+        })
+        .catch(error => {
+            console.log("pkcheck failed", error);
+
+            // Fall back to cockpit.permissions, "pkcheck" might not be available,
+            // always allow edits by admins
+            const permission = cockpit.permission({ admin: true });
+            const update_permissions = () => {
+                firewall.readonly = !permission.allowed;
+                firewall.debouncedEvent('changed');
+                firewall.debouncedGetZones();
+            };
+            permission.addEventListener("changed", update_permissions);
         });
 
 firewall.enable = () => firewalld_service.enable().then(() => firewalld_service.start());

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -122,6 +122,27 @@ class TestFirewall(NetworkCase):
             ".*The name org.fedoraproject.FirewallD1 was not provided by any .service files.*",
             ".*org.fedoraproject.FirewallD1: .*: GDBus.Error:org.freedesktop.DBus.Error.NoReply.*")
 
+    # test missing "pkcheck" binary, in that case fallback to the admin check
+    def testPkcheckMissing(self):
+        b = self.browser
+        m = self.machine
+
+        # Path to the "pkcheck" PolicyKit utility
+        pkcheck = m.execute("which pkcheck").strip()
+        # "Hide" pkcheck
+        m.execute(f"mount --bind /dev/null '{pkcheck}'")
+
+        try:
+            # Regular user is not allowed to change the firewall switch
+            self.login_and_go("/network", superuser=False)
+            b.wait_visible("#networking-firewall-switch:disabled")
+
+            # Super user is allowed to change the firewall switch
+            b.relogin("/network", superuser=True)
+            b.wait_visible("#networking-firewall-switch:not([disabled])")
+        finally:
+            m.execute(f"umount '{pkcheck}'")
+
     def testFirewallPage(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
## The Problem

See issue https://github.com/cockpit-project/cockpit/issues/17669.

The firewall configuration uses the `pkcheck` tool for checking the user permissions. But that tool might not be available in a minimal system.

## The Solution

If the `pkgcheck` test fails fallback to the usual root permission check.

## Testing

Tested manually with the patched plugin.

## Screenshots

Before applying the patch the firewall configuration could not be changed:

![cockpit_fw_no_permission](https://user-images.githubusercontent.com/907998/192549529-e09f26bf-00f4-486f-89ce-f438fa701c90.png)

After applying the patch the switch is enabled and changing the value works correctly.

![cockpit_fw_fixed](https://user-images.githubusercontent.com/907998/192549926-e476334c-60aa-4361-b27c-1c642cadf9b3.png)

