### PR TITLE
test: Fix TestNetworkingBasic.testBasic for stopped pcp

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -33,6 +33,9 @@ class TestNetworkingBasic(NetworkCase):
             # screenshot assumes running firewalld and absent virbr0 (in particular, *3* interfaces)
             m.execute("systemctl start firewalld")
 
+            # ensure PCP is on, so that we get the zoom/range selectors
+            m.execute("systemctl start pmlogger")
+
         self.login_and_go("/network")
         b.wait_visible("#networking")
 


### PR DESCRIPTION
The zoom and range selector on the Networking metrics is only visible if PCP is running. Make sure that is the case, as
https://github.com/cockpit-project/bots/pull/4159 will disable it by default.