### PR TITLE
python: correctly log possible None value

### DIFF
--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -232,7 +232,7 @@ class FsWatchChannel(Channel):
             self.send_message(event=event, path=self._path, tag=self._tag, type=type_)
 
     def do_identity_changed(self, fd, err):
-        logger.debug("do_identity_changed(%s): fd %i, err %s", self._path, fd, err)
+        logger.debug("do_identity_changed(%s): fd %s, err %s", self._path, str(fd), err)
         self._tag = tag_from_fd(fd) if fd else '-'
         if self._active:
             self.send_message(event='created' if fd else 'deleted', path=self._path, tag=self._tag)


### PR DESCRIPTION
Or do you prefer to special case this? if `fd is None`: lala