### PR TITLE
Document and test TCP stream channel, implement it for the pybridge

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -767,6 +767,10 @@ Additional "open" command options should be specified with a channel of
 this payload type:
 
  * "unix": Open a channel with the given unix socket.
+ * "port": Open a channel with the given TCP port on localhost.
+ * "address": Open a channel that communicates with the given
+    address instead of localhost. This can be an IP address or a valid
+    host name. To use this option you must also specify a port.
  * "batch": Batches data coming from the stream in blocks of at least this
    size. This is not a guarantee. After a short timeout the data will be
    sent even if the data doesn't match the batch size. Defaults to zero.

--- a/pkg/base1/test-stream.js
+++ b/pkg/base1/test-stream.js
@@ -1,0 +1,86 @@
+import cockpit from "cockpit";
+import QUnit from "qunit-tests";
+
+const QS_REQUEST = "HEAD /mock/qs HTTP/1.0\nHOST: localhost\n\n";
+
+const test_server = {
+    address: window.location.hostname,
+    port: parseInt(window.location.port, 10)
+};
+
+QUnit.test.skipWithPybridge("TCP stream port without a service", assert => {
+    const done = assert.async();
+    assert.expect(1);
+
+    const channel = cockpit.channel({ payload: "stream", address: "127.0.0.99", port: 2222 });
+
+    channel.addEventListener("close", (ev, options) => {
+        assert.equal(options.problem, "not-found", "channel should have failed");
+        done();
+    });
+});
+
+QUnit.test.skipWithPybridge("TCP stream address without a port", assert => {
+    const done = assert.async();
+    assert.expect(2);
+
+    const channel = cockpit.channel({ payload: "stream", address: "127.0.0.99" });
+
+    channel.addEventListener("close", (ev, options) => {
+        assert.equal(options.problem, "protocol-error", "channel should have failed");
+        assert.equal(options.message, 'no "port" or "unix" or other address option for channel', "helpful error");
+        done();
+    });
+});
+
+QUnit.test.skipWithPybridge("TCP text stream", async assert => {
+    const done = assert.async();
+    assert.expect(2);
+
+    const channel = cockpit.channel({
+        payload: "stream",
+        address: test_server.address,
+        port: test_server.port
+    });
+
+    channel.addEventListener("message", (ev, data) => {
+        assert.ok(data.startsWith("HTTP/1.1 200 OK"), "got successful HTTP response");
+        channel.close();
+    });
+
+    channel.addEventListener("close", (ev, options) => {
+        assert.equal(options.problem, undefined, "channel should have succeeded");
+        done();
+    });
+
+    channel.send(QS_REQUEST);
+    channel.control({ command: "done" });
+});
+
+QUnit.test.skipWithPybridge("TCP binary stream", async assert => {
+    const done = assert.async();
+    assert.expect(2);
+
+    const channel = cockpit.channel({
+        payload: "stream",
+        binary: true,
+        address: test_server.address,
+        port: test_server.port
+    });
+
+    channel.addEventListener("message", (ev, data) => {
+        const text = new TextDecoder().decode(data);
+        assert.ok(text.startsWith("HTTP/1.1 200 OK"), "got successful HTTP response");
+        channel.close();
+    });
+
+    channel.addEventListener("close", (ev, options) => {
+        assert.equal(options.problem, undefined, "channel should have succeeded");
+        done();
+    });
+
+    channel.send(Uint8Array.from(QS_REQUEST.split('').map(c => c.charCodeAt())));
+    channel.control({ command: "done" });
+});
+
+QUnit.start();

--- a/pkg/base1/test-stream.js
+++ b/pkg/base1/test-stream.js
@@ -8,19 +8,27 @@ const test_server = {
     port: parseInt(window.location.port, 10)
 };
 
-QUnit.test.skipWithPybridge("TCP stream port without a service", assert => {
+QUnit.test("TCP stream port without a service", async assert => {
     const done = assert.async();
-    assert.expect(1);
+    assert.expect(2);
+
+    const is_pybridge = await QUnit.mock_info("pybridge");
 
     const channel = cockpit.channel({ payload: "stream", address: "127.0.0.99", port: 2222 });
 
     channel.addEventListener("close", (ev, options) => {
         assert.equal(options.problem, "not-found", "channel should have failed");
+        if (is_pybridge)
+            assert.equal(options.message,
+                         "[Errno 111] Connect call failed ('127.0.0.99', 2222)",
+                         "detailed error message");
+        else
+            assert.equal(options.message, undefined, "C bridge does not give detailed error message");
         done();
     });
 });
 
-QUnit.test.skipWithPybridge("TCP stream address without a port", assert => {
+QUnit.test("TCP stream address without a port", assert => {
     const done = assert.async();
     assert.expect(2);
 
@@ -33,7 +41,7 @@ QUnit.test.skipWithPybridge("TCP stream address without a port", assert => {
     });
 });
 
-QUnit.test.skipWithPybridge("TCP text stream", async assert => {
+QUnit.test("TCP text stream", async assert => {
     const done = assert.async();
     assert.expect(2);
 
@@ -57,7 +65,7 @@ QUnit.test.skipWithPybridge("TCP text stream", async assert => {
     channel.control({ command: "done" });
 });
 
-QUnit.test.skipWithPybridge("TCP binary stream", async assert => {
+QUnit.test("TCP binary stream", async assert => {
     const done = assert.async();
     assert.expect(2);
 

--- a/src/cockpit/channels/__init__.py
+++ b/src/cockpit/channels/__init__.py
@@ -20,7 +20,7 @@ from .filesystem import FsListChannel, FsReadChannel, FsReplaceChannel, FsWatchC
 from .http import HttpChannel
 from .metrics import InternalMetricsChannel
 from .packages import PackagesChannel
-from .stream import SubprocessStreamChannel, UnixStreamChannel
+from .stream import SubprocessStreamChannel, SocketStreamChannel
 from .trivial import EchoChannel, NullChannel
 
 
@@ -36,5 +36,5 @@ CHANNEL_TYPES = [
     NullChannel,
     PackagesChannel,
     SubprocessStreamChannel,
-    UnixStreamChannel,
+    SocketStreamChannel,
 ]

--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -46,7 +46,7 @@ class UnixStreamChannel(ProtocolChannel):
     payload = 'stream'
     restrictions = (('unix', None),)
 
-    def create_transport(self, loop: asyncio.AbstractEventLoop, options: Dict[str, object]) -> SocketTransport:
+    async def create_transport(self, loop: asyncio.AbstractEventLoop, options: Dict[str, object]) -> SocketTransport:
         path: str = options['unix']
         connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
         connection.connect(path)
@@ -86,7 +86,7 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
             # already gone? fine!
             logger.debug('Received close signal from peer, but process %i is already gone', pid)
 
-    def create_transport(self, loop: asyncio.AbstractEventLoop, options: Dict[str, object]) -> SubprocessTransport:
+    async def create_transport(self, loop: asyncio.AbstractEventLoop, options: Dict[str, object]) -> SubprocessTransport:
         args: list[str] = options['spawn']
         err: Optional[str] = options.get('err')
         cwd: Optional[str] = options.get('directory')

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -399,27 +399,6 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
             self._sock = None
 
 
-class SocketTransport(_Transport):
-    """A Transport subclass that can wrap any socket"""
-    _socket: socket.socket
-
-    def __init__(self,
-                 loop: asyncio.AbstractEventLoop,
-                 protocol: asyncio.Protocol,
-                 sock: socket.socket):
-        super().__init__(loop, protocol, sock.fileno(), sock.fileno(), {'socket': sock})
-        self._socket = sock
-
-    def _close(self) -> None:
-        self._socket.close()
-
-    def can_write_eof(self) -> bool:
-        return True
-
-    def _write_eof_now(self) -> None:
-        self._socket.shutdown(socket.SHUT_WR)
-
-
 class StdioTransport(_Transport):
     """A bi-directional transport that corresponds to stdin/out.
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -162,6 +162,7 @@ const info = {
         "base1/test-series",
         "base1/test-spawn-proc",
         "base1/test-spawn",
+        "base1/test-stream",
         "base1/test-user",
         "base1/test-utf8",
         "base1/test-websocket",


### PR DESCRIPTION
This will fix c-machine's [console test failures](https://cockpit-logs.us-east-1.linodeobjects.com/pull-935-20230203-091154-9b4701a9-fedora-37-pybridge/log.html), see https://github.com/cockpit-project/cockpit-machines/pull/935 . I locally ran all the console tests with this pybridge update, and they pass now.