### PR TITLE
ssh: Increase GSource poll timeout

### DIFF
--- a/src/ssh/cockpitsshrelay.c
+++ b/src/ssh/cockpitsshrelay.c
@@ -2065,7 +2065,7 @@ cockpit_ssh_source_prepare (GSource *source,
   CockpitSshRelay *self = cs->relay;
   gint status;
 
-  *timeout = 1;
+  *timeout = 100;
 
   status = ssh_get_status (self->session);
 


### PR DESCRIPTION
We don't want poll() to wake up every 1ms, as that causes cockpit-ssh to
burn a noticeable amount of CPU. We still need to handle the occasional
`status == SSH_READ_PENDING`, so we can't wait indefinitely; but at
least increase the timeout to 100ms.

Fixes #17466