### PR TITLE
test: Speed up CI runs with our jumpstart cache

### DIFF
--- a/test/run
+++ b/test/run
@@ -7,6 +7,7 @@ set -eu
 
 tools/make-bots
 test/common/pixel-tests pull
+tools/webpack-jumpstart --partial || true
 
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 

--- a/tools/webpack-jumpstart
+++ b/tools/webpack-jumpstart
@@ -104,6 +104,10 @@ if test -n "${partial}"; then
             tag="sha-${commit}"
             break
         fi
+        if git show --oneline --name-only "$commit" | grep -q '^node_modules'; then
+            echo "commit $commit changes node_modules" >&2
+            break
+        fi
     done
     if [ -z "${tag}" ]; then
         echo "Unable to find any suitable commit" >&2


### PR DESCRIPTION
Only build changed webpacks. This takes off some 5 minutes (and heavy CPU load) for every test from the bots.

This was already applied in commit a7dcaf554dc6 half a year ago, but reverted in commit 0b25285522 because `webpack-jumpstart --partial` did not handle node_module/ updates correctly. But commit 3a77525f8e4d6a6e fixed that, it now removes all webpacks which are affected by a node_modules/ update (usually all of them).

-----

I validated this with the most recent PF update:

```sh
# check out latest package.json change
git checkout c49fc4b1d544c10375f9040fb63813d0784d61ea
# change it to make it not have a jumpstart cache
git commit --amend --no-edit
# cherry-pick the commit following the above update (SELinux, does not affect webpacks)
git cherry-pick 755d372e50395256de6914fa6a72691c57d55160
```

Now jumpstart DTRT:
```
$ tools/webpack-jumpstart --partial
  FETCH    dist  [ref: tag sha-776460684e6bdf81542934525e0f9272b21c3e5a]
  COPY     package-lock.json
  UNPACK   dist  [ref: sha-776460684e6bdf81542934525e0f9272b21c3e5a]
  REMOVE   dist/apps
  REMOVE   dist/base1
  REMOVE   dist/kdump
  REMOVE   dist/metrics
  REMOVE   dist/networkmanager
  REMOVE   dist/packagekit
  REMOVE   dist/playground
  REMOVE   dist/selinux
  REMOVE   dist/shell
  REMOVE   dist/sosreport
  REMOVE   dist/static
  REMOVE   dist/storaged
  REMOVE   dist/systemd
  REMOVE   dist/tuned
  REMOVE   dist/users

$ ls -l dist/
# total 0
```

Earlier version didn't:
```
$ git clean -ffdx
$ git show 3a77525f8e4d6a6ee7c99341846a543a6dab0a66^:tools/webpack-jumpstart | sed '/^cd/d' > /tmp/wj
$ sh /tmp/wj --partial
  FETCH    dist  [ref: tag sha-776460684e6bdf81542934525e0f9272b21c3e5a]
  COPY     package-lock.json
  UNPACK   dist  [ref: sha-776460684e6bdf81542934525e0f9272b21c3e5a]
  TOUCH    package.json

# ... and all of dist/ is intact
```