### PR TITLE
pybridge: Don't timeout D-Bus method calls by default

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -289,7 +289,7 @@ class DBusChannel(Channel):
 
     async def do_call(self, message):
         path, iface, method, args = message['call']
-        timeout = message.get('timeout')
+        timeout = message.get('timeout', 2**64 - 1)
         cookie = message.get('id')
         flags = message.get('flags')
         type = message.get('type')

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase
-from testlib import test_main, todoPybridge
+from testlib import test_main
 
 
 class TestStorageFormat(StorageCase):
@@ -90,7 +90,6 @@ class TestStorageFormat(StorageCase):
         else:
             check_type("ntfs", 128)
 
-    @todoPybridge()
     def testFormatCancel(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import time
+
 import parent  # noqa: F401
 from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
 
@@ -123,6 +125,8 @@ session include system-auth
 
         b.open_superuser_dialog()
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+        # Let the dialog sit there for 45 seconds, to test that this doesn't trigger a D-Bus timeout.
+        time.sleep(45)
         b.set_input_text(".pf-c-modal-box:contains('Switch to administrative access') input", "foobar")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "universe and everything")


### PR DESCRIPTION
This is what the C bridge does, and some parts of Cockpit rely on it.