### PR TITLE
workflows: Avoid pkg/build in weblate-sync-pot.yml

### DIFF
--- a/.github/workflows/weblate-sync-pot.yml
+++ b/.github/workflows/weblate-sync-pot.yml
@@ -11,23 +11,27 @@ jobs:
     environment: cockpit-weblate
     permissions:
       pull-requests: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/cockpit-project/unit-tests
+      options: --user root
+    timeout-minutes: 10
     steps:
-      - name: Set up dependencies
-        run: |
-          sudo apt update
-          sudo apt install -y --no-install-recommends gettext
+      # https://github.blog/2022-04-12-git-security-vulnerability-announced/
+      - name: Pacify git's permission check
+        run: git config --global --add safe.directory /__w/
 
       - name: Clone source repository
         uses: actions/checkout@v3
         with:
           path: src
-
-      - name: Install node_modules
-        run: make -C src -f pkg/build package-lock.json
+          fetch-depth: 0
 
       - name: Generate .pot file
-        run: make -C src -f po/Makefile.am po/cockpit.pot
+        run: |
+          cd src
+          ./autogen.sh
+          make po/cockpit.pot
 
       - name: Clone weblate repository
         uses: actions/checkout@v3

--- a/po/Makefile.am
+++ b/po/Makefile.am
@@ -1,11 +1,3 @@
-# Defaults for standalone operation
-srcdir ?= .
-AM_DEFAULT_VERBOSITY ?= 0
-
-AM_V_GEN ?= $(AM_V_GEN_$(V))
-AM_V_GEN_ ?= $(AM_V_GEN_$(AM_DEFAULT_VERBOSITY))
-AM_V_GEN_0 ?= @echo "  GEN " $@;
-
 # The concrete set of linguas we are using
 LINGUAS = $(shell cat $(srcdir)/po/LINGUAS)
 


### PR DESCRIPTION
We are going to eliminate pkg/build soon. Drop the shortcuts of calling    
various sub-Makefiles, and use the normal ./autogen.sh/make. This only    
takes an extra second and is much cleaner.    
    
Run the workflow in our unit-tests container, so that we don't have to    
install anything extra, and it becomes reproducible.    

-----

The [manually triggered workflow](https://github.com/cockpit-project/cockpit/actions/runs/4475684936) against this branch succeeded, and the [generated commit](https://github.com/cockpit-project/cockpit-weblate/commit/606ff0acb3a8a7c83457e13aa309ea70dce0bbd5) looks reasonable. There is some noise in the sort ordering of the location comments, presumably because of a different gettext version between the previous Ubuntu 20.04 and Debian testing, but that's harmless.