### PR TITLE
python: allow filtering of log messages on module names

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -154,6 +154,23 @@ def try_to_receive_stderr():
             os.close(stderr_fd)
 
 
+def setup_logging(debug: bool):
+    """Setup our logger with optional filtering of modules if COCKPIT_DEBUG env is set"""
+
+    modules = os.getenv('COCKPIT_DEBUG', '')
+    logging.basicConfig(format='%(name)s-%(levelname)s: %(message)s')
+
+    if debug or modules == 'all':
+        logging.getLogger().setLevel(level=logging.DEBUG)
+    elif modules:
+        for module in modules.split(','):
+            module = module.strip()
+            if not module:
+                continue
+
+            logging.getLogger(module).setLevel(logging.DEBUG)
+
+
 def main() -> None:
     # The --privileged bridge gets spawned with its stderr being consumed by a
     # pipe used for reading authentication-related message from sudo.  The
@@ -171,8 +188,7 @@ def main() -> None:
     parser.add_argument('--version', action='store_true', help='Show Cockpit version information')
     args = parser.parse_args()
 
-    if args.debug:
-        logging.basicConfig(level=logging.DEBUG)
+    setup_logging(args.debug)
 
     if args.packages:
         Packages().show()

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -74,7 +74,7 @@ class CockpitProtocol(asyncio.Protocol):
                 logger.debug('channel control received %s', message)
                 self.channel_control_received(channel, command, message)
             else:
-                logging.debug('transport control received %s', message)
+                logger.debug('transport control received %s', message)
                 self.transport_control_received(command, message)
 
     def consume_one_frame(self, view):

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1785,7 +1785,7 @@ class MachineCase(unittest.TestCase):
         # HACK: pybridge bugs
         if os.environ.get("TEST_SCENARIO") == "pybridge":
             self.allowed_messages += [
-                "ERROR:asyncio:Task was destroyed but it is pending!",
+                "asyncio-ERROR: Task was destroyed but it is pending!",
                 "task:.*Task pending.*cockpit/channels/dbus.py.*"]
 
             # Python 3.11 traceback annotation
@@ -1794,7 +1794,7 @@ class MachineCase(unittest.TestCase):
             self.allowed_messages += [
                 r"Exception ignored on calling ctypes callback function: <function Slot.__init__.<locals>.handler.*",
                 r"asyncio.exceptions.InvalidStateError: invalid state",
-                r"ERROR:asyncio:Exception in callback _Transport._read_ready.*",
+                r"asyncio-ERROR: Exception in callback _Transport._read_ready.*",
                 r"handle: <Handle _Transport._read_ready\(\)>",
                 r"Traceback \(most recent call last\):",
                 r"File .*asyncio/events.py.*",
@@ -1810,7 +1810,7 @@ class MachineCase(unittest.TestCase):
                 r"future.set_result\(message\)"]
 
             self.allowed_messages += [
-                r"ERROR:asyncio:Exception in callback BusMessage._coroutine_task_complete.*",
+                r"asyncio-ERROR: Exception in callback BusMessage._coroutine_task_complete.*",
                 r"handle: .*Handle BusMessage._coroutine_task_complete.*",
                 r"File .*/systemd_ctypes/bus.py.* in _coroutine_task_complete",
                 r"self.reply_method_function_return_value.*",

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -192,7 +192,7 @@ class TestSystemInfo(MachineCase):
             b.wait_text("#system_uptime", "4 months")
 
         self.allow_journal_messages("error loading contents of os-release: .*",  # C bridge
-                                    "Neither /etc/os-release nor /usr/lib/os-release exists",  # py bridge
+                                    ".* Neither /etc/os-release nor /usr/lib/os-release exists",  # py bridge
                                     "sudo: unable to resolve host host1.cockpit.lan: .*")
 
     def set_change_time_dialog_mode(self, mode):


### PR DESCRIPTION
In the Python bridge we setup a logger per module such as "cockpit.packages". By setting the COCKPIT_DEBUG environment variable we can now specify which modules we want to see logs for (comma separate values). If you want to see logging for all modules set COCKPIT_DEBUG to "all".

Setting COCKPIT_DEBUG also sets the log level to debug.