### PR TITLE
pyproject.toml: enable pytest --strict-markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ disable = [
 ]
 
 [tool.pytest.ini_options]
+addopts = ['--strict-markers']  # cf. https://github.com/cockpit-project/cockpit/pull/18584#issuecomment-1490243994
 pythonpath = ["src"]
 testpaths = ["test/pytest"]
 log_cli = true


### PR DESCRIPTION
As discussed in #18584, pytest really should not be ignoring unknown marks.  Let's make sure that gets treated as an error.

 - [x] refresh unit-tests container: [workflow run](https://github.com/cockpit-project/cockpit/actions/runs/4565962519)