### PR TITLE
test: Factorize OS specific test skips

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -22,6 +22,7 @@ from time import sleep
 import argparse
 import base64
 import errno
+import fnmatch
 import os
 import shutil
 import socket
@@ -41,6 +42,8 @@ from typing import Any, Callable, Dict, List, Optional, Union
 
 import testvm
 import cdp
+
+from lib.constants import OSTREE_IMAGES
 
 from lcov import write_lcov
 
@@ -71,6 +74,7 @@ __all__ = (
     'skipImage',
     'skipDistroPackage',
     'skipMobile',
+    'skipOstree',
     'skipBrowser',
     'skipPackage',
     'todo',
@@ -2151,7 +2155,13 @@ def skipBrowser(reason: str, *args: str):
 
 
 def skipImage(reason: str, *args: str):
-    if testvm.DEFAULT_IMAGE in args:
+    if any(fnmatch.fnmatch(testvm.DEFAULT_IMAGE, arg) for arg in args):
+        return unittest.skip("{0}: {1}".format(testvm.DEFAULT_IMAGE, reason))
+    return lambda testEntity: testEntity
+
+
+def skipOstree(reason: str):
+    if testvm.DEFAULT_IMAGE in OSTREE_IMAGES:
         return unittest.skip("{0}: {1}".format(testvm.DEFAULT_IMAGE, reason))
     return lambda testEntity: testEntity
 

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -19,11 +19,11 @@
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import skipImage, skipPackage, test_main
+from testlib import skipImage, skipOstree, skipPackage, test_main
 
 
 @skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
-@skipImage("Not supported", "fedora-coreos", "rhel4edge")
+@skipOstree("Not supported")
 @skipPackage("cockpit-apps")
 class TestApps(PackageCase):
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -23,7 +23,7 @@ import os
 import subprocess
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipBrowser, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, TEST_DIR, nondestructive, skipBrowser, skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 
 @skipDistroPackage()
@@ -179,7 +179,7 @@ class TestConnection(MachineCase):
         self.allow_core_dumps = True
         self.allow_journal_messages(".*org.freedesktop.hostname1.*DBus.Error.NoReply.*")
 
-    @skipImage("OSTree doesn't use systemd units", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't use systemd units")
     def testUnitLifecycle(self):
         m = self.machine
 
@@ -280,7 +280,7 @@ class TestConnection(MachineCase):
             out = m.execute(f"su -c '! nc -U /run/cockpit/wsinstance/{s} 2>&1 || exit 1' admin")
             self.assertIn("Permission denied", out)
 
-    @skipImage("OSTree doesn't use systemd units", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't use systemd units")
     def testHttpsInstanceDoS(self):
         m = self.machine
         # prevent generating core dump artifacts
@@ -485,7 +485,7 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages('peer did not close io when expected')
 
-    @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't have cockpit-ws")
     def test100YearsCert(self):
         m = self.machine
 
@@ -529,7 +529,7 @@ class TestConnection(MachineCase):
         m.execute(f'test ! {selfsign} -nt /tmp/timestamp')
         m.execute('rm /tmp/timestamp')
 
-    @skipImage("OSTree doesn't use systemd units", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't use systemd units")
     def testSocket(self):
         m = self.machine
 
@@ -599,7 +599,7 @@ class TestConnection(MachineCase):
 
         self.allow_journal_messages(".*Peer failed to perform TLS handshake")
 
-    @skipImage("Can't remove/upgrade packages on OSTree", "fedora-coreos", "rhel4edge")
+    @skipOstree("Can't remove/upgrade packages on OSTree")
     def testWsPackage(self):
         m = self.machine
 
@@ -672,7 +672,7 @@ class TestConnection(MachineCase):
         if root_login_disallowed:
             self.assertIn('root', m.execute("cat /etc/cockpit/disallowed-users"))
 
-    @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't have cockpit-ws")
     @nondestructive
     def testCommandline(self):
         m = self.machine
@@ -744,7 +744,7 @@ class TestConnection(MachineCase):
         headers = m.execute("curl -s --head http://172.27.0.15:9090/cockpit+123/channel/foo")
         self.assertIn("HTTP/1.1 404 Not Found\r\n", headers)
 
-    @skipImage("ssh root login not allowed", "fedora-coreos", "rhel4edge")
+    @skipOstree("ssh root login not allowed")
     @nondestructive
     def testFlowControl(self):
         m = self.machine
@@ -771,7 +771,7 @@ class TestConnection(MachineCase):
         # This fails when flow control is not present
         self.assertLess(rss, 250000)
 
-    @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos", "rhel4edge")
+    @skipOstree("OSTree doesn't have cockpit-ws")
     @nondestructive
     def testLocalSession(self):
         m = self.machine
@@ -808,8 +808,8 @@ export XDG_CONFIG_DIRS=/usr/local
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
 
-    @skipImage("OSTree doesn't have cockpit-ws", "fedora-coreos", "rhel4edge")
-    @skipImage("Kernel does not allow user namespaces", "debian-stable", "debian-testing")
+    @skipOstree("OSTree doesn't have cockpit-ws")
+    @skipImage("Kernel does not allow user namespaces", "debian-*")
     def testCockpitDesktop(self):
         m = self.machine
 
@@ -1041,7 +1041,7 @@ until pgrep -f '/usr/bin/cockpit-bridge.*--privileged'; do sleep 1; done
         b.wait_visible("#login")
         b.assert_pixels("body", "login-screen")
 
-    @skipImage("no cockpit-ws package", "fedora-coreos", "rhel4edge")
+    @skipOstree("no cockpit-ws package")
     def testAuthUnixPath(self):
         '''test UnixPath for auth method in cockpit.conf'''
         m = self.machine
@@ -1123,8 +1123,8 @@ ProtocolHeader = X-Forwarded-Proto
         b.logout()
         b.cdp.invoke("Browser.close")
 
-    @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos", "rhel4edge",
-               "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "ubuntu-stable", "ubuntu-2204", "arch")
+    @skipImage("nginx not installed", "centos-8-stream", "rhel-*", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("nginx not installed")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxTLS(self):
         '''test proxying to Cockpit with TLS
@@ -1202,8 +1202,8 @@ server {
         b.click('#login-button')
         b.wait_visible('article.system-health')
 
-    @skipImage("nginx not installed", "centos-8-stream", "debian-stable", "debian-testing", "fedora-coreos", "rhel4edge",
-               "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "ubuntu-stable", "ubuntu-2204", "arch")
+    @skipImage("nginx not installed", "centos-8-stream", "rhel-*", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("nginx not installed")
     @skipBrowser("Firefox needs proper cert and CA", "firefox")
     def testNginxNoTLS(self):
         '''test proxying to Cockpit with plain HTTP

--- a/test/verify/check-examples
+++ b/test/verify/check-examples
@@ -3,7 +3,7 @@
 import os
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, TEST_DIR, nondestructive, skipDistroPackage, skipOstree, test_main
 from fmf_metadata import FMF
 
 
@@ -54,7 +54,7 @@ class TestXHRProxy(MachineCase):
         self.machine.upload([os.path.join(EXAMPLES_DIR, "xhr-proxy")], "/home/admin/.local/share/cockpit/")
 
     @FMF.tag("example2")
-    @skipImage("No Python installed", "fedora-coreos", "rhel4edge")
+    @skipOstree("No Python installed")
     def testBasic(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, timeout
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, skipOstree, test_main, timeout
 from lib.constants import TEST_OS_DEFAULT
 
 
@@ -49,8 +49,8 @@ class KdumpHelpers(MachineCase):
         self.machine.wait_boot(timeout_sec=300)
 
 
-@skipImage("kexec-tools not installed", "fedora-coreos", "rhel4edge", "debian-stable",
-           "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+@skipOstree("kexec-tools not installed")
+@skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
 @timeout(900)
 @skipDistroPackage()
 class TestKdump(KdumpHelpers):
@@ -376,8 +376,8 @@ class TestKdump(KdumpHelpers):
         b.wait_text("#kdump-target-info", "Remote over CIFS/SMB")
 
 
-@skipImage("kexec-tools not installed", "fedora-coreos", "rhel4edge", "debian-stable",
-           "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+@skipOstree("kexec-tools not installed")
+@skipImage("kexec-tools not installed", "debian-*", "ubuntu-*", "arch")
 @timeout(900)
 @skipDistroPackage()
 class TestKdumpNFS(KdumpHelpers):

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -18,10 +18,10 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, skipDistroPackage, skipOstree, test_main
 
 
-@skipImage("OSTree always uses loopback", "fedora-coreos", "rhel4edge")
+@skipOstree("OSTree always uses loopback")
 @skipDistroPackage()
 class TestLoopback(MachineCase):
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -9,7 +9,7 @@ import time
 # import Cockpit's machinery for test VMs and its browser test API
 import parent  # noqa: F401
 import packagelib
-from testlib import (Browser, Error, MachineCase, nondestructive, skipDistroPackage, skipImage,
+from testlib import (Browser, Error, MachineCase, nondestructive, skipDistroPackage, skipImage, skipOstree,
                      skipMobile, test_main, wait)
 
 from machine_core import ssh_connection
@@ -156,7 +156,7 @@ class TestHistoryMetrics(MachineCase):
         })""")
         self.assertLessEqual(leading_empty, 4)
 
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testBasic(self):
         b = self.browser
         m = self.machine
@@ -222,7 +222,7 @@ class TestHistoryMetrics(MachineCase):
         b.enter_page("/system")
         b.wait_visible('.system-information')
 
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testEvents(self):
         b = self.browser
         m = self.machine
@@ -472,7 +472,7 @@ class TestHistoryMetrics(MachineCase):
         self.assertIn("until=2021-3-8%2010%3A39%3A45", url)
 
     @nondestructive
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testNoDataEnable(self):
         b = self.browser
         m = self.machine
@@ -507,7 +507,7 @@ class TestHistoryMetrics(MachineCase):
         b.logout()
 
     @nondestructive
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testNoDataFailed(self):
         b = self.browser
         m = self.machine
@@ -534,7 +534,7 @@ class TestHistoryMetrics(MachineCase):
             b.wait_in_text("#service-details", "pmlogger.service")
 
     @nondestructive
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testLoggerSettings(self):
         b = self.browser
         m = self.machine
@@ -568,7 +568,7 @@ class TestHistoryMetrics(MachineCase):
         self.assertEqual(m.execute("systemctl is-enabled pmlogger").strip(), "enabled")
 
     @nondestructive
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testPmProxySettings(self):
         b = self.browser
         m = self.machine
@@ -1185,7 +1185,7 @@ BEGIN {{
         b.wait_visible(progress_sel)
         self.assertFalse(b.is_present("#current-disks-usage button"))
 
-    @skipImage("no netcat on CoreOS", "fedora-coreos", "rhel4edge")
+    @skipOstree("no netcat on CoreOS")
     def testNetwork(self):
         b = self.browser
         m = self.machine
@@ -1337,7 +1337,7 @@ class TestMultiCPU(MachineCase):
         "0": {"cpus": 2}
     }
 
-    @skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+    @skipOstree("no PCP support")
     def testCPUUsage(self):
         b = self.browser
         m = self.machine
@@ -1375,7 +1375,7 @@ class TestMultiCPU(MachineCase):
         b.wait(lambda: int(b.text("#current-cpu-usage .pf-c-progress__status").split()[-1].rstrip('%')) <= 70)
 
 
-@skipImage("no PCP support", "fedora-coreos", "rhel4edge")
+@skipOstree("no PCP support")
 @skipDistroPackage()
 @skipMobile()
 class TestGrafanaClient(MachineCase):

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import nondestructive, skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 from lib.constants import TEST_OS_DEFAULT
 
@@ -267,7 +267,7 @@ class TestBondingVirt(NetworkCase):
         "machine2": {"image": TEST_OS_DEFAULT, "address": "10.111.113.2/20", "dhcp": True, "memory_mb": 256}
     }
 
-    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable")
+    @skipImage("Main interface can't be managed", "debian-*", "ubuntu-*")
     def testMain(self):
         b = self.browser
         m = self.machine
@@ -298,8 +298,8 @@ class TestBondingVirt(NetworkCase):
         b.wait_visible(f"#networking-interfaces tr[data-interface='{iface}']")
 
     @skipImage("TODO: no dhclient on Arch image", "arch")
-    @skipImage("Main interface can't be managed", "debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable")
-    @skipImage("not using dhclient", "fedora-coreos", "rhel4edge")
+    @skipImage("Main interface can't be managed", "debian-*", "ubuntu-*")
+    @skipOstree("not using dhclient")
     def testSlowly(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-checkpoints
+++ b/test/verify/check-networkmanager-checkpoints
@@ -19,10 +19,10 @@
 
 import parent  # noqa: F401
 from netlib import NetworkCase, re
-from testlib import skipDistroPackage, skipImage, test_main, wait
+from testlib import skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 
-@skipImage("No network checkpoint support", "ubuntu-2204", "ubuntu-stable")
+@skipImage("No network checkpoint support", "ubuntu-*")
 @skipDistroPackage()
 class TestNetworkingCheckpoints(NetworkCase):
     def testCheckpoint(self):
@@ -66,8 +66,9 @@ class TestNetworkingCheckpoints(NetworkCase):
                 b.click("#confirm-breaking-change-popup button:contains('Keep connection')")
             b.wait_not_present("#confirm-breaking-change-popup")
 
-    @skipImage("Main interface settings are read-only", "debian-stable", "debian-testing")
-    @skipImage("not using dhclient", "fedora-coreos", "rhel4edge", "arch")
+    @skipImage("Main interface settings are read-only", "debian-*")
+    @skipImage("not using dhclient", "arch")
+    @skipOstree("not using dhclient")
     def testCheckpointSlowRollback(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 import time
-from testlib import Error, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import Error, nondestructive, skipDistroPackage, skipOstree, test_main, wait
 from netlib import NetworkCase
 
 
@@ -46,7 +46,7 @@ def get_active_rules(machine):
     return active_rules
 
 
-@skipImage("no firewalld", "fedora-coreos", "rhel4edge")
+@skipOstree("no firewalld")
 @nondestructive
 @skipDistroPackage()
 class TestFirewall(NetworkCase):

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -20,10 +20,10 @@
 import parent  # noqa: F401
 import json
 from netlib import NetworkCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import nondestructive, skipDistroPackage, skipImage, skipOstree, test_main
 
 
-@skipImage("NetworkManager-team not installed", "fedora-coreos", "rhel4edge")
+@skipOstree("NetworkManager-team not installed")
 @skipImage("TODO: networkmanager fails on Arch Linux", "arch")
 @skipDistroPackage()
 @nondestructive

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -23,7 +23,7 @@ import time
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import nondestructive, skipDistroPackage, skipImage, skipOstree, test_main
 
 
 WAIT_SCRIPT = """
@@ -38,9 +38,7 @@ done
 """
 
 OSesWithoutTracer = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "fedora-coreos", "rhel4edge"]
-OSesWithoutKpatch = ["debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch",
-                     "fedora-coreos", "rhel4edge", "fedora-36", "fedora-37", "fedora-38", "fedora-testing",
-                     "centos-8-stream", "centos-9-stream"]
+OSesWithoutKpatch = ["debian-*", "ubuntu-*", "arch", "fedora-*", "rhel4edge", "centos-*"]
 
 
 class NoSubManCase(PackageCase):
@@ -59,7 +57,7 @@ class NoSubManCase(PackageCase):
 
 
 @skipImage("TODO: Fails with 401 on our test runners", "arch")
-@skipImage("Image uses OSTree", "fedora-coreos", "rhel4edge")
+@skipOstree("Image uses OSTree")
 class TestUpdates(NoSubManCase):
 
     def setUp(self):
@@ -1164,7 +1162,7 @@ ExecStart=/usr/local/bin/{packageName}
 
 
 @skipImage("TODO: Arch Linux has no cockpit-ws package, it's in cockpit", "arch")
-@skipImage("Image uses OSTree", "fedora-coreos", "rhel4edge")
+@skipOstree("Image uses OSTree")
 class TestWsUpdate(NoSubManCase):
     def testBasic(self):
         # The main case for this is that cockpit-ws itself gets upgraded, which

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -21,7 +21,7 @@ import time
 import os
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main
 
 RHEL_DOC_BASE = "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console"
 
@@ -616,7 +616,7 @@ OnCalendar=daily
         b.key_press("stuff/")
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "other")
 
-    @skipImage("No PCP available", "fedora-coreos", "rhel4edge")
+    @skipOstree("No PCP available")
     def testPlots(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main
 
 
 @skipDistroPackage()
@@ -62,7 +62,7 @@ class TestReauthorize(MachineCase):
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')
 
-    @skipImage("ssh root login not allowed", "fedora-coreos", "rhel4edge")
+    @skipOstree("ssh root login not allowed")
     def testSuper(self):
         b = self.browser
 

--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -18,7 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import Error, MachineCase, skipBrowser, skipDistroPackage, skipImage, test_main
+from testlib import Error, MachineCase, skipBrowser, skipDistroPackage, skipImage, skipOstree, test_main
 from lib.constants import TEST_OS_DEFAULT
 
 import time
@@ -64,7 +64,8 @@ class TestSelinux(MachineCase):
         "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 512}
     }
 
-    @skipImage("No setroubleshoot", "debian-stable", "debian-testing", "fedora-coreos", "rhel4edge", "ubuntu-2204", "ubuntu-stable", "arch")
+    @skipImage("No setroubleshoot", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("No setroubleshoot")
     @skipBrowser("Firefox needs http to access clipboard", "firefox")
     def testTroubleshootAlerts(self):
         b = self.browser
@@ -303,7 +304,8 @@ class TestSelinux(MachineCase):
         b.relogin("/selinux/setroubleshoot", "admin", superuser=False)
         b.wait_text("ul[aria-label='System modifications']", "The logged in user is not permitted to view system modifications")
 
-    @skipImage("No cockpit-selinux", "debian-stable", "debian-testing", "fedora-coreos", "rhel4edge", "ubuntu-2204", "ubuntu-stable", "arch")
+    @skipImage("No cockpit-selinux", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("No cockpit-selinux")
     def testEnforcingToggle(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -24,10 +24,11 @@ import tarfile
 import subprocess
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 
-@skipImage("No sosreport", "fedora-coreos", "rhel4edge", "arch")
+@skipOstree("No sosreport")
+@skipImage("No sosreport", "arch")
 @nondestructive
 @skipDistroPackage()
 class TestSOS(MachineCase):

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -23,7 +23,7 @@ import time
 import re
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, nondestructive, skipBrowser, skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 
 @nondestructive
@@ -189,7 +189,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     r"pam_succeed_if\(cockpit:auth\): requirement .* not met by user .*",
                                     "noise-rc-.*")
 
-    @skipImage("logs in via ssh, not cockpit-session", "fedora-coreos", "rhel4edge")
+    @skipOstree("logs in via ssh, not cockpit-session")
     def testLogging(self):
         m = self.machine
         b = self.browser
@@ -389,8 +389,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_restart_journal_messages()
 
-    @skipImage("No tlog", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204",
-               "rhel-8-7", "rhel-9-1", "centos-8-stream", "fedora-coreos", "rhel4edge", "arch")
+    @skipImage("No tlog", "debian-*", "ubuntu-*", "arch", "centos-8-stream")
+    @skipOstree("No tlog")
     def testSessionRecordingShell(self):
         m = self.machine
         b = self.browser
@@ -444,8 +444,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
                                     "couldn't parse login input: Malformed input",
                                     "couldn't parse login input: Authentication failed")
 
-    @skipImage("No SELinux", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
-    @skipImage("No semanage", "fedora-coreos", "rhel4edge")
+    @skipImage("No SELinux", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("No semanage")
     def testSELinuxRestrictedUser(self):
         m = self.machine
         b = self.browser
@@ -561,7 +561,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.check_shell()
 
-    @skipImage("Starting on OSTree is weird", "fedora-coreos", "rhel4edge")
+    @skipOstree("Starting on OSTree is weird")
     def testFailingWebsocket(self, safari=False, cacert=False):
         m = self.machine
         b = self.browser
@@ -599,12 +599,12 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
             b.wait_not_present("#safari-cert-help")
 
     @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
-    @skipImage("Starting on OSTree is weird", "fedora-coreos", "rhel4edge")
+    @skipOstree("Starting on OSTree is weird")
     def testFailingWebsocketSafari(self):
         self.testFailingWebsocket(safari=True, cacert=True)
 
     @skipBrowser("Enough when only chromium pretends to be a different browser", "firefox")
-    @skipImage("Starting on OSTree is weird", "fedora-coreos", "rhel4edge")
+    @skipOstree("Starting on OSTree is weird")
     def testFailingWebsocketSafariNoCA(self):
         self.testFailingWebsocket(safari=True, cacert=False)
 
@@ -723,7 +723,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         self.allow_journal_messages(".*[aA]ccount .*locked due to .* failed logins.*")
         self.allow_journal_messages(".*minutes left to unlock.*")
 
-    @skipImage("root logins disabled by default with ssh", "fedora-coreos", "rhel4edge")
+    @skipOstree("root logins disabled by default with ssh")
     def testPamAccess(self):
         b = self.browser
         m = self.machine
@@ -745,7 +745,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         self.allow_journal_messages(r"cockpit-session: user account access failed.*root.*")
 
-    @skipImage("sssd not available", "fedora-coreos", "rhel4edge")
+    @skipOstree("sssd not available")
     def testClientCertAuthentication(self):
         m = self.machine
 

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -22,8 +22,7 @@ from storagelib import StorageCase
 from testlib import skipImage, test_main
 
 
-@skipImage("UDisks doesn't have support for iSCSI", "debian-stable", "debian-testing",
-           "ubuntu-2204", "ubuntu-stable", "arch")
+@skipImage("UDisks doesn't have support for iSCSI", "debian-*", "ubuntu-*", "arch")
 class TestStorageISCSI(StorageCase):
 
     def testISCSI(self):

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -616,8 +616,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
         self.confirm()
         b.wait_not_present(panel + 'ul li:contains("Slot 1")')
 
-    @skipImage("TODO: don't know how to encrypt the rootfs",
-               "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
+    @skipImage("TODO: don't know how to encrypt the rootfs", "debian-*", "ubuntu-*", "arch")
     @timeout(1200)
     def testRootReboot(self):
         m = self.machine

--- a/test/verify/check-storage-multipath
+++ b/test/verify/check-storage-multipath
@@ -22,7 +22,7 @@ from storagelib import StorageCase
 from testlib import skipImage, test_main
 
 
-@skipImage("UDisks doesn't have support for multipath", "debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+@skipImage("UDisks doesn't have support for multipath", "debian-*", "ubuntu-*", "arch")
 class TestStorageMultipath(StorageCase):
 
     def testBasic(self):

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -20,7 +20,7 @@
 import parent  # noqa: F401
 from packagelib import PackageCase
 from storagelib import StorageCase, StorageHelpers
-from testlib import nondestructive, skipImage, test_main
+from testlib import nondestructive, skipOstree, test_main
 
 
 @nondestructive
@@ -298,7 +298,7 @@ class TestStorageNfs(StorageCase):
 
 
 # Re-use allowed journal messages from StorageCase
-@skipImage("No udisks/cockpit-storaged on OSTree images", "fedora-coreos", "rhel4edge")
+@skipOstree("No udisks/cockpit-storaged on OSTree images")
 @nondestructive
 class TestStoragePackagesNFS(PackageCase, StorageCase, StorageHelpers):
 

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -23,7 +23,7 @@ from storagelib import StorageCase
 from testlib import skipImage, test_main
 
 
-@skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204")
+@skipImage("No Stratis", "debian-*", "ubuntu-*")
 class TestStorageStratis(StorageCase):
     def setUp(self):
         super().setUp()
@@ -376,8 +376,8 @@ class TestStorageStratis(StorageCase):
         self.wait_mounted(1, 1)
 
 
-@skipImage("No Stratis", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
-@skipImage("No Stratis on demand", "rhel-9-1", "rhel-8-7", "rhel-8-8")
+@skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
+@skipImage("No Stratis on demand", "rhel-8-*")
 class TestStoragePackagesStratis(PackageCase, StorageCase):
 
     def testStratisOndemandInstallation(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -21,7 +21,7 @@ import re
 import time
 
 import parent  # noqa: F401
-from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, enableAxe, nondestructive, skipDistroPackage, skipImage, skipOstree, test_main, wait
 
 
 os_release = """
@@ -881,7 +881,8 @@ password=foobar
         dbus_call = 'busctl get-property org.freedesktop.login1 /org/freedesktop/login1  org.freedesktop.login1.Manager ScheduledShutdown'
         self.assertIn('(st) "" ', m.execute(dbus_call).strip())
 
-    @skipImage("crypto-policies not available", "fedora-coreos", "rhel4edge", "debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+    @skipImage("crypto-policies not available", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("crypto-policies not available")
     def testCryptoPolicies(self):
         m = self.machine
         b = self.browser
@@ -934,7 +935,8 @@ password=foobar
         b.wait_in_text(".pf-c-menu__item.pf-m-selected", "Custom crypto policy")
         b.click("#crypto-policy-dialog button.pf-c-button.pf-m-link")
 
-    @skipImage("crypto-policies not available", "fedora-coreos", "rhel4edge", "debian-stable", "debian-testing", "ubuntu-2204", "ubuntu-stable", "arch")
+    @skipImage("crypto-policies not available", "debian-*", "ubuntu-*", "arch")
+    @skipOstree("crypto-policies not available")
     def testInconsistentCryptoPolicy(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -23,6 +23,8 @@ import time
 
 sleep_crash_list_sel = "#journal-box .cockpit-logline .cockpit-log-message:contains('(sleep) crashed in')"
 
+NO_ABRT = ["debian-*", "ubuntu-*", "fedora-coreos", "rhel*", "centos-8-*", "arch"]
+
 
 @skipDistroPackage()
 class TestJournal(MachineCase):
@@ -521,9 +523,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible(journal_line_selector.format("WARNING_MESSAGE"))
         b.wait_visible(journal_line_selector.format("INFO_MESSAGE"))
 
-    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel4edge", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
-               "arch")
+    @skipImage("ABRT not available", *NO_ABRT)
     @nondestructive
     def testAbrtSegv(self):
         b = self.browser
@@ -555,9 +555,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.click("#abrt-details .pf-c-accordion__toggle:contains('core_backtrace')")
         b.wait_visible("#abrt-details .pf-c-accordion__expanded-content-body dt:contains('signal') + dd:contains('11')")
 
-    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel4edge", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
-               "arch")
+    @skipImage("ABRT not available", *NO_ABRT)
     @nondestructive
     def testAbrtDelete(self):
         b = self.browser
@@ -587,9 +585,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.wait_visible(".pf-c-card__title:contains('(sleep) crashed in')")
         b.wait_not_present("button.pf-m-danger:contains('Delete')")
 
-    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel4edge", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
-               "arch")
+    @skipImage("ABRT not available", *NO_ABRT)
     @nondestructive
     def testAbrtReport(self):
         # The testing server is located at verify/files/mock-faf-server.py
@@ -652,9 +648,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.click(".pf-c-modal-box__footer button:contains('No')")
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') a[href='https://bugzilla.example.com/show_bug.cgi?id=123456']")
 
-    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel4edge", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
-               "arch")
+    @skipImage("ABRT not available", *NO_ABRT)
     @nondestructive
     def testAbrtReportCancel(self):
         b = self.browser
@@ -688,9 +682,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         b.click("#abrt-reporting .pf-l-split:contains('Report to Cockpit') button:contains('Cancel')")
         b.wait_visible("#abrt-reporting .pf-l-split:contains('Report to Cockpit') .pf-l-split__item:contains('Reporting was canceled')")
 
-    @skipImage("ABRT not available", "debian-stable", "debian-testing", "ubuntu-stable",
-               "ubuntu-2204", "fedora-coreos", "rhel4edge", "rhel-8-7", "rhel-8-8", "rhel-9-1", "rhel-9-2", "centos-8-stream",
-               "arch")
+    @skipImage("ABRT not available", *NO_ABRT)
     @nondestructive
     def testAbrtReportNoReportd(self):
         b = self.browser

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -27,8 +27,8 @@ import base64
 import parent  # noqa: F401
 
 import packagelib
-from testlib import (Error, MachineCase, no_retry_when_changed, nondestructive, skipBrowser, skipDistroPackage, skipImage,
-                     todoPybridge, test_main, wait, timeout)
+from testlib import (Error, MachineCase, no_retry_when_changed, nondestructive, skipBrowser, skipDistroPackage,
+                     skipImage, skipOstree, todoPybridge, test_main, wait, timeout)
 
 
 WAIT_KRB_SCRIPT = """
@@ -84,7 +84,6 @@ ExecStart=/bin/true
     machine.execute("systemctl unmask chrony")
 
 
-@skipImage("No realmd available", "arch")
 @skipDistroPackage()
 class CommonTests:
     @timeout(900)
@@ -478,7 +477,8 @@ class CommonTests:
         m.execute("mv /etc/sssd/pki/sssd_auth_ca_db.pem.valid /etc/sssd/pki/sssd_auth_ca_db.pem")
 
 
-@skipImage("No realmd available", "fedora-coreos", "rhel4edge", "arch")
+@skipOstree("No realmd available")
+@skipImage("No realmd available", "arch")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestRealms(MachineCase):
@@ -501,7 +501,7 @@ class TestRealms(MachineCase):
         self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
 
 
-@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
+@skipImage("freeipa not currently available", "debian-*")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
@@ -843,7 +843,7 @@ ipa-advise enable-admins-sudo | sh -ex
         m.execute(f"! su -c '{ccache_env} klist' alice")
 
 
-@skipImage("adcli not on test images", "debian-stable", "debian-testing", "ubuntu-stable", "ubuntu-2204", "arch")
+@skipImage("adcli not on test images", "debian-*", "ubuntu-*")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestAD(TestRealms, CommonTests):
@@ -1002,8 +1002,9 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 # This is here because our test framework can't run ipa VM's twice
 
 
-@skipImage("No realmd available", "fedora-coreos", "rhel4edge", "arch")
-@skipImage("freeipa not currently available", "debian-stable", "debian-testing", "arch")
+@skipOstree("No realmd available")
+@skipImage("No realmd available", "arch")
+@skipImage("freeipa not currently available", "debian-*")
 @skipDistroPackage()
 @no_retry_when_changed
 class TestKerberos(MachineCase):
@@ -1135,7 +1136,7 @@ class TestKerberos(MachineCase):
 
 
 @skipImage("No realmd available", "arch")
-@skipImage("Package (un)install does not work on OSTree", "fedora-coreos", "rhel4edge")
+@skipOstree("Package (un)install does not work on OSTree")
 @skipDistroPackage()
 class TestPackageInstall(packagelib.PackageCase):
 

--- a/test/verify/check-system-tuned
+++ b/test/verify/check-system-tuned
@@ -18,11 +18,12 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, skipOstree, test_main
 
 
 @nondestructive
-@skipImage("No tuned packaged", "fedora-coreos", "rhel4edge", "arch")
+@skipOstree("No tuned packaged")
+@skipImage("No tuned packaged", "arch")
 @skipDistroPackage()
 class TestTuned(MachineCase):
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -20,7 +20,7 @@
 import datetime
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, test_main, wait
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main, wait
 
 
 @nondestructive
@@ -540,7 +540,7 @@ class TestAccounts(MachineCase):
         b.click('#account-set-password-dialog button.apply')
         b.wait_in_text("#account-set-password-dialog .pf-c-modal-box__body", "must wait longer")
 
-    @skipImage("ssh root login not allowed", "fedora-coreos", "rhel4edge")
+    @skipOstree("ssh root login not allowed")
     def testRootLogin(self):
         m = self.machine
         b = self.browser
@@ -682,7 +682,7 @@ class TestAccounts(MachineCase):
         b.wait_in_text("#password-expiration-text", "Password must be changed")
         self.assertEqual(self.accountExpiryInfo("scruffy", "Password expires"), "password must be changed")
 
-    @skipImage("User is not shown as logged in when logged in through Cockpit", "fedora-coreos", "rhel4edge")
+    @skipOstree("User is not shown as logged in when logged in through Cockpit")
     def testAccountLogs(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Add globbing support in testlib.skipImage() and add testlib.skipOstree(). This makes it easier in the future to add/remove OSes.