### PR TITLE
test: Update expected pybridge messages for fedora-37

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1767,6 +1767,9 @@ class MachineCase(unittest.TestCase):
                 "ERROR:asyncio:Task was destroyed but it is pending!",
                 "task:.*Task pending.*cockpit/channels/dbus.py.*"]
 
+            # Python 3.11 traceback annotation
+            self.allowed_messages.append(r"\s*\^+\s*")
+
             self.allowed_messages += [
                 r"Exception ignored on calling ctypes callback function: <function Slot.__init__.<locals>.handler.*",
                 r"asyncio.exceptions.InvalidStateError: invalid state",
@@ -1826,7 +1829,7 @@ class MachineCase(unittest.TestCase):
                 r"AssertionError",
             ]
 
-            self.allowed_messages.append(".* is not in the sudoers file.  This incident will be reported.")
+            self.allowed_messages.append(".* is not in the sudoers file.*")
             self.allowed_messages.append("sudo: no valid sudoers sources found, quitting")
 
             # TestSuperuser.testWrongPasswd, message should go to the caller, not the journal


### PR DESCRIPTION
Python 3.11 marks the throwing part of the line with a `^^^^^` marker of variable length. Ignore these in the pybridge scenario as long as we have ignored tracebacks there.

Fedora 37's sudo also stopped reporting non-suders to Santa's naughty list [1], adjust the error message.
    
[1] https://xkcd.com/838/

----

https://github.com/cockpit-project/bots/pull/4242 bumped TEST_OS_DEFAULT to fedora-37, which now causes pybridge failures [like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4242-20230105-141645-5ea0d915-fedora-37-pybridge-cockpit-project-cockpit/log.html)