### PR TITLE
flatpak: preserve xml declaration in installed metainfo

### DIFF
--- a/containers/flatpak/Makefile.am
+++ b/containers/flatpak/Makefile.am
@@ -11,12 +11,13 @@ install-for-flatpak: \
 		install-dist_scalableiconDATA \
 		install-dist_symboliciconDATA \
 		$(NULL)
+	appstream-util validate --nonet src/client/org.cockpit_project.CockpitClient.metainfo.xml
 	if test -s "${DOWNSTREAM_RELEASES_XML}"; then \
 	    $(top_srcdir)/tools/patch-metainfo \
 	        '$(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml' \
 	        "${DOWNSTREAM_RELEASES_XML}"; \
 	fi
-	appstream-util validate --nonet src/client/org.cockpit_project.CockpitClient.metainfo.xml
+	appstream-util validate --nonet $(DESTDIR)$(datadir)/metainfo/org.cockpit_project.CockpitClient.metainfo.xml
 	mkdir -p $(DESTDIR)/$(bindir)
 	ln -sfTv $(cockpitclientdir)/cockpit-client $(DESTDIR)/$(bindir)/cockpit-client
 	cp -rT dist/static $(pkgdatadir)/static

--- a/tools/patch-metainfo
+++ b/tools/patch-metainfo
@@ -32,4 +32,4 @@ if stub_release is not None:
 
 metainfo_releases.extend(releases_releases)
 
-metainfo.write(args.metainfo)
+metainfo.write(args.metainfo, encoding='utf-8', xml_declaration=True)


### PR DESCRIPTION
The flathub appdata validation requires an <?xml?> line.

If we want one of those, we need to pass the `xml_declaration=True` kwarg to `ElementTree.write()`.

To make sure we catch issues like this for ourselves, validate the in-tree metainfo before patching it, and validate the installed copy after patching.