### PR TITLE
storage: Assorted fixes, part 17

### DIFF
--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -195,10 +195,10 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
     const crypto_extra_options = unparse_options(crypto_split_options);
 
     let [, old_dir, old_opts] = get_fstab_config(block, true);
-    if (!old_opts || old_opts == "defaults")
+    if (!old_opts)
         old_opts = initial_mount_options(client, block);
 
-    const split_options = parse_options(old_opts == "defaults" ? "" : old_opts);
+    const split_options = parse_options(old_opts);
     extract_option(split_options, "noauto");
     const opt_ro = extract_option(split_options, "ro");
     const opt_never_auto = extract_option(split_options, "x-cockpit-never-auto");

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -308,7 +308,7 @@ export function mounting_dialog(client, block, mode, forced_options) {
                                 .then(maybe_mount));
                     else if (old_config && !new_config)
                         return block.RemoveConfigurationItem(old_config, {});
-                    else if (old_config && new_config && (new_dir != old_dir || new_opts != old_opts))
+                    else if (old_config && new_config)
                         return (block.UpdateConfigurationItem(old_config, new_config, {})
                                 .then(maybe_mount));
                     else if (new_config && !is_mounted(client, block))

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -253,7 +253,10 @@ export function mounting_dialog(client, block, mode, forced_options) {
                                                     if (mounted_at == new_dir)
                                                         return;
                                                     return (undo()
-                                                            .then(() => client.mount_at(block, old_dir))
+                                                            .then(() => {
+                                                                if (is_filesystem_mounted)
+                                                                    return client.mount_at(block, old_dir);
+                                                            })
                                                             .catch(ignored_error => {
                                                                 console.warn("Error during undo:", ignored_error);
                                                             })

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -254,11 +254,10 @@ export function mounting_dialog(client, block, mode, forced_options) {
                                                         return;
                                                     return (undo()
                                                             .then(() => client.mount_at(block, old_dir))
-                                                            .then(() => Promise.reject(error))
                                                             .catch(ignored_error => {
                                                                 console.warn("Error during undo:", ignored_error);
-                                                                return Promise.reject(error);
-                                                            }));
+                                                            })
+                                                            .then(() => Promise.reject(error)));
                                                 }));
                                     }));
                         }));

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -67,7 +67,7 @@ export function get_fstab_config(block, also_child_config) {
 
     if (config && utils.decode_filename(config[1].type.v) != "swap") {
         let dir = utils.decode_filename(config[1].dir.v);
-        const opts = (utils.decode_filename(config[1].opts.v)
+        let opts = (utils.decode_filename(config[1].opts.v)
                 .split(",")
                 .filter(function (s) { return s.indexOf("x-parent") !== 0 })
                 .join(","));
@@ -77,6 +77,8 @@ export function get_fstab_config(block, also_child_config) {
                 .join(","));
         if (dir[0] != "/")
             dir = "/" + dir;
+        if (opts == "defaults")
+            opts = "";
         return [config, dir, opts, parents];
     } else
         return [];
@@ -174,7 +176,7 @@ export function mounting_dialog(client, block, mode, forced_options) {
     const [old_config, old_dir, old_opts, old_parents] = get_fstab_config(block, true);
     const options = old_config ? old_opts : initial_tab_options(client, block, true);
 
-    const split_options = parse_options(options == "defaults" ? "" : options);
+    const split_options = parse_options(options);
     extract_option(split_options, "noauto");
     const opt_never_auto = extract_option(split_options, "x-cockpit-never-auto");
     const opt_ro = extract_option(split_options, "ro");
@@ -499,7 +501,7 @@ export class FilesystemTab extends React.Component {
 
         const is_filesystem_mounted = is_mounted(self.props.client, block);
         const [old_config, old_dir, old_opts, old_parents] = get_fstab_config(block, true);
-        const split_options = parse_options(old_opts == "defaults" ? "" : old_opts);
+        const split_options = parse_options(old_opts);
         extract_option(split_options, "noauto");
         const opt_ro = extract_option(split_options, "ro");
         const opt_never_auto = extract_option(split_options, "x-cockpit-never-auto");
@@ -510,7 +512,7 @@ export class FilesystemTab extends React.Component {
 
         let mount_point_text = null;
         if (old_dir) {
-            if (old_opts && old_opts != "defaults") {
+            if (old_opts) {
                 let opt_texts = [];
                 if (opt_ro)
                     opt_texts.push(_("read only"));

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -490,6 +490,11 @@ class StorageHelpers:
             self.content_tab_wait_in_info(row, col, "Mount point",
                                           cond=lambda cell: "The filesystem is not mounted" not in self.browser.text(cell))
 
+    def wait_not_mounted(self, row, col):
+        with self.browser.wait_timeout(30):
+            self.content_tab_wait_in_info(row, col, "Mount point",
+                                          cond=lambda cell: "The filesystem is not mounted" in self.browser.text(cell))
+
     def setup_systemd_password_agent(self, password):
         # This sets up a systemd password agent that replies to all
         # queries with the given password.

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -440,6 +440,31 @@ ExecStart=/usr/bin/sleep infinity
         self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
         self.wait_not_mounted(1, 1)
 
+        # Mount
+        self.content_row_action(1, "Mount")
+        self.dialog({})
+
+        # Apply the dialog without changes and verify that the
+        # filesystem is still mounted afterwards.  Cockpit used to
+        # have a bug where this would accidentally unmount the
+        # filesystem.
+
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog({})
+        self.wait_mounted(1, 1)
+
+        # Try to set a bad option while the filesystem is mounted.
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog_wait_open()
+        self.dialog_set_val("mount_options.extra", "hurr")
+        self.dialog_apply()
+        self.dialog_wait_alert("bad option")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.wait_mounted(1, 1)
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -432,10 +432,13 @@ ExecStart=/usr/bin/sleep infinity
         self.dialog_apply()
         self.dialog_wait_alert("bad option")
         self.dialog_cancel()
+        self.dialog_wait_close()
 
-        # No changes should have been done to fstab
+        # No changes should have been done to fstab, and the
+        # filesystem should not be mounted.
         self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
         self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.wait_not_mounted(1, 1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The "Mount configuration" dialog unmounts the filesystem, changes fstab, and then re-mounts it.  However, if neither the mountpoint nor the options would change, the last two steps would be skipped, leaving the filesystem accidentally unmounted.

This is fixed here by not optimizing empty changes.  This is what other storage dialogs also do.