### PR TITLE
Fix: Add services button disabled for no input

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -329,6 +329,7 @@ class AddEditServicesModal extends React.Component {
         };
         this.save = this.save.bind(this);
         this.edit = this.edit.bind(this);
+        this.checkNullValues = this.checkNullValues.bind(this);
         this.onFilterChanged = this.onFilterChanged.bind(this);
         this.onToggleService = this.onToggleService.bind(this);
         this.setId = this.setId.bind(this);
@@ -351,6 +352,10 @@ class AddEditServicesModal extends React.Component {
     getCustomId() {
         const all_ports = this.state.custom_tcp_ports.concat(this.state.custom_udp_ports);
         return "custom--" + all_ports.map(this.getName).join('-');
+    }
+
+    checkNullValues() {
+        return (!this.state.custom_tcp_value && !this.state.custom_udp_value);
     }
 
     edit(event) {
@@ -599,7 +604,7 @@ class AddEditServicesModal extends React.Component {
                                isInline
                                title={_("Adding custom ports will reload firewalld. A reload will result in the loss of any runtime-only configuration!")} />
                        }
-                       <Button variant='primary' onClick={this.props.custom_id ? this.edit : this.save} aria-label={titleText}>
+                       <Button variant='primary' isDisabled={(this.state.custom && this.checkNullValues()) || (!this.state.custom && !this.state.selected.size)} onClick={this.props.custom_id ? this.edit : this.save} aria-label={titleText}>
                            {addText}
                        </Button>
                        <Button variant='link' className='btn-cancel' onClick={Dialogs.close}>

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -262,7 +262,8 @@ class TestFirewall(NetworkCase):
         b.assert_pixels(".pf-c-modal-box", "firewall-add-services-to-zone-modal", wait_delay=3)
 
         # don't select anything in the dialog
-        b.click(f"#add-services-dialog footer .{self.btn_primary}")
+        b.wait_visible(f"#add-services-dialog .{self.btn_primary}.pf-m-disabled")
+        b.click("#add-services-dialog footer .btn-cancel")
         b.wait_not_present(".pf-c-modal-box")
 
         def addService(zone, service):


### PR DESCRIPTION
Resolves Issue #18419 . Trying to disable the Add services/Add port primary button if nothing is chosen using props and a handler function.