### PR TITLE
Move dark theme handling to pkg/lib/cockpit-dark-theme.js out of the shell

### DIFF
--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html class="pf-theme-dark">
+<html id="applications-page" class="pf-theme-dark">
   <head>
     <title translate="yes">Applications</title>
     <meta charset="utf-8">

--- a/pkg/apps/index.jsx
+++ b/pkg/apps/index.jsx
@@ -19,6 +19,7 @@
 
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import "polyfills";
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from "cockpit";
 

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html lang="en">
+<html id="kdump-page" lang="en" class="pf-theme-dark">
 <head>
     <meta charset="utf-8">
     <title translate="yes">Kernel dump</title>

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -19,6 +19,7 @@
 
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from "cockpit";
 

--- a/pkg/lib/cockpit-dark-theme.js
+++ b/pkg/lib/cockpit-dark-theme.js
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2022 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+function debug() {
+    if (window.debugging == "all" || window.debugging == "style") {
+        console.debug([`cockpit-dark-theme: ${document.documentElement.id}:`, ...arguments].join(" "));
+    }
+}
+
+function changeDarkThemeClass(documentElement, dark_mode) {
+    debug(`Setting cockpit theme to ${dark_mode ? "dark" : "light"}`);
+
+    if (dark_mode) {
+        documentElement.classList.add('pf-theme-dark');
+    } else {
+        documentElement.classList.remove('pf-theme-dark');
+    }
+}
+
+function _setDarkMode(_style) {
+    const style = _style || localStorage.getItem('shell:style') || 'auto';
+    let dark_mode;
+    // If a user set's an explicit theme, ignore system changes.
+    if ((window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && style === "auto") || style === "dark") {
+        dark_mode = true;
+    } else {
+        dark_mode = false;
+    }
+    changeDarkThemeClass(document.documentElement, dark_mode);
+}
+
+window.addEventListener("storage", event => {
+    if (event.key === "shell:style") {
+        debug(`Storage element 'shell:style' changed from  ${event.oldValue} to ${event.newValue}`);
+
+        _setDarkMode();
+    }
+});
+
+// When changing the theme from the shell switcher the localstorage change will not fire for the same page (aka shell)
+// so we need to listen for the event on the window object.
+window.addEventListener("cockpit-style", event => {
+    const style = event.detail.style;
+    debug(`Event received from shell with 'cockpit-style'  ${style}`);
+
+    _setDarkMode(style);
+});
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    debug(`Operating system theme preference changed to ${window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? "dark" : "light"}`);
+    _setDarkMode();
+});
+
+_setDarkMode();

--- a/pkg/metrics/index.html
+++ b/pkg/metrics/index.html
@@ -15,7 +15,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with this package; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html lang="en">
+<html id="metrics-page" lang="en">
 <head>
     <title translate>Metrics and history</title>
     <meta charset="utf-8">

--- a/pkg/metrics/index.js
+++ b/pkg/metrics/index.js
@@ -18,6 +18,7 @@
  */
 
 import "../lib/patternfly/patternfly-4-cockpit.scss";
+import 'cockpit-dark-theme'; // once per page
 
 import React from 'react';
 import { createRoot } from "react-dom/client";

--- a/pkg/networkmanager/app.jsx
+++ b/pkg/networkmanager/app.jsx
@@ -18,6 +18,7 @@
  */
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import cockpit from "cockpit";
+import 'cockpit-dark-theme'; // once per page
 import React, { useRef } from 'react';
 import { createRoot } from "react-dom/client";
 

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -18,6 +18,7 @@
  */
 
 import '../lib/patternfly/patternfly-4-cockpit.scss';
+import 'cockpit-dark-theme'; // once per page
 import cockpit from "cockpit";
 import React, { useState } from 'react';
 import { createRoot } from "react-dom/client";

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -18,7 +18,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html class="pf-theme-dark">
+<html id="networkmanager-page" class="pf-theme-dark">
 <head>
   <title translate="yes">Networking</title>
   <meta charset="utf-8">

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html class="pf-theme-dark">
+<html id="packagekit-page" class="pf-theme-dark">
 
 <head>
   <title translate>Software updates</title>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -18,6 +18,7 @@
  */
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from "cockpit";
 import React, { useState, useEffect } from "react";

--- a/pkg/playground/index.html
+++ b/pkg/playground/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html id="playground-page" class="pf-theme-dark">
 <head>
     <meta charset="utf-8">
     <title>Cockpit Development Playground</title>

--- a/pkg/playground/index.js
+++ b/pkg/playground/index.js
@@ -1,5 +1,6 @@
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import "../../node_modules/@patternfly/patternfly/components/Button/button.css";
+import 'cockpit-dark-theme'; // once per page
 import cockpit from "cockpit";
 import { page_status } from "notifications";
 

--- a/pkg/selinux/setroubleshoot.html
+++ b/pkg/selinux/setroubleshoot.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html lang="en">
+<html id="selinux-page" lang="en">
 <head>
     <meta charset="utf-8">
     <title translate="yes">SELinux troubleshoot</title>

--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -18,6 +18,7 @@
  */
 
 import cockpit from "cockpit";
+import 'cockpit-dark-theme'; // once per page
 
 import React from "react";
 import { createRoot } from "react-dom/client";

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="index-page pf-theme-dark">
+<html id="shell-page" class="index-page pf-theme-dark">
   <head>
     <title>Cockpit</title>
     <meta charset="utf-8">

--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -17,6 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'cockpit-dark-theme'; // once per page
 import cockpit from "cockpit";
 import React from "react";
 import { createRoot } from "react-dom/client";

--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -105,12 +105,15 @@ export class TopNav extends React.Component {
     handleModeClick = (isSelected, event) => {
         const theme = event.currentTarget.id;
         this.setState({ theme: theme });
+
         const styleEvent = new CustomEvent("cockpit-style", {
             detail: {
                 style: theme,
             }
         });
         window.dispatchEvent(styleEvent);
+
+        localStorage.setItem("shell:style", theme);
     }
 
     render() {

--- a/pkg/sosreport/index.jsx
+++ b/pkg/sosreport/index.jsx
@@ -20,6 +20,7 @@
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import './sosreport.scss';
 import "polyfills";
+import 'cockpit-dark-theme'; // once per page
 
 import React, { useState } from "react";
 import { createRoot } from 'react-dom/client';

--- a/pkg/storaged/devices.jsx
+++ b/pkg/storaged/devices.jsx
@@ -18,6 +18,7 @@
  */
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from "cockpit";
 import React from "react";

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html id="system-hwinfo-page" class="pf-theme-dark">
 <head>
     <title translate="yes">Hardware information</title>
     <meta charset="utf-8">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -1,13 +1,11 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html id="system-overview-page" class="pf-theme-dark">
 <head>
   <meta charset="utf-8">
   <title>Overview</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-
   <link rel="stylesheet" href="overview.css">
-
   <script type="text/javascript" src="../base1/cockpit.js"></script>
   <script type="text/javascript" src="../base1/po.js"></script>
   <script type="text/javascript" src="overview.js"></script>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html class="pf-theme-dark">
+<html id="system-logs-page" class="pf-theme-dark">
 
 <head>
   <title translate>Journal</title>

--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -18,6 +18,7 @@
  */
 
 import '../lib/patternfly/patternfly-4-cockpit.scss';
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from "cockpit";
 import React, { useState, useEffect } from 'react';

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -19,6 +19,7 @@
 
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills';
+import 'cockpit-dark-theme'; // once per page
 import cockpit from "cockpit";
 
 import React from 'react';

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html id="system-services-page" class="pf-theme-dark">
 <head>
     <title translate="yes">Services</title>
     <meta charset="utf-8">

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -19,6 +19,7 @@
 
 import '../../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
+import 'cockpit-dark-theme'; // once per page
 
 import React, { useState, useEffect, useCallback } from "react";
 import { createRoot } from 'react-dom/client';

--- a/pkg/systemd/terminal.html
+++ b/pkg/systemd/terminal.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html id="system-terminal-page" class="pf-theme-dark">
 <head>
     <title translate="yes">Terminal</title>
     <meta charset="utf-8">

--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -1,4 +1,5 @@
 import cockpit from "cockpit";
+import 'cockpit-dark-theme'; // once per page
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 
 import React from "react";

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -18,7 +18,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html class="pf-theme-dark">
+<html id="users-page" class="pf-theme-dark">
 <head>
     <title translate="yes">Local accounts</title>
     <meta charset="utf-8">

--- a/pkg/users/local.js
+++ b/pkg/users/local.js
@@ -18,6 +18,7 @@
  */
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
+import 'cockpit-dark-theme'; // once per page
 
 import cockpit from 'cockpit';
 import React, { useState, useEffect } from 'react';

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -30,12 +30,13 @@ class TestMenu(MachineCase):
     def testDarkThemeSwitcher(self):
         b = self.browser
 
-        def switch_style(style_class):
+        def switch_style(style_class, prevPage="system"):
+            b.switch_to_top()
             b.click("#toggle-menu")
             b.click(f"#topnav {style_class}")
+            b.enter_page(f"/{prevPage}")
 
         self.login_and_go("/system")
-        b.switch_to_top()
         switch_style("#dark")
         b._wait_present("html.pf-theme-dark")
 


### PR DESCRIPTION
There are scenarios where cockpit-system (package shipping shell code) is not installed: e.g. when using cockpit-desktop or embedding, the shell isn't required.

On this scenario users would miss the support for dark theme. Therefore this commit will move the theme handling to a new file, in pkg/lib which should be included in all cockpit pages.