### PR TITLE
.github: update webpack-jumpstart actions

### DIFF
--- a/.github/workflows/webpack-jumpstart.yml
+++ b/.github/workflows/webpack-jumpstart.yml
@@ -32,7 +32,7 @@ jobs:
           docker container rm -f "${id}"
 
       - name: Create artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: webpack-jumpstart
           path: webpack-jumpstart.tar
@@ -62,7 +62,7 @@ jobs:
             git remote add cache "ssh://git@github.com/${GITHUB_REPOSITORY%/*}/cockpit-dist"
 
       - name: Download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: webpack-jumpstart
           path: artifact


### PR DESCRIPTION
actions/{download,upload}-artifact@v3 uses nodejs 16 as runtime instead of the deprecated nodejs 12 runtime.

Seems I forgot some as can be seen [here](https://github.com/cockpit-project/cockpit/actions/runs/3319238959), not sure about the last warning we never use `set-output` so I guess that might be the action we use doing it?