### PR TITLE
ws: always take packages from the first host

### DIFF
--- a/src/ws/cockpitchannelresponse.c
+++ b/src/ws/cockpitchannelresponse.c
@@ -617,7 +617,6 @@ cockpit_channel_response_serve (CockpitWebService *service,
                                          "payload", "http-stream1",
                                          "internal", "packages",
                                          "method", "GET",
-                                         "host", host,
                                          "path", path,
                                          "binary", "raw",
                                          NULL);


### PR DESCRIPTION
When constructing requests to the packages webserver in the bridge, in response to incoming GET requests, always route the request to the bridge on the login host.

This prevents the additional hosts that we login to from sending us evil JS.