### PR TITLE
python: don't signal already-exited processes

### DIFF
--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -398,6 +398,7 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
         # It's on us now to check it, but that's easy:
         if self._returncode is not None:
             logger.debug("won't attempt %s to process %i.  It exited already.", sig, self._process.pid)
+            return
 
         try:
             os.kill(self._process.pid, sig)


### PR DESCRIPTION
In 95bffd540ce450792341b99d80ffc98762158c8e we implement our own "safe" signal sending logic.  In order to avoid sending signals to PIDs that may have been recycled, we carefully go out of our way to detect if the process has exited, log a message about it, and then ... send the signal anyway.

Add the obviously-missing `return` statement.