### PR TITLE
lib: cockpit-components-file-autocomplete: fix moving back to previous path

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -104,7 +104,7 @@ export class FileAutoComplete extends React.Component {
         });
 
         channel.addEventListener("close", (ev, data) => {
-            this.finishUpdate(results, cockpit.format(cockpit.message(data)), path);
+            this.finishUpdate(results, data.message, path);
         });
 
         channel.addEventListener("message", (ev, data) => {
@@ -137,9 +137,8 @@ export class FileAutoComplete extends React.Component {
             this.props.onChange('');
 
         if (!error)
-            this.setState({ directory: directory });
+            this.setState({ displayFiles: listItems, directory });
         this.setState({
-            displayFiles: listItems,
             error: error,
         });
     }

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -311,6 +311,15 @@ session    optional     pam_ssh_add.so
         b.click("#ssh-file-add")
         b.wait_text("#credentials-modal .pf-m-error > .pf-c-helper-text__item-text", "Not a valid private key")
 
+        b.click("#credentials-modal .pf-c-select__toggle-typeahead")
+        b.set_input_text("#credentials-modal .pf-c-select__toggle-typeahead", "/var/test/")
+        b.wait_in_text("#credentials-modal .pf-c-select__menu-item.pf-m-disabled", "No such file or directory")
+        b.focus("#credentials-modal .pf-c-select__toggle-typeahead")
+        b.key_press("\b\b\b\b\b")
+        b.wait_visible("#credentials-modal .pf-c-select__menu-item.directory:contains('/var/lib/')")
+        b.click("#credentials-modal .pf-c-select__toggle-clear")
+        b.wait_val("#credentials-modal .pf-c-select__toggle-typeahead", "")
+
         b.set_file_autocomplete_val("#ssh-file-add-key", "/tmp/new.rsa")
         b.click("#ssh-file-add")
         b.wait_not_present("#ssh-file-add")


### PR DESCRIPTION
Only update the file list if the directory exists in path. This approach solves the current issue where the menu list is not updating correctly, if pressing backspace to get some parent existing directory after a wrong path was given.

Also fix the error message; cockpit.message does not return a string if 'message' is not an attribute of the object parsed as this is now appearing wrongly.

Related to https://bugzilla.redhat.com/show_bug.cgi?id=1999945