### PR TITLE
systemd/service: Track pinned units by unit name (ID), not object path; code cleanups

### DIFF
--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -222,7 +222,7 @@ export class ServiceDetails extends React.Component {
             unit_properties: {},
             showDeleteDialog: false,
             unitPaths: [],
-            isPinned: this.props.pinnedUnits.includes(this.props.unit.path),
+            isPinned: this.props.pinnedUnits.includes(this.props.unit.Id),
         };
 
         this.onOnOffSwitch = this.onOnOffSwitch.bind(this);
@@ -331,8 +331,8 @@ export class ServiceDetails extends React.Component {
 
     pinUnit() {
         const newPinned = this.state.isPinned
-            ? this.props.pinnedUnits.filter(unitId => unitId != this.props.unit.path)
-            : [...this.props.pinnedUnits, this.props.unit.path];
+            ? this.props.pinnedUnits.filter(unitId => unitId != this.props.unit.Id)
+            : [...this.props.pinnedUnits, this.props.unit.Id];
 
         localStorage.setItem('systemd:pinnedUnits', JSON.stringify(newPinned));
         this.setState(prevState => ({ isPinned: !prevState.isPinned }));

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -222,6 +222,7 @@ export class ServiceDetails extends React.Component {
             unit_properties: {},
             showDeleteDialog: false,
             unitPaths: [],
+            isPinned: this.props.pinnedUnits.includes(this.props.unit.path),
         };
 
         this.onOnOffSwitch = this.onOnOffSwitch.bind(this);
@@ -329,20 +330,12 @@ export class ServiceDetails extends React.Component {
     }
 
     pinUnit() {
-        let pinnedUnits = [];
-        try {
-            pinnedUnits = JSON.parse(localStorage.getItem('systemd:pinnedUnits')) || [];
-        } catch (err) {
-            console.warn("exception while parsing systemd:pinnedUnits", err);
-        }
+        const newPinned = this.state.isPinned
+            ? this.props.pinnedUnits.filter(unitId => unitId != this.props.unit.path)
+            : [...this.props.pinnedUnits, this.props.unit.path];
 
-        if (this.props.isPinned) {
-            pinnedUnits = pinnedUnits.filter(unitId => unitId != this.props.unit.path);
-        } else {
-            pinnedUnits.push(this.props.unit.path);
-        }
-
-        localStorage.setItem('systemd:pinnedUnits', JSON.stringify(pinnedUnits));
+        localStorage.setItem('systemd:pinnedUnits', JSON.stringify(newPinned));
+        this.setState(prevState => ({ isPinned: !prevState.isPinned }));
         dispatchEvent(new Event('storage'));
     }
 
@@ -614,7 +607,7 @@ export class ServiceDetails extends React.Component {
                     : <>
                         <CardTitle className="service-top-panel">
                             <Text component={TextVariants.h2} className="service-name">{this.props.unit.Description}</Text>
-                            {this.props.isPinned &&
+                            {this.state.isPinned &&
                                 <Tooltip content={_("Pinned unit")}>
                                     <ThumbtackIcon className='service-thumbtack-icon' />
                                 </Tooltip>}
@@ -634,7 +627,7 @@ export class ServiceDetails extends React.Component {
                                                     actionCallback={this.unitAction} fileActionCallback={this.unitFileAction}
                                                     deleteActionCallback={isCustom && isTimer ? this.deleteAction : null}
                                                     disabled={this.state.waitsAction || this.state.waitsFileAction}
-                                                    isPinned={this.props.isPinned} pinUnitCallback={this.pinUnit} />
+                                                    isPinned={this.state.isPinned} pinUnitCallback={this.pinUnit} />
                                 </>
                             }
                         </CardTitle>

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -60,7 +60,7 @@ export class Service extends React.Component {
                                 permitted={superuser.allowed}
                                 loadingUnits={this.props.loadingUnits}
                                 isValid={this.props.unitIsValid}
-                                isPinned={this.props.isPinned}
+                                pinnedUnits={this.props.pinnedUnits}
         />;
 
         const unit_type = this.props.owner == "system" ? "UNIT" : "USER_UNIT";

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -155,13 +155,6 @@ class ServicesPageBody extends React.Component {
             currentStatus: null,
         };
 
-        try {
-            this.state.pinnedUnits = JSON.parse(localStorage.getItem('systemd:pinnedUnits')) || [];
-        } catch (err) {
-            console.warn("exception while parsing systemd:pinnedUnits", err);
-            this.state.pinnedUnits = [];
-        }
-
         this.filtersRef = React.createRef();
 
         // Possible LoadState values: stub, loaded, not-found, bad-setting, error, merged, masked
@@ -214,6 +207,7 @@ class ServicesPageBody extends React.Component {
         this.processFailedUnits = this.processFailedUnits.bind(this);
         this.listUnits = this.listUnits.bind(this);
         this.getUnitByPath = this.getUnitByPath.bind(this);
+        this.loadPinnedUnits = this.loadPinnedUnits.bind(this);
         this.onOptionsChanged = this.onOptionsChanged.bind(this);
         this.compareUnits = this.compareUnits.bind(this);
 
@@ -319,14 +313,8 @@ class ServicesPageBody extends React.Component {
                 this.listUnits();
         });
 
-        addEventListener('storage', () => {
-            try {
-                this.setState({ pinnedUnits: JSON.parse(localStorage.getItem('systemd:pinnedUnits')) || [] });
-            } catch (err) {
-                console.warn("exception while parsing systemd:pinnedUnits", err);
-                this.setState({ pinnedUnits: [] });
-            }
-        });
+        addEventListener('storage', this.loadPinnedUnits);
+        this.loadPinnedUnits();
 
         this.timedated_subscription = timedate_client.subscribe({
             path_namespace: "/org/freedesktop/timedate1",
@@ -341,6 +329,15 @@ class ServicesPageBody extends React.Component {
             return false;
 
         return true;
+    }
+
+    loadPinnedUnits() {
+        try {
+            this.setState({ pinnedUnits: JSON.parse(localStorage.getItem('systemd:pinnedUnits')) || [] });
+        } catch (err) {
+            console.warn("exception while parsing systemd:pinnedUnits", err);
+            this.setState({ pinnedUnits: [] });
+        }
     }
 
     /**
@@ -786,7 +783,7 @@ class ServicesPageBody extends React.Component {
                             loadingUnits={this.props.isLoading}
                             getUnitByPath={this.getUnitByPath}
                             unit={unit}
-                            isPinned={this.state.pinnedUnits.includes(unit.path)}
+                            pinnedUnits={this.state.pinnedUnits}
             />;
         }
 

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -521,8 +521,8 @@ class ServicesPageBody extends React.Component {
         const unit_b = unit_b_t[1];
         const failed_a = unit_a.HasFailed ? 1 : 0;
         const failed_b = unit_b.HasFailed ? 1 : 0;
-        const pinned_a = this.state.pinnedUnits.includes(unit_a.path) ? 1 : 0;
-        const pinned_b = this.state.pinnedUnits.includes(unit_b.path) ? 1 : 0;
+        const pinned_a = this.state.pinnedUnits.includes(unit_a.Id) ? 1 : 0;
+        const pinned_b = this.state.pinnedUnits.includes(unit_b.Id) ? 1 : 0;
 
         if (!unit_a || !unit_b)
             return false;
@@ -834,7 +834,7 @@ class ServicesPageBody extends React.Component {
                         !filters.activeState.includes(this.activeState[unit.ActiveState]))
                         return false;
 
-                    unit.IsPinned = this.state.pinnedUnits.includes(unit.path);
+                    unit.IsPinned = this.state.pinnedUnits.includes(unit.Id);
                     return true;
                 })
                 .map(unit_id => [unit_id, unit_by_path[this.path_by_id[unit_id]]])


### PR DESCRIPTION
Judging by the .filter() call, this had been the intention from the        
start. There is no advantage with tracking the object paths instead:        
        
 * They are not any more unique than IDs, they are even the same for        
   system and user units.        
        
 * They require an extra LoadUnit() to compute, which we want to stop        
   doing.        
        
 * They are an internal implementation detail of systemd, which can        
   change in principle.        
        
This is a breaking change, as it will disregard existing        
`systemd:pinnedUnits` settings from localstore. This has existed for        
less than a year (commit 065bf82d83), is not very easy to discover, and        
is not crucial, so we can hopefully get away with it.        

----

Also add some code cleanup.

## Services: Pinned units need to be re-done

The data storage for "pinned" systemd units has changed. After upgrading to this Cockpit version, you need to re-pin units.