### PR TITLE
test: Put back another pybridge crash message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1806,6 +1806,7 @@ class MachineCase(unittest.TestCase):
                 r"File .*/systemd_ctypes/bus.py.* in handler",
                 r"return 1 if callback.*BusMessage.ref.* else 0",
                 r"File .*/systemd_ctypes/bus.py.* in done",
+                r".*future.set_exception\(error\)",
                 r"future.set_result\(message\)"]
 
             self.allowed_messages += [


### PR DESCRIPTION
That was also removed in commit 89bd6896883, but still happens occasionally. But it did *not* happen in testSessionRecordingShell but in testLogging, so move it into the block which covers the rest of the exception.

---

Fixes https://cockpit-logs.us-east-1.linodeobjects.com/pull-17992-20230125-145211-18fde629-fedora-37-pybridge/log.html#145