### PR TITLE
hwinfo: add missing cockpit-dark-theme import

### DIFF
--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -17,6 +17,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
  */
 
+import 'cockpit-dark-theme'; // once per page
 import '../lib/patternfly/patternfly-4-cockpit.scss';
 import 'polyfills'; // once per application
 


### PR DESCRIPTION
Fixes #18103