### PR TITLE
test: Fix qunit test path and missing pytest-asyncio

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -42,7 +42,7 @@ edit files as you normally would. Building and running tests happens inside the
 toolbox container. If desired, you can install additional packages with
 `sudo dnf install`.
 
-The Cockpit team occasionally refreshes the `tasks` container image. 
+The Cockpit team occasionally refreshes the `tasks` container image.
 To re-create your development container from the latest image, run:
 
     podman pull quay.io/cockpit/tasks
@@ -142,13 +142,13 @@ directory. For QUnit tests (JavaScript), you can run
     ./test-server
 
 which will output a URL to connect to with a browser, such as
-<http://localhost:8765/dist/base1/test-dbus.html>. Adjust the path for different
+<http://localhost:8765/qunit/base1/test-dbus.html>. Adjust the path for different
 tests and inspect the results there.
 
 You can also run individual tests by specifying the `TESTS` environment
 variable:
 
-    make check TESTS=dist/base1/test-chan.html
+    make check TESTS=qunit/base1/test-chan.html
 
 There are also static code and syntax checks which you should run often:
 

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -43,6 +43,7 @@ dependencies="\
     pkg-config \
     python3 \
     python3-mypy \
+    python3-pytest-asyncio \
     python3-pytest-cov \
     python3-pytest-timeout \
     ssh \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,12 +11,12 @@ sbin_PROGRAMS =
 export PYTEST_TIMEOUT = 120
 
 .PHONY: pytest
-pytest: $(BUILT_SOURCES) $(MANIFESTS)
+pytest: $(BUILT_SOURCES) $(DIST_STAMP) $(MANIFESTS)
 	$(MAKE) test-server
 	cd '$(srcdir)' && abs_builddir='$(abs_builddir)' pytest
 
 .PHONY: pytest-cov
-pytest-cov: $(BUILT_SOURCES) $(MANIFESTS)
+pytest-cov: $(BUILT_SOURCES) $(DIST_STAMP) $(MANIFESTS)
 	$(MAKE) test-server
 	cd '$(srcdir)' && abs_builddir='$(abs_builddir)' pytest --cov
 

--- a/src/ws/test-server.c
+++ b/src/ws/test-server.c
@@ -749,7 +749,7 @@ server_ready (void)
       g_print ("**********************************************************************\n"
            "Please connect a supported web browser to\n"
            "\n"
-           " %s/dist/base1/test-dbus.html\n"
+           " %s/qunit/base1/test-dbus.html\n"
            "\n"
            "and check that the test suite passes. Press Ctrl+C to exit.\n"
            "**********************************************************************\n"

--- a/test/pytest/test_browser.py
+++ b/test/pytest/test_browser.py
@@ -17,7 +17,7 @@ XFAIL = {
 }
 
 
-@pytest.mark.parametrize('html', glob.glob('*/test-*.html', root_dir=f'{SRCDIR}/dist'))
+@pytest.mark.parametrize('html', glob.glob('*/test-*.html', root_dir=f'{SRCDIR}/qunit'))
 def test_browser(html):
     if not os.path.exists(f'{BUILDDIR}/test-server'):
         pytest.skip('no test-server')
@@ -34,4 +34,4 @@ def test_browser(html):
     # Merge 2>&1 so that pytest displays an interleaved log
     subprocess.run(['test/common/tap-cdp', f'{BUILDDIR}/test-server',
                     sys.executable, '-m', *coverage, 'cockpit.bridge', '--debug',
-                    f'./dist/{html}'], check=True, stderr=subprocess.STDOUT)
+                    f'./qunit/{html}'], check=True, stderr=subprocess.STDOUT)


### PR DESCRIPTION
Commit 18576f7d18e moved them to /qunit. Adjust the pytest wrapper, documentation and example accordingly. This brings back the HTML tests in the pytest unit test run.

----

Oops! See a [recent pytest-cov run](https://github.com/cockpit-project/cockpit/actions/runs/4551701495/jobs/8026098929?pr=18577#step:4:280), there are no HTML tests.