### PR TITLE
test: drop Debian networkmanager hack

### DIFF
--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -35,8 +35,6 @@ class TestNetworkingCheckpoints(NetworkCase):
         if "debian" in m.image:
             self.sed_file("s/managed=false/managed=true/", "/etc/NetworkManager/NetworkManager.conf",
                           "systemctl restart NetworkManager")
-            # HACK - https://bugzilla.redhat.com/show_bug.cgi?id=1400525
-            wait(lambda: m.execute(f"nmcli dev con {iface}"))
 
         self.login_and_go("/network")
         self.nm_checkpoints_enable()


### PR DESCRIPTION
After adding Arch Linux testing support for checkpoints, I discovered the workaround is not required anymore for Debian as well. This was supposedly fixed in NetworkManager master in 2016.