### PR TITLE
accounts: Redesign password process

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -18,7 +18,8 @@
  */
 import cockpit from 'cockpit';
 import React, { useState } from 'react';
-import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Progress, ProgressMeasureLocation, ProgressSize } from "@patternfly/react-core/dist/esm/components/Progress/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
@@ -100,12 +101,12 @@ export const PasswordFormFields = ({
                                </button>
                            </Popover>
                        }
-                       helperTextInvalid={error_password}
-                       validated={error_password ? "error" : "default"}
+                       validated={error_password ? "warning" : "default"}
                        id={idPrefix + "-pw1-group"}
                        fieldId={idPrefix + "-pw1"}>
                 <TextInput className="check-passwords" type="password" id={idPrefix + "-pw1"}
-                           autoComplete="new-password" value={password} onChange={onPasswordChanged} />
+                           autoComplete="new-password" value={password} onChange={onPasswordChanged}
+                           validated={error_password ? "warning" : "default"} />
                 <div>
                     <Progress id={idPrefix + "-meter"}
                               className={"ct-password-strength-meter " + variant}
@@ -116,6 +117,13 @@ export const PasswordFormFields = ({
                               value={Number.isInteger(passwordStrength) ? passwordStrength : 0} />
                     <div id={idPrefix + "-password-meter-message"} className="pf-c-form__helper-text" aria-live="polite">{passwordMessage}</div>
                 </div>
+                {error_password && <FormHelperText isHidden={false} component="div">
+                    <HelperText component="ul" aria-live="polite" id="password-error-message">
+                        <HelperTextItem isDynamic variant="warning" component="li">
+                            {error_password}
+                        </HelperTextItem>
+                    </HelperText>
+                </FormHelperText>}
             </FormGroup>
 
             {password_confirm_label && <FormGroup label={password_confirm_label}

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -131,7 +131,7 @@ function AccountCreateBody({ state, errors, change, shells }) {
             </FormGroup>
 
             <PasswordFormFields password_label={_("Password")}
-                                password_confirm_label={_("Confirm")}
+                                password_confirm_label={_("Confirm password")}
                                 error_password={errors?.password}
                                 error_password_confirm={errors?.password_confirm}
                                 idPrefix="accounts-create-password"

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -57,9 +57,9 @@ def createUser(
     machine,
     user_name,
     real_name,
-    password,
     locked,
     force_password_change,
+    password=None,
     custom_home_dir=None,
     default_shell=None,
     custom_shell=None,
@@ -75,8 +75,9 @@ def createUser(
 
     browser.set_input_text('#accounts-create-user-name', user_name)
     browser.set_input_text('#accounts-create-real-name', real_name)
-    browser.set_input_text('#accounts-create-password-pw1', password)
-    browser.set_input_text('#accounts-create-password-pw2', password)
+    if password:
+        browser.set_input_text('#accounts-create-password-pw1', password)
+        browser.set_input_text('#accounts-create-password-pw2', password)
 
     if locked:
         browser.click('#accounts-create-locked')
@@ -228,6 +229,7 @@ class TestAccounts(MachineCase):
 
         # changing input clears the error message
         b.set_input_text('#accounts-create-password-pw1', "test")
+        b.set_input_text('#accounts-create-password-pw2', "test")
         b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error")
 
         # correct password confirmation
@@ -392,6 +394,65 @@ class TestAccounts(MachineCase):
         self.login_and_go("/users")
         # Create a locked user with weak password
         self.sed_file('s/^SHELL=.*$/SHELL=/', '/etc/default/useradd')
+        self.allow_journal_messages(".*required to change your password immediately.*")
+        self.allow_journal_messages(".*user account or password has expired.*")
+
+        createUser(
+            browser=b,
+            machine=m,
+            user_name="js",
+            real_name="Jussi Senior",
+            locked=True,
+            force_password_change=False,
+            verify_created=False,
+        )
+
+        # Check Confirm password is not validated until it's at least the same length as the first password
+        # Once they are the same length, it should valitate the Confirm password after each keystroke
+        b.set_input_text('#accounts-create-password-pw1', "foobar")
+        b.set_input_text('#accounts-create-password-pw2', "bar")
+        b.wait_not_present("#accounts-create-password-pw2-helper")
+        b.set_input_text('#accounts-create-password-pw2', "foobarfoo")
+        b.wait_visible("#accounts-create-password-pw2-helper")
+        b.wait_in_text("#accounts-create-password-pw2-helper", "The passwords do not match")
+        b.set_input_text('#accounts-create-password-pw2', "bar")
+        b.wait_visible("#accounts-create-password-pw2-helper")
+        b.wait_in_text("#accounts-create-password-pw2-helper", "The passwords do not match")
+        b.set_input_text('#accounts-create-password-pw2', "foobar")
+        b.wait_not_present("#accounts-create-password-pw2-helper")
+
+        b.click('#accounts-create-dialog button.cancel')
+        b.wait_not_present('#account-set-password-dialog')
+
+        createUser(
+            browser=b,
+            machine=m,
+            user_name="js",
+            real_name="Jussi Senior",
+            locked=True,
+            force_password_change=False,
+            verify_created=False,
+        )
+
+        # Check Confirm password is not validated until the form is submitted
+        # Once it is submitted, it should valitate the Confirm password after each keystroke
+        b.set_input_text('#accounts-create-password-pw1', "foobar")
+        b.set_input_text('#accounts-create-password-pw2', "bar")
+        b.wait_not_present("#accounts-create-password-pw2-helper")
+        b.click('#accounts-create-dialog button.apply')
+        b.wait_visible("#accounts-create-password-pw2-helper")
+        b.wait_in_text("#accounts-create-password-pw2-helper", "The passwords do not match")
+        b.set_input_text('#accounts-create-password-pw2', "barfoo")
+        b.wait_visible("#accounts-create-password-pw2-helper")
+        b.wait_in_text("#accounts-create-password-pw2-helper", "The passwords do not match")
+        b.set_input_text('#accounts-create-password-pw2', "foobarfoo")
+        b.wait_visible("#accounts-create-password-pw2-helper")
+        b.wait_in_text("#accounts-create-password-pw2-helper", "The passwords do not match")
+        b.set_input_text('#accounts-create-password-pw2', "foobar")
+        b.wait_not_present("#accounts-create-password-pw2-helper")
+
+        b.click('#accounts-create-dialog button.cancel')
+        b.wait_not_present('#account-set-password-dialog')
 
         createUser(
             browser=b,
@@ -604,9 +665,6 @@ class TestAccounts(MachineCase):
         b.set_val('#conversation-input', good_password_2)
         b.click('#login-button')
         b.wait_visible('#content')
-
-        self.allow_journal_messages(".*required to change your password immediately.*")
-        self.allow_journal_messages(".*user account or password has expired.*")
 
     def testCustomUID(self):
         b = self.browser

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -224,19 +224,19 @@ class TestAccounts(MachineCase):
         b.set_input_text('#accounts-create-password-pw1', long_password)
         b.set_input_text('#accounts-create-password-pw2', long_password)
         b.click('#accounts-create-dialog button.apply')
-        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "Password is longer than 256 characters")
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning", "Password is longer than 256 characters")
         b.wait_not_present('#accounts-create-dialog button.pf-m-warning')
 
         # changing input clears the error message
         b.set_input_text('#accounts-create-password-pw1', "test")
         b.set_input_text('#accounts-create-password-pw2', "test")
-        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error")
+        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning")
 
         # correct password confirmation
         b.set_input_text('#accounts-create-password-pw1', good_password)
         b.set_input_text('#accounts-create-password-pw2', good_password)
         b.click('#accounts-create-dialog button.apply')
-        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error")
+        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning")
         b.wait_not_present('#accounts-create-dialog')
         b.wait_in_text('#accounts-list', "Berta Bestimmt")
 
@@ -466,16 +466,16 @@ class TestAccounts(MachineCase):
         )
 
         # Password is weak, lets change it to another weak - this should still not accept
-        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "Password quality check failed:")
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning", "Password quality check failed:")
         b.wait_visible('#accounts-create-dialog button.pf-m-warning')
         b.set_input_text('#accounts-create-password-pw1', "bar")
         b.set_input_text('#accounts-create-password-pw2', "bar")
-        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error")
+        b.wait_not_present("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning")
         b.wait_not_present('#accounts-create-dialog button.pf-m-warning')
         b.click('#accounts-create-dialog button.apply')
 
         # Password is weak, confirm button should be disabled after first click
-        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "Password quality check failed:")
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text .pf-m-warning", "Password quality check failed:")
         b.wait_visible("button.apply:disabled")
 
         # Lets confirm the weak password now
@@ -557,7 +557,7 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw2", 'a')
         b.wait_visible("#account-set-password-meter.danger")
         b.click('#account-set-password-dialog button.apply')
-        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error", "Password quality check failed:")
+        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text .pf-m-warning", "Password quality check failed:")
         b.wait_visible('#account-set-password-dialog button.pf-m-warning')
 
         # password mismatch
@@ -571,9 +571,9 @@ class TestAccounts(MachineCase):
         long_password = "2a02-x!h4a" * 30
         b.set_input_text('#account-set-password-pw1', long_password)
         b.set_input_text('#account-set-password-pw2', long_password)
-        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error")
+        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text .pf-m-warning")
         b.click('#account-set-password-dialog button.apply')
-        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error", "Password is longer than 256 characters")
+        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text .pf-m-warning", "Password is longer than 256 characters")
         b.wait_not_present('#account-set-password-dialog button.pf-m-warning')
 
         good_password_2 = "cEwghLY§X9R&m8RLwk4Xfed9Bw="
@@ -581,7 +581,7 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw1", good_password_2)
         b.set_input_text("#account-set-password-pw2", good_password_2)
         b.wait_visible("#account-set-password-meter.success")
-        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error")
+        b.wait_not_present("#account-set-password-dialog .pf-c-form__helper-text .pf-m-warning")
         b.click('#account-set-password-dialog button.apply')
         b.wait_not_present('#account-set-password-dialog')
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -65,13 +65,16 @@ def createUser(
     custom_shell=None,
     uid=None,
     expected_uid=None,
-    verify_created=True
+    verify_created=True,
+    run_assert_pixels=False,
 ):
     if default_shell is None:
         default_shell = getUserAddDetails(machine)["SHELL"]
     browser.wait_visible('#accounts-create')
     browser.click('#accounts-create')
     browser.wait_visible('#accounts-create-dialog')
+    if run_assert_pixels:
+        browser.assert_pixels("#accounts-create-dialog", "accounts-create-dialog")
 
     browser.set_input_text('#accounts-create-user-name', user_name)
     browser.set_input_text('#accounts-create-real-name', real_name)
@@ -263,7 +266,8 @@ class TestAccounts(MachineCase):
             password=good_password,
             locked=False,
             force_password_change=True,
-            default_shell="/bin/true"
+            default_shell="/bin/true",
+            run_assert_pixels=True
         )
 
         # Test actions in kebab menu


### PR DESCRIPTION
TODO:
- [x] add pixel tests

Fixes #18391 

# Accounts: Improve password process

There are several improvements to the process of setting passwords during account creation:
- The confirmation password is validated and doesn't match, validation is done after each keystroke. This improves user experience, as the user doesn't have to click "Create" whenever they want to know if passwords match.
- Password validation is now presented as warning, since a weak password is not actually forbidden, but discouraged nevertheless.

![Screenshot from 2023-04-05 12-41-47](https://user-images.githubusercontent.com/42733240/230057976-69fa2dc4-01f3-4560-adf8-2f22ee680fec.png)

