### PR TITLE
modules: update systemd_ctypes

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -137,9 +137,7 @@ async def run(args) -> None:
 
     logger.debug('Starting the router.')
     router = Bridge(args)
-    loop = asyncio.get_running_loop()
-    loop.set_debug(args.debug)
-    StdioTransport(loop, router)
+    StdioTransport(asyncio.get_running_loop(), router)
 
     logger.debug('Startup done.  Looping until connection closes.')
 
@@ -218,7 +216,7 @@ def main() -> None:
         print(json.dumps(Packages().get_bridge_configs(), indent=2))
     else:
         # asyncio.run() shim for Python 3.6 support
-        run_async(run(args))
+        run_async(run(args), debug=args.debug)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This supports asyncio.run()'s debug argument and D-Bus name owning API 
(paving the way for rewriting the unit test D-Bus mock server in
Python).

Revert the debug= bits from commit cbcd6ecc4a41, we can simplify this
again.