### PR TITLE
modules: update systemd_ctypes

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -159,7 +159,7 @@ class InterfaceCache:
 
 
 def notify_update(notify, path, interface_name, props):
-    notify.setdefault(path, {})[interface_name] = {k: v['v'] for k, v in props.items()}
+    notify.setdefault(path, {})[interface_name] = {k: v.value for k, v in props.items()}
 
 
 class DBusChannel(Channel):

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -20,7 +20,9 @@ import json
 import logging
 import uuid
 
-from typing import Dict, Optional
+from typing import ClassVar, Dict, Optional
+
+from ._vendor import systemd_ctypes
 
 
 logger = logging.getLogger(__name__)
@@ -56,6 +58,7 @@ class CockpitProtocol(asyncio.Protocol):
     We need to use this because Python's SelectorEventLoop doesn't supported
     buffered protocols.
     """
+    json_encoder: ClassVar[json.JSONEncoder] = systemd_ctypes.JSONEncoder(indent=2)
     transport: Optional[asyncio.Transport] = None
     buffer = b''
     _closed: bool = False
@@ -200,7 +203,7 @@ class CockpitProtocol(asyncio.Protocol):
                 del kwargs[name]
 
         logger.debug('sending message %s %s', _channel, kwargs)
-        pretty = json.dumps(kwargs, indent=2) + '\n'
+        pretty = CockpitProtocol.json_encoder.encode(kwargs) + '\n'
         self.write_channel_data(_channel, pretty.encode('utf-8'))
 
     def write_control(self, **kwargs):


### PR DESCRIPTION
The latest version of systemd_ctypes brings in a new approach to D-Bus serialization which is substantially more efficient and somewhat cleaner, but less Cockpit-compatible.

Fortunately, it also includes a new JSONEncoder subclass that knows how to represent the new types ('bytes' instead of base64 encoded text, and 'Variant' instances instead of magic dicts) in the expected JSON format.

On the sending side, the serializer code implicitly supports these magic forms if it sees them, so we don't need any changes there.

<hr/>

Doing this as a separate PR just in case the substantial changes in systemd_ctype have unanticipated side-effects.