### PR TITLE
test: Robustify sos tar reading

### DIFF
--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -98,7 +98,10 @@ only-plugins=release,date,host,cgroups,networking
         subprocess.call(["gpg", "--batch", "--yes", "--passphrase", "foobar",
                          "--output", report, "--decrypt", report_gpg])
         with tarfile.open(report) as tar:
-            tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))
+            # the tarball contains a single subdirectory, get its name
+            names = tar.getnames()
+            topdir = names[0].split("/")[0]
+            tar.getmember(os.path.join(topdir, "etc/os-release"))
 
         b.click("tr:contains(mylabel) button.pf-c-dropdown__toggle")
         b.click("tr:contains(mylabel) li:contains(Delete)")

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import time
 import glob
 import os.path
 import tarfile
@@ -96,19 +95,10 @@ only-plugins=release,date,host,cgroups,networking
 
         # Check that /etc/release was saved. It the files does not exist, getmember raises KeyError
         # Sometimes it takes a bit of time until the file can be opened. Try it 3 times.
-        tries = 0
-        while True:
-            try:
-                subprocess.call(["gpg", "--batch", "--yes", "--passphrase", "foobar",
-                                 "--output", report, "--decrypt", report_gpg])
-                with tarfile.open(report) as tar:
-                    tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))
-                break
-            except Exception as ex:
-                tries += 1
-                if tries > 3 or isinstance(ex, KeyError):
-                    raise ex
-                time.sleep(1)
+        subprocess.call(["gpg", "--batch", "--yes", "--passphrase", "foobar",
+                         "--output", report, "--decrypt", report_gpg])
+        with tarfile.open(report) as tar:
+            tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))
 
         b.click("tr:contains(mylabel) button.pf-c-dropdown__toggle")
         b.click("tr:contains(mylabel) li:contains(Delete)")


### PR DESCRIPTION
In Fedora rawhide, the tarball now does not contain the top-level    
directory as first entry, but an actual file like    
"sosreport-host0-mylabel-2023-04-03-yyffcgw/version.txt". Trying to join    
that with another path is going to fail. Make this more robust by only    
taking the top-level directory name from the first entry.    

---

Cockpit's TF rawhide tests recently [started to fail like this](https://artifacts.dev.testing-farm.io/f817c1df-c135-4967-aca7-dbd5acad1c40/):
```
Traceback (most recent call last):
  File "/var/ARTIFACTS/work-basicp6iwkmif/plans/all/basic/discover/default-0/tests/test/verify/check-sosreport", line 110, in testBasic
    raise ex
  File "/var/ARTIFACTS/work-basicp6iwkmif/plans/all/basic/discover/default-0/tests/test/verify/check-sosreport", line 105, in testBasic
    tar.getmember(os.path.join(tar.getnames()[0], "etc/os-release"))
  File "/usr/lib64/python3.11/tarfile.py", line 1813, in getmember
    raise KeyError("filename %r not found" % name)
KeyError: "filename 'sosreport-host0-mylabel-2023-04-03-yyffcgw/version.txt/etc/os-release' not found"
```

This doesn't reproduce in a local `image-prepare fedora-rawhide` (not even after `dnf update`), but it's very clear what happens.