### PR TITLE
shell: python: load translations via manifest.js

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -44,10 +44,7 @@ function get_plural_expr(statement) {
     return expr;
 }
 
-function buildFile(po_file, subdir, webpack_module, webpack_compilation) {
-    if (webpack_compilation)
-        webpack_compilation.fileDependencies.add(po_file);
-
+function buildFile(po_file, subdir, webpack_module, webpack_compilation, out_path, filter) {
     return new Promise((resolve, reject) => {
         // Read the PO file, remove fuzzy/disabled lines to avoid tripping up the validator
         const po_data = fs.readFileSync(po_file, 'utf8')
@@ -81,6 +78,9 @@ function buildFile(po_file, subdir, webpack_module, webpack_compilation) {
                 if (translation.comments.flag?.match(/\bfuzzy\b/))
                     continue;
 
+                if (!references.some(filter))
+                    continue;
+
                 const key = JSON.stringify(context_prefix + msgid);
                 // cockpit.js always ignores the first item
                 chunks.push(`,\n ${key}: [\n  null`);
@@ -95,8 +95,6 @@ function buildFile(po_file, subdir, webpack_module, webpack_compilation) {
         const wrapper = config.wrapper?.(subdir) || DEFAULT_WRAPPER;
         const output = wrapper.replace('PO_DATA', chunks.join('')) + '\n';
 
-        const lang = path.basename(po_file).slice(0, -3);
-        const out_path = (subdir ? (subdir + '/') : '') + 'po.' + lang + '.js';
         if (webpack_compilation)
             webpack_compilation.emitAsset(out_path, new webpack_module.sources.RawSource(output));
         else
@@ -115,9 +113,20 @@ function init(options) {
 
 function run(webpack_module, webpack_compilation) {
     const promises = [];
-    config.subdirs.map(subdir =>
-        promises.push(...get_po_files().map(po_file =>
-            buildFile(po_file, subdir, webpack_module, webpack_compilation))));
+    for (const subdir of config.subdirs) {
+        for (const po_file of get_po_files()) {
+            if (webpack_compilation)
+                webpack_compilation.fileDependencies.add(po_file);
+            const lang = path.basename(po_file).slice(0, -3);
+            promises.push(Promise.all([
+                // Separate translations for the manifest.json file and normal pages
+                buildFile(po_file, subdir, webpack_module, webpack_compilation,
+                          `${subdir}/po.${lang}.js`, str => !str.includes('manifest.json')),
+                buildFile(po_file, subdir, webpack_module, webpack_compilation,
+                          `${subdir}/po.manifest.${lang}.js`, str => str.includes('manifest.json'))
+            ]));
+        }
+    }
     return Promise.all(promises);
 }
 

--- a/pkg/shell/index.html
+++ b/pkg/shell/index.html
@@ -8,7 +8,10 @@
     <link href="../../static/branding.css" rel="stylesheet" />
     <script src="../base1/cockpit.js"></script>
     <script src="../manifests.js"></script>
+    <!-- HACK: C bridge loads translations via glob and Python via manifest.js -->
+    <script src="../*/po.manifest.js"></script>
     <script src="../*/po.js"></script>
+    <script src="po.js"></script>
   </head>
   <body class="pf-v5-m-tabular-nums" hidden="true">
     <div id="main" class="page">


### PR DESCRIPTION
Split the po files into po.$lang.js and po.manifest.$lang.js so the shell can only serve the translated manifests. As previously the shell loaded it's own translations via globbing for the Python bridge we need to explicitly load the po.js file.

Closes #18224

* [ ] Handle comment about inverse filter predicate
* [x] Drop duplication