### PR TITLE
python: run the static code linters from pytest

### DIFF
--- a/test/pytest/test_linters.py
+++ b/test/pytest/test_linters.py
@@ -1,0 +1,15 @@
+import glob
+import os
+import subprocess
+import sys
+
+import pytest
+
+SRCDIR = os.path.realpath(f'{__file__}/../../..')
+
+
+@pytest.mark.parametrize('linter', ['flake8', 'pycodestyle', 'pylint', 'vulture'])
+def test_lint(linter):
+    pytest.importorskip(linter)
+    files = glob.glob(f'{SRCDIR}/src/cockpit/**/*.py', recursive=True)
+    subprocess.run([sys.executable, '-m', linter, *files], cwd=SRCDIR)


### PR DESCRIPTION
Similar to the browser tests, add some more adaptor code for running our static checkers from pytest.