### PR TITLE
tools/venv: build a venv with cockpit installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ Makefile.in
 # toplevel (/...)
 /*.list
 /.coverage
+/.venv/
 /Coverage
 /aclocal.m4
 /autom4te.cache
@@ -54,6 +55,7 @@ Makefile.in
 /package-lock.json
 /socket-activation-helper
 /stamp-h1
+/setup.cfg
 /tags
 /test-*
 /test_rsa_key

--- a/tools/venv
+++ b/tools/venv
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -eux
+
+cd "${0%/*}/.."
+tools/systemd_ctypes
+rm -rf .venv
+python3 -m venv --system-site-packages --without-pip .venv
+touch setup.cfg
+.venv/bin/python3 -m pip install --no-index --no-build-isolation -e .


### PR DESCRIPTION
This creates a virtual environment in .venv/ and installs the Python package into it, in editable mode.  That lets you run .venv/bin/cockpit-bridge, for example, or activate the environment.



This is a fun toy.  I find it useful.