### PR TITLE
TMT fixes

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -131,6 +131,11 @@ if [ "$PLAN" = "basic" ]; then
               TestJournal.testAbrtSegv
               "
 
+    # no cockpit-tests package in RHEL 8
+    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ]; then
+        EXCLUDES="$EXCLUDES TestLogin.testSELinuxRestrictedUser"
+    fi
+
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES
               TestAccounts.testAccountLogs

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -34,10 +34,6 @@ if [ -d .git ]; then
 fi
 
 export TEST_OS="${ID}-${VERSION_ID/./-}"
-# HACK: upstream does not yet know about rawhide
-if [ "$TEST_OS" = "fedora-38" ]; then
-    export TEST_OS=fedora-36
-fi
 
 if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -33,8 +33,9 @@ class TestNetworkingBasic(NetworkCase):
             # screenshot assumes running firewalld and absent virbr0 (in particular, *3* interfaces)
             m.execute("systemctl start firewalld")
 
-            # ensure PCP is on, so that we get the zoom/range selectors
-            m.execute("systemctl start pmlogger")
+            # ensure PCP is on for pixel tests, so that we get the zoom/range selectors
+            if b.pixels_label:
+                m.execute("systemctl start pmlogger")
 
         self.login_and_go("/network")
         b.wait_visible("#networking")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -39,7 +39,8 @@ done
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos"]
 OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch",
-                     "fedora-coreos", "fedora-36", "fedora-37", "fedora-testing", "centos-8-stream", "centos-9-stream"]
+                     "fedora-coreos", "fedora-36", "fedora-37", "fedora-38", "fedora-testing",
+                     "centos-8-stream", "centos-9-stream"]
 
 
 class NoSubManCase(PackageCase):
@@ -1257,7 +1258,7 @@ class TestKpatchInstall(NoSubManCase):
 
 @skipImage("Image uses OSTree", "fedora-coreos")
 @skipImage("No subscriptions", "debian-stable", "debian-testing", "centos-8-stream",
-           "fedora-36", "fedora-37", "fedora-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+           "fedora-36", "fedora-37", "fedora-38", "fedora-testing", "ubuntu-2204", "ubuntu-stable", "arch")
 class TestUpdatesSubscriptions(PackageCase):
     provision = {
         "0": {"address": "10.111.112.1/20", "dns": "10.111.112.1", "memory_mb": 512},


### PR DESCRIPTION
These should fix the downstream RHEL 8.8 release ([internal MR](https://gitlab.com/redhat/rhel/rpms/cockpit/-/merge_requests/6)) and hopefully after https://github.com/cockpit-project/bots/pull/4174 also the [rawhide failures](https://artifacts.dev.testing-farm.io/5d97011b-d9fd-417e-b168-0a0f753870be/)