### PR TITLE
webpack.config.js: don't gzip .html pages

### DIFF
--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -26,7 +26,6 @@ def line_sel(i):
 
 
 @skipDistroPackage()
-@todoPybridge()
 class TestTerminal(MachineCase):
     def setUp(self):
         super().setUp()
@@ -43,6 +42,7 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         self.machine.execute("systemctl reset-failed")
 
     @skipBrowser("Firefox needs http to access clipboard", "firefox")
+    @todoPybridge()
     @nondestructive
     def testBasic(self):
         b = self.browser

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -356,7 +356,7 @@ if (production) {
         exclude: [
             '/test-[^/]+.$', // don't compress test cases
             '^static/[^/]+$', // cockpit-ws cannot currently serve compressed login page
-            '^shell/index.html$', // COMPAT: Support older cockpit-ws binaries. See #14673
+            '\\.html$', // HTML pages get patched by cockpit-ws, can't be compressed
         ].map(r => new RegExp(r)),
     }));
 }


### PR DESCRIPTION
The python bridge doesn't know how to decompress gzip, and -ws requires HTML to be decompressed so that it can patch it while serving it to the client.

All of our .html pages are small anyway, and since we're serving them uncompressed, we may as well also have them on disk uncompressed, saving ourselves the trouble.

 - [x] https://github.com/cockpit-project/cockpit/pull/18190 so that we don't try to jumpstart across a config change