### PR TITLE
test: Install dnf-automatic into TMT images

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -8,6 +8,7 @@
     - python3
     - libvirt-python3
     # required by tests
+    - dnf-automatic
     - glibc-all-langpacks
     - firewalld
     - sssd-dbus


### PR DESCRIPTION
These images seem to have contained it until recently, but now we need to ask for it explicitly.