### PR TITLE
test: Skip failing tests for pybridge scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -30,7 +30,7 @@ case $TEST_SCENARIO in
         test/image-prepare --verbose $TEST_OS
         python3 -m build --no-isolation --wheel --outdir tmp/wheel
         bots/image-customize --verbose --no-network --install tmp/wheel/*.whl "${TEST_OS}"
-        test/common/run-tests --jobs ${TEST_JOBS:-1} --no-retry-fail --test-dir test/verify --track-naughties
+        test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties
         ;;
     *)
         echo "Unknown test scenario: $TEST_SCENARIO"

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import skipImage, skipPackage, test_main
+from testlib import skipImage, skipPackage, todoPybridge, test_main
 
 
 @skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
@@ -78,6 +78,7 @@ class TestApps(PackageCase):
         # ignore the corresponding journal entry
         self.allow_journal_messages("org.freedesktop.PackageKit.*org.freedesktop.DBus.Error.NoReply.*")
 
+    @todoPybridge()
     def testBasic(self, urlroot=""):
         b = self.browser
         m = self.machine
@@ -125,9 +126,11 @@ class TestApps(PackageCase):
         b.wait_visible(f".app-list .pf-c-data-list__item-row:contains('app-1') img[src^='{urlroot}/cockpit/channel/']")
         m.execute("! test -f /stamp-app-1-1.0-1")
 
+    @todoPybridge()
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
 
+    @todoPybridge()
     def testL10N(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -21,9 +21,10 @@ import base64
 import time
 import os
 import subprocess
+import unittest
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipBrowser, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, TEST_DIR, nondestructive, skipBrowser, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 @skipDistroPackage()
@@ -746,6 +747,7 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
 
     @skipImage("ssh root login not allowed", "fedora-coreos")
+    @unittest.skipIf(os.getenv("TEST_SCENARIO") == "pybridge", "wedges up VM too hard, and crashes hard")
     @nondestructive
     def testFlowControl(self):
         m = self.machine
@@ -811,6 +813,7 @@ export XDG_CONFIG_DIRS=/usr/local
 
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     @skipImage("Kernel does not allow user namespaces", "debian-stable", "debian-testing")
+    @todoPybridge()
     def testCockpitDesktop(self):
         m = self.machine
 

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -3,7 +3,7 @@
 import os
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 from fmf_metadata import FMF
 
 
@@ -103,6 +103,8 @@ class TestLongRunning(MachineCase):
         # clean up after test failures
         self.addCleanup(m.execute, "systemctl stop cockpit-longrunning.service 2>/dev/null && systemctl reset-failed cockpit-longrunning.service || true")
 
+    # sometimes fails with: unexpected failure of GetUnit(cockpit-longrunning.service): Not permitted to perform this action
+    @todoPybridge("fails unpredictably with pybridge", flaky=True)
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, timeout
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, todoPybridge, timeout
 from lib.constants import TEST_OS_DEFAULT
 
 
@@ -60,6 +60,7 @@ class TestKdump(KdumpHelpers):
         self.machine.execute("cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys")
         self.machine.execute("ssh-keyscan -H localhost >> /root/.ssh/known_hosts")
 
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -10,7 +10,7 @@ import time
 import parent  # noqa: F401
 import packagelib
 from testlib import (Browser, Error, MachineCase, nondestructive, skipDistroPackage, skipImage,
-                     skipMobile, test_main, wait)
+                     skipMobile, todoPybridge, test_main, wait)
 
 from machine_core import ssh_connection
 from lib.constants import TEST_OS_DEFAULT
@@ -157,6 +157,7 @@ class TestHistoryMetrics(MachineCase):
         self.assertLessEqual(leading_empty, 4)
 
     @skipImage("no PCP support", "fedora-coreos")
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -205,6 +206,7 @@ class TestHistoryMetrics(MachineCase):
         b.wait_visible('.system-information')
 
     @skipImage("no PCP support", "fedora-coreos")
+    @todoPybridge()
     def testEvents(self):
         b = self.browser
         m = self.machine
@@ -455,6 +457,7 @@ class TestHistoryMetrics(MachineCase):
 
     @nondestructive
     @skipImage("no PCP support", "fedora-coreos")
+    @todoPybridge()
     def testNoDataEnable(self):
         b = self.browser
         m = self.machine
@@ -552,6 +555,7 @@ class TestHistoryMetrics(MachineCase):
     @nondestructive
     @skipImage("TODO: pm proxy alert doesn't show on Arch Linux", "arch")
     @skipImage("no PCP support", "fedora-coreos")
+    @todoPybridge()
     def testPmProxySettings(self):
         b = self.browser
         m = self.machine
@@ -731,6 +735,7 @@ class TestCurrentMetrics(MachineCase):
                                               "systemctl --user stop cockpittest.slice 2>/dev/null || true'")
         login(self)
 
+    @todoPybridge()
     def testCPU(self):
         b = self.browser
         m = self.machine
@@ -1071,6 +1076,7 @@ BEGIN {{
             b.enter_page("/system/services")
             b.wait_in_text(".service-name", "memhog.sh")
 
+    @todoPybridge()
     def testDiskIO(self):
         b = self.browser
         m = self.machine
@@ -1197,6 +1203,7 @@ BEGIN {{
 @skipImage("TODO: Arch Linux packagekit support", "arch")
 @skipDistroPackage()
 class TestMetricsPackages(packagelib.PackageCase):
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -1315,6 +1322,7 @@ class TestMultiCPU(MachineCase):
     }
 
     @skipImage("no PCP support", "fedora-coreos")
+    @todoPybridge()
     def testCPUUsage(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -19,11 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, test_main, wait
+from testlib import nondestructive, skipDistroPackage, todoPybridge, test_main, wait
 
 
 @nondestructive
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingBasic(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -19,13 +19,14 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @nondestructive
 @skipDistroPackage()
+@todoPybridge()
 class TestBonding(NetworkCase):
     def testBasic(self):
         b = self.browser
@@ -261,6 +262,7 @@ class TestBonding(NetworkCase):
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestBondingVirt(NetworkCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -19,11 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, test_main
+from testlib import nondestructive, skipDistroPackage, todoPybridge, test_main
 
 
 @nondestructive
 @skipDistroPackage()
+@todoPybridge()
 class TestBridge(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -19,11 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase, re
-from testlib import skipDistroPackage, skipImage, test_main, wait
+from testlib import skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 @skipImage("No network checkpoint support", "ubuntu-2204", "ubuntu-stable")
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingCheckpoints(NetworkCase):
     def testCheckpoint(self):
         b = self.browser

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 import time
-from testlib import Error, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import Error, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 from netlib import NetworkCase
 
 
@@ -49,6 +49,7 @@ def get_active_rules(machine):
 @skipImage("no firewalld", "fedora-coreos")
 @nondestructive
 @skipDistroPackage()
+@todoPybridge()
 class TestFirewall(NetworkCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -19,12 +19,13 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import skipDistroPackage, test_main
+from testlib import skipDistroPackage, todoPybridge, test_main
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingMAC(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-mtu
+++ b/test/verify/check-networkmanager-mtu
@@ -19,12 +19,13 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import skipDistroPackage, test_main, wait
+from testlib import skipDistroPackage, test_main, todoPybridge, wait
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingMTU(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -19,11 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, test_main, wait
+from testlib import nondestructive, skipDistroPackage, todoPybridge, test_main, wait
 
 
 @skipDistroPackage()
 @nondestructive
+@todoPybridge()
 class TestNetworkingOther(NetworkCase):
     def testOther(self):
         b = self.browser

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -19,12 +19,13 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import skipDistroPackage, test_main, wait
+from testlib import skipDistroPackage, test_main, todoPybridge, wait
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingSettings(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -20,13 +20,14 @@
 import parent  # noqa: F401
 import json
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
 
 @skipImage("NetworkManager-team not installed", "fedora-coreos")
 @skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 @skipDistroPackage()
 @nondestructive
+@todoPybridge()
 class TestTeam(NetworkCase):
     def testBasic(self):
         b = self.browser

--- a/test/verify/check-networkmanager-unmanaged
+++ b/test/verify/check-networkmanager-unmanaged
@@ -19,12 +19,13 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import skipDistroPackage, test_main
+from testlib import skipDistroPackage, todoPybridge, test_main
 
 from lib.constants import TEST_OS_DEFAULT
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingUnmanaged(NetworkCase):
     provision = {
         "machine1": {"memory_mb": 512},

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -19,11 +19,12 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, test_main
+from testlib import nondestructive, skipDistroPackage, todoPybridge, test_main
 
 
 @nondestructive
 @skipDistroPackage()
+@todoPybridge()
 class TestNetworkingVLAN(NetworkCase):
     def testVlan(self):
         b = self.browser

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -23,7 +23,7 @@ import time
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
 
 WAIT_SCRIPT = """
@@ -282,6 +282,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
 
     @nondestructive
+    @todoPybridge()
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -435,6 +436,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
 
     @skipImage("TODO: Packagekit on Arch does not detect the pear update", "arch")
     @skipImage("tracer not available", *OSesWithoutTracer)
+    @todoPybridge(".updates-success-table randomly appears or not with pybridge", flaky=True)
     def testTracer(self):
         b = self.browser
         m = self.machine
@@ -980,6 +982,7 @@ ExecStart=/usr/local/bin/{packageName}
 
         # seems we can't verify that the description has a scrollbar
 
+    @todoPybridge("sometimes locks up packagekit hard, warning: python.error in the JS log", flaky=True)
     def testRebootAfterSuccess(self):
         b = self.browser
         m = self.machine
@@ -1043,6 +1046,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertFalse(b.is_present("#app button"))
 
     @nondestructive
+    @todoPybridge()
     def testPackageKitCrash(self):
         b = self.browser
         m = self.machine
@@ -1080,6 +1084,7 @@ ExecStart=/usr/local/bin/{packageName}
         b.wait_in_text("#app .pf-c-page .pf-c-empty-state__body", "PackageKit crashed")
 
     @nondestructive
+    @todoPybridge()
     def testNoPackageKit(self):
         b = self.browser
         m = self.machine
@@ -1148,6 +1153,7 @@ ExecStart=/usr/local/bin/{packageName}
 @skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
 @skipImage("Image uses OSTree", "fedora-coreos")
 class TestWsUpdate(NoSubManCase):
+    @todoPybridge()
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which
         # restarts the service and terminates the connection. As we can't

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, test_main
+from testlib import MachineCase, nondestructive, todoPybridge, test_main
 
 
 test_manifest = """
@@ -52,6 +52,7 @@ test_html = """
 @nondestructive
 class TestPackages(MachineCase):
 
+    @todoPybridge()
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -21,7 +21,7 @@ import time
 import os
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
 RHEL_DOC_BASE = "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console"
 
@@ -64,6 +64,7 @@ class TestPages(MachineCase):
         self.browser.click(".display-language-menu")
         self.browser.wait_visible('#display-language-modal')
 
+    @todoPybridge()
     def testBasic(self):
         m = self.machine
         b = self.browser
@@ -310,6 +311,7 @@ OnCalendar=daily
             })""", language)
             b.wait_attr(".index-page", "lang", language)
 
+    @todoPybridge()
     def testPtBRLocale(self):
         m = self.machine
         b = self.browser
@@ -404,6 +406,7 @@ OnCalendar=daily
 
         self.allow_restart_journal_messages()
 
+    @todoPybridge()
     def testShellReload(self):
         b = self.browser
         m = self.machine
@@ -417,6 +420,7 @@ OnCalendar=daily
         b.reload()
         self.check_system_menu("FOO!", True)
 
+    @todoPybridge()
     def testMenuSearch(self):
         b = self.browser
         m = self.machine
@@ -617,6 +621,7 @@ OnCalendar=daily
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "other")
 
     @skipImage("No PCP available", "fedora-coreos")
+    @todoPybridge()
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -18,13 +18,14 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
 
 @skipDistroPackage()
 @nondestructive
 class TestReauthorize(MachineCase):
 
+    @todoPybridge()
     def testBasic(self):
         self.allow_journal_messages('.*dropping message while waiting for child to exit.*')
         b = self.browser

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -18,13 +18,14 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, todoPybridge, test_main
 
 
 @skipDistroPackage()
 @nondestructive
 class TestActivePages(MachineCase):
 
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -20,7 +20,7 @@
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, no_retry_when_changed, skipDistroPackage, test_main
+from testlib import MachineCase, no_retry_when_changed, skipDistroPackage, todoPybridge, test_main
 
 
 @skipDistroPackage()
@@ -102,6 +102,7 @@ class HostSwitcherHelpers:
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     provision = {
         'machine1': {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, test_main
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, todoPybridge, test_main
 
 
 FP_SHA256 = "SHA256:iyVAl4Z8riL9Jg4fV9Wv/6cbqebdDtsBEMkojNLLYX8"
@@ -29,6 +29,7 @@ KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3
 class TestKeys(MachineCase):
 
     @nondestructive
+    @todoPybridge()
     def testAuthorizedKeys(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -20,7 +20,7 @@
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, test_main
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, todoPybridge, test_main
 
 
 @nondestructive
@@ -120,6 +120,7 @@ class TestMenu(MachineCase):
         # don't actually fail this test
         b.allow_oops = True
 
+    @todoPybridge()
     def testSessionTimeout(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -22,7 +22,7 @@ import subprocess
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, skipDistroPackage, skipImage, todoPybridge, test_main
 
 
 def break_hostkey(m, address):
@@ -136,6 +136,7 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestMultiMachineAdd(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 660},
@@ -389,6 +390,7 @@ class TestMultiMachine(MachineCase):
         self.machine.start_cockpit()
         self.checkDirectLogin('/')
 
+    @todoPybridge()
     def testUrlRoot(self):
         b = self.browser
         m = self.machine
@@ -450,6 +452,7 @@ class TestMultiMachine(MachineCase):
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/cockpit-new/system"')
 
+    @todoPybridge()
     def testExternalPage(self):
         b = self.browser
         m1 = self.machine
@@ -481,6 +484,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
 
+    @todoPybridge()
     def testFrameNavigation(self):
         b = self.browser
         m2 = self.machine2
@@ -566,6 +570,7 @@ class TestMultiMachine(MachineCase):
                                     ".*: bridge program failed: Child process exited with code .*",
                                     "/playground/test.html: failed to retrieve resource: authentication-failed")
 
+    @todoPybridge()
     def testFrameReload(self):
         b = self.browser
 
@@ -607,6 +612,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
 
+    @todoPybridge()
     def testTroubleshooting(self):
         b = self.browser
         m1 = self.machine
@@ -741,6 +747,7 @@ class TestMultiMachine(MachineCase):
                                     '.*: server offered unsupported authentication methods: .*')
 
     @skipImage("TODO: Broken on Arch Linux", "arch")
+    @todoPybridge()
     def testSshKeySetup(self):
         b = self.browser
         m1 = self.machine
@@ -837,6 +844,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
 
+    @todoPybridge()
     def testSshKeySetupCustom(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -21,7 +21,7 @@ import re
 import subprocess
 
 import parent  # noqa: F401
-from testlib import MachineCase, skipBrowser, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, skipBrowser, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 def kill_user_admin(machine):
@@ -59,6 +59,7 @@ KEY_IDS_MD5 = [
 
 @skipImage("TODO: ssh key check fails on Arch Linux", "arch")
 @skipDistroPackage()
+@todoPybridge()
 class TestMultiMachineKeyAuth(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "memory_mb": 512},

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, skipDistroPackage, test_main, wait
+from testlib import MachineCase, skipDistroPackage, test_main, todoPybridge, wait
 
 
 def wait_addresses(b, expected):
@@ -95,6 +95,7 @@ class TestMultiOS(MachineCase):
                 .proxy("org.freedesktop.DBus", "/").call("GetId");
         })""", address)
 
+    @todoPybridge()
     def testCentOS7(self):
         dev_m = self.machine
         dev_b = self.browser
@@ -166,6 +167,7 @@ class TestMultiOSDirect(MachineCase):
         "centos-7": {"address": "10.111.113.5/20", "image": "centos-7", "memory_mb": 512}
     }
 
+    @todoPybridge()
     def testCentos7Direct(self):
         b = self.browser
 

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -24,7 +24,7 @@ import tarfile
 import subprocess
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 @skipImage("No sosreport", "fedora-coreos", "arch")
@@ -32,6 +32,7 @@ from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, t
 @skipDistroPackage()
 class TestSOS(MachineCase):
 
+    @todoPybridge()
     def testBasic(self, urlroot=""):
         b = self.browser
         m = self.machine
@@ -116,6 +117,7 @@ only-plugins=release,date,host,cgroups,networking
 
         self.allow_journal_messages('.*comm="sosreport".*')
 
+    @todoPybridge()
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
 
@@ -150,6 +152,7 @@ only-plugins=release,date,host,cgroups,networking
         self.assertEqual(m.execute("ls -l /var/tmp/sosreport*mylabel*.tar.xz | wc -l").strip(), "1")
         self.assertGreater(int(m.execute("tar --wildcards -xaOf /var/tmp/sosreport*mylabel*.tar.xz '*/sos_logs/sos.log' | grep -c 'DEBUG: \\[plugin:release\\]'")), 5)
 
+    @todoPybridge()
     def testCancel(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase
-from testlib import test_main
+from testlib import test_main, todoPybridge
 
 
 class TestStorageFormat(StorageCase):
@@ -90,6 +90,7 @@ class TestStorageFormat(StorageCase):
         else:
             check_type("ntfs", 128)
 
+    @todoPybridge()
     def testFormatCancel(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase
-from testlib import test_main, wait
+from testlib import test_main, todoPybridge, wait
 
 
 class TestStorageLuks(StorageCase):
@@ -29,6 +29,7 @@ class TestStorageLuks(StorageCase):
         "0": {"memory_mb": 1536}
     }
 
+    @todoPybridge()
     def testLuks(self):
         self.allow_journal_messages("Device is not initialized.*", ".*could not be opened.")
         m = self.machine

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -20,7 +20,7 @@
 import parent  # noqa: F401
 from packagelib import PackageCase
 from storagelib import StorageCase, StorageHelpers
-from testlib import nondestructive, skipImage, test_main
+from testlib import nondestructive, skipImage, todoPybridge, test_main
 
 
 @nondestructive
@@ -298,6 +298,7 @@ class TestStorageNfs(StorageCase):
 @nondestructive
 class TestStoragePackagesNFS(PackageCase, StorageCase, StorageHelpers):
 
+    @todoPybridge()
     def testNfsMissingPackages(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -20,10 +20,11 @@
 import parent  # noqa: F401
 from packagelib import PackageCase
 from storagelib import StorageCase
-from testlib import skipImage, test_main
+from testlib import skipImage, todoPybridge, test_main
 
 
 @skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204")
+@todoPybridge()
 class TestStorageStratis(StorageCase):
     def setUp(self):
         super().setUp()
@@ -378,6 +379,7 @@ class TestStorageStratis(StorageCase):
 
 @skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
 @skipImage("No Stratis on demand", "rhel-9-1", "rhel-8-7", "rhel-8-8")
+@todoPybridge()
 class TestStoragePackagesStratis(PackageCase, StorageCase):
 
     def testStratisOndemandInstallation(self):

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
 
 def allow_old_cockpit_ws_messages(test):
@@ -32,6 +32,7 @@ def allow_old_cockpit_ws_messages(test):
 @nondestructive
 @skipDistroPackage()
 class TestSuperuser(MachineCase):
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -130,6 +131,7 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Switch to administrative access')")
         b.check_superuser_indicator("Administrative access")
 
+    @todoPybridge()
     def testWrongPasswd(self):
         b = self.browser
 
@@ -154,6 +156,7 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.check_superuser_indicator("Limited access")
 
+    @todoPybridge()
     def testNotAdmin(self):
         b = self.browser
         m = self.machine
@@ -177,6 +180,7 @@ session include system-auth
         b.click(".pf-c-modal-box:contains('Problem becoming administrator') button:contains('Close')")
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
 
+    @todoPybridge()
     def testBrokenBridgeConfig(self):
         b = self.browser
         m = self.machine
@@ -211,6 +215,7 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.check_superuser_indicator("Limited access")
 
+    @todoPybridge()
     def testRemoveBridgeConfig(self):
         b = self.browser
 
@@ -229,6 +234,7 @@ session include system-auth
         b.leave_page()
         b.check_superuser_indicator("Limited access")
 
+    @todoPybridge()
     def testSingleLabelBridgeConfig(self):
         b = self.browser
 
@@ -256,6 +262,7 @@ session include system-auth
         b.click(".pf-c-modal-box button:contains('Close')")
         b.check_superuser_indicator("Limited access")
 
+    @todoPybridge()
     def testMultipleBridgeConfig(self):
         b = self.browser
 
@@ -373,6 +380,7 @@ class TestSuperuserOldShell(MachineCase):
 
 @skipImage("TODO: broken on Arch Linux", "arch")
 @skipDistroPackage()
+@todoPybridge()
 class TestSuperuserOldWebserver(MachineCase):
     provision = {
         "machine1": {"address": "10.111.113.1/20", "image": "centos-7", "memory_mb": 512},
@@ -469,6 +477,7 @@ class TestSuperuserDashboard(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
+    @todoPybridge()
     def test(self):
         b = self.browser
 
@@ -528,6 +537,7 @@ class TestSuperuserOldDashboard(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
+    @todoPybridge()
     def test(self):
         b = self.browser
         m = self.machines["machine1"]
@@ -590,6 +600,7 @@ class TestSuperuserDashboardOldMachine(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "image": "centos-7"},
     }
 
+    @todoPybridge()
     def test(self):
         b = self.browser
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -21,7 +21,7 @@ import re
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 os_release = """
@@ -202,6 +202,7 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text("#system_information_change_systime .pf-c-form__group-label:contains('Set time') + div > .pf-c-select > button", mode)
 
     @skipImage("TODO: systemd-timesyncd responds too slow on Arch Linux", "arch")
+    @todoPybridge()
     def testTime(self):
         m = self.machine
         b = self.browser
@@ -344,6 +345,7 @@ class TestSystemInfo(MachineCase):
         wait(lambda: get_timesyncd_start() > prev_timesyncd_start, delay=0.2)
 
     @nondestructive
+    @todoPybridge()
     def testMotd(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 import time
 
 sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
@@ -525,6 +525,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
+    @todoPybridge()
     def testAbrtSegv(self):
         b = self.browser
         m = self.machine
@@ -559,6 +560,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
+    @todoPybridge()
     def testAbrtDelete(self):
         b = self.browser
         m = self.machine
@@ -591,6 +593,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
+    @todoPybridge()
     def testAbrtReport(self):
         # The testing server is located at verify/files/mock-faf-server.py
         # Adjust Handler.known for for the expected succession of known/unknown problems
@@ -656,6 +659,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
+    @todoPybridge()
     def testAbrtReportCancel(self):
         b = self.browser
         m = self.machine
@@ -692,6 +696,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
+    @todoPybridge()
     def testAbrtReportNoReportd(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -28,7 +28,7 @@ import parent  # noqa: F401
 
 import packagelib
 from testlib import (Error, MachineCase, no_retry_when_changed, nondestructive, skipBrowser, skipDistroPackage, skipImage,
-                     test_main, wait, timeout)
+                     todoPybridge, test_main, wait, timeout)
 
 
 WAIT_KRB_SCRIPT = """
@@ -88,6 +88,7 @@ ExecStart=/bin/true
 @skipDistroPackage()
 class CommonTests:
     @timeout(900)
+    @todoPybridge()
     def testQualifiedUsers(self):
         m = self.machine
         b = self.browser
@@ -620,6 +621,7 @@ class TestIPA(TestRealms, CommonTests):
         # should have stopped cert tracking
         wait(lambda: "status:" not in m.execute("ipa-getcert list"))
 
+    @todoPybridge()
     def testUnqualifiedUsers(self):
         '''Extend the common test with 2FA login'''
 
@@ -701,6 +703,7 @@ class TestIPA(TestRealms, CommonTests):
                                     "sudo: unable to resolve host x0.cockpit.lan: Name or service not known")
 
     @timeout(900)
+    @todoPybridge()
     def testClientCertAuthentication(self):
         m = self.machine
         b = self.browser
@@ -886,6 +889,7 @@ class TestAD(TestRealms, CommonTests):
 
         pass
 
+    @todoPybridge()
     def testUnqualifiedUsers(self):
         '''Extend the test to check a new AD user'''
 
@@ -1028,6 +1032,7 @@ class TestKerberos(MachineCase):
         self.machine.execute(WAIT_KRB_SCRIPT.format("admin"), timeout=300)
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
+    @todoPybridge()
     def testNegotiate(self):
         self.allow_hostkey_messages()
         b = self.browser
@@ -1157,6 +1162,7 @@ class TestPackageInstall(packagelib.PackageCase):
                     return False
             b.wait(check)
 
+    @todoPybridge()
     def testInstall(self):
         m = self.machine
         b = self.browser
@@ -1206,6 +1212,7 @@ class TestPackageInstall(packagelib.PackageCase):
         m.execute("test -e /realmd-stub")
 
     @nondestructive
+    @todoPybridge()
     def testDialogTransition(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -17,10 +17,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import time
+import unittest
+
 import parent  # noqa: F401
 import testvm
-from testlib import MachineCase, nondestructive, skipDistroPackage, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, todoPybridge, test_main, wait
 
 
 @nondestructive
@@ -171,9 +174,11 @@ done
             "su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); "
             "for op in stop reset-failed disable; do systemctl --user $op test test-fail || true; done'")
 
+    @todoPybridge()
     def testBasic(self):
         self._testBasic()
 
+    @todoPybridge()
     def testBasicSession(self):
         self._testBasic(True)
 
@@ -1107,6 +1112,8 @@ class TestTimers(MachineCase):
     def wait_page_load(self):
         self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
 
+    @unittest.skipIf(os.getenv("TEST_SCENARIO") == "pybridge",
+                     "pybridge logs are too messy to catch with expected message filters")
     def testCreate(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, skipDistroPackage, test_main
+from testlib import MachineCase, skipDistroPackage, todoPybridge, test_main
 
 
 @skipDistroPackage()
@@ -33,6 +33,7 @@ class TestShutdownRestart(MachineCase):
         self.machine.execute("hostnamectl set-hostname machine1")
         self.machines['machine2'].execute("hostnamectl set-hostname machine2")
 
+    @todoPybridge()
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, test_main
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, todoPybridge, test_main
 
 
 def line_sel(i):
@@ -26,6 +26,7 @@ def line_sel(i):
 
 
 @skipDistroPackage()
+@todoPybridge()
 class TestTerminal(MachineCase):
     def setUp(self):
         super().setUp()

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -20,13 +20,14 @@
 import datetime
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
 
 
 @nondestructive
 @skipDistroPackage()
 class TestAccounts(MachineCase):
 
+    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Let's get the scenario to green, and re-enable tests as we fix them.

---

https://issues.redhat.com/browse/COCKPIT-882

 - [reference run on  current main](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221214-143444-aa8f6793-fedora-36-pybridge/log.html)
 - [non-current successful run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221216-132659-3b488e57-fedora-36-pybridge/log.html), [another one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221216-142401-b4036bbe-fedora-36-pybridge/log.html)

Depending PRs:
 - #18041
 - #18043 
 - #18044
 - #18046
 - #18049
 - #18045

Noteworthy test failures:
 - [x] [TestCurrentMetrics.testDiskIO](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221215-064658-7fd5dc02-fedora-36-pybridge/log.html#116): "wrong username or password". This causes a [JSONDecodeError bridge crash](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221215-165208-9ff13c4a-fedora-36-pybridge/TestCurrentMetrics-testDiskIO-fedora-36-127.0.0.2-2301-FAIL.log.gz). Fixed in a commit here and #18049

 - [x]  [TestSystemInfo.testBasic](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221215-165208-9ff13c4a-fedora-36-pybridge/log.html#274) causes a `FileNotFoundError` crash in the bridge. Fixed in a commit here and #18049

 - [x] There ABRT tests fail on "Cockpit shows an Oops". I can reproduce this on `TestJournal.testAbrtDelete` where it says:

        TypeError: Cannot read properties of undefined (reading 'ID')\n    at http://127.0.0.2:9091/cockpit/@localhost/system/logs.js:2:551352\n

    Fixed in #18044, and also included here.

 - [x] Lots of test crash with a JS exception "RuntimeError: RangeError: Invalid time value" in services.js:23203:66  at "Module.dateTime" → ServicesPageBody.addTimerProperties (useful trace with `NODE_ENV=development`). I can reproduce with `TestAutoUpdates.testBasic` and with `TestAD.testQualifiedUsers`; the problem is that it tries to call `Intl.DateTimeFormat('en-US').format(18446744073709552000/1000)` which is invalid and causes that bug. The issues is that `timer_unit.NextElapseUSecMonotonic == 18446744073709552000 == 0x10000000000000180` is clearly bogus. Fixed in #18041 and here.

 - [x] [TestUpdates.testInfoSecurity](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221215-165208-9ff13c4a-fedora-36-pybridge/log.html#163) is a flake, added a commit to fix it here and in #18049

- [x] [TestUpdates.testRebootAfterSuccess](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221215-165208-9ff13c4a-fedora-36-pybridge/log.html#168): attempted a fix in #18049 by waiting longer, but that's not enough; the "Initializing.." is really stuck. This reproduces locally in about 50% of cases. The only hint of failure is that "warning: python.error" in the JS log; packagekitd.service, `pkcon get-transactions` are fine. But interestingly, reloading the page gets into the same "stuck" state again, and `pkcon get-updates` is stuck as well, which makes this nice to iterate. Even after logging out from cockpit, `pkcon get-updates` is stuck, so something thoroughly killed PackageKit. Skipped for now.

- [x] [TestTimers.testCreate](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221216-090333-05d0b1aa-fedora-36-pybridge/log.html#319) is flaky, and sometimes crashes with a bridge PermissionError; not sure if that's the user or the root bridge. Skipped for now.

 - [x] [TestAccounts.testExpire](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18039-20221216-090333-05d0b1aa-fedora-36-pybridge/log.html#325) sometimes fails with "internal error", but there's no bridge crash in the logs. Needs deeper debugging, but this isn't just a matter of waiting longer. Skipped for now.

- [x] There are several flakes. They should be dealt with by re-enabling auto-retries: `TestKdump.testBasic`, `TestAutoUpdates.testBasic`,  `TestSelinux.testTroubleshootAlerts`, `TestTimers.testCreate`, `TestReverseProxy.testNginxNoTLS` . Re-enabling auto-retries of failures helps enough.

 - Calling methods on D-Bus proxies is broken.  Simplest reproducer is to go to /playground/pkgs and press the reload button. This also breaks ABRT. Tests are skipped, but this is pretty basic functionality. @mvollmer


 - several tests fail and just have "warning: python.error" in the journal. We need to show these errors properly

