### PR TITLE
test: Don't use "journalctl -n -u"

### DIFF
--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -161,7 +161,7 @@ class TestNetworkingCheckpoints(NetworkCase):
         # back.
 
         def checkpoint_was_destroyed():
-            lines = m.execute("journalctl -n 1000 -u NetworkManager | grep op=").split("\n")
+            lines = m.execute("journalctl -u NetworkManager | grep op=").split("\n")
             last_checkpoint = None
             for line in lines:
                 match = re.search('op="checkpoint-create" arg="([^"]*)"', line)


### PR DESCRIPTION
This seems to be bugged when systemd 251 rotates journal files, see https://github.com/systemd/systemd/issues/25063.

The NetworkManager journal is shorter than 1000 lines in this test anyway, so dropping "-n 1000" has no effect on performance.