### PR TITLE
all: eliminate ct-pagesection-mobile class

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -140,7 +140,7 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
 
     return (
         <Page id="list-page">
-            <PageSection variant={PageSectionVariants.light} className="ct-pagesection-mobile">
+            <PageSection variant={PageSectionVariants.light}>
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     <h2 className="pf-u-font-size-3xl">{_("Applications")}</h2>
                     <FlexItem align={{ default: 'alignRight' }}>
@@ -153,7 +153,7 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
             </PageSection>
             {comps.length == 0
                 ? <EmptyStatePanel title={ _("No applications installed or available.") } />
-                : <PageSection className="ct-pagesection-mobile">
+                : <PageSection>
                     <Card>
                         <DataList aria-label={_("Applications list")}>
                             { tbody }

--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -152,7 +152,7 @@ export const Application = ({ metainfo_db, id, progress, progress_title, action 
                       <BreadcrumbItem isActive>{comp ? comp.name : id}</BreadcrumbItem>
                   </Breadcrumb>
               }>
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 {render_comp()}
             </PageSection>
         </Page>

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -486,7 +486,7 @@ export class KdumpPage extends React.Component {
                         {kdumpSwitch}
                     </Flex>
                 </PageSection>
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <Card>
                         <CardBody>
                             <DescriptionList className="pf-m-horizontal-on-sm">

--- a/pkg/lib/cockpit-components-firewalld-request.jsx
+++ b/pkg/lib/cockpit-components-firewalld-request.jsx
@@ -45,7 +45,7 @@ function debug() {
  * Properties:
  *   - service (string, required): firewalld service name
  *   - title (string, required): Human readable/translated alert title
- *   - pageSection (bool, optional, default false): Render the alert inside a <PageSection className="ct-pagesection-mobile">
+ *   - pageSection (bool, optional, default false): Render the alert inside a <PageSection>
  */
 export const FirewalldRequest = ({ service, title, pageSection }) => {
     const [zones, setZones] = useState(null);
@@ -163,7 +163,7 @@ export const FirewalldRequest = ({ service, title, pageSection }) => {
     }
 
     if (pageSection)
-        return <PageSection className="ct-no-bottom-padding ct-pagesection-mobile">{alert}</PageSection>;
+        return <PageSection className="ct-no-bottom-padding">{alert}</PageSection>;
     else
         return alert;
 };

--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -201,14 +201,3 @@ html:not(.index-page) body {
   margin-top: var(--offset);
   margin-bottom: var(--offset);
 }
-
-// Drop side padding in mobile mode,
-// intended mainly for PF PageSection elements (pf-c-page__main-section).
-// It's similar to adding padding={{ default: 'noPadding', sm: 'padding' }},
-// except this only affects the sides, not the top and bottom.
-@media screen and (max-width: $pf-global--breakpoint--sm) {
-  .ct-pagesection-mobile {
-    padding-left: 0;
-    padding-right: 0;
-  }
-}

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -400,3 +400,14 @@ svg {
     transform: scaleX(-100%);
   }
 }
+
+// Drop side padding in mobile mode,
+// intended mainly for PF PageSection elements (pf-c-page__main-section).
+// It's similar to adding padding={{ default: 'noPadding', sm: 'padding' }},
+// except this only affects the sides, not the top and bottom.
+@media screen and (max-width: $pf-global--breakpoint--sm) {
+  .pf-c-page__main > section.pf-c-page__main-section:not(.pf-m-padding) {
+    padding-left: 0;
+    padding-right: 0;
+  }
+}

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1735,10 +1735,10 @@ export const Application = () => {
             }>
                 { firewalldRequest &&
                 <FirewalldRequest service={firewalldRequest.service} title={firewalldRequest.title} pageSection /> }
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <CurrentMetrics />
                 </PageSection>
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <MetricsHistory firewalldRequest={setFirewalldRequest}
                                     needsLogout={needsLogout}
                                     setNeedsLogout={setNeedsLogout} />

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -1056,7 +1056,7 @@ export class Firewall extends React.Component {
                               { enabled && !firewall.readonly && <span className="btn-group">{addZoneAction}</span> }
                           </Flex>
                       </PageSection>}>
-                <PageSection id="zones-listing" className="ct-pagesection-mobile">
+                <PageSection id="zones-listing">
                     { enabled && <Stack hasGutter>
                         {
                             zones.map(z => <ZoneSection key={z.id}

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -704,10 +704,10 @@ export const NetworkInterfacePage = ({
                           {dev_name}
                       </BreadcrumbItem>
                   </Breadcrumb>}>
-            <PageSection variant={PageSectionVariants.light} className="ct-pagesection-mobile">
+            <PageSection variant={PageSectionVariants.light}>
                 <NetworkPlots plot_state={plot_state} />
             </PageSection>
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 <Gallery hasGutter>
                     <Card className="network-interface-details">
                         <CardHeader>

--- a/pkg/networkmanager/network-main.jsx
+++ b/pkg/networkmanager/network-main.jsx
@@ -143,7 +143,7 @@ export const NetworkPage = ({ privileged, operationInProgress, usage_monitor, pl
             <PageSection id="networking-graphs" className="networking-graphs" variant={PageSectionVariants.light}>
                 <NetworkPlots plot_state={plot_state} />
             </PageSection>
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 <Gallery hasGutter>
                     {firewall.installed && <Card id="networking-firewall-summary">
                         <CardHeader>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1450,7 +1450,7 @@ class OsUpdates extends React.Component {
 
             return (
                 <>
-                    <PageSection className="ct-pagesection-mobile">
+                    <PageSection>
                         <Gallery className='ct-cards-grid' hasGutter>
                             <CardsPage handleRefresh={this.handleRefresh}
                                        applySecurity={applySecurity}
@@ -1587,7 +1587,7 @@ class OsUpdates extends React.Component {
 
             return (
                 <>
-                    <PageSection className="ct-pagesection-mobile">
+                    <PageSection>
                         <Gallery className='ct-cards-grid' hasGutter>
                             <CardsPage onValueChanged={this.onValueChanged} handleRefresh={this.handleRefresh} {...this.state} />
                         </Gallery>
@@ -1629,7 +1629,7 @@ class OsUpdates extends React.Component {
     render() {
         let content = this.renderContent();
         if (!["available", "uptodate"].includes(this.state.state))
-            content = <PageSection variant={PageSectionVariants.light} className="ct-pagesection-mobile">{content}</PageSection>;
+            content = <PageSection variant={PageSectionVariants.light}>{content}</PageSection>;
 
         return (
             <WithDialogs>

--- a/pkg/selinux/setroubleshoot-view.jsx
+++ b/pkg/selinux/setroubleshoot-view.jsx
@@ -445,7 +445,7 @@ export class SETroubleshootPage extends React.Component {
             <>
                 {errorMessage}
                 <Page>
-                    <PageSection variant={PageSectionVariants.light}>
+                    <PageSection padding={{ default: "padding" }} variant={PageSectionVariants.light}>
                         <SELinuxStatus
                             selinuxStatus={this.props.selinuxStatus}
                             selinuxStatusError={this.props.selinuxStatusError}
@@ -453,7 +453,7 @@ export class SETroubleshootPage extends React.Component {
                             dismissError={this.props.dismissStatusError}
                         />
                     </PageSection>
-                    <PageSection className="ct-pagesection-mobile">
+                    <PageSection>
                         <Stack hasGutter>
                             <StackItem>{modifications}</StackItem>
                             <StackItem>{troubleshooting}</StackItem>

--- a/pkg/sosreport/index.jsx
+++ b/pkg/sosreport/index.jsx
@@ -527,7 +527,7 @@ const SOSPage = () => {
     return (
         <WithDialogs>
             <Page>
-                <PageSection variant={PageSectionVariants.light}>
+                <PageSection padding={{ default: "padding" }} variant={PageSectionVariants.light}>
                     <Flex alignItems={{ default: 'alignItemsCenter' }}>
                         <h2 className="pf-u-font-size-3xl">{_("System diagnostics")}</h2>
                     </Flex>

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -140,7 +140,7 @@ export class Details extends React.Component {
                           <BreadcrumbItem to="#/">{_("Storage")}</BreadcrumbItem>
                           <BreadcrumbItem isActive>{name}</BreadcrumbItem>
                       </Breadcrumb>}>
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <Grid hasGutter>
                         {body}
                     </Grid>

--- a/pkg/storaged/multipath.jsx
+++ b/pkg/storaged/multipath.jsx
@@ -67,7 +67,7 @@ export class MultipathAlert extends React.Component {
         if (multipath_broken && !multipathd_running)
             return (
                 <Page>
-                    <PageSection className="ct-pagesection-mobile">
+                    <PageSection>
                         <Alert isInline variant='danger'
                             actionClose={<AlertActionLink variant='secondary' onClick={activate}>{_("Start multipath")}</AlertActionLink>}
                             title={_("There are devices with multiple paths on the system, but the multipath service is not running.")}

--- a/pkg/storaged/overview.jsx
+++ b/pkg/storaged/overview.jsx
@@ -37,7 +37,7 @@ import { StorageLogsPanel } from "./logs-panel.jsx";
 export const Overview = ({ client, plot_state }) => {
     return (
         <Page id="main-storage">
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 <Grid hasGutter>
                     <GridItem md={8} lg={9}>
                         <Gallery hasGutter>

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -326,7 +326,7 @@ class HardwareInfo extends React.Component {
                           <BreadcrumbItem onClick={ () => cockpit.jump("/system", cockpit.transport.host)} className="pf-c-breadcrumb__link">{ _("Overview") }</BreadcrumbItem>
                           <BreadcrumbItem isActive>{ _("Hardware information") }</BreadcrumbItem>
                       </Breadcrumb>}>
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <Gallery hasGutter>
                         <Card>
                             <CardHeader>

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -176,7 +176,7 @@ export class LogEntry extends React.Component {
                               {breadcrumb}
                           </BreadcrumbItem>
                       </Breadcrumb>}>
-                <PageSection className="ct-pagesection-mobile">
+                <PageSection>
                     <Gallery hasGutter>
                         {content}
                     </Gallery>

--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -183,7 +183,7 @@ export const LogsPage = () => {
 
     return (
         <Page>
-            <PageSection id="journal" padding={{ default: 'noPadding' }} className="ct-pagesection-mobile">
+            <PageSection id="journal" padding={{ default: 'noPadding' }}>
                 <Toolbar>
                     <ToolbarContent>
                         <ToolbarToggleGroup className="pf-u-flex-wrap pf-u-flex-grow-1" toggleIcon={<><span className="pf-c-button__icon pf-m-start"><FilterIcon /></span>{_("Toggle filters")}</>} breakpoint="md">

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -145,10 +145,10 @@ class OverviewPage extends React.Component {
 
         return (
             <Page>
-                <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }} className="ct-pagesection-mobile">
+                <PageSection variant={PageSectionVariants.light} padding={{ default: 'noPadding' }}>
                     <SuperuserAlert />
                 </PageSection>
-                <PageSection variant={PageSectionVariants.light} className='ct-overview-header'>
+                <PageSection variant={PageSectionVariants.light} className='ct-overview-header' padding={{ default: 'padding' }}>
                     <div className='ct-overview-header-hostname'>
                         <h1>
                             {this.hostname_text()}
@@ -163,7 +163,7 @@ class OverviewPage extends React.Component {
                         { headerActions }
                     </div>
                 </PageSection>
-                <PageSection variant={PageSectionVariants.default} className="ct-pagesection-mobile">
+                <PageSection variant={PageSectionVariants.default}>
                     <Gallery className='ct-system-overview' hasGutter>
                         <MotdCard />
                         <HealthCard />

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -85,7 +85,7 @@ export class Service extends React.Component {
                                   {this.props.unit.Id}
                               </BreadcrumbItem>
                           </Breadcrumb>}>
-                    <PageSection className="ct-pagesection-mobile">
+                    <PageSection>
                         <Gallery hasGutter>
                             <GalleryItem id="service-details-unit">{serviceDetails}</GalleryItem>
                             {((this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") && this.props.owner == "system") &&

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -845,7 +845,7 @@ class ServicesPageBody extends React.Component {
                 .sort(this.compareUnits);
 
         return (
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 <Card isCompact>
                     <ServicesPageFilters activeStateDropdownOptions={activeStateDropdownOptions}
                                          fileStateDropdownOptions={fileStateDropdownOptions}
@@ -1024,7 +1024,7 @@ const ServicesPage = () => {
         <WithDialogs>
             <Page>
                 {path.length == 0 &&
-                <PageSection variant={PageSectionVariants.light} type="nav" className="services-header ct-pagesection-mobile">
+                <PageSection variant={PageSectionVariants.light} type="nav" className="services-header">
                     <Flex>
                         <ServiceTabs activeTab={activeTab}
                                       tabErrors={tabErrors}

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -232,7 +232,7 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                       <BreadcrumbItem to="#/">{_("Accounts")}</BreadcrumbItem>
                       <BreadcrumbItem isActive>{title_name}</BreadcrumbItem>
                   </Breadcrumb>}>
-            <PageSection className="ct-pagesection-mobile">
+            <PageSection>
                 <Gallery hasGutter>
                     <Card className="account-details" id="account-details">
                         <CardHeader>


### PR DESCRIPTION
* [x] This needs pixel tests updates as the previous class had forgotten a few pages :disappointed: 

This class removes side padding in mobile view for the page section component. This is a clear patternfly override and should be treated as such, by being placed in the patternfly-overrides file.