### PR TITLE
Support manifest conditions

### DIFF
--- a/doc/guide/packages.xml
+++ b/doc/guide/packages.xml
@@ -108,6 +108,16 @@ $ cockpit-bridge --packages
           where there are conflicts. For example given two packages with the same
           <code>name</code> a package is chosen based on its priority.</para></listitem>
       </varlistentry>
+      <!-- TODO: enable this once moving to the Python bridge by default; also update example below
+      <varlistentry>
+        <term>conditions</term>
+        <listitem><para>An optional list of <code>{"predicate": "value"}</code> objects. Cockpit will only
+          consider the package if <emphasis>all</emphasis> conditions are met. Currently supported predicates
+          are <code>path-exists</code> and <code>path-not-exists</code>. Unknown predicates are ignored.
+          This is preferable to using <code>priority</code>, but only available since Cockpit FIXME-RELEASE.</para>
+        </listitem>
+      </varlistentry>
+      -->
       <varlistentry>
         <term>requires</term>
         <listitem><para>An optional JSON object that contains a <code>"cockpit"</code>
@@ -251,6 +261,28 @@ $ cockpit-bridge --packages
   }
 }
 </programlisting>
+
+<!-- TODO: enable this once moving to the Python bridge by default
+<programlisting>
+{
+  "version": 0,
+  "require": {
+    "cockpit": "120"
+  },
+  "conditions": [
+    {"path-exists": "/usr/bin/mytool"},
+    {"path-exists": "/etc/mytool.conf"},
+    {"path-not-exist": "/etc/incompatible-tool"}
+  ],
+  "tools": {
+     "mytool": {
+        "label": "My Tool",
+        "path": "tool.html"
+     }
+  }
+}
+</programlisting>
+-->
 
   </section>
 

--- a/pkg/packagekit/manifest.json
+++ b/pkg/packagekit/manifest.json
@@ -1,6 +1,11 @@
 {
     "name": "updates",
     "priority": 0,
+    "conditions": [
+        {"path-exists": "/lib/systemd/system/packagekit.service"},
+        {"path-not-exists": "/sysroot/ostree"}
+    ],
+
     "tools": {
         "index": {
             "label": "Software updates",

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -102,3 +102,53 @@ class TestPackages(unittest.TestCase):
         parsed = json.loads(packages.manifests)
         assert parsed['basic'] == {'name': 'basic', 'description': 'VIP', 'priority': 100}
         assert parsed['guest'] == {'description': 'Guest'}
+
+    def add_conditional_manifest(self, name, conditions):
+        (self.package_dir / name).mkdir()
+        (self.package_dir / name / 'manifest.json').write_text(f'{{"conditions": [ {conditions} ] }}')
+
+    def test_conditions(self):
+        self.add_conditional_manifest('empty', '')
+
+        # path-exists only
+        self.add_conditional_manifest('exists-1-yes', '{"path-exists": "/usr"}')
+        self.add_conditional_manifest('exists-1-no', '{"path-exists": "/nonexisting"}')
+        self.add_conditional_manifest('exists-2-yes', '{"path-exists": "/usr"}, {"path-exists": "/bin/sh"}')
+        self.add_conditional_manifest('exists-2-no', '{"path-exists": "/usr"}, {"path-exists": "/nonexisting"}')
+
+        # path-not-exists only
+        self.add_conditional_manifest('notexists-1-yes', '{"path-not-exists": "/nonexisting"}')
+        self.add_conditional_manifest('notexists-1-no', '{"path-not-exists": "/usr"}')
+        self.add_conditional_manifest('notexists-2-yes', '{"path-not-exists": "/nonexisting"}, {"path-not-exists": "/obscure"}')
+        self.add_conditional_manifest('notexists-2-no', '{"path-not-exists": "/nonexisting"}, {"path-not-exists": "/usr"}')
+
+        # mixed
+        self.add_conditional_manifest('mixed-yes', '{"path-exists": "/usr"}, {"path-not-exists": "/nonexisting"}')
+        self.add_conditional_manifest('mixed-no', '{"path-exists": "/nonexisting"}, {"path-not-exists": "/obscure"}')
+
+        packages = Packages()
+        assert set(packages.packages.keys()) == {
+            'basic', 'empty', 'exists-1-yes', 'exists-2-yes', 'notexists-1-yes', 'notexists-2-yes', 'mixed-yes'
+        }
+
+    def test_conditions_errors(self):
+        self.add_conditional_manifest('broken-syntax-1', '1')
+        self.add_conditional_manifest('broken-syntax-2', '["path-exists"]')
+        self.add_conditional_manifest('broken-syntax-3', '{"path-exists": "/foo", "path-not-exists": "/bar"}')
+
+        self.add_conditional_manifest('unknown-predicate-good', '{"path-exists": "/usr"}, {"frobnicated": true}')
+        self.add_conditional_manifest('unknown-predicate-bad', '{"path-exists": "/nonexisting"}, {"frobnicated": true}')
+
+        packages = Packages()
+        assert set(packages.packages.keys()) == {'basic', 'unknown-predicate-good'}
+
+    def test_condition_hides_priority(self):
+        (self.package_dir / 'vip').mkdir()
+        (self.package_dir / 'vip' / 'manifest.json').write_text(
+            '{"name": "basic", "description": "VIP", "priority": 100, "conditions": [{"path-exists": "/nonexisting"}]}')
+
+        packages = Packages()
+        assert packages.packages['basic'].name == 'basic'
+        assert packages.packages['basic'].manifest['description'] == 'standard package'
+        assert packages.packages['basic'].manifest['requires'] == {'cockpit': "42"}
+        assert packages.packages['basic'].priority == 1

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1097,16 +1097,32 @@ ExecStart=/usr/local/bin/{packageName}
                            systemctl daemon-reload'''.format(system_service))
 
         m.start_cockpit()
-        b.login_and_go("/updates")
+        if os.environ.get("TEST_SCENARIO") != "pybridge":
+            # TODO: conditions not implemented on C bridge; once we drop it, drop this special case and
+            # enable the manifest documentation for conditions in doc/guide/packages.xml
+            self.assertIn("\nupdates", m.execute("cockpit-bridge --packages"))
+            b.login_and_go("/updates")
 
-        # error message present
-        b.wait_in_text(".pf-c-page__main-section .pf-c-empty-state__body", "PackageKit is not installed")
+            # error message present
+            b.wait_in_text(".pf-c-page__main-section .pf-c-empty-state__body", "PackageKit is not installed")
 
-        # update status on front page should be invisible
-        b.go("/system")
-        b.enter_page("/system")
-        b.wait_text(self.update_text, "Loading available updates failed")
-        self.assertIn("exclamation", b.attr(self.update_icon, "class"))
+            # update status on front page should show error
+            b.go("/system")
+            b.enter_page("/system")
+            b.wait_text(self.update_text, "Loading available updates failed")
+            self.assertIn("exclamation", b.attr(self.update_icon, "class"))
+        else:
+            self.assertNotIn("\nupdates", m.execute("cockpit-bridge --packages"))
+            # should not appear in the menu at all
+            self.login_and_go(None)
+            b.wait_in_text("#host-apps .pf-m-current", "Overview")
+            self.assertNotIn("Updates", b.text("#host-apps .pf-m-current"))
+
+            # update status on front page should be invisible
+            b.go("/system")
+            b.enter_page("/system")
+            b.wait_visible(".system-health")
+            self.assertFalse(b.is_present(self.update_text))
 
     @skipDistroPackage()
     @nondestructive


### PR DESCRIPTION
These pave the way for bundling packages together with the webserver, and only showing them if the target system actually supports the corresponding functionality. For example, CoreOS does not have libvirt, so we can bundle but    
hide the "Machines" page on such systems.    
        
This also allows us to better handle ostree vs. packagekit -- even if a user installs cockpit-ostree on a standard RPM system, they should still see the packagekit version of "Software Updates" (see https://github.com/cockpit-project/cockpit-ostree/issues/295). This is a more flexible approach than the old static `priority` field.        
        
Take inspiration from systemd unit files, which support e.g. `ConditionPathExists=`. The conditions should be declarative and cheap to evaluate. Support file exists/not exists tests for now, which should suffice for most use cases. The format and implementation is easy to extend in the future.                   

This also adds a condition (and integration) test to the packagekit "Software Updates" page.

- [x] ~Implement for C bridge, or decide that we don't actually need/want that~ -- let's skip that
- [x] Add documentation: disabled for now, but we'll get a reminder through a failing test once we switch over