### PR TITLE
test: Bump timeout for CDP response

### DIFF
--- a/test/common/cdp.py
+++ b/test/common/cdp.py
@@ -295,7 +295,7 @@ class CDP:
         # wait for CDP to be up and have at least one target
         for retry in range(120):
             try:
-                res = urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json/list", timeout=5)
+                res = urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json/list", timeout=30)
                 if res.getcode() == 200 and json.loads(res.read()):
                     break
             except URLError:


### PR DESCRIPTION
The short timeout caused test failures when running on RHEL 8.

----

This broke the downstream release earlier today, and I confirmed that this fixed it. For the Red Hatters out here, see https://gitlab.com/redhat/rhel/rpms/cockpit/-/merge_requests/11