### PR TITLE
cc-table: fix infinite call of useEffect hook

### DIFF
--- a/pkg/lib/cockpit-components-table.jsx
+++ b/pkg/lib/cockpit-components-table.jsx
@@ -78,41 +78,32 @@ export const ListingTable = ({
     sortMethod,
     ...extraProps
 }) => {
-    let rows = tableRows;
-
+    let rows = [...tableRows];
     const [expanded, setExpanded] = useState({});
     const [newItems, setNewItems] = useState([]);
     const [currentRowsKeys, setCurrentRowsKeys] = useState([]);
     const [activeSortIndex, setActiveSortIndex] = useState(sortBy ? sortBy.index : 0);
     const [activeSortDirection, setActiveSortDirection] = useState(sortBy ? sortBy.direction : SortByDirection.asc);
+    const rowKeys = rows.map(row => row.props ? row.props.key : undefined)
+            .filter(key => key !== undefined);
+    const rowKeysStr = JSON.stringify(rowKeys);
+    const currentRowsKeysStr = JSON.stringify(currentRowsKeys);
 
     useEffect(() => {
-        const getRowKeys = rows => {
-            const keys = [];
-
-            rows.forEach(row => {
-                if (row.props && row.props.key !== undefined)
-                    keys.push(row.props.key);
-            });
-
-            return keys;
-        };
-
-        const current_keys = getRowKeys(rows);
-        if (JSON.stringify(current_keys) === JSON.stringify(currentRowsKeys))
-            return;
-
         // Don't highlight all when the list gets loaded
-        if (currentRowsKeys.length !== 0) {
-            const new_keys = current_keys.filter(key => currentRowsKeys.indexOf(key) === -1);
+        const _currentRowsKeys = JSON.parse(currentRowsKeysStr);
+        const _rowKeys = JSON.parse(rowKeysStr);
+
+        if (_currentRowsKeys.length !== 0) {
+            const new_keys = _rowKeys.filter(key => _currentRowsKeys.indexOf(key) === -1);
             if (new_keys.length) {
                 setTimeout(() => setNewItems(items => items.filter(item => new_keys.indexOf(item) < 0)), 4000);
-                setNewItems([...newItems, ...new_keys]);
+                setNewItems(ni => [...ni, ...new_keys]);
             }
         }
 
-        setCurrentRowsKeys([...new Set([...currentRowsKeys, ...current_keys])]);
-    }, [rows, currentRowsKeys, newItems]);
+        setCurrentRowsKeys(crk => [...new Set([...crk, ..._rowKeys])]);
+    }, [currentRowsKeysStr, rowKeysStr]);
 
     const isSortable = cells.some(col => col.sortable);
     const isExpandable = rows.some(row => row.expandedContent);


### PR DESCRIPTION
Arrays as dependencies in hooks are very problematic and often result in too many uneccessary re-renders. This solution simply serializes the array of row keys into a JSON string object before passing them to the useEffect deps list.

This fixes some issues with the use of the ListingTable component among which the most prominent being the 'ct-new-item' class being added > 100 times in some cases.

This fixes warnings in all pages that use ListingTable component - error: Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.%s 
