### PR TITLE
systemd: set a different text color in the dark theme

### DIFF
--- a/pkg/systemd/service-details.scss
+++ b/pkg/systemd/service-details.scss
@@ -88,6 +88,10 @@
   padding-left: 1em;
 }
 
+.pf-theme-dark .side-note {
+  color: var(--pf-global--Color--200);
+}
+
 .font-xs {
   font-size: var(--pf-global--FontSize--xs);
 }


### PR DESCRIPTION
The current version is barely readable in the dark theme.

Before:

![image](https://user-images.githubusercontent.com/67428/228215138-36c5bb1c-1c34-40e4-a2ce-eaa2d0805bae.png)

After:

![image](https://user-images.githubusercontent.com/67428/228215185-ba9df52c-0deb-4c66-9691-49fbc98ad574.png)
