### PR TITLE
python: Send null owner D-Bus signal for absent services

### DIFF
--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -131,6 +131,17 @@ QUnit.test("owned messages", function (assert) {
     acquire_name();
 });
 
+QUnit.test("owned message for absent service", assert => {
+    const done = assert.async();
+    assert.expect(1);
+
+    const dbus = cockpit.dbus("com.redhat.Cockpit.DBusTests.NotExisting", { bus: "session" });
+    dbus.addEventListener("owner", (_event, owner) => {
+        assert.strictEqual(owner, null, "no owner");
+        done();
+    });
+});
+
 QUnit.test.skipWithPybridge("bad dbus address", function (assert) {
     const done = assert.async();
     assert.expect(1);

--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -73,7 +73,7 @@ QUnit.test("watch promise recursive", function (assert) {
     assert.equal(typeof promise3.remove, "function", "promise3.remove()");
 });
 
-QUnit.test.skipWithPybridge("owned messages", function (assert) {
+QUnit.test("owned messages", function (assert) {
     const done = assert.async();
     assert.expect(9);
 

--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -331,7 +331,7 @@ function fetchZoneInfos(zones) {
 initFirewalldDbus();
 
 cockpit.spawn(['sh', '-c', 'pkcheck --action-id org.fedoraproject.FirewallD1.all --process $$ --allow-user-interaction 2>&1'], { superuser: "try" })
-        .done(() => {
+        .then(() => {
             firewall.readonly = false;
             firewall.debouncedEvent('changed');
             firewall.debouncedGetZones();

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -548,7 +548,7 @@ class AddEditServicesModal extends React.Component {
         firewall.getAvailableServices()
                 .then(services => this.setState({ services }));
         cockpit.file('/etc/services').read()
-                .done(content => this.setState({
+                .then(content => this.setState({
                     avail_services: this.parseServices(content)
                 }));
     }

--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -212,6 +212,7 @@ class DBusChannel(Channel):
                                                      "StartServiceByName", "su", self.name, 0)
                 except BusError as error:
                     logger.debug("Failed to start service '%s': %s", self.name, error.message)
+                    self.send_message(owner=None)
             else:
                 logger.debug("Failed to get owner of service '%s': %s", self.name, error.message)
         else:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1799,7 +1799,8 @@ class MachineCase(unittest.TestCase):
                 r"File .*asyncio/events.py.*",
                 r"self._context.run\(self._callback, \*self._args\)",
                 r"File .*cockpit/transports.py.* _read_ready",
-                r"data = os.read\(self._in_fd, _Transport.BLOCK_SIZE\)"]
+                r"data = os.read\(self._in_fd, _Transport.BLOCK_SIZE\)",
+                r"ConnectionResetError: \[Errno 104\] Connection reset by peer"]
 
             self.allowed_messages += [
                 r"File .*/systemd_ctypes/bus.py.* in handler",

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 import time
-from testlib import Error, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
+from testlib import Error, nondestructive, skipDistroPackage, skipImage, test_main, wait
 from netlib import NetworkCase
 
 
@@ -63,7 +63,6 @@ class TestFirewall(NetworkCase):
         if m.image == "arch":
             m.execute("firewall-cmd --zone 'public' --change-interface='eth0'; firewall-cmd --runtime-to-permanent")
 
-    @todoPybridge()
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine
@@ -144,7 +143,6 @@ class TestFirewall(NetworkCase):
         finally:
             m.execute(f"umount '{pkcheck}'")
 
-    @todoPybridge()
     def testFirewallPage(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
As per documentation [1], send an `owner: null` signal when a D-Bus
service does not exist. That's what the C bridge does, and at least the 
Firewall page relies on that.

[1] https://cockpit-project.org/guide/latest/cockpit-dbus.html#cockpit-dbus-onowned
