### PR TITLE
Allow root login on RHEL 8

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -604,6 +604,10 @@ class TestConnection(MachineCase):
     def testWsPackage(self):
         m = self.machine
 
+        # On RHEL-8 SSH allows password root login by default, so Cockpit does too.
+        ROOT_LOGIN_ENABLED = ['rhel-8', 'centos-8']
+        root_login_disallowed = not any(m.image.startswith(img) for img in ROOT_LOGIN_ENABLED)
+
         if m.image.startswith("debian") or m.image.startswith("ubuntu"):
             # clean up debug symbols, they get in the way of upgrading
             m.execute("dpkg --purge cockpit-ws-dbgsym")
@@ -634,7 +638,8 @@ class TestConnection(MachineCase):
         # clean install sets up dynamic motd/issue symlink and pam disallowed users.
         self.assertIn('Activate the web console', m.execute("cat /etc/motd.d/cockpit"))
         self.assertIn('Activate the web console', m.execute("cat /etc/issue.d/cockpit.issue"))
-        self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
+        if root_login_disallowed:
+            self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
         # remove disallowed-users to simulate an upgrade where we did not have this file yet.
         m.execute("rm /etc/cockpit/disallowed-users")
 
@@ -665,7 +670,8 @@ class TestConnection(MachineCase):
         # verify that we installed relative links in the new package
         self.assertEqual(m.execute("readlink /etc/motd.d/cockpit").strip(), "../../run/cockpit/motd")
         self.assertEqual(m.execute("readlink /etc/issue.d/cockpit.issue").strip(), "../../run/cockpit/motd")
-        self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
+        if root_login_disallowed:
+            self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     @nondestructive

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -724,12 +724,13 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b = self.browser
         m = self.machine
 
-        # root login is disabled by default via /etc/cockpit/disallowed-users
         m.start_cockpit()
-
         b.open("/system")
-        b.try_login("root", "foobar")
-        b.wait_in_text("#login-error-message", "Wrong user name or password")
+
+        # root login is disabled by default via /etc/cockpit/disallowed-users on everything except RHEL 8
+        if not m.image.startswith("rhel-8") and not m.image.startswith("centos-8"):
+            b.try_login("root", "foobar")
+            b.wait_in_text("#login-error-message", "Wrong user name or password")
 
         # disable root login with pam_access
         self.enable_root_login()

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -74,6 +74,13 @@ Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{v
 %define build_optional 1
 %endif
 
+# Allow root login in Cockpit on RHEL 8 and lower as it also allows password login over SSH.
+%if 0%{?rhel} && 0%{?rhel} <= 8
+%define disallow_root 0
+%else
+%define disallow_root 1
+%endif
+
 # Ship custom SELinux policy (but not for cockpit-appstream)
 %if "%{name}" == "cockpit"
 %define selinuxtype targeted
@@ -481,7 +488,10 @@ if [ "$1" = 1 ]; then
     mkdir -p /etc/motd.d /etc/issue.d
     ln -s ../../run/cockpit/motd /etc/motd.d/cockpit
     ln -s ../../run/cockpit/motd /etc/issue.d/cockpit.issue
-    printf "# List of users which are not allowed to login to Cockpit\nroot\n" > /etc/cockpit/disallowed-users
+    printf "# List of users which are not allowed to login to Cockpit\n" > /etc/cockpit/disallowed-users
+%if 0%{?disallow_root}
+    printf "root\n" >> /etc/cockpit/disallowed-users
+%endif
     chmod 644 /etc/cockpit/disallowed-users
 fi
 


### PR DESCRIPTION
With the disallowed-users feature we now disable root login by default in Cockpit. In RHEL 8 however, a default install can login as root over ssh with password authentication so allow this as well in Cockpit.

The /etc/cockpit/disallowed-users file is kept as then administrators can optionally easily disable root login when wanted.

@martinpitt @marusak do we want what I did? My reasoning is that it's then easier to disable if required.