### PR TITLE
test: Restore /etc/default/useradd in check-users

### DIFF
--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -331,7 +331,7 @@ class TestAccounts(MachineCase):
 
         self.login_and_go("/users")
         # Create a locked user with weak password
-        m.execute("sed -i 's/^SHELL=.*$/SHELL=/' /etc/default/useradd")
+        self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd')
 
         createUser(
             browser=b,


### PR DESCRIPTION
Previously this permanently destroyed /etc/default/useradd, causing subsequent test failures.

----

This should fix failures like [this](https://artifacts.dev.testing-farm.io/2126f39f-d12c-4261-900d-19678f3dcf3f/), [this](https://artifacts.dev.testing-farm.io/9760a0b6-ee14-4fe8-bba1-1d26e8cc2424/), [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18375-20230221-051235-e18f07a1-arch/log.html#173-2), or [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18375-20230221-051241-e18f07a1-rhel-9-2/log.html#173-2)