### PR TITLE
python: Fixes for Python 3.6

### DIFF
--- a/.github/workflows/pybridge-c8s.yml
+++ b/.github/workflows/pybridge-c8s.yml
@@ -1,0 +1,64 @@
+# This is a temporary hack until we manage to get the integration tests going on C8S
+name: pybridge
+on: pull_request
+jobs:
+  c8s:
+    runs-on: ubuntu-22.04
+    permissions: {}
+    container: quay.io/centos/centos:stream8
+
+    timeout-minutes: 15
+    steps:
+      - name: Install dependencies
+        run: dnf install -y git-core python3-pytest python3
+
+      - name: Clone repository
+        uses: actions/checkout@v3
+
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/cockpit/cockpit
+
+      - name: Install systemd-ctypes
+        run: tools/systemd_ctypes
+
+      - name: Check --help
+        run: PYTHONPATH=src python3 -m cockpit.bridge --help
+
+      - name: Check --packages
+        # we can totally fake this, we only need a bunch of manifest.json
+        run: |
+          ln -s pkg cockpit
+          out=$(XDG_DATA_DIRS=. PYTHONPATH=src python3 -m cockpit.bridge --packages)
+          echo "$out"
+          echo "$out" | grep -q "^metrics"
+
+      - name: Check a channel
+        # TODO: cockpit.print still broken with Python 3.6
+        # PYTHONPATH=src python3 -m cockpit.print open fslist1 path=/etc watch=False
+        run: |
+          set -eux
+          (cat <<EOF; sleep 2) | COCKPIT_DEBUG=all PYTHONPATH=src python3 -m cockpit.bridge > /tmp/out
+          64
+
+          {
+            "command": "init",
+            "host": "localhost",
+            "version": 1
+          }
+          105
+
+          {
+            "command": "open",
+            "channel": "ch1",
+            "payload": "fslist1",
+            "path": "/etc",
+            "watch": false
+          }
+          EOF
+          cat /tmp/out
+          grep -q '"event": "present"' /tmp/out
+          grep -q '"path": "os-release"' /tmp/out
+
+
+      # TODO: get pytests working, but that is seriously hard

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -27,7 +27,7 @@ import sys
 
 from typing import Dict, Iterable, List, Tuple, Type
 
-from systemd_ctypes import EventLoopPolicy, bus
+from systemd_ctypes import EventLoopPolicy, bus, run_async
 
 from .channel import ChannelRoutingRule
 from .channels import CHANNEL_TYPES
@@ -137,7 +137,9 @@ async def run(args) -> None:
 
     logger.debug('Starting the router.')
     router = Bridge(args)
-    StdioTransport(asyncio.get_running_loop(), router)
+    loop = asyncio.get_running_loop()
+    loop.set_debug(args.debug)
+    StdioTransport(loop, router)
 
     logger.debug('Startup done.  Looping until connection closes.')
 
@@ -216,7 +218,8 @@ def main() -> None:
         print(json.dumps(Packages().get_bridge_configs(), indent=2))
     else:
         asyncio.set_event_loop_policy(EventLoopPolicy())
-        asyncio.run(run(args), debug=args.debug)
+        # asyncio.run() shim for Python 3.6 support
+        run_async(run(args))
 
 
 if __name__ == '__main__':

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -44,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 class InternalBus:
-    exportees: list[bus.Slot]
+    exportees: List[bus.Slot]
 
     def __init__(self, exports: Iterable[Tuple[str, Type[bus.BaseObject]]]):
         client_socket, server_socket = socket.socketpair()

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -372,9 +372,11 @@ class AsyncChannel(Channel):
             self.close(**exc.kwargs)
 
     async def read(self):
-        while not isinstance(item := await self.receive_queue.get(), bytes):
+        while True:
+            item = await self.receive_queue.get()
+            if isinstance(item, bytes):
+                return item
             self.send_pong(item)
-        return item
 
     async def write(self, data):
         if not self.send_data(data):

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
-
 import asyncio
 import logging
 
@@ -29,9 +27,9 @@ logger = logging.getLogger(__name__)
 
 
 class ChannelRoutingRule(RoutingRule):
-    table: Dict[str, List[Type[Channel]]]
+    table: Dict[str, List[Type['Channel']]]
 
-    def __init__(self, router: Router, channel_types: List[Type[Channel]]):
+    def __init__(self, router: Router, channel_types: List[Type['Channel']]):
         super().__init__(router)
         self.table = {}
 
@@ -62,7 +60,7 @@ class ChannelRoutingRule(RoutingRule):
         # Everything checked out
         return True
 
-    def apply_rule(self, options: Dict[str, object]) -> Optional[Channel]:
+    def apply_rule(self, options: Dict[str, object]) -> Optional['Channel']:
         assert self.router is not None
 
         payload = options.get('payload')
@@ -421,7 +419,7 @@ class GeneratorChannel(Channel):
     DataGenerator = Generator[bytes, None, Optional[Dict[str, object]]]
     __generator: DataGenerator
 
-    def do_yield_data(self, options: dict[str, object]) -> DataGenerator:
+    def do_yield_data(self, options: Dict[str, object]) -> 'DataGenerator':
         raise NotImplementedError
 
     def do_open(self, options: Dict[str, object]) -> None:

--- a/src/cockpit/channels/packages.py
+++ b/src/cockpit/channels/packages.py
@@ -49,7 +49,7 @@ class PackagesChannel(Channel):
 
     def http_error(self, status, message):
         # with (importlib.resources.file('cockpit.data') / 'data' / 'fail.html').open() ...  (from py3.7)
-        fail_path = __file__.removesuffix('/channels/packages.py') + '/data/fail.html'
+        fail_path = __file__.replace('/channels/packages.py', '/data/fail.html')
         template = __loader__.get_data(fail_path)
         self.send_message(status=status, reason='ERROR', headers={'Content-Type': 'text/html; charset=utf-8'})
         self.send_data(template.replace(b'@@message@@', message.encode('utf-8')))

--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -103,7 +103,8 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
         return args
 
     def do_options(self, options):
-        if window := options.get('window'):
+        window = options.get('window')
+        if window is not None:
             self._transport.set_window_size(**window)
 
     def do_close(self):

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -149,7 +149,7 @@ class Package:
     PO_JS_RE: ClassVar[Pattern] = re.compile(r'po\.([^.]+)\.js(\.gz)?')
 
     # A built in base set of "English" translations
-    PO_EN_JS: ClassVar[Entity] = b'', mimetypes.guess_type('po.js')
+    PO_EN_JS: ClassVar[Entity] = (b'', mimetypes.guess_type('po.js'))
     BASE_TRANSLATIONS: ClassVar[Entities] = {'en': PO_EN_JS, 'en-us': PO_EN_JS}
 
     files: Entities

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -229,7 +229,8 @@ class Package:
             lower_locale = locale.lower().replace('_', '-')
             self.translations[lower_locale] = data, guessed_type
         else:
-            self.files[rel.removesuffix('.gz')] = data, guessed_type
+            basename = rel[:-3] if rel.endswith('.gz') else rel
+            self.files[basename] = data, guessed_type
 
         # Perform checksum calculation
         sha = hashlib.sha256(data).hexdigest()

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os
@@ -31,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 class PeerStateListener:
-    def peer_state_changed(self, peer: Peer, event: str, exc: Optional[Exception] = None) -> None:
+    def peer_state_changed(self, peer: 'Peer', event: str, exc: Optional[Exception] = None) -> None:
         """Signal a state change in the Peer.
 
         This is called on:
@@ -40,7 +38,7 @@ class PeerStateListener:
             - connection lost (event='closed', exc possibly set)
         """
 
-    def peer_authorization_request(self, peer: Peer, message: Optional[str], prompt: str, echo: bool) -> None:
+    def peer_authorization_request(self, peer: 'Peer', message: Optional[str], prompt: str, echo: bool) -> None:
         """Request authentication for connecting to the peer.
 
         The state listener should respond by calling .authorize_response() on the Peer.
@@ -206,7 +204,7 @@ class PeerRoutingRule(RoutingRule, PeerStateListener):
 
         return self.peer
 
-    def peer_state_changed(self, peer: Peer, event: str, exc: Optional[Exception] = None):
+    def peer_state_changed(self, peer: 'Peer', event: str, exc: Optional[Exception] = None):
         logger.debug('%s got peer state event %s %s %s', self, peer, event, exc)
         if event == 'init':
             pass

--- a/src/cockpit/router.py
+++ b/src/cockpit/router.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
-
 import collections
 import logging
 
@@ -59,10 +57,10 @@ class ExecutionQueue:
 
 
 class Endpoint:
-    router: Router
+    router: 'Router'
     __endpoint_frozen_queue: Optional[ExecutionQueue] = None
 
-    def __init__(self, router: Router):
+    def __init__(self, router: 'Router'):
         self.router = router
 
     def endpoint_is_frozen(self) -> bool:
@@ -106,9 +104,9 @@ class RoutingError(Exception):
 
 
 class RoutingRule:
-    router: Router
+    router: 'Router'
 
-    def __init__(self, router: Router):
+    def __init__(self, router: 'Router'):
         self.router = router
 
     def apply_rule(self, options: Dict[str, object]) -> Optional[Endpoint]:

--- a/src/cockpit/samples.py
+++ b/src/cockpit/samples.py
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import collections
 import os
 from systemd_ctypes import Handle
 
-from typing import Any, Iterable, List, NamedTuple, Optional
+from typing import Any, DefaultDict, Iterable, List, NamedTuple, Optional
 
 
 USER_HZ = os.sysconf(os.sysconf_names['SC_CLK_TCK'])
@@ -28,7 +27,7 @@ HWMON_PATH = '/sys/class/hwmon'
 
 # we would like to do this, but mypy complains; https://github.com/python/mypy/issues/2900
 # Samples = collections.defaultdict[str, Union[float, Dict[str, Union[float, None]]]]
-Samples = collections.defaultdict[str, Any]
+Samples = DefaultDict[str, Any]
 
 
 class SampleDescription(NamedTuple):

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import os
@@ -38,24 +36,24 @@ SUPERUSER_AUTH_COOKIE = 'supermarius'
 class SuperuserStartup:
     peer: Peer  # the peer that's being started
 
-    def success(self, rule: SuperuserRoutingRule) -> None:
+    def success(self, rule: 'SuperuserRoutingRule') -> None:
         raise NotImplementedError
 
-    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+    def failed(self, rule: 'SuperuserRoutingRule', exc: Exception) -> None:
         raise NotImplementedError
 
-    def auth(self, rule: SuperuserRoutingRule, message: Optional[str], prompt: str, echo: bool) -> None:
+    def auth(self, rule: 'SuperuserRoutingRule', message: Optional[str], prompt: str, echo: bool) -> None:
         raise NotImplementedError
 
 
 class ControlMessageStartup(SuperuserStartup):
-    def success(self, rule: SuperuserRoutingRule) -> None:
+    def success(self, rule: 'SuperuserRoutingRule') -> None:
         rule.router.write_control(command='superuser-init-done')
 
-    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+    def failed(self, rule: 'SuperuserRoutingRule', exc: Exception) -> None:
         rule.router.write_control(command='superuser-init-done')
 
-    def auth(self, rule: SuperuserRoutingRule, message: Optional[str], prompt: str, echo: bool) -> None:
+    def auth(self, rule: 'SuperuserRoutingRule', message: Optional[str], prompt: str, echo: bool) -> None:
         username = pwd.getpwuid(os.getuid()).pw_name
         hexuser = ''.join(f'{c:02x}' for c in username.encode('ascii'))
         rule.router.write_control(command='authorize', cookie=SUPERUSER_AUTH_COOKIE, challenge=f'plain1:{hexuser}')
@@ -67,13 +65,13 @@ class DBusStartup(SuperuserStartup):
     def __init__(self):
         self.future = asyncio.get_running_loop().create_future()
 
-    def success(self, rule: SuperuserRoutingRule) -> None:
+    def success(self, rule: 'SuperuserRoutingRule') -> None:
         self.future.set_result(None)
 
-    def failed(self, rule: SuperuserRoutingRule, exc: Exception) -> None:
+    def failed(self, rule: 'SuperuserRoutingRule', exc: Exception) -> None:
         self.future.set_exception(bus.BusError('cockpit.Superuser.Error', str(exc)))
 
-    def auth(self, rule: SuperuserRoutingRule, message: Optional[str], prompt: str, echo: bool) -> None:
+    def auth(self, rule: 'SuperuserRoutingRule', message: Optional[str], prompt: str, echo: bool) -> None:
         rule.prompt(message or '', prompt, '', echo, '')
 
     async def wait(self) -> None:

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -29,7 +29,7 @@ import struct
 import subprocess
 import termios
 
-from typing import Any, ClassVar, Dict, Optional, Sequence, Tuple
+from typing import Any, ClassVar, Deque, Dict, List, Optional, Sequence, Tuple
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class _Transport(asyncio.Transport):
     _loop: asyncio.AbstractEventLoop
     _protocol: asyncio.Protocol
 
-    _queue: Optional[collections.deque[bytes]]
+    _queue: Optional[Deque[bytes]]
     _in_fd: int
     _out_fd: int
     _closing: bool
@@ -273,7 +273,7 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
 
     _sock: Optional[socket.socket] = None
     _pty_fd: Optional[int] = None
-    _process: subprocess.Popen[bytes]
+    _process: 'subprocess.Popen[bytes]'
     _stderr: Optional['Spooler']
 
     @staticmethod
@@ -428,7 +428,7 @@ class Spooler:
 
     _loop: asyncio.AbstractEventLoop
     _fd: int
-    _contents: list[bytes]
+    _contents: List[bytes]
 
     def __init__(self, loop: asyncio.AbstractEventLoop, fd: int):
         self._loop = loop

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -24,7 +24,7 @@ class test_iface(systemd_ctypes.bus.Object):
 
 
 class MockTransport(asyncio.Transport):
-    queue: asyncio.Queue[Tuple[str, bytes]]
+    queue: 'asyncio.Queue[Tuple[str, bytes]]'
     next_id: int = 0
 
     def send_json(self, _channel: str, **kwargs) -> None:

--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -24,7 +24,7 @@ import subprocess
 import unittest
 import unittest.mock
 
-from typing import Any, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import cockpit.transports
 
@@ -38,7 +38,7 @@ class Protocol(cockpit.transports.SubprocessProtocol):
     close_on_eof: bool = True
     eof: bool = False
     exc: Optional[Exception] = None
-    output: Optional[list[bytes]] = None
+    output: Optional[List[bytes]] = None
 
     def connection_made(self, transport: asyncio.BaseTransport) -> None:
         assert isinstance(transport, asyncio.Transport)


### PR DESCRIPTION
With that, I can  run `PYTHONPATH=src python3 -m cockpit.bridge --packages` in a centos 8 container without crashing any more:
```
# PYTHONPATH=src python3 -m cockpit.bridge --packages
cockpit.packages-WARNING: Could not detect libexecdir
base1                                                         /usr/share/cockpit/base1
kdump                                                         /usr/share/cockpit/kdump
metrics                                                       /usr/share/cockpit/metrics
network                                                       /usr/share/cockpit/networkmanager
performance                                                   /usr/share/cockpit/tuned
selinux                                                       /usr/share/cockpit/selinux
shell                                                         /usr/share/cockpit/shell
sosreport                                                     /usr/share/cockpit/sosreport
ssh                                                           /usr/share/cockpit/ssh
system                                                        /usr/share/cockpit/systemd
users                                                         /usr/share/cockpit/users
checksum = 3f17958463c66de080c7377ab561c9d5a4b527ca9563bf8601db411feccd47dc
```

I can also open channels:
```
# (cat <<EOF; sleep 2) |COCKPIT_DEBUG=all PYTHONPATH=src python3 -m cockpit.bridge | cat
64

{
  "command": "init",
  "host": "localhost",
  "version": 1
}
105

{
  "command": "open",
  "channel": "ch1",
  "payload": "fslist1",
  "path": "/etc",
  "watch": false
}
EOF
```
gets me lots of
```
ch1
{
  "event": "present",
  "path": "polkit-1",
  "type": "directory"
}
```

I also validated that I did not break mypy, I get the same 95 errors as on main. (Also see #18295).

Unfortunately running pytest is still very broken. There is no `unittest.IsolatedAsyncioTestCase`, `TypeError: glob() got an unexpected keyword argument 'root_dir'` and other goodies. But this should at least be good enough to run the integration tests.

 - [x] https://github.com/allisonkarlitskaya/systemd_ctypes/pull/49