### PR TITLE
fmf: Use node.js 16 for RHEL 8 tests

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -26,6 +26,11 @@ rpm -q cockpit-system
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)
 dnf install --disablerepo=fedora-cisco-openh264 -y --setopt=install_weak_deps=False firefox
 
+# nodejs 10 is too old for current Cockpit test API
+if grep -q platform:el8 /etc/os-release; then
+    dnf module switch-to -y nodejs:16
+fi
+
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd
 if rpm -q setroubleshoot-server; then


### PR DESCRIPTION
The import syntax introduced in commit 54f2fd58a364 does not work with the old node.js 10 which is still the default in RHEL 10. Install the newer version 16 instead.

I did that on all other projects (like [1]), but forgot it here.

[1] https://github.com/cockpit-project/starter-kit/pull/625

----

It's likely that this will still fail some tests, as we introduced a regression earlier on (which is why this failure slipped through), but this should turn this [complete disaster](https://artifacts.dev.testing-farm.io/ec3b56e4-1ebe-4995-be0d-a80ce1d7546b/) into "most tests work".