### PR TITLE
pkg: Support more than one target in window.debugging

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -408,7 +408,7 @@ in the browser storage. To do this run the following in your javascript console:
     >> sessionStorage.debugging = "all"
 
 You'll notice that there's a ton of messages that get shown. If you
-want to be more specific, instead of "all" use one of the following
+want to be more specific, instead of "all" use one or more of the following
 specific types:
 
     "all"      // All available debug messages
@@ -417,7 +417,9 @@ specific types:
     "http"     // HTTP (via the server) related debug messages
     "spawn"    // Debug messages related to executing processes
 
-There are other strings related to the code you may be working on.
+There are other strings related to the code you may be working on. For example,
+the metrics page shows debug information with the value `metrics`. Do
+`git grep window.debugging pkg` to find out all available ones.
 
 In addition, if you want your debug setting to survive a browser refresh or
 Cockpit log out, use something like:

--- a/pkg/lib/cockpit-components-firewalld-request.jsx
+++ b/pkg/lib/cockpit-components-firewalld-request.jsx
@@ -30,7 +30,7 @@ const _ = cockpit.gettext;
 const firewalld = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
 
 function debug() {
-    if (window.debugging == "all" || window.debugging == "firewall")
+    if (window.debugging == "all" || window.debugging?.includes("firewall"))
         console.debug.apply(console, arguments);
 }
 

--- a/pkg/lib/cockpit-dark-theme.js
+++ b/pkg/lib/cockpit-dark-theme.js
@@ -18,7 +18,7 @@
  */
 
 function debug() {
-    if (window.debugging == "all" || window.debugging == "style") {
+    if (window.debugging == "all" || window.debugging?.includes("style")) {
         console.debug([`cockpit-dark-theme: ${document.documentElement.id}:`, ...arguments].join(" "));
     }
 }

--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -226,7 +226,7 @@ window.addEventListener('beforeunload', function() {
 }, false);
 
 function transport_debug() {
-    if (window.debugging == "all" || window.debugging == "channel")
+    if (window.debugging == "all" || window.debugging?.includes("channel"))
         console.debug.apply(console, arguments);
 }
 
@@ -2737,7 +2737,7 @@ function factory() {
     }
 
     function spawn_debug() {
-        if (window.debugging == "all" || window.debugging == "spawn")
+        if (window.debugging == "all" || window.debugging?.includes("spawn"))
             console.debug.apply(console, arguments);
     }
 
@@ -2819,7 +2819,7 @@ function factory() {
     };
 
     function dbus_debug() {
-        if (window.debugging == "all" || window.debugging == "dbus")
+        if (window.debugging == "all" || window.debugging?.includes("dbus"))
             console.debug.apply(console, arguments);
     }
 
@@ -3998,7 +3998,7 @@ function factory() {
     }
 
     function http_debug() {
-        if (window.debugging == "all" || window.debugging == "http")
+        if (window.debugging == "all" || window.debugging?.includes("http"))
             console.debug.apply(console, arguments);
     }
 

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -194,7 +194,7 @@ const HISTORY_METRICS = [
 ];
 
 function debug() {
-    if (window.debugging == "all" || window.debugging == "metrics")
+    if (window.debugging == "all" || window.debugging?.includes("metrics"))
         console.debug.apply(console, arguments);
 }
 

--- a/pkg/packagekit/autoupdates.jsx
+++ b/pkg/packagekit/autoupdates.jsx
@@ -35,7 +35,7 @@ import { useInit } from "hooks";
 const _ = cockpit.gettext;
 
 function debug() {
-    if (window.debugging == "all" || window.debugging == "packagekit")
+    if (window.debugging == "all" || window.debugging?.includes("packagekit"))
         console.debug.apply(console, arguments);
 }
 


### PR DESCRIPTION
It is sometimes necessary to enable more than one debug target, e.g. `dbus` and `services`. But `all` is too much of a firehose.

Check window.debugging for a substring instead of equality, similar to what the Services page did in commit 0d6166b17453.