### PR TITLE
Don't invoke our esbuild plugins when the build has errors

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -112,7 +112,7 @@ export const cockpitPoEsbuildPlugin = options => ({
     name: 'cockpitPoEsbuildPlugin',
     setup(build) {
         init({ ...options, outdir: build.initialOptions.outdir });
-        build.onEnd(async () => { await run() });
+        build.onEnd(async result => { result.errors.length === 0 && await run() });
     },
 });
 

--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -34,7 +34,7 @@ export const cockpitRsyncEsbuildPlugin = options => ({
     name: 'cockpitRsyncPlugin',
     setup(build) {
         init(options || {});
-        build.onEnd(() => run(() => {}));
+        build.onEnd(result => result.errors.length === 0 && run(() => {}));
     },
 });
 


### PR DESCRIPTION
This makes working on podman a lot better as when the build fails the dist dir is not there and rsync just kill's everything and I notice it minutes later :)