### PR TITLE
python: simplify "kill" logic in router

### DIFF
--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -161,6 +161,9 @@ class Peer(CockpitProtocolClient, SubprocessProtocol, Endpoint):
     def do_channel_data(self, channel: str, data: bytes) -> None:
         self.write_channel_data(channel, data)
 
+    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+        self.write_control(command='kill', host=host, group=group)
+
 
 class PeerRoutingRule(RoutingRule, PeerStateListener):
     config: Dict[str, object]

--- a/test/verify/check-shell-active-pages
+++ b/test/verify/check-shell-active-pages
@@ -18,14 +18,12 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, todoPybridge, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, test_main
 
 
 @skipDistroPackage()
 @nondestructive
 class TestActivePages(MachineCase):
-
-    @todoPybridge()
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Drop the logic for keeping track of which channels belong to which groups and just call .do_kill() on every endpoint that the router knows about, with the group and host details.

That slow, but 'kill' happens fairly infrequently.
    
Channel now keeps track of its own group on open and implements .do_kill() by calling the .do_close() handling if the group matches. Peer simply directly passes the message on to the peer.

This let's us drop one more `@todo`.
    
Fixes #18244

 - [x]  #18359