### PR TITLE
test: Prevent bash TCO when keeping a mount point busy

### DIFF
--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -42,8 +42,10 @@ class TestStorageUsed(StorageCase):
         m.execute("mke2fs -q -L TEST /dev/mapper/dm-test")
         m.execute("mount /dev/mapper/dm-test /mnt")
 
-        # Keep the mount point busy
-        sleep_pid = m.spawn("cd /mnt; sleep infinity", "sleep")
+        # Keep the mount point busy.  The extra "true" is here to
+        # prevent bash from applying tail call optimization to the
+        # "sleep" invocation.
+        sleep_pid = m.spawn("cd /mnt; sleep infinity; true", "sleep")
         self.write_file("/etc/systemd/system/keep-mnt-busy.service",
                         """
 [Unit]


### PR DESCRIPTION
Different versions of bash do tail call optimization in different scenarios, and the "Currently in use" pop-up would either show the bash process or not (depending on whether TCO was done). So let's prevent bash from doing TCO of the "sleep" call.