### PR TITLE
build: patch <releases> in metainfo on install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - id: publish
         name: Publish GitHub release
-        uses: cockpit-project/action-release@62db9d9850a1adec300500d84035c4f523fd5290
+        uses: cockpit-project/action-release@d922a7ea21329cb46762e52a218c120e388fb0c1
         with:
           filename: "cockpit-${{ github.ref_name }}.tar.xz"
 
@@ -40,6 +40,7 @@ jobs:
       filename: ${{ steps.publish.outputs.filename }}
       checksum: ${{ steps.publish.outputs.checksum }}
       download: ${{ steps.publish.outputs.download }}
+      body: ${{ steps.publish.outputs.body }}
 
   guide:
     needs: source
@@ -101,6 +102,10 @@ jobs:
     permissions: {}
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
       - name: Checkout source repository
         uses: actions/checkout@v3
         with:
@@ -116,18 +121,24 @@ jobs:
           fetch-depth: 0
 
       - name: Update flathub repository
+        env:
+          DOWNLOAD: ${{ needs.source.outputs.download }}
+          CHECKSUM: ${{ needs.source.outputs.checksum }}
+          TAG_BODY: ${{ needs.source.outputs.body }}
         run: |
           set -x
-
-          DOWNLOAD='${{ needs.source.outputs.download }}'
-          CHECKSUM='${{ needs.source.outputs.checksum }}'
 
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
 
           cd flathub
           git checkout -b "${{ github.ref_name }}"
+          printf '%s\n' "${TAG_BODY}" | ../src/containers/flatpak/add-release \
+             org.cockpit_project.CockpitClient.releases.xml \
+             "${{ github.ref_name }}" \
+             "$(date +%Y-%m%d)"
           git add "$(../src/containers/flatpak/prepare "${DOWNLOAD}" "${CHECKSUM}")"
+          git add org.cockpit_project.CockpitClient.releases.xml
           git commit -m "Update to version ${{ github.ref_name }}"
           git show
           git push git@github.com:cockpit-project/org.cockpit_project.CockpitClient HEAD

--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -11,6 +11,11 @@ install-for-flatpak: \
 		install-dist_scalableiconDATA \
 		install-dist_symboliciconDATA \
 		$(NULL)
+	if test -s "${DOWNSTREAM_RELEASES_XML}"; then \
+	    $(top_srcdir)/tools/patch-metainfo \
+	        '$(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml' \
+	        "${DOWNSTREAM_RELEASES_XML}"; \
+	fi
 	appstream-util validate --nonet src/client/org.cockpit_project.CockpitClient.metainfo.xml
 	mkdir -p $(DESTDIR)/$(bindir)
 	ln -sfTv $(cockpitclientdir)/cockpit-client $(DESTDIR)/$(bindir)/cockpit-client

--- a/containers/flatpak/add-release
+++ b/containers/flatpak/add-release
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+
+# Pretend like this is a little bit functional
+def element(tag, text=None, children=(), **kwargs):
+    tag = ET.Element(tag, kwargs)
+    tag.text = text
+    tag.extend(children)
+    return tag
+
+
+def points_from_body(body):
+    for text in re.split('^ *-', body, flags=re.MULTILINE):
+        if point := ' '.join(text.split()).strip():
+            yield element('li', point)
+
+
+def format_release(version, date, body):
+    return element('release', version=version, date=date, children=[
+        element('url', f'https://cockpit-project.org/blog/cockpit-{version}.html', type='details'),
+        element('description', children=[
+            element('p', f'Changes in Cockpit {version}:'),
+            element('ul', children=points_from_body(body))
+        ])
+    ])
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('releases', help='Release history XML file, eg. releases.xml')
+    parser.add_argument('version', help='The version number of the release')
+    parser.add_argument('date', help='The date of the release')
+    args = parser.parse_args()
+
+    tree = ET.parse(args.releases)
+    releases = tree.find('releases')
+    releases.insert(0, format_release(args.version, args.date, sys.stdin.read()))
+    ET.indent(releases, space="  ", level=1)
+    tree.write(args.releases, encoding='utf-8', xml_declaration=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/containers/flatpak/cockpit-client.yml.in
+++ b/containers/flatpak/cockpit-client.yml.in
@@ -25,9 +25,13 @@ modules:
       - --disable-doc
     make-args:
       - build-for-flatpak
+    make-install-args:
+      - DOWNSTREAM_RELEASES_XML=@FLATPAK_ID@.releases.xml
     install-rule: install-for-flatpak
 
     sources:
       - type: archive
         @ARCHIVE_TYPE@: @ARCHIVE_LOCATION@
         sha256: @ARCHIVE_SHA256@
+      - type: file
+        path: @FLATPAK_ID@.releases.xml

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -63,4 +63,5 @@ sed \
     -e "s|@ARCHIVE_SHA256@|${ARCHIVE_SHA256}|" \
     "${0%/*}/cockpit-client.yml.in" > "${FLATPAK_ID}.yml.tmp"
 mv "${FLATPAK_ID}.yml.tmp" "${FLATPAK_ID}.yml"
+touch "${FLATPAK_ID}.releases.xml"
 echo "${FLATPAK_ID}.yml"

--- a/tools/patch-metainfo
+++ b/tools/patch-metainfo
@@ -1,0 +1,35 @@
+#!/usr/bin/python3
+
+# Merges a downstream releases.xml file with the upstream metainfo.xml.
+#
+# Opens the metainfo file, finds the <releases> tag, and replaces its contents
+# with the contents of the <releases> tag found in the releases file.
+#
+# This facilitates keeping a downstream changelog, not shipped in tarballs.
+#
+# This substitution is meant to be done at `make install` time.  Set the
+# `DOWNSTREAM_RELEASES_XML` environment variable while calling `make install`.
+
+import argparse
+import xml.etree.ElementTree as ET
+
+parser = argparse.ArgumentParser()
+parser.add_argument('metainfo')
+parser.add_argument('releases')
+args = parser.parse_args()
+
+releases = ET.parse(args.releases)
+releases_releases = releases.find('releases')
+assert releases_releases is not None
+
+metainfo = ET.parse(args.metainfo)
+metainfo_releases = metainfo.find('releases')
+assert metainfo_releases is not None
+
+stub_release = metainfo_releases.find('release')
+if stub_release is not None:
+    metainfo_releases.remove(stub_release)
+
+metainfo_releases.extend(releases_releases)
+
+metainfo.write(args.metainfo)


### PR DESCRIPTION
If a DOWNSTREAM_RELEASES_XML environment variable is set while calling `make install` then patch the installed metainfo for Cockpit Client to use the release history from that external file.

This allows downstream packaging of Cockpit Client (particularly the Flatpak) to maintain its own version history, now that we don't ship one for ourselves.