### PR TITLE
python: Clean up children of spawned processes

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1082,7 +1082,7 @@ class OsUpdates extends React.Component {
         if (!this._mounted)
             return;
 
-        if (ex.problem === "not-found")
+        if (ex.problem === "not-found" || ex.name?.includes("DBus.Error.ServiceUnknown"))
             ex = _("PackageKit is not installed");
         this.state.errorMessages.push(ex.detail || ex.message || ex);
         this.setState({ state: "loadError" });

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -18,14 +18,13 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
 
 
 @skipDistroPackage()
 @nondestructive
 class TestReauthorize(MachineCase):
 
-    @todoPybridge()
     def testBasic(self):
         self.allow_journal_messages('.*dropping message while waiting for child to exit.*')
         b = self.browser

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -20,7 +20,7 @@
 import parent  # noqa: F401
 from storagelib import StorageCase
 from packagelib import PackageCase
-from testlib import skipImage, test_main, todoPybridge, wait, timeout, attach
+from testlib import skipImage, test_main, wait, timeout, attach
 import subprocess
 
 
@@ -38,7 +38,6 @@ class TestStorageLuks(StorageCase):
         "0": {"memory_mb": 1536}
     }
 
-    @todoPybridge()
     def testLuks(self):
         self.allow_journal_messages("Device is not initialized.*", ".*could not be opened.")
         m = self.machine


### PR DESCRIPTION
Set `prctl(SET_PDEATHSIG, SIGHUP)` for cockpit.spawn() and friends, to clean up subprocesses of the spawned process. The C bridge does that also (in cockpitpipe.c).