### PR TITLE
lib: port the current manual NTP server dialog to PF

### DIFF
--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -20,12 +20,13 @@ import cockpit from "cockpit";
 import React, { useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { DatePicker } from "@patternfly/react-core/dist/esm/components/DatePicker/index.js";
-import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
+import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select/index.js";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import { TimePicker } from "@patternfly/react-core/dist/esm/components/TimePicker/index.js";
+import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { CloseIcon, ExclamationCircleIcon, InfoCircleIcon, PlusIcon } from "@patternfly/react-icons";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
 import { useObject, useEvent } from "hooks.js";
@@ -562,26 +563,19 @@ function ChangeSystimeBody({ state, errors, change }) {
     }
 
     const ntp_servers = (
-        <table>
-            <tbody>
-                { custom_ntp.servers.map((s, i) => (
-                    <tr key={i}>
-                        <td style={{ width: "100%" }}>
-                            <input type="text" className="form-control" value={s} placeholder={_("NTP server")}
-                onChange={event => change_server(event, i, event.target.value)} />
-                        </td>
-                        <td>
-                            <Button variant="secondary" onClick={event => add_server(event, i)} icon={ <PlusIcon /> } />
-                        </td>
-                        <td>
-                            <Button variant="secondary" onClick={event => remove_server(event, i)}
-                                    icon={ <CloseIcon /> }
-                                    isDisabled={i == custom_ntp.servers.length - 1} />
-                        </td>
-                    </tr>))
-                }
-            </tbody>
-        </table>);
+        custom_ntp.servers.map((s, i) => (
+            <Flex className="ntp-server-input-group" spaceItems={{ default: 'spaceItemsSm' }} key={i}>
+                <FlexItem grow={{ default: 'grow' }}>
+                    <TextInput value={s} placeholder={_("NTP server")} aria-label={_("NTP server")}
+                               onChange={(value, event) => change_server(event, i, value)} />
+                </FlexItem>
+                <Button variant="secondary" onClick={event => add_server(event, i)}
+                        icon={ <PlusIcon /> } />
+                <Button variant="secondary" onClick={event => remove_server(event, i)}
+                        icon={ <CloseIcon /> } isDisabled={i === custom_ntp.servers.length - 1} />
+            </Flex>
+        ))
+    );
 
     const mode_options = [
         <SelectOption key="manual_time" value="manual_time">{_("Manually")}</SelectOption>,
@@ -648,10 +642,8 @@ function ChangeSystimeBody({ state, errors, change }) {
                 }
                 { mode == "ntp_time_custom" &&
                     <Validated errors={errors} error_key="ntp_servers">
-                        <div id="systime-ntp-servers-row">
-                            <div id="systime-ntp-servers">
-                                { ntp_servers }
-                            </div>
+                        <div id="systime-ntp-servers">
+                            { ntp_servers }
                         </div>
                     </Validated>
                 }

--- a/pkg/lib/serverTime.scss
+++ b/pkg/lib/serverTime.scss
@@ -1,3 +1,7 @@
 .ct-serverTime-time-picker {
   max-width: 7rem;
 }
+
+.ntp-server-input-group:not(:last-child) {
+  margin-bottom: var(--pf-global--spacer--sm);
+}

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -311,9 +311,9 @@ class TestSystemInfo(PackageCase):
 
         # Add two NTP servers.
         self.set_change_time_dialog_mode("Automatically using specific NTP servers")
-        b.set_input_text("#systime-ntp-servers tr:nth-child(1) input", "0.pool.ntp.org")
-        b.click('#systime-ntp-servers tr:nth-child(1) button:first-child')
-        b.set_input_text("#systime-ntp-servers tr:nth-child(2) input", "1.pool.ntp.org")
+        b.set_input_text("#systime-ntp-servers div:nth-child(1) input", "0.pool.ntp.org")
+        b.click('#systime-ntp-servers div:nth-child(1) button')
+        b.set_input_text("#systime-ntp-servers div:nth-child(2) input", "1.pool.ntp.org")
         b.click("#system_information_change_systime .apply")
         with b.wait_timeout(120):  # Changing time on Arch can be slow
             b.wait_not_present("#system_information_change_systime")
@@ -331,7 +331,7 @@ class TestSystemInfo(PackageCase):
         b.wait_attr("#system_information_systime_button", "data-timedated-initialized", "true")
         b.click("#system_information_systime_button")
         b.wait_visible("#system_information_change_systime")
-        b.wait_val("#systime-ntp-servers tr:nth-child(1) input", "2.pool.ntp.org")
+        b.wait_val("#systime-ntp-servers div:nth-child(1) input", "2.pool.ntp.org")
         self.set_change_time_dialog_mode("Automatically using NTP")
         b.wait_not_present("#systime-ntp-servers")
         b.click("#system_information_change_systime .apply")
@@ -376,9 +376,9 @@ class TestSystemInfo(PackageCase):
 
         # Add two NTP servers.
         self.set_change_time_dialog_mode("Automatically using additional NTP servers")
-        b.set_input_text("#systime-ntp-servers tr:nth-child(1) input", "0.pool.ntp.org")
-        b.click('#systime-ntp-servers tr:nth-child(1) button:first-child')
-        b.set_input_text("#systime-ntp-servers tr:nth-child(2) input", "1.pool.ntp.org")
+        b.set_input_text("#systime-ntp-servers div:nth-child(1) input", "0.pool.ntp.org")
+        b.click('#systime-ntp-servers div:nth-child(1) button')
+        b.set_input_text("#systime-ntp-servers div:nth-child(2) input", "1.pool.ntp.org")
         b.click("#system_information_change_systime .apply")
         b.wait_not_present("#system_information_change_systime")
 
@@ -396,7 +396,7 @@ class TestSystemInfo(PackageCase):
         b.wait_attr("#system_information_systime_button", "data-timedated-initialized", "true")
         b.click("#system_information_systime_button")
         b.wait_visible("#system_information_change_systime")
-        b.wait_val("#systime-ntp-servers tr:nth-child(1) input", "2.pool.ntp.org")
+        b.wait_val("#systime-ntp-servers div:nth-child(1) input", "2.pool.ntp.org")
         self.set_change_time_dialog_mode("Automatically using NTP")
         b.wait_not_present("#systime-ntp-servers")
         b.click("#system_information_change_systime .apply")


### PR DESCRIPTION
Use Patternfly elements for input elements and buttons, in a later follow up look into using FormFieldGroup's.

Closes #18496

![image](https://user-images.githubusercontent.com/67428/226839644-cf512280-3af7-40c7-9e35-975f40242b89.png)
