### PR TITLE
FMF: RHEL fixes

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -37,6 +37,11 @@ if grep -q 'ID=.*fedora' /etc/os-release; then
     dnf install -y tcsh
 fi
 
+if grep -q 'ID=.*rhel' /etc/os-release; then
+    # required by TestUpdates.testKpatch, but kpatch is only in RHEL
+    dnf install -y kpatch kpatch-dnf
+fi
+
 #HACK: unbreak RHEL 9's default choice of 999999999 rounds, see https://bugzilla.redhat.com/show_bug.cgi?id=1993919
 sed -ie 's/#SHA_CRYPT_MAX_ROUNDS 5000/SHA_CRYPT_MAX_ROUNDS 5000/' /etc/login.defs
 

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -95,6 +95,15 @@ if [ "$PLAN" = "optional" ]; then
               TestUpdates.testNoPackageKit
               TestUpdates.testInfoTruncation
               "
+
+    # RHEL test machines have a lot of junk mounted on /mnt
+    if [ "${TEST_OS#rhel-}" != "$TEST_OS" ]; then
+        EXCLUDES="$EXCLUDES
+            TestStorageNfs.testNfsBusy
+            TestStorageNfs.testNfsClient
+            TestStorageNfs.testNfsMountWithoutDiscovery
+            "
+    fi
 fi
 
 if [ "$PLAN" = "basic" ]; then

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -86,6 +86,10 @@ if [ "$PLAN" = "optional" ]; then
               TestAutoUpdates.testBasic
               TestAutoUpdates.testPrivilegeChange
 
+              TestStoragePackagesNFS.testNfsMissingPackages
+              TestStoragePartitions.testSizeSlider
+              TestStorageIgnored.testIgnored
+
               TestUpdates.testUnprivileged
               TestUpdates.testPackageKitCrash
               TestUpdates.testNoPackageKit
@@ -134,10 +138,6 @@ if [ "$PLAN" = "basic" ]; then
               TestLogin.testRaw
               TestLogin.testServer
               TestLogin.testUnsupportedBrowser
-
-              TestStoragePackagesNFS.testNfsMissingPackages
-              TestStoragePartitions.testSizeSlider
-              TestStorageIgnored.testIgnored
 
               TestSOS.testWithUrlRoot
               TestSOS.testCancel


### PR DESCRIPTION
279 failed in RHEL 9 gating, due to some TF machine specific differences and a missing test dependency.

I tried to test this with a draft PR against RHEL, but tests don't run there. I asked, but I'm fairly sure about these fixes.