### PR TITLE
test: Clean up decorator implementation

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -330,15 +330,14 @@ def detect_tests(test_files, image, opts):
                 # most tests should take much less than 10mins, so default to that;
                 # longer tests can be annotated with @timeout(seconds)
                 # check the test function first, fall back to the class'es timeout
-                test_timeout = getattr(test_method, "__timeout", getattr(test, "__timeout", 600))
                 if opts.tests and not any([t in test_str for t in opts.tests]):
                     continue
                 if test_str in opts.exclude:
                     continue
-                nd = getattr(test_method, "_testlib__non_destructive", False)
-                rwa = getattr(test_method, "_testlib__retry_when_affected", True)
-                todo = getattr(test_method, "_testlib_todo",
-                               getattr(test.__class__, "_testlib_todo", None))
+                test_timeout = testlib.get_decorator(test_method, test, "timeout", 600)
+                nd = testlib.get_decorator(test_method, test, "nondestructive")
+                rwa = not testlib.get_decorator(test_method, test, "no_retry_when_changed")
+                todo = testlib.get_decorator(test_method, test, "todo")
                 if getattr(test.__class__, "provision", None):
                     # each additionally provisioned VM costs parallel test capacity
                     cost = len(test.__class__.provision)


### PR DESCRIPTION
Our cockpit test specific decorators were using wildly different
implementations. Make them consistent by always adding a
`_testlib__decoratorname` attribute to the test method or class.

Introduce a `get_decorator()` helper which returns the decorator value on the 
test method or class. This avoids the custom code which iterates over the 
class'es methods and duplicates the value.

This also debundles testlib from the `fmf_metadata` library, which we
have never used so far, and don't really plan to either.

There are still two kinds of decorators now: These with arguments, like @todo,
or even the empty-argumented skipDistroPackage(); and the ones without
arguments, like @nondestructive. This is still a bit confusing, but converting
the latter is more intrusive.