### PR TITLE
users: Retain authorized_keys file permissions

### DIFF
--- a/pkg/users/authorized-keys.js
+++ b/pkg/users/authorized-keys.js
@@ -114,24 +114,12 @@ function AuthorizedKeys (user_name, home_dir) {
                 });
     };
 
-    self.remove_key = function(key) {
-        return file.modify(function(content) {
-            let lines = null;
-            const new_lines = [];
-
-            if (!content)
-                return "";
-
-            lines = content.trim().split('\n');
-            for (let i = 0; i < lines.length; i++) {
-                if (lines[i] === key)
-                    key = undefined;
-                else
-                    new_lines.push(lines[i]);
-            }
-            return new_lines.join("\n");
-        });
-    };
+    // don't use cockpit.file.modify() here, as that doesn't preserve permissions
+    // (https://github.com/cockpit-project/cockpit/issues/18033)
+    self.remove_key = key => cockpit.spawn(
+        ["sed", "-i", "\\!^" + key + "$!d", filename],
+        { superuser: "try", err: "message" }
+    );
 
     self.close = function() {
         if (watch)

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -37,18 +37,8 @@ class TestKeys(MachineCase):
         m.execute("useradd user -s /bin/bash -m -c User")
         m.execute("echo user:foobar | chpasswd")
 
-        m.start_cockpit()
-
-        def login(user, password):
-            b.open("/system")
-            b.wait_visible("#login")
-            b.set_val("#login-user-input", user)
-            b.set_val("#login-password-input", password)
-            b.click('#login-button')
-            b.enter_page("/system")
-
-            b.go("/users#/" + user)
-            b.enter_page("/users")
+        def login(user):
+            self.login_and_go("/users#/" + user, user=user, superuser=False)
             b.wait_text("#account-user-name", user)
 
         def add_key(key, fp_sh256, comment):
@@ -66,7 +56,7 @@ class TestKeys(MachineCase):
             self.assertIn(fp_sh256, text)
 
         # no keys
-        login("user", "foobar")
+        login("user")
         b.wait_in_text("#account-authorized-keys", "no authorized public keys")
 
         # add bad
@@ -96,7 +86,7 @@ class TestKeys(MachineCase):
         self.assertNotIn(".ssh", m.execute("ls /home/user"))
 
         # Log in as admin
-        login("admin", "foobar")
+        login("admin")
         b.go("#/user")
 
         if "ubuntu" not in m.image and "debian" not in m.image:
@@ -135,7 +125,7 @@ class TestKeys(MachineCase):
         b.logout()
 
         # User can still see their keys
-        login("user", "foobar")
+        login("user")
         b.wait_in_text("#account-authorized-keys-list tr:first-child", "test-name")
 
         b.click("#account-authorized-keys-list tr:first-child button")

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -97,17 +97,20 @@ class TestKeys(MachineCase):
 
         b.wait_in_text("#account-authorized-keys", "no authorized public keys")
 
+        def check_perms():
+            perms = m.execute("getfacl -a /home/user/.ssh")
+            self.assertIn("owner: user", perms)
+
+            perms = m.execute("getfacl -a /home/user/.ssh/authorized_keys")
+            self.assertIn("owner: user", perms)
+            self.assertIn("user::rw-", perms)
+            self.assertIn("group::---", perms)
+            self.assertIn("other::---", perms)
+
         # Adding keys sets permissions properly
         b.wait_text("#account-user-name", "user")
         add_key(KEY, FP_SHA256, "test-name")
-        perms = m.execute("getfacl -a /home/user/.ssh")
-        self.assertIn("owner: user", perms)
-
-        perms = m.execute("getfacl -a /home/user/.ssh/authorized_keys")
-        self.assertIn("owner: user", perms)
-        self.assertIn("user::rw-", perms)
-        self.assertIn("group::---", perms)
-        self.assertIn("other::---", perms)
+        check_perms()
 
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
 
@@ -121,7 +124,9 @@ class TestKeys(MachineCase):
         b.wait_not_in_text("#account-authorized-keys", "Invalid key")
         b.wait_js_func("ph_count_check", "#account-authorized-keys-list tr", 1)
         data = m.execute("cat /home/user/.ssh/authorized_keys")
-        self.assertEqual(data, KEY + '\n')
+        self.assertEqual(data, KEY + "\n\n")
+        # Permissions are still ok
+        check_perms()
         b.logout()
 
         # User can still see their keys


### PR DESCRIPTION
cockpit.file().replace() creates an entirely new file with root:root    
permissions, which completely breaks a user's ~/.ssh/authorized_keys    
file when removing a key.    
    
Until we have a more powerful file API, use `sed -i` instead, which    
keeps file permissions of existing files. This doesn't automagically    
remove empty lines, so adjust the integration test to expect the extra    
empty line that it added a few lines up.    
    
Fixes #11876    