### PR TITLE
tools: Use GitHub API in debian/watch

### DIFF
--- a/tools/debian/watch
+++ b/tools/debian/watch
@@ -1,2 +1,5 @@
 version=4
-https://github.com/cockpit-project/cockpit/releases/ .*/cockpit-([\d\.]+)\.tar\.xz
+opts="searchmode=plain, \
+filenamemangle=s/.+\/@PACKAGE@-@ANY_VERSION@.tar.gz/@PACKAGE@-$1\.tar\.xz/" \
+https://api.github.com/repos/cockpit-project/@PACKAGE@/releases \
+https://github.com/cockpit-project/@PACKAGE@/releases/download/\d[\.\d]*/@PACKAGE@-@ANY_VERSION@.tar.xz


### PR DESCRIPTION
The /releases page has become JavaScript-y recently and thus unreadable by machines. Scan the API instead and construct a download URL.

----

`curl https://github.com/cockpit-project/cockpit/releases/` is just gibberish now. I already applied this change downstream, and it works:
```
❱❱❱ uscan --report --verbose
   uscan info: Found the following matching hrefs on the web page (newest first):
   https://github.com/cockpit-project/cockpit/releases/download/282/cockpit-282.tar.xz (282) index=282-4 
   https://github.com/cockpit-project/cockpit/releases/download/281/cockpit-281.tar.xz (281) index=281-4 
   https://github.com/cockpit-project/cockpit/releases/download/280.1/cockpit-280.1.tar.xz (280.1) index=280.1-4 
[...]
uscan info: Matching target for filenamemangle: https://github.com/cockpit-project/cockpit/releases/download/282/cockpit-282.tar.xz
uscan info: Filename (filenamemangled) for downloaded file: cockpit-282.tar.xz
uscan info: Newest version of cockpit on remote site is 282, local version is 282
uscan info:  => Package is up to date from:
             => https://github.com/cockpit-project/cockpit/releases/download/282/cockpit-282.tar.xz
```
I did the 282 Debian release with that.