### PR TITLE
test: enable clevs tang test on Arch Linux

### DIFF
--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase
-from testlib import skipImage, test_main, wait
+from testlib import test_main, wait
 
 
 class TestStorageLuks(StorageCase):
@@ -189,7 +189,6 @@ class TestStorageLuks(StorageCase):
         b.logout()
         wait(lambda: m.execute("(loginctl list-users | grep admin) || true") == "")
 
-    @skipImage("TODO: clevis missing on Arch image", "arch")
     def testClevisTang(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Works locally, let's verify it here after the refresh:

https://github.com/cockpit-project/bots/pull/3998