### PR TITLE
systemd: Don't wind back time when adding timer properties

### DIFF
--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -685,15 +685,17 @@ class ServicesPageBody extends React.Component {
             if (unitNew.ActiveState == "active") {
                 const timer_unit = systemd_client[this.props.owner].proxy('org.freedesktop.systemd1.Timer', unitNew.path);
                 timer_unit.wait(() => {
-                    if (timer_unit.valid)
-                        if (this.addTimerProperties(timer_unit, unitNew)) {
+                    if (timer_unit.valid) {
+                        const unit = this.state.unit_by_path[path];
+                        if (unit && this.addTimerProperties(timer_unit, unit)) {
                             this.setState(prevState => ({
                                 unit_by_path: {
                                     ...prevState.unit_by_path,
-                                    [path]: unitNew,
+                                    [path]: unit,
                                 }
                             }));
                         }
+                    }
                 });
             }
         }


### PR DESCRIPTION
By the time the timer proxy is ready, the unit state might have already been replaced with something new.

This was the reason for this failure: https://cockpit-logs.us-east-1.linodeobjects.com/pull-4465-20230227-232035-10d7d9c6-centos-8-stream-pybridge-cockpit-project-cockpit/log.html#291