### PR TITLE
python: Respect umask in fsreplace1

### DIFF
--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -120,16 +120,20 @@ QUnit.test("binary false", function (assert) {
             });
 });
 
-QUnit.test("simple replace", function (assert) {
+QUnit.only("simple replace", function (assert) {
     const done = assert.async();
-    assert.expect(2);
+    assert.expect(3);
     cockpit.file(dir + "/bar").replace("4321\n")
             .always(function() {
                 assert.equal(this.state(), "resolved", "didn't fail");
                 cockpit.spawn(["cat", dir + "/bar"])
                         .done(function (res) {
                             assert.equal(res, "4321\n", "correct content");
-                            done();
+                            cockpit.spawn(["stat", "-c", "%a", dir + "/bar"])
+                                    .done(res => {
+                                        assert.equal(res, "644\n", "correct permissions");
+                                        done();
+                                    });
                         });
             });
 });

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, todoPybridge, test_main
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, test_main
 
 
 FP_SHA256 = "SHA256:iyVAl4Z8riL9Jg4fV9Wv/6cbqebdDtsBEMkojNLLYX8"
@@ -29,7 +29,6 @@ KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3
 class TestKeys(MachineCase):
 
     @nondestructive
-    @todoPybridge()
     def testAuthorizedKeys(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -21,7 +21,7 @@ import re
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, test_main, wait
 
 
 os_release = """
@@ -344,7 +344,6 @@ class TestSystemInfo(MachineCase):
         wait(lambda: get_timesyncd_start() > prev_timesyncd_start, delay=0.2)
 
     @nondestructive
-    @todoPybridge()
     def testMotd(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
NamedTemporaryFile always creates files with 600 permissions, thus    
making e.g. /etc/motd unreadable for users (which breaks    
TestSystemInfo.testMotd).    
    
Unfortunately there is no good Linux API for atomically replacing a file    
as user:    
    
 * mkstemp() and friends create too tight permissions.    
    
 * chowning the file after writing would be fine, but Linux has no API    
   to get the current umask other than scraping it out of /proc (and    
   calling umask(2) twice is a race condition and ugly).    
    
 * open(O_TMPFILE) would be cool, but it's not supported on some    
   file systems (e.g. not on overlayfs or NFS), and does not work with    
   existing files [1].    
    
So, move to the same "Find a free file name ourselves" approach that the    
C bridge does, but use a random 6-character string instead of just    
counting to 1000.    
    
[1] https://patchwork.kernel.org/project/linux-fsdevel/patch/c823982d5b46ea888dc1fdf26c067a7aa0f3585f.1490103963.git.osandov@fb.com/


[1] https://patchwork.kernel.org/project/linux-fsdevel/patch/c823982d5b46ea888dc1fdf26c067a7aa0f3585f.1490103963.git.osandov@fb.com/