### PR TITLE
Kdump refactor

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -25,6 +25,7 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Card, CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup, FormSection } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
@@ -486,6 +487,9 @@ export class KdumpPage extends React.Component {
                             {_("Kernel crash dump")}
                         </Title>
                         {kdumpSwitch}
+                        <HelperText>
+                            <HelperTextItem variant="indeterminate">{serviceRunning ? _("Enabled") : _("Disabled")}</HelperTextItem>
+                        </HelperText>
                     </Flex>
                 </PageSection>
                 <PageSection>

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -191,7 +191,7 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                                        onChange={setServer} isRequired />
                         </FormGroup>
 
-                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("ssh key")}>
+                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("SSH key")}>
                             <TextInput id="kdump-settings-ssh-key" key="ssh"
                                        placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
                                        onChange={setSSHKey} />

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -152,41 +152,43 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                 </FormGroup>
 
                 {storageLocation === "local" &&
-                    <FormGroup fieldId="kdump-settings-local-directory" label={_("Directory")}>
+                    <FormGroup fieldId="kdump-settings-local-directory" label={_("Directory")} isRequired>
                         <TextInput id="kdump-settings-local-directory" key="directory"
                                    placeholder="/var/crash" value={directory}
                                    data-stored={directory}
-                                   onChange={setDirectory} />
+                                   onChange={setDirectory}
+                                   isRequired />
                     </FormGroup>
                 }
 
                 {storageLocation === "nfs" &&
                     <>
-                        <FormGroup fieldId="kdump-settings-nfs-server" label={_("Server")}>
+                        <FormGroup fieldId="kdump-settings-nfs-server" label={_("Server")} isRequired>
                             <TextInput id="kdump-settings-nfs-server" key="server"
                                     placeholder="penguin.example.com" value={server}
-                                    onChange={setServer} />
+                                    onChange={setServer} isRequired />
                         </FormGroup>
-                        <FormGroup fieldId="kdump-settings-nfs-export" label={_("Export")}>
+                        <FormGroup fieldId="kdump-settings-nfs-export" label={_("Export")} isRequired>
                             <TextInput id="kdump-settings-nfs-export" key="export"
                                     placeholder="/export/cores" value={exportPath}
-                                    onChange={setExportPath} />
+                                    onChange={setExportPath} isRequired />
                         </FormGroup>
-                        <FormGroup fieldId="kdump-settings-nfs-directory" label={_("Directory")}>
+                        <FormGroup fieldId="kdump-settings-nfs-directory" label={_("Directory")} isRequired>
                             <TextInput id="kdump-settings-nfs-directory" key="directory"
                                     placeholder="/var/crash" value={directory}
                                     data-stored={directory}
-                                    onChange={setDirectory} />
+                                    onChange={setDirectory}
+                                    isRequired />
                         </FormGroup>
                     </>
                 }
 
                 {storageLocation === "ssh" &&
                     <>
-                        <FormGroup fieldId="kdump-settings-ssh-server" label={_("Server")}>
+                        <FormGroup fieldId="kdump-settings-ssh-server" label={_("Server")} isRequired>
                             <TextInput id="kdump-settings-ssh-server" key="server"
                                        placeholder="user@server.com" value={server}
-                                       onChange={setServer} />
+                                       onChange={setServer} isRequired />
                         </FormGroup>
 
                         <FormGroup fieldId="kdump-settings-ssh-key" label={_("ssh key")}>
@@ -195,11 +197,12 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                                        onChange={setSSHKey} />
                         </FormGroup>
 
-                        <FormGroup fieldId="kdump-settings-ssh-directory" label={_("Directory")}>
+                        <FormGroup fieldId="kdump-settings-ssh-directory" label={_("Directory")} isRequired>
                             <TextInput id="kdump-settings-ssh-directory" key="directory"
                                        placeholder="/var/crash" value={directory}
                                        data-stored={directory}
-                                       onChange={setDirectory} />
+                                       onChange={setDirectory}
+                                       isRequired />
                         </FormGroup>
                     </>
                 }

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -254,12 +254,7 @@ export class KdumpPage extends React.Component {
                 });
     }
 
-    handleTestSettingsClick(e) {
-        // only consider primary mouse button
-        if (!e || e.button !== 0)
-            return;
-        // don't let the click "fall through" to the dialog that we are about to open
-        e.preventDefault();
+    handleTestSettingsClick() {
         // open a dialog to confirm crashing the kernel to test the settings - then do it
         const self = this;
         // open the confirmation dialog
@@ -284,10 +279,7 @@ export class KdumpPage extends React.Component {
         this.setState({ dialogObj });
     }
 
-    handleServiceDetailsClick(e) {
-        // only consider primary mouse button
-        if (!e || e.button !== 0)
-            return;
+    handleServiceDetailsClick() {
         cockpit.jump("/system/services#/kdump.service", cockpit.transport.host);
     }
 
@@ -295,11 +287,7 @@ export class KdumpPage extends React.Component {
         this.setState({ dialogSettings: undefined, dialogObj: undefined });
     }
 
-    handleSettingsClick(e) {
-        // only consider primary mouse button
-        if (!e || e.button !== 0)
-            return;
-        e.preventDefault();
+    handleSettingsClick() {
         const self = this;
         const settings = { };
         Object.keys(self.props.kdumpStatus.config).forEach((key) => {

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -24,6 +24,7 @@ import React, { useEffect, useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Card, CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup, FormSection } from "@patternfly/react-core/dist/esm/components/Form/index.js";
@@ -51,6 +52,7 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
     const [isSaving, setIsSaving] = useState(false);
     const [error, setError] = useState(null);
     const [isFormValid, setFormValid] = useState(true);
+    const [validationErrors, setValidationErrors] = useState({});
 
     const [storageLocation, setStorageLocation] = useState(Object.keys(settings.targets)[0]);
     // common options
@@ -75,6 +77,15 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
         setDirectory("/var/crash");
         setServer("");
         setStorageLocation(target);
+    };
+
+    const changeSSHKey = value => {
+        if (value.trim() && !value.match("/.+")) {
+            setValidationErrors({ sshkey: _("SSH key isn't a path") });
+        } else {
+            setValidationErrors({});
+        }
+        setSSHKey(value);
     };
 
     const saveSettings = () => {
@@ -133,7 +144,7 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                    <>
                        <Button variant="primary"
                                isLoading={isSaving}
-                               isDisabled={isSaving || !isFormValid}
+                               isDisabled={isSaving || !isFormValid || Object.keys(validationErrors).length !== 0}
                                onClick={saveSettings}>
                            {_("Save changes")}
                        </Button>
@@ -200,10 +211,14 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                                        onChange={setServer} isRequired />
                         </FormGroup>
 
-                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("SSH key")}>
+                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("SSH key")}
+                                   helperTextInvalid={validationErrors.sshkey}
+                                   helperTextInvalidIcon={<ExclamationCircleIcon />}
+                                   validated={validationErrors.sshkey ? "error" : "default"}>
                             <TextInput id="kdump-settings-ssh-key" key="ssh"
                                        placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
-                                       onChange={setSSHKey} />
+                                       onChange={changeSSHKey}
+                                       validated={validationErrors.sshkey ? "error" : "default"} />
                         </FormGroup>
 
                         <FormGroup fieldId="kdump-settings-ssh-directory" label={_("Directory")} isRequired>

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -29,6 +29,7 @@ import { createRoot } from "react-dom/client";
 import { KdumpPage } from "./kdump-view.jsx";
 import * as kdumpClient from "./kdump-client.js";
 import { superuser } from "superuser";
+import { WithDialogs } from "dialogs.jsx";
 
 import './kdump.scss';
 
@@ -61,7 +62,7 @@ const initStore = function(rootElement) {
         });
     }
     const render = function() {
-        root.render(React.createElement(KdumpPage, {
+        root.render(<WithDialogs>{React.createElement(KdumpPage, {
             kdumpActive: false,
             onSetServiceState: setServiceState,
             stateChanging: dataStore.stateChanging,
@@ -70,7 +71,7 @@ const initStore = function(rootElement) {
             kdumpCmdlineEnabled: dataStore.crashkernel || false,
             onSaveSettings: dataStore.saveSettings,
             onCrashKernel: dataStore.kdumpClient.crashKernel,
-        }));
+        })}</WithDialogs>);
     };
     dataStore.render = render;
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -111,11 +111,9 @@ class TestKdump(KdumpHelpers):
         b.set_val("#kdump-settings-location", "nfs")
         serverInput = "#kdump-settings-nfs-server"
         b.set_input_text(serverInput, "")
-        b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs server is empty")
+        b.wait_visible(f"#kdump-settings-dialog button{self.primary_btn_class}:disabled")
         b.set_input_text(serverInput, "localhost")
-        b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs export is empty")
+        b.wait_visible(f"#kdump-settings-dialog button{self.primary_btn_class}:disabled")
         b.click("#kdump-settings-dialog button.cancel")
         b.wait_not_present("#kdump-settings-dialog")
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -113,8 +113,6 @@ class TestKdump(KdumpHelpers):
         b.set_input_text(serverInput, "")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs server is empty")
-        # no further details/journal
-        self.assertFalse(b.is_present("#kdump-settings-dialog .pf-c-code-block__code"))
         b.set_input_text(serverInput, "localhost")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_in_text("#kdump-settings-dialog h4.pf-c-alert__title", "Unable to save settings: nfs export is empty")


### PR DESCRIPTION
This is the start of a bigger refactor effort of the kdump page. To not make the PR have ~ 10 commits, I've decided to stop at 5 and then focus on adding inline validation. 

What is expected as follow up:

* [ ] Move the kdump test settings to a separate modal class
* [x] Add real Patternfly approved validation instead of only when a user clicks save
* [ ]  Make the KdumpPage class a functional component, it should not have state left after the test settings modal is created so should be fairly easy