### PR TITLE
containers/ws: Clean up and re-automate release

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -9,28 +9,15 @@ jobs:
     environment: quay.io
     permissions: {}
     timeout-minutes: 20
+    env:
+      RUNC: docker
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
       - name: Log into container registry
-        run: docker login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: $RUNC login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
 
       - name: Build and push ws container
-        run: |
-          TAG=$(date +%Y-%m-%d)
-          docker build -t quay.io/cockpit/ws:$TAG containers/ws
-
-          # smoke test
-          docker run --name ws -p 9090:9090 -d quay.io/cockpit/ws:$TAG
-          until curl --fail --show-error -k --head https://localhost:9090; do
-              sleep 1
-          done
-          docker rm -f ws
-
-          docker tag quay.io/cockpit/ws:$TAG quay.io/cockpit/ws:latest
-
-          # push both tags
-          docker push quay.io/cockpit/ws:$TAG
-          docker push quay.io/cockpit/ws:latest
+        run: containers/ws/release.sh

--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -1,5 +1,8 @@
 name: build-ws-container
 on:
+  # auto-refresh every Monday morning
+  schedule:
+    - cron: '0 2 * * 1'
   # can be run manually on https://github.com/cockpit-project/cockpit/actions
   workflow_dispatch:
 

--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -2,15 +2,6 @@
 
 set -ex
 
-package_name()
-{
-    package="$1"
-    if [ -n "$VERSION" ]; then
-        package="$package-$VERSION"
-    fi
-    echo "$package"
-}
-
 OSVER=$(. /etc/os-release && echo "$VERSION_ID")
 
 INSTALL="dnf install -y --installroot=/build --releasever=$OSVER --setopt=install_weak_deps=False"
@@ -23,11 +14,7 @@ rpm=$(ls /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-b
 if [ -n "$rpm" ]; then
     $INSTALL /container/rpms/cockpit-ws-*$OSVER.*$arch.rpm /container/rpms/cockpit-bridge-*$OSVER.*$arch.rpm
 else
-    # pull packages from https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/
-    echo -e '[group_cockpit-cockpit-preview]\nname=Copr repo for cockpit-preview owned by @cockpit\nbaseurl=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/fedora-$releasever-$basearch/\ntype=rpm-md\ngpgcheck=1\ngpgkey=https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg\nrepo_gpgcheck=0\nenabled=1\nenabled_metadata=1' > /build/etc/yum.repos.d/cockpit.repo
-    ws=$(package_name "cockpit-ws")
-    bridge=$(package_name "cockpit-bridge")
-    $INSTALL "$ws" "$bridge"
+    $INSTALL cockpit-ws cockpit-bridge
 fi
 
 rm -rf /build/var/cache/dnf /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*

--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -30,8 +30,5 @@ else
     $INSTALL "$ws" "$bridge"
 fi
 
-# HACK: fix for older cockpit-certificate-helper
-sed -i '/^COCKPIT_GROUP=/ s/=.*$/=/; s_/etc/machine-id_/dev/null_' /build/usr/libexec/cockpit-certificate-helper
-
 rm -rf /build/var/cache/dnf /build/var/lib/dnf /build/var/lib/rpm* /build/var/log/*
 rm -rf /container/rpms || true

--- a/containers/ws/release.sh
+++ b/containers/ws/release.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eux
+
+if [ -z "${RUNC:-}" ]; then
+    RUNC=$(command -v podman || command -v docker) || {
+        echo "ERROR: podman or docker required" >&2
+        exit 1
+    }
+fi
+
+TAG=$(date +%Y-%m-%d)
+$RUNC build -t quay.io/cockpit/ws:$TAG containers/ws
+
+# smoke test
+$RUNC run --name ws -p 9090:9090 -d quay.io/cockpit/ws:$TAG
+until curl --fail --show-error -k --head https://localhost:9090; do
+    sleep 1
+done
+$RUNC rm -f ws
+
+$RUNC tag quay.io/cockpit/ws:$TAG quay.io/cockpit/ws:latest
+
+# push both tags
+$RUNC push quay.io/cockpit/ws:$TAG
+$RUNC push quay.io/cockpit/ws:latest

--- a/containers/ws/release.sh
+++ b/containers/ws/release.sh
@@ -8,18 +8,23 @@ if [ -z "${RUNC:-}" ]; then
     }
 fi
 
-TAG=$(date +%Y-%m-%d)
-$RUNC build -t quay.io/cockpit/ws:$TAG containers/ws
+$RUNC build -t quay.io/cockpit/ws:release containers/ws
 
 # smoke test
 name=ws-release
-$RUNC run --name $name -p 19999:9090 -d quay.io/cockpit/ws:$TAG
+$RUNC run --name $name -p 19999:9090 -d quay.io/cockpit/ws:release
 until curl --fail --show-error -k --head https://localhost:19999; do
     sleep 1
 done
+
+# determine cockpit version
+TAG=$($RUNC exec $name cockpit-bridge --version | sed -n '/^Version:/ { s/^.*: //p }')
+
 $RUNC rm -f $name
 
-$RUNC tag quay.io/cockpit/ws:$TAG quay.io/cockpit/ws:latest
+$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:$TAG
+$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:latest
+$RUNC rmi quay.io/cockpit/ws:release
 
 # push both tags
 $RUNC push quay.io/cockpit/ws:$TAG

--- a/containers/ws/release.sh
+++ b/containers/ws/release.sh
@@ -12,11 +12,12 @@ TAG=$(date +%Y-%m-%d)
 $RUNC build -t quay.io/cockpit/ws:$TAG containers/ws
 
 # smoke test
-$RUNC run --name ws -p 9090:9090 -d quay.io/cockpit/ws:$TAG
-until curl --fail --show-error -k --head https://localhost:9090; do
+name=ws-release
+$RUNC run --name $name -p 19999:9090 -d quay.io/cockpit/ws:$TAG
+until curl --fail --show-error -k --head https://localhost:19999; do
     sleep 1
 done
-$RUNC rm -f ws
+$RUNC rm -f $name
 
 $RUNC tag quay.io/cockpit/ws:$TAG quay.io/cockpit/ws:latest
 


### PR DESCRIPTION
This brings back automatic releases. As we now build from pure Fedora, we cannot predict when they actually make it through bodi. But refreshing them every week is good enough in most cases (and if not, we can still trigger a manual refresh).

It's also desirable to refresh the container image regularly even if there is no new cockpit upstream release -- it can then still pick up Fedora security fixes in other packages.


