### PR TITLE
test: Show lines starting with "WARNING:" for successful tests

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -184,6 +184,9 @@ class Test:
         # be quiet in TAP mode for successful tests
         lines = self.output.strip().splitlines(keepends=True)
         if print_tap and self.returncode == 0 and len(lines) > 0:
+            for line in lines[:-1]:
+                if line.startswith(b"WARNING:"):
+                    write_line(line)
             write_line(lines[-1])
         else:
             for line in lines:


### PR DESCRIPTION
In the interest of saving space, we don't log all output from successful tests.  However, it is useful to see warnings like the recently introduced one for waits that get close to their timeout.