### PR TITLE
doc: drop host option from our documentation

### DIFF
--- a/doc/guide/cockpit-channel.xml
+++ b/doc/guide/cockpit-channel.xml
@@ -36,13 +36,6 @@ channel = cockpit.channel(options)
           depending on browser support.</para></listitem>
       </varlistentry>
       <varlistentry>
-        <term><code>"host"</code></term>
-        <listitem><para>The host to open the channel to. If an alternate user or port is
-          required it can be specified as <code>"user@myhost:port"</code>. If no host
-          is specified then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
-      </varlistentry>
-      <varlistentry>
         <term><code>"payload"</code></term>
         <listitem><para>The payload type for the channel. Only specific payload
           types are supported.</para></listitem>

--- a/doc/guide/cockpit-dbus.xml
+++ b/doc/guide/cockpit-dbus.xml
@@ -123,13 +123,6 @@ client = cockpit.dbus(name, [options])
             <code>"none"</code>.</para></listitem>
       </varlistentry>
       <varlistentry>
-        <term><code>"host"</code></term>
-        <listitem><para>The host to open the channel to. If an alternate user or port is
-          required it can be specified as <code>"user@myhost:port"</code>. If no host is
-          specified then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
-      </varlistentry>
-      <varlistentry>
         <term><code>"superuser"</code></term>
         <listitem><para>Set to <code>"require"</code> to talk to this service as root.
           The DBus service will see the DBus method calls and accesses as coming from root,

--- a/doc/guide/cockpit-file.xml
+++ b/doc/guide/cockpit-file.xml
@@ -18,7 +18,6 @@ file = cockpit.file(path,
                       binary: boolean,
                       max_read_size: int,
                       superuser: string,
-                      host: string
                     })
 
 promise = file.read()
@@ -70,7 +69,7 @@ cockpit.file("/path/to/file").read()
     <para>It is not an error when the file does not exist. In this case, the
       <code>then()</code> callback will be called with a <code>null</code>
       value for <code>content</code> and <code>tag</code> is <code>"-"</code>.</para>
-      <para>The <code>superuser</code> and <code>host</code> options can be used the same way
+      <para>The <code>superuser</code> option can be used the same way
       as described in the <link linkend="cockpit-channels-channel">cockpit.channel()</link>
       to provide a different access level to the file.</para>
     <para>You can use the <code>max_read_size</code> option to limit

--- a/doc/guide/cockpit-spawn.xml
+++ b/doc/guide/cockpit-spawn.xml
@@ -48,13 +48,6 @@ process = cockpit.spawn(args, [options])
           When the <code>"pty"</code> field is set, this field has no effect.</para></listitem>
       </varlistentry>
       <varlistentry>
-        <term><code>"host"</code></term>
-        <listitem><para>The remote host to spawn the process on. If an alternate user or port is
-          required it can be specified as <code>"user@myhost:port"</code>. If no host is
-          specified then the correct one will be automatically selected based on the page
-          calling this function.</para></listitem>
-      </varlistentry>
-      <varlistentry>
         <term><code>"environ"</code></term>
         <listitem><para>An optional array that contains strings to be used as
           additional environment variables for the new process. These are


### PR DESCRIPTION
We want to move away from running commands on a different connected host from JavaScript. In the future we will completely block the ability to specify a different host then the current iframe's host.