### PR TITLE
test: Disable preloading for release builds as well

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2098,16 +2098,11 @@ class MachineCase(unittest.TestCase):
         """Setup provisioned hosts for testing
 
         This sets the hostname of all machines to the name given in the
-        provision dictionary and optionally disabled preload when it runs
-        on a development build.
+        provision dictionary and optionally disabled preload.
         """
-
         for name, m in self.machines.items():
             m.execute(f"hostnamectl set-hostname {name}")
-            # Disable preloading on all machines ("machine1" is done in testlib.py)
-            # Preloading on machines with debug build can overload the browser and cause slowness and browser crashes
-            # In these tests we actually switch between machines in quick succession which can make things even worse
-            if disable_preload and self.is_devel_build():
+            if disable_preload:
                 self.disable_preload("packagekit", "playground", "systemd", machine=m)
 
 

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -160,6 +160,9 @@ class TestMultiMachineAdd(MachineCase):
         self.machine2 = self.machines['machine2']
         self.machine3 = self.machines['machine3']
 
+        # Disable preloading on all machines
+        # Preloading on machines debug build can overload the browser and cause slowness and browser crashes,
+        # and failing to load sofware updates breaks pixel tests in release builds
         self.setup_provisioned_hosts(disable_preload=True)
         self.setup_ssh_auth()
 

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -910,6 +910,8 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         m.execute("useradd --create-home user")
         m.execute("echo user:foobar | chpasswd")
         m.start_cockpit()
+        # the quick succession of login/logout is too much for packagekit's brain
+        self.disable_preload("packagekit", "playground", "systemd")
 
         def check_server(server, expect_fp_ack):
             b.open('/')


### PR DESCRIPTION
In TestHostSwitching.testBasic, the auxiliary machines often fail to load software updates. This breaks the pixel test, as there is an additional icon in the main menu which also changes the column sizes.

Change setup_provisioned_hosts() to always respect the `disable_preload` argument. If necessary, we can do the `self.is_devel_build` in the caller, but it's not really relevant: We already have several explicit integration tests to check the preload functionality (e.g. TestUpdates.testBasic).

The recent commit 7663244c8c2e also overzealously moved a comment. Move it back, and adjust it for the updated situation above.

---

[example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18466-20230309-140241-2a80128f-fedora-37/log.html), [example 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18478-20230309-181427-20d2e50a-fedora-37-bots-4498/log.html)