### PR TITLE
tools: Update Debian's policykit-1 dependency for package split

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -125,7 +125,8 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${source:Version}),
          libpwquality-tools,
          openssl,
-Recommends: sudo | policykit-1
+# policykit-1 was split into multiple packages; keep old name for Debian 11 and Ubuntu
+Recommends: sudo | pkexec | policykit-1
 Provides: cockpit-shell,
           cockpit-systemd,
           cockpit-tuned,


### PR DESCRIPTION
In Debian, policykit-1 0.120-4 got split into multiple smaller packages, in particular `pkexec` and `polkitd`. Cockpit can call `pkexec` and does not directly talk to `org.freedesktop.PolicyKit1`, so update the recommendation for `pkexec`. Still keep the old name as a fallback, to keep the package backportable to Debian 11 and Ubuntu.

https://bugs.debian.org/1025556