### PR TITLE
test: Relax test skip expected output

### DIFF
--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -126,7 +126,7 @@ class TestRunTest(MachineCase):
         self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail # RETRY 2 \(be robust against unstable tests\)\n")
         self.assertRegex(stdout, rb"\nnot ok 1 .*test\/verify\/check-example TestExample.testFail\n")
         self.assertNotRegex(stdout, b"RETRY 3")
-        self.assertRegex(stdout, rb"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample\)\n")
+        self.assertRegex(stdout, rb"\nok 2 .*test\/verify\/check-example TestExample.testSkip # SKIP testSkip \(__main__\.TestExample")
         self.assertRegex(stdout, rb"# 1 TESTS FAILED \[\d*s on .*, 2 parallel tests, 0 serial tests: \]")
 
         # Check retry logic for changed tests


### PR DESCRIPTION
In Fedora 37's Python, the skip message now contains the test name:

    # SKIP testSkip (__main__.TestExample.testSkip)\n

Relax the regular expression, we don't need to pin it down *that* precisely.

----

This got exposed by https://github.com/cockpit-project/cockpituous/pull/531 , so that [this test now fails everywhere](https://cockpit-logs.us-east-1.linodeobjects.com/pull-17839-20221026-054748-c5ecd1ca-arch/log.html#307-2). I think this is harmless/obvious enough to fix without rolling back the tasks container. This would also happen for developers locally, so we need to fix it either way.