### PR TITLE
python: Fix D-Bus timeout

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -289,10 +289,17 @@ class DBusChannel(Channel):
 
     async def do_call(self, message):
         path, iface, method, args = message['call']
-        timeout = message.get('timeout', 2**64 - 1)
         cookie = message.get('id')
         flags = message.get('flags')
         type = message.get('type')
+
+        timeout = message.get('timeout')
+        if timeout is not None:
+            # sd_bus timeout is µs, cockpit API timeout is ms
+            timeout *= 1000
+        else:
+            # sd_bus has no "indefinite" timeout, so use MAX_UINT64
+            timeout = 2 ** 64 - 1
 
         # We have to figure out the signature of the call.  Either we got told it:
         signature = type


### PR DESCRIPTION
sd_bus_call()'s timeout is in microseconds, while our API is in milliseconds. Convert the timeout appropriately.

[1] https://www.freedesktop.org/software/systemd/man/sd_bus_call.html

----

This should "accidentally" fix most PackageKit tests, [letting this run once](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18163-20230112-111112-e9b5d701-fedora-37-pybridge/log.html) . But PR #18155 fixes them in a much more elegant way, so I'll wait for that to land to avoid collisions on removing `@todoPybridge`.