### PR TITLE
systemd: Drop loading of non-existing performance.js

### DIFF
--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -14,6 +14,5 @@
 </head>
 <body class="pf-m-redhat-font pf-m-tabular-nums">
   <div class="ct-page-fill" id="overview"></div>
-  <script src="../performance/performance.js"></script>
 </body>
 </html>


### PR DESCRIPTION
tuned/performance.js has not existed as a separate webpack for a long time. This causes an unsightly error message.