### PR TITLE
pkg: Use only full path imports as tree shaking is imperfect

### DIFF
--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -21,9 +21,8 @@ import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
 import React from "react";
-import {
-    HelperText, HelperTextItem, FormHelperText,
-} from "@patternfly/react-core";
+import { FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { HelperText, HelperTextItem, } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { ExclamationTriangleIcon, InfoCircleIcon } from "@patternfly/react-icons";
 
 import {


### PR DESCRIPTION
This affects the bundle size noticeable. In particular this change reducer the production bundle size from 25.9 mb to 25.3 mb.