### PR TITLE
python: Update libexecdir detection to look for a cockpit-bridge package program

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -68,7 +68,7 @@ def get_libexecdir() -> str:
     global LIBEXECDIR
     if LIBEXECDIR is None:
         for candidate in ['/usr/local/libexec', '/usr/libexec', '/usr/local/lib/cockpit', '/usr/lib/cockpit']:
-            if os.path.exists(os.path.join(candidate, 'cockpit-certificate-helper')):
+            if os.path.exists(os.path.join(candidate, 'cockpit-askpass')):
                 LIBEXECDIR = candidate
                 break
         else:


### PR DESCRIPTION
cockpit-certificate-helper was a poor choice, because it is shipped in cockpit-ws. That isn't a dependency of any of our packages, and in particular it is neither installed nor desired on our Fedora CoreOS image. Thus change it to "cockpit-askpass", which is shipped in the cockpit-bridge package.

---

This goes a long way towards fixing cockpit-ostree with the pybridge, see https://github.com/cockpit-project/cockpit-ostree/pull/323