### PR TITLE
Storage: Correctly highlight dangerous menu items in red 

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -147,7 +147,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     }
 
     function add_menu_danger_action(title, func) {
-        tab_menu_danger_actions.push({ title, func });
+        tab_menu_danger_actions.push({ title, func, danger: true });
     }
 
     const tabs = [];
@@ -515,7 +515,7 @@ function block_description(client, block) {
 function append_row(client, rows, level, key, name, desc, tabs, job_object) {
     function menuitem(action) {
         if (action.title)
-            return <StorageMenuItem onlyNarrow={action.only_narrow} key={action.title} onClick={action.func}>{action.title}</StorageMenuItem>;
+            return <StorageMenuItem onlyNarrow={action.only_narrow} key={action.title} onClick={action.func} danger={action.danger}>{action.title}</StorageMenuItem>;
         else
             return <DropdownSeparator className={action.only_narrow ? "show-only-when-narrow" : null} key="sep" />;
     }

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -215,8 +215,8 @@ export const StorageUsageBar = ({ stats, critical, block, offset, total, small }
         </div>);
 };
 
-export const StorageMenuItem = ({ onClick, onlyNarrow, children }) => (
-    <DropdownItem className={onlyNarrow ? "show-only-when-narrow" : null}
+export const StorageMenuItem = ({ onClick, onlyNarrow, danger, children }) => (
+    <DropdownItem className={(onlyNarrow ? "show-only-when-narrow" : null) + " " + (danger ? "delete-resource-red" : null)}
                   onKeyPress={checked(onClick)}
                   onClick={checked(onClick)}>
         {children}

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -216,7 +216,7 @@ export const StorageUsageBar = ({ stats, critical, block, offset, total, small }
 };
 
 export const StorageMenuItem = ({ onClick, onlyNarrow, danger, children }) => (
-    <DropdownItem className={(onlyNarrow ? "show-only-when-narrow" : null) + " " + (danger ? "delete-resource-red" : null)}
+    <DropdownItem className={(onlyNarrow ? "show-only-when-narrow" : "") + (danger ? " delete-resource-red" : "")}
                   onKeyPress={checked(onClick)}
                   onClick={checked(onClick)}>
         {children}

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -322,6 +322,10 @@ td.storage-action {
   }
 }
 
+.delete-resource-red {
+  color: var(--pf-global--danger-color--200);
+}
+
 .pf-c-modal-box .slot-warning {
   color: var(--pf-global--danger-color--200);
 }

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -598,7 +598,7 @@ export const StratisPoolDetails = ({ client, pool }) => {
             menuitems.push(<StorageMenuItem key="unmount" onClick={unmount}>{_("Unmount")}</StorageMenuItem>);
         menuitems.push(<StorageMenuItem key="rename" onClick={rename_fsys}>{_("Rename")}</StorageMenuItem>);
         menuitems.push(<StorageMenuItem key="snapshot" onClick={snapshot_fsys}>{_("Snapshot")}</StorageMenuItem>);
-        menuitems.push(<StorageMenuItem key="del" onClick={delete_fsys}>{_("Delete")}</StorageMenuItem>);
+        menuitems.push(<StorageMenuItem key="del" onClick={delete_fsys} danger>{_("Delete")}</StorageMenuItem>);
 
         const cols = [
             {


### PR DESCRIPTION
Closes #18415.

Dangerous menu items, such as 'Delete', were not highlighted in a red color correctly.

I added a 'danger' property to the `tab_menu_danger_actions` array, to identify the items in `StorageMenuItem`.

Here is a screenshot:
![image](https://user-images.githubusercontent.com/90795679/222242523-d7943495-e6ee-4cdf-a0e3-684138ec1f8e.png)

I think this makes the separate 'danger' array redundant, since they get merged into one array later. It could simply be one array with a 'danger' property set to false/true. I'm not sure if that would break the separator line placement, but I think placing it afterwards when the array is full won't be an issue.

Please let me know what changes I should make to this PR, I'm open to trying a different approach if needed. Thanks!