### PR TITLE
shell/scss: Fix dark theme code background for new ssh host modal

### DIFF
--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -31,6 +31,7 @@ import PropTypes from 'prop-types';
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
+import { ClipboardCopy } from "@patternfly/react-core/dist/esm/components/ClipboardCopy/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
@@ -463,10 +464,10 @@ class HostKey extends React.Component {
             body = <>
                 <Alert variant='danger' isInline title={_("Changed keys are often the result of an operating system reinstallation. However, an unexpected change may indicate a third-party attempt to intercept your connection.")} />
                 <p>{_("To ensure that your connection is not intercepted by a malicious third-party, please verify the host key fingerprint:")}</p>
-                <pre className="hostkey-fingerprint">{fp}</pre>
+                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-fingerprint pf-u-font-family-monospace">{fp}</ClipboardCopy>
                 <p className="hostkey-type">({key_type})</p>
                 <p>{cockpit.format(_("To verify a fingerprint, run the following on $0 while physically sitting at the machine or through a trusted network:"), this.props.host)}</p>
-                <pre className="hostkey-verify-help-cmds">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</pre>
+                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help-cmds pf-u-font-family-monospace">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</ClipboardCopy>
                 <p>{_("The resulting fingerprint is fine to share via public methods, including email.")}</p>
                 <p>{_("If the fingerprint matches, click 'Accept key and connect'. Otherwise, do not connect and contact your administrator.")}</p>
             </>;
@@ -474,10 +475,10 @@ class HostKey extends React.Component {
             body = <>
                 <p>{cockpit.format(_("You are connecting to $0 for the first time."), this.props.host)}</p>
                 <p>{_("To ensure that your connection is not intercepted by a malicious third-party, please verify the host key fingerprint:")}</p>
-                <pre className="hostkey-fingerprint">{fp}</pre>
+                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-fingerprint pf-u-font-family-monospace">{fp}</ClipboardCopy>
                 <p className="hostkey-type">({key_type})</p>
                 <p>{cockpit.format(_("To verify a fingerprint, run the following on $0 while physically sitting at the machine or through a trusted network:"), this.props.host)}</p>
-                <pre className="hostkey-verify-help-cmds">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</pre>
+                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help-cmds pf-u-font-family-monospace">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</ClipboardCopy>
                 <p>{_("The resulting fingerprint is fine to share via public methods, including email.")}</p>
                 <p>{_("If the fingerprint matches, click 'Accept key and connect'. Otherwise, do not connect and contact your administrator.")}</p>
             </>;

--- a/pkg/shell/shell.scss
+++ b/pkg/shell/shell.scss
@@ -23,6 +23,7 @@
 @use "table";
 @use "nav";
 @import "@patternfly/patternfly/components/Select/select.css";
+@import "@patternfly/patternfly/utilities/Text/text.css";
 
 :root {
   --ct-color-host-accent: var(--pf-global--active-color--100);
@@ -223,24 +224,8 @@ $desktop: $phone + 1px;
   }
 }
 
-.hostkey-fingerprint {
-  font-size: large;
-  font-weight: bold;
-  margin-top: var(--pf-global--spacer--md);
-  border: none;
-  background-color: transparent;
-}
-
 .hostkey-type {
   font-size: small;
-}
-
-.hostkey-verify-help-cmds {
-  border-radius: 0.25rem;
-  padding: 0.5rem 1rem;
-  background: #ddd;
-  margin-top: var(--pf-global--spacer--md);
-  margin-bottom: var(--pf-global--spacer--md);
 }
 
 /* Alert fixups */


### PR DESCRIPTION
When adding a new SSH host for the first time, cockpit shows a modal with a line of code to verify the fingerprint. The background color in dark theme makes it almost impossible to read.

I added a condition for dark theme in the `scss`, let me know if this needs any changes!

## Before:

![image](https://user-images.githubusercontent.com/90795679/224548231-3b45fd7b-6fbd-474b-850f-66f3c5862920.png)



## After:

![image](https://user-images.githubusercontent.com/90795679/224548052-eedc0a12-a840-4699-99ce-650ab496ad66.png)

