### PR TITLE
python: add pytest-timeout, set PYTEST_TIMEOUT=120

### DIFF
--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -43,6 +43,7 @@ dependencies="\
     pkg-config \
     python3 \
     python3-pytest-cov \
+    python3-pytest-timeout \
     sassc \
     ssh \
     strace \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,9 @@ pyTESTS = $(pyTESTS_PASSING) $(pyTESTS_FAILING)
 pycheck: cockpit-bridge.pyz
 	$(MAKE) check XFAIL_TESTS='$(pyTESTS_FAILING)' TESTS='$(pyTESTS)' COCKPIT_BRIDGE=./cockpit-bridge.pyz
 
+# Will only be honoured if pytest-timeout plugin is installed
+export PYTEST_TIMEOUT = 120
+
 .PHONY: pytest
 pytest: $(SYSTEMD_CTYPES_STAMP)
 	cd '$(srcdir)' && pytest


### PR DESCRIPTION
Add python3-pytest-timeout to the unit-tests container and set PYTEST_TIMEOUT=120 in the Makefile, near the `pytest` targets.

This means that the timeout will be honoured if the plugin is available (as in the unit-tests container) but will be ignored if it's not (in order to reduce dependencies for other users).

This seems to be the only approach which accomplishes that.  Putting it in the config file triggers a warning if the plugin is missing, and passing it on the commandline is a hard error in that case.

 - [ ] actually remember to rebuild the container after landing