### PR TITLE
python: catch BusError on Properties.Get

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -409,9 +409,14 @@ class DBusChannel(Channel):
                 name, props, invalids = message.get_body()
                 logger.debug('NOTIFY: %s %s %s %s', path, name, props, invalids)
                 for inv in invalids:
-                    reply, = await self.bus.call_method_async(self.name, path,
-                                                              'org.freedesktop.DBus.Properties', 'Get',
-                                                              'ss', name, inv)
+                    try:
+                        reply, = await self.bus.call_method_async(self.name, path,
+                                                                  'org.freedesktop.DBus.Properties', 'Get',
+                                                                  'ss', name, inv)
+                    except BusError as exc:
+                        logger.debug('failed to fetch property %s.%s on %s %s: %s',
+                                     name, inv, self.name, path, str(exc))
+                        continue
                     props[inv] = reply
                 notify = {}
                 notify_update(notify, path, name, props)


### PR DESCRIPTION
For DBus interfaces that notify property invalidations (without specifying the new value) we immediately try to "Get" the new value so that we can send it to JS.  The call to do this was missing a try: to catch the BusError which might result if that Get call fails.

Catch the failure and log a debug message.

Fixes #18358