### PR TITLE
systemd: add minutely option to create timer modal

### DIFF
--- a/pkg/systemd/services/timer-dialog-helpers.js
+++ b/pkg/systemd/services/timer-dialog-helpers.js
@@ -38,6 +38,9 @@ export function create_timer({ name, description, command, delay, delayUnit, del
     if (delay == "specific-time" && repeat == "no") {
         const today = new Date(clock_realtime_now);
         timer_unit.OnCalendar = `OnCalendar=${today.getFullYear()}-${month_day_str(today)} ${specificTime}:00`;
+    } else if (repeat == "minutely") {
+        timer_unit.repeat_second = repeat_array.map(item => Number(item.second));
+        timer_unit.OnCalendar = "OnCalendar=*-*-* *:*:" + timer_unit.repeat_second.join(",");
     } else if (repeat == "hourly") {
         timer_unit.repeat_minute = repeat_array.map(item => Number(item.minute));
         timer_unit.OnCalendar = "OnCalendar=*-*-* *:" + timer_unit.repeat_minute.join(",");
@@ -50,7 +53,7 @@ export function create_timer({ name, description, command, delay, delayUnit, del
     } else if (repeat == "yearly") {
         timer_unit.OnCalendar = repeat_array.map(item => `OnCalendar=*-${month_day_str(new Date(item.date))} ${item.time}:00`);
     }
-    if (repeat != "hourly" && delay == "specific-time")
+    if (repeat != "hourly" && repeat != "minutely" && delay == "specific-time")
         timer_unit.OnCalendar = timer_unit.OnCalendar.toString().replaceAll(",", "\n");
     return create_timer_file({ timer_unit, delay, owner });
 }

--- a/pkg/systemd/services/timer-dialog.jsx
+++ b/pkg/systemd/services/timer-dialog.jsx
@@ -228,7 +228,9 @@ const CreateTimerDialogBody = ({ owner }) => {
                                                 return;
 
                                             setRepeat(value);
-                                            if (value == "hourly")
+                                            if (value == "minutely")
+                                                setRepeatPatterns([{ key: 0, second: "0" }]);
+                                            else if (value == "hourly")
                                                 setRepeatPatterns([{ key: 0, minute: "0" }]);
                                             else if (value == "daily")
                                                 setRepeatPatterns([{ key: 0, time: "00:00" }]);
@@ -241,6 +243,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                                         }}
                                         aria-label={_("Repeat")}>
                                 <FormSelectOption value="no" label={_("Don't repeat")} />
+                                <FormSelectOption value="minutely" label={_("Minutely")} />
                                 <FormSelectOption value="hourly" label={_("Hourly")} />
                                 <FormSelectOption value="daily" label={_("Daily")} />
                                 <FormSelectOption value="weekly" label={_("Weekly")} />
@@ -256,7 +259,9 @@ const CreateTimerDialogBody = ({ owner }) => {
                         </FormGroup>}
                         {repeatPatterns.map((item, idx) => {
                             let label;
-                            if (repeat == "hourly")
+                            if (repeat == "minutely")
+                                label = _("At second");
+                            else if (repeat == "hourly")
                                 label = _("At minute");
                             else if (repeat == "daily")
                                 label = _("Run at");
@@ -273,11 +278,30 @@ const CreateTimerDialogBody = ({ owner }) => {
                                 helperTextInvalid = _("Minute needs to be a number between 0-59");
                             }
 
+                            const sec = repeatPatterns[idx].second;
+                            const validationFailedSecond = !(/^[0-9]+$/.test(sec) && sec <= 59 && sec >= 0);
+
+                            if (submitted && repeat == 'minutely' && validationFailedSecond) {
+                                validated = "error";
+                                helperTextInvalid = _("Second needs to be a number between 0-59");
+                            }
+
                             return (
                                 <FormGroup label={label} key={item.key}
                                            validated={validated}
                                            helperTextInvalid={helperTextInvalid}>
                                     <Flex className="specific-repeat-group" data-index={idx}>
+                                        {repeat == "minutely" &&
+                                            <TextInput className='delay-number'
+                                                       id={repeat}
+                                                       value={repeatPatterns[idx].second}
+                                                       onChange={second => {
+                                                           const arr = [...repeatPatterns];
+                                                           arr[idx].second = second;
+                                                           setRepeatPatterns(arr);
+                                                       }}
+                                                       validated={submitted && validationFailedSecond ? "error" : "default"} />
+                                        }
                                         {repeat == "hourly" && <>
                                             <TextInput className='delay-number'
                                                        value={repeatPatterns[idx].minute}
@@ -351,7 +375,9 @@ const CreateTimerDialogBody = ({ owner }) => {
                                                 <Button aria-label={_("Add")}
                                                         variant="secondary"
                                                         onClick={() => {
-                                                            if (repeat == "hourly")
+                                                            if (repeat == "minutely")
+                                                                setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, second: "0" }]);
+                                                            else if (repeat == "hourly")
                                                                 setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, minute: "0" }]);
                                                             else if (repeat == "daily")
                                                                 setRepeatPatterns([...repeatPatterns, { key: repeatPatterns.length, time: "00:00" }]);

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1362,6 +1362,30 @@ class TestTimers(MachineCase):
         m.execute("timedatectl set-time '2036-04-10 04:10:00'")
         wait_systemctl_timer("2036-04-10 04:26")
         self.assertIn("2036-04-10 04:26", m.execute("systemctl list-timers"))
+
+        # creates a new minutely timer that runs at *:*:05 and at *:*:20
+        b.click('#create-timer')
+        b.wait_visible("#timer-dialog")
+        b.set_input_text("#servicename", "minutely_timer")
+        b.set_input_text("#description", "Minutely timer")
+        b.set_input_text("#command", "/bin/sh -c '/bin/date >> /tmp/date'")
+        b.select_from_dropdown("#drop-repeat", "minutely")
+        b.click("[data-index=0] [aria-label=Add]")
+        b.set_input_text("[data-index=0] input", "05")
+        b.set_input_text("[data-index=1] input", "20")
+        b.click("#timer-save-button")
+        b.wait_not_present("#timer-dialog")
+        b.wait_visible(self.svc_sel('minutely_timer.timer'))
+
+        m.execute("timedatectl set-time '2036-04-10 04:15:07'")
+        b.wait_visible(self.svc_sel('minutely_timer.timer'))
+        b.wait_in_text(self.svc_sel('minutely_timer.timer'), "Minutely timer")
+        wait_systemctl_timer("2036-04-10 04:15:20")
+        self.assertIn("2036-04-10 04:15:20", m.execute("systemctl list-timers | grep minutely_timer.timer"))
+        m.execute("timedatectl set-time '2036-04-10 04:15:55'")
+        wait_systemctl_timer("2036-04-10 04:16:05")
+        self.assertIn("2036-04-10 04:16:05", m.execute("systemctl list-timers | grep minutely_timer.timer"))
+
         # creates a new timer that runs at today at 23:59
         b.wait_visible("#create-timer")
         b.click('#create-timer')


### PR DESCRIPTION
Split off the minutely option https://github.com/cockpit-project/cockpit/pull/17592

---

# Create timer minutely option

The create timer dialog now allows to specify a minutely interval for systemd timers.