### PR TITLE
various: replace mentions of IRC with Matrix

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -350,7 +350,9 @@ unrelated to the commit message.
 Cockpit is a designed project. Anything that the user will see should have
 design done first. This is done on the wiki and mailing list.
 
-Bigger changes need to be discussed on the #cockpit IRC channel or our mailing list
+Bigger changes need to be discussed on the
+[#cockpit:fedoraproject.org](https://matrix.to/#/#cockpit:fedoraproject.org)
+Matrix channel or our mailing list
 [cockpit-devel@lists.fedoraproject.org](https://lists.fedorahosted.org/admin/lists/cockpit-devel.lists.fedorahosted.org/)
 before you invest too much time and energy.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ between these hosts.
 
  * [Making changes to Cockpit](HACKING.md)
  * [How to contribute, developer documentation](https://github.com/cockpit-project/cockpit/wiki/Contributing)
- * IRC Channel: #cockpit on [libera.chat](https://libera.chat/)
+ * Matrix Channel: [#cockpit:fedoraproject.org](https://matrix.to/#/#cockpit:fedoraproject.org)
  * [Mailing List](https://lists.fedorahosted.org/admin/lists/cockpit-devel.lists.fedorahosted.org/)
  * [Guiding Principles](https://cockpit-project.org/ideals.html)
  * [Release Notes](https://cockpit-project.org/blog/category/release.html)


### PR DESCRIPTION
The Cockpit Project is now on Matrix at #cockpit:fedoraproject.org.