### PR TITLE
test: Don't swallow duplicate Browser messages by default

### DIFF
--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -66,7 +66,6 @@ const messages = [];
 let logPromiseResolver;
 let nReportedLogMessages = 0;
 const unhandledExceptions = [];
-const shownMessages = []; // Show every message just once, keep here seen messages
 
 function clearExceptions() {
     unhandledExceptions.length = 0;
@@ -78,13 +77,8 @@ function setupLogging(client) {
 
     client.Runtime.consoleAPICalled(info => {
         const msg = info.args.map(v => (v.value || "").toString()).join(" ");
-
         messages.push([info.type, msg]);
-        if (shownMessages.indexOf(msg) == -1) {
-            if (!enable_debug) // disable message de-duplication in --trace mode
-                shownMessages.push(msg);
-            process.stderr.write("> " + info.type + ": " + msg + "\n");
-        }
+        process.stderr.write("> " + info.type + ": " + msg + "\n");
 
         resolveLogPromise();
     });
@@ -124,15 +118,7 @@ function setupLogging(client) {
         messages.push(["cdp", msg]);
         /* Ignore authentication failure log lines that don't denote failures */
         if (!(msg.url || "").endsWith("/login") || (msg.text || "").indexOf("401") === -1) {
-            const orig = { ...msg };
-            delete msg.timestamp;
-            delete msg.args;
-            const msgstr = JSON.stringify(msg);
-            if (shownMessages.indexOf(msgstr) == -1) {
-                if (!enable_debug) // disable message de-duplication in --trace mode
-                    shownMessages.push(msgstr);
-                process.stderr.write("CDP: " + JSON.stringify(orig) + "\n");
-            }
+            process.stderr.write("CDP: " + JSON.stringify(msg) + "\n");
         }
         resolveLogPromise();
     });

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -82,7 +82,6 @@ const messages = [];
 let logPromiseResolver;
 let nReportedLogMessages = 0;
 const unhandledExceptions = [];
-const shownMessages = []; // Show every message just once, keep here seen messages
 
 function clearExceptions() {
     unhandledExceptions.length = 0;
@@ -95,11 +94,7 @@ function setupLogging(client) {
     client.Runtime.consoleAPICalled(info => {
         const msg = info.args.map(v => (v.value || "").toString()).join(" ");
         messages.push([info.type, msg]);
-        if (shownMessages.indexOf(msg) == -1) {
-            if (!enable_debug) // disable message de-duplication in --trace mode
-                shownMessages.push(msg);
-            process.stderr.write("> " + info.type + ": " + msg + "\n");
-        }
+        process.stderr.write("> " + info.type + ": " + msg + "\n");
 
         resolveLogPromise();
     });
@@ -160,15 +155,7 @@ function setupLogging(client) {
             messages.push(["cdp", msg]);
             /* Ignore authentication failure log lines that don't denote failures */
             if (!(msg.url || "").endsWith("/login") || (text || "").indexOf("401") === -1) {
-                const orig = { ...msg };
-                delete msg.timestamp;
-                delete msg.args;
-                const msgstr = JSON.stringify(msg);
-                if (shownMessages.indexOf(msgstr) == -1) {
-                    if (!enable_debug) // disable message de-duplication in --trace mode
-                        shownMessages.push(msgstr);
-                    process.stderr.write("CDP: " + JSON.stringify(orig) + "\n");
-                }
+                process.stderr.write("CDP: " + JSON.stringify(msg) + "\n");
             }
             resolveLogPromise();
         }


### PR DESCRIPTION
But leave the code in place in case we need to switch this on again.