### PR TITLE
login: Change key verify command background

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -548,7 +548,7 @@ label.checkbox {
 #hostkey-verify-help-cmds {
   border-radius: 0.25rem;
   padding: 0.5rem 1rem;
-  background: #ddd;
+  background: rgb(150 150 150 / 20%);
 }
 
 .pf-c-button .spinner,


### PR DESCRIPTION
Make the background transparent, so it works in light and dark mode.

Fixes #18307