### PR TITLE
#17822 - Validation of real name field

### DIFF
--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -116,6 +116,23 @@ function validate_username(username, accounts) {
     return null;
 }
 
+function is_valid_char_real_name(c) {
+    return (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        c == '.' || c == '_' || c == '-' || c == ' ';
+}
+
+function validate_real_name(real_name) {
+    if (!real_name)
+        return _("No real name specified");
+
+    for (let i = 0; i < real_name.length; i++) {
+        if (!is_valid_char_real_name(real_name[i]))
+            return _("The full name can only consist of letters from a-z, digits, dots, dashes, underscores and spaces.");
+    }
+}
+
 function suggest_username(realname) {
     function remove_diacritics(str) {
         const translate_table = {
@@ -203,8 +220,7 @@ export function account_create_dialog(accounts) {
     function validate(force, real_name, user_name, password, password_confirm) {
         const errs = { };
 
-        if (!real_name)
-            errors.real_name = _("No real name specified");
+        errs.real_name = validate_real_name(real_name)
 
         if (password != password_confirm)
             errs.password_confirm = _("The passwords do not match");

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -116,21 +116,13 @@ function validate_username(username, accounts) {
     return null;
 }
 
-function is_valid_char_real_name(c) {
-    return (c >= 'a' && c <= 'z') ||
-        (c >= 'A' && c <= 'Z') ||
-        (c >= '0' && c <= '9') ||
-        c == '.' || c == '_' || c == '-' || c == ' ';
-}
-
 function validate_real_name(real_name) {
     if (!real_name)
         return _("No real name specified");
 
-    for (let i = 0; i < real_name.length; i++) {
-        if (!is_valid_char_real_name(real_name[i]))
-            return _("The full name can only consist of letters from a-z, digits, dots, dashes, underscores and spaces.");
-    }
+    const real_name_chars = Array.from(real_name);
+    if (!real_name_chars.every(character => character != ':'))
+        return _("The full name must not contain colons.");
 }
 
 function suggest_username(realname) {
@@ -220,7 +212,7 @@ export function account_create_dialog(accounts) {
     function validate(force, real_name, user_name, password, password_confirm) {
         const errs = { };
 
-        errs.real_name = validate_real_name(real_name)
+        errs.real_name = validate_real_name(real_name);
 
         if (password != password_confirm)
             errs.password_confirm = _("The passwords do not match");

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -121,7 +121,7 @@ function validate_real_name(real_name) {
         return _("No real name specified");
 
     const real_name_chars = Array.from(real_name);
-    if (!real_name_chars.every(character => character != ':'))
+    if (real_name_chars.includes(':'))
         return _("The full name must not contain colons.");
 }
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -77,6 +77,12 @@ class TestAccounts(MachineCase):
         b.wait_visible("#accounts")
         b.wait_not_in_text('#accounts-list', "Anton Arbitrary")
 
+        # Attempt a real name with a colon
+        b.set_input_text('#account-real-name', "Col:n Colon")  # This should fail
+        b.click('#accounts-create-dialog button.apply')
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "The full name must not contain colons.")
+        b.wait_not_present('#accounts-create-dialog button.pf-m-warning')
+
         # Check root user
         b.go("#/root")
         b.wait_text("#account-user-name", "root")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -80,10 +80,13 @@ class TestAccounts(MachineCase):
         # Attempt a real name with a colon
         b.click('#accounts-create')
         b.wait_visible('#accounts-create-dialog')
-        b.set_input_text('#account-real-name', "Col:n Colon")  # This should fail
+        b.set_input_text('#accounts-create-real-name', "Col:n Colon")  # This should fail
+        b.set_input_text('#accounts-create-password-pw1', good_password)
+        b.set_input_text('#accounts-create-password-pw2', good_password)
         b.click('#accounts-create-dialog button.apply')
         b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "The full name must not contain colons.")
-        b.wait_not_present('#accounts-create-dialog button.pf-m-warning')
+        b.click('#accounts-create-dialog button.cancel')
+        b.wait_visible("#accounts")
 
         # Check root user
         b.go("#/root")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -78,6 +78,8 @@ class TestAccounts(MachineCase):
         b.wait_not_in_text('#accounts-list', "Anton Arbitrary")
 
         # Attempt a real name with a colon
+        b.click('#accounts-create')
+        b.wait_visible('#accounts-create-dialog')
         b.set_input_text('#account-real-name', "Col:n Colon")  # This should fail
         b.click('#accounts-create-dialog button.apply')
         b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "The full name must not contain colons.")


### PR DESCRIPTION
Created a validation method for real_name field with char set of a-z A-Z 0-9 ._-
Replaced the if statement in validate function with a call to validate_real_name which includes the empty real_name check.

Results in the following:
![image](https://user-images.githubusercontent.com/1063820/203648856-92ec6383-4afe-4d63-ac04-4131cc758ca4.png)
