### PR TITLE
tools: add po plugin as input for webpack-make

### DIFF
--- a/tools/webpack-make.js
+++ b/tools/webpack-make.js
@@ -107,6 +107,7 @@ function generateDeps(makefile, stats) {
         'package-lock.json',
         'tools/webpack-make.js',
         'webpack.config.js',
+        'pkg/lib/cockpit-po-plugin.js',
     ]);
 
     for (const file of stats.compilation.fileDependencies) {


### PR DESCRIPTION
When changing the po plugin our webpack's should be rebuild.