### PR TITLE
systemd: Avoid path_namespace watches with org.freedesktop.problems

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1778,7 +1778,8 @@ class MachineCase(unittest.TestCase):
                 r"File .*asyncio/events.py.*",
                 r"self._context.run\(self._callback, \*self._args\)",
                 r"File .*cockpit/transports.py.* _read_ready",
-                r"data = os.read\(self._in_fd, _Transport.BLOCK_SIZE\)"]
+                r"data = os.read\(self._in_fd, _Transport.BLOCK_SIZE\)",
+                r"ConnectionResetError: \[Errno 104\] Connection reset by peer"]
 
             self.allowed_messages += [
                 r"File .*/systemd_ctypes/bus.py.* in handler",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1816,6 +1816,17 @@ class MachineCase(unittest.TestCase):
                 r"self.packages.*.serve_file.*",
                 r"KeyError: 'manifests.json'"]
 
+            # https://cockpit-logs.us-east-1.linodeobjects.com/pull-18052-20221219-220331-9aa9eeeb-fedora-36-pybridge/log.html#150
+            self.allowed_messages += [
+                r"self.channel_data_received\(channel, data\)",
+                r"File .*/cockpit/peer.py.*, in channel_data_received",
+                r"self.send_channel_data\(channel, data\)",
+                r"self.router.write_channel_data\(channel, data\)",
+                r"self.transport.write\(header . payload\)",
+                r"assert not self._closing",
+                r"AssertionError",
+            ]
+
             self.allowed_messages.append(".* is not in the sudoers file.  This incident will be reported.")
             self.allowed_messages.append("sudo: no valid sudoers sources found, quitting")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -525,7 +525,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
-    @todoPybridge()
     def testAbrtSegv(self):
         b = self.browser
         m = self.machine
@@ -560,7 +559,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
-    @todoPybridge()
     def testAbrtDelete(self):
         b = self.browser
         m = self.machine
@@ -659,7 +657,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
-    @todoPybridge()
+    @todoPybridge(flaky=True)
     def testAbrtReportCancel(self):
         b = self.browser
         m = self.machine
@@ -696,7 +694,6 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
-    @todoPybridge()
     def testAbrtReportNoReportd(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -27,7 +27,7 @@ from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, t
 @skipDistroPackage()
 class TestAccounts(MachineCase):
 
-    @todoPybridge()
+    @todoPybridge(flaky=True)
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
o.fd.problems does not have a ObjectManager and we might not want to create a DBusProxies object for it, which relies on emulating a ObjectManager via Introspection.

Thus, let's create the array of DBusProxy:s explicitly.
