### PR TITLE
python: Go back to pipes for spawn channels

### DIFF
--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -149,7 +149,8 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
             env.update(dict(e.split('=', 1) for e in environ))
 
         try:
-            transport = SubprocessTransport(loop, self, args, pty, window, env=env, cwd=cwd, stderr=stderr,
+            transport = SubprocessTransport(loop, self, args, pty, window=window,
+                                            env=env, cwd=cwd, stderr=stderr,
                                             preexec_fn=lambda: prctl(SET_PDEATHSIG, signal.SIGHUP))
             logger.debug('Spawned process args=%s pid=%i', args, transport.get_pid())
             return transport

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -73,7 +73,8 @@ class Peer(CockpitProtocolClient, SubprocessProtocol, Endpoint):
     def spawn(self, argv: Sequence[str], env: Sequence[str], **kwargs) -> asyncio.Transport:
         loop = asyncio.get_running_loop()
         user_env = dict(e.split('=', 1) for e in env)
-        return SubprocessTransport(loop, self, argv, env=dict(os.environ, **user_env), **kwargs)
+        # cockpit-askpass needs to talk the Cockpit protocol r/w on fd 0, thus use a socket
+        return SubprocessTransport(loop, self, argv, use_socket=True, env=dict(os.environ, **user_env), **kwargs)
 
     # Handling of interesting events
     def do_ready(self) -> None:

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -331,34 +331,46 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
                  protocol: SubprocessProtocol,
                  args: Sequence[str],
                  pty: bool = False,
+                 use_socket: bool = False,
                  window: Optional[Dict[str, int]] = None,
                  **kwargs: Any):
         if pty:
-            our_fd, session_fd = os.openpty()
+            self._pty_fd, session_fd = os.openpty()
             kwargs['stderr'] = session_fd
             self._eio_is_eof = True
-            self._pty_fd = our_fd
+            in_fd = self._pty_fd
+            out_fd = in_fd
 
             if window is not None:
                 self.set_window_size(**window)
-        else:
+        elif use_socket:
             self._sock, sock = socket.socketpair()
-            our_fd = self._sock.fileno()
+            in_fd = self._sock.fileno()
+            out_fd = in_fd
             session_fd = sock.detach()
+        else:
+            # normal pipes
+            session_fd = None
 
-        try:
-            self._process = subprocess.Popen(args,
-                                             stdin=session_fd, stdout=session_fd,
-                                             start_new_session=True, **kwargs)
-        finally:
-            os.close(session_fd)
+        if session_fd:
+            try:
+                self._process = subprocess.Popen(args,
+                                                 stdin=session_fd, stdout=session_fd,
+                                                 start_new_session=True, **kwargs)
+            finally:
+                os.close(session_fd)
+        else:
+            self._process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, **kwargs)
+            assert self._process.stdin and self._process.stdout
+            in_fd = self._process.stdout.fileno()
+            out_fd = self._process.stdin.fileno()
 
         if self._process.stderr is not None:
             self._stderr = Spooler(loop, self._process.stderr.fileno())
         else:
             self._stderr = None
 
-        super().__init__(loop, protocol, our_fd, our_fd)
+        super().__init__(loop, protocol, in_fd, out_fd)
 
         self._get_watcher(loop).add_child_handler(self._process.pid, self._exited)
 
@@ -367,11 +379,15 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
         fcntl.ioctl(self._pty_fd, termios.TIOCSWINSZ, struct.pack('2H4x', rows, cols))
 
     def can_write_eof(self) -> bool:
-        return self._sock is not None
+        return self._sock is not None or (self._process is not None and self._process.stdin is not None)
 
     def _write_eof_now(self) -> None:
-        assert self._sock is not None
-        self._sock.shutdown(socket.SHUT_WR)
+        if self._sock is not None:
+            self._sock.shutdown(socket.SHUT_WR)
+        else:
+            assert self._process is not None and self._process.stdin is not None
+            self._process.stdin.close()
+            self._out_fd = -1
 
     def get_pid(self) -> int:
         assert self._process is not None


### PR DESCRIPTION
Commit 8f1b75e5d6445a1ba moved SubprocessTransport from pipes to a socketpair(), as cockpit-askpass depends on that. However, we don't want to do that for spawn channels, as fd 0 being a writable Unix socket is e.g. rejected by SELinux on RHEL 8, and may also be unexpected in other scenarios.

So reintroduce support for pipes, make that the default, and add a `use_socket` flag for it which we enable for Peers only.

This changes the argument order, so explicitly pass `window` as a kwarg instead of positional arg in stream.py. But it still makes more sense to add the argument next to the `pty` flag rather than trying to keep the (internal-only) API.    

---

Broken out from PR #18318, see https://github.com/cockpit-project/cockpit/pull/18318#issuecomment-1436414420 and the previous comment for all the gory debug details. This matches what the C bridge does and [fixes running on RHEL 8](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18318-20230221-105343-68dc41d4-centos-8-stream-pybridge/log.html)

I changed #18318 to skip `TestStratis.testEncrypted` on RHEL/CentOS 8 for the time being. Once this (or a replacement) lands, the test should be unskipped again.