### PR TITLE
pf4: Fix dark mode dropmarker in form controls

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -254,6 +254,12 @@ svg {
 
 // Dark mode fixes for several PF components
 @media (prefers-color-scheme: dark) {
+  // Fix dropmarker showing as check icon
+  // https://github.com/patternfly/patternfly/issues/5215
+  .pf-theme-dark .pf-c-form-control {
+    --pf-c-form-control__select--BackgroundUrl: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='%23e0e0e0' d='M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z'/%3E%3C/svg%3E");
+  }
+
   // Fix PF disabled colors
   :disabled, .pf-m-disabled, .pf-m-aria-disabled {
     // Darken background; otherwise it matches active dropdowns and inputs


### PR DESCRIPTION
I'm specifically not using `:where()` here to bump up the specificity so that this will always take precedence over PF4's broken version. (So we don't have to use `!important`, in other words.)