### PR TITLE
systemd: disable create timer button on unit load

### DIFF
--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -153,7 +153,6 @@ class ServicesPageBody extends React.Component {
             currentTextFilter: '',
 
             unit_by_path: {},
-            loadingUnits: false,
             isFullyLoaded: false,
 
             error: null,
@@ -245,10 +244,10 @@ class ServicesPageBody extends React.Component {
                     .catch(error => {
                         if (error.name != "org.freedesktop.systemd1.AlreadySubscribed" &&
                         error.name != "org.freedesktop.DBus.Error.FileExists")
-                            this.setState({ error: cockpit.format(_("Subscribing to systemd signals failed: $0"), error.toString()), loadingUnits: false });
+                            this.setState({ error: cockpit.format(_("Subscribing to systemd signals failed: $0"), error.toString()) });
                     });
         })
-                .catch(ex => this.setState({ error: cockpit.format(_("Connecting to dbus failed: $0"), ex.toString()), loadingUnits: false }));
+                .catch(ex => this.setState({ error: cockpit.format(_("Connecting to dbus failed: $0"), ex.toString()) }));
 
         cockpit.addEventListener("visibilitychange", () => {
             if (!cockpit.hidden) {
@@ -273,7 +272,7 @@ class ServicesPageBody extends React.Component {
             interface: "org.freedesktop.DBus.Properties",
             member: "PropertiesChanged"
         }, (path, iface, signal, args) => {
-            if (this.state.loadingUnits)
+            if (this.props.isLoading)
                 return;
 
             if (this.state.unit_by_path[path] &&
@@ -308,7 +307,7 @@ class ServicesPageBody extends React.Component {
 
         systemd_client[this.props.owner].subscribe({ interface: SD_MANAGER, member: "Reloading" }, (path, iface, signal, args) => {
             const reloading = args[0];
-            if (!reloading && !this.state.loadingUnits)
+            if (!reloading && !this.props.isLoading)
                 this.listUnits();
         });
 
@@ -393,7 +392,8 @@ class ServicesPageBody extends React.Component {
             return this.listFailedUnits();
 
         // Reinitialize the state variables for the units
-        this.setState({ loadingUnits: true, currentStatus: _("Listing units") });
+        this.setState({ currentStatus: _("Listing units") });
+        this.props.setIsLoading(true);
 
         this.seenPaths = new Set();
 
@@ -458,7 +458,10 @@ class ServicesPageBody extends React.Component {
                                         this.seenPaths.add(unit_path);
 
                                         return this.getUnitByPath(unit_path);
-                                    }, ex => this.setState({ error: cockpit.format(_("Loading unit failed: $0"), ex.toString()), loadingUnits: false })));
+                                    }, ex => {
+                                        this.props.isLoading(false);
+                                        this.setState({ error: cockpit.format(_("Loading unit failed: $0"), ex.toString()) });
+                                    }));
                                 });
 
                                 Promise.all(promisesLoad)
@@ -481,14 +484,20 @@ class ServicesPageBody extends React.Component {
                                             if (hasExtraEntries)
                                                 newState.unit_by_path = unit_by_path;
 
-                                            newState.loadingUnits = false;
                                             newState.isFullyLoaded = true;
+                                            this.props.setIsLoading(false);
 
                                             this.setState(newState);
                                             this.processFailedUnits();
                                         });
-                            }, ex => this.setState({ error: cockpit.format(_("Listing unit files failed: $0"), ex.toString()), loadingUnits: false }));
-                }, ex => this.setState({ error: cockpit.format(_("Listing units failed: $0"), ex.toString()), loadingUnits: false }));
+                            }, ex => {
+                                this.props.isLoading(false);
+                                this.setState({ error: cockpit.format(_("Listing unit files failed: $0"), ex.toString()) });
+                            });
+                }, ex => {
+                    this.props.isLoading(false);
+                    this.setState({ error: cockpit.format(_("Listing units failed: $0"), ex.toString()) });
+                });
     }
 
     /**
@@ -777,7 +786,7 @@ class ServicesPageBody extends React.Component {
             return <Service unitIsValid={unitId => { const path = get_unit_path(unitId); return path !== undefined && this.state.unit_by_path[path].LoadState != 'not-found' }}
                             owner={this.props.owner}
                             key={unit_id}
-                            loadingUnits={this.state.loadingUnits}
+                            loadingUnits={this.props.isLoading}
                             getUnitByPath={this.getUnitByPath}
                             unit={unit}
                             isPinned={this.state.pinnedUnits.includes(unit.path)}
@@ -843,7 +852,7 @@ class ServicesPageBody extends React.Component {
                     <ServicesPageFilters activeStateDropdownOptions={activeStateDropdownOptions}
                                          fileStateDropdownOptions={fileStateDropdownOptions}
                                          filtersRef={this.filtersRef}
-                                         loadingUnits={this.state.loadingUnits}
+                                         loadingUnits={this.props.isLoading}
                                          onCurrentTextFilterChanged={this.onCurrentTextFilterChanged}
                                          onFiltersChanged={this.onFiltersChanged}
                     />
@@ -1000,6 +1009,7 @@ const ServicesPageFilters = ({
 const ServicesPage = () => {
     const [tabErrors, setTabErrors] = useState({});
     const [loggedUser, setLoggedUser] = useState();
+    const [isLoading, setIsLoading] = useState(false);
 
     useEffect(() => {
         cockpit.user()
@@ -1044,7 +1054,7 @@ const ServicesPage = () => {
                                                                                           onChange={() => setOwner("user")} />
                             </ToggleGroup>}
                         </FlexItem>
-                        {activeTab == "timer" && owner == "system" && superuser.allowed && <CreateTimerDialog owner={owner} />}
+                        {activeTab == "timer" && owner == "system" && superuser.allowed && <CreateTimerDialog isLoading={isLoading} owner={owner} />}
                     </Flex>
                 </PageSection>}
                 <ServicesPageBody
@@ -1054,6 +1064,8 @@ const ServicesPage = () => {
                     path={path}
                     privileged={superuser.allowed}
                     setTabErrors={setTabErrors}
+                    isLoading={isLoading}
+                    setIsLoading={setIsLoading}
                 />
             </Page>
         </WithDialogs>

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -44,12 +44,13 @@ import "./timers.scss";
 
 const _ = cockpit.gettext;
 
-export const CreateTimerDialog = ({ owner }) => {
+export const CreateTimerDialog = ({ owner, isLoading }) => {
     const Dialogs = useDialogs();
     return (
         <Button key='create-timer-action'
                 variant="secondary"
                 id="create-timer"
+                isDisabled={isLoading}
                 onClick={() => {
                     updateTime();
                     Dialogs.show(<CreateTimerDialogBody owner={owner} />);


### PR DESCRIPTION
In our tests we have a flake where `boot_timer.timer` does not show up after it has been created. This is caused due to `loadingUnits` being `true` so when we press create we do not refresh the list again. This race condition is now resolved as we don't allow a user to create a new timer if we are still loading units.