### PR TITLE
pytest: Fix TestPackages for environments with ~/.local/share/cockpit/

### DIFF
--- a/test/pytest/test_code.py
+++ b/test/pytest/test_code.py
@@ -27,4 +27,5 @@ ROOT_DIR = os.path.realpath(f'{__file__}/../../..')
 @pytest.mark.skipif(not shutil.which('mypy'), reason='mypy is not installed')
 def test_bridge_mypy():
     # only test src/cockpit; src/systemd_ctypes does not have type annotations yet
-    subprocess.check_call(['mypy', 'src/cockpit'], cwd=ROOT_DIR)
+    # disable caching, as it otherwise often crashes with "Cannot find component 'inotify' for 'systemd_ctypes...."
+    subprocess.check_call(['mypy', '--no-incremental', 'src/cockpit'], cwd=ROOT_DIR)

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -41,6 +41,7 @@ class TestPackages(unittest.TestCase):
         self.package_dir = self.workdir / 'cockpit'
         self.package_dir.mkdir()
         os.environ['XDG_DATA_DIRS'] = str(self.workdir)
+        os.environ['XDG_DATA_HOME'] = '/nonexisting'
 
         (self.package_dir / 'basic').mkdir()
         (self.package_dir / 'basic' / 'manifest.json').write_text(


### PR DESCRIPTION
We need to divert `$XDG_DATA_HOME` as well to hide any existing ~/.local/share/cockpit/, to avoid assertion failures on on unexpected packages.