### PR TITLE
pf, dark: Fix disabled buttons in modals

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -270,6 +270,12 @@ svg {
     --pf-c-button--disabled--Color: #8d9093;
   }
 
+  // Fix PF disabled colors again, for modals
+  .pf-c-modal-box :is(:disabled, .pf-m-disabled, .pf-m-aria-disabled) {
+    // Alter background again, otherwise it matches modal background
+    --pf-c-button--disabled--BackgroundColor: var(--pf-global--BackgroundColor--dark-400);
+  }
+
   // Change background color behind cards
   // (matches PF surge website; PF doesn't specify otherwise)
   .pf-c-page__main-section {


### PR DESCRIPTION
To fix disabled buttons in dark mode in general, we had to change the background and contrast. To fix the buttons in modals, we also need to change the background, as otherwise the background is the same color.