### PR TITLE
containers: fix unit-tests with no submodules

### DIFF
--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -124,7 +124,7 @@ def main():
                        help='Build the HEAD commit, plus changes on the filesystem (default)')
 
     group = parser.add_argument_group(title='Preparation').add_mutually_exclusive_group()
-    group.add_argument('--submodule', action='append', help='Check out this submodule')
+    group.add_argument('--submodule', action='append', default=[], help='Check out this submodule')
     group.add_argument('--no-node-modules', action='store_true',
                        help='Disable checking out node_modules/ during preparation')
     group.add_argument('--no-jumpstart', action='store_true',


### PR DESCRIPTION
The 'append' action of ArgumentParser will set an empty list as the value of the argument in the return namespace, but only the first time an argument is encountered.

Put another way: in case the argument isn't given, we get `None`, instead of `[]`.  We then go on to try to iterate over this to build the arguments to `git clone`, which doesn't work very well.

Use `default=` to make sure we always have a list.

 - [x] test refresh: https://github.com/cockpit-project/cockpit/actions/runs/3408639784