### PR TITLE
pkg: correct indexOf function call in cockpit.location.encoding

### DIFF
--- a/pkg/base1/test-location.js
+++ b/pkg/base1/test-location.js
@@ -298,4 +298,22 @@ QUnit.test("test", function (assert) {
     window.location.hash = "#/other";
 });
 
+/* Set url_root in beforeEach so the test does not flake */
+QUnit.module("url_root tests", {
+    beforeEach: () => {
+        window.mock = { url_root: "cockpit" };
+    },
+    afterEach: () => {
+        window.mock = null;
+    }
+});
+
+QUnit.test("encode", assert => {
+    let path = cockpit.location.encode("path", "", true);
+    assert.equal(path, "/cockpit/path", "path is correct");
+    /* an existing url_root should not be prepended */
+    path = cockpit.location.encode("/cockpit/path", "", true);
+    assert.equal(path, "/cockpit/path", "path is correct");
+});
+
 QUnit.start();

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2474,6 +2474,10 @@ function factory() {
         const self = this;
         const application = cockpit.transport.application();
         self.url_root = url_root || "";
+
+        if (window.mock && window.mock.url_root)
+            self.url_root = window.mock.url_root;
+
         if (application.indexOf("cockpit+=") === 0) {
             if (self.url_root)
                 self.url_root += '/';
@@ -2516,7 +2520,7 @@ function factory() {
                 path = decode_path(path);
 
             let href = "/" + path.map(encodeURIComponent).join("/");
-            if (with_root && self.url_root && href.indexOf("/" + self.url_root + "/" !== 0))
+            if (with_root && self.url_root && href.indexOf("/" + self.url_root + "/") !== 0)
                 href = "/" + self.url_root + href;
 
             /* Undo unnecessary encoding of these */


### PR DESCRIPTION
The originally introduced cockpit.location.encode function incorrectly does the 0 comparison in the indexOf call, so with url_root set the encode function would always prepend the url_root. As "foo".indexOf(true) returns -1 which is truthy in JavaScript.