### PR TITLE
base1, lib: Avoid top-level await

### DIFF
--- a/pkg/base1/test-file.js
+++ b/pkg/base1/test-file.js
@@ -1,6 +1,8 @@
 import cockpit from "cockpit";
 import QUnit from "qunit-tests";
 
+let dir;
+
 QUnit.test("simple read", async assert => {
     const file = cockpit.file(dir + "/foo");
     assert.equal(file.path, dir + "/foo", "file has path");
@@ -423,6 +425,8 @@ QUnit.test("remove testdir", async assert => {
     assert.ok(true, "did not crash");
 });
 
-const resp = await cockpit.spawn(["bash", "-c", "d=$(mktemp -d); echo '1234' >$d/foo; echo '{ \"foo\": 12 }' >$d/foo.json; echo -en '\\x00\\x01\\x02\\x03' >$d/foo.bin; dd if=/dev/zero of=$d/large.bin bs=1k count=512; echo $d"]);
-const dir = resp.replace(/\n$/, "");
-QUnit.start();
+(async () => {
+    const resp = await cockpit.spawn(["bash", "-c", "d=$(mktemp -d); echo '1234' >$d/foo; echo '{ \"foo\": 12 }' >$d/foo.json; echo -en '\\x00\\x01\\x02\\x03' >$d/foo.bin; dd if=/dev/zero of=$d/large.bin bs=1k count=512; echo $d"]);
+    dir = resp.replace(/\n$/, "");
+    QUnit.start();
+})();

--- a/pkg/lib/qunit-tests.js
+++ b/pkg/lib/qunit-tests.js
@@ -31,10 +31,17 @@ QUnit.mock_info = async key => {
 // Convenience for skipping tests that the python bridge can't yet
 // handle.
 
-if (await QUnit.mock_info("pybridge"))
-    QUnit.test.skipWithPybridge = QUnit.test.skip;
-else
-    QUnit.test.skipWithPybridge = QUnit.test;
+let is_pybridge = null;
+
+QUnit.test.skipWithPybridge = async (name, callback) => {
+    if (is_pybridge === null)
+        is_pybridge = await QUnit.mock_info("pybridge");
+
+    if (is_pybridge)
+        QUnit.test.skip(name, callback);
+    else
+        QUnit.test(name, callback);
+};
 
 /* Always use explicit start */
 QUnit.config.autostart = false;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -424,10 +424,6 @@ export default {
         ],
     },
 
-    experiments: {
-        topLevelAwait: true,
-    },
-
     module: {
         rules: [
             {


### PR DESCRIPTION
This is still incompatible with esbuild and also older nodejs versions.

----

@KKoukiou : This should help with esbuild-ifying cockpit itself. Any other trouble?