### PR TITLE
TESTS: webpack-jumpstart build for PR #18536

### DIFF
--- a/pkg/systemd/overview-cards/healthCard.jsx
+++ b/pkg/systemd/overview-cards/healthCard.jsx
@@ -35,7 +35,7 @@ export class HealthCard extends React.Component {
     render() {
         return (
             <Card className="system-health">
-                <CardTitle>{_("Health")}</CardTitle>
+                <CardTitle>{_("'sup?")}</CardTitle>
                 <CardBody>
                     <ul className="system-health-events">
                         <PageStatusNotifications />


### PR DESCRIPTION
We can't test the jumpstart build in #18536 directly, as it runs on `pull_request_target`. This is a dummy PR to double-check that it still works.