### PR TITLE
shell: Use correct default lang attribute

### DIFF
--- a/pkg/shell/base_index.js
+++ b/pkg/shell/base_index.js
@@ -37,7 +37,7 @@ function Frames(index, setupIdleResetTimers) {
     const self = this;
     let language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
     if (!language)
-        language = "en-us";
+        language = navigator.language.toLowerCase(); // Default to Accept-Language header
 
     /* Lists of frames, by host */
     self.iframes = { };

--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -594,7 +594,7 @@ if (document.documentElement.classList.contains("index-page")) {
 
     let language = document.cookie.replace(/(?:(?:^|.*;\s*)CockpitLang\s*=\s*([^;]*).*$)|^.*$/, "$1");
     if (!language)
-        language = "en-us";
+        language = navigator.language.toLowerCase(); // Default to Accept-Language header
     document.documentElement.lang = language;
 
     window.addEventListener("message", message_queue, false);


### PR DESCRIPTION
When `CockpitLang` cookie is not set (meaning the user hasn't changed language manually in the UI) we should not default to English as the UI will be in the preferred user language as parsed from Accept-Language header.