### PR TITLE
bridge: python: drop disk.all.ops

### DIFF
--- a/src/bridge/cockpitdisksamples.c
+++ b/src/bridge/cockpitdisksamples.c
@@ -148,7 +148,6 @@ cockpit_disk_samples (CockpitSamples *samples)
 
   cockpit_samples_sample (samples, "disk.all.read", NULL, bytes_read);
   cockpit_samples_sample (samples, "disk.all.written", NULL, bytes_written);
-  cockpit_samples_sample (samples, "disk.all.ops", NULL, num_ops);
 
 out:
   g_strfreev (lines);

--- a/src/cockpit/samples.py
+++ b/src/cockpit/samples.py
@@ -183,7 +183,6 @@ class DiskSampler(Sampler):
 
             samples['disk.all.read'] = all_read_bytes
             samples['disk.all.written'] = all_written_bytes
-            samples['disk.all.ops'] = num_ops
 
 
 class CGroupSampler(Sampler):


### PR DESCRIPTION
This was added in 2015 but it seems the client never used it, as there are no plans to use it drop it.

Was added in af2d488a27b7beb7e410a673923442ead7d02ac2 
The overhead of keeping it is minimal to be fair, but seems a bit wasteful to keep things which are unused since 2015 :)