### PR TITLE
systemd: remove position="right" for service dropdown

### DIFF
--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -187,7 +187,6 @@ const ServiceActions = ({ masked, active, failed, canReload, actionCallback, del
                   isOpen={isActionOpen}
                   isPlain
                   onSelect={() => setIsActionOpen(!isActionOpen)}
-                  position='right'
                   dropdownItems={actions} />
     );
 };


### PR DESCRIPTION
This causes issue on mobile and with very tiny service names which makes the dropdown disappear under the sidebar menu on mobile and small screens.

See https://github.com/cockpit-project/cockpit/issues/17596#issuecomment-1317365314 for screenshots