### PR TITLE
python: Avoid waiting for the child in SubprocessStreamChannel.do_close()

### DIFF
--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -95,9 +95,10 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
         env.update(options.get('env') or [])
 
         try:
-            logger.debug('Spawning process args=%s', args)
-            return SubprocessTransport(loop, self, args, pty, window, env=env, cwd=cwd, stderr=stderr,
-                                       preexec_fn=lambda: prctl(SET_PDEATHSIG, signal.SIGHUP))
+            transport = SubprocessTransport(loop, self, args, pty, window, env=env, cwd=cwd, stderr=stderr,
+                                            preexec_fn=lambda: prctl(SET_PDEATHSIG, signal.SIGHUP))
+            logger.debug('Spawned process args=%s pid=%i', args, transport.get_pid())
+            return transport
         except FileNotFoundError as error:
             raise ChannelError('not-found') from error
         except PermissionError as error:


### PR DESCRIPTION
Commit e100e4d8b introduced a race condition: asyncio installs a "child    
watcher" (via pidfd) for all launched subprocesses, and expects it to be    
able to read the processes' exit code. But subprocess'es terminate()    
method *also* does that. If the process is still running, this is    
harmless (as it will just return None), but if the process terminates    
around the same time as cancelling it, it can happen that the process    
stopped in terminate(), it waits() the child and collects the exit code,    
and asyncio's child watcher then does not get it any more. This causes    
warnings like    
    
    asyncio:child process pid <PID> exit status already read:  will report returncode 255    
    
We actually want to retain that; terminate()'s wait call is just for    
avoiding PID reuse races, but that race is negligible for us.    
cockpit.spawn() already ensures that do_close() is only actually called    
for valid (running) processes, and the kernel usually makes sure that a    
PID does not get re-used immediately.    

----

This should fix [these failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18185-20230117-164632-269e4108-fedora-37-pybridge/log.html#315). I realize that this is somewhat hackish, but I'm afraid I'm too stupid to do better here. See https://github.com/cockpit-project/cockpit/pull/18188#issuecomment-1386470504 for my many failed attempts to catch this in a unit test. I understand fairly well *why* this happens, but I don't have a good idea how to improve it to be completely race free.