### PR TITLE
python: Fix "python.error" JS warning

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -40,6 +40,7 @@ import asyncio
 import errno
 import json
 import logging
+import traceback
 import xml.etree.ElementTree as ET
 
 from systemd_ctypes import Bus, BusError, introspection
@@ -330,7 +331,9 @@ class DBusChannel(Channel):
             # actually, should send the fields from the message body
             self.send_message(error=[error.name, [error.message]], id=cookie)
         except Exception as exc:
-            self.send_message(error=['python.error', [str(exc)]], id=cookie)
+            logger.exception("do_call(%s): generic exception", message)
+            printable = '\n'.join(traceback.format_exception(exc))
+            self.send_message(error=['python.error', [printable]], id=cookie)
 
     async def do_add_match(self, message):
         add_match = message['add-match']

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -31,8 +31,8 @@ class cockpit_Config(bus.Object):
     def __init__(self):
         ...
 
-    @bus.Interface.Method(out_types='u', in_types='suuu')
-    def get_u_int(self, name, _minimum, default, _maximum):
+    @bus.Interface.Method(out_types='u', in_types='ssuuu')
+    def get_u_int(self, _section, _key, default, _minimum, _maximum):
         return default
 
 


### PR DESCRIPTION
I am debugging the "python.error" in the log which we get on the Overview page, which is throughly unhelpful. The first commit turns this into both a JS log:
```
Traceback (most recent call last):

  File "/usr/lib/python3.11/site-packages/cockpit/channels/dbus.py", line 321, in do_call
    reply = await self.bus.call_method_async(self.name, path, iface, method, signature, *args,
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 382, in call_method_async
    message = self.message_new_method_call(destination, path, interface, member, types, *args)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 349, in message_new_method_call
    message.append(types, *args)

  File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 156, in append
    assert len(infos) == len(args)
           ^^^^^^^^^^^^^^^^^^^^^^^

AssertionError
index.js:2:637875
```
as well as a journal message:
```
cockpit-ws[5707]: WARNING:cockpit.channels.dbus:do_call({'call': ['/config', 'cockpit.Config', 'GetUInt', ['Session', 'IdleTimeout', 0, 240, 0]], 'id': '4'}): generic exception Traceback (most recent call last):
cockpit-ws[5707]:   File "/usr/lib/python3.11/site-packages/cockpit/channels/dbus.py", line 321, in do_call
cockpit-ws[5707]:     reply = await self.bus.call_method_async(self.name, path, iface, method, signature, *args,
cockpit-ws[5707]:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cockpit-ws[5707]:   File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 382, in call_method_async
cockpit-ws[5707]:     message = self.message_new_method_call(destination, path, interface, member, types, *args)
cockpit-ws[5707]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cockpit-ws[5707]:   File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 349, in message_new_method_call
cockpit-ws[5707]:     message.append(types, *args)
cockpit-ws[5707]:   File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 156, in append
cockpit-ws[5707]:     assert len(infos) == len(args)
cockpit-ws[5707]:            ^^^^^^^^^^^^^^^^^^^^^^^
cockpit-ws[5707]: AssertionError
```

The second commit fixes the root cause of this, the cockpit.Config.GetUInt() stub was wrong. As the next step, I'm actually going to implement it, which will fix a few more tests.