### PR TITLE
users: append's dropdown's menu to document body

### DIFF
--- a/pkg/users/accounts-list.js
+++ b/pkg/users/accounts-list.js
@@ -110,6 +110,8 @@ const UserActions = ({ account }) => {
                 isPlain
                 isOpen={isKebabOpen}
                 position="right"
+                id="accounts-actions"
+                menuAppendTo={document.body}
                 dropdownItems={actions} />
     );
     return kebab;

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -30,7 +30,7 @@ def performUserAction(browser, user, action):
     browser.wait_visible(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown button")
     browser.click(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown button")
     browser.wait_visible(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown button[aria-expanded=true]")
-    browser.click(f"#accounts-list tbody tr:contains({user}) .pf-c-dropdown__menu li:contains({action})")
+    browser.click(f".pf-c-dropdown__menu-item:contains({action})")
 
 
 def createUser(browser, user_name, real_name, password, locked, force_password_change, verify_created=True):
@@ -211,7 +211,7 @@ class TestAccounts(MachineCase):
         b.click("#account-confirm-lock-dialog footer .pf-m-danger.apply")
         # lock option is now disabled
         b.click("#accounts-list tbody tr:contains(robert) .pf-c-dropdown button")
-        b.wait_in_text("#accounts-list tbody tr:contains(robert) .pf-c-dropdown__menu li:contains('Lock account') .pf-m-disabled", 'Lock account')
+        b.wait_in_text(".pf-c-dropdown__menu li:contains('Lock account') .pf-m-disabled", 'Lock account')
         b.click("#accounts-list tbody tr:contains(robert) .pf-c-dropdown button")
         # change is visible on details page
         performUserAction(b, 'robert', 'Edit user')

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -331,7 +331,7 @@ class TestAccounts(MachineCase):
 
         self.login_and_go("/users")
         # Create a locked user with weak password
-        m.execute("sed -i 's/^SHELL=.*$/SHELL=/' /etc/default/useradd")
+        self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd')
 
         createUser(
             browser=b,


### PR DESCRIPTION
The default is to render it inline. However, our tests showed that the clicks were often eaten (actions dialogs not opening causing flakes). I blame this on the Table component messing up with the events, so let's unnest the actions Dropdown from the Table as a fix.