### PR TITLE
autogen: Copy automake tools

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -7,7 +7,7 @@ srcdir="${0%/*}"
 (
     cd "${srcdir}"
     echo "m4_define(VERSION_NUMBER, [$(git describe --tags --abbrev=0)+git])" > version.m4
-    autoreconf -is --warnings obsolete
+    autoreconf -i --warnings obsolete
 )
 
 [ -n "${NOCONFIGURE:-}" ] && exit


### PR DESCRIPTION
autogen: Copy automake tools

Building the dist tarball in the current Fedora 37 cockpit/tasks
container now fails when running as user podman container, when using
systemd-homed:

    cp: failed to preserve ownership for 'cockpit-279.39.gb4b41375f/tools/compile': Value too large for defined data type

This was due to a change in systemd 251 with mapped user IDs[1][2].

Work around this by copying the files instead of symlinking them. That
is the default behaviour anyway, and does not hurt much: git trees are 
regularly cleaned by developers anyway, and dist tarballs contain a copy
either way.

[1] https://github.com/systemd/systemd/blob/1d679b208d982bd5b8ba893981774cac5959b4b4/NEWS#L789
[2] https://bugzilla.redhat.com/show_bug.cgi?id=2144558
