### PR TITLE
Enable more Arch Linux NetworkManager tests

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -19,12 +19,11 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import nondestructive, skipDistroPackage, test_main, wait
 
 
 @nondestructive
 @skipDistroPackage()
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestNetworkingBasic(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -26,7 +26,6 @@ from lib.constants import TEST_OS_DEFAULT
 
 @nondestructive
 @skipDistroPackage()
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestBonding(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -19,12 +19,11 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import nondestructive, skipDistroPackage, test_main
 
 
 @nondestructive
 @skipDistroPackage()
-@skipImage("TODO: testBasic fails on Arch Linux", "arch")
 class TestBridge(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -46,7 +46,6 @@ def get_active_rules(machine):
     return active_rules
 
 
-@skipImage("TODO: Arch Linux shows no firewalld page", "arch")
 @skipImage("no firewalld", "fedora-coreos")
 @nondestructive
 @skipDistroPackage()
@@ -59,6 +58,10 @@ class TestFirewall(NetworkCase):
         self.btn_danger = "pf-m-danger"
         self.btn_primary = "pf-m-primary"
         self.default_zone = "Public zone"
+
+        # Arch Linux image has no active zones by default
+        if m.image == "arch":
+            m.execute("firewall-cmd --zone 'public' --change-interface='eth0'; firewall-cmd --runtime-to-permanent")
 
     def testNetworkingPage(self):
         b = self.browser

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -19,13 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import skipDistroPackage, skipImage, test_main, wait
+from testlib import skipDistroPackage, test_main, wait
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
-@skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 class TestNetworkingMTU(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},


### PR DESCRIPTION
This extends enabled testset, something is still wrong with bond/team tests which needs more investigation.