### PR TITLE
packit: Re-add post-upstream-clone to copr_build

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -49,6 +49,13 @@ jobs:
     project: "cockpit-preview"
     preserve_project: True
     actions:
+      # same as the global one, but specifying actions: does not inherit
+      post-upstream-clone:
+        # build patched spec
+        - tools/node-modules make_package_lock_json
+        - cp tools/cockpit.spec .
+        # packit will compute and set the version by itself
+        - tools/fix-spec ./cockpit.spec 0
       # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
       # really should be the default, see https://github.com/packit/packit-service/issues/1505
       create-archive:


### PR DESCRIPTION
In commit 940cc5cd1 I dropped the copr_build's `post-upstream-clone:` action as it became identical to the global one, and I thought it would be inherited. But it turns out that specifying `actions:` replaces the global object entirely. That made release COPR builds fail on missing spec file.

Copy the post-upstream-clone command and add a comment why it's necessary. We'll have to keep this until
https://github.com/packit/packit-service/issues/1505 gets fixed.

----

See the recent srpm build failure from release 289: https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/build/5745838/