### PR TITLE
configure: Fix check for xgettext

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -178,9 +178,9 @@ else
 fi
 AC_SUBST([systemdunitdir], [$systemdunitdir])
 
-# We need msgcat, msgfmt, msggrep, msgmerge, but they're all in the same
+# We need msgcat, msgfmt, and xgettext, but they're all in the same
 # package as xgettext, and we find them by PATH, so just check for the one.
-AC_PATH_PROG([XGETTEXT], [xsltproc], [no])
+AC_PATH_PROG([XGETTEXT], [xgettext], [no])
 if test "$XGETTEXT" = "no"; then
         AC_MSG_ERROR([Please install gettext tools])
 fi

--- a/packit.yaml
+++ b/packit.yaml
@@ -15,6 +15,7 @@ actions:
 srpm_build_deps:
   - automake
   - gcc
+  - gettext
   - glib2-devel
   - make
   - systemd-devel


### PR DESCRIPTION
Actually check for the "xgettext" binary in the relevant section. xsltproc is already checked further down, conditionalized by --enable-docs. The latter is also in a different package.

See https://github.com/cockpit-project/cockpit/discussions/18408