### PR TITLE
run-tests: Fix test EXCLUDE to cover centos-8

### DIFF
--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -118,7 +118,7 @@ if [ "$PLAN" = "basic" ]; then
     # PCI devices list is not predictable
     EXCLUDES="$EXCLUDES TestSystemInfo.testHardwareInfo"
 
-    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ]; then
+    if [ "${TEST_OS#rhel-8}" != "$TEST_OS" ] || [ "${TEST_OS#centos-8}" != "$TEST_OS" ]; then
         # no cockpit-tests package in RHEL 8
         EXCLUDES="$EXCLUDES TestLogin.testSELinuxRestrictedUser"
 


### PR DESCRIPTION
This should fix last failure on https://gitlab.com/redhat/centos-stream/rpms/cockpit/-/merge_requests/46

These tests run on centos-8.