### PR TITLE
Don't set max-width for Patternfly's select

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -39,8 +39,11 @@ to wrap around when there isn't enough space.
   flex-wrap: wrap;
 }
 
+/* Fix select menu rendering */
 ul.pf-c-select__menu {
-  max-height: 20rem;
+  /* Don't get too tall */
+  max-height: min(20rem, 50vh);
+  /* Don't have a horizontal scrollbar */
   overflow-y: auto;
 }
 

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -40,7 +40,6 @@ to wrap around when there isn't enough space.
 }
 
 ul.pf-c-select__menu {
-  max-width: 20rem;
   max-height: 20rem;
   overflow-y: auto;
 }


### PR DESCRIPTION
Since new patternfly update, [this PF commit](https://github.com/patternfly/patternfly/commit/5c0c776fbe056a7829c47cdb81d59a8a190e4a84) changed the width of our Selectors all across Cockpit and [broke pixel tests.](https://github.com/cockpit-project/cockpit-machines/pull/840)
![Screenshot from 2022-11-04 13-17-37](https://user-images.githubusercontent.com/42733240/199974674-e42a3d3b-3e70-45fd-a523-61c106082230.png)
![Screenshot from 2022-11-04 13-17-44](https://user-images.githubusercontent.com/42733240/199974669-b12c30df-1346-41dd-8681-7c87f2202dd4.png)

However after digging into it, it seems that there is nothing wrong with [that PF commit](https://github.com/patternfly/patternfly/commit/5c0c776fbe056a7829c47cdb81d59a8a190e4a84), but rather it only managed for our custom patternfly override to take effect, which was setting Selector's menu to `20rem`.
To me, that override doesn't seem right, as we have selectors wider that. I guess it was introduced by accident or is no longer viable.