### PR TITLE
shell: Fix manifest loading race condition

### DIFF
--- a/pkg/shell/machines/machines.js
+++ b/pkg/shell/machines/machines.js
@@ -550,7 +550,7 @@ function Loader(machines, session_only) {
         let open = local;
 
         let url;
-        if (!machine.manifests) {
+        if (!machine.manifests || Object.keys(machine.manifests).length === 0) {
             if (machine.checksum)
                 url = "../../" + machine.checksum + "/manifests.json";
             else


### PR DESCRIPTION
All `<script>` tags get loaded in parallel, in particular manifests.js and shell.js. This means that Loader cannot rely on `cockpit.manifests` being initialized already -- if it runs before `manifests.js` is done with setting `cockpit.manifests`, then the initial `overlay.manifests` gets set to `{}` (the uninitialized default in cockpit.js).

But `{}` is truthy in JS, which made Loader think that the manifests were already initialized, and thus never actually requested it.

Fix the condition to also load manifests for an empty object to fix that.

-----

This was quite a learning exercise for me since yesterday :grin:  This was the symptom:

![no-results](https://user-images.githubusercontent.com/200109/227134888-c17bdb33-96e0-4873-ba8e-a92e625756d9.png)

We never got a bug report about this happening in the wild, presumably because shell.js's structure just happened to be "slow" enough for manifests.js to always finish before `Loader` started. But esbuild apparently structures the bundle a bit differently, so that this [fails very often](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18447-20230322-065259-f76d494f-fedora-37/log.html) like [this screenshot](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18447-20230322-065259-f76d494f-fedora-37/TestPages-testBasic-fedora-37-127.0.0.2-2301-FAIL.png).

This was perfectly reproducible locally -- the shell nav menu was always empty after logging in, and started to work after a page reload (when manifests.js was cached).

Curiously, I was even able to reproduce this on main, when running

    ln -s dist cockpit
    XDG_DATA_DIRS=`pwd` /usr/libexec/cockpit-ws --no-tls -p 9998 --local-session=cockpit-bridge

Firefox' performance inspector was useful to confirm my suspicion of parallel loading:

![js-load-parallel](https://user-images.githubusercontent.com/200109/227134939-de99a8fd-cf8e-4bad-83c7-2a680e6c15f6.png)

I also added this fix to #18447, and in the [current test run](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18447-20230323-072347-1f624673-fedora-37/log.html) at least *this* problem does not occur any more.