### PR TITLE
systemd: show multiple dialog errors correctly

### DIFF
--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -21,7 +21,8 @@ import { Card, CardBody, CardTitle } from "@patternfly/react-core/dist/esm/compo
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
-import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { Form, FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { HelperText, HelperTextItem, } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
@@ -288,9 +289,19 @@ const PageSystemInformationChangeHostname = () => {
                     <TextInput id="sich-pretty-hostname" value={pretty} onChange={onPrettyChanged} />
                 </FormGroup>
                 <FormGroup fieldId="sich-hostname" label={_("Real host name")}
-                           helperTextInvalid={error.join("\n")}
-                           validated={error.length ? "error" : "default"}>
-                    <TextInput id="sich-hostname" value={hostname} onChange={onHostnameChanged} />
+                           validated={error.length ? "error" : "default"}
+                           helperTextInvalid={
+                               <FormHelperText isHidden={false} component="div">
+                                   <HelperText>
+                                       {error.map((err, i) =>
+                                           <HelperTextItem key={i} variant="error">
+                                               {err}
+                                           </HelperTextItem>
+                                       )}
+                                   </HelperText>
+                               </FormHelperText>
+                           }>
+                    <TextInput id="sich-hostname" value={hostname} onChange={onHostnameChanged} validated={error.length ? "error" : "default"} />
                 </FormGroup>
             </Form>
         </Modal>


### PR DESCRIPTION
Show multiple errors under each other instead of on the same line using standard PF components.

Old
![image](https://user-images.githubusercontent.com/67428/229136701-7c627254-3b05-47d9-b694-0f749e43e487.png)

New
![image](https://user-images.githubusercontent.com/67428/229163337-a3300e69-ec84-4656-a85f-f77688f62b37.png)
