### PR TITLE
test: Fix session cleanup for rawhide

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1588,6 +1588,9 @@ class MachineCase(unittest.TestCase):
                                         rm -rf /run/user/$u
                                     done""")
 
+            # Restart logind to mop up empty "closing" sessions
+            self.machine.execute("systemctl restart systemd-logind")
+
             # Terminate all other Cockpit sessions
             sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
             for s in sessions:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1592,7 +1592,7 @@ class MachineCase(unittest.TestCase):
             sessions = self.machine.execute("loginctl --no-legend list-sessions | awk '/web console/ { print $1 }'").strip().split()
             for s in sessions:
                 # Don't insist that terminating works, the session might be gone by now.
-                self.machine.execute(f"loginctl kill-session {s}; loginctl terminate-session {s} || true")
+                self.machine.execute(f"loginctl kill-session {s} || true; loginctl terminate-session {s} || true")
 
                 # Wait for it to be gone
                 try:


### PR DESCRIPTION
In Fedora rawhide this started to fail often with

    Could not kill session: No such file or directory

This is okay -- it's an inherent TOCTOU race condition, sessions can get cleaned up during the loop. This is some late fallout from .execute() getting strict [1], it just happened to (mostly) work until now.

[1] https://github.com/cockpit-project/bots/commit/b7d0edba5d02

----

This avoids occasional failures like [this](https://artifacts.dev.testing-farm.io/b686f17b-c254-4e0a-a76f-d06304392c61/#artifacts-Fedora-Rawhide:x86_64:/plans/all/optional), or the [complete mess](https://artifacts.dev.testing-farm.io/01a177c2-f55c-4471-8102-9eb75cfef9d5/) that breaks the current [284 rawhide update](https://bodhi.fedoraproject.org/updates/FEDORA-2023-44a632e396). Recently, all our rawhide packit tests in cockpit became red due to this.

FTR, I can locally reproduce this with `tmt run`, but not with our own fedora-rawhide image.