### PR TITLE
systemd: Use sysusers.d to create ws users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ Makefile.in
 /src/systemd/cockpit*.service
 /src/systemd/cockpit*.socket
 /src/systemd/cockpit-tempfiles.conf
+/src/systemd/sysusers/*.conf
 /src/tls/cockpit-certificate-helper
 /src/ws/cockpit-desktop
 /src/ws/cockpit.appdata.xml

--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -1,5 +1,5 @@
 # -----------------------------------------------------------------------------
-# all systemd units, tmpfiles, and related helpers
+# all systemd units, users, tmpfiles, and related helpers
 
 nodist_systemdunit_DATA = \
 	src/systemd/cockpit-motd.service \
@@ -31,6 +31,9 @@ install-exec-hook::
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/systemd/cockpit-tempfiles.conf
 
+sysusersdir = $(prefix)/lib/sysusers.d
+nodist_sysusers_DATA = src/systemd/sysusers/cockpit.conf
+
 # we can't generate these with config.status because,
 # eg. it does "@libexecdir@" -> "${exec_prefix}/libexec"
 src/systemd/%: src/systemd/%.in
@@ -48,6 +51,7 @@ src/systemd/%: src/systemd/%.in
 systemdgenerated = \
 	$(nodist_systemdunit_DATA) \
 	$(nodist_tempconf_DATA) \
+	$(nodist_sysusers_DATA) \
 	$(NULL)
 systemdgenerated_in = $(patsubst %,%.in,$(systemdgenerated))
 

--- a/src/systemd/sysusers/cockpit.conf.in
+++ b/src/systemd/sysusers/cockpit.conf.in
@@ -1,0 +1,2 @@
+u @user@ - "User for cockpit web service"
+u @wsinstanceuser@ - "User for cockpit-ws instances"

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -674,6 +674,16 @@ class TestConnection(MachineCase):
         if root_login_disallowed:
             self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
 
+        # system users are regenerated at boot
+        m.execute("systemctl stop cockpit cockpit.socket")
+        m.execute("userdel cockpit-ws; userdel cockpit-wsinstance; ! grep cockpit /etc/passwd /etc/group")
+        # HACK: ConditionNeedsUpdate=/etc does not notice changed /etc/passwd file
+        m.execute("rm -f /etc/.updated")
+        m.reboot()
+        m.execute("systemctl start cockpit.socket")
+        headers = m.curl("--head", "--fail", "http://127.0.0.1:9090/cockpit/static/login.html")
+        self.assertIn("HTTP/1.1 200 OK\r\n", headers)
+
     @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos")
     @nondestructive
     def testCommandline(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -174,7 +174,7 @@ class TestKdump(KdumpHelpers):
 
         # crash the kernel and make sure it wrote a report into the right directory
         self.crashKernel()
-        m.execute(f"until test -e {customPath}/127.0.0.1*/vmcore; do sleep 1; done")
+        m.execute(f"until test -e {customPath}/127.0.0.1*/vmcore; do sleep 1; done", timeout=180)
         self.assertIn("Kdump compressed dump", m.execute(f"file {customPath}/127.0.0.1*/vmcore"))
 
     @nondestructive

--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -15,13 +15,9 @@ install=cockpit.install
 makedepends=(krb5 libssh accountsservice perl-json perl-locale-po json-glib glib-networking
              git intltool gtk-doc gobject-introspection networkmanager libgsystem xmlto npm pcp)
 source=("cockpit-${pkgver}.tar.xz"
-        "cockpit.pam"
-        "cockpit-ws.sysuser.conf"
-        "cockpit-wsinstance.sysuser.conf")
+        "cockpit.pam")
 sha256sums=('SKIP'
-            'b95cdb0a336b7c1af9af9da1eed8520dfb8eae51869609416d380fee0357c523'
-            '1ad9dad75858264778bd94799b60c651f7cc1c7f7fa1c54622174303e639287a'
-            '46ee8ecad7bc97ba588ab9471dde76e41c00daf40658902425626c3a1938b438')
+            'b95cdb0a336b7c1af9af9da1eed8520dfb8eae51869609416d380fee0357c523')
 
 prepare() {
   cd cockpit-$pkgver
@@ -58,8 +54,6 @@ package_cockpit() {
   make DESTDIR="$pkgdir" install
   rm -rf "$pkgdir"/usr/{src,lib/firewalld}
   install -Dm644 "$srcdir"/cockpit.pam "$pkgdir"/etc/pam.d/cockpit
-  install -Dm644 "$srcdir"/cockpit-ws.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-ws.conf
-  install -Dm644 "$srcdir"/cockpit-wsinstance.sysuser.conf "$pkgdir"/usr/lib/sysusers.d/cockpit-wsinstance.conf
 
   echo "z /usr/lib/cockpit/cockpit-session - - cockpit-wsinstance -" >> "$pkgdir"/usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 

--- a/tools/arch/cockpit-ws.sysuser.conf
+++ b/tools/arch/cockpit-ws.sysuser.conf
@@ -1,1 +1,0 @@
-u cockpit-ws - "User for cockpit web service"

--- a/tools/arch/cockpit-wsinstance.sysuser.conf
+++ b/tools/arch/cockpit-wsinstance.sysuser.conf
@@ -1,1 +1,0 @@
-u cockpit-wsinstance - "User for cockpit-ws instances"

--- a/tools/debian/cockpit-ws.install
+++ b/tools/debian/cockpit-ws.install
@@ -12,6 +12,7 @@ lib/systemd/system/cockpit-wsinstance-https@.socket
 lib/systemd/system/system-cockpithttps.slice
 lib/*/security/pam_ssh_add.so
 lib/*/security/pam_cockpit_cert.so
+usr/lib/sysusers.d/cockpit.conf
 usr/lib/tmpfiles.d/cockpit-tempfiles.conf
 usr/lib/cockpit/cockpit-session
 usr/lib/cockpit/cockpit-ws

--- a/tools/debian/cockpit-ws.postinst
+++ b/tools/debian/cockpit-ws.postinst
@@ -1,20 +1,17 @@
 #!/bin/sh
 set -e
 
-adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-ws
-adduser --system --group --home /nonexistent --no-create-home --quiet cockpit-wsinstance
-
 # change group of cockpit-session on upgrades (changed in version 203)
 if OUT=$(dpkg-statoverride --list /usr/lib/cockpit/cockpit-session) && [ "$OUT#root cockpit-ws 4750}" != "$OUT" ]; then
     echo "Adjusting /usr/lib/cockpit/cockpit-session permissions..."
     dpkg-statoverride --remove /usr/lib/cockpit/cockpit-session
 fi
 
+#DEBHELPER#
+
 if ! dpkg-statoverride --list /usr/lib/cockpit/cockpit-session >/dev/null; then
     dpkg-statoverride --update --add root cockpit-wsinstance 4750 /usr/lib/cockpit/cockpit-session
 fi
-
-#DEBHELPER#
 
 # restart cockpit.service on package upgrades, if it's already running
 if [ -d /run/systemd/system ] && [ -n "$2" ]; then
@@ -37,4 +34,3 @@ if grep --color=auto pam_cockpit_cert /etc/pam.d/cockpit; then
     echo '**** WARNING: future release; remove it from your /etc/pam.d/cockpit.'
     echo '**** WARNING:'
 fi
-

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -46,6 +46,8 @@ override_dh_install:
 	dh_install -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
 
+	dh_installsysusers
+
 # will be the default in compat 13
 override_dh_missing:
 	dh_missing --fail-missing

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -43,5 +43,9 @@ override_dh_install:
 	rm -r debian/tmp/usr/share/cockpit/selinux
 	rm debian/tmp/usr/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 
-	dh_install --fail-missing -Xusr/src/debug
+	dh_install -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
+
+# will be the default in compat 13
+override_dh_missing:
+	dh_missing --fail-missing


### PR DESCRIPTION
Move to using systemd's sysusers declarative files [1] for creating our 
system users/groups. Arch already does that, Fedora moved to it since
Fedora 32 [2], and Debian supports it as well [3].

In debian/cockpit-ws.postinst, move the `#DEBHELPER#` block above the 
statoverride, as the former now generates the user, and the latter needs
it.

Unfortunately Fedora/rpm's `%attr` does not really work with sysusers
files shipped upstream yet. The conf files are not installed yet during
`%pre`, but creating the users in `%post` is too late for the file
unpack phase, so cockpit-session would get the wrong permissions. Thus
duplicate the two sysusers config lines verbatim in `%pre`, which is at
least marginally better than calling `useradd` etc. programmatically.

Extend TestConnection.testWsPackage to remove the system users, reboot,
and validate that cockpit still works. This ensures correct sysusers.d
packaging across all distributions, as our normal CI images already have
the system users.

Fixes #15027

[1] https://www.freedesktop.org/software/systemd/man/sysusers.d.html
[2] https://fedoraproject.org/wiki/Changes/Adopting_sysusers.d_format
[3] https://manpages.debian.org/dh_installsysusers

-----

 - [ ] Rework this after PR #16808

We originally tried `DynamicUser=` in #16811, but that has been blocked for too long. IMHO this is a nice improvement already, and does not block moving to DynamicUser= in the future.