### PR TITLE
gitleaks: Ignore mock SSH keys

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,5 @@
+# # help Red Hat ignore false positives during its code scans
+[allowlist]
+paths = [
+    'src/ssh/mock.*key',
+]


### PR DESCRIPTION
Quiesce Red Hat's security scanner about allegedly leaking private SSH keys. These are static keys for our unit tests.

---

I got an alert email when I updated the main branch on my fork. This is apparently a fairly new thing. Unfortunately I didn't find a public documentation about it, but as a Red Hatter you can [look here](https://source.redhat.com/departments/it/it-information-security/wiki/pattern_distribution_server).