### PR TITLE
test: Python 3.11 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "axe-core": "^2.6.1",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
-    "chrome-remote-interface": "^0.25.2",
+    "chrome-remote-interface": "^0.31.2",
     "clean-css": "~3.4.20",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^0.28.10",


### PR DESCRIPTION
Python 3.11 changed it's unittest internals for the Outcome class and no longer calls testPartExecutor with isTest as it used too. The Outcome class now has a TestResult attribute which records failures, errors and successful tests different.