### PR TITLE
users: Allow specifying home directory and shell during account creation

### DIFF
--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -23,6 +23,7 @@ import React from 'react';
 import { Bullseye } from "@patternfly/react-core/dist/esm/layouts/Bullseye/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
@@ -42,10 +43,11 @@ function get_default_home_dir(base_home_dir, user_name) {
         : "";
 }
 
-function AccountCreateBody({ state, errors, change }) {
+function AccountCreateBody({ state, errors, change, shells }) {
     const {
         real_name, user_name,
         locked, change_passw_force,
+        shell, isShellSelectExpanded,
     } = state;
 
     return (
@@ -76,6 +78,20 @@ function AccountCreateBody({ state, errors, change }) {
                     onChange={value => change("home_dir", value)}
                     placeholder={_("Path to directory")}
                     value={state.home_dir} />
+            </FormGroup>
+
+            <FormGroup label={_("Shell")}
+                       fieldId="accounts-create-user-shell">
+                <Select variant={SelectVariant.single}
+                        toggleId="accounts-create-user-shell"
+                        onToggle={statusIsExpanded => change("isShellSelectExpanded", statusIsExpanded)}
+                        onSelect={(event, selection) => { change("shell", selection); change("isShellSelectExpanded", false) }}
+                        selections={shell}
+                        isOpen={isShellSelectExpanded}
+                        aria-labelledby="vm-state-select"
+                        menuAppendTo="parent">
+                    { shells.map(shell_path => <SelectOption value={shell_path} key={shell_path} label={shell_path}>{shell_path}</SelectOption>) }
+                </Select>
             </FormGroup>
 
             <FormGroup label={_("User ID")}
@@ -218,7 +234,7 @@ function suggest_username(realname) {
     return remove_diacritics(result);
 }
 
-export function account_create_dialog(accounts, min_uid, max_uid) {
+export function account_create_dialog(accounts, min_uid, max_uid, shells) {
     let dlg = null;
 
     const used_ids = accounts.map(a => a.uid);
@@ -241,6 +257,7 @@ export function account_create_dialog(accounts, min_uid, max_uid) {
         max_uid,
         home_dir: null,
         home_dir_dirty: false,
+        isShellSelectExpanded: false,
     };
     let errors = { };
 
@@ -423,7 +440,7 @@ export function account_create_dialog(accounts, min_uid, max_uid) {
                 </Bullseye>
             );
         } else {
-            props.body = <AccountCreateBody state={state} errors={errors} change={change} />;
+            props.body = <AccountCreateBody state={state} errors={errors} change={change} shells={shells} />;
         }
 
         const footer = {

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -52,7 +52,7 @@ def performUserAction(browser, user, action):
     browser.click(f".pf-c-dropdown__menu-item:contains({action})")
 
 
-def createUser(browser, user_name, real_name, password, locked, force_password_change, uid=None, expected_uid=None, verify_created=True):
+def createUser(browser, user_name, real_name, password, locked, force_password_change, custom_home_dir=None, uid=None, expected_uid=None, verify_created=True):
     browser.wait_visible('#accounts-create')
     browser.click('#accounts-create')
     browser.wait_visible('#accounts-create-dialog')
@@ -74,6 +74,13 @@ def createUser(browser, user_name, real_name, password, locked, force_password_c
         browser.wait_visible(f'#accounts-create-user-uid[value="{expected_uid}"]')
     if uid is not None:
         browser.set_input_text('#accounts-create-user-uid', uid)
+    if custom_home_dir is not None:
+        browser.set_input_text('#accounts-create-user-home-dir', custom_home_dir)
+    else:
+        default_home_dir = getUserAddDetails(machine)["HOME"]
+        expected_home_dir = default_home_dir + "/" + user_name
+        browser.wait_visible(f"#accounts-create-user-home-dir[value='{expected_home_dir}']")
+
 
     browser.click('#accounts-create-dialog button.apply')
 
@@ -685,6 +692,73 @@ class TestAccounts(MachineCase):
         b.wait_in_text("#accounts-create-user-uid-helper", "positive integer")
         b.click("#accounts-create-dialog button.cancel")
         b.wait_not_present("#accounts-create-dialog")
+
+    def testCustomUserProperties(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/users")
+
+        # Test custom home directory
+        custom_dir_path = "/home/mycustomdir"
+        createUser(
+            browser=b,
+            user_name="jussi",
+            real_name="Jussi Junior",
+            password=good_password,
+            locked=False,
+            custom_home_dir=custom_dir_path,
+            force_password_change=False,
+            verify_created=True,
+        )
+
+        b.go("#/jussi")
+        b.wait_text("#account-home-dir", custom_dir_path)
+        m.execute(f"test -d {custom_dir_path}")
+        m.execute("! test -d /home/jussi")
+
+        b.go("/users")
+        # Check assigning a file as home directory fails
+        m.execute("touch /home/isfile")
+        createUser(
+            browser=b,
+            machine=m,
+            user_name="file",
+            real_name="File Filerson",
+            password=good_password,
+            locked=False,
+            custom_home_dir="/home/isfile",
+            force_password_change=False,
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-home-dir-helper", "existing file")
+        b.wait_visible("button.apply:disabled")
+        b.click("button.cancel")
+        b.wait_not_present("#accounts-create-dialog")
+
+        b.go("/users")
+        # Check assigning existing home directory to a new user
+        m.execute("mkdir /home/existingdir")
+        createUser(
+            browser=b,
+            user_name="stealer",
+            real_name="Stealer OfHomeDirectison",
+            password=good_password,
+            locked=False,
+            custom_home_dir="/home/existingdir",
+            force_password_change=False,
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-home-dir-helper", "already exists")
+        b.wait_visible("button.apply:disabled")
+        self.assertEqual(m.execute("stat -c '%U %G' /home/existingdir").rstrip(), "root root")
+        b.click("button:contains('Create and change ownership of home directory')")
+        b.wait_not_present("#accounts-create-dialog")
+        b.wait_in_text("#accounts-list", "Stealer OfHomeDirectison")
+        # Verify that ownership of home directory was changed to the new user
+        self.assertEqual(m.execute("stat -c '%U %G' /home/existingdir").rstrip(), "stealer stealer")
 
     def testUnprivileged(self):
         m = self.machine

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -52,7 +52,23 @@ def performUserAction(browser, user, action):
     browser.click(f".pf-c-dropdown__menu-item:contains({action})")
 
 
-def createUser(browser, user_name, real_name, password, locked, force_password_change, custom_home_dir=None, uid=None, expected_uid=None, verify_created=True):
+def createUser(
+    browser,
+    machine,
+    user_name,
+    real_name,
+    password,
+    locked,
+    force_password_change,
+    custom_home_dir=None,
+    default_shell=None,
+    custom_shell=None,
+    uid=None,
+    expected_uid=None,
+    verify_created=True
+):
+    if default_shell is None:
+        default_shell = getUserAddDetails(machine)["SHELL"]
     browser.wait_visible('#accounts-create')
     browser.click('#accounts-create')
     browser.wait_visible('#accounts-create-dialog')
@@ -81,6 +97,11 @@ def createUser(browser, user_name, real_name, password, locked, force_password_c
         expected_home_dir = default_home_dir + "/" + user_name
         browser.wait_visible(f"#accounts-create-user-home-dir[value='{expected_home_dir}']")
 
+    if custom_shell:
+        browser.click("#accounts-create-user-shell")
+        browser.click(f"li button[label='{custom_shell}']")
+    else:
+        browser.wait_in_text('#accounts-create-user-shell', default_shell)
 
     browser.click('#accounts-create-dialog button.apply')
 
@@ -234,11 +255,13 @@ class TestAccounts(MachineCase):
         b.login_and_go("/users")
         createUser(
             browser=b,
+            machine=m,
             user_name="robert",
             real_name="Robert Robertson",
             password=good_password,
             locked=False,
             force_password_change=True,
+            default_shell="/bin/true"
         )
 
         # Test actions in kebab menu
@@ -279,6 +302,7 @@ class TestAccounts(MachineCase):
 
         createUser(
             browser=b,
+            machine=m,
             user_name="robert",
             real_name="Robert Robertson",
             password=good_password,
@@ -371,6 +395,7 @@ class TestAccounts(MachineCase):
 
         createUser(
             browser=b,
+            machine=m,
             user_name="jussi",
             real_name="Jussi Junior",
             password="foo",
@@ -541,6 +566,7 @@ class TestAccounts(MachineCase):
         b.go('/users')
         createUser(
             browser=b,
+            machine=m,
             user_name="robert",
             real_name="Robert Robertson",
             password=good_password,
@@ -584,12 +610,14 @@ class TestAccounts(MachineCase):
 
     def testCustomUID(self):
         b = self.browser
+        m = self.machine
 
         self.login_and_go("/users")
 
         # Test custom UID
         createUser(
             browser=b,
+            machine=m,
             user_name="bob",
             real_name="Bob Bobson",
             password=good_password,
@@ -603,6 +631,7 @@ class TestAccounts(MachineCase):
         # Test dialog predicts corrent next available UID
         createUser(
             browser=b,
+            machine=m,
             user_name="john",
             real_name="John Johnson",
             password=good_password,
@@ -616,6 +645,7 @@ class TestAccounts(MachineCase):
         # Test creation of users with the same UID
         createUser(
             browser=b,
+            machine=m,
             user_name="jack",
             real_name="Jack Jackson",
             password=good_password,
@@ -636,6 +666,7 @@ class TestAccounts(MachineCase):
         # No UID specified -> useradd chooses UID for us
         createUser(
             browser=b,
+            machine=m,
             user_name="nouidspecified",
             real_name="NoUID Specified",
             password=good_password,
@@ -648,6 +679,7 @@ class TestAccounts(MachineCase):
         # UID cannot be lower than UID_MIN
         createUser(
             browser=b,
+            machine=m,
             user_name="failedfailson",
             real_name="Failed Failson",
             password=good_password,
@@ -664,6 +696,7 @@ class TestAccounts(MachineCase):
         # UID cannot be higher than UID_MAX
         createUser(
             browser=b,
+            machine=m,
             user_name="failedfailson",
             real_name="Failed Failson",
             password=good_password,
@@ -680,6 +713,7 @@ class TestAccounts(MachineCase):
         # UID must be a positive integer
         createUser(
             browser=b,
+            machine=m,
             user_name="failedfailson",
             real_name="Failed Failson",
             password=good_password,
@@ -703,6 +737,7 @@ class TestAccounts(MachineCase):
         custom_dir_path = "/home/mycustomdir"
         createUser(
             browser=b,
+            machine=m,
             user_name="jussi",
             real_name="Jussi Junior",
             password=good_password,
@@ -742,6 +777,7 @@ class TestAccounts(MachineCase):
         m.execute("mkdir /home/existingdir")
         createUser(
             browser=b,
+            machine=m,
             user_name="stealer",
             real_name="Stealer OfHomeDirectison",
             password=good_password,
@@ -759,6 +795,26 @@ class TestAccounts(MachineCase):
         b.wait_in_text("#accounts-list", "Stealer OfHomeDirectison")
         # Verify that ownership of home directory was changed to the new user
         self.assertEqual(m.execute("stat -c '%U %G' /home/existingdir").rstrip(), "stealer stealer")
+
+        default_shell = getUserAddDetails(m)["SHELL"]
+        custom_shell = "/bin/sh"
+        if default_shell == custom_shell:
+            custom_shell = "/bin/bash"
+
+        createUser(
+            browser=b,
+            machine=m,
+            user_name="robert",
+            real_name="Robert Robertson",
+            password=good_password,
+            locked=False,
+            custom_shell=custom_shell,
+            force_password_change=False,
+            verify_created=True,
+        )
+
+        b.go("#/robert")
+        b.wait_text("#account-shell", custom_shell)
 
     def testUnprivileged(self):
         m = self.machine


### PR DESCRIPTION
This add ability to specify custom home directory and custom shell for newly created users:

![Screenshot from 2023-01-26 11-38-24](https://user-images.githubusercontent.com/42733240/214816791-05709147-971f-48d0-a26c-43003815c04f.png)

[Screencast from 2023-01-26 11-41-05.webm](https://user-images.githubusercontent.com/42733240/214817073-addde521-f013-4eb7-a4b0-54fb7fa5edcc.webm)

If user tries to use home directory which already exists:
![Screenshot from 2023-01-26 14-36-46](https://user-images.githubusercontent.com/42733240/214849329-b000ec2e-ce4d-44ae-8aa5-645712d14dbc.png)



I also added the listing of those user's home directory and shell into user's details page:
![Screenshot from 2023-01-26 11-43-37](https://user-images.githubusercontent.com/42733240/214816885-1f55ba94-a763-44ed-bd77-4667331e5304.png)
