### PR TITLE
systemd/services: Avoid time.clock_gettime_ns()

### DIFF
--- a/pkg/systemd/services.jsx
+++ b/pkg/systemd/services.jsx
@@ -72,12 +72,12 @@ function debug() {
 
 export function updateTime() {
     // To correctly interpret monotonic timers, we need to read CLOCK_MONOTONIC. This cannot be read with shell tools
-    python.spawn("import time; print(time.clock_gettime_ns(time.CLOCK_REALTIME), time.clock_gettime_ns(time.CLOCK_MONOTONIC))",
+    python.spawn("import time; print(int(time.clock_gettime(time.CLOCK_REALTIME) * 1000000), int(time.clock_gettime(time.CLOCK_MONOTONIC) * 1000000))",
                  null, { err: "message" })
             .then(output => {
-                const [realtime, monotonic] = output.split(' ').map(ns => parseInt(ns));
-                clock_realtime_now = realtime / 1000000;
-                monotonic_timer_base = (realtime - monotonic) / 1000;
+                const [realtime_us, monotonic_us] = output.split(' ').map(t => parseInt(t));
+                clock_realtime_now = realtime_us / 1000;
+                monotonic_timer_base = realtime_us - monotonic_us;
                 debug("Read clocks with Python; realtime", clock_realtime_now, "monotonic base", monotonic_timer_base);
             })
             .catch(ex => {


### PR DESCRIPTION
This does not yet exist in Python 3.6 (on RHEL 8), thus causing a warning message and the root-only fallback. Use time.clock_gettime() instead, which was introduced in Python 3.3 already.

Change the Python code to return µs instead of ns, which simplifies the calculation.

---

This was a regression from #18466, but I didn't notice because we don't show errors from passed tests. In failed tests it [looks like this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18532-20230320-165624-d2a3bf0e-centos-8-stream-pybridge/log.html#302-2):

    AttributeError: module 'time' has no attribute 'clock_gettime_ns'
