### PR TITLE
test: Get along with /usr/local/bin/cockpit-bridge

### DIFF
--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -875,7 +875,7 @@ ResultActive=yes""")
         m.write(r"/tmp/browser.sh", """#!/bin/sh -e
 curl --silent --compressed -o /tmp/out.html "$@"
 # wait until privileged bridge starts
-until pgrep -f '/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
+until pgrep -f '[c]ockpit-bridge.*--privileged'; do sleep 1; done
 """)
         m.execute("chmod 755 /tmp/browser.sh")
         m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin")
@@ -886,7 +886,7 @@ until pgrep -f '/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_journal_messages(".*Peer failed to perform TLS handshake.*")
         self.allow_journal_messages(r".*cannot reauthorize identity\(s\): unix-user:.*")
-        self.allow_journal_messages("admin: Executing command .*COMMAND=/usr/bin/cockpit-bridge --privileged.*")
+        self.allow_journal_messages("admin: Executing command .*COMMAND=.*cockpit-bridge --privileged.*")
 
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testReverseProxy(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -153,7 +153,7 @@ class TestConnection(MachineCase):
             self.allow_journal_messages(".*cockpit-session: bridge program failed.*")
 
             # pretend cockpit-bridge is not installed, expect specific error message
-            m.execute("mv /usr/bin/cockpit-bridge /usr/bin/cockpit-bridge.disabled")
+            m.execute("while B=$(command -v cockpit-bridge); do mv $B ${B}.disabled; done")
             b.open("/system")
             b.wait_visible("#login")
             b.set_val("#login-user-input", "admin")
@@ -161,7 +161,7 @@ class TestConnection(MachineCase):
             b.click('#login-button')
             b.wait_visible('#login-fatal-message')
             b.wait_text('#login-fatal-message', "The cockpit package is not installed")
-            m.execute("mv /usr/bin/cockpit-bridge.disabled /usr/bin/cockpit-bridge")
+            m.execute("while B=$(command -v cockpit-bridge.disabled); do mv $B ${B%.disabled}; done")
 
         # Lets crash a systemd-controlled process and see if we get a proper backtrace in the logs
         # This helps with debugging failures in the tests elsewhere

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -37,7 +37,7 @@ class TestLoopback(MachineCase):
         b.logout()
         b.wait_visible("#login")
 
-        m.execute("rm /usr/bin/cockpit-bridge")
+        m.execute("while B=$(command -v cockpit-bridge); do rm $B; done")
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -29,7 +29,7 @@ def allow_old_cockpit_ws_messages(test):
     test.allow_journal_messages("logged in user session",
                                 "New connection to session from.*",
                                 "pam_unix(polkit-1:session): session opened for user root by .*uid=.*",
-                                "admin: Executing command .*COMMAND=/usr/bin/cockpit-bridge --privileged.*")
+                                "admin: Executing command .*COMMAND=.*cockpit-bridge --privileged.*")
 
 
 @nondestructive


### PR DESCRIPTION
This happens in the pybridge scenario once image-customize changes to
installing wheels into /usr/local [1]. We need while loops to cover all
installed "cockpit-bridge" commands.
    
[1] https://github.com/cockpit-project/bots/pull/4397
