### PR TITLE
test: Avoid multi-arch conflict on mock-pam-conv-mod.so

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -162,12 +162,11 @@ mock_pam_conv_mod_so_CFLAGS = -fPIC $(AM_CFLAGS)
 mock_pam_conv_mod_so_LDFLAGS = -shared
 mock_pam_conv_mod_so_LDADD = $(PAM_LIBS)
 
-testassetsdir = $(prefix)/lib/cockpit-test-assets
 testserviceddir = $(systemdunitdir)/cockpit.service.d
 
 install-tests::
-	mkdir -p $(DESTDIR)$(testassetsdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
-	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(testassetsdir)
+	mkdir -p $(DESTDIR)$(pamdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
+	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(pamdir)/
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -356,9 +356,9 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # On Arch Linux the ordering matters due to an auth include for system-remote-login
         if self.machine.image == "arch":
-            self.sed_file('1 a auth       required    /usr/lib/cockpit-test-assets/mock-pam-conv-mod.so', conf)
+            self.sed_file('1 a auth       required    mock-pam-conv-mod.so', conf)
         else:
-            self.sed_file('5 a auth       required    /usr/lib/cockpit-test-assets/mock-pam-conv-mod.so', conf)
+            self.sed_file('5 a auth       required    mock-pam-conv-mod.so', conf)
 
         m.start_cockpit()
         b.open("/system")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -107,14 +107,14 @@ class TestSuperuser(MachineCase):
         if "debian" in m.image or "ubuntu" in m.image:
             self.write_file("/etc/pam.d/sudo", """
 auth required pam_unix.so
-auth required /usr/lib/cockpit-test-assets/mock-pam-conv-mod.so
+auth required mock-pam-conv-mod.so
 @include common-account
 @include common-session-noninteractive
 """)
         else:
             self.write_file("/etc/pam.d/sudo", """
 auth required pam_unix.so
-auth required /usr/lib/cockpit-test-assets/mock-pam-conv-mod.so
+auth required mock-pam-conv-mod.so
 account include system-auth
 password include system-auth
 session include system-auth

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -256,7 +256,8 @@ done
 for libexec in cockpit-askpass cockpit-session cockpit-ws cockpit-tls cockpit-wsinstance-factory cockpit-client cockpit-client.ui cockpit-desktop cockpit-certificate-helper cockpit-certificate-ensure; do
     rm %{buildroot}/%{_libexecdir}/$libexec
 done
-rm -r %{buildroot}/%{_libdir}/security %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
+rm -r %{buildroot}/%{_sysconfdir}/pam.d %{buildroot}/%{_sysconfdir}/motd.d %{buildroot}/%{_sysconfdir}/issue.d
+rm -f %{buildroot}/%{_libdir}/security/pam_*
 rm %{buildroot}/usr/bin/cockpit-bridge
 rm -f %{buildroot}%{_libexecdir}/cockpit-ssh
 rm -f %{buildroot}%{_datadir}/metainfo/cockpit.appdata.xml
@@ -268,7 +269,7 @@ for pkg in apps packagekit pcp playground storaged; do
     rm -rf %{buildroot}/%{_datadir}/cockpit/$pkg
 done
 # files from -tests
-rm -r %{buildroot}/%{_prefix}/%{__lib}/cockpit-test-assets
+rm -f %{buildroot}/%{pamdir}/mock-pam-conv-mod.so
 # files from -pcp
 rm -r %{buildroot}/%{_libexecdir}/cockpit-pcp %{buildroot}/%{_localstatedir}/lib/pcp/
 # files from -storaged
@@ -622,7 +623,7 @@ This package contains tests and files used while testing Cockpit.
 These files are not required for running Cockpit.
 
 %files -n cockpit-tests -f tests.list
-%{_prefix}/%{__lib}/cockpit-test-assets
+%{pamdir}/mock-pam-conv-mod.so
 
 %package -n cockpit-pcp
 Summary: Cockpit PCP integration


### PR DESCRIPTION
In Fedora you can install multiple architectures of a package
simultaneously. This causes a file conflict when trying to install both
the i686 and x86_64 architecture of "cockpit-tests", as they both ship
/usr/lib/cockpit-test-assets/mock-pam-conv-mod.so (and this is not a
magic multi-arch directory).

This is of no practical importance other than that rpminspect complains,
which causes a nasty red stain in gating.

Install the file into the proper PAM dir right away. This is properly
multi-arched in both Debian and Fedora, and tests then don't need to
know the exact directory any more. For people installing from upstream
this is still sufficiently guarded, as `make install` does not install
that module (only `make test-install` does).

---

This is the [rpmdeplint failure](https://artifacts.dev.testing-farm.io/0e7f4544-b665-47ac-8811-6f813efceab8/) of cockpit's [Fedora updates](https://bodhi.fedoraproject.org/updates/FEDORA-2022-4f1a38ada0). 

(I am also handling the rpminspect failure, but that needs to be addressed in rpmdeplint-data-fedora -- [fix](https://github.com/rpminspect/rpminspect-data-fedora/pull/29))