### PR TITLE
ws: Fix rpm debug symbol extraction for mock-pam-conv-mod.so

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -166,7 +166,7 @@ testserviceddir = $(systemdunitdir)/cockpit.service.d
 
 install-tests::
 	mkdir -p $(DESTDIR)$(pamdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
-	$(INSTALL_DATA) mock-pam-conv-mod.so $(DESTDIR)$(pamdir)/
+	$(INSTALL_PROGRAM) mock-pam-conv-mod.so $(DESTDIR)$(pamdir)/
 
 install-exec-hook::
 	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d


### PR DESCRIPTION
find-debuginfo(1) only considers executable files for debug info extraction. We installed most of our PAM libraries as executable already, but not mock-pam-conv-mod.so. That causes rpminspect to complain that a non-debug package contains debug symbols.

----

This fixes a [long-standing rpminspect failure](https://artifacts.dev.testing-farm.io/21ae9e81-96e6-4122-9ccc-d5e80c71f1b1/) that we have to waive all the time. Let's fix it properly.

Now the rpm build log shows that it finds the lib and its debug symbols:
```
 /usr/bin/find-debuginfo -j8 --strict-build-id -m -i --build-id-seed 284.7.gabb9ed480.dirty-1.fc37 --unique-debug-suffix -284.7.gabb9ed480.dirty-1.fc37.x86_64 --unique-debug-src-base cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64 --run-dwz --dwz-low-mem-die-limit 10000000 --dwz-max-die-limit 110000000 -S debugsourcefiles.list /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILD/cockpit-284.7.gabb9ed480.dirty
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/lib64/security/pam_cockpit_cert.so
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/lib64/security/mock-pam-conv-mod.so
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/bin/cockpit-bridge
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/lib64/security/pam_ssh_add.so
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-certificate-ensure
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-pcp
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-askpass
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-session
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-ssh
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-tls
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-ws
extracting debug info from /var/home/martin/upstream/cockpit/main/rpm-build.ido4vk/BUILDROOT/cockpit-284.7.gabb9ed480.dirty-1.fc37.x86_64/usr/libexec/cockpit-wsinstance-factory
```

and `less cockpit-debuginfo-284.7.gabb9ed480.dirty-1.fc37.x86_64.rpm` confirms that it now contains /usr/lib/debug/usr/lib64/security/mock-pam-conv-mod.so-284.7.gabb9ed480.dirty-1.fc37.x86_64.debug