### PR TITLE
Software Update: Fix output logs printing in one line when failing to load updates in software update page

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1477,27 +1477,18 @@ class OsUpdates extends React.Component {
                     <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
                                      icon={ ExclamationCircleIcon }
                                      paragraph={
-                                         <TextContent>
-                                             <Text component={TextVariants.p}>
-                                                 {_("Please reload the page after resolving the issue.")}
-                                             </Text>
-                                         </TextContent>
+                                         <Text component={TextVariants.p}>
+                                             {_("Please reload the page after resolving the issue.")}
+                                         </Text>
                                      }
                     />
                     <Grid hasGutter>
                         <GridItem span="12" className="error-log">
-                            <ExpandableSection toggleText={_("View error log")} onToggle={() => {
-                                const log = document.getElementById("error-log");
-                                log.scrollTop = log.scrollHeight;
-                            }}>
-                                <div id="error-log" className="error-log-content">
-                                    <CodeBlockCode>
-                                        {this.state.errorMessages
-                                                .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
-                                                .map(m => <span key={m}>{m}</span>)}
-                                    </CodeBlockCode>
-                                </div>
-                            </ExpandableSection>
+                            <CodeBlockCode>
+                                {this.state.errorMessages
+                                        .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                        .map(m => <span key={m}>{m}</span>)}
+                            </CodeBlockCode>
                         </GridItem>
                     </Grid>
                 </div>

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -27,7 +27,7 @@ import { createRoot } from 'react-dom/client';
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
-import { CodeBlockCode, CodeBlock } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
+import { CodeBlock, CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
@@ -1483,7 +1483,7 @@ class OsUpdates extends React.Component {
                                         </TextContent>
                                     }
                     />
-                    <CodeBlock>
+                    <CodeBlock className='pf-u-mx-auto error-log'>
                         <CodeBlockCode>
                             {this.state.errorMessages
                                     .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -43,6 +43,7 @@ import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/inde
 import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
+import { CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
 
 import {
     BugIcon,
@@ -76,7 +77,6 @@ import * as python from "python.js";
 import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
-import { CodeBlockCode } from '@patternfly/react-core';
 
 const _ = cockpit.gettext;
 

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -27,6 +27,7 @@ import { createRoot } from 'react-dom/client';
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
+import { CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
@@ -43,7 +44,6 @@ import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/inde
 import { Stack, StackItem } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
-import { CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
 
 import {
     BugIcon,
@@ -1473,21 +1473,23 @@ class OsUpdates extends React.Component {
             });
 
             return (
-                <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
-                                 icon={ ExclamationCircleIcon }
-                                 paragraph={
-                                     <TextContent>
-                                         <Text component={TextVariants.p}>
-                                             {_("Please resolve the issue and reload this page.")}
-                                         </Text>
-                                         <CodeBlockCode className='error-log'>
-                                             {this.state.errorMessages
-                                                     .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
-                                                     .map(m => <span key={m}>{m}</span>)}
-                                         </CodeBlockCode>
-                                     </TextContent>
-                                 }
-                />
+                <Stack hasGutter>
+                    <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
+                                    icon={ ExclamationCircleIcon }
+                                    paragraph={
+                                        <TextContent>
+                                            <Text component={TextVariants.p}>
+                                                {_("Please resolve the issue and reload this page.")}
+                                            </Text>
+                                        </TextContent>
+                                    }
+                    />
+                    <CodeBlockCode className='error-log'>
+                        {this.state.errorMessages
+                                .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                .map(m => <span key={m}>{m}</span>)}
+                    </CodeBlockCode>
+                </Stack>
             );
 
         case "applying":

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1473,25 +1473,21 @@ class OsUpdates extends React.Component {
             });
 
             return (
-                <div className='update-error-main-view'>
-                    <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
-                                     icon={ ExclamationCircleIcon }
-                                     paragraph={
+                <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
+                                 icon={ ExclamationCircleIcon }
+                                 paragraph={
+                                     <TextContent>
                                          <Text component={TextVariants.p}>
-                                             {_("Please reload the page after resolving the issue.")}
+                                             {_("Please resolve the issue and reload this page.")}
                                          </Text>
-                                     }
-                    />
-                    <Grid hasGutter>
-                        <GridItem span="12" className="error-log">
-                            <CodeBlockCode>
-                                {this.state.errorMessages
-                                        .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
-                                        .map(m => <span key={m}>{m}</span>)}
-                            </CodeBlockCode>
-                        </GridItem>
-                    </Grid>
-                </div>
+                                         <CodeBlockCode className='error-log'>
+                                             {this.state.errorMessages
+                                                     .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                                     .map(m => <span key={m}>{m}</span>)}
+                                         </CodeBlockCode>
+                                     </TextContent>
+                                 }
+                />
             );
 
         case "applying":

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -76,6 +76,7 @@ import * as python from "python.js";
 import callTracerScript from './callTracer.py';
 
 import "./updates.scss";
+import { CodeBlockCode } from '@patternfly/react-core';
 
 const _ = cockpit.gettext;
 
@@ -1472,23 +1473,34 @@ class OsUpdates extends React.Component {
             });
 
             return (
-                <>
+                <div className='update-error-main-view'>
                     <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
                                      icon={ ExclamationCircleIcon }
                                      paragraph={
                                          <TextContent>
-                                             <Text component={TextVariants.p}>
-                                                 {this.state.errorMessages
-                                                         .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
-                                                         .map(m => <span key={m}>{m}</span>)}
-                                             </Text>
                                              <Text component={TextVariants.p}>
                                                  {_("Please reload the page after resolving the issue.")}
                                              </Text>
                                          </TextContent>
                                      }
                     />
-                </>
+                    <Grid hasGutter>
+                        <GridItem span="12" className="error-log">
+                            <ExpandableSection toggleText={_("View error log")} onToggle={() => {
+                                const log = document.getElementById("error-log");
+                                log.scrollTop = log.scrollHeight;
+                            }}>
+                                <div id="error-log" className="error-log-content">
+                                    <CodeBlockCode>
+                                        {this.state.errorMessages
+                                                .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                                .map(m => <span key={m}>{m}</span>)}
+                                    </CodeBlockCode>
+                                </div>
+                            </ExpandableSection>
+                        </GridItem>
+                    </Grid>
+                </div>
             );
 
         case "applying":

--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -27,7 +27,7 @@ import { createRoot } from 'react-dom/client';
 import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { Badge } from "@patternfly/react-core/dist/esm/components/Badge/index.js";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
-import { CodeBlockCode } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
+import { CodeBlockCode, CodeBlock } from "@patternfly/react-core/dist/esm/components/CodeBlock/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
@@ -1471,9 +1471,8 @@ class OsUpdates extends React.Component {
                 type: "error",
                 title: STATE_HEADINGS[this.state.state],
             });
-
             return (
-                <Stack hasGutter>
+                <Stack>
                     <EmptyStatePanel title={ STATE_HEADINGS[this.state.state] }
                                     icon={ ExclamationCircleIcon }
                                     paragraph={
@@ -1484,11 +1483,13 @@ class OsUpdates extends React.Component {
                                         </TextContent>
                                     }
                     />
-                    <CodeBlockCode className='error-log'>
-                        {this.state.errorMessages
-                                .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
-                                .map(m => <span key={m}>{m}</span>)}
-                    </CodeBlockCode>
+                    <CodeBlock>
+                        <CodeBlockCode>
+                            {this.state.errorMessages
+                                    .filter((m, index) => index == 0 || m != this.state.errorMessages[index - 1])
+                                    .map(m => <span key={m}>{m}</span>)}
+                        </CodeBlockCode>
+                    </CodeBlock>
                 </Stack>
             );
 

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -153,6 +153,11 @@ div.changelog {
   }
 }
 
+// prevent overflowo on small screens
+.error-log {
+  max-width: 100%;
+}
+
 .update-log {
   text-align: center;
 

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -153,6 +153,20 @@ div.changelog {
   }
 }
 
+/* Update error view: same styles as of updating view */
+.update-error-main-view {
+  max-width: 60rem;
+  margin: 0 auto;
+}
+
+.error-log {
+  text-align: left;
+
+  .error-log-content {
+    margin: 0 10ex;
+  }
+}
+
 .update-log {
   text-align: center;
 

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -160,11 +160,9 @@ div.changelog {
 }
 
 .error-log {
+  font-size: var(--pf-global--FontSize--sm);
   text-align: left;
-
-  .error-log-content {
-    margin: 0 10ex;
-  }
+  margin: 0 5ex;
 }
 
 .update-log {

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -153,12 +153,6 @@ div.changelog {
   }
 }
 
-/* Update error view: same styles as of updating view */
-.update-error-main-view {
-  max-width: 60rem;
-  margin: 0 auto;
-}
-
 .error-log {
   font-size: var(--pf-global--FontSize--sm);
   text-align: left;

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -154,9 +154,10 @@ div.changelog {
 }
 
 .error-log {
-  font-size: var(--pf-global--FontSize--sm);
-  text-align: left;
-  margin: 0 5ex;
+  margin: 0 auto;
+  padding: 0 3ex;
+  max-width: fit-content;
+  width: 100%;
 }
 
 .update-log {

--- a/pkg/packagekit/updates.scss
+++ b/pkg/packagekit/updates.scss
@@ -153,13 +153,6 @@ div.changelog {
   }
 }
 
-.error-log {
-  margin: 0 auto;
-  padding: 0 3ex;
-  max-width: fit-content;
-  width: 100%;
-}
-
 .update-log {
   text-align: center;
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1036,8 +1036,6 @@ ExecStart=/usr/local/bin/{packageName}
         # error message visible
         b.wait_visible("#app .pf-c-page .pf-c-empty-state__body")
 
-        # self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body .pf-c-content span:first-of-type"),
-        #                  "missing|downloading|not.*available|No such file or directory|download library error")
         self.assertRegex(b.text("#app .pf-c-page .pf-l-stack .pf-c-code-block .pf-c-code-block__content .pf-c-code-block__pre .pf-c-code-block__code span:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory|download library error")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1038,8 +1038,7 @@ ExecStart=/usr/local/bin/{packageName}
 
         # self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body .pf-c-content span:first-of-type"),
         #                  "missing|downloading|not.*available|No such file or directory|download library error")
-
-        self.assertRegex(b.text("#app .pf-c-page .pf-l-stack .pf-c-code-block__pre .pf-c-code-block__code span:first-of-type"),
+        self.assertRegex(b.text("#app .pf-c-page .pf-l-stack .pf-c-code-block .pf-c-code-block__content .pf-c-code-block__pre .pf-c-code-block__code span:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory|download library error")
 
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1036,8 +1036,12 @@ ExecStart=/usr/local/bin/{packageName}
         # error message visible
         b.wait_visible("#app .pf-c-page .pf-c-empty-state__body")
 
-        self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body .pf-c-content span:first-of-type"),
+        # self.assertRegex(b.text("#app .pf-c-page .pf-c-empty-state__body .pf-c-content span:first-of-type"),
+        #                  "missing|downloading|not.*available|No such file or directory|download library error")
+
+        self.assertRegex(b.text("#app .pf-c-page .pf-l-stack .pf-c-code-block__pre .pf-c-code-block__code span:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory|download library error")
+
 
         # not expecting any buttons
         self.assertFalse(b.is_present("#app button"))

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1078,7 +1078,7 @@ ExecStart=/usr/local/bin/{packageName}
         self.allow_journal_messages(".*")
 
         # error message visible
-        b.wait_in_text("#app .pf-c-page .pf-c-empty-state__body", "PackageKit crashed")
+        b.wait_in_text("#app .pf-c-page .pf-l-stack .pf-c-code-block__content", "PackageKit crashed")
 
     @nondestructive
     def testNoPackageKit(self):
@@ -1103,7 +1103,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.login_and_go("/updates")
 
             # error message present
-            b.wait_in_text(".pf-c-page__main-section .pf-c-empty-state__body", "PackageKit is not installed")
+            b.wait_in_text(".pf-c-page__main-section .pf-l-stack .pf-c-code-block__content", "PackageKit is not installed")
 
             # update status on front page should show error
             b.go("/system")
@@ -1143,7 +1143,7 @@ ExecStart=/usr/local/bin/{packageName}
         # but applying updates is not; FIXME: this is a crappy UX
         b.click("#available-updates button#install-all")
         # error message visible
-        b.wait_in_text("#app .pf-c-empty-state__body", "authentication")
+        b.wait_in_text("#app .pf-c-code-block__content", "authentication")
 
         # page adjusts automatically to privilege change
         b.become_superuser()

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1039,7 +1039,6 @@ ExecStart=/usr/local/bin/{packageName}
         self.assertRegex(b.text("#app .pf-c-page .pf-l-stack .pf-c-code-block .pf-c-code-block__content .pf-c-code-block__pre .pf-c-code-block__code span:first-of-type"),
                          "missing|downloading|not.*available|No such file or directory|download library error")
 
-
         # not expecting any buttons
         self.assertFalse(b.is_present("#app button"))
 


### PR DESCRIPTION
Resolves #18581 
Software updates: Output when failing to load updates come in a single line

The updated design follows the [`<ApplyUpdates>` component](https://github.com/cockpit-project/cockpit/blob/891fb8648cb732b4fdf9b93a6e35876eb81fdea0/pkg/packagekit/updates.jsx#L593)'s design to include error logs in a `<CodeBlockCode>` in an `<Expandable>`. 

## File changes
* pkg/packagekit/updates.jsx: 
    * Move logs outside of `<EmptyStatePanel>`'s paragraph to an `<Expandable>` component inside a `<CodeBlockCode>` to correctly print logs on separate lines (the bug), 
    * Move the *'Please reload the page after resolving the issue.'* message above the logs.
* pkg/packagekit/updates.scss:
    * Add class selectors following the styles in `progress-main-view`, `.update-log` and `.update-log-content` as well as include `text-align: left;` for the log output.
    
## Screenshots

Before|After
:---:|:---:
![Single line log on updates error](https://user-images.githubusercontent.com/68462214/228627189-60de8bdd-a1ad-4eb0-8604-a83368c5970f.png)|![Fixed](https://user-images.githubusercontent.com/68462214/229252063-0386cd7d-c10a-45d5-ac0a-004f08453520.png)
