### PR TITLE
systemd: Fix ObjectManager path for realmd, improve error logging

### DIFF
--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -107,7 +107,7 @@ export class RealmdClient {
         this.dbus_realmd.watch(MANAGER);
         this.dbus_realmd.addEventListener("close", this.onClose);
 
-        this.realms = this.dbus_realmd.proxies(REALM);
+        this.realms = this.dbus_realmd.proxies(REALM, MANAGER);
         this.realms.addEventListener("changed", this.onRealmsChanged);
     }
 

--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -452,6 +452,7 @@ class DBusChannel(Channel):
                 self.send_message(notify=notify)
                 self.send_message(reply=[], id=message['id'])
         except BusError as error:
+            logger.debug("do_watch(%s) caught D-Bus error: %s", message, error.message)
             self.send_message(error=[error.name, [error.message]], id=cookie)
 
     async def do_meta(self, message):

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -88,7 +88,6 @@ ExecStart=/bin/true
 @skipDistroPackage()
 class CommonTests:
     @timeout(900)
-    @todoPybridge()
     def testQualifiedUsers(self):
         m = self.machine
         b = self.browser
@@ -622,6 +621,9 @@ class TestIPA(TestRealms, CommonTests):
         wait(lambda: "status:" not in m.execute("ipa-getcert list"))
 
     @todoPybridge()
+    def testQualifiedUsers(self):
+        super().testQualifiedUsers()
+
     def testUnqualifiedUsers(self):
         '''Extend the common test with 2FA login'''
 
@@ -889,7 +891,6 @@ class TestAD(TestRealms, CommonTests):
 
         pass
 
-    @todoPybridge()
     def testUnqualifiedUsers(self):
         '''Extend the test to check a new AD user'''
 


### PR DESCRIPTION
realmd's ObjectManager is on the primary manager object (`/org/freedesktop/realmd` aka. `MANAGER`), not at proxies()'s default path_namespace `/`.

The C bridge papered over this with its ObjectManager emulation, but the Python bridge does not do that.

Unfortunately testQualifiedUsers is still broken with the Python bridge, it fails later on the Services page with "interactive authentication required". This is unrelated to realmd, though.

-----

[attempt 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18143-20230109-102959-5a0811fe-fedora-37-pybridge/log.html#32)