### PR TITLE
test: Adjust VDO tests for latest RHEL 9.2 image

### DIFF
--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -116,7 +116,7 @@ class TestStorageVDO(StorageCase):
 
         b.click("input[aria-label='Use deduplication']")
         b.wait_visible("input[aria-label='Use deduplication']:not(checked):not([disabled])")
-        wait_prop(pool_name, "vdo_index_state", "offline")
+        wait_prop(pool_name, "vdo_index_state", r"offline\|closed")
         b.click("input[aria-label='Use deduplication']")
         b.wait_visible("input[aria-label='Use deduplication']:checked:not([disabled])")
         wait_prop(pool_name, "vdo_index_state", "online")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -32,6 +32,8 @@ SIZE_10G = "10000000000"
 
 class TestStorageVDO(StorageCase):
 
+    provision = {"0": {"memory_mb": 1800}}
+
     def testVdo(self):
         m = self.machine
         b = self.browser
@@ -401,6 +403,8 @@ config: !Configuration
 @unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel") or testvm.DEFAULT_IMAGE.startswith("centos"),
                      "VDO API only supported on RHEL")
 class TestStoragePackagesVDO(PackageCase, StorageHelpers):
+
+    provision = {"0": {"memory_mb": 1500}}
 
     def testVdoMissingPackages(self):
         m = self.machine


### PR DESCRIPTION
See https://github.com/cockpit-project/bots/pull/4291 . I tested this locally against thew new RHEL image, and also triggered a run against the refreshed image here.