### PR TITLE
bridge: AMD CPU temperature detection

### DIFF
--- a/test/pytest/test_samples.py
+++ b/test/pytest/test_samples.py
@@ -20,12 +20,79 @@ import multiprocessing
 import numbers
 import os
 import unittest
+from unittest import mock
+from pathlib import Path
 
 import pytest
 
 import cockpit.samples
 
 
+@pytest.fixture(scope="session")
+def hwmon_mock(tmpdir_factory):
+    hwmon_dir = Path(tmpdir_factory.mktemp('hwmon'))
+
+    # hwmon1 - no name
+    Path(hwmon_dir, 'hwmon1').mkdir()
+
+    # hwmon2 - no label (on ARM)
+    hwmon2_dir = hwmon_dir / 'hwmon2'
+    hwmon2_dir.mkdir()
+    with open(hwmon2_dir / 'name', 'w') as fp:
+        fp.write('cpu_thermal')
+    with open(hwmon2_dir / 'temp1_input', 'w') as fp:
+        fp.write('32000')
+
+    # hwmon3 - AMD workaround #18098
+    hwmon3_dir = hwmon_dir / 'hwmon3'
+    hwmon3_dir.mkdir()
+    with open(hwmon3_dir / 'name', 'w') as fp:
+        fp.write('k10temp')
+    with open(hwmon3_dir / 'temp1_input', 'w') as fp:
+        fp.write('27500')
+    with open(hwmon3_dir / 'temp1_label', 'w') as fp:
+        fp.write('Tctl')
+    with open(hwmon3_dir / 'temp3_input', 'w') as fp:
+        fp.write('37000')
+    with open(hwmon3_dir / 'temp3_label', 'w') as fp:
+        fp.write('Tccd1')
+
+    # hwmon4 - Intel coretemp
+    hwmon4_dir = hwmon_dir / 'hwmon4'
+    hwmon4_dir.mkdir()
+
+    with open(hwmon4_dir / 'name', 'w') as fp:
+        fp.write('coretemp')
+    with open(hwmon4_dir / 'temp1_input', 'w') as fp:
+        fp.write('47000')
+    with open(hwmon4_dir / 'temp1_label', 'w') as fp:
+        fp.write('Package id 0')
+    with open(hwmon4_dir / 'temp2_input', 'w') as fp:
+        fp.write('46000')
+    with open(hwmon4_dir / 'temp2_label', 'w') as fp:
+        fp.write('Core 0')
+    with open(hwmon4_dir / 'temp3_input', 'w') as fp:
+        fp.write('46000')
+    with open(hwmon4_dir / 'temp3_label', 'w') as fp:
+        fp.write('Core 1')
+    with open(hwmon4_dir / 'temp4_input', 'w') as fp:
+        fp.write('46000')
+    with open(hwmon4_dir / 'temp4_label', 'w') as fp:
+        fp.write('Core 2')
+
+    return str(hwmon_dir)
+
+
+@pytest.fixture(scope="class")
+def samples_fixture(request, hwmon_mock):
+    class MockSamples:
+        def __init__(self):
+            self.hwmon_mock = hwmon_mock
+
+    request.cls.mock = MockSamples()
+
+
+@pytest.mark.usefixtures("samples_fixture")
 class TestSamples(unittest.TestCase):
     def get_checked_samples(self, sampler: cockpit.samples.Sampler) -> cockpit.samples.Samples:
         cls = sampler.__class__
@@ -73,11 +140,15 @@ class TestSamples(unittest.TestCase):
 
     def test_cpu_temperature(self):
         samples = collections.defaultdict(dict)
-        cockpit.samples.CPUTemperatureSampler().sample(samples)
-        if not samples:
-            pytest.xfail('No CPU temperature present')
+        with mock.patch("cockpit.samples.HWMON_PATH", self.mock.hwmon_mock):
+            cockpit.samples.CPUTemperatureSampler().sample(samples)
+            samples = self.get_checked_samples(cockpit.samples.CPUTemperatureSampler())
+            for name, temperature in samples['cpu.temperature'].items():
+                # no name
+                assert 'hwmon1' not in name
 
-        samples = self.get_checked_samples(cockpit.samples.CPUTemperatureSampler())
-        for name, temperature in samples['cpu.temperature'].items():
-            assert name.startswith('/sys/')
-            assert 0 < temperature < 200  # !!
+                assert 20 < temperature < 50
+
+            expected = ['hwmon4/temp4_input', 'hwmon4/temp3_input', 'hwmon4/temp2_input', 'hwmon4/temp1_input', 'hwmon3/temp3_input', 'hwmon2/temp1_input']
+            sensors = [os.path.join(os.path.basename(os.path.dirname(p)), os.path.basename(p)) for p in samples['cpu.temperature']]
+            assert sorted(sensors) == sorted(expected)


### PR DESCRIPTION
For AMD CPU's a Tctl and Tccd1 sensor exists, we want to show the values from Tccd1. HWmon devices do not show up how we expect them, we expect them to show up as 1,2,3 but for k10temp it reports as 1,3 so we never showed the value of Tccd1 as it's temp3_label for me.

I'd love to add a test for the Python bridge but unsure how easy it is. I also dislike the solution a lot, maybe we can count the times we can't open a sensor and if it's more then ~ 5 we break the loop?