### PR TITLE
package.json: update xterm and bring xterm-addon-canvas

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "remarkable": "2.0.1",
     "throttle-debounce": "2.3.0",
     "uuid": "7.0.3",
-    "xterm": "4.18.0"
+    "xterm": "5.1.0",
+    "xterm-addon-canvas": "0.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",


### PR DESCRIPTION
https://paste.centos.org/view/2e4fad7a

Pasting the reproducer also here:


```shell
[kkoukiou@sequioa cockpit]$ git clean -fdx
[kkoukiou@sequioa cockpit]$ git reset --hard origin/main 
HEAD is now at 91b3d1949 python: Fix D-Bus timeout
[kkoukiou@sequioa cockpit]$ ./tools/make-bots
  FETCH    bots  
  CLONE    bots  [ref: main]
[kkoukiou@sequioa cockpit]$ ./tools/node-modules checkout 
  REMOVE   node_modules
  CLONE    node_modules  [ref: 3062b3b024b2db32f6f66f97e303f4fc190d085c]
[kkoukiou@sequioa cockpit]$ vim package.json 
[kkoukiou@sequioa cockpit]$ git add package.json
[kkoukiou@sequioa cockpit]$ git commit -m "package.json: update xterm and bring xterm-addon-canvas"
[main 61f81c44e] package.json: update xterm and bring xterm-addon-canvas
 1 file changed, 2 insertions(+), 1 deletion(-)
[kkoukiou@sequioa cockpit]$ ./tools/node-modules install
+ tee package.json
+ wait -n
+ npm install --ignore-scripts
npm WARN deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated popper.js@1.16.1: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
npm WARN deprecated core-js@2.6.12: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.

added 801 packages, and audited 802 packages in 59s

144 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
+ cp package.json node_modules/.package.json
+ tar '--directory=node_modules' --create .
  INDEX    node_modules
  REMOVE   node_modules
  CLONE    node_modules  [ref: f970a5060ea663166e206b013578e35f6542f3fd]
Next steps:

  - git add node_modules && git commit
  - tools/node-modules push

[kkoukiou@sequioa cockpit]$ ./tools/node-modules push 
  PUSH     node-cache sha-f970a5060ea663166e206b013578e35f6542f3fd
Enumerating objects: 28886, done.
Counting objects: 100% (28886/28886), done.
Delta compression using up to 4 threads
Compressing objects: 100% (19086/19086), done.
Writing objects: 100% (28886/28886), 28.55 MiB | 1.23 MiB/s, done.
Total 28886 (delta 7715), reused 28264 (delta 7633), pack-reused 0
remote: Resolving deltas: 100% (7715/7715), done.
To github.com:cockpit-project/node-cache
 * [new tag]           sha-f970a5060ea663166e206b013578e35f6542f3fd -> sha-f970a5060ea663166e206b013578e35f6542f3fd
[kkoukiou@sequioa cockpit]$ git add node_modules
[kkoukiou@sequioa cockpit]$ git commit --am
[main 389a5c21f] package.json: update xterm and bring xterm-addon-canvas
 Date: Thu Jan 12 16:18:05 2023 +0100
 2 files changed, 3 insertions(+), 2 deletions(-)
[kkoukiou@sequioa cockpit]$ git show
commit 389a5c21f55df9d35d6a1ccba01c064a4ee8bee7 (HEAD -> main)
Author: Katerina Koukiou <kkoukiou@redhat.com>
Date:   Thu Jan 12 16:18:05 2023 +0100

    package.json: update xterm and bring xterm-addon-canvas

diff --git node_modules node_modules
index 3062b3b02..f970a5060 160000
--- node_modules
+++ node_modules
@@ -1 +1 @@
-Subproject commit 3062b3b024b2db32f6f66f97e303f4fc190d085c
+Subproject commit f970a5060ea663166e206b013578e35f6542f3fd
diff --git package.json package.json
index 6d95477a1..3126b727a 100644
--- package.json
+++ package.json
@@ -20,7 +20,8 @@
     "remarkable": "2.0.1",
     "throttle-debounce": "2.3.0",
     "uuid": "7.0.3",
-    "xterm": "4.18.0"
+    "xterm": "5.1.0",
+    "xterm-addon-canvas": "0.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

```