### PR TITLE
lib: port cockpit.user to use standard promises

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -2391,29 +2391,25 @@ function factory() {
 
     let the_user = null;
     cockpit.user = function () {
-        const dfd = cockpit.defer();
-        if (!the_user) {
-            const dbus = cockpit.dbus(null, { bus: "internal" });
-            dbus.call("/user", "org.freedesktop.DBus.Properties", "GetAll",
-                      ["cockpit.User"], { type: "s" })
-                .then(([user]) => {
-                    the_user = {
-                        id: user.Id.v,
-                        name: user.Name.v,
-                        full_name: user.Full.v,
-                        groups: user.Groups.v,
-                        home: user.Home.v,
-                        shell: user.Shell.v
-                    };
-                    dfd.resolve(the_user);
-                })
-                .catch(ex => dfd.reject(ex))
-                .finally(() => dbus.close());
-        } else {
-            dfd.resolve(the_user);
-        }
-
-        return dfd.promise;
+            if (!the_user) {
+                const dbus = cockpit.dbus(null, { bus: "internal" });
+                return dbus.call("/user", "org.freedesktop.DBus.Properties", "GetAll",
+                          ["cockpit.User"], { type: "s" })
+                    .then(([user]) => {
+                        the_user = {
+                            id: user.Id.v,
+                            name: user.Name.v,
+                            full_name: user.Full.v,
+                            groups: user.Groups.v,
+                            home: user.Home.v,
+                            shell: user.Shell.v
+                        };
+                        return the_user;
+                    })
+                    .finally(() => dbus.close());
+            } else {
+                return Promise.resolve(the_user);
+            }
     };
 
     /* ------------------------------------------------------------------------

--- a/pkg/lib/hooks.js
+++ b/pkg/lib/hooks.js
@@ -88,7 +88,7 @@ export function usePageLocation() {
 
 const cockpit_user_promise = cockpit.user();
 let cockpit_user = null;
-cockpit_user_promise.then(user => { cockpit_user = user });
+cockpit_user_promise.then(user => { cockpit_user = user }).catch(err => console.log(err));
 
 export function useLoggedInUser() {
     const [user, setUser] = useState(cockpit_user);

--- a/pkg/shell/hosts.jsx
+++ b/pkg/shell/hosts.jsx
@@ -70,7 +70,7 @@ export class CockpitHosts extends React.Component {
     componentDidMount() {
         cockpit.user().then(user => {
             this.setState({ current_user: user.name || "" });
-        });
+        }).catch(exc => console.log(exc));
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {

--- a/pkg/shell/indexes.jsx
+++ b/pkg/shell/indexes.jsx
@@ -97,7 +97,7 @@ function MachinesIndex(index_options, machines, loader) {
     let current_user = "";
     cockpit.user().then(user => {
         current_user = user.name || "";
-    });
+    }).catch(exc => console.log(exc));
 
     /* Navigation */
     let ready = false;


### PR DESCRIPTION
If I understood it correctly, we completely want to drop `cockpit.defer`. This seems a bit tricky in the other cases like the DBusClient and cockpit.http, but seems doable for `cockpit.file` as a start :)

## Warning: this breaks API

We now return a proper Promise instead of an `function`. So this requires some code fixing as with `useEffect` in 1f5724d4e9a707b65279f49fa1bced2dae877f34 and ofcourse we can't use `.done()` or `.fail()`.

I want to land this tomorrow after the release and then on Thursday cockpit-lib-update runs and I can deal with the potential fallout in podman, machines, .etc. 