### PR TITLE
users: Show loading state

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -51,6 +51,7 @@ import './cockpit-components-table.scss';
  * - emptyCaptionDetail: extra details to show after emptyCaption if list is empty
  * - emptyComponent: Whole empty state component to show if the list is empty
  * - isEmptyStateInTable: if empty state is result of a filter function this should be set, otherwise false
+ * - loading: Set to string when the content is still loading. This string is shown.
  * - variant: For compact tables pass 'compact'
  * - gridBreakPoint: Specifies the grid breakpoints ('', 'grid' | 'grid-md' | 'grid-lg' | 'grid-xl' | 'grid-2xl')
  * - sortBy: { index: Number, direction: SortByDirection }
@@ -68,6 +69,7 @@ export const ListingTable = ({
     emptyCaptionDetail,
     emptyComponent,
     isEmptyStateInTable = false,
+    loading = '',
     onRowClick,
     onSelect,
     rows: tableRows = [],
@@ -132,6 +134,13 @@ export const ListingTable = ({
             </header>
             : null
     );
+
+    if (loading)
+        return <EmptyState>
+            <EmptyStateBody>
+                {loading}
+            </EmptyStateBody>
+        </EmptyState>;
 
     if (rows == 0) {
         let emptyState = null;

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -30,6 +30,7 @@ import {
     Page, PageSection,
     Gallery, Text, TextVariants, Breadcrumb, BreadcrumbItem,
     Form, FormGroup, TextInput,
+    Spinner,
     Title, Popover
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon, HelpIcon } from '@patternfly/react-icons';
@@ -171,6 +172,17 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                     get_expire(user).then(setExpiration);
                 })
                 .catch(show_unexpected_error);
+    }
+
+    if (!accounts.length) {
+        return (
+            <EmptyState variant={EmptyStateVariant.small}>
+                <Spinner isSVG size="xl" />
+                <Title headingLevel="h1" size="lg">
+                    {_("Loading...")}
+                </Title>
+            </EmptyState>
+        );
     }
 
     const account = accounts.find(acc => acc.name == user);

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -26,6 +26,7 @@ import {
     Card, CardExpandableContent, CardHeader, CardTitle,
     Dropdown, DropdownItem, DropdownSeparator,
     Flex, FlexItem,
+    HelperText, HelperTextItem,
     KebabToggle, Label,
     Page, PageSection,
     SearchInput, Stack,
@@ -294,7 +295,8 @@ const GroupsList = ({ groups, accounts }) => {
                 }}>
                 <CardTitle className="pf-l-flex pf-m-space-items-sm pf-m-align-items-center">
                     <Text component={TextVariants.h2}>{_("Groups")}</Text>
-                    {!isExpanded && <>
+                    {(!isExpanded && !groups.length) && <HelperText> <HelperTextItem variant="indeterminate">{_("Loading...")}</HelperTextItem></HelperText>}
+                    {(!isExpanded && groups.length > 0) && <>
                         {groups.slice(0, 3)
                                 .map(group => {
                                     const color = group.isAdmin ? "gold" : "cyan";
@@ -314,6 +316,7 @@ const GroupsList = ({ groups, accounts }) => {
                 <ListingTable columns={columns}
                     id="groups-list"
                     rows={ groups.map(a => getGroupRow(a, accounts)) }
+                    loading={ groups.length && accounts.length ? '' : _("Loading...") }
                     sortMethod={sortRows}
                     variant="compact" sortBy={{ index: 2, direction: SortByDirection.asc }} />
             </CardExpandableContent>
@@ -410,6 +413,7 @@ const AccountsList = ({ accounts, current_user, groups }) => {
             <ListingTable columns={columns}
                           id="accounts-list"
                           rows={ filtered_accounts.map(a => getAccountRow(a, current_user === a.name, groups)) }
+                          loading={ filtered_accounts.length ? '' : _("Loading...") }
                           sortMethod={sortRows}
                           emptyComponent={<EmptyStatePanel title={_("No matching results")} icon={SearchIcon} />}
                           variant="compact" sortBy={{ index: 0, direction: SortByDirection.asc }} />

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -50,20 +50,19 @@ function AccountsPage() {
         return handle.close;
     }, [path, accounts, shadow]);
 
-    if (!accounts || !groups || !current_user_info || !details)
-        return null;
-
     // lastlog uses same sorting as /etc/passwd therefore arrays can be combined based on index
-    const accountsInfo = accounts.map((account, i) => {
-        return Object.assign({}, account, details[i]);
-    });
+    let accountsInfo = [];
+    if (accounts && details)
+        accountsInfo = accounts.map((account, i) => {
+            return Object.assign({}, account, details[i]);
+        });
 
     if (path.length === 0) {
-        return <AccountsMain accountsInfo={accountsInfo} current_user={current_user_info.name} groups={groups} />;
+        return <AccountsMain accountsInfo={accountsInfo} current_user={current_user_info && current_user_info.name} groups={groups || []} />;
     } else
         return (
-            <AccountDetails accounts={accountsInfo} groups={groups} shadow={shadow}
-                            current_user={current_user_info.name} user={path[0]} />
+            <AccountDetails accounts={accountsInfo} groups={groups || []} shadow={shadow || []}
+                            current_user={current_user_info && current_user_info.name} user={path[0]} />
         );
 }
 


### PR DESCRIPTION
Current implementation would show blank page and wait until everything was loaded. Now the overview is shown with loading state inside groups and users views. Details page shows big spinner.

![Screenshot from 2022-12-09 13-08-21](https://user-images.githubusercontent.com/12330670/206703465-04961ad4-328c-4f99-af01-643f2cd54c3e.png)
![Screenshot from 2022-12-09 13-08-08](https://user-images.githubusercontent.com/12330670/206703468-d87175e7-d1b7-4114-95cc-e60d3ee9dbb4.png)
