### PR TITLE
python: Report detailed error message when opening fsread1 channel fails

### DIFF
--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -109,8 +109,8 @@ class FsReadChannel(GeneratorChannel):
             return {'tag': '-'}
         except PermissionError:
             raise ChannelError('access-denied')
-        except OSError:
-            raise ChannelError('internal-error')
+        except OSError as error:
+            raise ChannelError('internal-error', message=str(error)) from error
 
 
 class FsReplaceChannel(Channel):

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -47,13 +47,13 @@ class MockTransport(asyncio.Transport):
         self.send_json('', command='open', channel=channel, payload=payload, **kwargs)
         return channel
 
-    async def check_open(self, payload, channel=None, problem=None, **kwargs):
+    async def check_open(self, payload, channel=None, problem=None, reply_keys: Optional[Dict[str, object]] = None, **kwargs):
         ch = self.send_open(payload, channel, **kwargs)
         if problem is None:
-            await self.assert_msg('', command='ready', channel=ch)
+            await self.assert_msg('', command='ready', channel=ch, **(reply_keys or {}))
             assert ch in self.protocol.open_channels
         else:
-            await self.assert_msg('', command='close', channel=ch, problem=problem)
+            await self.assert_msg('', command='close', channel=ch, problem=problem, **(reply_keys or {}))
             assert ch not in self.protocol.open_channels
         return ch
 

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -510,3 +510,9 @@ class TestBridge(unittest.IsolatedAsyncioTestCase):
         assert not all(d for d in data[0][0])
         # memory.used should be an integer
         assert isinstance(data[0][1], int)
+
+    async def test_fsread1_errors(self):
+        await self.start()
+        await self.transport.check_open('fsread1', path='/etc/shadow', problem='access-denied')
+        await self.transport.check_open('fsread1', path='/', problem='internal-error',
+                                        reply_keys={'message': "[Errno 21] Is a directory: '/'"})


### PR DESCRIPTION
Teach check_open() about validating the `message` part of `close`, when given.

----

Leftover from https://github.com/cockpit-project/cockpit/pull/18257/commits/f128b1b3991481b4e0e1aede8c431a81fea6ddee#r1090499063