### PR TITLE
selinux: Fix menu entry

### DIFF
--- a/pkg/selinux/manifest.json
+++ b/pkg/selinux/manifest.json
@@ -1,6 +1,6 @@
 {
     "tools": {
-        "setroubleshoot": {
+        "index": {
             "label": "SELinux",
             "keywords": [
                 {


### PR DESCRIPTION
This was forgotten in commit d4451584e56. Clicking on the menu would try to go to /selinux/setroubleshoot, which does not exist any more. The tests didn't catch that as they directly go to /selinux instead of clicking the menu.

---

This is a pretty major regression, and it slipped into 288. I will :-1: our current F37/F38 bodhi updates, let's do a 288.1 after that.