### PR TITLE
test: TestJournal.testAbrtReport is flaky with Python

### DIFF
--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -591,7 +591,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
                "ubuntu-2204", "fedora-coreos", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
                "arch")
     @nondestructive
-    @todoPybridge()
+    @todoPybridge(flaky=True)
     def testAbrtReport(self):
         # The testing server is located at verify/files/mock-faf-server.py
         # Adjust Handler.known for for the expected succession of known/unknown problems


### PR DESCRIPTION
It manages to pass sometimes.

For example [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18120-20230104-083837-3edbe1d8-fedora-36-pybridge/log.html#274)