### PR TITLE
systemd/services: Avoid excessive D-Bus calls and simplify state management

### DIFF
--- a/pkg/systemd/services/busnames.js
+++ b/pkg/systemd/services/busnames.js
@@ -2,6 +2,8 @@ const s_bus = {
     BUS_NAME: "org.freedesktop.systemd1",
     O_MANAGER: "/org/freedesktop/systemd1",
     I_MANAGER: "org.freedesktop.systemd1.Manager",
+    I_PROPS: "org.freedesktop.DBus.Properties",
+    I_UNIT: "org.freedesktop.systemd1.Unit",
     I_TIMER: "org.freedesktop.systemd1.Timer",
     I_SOCKET: "org.freedesktop.systemd1.Socket",
 };

--- a/pkg/systemd/services/service-details.jsx
+++ b/pkg/systemd/services/service-details.jsx
@@ -203,7 +203,9 @@ const ServiceActions = ({ masked, active, failed, canReload, actionCallback, del
  * Enables user to control this unit like starting, enabling, etc. the service.
  * Required props:
  *  -  unit
- *      Unit as returned from systemd dbus API
+ *      as returned from systemd org.freedesktop.systemd1.{Unit,Socket}
+ *      D-Bus interface, but with unwrapped variants, and with additional "path"
+ *      property and addTimerProperties()
  *  -  permitted
  *      True if user can control this unit
  *  -  systemdManager

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -21,50 +21,130 @@ import React from "react";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
 import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery, GalleryItem } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
+import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
 import { ServiceDetails } from "./service-details.jsx";
 import { LogsPanel } from "cockpit-components-logs-panel.jsx";
 import { superuser } from 'superuser';
 import { WithDialogs } from "dialogs.jsx";
 
+import s_bus from "./busnames.js";
+
 import cockpit from "cockpit";
 
 const _ = cockpit.gettext;
+
+function debug() {
+    if (window.debugging == "all" || window.debugging?.includes("service-details")) // not-covered: debugging
+        console.debug.apply(console, arguments); // not-covered: debugging
+}
 
 export class Service extends React.Component {
     constructor(props) {
         super(props);
 
         this.state = {
-            /* The initial load of the Services page will not call GetAll for units Properties
-             * since ListUnits API call already has provided us with a subset of the Properties.
-             * As a result, properties like the 'Requires' are not present in the state at this point.
-             * If it's the first time to open this service's details page we need to fetch
-             * the unit properties by calling getUnitByPath.
-             */
-            shouldFetchProps: props.unit.Names === undefined,
+            unit_id: null,
+            unit_props: null,
+            error: null,
+            reloading: false,
         };
+
+        this.path = null;
+        this.subscriptions = [];
     }
 
-    componentDidMount() {
-        if (this.state.shouldFetchProps)
-            this.props.getUnitByPath(this.props.unit.path).finally(() => this.setState({ shouldFetchProps: false }));
+    async componentDidMount() {
+        const dbus = this.props.dbusClient;
+        const [path] = await dbus.call(s_bus.O_MANAGER, s_bus.I_MANAGER, "LoadUnit", [this.props.unitId]);
+        this.path = path;
+
+        this.subscriptions.push(dbus.subscribe(
+            { interface: s_bus.I_MANAGER, member: "Reloading" },
+            async (_path, _iface, _signal, [reloading]) => {
+                debug("Service detail", this.props.unitId, "Reloading", reloading);
+                this.setState({ reloading });
+                if (!reloading)
+                    await this.updateProperties();
+            }));
+
+        this.subscriptions.push(dbus.subscribe(
+            { path, interface: s_bus.I_PROPS, member: "PropertiesChanged" }, async () => {
+                debug("Service detail", this.props.unitId, "PropertiesChanged");
+                await this.updateProperties();
+            }));
+
+        /* We need this *only* to pick up failed Conditions after attempting to start a service, as the unit immediately gets
+         * unloaded again and we don't get a PropertiesChanged signal. */
+        this.subscriptions.push(dbus.subscribe(
+            { interface: s_bus.I_MANAGER, member: "JobRemoved" }, async (_p, _i, _s, [_job_id, _job_path, unit, result]) => {
+                if (unit === this.props.unitId && result === "done") {
+                    debug("Service detail", this.props.unitId, "JobRemoved");
+                    await this.updateProperties();
+                }
+            }));
+
+        debug("Service detail", this.props.unitId, "componentDidMount, loading initial properties");
+        await this.updateProperties();
+    }
+
+    componentWillUnmount() {
+        this.subscriptions.forEach(s => s.remove());
+        this.subscriptions = [];
+        debug("Service detail", this.props.unitId, "componentWillUnmount");
+    }
+
+    async updateProperties() {
+        const dbus = this.props.dbusClient;
+        const unit_id = this.props.unitId;
+
+        try {
+            const [unit_props] = await dbus.call(this.path, s_bus.I_PROPS, "GetAll", [s_bus.I_UNIT]);
+            // unwrap variants
+            for (const key in unit_props)
+                unit_props[key] = unit_props[key].v;
+
+            if (unit_id.endsWith(".timer")) {
+                const [timer_props] = await dbus.call(this.path, s_bus.I_PROPS, "GetAll", [s_bus.I_TIMER]);
+                // unwrap variants
+                for (const key in timer_props)
+                    timer_props[key] = timer_props[key].v;
+                this.props.addTimerProperties(timer_props, unit_props);
+            }
+
+            if (unit_id.endsWith(".socket")) {
+                const [socket_props] = await dbus.call(this.path, s_bus.I_PROPS, "GetAll", [s_bus.I_SOCKET]);
+                unit_props.Listen = socket_props.Listen.v;
+            }
+
+            unit_props.path = this.path;
+
+            debug("Service detail", unit_id, "updated properties:", JSON.stringify(unit_props));
+            this.setState({ unit_id, unit_props, error: null });
+        } catch (ex) {
+            this.setState({ error: ex.toString() }); // not-covered: unexpected OS error
+        }
     }
 
     render() {
-        if (this.state.shouldFetchProps || this.props.unit.Names === undefined)
-            return null;
+        if (this.state.error)
+            return <EmptyStatePanel title={_("Loading unit failed")} icon={ExclamationCircleIcon} paragraph={this.state.error} />;
 
-        const serviceDetails = <ServiceDetails unit={this.props.unit}
+        const cur_unit_id = this.props.unitId;
+
+        if (this.state.unit_props === null)
+            return <EmptyStatePanel loading title={_("Loading...")} paragraph={cur_unit_id} />;
+
+        const serviceDetails = <ServiceDetails unit={this.state.unit_props}
                                 owner={this.props.owner}
                                 permitted={superuser.allowed}
-                                loadingUnits={this.props.loadingUnits}
+                                loadingUnits={this.state.reloading}
                                 isValid={this.props.unitIsValid}
                                 pinnedUnits={this.props.pinnedUnits}
         />;
 
         const unit_type = this.props.owner == "system" ? "UNIT" : "USER_UNIT";
-        const cur_unit_id = this.props.unit.Id;
         const match = [
             "_SYSTEMD_" + unit_type + "=" + cur_unit_id, "+",
             "COREDUMP_" + unit_type + "=" + cur_unit_id, "+",
@@ -72,6 +152,8 @@ export class Service extends React.Component {
         ];
         const service_type = this.props.owner == "system" ? "service" : "user-service";
         const url = "/system/logs/#/?prio=debug&" + service_type + "=" + cur_unit_id;
+
+        const load_state = this.state.unit_props.LoadState;
 
         return (
             <WithDialogs>
@@ -82,13 +164,13 @@ export class Service extends React.Component {
                           <Breadcrumb>
                               <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
                               <BreadcrumbItem isActive>
-                                  {this.props.unit.Id}
+                                  {cur_unit_id}
                               </BreadcrumbItem>
                           </Breadcrumb>}>
                     <PageSection>
                         <Gallery hasGutter>
                             <GalleryItem id="service-details-unit">{serviceDetails}</GalleryItem>
-                            {(this.props.unit.LoadState === "loaded" || this.props.unit.LoadState === "masked") &&
+                            {(load_state === "loaded" || load_state === "masked") &&
                             <GalleryItem id="service-details-logs">
                                 <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", [service_type]: cur_unit_id }} />
                             </GalleryItem>}

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -112,9 +112,6 @@ export class Service extends React.Component {
 
             if (unit_id.endsWith(".timer")) {
                 const [timer_props] = await dbus.call(this.path, s_bus.I_PROPS, "GetAll", [s_bus.I_TIMER]);
-                // unwrap variants
-                for (const key in timer_props)
-                    timer_props[key] = timer_props[key].v;
                 this.props.addTimerProperties(timer_props, unit_props);
             }
 
@@ -136,10 +133,8 @@ export class Service extends React.Component {
         if (this.state.error)
             return <EmptyStatePanel title={_("Loading unit failed")} icon={ExclamationCircleIcon} paragraph={this.state.error} />;
 
-        const cur_unit_id = this.props.unitId;
-
         if (this.state.unit_props === null)
-            return <EmptyStatePanel loading title={_("Loading...")} paragraph={cur_unit_id} />;
+            return <EmptyStatePanel loading title={_("Loading...")} paragraph={this.props.unitId} />;
 
         const serviceDetails = <ServiceDetails unit={this.state.unit_props}
                                 owner={this.props.owner}
@@ -148,6 +143,9 @@ export class Service extends React.Component {
                                 isValid={this.props.unitIsValid}
                                 pinnedUnits={this.props.pinnedUnits}
         />;
+
+        // resolve Alias name to primary ID
+        const cur_unit_id = this.state.unit_props.Id;
 
         const unit_type = this.props.owner == "system" ? "UNIT" : "USER_UNIT";
         const match = [

--- a/pkg/systemd/services/service.jsx
+++ b/pkg/systemd/services/service.jsx
@@ -57,8 +57,13 @@ export class Service extends React.Component {
 
     async componentDidMount() {
         const dbus = this.props.dbusClient;
-        const [path] = await dbus.call(s_bus.O_MANAGER, s_bus.I_MANAGER, "LoadUnit", [this.props.unitId]);
-        this.path = path;
+        try {
+            const [path] = await dbus.call(s_bus.O_MANAGER, s_bus.I_MANAGER, "LoadUnit", [this.props.unitId]);
+            this.path = path;
+        } catch (ex) {
+            this.setState({ error: ex.toString() });
+            return;
+        }
 
         this.subscriptions.push(dbus.subscribe(
             { interface: s_bus.I_MANAGER, member: "Reloading" },
@@ -70,7 +75,7 @@ export class Service extends React.Component {
             }));
 
         this.subscriptions.push(dbus.subscribe(
-            { path, interface: s_bus.I_PROPS, member: "PropertiesChanged" }, async () => {
+            { path: this.path, interface: s_bus.I_PROPS, member: "PropertiesChanged" }, async () => {
                 debug("Service detail", this.props.unitId, "PropertiesChanged");
                 await this.updateProperties();
             }));

--- a/pkg/systemd/services/services-list.jsx
+++ b/pkg/systemd/services/services-list.jsx
@@ -110,10 +110,10 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
         {
             title: (
                 <Flex id={cockpit.format("$0-service-unit-state", Id)} className='service-unit-status-flex-container'>
-                    {CombinedState && <FlexItem flex={{ default: 'flex_2' }} className={"service-unit-status" + (HasFailed ? " service-unit-status-failed" : "")}>
+                    <FlexItem flex={{ default: 'flex_2' }} className={"service-unit-status" + (HasFailed ? " service-unit-status-failed" : "")}>
                         {HasFailed && <ExclamationCircleIcon className='ct-exclamation-circle' />}
                         {CombinedState}
-                    </FlexItem>}
+                    </FlexItem>
                     <FlexItem flex={{ default: 'flex_1' }}>
                         {tooltipMessage ? <Tooltip id="switch-unit-state" content={tooltipMessage} position={TooltipPosition.left}>{unitFileState}</Tooltip> : unitFileState}
                     </FlexItem>

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -206,10 +206,10 @@ class ServicesPageBody extends React.Component {
         /* Function for manipulating with the API results and store the units in the React state */
         this.processFailedUnits = this.processFailedUnits.bind(this);
         this.listUnits = this.listUnits.bind(this);
-        this.getUnitByPath = this.getUnitByPath.bind(this);
         this.loadPinnedUnits = this.loadPinnedUnits.bind(this);
         this.onOptionsChanged = this.onOptionsChanged.bind(this);
         this.compareUnits = this.compareUnits.bind(this);
+        this.addTimerProperties = this.addTimerProperties.bind(this);
 
         this.seenPaths = new Set();
         this.path_by_id = {};
@@ -783,9 +783,9 @@ class ServicesPageBody extends React.Component {
             return <Service unitIsValid={unitId => { const path = get_unit_path(unitId); return path !== undefined && this.state.unit_by_path[path].LoadState != 'not-found' }}
                             owner={this.props.owner}
                             key={unit_id}
-                            loadingUnits={this.props.isLoading}
-                            getUnitByPath={this.getUnitByPath}
-                            unit={unit}
+                            unitId={unit_id}
+                            dbusClient={systemd_client[this.props.owner]}
+                            addTimerProperties={this.addTimerProperties}
                             pinnedUnits={this.state.pinnedUnits}
             />;
         }

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -1025,7 +1025,7 @@ const ServicesPage = () => {
 
     const activeTab = options.type || 'service';
     const owner = options.owner || 'system';
-    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, { ...options, owner });
+    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, { ...cockpit.location.options, owner });
 
     if (owner !== 'system' && owner !== 'user') {
         console.warn("not a valid location: " + path);
@@ -1042,7 +1042,7 @@ const ServicesPage = () => {
                         <ServiceTabs activeTab={activeTab}
                                       tabErrors={tabErrors}
                                       onChange={activeTab => {
-                                          cockpit.location.go(cockpit.location.path, { ...options, type: activeTab });
+                                          cockpit.location.go(cockpit.location.path, { ...cockpit.location.options, type: activeTab });
                                       }} />
                         <FlexItem align={{ default: 'alignRight' }}>
                             {loggedUser && loggedUser !== 'root' && <ToggleGroup>

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -23,7 +23,6 @@ import 'cockpit-dark-theme'; // once per page
 
 import React, { useState, useEffect, useCallback } from "react";
 import { createRoot } from 'react-dom/client';
-import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select/index.js";
 import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
@@ -762,23 +761,6 @@ class ServicesPageBody extends React.Component {
         if (path.length == 1) {
             const unit_id = path[0];
             const get_unit_path = (unit_id) => this.path_by_id[unit_id];
-            const unit_path = get_unit_path(unit_id);
-            const unit = this.state.unit_by_path[unit_path];
-
-            if (unit_path === undefined || unit === undefined || unit.LoadState === 'not-found') {
-                const path = "/system/services" + (this.props.owner === "user" ? "#/?owner=user" : "");
-                return <EmptyStatePanel
-                            icon={ExclamationCircleIcon}
-                            title={_("Unit not found")}
-                            paragraph={
-                                <Button variant="link"
-                                        component="a"
-                                        onClick={() => cockpit.jump(path, cockpit.transport.host)}>
-                                    {_("View all services")}
-                                </Button>
-                            }
-                />;
-            }
 
             return <Service unitIsValid={unitId => { const path = get_unit_path(unitId); return path !== undefined && this.state.unit_by_path[path].LoadState != 'not-found' }}
                             owner={this.props.owner}

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -1025,7 +1025,7 @@ const ServicesPage = () => {
 
     const activeTab = options.type || 'service';
     const owner = options.owner || 'system';
-    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, Object.assign(options, { owner }));
+    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, { ...options, owner });
 
     if (owner !== 'system' && owner !== 'user') {
         console.warn("not a valid location: " + path);
@@ -1042,7 +1042,7 @@ const ServicesPage = () => {
                         <ServiceTabs activeTab={activeTab}
                                       tabErrors={tabErrors}
                                       onChange={activeTab => {
-                                          cockpit.location.go(cockpit.location.path, Object.assign(options, { type: activeTab }));
+                                          cockpit.location.go(cockpit.location.path, { ...options, type: activeTab });
                                       }} />
                         <FlexItem align={{ default: 'alignRight' }}>
                             {loggedUser && loggedUser !== 'root' && <ToggleGroup>

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -528,10 +528,8 @@ class TestHistoryMetrics(MachineCase):
 
         # Troubleshoot
         b.click(".pf-c-empty-state button.pf-m-link")
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.enter_page("/system/services")
-            b.wait_in_text("#service-details", "pmlogger.service")
+        b.enter_page("/system/services")
+        b.wait_in_text("#service-details", "pmlogger.service")
 
     @nondestructive
     @skipOstree("no PCP support")
@@ -1019,9 +1017,7 @@ BEGIN {{
         # table entries are links to Services page
         b.click("table[aria-label='Top 5 memory services'] tbody tr:nth-of-type(1) td[data-label='Service'] a span")
         b.enter_page("/system/services")
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.wait_in_text("#path", "/mem-hog.service")
+        b.wait_in_text("#path", "/mem-hog.service")
         b.wait_in_text(".service-name", "memhog.sh")
 
         b.go("/metrics")

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -234,9 +234,7 @@ class TestNetworkingBasic(NetworkCase):
         assert_stopped(True)
         b.click("#networking-nm-crashed a")
         b.enter_page("/system/services")
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.wait_text(".service-name", "Network Manager")
+        b.wait_text(".service-name", "Network Manager")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -112,9 +112,7 @@ OnCalendar=daily
         b.enter_page("/system/services")
         b.reload()
         b.enter_page("/system/services")
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.wait_text(".service-name", "Test Service")
+        b.wait_text(".service-name", "Test Service")
         b.switch_to_top()
         self.checkDocs(["Managing services"])
         b.click("#toggle-docs")
@@ -130,9 +128,7 @@ OnCalendar=daily
 
         m.restart_cockpit()
         b.relogin("/system/services")
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.wait_text(".service-name", "Test Service")
+        b.wait_text(".service-name", "Test Service")
 
         # check that navigating away and back preserves place
         b.click_system_menu("/system")

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -53,11 +53,11 @@ class TestReauthorize(MachineCase):
         m.execute("touch /tmp/playground-test-lock")
         b.click(".lock-channel button")
         b.wait_in_text(".lock-channel span", 'locked')
-        m.execute("! flock -n /tmp/playground-test-lock true")
+        m.execute("! flock --nonblock /tmp/playground-test-lock true")
 
         # Deauthorize user
         b.drop_superuser()
-        m.execute("flock -n /tmp/playground-test-lock true")
+        m.execute("flock --timeout 10 /tmp/playground-test-lock true")
         b.click(".cockpit-internal-reauthorize button")
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -161,9 +161,7 @@ class CommonTests:
 
         # log in as domain admin and check that we can do privileged operations
         b.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user=f'{self.admin_user}@cockpit.lan', password=self.admin_password)
-        # FIXME: Services page is too slow
-        with b.wait_timeout(60):
-            b.wait_in_text("#statuses", "Running")
+        b.wait_in_text("#statuses", "Running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")
@@ -176,9 +174,7 @@ class CommonTests:
         b.login_and_go('/system', user=f'{self.admin_user.lower()}@COCKPIT.LAN', password=self.admin_password)
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
-        # FIXME: Services page is too slow
-        with b.wait_timeout(60):
-            b.wait_in_text("#statuses", "Not running")
+        b.wait_in_text("#statuses", "Not running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Start')")
         b.wait_in_text("#statuses", "Running")
@@ -324,9 +320,7 @@ class CommonTests:
         b.go('/system/services#/systemd-tmpfiles-clean.timer')
         b.enter_page('/system/services')
 
-        # FIXME: Services page is too slow
-        with b.wait_timeout(30):
-            b.wait_in_text("#statuses", "Running")
+        b.wait_in_text("#statuses", "Running")
         b.click(".service-top-panel .pf-c-dropdown button")
         b.click(".service-top-panel .pf-c-dropdown__menu a:contains('Stop')")
         b.wait_in_text("#statuses", "Not running")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -631,14 +631,20 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         # Check that listen is not shown for .service units
         b.wait_not_present("#listen")
 
-        # Check 'Unit not found' pattern
-        b.go(f'/system/services#/nonexistent{suffix}')
-        b.wait_in_text(".pf-c-empty-state", "Unit not found")
+        # Check empty state error for nonexisent unit with valid name
+        b.go(f'/system/services#/nonexistent.service{suffix}')
+        b.wait_in_text(".pf-c-empty-state", "Unit nonexistent.service not found")
         b.click("a:contains('View all services')")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/system/services"')
         if user:
             b.wait_js_cond(f"window.location.hash === '#/{suffix}'")
+
+        # Check empty state error for invalid unit name
+        b.go(f'/system/services#/nonexistent{suffix}')
+        b.enter_page("/system/services")
+        b.wait_in_text(".pf-c-empty-state", "Loading unit failed")
+        b.wait_in_text(".pf-c-empty-state", "Unit name nonexistent is not valid")
 
     def testLogs(self):
         self._testLogs(False)
@@ -1097,7 +1103,7 @@ Where=/fail
 
         self.do_action("Stop")
 
-        b.wait_in_text(".pf-c-empty-state", "Unit not found")
+        b.wait_in_text(".pf-c-empty-state", "Unit test-transient.service not found")
         b.click("a:contains('View all services')")
         b.switch_to_top()
         b.wait_js_cond('window.location.pathname == "/system/services"')

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1175,6 +1175,64 @@ Where=/fail
         self.assertNotIn("Not running", b.text(".services-list"))
         self.assertNotIn("Static", b.text(".services-list"))
 
+    def testAlias(self):
+        m = self.machine
+        b = self.browser
+        self.write_file("/etc/systemd/system/flower-rose.service",
+                        """
+[Unit]
+Description=Smell sweet
+
+[Service]
+ExecStart=/bin/echo Perfume
+RemainAfterExit=yes
+
+[Install]
+Alias=flower-byanyothername.service
+WantedBy=multi-user.target
+""")
+        m.execute("systemctl enable flower-rose.service")
+        self.addCleanup(m.execute, "systemctl disable --now flower-rose.service")
+
+        self.login_and_go("/system/services#/?name=flower")
+
+        # overview: primary unit
+        self.wait_service_present("flower-rose.service")
+        # FIXME: This ought to be "Enabled", but is "Alias" right now
+        # self.wait_service_in_panel("flower-rose.service", "Enabled")
+        self.wait_service_state("flower-rose.service", "inactive")
+
+        # overview: alias
+        self.wait_service_present("flower-byanyothername.service")
+        if m.image.startswith("rhel-8") or m.image.startswith("centos-8"):
+            # old systemd does not have unit file state "alias" yet
+            self.wait_service_in_panel("flower-byanyothername.service", "Enabled")
+        else:
+            self.wait_service_in_panel("flower-byanyothername.service", "Alias")
+        self.wait_service_state("flower-byanyothername.service", "inactive")
+
+        # both react to state changes
+        m.execute("systemctl start flower-byanyothername.service")
+        self.wait_service_state("flower-rose.service", "active")
+        self.wait_service_state("flower-byanyothername.service", "active")
+
+        # details: primary unit
+        self.goto_service("flower-rose.service")
+        b.wait_in_text("#statuses", "Running")
+        # FIXME: This is broken right now and shows "Static"
+        # b.wait_in_text("#statuses", "Automatically starts")
+        b.wait_in_text("#service-details-unit", "/etc/systemd/system/flower-rose.service")
+        b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "Perfume")
+
+        # details: alias
+        b.click(".pf-c-breadcrumb a:contains('Services')")
+        self.goto_service("flower-byanyothername.service")
+        b.wait_in_text("#statuses", "Running")
+        # FIXME: This ought to be "Alias" or "Automatically starts"; shows "Static" right now
+        # b.wait_in_text("#statuses", "Alias")
+        b.wait_in_text("#service-details-unit", "/etc/systemd/system/flower-rose.service")
+        b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "Perfume")
+
 
 @skipDistroPackage()
 class TestTimers(MachineCase):

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -45,9 +45,6 @@ class TestServices(MachineCase):
         self.restore_dir("/etc/xdg/systemd/user", user_post_restore, True)
         self.restore_dir("/home/admin/.config", user_post_restore, True)
 
-        # FIXME: this page is too slow
-        self.browser.wait_timeout(60)
-
     def run_systemctl(self, user, cmd):
         if user:
             self.machine.execute(f"su - admin -c 'export XDG_RUNTIME_DIR=/run/user/$(id -u admin); systemctl --user {cmd}'")
@@ -301,7 +298,7 @@ WantedBy=default.target
         if not user:
             # Make sure that symlinked services also appear in the list
             self.wait_service_state("reboot.target", "inactive")
-            self.wait_service_state("ctrl-alt-del.target", "inactive")
+            self.wait_service_present("ctrl-alt-del.target")
             self.goto_service("ctrl-alt-del.target")
             b.wait_in_text(".service-name", "Reboot")
             b.click("#services-page .pf-c-breadcrumb__link")
@@ -500,7 +497,7 @@ WantedBy=default.target
         # Filter by description capital letters included
         init_filter_state()
         b.set_input_text("#services-text-filter input", "Test Service")
-        self.wait_service_present("test.service")
+        # test.service is not loaded, thus description search does not find it
         self.wait_service_present("test-fail.service")
         if not user:
             b.assert_pixels("#services-page", "text-filter-test", skip_layouts=["mobile"])
@@ -1204,8 +1201,7 @@ WantedBy=multi-user.target
 
         # overview: primary unit
         self.wait_service_present("flower-rose.service")
-        # FIXME: This ought to be "Enabled", but is "Alias" right now
-        # self.wait_service_in_panel("flower-rose.service", "Enabled")
+        self.wait_service_in_panel("flower-rose.service", "Enabled")
         self.wait_service_state("flower-rose.service", "inactive")
 
         # overview: alias
@@ -1215,18 +1211,18 @@ WantedBy=multi-user.target
             self.wait_service_in_panel("flower-byanyothername.service", "Enabled")
         else:
             self.wait_service_in_panel("flower-byanyothername.service", "Alias")
-        self.wait_service_state("flower-byanyothername.service", "inactive")
+        # runtime status of aliases is unknown in list view
+        self.wait_service_state("flower-byanyothername.service", "")
 
         # both react to state changes
         m.execute("systemctl start flower-byanyothername.service")
         self.wait_service_state("flower-rose.service", "active")
-        self.wait_service_state("flower-byanyothername.service", "active")
+        self.wait_service_state("flower-byanyothername.service", "")
 
         # details: primary unit
         self.goto_service("flower-rose.service")
         b.wait_in_text("#statuses", "Running")
-        # FIXME: This is broken right now and shows "Static"
-        # b.wait_in_text("#statuses", "Automatically starts")
+        b.wait_in_text("#statuses", "Automatically starts")
         b.wait_in_text("#service-details-unit", "/etc/systemd/system/flower-rose.service")
         b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "Perfume")
 
@@ -1234,8 +1230,7 @@ WantedBy=multi-user.target
         b.click(".pf-c-breadcrumb a:contains('Services')")
         self.goto_service("flower-byanyothername.service")
         b.wait_in_text("#statuses", "Running")
-        # FIXME: This ought to be "Alias" or "Automatically starts"; shows "Static" right now
-        # b.wait_in_text("#statuses", "Alias")
+        b.wait_in_text("#statuses", "Automatically starts")
         b.wait_in_text("#service-details-unit", "/etc/systemd/system/flower-rose.service")
         b.wait_in_text('.cockpit-log-panel .pf-c-card__body', "Perfume")
 
@@ -1270,9 +1265,6 @@ class TestTimers(MachineCase):
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
         m.reboot()
-
-        # FIXME: this page is too slow
-        b.wait_timeout(30)
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -618,6 +618,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             self.run_systemctl(user, "start mem-hog.service")
             # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")
+            b.wait_visible("#memory .pf-c-description-list__text")
             initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
             self.assertGreater(initial_memory, 0.5)
             m.execute(f"touch /tmp/continue{params}")


### PR DESCRIPTION
The services list does way too much: It loads all units, even the ones which are completely unused, and thus systemd intentionally ignores them. On top of that, it was getting all properties of all interfaces of all units plus installing proxies, so loading the page required an avalanche of (literally) thousands of D-Bus messages; and it was not even using most of the properties in the summary view.

This PR optimizes this, and drops all extended test timeouts related to the services page. Please see the individual commits for details.

---
    
TODO/Blockers:
 - [x] #18411
 - [x] #18416
 - [x] #18420
 - [x] #18445
 - [x] handle transient units which go away    
 - [x] loading sometimes triggers an expensive loop, causing systemd to spin 100% CPU for 30s    
 - [x] fix lagging failure notifications; difficult to fix on main, but easy after the state rework
 - [x] fix [TestServices.testConditions on c8s/pybridge](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230228-173303-e246369c-centos-8-stream-pybridge/log.html#328-2) (also happens with C bridge)
 - [x] update pixel tests for changed "unloaded test.service" behaviour in testBasic

Spotted flakes while working on this, which are independent:
 - [x] failure to switch to details page: [example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230302-093755-0a6f967e-arch/log.html#339-2), [example 2](https://artifacts.dev.testing-farm.io/b2c3c498-912e-4511-966c-8c081eb9744b/), [example 3](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230302-135425-7d52084a-rhel-8-8/log.html#305-2). This also [happens on main](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18442-20230303-083420-6f3008ed-ubuntu-stable/log.html#297). Split out to issue #18443
 - [x] fix `testTransientUnits` [flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230303-201537-c95d73be-fedora-37-devel/log.html#339), [other flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230303-185421-c95d73be-ubuntu-stable/log.html#339)
 - [x] fix other `testTransientUnits` [flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230303-075148-3f6b1c8a-ubuntu-2204/log.html#339), the autocollect one runs for too long
 - [x] `#memory` is polled, need to wait for it to appear: [log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230306-113232-5d848c5b-debian-stable/log.html#327-2): #18458
 - [x] `TestReauthorize.testBasic` flock race [log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230307-041208-85c1feee-fedora-37-pybridge/log.html#108): #18458
 - [x] pre-filling of filter from URL in `testServicesFiltersURLConsistency`: [debug log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230307-065433-1c06e6c8-fedora-coreos/log.html#308); also [happens on](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18458-20230307-065645-03ca754c-arch/log.html#337) [main](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18458-20230307-065645-03ca754c-fedora-38/log.html#337-1)
 - [ ] `TestPages.testBasic` [debug log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230307-120556-7e7cb6b6-centos-8-stream-pybridge/log.html#302-2): Tracked in issue #18465
 
Follow-ups for further optimization:
 - [x] Avoid listUnits() on a PropertiesChanged of a unloaded unit; GetAll() perhaps?
 - [ ] Lazy-load timers, instead of blocking the main view
 - [ ] After that :arrow_up: , consider if the listFailedUnits() is still actually worth it, as it should be cheap enough
 - [x] ~clean up listeners in componentWillUnmount() to avoid duplicate invocations~ no measurable improvements nor duplicate calls, so skipping 
