### PR TITLE
python: Implement /config and /environment internal bus objects

### DIFF
--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -756,7 +756,7 @@ QUnit.test.skipWithPybridge("separate dbus connections for channel groups", func
     });
 });
 
-QUnit.test.skipWithPybridge("cockpit.Config internal D-Bus API", async assert => {
+QUnit.test("cockpit.Config internal D-Bus API", async assert => {
     const dbus = cockpit.dbus(null, { bus: "internal" });
 
     // Get temp config dir to see where to place our test config

--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -767,6 +767,7 @@ QUnit.test.skipWithPybridge("cockpit.Config internal D-Bus API", async assert =>
 [SomeSection]
 SomeA = one
 SomethingElse = 2
+LargeNum = 12345
 
 [Other]
 Flavor=chocolate
@@ -788,8 +789,17 @@ Empty=
     assert.equal(await proxy.GetUInt("SomeSection", "NotExisting", 10, 100, 0), 10);
     // out of bounds, clamp to minimum
     assert.equal(await proxy.GetUInt("SomeSection", "SomethingElse", 42, 50, 5), 5);
+    // out of bounds, clamp to maximum
+    assert.equal(await proxy.GetUInt("SomeSection", "LargeNum", 42, 50, 5), 50);
+    // not an integer value, returns default
+    assert.equal(await proxy.GetUInt("SomeSection", "SomeA", 10, 100, 0), 10);
 
-    // test GetString with non-existing section/key
+    // test GetString with non-existing section
+    assert.rejects(proxy.GetString("UnknownSection", "SomeKey"),
+                   /key.*UnknownSection.*not exist/,
+                   "unknown section raises an error");
+
+    // test GetString with non-existing key in existing section
     assert.rejects(proxy.GetString("SomeSection", "UnknownKey"),
                    /key.*UnknownKey.*not exist/,
                    "unknown key raises an error");

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -30,6 +30,7 @@ from systemd_ctypes import EventLoopPolicy, bus
 
 from .channel import ChannelRoutingRule
 from .channels import CHANNEL_TYPES
+from .config import Config, Environment
 from .internal_endpoints import EXPORTS
 from .packages import Packages
 from .remote import HostRoutingRule
@@ -62,6 +63,8 @@ class Bridge(Router):
         self.superuser_rule = SuperuserRoutingRule(self, args.privileged)
         self.internal_bus.export('/superuser', self.superuser_rule)
         self.internal_bus.export('/packages', self.packages)
+        self.internal_bus.export('/config', Config())
+        self.internal_bus.export('/environment', Environment())
 
         super().__init__([
             HostRoutingRule(self),

--- a/src/cockpit/config.py
+++ b/src/cockpit/config.py
@@ -15,10 +15,65 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import configparser
+import logging
 import os
 
 from pathlib import Path
 
+from systemd_ctypes import bus
+
+logger = logging.getLogger(__name__)
+
 ETC_COCKPIT = Path('/etc/cockpit')
 XDG_CONFIG_HOME = Path(os.getenv('XDG_CONFIG_HOME') or os.path.expanduser('~/.config'))
 DOT_CONFIG_COCKPIT = XDG_CONFIG_HOME / 'cockpit'
+
+
+class Config(bus.Object, interface='cockpit.Config'):
+    def __init__(self):
+        self.reload()
+
+    @bus.Interface.Method(out_types='s', in_types='ss')
+    def get_string(self, section, key):
+        try:
+            return self.config[section][key]
+        except KeyError:
+            raise bus.BusError('cockpit.Config.KeyError', f'key {key} in section {section} does not exist')
+
+    @bus.Interface.Method(out_types='u', in_types='ssuuu')
+    def get_u_int(self, section, key, default, maximum, minimum):
+        try:
+            value = self.config[section][key]
+        except KeyError:
+            return default
+
+        try:
+            int_val = int(value)
+        except ValueError:
+            logger.warning(f'cockpit.conf: [{section}] {key} is not an integer')
+            return default
+
+        return min(max(int_val, minimum), maximum)
+
+    @bus.Interface.Method()
+    def reload(self):
+        self.config = configparser.ConfigParser(interpolation=None)
+
+        config_dirs = os.environ.get('XDG_CONFIG_DIRS', '/etc').split(':')
+        for config_dir in config_dirs:
+            config_file = os.path.join(config_dir, 'cockpit', 'cockpit.conf')
+            if os.path.exists(config_file):
+                logger.debug("cockpit.Config: loading %s", config_file)
+                self.config.read(config_file)
+                break
+
+        # it's ok to not have a config file and thus leave self.config empty
+
+
+class Environment(bus.Object, interface='cockpit.Environment'):
+    variables = bus.Interface.Property('a{ss}')
+
+    @variables.getter
+    def get_variables(self):
+        return os.environ.copy()

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -27,15 +27,6 @@ from systemd_ctypes import bus
 logger = logging.getLogger(__name__)
 
 
-class cockpit_Config(bus.Object):
-    def __init__(self):
-        ...
-
-    @bus.Interface.Method(out_types='u', in_types='ssuuu')
-    def get_u_int(self, _section, _key, default, _minimum, _maximum):
-        return default
-
-
 class cockpit_LoginMessages(bus.Object):
     messages: Optional[str] = None
 
@@ -96,7 +87,6 @@ class cockpit_User(bus.Object):
 
 EXPORTS = [
     ('/LoginMessages', cockpit_LoginMessages),
-    ('/config', cockpit_Config),
     ('/machines', cockpit_Machines),
     ('/user', cockpit_User),
 ]

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -29,7 +29,7 @@ from systemd_ctypes import bus
 from . import config
 
 VERSION = '300'
-logger = logging.getLogger('cockpit.packages')
+logger = logging.getLogger(__name__)
 
 
 # Sorting is important because the checksums are dependent on the order we

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -22,7 +22,7 @@ import logging
 from typing import Dict, Optional
 
 
-logger = logging.getLogger('cockpit.protocol')
+logger = logging.getLogger(__name__)
 
 
 class CockpitProtocolError(Exception):

--- a/test/pytest/test_browser.py
+++ b/test/pytest/test_browser.py
@@ -33,5 +33,5 @@ def test_browser(html):
 
     # Merge 2>&1 so that pytest displays an interleaved log
     subprocess.run(['test/common/tap-cdp', f'{BUILDDIR}/test-server',
-                    sys.executable, '-m', *coverage, 'cockpit.bridge',
+                    sys.executable, '-m', *coverage, 'cockpit.bridge', '--debug',
                     f'./dist/{html}'], check=True, stderr=subprocess.STDOUT)

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -20,7 +20,7 @@
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, todoPybridge, test_main
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, test_main
 
 
 @nondestructive
@@ -121,7 +121,6 @@ class TestMenu(MachineCase):
         # don't actually fail this test
         b.allow_oops = True
 
-    @todoPybridge()
     def testSessionTimeout(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
These behave like the C bridge, except that the bridge now logs a
warning if a config key is expected to be an integer, but isn't. That
will help admins to track down why their config change is not effective.

----

 - Builds on top of PR #18147