### PR TITLE
containers: Move ws to Fedora 37

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:36 AS builder
+FROM registry.fedoraproject.org/fedora:37 AS builder
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 


### PR DESCRIPTION
Blocks https://github.com/cockpit-project/bots/pull/4347. This cannot really be tested in CI, as that only updates the existing container. I have some difficulty testing this locally, as both on main and on this branch `podman build -t localhost/ws containers/ws/` fails with "RPM: error: Unable to change root directory: Operation not permitted".

I [built it on GitHub](https://github.com/cockpit-project/cockpit/actions/runs/4171076388) instead. This resulted in [tag 284](https://quay.io/repository/cockpit/ws?tab=tags). I ran `podman run -d --name cockpit-bastion -p 9999:9090 quay.io/cockpit/ws` and validated that I can log in at https://localhost:9999.
