### PR TITLE
lib: Add esbuild plugins for eslint, stylelint, and compression

### DIFF
--- a/pkg/lib/esbuild-compress-plugin.js
+++ b/pkg/lib/esbuild-compress-plugin.js
@@ -1,0 +1,29 @@
+/* There is https://www.npmjs.com/package/esbuild-plugin-compress but it does
+ * not work together with our PO plugin, they are incompatible due to requiring
+ * different values for `write:`. We may be able to change our plugins to work
+ * with `write: false`, but this is easy enough to implement ourselves.
+*/
+
+import { opendir } from 'node:fs/promises';
+import util from 'node:util';
+import child_process from 'node:child_process';
+
+const NAME = 'cockpitCompressPlugin';
+
+const exec = util.promisify(child_process.execFile);
+
+export const cockpitCompressPlugin = ({
+    name: NAME,
+    setup(build) {
+        build.onEnd(async () => {
+            const gzipPromises = [];
+            for await (const dirent of await opendir('dist')) {
+                if (dirent.name.endsWith('.js') || dirent.name.endsWith('.css')) {
+                    gzipPromises.push(exec('gzip', ['-9', 'dist/' + dirent.name]));
+                }
+            }
+            await Promise.all(gzipPromises);
+            return null;
+        });
+    }
+});

--- a/pkg/lib/esbuild-eslint-plugin.js
+++ b/pkg/lib/esbuild-eslint-plugin.js
@@ -1,0 +1,33 @@
+// Replace with plugin from npmjs once they become good enough
+// Candidate 1: requires https://github.com/to-codando/esbuild-plugin-linter/issues/1 and https://github.com/to-codando/esbuild-plugin-linter/issues/3 to get fixed
+// Candidate 2: requires https://github.com/robinloeffel/esbuild-plugin-eslint/issues/4 and https://github.com/robinloeffel/esbuild-plugin-eslint/issues/5 to get fixed
+
+import { ESLint } from 'eslint';
+
+const NAME = 'eslintPlugin';
+
+export const eslintPlugin = {
+    name: NAME,
+    setup(build) {
+        const filesToLint = [];
+        const eslint = new ESLint();
+        const filter = /src\/.*\.(jsx?|js?)$/;
+
+        build.onLoad({ filter }, ({ path }) => {
+            filesToLint.push(path);
+        });
+
+        build.onEnd(async () => {
+            const result = await eslint.lintFiles(filesToLint);
+            const formatter = await eslint.loadFormatter('stylish');
+            const output = formatter.format(result);
+            if (output.length > 0) {
+                console.log(output); // eslint-disable no-console
+                return {
+                    errors: [{ pluginName: NAME, text: 'ESLint errors found' }]
+                };
+            }
+            return null;
+        });
+    },
+};

--- a/pkg/lib/esbuild-stylelint-plugin.js
+++ b/pkg/lib/esbuild-stylelint-plugin.js
@@ -1,0 +1,39 @@
+// FIXME: replace when issues get fixed:
+// - https://github.com/ordros/esbuild-plugin-stylelint/issues/1
+// - https://github.com/ordros/esbuild-plugin-stylelint/issues/2
+
+import * as stylelint from 'stylelint';
+import * as formatter from 'stylelint-formatter-pretty';
+
+const NAME = 'stylelintPlugin';
+
+export const stylelintPlugin = ({
+    filter = /\.(s?css)$/,
+    ...stylelintOptions
+} = {}) => ({
+    name: NAME,
+    setup(build) {
+        const targetFiles = [];
+        build.onLoad({ filter }, ({ path }) => {
+            if (!path.includes('node_modules')) {
+                targetFiles.push(path);
+            }
+        });
+
+        build.onEnd(async () => {
+            const result = await stylelint.default.lint({
+                formatter: formatter.default,
+                ...stylelintOptions,
+                files: targetFiles,
+            });
+            const { output } = result;
+            if (output.length > 0) {
+                console.log(output); // eslint-disable no-console
+                return {
+                    errors: [{ pluginName: NAME, text: 'stylelint errors found' }]
+                };
+            }
+            return null;
+        });
+    }
+});


### PR DESCRIPTION
There are existing plugins on npmjs.com for these tasks, but they are not good enough yet. See the comments at the top for details.

With these, we now have all the tools to build Cockpit pages with https://esbuild.github.io/.

----

Taken from https://github.com/cockpit-project/cockpit-podman/pull/1210 . Once this lands, we can pull them into cockpit-podman.