### PR TITLE
fmf: Skip TestAccounts.testUserPasswords

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -127,9 +127,13 @@ if [ "$PLAN" = "basic" ]; then
               TestJournal.testAbrtSegv
               "
 
-    # no cockpit-tests package in RHEL 8
     if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ]; then
+        # no cockpit-tests package in RHEL 8
         EXCLUDES="$EXCLUDES TestLogin.testSELinuxRestrictedUser"
+
+        # fails to start second browser, timing out on http://127.0.0.1:{cdp_port}/json/list
+        # impossible to debug without access to the infra
+        EXCLUDES="$EXCLUDES TestAccounts.testUserPasswords"
     fi
 
     # These don't test more external APIs


### PR DESCRIPTION
This test fails in about 80% of runs on RHEL Testing Farm machines:

```
 File "tests/test/common/cdp.py", line 298, in start
    res = urllib.request.urlopen(f"http://127.0.0.1:{cdp_port}/json/list", timeout=5)
socket.timeout: timed out
```

When it tries to open `b2` (the second browser instance). Waiting longer does not help, this is thoroughly broken. As there is little to no chance to debug this in a hurry without access to the affected machines, and it does not happen on the public TF ranch nor our own CI, skip the test on RHEL.