### PR TITLE
Fix cpu temperature sensors detection - FIX COMMIT MESSAGE ON LANDING

### DIFF
--- a/src/bridge/cockpitcpusamples.c
+++ b/src/bridge/cockpitcpusamples.c
@@ -166,7 +166,7 @@ detect_cpu_sensors (GList **devices,
   while ((name = g_dir_read_name (dir)))
     {
       uint i;
-      if (sscanf(name, "temp%d_input", &i) != 1)
+      if (!g_str_has_suffix (name, "_input") || (sscanf(name, "temp%d_input", &i) != 1))
           continue;
 
       g_autofree char *sensor_path = g_build_filename (path, name, NULL);

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -887,10 +887,13 @@ class TestCurrentMetrics(MachineCase):
         # Tctl (temp1_input) will be ignored
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_label", "Tctl")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_input", "40000")
+        m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_max", "100000")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_label", "Tccd1")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_input", "35000")
+        m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_max", "100000")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp3_label", "Tccd3")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp3_input", "30000")
+        m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp3_max", "100000")
 
         b.logout()
         self.login_and_go("/metrics")
@@ -931,8 +934,10 @@ class TestCurrentMetrics(MachineCase):
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/name", "coretemp")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_label", "Package id 0")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_input", "60000")
+        m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_crit", "100000")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_label", "Core 0")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_input", "50000")
+        m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_crit", "100000")
 
         b.logout()
         self.login_and_go("/metrics")


### PR DESCRIPTION
Fixes: #18335
Also adds files containing critical cpu temperature so our tests catch if incorrect values are sampled.