### PR TITLE
test: add setup_provisioned_hosts helper for multi machine tests

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2094,6 +2094,22 @@ class MachineCase(unittest.TestCase):
         if not self.machine.ostree_image and self.file_exists(disallowed_conf):
             self.sed_file('/root/d', disallowed_conf)
 
+    def setup_provisioned_hosts(self, disable_preload: bool = False):
+        """Setup provisioned hosts for testing
+
+        This sets the hostname of all machines to the name given in the
+        provision dictionary and optionally disabled preload when it runs
+        on a development build.
+        """
+
+        for name, m in self.machines.items():
+            m.execute(f"hostnamectl set-hostname {name}")
+            # Disable preloading on all machines ("machine1" is done in testlib.py)
+            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
+            # In these tests we actually switch between machines in quick succession which can make things even worse
+            if disable_preload and self.is_devel_build():
+                self.disable_preload("packagekit", "playground", "systemd", machine=m)
+
 
 ###########################
 # Global helper functions

--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -113,18 +113,10 @@ class TestHostSwitching(MachineCase, HostSwitcherHelpers):
     def setUp(self):
         super().setUp()
 
-        # Disable preloading on all machines ("machine1" is done in testlib.py)
-        # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-        # In these tests we actually switch between machines in quick succession which can make things even worse
-        if self.is_devel_build():
-            for machine in ["machine2", "machine3"]:
-                self.disable_preload("packagekit", "playground", "systemd", machine=self.machines[machine])
-        # Also, quick logouts cause async preloads to run into "ReferenceError: cockpit is not defined"
-        self.disable_preload("packagekit", "playground", "systemd")
-
+        self.setup_provisioned_hosts(disable_preload=True)
+        # Override hostname from machine1 to localhost
         self.machines["machine1"].execute("hostnamectl set-hostname localhost")
-        self.machines["machine2"].execute("hostnamectl set-hostname machine2")
-        self.machines["machine3"].execute("hostnamectl set-hostname machine3")
+
         self.setup_ssh_auth()
 
         # removing machines interrupts channels

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -160,16 +160,7 @@ class TestMultiMachineAdd(MachineCase):
         self.machine2 = self.machines['machine2']
         self.machine3 = self.machines['machine3']
 
-        for name in ['machine2', 'machine3']:
-            m = self.machines[name]
-            m.execute(f"hostnamectl set-hostname {name}")
-
-            # Disable preloading on all machines ("machine1" is done in testlib.py)
-            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-            # In these tests we actually switch between machines in quick succession which can make things even worse
-            if self.is_devel_build():
-                self.disable_preload("packagekit", "playground", "systemd")
-
+        self.setup_provisioned_hosts(disable_preload=True)
         self.setup_ssh_auth()
 
     def testBasic(self):
@@ -262,21 +253,11 @@ class TestMultiMachine(MachineCase):
     def setUp(self):
         super().setUp()
 
-        self.machine.execute("hostnamectl set-hostname machine1")
-        self.allow_journal_messages("sudo: unable to resolve host machine1: .*")
-
         self.machine2 = self.machines['machine2']
         self.machine3 = self.machines['machine3']
+        self.allow_journal_messages("sudo: unable to resolve host machine1: .*")
 
-        for name in ['machine2', 'machine3']:
-            m = self.machines[name]
-            m.execute(f"hostnamectl set-hostname {name}")
-
-            # Disable preloading on all machines ("machine1" is done in testlib.py)
-            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-            # In these tests we actually switch between machines in quick succession which can make things even worse
-            if self.is_devel_build():
-                self.disable_preload("packagekit", "playground", "systemd")
+        self.setup_provisioned_hosts(disable_preload=True)
 
     def checkDirectLogin(self, root='/', known_host=False):
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -484,6 +484,7 @@ class TestSuperuserDashboard(MachineCase):
     @todoPybridge()
     def test(self):
         b = self.browser
+        self.setup_provisioned_hosts()
 
         self.login_and_go()
         b.go("/@10.111.113.2")
@@ -548,6 +549,7 @@ class TestSuperuserOldDashboard(MachineCase):
 
         allow_old_cockpit_ws_messages(self)
         self.allow_hostkey_messages()
+        self.setup_provisioned_hosts()
 
         m.execute("firewall-cmd --add-service cockpit")
         m.start_cockpit()
@@ -608,6 +610,7 @@ class TestSuperuserDashboardOldMachine(MachineCase):
     def test(self):
         b = self.browser
 
+        self.setup_provisioned_hosts()
         self.login_and_go()
         b.go("/@10.111.113.2")
         b.wait_visible("#machine-troubleshoot")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -30,8 +30,7 @@ class TestShutdownRestart(MachineCase):
 
     def setUp(self):
         super().setUp()
-        self.machine.execute("hostnamectl set-hostname machine1")
-        self.machines['machine2'].execute("hostnamectl set-hostname machine2")
+        self.setup_provisioned_hosts()
 
     @todoPybridge()
     def testBasic(self):


### PR DESCRIPTION
Introduce a new helper function which sets the hostname for all test machines, disables preload of pages when required and adds an Arch Linux systemd 253 / sssd related workaround. This writes all provisioned machines to /etc/hosts so DNS resolving is speedy.