### PR TITLE
containers: Make webpack-jumpstart --partial in unit test opportunistic

### DIFF
--- a/containers/unit-tests/start
+++ b/containers/unit-tests/start
@@ -86,7 +86,7 @@ class SourceDirectory(PodmanTemporaryDirectory):
             if args.wait:
                 run([f'{self.name}/tools/webpack-jumpstart', '--wait'], check=True)
             elif not args.no_jumpstart:
-                run([f'{self.name}/tools/webpack-jumpstart', '--partial'], check=True)
+                run([f'{self.name}/tools/webpack-jumpstart', '--partial'], check=False)
 
 
 class ResultsDirectory(PodmanTemporaryDirectory):


### PR DESCRIPTION
This *will* fail on any PR which changes package.json/rebuilds node_modules, with "Unable to find any suitable commit". That's fine, we have to bite the bullet and rebuild the webpack ourselves then. We could alternatively use `--wait`, but that would not save wallclock time, just some CPU usage.

Do the same thing as test/run, and ignore failures.

----

This broke e.g. in PR #18157 [like this](https://github.com/cockpit-project/cockpit/actions/runs/3901936824/jobs/6664384863). This is also the reason why each npm-update bot PR like PR #18414 [fails its first run](https://github.com/cockpit-project/cockpit/actions/runs/3870398368/attempts/1), and the [retry](https://github.com/cockpit-project/cockpit/actions/runs/3870398368) works after the "build jumpstart cache" workflow finishes.