### PR TITLE
selinux: Allow cockpit-session to run gnome-keyring

### DIFF
--- a/selinux/cockpit.te
+++ b/selinux/cockpit.te
@@ -198,3 +198,7 @@ optional_policy(`
     ')
     cockpit_read_pid_files(local_login_t)
 ')
+
+optional_policy(`
+    gnome_exec_keyringd(cockpit_session_t)
+')


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2165996