### PR TITLE
.github: update release action workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - id: publish
         name: Publish GitHub release
-        uses: cockpit-project/action-release@d922a7ea21329cb46762e52a218c120e388fb0c1
+        uses: cockpit-project/action-release@d88d994da62d1451c7073e26748c18413fcdf46e9
         with:
           filename: "cockpit-${{ github.ref_name }}.tar.xz"
 


### PR DESCRIPTION
Our latest action-release workflow no longer uses a deprecated github-script version.