### PR TITLE
fmf: Factorize and merge plan files

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,0 +1,19 @@
+discover:
+    how: fmf
+execute:
+    how: tmt
+
+/basic:
+    summary: Run tests for basic packages
+    discover+:
+        test: /test/browser/basic
+
+/network:
+    summary: Run tests for cockpit-networkmanager
+    discover+:
+        test: /test/browser/network
+
+/optional:
+    summary: Run tests for optional packages
+    discover+:
+        test: /test/browser/optional

--- a/plans/basic.fmf
+++ b/plans/basic.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run tests for basic packages
-discover:
-    how: fmf
-    test: /test/browser/basic
-execute:
-    how: tmt

--- a/plans/network.fmf
+++ b/plans/network.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run tests for cockpit-networkmanager
-discover:
-    how: fmf
-    test: /test/browser/network
-execute:
-    how: tmt

--- a/plans/optional.fmf
+++ b/plans/optional.fmf
@@ -1,7 +1,0 @@
-summary:
-    Run tests for optional packages
-discover:
-    how: fmf
-    test: /test/browser/optional
-execute:
-    how: tmt


### PR DESCRIPTION
FMF plans can inherit common properties [1]. Go back to a single plans/all.fmf (like it was until commit fe4721cdcd1), put the common properties at the top, and enumerate the three plans with their specific properties.

This will make it easier to keep the Fedora downstream dist-git in sync.

[1] https://tmt.readthedocs.io/en/latest/examples.html#inherit-plans

---

Thanks to @psss for pointing this out!