### PR TITLE
selinux: Fix React crash on API/CLI errors

### DIFF
--- a/pkg/selinux/setroubleshoot.js
+++ b/pkg/selinux/setroubleshoot.js
@@ -114,7 +114,7 @@ const initStore = function(rootElement) {
                     dataStore.entries[idx].details.pluginAnalysis[fixId].fix = {
                         plugin: analysisId,
                         running: false,
-                        result: error,
+                        result: error.toString(),
                         success: false,
                     };
                     dataStore.render();
@@ -140,7 +140,7 @@ const initStore = function(rootElement) {
                     dataStore.render();
                 })
                 .catch(error => {
-                    dataStore.error = error;
+                    dataStore.error = error.toString();
                     dataStore.render();
                 });
     };

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -140,6 +140,25 @@ class TestSelinux(MachineCase):
         sebool_selector1 = panel_selector + " .selinux-details:contains('httpd_enable_homedirs')"
         b.wait_in_text(sebool_selector1, "by enabling the 'httpd_enable_homedirs' boolean.")
 
+        # sabotage the solution command to test failure alerts
+        sebool_path = m.execute("command -v setsebool").strip()
+        m.execute(f"chmod a-x {sebool_path}")
+        b.click(f"{sebool_selector1} button{self.default_btn_class}")
+        b.wait_in_text(f"{sebool_selector1} .pf-c-alert", "Solution failed")
+        b.wait_in_text(f"{sebool_selector1} .pf-c-alert", "setsebool: Permission denied")
+
+        # we can't re-attempt the solution, dismiss it
+        b.click(row_selector + " input[type=checkbox]")
+        b.click(dismiss_sel)
+        b.wait_not_present(row_selector)
+        # unbreak sebool, and trigger the error again
+        m.execute(f"chmod a+x {sebool_path}; rm -r ~admin/public_html")
+        self.machine.execute(SELINUX_SEBOOL_ALERT_SCRIPT)
+        with b.wait_timeout(60):
+            b.wait_visible(row_selector)
+        b.click(toggle_selector)
+
+        # applying solution works now
         b.click(sebool_selector1 + " button" + self.default_btn_class)
         b.wait_in_text(sebool_selector1 + " .pf-c-alert__title", "Solution applied successfully")
         self.assertIn("-> on", m.execute("getsebool httpd_enable_homedirs"))


### PR DESCRIPTION
When cockpit.script(runCommmand) or deleting an error fails, we catch an    
"error" object. Don't try to stuff that into the `<Alert>` as-is, as it    
will make React crash with    
    
    RuntimeError: Error: Objects are not valid as a React child (found: [object Error]).    
    
Convert the errors to a string first.    
    
That does not fix the underlying reason/race condition why applying the    
solution sometimes fails in TestSelinux.testTroubleshootAlerts, but it    
will make the failure a lot more useful both for the user and the test.    

-----

This addresses a common flake, [example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18169-20230113-155342-727d20de-centos-8-stream/log.html#138), [example 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18169-20230113-155342-727d20de-rhel-8-8/log.html#138).

This isn't easy to reproduce locally, but I have some reasonable success with two parallel loops of

    for i in $(seq 10); do TEST_OS=rhel-8-8 test/verify/check-selinux TestSelinux.testTroubleshootAlerts -stv || break; done