### PR TITLE
.github: fix extranous 'd' before commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
       - id: publish
         name: Publish GitHub release
-        uses: cockpit-project/action-release@d88d994da62d1451c7073e26748c18413fcdf46e9
+        uses: cockpit-project/action-release@88d994da62d1451c7073e26748c18413fcdf46e9
         with:
           filename: "cockpit-${{ github.ref_name }}.tar.xz"
 


### PR DESCRIPTION
Should be https://github.com/cockpit-project/action-release/commit/88d994da62d1451c7073e26748c18413fcdf46e9