### PR TITLE
packit: Drop targets list from COPR build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -44,14 +44,6 @@ jobs:
     owner: "@cockpit"
     project: "cockpit-preview"
     preserve_project: True
-    # HACK: hardcoding this list is redundant and hard to change; packit
-    # should just use the existing config for permanent COPRs;
-    # https://github.com/packit/packit-service/issues/1499
-    targets:
-      - fedora-36
-      - fedora-37
-      - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
     actions:
       post-upstream-clone:
         # HACK: spec must be next to the generated tarball; https://github.com/packit/packit/issues/1621


### PR DESCRIPTION
Hardcoding this list is redundant and hard to change: changing the COPR config and updating all our projects' packit.yml files needs to happen in lockstep.

packit now learned to just read the configuration from an existing COPR repository, so drop the target list entirely. See
https://github.com/packit/packit-service/issues/1499

----

I tested this on cockpit-ostree, see https://github.com/cockpit-project/cockpit-ostree/pull/283