### PR TITLE
test: rhel4edge insights-client improvements

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -791,7 +791,8 @@ password=foobar
 
         # Enable insights, results should appear automatically
         m.execute("insights-client --register")
-        b.wait_in_text(".system-health-insights a", "3 hits, including important")
+        with b.wait_timeout(60):
+            b.wait_in_text(".system-health-insights a", "3 hits, including important")
         self.assertIn("123-nice-id", b.attr(".system-health-insights a", "href"))
 
         # Switch to limited access, insights status will disappear completely

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -756,6 +756,13 @@ fi
         if not m.image.startswith("rhel"):
             self.skipTest("insights-client is only on RHEL")
 
+        # insights-client might get started during boot and might then
+        # run concurrently with our explicit "insights-client
+        # --register" below.  insights-client is not designed to be
+        # run concurrently and there is no protection against it,
+        # apparently.  So let's prevent that.
+        m.execute("systemctl disable --now insights-client")
+
         # Pretend that the Subscriptions page can do Insights stuff
         m.write("/etc/cockpit/subscription-manager.override.json", '{ "features": { "insights": true } }')
 


### PR DESCRIPTION
This seems to matter on rhel4edge: https://cockpit-logs.us-east-1.linodeobjects.com/pull-17888-20230302-131217-6e09dda4-rhel4edge/log.html#233

I think enabling insights-client.service is wrong, in general.  It is started by a timer, normally, and doesn't need to be enabled.  Also, there is the additional insights-client-boot.service for running it on the next boot.  So I don't know what insights-client.service is enabled for.