### PR TITLE
testlib: add a @todo decorator

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -91,7 +91,6 @@ class Test:
         print_tap = not opts.list
         affected = any([self.command[0].endswith(t) for t in affected_tests])
         retry_reason = ""
-        skip_reason = ""
 
         # Try affected tests 3 times
         if self.returncode == 0 and affected and self.retry_when_affected and self.retries < 2:
@@ -105,9 +104,11 @@ class Test:
             lines = self.output.splitlines()
             skip_reason = lines[-1].strip().decode("utf-8")
             self.output = b"\n".join(lines[:-1])
-
-        if self.returncode in [0, 77]:
             self._print_test(print_tap, skip_reason=skip_reason)
+            return None, 0
+
+        if self.returncode == 0:
+            self._print_test(print_tap)
             return None, 0
 
         if not opts.thorough:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -121,6 +121,7 @@ class Test:
                 reason = proc.communicate(self.output + ("not ok " + str(self)).encode())[0].strip()
 
                 if proc.returncode == 77:
+                    self.returncode = proc.returncode
                     self._print_test(skip_reason="# SKIP {0}".format(reason.decode("utf-8")))
                     return None, 0
 
@@ -183,12 +184,8 @@ class Test:
             return
 
         print()  # Tap needs to start on a separate line
-        if self.returncode == 0:
-            print(f"ok {self}{retry_reason}")
-        elif skip_reason:
-            print(f"ok {self}{skip_reason}")
-        else:
-            print(f"not ok {self}{retry_reason}")
+        status = 'ok' if self.returncode in [0, 77] else 'not ok'
+        print(f"{status} {self}{retry_reason}{skip_reason}")
         flush_stdout()
 
 

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -41,7 +41,7 @@ def flush_stdout():
 
 
 class Test:
-    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, cost=1):
+    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, todo, cost=1):
         self.process = None
         self.retries = 0
         self.test_id = test_id
@@ -50,6 +50,7 @@ class Test:
         self.nondestructive = nondestructive
         self.machine_id = None
         self.retry_when_affected = retry_when_affected
+        self.todo = todo
         self.cost = cost
         self.returncode = None
 
@@ -107,6 +108,21 @@ class Test:
             self._print_test(print_tap, skip_reason=skip_reason)
             return None, 0
 
+        # If the test was marked with @todo then...
+        if self.todo is not None:
+            todo_reason, flaky = self.todo
+            if self.returncode == 0 and not flaky:
+                # The test passed, but it shouldn't have.
+                self.returncode = 1  # that's a fail
+                self._print_test(print_tap, todo_reason=f'# expected failure: {todo_reason}')
+                return None, 1
+            else:
+                # The test either failed (always OK) or passed (and flaky=True)
+                # Outputs  'not ok 1 test # TODO ...'
+                #      or  'ok 1 test # TODO ...'
+                self._print_test(print_tap, todo_reason=f'# TODO {todo_reason}')
+                return None, 0
+
         if self.returncode == 0:
             self._print_test(print_tap)
             return None, 0
@@ -155,7 +171,7 @@ class Test:
         nd = f" [ND@{self.machine_id}]" if self.nondestructive else ""
         return f"{self.test_id} {self.command[0]} {self.command[-1]}{cost}{nd}"
 
-    def _print_test(self, print_tap=True, retry_reason="", skip_reason=""):
+    def _print_test(self, print_tap=True, retry_reason="", skip_reason="", todo_reason=""):
         def write_line(line):
             while line:
                 try:
@@ -177,15 +193,17 @@ class Test:
             retry_reason = " " + retry_reason
         if skip_reason:
             skip_reason = " " + skip_reason
+        if todo_reason:
+            todo_reason = " " + todo_reason
 
         if not print_tap:
-            print(retry_reason + skip_reason)
+            print(retry_reason + skip_reason + todo_reason)
             flush_stdout()
             return
 
         print()  # Tap needs to start on a separate line
         status = 'ok' if self.returncode in [0, 77] else 'not ok'
-        print(f"{status} {self}{retry_reason}{skip_reason}")
+        print(f"{status} {self}{retry_reason}{skip_reason}{todo_reason}")
         flush_stdout()
 
 
@@ -319,12 +337,14 @@ def detect_tests(test_files, image, opts):
                     continue
                 nd = getattr(test_method, "_testlib__non_destructive", False)
                 rwa = getattr(test_method, "_testlib__retry_when_affected", True)
+                todo = getattr(test_method, "_testlib_todo",
+                               getattr(test.__class__, "_testlib_todo", None))
                 if getattr(test.__class__, "provision", None):
                     # each additionally provisioned VM costs parallel test capacity
                     cost = len(test.__class__.provision)
                 else:
                     cost = 1
-                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, cost=cost)
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, todo, cost=cost)
                 if nd:
                     serial_tests.append(test)
                 else:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -75,6 +75,7 @@ __all__ = (
     'skipMobile',
     'skipBrowser',
     'skipPackage',
+    'todo',
     'enableAxe',
     'timeout',
     'Error',
@@ -2117,6 +2118,22 @@ def no_retry_when_changed(testEntity):
     else:
         raise Error("The no_retry_when_changed decorator can only be used on test classes and test methods")
     return testEntity
+
+
+def todo(reason='', flaky=False):
+    """Tests decorated with @todo are expected to fail.
+
+    An optional reason can be given, and will appear in the TAP output if run
+    via run-tests.
+
+    If flaky=False (the default) then the test is expected to always fail.  An
+    unexpected pass is considered to be an error in that case.  If flaky=True
+    then a pass is not considered to be an error.
+    """
+    def wrapper(testEntity):
+        testEntity._testlib_todo = (reason, flaky)
+        return testEntity
+    return wrapper
 
 
 def checkRunAxe():

--- a/test/verify/check-example
+++ b/test/verify/check-example
@@ -23,7 +23,7 @@ import time
 import unittest
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipPackage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipPackage, test_main, todo
 from fmf_metadata import FMF
 
 
@@ -89,6 +89,32 @@ class TestSimple(unittest.TestCase):
 
     def testThree(self):
         self.assertTrue(True)
+
+
+@FMF.tag("example")
+@skipDistroPackage()
+class TestTodo(unittest.TestCase):
+    def setUp(self):
+        if not os.environ.get('TEST_TODO'):
+            self.skipTest('not testing TestTodo')
+
+    @todo('2 is not yet sufficiently large')
+    def testTodoFail(self):
+        assert 2 + 2 == 5
+
+    @todo('2 is not yet sufficiently large')
+    def testTodoPass(self):
+        assert 2 + 2 == 4
+
+    @todo('2 is not yet sufficiently large', flaky=True)
+    def testTodoFailFlaky(self):
+        phase_modulator_js = 2.0 ** 32
+        assert 2 + 2 + phase_modulator_js == 5 + phase_modulator_js
+
+    @todo('2 is not yet sufficiently large', flaky=True)
+    def testTodoPassFlaky(self):
+        phase_modulator_js = 2.0 ** 64
+        assert 2 + 2 + phase_modulator_js == 5 + phase_modulator_js
 
 
 if __name__ == '__main__':

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -215,6 +215,37 @@ class TestSystemd(unittest.TestCase):
         self.assertRegex(stdout, rb"\nok .* TestSystemd.testBasic\n")
         self.assertNotRegex(stdout, b"RETRY")
 
+    def testTodo(self):
+        env = os.environ.copy()
+        try:
+            del env["TEST_JOBS"]
+        except KeyError:
+            pass
+        env["TEST_TODO"] = "1"
+
+        process = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "TestTodo"],
+                                 env=env, capture_output=True)
+        stdout = process.stdout
+
+        expected_fails = 0
+
+        # A @todo test which fails should write 'not ok ... # TODO ...'
+        self.assertRegex(stdout, rb"\nnot ok . .*test/verify/check-example TestTodo.testTodoFail # TODO 2 is not yet sufficiently large\n")
+
+        # A @todo test which passes should write 'not ok ... # expected failure ...' and hard fail
+        self.assertRegex(stdout, rb"\nnot ok . .*test/verify/check-example TestTodo.testTodoPass # expected failure: 2 is not yet sufficiently large\n")
+        expected_fails += 1
+
+        # A @todo(flaky=True) test which fails writes 'not ok ... # TODO ...' just like flaky=False
+        self.assertRegex(stdout, rb"\nnot ok . .*test/verify/check-example TestTodo.testTodoFailFlaky # TODO 2 is not yet sufficiently large\n")
+
+        # But @todo(flaky=True) which passes writes 'ok ... # TODO ...' and isn't a hard fail
+        self.assertRegex(stdout, rb"\nok . .*test/verify/check-example TestTodo.testTodoPassFlaky # TODO 2 is not yet sufficiently large\n")
+
+        # There should have been 4 cases: pass/fail flaky and pass/fail non-flaky
+        # The 'pass' non-flaky case results in a positive return code (expected_fails is 1)
+        self.assertEqual(process.returncode, expected_fails)
+
 
 @skipDistroPackage()
 @nondestructive


### PR DESCRIPTION
Decorated testcases will be marked as "TODO" and report as per the TAP specification.

The test will be counted as a fail, the individual test case run will return non-zero, and run-tests will report "not ok", but the failure will not be counted towards the total number of failures reported as part of the exit status.


This is my counter-proposal to the use of xfail in #18039 