### PR TITLE
python: superuser peer bridge (--privileged mode)

### DIFF
--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -50,23 +50,6 @@ class cockpit_Packages(bus.Object):
     ...
 
 
-class cockpit_Superuser(bus.Object):
-    bridges = bus.Interface.Property('as', value=['sudo', 'pkexec'])
-    current = bus.Interface.Property('s', value='none')
-
-    @bus.Interface.Method(in_types=['s'])
-    def start(self, _bridge):
-        ...
-
-    @bus.Interface.Method()
-    def stop(self):
-        ...
-
-    @bus.Interface.Method(in_types=['s'])
-    def answer(self, reply):
-        ...
-
-
 class cockpit_User(bus.Object):
     name = bus.Interface.Property('s', value='')
     full = bus.Interface.Property('s', value='')
@@ -90,6 +73,5 @@ EXPORTS = [
     ('/config', cockpit_Config),
     ('/machines', cockpit_Machines),
     ('/packages', cockpit_Packages),
-    ('/superuser', cockpit_Superuser),
     ('/user', cockpit_User),
 ]

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -15,41 +15,130 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from __future__ import annotations
+
 import asyncio
-import socket
-import subprocess
+import logging
+import os
 
-from .router import Endpoint
+from typing import Any, Dict, Optional, Set
+
+from .router import Endpoint, Router
 from .protocol import CockpitProtocolClient
+from .transports import SubprocessTransport, SubprocessProtocol
+
+logger = logging.getLogger(__name__)
 
 
-class PeerProtocol(CockpitProtocolClient):
-    def __init__(self, upstream):
-        self.upstream = upstream
+class PeerStateListener:
+    def peer_state_changed(self, peer: Peer, event: str, exc: Optional[Exception] = None) -> None:
+        """Signal a state change in the Peer.
 
-    def do_ready(self):
-        pass
+        This is called on:
+            - connection made (event='connect')
+            - init message received (event='init')
+            - connection lost (event='closed', exc possibly set)
+        """
 
-    def do_init(self, message):
-        # TODO: send init
-        pass
+    def peer_authorization_request(self, peer: Peer, prompt: str, echo: bool) -> None:
+        """Request authentication for connecting to the peer.
 
-    def do_frame(self, frame):
-        self.upstream.send_frame(frame)
+        The state listener should respond by calling .authorize_response() on the Peer.
+        """
 
 
-class Peer(Endpoint):
-    subprocess = None
-    protocol = None
+class Peer(CockpitProtocolClient, SubprocessProtocol, Endpoint):
+    name: str
+    init_host: str
+    state_listener: Optional[PeerStateListener]
 
-    async def start(self, args):
-        protocol_sock, subprocess_sock = socket.socketpair()
-        self.subprocess = subprocess.Popen(args, stdin=subprocess_sock, stdout=subprocess_sock)
-        loop = asyncio.get_event_loop()
-        await loop.connect_accepted_socket(PeerProtocol, protocol_sock)
+    channels: Set[str]
 
-    def do_channel_control(self, channel, command, message):
-        raise NotImplementedError
+    authorize_pending: Optional[str] = None  # the cookie of the pending request
 
-    def do_channel_data(self, channel, data):
-        raise NotImplementedError
+    def __init__(self,
+                 router: Router,
+                 name: str,
+                 state_listener: Optional[PeerStateListener] = None,
+                 init_host: Optional[str] = None):
+        super().__init__(router)
+
+        self.name = name
+        self.state_listener = state_listener
+
+        assert router.init_host is not None
+        self.init_host = init_host or router.init_host
+
+        self.channels = set()
+        self.authorize_pending = None
+
+    def spawn(self, argv: list[str], env: Dict[str, str]) -> asyncio.Transport:
+        loop = asyncio.get_running_loop()
+        return SubprocessTransport(loop, self, argv, env=dict(os.environ, **env))
+
+    # Handling of interesting events
+    def do_ready(self) -> None:
+        logger.debug('Peer %s connection established', self.name)
+        if self.state_listener is not None:
+            self.state_listener.peer_state_changed(self, 'connected')
+
+    def do_init(self, message: Dict[str, Any]) -> None:
+        logger.debug('Peer %s connection got init message', self.name)
+        if self.state_listener is not None:
+            self.state_listener.peer_state_changed(self, 'init')
+        self.write_control(command='init', version='1', host=self.init_host)
+
+    def do_closed(self, exc: Optional[Exception]) -> None:
+        logger.debug('Peer %s connection lost %s', self.name, exc)
+
+        # We need to synthesize close messages for all open channels
+        while self.channels:
+            self.send_channel_control(self.channels.pop(), 'close', problem='disconnected')
+
+        if self.state_listener is not None:
+            self.state_listener.peer_state_changed(self, 'closed', exc)
+
+    def do_authorize(self, message: Dict[str, object]) -> None:
+        cookie = message.get('cookie')
+        prompt = message.get('prompt')
+        logger.debug('Peer %s request, cookie=%s, prompt=%s', self.name, cookie, prompt)
+        if self.state_listener is not None and isinstance(cookie, str) and isinstance(prompt, str):
+            self.authorize_pending = cookie
+            self.state_listener.peer_authorization_request(self, prompt, False)
+
+    def authorize_response(self, response: str) -> None:
+        logger.debug('Peer %s response, cookie=%s, response=%s', self.name, self.authorize_pending, response)
+        cookie = self.authorize_pending
+        if cookie is not None:
+            self.authorize_pending = None
+            self.write_control(command='authorize', cookie=cookie, response=response)
+
+    def process_exited(self) -> None:
+        assert isinstance(self.transport, SubprocessTransport)
+        logger.debug('Peer %s exited, status %d', self.name, self.transport.get_returncode())
+
+    def close(self) -> None:
+        if self.transport is not None:
+            self.transport.close()
+
+    # Forwarding data: from the peer to the router
+    def channel_control_received(self, channel: str, command: str, message: Dict[str, object]) -> None:
+        if command == 'close':
+            self.channels.discard(channel)
+
+        self.send_channel_control(**message)
+
+    def channel_data_received(self, channel: str, data: bytes) -> None:
+        self.send_channel_data(channel, data)
+
+    # Forwarding data: from the router to the peer
+    def do_channel_control(self, channel: str, command: str, message: Dict[str, object]) -> None:
+        if command == 'open':
+            self.channels.add(channel)
+        elif command == 'close':
+            self.channels.discard(channel)
+
+        self.write_control(**message)
+
+    def do_channel_data(self, channel: str, data: bytes) -> None:
+        self.write_channel_data(channel, data)

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -41,8 +41,11 @@ class CockpitProtocol(asyncio.Protocol):
     buffer = b''
     _communication_done: Optional[asyncio.Future] = None
 
-    def do_ready(self):
+    def do_ready(self) -> None:
         raise NotImplementedError
+
+    def do_closed(self, exc: Optional[Exception]) -> None:
+        pass
 
     def transport_control_received(self, command: str, message: Dict[str, object]) -> None:
         raise NotImplementedError

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -220,6 +220,9 @@ class CockpitProtocolServer(CockpitProtocol):
     def do_init(self, message):
         pass
 
+    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+        raise NotImplementedError
+
     def transport_control_received(self, command, message):
         if command == 'init':
             try:
@@ -235,6 +238,8 @@ class CockpitProtocolServer(CockpitProtocol):
             except KeyError as exc:
                 raise CockpitProtocolError('missing host field', 'protocol-error') from exc
             self.do_init(message)
+        elif command == 'kill':
+            self.do_kill(message.get('host'), message.get('group'))
         else:
             raise CockpitProtocolError(f'unexpected control message {command} received')
 

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -1,0 +1,198 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2022 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import pwd
+
+from systemd_ctypes import bus
+
+from typing import Dict, Optional
+
+from .router import Router, RoutingError, RoutingRule
+from .peer import Peer, PeerStateListener
+
+logger = logging.getLogger(__name__)
+
+SUPERUSER_AUTH_COOKIE = 'supermarius'
+
+# Keep a static list, for the time being.
+SUPERUSER_BRIDGES = {
+    'sudo': (
+        ['sudo', '--askpass', 'cockpit-bridge', '--privileged'], {
+            'SUDO_ASKPASS': '/usr/libexec/cockpit-askpass'
+        }
+    ),
+}
+
+
+class SuperuserStartup:
+    peer: Peer  # the peer that's being started
+
+    def success(self, rule: SuperuserRoutingRule) -> None:
+        raise NotImplementedError
+
+    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+        raise NotImplementedError
+
+    def auth(self, rule: SuperuserRoutingRule, prompt: str, echo: bool) -> None:
+        raise NotImplementedError
+
+
+class ControlMessageStartup(SuperuserStartup):
+    def success(self, rule: SuperuserRoutingRule) -> None:
+        rule.router.write_control(command='superuser-init-done')
+
+    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+        rule.router.write_control(command='superuser-init-done')
+
+    def auth(self, rule: SuperuserRoutingRule, prompt: str, echo: bool) -> None:
+        username = pwd.getpwuid(os.getuid()).pw_name
+        hexuser = ''.join(f'{c:02x}' for c in username.encode('ascii'))
+        rule.router.write_control(command='authorize', cookie=SUPERUSER_AUTH_COOKIE, challenge=f'plain1:{hexuser}')
+
+
+class DBusStartup(SuperuserStartup):
+    future: asyncio.Future
+
+    def __init__(self):
+        self.future = asyncio.get_running_loop().create_future()
+
+    def success(self, rule: SuperuserRoutingRule) -> None:
+        self.future.set_result(None)
+
+    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+        self.future.set_exception(exc)
+
+    def auth(self, rule: SuperuserRoutingRule, prompt: str, echo: bool) -> None:
+        rule.prompt('', prompt, '', echo, '')
+
+    async def wait(self) -> None:
+        await self.future
+
+
+class SuperuserRoutingRule(PeerStateListener, RoutingRule, bus.Object, interface='cockpit.Superuser'):
+    startup: Optional[SuperuserStartup]
+    peer: Optional[Peer]
+
+    # D-Bus signals
+    prompt = bus.Interface.Signal('s', 's', 's', 'b', 's')  # message, prompt, default, echo, error
+
+    # D-Bus properties
+    bridges = bus.Interface.Property('as', value=[])
+    current = bus.Interface.Property('s', value='none')
+
+    # RoutingRule
+    def apply_rule(self, options: Dict[str, object]) -> Optional[Peer]:
+        superuser = options.get('superuser')
+
+        if not superuser or self.current == 'root':
+            # superuser not requested, or already superuser?  Next rule.
+            return None
+        elif self.peer or superuser == 'try':
+            # superuser requested and active?  Return it.
+            # 'try' requested?  Either return the peer, or None.
+            return self.peer
+        else:
+            # superuser requested, but not active?  That's an error.
+            raise RoutingError('access-denied')
+
+    # PeerStateListener hooks
+    def peer_state_changed(self, peer: Peer, event: str, exc: Optional[Exception] = None) -> None:
+        logger.debug('Peer %s state changed -> %s', peer.name, event)
+        if event == 'connected':
+            self.current = 'init'
+
+        elif event == 'init':
+            self.peer = peer
+            self.current = peer.name
+            if self.startup is not None:
+                self.startup.success(self)
+                self.startup = None
+
+        elif event == 'closed':
+            self.current = 'none'
+            self.peer = None
+
+            if self.startup is not None:
+                self.startup.failed(self, exc or ConnectionResetError('connection lost'))
+                self.startup = None
+
+    def peer_authorization_request(self, peer: Peer, prompt: str, echo: bool) -> None:
+        if self.startup:
+            self.startup.auth(self, prompt, echo)
+
+    def __init__(self, router: Router, privileged: bool = False):
+        super().__init__(router)
+
+        self.bridges = list(SUPERUSER_BRIDGES)
+        self.peer = None
+        self.startup = None
+
+        if privileged or os.getuid() == 0:
+            self.current = 'root'
+
+    def go(self, startup: SuperuserStartup, name: str) -> None:
+        assert self.current == 'none'
+        assert self.peer is None
+        assert self.startup is None
+
+        args, env = SUPERUSER_BRIDGES[name]
+        startup.peer = Peer(self.router, name, self)
+        startup.peer.spawn(args, env)
+
+        # We do this step last, only after everything above was successful.  If
+        # anything above raises an error, it will all go away neatly, without
+        # side-effects.
+        self.startup = startup
+
+    def init(self, params: Dict[str, object]) -> None:
+        name = params.get('id')
+        if not isinstance(name, str) or name == 'any':
+            name = 'sudo'
+        self.go(ControlMessageStartup(), name)
+
+    # D-Bus methods
+    @bus.Interface.Method(in_types=['s'])
+    async def start(self, name: str) -> None:
+        if self.current != 'none':
+            raise bus.BusError('cockpit.Superuser.Error', 'Superuser bridge already running')
+
+        try:
+            startup = DBusStartup()
+            self.go(startup, name)
+            await startup.wait()
+        except KeyError as exc:
+            raise bus.BusError('cockpit.Superuser.Error', 'Unknown superuser bridge type') from exc
+        except OSError as exc:
+            raise bus.BusError('cockpit.Superuser.Error', f'Failed to start peer bridge: {exc}') from exc
+
+    @bus.Interface.Method()
+    def stop(self) -> None:
+        if self.peer is not None:
+            self.peer.close()
+
+        # close() should have disconnected the peer immediately
+        assert self.peer is None
+
+    @bus.Interface.Method(in_types=['s'])
+    def answer(self, reply: str) -> None:
+        if self.startup is not None:
+            self.startup.peer.authorize_response(reply)

--- a/test/pytest/pseudo.py
+++ b/test/pytest/pseudo.py
@@ -1,0 +1,16 @@
+import os
+import json
+import sys
+
+pw = os.environ.get('PSEUDO_PASSWORD')
+if pw:
+    challenge = '\n{"command":"authorize", "challenge":"plain1:", "cookie":"dontcare", "prompt": "can haz pw?"}\n'
+    sys.stdout.write(f'{len(challenge)}\n{challenge}')
+    sys.stdout.flush()
+
+    response = json.loads(sys.stdin.read(int(sys.stdin.readline())))
+    if response.get('response') != pw:
+        sys.stderr.write('pseudo says: Bad password\n')
+        sys.exit(1)
+
+os.execvp(sys.argv[1], sys.argv[1:])


### PR DESCRIPTION
This is semi-working.  Let's start discussing it.

The new `test_superuser()` case in `test/pytest/test_bridge.py` is probably a nice place to look to get an idea of what's already working here.

 - [x] implement `kill` transport control command
 - [x] implement superuser-on-init
 - [x] #17964
 - [x] #17973
 - [x] #17977