### PR TITLE
Fix two test flakes

### DIFF
--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -216,7 +216,7 @@ class ServicesPageBody extends React.Component {
     }
 
     onOptionsChanged(options) {
-        const currentOptions = { ...cockpit.location.options, ...options };
+        const currentOptions = { ...this.props.options, ...options };
 
         if (!currentOptions.activestate || options.activestate == "[]")
             delete currentOptions.activestate;

--- a/pkg/systemd/services/services.jsx
+++ b/pkg/systemd/services/services.jsx
@@ -1024,7 +1024,7 @@ const ServicesPage = () => {
 
     const activeTab = options.type || 'service';
     const owner = options.owner || 'system';
-    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, Object.assign(options, { owner }));
+    const setOwner = (owner) => cockpit.location.go(cockpit.location.path, { ...options, owner });
 
     if (owner !== 'system' && owner !== 'user') {
         console.warn("not a valid location: " + path);
@@ -1041,7 +1041,7 @@ const ServicesPage = () => {
                         <ServiceTabs activeTab={activeTab}
                                       tabErrors={tabErrors}
                                       onChange={activeTab => {
-                                          cockpit.location.go(cockpit.location.path, Object.assign(options, { type: activeTab }));
+                                          cockpit.location.go(cockpit.location.path, { ...options, type: activeTab });
                                       }} />
                         <FlexItem align={{ default: 'alignRight' }}>
                             {loggedUser && loggedUser !== 'root' && <ToggleGroup>

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -53,11 +53,11 @@ class TestReauthorize(MachineCase):
         m.execute("touch /tmp/playground-test-lock")
         b.click(".lock-channel button")
         b.wait_in_text(".lock-channel span", 'locked')
-        m.execute("! flock -n /tmp/playground-test-lock true")
+        m.execute("! flock --nonblock /tmp/playground-test-lock true")
 
         # Deauthorize user
         b.drop_superuser()
-        m.execute("flock -n /tmp/playground-test-lock true")
+        m.execute("flock --timeout 10 /tmp/playground-test-lock true")
         b.click(".cockpit-internal-reauthorize button")
         b.wait_in_text(".cockpit-internal-reauthorize span", 'result:')
         self.assertEqual(b.text(".cockpit-internal-reauthorize span"), 'result: access-denied')

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -618,6 +618,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             self.run_systemctl(user, "start mem-hog.service")
             # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")
+            b.wait_visible("#memory .pf-c-description-list__text")
             initial_memory = float(b.text("#memory .pf-c-description-list__text").split(" ")[0])
             self.assertGreater(initial_memory, 0.5)
             m.execute(f"touch /tmp/continue{params}")


### PR DESCRIPTION
[#memory poll example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230306-113232-5d848c5b-debian-stable/log.html#327-2)

[TestReauthorize flock race example](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18422-20230307-041208-85c1feee-fedora-37-pybridge/log.html#108)

By-catches while staring at test failures in #18422