### PR TITLE
python: Close unix stream channels on EOF

### DIFF
--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -50,6 +50,7 @@ class UnixStreamChannel(ProtocolChannel):
         path: str = options['unix']
         connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         connection.connect(path)
+        self.close_on_eof()
         return SocketTransport(loop, self, connection)
 
 


### PR DESCRIPTION
This is what the C bridge does, and podman relies on it.

-----

This fixes podman's `TestApplication.testNotRunning` (... almost, still an unexpected message). Tested interactively with

```
rm -f /tmp/sock;  nc -l -U /tmp/sock
PYTHONPATH=src python3 -m cockpit.print open stream unix=/tmp/sock : wait | ./cockpit-bridge | cat
```
Now ^C netcat. C bridge sends a done and a close:
```
{"command":"done","channel":"1"}
{"command":"close","channel":"1"}
```

But the py bridge only sends the "done". With this fix, it sends the "close" as well:
```
PYTHONPATH=src python3 -m cockpit.print open stream unix=/tmp/sock : wait | COCKPIT_DEBUG=all PYTHONPATH=src python3 -m cockpit.bridge | cat
```

I'll still try to make a unit test of some sort here, but it's a bit awkward from QUnit.