### PR TITLE
 lib: Add development support for remote hosts 

### DIFF
--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -6,17 +6,20 @@ module.exports = class {
             options = {};
         this.dest = options.dest || "";
         this.source = options.source || "dist/";
+        this.ssh_host = process.env.RSYNC || process.env.RSYNC_DEVEL;
 
         // ensure the target directory exists
-        if (process.env.RSYNC)
-            child_process.spawnSync("ssh", [process.env.RSYNC, "mkdir", "-p", "/usr/local/share/cockpit/"], { stdio: "inherit" });
+        if (this.ssh_host) {
+            this.rsync_dir = process.env.RSYNC ? "/usr/local/share/cockpit/" : "~/.local/share/cockpit/";
+            child_process.spawnSync("ssh", [this.ssh_host, "mkdir", "-p", this.rsync_dir], { stdio: "inherit" });
+        }
     }
 
     apply(compiler) {
         compiler.hooks.afterEmit.tapAsync('WebpackHookPlugin', (compilation, callback) => {
-            if (process.env.RSYNC) {
+            if (this.ssh_host) {
                 const proc = child_process.spawn("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
-                    this.source, process.env.RSYNC + ":/usr/local/share/cockpit/" + this.dest], { stdio: "inherit" });
+                    this.source, this.ssh_host + ":" + this.rsync_dir + this.dest], { stdio: "inherit" });
                 proc.on('close', (code) => {
                     if (code !== 0) {
                         process.exit(1);


### PR DESCRIPTION
Adds the variable `RSYNC_DEVEL` for starter-kit.

`RSYNC_DEVEL` uses `~/.local/share/cockpit/` instead of `/usr/local/share/cockpit/`.
This helps for developing on a remote host.