### PR TITLE
selinux: Allow fowner capability to cockpit-session

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -134,7 +134,7 @@ optional_policy(`
 
 # cockpit-session changes to the actual logged in user
 # pam_faillock chowns the state file to the target user
-allow cockpit_session_t self:capability { chown dac_override dac_read_search setgid setuid sys_admin sys_resource };
+allow cockpit_session_t self:capability { chown fowner dac_override dac_read_search setgid setuid sys_admin sys_resource };
 allow cockpit_session_t self:process { setexec setrlimit setsched signal_perms };
 
 read_files_pattern(cockpit_session_t, cockpit_var_lib_t, cockpit_var_lib_t)


### PR DESCRIPTION
Most recent Fedora 37's pam_faillock tries to chown/chmod/etc. some state files, which requires `CAP_FOWNER`. Grant this, as it's less dangerous than `CAP_DAC_OVERRIDE`.

See https://github.com/cockpit-project/bots/pull/3974

---

I verified this on the new image in https://github.com/cockpit-project/bots/pull/3974 with `test/verify/check-static-login TestLogin.testFaillock`.