### PR TITLE
lib: file-autocomplete: Fix descend into directory

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -61,9 +61,13 @@ export class FileAutoComplete extends React.Component {
                     .find(entry => (entry.type == 'directory' && entry.path == path + '/') || (entry.type == 'file' && entry.path == path));
 
             if (match) {
+                // If match file path is a prefix of another file, do not update current directory,
+                // since we cannot tell file/directory user wants to select
+                // https://bugzilla.redhat.com/show_bug.cgi?id=2097662
+                const isPrefix = this.state.displayFiles.filter(entry => entry.path.startsWith(value)).length > 1;
                 // If the inserted string corresponds to a directory listed in the results
                 // update the current directory and refetch results
-                if (match.type == 'directory')
+                if (match.type == 'directory' && !isPrefix)
                     cb(match.path);
                 else
                     this.setState({ value: match.path });

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -565,6 +565,7 @@ OnCalendar=daily
 
         stuff = os.path.join(self.vm_tmpdir, "stuff")
         # prepare a directory for testing file autocomplete widget
+        m.execute(f"mkdir -p {stuff}/dir")
         m.execute(f"mkdir -p {stuff}/dir1")
         m.write(f"{stuff}/file1.txt", "")
 
@@ -575,9 +576,18 @@ OnCalendar=daily
         b.key_press(stuff + "/")
         # need to wait for the widget's "fast typing" inhibition delay to trigger the completion popup
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", stuff + "/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "dir1/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", "dir/")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "dir1/")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "file1.txt")
         b.click("#file-autocomplete-widget li:nth-of-type(2) button")
+
+        # clear the file completion widget
+        b.click("#demo-file-ac div:first-of-type div:first-of-type button:nth-of-type(1)")
+        # test if input matches one entry, but is the prefix of other entry, widget should not descend into directory
+        b.focus("#demo-file-ac input[type=text]")
+        b.key_press(stuff + "/dir")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", stuff + "/dir")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(2) button", stuff + "/dir1")
 
         # clear the file completion widget
         b.click("#demo-file-ac div:first-of-type div:first-of-type button:nth-of-type(1)")
@@ -585,8 +595,8 @@ OnCalendar=daily
         b.focus("#demo-file-ac input[type=text]")
         b.key_press(stuff + "/")
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", stuff + "/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
-        b.click("#file-autocomplete-widget li:nth-of-type(3) button")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "file1.txt")
+        b.click("#file-autocomplete-widget li:nth-of-type(4) button")
         b.wait_not_present("#file-autocomplete-widget li")
 
         # now update file1, check robustness with dynamic events
@@ -598,7 +608,7 @@ OnCalendar=daily
         b.wait_in_text("#file-autocomplete-widget li:nth-of-type(1) button", "file1.txt")
         b.key_press(["\b"] * 4)
         # input is now $stuff/, so all listings should be available
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(3) button", "file1.txt")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "file1.txt")
 
         # add new file
         m.execute(f"touch {stuff}/other")
@@ -610,7 +620,7 @@ OnCalendar=daily
         b.key_press(["\b"] * 6)
         time.sleep(1)
         b.key_press("stuff/")
-        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(4) button", "other")
+        b.wait_in_text("#file-autocomplete-widget li:nth-of-type(5) button", "other")
 
     @skipOstree("No PCP available")
     def testPlots(self):


### PR DESCRIPTION
If FileAutoComplete input matches one entry, but is the prefix of another entry, widget should not descend into directory yet.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2097662

Quick explanation of what bug does this fix:

1. `mkdir /tmp/test; mkdir /tmp/test-1`
2. Type `/tmp/test` into FileAutoComplete

Expected result:
Listed files/directories are /tmp/test and /tmp/test-1

Actual result:
FileAutoComplete descends into /tmp/test and lists file from there