### PR TITLE
python: Respect umask in fsreplace1 (umask version)

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -31,7 +31,7 @@ from systemd_ctypes import EventLoopPolicy, bus
 
 from .channel import ChannelRoutingRule
 from .channels import CHANNEL_TYPES
-from .config import Config, Environment
+from .config import Config, Environment, init_umask
 from .internal_endpoints import EXPORTS
 from .packages import Packages
 from .remote import HostRoutingRule
@@ -189,6 +189,9 @@ def main() -> None:
     args = parser.parse_args()
 
     setup_logging(args.debug)
+
+    # do this before any threading
+    init_umask()
 
     if args.packages:
         Packages().show()

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -23,6 +23,7 @@ from systemd_ctypes import PathWatch
 from systemd_ctypes.inotify import Event as InotifyEvent
 
 from ..channel import Channel, ChannelError
+from ..config import get_umask
 
 logger = logging.getLogger(__name__)
 
@@ -141,6 +142,7 @@ class FsReplaceChannel(Channel):
             if self._tag and self._tag != tag_from_path(self._path):
                 raise ChannelError('change-conflict')
 
+            os.chmod(self._tempfile.name, 0o666 & ~get_umask())
             os.rename(self._tempfile.name, self._path)
             self._tempfile.close()
             self._tempfile = None

--- a/src/cockpit/config.py
+++ b/src/cockpit/config.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from systemd_ctypes import bus
 
 logger = logging.getLogger(__name__)
+_umask = None
 
 ETC_COCKPIT = Path('/etc/cockpit')
 XDG_CONFIG_HOME = Path(os.getenv('XDG_CONFIG_HOME') or os.path.expanduser('~/.config'))
@@ -77,3 +78,15 @@ class Environment(bus.Object, interface='cockpit.Environment'):
     @variables.getter
     def get_variables(self):
         return os.environ.copy()
+
+
+def init_umask():
+    global _umask
+    assert _umask is None
+    _umask = os.umask(0o077)
+    os.umask(_umask)  # restore umask
+
+
+def get_umask():
+    assert _umask is not None
+    return _umask

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, todoPybridge, test_main
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, test_main
 
 
 FP_SHA256 = "SHA256:iyVAl4Z8riL9Jg4fV9Wv/6cbqebdDtsBEMkojNLLYX8"
@@ -29,7 +29,6 @@ KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3
 class TestKeys(MachineCase):
 
     @nondestructive
-    @todoPybridge()
     def testAuthorizedKeys(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -21,7 +21,7 @@ import re
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, test_main, wait
 
 
 os_release = """
@@ -344,7 +344,6 @@ class TestSystemInfo(MachineCase):
         wait(lambda: get_timesyncd_start() > prev_timesyncd_start, delay=0.2)
 
     @nondestructive
-    @todoPybridge()
     def testMotd(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
NamedTemporaryFile always creates files with 600 permissions, thus making e.g. /etc/motd unreadable for users (which breaks TestSystemInfo.testMotd). So lazily read the current umask (as we don't change it anywhere), and fix the file permissions right before renaming.

Detecting the current umask is a bit nasty, as one has to call umask(2) twice. But that's the recommended method, and if it's good enough for umask(1), it's good enough for us. Unfortunately there is no really good Linux API for atomically replacing a file as user, all the other options are much worse.

----

This is an alternative to PR #18193. I personally like it better.