### PR TITLE
tools: Bring back missing files check in Debian packaging

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -174,7 +174,7 @@ class TestKdump(KdumpHelpers):
 
         # crash the kernel and make sure it wrote a report into the right directory
         self.crashKernel()
-        m.execute(f"until test -e {customPath}/127.0.0.1*/vmcore; do sleep 1; done")
+        m.execute(f"until test -e {customPath}/127.0.0.1*/vmcore; do sleep 1; done", timeout=180)
         self.assertIn("Kdump compressed dump", m.execute(f"file {customPath}/127.0.0.1*/vmcore"))
 
     @nondestructive

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -43,5 +43,9 @@ override_dh_install:
 	rm -r debian/tmp/usr/share/cockpit/selinux
 	rm debian/tmp/usr/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 
-	dh_install --fail-missing -Xusr/src/debug
+	dh_install -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
+
+# will be the default in compat 13
+override_dh_missing:
+	dh_missing --fail-missing


### PR DESCRIPTION
`dh_install --fail-missing` has been deprecated for a while and got 
removed in dh compat level 12 (which we use). Use `dh_missing` instead.
We can drop the override once we move to dh compat level 13. This fixes
the warning during build:

    dh_install: warning: Please use dh_missing --list-missing/--fail-missing instead
    dh_install: warning: This feature will be removed in compat 12. 
