### PR TITLE
Update documentation and comments to not be webpack specific

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -186,7 +186,7 @@ The tests require at least `pytest` 7.0.0 or higher to run.
 Cockpit uses [ESLint](https://eslint.org/) to automatically check JavaScript
 code style in `.js` and `.jsx` files.
 
-The linter is executed within every build as a webpack preloader.
+The linter is executed on every build.
 
 For developer convenience, the ESLint can be started explicitly by:
 
@@ -209,7 +209,7 @@ unused identifiers, and other JavaScript-related issues:
 Cockpit uses [Stylelint](https://stylelint.io/) to automatically check CSS code
 style in `.css` and `.scss` files.
 
-The linter is executed within every build as a webpack preloader.
+The linter is executed on every build.
 
 For developer convenience, the Stylelint can be started explicitly by:
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -64,7 +64,7 @@ DISTCHECK_CONFIGURE_FLAGS = --enable-prefix-only
 distcheck-hook::
 	find $(distdir) -name '*.metainfo.xml' -o -name '*.appdata.xml' | xargs appstream-util validate --nonet
 
-# validate that we don't bundle fonts in webpacks
+# validate that we don't bundle the embedded patternfly font files, we use them from /static/fonts/
 distcheck-hook::
 	! grep --color=auto -rn "\.\./fonts/OpenSans\|fonts/.*eot\|truetype" $(distdir)/dist
 

--- a/build.js
+++ b/build.js
@@ -9,8 +9,8 @@ child_process.spawnSync('tools/node-modules', ['make_package_lock_json'], { stdi
 
 const parser = (await import('argparse')).default.ArgumentParser();
 parser.add_argument('-c', '--config', { help: "Path to webpack.config.js", default: "webpack.config.js" });
-parser.add_argument('-r', '--rsync', { help: "rsync webpack to ssh target after build", metavar: "HOST" });
-parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable webpack watch mode" });
+parser.add_argument('-r', '--rsync', { help: "rsync bundles to ssh target after build", metavar: "HOST" });
+parser.add_argument('-w', '--watch', { action: 'store_true', help: "Enable watch mode" });
 parser.add_argument('-e', '--no-eslint', { action: 'store_true', help: "Disable eslint linting" });
 parser.add_argument('-s', '--no-stylelint', { action: 'store_true', help: "Disable stylelint linting" });
 parser.add_argument('onlydir', { nargs: '?', help: "The pkg/<DIRECTORY> to build (eg. base1, shell, ...)", metavar: "DIRECTORY" });

--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -25,7 +25,7 @@ dist_sshmanifest_DATA = pkg/ssh/manifest.json
 # one built file in dist/ which we use as dependency
 DIST_STAMP = $(srcdir)/dist/static/manifest.json
 
-# dynamic pkg → dist dependency, to rebuild the webpack if any web related file changes
+# dynamic pkg → dist dependency, to rebuild the bundles if any web related file changes
 # exclude automake unit test log files
 PKG_INPUTS = $(shell find $(srcdir)/pkg -type f ! -name 'test*.trs' ! -name 'test*.log')
 
@@ -33,7 +33,7 @@ V_BUNDLE = $(V_BUNDLE_$(V))
 V_BUNDLE_ = $(V_BUNDLE_$(AM_DEFAULT_VERBOSITY))
 V_BUNDLE_0 = @echo "  BUNDLE   dist";
 
-# delete the stamp first; webpack won't touch it if the contents didn't change,
+# delete the stamp first; neither webpack nor esbuild touch it if the contents didn't change,
 # but this is just a representative for all of dist/*
 $(DIST_STAMP): $(srcdir)/package-lock.json $(PKG_INPUTS)
 	@rm -f $(DIST_STAMP)

--- a/pkg/lib/README
+++ b/pkg/lib/README
@@ -1,5 +1,5 @@
 # Cockpit shared components
 
-This directory contains React components, JavaScript modules, webpack/eslint
+This directory contains React components, JavaScript modules, webpack/esbuild
 plugins, and build tools which are shared between all Cockpit projects.
 External projects usually clone this directory into their own source tree.

--- a/pkg/lib/patternfly/patternfly-4-cockpit.scss
+++ b/pkg/lib/patternfly/patternfly-4-cockpit.scss
@@ -5,6 +5,5 @@ $pf-global--disable-fontawesome: true !default; // Disable Font Awesome 5 Free
 
 @import "@patternfly/patternfly/patternfly-base.scss";
 
-/* Import our own fonts since the PF4 font-face rules are filtered out in
- * webpack.config.js */
+/* Import our own fonts since the PF4 font-face rules are filtered out in build.js */
 @import "./fonts";

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -56,7 +56,7 @@ def directory_items(path):
 # HACK: We eventually want to get rid of all ${libexecdir} in manifests:
 # - rewrite cockpit-{ssh,pcp} in Python and import them as module instead of exec'ing
 # - rewrite cockpit-askpass in Python and write it into a temporary file
-# - bundle helper shell scripts into their webpacks
+# - bundle helper shell scripts
 # Until then, we need this libexecdir detection hack.
 LIBEXECDIR = None
 

--- a/test/README.md
+++ b/test/README.md
@@ -136,7 +136,7 @@ for details about the tools and configuration for these.
 Each `image-prepare` invocation will always start from the pristine image and
 ignore the current overlay in `test/images`. It is thorough, but also rather
 slow. If you want to iterate on changing only JavaScript/HTML code, you can use
-this shortcut to copy updated webpacks into a prepared VM overlay image:
+this shortcut to copy updated bundles into a prepared VM overlay image:
 
     make && bots/image-customize -u dist:/usr/share/cockpit/ $TEST_OS
 
@@ -157,7 +157,7 @@ In particular, you can use our standard test VMs with this mode:
 Note the SSH and cockpit ports. If this is the only running VM, it will have
 the addresses in the example below, otherwise the port will be different.
 
-Now you can change the code (see [HACKING.md](../HACKING.md) for webpack watch
+Now you can change the code (see [HACKING.md](../HACKING.md) for watch
 mode), copy it into the VM, and run the test against it:
 
     test/verify/check-connection --machine 127.0.0.2:2201 --browser 127.0.0.2:9091

--- a/tools/README.dist
+++ b/tools/README.dist
@@ -1,8 +1,7 @@
 Webpack build output
 ====================
 
-This directory is populated with the built Cockpit packages from webpack (see
-HACKING.md).
+This directory is populated with the built Cockpit packages (see HACKING.md).
 
 You can link this directory into your home directory and have
 Cockpit on your local machine use the built packages:

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -75,7 +75,7 @@ with open(TEMPLATE_FILE, encoding='UTF-8') as f:
 
 license_ids = template_licenses(template)
 
-# scan dist/ webpacks for third-party copyrights and licenses
+# scan dist/ bundles for third-party copyrights and licenses
 
 dist_copyrights = {}  # Files: dirglob → set(copyrights)
 dist_licenses = {}  # Files: dirglob → set(licenses)
@@ -103,7 +103,7 @@ for directory, _subdirs, files in os.walk(f'{BASE_DIR}/dist'):
                 if license.lower() not in license_ids:
                     raise KeyError('License {license} not found in {TEMPLATE_FILE}')
 
-            # All webpacks also contain our own code
+            # All bundles also contain our own code
             licenses.add("LGPL-2.1-or-later")
 
             dist_licenses.setdefault(directory_glob, set()).update(licenses)
@@ -112,7 +112,7 @@ for directory, _subdirs, files in os.walk(f'{BASE_DIR}/dist'):
             if not copyrights:
                 raise SystemError('Did not find any copyrights in:\n%s' % comment)
 
-            # All webpacks also contain our own code
+            # All bundles also contain our own code
             copyrights.add(own_copyright)
 
             dist_copyrights.setdefault(directory_glob, set()).update(copyrights)

--- a/tools/debian/copyright.template
+++ b/tools/debian/copyright.template
@@ -3,12 +3,12 @@ Upstream-Name: cockpit
 Source: https://github.com/cockpit-project/cockpit
 Comment:
  This does not directly cover the files in dist/*. These are "minified" and
- compressed JavaScript/HTML files built from pkg/* and node_modules/* with
- node, npm, and webpack. Their copyrights and licenses are described below.
- Rebuilding these requires internet access as that process needs to download
- additional npm modules from the Internet, thus upstream ships the pre-minified
- webpacks as part of the upstream release tarball so that the package can be
- built without internet access and lots of extra unpackaged build dependencies.
+ compressed JavaScript/HTML files built from pkg/* and node_modules/*. Their
+ copyrights and licenses are described below. Rebuilding these requires
+ internet access as that process needs to download additional npm modules from
+ the Internet, thus upstream ships the pre-minified bundles as part of the
+ upstream release tarball so that the package can be built without internet
+ access and lots of extra unpackaged build dependencies.
 
 Files: *
 Copyright: 2013-2016  Red Hat, Inc.

--- a/tools/debian/source/lintian-overrides
+++ b/tools/debian/source/lintian-overrides
@@ -3,5 +3,5 @@ cockpit source: source-is-missing *pkg/static/login.html*
 cockpit source: source-is-missing *src/common/fail.html*
 # source contains NPM modules required for running browser integration tests
 cockpit source: source-is-missing *node_modules/*
-# dist/ is (pre-)built by webpack from pkg/ and node_modules, see webpack.config.js
+# dist/ is (pre-)built from pkg/ and node_modules, see ./build.js
 cockpit source: source-is-missing *dist/*

--- a/tools/node-modules
+++ b/tools/node-modules
@@ -111,8 +111,7 @@ cmd_make_package_lock_json() {
     # Run from make to ensure package-lock.json is up to date
 
     # package-lock.json is used as the stamp file for all things that use
-    # node_modules (mostly webpack), so this is the main bit of glue that
-    # drives the entire process
+    # node_modules, so this is the main bit of glue that drives the entire process
 
     # We try our best not to touch package-lock.json unless it actually changes
 


### PR DESCRIPTION
webpack is an implementation detail and soon change to esbuild. Make the verbiage more neutral.

---

Split from PR #18447 to reduce the noise there.