### PR TITLE
Multi-arch builds for WS container and other improvements

### DIFF
--- a/.github/workflows/build-ws-container.yml
+++ b/.github/workflows/build-ws-container.yml
@@ -10,17 +10,21 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     environment: quay.io
-    permissions: {}
-    timeout-minutes: 20
+    permissions: { }
+    timeout-minutes: 60
     env:
       RUNC: docker
+      ARCHS: amd64 arm64
 
     steps:
       - name: Clone repository
         uses: actions/checkout@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Log into container registry
-        run: $RUNC login -u ${{ secrets.QUAY_BOTUSER }} -p ${{ secrets.QUAY_TOKEN }} quay.io
+        run: echo "${{ secrets.QUAY_TOKEN }}" | $RUNC login -u ${{ secrets.QUAY_BOTUSER }} --password-stdin quay.io
 
       - name: Build and push ws container
         run: containers/ws/release.sh

--- a/containers/ws/README.md
+++ b/containers/ws/README.md
@@ -1,99 +1,153 @@
-# Cockpit on Fedora CoreOS or other container hosts
+# Cockpit WS Container
 
-The standard Fedora and Red Hat Enterprise Linux CoreOS images does not contain
-Cockpit packages.
+This container is suitable for scenarios where you can not or wish not to deploy the Cockpit Web Service and browser
+application natively.
 
-1. Install Cockpit packages as overlay RPMs:
+## Tags
+
+The following tags are provided for the image:
+
+- `:latest`, `:latest-amd64`, `:latest-arm64` point to the latest images and their respective architecture
+- `:{Cockpit WS Version}`, `:{Cockpit WS Version}-amd64`, `:{Cockpit WS Version}-arm64` (e. g. `:280-amd64`) point to
+  images with the specified Cockpit WS version and their respective platform
+
+## Preparing Managed Host
+
+The hosts you want to manage via this container need to have both `cockpit-system` installed and SSH access enabled.
+
+Depending on your configuration, you may want to install
+[additional extensions](https://packages.fedoraproject.org/search?query=cockpit-) as well, such as `cockpit-kdump` or
+`cockpit-networkmanager`.
+
+The standard Fedora and Red Hat Enterprise Linux CoreOS images do not provide Cockpit packages. If you wish to install
+the container on CoreOS or simply manage such a system, you need to follow these
+steps to setup Cockpit:
+
+1. Install Cockpit core packages as overlay RPMs:
    ```
    rpm-ostree install cockpit-system cockpit-ostree cockpit-podman
    ```
-
-   Depending on your configuration, you may want to use
-   [other extensions](https://apps.fedoraproject.org/packages/s/cockpit-) as
-   well, such as `cockpit-kdump` or `cockpit-networkmanager`.
 
    If you have a custom-built OSTree, simply include the same packages in your build.
 
 2. Reboot
 
-Steps 1 and 2 are enough when the CoreOS machine is only connected to through another host running Cockpit.
+3. Continue with setting up the Cockpit WS container below
 
-If you want to also run a web server to log in directly on the CoreOS host, you
-can use this container in two modes.
+## Running the Cockpit WS Container
 
-## Privileged ws container
+There are two modes in which this container can operate.
 
-Privileged mode provides tight integration with the host: You can use the
-host's users and their passwords to log in, and Cockpit's branding will adjust
-to the host operating system.
+### Privileged Mode
 
-1. Enable password based SSH logins, unless you only use [SSO logins](https://cockpit-project.org/guide/latest/sso.html):
-   ```
-   echo 'PasswordAuthentication yes' | sudo tee /etc/ssh/sshd_config.d/02-enable-passwords.conf
-   sudo systemctl try-restart sshd
-   ```
+Privileged mode provides tight integration with the host. You can use the host's users and their passwords to log in,
+and Cockpit's branding will adjust to the host operating system.
 
-2. Run the Cockpit web service with a privileged container (as root):
+1. Run the Cockpit web service with a privileged container (as root):
    ```
    podman container runlabel --name cockpit-ws RUN quay.io/cockpit/ws
    ```
 
-3. Make Cockpit start on boot:
+2. Make Cockpit start on boot:
    ```
    podman container runlabel INSTALL quay.io/cockpit/ws
    systemctl enable cockpit.service
    ```
 
-Afterward, use a web browser to log into port `9090` on your host IP address as usual.
+### Unprivileged Mode (Bastion Container)
 
-## Unprivileged bastion container
-
-When you run the container without `--privileged`, it presents an unbranded
-login page. The user always has to specify a host name, and it connects to that
-host with SSH.
+When you run the container without `--privileged`, it presents an unbranded login page. The user always has to specify a
+host name, and it connects to that host with SSH.
 
 ```
-podman run -d --name cockpit-bastion -p 9090:9090 quay.io/cockpit/ws
+podman run -d \
+   --name cockpit \
+   -p 9090:9090 \
+   quay.io/cockpit/ws
 ```
 
-This mode is suitable for deploying to e.g. Kubernetes or similar environments
-where you cannot have or want privileged containers. In this "bastion host
-mode", you can get a Cockpit for servers in your data center without opening an
-extra port for cockpit-ws on them.
+You can still log into the container's host if you specify its **public** address or alternatively
+`host.containers.internal` if you're running the container with [podman](https://podman.io).
 
-You can still log into the ws container's host if you specify its *public*
-address. [podman](https://podman.io/) provides the special name
-`host.containers.internal` for that.
+This mode is suitable for deploying to e.g. Kubernetes or similar environments where you can not have or want privileged
+containers. In this "bastion" mode you can run Cockpit without ensuring you can connect to the managed hosts directly.
+The container can simply sit at the edge between your public and your internal networks.
 
-### Configuration
+## Configuration
 
-By default, the container uses an internal
-[cockpit.conf](https://cockpit-project.org/guide/latest/cockpit.conf.5.html)
-which sets `RequireHost = true` and a neutral login title. You can customize
-this by passing your own configuration as a volume:
+### Cockpit Configuration
 
-    -v /path/to/your/cockpit.conf:/etc/cockpit/cockpit.conf:ro,Z
+By default, the container uses an [cockpit.conf](https://cockpit-project.org/guide/latest/cockpit.conf.5.html) which
+requires you to enter a hostname on every login and displays a neutral login page and title.
 
-Similarly you can also provide a custom `/etc/os-release` to change the
-branding.
+You can customize this behaviour and more, by passing your own configuration as a volume:
 
-### SSH authentication
+```
+-v /path/to/your/cockpit.conf:/etc/cockpit/cockpit.conf:ro,Z
+```
 
-The login page asks the user to confirm unknown SSH host key fingerprints.  You
-can mount your known host keys into the container at
-`/etc/ssh/ssh_known_hosts`, or set the environment variable
-`COCKPIT_SSH_KNOWN_HOSTS_FILE` to specify a different location:
+Similarly you can also provide a custom `/etc/os-release` to change the branding, e.g. by using the host's information:
 
-    -v /path/to/known_hosts:/etc/ssh/ssh_known_hosts:ro,Z
+```
+-v /etc/os-release:/etc/os-release:ro,Z
+```
 
-You can also mount an encrypted private key inside the container and set the environment variable `COCKPIT_SSH_KEY_PATH` to point to it:
+The container will create a self signed certificate unless one is provided within `/etc/cockpit/ws-certs.d`. You can
+provide your own certificate and Cockpit will automatically use it:
 
-    -e COCKPIT_SSH_KEY_PATH=/id_rsa -v ~/.ssh/id_rsa:/id_rsa:ro,Z
+```
+-v /path/to/your/cert.crt:/etc/cockpit/ws-certs.d/cert.crt:ro,Z \
+-v /path/to/your/cert.key:/etc/cockpit/ws-certs.d/cert.key:ro,Z
+```
 
-Then cockpit will use the provided password to decrypt the key and establish an SSH connection to the given host using that private key.
+For more guides on configuring Cockpit, see the following pages:
 
-## More Info
+- https://cockpit-project.org/guide/latest/cockpit.conf.5
+- https://cockpit-project.org/guide/latest/guide
 
- * [Cockpit Project](https://cockpit-project.org)
- * [Cockpit Development](https://github.com/cockpit-project/cockpit)
- * [cockpit/ws quay.io page](https://quay.io/repository/cockpit/ws)
+### SSH Authentication
+
+Normally the the login page asks the user to confirm unknown SSH host key fingerprints. Confirmed keys will be stored in
+
+You can mount your known host keys into the container at `/etc/ssh/ssh_known_hosts`:
+
+```
+-v /host/path/to/known_hosts:/etc/ssh/ssh_known_hosts:ro,Z
+```
+
+Or mount them to a different location and specify the environment variable `COCKPIT_SSH_KNOWN_HOSTS_FILE`:
+
+```
+-v /host/path/to/known_hosts:/container/path/to/known_hosts:ro,Z \
+-e COCKPIT_SSH_KNOWN_HOSTS_FILE=/container/path/to/known_hosts
+```
+
+The container's default `cockpit.conf` enables you to use a **single** key file as identity when connecting to managed
+hosts. If you wish to customize the configuration file, but use SSH authentication, make sure the following lines are
+added to your configuration file:
+
+```
+[Basic]
+Command = /container/cockpit-auth-ssh-key
+
+[Ssh-Login]
+Command = /container/cockpit-auth-ssh-key
+```
+
+Then mount an **encrypted** private key inside the container and set the environment
+variable `COCKPIT_SSH_KEY_PATH` to point to it:
+
+```
+-v /host/path/to/key:/container/path/to/key:ro,Z \ 
+-e COCKPIT_SSH_KEY_PATH=/container/path/to/key
+```
+
+Cockpit will use the provided password on every login to decrypt the key and establish an SSH connection to the given
+host using that private key. **If the decryption fails, the provided password will be used for username/password
+authentication on the provided host instead.**
+
+## More Information
+
+* [Cockpit Project](https://cockpit-project.org)
+* [Cockpit Development](https://github.com/cockpit-project/cockpit)
+* [cockpit/ws quay.io page](https://quay.io/repository/cockpit/ws)

--- a/containers/ws/default-bastion.conf
+++ b/containers/ws/default-bastion.conf
@@ -1,6 +1,6 @@
 [WebService]
 ProtocolHeader = X-Forwarded-Proto
-LoginTitle = Cockpit Bastion
+LoginTitle = Cockpit
 RequireHost = true
 
 [Negotiate]

--- a/containers/ws/install.sh
+++ b/containers/ws/install.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-
 set -ex
 
 OSVER=$(. /etc/os-release && echo "$VERSION_ID")

--- a/containers/ws/label-install
+++ b/containers/ws/label-install
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/sh
+set -eu
 
 # This is the install script for cockpit-ws when run in a privileged container
 # We expect that cockpit-bridge and related stuff is already in the host.

--- a/containers/ws/label-uninstall
+++ b/containers/ws/label-uninstall
@@ -1,4 +1,5 @@
-#!/bin/sh -eu
+#!/bin/sh
+set -eu
 
 # This is the install script for Cockpit when run in a privileged container
 #

--- a/containers/ws/release.sh
+++ b/containers/ws/release.sh
@@ -8,24 +8,52 @@ if [ -z "${RUNC:-}" ]; then
     }
 fi
 
-$RUNC build -t quay.io/cockpit/ws:release containers/ws
+# only build on host architecture per default
+if [ -z "${ARCHS:-}" ]; then
+    case $(uname -m) in
+        x86_64) ARCHS="amd64" ;;
+        arm64) ARCHS="arm64" ;;
+    esac
+fi
+for arch in $ARCHS; do
+    $RUNC buildx build --platform="linux/${arch}" -t "quay.io/cockpit/ws:release-${arch}" containers/ws
+done
 
 # smoke test
-name=ws-release
-$RUNC run --name $name -p 19999:9090 -d quay.io/cockpit/ws:release
-until curl --fail --show-error -k --head https://localhost:19999; do
-    sleep 1
+first_arch=$(echo "${ARCHS}" | cut -d " " -f 1)
+test_container=ws-release
+$RUNC run --name "${test_container}" -p 19999:9090 -d "quay.io/cockpit/ws:release-${first_arch}"
+
+for i in $(seq 1 30); do
+    curl --fail --show-error -k --head https://localhost:19999 && break
+
+    [ "${i}" -eq 30 ] && $RUNC rm -f "${test_container}" && exit 1 || sleep 1
 done
 
 # determine cockpit version
-TAG=$($RUNC exec $name cockpit-bridge --version | sed -n '/^Version:/ { s/^.*: //p }')
+version=$($RUNC exec "${test_container}" cockpit-bridge --version | sed -n 's/^Version: *//p')
 
-$RUNC rm -f $name
+$RUNC rm -f "${test_container}"
 
-$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:$TAG
-$RUNC tag quay.io/cockpit/ws:release quay.io/cockpit/ws:latest
-$RUNC rmi quay.io/cockpit/ws:release
+version_arch_tags=""
+for arch in $ARCHS; do
+    release_arch_tag="quay.io/cockpit/ws:release-${arch}"
+    version_arch_tag="quay.io/cockpit/ws:${version}-${arch}"
+    latest_arch_tag="quay.io/cockpit/ws:latest-${arch}"
 
-# push both tags
-$RUNC push quay.io/cockpit/ws:$TAG
-$RUNC push quay.io/cockpit/ws:latest
+    version_arch_tags="${version_arch_tags} ${version_arch_tag}"
+
+    $RUNC tag "${release_arch_tag}" "${version_arch_tag}"
+    $RUNC tag "${release_arch_tag}" "${latest_arch_tag}"
+
+    $RUNC push "${version_arch_tag}"
+    $RUNC push "${latest_arch_tag}"
+
+    $RUNC rmi "${release_arch_tag}"
+done
+
+version_tag="quay.io/cockpit/ws:${version}"
+$RUNC manifest create "${version_tag}" ${version_arch_tags}
+
+$RUNC manifest push "${version_tag}" "${version_tag}"
+$RUNC manifest push "${version_tag}" "quay.io/cockpit/ws:latest"


### PR DESCRIPTION
This PR changes the image tags for the WS container and adds ARM64 builds via Docker Buildx or podman buildx. I've tried to keep changes as minimal as possible, since I don't have a good enough overview to fully understand the workflows on this repository and want to avoid any collateral damage.

I'm not fully satisfied with this solution and I have a few open topics I'd like to take care of in the next few days or weeks, hence the draft status:

- [ ] I've not been able testing to push to quay.io itself, only to my private packages on the GHCR. *pitti*: That's fine, I don't expect any trouble there, and if there is I'm happy to deal with it once this is ready to land.
- [ ] The smoke test currently only tests the first built image. *pitti* See review comment thread below.
- [ ] I've not tested the local RPM installation due to lack of time, I'd appreciate help on that as well. *pitti* our "fedora-coreos" integration test does that.
- [x] I'm not fully aware of how the packages are published to the Fedora repositories, but I suppose that in rare cases the available x86 version of Cockpit is different than the arm64 version when a new Cockpit package was just released. *pitti*: No, a new version always enters Fedora for all architectures at the same time. This is fine.
- [ ] The image itself could be a little "optimized" by reducing the files added to the container. For instance it's not necessary to include the release scripts as well as the README in the container. *pitti* Let's do this in a separate PR, to not make this unnecessarily complex.
- [x] The README for the container (also displayed on quay.io) is missing a few things I'd like it to point out, e. g. an overview of the available image tags and some info on the SSH key authentication.
- [x] The [Docker Hub page for the container](https://hub.docker.com/r/cockpit/ws) should be updated to inform of the deprecation of the images there and link to quay.io *pitti*: Done, thanks for pointing out!

The release script itself can be run via Docker or podman, that's the main reason this has been rather cumbersome to implement. **If that's not a requirement I'd be happy to simplify the workflow.** It should be possible to replace most if not all of the image tagging/multi-arch stuff currently in the script via GitHub actions provided by Docker. *pitti*: I'm a bit wary of dropping docker; we used to have problems in the past that old docker versions could not read podman-generated images (IIRC because docker was not able to read the new manifest format or something such). So for now, let's keep building the official images with docker.

Also a side note: Docker Buildx is pretty slow when building an ARM image on x86. It took about 30 minutes for ARM image to be built when I tested this. *pitti*: Yup, that's QEMU full system emulation for you :grin: 