### PR TITLE
selinux: Allow cockpit-session to write user's home

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -172,6 +172,9 @@ userdom_spec_domtrans_all_users(cockpit_session_t)
 userdom_noatsecure_login_userdomain(cockpit_session_t)
 usermanage_read_crack_db(cockpit_session_t)
 
+# pam_google_authenticator needs to create and rename files in home dir
+userdom_manage_user_home_content(cockpit_session_t)
+
 optional_policy(`
     ssh_agent_signal(cockpit_session_t)
 ')


### PR DESCRIPTION
pam_google_authenticator creates a new ~/.google_authenticator.TMPSUFFIX and renames it.

https://bugzilla.redhat.com/show_bug.cgi?id=2157901

----

See https://bugzilla.redhat.com/show_bug.cgi?id=2157901#c6 for how I reproduced and tested this. We don't have the google-authenticator package on our images, and the OTP token computation also is quite complicated to automate.