### PR TITLE
Serve po.js in the Python Bridge

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -184,7 +184,6 @@ class Package:
 
             yield f'{base}.{ext}'
             yield f'{base}.min.{ext}'
-            yield f'{base}.{ext}'
             yield f'{base}.{ext}.gz'
             yield f'{base}.min.{ext}.gz'
 

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -1,0 +1,28 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from cockpit.packages import parse_accept_language
+
+
+@pytest.mark.parametrize("test_input,expected", [
+                         ('de-at, zh-CH, en,', ['de-at', 'zh-CH', 'en']),
+                         ('es-es, nl;q=0.8, fr;q=0.9', ['es-es', 'fr', 'nl']),
+                         ('fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', ['fr-CH', 'fr', 'en', 'de', '*'])])
+def test_parse_accept_language(test_input, expected):
+    assert parse_accept_language(test_input) == expected


### PR DESCRIPTION
Implement serving po.js files based on the Accept-Language header. So far this only implements it for normal pages, for the shell we need to rewrite the currently used `/*/po.js` implementation into something else (follow up).


![Screenshot from 2023-01-11 18-38-59](https://user-images.githubusercontent.com/67428/211878439-a59bbb5f-986e-4bf2-bac2-1fe4c35cd48f.png)

