### PR TITLE
python: Fix fslist1 FileNotFoundError crash

### DIFF
--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -71,7 +71,17 @@ class FsListChannel(Channel):
         if watch:
             raise ChannelError('not-supported', message='watching is not implemented, use fswatch1')
 
-        for entry in os.scandir(path):
+        try:
+            scan_dir = os.scandir(path)
+        except OSError as error:
+            if isinstance(error, FileNotFoundError):
+                problem = 'not-found'
+            elif isinstance(error, PermissionError):
+                problem = 'access-denied'
+            else:
+                problem = 'internal-error'
+            raise ChannelError(problem, message=str(error)) from error
+        for entry in scan_dir:
             self.send_entry("present", entry)
 
         if not watch:


### PR DESCRIPTION
Trying to list a nonexisting directory crashed the bridge. Report a    
proper channel problem instead.    
    
Add unit tests.    


----

- [x] Builds on top of PR #18285

This fixes the last [cockpit-machines failure](https://github.com/cockpit-project/cockpit-machines/pull/935). I ran `TestMachinesFilesystems.testBasicSystemConnection` with this fix and it passes now.