### PR TITLE
tools: Bring back missing files check in Debian packaging

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -43,3 +43,7 @@ override_dh_install:
 
 	dh_install -Xusr/src/debug
 	make install-tests DESTDIR=debian/cockpit-tests
+
+# will be the default in compat 13
+override_dh_missing:
+	dh_missing --fail-missing


### PR DESCRIPTION
`dh_install --fail-missing` has been deprecated for a while and got removed in dh compat level 12 (which we use). Use `dh_missing` instead. We can drop the override once we move to dh compat level 13. This fixes the warning during build:

    dh_install: warning: Please use dh_missing --list-missing/--fail-missing instead
    dh_install: warning: This feature will be removed in compat 12.