### PR TITLE
python: Add support for freezing endpoints

### DIFF
--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -123,9 +123,9 @@ class SuperuserRoutingRule(PeerStateListener, RoutingRule, bus.Object, interface
         logger.debug('Peer %s state changed -> %s', peer.name, event)
         if event == 'connected':
             self.current = 'init'
+            self.peer = peer
 
         elif event == 'init':
-            self.peer = peer
             self.current = peer.name
             if self.startup is not None:
                 self.startup.success(self)

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -3,7 +3,7 @@
 import os
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
+from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipImage, test_main
 from fmf_metadata import FMF
 
 
@@ -104,7 +104,6 @@ class TestLongRunning(MachineCase):
         self.addCleanup(m.execute, "systemctl stop cockpit-longrunning.service 2>/dev/null && systemctl reset-failed cockpit-longrunning.service || true")
 
     # sometimes fails with: unexpected failure of GetUnit(cockpit-longrunning.service): Not permitted to perform this action
-    @todoPybridge("fails unpredictably with python bridge", flaky=True)
     def testBasic(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -738,7 +738,6 @@ class TestCurrentMetrics(MachineCase):
                                               "systemctl --user stop cockpittest.slice 2>/dev/null || true'")
         login(self)
 
-    @todoPybridge()
     def testCPU(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -202,7 +202,6 @@ class TestSystemInfo(MachineCase):
         b.wait_in_text("#system_information_change_systime .pf-c-form__group-label:contains('Set time') + div > .pf-c-select > button", mode)
 
     @skipImage("TODO: systemd-timesyncd responds too slow on Arch Linux", "arch")
-    @todoPybridge()
     def testTime(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
This is my best guess about why `TestLongRunning.testBasic` is failing.  Let's see if it helps.