### PR TITLE
patternfly-overrides: Remove obsolete/wrong overrides 

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -118,28 +118,6 @@ svg {
   }
 }
 
-// Alignment of checks is incorrect and inconsistent across browsers
-// Upstream issue: https://github.com/patternfly/patternfly/issues/3868
-.pf-c-check > .pf-c-check__input {
-  // Set the height of the input widget to be the same as its label
-  --pf-c-check__input--Height: var(--pf-c-check__label--FontSize);
-  // Offset by the top half of the difference between the height and the line height
-  --pf-c-check__input--MarginTop: calc((var(--pf-c-check__label--LineHeight) - 1) / 2 * var(--pf-c-check__input--Height));
-  // PF3 sets a margin which messes with PF4, so set PF4's rule again here (Cockpit-specific mix of PF3+PF4)
-  margin-top: var(--pf-c-check__input--MarginTop);
-}
-
-// Alignment of checks is incorrect and inconsistent across browsers
-// Upstream issue: https://github.com/patternfly/patternfly/issues/3868
-.pf-c-radio > .pf-c-radio__input {
-  // Set the height of the input widget to be the same as its label
-  --pf-c-radio__input--Height: var(--pf-c-radio__label--FontSize);
-  // Offset by the top half of the difference between the height and the line height
-  --pf-c-radio__input--MarginTop: calc((var(--pf-c-radio__label--LineHeight) - 1) / 2 * var(--pf-c-radio__input--Height));
-  // PF3 sets a margin which messes with PF4, so set PF4's rule again here (Cockpit-specific mix of PF3+PF4)
-  margin-top: var(--pf-c-radio__input--MarginTop);
-}
-
 // Add some spacing to nested form groups - PF4 does not support these yet
 // https://github.com/patternfly/patternfly-design/issues/1012
 .pf-c-form__group-control {

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -87,7 +87,7 @@ svg {
   // Make sure that the buttons always appear in the next line from the inline alerts
   .pf-c-modal-box__footer {
     flex-wrap: wrap;
-    gap: var(--pf-global--spacer--sm);
+    row-gap: var(--pf-global--spacer--sm);
 
     > div:not(.pf-c-button):not(.dialog-wait-ct) {
       flex: 0 0 100%;


### PR DESCRIPTION
Patternfly handles it differently we margins and I don't see the reason to override it.

This was introduced with the massive PF3 -> PF4 rewrite and is not relevant any more.

This is expected to reduce slightly the space between the Primary and Cancel buttons in modals, which aligns with how these looks on the Patternfly site.