### PR TITLE
packagekit: format changelog description

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -350,7 +350,7 @@ function updateItem(remarkable, info, pkgNames, key) {
     }
 
     const expandedContent = (
-        <>
+        <Flex justifyContent={{ default: 'justifyContentSpaceBetween' }}>
             <DescriptionList>
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Packages")}</DescriptionListTerm>
@@ -381,8 +381,8 @@ function updateItem(remarkable, info, pkgNames, key) {
                     </DescriptionListGroup>
                     : null }
             </DescriptionList>
-            {description}
-        </>
+            <TextContent>{description}</TextContent>
+        </Flex>
     );
 
     return {


### PR DESCRIPTION
Also bring changelog to the right of the other description items, if there is enough space.

See https://github.com/cockpit-project/cockpit/issues/17789#issuecomment-1268153359 for the design direction.

Closes #17789

Now:
![Screen Shot 2022-12-19 at 19 07 59](https://user-images.githubusercontent.com/14921356/208493499-d30dd213-a70e-413a-8e46-7761c8bbe0c6.png)

Before:
![Screen Shot 2022-12-19 at 18 52 11](https://user-images.githubusercontent.com/14921356/208493716-0d7ea7fe-0d4d-4273-8633-45a391004020.png)

