### PR TITLE
lib: table: keys can be '0' which is falsy but still a valid key

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -91,7 +91,7 @@ export const ListingTable = ({
             const keys = [];
 
             rows.forEach(row => {
-                if (row.props && row.props.key)
+                if (row.props && row.props.key !== undefined)
                     keys.push(row.props.key);
             });
 


### PR DESCRIPTION
Fixes #18053
Fixes #18054