### PR TITLE
packagekit: Avoid redundant property GetAll() call on update transaction

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -144,8 +144,9 @@ export function watchTransaction(transactionPath, signalHandlers, notifyHandler)
         notifyReturn = client.watch(transactionPath);
         subscriptions.push(notifyReturn);
         client.addEventListener("notify", reply => {
-            if (transactionPath in reply.detail && transactionInterface in reply.detail[transactionPath])
-                notifyHandler(reply.detail[transactionPath][transactionInterface], transactionPath);
+            const iface = reply?.detail?.[transactionPath]?.[transactionInterface];
+            if (iface)
+                notifyHandler(iface, transactionPath);
         });
     }
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -396,6 +396,8 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         b.click("#available-updates button#install-all")
         b.wait_visible(".progress-main-view")
         b.wait_not_present(".progress-main-view button.pf-m-secondary")
+        # gets stuck at vanilla, which needs install_lockfile
+        b.wait_in_text("#app div.progress-description", "vanilla 1.0-2")
 
         # update log only exists in the expander, collapsed by default
         self.assertFalse(b.is_visible("#update-log"))

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -23,7 +23,7 @@ import time
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
+from testlib import nondestructive, skipDistroPackage, skipImage, test_main
 
 
 WAIT_SCRIPT = """
@@ -282,7 +282,6 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         m.execute("rpm -q kpatch-patch-" + sanitized_kernel_ver)
 
     @nondestructive
-    @todoPybridge()
     def testBasic(self):
         # no security updates, no changelogs
         b = self.browser
@@ -438,7 +437,6 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
 
     @skipImage("TODO: Packagekit on Arch does not detect the pear update", "arch")
     @skipImage("tracer not available", *OSesWithoutTracer)
-    @todoPybridge(".updates-success-table randomly appears or not with python bridge", flaky=True)
     def testTracer(self):
         b = self.browser
         m = self.machine
@@ -984,7 +982,6 @@ ExecStart=/usr/local/bin/{packageName}
 
         # seems we can't verify that the description has a scrollbar
 
-    @todoPybridge("sometimes locks up packagekit hard, warning: python.error in the JS log", flaky=True)
     def testRebootAfterSuccess(self):
         b = self.browser
         m = self.machine
@@ -1048,7 +1045,6 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertFalse(b.is_present("#app button"))
 
     @nondestructive
-    @todoPybridge(flaky=True)
     def testPackageKitCrash(self):
         b = self.browser
         m = self.machine
@@ -1154,7 +1150,6 @@ ExecStart=/usr/local/bin/{packageName}
 @skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
 @skipImage("Image uses OSTree", "fedora-coreos")
 class TestWsUpdate(NoSubManCase):
-    @todoPybridge()
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which
         # restarts the service and terminates the connection. As we can't


### PR DESCRIPTION
This has always been racy due to the short 0.5s timeout. This often timed out    
with the Python bridge, as PackageKit isn't the fastest thing on earth. Butit's    
also not necessary at all: We already get told about property updates via the    
`notify` handler.    
    
So let's rework this to make the whole structure a lot simpler: Turn    
ApplyUpdates into a pure functional component, and drop its second    
watchTransaction() for packages. Let OsUpdates' watchTransaction() pick up    
`Packages` signals and all property values. This works because the initial    
`notify` event always includes the full set of properties.    
    
Also improve the initialization: At the beginning of an update we usually get    
`Percentage` properties from PackageKit before the first `Package` signal. If    
that happens, move from the "Initializing" empty state to the progress bar    
already. That provides better visual feedback, and it's also what    
TestUpdates.testBasic expects. With that, `lastAction` can now be `undefined`,    
so handle that in the JSX. 

---

This should fix *all* check-packagekit tests in the pybridge scenario.