### PR TITLE
python: Fix KeyError on overriding nonexisting manifest keys

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -201,7 +201,7 @@ class Package:
         result = dict(target if isinstance(target, dict) else {})
         for name, value in patch.items():
             if value is not None:
-                result[name] = Package.merge_patch(result[name], value)
+                result[name] = Package.merge_patch(result.get(name), value)
             else:
                 result.pop(name)
         return result

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -66,18 +66,24 @@ class TestPackages(unittest.TestCase):
             cockpit.config.ETC_COCKPIT = orig_etc_config
         self.addCleanup(cleanUp)
 
-        (config_dir / 'basic.override.json').write_text('{"description": "overridden package"}')
+        (config_dir / 'basic.override.json').write_text('{"description": "overridden package", "priority": 5}')
 
         packages = Packages()
         assert len(packages.packages) == 1
         # original attributes
         assert packages.packages['basic'].name == 'basic'
         assert packages.packages['basic'].manifest['requires'] == {'cockpit': '42'}
-        assert packages.packages['basic'].priority == 1
         # overridden attributes
         assert packages.packages['basic'].manifest['description'] == 'overridden package'
+        assert packages.packages['basic'].priority == 5
 
-        assert packages.manifests == '{"basic": {"description": "overridden package", "requires": {"cockpit": "42"}}}'
+        assert json.loads(packages.manifests) == {
+            'basic': {
+                'description': 'overridden package',
+                'requires': {'cockpit': '42'},
+                'priority': 5,
+            }
+        }
 
     def test_priority(self):
         (self.package_dir / 'vip').mkdir()

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -15,9 +15,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
 import pytest
 
-from cockpit.packages import parse_accept_language
+import cockpit.config
+from cockpit.packages import parse_accept_language, Packages
 
 
 @pytest.mark.parametrize("test_input,expected", [
@@ -26,3 +33,66 @@ from cockpit.packages import parse_accept_language
                          ('fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', ['fr-ch', 'fr', 'en', 'de', '*'])])
 def test_parse_accept_language(test_input, expected):
     assert parse_accept_language({'Accept-Language': test_input}) == expected
+
+
+class TestPackages(unittest.TestCase):
+    def setUp(self):
+        self.workdir = Path(tempfile.mkdtemp(prefix='cockpit-packages-test-'))
+        self.package_dir = self.workdir / 'cockpit'
+        self.package_dir.mkdir()
+        os.environ['XDG_DATA_DIRS'] = str(self.workdir)
+
+        (self.package_dir / 'basic').mkdir()
+        (self.package_dir / 'basic' / 'manifest.json').write_text(
+            '{"description": "standard package", "requires": {"cockpit": "42"}}')
+
+    def test_basic(self):
+        packages = Packages()
+        assert len(packages.packages) == 1
+        assert packages.packages['basic'].name == 'basic'
+        assert packages.packages['basic'].manifest['description'] == 'standard package'
+        assert packages.packages['basic'].manifest['requires'] == {'cockpit': "42"}
+        assert packages.packages['basic'].priority == 1
+
+        assert packages.manifests == '{"basic": {"description": "standard package", "requires": {"cockpit": "42"}}}'
+
+    def test_override_etc(self):
+        config_dir = self.workdir / 'config'
+        config_dir.mkdir()
+        orig_etc_config = cockpit.config.ETC_COCKPIT
+        cockpit.config.ETC_COCKPIT = config_dir
+
+        def cleanUp():
+            cockpit.config.ETC_COCKPIT = orig_etc_config
+        self.addCleanup(cleanUp)
+
+        (config_dir / 'basic.override.json').write_text('{"description": "overridden package"}')
+
+        packages = Packages()
+        assert len(packages.packages) == 1
+        # original attributes
+        assert packages.packages['basic'].name == 'basic'
+        assert packages.packages['basic'].manifest['requires'] == {'cockpit': '42'}
+        assert packages.packages['basic'].priority == 1
+        # overridden attributes
+        assert packages.packages['basic'].manifest['description'] == 'overridden package'
+
+        assert packages.manifests == '{"basic": {"description": "overridden package", "requires": {"cockpit": "42"}}}'
+
+    def test_priority(self):
+        (self.package_dir / 'vip').mkdir()
+        (self.package_dir / 'vip' / 'manifest.json').write_text('{"name": "basic", "description": "VIP", "priority": 100}')
+        (self.package_dir / 'guest').mkdir()
+        (self.package_dir / 'guest' / 'manifest.json').write_text('{"description": "Guest"}')
+
+        packages = Packages()
+        assert len(packages.packages) == 2
+        assert packages.packages['basic'].name == 'basic'
+        assert packages.packages['basic'].priority == 100
+        assert packages.packages['basic'].manifest['description'] == 'VIP'
+        assert packages.packages['guest'].name == 'guest'
+        assert packages.packages['guest'].priority == 1
+
+        parsed = json.loads(packages.manifests)
+        assert parsed['basic'] == {'name': 'basic', 'description': 'VIP', 'priority': 100}
+        assert parsed['guest'] == {'description': 'Guest'}


### PR DESCRIPTION
Split out from PR #18291, it's unrelated and a good fix in its own right.