### PR TITLE
Injector proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ Makefile.in
 /configure
 /dist/
 /frob-websocket
+/injector.pyz
 /lcov/
 /mock-*
 /package-lock.json

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -53,9 +53,14 @@ pyTESTS = $(pyTESTS_PASSING) $(pyTESTS_FAILING)
 pycheck: cockpit-bridge.pyz
 	$(MAKE) check XFAIL_TESTS='$(pyTESTS_FAILING)' TESTS='$(pyTESTS)' COCKPIT_BRIDGE=./cockpit-bridge.pyz
 
+injcheck: injector.pyz
+	$(MAKE) check XFAIL_TESTS='$(pyTESTS_FAILING)' TESTS='$(pyTESTS)' COCKPIT_BRIDGE=./injector.pyz
+
 PYTHON_BRIDGE_FILES = \
 	src/cockpit/__init__.py \
 	src/cockpit/bridge.py \
+	src/cockpit/bootloader.py \
+	src/cockpit/injector.py \
 	src/cockpit/channel.py \
 	src/cockpit/channels/__init__.py \
 	src/cockpit/channels/dbus.py \
@@ -92,6 +97,23 @@ cockpit-bridge.pyz: $(MANIFESTS) $(PYTHON_BRIDGE_FILES) $(SYSTEMD_CTYPES_STAMP)
 	@mkdir -p tmp/pyz
 	@cp -r $(srcdir)/dist $(srcdir)/src/cockpit src/systemd_ctypes/ tmp/pyz
 	$(AM_V_GEN) python3 -m zipapp --python /usr/bin/python3 --output $@ --main cockpit.bridge:main tmp/pyz
+	@chmod a+x $@
+
+CLEANFILES += injector.pyz
+injector.pyz: $(MANIFESTS) $(PYTHON_BRIDGE_FILES) $(SYSTEMD_CTYPES_STAMP)
+	@rm -rf tmp/bundle-pyz
+	@mkdir -p tmp/bundle-pyz tmp/bundle-pyz/dist/ssh tmp/bundle-pyz/dist/shell
+	@cp -r $(srcdir)/src/cockpit src/systemd_ctypes/ tmp/bundle-pyz
+	@cp -r $(srcdir)/pkg/ssh/manifest.json tmp/bundle-pyz/dist/ssh
+	@cp -r $(srcdir)/pkg/shell/manifest.json tmp/bundle-pyz/dist/shell
+	@rm -rf tmp/injector-pyz
+	@mkdir -p tmp/injector-pyz
+	@cp -r $(srcdir)/dist $(srcdir)/src/cockpit src/systemd_ctypes/ tmp/injector-pyz
+	@mkdir -p tmp/injector-pyz/cockpit/data
+	@python3 -m zipapp --output tmp/injector-pyz/cockpit/data/bundle.pyz --main cockpit.bridge:main tmp/bundle-pyz
+	@$(srcdir)/src/cockpit/mkbootloader.py $(srcdir)/src/cockpit/bootloader.py Cockpit '$(VERSION)' tmp/injector-pyz/cockpit/data/bundle.pyz >> tmp/injector-pyz/cockpit/data/bootloader.py
+	ls --color=auto -lR tmp/injector-pyz/cockpit/data
+	$(AM_V_GEN) python3 -m zipapp --python /usr/bin/python3 --output $@ --main cockpit.injector:main tmp/injector-pyz
 	@chmod a+x $@
 
 .PHONY: pcc

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -20,9 +20,14 @@ import asyncio
 
 from typing import Any, Dict, Iterable, Optional, Tuple
 
+from .protocol import CockpitProtocol
+
 
 class Endpoint:
-    router = None
+    router: CockpitProtocol
+
+    def __init__(self, router):
+        self.router = router
 
     def do_channel_control(self, command, message):
         raise NotImplementedError

--- a/src/cockpit/injector.py
+++ b/src/cockpit/injector.py
@@ -1,0 +1,160 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+This is the injector component.
+
+It turns a Python interpreter (with nothing else installed) into a Cockpit
+bridge.  It does three things in order to accomplish this:
+
+    - at the start of the session the injector sends a small "bootloader" into
+      the Python interpreter which is responsible for arranging for the bridge
+      code to run.
+
+    - if the remote side doesn't have a copy of the bridge, the injector it
+      sends it.
+
+    - the injector contains a copy of the package serving logic, so packages
+      are served from local files.  The packages provided from the remote side
+      are currently ignored.
+
+For the most part, the injector acts as a wrapper around the remotely-running
+bridge, filling in the gaps to turn it into a complete cockpit-bridge, from the
+viewpoint of whoever invoked it (ie: cockpit-ws).
+
+At some point, the package serving component can be moved up the stack (ie:
+closer to the browser).  The injection of the bootloader and the bridge code
+could also theoretically be done from cockpit-ws (or its eventual successor).
+"""
+
+import asyncio
+import logging
+import sys
+
+from typing import Any, Dict
+from importlib.resources import files
+
+from .channels import PackagesChannel
+from .packages import Packages
+from .protocol import CockpitProtocol
+from .transports import StdioTransport, SubprocessTransport
+
+
+logger = logging.getLogger(__name__)
+
+
+class InjectorFrontend(CockpitProtocol):
+    backend: CockpitProtocol
+    channels: Dict[str, PackagesChannel]
+    packages: Packages
+
+    def __init__(self, backend) -> None:
+        self.backend = backend
+        backend.frontend = self
+        self.channels = {}
+        self.packages = Packages()
+
+    def do_transport_control(self, command: str, message: Dict[str, Any]) -> None:
+        logger.debug('Transport control')
+        self.backend.send_control(**message)
+
+    def do_channel_control(self, channel: str, command: str, message: Dict[str, Any]) -> None:
+        logger.debug('Channel control')
+        if command == 'open' and \
+           message.get('payload') == 'http-stream1' and \
+           message.get('internal') == 'packages':
+            self.channels[channel] = PackagesChannel(self)
+
+        if channel in self.channels:
+            self.channels[channel].do_channel_control(command, message)
+        else:
+            self.backend.send_control(**message)
+
+        if command == 'close' and channel in self.channels:
+            del self.channels[channel]
+
+    def do_channel_data(self, channel: str, data: bytes) -> None:
+        logger.debug('Channel data')
+        if channel in self.channels:
+            self.channels[channel].do_channel_data(channel, data)
+        else:
+            self.backend.send_data(channel, data)
+
+    def do_ready(self) -> None:
+        # The process begins from the backend.
+        pass
+
+    def send_init(self, message: Dict[str, Any]) -> None:
+        message.update(checksum=self.packages.checksum,
+                       packages={p: None for p in self.packages.packages})
+        self.send_control(**message)
+
+
+class InjectorBackend(CockpitProtocol):
+    data: bytes
+    start_line: bytes
+    frontend: InjectorFrontend
+
+    def do_transport_control(self, command: str, message: Dict[str, Any]) -> None:
+        assert self.transport is not None
+
+        if command == 'need-script':
+            logger.debug('Sending script %s', message)
+            resources = files(__package__)
+            data = resources.joinpath('data/bundle.pyz').read_bytes()
+            self.transport.write(data)
+        elif command == 'init':
+            self.frontend.send_init(message)
+        else:
+            self.frontend.send_control(**message)
+
+    def do_channel_control(self, channel: str, command: str, message: Dict[str, Any]) -> None:
+        self.frontend.send_control(**message)
+
+    def do_channel_data(self, channel: str, data: bytes) -> None:
+        self.frontend.send_data(channel, data)
+
+    def do_ready(self) -> None:
+        assert self.transport is not None
+
+        # we start by sending the bootloader
+        resources = files(__package__)
+        bootloader = resources.joinpath('data/bootloader.py').read_bytes()
+        self.transport.write(bootloader)
+
+
+async def run() -> None:
+    loop = asyncio.get_running_loop()
+
+    backend = InjectorBackend()
+    frontend = InjectorFrontend(backend)
+
+    # can be used to ssh to another host, for example
+    cmd = sys.argv[1:] + ['python3', '-i']
+
+    StdioTransport(loop, frontend)
+    SubprocessTransport(loop, backend, cmd, None, None)
+
+    await frontend.communicate()
+
+
+def main() -> None:
+    asyncio.run(run(), debug=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/cockpit/mkbootloader.py
+++ b/src/cockpit/mkbootloader.py
@@ -1,0 +1,28 @@
+#!/usr/bin/python3
+
+import argparse
+import hashlib
+
+parser = argparse.ArgumentParser()
+parser.add_argument('bootloader')
+parser.add_argument('name')
+parser.add_argument('version')
+parser.add_argument('filename')
+args = parser.parse_args()
+
+# The bootloader body needs to have no newlines inside of it
+# or else the REPL will return to the top-level
+with open(args.bootloader) as file:
+    for line in file.read().splitlines():
+        if line:
+            print(line)
+
+# This is our payload
+with open(args.filename, 'rb') as file:
+    data = file.read()
+    sha256 = hashlib.sha256(data).hexdigest()
+
+# Now we add one newline, plus the invocation of the bootloader
+print()
+print('BOOTLOADER = Bootloader()')
+print(f'BOOTLOADER.start("{args.name}", "{args.version}", "{sha256}", {len(data)})')

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -37,7 +37,7 @@ class CockpitProtocol(asyncio.Protocol):
     We need to use this because Python's SelectorEventLoop doesn't supported
     buffered protocols.
     '''
-    transport = None
+    transport: Optional[asyncio.Transport] = None
     buffer = b''
     _communication_done: Optional[asyncio.Future] = None
 

--- a/src/cockpit/router.py
+++ b/src/cockpit/router.py
@@ -93,14 +93,13 @@ class Router(CockpitProtocolServer):
             try:
                 endpoint = self.peers[peer_opts]
             except KeyError:
-                endpoint = result()
+                endpoint = result(self)
                 endpoint.start(**dict(zip(peer_keys, peer_opts)))
                 self.peers[peer_opts] = endpoint
         else:
             assert issubclass(result, Channel)
-            endpoint = result()
+            endpoint = result(self)
 
-        endpoint.router = self
         return endpoint
 
     def do_init(self, message):


### PR DESCRIPTION
Here's a proof of concept for how the Python bridge can be used in the future.

We create a separate `injector.pyz` bundle, which contains:
 - the `cockpit/` and `systemd_ctypes/` code
 - the packages (`dist/`)
 - a "bootloader" script
 - another small bundle, containing:
   - the `cockpit/` and `systemd_ctypes/` code
   - no packages

When you run `injector.pyz` it runs a Python interpreter and plays the bootloader into it.  If the bootloader discovers that we already have the correct version of the bridge (in `~/.cache`) then it will run it.  Otherwise, it requests it from the injector, and runs it.

Since there's no packages on the remote side, the injector serves those from its own bundle, by diverting incoming requests to the `internal`:`packages` endpoint.

This all seems to work fairly OK, although (for a currently unknown reason) several unit tests are failing.

Here's a test:

```sh
$ cat ~/.local/bin/cockpit-bridge 
#!/bin/sh

~/src/cockpit/injector/injector.pyz ssh cockpit-7
```

and then I accessed `localhost` from Cockpit Client (ie: run the above script) and saw:

![image](https://user-images.githubusercontent.com/36541154/198274472-fa6574f2-5e78-4e02-b944-9dc00843319b.png)

Note that `cockpit-7` is a Fedora IoT machine with no extra packages installed.