### PR TITLE
test: Fix testPmProxySettings on arch

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -558,6 +558,8 @@ class TestHistoryMetrics(MachineCase):
         b = self.browser
         m = self.machine
 
+        m.execute("systemctl start firewalld")
+
         # Arch Linux has no active zone by default which the firewalld port alert test requires.
         if m.image == "arch":
             m.execute("firewall-cmd --zone=public --change-interface eth0 --permanent")
@@ -606,7 +608,6 @@ class TestHistoryMetrics(MachineCase):
         # start in a defined state; all test images have pcp and redis pre-installed
         m.execute(f"systemctl disable --now pmlogger pmie pmproxy {redis}")
         m.execute("systemctl reset-failed")
-        m.execute("systemctl start firewalld")
         # ensure pmproxy is not already opened in firewall
         m.execute("firewall-cmd --remove-service pmproxy; firewall-cmd --permanent --remove-service pmproxy")
         self.login_and_go("/metrics")


### PR DESCRIPTION
The test calls firewall-cmd at the beginning on arch, but it previously happened a lot that firewalld was not running. Move the starting earlier to fix that.

----

Should fix [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18183-20230118-140022-0e5ecfac-arch/log.html#67-2), which happens in every other PR right now. [another example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18206-20230119-140747-26fe7912-arch/log.html)