### PR TITLE
test: use Machine.ostree_image where possible

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1164,7 +1164,7 @@ BEGIN {{
         b.wait(lambda: progressValue(self, ".pf-c-progress[data-disk-usage-target='/var/cockpittest']") >= 90)
 
         # clicking on progress leads to the storage page
-        if m.image not in ["fedora-coreos", "rhel4edge"]:
+        if not m.ostree_image:
             self.assertTrue(b.is_present("#current-disks-usage button"))
             b.click(progress_sel)
             b.enter_page("/storage")
@@ -1224,7 +1224,7 @@ class TestMetricsPackages(packagelib.PackageCase):
         b = self.browser
         m = self.machine
 
-        if m.image in ["fedora-coreos", "rhel4edge"]:
+        if m.ostree_image:
             self.login_and_go("/metrics")
             b.wait_in_text(".pf-c-empty-state", "cockpit-pcp is missing")
             b.wait_not_present(".pf-c-empty-state button.pf-m-primary")

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -253,8 +253,8 @@ class TestNetworkingBasic(NetworkCase):
         assert_running()
         wait(lambda: m.execute("systemctl is-enabled NetworkManager"))
 
-        # /usr in coreos is readonly
-        if m.image not in ["fedora-coreos", "rhel4edge"]:
+        # /usr in ostree is readonly
+        if not m.ostree_image:
             # remove the NM service file, test 'no-found' notification
             # This works for ND tests since there is a self.addCleanup(m.execute, "systemctl enable --now NetworkManager") in the start of the test
             self.restore_file('/usr/lib/systemd/system/NetworkManager.service')

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -504,7 +504,7 @@ OnCalendar=daily
         b.key_press(chr(40), use_ord=True)  # arrow down
         b.key_press(chr(40), use_ord=True)  # arrow down
         b.key_press("\r")
-        if m.image in ["fedora-coreos", "rhel4edge"]:
+        if m.ostree_image:
             b.enter_page("/users")
         else:
             b.enter_page("/storage")
@@ -799,7 +799,7 @@ OnCalendar=daily
         assert_location("/system")
 
         # CoreOS does not keep login history
-        if self.machine.image not in ["fedora-coreos", "rhel4edge"]:
+        if not self.machine.ostree_image:
 
             b.enter_page("/system")
             b.click("button:contains(View login history)")

--- a/test/verify/check-shell-menu
+++ b/test/verify/check-shell-menu
@@ -75,7 +75,7 @@ class TestMenu(MachineCase):
         b.click('#toggle-docs')
         b.click('button:contains("About Web Console")')
         b.wait_visible('#about-cockpit-modal:contains("Cockpit is an interactive Linux server admin interface")')
-        if m.image not in ["fedora-coreos", "rhel4edge"]:
+        if not m.ostree_image:
             pkgname = "cockpit" if m.image == "arch" else "cockpit-bridge"
             b.wait_visible(f'#about-cockpit-modal:contains("{pkgname}")')
         b.click('.pf-c-about-modal-box__close button')

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -103,7 +103,7 @@ def change_ssh_port(machine, address, port=None, timeout_sec=120):
     # Keep in mind that not all operating systems have firewalld
     machine.execute(f"firewall-cmd --permanent --zone=public --add-port={port}/tcp || true")
     machine.execute("firewall-cmd --reload || true")
-    if machine.image in ["fedora-coreos", "rhel4edge"]:  # no semanage
+    if machine.ostree_image:  # no semanage
         machine.execute("setenforce 0")
     else:
         machine.execute(f"! selinuxenabled || semanage port -a -t ssh_port_t -p tcp {port}")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -119,14 +119,14 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         b.login_and_go()
         self.check_shell()
 
-        if m.image not in ["fedora-coreos", "rhel4edge"]:  # logs in via ssh, not cockpit-session
+        if not m.ostree_image:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         # reload, which should log us in with the cookie
         b.reload()
         self.check_shell()
 
-        if m.image not in ["fedora-coreos", "rhel4edge"]:  # logs in via ssh, not cockpit-session
+        if not m.ostree_image:  # logs in via ssh, not cockpit-session
             self.assertRegex(m.execute("who"), r"(^|\n)admin *web.*(\d+\.\d+|::)")
 
         b.go("/users#/admin")
@@ -713,8 +713,8 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         # and login again
         expect_successful_login("admin", "foobar")
 
-        # fedora-coreos and rhel4edge log in via sshd, which forbids root logging in with a password
-        if m.image not in ["fedora-coreos", "rhel4edge"]:
+        # ostree images log in via sshd, which forbids root logging in with a password
+        if not m.ostree_image:
             # make sure root never gets locked out
             for n in range(1, 10):
                 expect_failed_login("root", "bad", n)


### PR DESCRIPTION
Prefer using `ostree_image` so we can easily add a new ostree variant for testing.