### PR TITLE
makefiles: use prefix to allow usage in non fhs distros with less patching

### DIFF
--- a/src/systemd/Makefile.am
+++ b/src/systemd/Makefile.am
@@ -25,10 +25,10 @@ dist_motd_SCRIPTS = src/systemd/update-motd
 
 # Automake: 'Variables using ... ‘sysconf’ ... are installed by install-exec.'
 install-exec-hook::
-	mkdir -p $(DESTDIR)$(sysconfdir)/motd.d
-	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/motd.d/cockpit
-	mkdir -p $(DESTDIR)$(sysconfdir)/issue.d
-	ln -sTfr $(DESTDIR)/run/cockpit/motd $(DESTDIR)$(sysconfdir)/issue.d/cockpit.issue
+	mkdir -p $(DESTDIR)$(prefix)$(sysconfdir)/motd.d
+	ln -sTfr $(DESTDIR)$(prefix)/run/cockpit/motd $(DESTDIR)$(prefix)$(sysconfdir)/motd.d/cockpit
+	mkdir -p $(DESTDIR)$(prefix)$(sysconfdir)/issue.d
+	ln -sTfr $(DESTDIR)$(prefix)/run/cockpit/motd $(DESTDIR)$(prefix)$(sysconfdir)/issue.d/cockpit.issue
 
 tempconfdir = $(prefix)/lib/tmpfiles.d
 nodist_tempconf_DATA = src/systemd/cockpit-tempfiles.conf

--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -169,8 +169,8 @@ install-tests::
 	$(INSTALL_PROGRAM) mock-pam-conv-mod.so $(DESTDIR)$(pamdir)/
 
 install-exec-hook::
-	mkdir -p $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
-	chmod 755 $(DESTDIR)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(sysconfdir)/cockpit/machines.d
+	mkdir -p $(DESTDIR)$(prefix)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(prefix)$(sysconfdir)/cockpit/machines.d
+	chmod 755 $(DESTDIR)$(prefix)$(sysconfdir)/cockpit/ws-certs.d $(DESTDIR)$(prefix)$(sysconfdir)/cockpit/machines.d
 
 dist_check_DATA += \
 	src/ws/mock-combined.crt \


### PR DESCRIPTION
I am the maintainer, and daily driver user, of the cockpit package on NixOS.

Previously I used an approach based on patch files [1]  to fix some details in the code, so it would work with NixOS and some of these details would be convenient to be upstreamed.

The patch approach was replaced by a line substitution approach because it's resilient to line shifts because the patches can misalign and fail to be applied.

This patch basically instructs the makefiles to use the prefix because our builder uses $out (that is /nix/store/something) instead of /.

[1] https://github.com/NixOS/nixpkgs/blob/f7e045e14911989ce2222f3526941e1eb85cd3f0/pkgs/servers/monitoring/cockpit/default.nix