### PR TITLE
c8s/pybridge test: Skip three regressed tests and ignore new crash

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1804,6 +1804,29 @@ class MachineCase(unittest.TestCase):
                 "asyncio-ERROR: Task was destroyed but it is pending!",
                 "task:.*Task pending.*cockpit/channels/dbus.py.*"]
 
+            # happens fairly reliably with TestConnection.testTls and TestHistoryMetrics.testEvents
+            self.allowed_messages += [
+                r'asyncio-ERROR: Exception in callback None\(\)',
+                r'handle: <Handle cancelled>',
+                r'Traceback \(most recent call last\):',
+                r'File "/usr/lib64/python3.6/asyncio/events.py", line .*, in _run',
+                r'self._callback\(\*self._args\)',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/transports.py", line .*, in _read_ready',
+                r'self._protocol.data_received\(data\)',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/protocol.py", line .*, in data_received',
+                r'result = self.consume_one_frame\(self.buffer\)',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/protocol.py", line .*, in consume_one_frame',
+                r'self.frame_received.*',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/protocol.py", line .*, in frame_received',
+                r'self.channel_control_received\(channel, command, message\)',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/peer.py", line .*, in channel_control_received',
+                r'self.send_channel_control.*message.*',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/router.py", line .*, in send_channel_control',
+                r'self.router.drop_channel\(channel\)',
+                r'File "/usr/local/lib64/python3.6/site-packages/cockpit/router.py", line .*, in drop_channel',
+                r'assert channel in self.open_channels, \(self.open_channels, channel\)',
+                r"AssertionError: \({}, '.*'\)"]
+
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1799,6 +1799,7 @@ class MachineCase(unittest.TestCase):
 
         # HACK: pybridge bugs
         if os.environ.get("TEST_SCENARIO") == "pybridge":
+            # https://github.com/cockpit-project/cockpit/issues/18386
             self.allowed_messages += [
                 "asyncio-ERROR: Task was destroyed but it is pending!",
                 "task:.*Task pending.*cockpit/channels/dbus.py.*"]

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -21,9 +21,12 @@ import base64
 import time
 import os
 import subprocess
+import unittest
 
 import parent  # noqa: F401
-from testlib import MachineCase, TEST_DIR, nondestructive, skipBrowser, skipDistroPackage, skipImage, skipOstree, test_main, wait
+from testlib import (MachineCase, TEST_DIR, nondestructive, test_main, wait,
+                     skipBrowser, skipDistroPackage, skipImage, skipOstree)
+from testvm import DEFAULT_IMAGE
 
 
 @skipDistroPackage()
@@ -810,6 +813,10 @@ export XDG_CONFIG_DIRS=/usr/local
 
     @skipOstree("OSTree doesn't have cockpit-ws")
     @skipImage("Kernel does not allow user namespaces", "debian-*")
+    @unittest.skipIf(
+        os.environ.get("TEST_SCENARIO") == "pybridge" and
+        (DEFAULT_IMAGE.startswith("centos-8") or DEFAULT_IMAGE.startswith("rhel-8")),
+        "regression from https://github.com/cockpit-project/cockpit/pull/18398")
     def testCockpitDesktop(self):
         m = self.machine
 

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -17,14 +17,22 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import unittest
+
 import parent  # noqa: F401
 from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main
+from testvm import DEFAULT_IMAGE
 
 
 @skipDistroPackage()
 @nondestructive
 class TestReauthorize(MachineCase):
 
+    @unittest.skipIf(
+        os.environ.get("TEST_SCENARIO") == "pybridge" and
+        (DEFAULT_IMAGE.startswith("centos-8") or DEFAULT_IMAGE.startswith("rhel-8")),
+        "regression from https://github.com/cockpit-project/cockpit/pull/18398")
     def testBasic(self):
         self.allow_journal_messages('.*dropping message while waiting for child to exit.*')
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -19,9 +19,11 @@
 
 import os
 import time
+import unittest
 
 import parent  # noqa: F401
 from testlib import MachineCase, nondestructive, skipDistroPackage, skipImage, todoPybridge, test_main
+from testvm import DEFAULT_IMAGE
 
 
 def allow_old_cockpit_ws_messages(test):
@@ -212,6 +214,10 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.check_superuser_indicator("Limited access")
 
+    @unittest.skipIf(
+        os.environ.get("TEST_SCENARIO") == "pybridge" and
+        (DEFAULT_IMAGE.startswith("centos-8") or DEFAULT_IMAGE.startswith("rhel-8")),
+        "regression from https://github.com/cockpit-project/cockpit/pull/18398")
     def testRemoveBridgeConfig(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Unfortunately PR #18398 broke three tests and introduced a new crash as unexpected message. We didn't notice back then as that PR didn't run c8s/pybridge, only f-37/pybridge. Accept this as new baseline for now, so that we don't fail all PRs, and avoid accidentaly introducing further regressions.

Example failures: [one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18491-20230323-144756-5d101ba4-centos-8-stream-pybridge/log.html), [two](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18552-20230324-084110-5d219b81-centos-8-stream-pybridge/log.html)

I created https://issues.redhat.com/browse/COCKPIT-971 to track actually fixing this.