### PR TITLE
test: Rewrite chromium-cdp-driver.js using async/await

### DIFF
--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -108,12 +108,6 @@ function setupLogging(client) {
         if (details.className === "PhWaitCondTimeout")
             return;
 
-        // HACK: Sometimes on Firefox >= 77 xterm.js can raise following message when Cockpit is reloaded:
-        // `InvalidStateError: An attempt was made to use an object that is not, or is no longer, usable`
-        // It does not oops, everything is functional, safe to ignore for now
-        if (details.className === "InvalidStateError")
-            return;
-
         process.stderr.write(details.description || details.text || JSON.stringify(details) + "\n");
 
         unhandledExceptions.push(details.message ||

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -372,6 +372,7 @@ CDP(options)
                                 currentExecId = null;
                                 // HACK: Runtime.evaluate() fails with "Debugger: expected Debugger.Object, got Proxy"
                                 // translate that into a proper timeout exception
+                                // https://bugzilla.mozilla.org/show_bug.cgi?id=1702860
                                 if (err.response && err.response.data && err.response.data.indexOf("setTimeout handler*ph_wait_cond") > 0) {
                                     success(seq, {
                                         exceptionDetails: {


### PR DESCRIPTION
This makes the main function much less nested and simplifies the error handling. Also move to the readline API [1] instead of doing the buffering ourselves.
    
[1] https://nodejs.org/api/readline.html