### PR TITLE
bridge: Restore file owner/permissions in cockpit.file().replace()

### DIFF
--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -188,12 +188,22 @@ class FsReplaceChannel(Channel):
             if self._tag and self._tag != tag_from_path(self._path):
                 raise ChannelError('change-conflict')
 
+            # if the file exists already, keep its permissions
+            try:
+                stat = os.stat(self._path)
+            except FileNotFoundError:
+                pass
+            else:
+                os.chmod(self._temppath, stat.st_mode)
+                os.chown(self._temppath, stat.st_uid, stat.st_gid)
+
             try:
                 os.rename(self._temppath, self._path)
             except OSError:
                 # ensure to not leave the temp file behind
                 self.unlink_temppath()
                 raise
+
             self._tempfile.close()
             self._tempfile = None
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -97,17 +97,20 @@ class TestKeys(MachineCase):
 
         b.wait_in_text("#account-authorized-keys", "no authorized public keys")
 
+        def check_perms():
+            perms = m.execute("getfacl -a /home/user/.ssh")
+            self.assertIn("owner: user", perms)
+
+            perms = m.execute("getfacl -a /home/user/.ssh/authorized_keys")
+            self.assertIn("owner: user", perms)
+            self.assertIn("user::rw-", perms)
+            self.assertIn("group::---", perms)
+            self.assertIn("other::---", perms)
+
         # Adding keys sets permissions properly
         b.wait_text("#account-user-name", "user")
         add_key(KEY, FP_SHA256, "test-name")
-        perms = m.execute("getfacl -a /home/user/.ssh")
-        self.assertIn("owner: user", perms)
-
-        perms = m.execute("getfacl -a /home/user/.ssh/authorized_keys")
-        self.assertIn("owner: user", perms)
-        self.assertIn("user::rw-", perms)
-        self.assertIn("group::---", perms)
-        self.assertIn("other::---", perms)
+        check_perms()
 
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
 
@@ -122,6 +125,8 @@ class TestKeys(MachineCase):
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
         data = m.execute("cat /home/user/.ssh/authorized_keys")
         self.assertEqual(data, KEY + '\n')
+        # Permissions are still ok
+        check_perms()
         b.logout()
 
         # User can still see their keys


### PR DESCRIPTION
If the file already exists, restore its original owner, group, and    
permissions after renaming the temp file. This is still not perfect    
(e.g. SELinux context and xattrs), but at least a whole lot better.    
    
The reported example in issue #11876 was that Cockpit broke the file    
permissions of ~user/.ssh/authorized_keys after removing a key (to    
root:root 0644). Add an explicit integration check for that, as that    
also covers restoring the proper owner.    
    
Fixes #18033