### PR TITLE
tests: pixel-testing: introduce a scenario for RTL

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -166,6 +166,13 @@ $desktop: $phone + 1px;
   }
 }
 
+[dir="rtl"] {
+  // Not setting this breaks pixel tests
+  .screenreader-text {
+    right: -999px;
+  }
+}
+
 /* Desktop navigation */
 @media (min-width: $desktop) {
   // Adapt PF4's new header select for 2-up

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -51,6 +51,14 @@ function ph_set_val (sel, val) {
     el.dispatchEvent(ev);
 }
 
+function ph_set_text_direction(sel, direction) {
+    const el = ph_find(sel)
+
+    if (el.value === undefined)
+        throw new Error(sel + " does not have a value");
+    el.dir = direction;
+}
+
 function ph_has_val (sel, val) {
     return ph_val(sel) == val;
 }

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -409,7 +409,7 @@ class Browser:
         :param val: the value of the attribute
         """
         self._wait_present(selector + ':not([disabled]):not([aria-disabled=true])')
-        self.call_js_func('ph_set_attr', selector, attr, val and 'true' or 'false')
+        self.call_js_func('ph_set_attr', selector, attr, val)
 
     def get_checked(self, selector: str):
         """Get checked state of a given selector.

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -49,6 +49,7 @@ class TestNetworkingBasic(NetworkCase):
         b.wait_in_text("#networking-graphs", "Transmitting")
         b.wait_in_text("#networking-graphs", "Receiving")
 
+        # FIXME: rtl test was flaky, debug it and remove the skip
         b.assert_pixels(
             "#networking", "network-main",
             [
@@ -59,7 +60,7 @@ class TestNetworkingBasic(NetworkCase):
                 ".cockpit-log-panel .pf-c-card__body",
                 "#networking-firewall-summary .pf-c-card__body",
             ],
-            skip_layouts=['mobile']
+            skip_layouts=['mobile', 'rtl']
         )
 
         # Details of test iface

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -40,7 +40,8 @@ class TestAccounts(MachineCase):
         with b.wait_timeout(30):
             b.wait_in_text('#accounts-list', "anton")
 
-        b.assert_pixels("#users-page", "users-page", ignore=["td[data-label='Last active']", "button:contains('more...')"])
+        # FIXME: rtl test was flaky, debug it and remove the skip
+        b.assert_pixels("#users-page", "users-page", ignore=["td[data-label='Last active']", "button:contains('more...')"], skip_layouts=["rtl"])
 
         # There is only one badge and it is for admin
         b.wait_text('#current-account-badge', 'Your account')
@@ -729,7 +730,8 @@ class TestAccounts(MachineCase):
         b.click("#groups-view-toggle")
         b.wait_visible('#groups-list td[data-label="Group name"]:contains("testgroup0")')
 
-        b.assert_pixels("#groups-list tr:contains(testgroup0)", "group-row")
+        # FIXME: rtl test was flaky, debug it and remove the skip
+        b.assert_pixels("#groups-list tr:contains(testgroup0)", "group-row", skip_layouts=["rtl"])
 
         # Delete it
         performGroupAction(b, 'testgroup0', 'Delete group')


### PR DESCRIPTION
This commit introduces a new pixel test scenario for RTL (Right to Left). This scenario keeps using English for language but changes the direction of the language to be RTL.

The reasoning behind this choice is that pixel tests take screenshots in the middle of tests execution, by dynamically adopting the theme, browser size etc for the different scenarios.
However in order to change the UI language one needs to reload the page, which effectively means losing the application state. For this reason, we would need to set the language at the very beginning of each test if we wanted to properly test RTL with a language like Hebrew.

Since this means making a whole test run in another language, we decided that we will for the time being test RTL with English. This is obviously an unrealistic scenario but allows us to view spacing issues at least.