### PR TITLE
webpack-make: include $(SRCDIR) in stampfile name

### DIFF
--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -93,7 +93,7 @@ function process_result(err, stats) {
 }
 
 function generateDeps(makefile, stats) {
-    const stampfile = path.dirname(makefile) + '/manifest.json';
+    const stampfile = '$(srcdir)/' + path.dirname(makefile) + '/manifest.json';
     const dir = path.relative('', stats.compilation.outputOptions.path);
     const now = Math.floor(Date.now() / 1000);
 


### PR DESCRIPTION
When writing the Makefile.deps, make sure we consistently refer to the fact that the manifest.json is created in the SRCDIR.  Otherwise, when doing a builddir != srcdir build, we won't consider the dependencies at all.

Fixes #17462

This was the real cause of the weird timestamp issues in #17883 