### PR TITLE
Small fix in the italian translation

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -7946,7 +7946,7 @@ msgstr "Password utente"
 
 #: pkg/shell/credentials.jsx:89
 msgid "Use the following keys to authenticate against other systems"
-msgstr "Utilizza i seguenti tasti per autenticarsi in altri sistemi"
+msgstr "Utilizza le seguenti chiavi per autenticarti in altri sistemi"
 
 #: pkg/sosreport/index.jsx:331
 #, fuzzy


### PR DESCRIPTION
Fixed the string used for the localization.
The previous meaning was _key (from the keyboard)_ while now it correctly translates to _key (to open/unlock)_.