### PR TITLE
node_modules: update chrome-remote-interface to 0.32.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "argparse": "^2.0.1",
     "axe-core": "^3.5.2",
     "babel-loader": "^8.1.0",
-    "chrome-remote-interface": "^0.31.2",
+    "chrome-remote-interface": "^0.32.1",
     "compression-webpack-plugin": "^9.2.0",
     "copy-webpack-plugin": "^6.1.0",
     "css-loader": "^5.2.0",


### PR DESCRIPTION
Update to 0.32.1 for Chromium 111 compatibility. We need https://github.com/cyrus-and/chrome-remote-interface/commit/58ce8a3ad541709ab3883bc379e4a1dad5acb997 so the tests work.