### PR TITLE
lib: Make PO and rsync bundler plugins work for webpack and esbuild

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -1,115 +1,136 @@
-import path from 'path';
-import glob from 'glob';
-import fs from 'fs';
-import gettext_parser from 'gettext-parser';
-import Jed from 'jed';
-import webpack from 'webpack';
+import fs from "fs";
+import glob from "glob";
+import path from "path";
 
-const srcdir = process.env.SRCDIR || '.';
+import Jed from "jed";
+import gettext_parser from "gettext-parser";
 
-export default class {
-    constructor(options) {
-        if (!options)
-            options = {};
-        this.subdir = options.subdir || '';
-        this.wrapper = options.wrapper || 'cockpit.locale(PO_DATA);';
+const config = {};
+
+function get_po_files() {
+    try {
+        const linguas_file = path.resolve(config.srcdir, "po/LINGUAS");
+        const linguas = fs.readFileSync(linguas_file, 'utf8').match(/\S+/g);
+        return linguas.map(lang => path.resolve(config.srcdir, 'po', lang + '.po'));
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            throw error;
+        }
+
+        /* No LINGUAS file?  Fall back to globbing.
+         * Note: we won't detect .po files being added in this case.
+         */
+        return glob.sync(path.resolve(config.srcdir, 'po/*.po'));
+    }
+}
+
+function get_plural_expr(statement) {
+    try {
+        /* Check that the plural forms isn't being sneaky since we build a function here */
+        Jed.PF.parse(statement);
+    } catch (ex) {
+        console.error("bad plural forms: " + ex.message);
+        process.exit(1);
     }
 
-    get_po_files(compilation) {
-        try {
-            const linguas_file = path.resolve(srcdir, "po/LINGUAS");
-            const linguas = fs.readFileSync(linguas_file, 'utf8').match(/\S+/g);
-            compilation.fileDependencies.add(linguas_file); // Only after reading the file
-            return linguas.map(lang => path.resolve(srcdir, 'po', lang + '.po'));
-        } catch (error) {
-            if (error.code !== 'ENOENT') {
-                throw error;
-            }
+    const expr = statement.replace(/nplurals=[1-9]; plural=([^;]*);?$/, '(n) => $1');
+    if (expr === statement) {
+        console.error("bad plural forms: " + statement);
+        process.exit(1);
+    }
 
-            /* No LINGUAS file?  Fall back to globbing.
-             * Note: we won't detect .po files being added in this case.
-             */
-            return glob.sync(path.resolve(srcdir, 'po/*.po'));
+    return expr;
+}
+
+function buildFile(po_file, webpack_module, webpack_compilation) {
+    if (webpack_compilation)
+        webpack_compilation.fileDependencies.add(po_file);
+
+    return new Promise((resolve, reject) => {
+        const parsed = gettext_parser.po.parse(fs.readFileSync(po_file), 'utf8');
+        delete parsed.translations[""][""]; // second header copy
+
+        const rtl_langs = ["ar", "fa", "he", "ur"];
+        const dir = rtl_langs.includes(parsed.headers.language) ? "rtl" : "ltr";
+
+        // cockpit.js only looks at "plural-forms" and "language"
+        const chunks = [
+            '{\n',
+            ' "": {\n',
+            `  "plural-forms": ${get_plural_expr(parsed.headers['plural-forms'])},\n`,
+            `  "language": "${parsed.headers.language}",\n`,
+            `  "language-direction": "${dir}"\n`,
+            ' }'
+        ];
+        for (const [msgctxt, context] of Object.entries(parsed.translations)) {
+            const context_prefix = msgctxt ? msgctxt + '\u0004' : ''; /* for cockpit.ngettext */
+
+            for (const [msgid, translation] of Object.entries(context)) {
+                /* Only include msgids which appear in this source directory */
+                const references = translation.comments.reference.split(/\s/);
+                if (!references.some(str => str.startsWith(`pkg/${config.subdir}`) || str.startsWith('src')))
+                    continue;
+
+                if (translation.comments.flag && translation.comments.flag.match(/\bfuzzy\b/))
+                    continue;
+
+                const key = JSON.stringify(context_prefix + msgid);
+                // cockpit.js always ignores the first item
+                chunks.push(`,\n ${key}: [\n  null`);
+                for (const str of translation.msgstr) {
+                    chunks.push(',\n  ' + JSON.stringify(str));
+                }
+                chunks.push('\n ]');
+            }
         }
+        chunks.push('\n}');
+
+        const output = config.wrapper.replace('PO_DATA', chunks.join('')) + '\n';
+
+        const lang = path.basename(po_file).slice(0, -3);
+        const out_path = config.subdir + 'po.' + lang + '.js';
+        if (webpack_compilation)
+            webpack_compilation.emitAsset(out_path, new webpack_module.sources.RawSource(output));
+        else
+            fs.writeFileSync(path.resolve(config.outdir, out_path), output);
+        return resolve();
+    });
+}
+
+function init(options) {
+    config.srcdir = process.env.SRCDIR || './';
+    config.subdir = options.subdir || '';
+    config.wrapper = options.wrapper || 'cockpit.locale(PO_DATA)';
+    config.outdir = options.outdir || './dist';
+}
+
+function run(webpack_module, webpack_compilation) {
+    return Promise.all(get_po_files().map(f => buildFile(f, webpack_module, webpack_compilation)));
+}
+
+export const cockpitPoEsbuildPlugin = options => ({
+    name: 'cockpitPoEsbuildPlugin',
+    setup(build) {
+        init({ ...options, outdir: build.initialOptions.outdir });
+        build.onEnd(async () => { await run() });
+    },
+});
+
+export class CockpitPoWebpackPlugin {
+    constructor(options) {
+        init(options || {});
     }
 
     apply(compiler) {
-        compiler.hooks.thisCompilation.tap('CockpitPoPlugin', compilation => {
+        compiler.hooks.thisCompilation.tap('CockpitPoWebpackPlugin', async compilation => {
+            const webpack = (await import('webpack')).default;
             compilation.hooks.processAssets.tapPromise(
                 {
-                    name: 'CockpitPoPlugin',
+                    name: 'CockpitPoWebpackPlugin',
                     stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONAL,
                 },
-                () => Promise.all(this.get_po_files(compilation).map(f => this.buildFile(f, compilation)))
+                () => run(webpack, compilation)
             );
-        });
-    }
-
-    get_plural_expr(statement) {
-        try {
-            /* Check that the plural forms isn't being sneaky since we build a function here */
-            Jed.PF.parse(statement);
-        } catch (ex) {
-            console.error("bad plural forms: " + ex.message);
-            process.exit(1);
-        }
-
-        const expr = statement.replace(/nplurals=[1-9]; plural=([^;]*);?$/, '(n) => $1');
-        if (expr === statement) {
-            console.error("bad plural forms: " + statement);
-            process.exit(1);
-        }
-
-        return expr;
-    }
-
-    buildFile(po_file, compilation) {
-        compilation.fileDependencies.add(po_file);
-
-        return new Promise((resolve, reject) => {
-            const parsed = gettext_parser.po.parse(fs.readFileSync(po_file), 'utf8');
-            delete parsed.translations[""][""]; // second header copy
-
-            const rtl_langs = ["ar", "fa", "he", "ur"];
-            const dir = rtl_langs.includes(parsed.headers.language) ? "rtl" : "ltr";
-
-            // cockpit.js only looks at "plural-forms" and "language"
-            const chunks = [
-                '{\n',
-                ' "": {\n',
-                `  "plural-forms": ${this.get_plural_expr(parsed.headers['plural-forms'])},\n`,
-                `  "language": "${parsed.headers.language}",\n`,
-                `  "language-direction": "${dir}"\n`,
-                ' }'
-            ];
-            for (const [msgctxt, context] of Object.entries(parsed.translations)) {
-                const context_prefix = msgctxt ? msgctxt + '\u0004' : ''; /* for cockpit.ngettext */
-
-                for (const [msgid, translation] of Object.entries(context)) {
-                    /* Only include msgids which appear in this source directory */
-                    const references = translation.comments.reference.split(/\s/);
-                    if (!references.some(str => str.startsWith(`pkg/${this.subdir}`) || str.startsWith('src')))
-                        continue;
-
-                    if (translation.comments.flag && translation.comments.flag.match(/\bfuzzy\b/))
-                        continue;
-
-                    const key = JSON.stringify(context_prefix + msgid);
-                    // cockpit.js always ignores the first item
-                    chunks.push(`,\n ${key}: [\n  null`);
-                    for (const str of translation.msgstr) {
-                        chunks.push(',\n  ' + JSON.stringify(str));
-                    }
-                    chunks.push('\n ]');
-                }
-            }
-            chunks.push('\n}');
-
-            const output = this.wrapper.replace('PO_DATA', chunks.join('')) + '\n';
-
-            const lang = path.basename(po_file).slice(0, -3);
-            compilation.emitAsset(this.subdir + 'po.' + lang + '.js', new webpack.sources.RawSource(output));
-            resolve();
         });
     }
 }

--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -1,35 +1,49 @@
-import child_process from 'child_process';
+import child_process from "child_process";
 
-export default class {
-    constructor(options) {
-        if (!options)
-            options = {};
-        this.dest = options.dest || "";
-        this.source = options.source || "dist/";
-        this.ssh_host = process.env.RSYNC || process.env.RSYNC_DEVEL;
+const config = {};
 
-        // ensure the target directory exists
-        if (this.ssh_host) {
-            this.rsync_dir = process.env.RSYNC ? "/usr/local/share/cockpit/" : "~/.local/share/cockpit/";
-            child_process.spawnSync("ssh", [this.ssh_host, "mkdir", "-p", this.rsync_dir], { stdio: "inherit" });
-        }
+function init(options) {
+    config.dest = options.dest || "";
+    config.source = options.source || "dist/";
+    config.ssh_host = process.env.RSYNC || process.env.RSYNC_DEVEL;
+
+    // ensure the target directory exists
+    if (config.ssh_host) {
+        config.rsync_dir = process.env.RSYNC ? "/usr/local/share/cockpit/" : "~/.local/share/cockpit/";
+        child_process.spawnSync("ssh", [config.ssh_host, "mkdir", "-p", config.rsync_dir], { stdio: "inherit" });
     }
+}
 
-    apply(compiler) {
-        compiler.hooks.afterEmit.tapAsync('WebpackHookPlugin', (compilation, callback) => {
-            if (this.ssh_host) {
-                const proc = child_process.spawn("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
-                    this.source, this.ssh_host + ":" + this.rsync_dir + this.dest], { stdio: "inherit" });
-                proc.on('close', (code) => {
-                    if (code !== 0) {
-                        process.exit(1);
-                    } else {
-                        callback();
-                    }
-                });
+function run(callback) {
+    if (config.ssh_host) {
+        const proc = child_process.spawn("rsync", ["--recursive", "--info=PROGRESS2", "--delete",
+            config.source, config.ssh_host + ":" + config.rsync_dir + config.dest], { stdio: "inherit" });
+        proc.on('close', (code) => {
+            if (code !== 0) {
+                process.exit(1);
             } else {
                 callback();
             }
         });
+    } else {
+        callback();
+    }
+}
+
+export const cockpitRsyncEsbuildPlugin = options => ({
+    name: 'cockpitRsyncPlugin',
+    setup(build) {
+        init(options || {});
+        build.onEnd(() => run(() => {}));
+    },
+});
+
+export class CockpitRsyncWebpackPlugin {
+    constructor(options) {
+        init(options || {});
+    }
+
+    apply(compiler) {
+        compiler.hooks.afterEmit.tapAsync('WebpackHookPlugin', (_compilation, callback) => run(callback));
     }
 }

--- a/tools/webpack-make.js
+++ b/tools/webpack-make.js
@@ -10,7 +10,7 @@ import path from 'path';
 import argparse from 'argparse';
 import fs from 'fs';
 import process from 'process';
-import CockpitRsyncPlugin from '../pkg/lib/cockpit-rsync-plugin.js';
+import { CockpitRsyncWebpackPlugin } from '../pkg/lib/cockpit-rsync-plugin.js';
 
 // argv0 is node
 const webpack_watch = process.argv[1].includes('webpack-watch');
@@ -52,7 +52,7 @@ import(config_path).then(module => {
     const config = module.default;
     if (args.rsync) {
         process.env.RSYNC = args.rsync;
-        config.plugins.push(new CockpitRsyncPlugin({ source: path.dirname(makefile) }));
+        config.plugins.push(new CockpitRsyncWebpackPlugin({ source: path.dirname(makefile) }));
     }
 
     const compiler = webpack(config);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ import TerserJSPlugin from 'terser-webpack-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import ESLintPlugin from 'eslint-webpack-plugin';
 import StylelintPlugin from 'stylelint-webpack-plugin';
-import CockpitPoPlugin from './pkg/lib/cockpit-po-plugin.js';
+import { CockpitPoWebpackPlugin } from './pkg/lib/cockpit-po-plugin.js';
 
 const info = {
     entries: {
@@ -333,7 +333,7 @@ const redhat_fonts = [
 const plugins = [
     new Copy({ patterns: info.files }),
     new MiniCssExtractPlugin({ filename: "[name].css" }),
-    new CockpitPoPlugin({
+    new CockpitPoWebpackPlugin({
         subdir: section,
         // login page does not have cockpit.js, but reads window.cockpit_po
         wrapper: (section === 'static/') ? 'window.cockpit_po = PO_DATA;' : undefined,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -330,16 +330,11 @@ const redhat_fonts = [
     };
 });
 
-function get_translation_reference_patterns () {
-    return undefined;
-}
-
 const plugins = [
     new Copy({ patterns: info.files }),
     new MiniCssExtractPlugin({ filename: "[name].css" }),
     new CockpitPoPlugin({
         subdir: section,
-        reference_patterns: get_translation_reference_patterns(),
         // login page does not have cockpit.js, but reads window.cockpit_po
         wrapper: (section === 'static/') ? 'window.cockpit_po = PO_DATA;' : undefined,
     }),


### PR DESCRIPTION
 - Pull out the common code into init() and run() functions, which leaves the webpack/esbuild glue relatively small.
 - Stop having a default export. The bundler config now explicitly needs to import the webpack or esbuild plugin.

---

This was developed in https://github.com/cockpit-project/cockpit-podman/pull/1210 , originally against cockpit-podman. I validated that generated po files are identical, and that watch mode with and without an rsync target work as expected, on all of cockpit, podman with esbuild, and podman with webpack.