### PR TITLE
lib: Remove PF override for svg's vertical-align

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -62,13 +62,6 @@ select.pf-c-form-control {
   }
 }
 
-/* All SVGs used in PF4 have some inline style to align them
- * https://github.com/patternfly/patternfly-react/issues/4767
- */
-svg {
-  vertical-align: -0.125em;
-}
-
 // The default gap between the rows in horizontal lists is too large
 .pf-c-description-list.pf-m-horizontal-on-sm,
 .pf-c-description-list.pf-m-horizontal {


### PR DESCRIPTION
This override used to fix [patternfly issue](https://github.com/patternfly/patternfly-react/issues/4767
), where svg icons were sometimes missing vertical-align, and then appearing too high. 
It seems that it has been fixed in PF, and now we have opposite issue that icons appear too low:
![Screenshot from 2023-04-14 13-33-51](https://user-images.githubusercontent.com/42733240/232033853-c6d8a418-3262-4fa1-8d47-e9c2ad626e06.png)
![Screenshot from 2023-04-14 13-32-01](https://user-images.githubusercontent.com/42733240/232033861-ee4a34c8-8962-471f-a52d-90bf8716ab1e.png)
