### PR TITLE
GitHub actions checkout

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Log into container registry
         run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io

--- a/.github/workflows/flatpak-test.yml
+++ b/.github/workflows/flatpak-test.yml
@@ -18,7 +18,7 @@ jobs:
         run: flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run npm-update bot
         run: |

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone target branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -26,11 +26,11 @@ jobs:
 
       - name: Clear .github-changes label
         if: ${{ !endsWith(github.event.action, 'labeled') }}
-        uses: actions/github-script@v3
+        uses: actions/github-script@v6
         with:
           script: |
             try {
-              await github.issues.removeLabel({
+              await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,

--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # need this to also fetch tags
           fetch-depth: 0

--- a/.github/workflows/urls-check.yml
+++ b/.github/workflows/urls-check.yml
@@ -13,7 +13,7 @@ jobs:
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/github-token
 
       - name: Clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Run urls-check action
         run: |

--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -21,13 +21,13 @@ jobs:
           sudo apt install -y --no-install-recommends gettext
 
       - name: Clone source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ssh-key: ${{ secrets.DEPLOY_KEY }}
           path: src
 
       - name: Clone weblate repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository }}-weblate
           path: weblate

--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt install -y --no-install-recommends gettext
 
       - name: Clone source repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: src
 
@@ -30,7 +30,7 @@ jobs:
         run: make -C src -f po/Makefile.am po/cockpit.pot
 
       - name: Clone weblate repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: weblate
           repository: ${{ github.repository }}-weblate


### PR DESCRIPTION
See the following links for more details:

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
https://github.com/actions/github-script#breaking-changes-in-v5

 - [x] test reposchutz by opening a PR against an origin branch