### PR TITLE
test: Disable partial webpack jumpstart for devel scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -7,15 +7,15 @@ set -eu
 
 tools/make-bots
 test/common/pixel-tests pull
+
+TEST_SCENARIO="${TEST_SCENARIO:-verify}"
+[ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || export NODE_ENV=development
 tools/webpack-jumpstart --partial || true
 
-TEST_SCENARIO=${TEST_SCENARIO:-verify}
-
-case $TEST_SCENARIO in
+case "$TEST_SCENARIO" in
     verify|devel|firefox|firefox-devel|pybridge)
         RUN_OPTS="--track-naughties"
         PREPARE_OPTS=""
-        [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || export NODE_ENV=development
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%devel}" ] || RUN_OPTS="$RUN_OPTS --coverage"
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO%%pybridge}" ] || PREPARE_OPTS="$PREPARE_OPTS --python"
         [ "${TEST_SCENARIO}" = "${TEST_SCENARIO##firefox}" ] || export TEST_BROWSER=firefox


### PR DESCRIPTION
We want the tests to generate full coverage information for all pages in the /devel scenario, not just for the ones affected by a PR.

----

See e.g. [this log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18203-20230118-140114-7fa0948c-fedora-37-devel/log) from PR #18203 which touched pkg/systemd only:
```
  FETCH    dist  [ref: tag sha-34d12a403e4cf029c7f5e99b8b87b3206101c331]
  REMOVE   dist/systemd
  WEBPACK  systemd
```

With this change, we'll go back to rebuilding everything.