### PR TITLE
test: Increase timeout for first Cockpit login

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1631,7 +1631,9 @@ class MachineCase(unittest.TestCase):
         if enable_root_login:
             self.enable_root_login()
         self.machine.start_cockpit(tls=tls)
-        self.browser.login_and_go(path, user=user, host=host, superuser=superuser, urlroot=urlroot, tls=tls)
+        # first load after starting cockpit tends to take longer, due to on-demand service start
+        with self.browser.wait_timeout(30):
+            self.browser.login_and_go(path, user=user, host=host, superuser=superuser, urlroot=urlroot, tls=tls)
 
     # List of allowed journal messages during tests; these need to match the *entire* message
     default_allowed_messages = [


### PR DESCRIPTION
In the last few weeks we have been getting a lot of random test failures like this:
```
Traceback (most recent call last):
  File "test/verify/check-system-terminal", line 51, in testBasic
    self.login_and_go("/system/terminal")
  [...]
    self.wait_visible("#login")
testlib.Error: timeout
wait_js_cond(ph_is_present("#login")): Uncaught (in promise) Error: condition did not become true
```

where the page was just blank, but there is no error in the journal. This happens especially often on the rhos-01 nested virt machines. As the first login after starting cockpit on demand can take longer on loaded machines, increase the timeout.

----

[recent example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230303-075148-3f6b1c8a-arch/log.html#260-2). I see this all the time, but so far I didn't collect the URLs.