### PR TITLE
python: metrics: fix rate calculation with 0 values

### DIFF
--- a/src/cockpit/channels/metrics.py
+++ b/src/cockpit/channels/metrics.py
@@ -121,7 +121,7 @@ class InternalMetricsChannel(AsyncChannel):
         return samples
 
     def calculate_sample_rate(self, value: Any, old_value: Optional[Any]):
-        if old_value and self.last_timestamp:
+        if old_value is not None and self.last_timestamp:
             return (value - old_value) / (self.next_timestamp - self.last_timestamp)
         else:
             return False


### PR DESCRIPTION
A conditional in the bridge aims to return a rate of change if it has a previous value from which to calculate a change, and the value "False" otherwise.  In case there is no previous value, it would be None.

Unfortunately that was coded like

```python
  if old_value:
```

instead of

```python
  if old_value is not None:
```

which means that if `old_value` happened to be `0`, we would keep reporting the rate of change as "false".

It just so happens that depending on which other tests ran before the `@nondestructive` `TestCurrentMetrics.testCPU`, the amount of "nice" CPU usage may or may not be zero, causing this bug to be triggered only sometimes.

When triggered, this was causing the CPU percentage to show up as NaN%.