### PR TITLE
test: Accept insights_client_t SELinux policy

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -276,7 +276,11 @@ class TestSelinux(MachineCase):
         b.reload()
         b.enter_page("/selinux/setroubleshoot")
         with b.wait_timeout(30):
-            b.wait_text("ul[aria-label='System modifications']", "No system modifications")
+            if m.image.startswith("rhel"):
+                # insights-client sets itself as permissive on RHEL, and `semanage permissive -D` gets OOM-killed
+                b.wait_text_matches("ul[aria-label='System modifications']", "No system modifications|permissive -a insights_client_t")
+            else:
+                b.wait_text("ul[aria-label='System modifications']", "No system modifications")
         b.relogin("/selinux/setroubleshoot", "admin", superuser=False)
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 


### PR DESCRIPTION
on RHEL, insights-client started to modify the default policy to make
itself permissive; accept that. We can't reset it with
`semanage permissive -D` as that OOMs.

---

This blocks the [rhel-8-8](https://github.com/cockpit-project/bots/pull/4178) and [rhel-9-2](https://github.com/cockpit-project/bots/pull/4226) image refreshes.