### PR TITLE
lib/cockpit-rsync-plugin: Fix return value on failures

### DIFF
--- a/pkg/lib/cockpit-rsync-plugin.js
+++ b/pkg/lib/cockpit-rsync-plugin.js
@@ -34,7 +34,7 @@ export const cockpitRsyncEsbuildPlugin = options => ({
     name: 'cockpitRsyncPlugin',
     setup(build) {
         init(options || {});
-        build.onEnd(result => result.errors.length === 0 && run(() => {}));
+        build.onEnd(result => result.errors.length === 0 ? run(() => {}) : {});
     },
 });
 


### PR DESCRIPTION
Not returning anything causes an ugly
```
✘ [ERROR] Expected onEnd() callback in plugin "cockpitRsyncPlugin" to return an object [plugin cockpitRsyncPlugin]
```
error when there is anything wrong in the compiled source (like an ESLint error). Immediately return an empty object in the failure case instead of `undefined`.

----

This doesn't yet do anything useful in cockpit itself, but I noticed it with c-podman, and tested it against that. See https://github.com/cockpit-project/cockpit-podman/pull/1243 . But it applies to the esbuildification in PR #18447 as well (also tested with that branch)