### PR TITLE
test: Ignore timedatex.service disconnection messages

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1712,6 +1712,9 @@ class MachineCase(unittest.TestCase):
         "pcp-archive: no such metric: .*: Unknown metric name",
         "pcp-archive: instance name lookup failed:.*",
         "pcp-archive: couldn't create pcp archive context for.*",
+
+        # timedatex.service shuts down after timeout, runs into race condition with property watching
+        ".*org.freedesktop.timedate1: couldn't get all properties.*Error:org.freedesktop.DBus.Error.NoReply.*",
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")


### PR DESCRIPTION
`timedatex.service` shuts down on inactivity. The overview page has a proxy on the systemd service object to watch for property changes, which will trigger a NoReply error on the proxy occasionally.

Adding this to dbus_error_matches_unknown() would hide actually interesting errors when a service crashes in the middle; so let's not do that, and ignore that message instead.

----

Seen [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18638-20230414-105408-16960b15-rhel-8-9/log.html#332) and it also broke the recent RHEL gating update for the same reason.

This is a rather lame change, but I don't really have a better idea.