### PR TITLE
Show service logs for user services

### DIFF
--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -40,7 +40,9 @@ const LogDetails = ({ entry }) => {
     general.sort();
 
     const id = entry.PROBLEM_BINARY || entry.UNIT || entry.SYSLOG_IDENTIFIER || "";
-    let service = entry.UNIT || entry.COREDUMP_UNIT || entry._SYSTEMD_UNIT || "";
+    let service = entry.USER_UNIT || entry.COREDUMP_USER_UNIT || entry._SYSTEMD_USER_UNIT || "";
+    const is_user = !!service;
+    service = service || entry.UNIT || entry.COREDUMP_UNIT || entry._SYSTEMD_UNIT || "";
 
     // Only show redirect for unit types we show
     if (["service", "target", "socket", "timer", "path"].indexOf(service.split(".").slice(-1)[0]) === -1)
@@ -55,7 +57,7 @@ const LogDetails = ({ entry }) => {
                     </CardHeaderMain>
                     { service &&
                         <CardActions>
-                            <Button variant="link" onClick={() => cockpit.jump("/system/services#/" + service) }>
+                            <Button variant="link" onClick={() => cockpit.jump("/system/services#/" + service + (is_user ? "?owner=user" : "")) }>
                                 {cockpit.format(_("Go to $0"), service)}
                             </Button>
                         </CardActions>

--- a/pkg/systemd/logsHelpers.js
+++ b/pkg/systemd/logsHelpers.js
@@ -58,6 +58,13 @@ export const getGrepFiltersFromOptions = ({ options }) => {
             match.push(...['_SYSTEMD_UNIT=' + s, "+", "COREDUMP_UNIT=" + s, "+", "UNIT=" + s]);
         });
         full_grep += "service:" + options.service + " ";
+    } else if (options["user-service"]) {
+        options["user-service"].split(",").forEach(s => {
+            if (!s.endsWith(".service"))
+                s = s + ".service";
+            match.push(...['_SYSTEMD_USER_UNIT=' + s, "+", "COREDUMP_USER_UNIT=" + s, "+", "USER_UNIT=" + s]);
+        });
+        full_grep += "user-service:" + options["user-service"] + " ";
     }
 
     if (options.tag && options.tag !== "*") {

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -65,13 +65,15 @@ export class Service extends React.Component {
                                 isPinned={this.props.isPinned}
         />;
 
+        const unit_type = this.props.owner == "system" ? "UNIT" : "USER_UNIT";
         const cur_unit_id = this.props.unit.Id;
         const match = [
-            "_SYSTEMD_UNIT=" + cur_unit_id, "+",
-            "COREDUMP_UNIT=" + cur_unit_id, "+",
-            "UNIT=" + cur_unit_id,
+            "_SYSTEMD_" + unit_type + "=" + cur_unit_id, "+",
+            "COREDUMP_" + unit_type + "=" + cur_unit_id, "+",
+            unit_type + "=" + cur_unit_id,
         ];
-        const url = "/system/logs/#/?prio=debug&service=" + cur_unit_id;
+        const service_type = this.props.owner == "system" ? "service" : "user-service";
+        const url = "/system/logs/#/?prio=debug&" + service_type + "=" + cur_unit_id;
 
         return (
             <WithDialogs>
@@ -88,9 +90,9 @@ export class Service extends React.Component {
                     <PageSection>
                         <Gallery hasGutter>
                             <GalleryItem id="service-details-unit">{serviceDetails}</GalleryItem>
-                            {((this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") && this.props.owner == "system") &&
+                            {(this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") &&
                             <GalleryItem id="service-details-logs">
-                                <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", service: cur_unit_id }} />
+                                <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", [service_type]: cur_unit_id }} />
                             </GalleryItem>}
                         </Gallery>
                     </PageSection>

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -163,6 +163,7 @@ if [ "$PLAN" = "basic" ]; then
               TestServices.testConditions
               TestServices.testHiddenFailure
               TestServices.testLogs
+              TestServices.testLogsUser
               TestServices.testNotFound
               TestServices.testNotifyFailed
               TestServices.testRelationships

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -45,6 +45,7 @@ class TestServices(MachineCase):
         user_post_restore = "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user daemon-reload; systemctl --user reset-failed'"
         self.restore_dir("/etc/systemd/user", user_post_restore, True)
         self.restore_dir("/etc/xdg/systemd/user", user_post_restore, True)
+        self.restore_dir("/home/admin/.config", user_post_restore, True)
 
         # FIXME: this page is too slow
         self.browser.wait_timeout(60)
@@ -153,7 +154,12 @@ WantedBy=default.target
 set -eu
 trap "echo STOP" 0
 
-journalctl --sync
+if [ $(id -u) -eq 0 ]; then
+    journalctl --sync
+else
+    # increase the chance for journal to catch up
+    sleep 5
+fi
 echo START
 while true; do
   sleep 5
@@ -165,7 +171,7 @@ done
         self.run_systemctl(True, "daemon-reload || true")
 
         # When the test fails while `test.service` is active, the process keeps running and
-        # `systemct status test.service` still shows it as active until this process dies
+        # `systemctl status test.service` still shows it as active until this process dies
         self.addCleanup(
             self.machine.execute,
             "for op in stop reset-failed disable; do systemctl $op test test-fail || true; done")
@@ -587,10 +593,7 @@ WantedBy=default.target
 
         # Check that journalbox shows empty state
         self.goto_service("systemd-exit.service")
-        if not user:
-            b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
-        else:
-            b.wait_not_present('.cockpit-log-panel')
+        b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
         b.wait_not_present("button:contains('View all logs')")
 
         b.go(f'/system/services#/{suffix}')
@@ -639,16 +642,29 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             b.wait_js_cond(f"window.location.hash === '#/{suffix}'")
 
     def testLogs(self):
+        self._testLogs(False)
+
+    def testLogsUser(self):
+        self._testLogs(True)
+
+    def _testLogs(self, user=False):
         b = self.browser
+        service_type = "user-service" if user else "service"
 
-        self.make_test_service()
+        def append_user(url):
+            if user:
+                return url + ("" if "#/" in url else "#/") + "?owner=user"
+            return url
 
-        self.login_and_go("/system/services")
+        self.make_test_service("/etc/systemd/user" if user else "/etc/systemd/system")
+
+        self.login_and_go(append_user("/system/services"))
         self.wait_page_load()
 
         # Check test.service and then start it
         self.goto_service("test.service")
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], False)
+        b.wait_text('.cockpit-log-panel .pf-c-card__body', "No log entries")
         self.toggle_onoff()
         self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], True)
         b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "START")
@@ -659,8 +675,8 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.wait_in_text("#journal-box .cockpit-log-panel > div:nth-child(2)", "WORKING")
         t = b.text("#journal-box .cockpit-log-panel > div:nth-child(3)") + b.text("#journal-box .cockpit-log-panel > div:nth-child(4)")
         self.assertIn("START", t)
-        b.wait_val("#journal-grep input", "priority:debug service:test.service ")
-        b.go("/system/services#test.service")
+        b.wait_val("#journal-grep input", f"priority:debug {service_type}:test.service ")
+        b.go(append_user("/system/services#/test.service"))
         b.enter_page("/system/services")
 
         b.wait_in_text(".cockpit-logline:nth-child(2)", "WORKING")
@@ -668,8 +684,8 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.enter_page("/system/logs")
         b.wait_text(".pf-c-card__title", "WORKING")
         b.click(".pf-c-breadcrumb li:contains('Logs')")
-        b.wait_val("#journal-grep input", "priority:debug service:test.service ")
-        b.go("/system/services#test.service")
+        b.wait_val("#journal-grep input", f"priority:debug {service_type}:test.service ")
+        b.go(append_user("/system/services#/test.service"))
         b.enter_page("/system/services")
 
         b.wait_in_text(".cockpit-logline:nth-child(2)", "WORKING")
@@ -677,7 +693,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         b.enter_page("/system/logs")
         b.click("button:contains('Go to test.service')")
         b.enter_page("/system/services")
-        b.wait_js_cond('window.location.hash === "#/test.service"')
+        b.wait_js_cond('window.location.hash === "' + append_user("#/test.service") + '"')
 
     def testApi(self):
         b = self.browser

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -142,24 +142,24 @@ class TestServices(MachineCase):
 Description=Test Service
 
 [Service]
-ExecStart=/bin/sh /usr/local/bin/test-service
-ExecReload=/bin/sh true
+ExecStart=/usr/local/bin/test-service
+ExecReload=/bin/true
 
 [Install]
 WantedBy=default.target
 """)
         self.write_file("/usr/local/bin/test-service",
-                        """
-#! /bin/sh
-
+                        """#!/bin/sh
+set -eu
 trap "echo STOP" 0
 
+journalctl --sync
 echo START
 while true; do
   sleep 5
   echo WORKING
 done
-""")
+""", perm="755")
         # After writing files out tell systemd about them
         self.run_systemctl(False, "daemon-reload")
         self.run_systemctl(True, "daemon-reload || true")


### PR DESCRIPTION
# Services: Show logs for user units

The Services page now shows journal logs for user systemd services.

![Screen Shot 2023-01-10 at 14 54 35](https://user-images.githubusercontent.com/14921356/211569687-d5213435-00f0-4abc-92f0-9b730df95ed3.png)



---------------------------
Removes the limitation mentioned in https://github.com/cockpit-project/cockpit/commit/154da47d947eb39ebf2bed4cf6e1ecfc1623a25e:
> * Hide service logs for user services. These are available but the
LogsPanel component will need some extension for supporting it.

![cockpit-user-service-logs](https://user-images.githubusercontent.com/22344007/207478183-4718847d-dd31-4853-859b-53d7ba50d89e.gif)
