### PR TITLE
Stop using pf-global--FontWeight--semi-bold as this is not existing i…

### DIFF
--- a/pkg/lib/cockpit-components-table.scss
+++ b/pkg/lib/cockpit-components-table.scss
@@ -77,7 +77,7 @@
   // Use PF4 style headings
   > thead th {
     font-size: var(--pf-global--FontSize--sm);
-    font-weight: var(--pf-global--FontWeight--semi-bold);
+    font-weight: var(--pf-global--FontWeight--bold);
   }
 
   // Adjust the padding for nested ct-tables in ct-tables

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -92,7 +92,7 @@
     border: none;
     font-size: var(--pf-global--FontSize--md);
     font-family: var(--pf-global--FontFamily--heading--sans-serif);
-    font-weight: var(--pf-global--FontWeight--semi-bold);
+    font-weight: var(--pf-global--FontWeight--bold);
     padding: var(--pf-global--spacer--lg) var(--pf-global--spacer--lg) var(--pf-global--spacer--sm);
   }
 }


### PR DESCRIPTION
…n PF-v5

Use the bold variant which is the same:
https://github.com/patternfly/patternfly/blob/main/src/patternfly/sass-utilities/scss-variables.scss#L227