### PR TITLE
containers: Add mypy to unit-tests

### DIFF
--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -45,7 +45,6 @@ dependencies="\
     python3-mypy \
     python3-pytest-cov \
     python3-pytest-timeout \
-    sassc \
     ssh \
     strace \
     valgrind \

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -42,6 +42,7 @@ dependencies="\
     nodejs \
     pkg-config \
     python3 \
+    python3-mypy \
     python3-pytest-cov \
     python3-pytest-timeout \
     sassc \


### PR DESCRIPTION
We are going to use it soon to cover the Python bridge.

---

See #18295 - that isn't ready yet, but I'd like to get the container update out of the way already, as it takes quite long to build in each PR.