### PR TITLE
test: add --python option to image-prepare

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -19,6 +19,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import glob
 import os
 import shlex
 import shutil
@@ -197,6 +198,17 @@ def validate_packages():
             """]
 
 
+def install_python_bridge():
+    subprocess.run([f'{BASE_DIR}/tools/systemd_ctypes'], check=True)
+
+    shutil.rmtree('tmp/wheel', ignore_errors=True)
+    subprocess.run([sys.executable, '-m', 'build', '--no-isolation', '--wheel', '--outdir', 'tmp/wheel'], check=True)
+    wheels = glob.glob('tmp/wheel/*.whl')
+    assert len(wheels) == 1
+
+    return ['--install', *wheels]
+
+
 def main():
     parser = argparse.ArgumentParser(
         description='Prepare testing environment, download images and build and install cockpit',
@@ -204,6 +216,7 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', help='Display verbose progress details')
     parser.add_argument('-q', '--quick', action='store_true', help='Skip unit tests to build faster')
     parser.add_argument('-o', '--overlay', action='store_true', help='Install into existing test/image/ overlay instead of from pristine base image')
+    parser.add_argument('-p', '--python', action='store_true', help='Install the python bridge into the image (experimental)')
     parser.add_argument('image', nargs='?', default=DEFAULT_IMAGE, help='The image to use')
     args = parser.parse_args()
 
@@ -226,6 +239,9 @@ def main():
 
     if not args.quick:
         customize += validate_packages()
+
+    if args.python:
+        customize += install_python_bridge()
 
     # post build/install test preparation
     customize += ["--script", os.path.join(TEST_DIR, "vm.install"), args.image]

--- a/test/run
+++ b/test/run
@@ -12,24 +12,20 @@ tools/webpack-jumpstart --partial || true
 TEST_SCENARIO=${TEST_SCENARIO:-verify}
 
 case $TEST_SCENARIO in
-    verify|devel|firefox|firefox-devel)
-        OPTS="--track-naughties"
+    verify|devel|firefox|firefox-devel|pybridge)
+        RUN_OPTS="--track-naughties"
+        PREPARE_OPTS=""
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || export NODE_ENV=development
-        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || OPTS="$OPTS --coverage"
+        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || RUN_OPTS="$RUN_OPTS --coverage"
+        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%pybridge}" ] || PREPARE_OPTS="$PREPARE_OPTS --python"
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox
-        test/image-prepare --verbose $TEST_OS
-        test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify ${OPTS}
+
+        test/image-prepare --verbose ${PREPARE_OPTS} "${TEST_OS}"
+        test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify ${RUN_OPTS}
         ;;
     dnf-copr*)
         bots/image-customize -v --run-command 'dnf -y copr enable rpmsoftwaremanagement/dnf-nightly && dnf -y --setopt=install_weak_deps=False update' $TEST_OS
         test/image-prepare --verbose --overlay $TEST_OS
-        test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties
-        ;;
-    pybridge)
-        tools/systemd_ctypes
-        test/image-prepare --verbose $TEST_OS
-        python3 -m build --no-isolation --wheel --outdir tmp/wheel
-        bots/image-customize --verbose --no-network --install tmp/wheel/*.whl "${TEST_OS}"
         test/common/run-tests --jobs ${TEST_JOBS:-1} --test-dir test/verify --track-naughties
         ;;
     *)


### PR DESCRIPTION
This will prepare an image with the Python bridge for manual testing, in the same way as was done for the /pybridge scenario in test/run.

Simplify test/run to reflect the fact that this is now just an option to image-prepare.