### PR TITLE
Drop obsolete versioned dependencies

### DIFF
--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-	"cockpit": "122"
-    },
-
     "tools": {
         "index": {
             "label": "Applications",

--- a/pkg/base1/test-http.js
+++ b/pkg/base1/test-http.js
@@ -34,10 +34,6 @@ QUnit.test("simple request", assert => {
     cockpit.http(test_server).get("/pkg/playground/manifest.json")
             .then(data => {
                 assert.deepEqual(JSON.parse(data), {
-                    requires: {
-                        cockpit: "122"
-                    },
-
                     tools: {
                         index: {
                             label: "Development"

--- a/pkg/kdump/manifest.json
+++ b/pkg/kdump/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-        "cockpit": "130"
-    },
-
     "tools": {
         "index": {
             "label": "Kernel dump",

--- a/pkg/metrics/manifest.json
+++ b/pkg/metrics/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-        "cockpit": "137"
-    },
-
     "parent": {
         "component": "system",
         "docs": [

--- a/pkg/networkmanager/manifest.json
+++ b/pkg/networkmanager/manifest.json
@@ -1,9 +1,5 @@
 {
     "name": "network",
-    "requires": {
-        "cockpit": "186"
-    },
-
     "menu": {
         "index": {
             "label": "Networking",

--- a/pkg/packagekit/manifest.json
+++ b/pkg/packagekit/manifest.json
@@ -1,10 +1,6 @@
 {
     "name": "updates",
     "priority": 0,
-    "requires": {
-        "cockpit": "186"
-    },
-
     "tools": {
         "index": {
             "label": "Software updates",

--- a/pkg/pcp/manifest.json
+++ b/pkg/pcp/manifest.json
@@ -1,6 +1,6 @@
 {
     "requires": {
-        "cockpit": "238.1.1"
+        "cockpit": "239"
     },
     "bridges": [
         {

--- a/pkg/playground/manifest.json
+++ b/pkg/playground/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-	"cockpit": "122"
-    },
-
     "tools": {
         "index": {
             "label": "Development"

--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-	"cockpit": "122"
-    },
-
     "tools": {
         "setroubleshoot": {
             "label": "SELinux",

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -1,6 +1,6 @@
 {
     "requires": {
-        "cockpit": "238.1.1"
+        "cockpit": "239"
     },
     "locales": {
         "cs-cz": "čeština",

--- a/pkg/sosreport/manifest.json
+++ b/pkg/sosreport/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-	"cockpit": "122"
-    },
-
     "tools": {
         "index": {
             "label": "Diagnostic reports",

--- a/pkg/ssh/manifest.json
+++ b/pkg/ssh/manifest.json
@@ -1,7 +1,4 @@
 {
-    "requires": {
-        "cockpit": "138"
-    },
     "priority": 100,
     "bridges": [
         {

--- a/pkg/tuned/manifest.json
+++ b/pkg/tuned/manifest.json
@@ -1,6 +1,3 @@
 {
-    "name": "performance",
-    "requires": {
-	"cockpit": "122"
-    }
+    "name": "performance"
 }

--- a/pkg/users/manifest.json
+++ b/pkg/users/manifest.json
@@ -1,8 +1,4 @@
 {
-    "requires": {
-	"cockpit": "122"
-    },
-
     "menu": {
         "index": {
             "label": "Accounts",

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -322,8 +322,6 @@ troubleshooting, interactive command-line sessions, and more.
 Summary: Cockpit bridge server-side component
 Requires: glib-networking
 Provides: cockpit-ssh = %{version}-%{release}
-# PR #10430 dropped workaround for ws' inability to understand x-host-key challenge
-Conflicts: cockpit-ws < 181.x
 # 233 dropped jquery.js, pages started to bundle it (commit 049e8b8dce)
 Conflicts: cockpit-dashboard < 233
 Conflicts: cockpit-networkmanager < 233
@@ -617,8 +615,8 @@ The Cockpit component for managing storage.  This package uses udisks.
 
 %package -n cockpit-tests
 Summary: Tests for Cockpit
-Requires: cockpit-bridge >= 138
-Requires: cockpit-system >= 138
+Requires: cockpit-bridge >= %{required_base}
+Requires: cockpit-system >= %{required_base}
 Requires: openssh-clients
 Provides: cockpit-test-assets = %{version}-%{release}
 


### PR DESCRIPTION
Drop cockpit version requirements for versions which are > 2 years old. None of the distributions that we support on the main branch have that ancient versions even in their backport repositories. This does not change anything in practice, as the rpm/deb dependencies are a *lot* stricter already (rpm has ≥ 266, deb has ≥ source version).

Also update the "238.1.1" requirement to "239". Back then that meant "the next version after 238.1".

Fewer magic numbers!

----

https://salsa.debian.org/debian/cockpit-podman/-/merge_requests/4 triggered me to have a closer look.