### PR TITLE
test: Skip "medium" layout for basic networking test

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -60,7 +60,8 @@ class TestNetworkingBasic(NetworkCase):
                 ".cockpit-log-panel .pf-c-card__body",
                 "#networking-firewall-summary .pf-c-card__body",
             ],
-            skip_layouts=['mobile', 'rtl']
+            # IPv6 addresses vary wildly, and their different rendered widths change the column widths
+            skip_layouts=['medium', 'mobile', 'rtl']
         )
 
         # Details of test iface


### PR DESCRIPTION
This dialog is too unstable -- each Fedora 37 refresh now seems to change the IPv6 address pattern and thus changes the column widths. We recently changed it in commit 2e9d91dc2f already, and the refresh in https://github.com/cockpit-project/bots/pull/4639 changes it again.