### PR TITLE
users: Show shell and home directory in user's details page

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -342,6 +342,12 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                                     </div>
                                 </FormGroup>
                                 }
+                                { account.home && <FormGroup fieldId="account-home-dir" hasNoPaddingTop label={_("Home directory")}>
+                                    <output id="account-home-dir">{account.home}</output>
+                                </FormGroup> }
+                                { account.shell && <FormGroup fieldId="account-shell" hasNoPaddingTop label={_("Shell")}>
+                                    <output id="account-shell">{account.shell}</output>
+                                </FormGroup> }
                             </Form>
                         </CardBody>
                     </Card>

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -18,12 +18,31 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
+import os
 
 import parent  # noqa: F401
 from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main, wait
 
 
 good_password = "tqymuVh.ZfZnP§9Wr=LM3JyG5yx"
+
+
+useradd_defaults = {}
+
+
+def getUserAddDetails(machine):
+    global useradd_defaults
+
+    if not useradd_defaults:  # dictionary is empty
+        useradd_defaults_str = machine.execute("useradd -D")
+        lines = useradd_defaults_str.split("\n")
+
+        for line in lines:
+            if line:
+                key, value = line.split("=")
+                useradd_defaults[key] = value
+
+    return useradd_defaults
 
 
 def performUserAction(browser, user, action):
@@ -94,6 +113,8 @@ class TestAccounts(MachineCase):
         b.set_input_text('#account-real-name', "Anton Arbitrary")
         b.wait_visible('#account-real-name:not([disabled])')
         b.wait_text("#account-title", "Anton Arbitrary")
+        b.wait_text("#account-home-dir", os.path.join(getUserAddDetails(m)["HOME"] + "/anton"))
+        b.wait_text("#account-shell", getUserAddDetails(m)["SHELL"])
         self.assertIn(":Anton Arbitrary:", m.execute("grep anton /etc/passwd"))
 
         # Add some other GECOS fields
@@ -134,6 +155,9 @@ class TestAccounts(MachineCase):
         b.wait_visible("#account-real-name[disabled]")
         b.wait_visible("#account-logout[disabled]")
         b.wait_visible("#account-locked:not(:checked)")
+        # check home directory and shell for root
+        b.wait_text("#account-home-dir", "/root")
+        b.wait_text("#account-shell", "/bin/bash")
         # root account should not be locked by default on our images
         self.assertIn(m.execute("passwd -S root").split()[1], ["P", "PS"])
         # now lock account


### PR DESCRIPTION
Split from https://github.com/cockpit-project/cockpit/pull/18234 as recommended


# Accounts: Show shell and home directory

The account's page now shows user's home directory and default shell.

![223722047-2885b1d2-2bbb-4694-8135-398d51a79387](https://user-images.githubusercontent.com/42733240/225583842-a7ce1ac5-555c-40f2-9afd-6cebf43cc14d.png)

