### PR TITLE
On-demand software additions on CoreOS

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -510,7 +510,7 @@ function init_model(callback) {
     }
 
     function enable_pk_features() {
-        return PK.detect().then(function (available) { client.features.packagekit = available });
+        return PK.detect_with_details().then(function (details) { client.features.packagekit_details = details });
     }
 
     function enable_stratis_feature() {

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -891,11 +891,15 @@ export class VGroup extends React.Component {
                     SelectOne("purpose", _("Purpose"),
                               {
                                   value: "block",
-                                  choices: purposes
+                                  choices: purposes,
+                                  validate: val => {
+                                      if (val == "vdo" && need_vdo_install && client.features.packagekit_details.reason == "immutable-os")
+                                          return cockpit.format(_("The $0 package needs to be added to the OS image."), vdo_package);
+                                  }
                               }),
                     Message(cockpit.format(_("The $0 package will be installed to create VDO devices."), vdo_package),
                             {
-                                visible: vals => vals.purpose === 'vdo' && need_vdo_install,
+                                visible: vals => vals.purpose === 'vdo' && need_vdo_install && client.features.packagekit_details.available,
                             }),
 
                     /* Not Implemented

--- a/pkg/storaged/optional-panel.jsx
+++ b/pkg/storaged/optional-panel.jsx
@@ -81,7 +81,7 @@ export class OptionalPanel extends React.Component {
         const feature_enabled = !feature || feature.is_enabled();
         const required_package = feature && feature.package;
 
-        if (!feature_enabled && !(required_package && this.props.client.features.packagekit))
+        if (!feature_enabled && !required_package)
             return null;
 
         function install() {

--- a/pkg/storaged/things-panel.jsx
+++ b/pkg/storaged/things-panel.jsx
@@ -43,7 +43,7 @@ export class ThingsPanel extends React.Component {
             const feature_enabled = !feature || feature.is_enabled();
             const required_package = feature && feature.package;
 
-            if (!feature_enabled && !(required_package && client.features.packagekit))
+            if (!feature_enabled && !required_package)
                 return null;
 
             function install_then_action() {

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -112,6 +112,8 @@ export class RealmdClient {
     }
 
     checkRealm(name) {
+        if (!this.dbus_realmd)
+            return Promise.reject();
         return this.dbus_realmd.call(MANAGER, PROVIDER, "Discover", [name, {}])
                 .then(([relevance, realms]) => {
                     if (realms.length == 0)

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -67,9 +67,12 @@ export class RealmdClient {
     onClose(ev, options) {
         if (options.problem === "not-found") {
             // see if we can install it
-            packagekit.detect().then(exists => {
-                if (exists) {
+            packagekit.detect_with_details().then(details => {
+                if (details.available) {
                     this.error = _("Joining a domain requires installation of realmd");
+                    this.install_realmd = true;
+                } else if (details.reason == "immutable-os") {
+                    this.error = _("Joining a domain requires adding of realmd to the OS image");
                     this.install_realmd = true;
                 } else {
                     this.error = _("Cannot join a domain because realmd is not available on this system");
@@ -210,7 +213,11 @@ export class RealmdClient {
 
     installPackage() {
         if (this.install_realmd) {
-            return install_dialog("realmd")
+            return install_dialog("realmd",
+                                  {
+                                      immutable_title: _("Add support for joining a domain"),
+                                      immutable_text: _("The $0 package needs to be added to the OS image in order to join a domain.")
+                                  })
                     .then(() => {
                         this.install_realmd = false;
                         this.initProxy();


### PR DESCRIPTION
https://www.youtube.com/watch?v=cNnVu2sjq2c

This allows (and expects) the install_dialog to be called without checking for PackageKit first.  The dialog itself will do the right thing like instructing people to add packages to the OS image on immutable OSes.  Thus, users of install_dialog can skip their PackageKit detection and always open the dialog.

Flows that use check_missing_packages and install_missing_packages directly need to be adapted individually.
