### PR TITLE
fmf: Split tests into separate parallel plans

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,6 +1,0 @@
-summary:
-    Run all tests
-discover:
-    how: fmf
-execute:
-    how: tmt

--- a/plans/basic.fmf
+++ b/plans/basic.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run tests for basic packages
+discover:
+    how: fmf
+    test: /test/browser/basic
+execute:
+    how: tmt

--- a/plans/network.fmf
+++ b/plans/network.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run tests for cockpit-networkmanager
+discover:
+    how: fmf
+    test: /test/browser/network
+execute:
+    how: tmt

--- a/plans/optional.fmf
+++ b/plans/optional.fmf
@@ -1,0 +1,7 @@
+summary:
+    Run tests for optional packages
+discover:
+    how: fmf
+    test: /test/browser/optional
+execute:
+    how: tmt

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -34,9 +34,6 @@ if grep -q 'ID=.*fedora' /etc/os-release; then
     dnf install -y tcsh
 fi
 
-# HACK: sosreport needs magic - https://bugzilla.redhat.com/show_bug.cgi?id=2120953
-dnf install -y python3-magic
-
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -2,6 +2,9 @@
 # This script is meant to be run on an ephemeral CI host, for packit/Fedora/RHEL gating.
 set -eux
 
+# like "basic", passed on to run-test.sh
+PLAN="$1"
+
 MYDIR="$(realpath $(dirname "$0"))"
 if [ -d source ]; then
     # path for standard-test-source
@@ -68,7 +71,7 @@ firewall-cmd --add-service=cockpit --permanent
 firewall-cmd --add-service=cockpit
 
 # Run tests as unprivileged user
-su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $MYDIR/run-test.sh" runtest
+su - -c "env TEST_BROWSER=firefox SOURCE=$SOURCE LOGS=$LOGS $MYDIR/run-test.sh $PLAN" runtest
 
 RC=$(cat $LOGS/exitcode)
 exit ${RC:-1}

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -8,16 +8,30 @@
     - python3
     - libvirt-python3
     # required by tests
-    - NetworkManager-team
     - glibc-all-langpacks
     - firewalld
-    - libvirt-daemon-config-network
     - sssd-dbus
     - subscription-manager
     - targetcli
     - tlog
     - tuned
   test: ./browser.sh basic
+  duration: 1h
+
+/network:
+  summary: Run browser integration tests for cockpit-networkmanager
+  require:
+    # build/test infra dependencies
+    - git
+    - make
+    - nodejs
+    - python3
+    - libvirt-python3
+    # required by tests
+    - NetworkManager-team
+    - firewalld
+    - libvirt-daemon-config-network
+  test: ./browser.sh network
   duration: 1h
 
 /optional:

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -20,6 +20,7 @@ require:
   - python3-tracer
   - rpm-build
   - sssd-dbus
+  - subscription-manager
   - targetcli
   - tlog
   - tuned

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -6,20 +6,12 @@
     - make
     - nodejs
     - python3
+    - libvirt-python3
     # required by tests
     - NetworkManager-team
-    - createrepo_c
-    - cryptsetup
-    - dnf-automatic
     - glibc-all-langpacks
     - firewalld
     - libvirt-daemon-config-network
-    - libvirt-python3
-    - lvm2
-    - udisks2-lvm2
-    - nfs-utils
-    - python3-tracer
-    - rpm-build
     - sssd-dbus
     - subscription-manager
     - targetcli
@@ -36,24 +28,18 @@
     - make
     - nodejs
     - python3
+    - libvirt-python3
     # required by tests
-    - NetworkManager-team
     - createrepo_c
     - cryptsetup
     - dnf-automatic
-    - glibc-all-langpacks
     - firewalld
-    - libvirt-daemon-config-network
-    - libvirt-python3
     - lvm2
     - udisks2-lvm2
     - nfs-utils
     - python3-tracer
     - rpm-build
-    - sssd-dbus
     - subscription-manager
     - targetcli
-    - tlog
-    - tuned
   test: ./browser.sh optional
   duration: 1h

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,29 +1,59 @@
-summary: Run browser integration tests on the host
-require:
-  # build/test infra dependencies
-  - git
-  - make
-  - nodejs
-  - python3
-  # required by tests
-  - NetworkManager-team
-  - createrepo_c
-  - cryptsetup
-  - dnf-automatic
-  - glibc-all-langpacks
-  - firewalld
-  - libvirt-daemon-config-network
-  - libvirt-python3
-  - lvm2
-  - udisks2-lvm2
-  - nfs-utils
-  - python3-tracer
-  - rpm-build
-  - sssd-dbus
-  - subscription-manager
-  - targetcli
-  - tlog
-  - tuned
+/basic:
+  summary: Run browser integration tests for basic Cockpit packages
+  require:
+    # build/test infra dependencies
+    - git
+    - make
+    - nodejs
+    - python3
+    # required by tests
+    - NetworkManager-team
+    - createrepo_c
+    - cryptsetup
+    - dnf-automatic
+    - glibc-all-langpacks
+    - firewalld
+    - libvirt-daemon-config-network
+    - libvirt-python3
+    - lvm2
+    - udisks2-lvm2
+    - nfs-utils
+    - python3-tracer
+    - rpm-build
+    - sssd-dbus
+    - subscription-manager
+    - targetcli
+    - tlog
+    - tuned
+  test: ./browser.sh basic
+  duration: 1h
 
-test: ./browser.sh
-duration: 1h
+/optional:
+  summary: Run browser integration tests for optional Cockpit packages
+  require:
+    # build/test infra dependencies
+    - git
+    - make
+    - nodejs
+    - python3
+    # required by tests
+    - NetworkManager-team
+    - createrepo_c
+    - cryptsetup
+    - dnf-automatic
+    - glibc-all-langpacks
+    - firewalld
+    - libvirt-daemon-config-network
+    - libvirt-python3
+    - lvm2
+    - udisks2-lvm2
+    - nfs-utils
+    - python3-tracer
+    - rpm-build
+    - sssd-dbus
+    - subscription-manager
+    - targetcli
+    - tlog
+    - tuned
+  test: ./browser.sh optional
+  duration: 1h

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -173,11 +173,6 @@ if [ -n "$test_basic" ]; then
               TestServices.testResetFailed
               TestServices.testTransientUnits
               "
-
-    # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=2058142
-    if [ "$TEST_OS" = "fedora-36" ]; then
-        EXCLUDES="$EXCLUDES TestSOS.testBasic"
-    fi
 fi
 
 exclude_options=""

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -178,13 +178,6 @@ if [ -n "$test_basic" ]; then
     if [ "$TEST_OS" = "fedora-36" ]; then
         EXCLUDES="$EXCLUDES TestSOS.testBasic"
     fi
-
-    # Firefox 91 (currently in centos-8-stream and centos-9-stream)
-    # can't download files ending in ".gpg".
-    if rpmquery firefox | grep -q ^firefox-91; then
-        EXCLUDES="$EXCLUDES TestSOS.testBasic"
-    fi
-
 fi
 
 exclude_options=""

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -32,11 +32,6 @@ if [ "$TEST_OS" = "fedora-38" ]; then
     export TEST_OS=fedora-36
 fi
 
-# HACK: 37 is beta
-if [ "$TEST_OS" = "fedora-37" ]; then
-    export TEST_OS=fedora-36
-fi
-
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -11,8 +11,8 @@ cd "$SOURCE"
 # on RHEL/CentOS 8 we have a split package, only test basic bits for "cockpit" and optional bits for "c-appstream"
 if [ "$PLATFORM_ID" = "platform:el8" ]; then
     if ls ../cockpit-appstream* 1> /dev/null 2>&1; then
-        if [ "$PLAN" = "basic" ]; then
-            echo "SKIP: not running basic tests for cockpit-appstream"
+        if [ "$PLAN" = "basic" ] || [ "$PLAN" = "network" ]; then
+            echo "SKIP: not running basic/network tests for cockpit-appstream"
             echo 0 > "$LOGS/exitcode"
             exit 0
         fi
@@ -97,17 +97,12 @@ if [ "$PLAN" = "basic" ]; then
     # Don't run TestPages, TestPackages, and TestTerminal at all -- not testing external APIs
     TESTS="$TESTS
         TestAccounts
-        TestBonding
-        TestBridge
-        TestFirewall
         TestKdump
         TestJournal
         TestLogin
-        TestNetworking
         TestServices
         TestSOS
         TestSystemInfo
-        TestTeam
         TestTuned
         "
 
@@ -129,16 +124,6 @@ if [ "$PLAN" = "basic" ]; then
               TestAccounts.testExpire
               TestAccounts.testRootLogin
               TestAccounts.testUnprivileged
-
-              TestBonding.testActive
-              TestBonding.testAmbiguousMember
-              TestBonding.testNonDefaultSettings
-
-              TestFirewall.testAddCustomServices
-              TestFirewall.testNetworkingPage
-
-              TestNetworkingBasic.testIpHelper
-              TestNetworkingBasic.testNoService
 
               TestLogin.testConversation
               TestLogin.testExpired
@@ -176,6 +161,30 @@ if [ "$PLAN" = "basic" ]; then
               TestServices.testTransientUnits
               "
 fi
+
+if [ "$PLAN" = "network" ]; then
+    TESTS="$TESTS
+        TestBonding
+        TestBridge
+        TestFirewall
+        TestNetworking
+        TestTeam
+        "
+
+    # These don't test more external APIs
+    EXCLUDES="$EXCLUDES
+              TestBonding.testActive
+              TestBonding.testAmbiguousMember
+              TestBonding.testNonDefaultSettings
+
+              TestFirewall.testAddCustomServices
+              TestFirewall.testNetworkingPage
+
+              TestNetworkingBasic.testIpHelper
+              TestNetworkingBasic.testNoService
+              "
+fi
+
 
 exclude_options=""
 for t in $EXCLUDES; do

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -38,8 +38,8 @@ done
 """
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos"]
-OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable",
-                     "fedora-coreos", "fedora-36", "fedora-37", "fedora-testing", "centos-8-stream", "arch"]
+OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch",
+                     "fedora-coreos", "fedora-36", "fedora-37", "fedora-testing", "centos-8-stream", "centos-9-stream"]
 
 
 class NoSubManCase(PackageCase):


### PR DESCRIPTION
On the Testing Farm we can run up to 5 parallel test plans. The natural
way to split them is our existing basic/optional package split for RHEL
8, so let's start with that. This mitigates the utterly slow Fedora
Rawhide tests due to a kernel bug [1], and also should generally speed
up results. The pre-tmt setup costs are about 6 minutes on Fedora 37, 
while the actual test runtime is about 22 minutes. So we shouldn't
over-split it, but two seems beneficial enough.

Pass the plan name to test/browser/run-test.sh. This replaces the 
implicit `$test_basic`/`$test_optional` variables. Rework the  RHEL 8
skips accordingly.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2139658

Fixes #17866

---

 - [x] Check that this is enough for Rawhide to pass
 - [x] Check the timings against #17866 whether this is a sufficient speedup
 - [x] Trim the test dependencies for basic/optional
