### PR TITLE
pkg: Update dist/ install rule to avoid `find` in dependencies

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -28,11 +28,8 @@ include pkg/build
 # seeing them during ./autogen.sh, but need make to find them at compile time.
 -include $(wildcard pkg/Makefile.qunit*)
 
-# automake doesn't support stripping initial path components (ie: `dist`) with
-# `nobase_`, so we create a cockpit/ symlink and use that instead.
-# That way, the files land in $(datadir)/cockpit/ and `dist` is avoided.
-all-local:: cockpit
-cockpit:
-	$(AM_V_GEN) ln -sf $(srcdir)/dist $@
+install-data-hook::
+	cd $(srcdir)/dist; find -type f -exec install -D -m 644 '{}' '$(DESTDIR)$(datadir)/cockpit/{}' \;
 
-nobase_data_DATA = $(patsubst dist/%,cockpit/%,$(shell find $(srcdir)/cockpit/ -type f))
+uninstall-hook:
+	rm -rf $(DESTDIR)$(datadir)/cockpit


### PR DESCRIPTION
This has caused a lot of confusing noise during build:

    find: ‘../../cockpit/’: No such file or directory

Because the `find` command runs on every invocation of `make`, even when dist/ was not built yet. We only really need this for `make install`, so replace this with a procedural rule. automake would previously generate `install` calls for all files in `Makefile.deps`, or now all files in dist/, so this is still functionally equivalent.

This also avoids the hack with creating a `cockpit` symlink.