### PR TITLE
test: mark testPackageKitCrash flaky on pybridge

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1046,7 +1046,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertFalse(b.is_present("#app button"))
 
     @nondestructive
-    @todoPybridge()
+    @todoPybridge(flaky=True)
     def testPackageKitCrash(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Test passed here https://cockpit-logs.us-east-1.linodeobjects.com/pull-18127-20230105-170902-7f10c11a-fedora-36-pybridge/log.html#113