### PR TITLE
accounts: Use table view for accounts overview

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -53,6 +53,7 @@ import './cockpit-components-table.scss';
  * - variant: For compact tables pass 'compact'
  * - gridBreakPoint: Specifies the grid breakpoints ('', 'grid' | 'grid-md' | 'grid-lg' | 'grid-xl' | 'grid-2xl')
  * - sortBy: { index: Number, direction: SortByDirection }
+ * - sortMethod: callback function used for sorting rows. Called with 3 parameters: sortMethod(rows, activeSortDirection, activeSortIndex)
  * - style: object of additional css rules
  * - afterToggle: function to be called when content is toggled
  */
@@ -70,6 +71,7 @@ export const ListingTable = ({
     rows: tableRows = [],
     showHeader = true,
     sortBy,
+    sortMethod,
     ...extraProps
 }) => {
     let rows = tableRows;
@@ -169,7 +171,7 @@ export const ListingTable = ({
         setActiveSortDirection(direction);
     };
 
-    const rowsComponents = (isSortable ? sortRows() : rows).map((row, rowIndex) => {
+    const rowsComponents = (isSortable ? (sortMethod ? sortMethod(rows, activeSortDirection, activeSortIndex) : sortRows()) : rows).map((row, rowIndex) => {
         const rowProps = row.props || {};
         if (onRowClick) {
             rowProps.isHoverable = true;

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -18,72 +18,273 @@
  */
 
 import cockpit from 'cockpit';
-import React from 'react';
+import React, { useState } from 'react';
 import { superuser } from "superuser";
 
-import { Button, Badge, Card, CardBody, Gallery, Page, PageSection, PageSectionVariants } from '@patternfly/react-core';
-import { UserIcon } from '@patternfly/react-icons';
+import {
+    Button, Badge,
+    Card, CardHeader, CardTitle,
+    Dropdown, DropdownItem, DropdownSeparator,
+    Flex, KebabToggle, Label,
+    Page, PageSection,
+    SearchInput,
+    Text, TextVariants,
+    Toolbar, ToolbarContent, ToolbarItem
+} from '@patternfly/react-core';
+import * as timeformat from "timeformat.js";
+import { EmptyStatePanel } from 'cockpit-components-empty-state.jsx';
+import { ListingTable } from 'cockpit-components-table.jsx';
+import { SearchIcon } from '@patternfly/react-icons';
+import { SortByDirection } from "@patternfly/react-table";
 import { account_create_dialog } from "./account-create-dialog.js";
+import { delete_account_dialog } from "./delete-account-dialog.js";
 
 const _ = cockpit.gettext;
 
-function AccountItem({ account, current }) {
-    function click(ev) {
-        if (!ev)
-            return;
+const UserActions = ({ account }) => {
+    const [isKebabOpen, setKebabOpen] = useState(false);
 
-        if (ev.type === 'click' && ev.button !== 0)
-            return;
+    const actions = [
+        <DropdownItem key="edit-user"
+                      onClick={ev => { ev.preventDefault(); cockpit.location.go(account.name) }}>
+            {_("Edit user")}
+        </DropdownItem>,
+        <DropdownSeparator key="separator-0" />,
+        <DropdownItem key="log-user-out"
+                      isDisabled={account.uid === 0 || !account.loggedIn}>
+            {_("Log user out")}
+        </DropdownItem>,
+        <DropdownSeparator key="separator-1" />,
+        <DropdownItem key="lock-account">
+            {_("Lock account")}
+        </DropdownItem>,
+        <DropdownItem key="delete-account"
+                      isDisabled={account.uid === 0}
+                      className={account.uid === 0 ? "" : "delete-account-red"}
+                      onClick={() => delete_account_dialog(account)}>
+            {_("Delete account")}
+        </DropdownItem>,
+    ];
 
-        if (ev.type === 'keypress' && ev.key !== "Enter")
-            return;
+    const kebab = (
+        <Dropdown toggle={<KebabToggle onToggle={setKebabOpen} />}
+                isPlain
+                isOpen={isKebabOpen}
+                position="right"
+                dropdownItems={actions} />
+    );
+    return kebab;
+};
 
-        cockpit.location.go([account.name]);
+const getAccountRow = (account, current, groups) => {
+    const adminGroups = ['sudo', 'root', 'wheel'];
+
+    const userGroups = groups.reduce((pV, group) => {
+        if (group.userlist.find(accountName => accountName === account.name)) {
+            const isAdmin = !!adminGroups.find(adm => adm === group.name);
+            return pV.concat({ name: group.name, members: group.userlist.length, isAdmin: isAdmin });
+        } else {
+            return pV;
+        }
+    }, []);
+
+    userGroups.sort((a, b) => {
+        if (a.isAdmin)
+            return -1;
+        if (b.isAdmin)
+            return 1;
+        if (a.members === b.members)
+            return a.name.localeCompare(b.name);
+        else
+            return b.members - a.members;
+    });
+
+    const userGroupLabels = userGroups.map(group => {
+        const color = group.isAdmin ? "gold" : "cyan";
+        return (
+            <Label key={group.name} variant="filled" color={color}>
+                {!group.isAdmin ? group.name : ("admin" + " (" + group.name + ")") }
+            </Label>
+        );
+    });
+
+    let loginText = "";
+    let loginSortKey = null;
+    if (account.loggedIn) {
+        loginText = _("Logged in");
+        loginSortKey = "logged in";
+    } else if (!account.lastLogin) {
+        loginText = _("Never logged in");
+        loginSortKey = "never";
+    } else {
+        loginSortKey = new Date(account.lastLogin);
+        loginText = timeformat.dateTime(loginSortKey);
     }
 
-    return (
-        <Card onClick={click} onKeyPress={click} isSelectable isCompact>
-            <CardBody className="cockpit-account">
-                <UserIcon className="cockpit-account-pic" />
-                <div className="cockpit-account-real-name">{account.gecos.split(',')[0]}</div>
-                <div className="cockpit-account-user-name">
+    const columns = [
+        {
+            title: (
+                <span>
                     <a href={"#/" + account.name}>{account.name}</a>
-                    {current && <Badge className="cockpit-account-badge">{_("Your account")}</Badge>}
-                </div>
-            </CardBody>
-        </Card>
-    );
-}
+                    {current && <Badge className="pf-u-ml-lg" id="current-account-badge">{_("Your account")}</Badge>}
+                </span>
+            ),
+            sortKey: account.name,
+            props: { width: 25, },
+        },
+        {
+            title: account.gecos.split(',')[0],
+            props: { width: 20, },
+        },
+        {
+            title: account.uid.toString(),
+            props: { width: 10, },
+        },
+        {
+            title: loginText,
+            sortKey: loginSortKey,
+            props: { width: 25, },
+        },
+        {
+            title: (
+                <Flex spaceItems={{ default: 'spaceItemsSm' }}>
+                    {userGroupLabels}
+                </Flex>
+            ),
+            props: { width: 20 },
+        },
+        {
+            title: <UserActions account={account} />,
+            props: { className: "pf-c-table__action" }
+        },
+    ];
 
-export function AccountsList({ accounts, current_user }) {
-    const filtered_accounts = accounts.filter(function(account) {
-        return !((account.uid < 1000 && account.uid !== 0) ||
+    return { columns };
+};
+
+const mapGroupsToAccount = (accounts, groups) => {
+    return accounts.map(account => {
+        const accountGroups = [];
+        groups.forEach(group => {
+            if (group.userlist.find(accountName => accountName === account.name))
+                accountGroups.push(group.name);
+        });
+        account.groups = accountGroups;
+
+        return account;
+    });
+};
+
+const AccountsList = ({ accountsInfo, current_user, groups }) => {
+    const [currentTextFilter, setCurrentTextFilter] = useState("");
+
+    const accounts = mapGroupsToAccount(accountsInfo, groups);
+
+    const filtered_accounts = accounts.filter(account => {
+        if ((account.uid < 1000 && account.uid !== 0) ||
                  account.shell.match(/^(\/usr)?\/sbin\/nologin/) ||
-                 account.shell === '/bin/false');
+                 account.shell === '/bin/false')
+            return false;
+
+        if (currentTextFilter !== "" &&
+            (account.name.toLowerCase().indexOf(currentTextFilter.toLowerCase()) === -1) &&
+            (account.gecos.toLowerCase().indexOf(currentTextFilter.toLowerCase()) === -1) &&
+            (account.uid.toString().indexOf(currentTextFilter.toLowerCase()) === -1) &&
+            (!account.groups.find(group => group.toLowerCase().indexOf(currentTextFilter.toLowerCase()) !== -1)))
+            return false;
+
+        return true;
     });
 
-    filtered_accounts.sort(function (a, b) {
-        if (current_user === a.name) return -1;
-        else if (current_user === b.name) return 1;
-        else if (!a.gecos) return -1;
-        else if (!b.gecos) return 1;
-        else return a.gecos.localeCompare(b.gecos);
-    });
+    const columns = [
+        { title: _("Username"), sortable: true },
+        { title: _("Full name"), sortable: true },
+        { title: _("ID"), sortable: true },
+        { title: _("Last active"), sortable: true },
+        { title: _("Group") },
+    ];
 
+    const sortRows = (rows, direction, idx) => {
+        const sortedRows = rows.sort((a, b) => {
+            const aitem = a.columns[idx];
+            const bitem = b.columns[idx];
+            const aname = a.columns[0];
+            const bname = b.columns[0];
+
+            // current user is always first
+            if (aname.sortKey === current_user)
+                return direction === SortByDirection.asc ? -1 : 1;
+            if (bname.sortKey === current_user)
+                return direction === SortByDirection.asc ? 1 : -1;
+            // sorting last login
+            if (idx === 3) {
+                if (aitem.sortKey === "logged in")
+                    return -1;
+                if (bitem.sortKey === "logged in")
+                    return 1;
+                if (aitem.sortKey === "never")
+                    return 1;
+                if (bitem.sortKey === "never")
+                    return -1;
+
+                return bitem.sortKey - aitem.sortKey;
+            }
+
+            return ((typeof aitem == 'string' ? aitem : (aitem.sortKey || aitem.title)).localeCompare(typeof bitem == 'string' ? bitem : (bitem.sortKey || bitem.title)));
+        });
+        return direction === SortByDirection.asc ? sortedRows : sortedRows.reverse();
+    };
+
+    const tableToolbar = (
+        <Toolbar>
+            <ToolbarContent className="accounts-toolbar-header">
+                <ToolbarItem>
+                    <SearchInput id="accounts-filter"
+                                 placeholder={_("Search for name, group or ID")}
+                                 value={currentTextFilter}
+                                 onChange={setCurrentTextFilter}
+                                 onClear={() => setCurrentTextFilter('')} />
+                </ToolbarItem>
+                { superuser.allowed &&
+                    <>
+                        <ToolbarItem variant="separator" />
+                        <ToolbarItem alignment={{ md: 'alignRight' }}>
+                            <Button id="accounts-create" onClick={() => account_create_dialog(accounts)}>
+                                {_("Create new account")}
+                            </Button>
+                        </ToolbarItem>
+                    </>
+                }
+            </ToolbarContent>
+        </Toolbar>
+    );
+
+    return (
+        <Card className="ct-card">
+            <CardHeader>
+                <CardTitle>
+                    <Text component={TextVariants.h2}>{_("Accounts")}</Text>
+                </CardTitle>
+                {tableToolbar}
+            </CardHeader>
+            {filtered_accounts.length === 0
+                ? <EmptyStatePanel title={_("No matching results")} icon={SearchIcon} />
+                : <ListingTable columns={columns}
+                              id="accounts-list"
+                              rows={ filtered_accounts.map(a => getAccountRow(a, current_user === a.name, groups)) }
+                              sortMethod={sortRows}
+                              variant="compact" sortBy={{ index: 0, direction: SortByDirection.asc }} />}
+        </Card>
+
+    );
+};
+
+export const AccountsMain = ({ accountsInfo, current_user, groups }) => {
     return (
         <Page id="accounts">
-            { superuser.allowed &&
-                <PageSection variant={PageSectionVariants.light}>
-                    <Button id="accounts-create" onClick={() => account_create_dialog(accounts)}>
-                        {_("Create new account")}
-                    </Button>
-                </PageSection>
-            }
-            <PageSection id="accounts-list">
-                <Gallery className='ct-system-overview' hasGutter>
-                    { filtered_accounts.map(a => <AccountItem key={a.name} account={a} current={current_user == a.name} />) }
-                </Gallery>
+            <PageSection>
+                <AccountsList accountsInfo={accountsInfo} current_user={current_user} groups={groups} />
             </PageSection>
         </Page>
     );
-}
+};

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -38,6 +38,8 @@ import { SearchIcon } from '@patternfly/react-icons';
 import { SortByDirection } from "@patternfly/react-table";
 import { account_create_dialog } from "./account-create-dialog.js";
 import { delete_account_dialog } from "./delete-account-dialog.js";
+import { lockAccountDialog } from "./lock-account-dialog.js";
+import { logoutAccountDialog } from "./logout-account-dialog.js";
 
 const _ = cockpit.gettext;
 
@@ -49,22 +51,28 @@ const UserActions = ({ account }) => {
                       onClick={ev => { ev.preventDefault(); cockpit.location.go(account.name) }}>
             {_("Edit user")}
         </DropdownItem>,
+    ];
+
+    superuser.allowed && actions.push(
         <DropdownSeparator key="separator-0" />,
         <DropdownItem key="log-user-out"
-                      isDisabled={account.uid === 0 || !account.loggedIn}>
+                      isDisabled={account.uid === 0 || !account.loggedIn}
+                      onClick={() => { setKebabOpen(false); logoutAccountDialog(account) }}>
             {_("Log user out")}
         </DropdownItem>,
         <DropdownSeparator key="separator-1" />,
-        <DropdownItem key="lock-account">
+        <DropdownItem key="lock-account"
+                      isDisabled={account.isLocked}
+                      onClick={() => { setKebabOpen(false); lockAccountDialog(account) }}>
             {_("Lock account")}
         </DropdownItem>,
         <DropdownItem key="delete-account"
                       isDisabled={account.uid === 0}
                       className={account.uid === 0 ? "" : "delete-account-red"}
-                      onClick={() => delete_account_dialog(account)}>
+                      onClick={() => { setKebabOpen(false); delete_account_dialog(account) }}>
             {_("Delete account")}
         </DropdownItem>,
-    ];
+    );
 
     const kebab = (
         <Dropdown toggle={<KebabToggle onToggle={setKebabOpen} />}

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -62,7 +62,7 @@ function AccountsPage() {
         return <AccountsMain accountsInfo={accountsInfo} current_user={current_user_info.name} groups={groups} />;
     } else
         return (
-            <AccountDetails accounts={accounts} groups={groups} shadow={shadow}
+            <AccountDetails accounts={accountsInfo} groups={groups} shadow={shadow}
                             current_user={current_user_info.name} user={path[0]} />
         );
 }

--- a/pkg/users/lock-account-dialog.js
+++ b/pkg/users/lock-account-dialog.js
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import { show_modal_dialog } from "cockpit-components-dialog.jsx";
+
+const _ = cockpit.gettext;
+
+export const lockAccountDialog = (account) => {
+    let dlg = null;
+
+    const props = {
+        id: "account-confirm-lock-dialog",
+        title: cockpit.format(_("Lock $0"), account.name),
+    };
+
+    const footer = {
+        actions: [
+            {
+                style: "danger",
+                caption: _("Lock"),
+                clicked: () => {
+                    return cockpit.spawn(["/usr/sbin/usermod", account.name, "--lock"], { superuser: "require", err: "message" })
+                            .catch(err => console.warn("Failed to log user out", err));
+                },
+            }
+        ]
+    };
+
+    if (!dlg)
+        dlg = show_modal_dialog(props, footer);
+    else {
+        dlg.setProps(props);
+        dlg.setFooterProps(footer);
+    }
+};

--- a/pkg/users/logout-account-dialog.js
+++ b/pkg/users/logout-account-dialog.js
@@ -1,0 +1,53 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2020 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+
+import { show_modal_dialog } from "cockpit-components-dialog.jsx";
+
+const _ = cockpit.gettext;
+
+export const logoutAccountDialog = (account) => {
+    let dlg = null;
+
+    const props = {
+        id: "account-confirm-logout-dialog",
+        title: cockpit.format(_("Logout $0"), account.name),
+    };
+
+    const footer = {
+        actions: [
+            {
+                style: "primary",
+                caption: _("Log out"),
+                clicked: () => {
+                    return cockpit.spawn(["/usr/bin/loginctl", "terminate-user", account.name], { superuser: "try", err: "message" })
+                            .catch(err => console.warn("Failed to log user out", err));
+                },
+            }
+        ]
+    };
+
+    if (!dlg)
+        dlg = show_modal_dialog(props, footer);
+    else {
+        dlg.setProps(props);
+        dlg.setFooterProps(footer);
+    }
+};

--- a/pkg/users/users.scss
+++ b/pkg/users/users.scss
@@ -5,6 +5,7 @@
 @import "@patternfly/patternfly/utilities/Spacing/spacing.css";
 @import "global-variables.scss";
 @import "@patternfly/patternfly/components/DataList/data-list.scss";
+@import "@patternfly/patternfly/components/Toolbar/toolbar.scss";
 
 #account .pf-c-card {
   @extend .ct-card;
@@ -73,6 +74,10 @@
   > a {
     margin-right: 0.5rem;
   }
+}
+
+.delete-account-red {
+  color: var(--pf-global--danger-color--200);
 }
 
 #account-details div.checkbox:first-child {
@@ -218,4 +223,8 @@
 
 .outline-question-circle-icon {
   margin-left: var(--pf-global--spacer--sm);
+}
+
+.accounts-toolbar-header > .pf-c-toolbar__content-section {
+  row-gap: var(--pf-global--spacer--sm);
 }

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -424,8 +424,7 @@ class TestMultiMachine(MachineCase):
         # Test subnav
         b.click_system_menu("/@10.111.113.2/users", enter=False)
         b.enter_page("/users", host="10.111.113.2")
-        b.wait_visible("#accounts-list")
-        b.click("#accounts-list .pf-c-card:first-child")
+        b.click('#accounts-list td[data-label="Username"] a[href="#/admin"]')
         b.wait_text("#account-user-name", "admin")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/cockpit-new/@10.111.113.2/users"')

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -40,11 +40,11 @@ class TestAccounts(MachineCase):
             b.wait_in_text('#accounts-list', "anton")
 
         # There is only one badge and it is for admin
-        b.wait_text('.cockpit-account-badge', 'Your account')
-        b.wait_js_cond('document.querySelector(".cockpit-account-badge").previousSibling.getAttribute("href") === "#/admin"')
+        b.wait_text('#current-account-badge', 'Your account')
+        b.wait_js_cond('document.querySelector("#current-account-badge").previousSibling.getAttribute("href") === "#/admin"')
 
         # The current account is the first in the list
-        b.wait_visible(".pf-c-card:first-child .cockpit-account-badge")
+        b.wait_visible("#accounts-list > tbody :first-child #current-account-badge")
 
         # Set a real name
         b.go("#/anton")
@@ -65,7 +65,7 @@ class TestAccounts(MachineCase):
         b.wait_text("#account-title", "Anton Arbitrary")
         # On the overview page it also shows only real name
         b.go("/users")
-        b.wait_text('.cockpit-account-real-name:contains("Anton")', "Anton Arbitrary")
+        b.wait_text('#accounts-list td[data-label="Full name"]:contains("Anton")', "Anton Arbitrary")
         b.go("/users/#anton")
 
         good_password = "tqymuVh.ZfZnP§9Wr=LM3JyG5yx"
@@ -219,11 +219,11 @@ class TestAccounts(MachineCase):
         b.login_and_go("/users", user="jussi", password="bar")
 
         # There is only one badge and it is for jussi
-        b.wait_text('.cockpit-account-badge', 'Your account')
-        b.wait_js_cond('document.querySelector(".cockpit-account-badge").previousSibling.getAttribute("href") === "#/jussi"')
+        b.wait_text('#current-account-badge', 'Your account')
+        b.wait_js_cond('document.querySelector("#current-account-badge").previousSibling.getAttribute("href") === "#/jussi"')
 
         # The current account is the first in the list
-        b.wait_visible(".pf-c-card:first-child .cockpit-account-badge")
+        b.wait_visible("#accounts-list > tbody :first-child #current-account-badge")
 
         b.go("#/jussi")
         b.wait_text("#account-user-name", "jussi")
@@ -292,7 +292,7 @@ class TestAccounts(MachineCase):
         b.go("/users")
         b.enter_page("/users")
         b.wait_in_text('#accounts-list', "damaged")
-        b.click('.cockpit-account-user-name a[href="#/damaged"]')
+        b.click('#accounts-list td[data-label="Username"] a[href="#/damaged"]')
         b.wait_in_text("#account-title", "Damaged")
 
         if m.image != "fedora-coreos":  # User is not shown as logged in when logged in through Cockpit
@@ -335,9 +335,13 @@ class TestAccounts(MachineCase):
 
         b.wait_not_present('#accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Robert Robertson")
-
         # Login as robert and check if password change is required
         b.logout()
+
+        # login in second window to check if last login is updated in accounts list
+        if m.image != "fedora-coreos":  # User is not shown as logged in when logged in through Cockpit
+            b2.login_and_go("/users")
+            b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", "Never logged in")
 
         # On OSTree this happens over ssh
         if m.ostree_image:
@@ -363,10 +367,114 @@ class TestAccounts(MachineCase):
         b.click('#login-button')
         b.wait_visible('#content')
 
+        def performUserAction(browser, user, action):
+            browser.click(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown button")
+            browser.click(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown__menu li:contains({action})")
+
+        if m.image != "fedora-coreos":
+            b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", "Logged in")
+            performUserAction(b2, 'robert', 'Log user out')
+            b2.click("#account-confirm-logout-dialog footer .pf-c-button.apply")
+
+            (year, month) = m.execute("date +'%Y %b'").strip().split()
+            b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", year)
+            b2.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Last active']", month)
+
+        b.logout()
+        b.login_and_go("/users")
+        # Test actions in kebab menu
+        # disable password
+        performUserAction(b, 'robert', 'Lock account')
+        b.click("#account-confirm-lock-dialog footer .pf-m-danger.apply")
+        # lock option is now disabled
+        b.click("#accounts-list tbody tr:contains(robert) .pf-c-dropdown button")
+        b.wait_in_text("#accounts-list tbody tr:contains(robert) .pf-c-dropdown__menu li:contains('Lock account') .pf-m-disabled", 'Lock account')
+        b.click("#accounts-list tbody tr:contains(robert) .pf-c-dropdown button")
+        # change is visible on details page
+        performUserAction(b, 'robert', 'Edit user')
+        b.wait_in_text('#account-title', 'Robert Robertson')
+        b.wait_visible('#account-locked:checked')
+        b.click("#account-locked")
+        b.go('/users')
+
+        # Check Robert's groups
+        b.wait_not_present("#accounts-list tbody tr:contains(robert) td[data-label='Group'] .pf-c-label")
+        if m.image != "fedora-coreos":  # Users group does not exist in coreos image
+            m.execute("/usr/sbin/usermod -aG users robert")
+            b.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Group'] .pf-c-label.pf-m-cyan", "users")
+        m.execute("/usr/sbin/usermod -aG wheel robert")
+        b.wait_in_text("#accounts-list tbody tr:contains(robert) td[data-label='Group'] .pf-c-label.pf-m-gold", "wheel")
+        m.execute("/usr/bin/gpasswd -d robert wheel")
+        b.wait_not_present("#accounts-list tbody tr:contains(robert) td[data-label='Group'] .pf-c-label.pf-m-gold")
+
+        # test filters
+        b.set_input_text("#accounts-filter input", "rOBeRt")
+        b.wait_in_text("#accounts-list tbody tr:first-child td[data-label='Username']", "robert")
+        b.set_input_text("#accounts-filter input", "root")
+        b.wait_in_text("#accounts-list tbody tr:first-child td[data-label='Username']", "root")
+
+        uid = "1000"
+        if "debian" in m.image or "ubuntu" in m.image:
+            uid = "1001"
+        b.set_input_text("#accounts-filter input", uid)
+        b.wait_in_text("#accounts-list tbody tr:first-child td[data-label='ID']", uid)
+        b.set_input_text("#accounts-filter input", "spooky")
+        b.wait_visible("#accounts div.pf-c-empty-state")
+
+        b.inject_js("""
+                    function getTextColumn(query_selector) {
+                        const values = [];
+                        document.querySelectorAll(query_selector).forEach(node => values.push(node.innerText));
+                        return values;
+                    }""")
+
+        def check_column_sort(query_selector, invert=False):
+            # current account is always in the first row
+            b.wait_in_text("#accounts-list tbody tr:first-child td[data-label='Username']", "admin")
+            values = b.eval_js(f"getTextColumn(\"{query_selector}\")")
+            for i in range(2, len(values)):
+                if (invert):
+                    b.wait(lambda: values[i - 1].lower() > values[i].lower())
+                else:
+                    b.wait(lambda: values[i - 1].lower() < values[i].lower())
+
+        # robert should be in users group
+        if m.image != "fedora-coreos":  # Users group does not exist in coreos image
+            b.set_input_text("#accounts-filter input", "users")
+            names = b.eval_js("getTextColumn(\"[data-label='Username'] a\")")
+            b.wait(lambda: "robert" in names)
+
+        # clear text filters
+        b.click("#accounts-filter button[aria-label='Reset']")
+
+        # check alphabetical order of Username
+        check_column_sort("[data-label='Username'] a")
+        b.click("#accounts-list > thead > tr > th:nth-child(1) > button")
+        check_column_sort("[data-label='Username'] a", invert=True)
+
+        # sort by full name
+        b.click("#accounts-list > thead > tr > th:nth-child(2) > button")
+        check_column_sort("[data-label='Full name']")
+        b.click("#accounts-list > thead > tr > th:nth-child(2) > button")
+        check_column_sort("[data-label='Full name']", invert=True)
+
+        # sort by ID
+        b.click("#accounts-list > thead > tr > th:nth-child(3) > button")
+        check_column_sort("[data-label='ID']")
+        b.click("#accounts-list > thead > tr > th:nth-child(3) > button")
+        check_column_sort("[data-label='ID']", invert=True)
+
+        # In fedora-core userdel for this user consistently fails
+        # userdel: user robert is currently used by process *
+        if m.image != "fedora-coreos":
+            performUserAction(b, 'robert', 'Delete account')
+            b.click("#account-confirm-delete-dialog footer button.pf-m-danger.apply")
+            b.wait_not_in_text('#accounts-list', "Robert Robertson")
+
         self.allow_journal_messages("Password quality check failed:")
         self.allow_journal_messages("The password is a palindrome")
         self.allow_journal_messages("passwd: user.*does not exist")
-        self.allow_journal_messages("passwd: Unknown user name 'anton'.")
+        self.allow_journal_messages("passwd: Unknown user name '.*'.")
         self.allow_journal_messages("lastlog: Unknown user or range: anton")
         self.allow_journal_messages(".*required to change your password immediately.*")
         self.allow_journal_messages(".*user account or password has expired.*")


### PR DESCRIPTION
TODO:
- [x] Show last login information
    - Log user out
    - Lock user
- [ ] Sorting by groups
- [x] clean up css



# Redesign accounts page

The new accounts page implementation brings in more details in the accounts summary view, add suports for filtering the list of users and lastly shows information about the groups per user.