### PR TITLE
test: Fall back to package.json during coverage processing

### DIFF
--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -143,12 +143,15 @@ class DistFile:
         return res
 
 
-def get_dist_map():
+def get_dist_map(package):
     dmap = {}
     for f in glob.glob(f"{BASE_DIR}/dist/*/manifest.json") + glob.glob(f"{BASE_DIR}/dist/manifest.json"):
         m = json.load(open(f))
         if "name" in m:
             dmap[m["name"]] = os.path.dirname(f)
+        elif f == f"{BASE_DIR}/dist/manifest.json":
+            if "name" in package:
+                dmap[package["name"]] = os.path.dirname(f)
     return dmap
 
 
@@ -282,7 +285,7 @@ def print_diff_coverage(path, file_hits, out):
 def write_lcov(covdata, outlabel):
 
     package = json.load(open(f"{BASE_DIR}/package.json"))
-    dist_map = get_dist_map()
+    dist_map = get_dist_map(package)
     file_hits = {}
 
     def covranges(functions):


### PR DESCRIPTION
External projects like cockpit-podman put their files directly into dist/ but install them into a subdirectory in /usr/share/cockpit/. For example, the dist/index.js file of cockpit-podman is installed as /usr/share/cockpit/podman/index.js.

During coverage processing, we need to map back from /usr/share/cockpit/podman/index.js to dist/index.js, and at the same time need to ignore other files like /usr/share/cockpit/storage/index.js.

This used to be done via the "name" element of manifest.json, but it is less intrusive to take the name from package.json, because it is already there.

This works as long as the Makefile of the external project also looks into package.json during installation.  Projects based on the starter-kit do this.