### PR TITLE
testlib: bring back "task destroyed but pending" messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1791,6 +1791,12 @@ class MachineCase(unittest.TestCase):
             self.allowed_messages.append("Failed to connect to coredump service: No such file or directory")
             self.allowed_messages.append("Failed to connect to coredump service: Connection refused")
 
+        # HACK: pybridge bugs
+        if os.environ.get("TEST_SCENARIO") == "pybridge":
+            self.allowed_messages += [
+                "asyncio-ERROR: Task was destroyed but it is pending!",
+                "task:.*Task pending.*cockpit/channels/dbus.py.*"]
+
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:


### PR DESCRIPTION
This was dropped in commit 435af1259e29d, but still happens occasionally on Fedora 37, and a lot on RHEL/CentOS 8. This should be addressed by PR #18274, but until that lands, we still need this filter.

----

[Fedora 37 example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-960-20230222-075223-9dce209d-fedora-37-pybridge/log.html#44), [c8s example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18318-20230217-121320-2cbd5f4d-centos-8-stream-pybridge/log.html#135)