### PR TITLE
webpack-make: include static depends in Makefile

### DIFF
--- a/pkg/build
+++ b/pkg/build
@@ -55,7 +55,7 @@ EXTRA_DIST += $(WEBPACK_INPUTS) $(WEBPACK_OUTPUTS)
 $(srcdir)/dist/%/Makefile.deps:
 	@true
 
-$(srcdir)/dist/%/manifest.json: $(srcdir)/tools/webpack-make $(srcdir)/package-lock.json $(srcdir)/webpack.config.js
+$(srcdir)/dist/%/manifest.json: $(srcdir)/package-lock.json
 	$(V_WEBPACK) cd $(srcdir) && NODE_ENV='$(NODE_ENV)' tools/termschutz tools/webpack-make $*
 
 -include $(WEBPACK_DEPS)

--- a/tools/webpack-make
+++ b/tools/webpack-make
@@ -97,7 +97,15 @@ function generateDeps(makefile, stats) {
     const dir = path.relative('', stats.compilation.outputOptions.path);
     const now = Math.floor(Date.now() / 1000);
 
-    const inputs = new Set();
+    /* If any of these changes, then everything definitely needs to be
+     * rebuilt.  These aren't mentioned in fileDependencies, though.
+     */
+    const inputs = new Set([
+        'package-lock.json',
+        'tools/webpack-make',
+        'webpack.config.js',
+    ]);
+
     for (const file of stats.compilation.fileDependencies) {
         // node modules  are handled by the dependency on package-lock.json
         if (file.includes('/node_modules/'))


### PR DESCRIPTION
Make sure we include the following dependencies, unconditionally, in each _INPUTS list:

  - webpack-make
  - package-lock.json
  - webpack.config.js

We previously handled those depends from the pkg/build Makefile, but now that we're making increased used of partial jumpstarts, we need to make sure these depends also end up in the Makefile so that we don't jumpstart files from across webpack configuration changes.