### PR TITLE
packagekit: don't call formatPackageId on itself

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -596,7 +596,7 @@ const ApplyUpdates = ({ transactionProps, actions, onCancel, rebootAfter, setReb
                     <div className="progress-description">
                         <Spinner isSVG size="md" />
                         <strong>{ PK_STATUS_STRINGS[lastAction?.status] || PK_STATUS_STRINGS[PK.Enum.STATUS_UPDATE] }</strong>
-                        &nbsp;{formatPackageId(curPackage)}
+                        &nbsp;{curPackage}
                     </div>
                     <Progress title={remain}
                               value={percentage}


### PR DESCRIPTION
After the refactoring in 8b3c35aaf0c6415c071 we now call formatPackageId twice which ends up showing a lot of undefined ( undefined ).

This still has some issues where it shows undefined in the progress bar because the first events we get are DOWNLOADING and not updating so we end up calling formatPackageKid with an empty string. However this requires an update to retrigger the issue so needs a quicker development cycle? Maybe our tests? However as this fixes some uglyness let's get this in first.