### PR TITLE
python: close all tasks before exiting the bridge

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -139,7 +139,7 @@ class Channel(Endpoint):
         pass
 
     def do_close(self):
-        pass
+        self.close()
 
     def do_options(self, message):
         raise ChannelError('not-supported', message='This channel does not implement "options"')

--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -94,7 +94,7 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
     def process_exited(self) -> None:
         self.close_on_eof()
 
-    def _close_args(self) -> Dict[str, object]:
+    def _get_close_args(self) -> Dict[str, object]:
         assert isinstance(self._transport, SubprocessTransport)
         args: Dict[str, object] = {'exit-status': self._transport.get_returncode()}
         stderr = self._transport.get_stderr()

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -169,19 +169,12 @@ class CockpitProtocol(asyncio.Protocol):
         self.write_message('', **kwargs)
 
     def data_received(self, data):
-        try:
-            self.buffer += data
-            while True:
-                result = self.consume_one_frame(self.buffer)
-                if result <= 0:
-                    return
-                self.buffer = self.buffer[result:]
-        except CockpitProtocolError as exc:
-            self.write_control(command="close", problem=exc.problem, exception=str(exc))
-            self.transport.close()
-
-    def eof_received(self):
-        self.write_control(command='close')
+        self.buffer += data
+        while True:
+            result = self.consume_one_frame(self.buffer)
+            if result <= 0:
+                return
+            self.buffer = self.buffer[result:]
 
     async def communicate(self) -> None:
         """Wait until communication is complete on this protocol."""

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1795,15 +1795,6 @@ class MachineCase(unittest.TestCase):
             self.allowed_messages.append("Failed to connect to coredump service: No such file or directory")
             self.allowed_messages.append("Failed to connect to coredump service: Connection refused")
 
-        # HACK: pybridge bugs
-        if os.environ.get("TEST_SCENARIO") == "pybridge":
-            self.allowed_messages += [
-                "asyncio-ERROR: Task was destroyed but it is pending!",
-                "task:.*Task pending.*cockpit/channels/dbus.py.*"]
-
-            # Python 3.11 traceback annotation
-            self.allowed_messages.append(r"\s*\^+\s*")
-
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -307,7 +307,6 @@ class TestBridge(unittest.IsolatedAsyncioTestCase):
         # try to open dbus on the root bridge
         root_dbus = await self.transport.check_open('dbus-json3', bus='internal', superuser=True)
         assert self.bridge.open_channels[root_dbus].name == 'pseudo'
-        assert self.bridge.open_channels[root_dbus].channels == {root_dbus}
 
         # verify that the bridge thinks that it's the root bridge
         await self.transport.assert_bus_props('/superuser', 'cockpit.Superuser',


### PR DESCRIPTION
Let's split this out from #18292 (which looks to have gained a dependency on #18340, which itself, needs work).

Let's make sure we wind down all tasks when closing the bridge.  This is implemented in two steps, basically:

 - no channel may send "close" until all of its tasks are complete
 - the bridge may not exit until all channels have sent "close"