### PR TITLE
Allow specifying UID during account creation

### DIFF
--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -62,13 +62,6 @@ function AccountCreateBody({ state, errors, change }) {
                            value={user_name} onChange={value => change("user_name", value)} />
             </FormGroup>
 
-            <PasswordFormFields password_label={_("Password")}
-                                password_confirm_label={_("Confirm")}
-                                error_password={errors?.password}
-                                error_password_confirm={errors?.password_confirm}
-                                idPrefix="accounts-create-password"
-                                change={change} />
-
             <FormGroup label={_("Authentication")} fieldId="accounts-create-locked" hasNoPaddingTop>
                 <Radio id="account-use-password"
                        label={_("Use password")}
@@ -95,6 +88,13 @@ function AccountCreateBody({ state, errors, change }) {
                     </FlexItem>
                 </Flex>
             </FormGroup>
+
+            <PasswordFormFields password_label={_("Password")}
+                                password_confirm_label={_("Confirm")}
+                                error_password={errors?.password}
+                                error_password_confirm={errors?.password_confirm}
+                                idPrefix="accounts-create-password"
+                                change={change} />
         </Form>
     );
 }

--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -357,7 +357,7 @@ const GroupsList = ({ groups, accounts, isExpanded, setIsExpanded, min_gid, max_
     );
 };
 
-const AccountsList = ({ accounts, current_user, groups, shells }) => {
+const AccountsList = ({ accounts, current_user, groups, min_uid, max_uid, shells }) => {
     const { options } = usePageLocation();
     const [currentTextFilter, setCurrentTextFilter] = useState(options.user || '');
     const filtered_accounts = accounts.filter(account => {
@@ -442,7 +442,7 @@ const AccountsList = ({ accounts, current_user, groups, shells }) => {
                     <>
                         <ToolbarItem variant="separator" />
                         <ToolbarItem alignment={{ md: 'alignRight' }}>
-                            <Button id="accounts-create" onClick={() => account_create_dialog(accounts, shells)}>
+                            <Button id="accounts-create" onClick={() => account_create_dialog(accounts, min_uid, max_uid, shells)}>
                                 {_("Create new account")}
                             </Button>
                         </ToolbarItem>
@@ -473,7 +473,7 @@ const AccountsList = ({ accounts, current_user, groups, shells }) => {
     );
 };
 
-export const AccountsMain = ({ accountsInfo, current_user, groups, isGroupsExpanded, setIsGroupsExpanded, min_gid, max_gid, shells }) => {
+export const AccountsMain = ({ accountsInfo, current_user, groups, isGroupsExpanded, setIsGroupsExpanded, min_gid, max_gid, min_uid, max_uid, shells }) => {
     const accounts = mapGroupsToAccount(accountsInfo, groups).filter(account => {
         if ((account.uid < 1000 && account.uid !== 0) ||
                  account.shell.match(/^(\/usr)?\/sbin\/nologin/) ||
@@ -487,7 +487,7 @@ export const AccountsMain = ({ accountsInfo, current_user, groups, isGroupsExpan
             <PageSection>
                 <Stack hasGutter>
                     <GroupsList accounts={accounts} groups={groups} isExpanded={isGroupsExpanded} setIsExpanded={setIsGroupsExpanded} min_gid={min_gid} max_gid={max_gid} />
-                    <AccountsList accounts={accounts} current_user={current_user} groups={groups} shells={shells} />
+                    <AccountsList accounts={accounts} current_user={current_user} groups={groups} shells={shells} min_uid={min_uid} max_uid={max_uid} />
                 </Stack>
             </PageSection>
         </Page>

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -63,17 +63,25 @@ function AccountsPage() {
     //  While that's unusual, "empty /etc" is a goal, and it shouldn't crash the page.
     const [min_gid, setMinGid] = useState(500);
     const [max_gid, setMaxGid] = useState(60000);
+    const [min_uid, setMinUid] = useState(500);
+    const [max_uid, setMaxUid] = useState(60000);
     useEffect(() => {
         if (!logindef)
             return;
 
         const minGid = parseInt(logindef.match(/^GID_MIN\s+(\d+)/m)[1]);
         const maxGid = parseInt(logindef.match(/^GID_MAX\s+(\d+)/m)[1]);
+        const minUid = parseInt(logindef.match(/^UID_MIN\s+(\d+)/m)[1]);
+        const maxUid = parseInt(logindef.match(/^UID_MAX\s+(\d+)/m)[1]);
 
         if (minGid)
             setMinGid(minGid);
         if (maxGid)
             setMaxGid(maxGid);
+        if (minUid)
+            setMinUid(minUid);
+        if (maxUid)
+            setMaxUid(maxUid);
     }, [logindef]);
 
     const [details, setDetails] = useState(null);
@@ -125,6 +133,8 @@ function AccountsPage() {
                 setIsGroupsExpanded={setIsGroupsExpanded}
                 min_gid={min_gid}
                 max_gid={max_gid}
+                min_uid={min_uid}
+                max_uid={max_uid}
                 shells={shells}
             />
         );

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -52,7 +52,7 @@ def performUserAction(browser, user, action):
     browser.click(f".pf-c-dropdown__menu-item:contains({action})")
 
 
-def createUser(browser, user_name, real_name, password, locked, force_password_change, verify_created=True):
+def createUser(browser, user_name, real_name, password, locked, force_password_change, uid=None, expected_uid=None, verify_created=True):
     browser.wait_visible('#accounts-create')
     browser.click('#accounts-create')
     browser.wait_visible('#accounts-create-dialog')
@@ -69,6 +69,11 @@ def createUser(browser, user_name, real_name, password, locked, force_password_c
         browser.wait_visible('#account-use-password:checked')
         browser.set_checked('#accounts-create-force-password-change', force_password_change)
         browser.wait_visible('#accounts-create-locked:not(:checked)')
+
+    if expected_uid is not None:
+        browser.wait_visible(f'#accounts-create-user-uid[value="{expected_uid}"]')
+    if uid is not None:
+        browser.set_input_text('#accounts-create-user-uid', uid)
 
     browser.click('#accounts-create-dialog button.apply')
 
@@ -569,6 +574,117 @@ class TestAccounts(MachineCase):
 
         self.allow_journal_messages(".*required to change your password immediately.*")
         self.allow_journal_messages(".*user account or password has expired.*")
+
+    def testCustomUID(self):
+        b = self.browser
+
+        self.login_and_go("/users")
+
+        # Test custom UID
+        createUser(
+            browser=b,
+            user_name="bob",
+            real_name="Bob Bobson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="1500",
+            verify_created=True,
+        )
+        b.wait_visible("#accounts-list td[data-label='Username']:contains('bob') + td + td:contains('1500')")
+
+        # Test dialog predicts corrent next available UID
+        createUser(
+            browser=b,
+            user_name="john",
+            real_name="John Johnson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            expected_uid="1501",
+            verify_created=True,
+        )
+        b.wait_visible("#accounts-list td[data-label='Username']:contains(john) + td + td:contains(1501)")
+
+        # Test creation of users with the same UID
+        createUser(
+            browser=b,
+            user_name="jack",
+            real_name="Jack Jackson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="1501",
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-uid-helper", "already used")
+        b.wait_visible("button.apply:disabled")
+        b.click("button:contains('Create account with non-unique UID')")
+        b.wait_not_present("#accounts-create-dialog")
+        b.wait_in_text("#accounts-list", "Jack Jackson")
+        b.wait_visible("#accounts-list td[data-label='Username']:contains(jack) + td + td:contains(1501)")
+        b.wait_visible("#accounts-list td[data-label='Username']:contains(john) + td + td:contains(1501)")
+
+        # No UID specified -> useradd chooses UID for us
+        createUser(
+            browser=b,
+            user_name="nouidspecified",
+            real_name="NoUID Specified",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="",
+            verify_created=True,
+        )
+
+        # UID cannot be lower than UID_MIN
+        createUser(
+            browser=b,
+            user_name="failedfailson",
+            real_name="Failed Failson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="1",
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-uid-helper", "lower than")
+        b.click("#accounts-create-dialog button.cancel")
+        b.wait_not_present("#accounts-create-dialog")
+
+        # UID cannot be higher than UID_MAX
+        createUser(
+            browser=b,
+            user_name="failedfailson",
+            real_name="Failed Failson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="9999999",
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-uid-helper", "higher than")
+        b.click("#accounts-create-dialog button.cancel")
+        b.wait_not_present("#accounts-create-dialog")
+
+        # UID must be a positive integer
+        createUser(
+            browser=b,
+            user_name="failedfailson",
+            real_name="Failed Failson",
+            password=good_password,
+            locked=False,
+            force_password_change=False,
+            uid="abc",
+            verify_created=False,
+        )
+        b.wait_visible("#accounts-create-dialog")
+        b.wait_in_text("#accounts-create-user-uid-helper", "positive integer")
+        b.click("#accounts-create-dialog button.cancel")
+        b.wait_not_present("#accounts-create-dialog")
 
     def testUnprivileged(self):
         m = self.machine


### PR DESCRIPTION
UID should be a integer bigger or same than 1000. There are use cases
when user would want multiple accounts to share the same UID. In such
case, a secondary confirmation button is shown to let user know that
the account will be created with a non-unique UID. The default UID is
prefilled with the next available based on the users at /etc/passwd.

[Screencast from 2023-02-15 16-23-31.webm](https://user-images.githubusercontent.com/42733240/219077484-a985e0d9-a4cf-495c-a668-cc853d4670fd.webm)
