### PR TITLE
python: Defer asyncio.Lock() creation for D-Bus

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -174,10 +174,6 @@ class DBusChannel(Channel):
     bus = None
     owner = None
 
-    # This needs to be a fair mutex so that outgoing messages don't
-    # get re-ordered.  asyncio.Lock is fair.
-    watch_processing_lock = asyncio.Lock()
-
     async def setup_name_owner_tracking(self):
         def send_owner(owner):
             # We must be careful not to send duplicate owner
@@ -245,6 +241,10 @@ class DBusChannel(Channel):
         except OSError as err:
             if err.errno != errno.EBUSY:
                 raise
+
+        # This needs to be a fair mutex so that outgoing messages don't
+        # get re-ordered.  asyncio.Lock is fair.
+        self.watch_processing_lock = asyncio.Lock()
 
         if self.name is not None:
             async def get_ready():


### PR DESCRIPTION
Initializing a global lock at program start is too early: At that point, systemd_ctypes has not yet initialized its own main loop. In Python 3.6 this causes tons of crashes like

    RuntimeError: Task <Task pending coro=<DBusChannel.do_open.<locals>.get_ready() running at
    /usr/lib64/python3.6/site-packages/cockpit/channels/dbus.py:251>
    cb=[set.discard()]> got Future <Future pending> attached to a different loop

This also moves the lock from a class to an instance variable -- it's not necessary to globally order messages, doing it for a single channel is sufficient.

----

I split this out from PR #18318 , I think this causes some fallout, e.g. [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18318-20230210-093531-e2e439f3-fedora-37-pybridge/log.html#72) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18318-20230210-075939-e2e439f3-centos-8-stream-pybridge/log.html#333). 

These look like this:
```
asyncio-ERROR: Task exception was never retrieved
future: <Task finished name='Task-11408' coro=<DBusChannel.setup_path_watch.<locals>.handler() done, defined at /usr/lib/python3.11/site-packages/cockpit/channels/dbus.py:405> exception=BusError('org.freedesktop.DBus.Error.AccessDenied: Failed to get file context on /usr/lib/systemd/system/NetworkManager.service.')>
Traceback (most recent call last):
  File "/usr/lib/python3.11/site-packages/cockpit/channels/dbus.py", line 411, in handler
    reply, = await self.bus.call_method_async(self.name, path,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 385, in call_method_async
    message = await self.call_async(message, timeout)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/systemd_ctypes/bus.py", line 379, in call_async
    return await pending.future
           ^^^^^^^^^^^^^^^^^^^^
systemd_ctypes.bus.BusError: org.freedesktop.DBus.Error.AccessDenied: Failed to get file context on /usr/lib/systemd/system/NetworkManager.service.
```

or this:

```
cockpit-ws[43642]: asyncio-ERROR: Task exception was never retrieved
cockpit-ws[43642]: future: <Task finished coro=<DBusChannel.do_open.<locals>.get_ready() done, defined at /usr/lib64/python3.6/site-packages/cockpit/channels/dbus.py:250> exception=InterruptedError(4, 'sd_bus_add_match: Interrupted system call')>
Traceback (most recent call last):    
  File "/usr/lib64/python3.6/site-packages/cockpit/channels/dbus.py", line 252, in get_ready    
    await self.setup_name_owner_tracking()    
  File "/usr/lib64/python3.6/site-packages/cockpit/channels/dbus.py", line 193, in setup_name_owner_tracking    
    arg0=self.name)    
  File "/usr/lib64/python3.6/site-packages/cockpit/channels/dbus.py", line 282, in add_signal_handler    
    self.matches.append(self.bus.add_match(r_string, func))    
  File "/usr/lib64/python3.6/site-packages/systemd_ctypes/bus.py", line 390, in add_match    
    super().add_match(byref(slot), rule, slot.callback, slot.userdata)    
  File "/usr/lib64/python3.6/site-packages/systemd_ctypes/librarywrapper.py", line 61, in wrapper    
    return func(*args)    
  File "/usr/lib64/python3.6/site-packages/systemd_ctypes/librarywrapper.py", line 26, in errcheck    
    raise OSError(-result, f'{func.__name__}: {os.strerror(-result)}')    
InterruptedError: [Errno 4] sd_bus_add_match: Interrupted system call    

```

I think these could have been previously hidden by running them on a wrong main loop?

So I think we need to (1) properly check failing tasks, and propagate their errors, (2) handle EINTR for `self.bus.add_match()` (it always seems to happen there), and (3) handle the AccessDenied error.

@mvollmer , does that ring a bell? I can look into this, but maybe you already have some ideas about how to do that properly.