### PR TITLE
Table higlighting fixes

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -49,6 +49,7 @@ import './cockpit-components-table.scss';
  *   }[]
  * - emptyCaption: header caption to show if list is empty
  * - emptyCaptionDetail: extra details to show after emptyCaption if list is empty
+ * - emptyComponent: Whole empty state component to show if the list is empty
  * - isEmptyStateInTable: if empty state is result of a filter function this should be set, otherwise false
  * - variant: For compact tables pass 'compact'
  * - gridBreakPoint: Specifies the grid breakpoints ('', 'grid' | 'grid-md' | 'grid-lg' | 'grid-xl' | 'grid-2xl')
@@ -65,6 +66,7 @@ export const ListingTable = ({
     columns: cells = [],
     emptyCaption = '',
     emptyCaptionDetail,
+    emptyComponent,
     isEmptyStateInTable = false,
     onRowClick,
     onSelect,
@@ -132,19 +134,23 @@ export const ListingTable = ({
     );
 
     if (rows == 0) {
-        const emptyState = (
-            <EmptyState>
-                <EmptyStateBody>
-                    <div>{emptyCaption}</div>
-                    <TextContent>
-                        <Text component={TextVariants.small}>
-                            {emptyCaptionDetail}
-                        </Text>
-                    </TextContent>
-                </EmptyStateBody>
-                {actions.length > 0 ? <EmptyStateSecondaryActions>{actions}</EmptyStateSecondaryActions> : null}
-            </EmptyState>
-        );
+        let emptyState = null;
+        if (emptyComponent)
+            emptyState = emptyComponent;
+        else
+            emptyState = (
+                <EmptyState>
+                    <EmptyStateBody>
+                        <div>{emptyCaption}</div>
+                        <TextContent>
+                            <Text component={TextVariants.small}>
+                                {emptyCaptionDetail}
+                            </Text>
+                        </TextContent>
+                    </EmptyStateBody>
+                    {actions.length > 0 ? <EmptyStateSecondaryActions>{actions}</EmptyStateSecondaryActions> : null}
+                </EmptyState>
+            );
         if (!isEmptyStateInTable)
             return emptyState;
 

--- a/pkg/systemd/services/services-list.jsx
+++ b/pkg/systemd/services/services-list.jsx
@@ -25,13 +25,15 @@ import {
     Tooltip, TooltipPosition, Badge,
 } from '@patternfly/react-core';
 import { ListingTable } from 'cockpit-components-table.jsx';
-import { ExclamationCircleIcon, ThumbtackIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, SearchIcon, ThumbtackIcon } from '@patternfly/react-icons';
+
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 
 import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
 
-export const ServicesList = ({ units, isTimer }) => {
+export const ServicesList = ({ units, isTimer, filtersRef }) => {
     let columns;
     if (!isTimer) {
         columns = [
@@ -51,6 +53,10 @@ export const ServicesList = ({ units, isTimer }) => {
                       showHeader={false}
                       id="services-list"
                       rows={ units.map(unit => getServicesRow({ key: unit[0], isTimer, shortId: unit[0], ...unit[1] })) }
+                      emptyComponent={<EmptyStatePanel icon={SearchIcon}
+                                                       paragraph={_("No results match the filter criteria. Clear all filters to show results.")}
+                                                       action={<Button id="clear-all-filters" onClick={() => { filtersRef.current() }} isInline variant='link'>{_("Clear all filters")}</Button>}
+                                                       title={_("No matching results")} /> }
                       className="services-list" />
     );
 };

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -24,7 +24,6 @@ import React, { useState, useEffect, useCallback } from "react";
 import { createRoot } from 'react-dom/client';
 import {
     Button,
-    Bullseye,
     Flex, FlexItem,
     Select, SelectVariant, SelectOption,
     Page, PageSection, PageSectionVariants,
@@ -37,7 +36,7 @@ import {
     ToolbarFilter,
     ToolbarToggleGroup,
 } from '@patternfly/react-core';
-import { SearchIcon, ExclamationCircleIcon, FilterIcon } from '@patternfly/react-icons';
+import { ExclamationCircleIcon, FilterIcon } from '@patternfly/react-icons';
 
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { Service } from "./service.jsx";
@@ -847,19 +846,10 @@ class ServicesPageBody extends React.Component {
                                          onCurrentTextFilterChanged={this.onCurrentTextFilterChanged}
                                          onFiltersChanged={this.onFiltersChanged}
                     />
-                    {units.length
-                        ? <ServicesList key={cockpit.format("$0-list", activeTab)}
-                                     isTimer={activeTab == 'timer'}
-                                     units={units} />
-                        : null}
-                    {units.length == 0
-                        ? <Bullseye>
-                            <EmptyStatePanel icon={SearchIcon}
-                                            paragraph={_("No results match the filter criteria. Clear all filters to show results.")}
-                                            action={<Button id="clear-all-filters" onClick={() => { this.filtersRef.current() }} isInline variant='link'>{_("Clear all filters")}</Button>}
-                                            title={_("No matching results")} />
-                        </Bullseye>
-                        : null}
+                    <ServicesList key={cockpit.format("$0-list", activeTab)}
+                                  isTimer={activeTab == 'timer'}
+                                  filtersRef={this.filtersRef}
+                                  units={units} />
                 </Card>
             </PageSection>
         );


### PR DESCRIPTION
This fixes podman and services pages. Possibly other places as well. Machines page is still broken when we initially show all VMs but this is unrelated to this implementation and we need to fix how we load VMs.