### PR TITLE
Enable mounting of /etc/cockpit as volume

### DIFF
--- a/containers/ws/label-run
+++ b/containers/ws/label-run
@@ -37,7 +37,7 @@ else
     fi
 
     # config can be customized, but provide a default suitable for a bastion host
-    mountpoint --quiet /etc/cockpit/cockpit.conf || ln -s /container/default-bastion.conf /etc/cockpit/cockpit.conf
+    mountpoint --quiet /etc/cockpit || mountpoint --quiet /etc/cockpit/cockpit.conf || ln -s /container/default-bastion.conf /etc/cockpit/cockpit.conf
 
     /usr/libexec/cockpit-certificate-ensure
 


### PR DESCRIPTION
A rather small change that would allow either `/etc/cockpit` or `/etc/cockpit/cockpit.conf` to be mounted via volume options for the WS container.
This should not break existing container deployments, since the link creation for the `default-bastion.conf` still is done if both the directory and the file are not mounted on start.