### PR TITLE
test: build a wheel for the pybridge scenario

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ Makefile.in
 /aclocal.m4
 /autom4te.cache
 /bots
+/build/
 /cockpit
 /cockpit-*.tar*
 /cockpit-*.xz
@@ -71,6 +72,7 @@ Makefile.in
 /pkg/*/*.metainfo.xml
 /po/*.pot
 /src/bridge/org.cockpit-project.cockpit-bridge.policy
+/src/cockpit.egg-info/
 /src/common/fail.html.c
 /src/systemd/cockpit*.service
 /src/systemd/cockpit*.socket

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,22 @@
+[build-system]
+requires = ["setuptools >= 61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "cockpit"
+version = '0'
+
+[project.scripts]
+cockpit-bridge = "cockpit.bridge:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = [
+  "cockpit",
+  "cockpit.channels",
+  "systemd_ctypes",
+]
+
 [tool.mypy]
 mypy_path = 'src'
 

--- a/test/run
+++ b/test/run
@@ -25,9 +25,10 @@ case $TEST_SCENARIO in
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties
         ;;
     pybridge)
+        tools/systemd_ctypes
         test/image-prepare --verbose $TEST_OS
-        make -C tmp/build-dist/ cockpit-bridge.pyz
-        bots/image-customize -v --upload tmp/build-dist/cockpit-bridge.pyz:/usr/bin/cockpit-bridge $TEST_OS
+        python3 -m build --no-isolation --wheel --outdir tmp/wheel
+        bots/image-customize --verbose --no-network --install tmp/wheel/*.whl "${TEST_OS}"
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties
         ;;
     *)


### PR DESCRIPTION
Since we dropped the Makefile rule for creating cockpit-bridge.pyz, the pybridge scenario has been broken.

Add some minimal pyproject.toml metadata required to build a wheel of the Python package.  Build this wheel on the outside, and inject it into the VM via image-customize.

Note: we no longer bother with building the C parts of the package anymore — we rely on the distro packages already present in the image.

 - [x] cockpit-project/cockpituous#532
 - [x] cockpit-project/bots#4068  (one way or the other)