### PR TITLE
test: enable TestAccounts.testBasic on Python bridge

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -20,14 +20,13 @@
 import datetime
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, wait
 
 
 @nondestructive
 @skipDistroPackage()
 class TestAccounts(MachineCase):
 
-    @todoPybridge(flaky=True)
     def testBasic(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Drop the flaky part as in 3c1d86d3fe3bd1c12c the leaking watchers and inefficient calling of cockpit.spawn for every user has been improved.

In the PR which introduced this commit the python bridge test succeeded.