### PR TITLE
test: exclude Kpatch on tmt

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -79,7 +79,7 @@ if [ "$PLAN" = "optional" ]; then
            "
 
     # Testing Farm machines often have pending restarts/reboot
-    EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart"
+    EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart TestUpdates.testKpatch"
 
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES


### PR DESCRIPTION
The gating test environment set's up and installs testing packages. This leaves the system in a state where there are services to restart/reboot making the kpatch test fail (as there is no continue button).