### PR TITLE
Fix 'edit' mode for hosts

### DIFF
--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -148,7 +148,8 @@ class AddMachine extends React.Component {
             error = _("The IP address or hostname cannot contain whitespace.");
         else {
             const machine = this.props.machines_ins.lookup(this.state.address);
-            if (machine && machine.on_disk && machine.address != this.props.old_address) {
+            const machine_address = machine ? full_address(this.props.machines_ins, machine.address) : undefined;
+            if (machine && machine.on_disk && machine_address != this.props.old_address) {
                 if (machine.visible)
                     error = _("This machine has already been added.");
                 else if (!this.state.userChanged)
@@ -243,8 +244,8 @@ class AddMachine extends React.Component {
         });
 
         const callback = this.onAddHost;
-        const title = this.state.old_machine && !this.state.old_machine.visible ? _("Edit host") : _("Add new host");
-        const submitText = this.state.old_machine && !this.state.old_machine.visible ? _("Set") : _("Add");
+        const title = this.state.old_machine ? _("Edit host") : _("Add new host");
+        const submitText = this.state.old_machine ? _("Set") : _("Add");
 
         const body = <Form isHorizontal>
             <FormGroup label={_("Host")} helperText={_("Can be a hostname, IP address, alias name, or ssh:// URI")}

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -353,12 +353,13 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         m2.execute("hostnamectl set-hostname machine2")
         m3.execute("hostnamectl set-hostname machine3")
 
-        self.allow_journal_messages("Could not chdir to home directory /home/franz: No such file or directory")
-        m1.execute("useradd franz")
-        m1.execute("echo franz:foobar | chpasswd")
-        m3.execute("useradd franz")
-        m3.execute("echo franz:foobar | chpasswd")
-        self.authorize_pubkey(m3, "franz", self.get_pubkey(m1, "admin"))
+        for user in ["franz", "hera"]:
+            self.allow_journal_messages(f"Could not chdir to home directory /home/{user}: No such file or directory")
+            m1.execute(f"useradd {user}")
+            m1.execute(f"echo {user}:foobar | chpasswd")
+            m3.execute(f"useradd {user}")
+            m3.execute(f"echo {user}:foobar | chpasswd")
+            self.authorize_pubkey(m3, user, self.get_pubkey(m1, "admin"))
 
         # This should all work without being admin on m1
         self.login_and_go(superuser=False)
@@ -371,7 +372,16 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
         b.click("button:contains('Edit hosts')")
         b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
 
-        b.wait_visible('#hosts_setup_server_dialog')
+        b.wait_visible('#hosts_setup_server_dialog .pf-c-modal-box__title:contains("Edit host")')
+        b.set_input_text('#add-machine-user', 'hera')
+        b.click('#hosts_setup_server_dialog .pf-m-primary')
+        with b.wait_timeout(30):
+            b.wait_not_present('#hosts_setup_server_dialog')
+
+        b.wait_text(".nav-item a[href='/@10.111.113.3']", "hera @machine3")
+
+        # Editing the username of an existing host is possible
+        b.click("#nav-hosts .nav-item a[href='/@10.111.113.3'] + span button.nav-action.pf-m-secondary")
         b.set_input_text('#add-machine-user', 'franz')
 
         def tab(n):


### PR DESCRIPTION
When editing hosts, the dialog should reflect the 'edit' mode with the title and primary buttons correctly.

Also it should be allowed to just change the username.

Fixes #17479