### PR TITLE
fmf: Add lvm2 test dependency

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -14,6 +14,8 @@ require:
   - firewalld
   - libvirt-daemon-config-network
   - libvirt-python3
+  - lvm2
+  - udisks2-lvm2
   - nfs-utils
   - python3-tracer
   - rpm-build


### PR DESCRIPTION
Our tests call `vgcreate`, make sure it is installed. It's not any more in the standard Fedora 37 images.

---

This should help with the [fedora-37 failures on the TF](https://artifacts.dev.testing-farm.io/d77ad533-8ef4-4a30-8a04-b0c16fe3f487/), where the storage tests fail with

    bash: line 1: vgcreate: command not found
