### PR TITLE
shell: feat. add TextBox to compare ssh-keyscan results

### DIFF
--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -33,11 +33,13 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { ClipboardCopy } from "@patternfly/react-core/dist/esm/components/ClipboardCopy/index.js";
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection/index.js";
-import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { Form, FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
+import { TextArea } from "@patternfly/react-core/dist/esm/components/TextArea/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 
@@ -398,6 +400,7 @@ class HostKey extends React.Component {
 
         this.state = {
             inProgress: false,
+            fpValidated: undefined,
             verifyExpanded: false,
             error_options: props.error_options,
         };
@@ -475,7 +478,24 @@ class HostKey extends React.Component {
                 <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-fingerprint pf-v5-u-font-family-monospace">{fp}</ClipboardCopy>
                 <p className="hostkey-type">({key_type})</p>
                 <p>{cockpit.format(_("To verify a fingerprint, run the following on $0 while physically sitting at the machine or through a trusted network:"), this.props.host)}</p>
-                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help-cmds pf-v5-u-font-family-monospace">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</ClipboardCopy>
+                <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help-cmds pf-v5-u-font-family-monospace">{`ssh-keyscan -t ${key_type} localhost | ssh-keygen -lf -`}</ClipboardCopy>
+                <p>{_("Optionally, paste the result below to compare fingerprint")}</p>
+                <Form>
+                    <FormGroup>
+                        <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" placeholder="# localhost:22 SSH-..."
+                                    validated={this.state.fpValidated}
+                                    onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? remote_fp.match(fp) ? "success" : "error" : undefined }) } } />
+                        {this.state.fpValidated && (
+                            <FormHelperText>
+                                <HelperText>
+                                    <HelperTextItem variant={this.state.fpValidated}>
+                                        {this.state.fpValidated == 'success' ? 'Fingerprint matched' : 'Fingerprint not present'}
+                                    </HelperTextItem>
+                                </HelperText>
+                            </FormHelperText>
+                        )}
+                    </FormGroup>
+                </Form>
                 <p>{_("The resulting fingerprint is fine to share via public methods, including email.")}</p>
                 <p>{_("If the fingerprint matches, click 'Trust and add host'. Otherwise, do not connect and contact your administrator.")}</p>
             </>;
@@ -490,9 +510,26 @@ class HostKey extends React.Component {
                                    isExpanded={this.state.verifyExpanded}
                                    onToggle={(_ev, verifyExpanded) => this.setState({ verifyExpanded }) }>
                     <div>{_("Run this command over a trusted network or physically on the remote machine:")}</div>
-                    <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help hostkey-verify-help-cmds pf-v5-u-font-family-monospace">ssh-keyscan -t {key_type} localhost | ssh-keygen -lf -</ClipboardCopy>
+                    <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help hostkey-verify-help-cmds pf-v5-u-font-family-monospace">{`ssh-keyscan -t ${key_type} localhost | ssh-keygen -lf -`}</ClipboardCopy>
                     <div>{_("The fingerprint should match:")} {fingerprint_help}</div>
                     <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help hostkey-fingerprint pf-v5-u-font-family-monospace">{fp}</ClipboardCopy>
+                    <div>{_("Optionally, paste the result below to compare fingerprint")}</div>
+                    <Form>
+                        <FormGroup>
+                            <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" placeholder="# localhost:22 SSH-..."
+                                        validated={this.state.fpValidated}
+                                        onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? remote_fp.match(fp) ? "success" : "error" : undefined }) } } />
+                            {this.state.fpValidated && (
+                                <FormHelperText>
+                                    <HelperText>
+                                        <HelperTextItem variant={this.state.fpValidated}>
+                                            {this.state.fpValidated == 'success' ? 'Fingerprint matched' : 'Fingerprint not present'}
+                                        </HelperTextItem>
+                                    </HelperText>
+                                </FormHelperText>
+                            )}
+                        </FormGroup>
+                    </Form>
                 </ExpandableSection>
                 <Alert variant='warning' isInline isPlain title={_("Malicious pages on a remote machine may affect other connected hosts")} />
             </>;

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -33,8 +33,7 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { ClipboardCopy } from "@patternfly/react-core/dist/esm/components/ClipboardCopy/index.js";
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection/index.js";
-import { Form, FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
-import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
@@ -479,21 +478,12 @@ class HostKey extends React.Component {
                 <p className="hostkey-type">({key_type})</p>
                 <p>{cockpit.format(_("To verify a fingerprint, run the following on $0 while physically sitting at the machine or through a trusted network:"), this.props.host)}</p>
                 <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help-cmds pf-v5-u-font-family-monospace">{`ssh-keyscan -t ${key_type} localhost | ssh-keygen -lf -`}</ClipboardCopy>
-                <p>{_("Optionally, paste the result below to compare fingerprint")}</p>
+                <p>{_("Optionally, paste the result below to compare fingerprints")}</p>
                 <Form>
                     <FormGroup>
-                        <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" placeholder="# localhost:22 SSH-..."
-                                    validated={this.state.fpValidated}
-                                    onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? remote_fp.match(fp) ? "success" : "error" : undefined }) } } />
-                        {this.state.fpValidated && (
-                            <FormHelperText>
-                                <HelperText>
-                                    <HelperTextItem variant={this.state.fpValidated}>
-                                        {this.state.fpValidated == 'success' ? 'Fingerprint matched' : 'Fingerprint not present'}
-                                    </HelperTextItem>
-                                </HelperText>
-                            </FormHelperText>
-                        )}
+                        <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" validated={this.state.fpValidated}
+                                  onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? (remote_fp.match(fp) ? "success" : "error") : undefined }) } } />
+                        {this.state.fpValidated && <FormHelper helperText={_("Fingerprint matches")} helperTextInvalid={_("Fingerprint does not match")} variant={this.state.fpValidated} />}
                     </FormGroup>
                 </Form>
                 <p>{_("The resulting fingerprint is fine to share via public methods, including email.")}</p>
@@ -513,21 +503,12 @@ class HostKey extends React.Component {
                     <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help hostkey-verify-help-cmds pf-v5-u-font-family-monospace">{`ssh-keyscan -t ${key_type} localhost | ssh-keygen -lf -`}</ClipboardCopy>
                     <div>{_("The fingerprint should match:")} {fingerprint_help}</div>
                     <ClipboardCopy isReadOnly hoverTip={_("Copy")} clickTip={_("Copied")} className="hostkey-verify-help hostkey-fingerprint pf-v5-u-font-family-monospace">{fp}</ClipboardCopy>
-                    <div>{_("Optionally, paste the result below to compare fingerprint")}</div>
+                    <div>{_("Optionally, paste the result below to compare fingerprints")}</div>
                     <Form>
                         <FormGroup>
-                            <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" placeholder="# localhost:22 SSH-..."
-                                        validated={this.state.fpValidated}
-                                        onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? remote_fp.match(fp) ? "success" : "error" : undefined }) } } />
-                            {this.state.fpValidated && (
-                                <FormHelperText>
-                                    <HelperText>
-                                        <HelperTextItem variant={this.state.fpValidated}>
-                                            {this.state.fpValidated == 'success' ? 'Fingerprint matched' : 'Fingerprint not present'}
-                                        </HelperTextItem>
-                                    </HelperText>
-                                </FormHelperText>
-                            )}
+                            <TextArea id="command-ssh-keyscan-result-paste" spellCheck="false" validated={this.state.fpValidated}
+                                      onChange={(_ev, remote_fp) => { this.setState({ fpValidated: remote_fp ? (remote_fp.match(fp) ? "success" : "error") : undefined }) } } />
+                            {this.state.fpValidated && <FormHelper helperText={_("Fingerprint matches")} helperTextInvalid={_("Fingerprint does not match")} variant={this.state.fpValidated} />}
                         </FormGroup>
                     </Form>
                 </ExpandableSection>


### PR DESCRIPTION
Closes #17636

Enhancement to the new host key verification front, allowing to paste the results from the ssh-keyscan command to perform quick comparison

- Compares the text with the expected fingerprint for an exact match
- Has validation feedback in the UI

A direct copy paste of the result from the shown command should fully compare and validate

This element is added in the front
![Screenshot_1](https://user-images.githubusercontent.com/39620234/230744258-27f42988-79f0-4156-9cae-79cc49af1811.png)

Example with negative response
![Screenshot_2](https://user-images.githubusercontent.com/39620234/230744584-de412bec-b3bc-4c3e-a26e-8bc8c88e6218.png)

Full view with positive response
![Screenshot_3](https://user-images.githubusercontent.com/39620234/230744590-8e1bb2da-4c17-4690-9aa0-ea8065038c1e.png)