### PR TITLE
python: apply user provided env variables

### DIFF
--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -457,3 +457,11 @@ class TestSubprocessTransport(unittest.IsolatedAsyncioTestCase):
         transport.set_window_size(44, 55)
         while b'44x55\r\n' not in protocol.get_output():
             await asyncio.sleep(0.1)
+
+    async def test_env(self) -> None:
+        protocol, transport = self.subprocess(['bash', '-ic', 'echo $HOME'],
+                                              pty=True,
+                                              env={'HOME': '/test'})
+        protocol.output = []
+        while b'/test\r\n' not in protocol.get_output():
+            await asyncio.sleep(0.1)

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, todoPybridge, test_main
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, test_main
 
 
 def line_sel(i):
@@ -42,7 +42,6 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         self.machine.execute("systemctl reset-failed")
 
     @skipBrowser("Firefox needs http to access clipboard", "firefox")
-    @todoPybridge()
     @nondestructive
     def testBasic(self):
         b = self.browser


### PR DESCRIPTION
Apply the user provided `environ` option, which makes the terminal page tests pass as now TERM is set to something sensible.

- [x] rebase on, and then land #18189
- [x] rebase on, and then land #18185