### PR TITLE
python: Add temporary ${libexecdir} expansion in manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ Makefile.in
 /cockpit-*.xz
 /cockpit-askpass
 /cockpit-bridge
-/cockpit-bridge.pyz
 /cockpit-certificate-ensure
 /cockpit-pcp
 /cockpit-session

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -177,6 +177,7 @@ export class RealmdClient {
                     const proc = cockpit.spawn([helper, "ipa", "request", kerberos.RealmName, user],
                                                { superuser: "require", err: "message" });
                     proc.input(password);
+                    proc.catch(ex => console.warn("Failed to run", helper, "ipa request:", ex.toString()));
                     return proc;
                 })
                 .catch(() => true); // no Kerberos domain? nevermind then


### PR DESCRIPTION
This provides the moral equivalent of what commit 94394128e8b6 did for    
the C bridge. However, we want to avoid parameterizing the py bridge    
with ./configure arguments, to keep it buildable with pip. Detect the    
path at runtime instead, there are only a few plausible options anyway.    
This is a temporary hack until we eliminate all `${libexecdir}` from    
manifests.    
    
This fixes joining an IPA domain, as it now finds    
cockpit-certificate-helper. TestIPA.testQualifiedUsers now gets much    
further, unfortunately it still fails on the remote host part of the    
test, as cockpit-ssh does not work yet.    
    
It also fixes the cockpit-{ssh,pcp,askpass} paths in the manifests, but as we    
don't do that routing yet, it does not fix any of the ssh/pcp tests yet.    
But it is a necessary prerequisite for actually implementing these.    

-----

Unfortunately the visible effect to the pybridge scenario is underwhelming, but this still feels like a stepping stone for implementing further functionality.