### PR TITLE
test: Use 'python bridge' when skipping tests

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -747,7 +747,7 @@ class TestConnection(MachineCase):
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
 
     @skipImage("ssh root login not allowed", "fedora-coreos")
-    @unittest.skipIf(os.getenv("TEST_SCENARIO") == "pybridge", "wedges up VM too hard, and crashes hard")
+    @unittest.skipIf(os.getenv("TEST_SCENARIO") == "pybridge", "python bridge wedges up VM too hard, and crashes hard")
     @nondestructive
     def testFlowControl(self):
         m = self.machine

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -104,7 +104,7 @@ class TestLongRunning(MachineCase):
         self.addCleanup(m.execute, "systemctl stop cockpit-longrunning.service 2>/dev/null && systemctl reset-failed cockpit-longrunning.service || true")
 
     # sometimes fails with: unexpected failure of GetUnit(cockpit-longrunning.service): Not permitted to perform this action
-    @todoPybridge("fails unpredictably with pybridge", flaky=True)
+    @todoPybridge("fails unpredictably with python bridge", flaky=True)
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -436,7 +436,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
 
     @skipImage("TODO: Packagekit on Arch does not detect the pear update", "arch")
     @skipImage("tracer not available", *OSesWithoutTracer)
-    @todoPybridge(".updates-success-table randomly appears or not with pybridge", flaky=True)
+    @todoPybridge(".updates-success-table randomly appears or not with python bridge", flaky=True)
     def testTracer(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1113,7 +1113,7 @@ class TestTimers(MachineCase):
         self.browser.wait_not_present(".pf-c-empty-state .pf-c-spinner[aria-valuetext='Loading...']")
 
     @unittest.skipIf(os.getenv("TEST_SCENARIO") == "pybridge",
-                     "pybridge logs are too messy to catch with expected message filters")
+                     "python bridge logs are too messy to catch with expected message filters")
     def testCreate(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
We want to be able to quickly know how many tests are skipped due to python bridge so this makes it easy to just search for 'python bridge' in test results.

For example, if I search for `python bridge` in [this log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18121-20230104-110815-da847583-fedora-36-pybridge/log.html) it shows 81 skips. There are 4 occurrences of `pybridge` but one of them is name of the scenario. And separately there is this "wedges hard" message. so all together 85 skips. There are 107 skipped tests, so 22 are skipped independently from python bridge. With this change I can just search for `python bridge` and see 85 straight away.