### PR TITLE
python: add a new packages.BridgeRule NamedTuple

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -17,7 +17,6 @@
 
 import argparse
 import asyncio
-import json
 import logging
 import pwd
 import os
@@ -208,7 +207,7 @@ def main() -> None:
     if args.packages:
         Packages().show()
     elif args.bridges:
-        print(json.dumps(Packages().get_bridges(), indent=2))
+        print(*Packages().get_bridges(), sep='\n')
     else:
         asyncio.set_event_loop_policy(EventLoopPolicy())
         asyncio.run(run(args), debug=args.debug)

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -94,7 +94,7 @@ class Peer(CockpitProtocolClient, SubprocessProtocol, Endpoint):
             logger.debug('Peer %s connection got init message', self.name)
             if self.state_listener is not None:
                 self.state_listener.peer_state_changed(self, 'init')
-            self.write_control(command='init', version='1', host=self.init_host)
+            self.write_control(command='init', version=1, host=self.init_host)
             self.thaw_endpoint()
         else:
             logger.warning('Peer %s connection got duplicate init message', self.name)

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -21,7 +21,7 @@ import asyncio
 import logging
 import os
 
-from typing import Any, Dict, Optional, Set
+from typing import Any, Dict, Optional, Sequence, Set
 
 from .router import Endpoint, Router
 from .protocol import CockpitProtocolClient
@@ -75,7 +75,7 @@ class Peer(CockpitProtocolClient, SubprocessProtocol, Endpoint):
         self.channels = set()
         self.authorize_pending = None
 
-    def spawn(self, argv: list[str], env: Dict[str, str], **kwargs) -> asyncio.Transport:
+    def spawn(self, argv: Sequence[str], env: Dict[str, str], **kwargs) -> asyncio.Transport:
         loop = asyncio.get_running_loop()
         return SubprocessTransport(loop, self, argv, env=dict(os.environ, **env), **kwargs)
 

--- a/src/cockpit/safely.py
+++ b/src/cockpit/safely.py
@@ -1,0 +1,74 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import contextlib
+
+from typing import Callable, Dict, Generator, List, Mapping, Type, TypeVar, Union
+
+T = TypeVar('T')
+D = TypeVar('D')
+
+
+@contextlib.contextmanager
+def catch(description: str, on_error: Callable) -> Generator[None, None, None]:
+    try:
+        yield
+    except (TypeError, KeyError) as err:
+        on_error(f'{description}: {err}')
+        raise
+
+
+def get(mapping: Mapping[str, object], key: str, expected_type: Type[T], *default: D) -> Union[T, D]:
+    try:
+        value = mapping[key]
+    except KeyError:
+        if default:
+            return default[0]
+        raise
+
+    if not isinstance(value, expected_type):
+        raise TypeError(f"item '{key}' must have type '{expected_type.__name__}'")
+
+    return value
+
+
+def get_list(mapping: Mapping[str, object], key: str, expected_item_type: Type[T], *default: D) -> Union[List[T], D]:
+    try:
+        value = get(mapping, key, list)
+    except KeyError:
+        if default:
+            return default[0]
+        raise
+
+    if not all(isinstance(item, expected_item_type) for item in value):
+        raise TypeError(f"item '{key}' must have type 'list[{expected_item_type.__name__}]'")
+
+    return value
+
+
+def get_dict(mapping: Mapping[str, object], key: str, expected_item_type: Type[T], *default: D) -> Union[Dict[str, T], D]:
+    try:
+        value = get(mapping, key, dict)
+    except KeyError:
+        if default:
+            return default[0]
+        raise
+
+    if not all(isinstance(item, expected_item_type) for item in value.values()):
+        raise TypeError(f"item '{key}' must have type 'dict[str, {expected_item_type.__name__}]'")
+
+    return value

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -28,7 +28,7 @@ import struct
 import subprocess
 import termios
 
-from typing import Any, ClassVar, Dict, Optional, Tuple
+from typing import Any, ClassVar, Dict, Optional, Sequence, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -328,7 +328,7 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
     def __init__(self,
                  loop: asyncio.AbstractEventLoop,
                  protocol: SubprocessProtocol,
-                 args: list[str],
+                 args: Sequence[str],
                  pty: bool = False,
                  window: Optional[Dict[str, int]] = None,
                  **kwargs: Any):

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Iterable, Optional, Tuple
 
 import systemd_ctypes
 from cockpit.bridge import Bridge
+from cockpit.packages import BridgeRule
 
 MOCK_HOSTNAME = 'mockbox'
 
@@ -199,17 +200,17 @@ class TestBridge(unittest.IsolatedAsyncioTestCase):
 
         # Add pseudo to the existing set of superuser rules
         rules = self.bridge.packages.get_bridges()
-        rules.append({
-            'label': 'pseudo',
-            'spawn': [
+        rules.append(BridgeRule(
+            name='pseudo',
+            label='pseudo',
+            spawn=(
                 sys.executable, os.path.abspath(f'{__file__}/../pseudo.py'),
                 sys.executable, '-m', 'cockpit.bridge', '--privileged'
-            ],
-            'environ': [
-                f'PYTHONPATH={":".join(sys.path)}'
-            ],
-            'privileged': True
-        })
+            ),
+            environ=(
+                ('PYTHONPATH', ":".join(sys.path)),
+            ),
+            privileged=True))
         self.bridge.superuser_rule.set_bridge_rules(rules)
 
     async def test_echo(self):


### PR DESCRIPTION
This is the data from a "bridges" section in a manifest.json file, in an immutable and type-safe form.

This is going to be helpful for creating bridge routing rules.

Also add `safely.py` which contains some experimental typesafe functions meant for deconstructing untrusted JSON data.  I'm not 100% sure I like the approach, but we're going to need something like this, and this is the best I can think of for the time being.