### PR TITLE
tools: disallow root login by default

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -42,6 +42,11 @@ if grep -q 'ID=.*rhel' /etc/os-release; then
     dnf install -y kpatch kpatch-dnf
 fi
 
+# On CentOS Stream 8 the cockpit package is upgraded so the file isn't touched.
+if [ ! -f /etc/cockpit/disallowed-users ]; then
+    echo 'root' > /etc/cockpit/disallowed-users
+fi
+
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1587,7 +1587,9 @@ class MachineCase(unittest.TestCase):
                 self.check_pixel_tests()
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
-    def login_and_go(self, path=None, user=None, host=None, superuser=True, urlroot=None, tls=False):
+    def login_and_go(self, path=None, user=None, host=None, superuser=True, urlroot=None, tls=False, enable_root_login=False):
+        if enable_root_login:
+            self.enable_root_login()
         self.machine.start_cockpit(tls=tls)
         self.browser.login_and_go(path, user=user, host=host, superuser=superuser, urlroot=urlroot, tls=tls)
 
@@ -2029,6 +2031,16 @@ class MachineCase(unittest.TestCase):
         m = self.machine
         self.restore_file(path, post_restore_action=post_restore_action)
         m.write(path, content, append=append, owner=owner, perm=perm)
+
+    def enable_root_login(self):
+        """Enable root login
+
+        By default root login is disabled in cockpit, removing the root entry of /etc/cockpit/disallowed-users allows root to login.
+        """
+
+        # fedora-coreos runs cockpit-ws in a containter so does not install cockpit-ws on the host
+        if not self.machine.ostree_image:
+            self.sed_file('/root/d', '/etc/cockpit/disallowed-users')
 
 
 def jsquote(js: str) -> str:

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -119,6 +119,10 @@ def build_install_rhel8(dist_tar, image, verbose, quick):
     # in distropkg, keep basic OS packages, otherwise build/install cockpit
     if 'distropkg' not in image:
         args += [
+            # remove already installed packages
+            "--run-command",
+            "if rpm -q cockpit-ws >/dev/null 2>&1; then rpm --erase --nodeps --verbose cockpit cockpit-ws cockpit-bridge cockpit-system; fi",
+
             # create cockpit.spec
             "--run-command",
             f"tar xf '{vm_dist_tar}' -O '*/tools/cockpit.spec' | sed '/%define build_all/d' > /var/tmp/cockpit.spec",

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -631,14 +631,20 @@ class TestConnection(MachineCase):
             else:
                 m.execute("rpm --erase cockpit cockpit-ws")
 
-        # upgrade from distro version (our images have cockpit-ws preinstalled) sets up dynamic motd/issue symlink
+        # clean install sets up dynamic motd/issue symlink and pam disallowed users.
         self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
         self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
+        self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
+        # remove disallowed-users to simulate an upgrade where we did not have this file yet.
+        m.execute("rm /etc/cockpit/disallowed-users")
 
         # package upgrade keeps them
         install()
         self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
         self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
+        # disallowed-users should not exists now as this is an upgrade
+        m.execute("test ! -e /etc/cockpit/disallowed-users")
+        m.execute("echo 'root' > /etc/cockpit/disallowed-users")
 
         # HACK: On Arch Linux the symlink is overwritten, bug?
         if m.image != "arch":
@@ -652,12 +658,14 @@ class TestConnection(MachineCase):
         remove()
         m.execute("test ! -e /etc/motd.d/cockpit")
         m.execute("test ! -e /etc/issue.d/cockpit.issue")
+        m.execute("test ! -e /etc/cockpit/disallowed-users")
 
         # fresh install (most of our test images have cockpit-ws preinstalled, so the first test above does not cover that)
         install()
         # verify that we installed relative links in the new package
         self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "../../run/cockpit/motd")
         self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "../../run/cockpit/motd")
+        self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     @nondestructive
@@ -737,7 +745,7 @@ class TestConnection(MachineCase):
         m = self.machine
         b = self.browser
 
-        self.login_and_go("/playground/speed", user="root")
+        self.login_and_go("/playground/speed", user="root", enable_root_login=True)
 
         # Check the speed playground page
         b.switch_to_top()

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -78,7 +78,7 @@ class TestReauthorize(MachineCase):
 
         # When root, the 'Limited access' etc indicators should not be visible
         b.logout()
-        self.login_and_go("/playground/test", user="root")
+        self.login_and_go("/playground/test", user="root", enable_root_login=True)
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'result: uid=0')
         b.leave_page()

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -639,6 +639,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             expect_fail_count(0, user=user)
             b.logout()
 
+        self.enable_root_login()
+
         # ensure we have no module in our pam config already
         # arch has faillock enabled by default
         if m.image != "arch":
@@ -720,13 +722,17 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
     @skipImage("root logins disabled by default with ssh", "fedora-coreos")
     def testPamAccess(self):
         b = self.browser
+        m = self.machine
 
-        # root login works by default
-        self.login_and_go("/system", user="root")
-        b.wait_visible('.system-information')
-        b.logout()
+        # root login is disabled by default via /etc/cockpit/disallowed-users
+        m.start_cockpit()
+
+        b.open("/system")
+        b.try_login("root", "foobar")
+        b.wait_in_text("#login-error-message", "Wrong user name or password")
 
         # disable root login with pam_access
+        self.enable_root_login()
         self.write_file("/etc/security/access.conf", "- : root : ALL\n", append=True)
         self.sed_file("1 aaccount required pam_access.so", "/etc/pam.d/cockpit")
         b.try_login(user="root")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -418,6 +418,7 @@ class TestAccounts(MachineCase):
         self.disable_preload("packagekit", "playground", "systemd")
 
         m.execute("useradd anton; echo anton:foobar | chpasswd")
+        self.enable_root_login()
         self.login_and_go("/users", user="root", superuser=False)
 
         # test this on root and a normal user account

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -11,6 +11,7 @@ pkgdesc='A systemd web based user interface for Linux servers'
 arch=('x86_64')
 url='https://cockpit-project.org/'
 license=(LGPL)
+install=cockpit.install
 makedepends=(krb5 libssh accountsservice perl-json perl-locale-po json-glib glib-networking
              git intltool gtk-doc gobject-introspection networkmanager libgsystem xmlto npm pcp)
 source=("cockpit-${pkgver}.tar.xz"
@@ -18,7 +19,7 @@ source=("cockpit-${pkgver}.tar.xz"
         "cockpit-ws.sysuser.conf"
         "cockpit-wsinstance.sysuser.conf")
 sha256sums=('SKIP'
-            'a979e236681c6a06906937cf0f012e976347af5d6d7e7ae04a11acb01cc2689d'
+            'b95cdb0a336b7c1af9af9da1eed8520dfb8eae51869609416d380fee0357c523'
             '1ad9dad75858264778bd94799b60c651f7cc1c7f7fa1c54622174303e639287a'
             '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
 

--- a/tools/arch/cockpit.install
+++ b/tools/arch/cockpit.install
@@ -1,0 +1,8 @@
+post_install() {
+  printf "# List of users which are not allowed to login to Cockpit\nroot\n" > /etc/cockpit/disallowed-users
+  chmod 644 /etc/cockpit/disallowed-users
+}
+
+post_remove() {
+  rm -f /etc/cockpit/disallowed-users
+}

--- a/tools/arch/cockpit.pam
+++ b/tools/arch/cockpit.pam
@@ -1,5 +1,7 @@
 #%PAM-1.0
 auth      include   system-remote-login
+# List of users to deny access to Cockpit, by default root is included.
+auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account   include   system-remote-login
 password  include   system-remote-login
 session   include   system-remote-login

--- a/tools/cockpit.debian.pam
+++ b/tools/cockpit.debian.pam
@@ -2,6 +2,8 @@
 auth       required     pam_sepermit.so
 auth       substack     common-auth
 auth       optional     pam_ssh_add.so
+# List of users to deny access to Cockpit, by default root is included.
+auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account    required     pam_nologin.so
 account    include      common-account
 password   include      common-password

--- a/tools/cockpit.pam
+++ b/tools/cockpit.pam
@@ -3,6 +3,8 @@ auth       required     pam_sepermit.so
 auth       substack     password-auth
 auth       include      postlogin
 auth       optional     pam_ssh_add.so
+# List of users to deny access to Cockpit, by default root is included.
+auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
 account    required     pam_nologin.so
 account    include      password-auth
 password   include      password-auth

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -429,6 +429,7 @@ authentication via sssd/FreeIPA.
 # created in %post, so that users can rm the files
 %ghost %{_sysconfdir}/issue.d/cockpit.issue
 %ghost %{_sysconfdir}/motd.d/cockpit
+%ghost %attr(0644, root, root) %{_sysconfdir}/cockpit/disallowed-users
 %dir %{_datadir}/cockpit/motd
 %{_datadir}/cockpit/motd/update-motd
 %{_datadir}/cockpit/motd/inactive.motd
@@ -477,10 +478,13 @@ if [ -x %{_sbindir}/selinuxenabled ]; then
 fi
 
 # set up dynamic motd/issue symlinks on first-time install; don't bring them back on upgrades if admin removed them
+# disable root login on first-time install; so existing installations aren't changed
 if [ "$1" = 1 ]; then
     mkdir -p /etc/motd.d /etc/issue.d
     ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
     ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
+    printf "# List of users which are not allowed to login to Cockpit\nroot\n" > /etc/cockpit/disallowed-users
+    chmod 644 /etc/cockpit/disallowed-users
 fi
 
 %tmpfiles_create cockpit-tempfiles.conf

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -26,6 +26,8 @@ if [ "$1" = "configure" ] && [ -z "$2" ]; then
     mkdir -p /etc/motd.d /etc/issue.d
     ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
     ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
+    printf "# List of users which are not allowed to login to Cockpit\nroot\n" > /etc/cockpit/disallowed-users
+    chmod 644 /etc/cockpit/disallowed-users
 fi
 
 # check for deprecated PAM config

--- a/tools/debian/cockpit-ws.postrm
+++ b/tools/debian/cockpit-ws.postrm
@@ -7,4 +7,5 @@ set -e
 if [ "$1" = purge ]; then
     [ -L /etc/motd.d/cockpit ] && rm /etc/motd.d/cockpit || true
     [ -L /etc/issue.d/cockpit.issue ] && rm /etc/issue.d/cockpit.issue || true
+    rm -f /etc/cockpit/disallowed-users
 fi


### PR DESCRIPTION
## Disallow root login by default
On all operating systems, logging in as root with a username/password via SSH has been disallowed for a long time. Cockpit now also disallows it by default on new installations, but still allows it on upgrades for backwards compatibility. You can configure this in `/etc/cockpit/disallowed-users`.