### PR TITLE
selinux: avoid AT_SECURE on exec from cockpit-session

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -164,8 +164,9 @@ auth_write_login_records(cockpit_session_t)
 corenet_tcp_bind_ssh_port(cockpit_session_t)
 corenet_tcp_connect_ssh_port(cockpit_session_t)
 
-# cockpit-session can execute cockpit-agent as the user
+# cockpit-session can execute cockpit-bridge as the user, without setting AT_SECURE
 userdom_spec_domtrans_all_users(cockpit_session_t)
+userdom_noatsecure_login_userdomain(cockpit_session_t)
 usermanage_read_crack_db(cockpit_session_t)
 
 optional_policy(`


### PR DESCRIPTION
Since cockpit-session has its own selinux label, executing other (differently-labelled) processes from it is considered to be a privilege boundary transition, similar to executing a setuid binary.

Because of this, `AT_SECURE` gets set in the auxiliary vector, causing the libc of the spawned process to enter "secure execution" mode.  Among other things, that causes `secure_getenv()` to return NULL, even if a particular variable is in the environment.

libsystemd uses `secure_getenv()` to look for the user's D-Bus.  If `AT_SECURE` is set, that will fail, causing `sd_bus_default_user()` to return `-ENOMEDIUM`.  This breaks the Python bridge.

The solution to this problem is to mark the state transition as `noatsecure`. That makes sense: there's no real scenario where cockpit-session attacks cockpit-bridge via its environment — cockpit-session is the (substantially) higher-privileged process here.

 - [x] Stop ruining our flake stats: https://github.com/cockpit-project/bots/pull/4129
 - [ ] Get this reviewed by SELinux team