### PR TITLE
tools: Declare bundled NPM dependencies in spec file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,8 @@ $(srcdir)/package-lock.json: FORCE
 EXTRA_DIST = README.md
 CLEANFILES += cockpit-*.tar.xz
 
-# We override distdir as we want to dist some git-tracked files and dist/ without explicitly listing
+# We override distdir as we want to dist some git-tracked files and dist/ without explicitly listing.
+# The spec also gets patched to declare bundled NPM dependencies.
 EXTRA_DIST += $(EXTRA_FILES)
 distdir: $(DISTFILES)
 	@if [ -e '$(srcdir)/.git' ]; then \
@@ -34,7 +35,7 @@ distdir: $(DISTFILES)
 		mv .extra_dist.tmp '$(srcdir)/.extra_dist'; fi
 	$(MAKE) $(AM_MAKEFLAGS) distdir-am EXTRA_FILES="$$(tr '\n' ' ' < $(srcdir)/.extra_dist) .extra_dist"
 	sed -i "s/[@]VERSION@/$(VERSION)/" "$(distdir)/src/client/org.cockpit_project.CockpitClient.metainfo.xml"
-	sed -i "/^Version:/ s/0/$(VERSION)/" "$(distdir)/tools/cockpit.spec"
+	$(srcdir)/tools/fix-spec $(distdir)/tools/cockpit.spec $(VERSION)
 	sed -i "/^pkgver=/ s/0/$(VERSION)/" "$(distdir)/tools/arch/PKGBUILD"
 	sed -i "1 s/0/$(VERSION)/" "$(distdir)/tools/debian/changelog"
 	cp -r "$(srcdir)/dist" "$(distdir)"

--- a/packit.yaml
+++ b/packit.yaml
@@ -1,10 +1,12 @@
 upstream_project_url: https://github.com/cockpit-project/cockpit
-# HACK: spec must be next to the generated tarball; https://github.com/packit/packit/issues/1621
 specfile_path: cockpit.spec
 actions:
   post-upstream-clone:
-    # HACK: spec must be next to the generated tarball; https://github.com/packit/packit/issues/1621
+    # build patched spec
+    - tools/node-modules make_package_lock_json
     - cp tools/cockpit.spec .
+    # packit will compute and set the version by itself
+    - tools/fix-spec ./cockpit.spec 0
 
   create-archive:
     - tools/make-dist
@@ -16,6 +18,7 @@ srpm_build_deps:
   - glib2-devel
   - make
   - nodejs
+  - npm
   - systemd-devel
 # use the nicely formatted release NEWS from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
@@ -46,11 +49,6 @@ jobs:
     project: "cockpit-preview"
     preserve_project: True
     actions:
-      post-upstream-clone:
-        # HACK: spec must be next to the generated tarball; https://github.com/packit/packit/issues/1621
-        - cp tools/cockpit.spec .
-        # HACK: https://github.com/packit/packit/issues/1560
-        - tools/node-modules checkout
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
       # really should be the default, see https://github.com/packit/packit-service/issues/1505
       create-archive:

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -392,6 +392,8 @@ Provides: cockpit-sosreport = %{version}-%{release}
 Recommends: (reportd if abrt)
 %endif
 
+#NPM_PROVIDES
+
 %description system
 This package contains the Cockpit shell and system configuration interfaces.
 

--- a/tools/fix-spec
+++ b/tools/fix-spec
@@ -1,0 +1,17 @@
+#!/bin/sh
+# patch given spec file to have the correct version and declare bundled NPM dependencies
+# Usage: fix-spec <spec-file> <version>
+set -eu
+
+spec="$1"
+version="$2"
+
+PROVIDES=$(npm ls --omit dev --package-lock-only --depth=Infinity |
+    grep -Eo '[^[:space:]]+@[^[:space:]]+' |
+    sort -u |
+    # only replace the *last* occurrence of @, not e.g. the one in @patternfly/..
+    sed 's/^/Provides: bundled(npm(/; s/\(.*\)@/\1)) = /')
+
+
+awk -v p="$PROVIDES" '/Version/ { gsub(/0/, "'$version'") }; gsub(/#NPM_PROVIDES/, p) 1' "$spec" > "$spec".new
+mv "$spec".new "$spec"


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2180520

We need to get a bit creative for packit: It needs the spec as first    
thing, so build it manually. Share the code in a separate tools/fix-spec    
for that.    
    
Drop the obsolete hack for https://github.com/packit/packit/issues/1560
as that was fixed in packit a while ago.

----

Same approach as in https://github.com/cockpit-project/starter-kit/pull/634 .

```
❱❱❱ rpm -q --provides -p cockpit-system-288.2.20.g7bd6d5159.dirty-1.fc37.noarch.rpm
bundled(npm(@patternfly/patternfly)) = 4.224.4
bundled(npm(@patternfly/react-core)) = 4.276.8
bundled(npm(@patternfly/react-icons)) = 4.93.6
bundled(npm(@patternfly/react-styles)) = 4.92.6
bundled(npm(@patternfly/react-table)) = 4.113.0
bundled(npm(@patternfly/react-tokens)) = 4.94.6
bundled(npm(argparse)) = 1.0.10
bundled(npm(attr-accept)) = 1.1.3
bundled(npm(autolinker)) = 3.16.2
bundled(npm(available-typed-arrays)) = 1.0.5
bundled(npm(call-bind)) = 1.0.2
bundled(npm(commander)) = 7.2.0
bundled(npm(core-js)) = 2.6.12
bundled(npm(deep-equal)) = 2.0.5
bundled(npm(define-properties)) = 1.2.0
bundled(npm(es-get-iterator)) = 1.1.3
bundled(npm(file-selector)) = 0.1.19
bundled(npm(focus-trap)) = 6.9.2
bundled(npm(for-each)) = 0.3.3
bundled(npm(function-bind)) = 1.1.1
bundled(npm(functions-have-names)) = 1.2.3
bundled(npm(get-intrinsic)) = 1.2.0
bundled(npm(globalyzer)) = 0.1.0
bundled(npm(globrex)) = 0.1.2
bundled(npm(gopd)) = 1.0.1
bundled(npm(has)) = 1.0.3
bundled(npm(has-bigints)) = 1.0.2
bundled(npm(has-property-descriptors)) = 1.0.0
bundled(npm(has-symbols)) = 1.0.3
bundled(npm(has-tostringtag)) = 1.0.0
bundled(npm(internal-slot)) = 1.0.5
bundled(npm(is-arguments)) = 1.1.1
bundled(npm(is-bigint)) = 1.0.4
bundled(npm(is-boolean-object)) = 1.1.2
bundled(npm(is-callable)) = 1.2.7
bundled(npm(is-date-object)) = 1.0.5
bundled(npm(is-map)) = 2.0.2
bundled(npm(is-number-object)) = 1.0.7
bundled(npm(is-regex)) = 1.1.4
bundled(npm(is-set)) = 2.0.2
bundled(npm(is-string)) = 1.0.7
bundled(npm(is-symbol)) = 1.0.4
bundled(npm(is-typed-array)) = 1.1.10
bundled(npm(is-weakmap)) = 2.0.1
bundled(npm(is-weakset)) = 2.0.2
bundled(npm(isarray)) = 2.0.5
bundled(npm(js-sha1)) = 0.6.0
bundled(npm(js-sha256)) = 0.9.0
bundled(npm(js-tokens)) = 4.0.0
bundled(npm(json-stable-stringify-without-jsonify)) = 1.0.1
bundled(npm(lodash)) = 4.17.21
bundled(npm(loose-envify)) = 1.4.0
bundled(npm(node-watch)) = 0.7.3
bundled(npm(object-assign)) = 4.1.1
bundled(npm(object-inspect)) = 1.12.3
bundled(npm(object-is)) = 1.1.5
bundled(npm(object-keys)) = 1.1.1
bundled(npm(object.assign)) = 4.1.4
bundled(npm(popper.js)) = 1.16.1
bundled(npm(prop-types)) = 15.8.1
bundled(npm(prop-types-extra)) = 1.1.1
bundled(npm(qunit)) = 2.18.2
bundled(npm(qunit-tap)) = 1.5.1
bundled(npm(react)) = 18.2.0
bundled(npm(react-dom)) = 18.2.0
bundled(npm(react-dropzone)) = 9.0.0
bundled(npm(react-is)) = 16.13.1
bundled(npm(regexp.prototype.flags)) = 1.4.3
bundled(npm(remarkable)) = 2.0.1
bundled(npm(scheduler)) = 0.23.0
bundled(npm(side-channel)) = 1.0.4
bundled(npm(sprintf-js)) = 1.0.3
bundled(npm(stop-iteration-iterator)) = 1.0.0
bundled(npm(tabbable)) = 5.3.3
bundled(npm(throttle-debounce)) = 2.3.0
bundled(npm(tiny-glob)) = 0.2.9
bundled(npm(tippy.js)) = 5.1.2
bundled(npm(tslib)) = 2.5.0
bundled(npm(uuid)) = 7.0.3
bundled(npm(warning)) = 4.0.3
bundled(npm(which-boxed-primitive)) = 1.0.2
bundled(npm(which-collection)) = 1.0.1
bundled(npm(which-typed-array)) = 1.1.9
bundled(npm(xterm)) = 5.1.0
bundled(npm(xterm-addon-canvas)) = 0.3.0
[... plus some other unrelated ones ...]
```

This also shows some noise, e.g. we should move qunit to devDependencies. I'll do that in an independent PR #18599, as it involves a node_modules refresh, and is probably unanimous (while this PR may have some discussion).