### PR TITLE
tests: temporarily disable stratis add block device dialog pixel test

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -155,7 +155,7 @@ class TestStorageStratis(StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val('disks', {dev_3: True})
         # FIXME: Remove ignore when fixed: https://bugzilla.redhat.com/show_bug.cgi?id=2183084
-        b.assert_pixels("#dialog", "add-disk", ignore=[".pf-c-data-list__item-content:contains(stratis)"])
+        # b.assert_pixels("#dialog", "add-disk", ignore=[".pf-c-data-list__item-content:contains(stratis)"])
         self.dialog_apply()
         self.dialog_wait_close()
 


### PR DESCRIPTION
The linked bugzilla [1] makes this dialog very unpredictable.

[1]  https://bugzilla.redhat.com/show_bug.cgi?id=2183084