### PR TITLE
test: Validate all Navigation menu page entries

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -809,6 +809,16 @@ OnCalendar=daily
             b.switch_to_top()
             assert_location("/system")
 
+    def testAllNavEntries(self):
+        b = self.browser
+        self.login_and_go()
+
+        # the <a> links should be unique by their href= attributes, so get these
+        hrefs = b.eval_js("[...document.querySelectorAll('#nav-system .nav-item a')].map(el => el.getAttribute('href'))")
+        for href in hrefs:
+            b.click(f"#nav-system .nav-item a[href='{href}']")
+            b.wait_visible(f"iframe.container-frame[name='cockpit1:localhost{href}'][data-loaded]")
+
 
 if __name__ == '__main__':
     test_main()


### PR DESCRIPTION
Walk over the whole menu and ensure that we get a successful iframe loaded. This validates the fix in commit 69183a160d1 and prevents future similar regressions.

----

When reverting commit 69183a160d1, this fails on the broken "SELinux" menu entry:

```
DP: frameNavigated {"frame":{"id":"9429BA6ECDBF5E32594376005BE12B93","parentId":"7C27BA0885EB1EA4BEC062EDDCCD0DAA","loaderId":"C819EF7257AA1065644B8A9E704E20C7","name":"cockpit1:localhost/selinux/setroubleshoot","url":"http://127.0.0.2:9091/cockpit/$3d64f0cf6985cff84aae0bc59c0420c23b0daf0b0e3de96b680a130d23eae0b2/selinux/setroubleshoot.html","urlFragment":"#/","domainAndRegistry":"","securityOrigin":"http://127.0.0.2:9091","mimeType":"text/html","adFrameStatus":{"adFrameType":"none"},"secureContextType":"SecureLocalhost","crossOriginIsolatedContextType":"NotIsolated","gatedAPIFeatures":[]},"type":"Navigation"}
CDP: {"source":"network","level":"error","text":"Failed to load resource: the server responded with a status of 404 (Not Found)","timestamp":1679646920711.673,"url":"http://127.0.0.2:9091/cockpit/$3d64f0cf6985cff84aae0bc59c0420c23b0daf0b0e3de96b680a130d23eae0b2/selinux/setroubleshoot.html#/","networkRequestId":"C819EF7257AA1065644B8A9E704E20C7"}
<- {'type': 'object', 'subtype': 'error', 'className': 'PhWaitCondTimeout', 'description': 'Error: condition did not become true\n    at <anonymous>:247:32', 'objectId': '-8106795917588400168.3.1'}
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/main/test/verify/check-pages", line 820, in testAllNavEntries
    b.wait_visible(f"iframe.container-frame[name='cockpit1:localhost{href}'][data-loaded]")
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 619, in wait_visible
    self._wait_present(selector)
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 610, in _wait_present
    self.wait_js_func('ph_is_present', selector)
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 604, in wait_js_func
    self.wait_js_cond("%s(%s)" % (func, ','.join(map(jsquote, args))))
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 590, in wait_js_cond
    self.raise_cdp_exception("timeout\nwait_js_cond", cond, result["exceptionDetails"], trailer)
  File "/var/home/martin/upstream/cockpit/main/test/common/testlib.py", line 296, in raise_cdp_exception
    raise Error("%s(%s): %s" % (func, arg, msg))
testlib.Error: timeout
wait_js_cond(ph_is_present("iframe.container-frame[name='cockpit1:localhost/selinux/setroubleshoot'][data-loaded]")): Uncaught (in promise) Error: condition did not become true
```

and the screenshot shows the "Not found" error page.