### PR TITLE
nav: fix toggling of the system dropdown

### DIFF
--- a/pkg/shell/nav.jsx
+++ b/pkg/shell/nav.jsx
@@ -25,10 +25,7 @@ export const SidebarToggle = () => {
     }, []);
 
     useEffect(() => {
-        if (active)
-            document.getElementById("nav-system").classList.add("interact");
-        else
-            document.getElementById("nav-system").classList.remove("interact");
+        document.getElementById("nav-system").classList.toggle("interact", active);
     }, [active]);
 
     return (

--- a/pkg/shell/nav.jsx
+++ b/pkg/shell/nav.jsx
@@ -19,10 +19,16 @@ export const SidebarToggle = () => {
     useEffect(() => {
         const handleClickOutside = () => setActive(false);
 
-        document.getElementById("nav-system").classList.toggle("interact");
         window.addEventListener("blur", handleClickOutside);
 
         return () => window.removeEventListener("blur", handleClickOutside);
+    }, []);
+
+    useEffect(() => {
+        if (active)
+            document.getElementById("nav-system").classList.add("interact");
+        else
+            document.getElementById("nav-system").classList.remove("interact");
     }, [active]);
 
     return (


### PR DESCRIPTION
* Don't assume 'active' state of dropdown when toggling the 'interact' class.
* Call the addEventListener only on component mount, and not each time the 'active' state changes.

Fixes #18182