### PR TITLE
Port to new way of using HelperText

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -24,7 +24,6 @@ import React, { useEffect, useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Card, CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
-import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-circle-icon';
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup, FormSection } from "@patternfly/react-core/dist/esm/components/Form/index.js";
@@ -42,6 +41,7 @@ import { OutlinedQuestionCircleIcon } from "@patternfly/react-icons";
 
 import { useDialogs, DialogsContext } from "dialogs.jsx";
 import { show_modal_dialog } from "cockpit-components-dialog.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 
 const _ = cockpit.gettext;
@@ -212,14 +212,12 @@ const KdumpSettingsModal = ({ settings, initialTarget, handleSave }) => {
                                        onChange={setServer} isRequired />
                         </FormGroup>
 
-                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("SSH key")}
-                                   helperTextInvalid={validationErrors.sshkey}
-                                   helperTextInvalidIcon={<ExclamationCircleIcon />}
-                                   validated={validationErrors.sshkey ? "error" : "default"}>
+                        <FormGroup fieldId="kdump-settings-ssh-key" label={_("SSH key")}>
                             <TextInput id="kdump-settings-ssh-key" key="ssh"
                                        placeholder="/root/.ssh/kdump_id_rsa" value={sshkey}
                                        onChange={changeSSHKey}
                                        validated={validationErrors.sshkey ? "error" : "default"} />
+                            <FormHelper helperTextInvalid={validationErrors.sshkey} />
                         </FormGroup>
 
                         <FormGroup fieldId="kdump-settings-ssh-directory" label={_("Directory")} isRequired>

--- a/pkg/lib/cockpit-components-form-helper.jsx
+++ b/pkg/lib/cockpit-components-form-helper.jsx
@@ -1,0 +1,45 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from "react";
+
+import { FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText";
+
+export const FormHelper = ({ helperText, helperTextInvalid, variant, icon, fieldId }) => {
+    const formHelperVariant = variant || (helperTextInvalid ? "error" : "default");
+
+    if (!(helperText || helperTextInvalid))
+        return null;
+
+    // FIXME: isHidden still adds some padding which is desired so that the form elements don't move when validation text appears
+    // Fix this seperately to avoid breaking pixe tests
+    return (
+        <FormHelperText isHidden={false}>
+            <HelperText>
+                <HelperTextItem
+                    id={fieldId ? (fieldId + "-helper") : undefined}
+                    variant={formHelperVariant}
+                    hasIcon={formHelperVariant !== "default" || icon} icon={icon}>
+                    {formHelperVariant === "error" ? helperTextInvalid : helperText}
+                </HelperTextItem>
+            </HelperText>
+        </FormHelperText>
+    );
+};

--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -25,6 +25,8 @@ import { Progress, ProgressMeasureLocation, ProgressSize } from "@patternfly/rea
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { HelpIcon } from '@patternfly/react-icons';
 
+import { FormHelper } from "cockpit-components-form-helper";
+
 import './cockpit-components-password.scss';
 
 const _ = cockpit.gettext;
@@ -127,12 +129,11 @@ export const PasswordFormFields = ({
             </FormGroup>
 
             {password_confirm_label && <FormGroup label={password_confirm_label}
-                       helperTextInvalid={error_password_confirm}
-                       validated={error_password_confirm ? "error" : "default"}
                        id={idPrefix + "-pw2-group"}
                        fieldId={idPrefix + "-pw2"}>
                 <TextInput type="password" id={idPrefix + "-pw2"} autoComplete="new-password"
                            value={passwordConfirm} onChange={value => { setConfirmPassword(value); change("password_confirm", value) }} />
+                <FormHelper fieldId={idPrefix + "-pw2"} helperTextInvalid={error_password_confirm} />
             </FormGroup>}
         </>
     );

--- a/pkg/lib/cockpit-components-shutdown.jsx
+++ b/pkg/lib/cockpit-components-shutdown.jsx
@@ -33,6 +33,7 @@ import { TimePicker } from "@patternfly/react-core/dist/esm/components/TimePicke
 import { ServerTime } from 'serverTime.js';
 import * as timeformat from "timeformat.js";
 import { DialogsContext } from "dialogs.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 
 import "cockpit-components-shutdown.scss";
 
@@ -197,9 +198,7 @@ export class ShutdownModal extends React.Component {
                         <FormGroup fieldId="message" label={_("Message to logged in users")}>
                             <TextArea id="message" resizeOrientation="vertical" value={this.state.message} onChange={v => this.setState({ message: v })} />
                         </FormGroup>
-                        <FormGroup fieldId="delay" label={_("Delay")}
-                                   helperTextInvalid={this.state.dateError}
-                                   validated={this.state.dateError ? "error" : "default"}>
+                        <FormGroup fieldId="delay" label={_("Delay")}>
                             <Flex className="shutdown-delay-group" alignItems={{ default: 'alignItemsCenter' }}>
                                 <Select toggleId="delay" isOpen={this.state.isOpen} selections={this.state.selected}
                                         isDisabled={!this.state.formFilled}
@@ -234,6 +233,7 @@ export class ShutdownModal extends React.Component {
                                                 onChange={(_, time, h, m) => this.updateTime(time, h, m) } />
                                 </>}
                             </Flex>
+                            <FormHelper fieldId="delay" helperTextInvalid={this.state.dateError} />
                         </FormGroup>
                     </Form>
                     {this.state.error && <Alert isInline variant='danger' title={this.state.error} />}

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -41,6 +41,7 @@ import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import firewall from "./firewall-client.js";
+import { FormHelper } from "cockpit-components-form-helper";
 import { ListingTable } from 'cockpit-components-table.jsx';
 import { ModalError } from "cockpit-components-inline-notification.jsx";
 import { EmptyStatePanel } from "cockpit-components-empty-state.jsx";
@@ -673,31 +674,28 @@ class AddEditServicesModal extends React.Component {
                     }
                     { !this.state.custom ||
                         <>
-                            <FormGroup label="TCP"
-                                       validated={this.state.tcp_error ? "error" : "default"}
-                                       helperText={_("Comma-separated ports, ranges, and services are accepted")}
-                                       helperTextInvalid={this.state.tcp_error}>
+                            <FormGroup label="TCP">
                                 <TextInput id="tcp-ports" type="text" onChange={this.validate}
                                            validated={this.state.tcp_error ? "error" : "default"}
                                            isDisabled={this.state.avail_services == null}
                                            value={this.state.custom_tcp_value}
                                            placeholder={_("Example: 22,ssh,8080,5900-5910")} />
+                                <FormHelper helperTextInvalid={this.state.tcp_error} helperText={_("Comma-separated ports, ranges, and services are accepted")} />
                             </FormGroup>
 
-                            <FormGroup label="UDP"
-                                       validated={this.state.udp_error ? "error" : "default"}
-                                       helperText={_("Comma-separated ports, ranges, and services are accepted")}
-                                       helperTextInvalid={this.state.udp_error}>
+                            <FormGroup label="UDP">
                                 <TextInput id="udp-ports" type="text" onChange={this.validate}
                                            validated={this.state.udp_error ? "error" : "default"}
                                            isDisabled={this.state.avail_services == null}
                                            value={this.state.custom_udp_value}
                                            placeholder={_("Example: 88,2019,nfs,rsync")} />
+                                <FormHelper helperTextInvalid={this.state.udp_error} helperText={_("Comma-separated ports, ranges, and services are accepted")} />
                             </FormGroup>
 
-                            <FormGroup label={_("ID")} helperText={_("If left empty, ID will be generated based on associated port services and port numbers")}>
+                            <FormGroup label={_("ID")}>
                                 <TextInput id="service-name" onChange={this.setId} isDisabled={!!this.props.custom_id || this.state.avail_services == null}
                                            value={this.state.custom_id} />
+                                <FormHelper helperText={_("If left empty, ID will be generated based on associated port services and port numbers")} />
                             </FormGroup>
 
                             <FormGroup label={_("Description")}>
@@ -854,7 +852,7 @@ class ActivateZoneModal extends React.Component {
                         <div id="add-zone-services-readonly">
                             { (this.state.zone && firewall.zones[this.state.zone].services.join(", ")) || _("None") }
                         </div>
-                        <FormHelperText isHidden={false}>{_("The cockpit service is automatically included")}</FormHelperText>
+                        <FormHelper helperText={_("The cockpit service is automatically included")} />
                     </FormGroup>
 
                     <FormGroup label={ _("Interfaces") } hasNoPaddingTop isInline>

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -38,6 +38,7 @@ import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
+import { FormHelper } from "cockpit-components-form-helper";
 import { ModalError } from "cockpit-components-inline-notification.jsx";
 
 const _ = cockpit.gettext;
@@ -247,18 +248,19 @@ class AddMachine extends React.Component {
         const submitText = this.state.old_machine ? _("Set") : _("Add");
 
         const body = <Form isHorizontal>
-            <FormGroup label={_("Host")} helperText={_("Can be a hostname, IP address, alias name, or ssh:// URI")}
-                validated={this.state.addressError ? "error" : "default"} helperTextInvalid={this.state.addressError}>
+            <FormGroup label={_("Host")}>
                 <TextInput id="add-machine-address" onChange={address => this.setState({ address })}
                         validated={this.state.addressError ? "error" : "default"} onBlur={this.onAddressChange}
                         isDisabled={this.props.old_address === "localhost"} list="options" value={this.state.address} />
                 <datalist id="options">
                     {invisible.map(a => <option key={a} value={a} />)}
                 </datalist>
+                <FormHelper helperTextInvalid={this.state.addressError} helperText={_("Can be a hostname, IP address, alias name, or ssh:// URI")} />
             </FormGroup>
-            <FormGroup label={_("User name")} helperText={_("When empty, connect with the current user")}>
+            <FormGroup label={_("User name")}>
                 <TextInput id="add-machine-user" onChange={value => this.setState({ user: value, userChanged: true })}
                         isDisabled={this.props.old_address === "localhost"} value={this.state.user} />
+                <FormHelper helperText={_("When empty, connect with the current user")} />
             </FormGroup>
             <FormGroup label={_("Color")}>
                 <input type="color" value={this.state.color} onChange={e => this.setState({ color: e.target.value }) } />
@@ -779,13 +781,15 @@ class ChangeAuth extends React.Component {
                 auto_text = _("Create a new SSH key and authorize it");
                 auto_details = <>
                     <p>{cockpit.format(_("A new SSH key at $0 will be created for $1 on $2 and it will be added to the $3 file of $4 on $5."), key, luser, lhost, afile, ruser, rhost)}</p>
-                    <FormGroup label={_("Key password")} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password_error}>
+                    <FormGroup label={_("Key password")}>
                         <TextInput id="login-setup-new-key-password" onChange={value => this.setState({ login_setup_new_key_password: value })}
                                 type="password" value={this.state.login_setup_new_key_password} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} />
+                        <FormHelper helperTextInvalid={this.state.login_setup_new_key_password_error} />
                     </FormGroup>
-                    <FormGroup label={_("Confirm key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password2_error}>
+                    <FormGroup label={_("Confirm key password")}>
                         <TextInput id="login-setup-new-key-password2" onChange={value => this.setState({ login_setup_new_key_password2: value })}
                                 type="password" value={this.state.login_setup_new_key_password2} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} />
+                        <FormHelper helperTextInvalid={this.state.login_setup_new_key_password2_error} />
                     </FormGroup>
                     <p>{cockpit.format(_("In order to allow log in to $0 as $1 without password in the future, use the login password of $2 on $3 as the key password, or leave the key password blank."), rhost, ruser, luser, lhost)}</p>
                 </>;
@@ -793,13 +797,16 @@ class ChangeAuth extends React.Component {
                 auto_text = cockpit.format(_("Change the password of $0"), key);
                 auto_details = <>
                     <p>{cockpit.format(_("By changing the password of the SSH key $0 to the login password of $1 on $2, the key will be automatically made available and you can log in to $3 without password in the future."), key, luser, lhost, afile, rhost)}</p>
-                    <FormGroup label={_("New key password")} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password_error}>
+                    <FormGroup label={_("New key password")}>
                         <TextInput id="login-setup-new-key-password" onChange={value => this.setState({ login_setup_new_key_password: value })}
                                 type="password" value={this.state.login_setup_new_key_password} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} />
+                        <FormHelper helperTextInvalid={this.state.login_setup_new_key_password_error} />
                     </FormGroup>
                     <FormGroup label={_("Confirm new key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password2_error}>
                         <TextInput id="login-setup-new-key-password2" onChange={value => this.setState({ login_setup_new_key_password2: value })}
                                 type="password" value={this.state.login_setup_new_key_password2} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} />
+
+                        <FormHelper helperTextInvalid={this.state.login_setup_new_key_password2_error} />
                     </FormGroup>
                     <p>{cockpit.format(_("In order to allow log in to $0 as $1 without password in the future, use the login password of $2 on $3 as the key password, or leave the key password blank."), rhost, ruser, luser, lhost)}</p>
                 </>;
@@ -832,15 +839,19 @@ class ChangeAuth extends React.Component {
                         </FormGroup>
                     }
                     {((both && this.state.auth === "password") || (!both && offer_login_password)) &&
-                        <FormGroup label={_("Password")} validated={this.state.custom_password_error ? "error" : "default"} helperTextInvalid={this.state.custom_password_error}>
+                        <FormGroup label={_("Password")}>
                             <TextInput id="login-custom-password" onChange={value => this.setState({ custom_password: value })}
                                        type="password" value={this.state.custom_password} validated={this.state.custom_password_error ? "error" : "default"} />
+                            <FormHelper helperTextInvalid={this.state.custom_password_error} />
                         </FormGroup>
                     }
                     {((both && this.state.auth === "key") || (!both && offer_key_password)) &&
-                        <FormGroup label={_("Key password")} helperText={cockpit.format(_("The SSH key $0 will be made available for the remainder of the session and will be available for login to other hosts as well."), this.state.identity_path)} validated={this.state.locked_identity_password_error ? "error" : "default"} helperTextInvalid={this.state.locked_identity_password_error}>
+                        <FormGroup label={_("Key password")}>
                             <TextInput id="locked-identity-password" onChange={value => this.setState({ locked_identity_password: value })}
                                     type="password" autoComplete="new-password" value={this.state.locked_identity_password} validated={this.state.locked_identity_password_error ? "error" : "default"} />
+                            <FormHelper
+                                helperText={cockpit.format(_("The SSH key $0 will be made available for the remainder of the session and will be available for login to other hosts as well."), this.state.identity_path)}
+                                helperTextInvalid={this.state.locked_identity_password_error} />
                         </FormGroup>
                     }
                     {offer_key_setup &&

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -53,6 +53,7 @@ import { SuperuserButton } from "../shell/superuser.jsx";
 import { fmt_to_fragments } from "utils.jsx";
 import * as timeformat from "timeformat";
 import { WithDialogs, useDialogs } from "dialogs.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 
 const _ = cockpit.gettext;
 
@@ -304,8 +305,7 @@ const SOSDialog = () => {
             <FormGroup label={_("Report label")}>
                 <TextInput id="sos-dialog-ti-1" value={label} onChange={setLabel} />
             </FormGroup>
-            <FormGroup label={_("Encryption passphrase")}
-                       helperText={_("Leave empty to skip encryption")}>
+            <FormGroup label={_("Encryption passphrase")}>
                 <InputGroup>
                     <TextInput type={showPassphrase ? "text" : "password"} value={passphrase} onChange={setPassphrase}
                                id="sos-dialog-ti-2" autoComplete="new-password" />
@@ -313,6 +313,7 @@ const SOSDialog = () => {
                         { showPassphrase ? <EyeSlashIcon /> : <EyeIcon /> }
                     </Button>
                 </InputGroup>
+                <FormHelper helperText={_("Leave empty to skip encryption")} />
             </FormGroup>
             <FormGroup label={_("Options")} hasNoPaddingTop>
                 <Checkbox label={_("Obfuscate network addresses, hostnames, and usernames")}

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -237,6 +237,7 @@ import { ExclamationTriangleIcon, InfoIcon, HelpIcon } from "@patternfly/react-i
 
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 
 import { fmt_size, block_name, format_size_and_text, format_delay, for_each_async } from "./utils.js";
 import { fmt_to_fragments } from "utils.jsx";
@@ -284,18 +285,18 @@ const Row = ({ field, values, errors, onChange }) => {
                 </>
             );
         return (
-            <FormGroup label={titleLabel} validated={validated}
-                       helperTextInvalid={error} helperText={explanation} hasNoPaddingTop={field.hasNoPaddingTop}>
+            <FormGroup label={titleLabel} hasNoPaddingTop={field.hasNoPaddingTop}>
                 { field_elts }
                 { nested_elts }
+                <FormHelper helperText={explanation} helperTextInvalid={validated && error} />
             </FormGroup>
         );
     } else if (!field.bare) {
         return (
-            <FormGroup validated={validated}
-                       helperTextInvalid={error} helperText={explanation} hasNoPaddingTop={field.hasNoPaddingTop}>
+            <FormGroup validated={validated} hasNoPaddingTop={field.hasNoPaddingTop}>
                 { field_elts }
                 { nested_elts }
+                <FormHelper helperText={explanation} helperTextInvalid={validated && error} />
             </FormGroup>
         );
     } else

--- a/pkg/systemd/overview-cards/configurationCard.jsx
+++ b/pkg/systemd/overview-cards/configurationCard.jsx
@@ -288,20 +288,17 @@ const PageSystemInformationChangeHostname = () => {
                 <FormGroup fieldId="sich-pretty-hostname" label={_("Pretty host name")}>
                     <TextInput id="sich-pretty-hostname" value={pretty} onChange={onPrettyChanged} />
                 </FormGroup>
-                <FormGroup fieldId="sich-hostname" label={_("Real host name")}
-                           validated={error.length ? "error" : "default"}
-                           helperTextInvalid={
-                               <FormHelperText isHidden={false} component="div">
-                                   <HelperText>
-                                       {error.map((err, i) =>
-                                           <HelperTextItem key={i} variant="error">
-                                               {err}
-                                           </HelperTextItem>
-                                       )}
-                                   </HelperText>
-                               </FormHelperText>
-                           }>
+                <FormGroup fieldId="sich-hostname" label={_("Real host name")}>
                     <TextInput id="sich-hostname" value={hostname} onChange={onHostnameChanged} validated={error.length ? "error" : "default"} />
+                    <FormHelperText isHidden={error.length == 0} component="div">
+                        <HelperText>
+                            {error.map((err, i) =>
+                                <HelperTextItem key={i} variant="error">
+                                    {err}
+                                </HelperTextItem>
+                            )}
+                        </HelperText>
+                    </FormHelperText>
                 </FormGroup>
             </Form>
         </Modal>

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -33,6 +33,7 @@ import cockpit from "cockpit";
 import { Privileged } from "cockpit-components-privileged.jsx";
 import { superuser } from "superuser";
 import { useEvent } from "hooks.js";
+import { FormHelper } from "cockpit-components-form-helper";
 import { install_dialog } from "cockpit-components-install-dialog.jsx";
 import * as packagekit from "packagekit.js";
 import { useDialogs } from "dialogs.jsx";
@@ -421,9 +422,7 @@ const JoinDialog = ({ realmd_client }) => {
                }
                title={ _("dialog-title", "Join a domain") }>
             <Form isHorizontal onSubmit={onJoin}>
-                <FormGroup label={ _("Domain address") } fieldId="realms-op-address" validated={addressValid}
-                           helperText={domainHelperText} helperTextInvalid={domainHelperText}
-                           helperTextIcon={domainHelperIcon} helperTextInvalidIcon={domainHelperIcon}>
+                <FormGroup label={ _("Domain address") } fieldId="realms-op-address" validated={addressValid}>
                     <TextInput id="realms-op-address" placeholder="domain.example.com"
                                data-discover={ (!addressValid || addressValid == "default") ? null : "done" }
                                value={address} onChange={validateAddress} isDisabled={pending} />
@@ -435,6 +434,7 @@ const JoinDialog = ({ realmd_client }) => {
                 <FormGroup label={ _("Domain administrator password") } fieldId="realms-op-admin-password">
                     <TextInput id="realms-op-admin-password" type="password" value={adminPassword} onChange={setAdminPassword} isDisabled={pending} />
                 </FormGroup>
+                <FormHelper fieldId="realms-op-address" helperText={domainHelperText} helperTextInvalid={addressValid == "error" && domainHelperText} icon={domainHelperIcon} />
             </Form>
         </Modal>);
 };

--- a/pkg/systemd/timer-dialog.jsx
+++ b/pkg/systemd/timer-dialog.jsx
@@ -31,6 +31,7 @@ import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/
 import { TimePicker } from "@patternfly/react-core/dist/esm/components/TimePicker/index.js";
 import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
 
+import { FormHelper } from "cockpit-components-form-helper";
 import { ModalError } from 'cockpit-components-inline-notification.jsx';
 import { useDialogs } from "dialogs.jsx";
 
@@ -154,31 +155,30 @@ const CreateTimerDialogBody = ({ owner }) => {
             {dialogError && <ModalError dialogError={_("Timer creation failed")} dialogErrorDetail={dialogError} />}
             <Form isHorizontal onSubmit={onSubmit}>
                 <FormGroup label={_("Name")}
-                           fieldId="servicename"
-                           validated={submitted && validationFailed.name ? "error" : "default"}
-                           helperTextInvalid={!name.trim().length ? _("This field cannot be empty") : _("Only alphabets, numbers, : , _ , . , @ , - are allowed")}>
+                           fieldId="servicename">
                     <TextInput id='servicename'
                                value={name}
                                validated={submitted && validationFailed.name ? "error" : "default"}
                                onChange={setName} />
+                    <FormHelper fieldId="servicename"
+                                helperTextInvalid={submitted && validationFailed.name && (!name.trim().length ? _("This field cannot be empty") : _("Only alphabets, numbers, : , _ , . , @ , - are allowed"))} />
                 </FormGroup>
                 <FormGroup label={_("Description")}
-                           fieldId="description"
-                           validated={submitted && validationFailed.description ? "error" : "default"}
-                           helperTextInvalid={_("This field cannot be empty")}>
+                           fieldId="description">
                     <TextInput id='description'
                                value={description}
                                validated={submitted && validationFailed.description ? "error" : "default"}
                                onChange={setDescription} />
+                    <FormHelper fieldId="description" helperTextInvalid={submitted && validationFailed.description && _("This field cannot be empty")} />
                 </FormGroup>
                 <FormGroup label={_("Command")}
-                           fieldId="command"
-                           validated={submitted && validationFailed.command ? "error" : "default"}
-                           helperTextInvalid={commandNotFound ? _("Command not found") : _("This field cannot be empty")}>
+                           fieldId="command">
                     <TextInput id='command'
                                value={command}
                                validated={submitted && validationFailed.command ? "error" : "default"}
                                onChange={str => { setCommandNotFound(false); setCommand(str) }} />
+                    <FormHelper fieldId="command"
+                                helperTextInvalid={submitted && validationFailed.command && (commandNotFound ? _("Command not found") : _("This field cannot be empty"))} />
                 </FormGroup>
                 <FormGroup label={_("Trigger")} hasNoPaddingTop>
                     <Flex>
@@ -197,9 +197,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                     </Flex>
                     { delay == "system-boot" &&
                     <FormGroup className="delay-group"
-                               label={_("Delay")}
-                               validated={submitted && validationFailed.delayNumber ? "error" : "default"}
-                               helperTextInvalid={_("Delay must be a number")}>
+                               label={_("Delay")}>
                         <Flex>
                             <TextInput className="delay-number"
                                        value={delayNumber}
@@ -215,6 +213,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                                 <FormSelectOption value="weeks" label={_("Weeks")} />
                             </FormSelect>
                         </Flex>
+                        <FormHelper helperTextInvalid={submitted && validationFailed.delayNumber && _("Delay must be a number")} />
                     </FormGroup> }
                     { delay == "specific-time" &&
                     <>
@@ -285,9 +284,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                             }
 
                             return (
-                                <FormGroup label={label} key={item.key}
-                                           validated={validated}
-                                           helperTextInvalid={helperTextInvalid}>
+                                <FormGroup label={label} key={item.key}>
                                     <Flex className="specific-repeat-group" data-index={idx}>
                                         {repeat == "minutely" &&
                                             <TextInput className='delay-number'
@@ -391,6 +388,7 @@ const CreateTimerDialogBody = ({ owner }) => {
                                             </InputGroup>
                                         </FlexItem>}
                                     </Flex>
+                                    <FormHelper helperTextInvalid={validated && helperTextInvalid} />
                                 </FormGroup>
                             );
                         })}

--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -31,6 +31,7 @@ import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
 import { has_errors, is_valid_char_name } from "./dialog-utils.js";
 import { passwd_change } from "./password-dialogs.js";
+import { FormHelper } from "cockpit-components-form-helper";
 import { password_quality, PasswordFormFields } from "cockpit-components-password.jsx";
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 import { HelpIcon } from '@patternfly/react-icons';
@@ -65,31 +66,28 @@ function AccountCreateBody({ state, errors, change, shells }) {
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
             <FormGroup label={_("Full name")}
-                       helperTextInvalid={errors?.real_name}
-                       validated={(errors?.real_name) ? "error" : "default"}
                        fieldId="accounts-create-real-name">
                 <TextInput id="accounts-create-real-name"
                            validated={(errors?.real_name) ? "error" : "default"}
                            value={real_name} onChange={value => change("real_name", value)} />
+                <FormHelper fieldId="accounts-create-real-name" helperTextInvalid={errors?.real_name} />
             </FormGroup>
 
             <FormGroup label={_("User name")}
-                       helperTextInvalid={errors?.user_name}
-                       validated={(errors?.user_name) ? "error" : "default"}
                        fieldId="accounts-create-user-name">
                 <TextInput id="accounts-create-user-name"
                            validated={(errors?.user_name) ? "error" : "default"}
                            value={user_name} onChange={value => change("user_name", value)} />
+                <FormHelper fieldId="accounts-create-user-name" helperTextInvalid={errors?.user_name} />
             </FormGroup>
 
             <FormGroup label={_("Home directory")}
-                       helperTextInvalid={errors && errors.home_dir}
-                       validated={(errors && errors.home_dir) ? "error" : "default"}
                        fieldId="accounts-create-user-home-dir">
                 <TextInput id="accounts-create-user-home-dir"
                     onChange={value => change("home_dir", value)}
                     placeholder={_("Path to directory")}
                     value={state.home_dir} />
+                <FormHelper fieldId="accounts-create-user-home-dir" helperTextInvalid={errors?.home_dir} />
             </FormGroup>
 
             <FormGroup label={_("Shell")}
@@ -107,12 +105,11 @@ function AccountCreateBody({ state, errors, change, shells }) {
             </FormGroup>
 
             <FormGroup label={_("User ID")}
-                       helperTextInvalid={errors && errors.uid}
-                       validated={errors?.uid ? "error" : "default"}
                        fieldId="accounts-create-user-uid">
                 <TextInput id="accounts-create-user-uid"
                     onChange={value => change("uid", value)}
                     value={state.uid} />
+                <FormHelper fieldId="accounts-create-user-uid" helperTextInvalid={errors?.uid} />
             </FormGroup>
 
             <FormGroup label={_("Authentication")} fieldId="accounts-create-locked" hasNoPaddingTop>

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -443,16 +443,6 @@ export const AccountGroupsSelect = ({ name, loggedIn, groups, setError }) => {
     return (
         <FormGroup
             fieldId="account-groups"
-            helperText={
-                (history.length > 0)
-                    ? <HelperText className="pf-c-form__helper-text">
-                        <Flex>
-                            {loggedIn && <HelperTextItem id="account-groups-helper" variant="warning">{_("The user must log out and log back in for the new configuration to take effect.")}</HelperTextItem>}
-                            {history.length > 0 && <Button variant="link" id="group-undo-btn" isInline icon={<UndoIcon />} onClick={undoGroupChanges}>{_("Undo")}</Button>}
-                        </Flex>
-                    </HelperText>
-                    : ''
-            }
             id="account-groups-form-group"
             label={_("Groups")}
             validated={history.length > 0 ? "warning" : "default"}
@@ -477,6 +467,15 @@ export const AccountGroupsSelect = ({ name, loggedIn, groups, setError }) => {
                     ))}
                 </Select>
                 : chipGroupComponent()}
+            {(history.length > 0)
+                ? <HelperText className="pf-c-form__helper-text">
+                    <Flex>
+                        {loggedIn && <HelperTextItem id="account-groups-helper" variant="warning">{_("The user must log out and log back in for the new configuration to take effect.")}</HelperTextItem>}
+                        {history.length > 0 && <Button variant="link" id="group-undo-btn" isInline icon={<UndoIcon />} onClick={undoGroupChanges}>{_("Undo")}</Button>}
+                    </Flex>
+                </HelperText>
+                : ''
+            }
         </FormGroup>
     );
 };

--- a/pkg/users/expiration-dialogs.js
+++ b/pkg/users/expiration-dialogs.js
@@ -20,7 +20,7 @@
 import cockpit from 'cockpit';
 import React from 'react';
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
-import { Form, FormGroup, FormHelperText } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { Radio } from "@patternfly/react-core/dist/esm/components/Radio/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { DatePicker } from "@patternfly/react-core/dist/esm/components/DatePicker/index.js";
@@ -28,6 +28,7 @@ import { DatePicker } from "@patternfly/react-core/dist/esm/components/DatePicke
 import { has_errors } from "./dialog-utils.js";
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 import * as timeformat from "timeformat.js";
+import { FormHelper } from "cockpit-components-form-helper";
 
 const _ = cockpit.gettext;
 
@@ -58,10 +59,7 @@ function AccountExpirationDialogBody({ state, errors, change, validate, update }
                            </Flex>
                        }
                        isChecked={mode == "expires"} onChange={() => change("mode", "expires")} />
-                {errors?.date &&
-                <FormHelperText isError isHidden={false}>
-                    {errors.date}
-                </FormHelperText>}
+                <FormHelper helperTextInvalid={errors?.date} />
             </FormGroup>
         </Form>
     );
@@ -164,10 +162,7 @@ function PasswordExpirationDialogBody({ state, errors, change }) {
                            <span id="password-expiration-after">{after}</span>
                        </>}
                        isChecked={mode == "expires"} onChange={() => change("mode", "expires")} />
-                {(errors?.days) &&
-                <FormHelperText isError isHidden={false}>
-                    {errors.days}
-                </FormHelperText>}
+                <FormHelper helperTextInvalid={errors?.days} />
             </FormGroup>
         </Form>
     );

--- a/pkg/users/group-create-dialog.js
+++ b/pkg/users/group-create-dialog.js
@@ -23,6 +23,7 @@ import React from 'react';
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 
 import { has_errors, is_valid_char_name } from "./dialog-utils.js";
 
@@ -36,23 +37,21 @@ function GroupCreateBody({ state, errors, change }) {
     return (
         <Form isHorizontal onSubmit={apply_modal_dialog}>
             <FormGroup label={_("Name")}
-                       helperTextInvalid={errors?.name}
-                       validated={(errors?.name) ? "error" : "default"}
                        fieldId="groups-create-name">
                 <TextInput id="groups-create-name"
                            validated={(errors?.name) ? "error" : "default"}
                            value={name} onChange={value => change("name", value)} />
+                <FormHelper fieldId="groups-create-name" helperTextInvalid={errors?.name} />
             </FormGroup>
 
             <FormGroup label={_("ID")}
                        hasNoPaddingTop
-                       helperTextInvalid={errors?.id}
-                       validated={(errors?.id) ? "error" : "default"}
                        isStack
                        fieldId="groups-create-id">
                 <TextInput id="groups-create-id"
                            validated={(errors?.id) ? "error" : "default"}
                            value={id} onChange={value => change("id", value)} />
+                <FormHelper fieldId="groups-create-id" helperTextInvalid={errors?.id} />
             </FormGroup>
         </Form>
     );

--- a/pkg/users/password-dialogs.js
+++ b/pkg/users/password-dialogs.js
@@ -26,6 +26,7 @@ import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/
 import { has_errors } from "./dialog-utils.js";
 import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
 import { password_quality, PasswordFormFields } from "cockpit-components-password.jsx";
+import { FormHelper } from "cockpit-components-form-helper";
 
 const _ = cockpit.gettext;
 
@@ -137,11 +138,10 @@ function SetPasswordDialogBody({ state, errors, change }) {
             <>
                 <input hidden disabled value={current_user} />
                 <FormGroup label={_("Old password")}
-                           helperTextInvalid={errors?.password_old}
-                           validated={(errors?.password_old) ? "error" : "default"}
                            fieldId="account-set-password-old">
                     <TextInput className="check-passwords" type="password" id="account-set-password-old"
                                autoComplete="current-password" value={password_old} onChange={value => change("password_old", value)} />
+                    <FormHelper helperTextInvalid={errors?.password_old} />
                 </FormGroup>
             </> }
             <PasswordFormFields password_label={_("New password")}

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -313,7 +313,7 @@ class StorageHelpers:
 
     def dialog_wait_error(self, field, val):
         # XXX - allow for more than one error
-        self.browser.wait_in_text('#dialog .pf-c-form__helper-text.pf-m-error', val)
+        self.browser.wait_in_text('#dialog .pf-c-form__helper-text .pf-m-error', val)
 
     def dialog_wait_not_present(self, field):
         self.browser.wait_not_present(self.dialog_field(field))

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -351,7 +351,7 @@ class TestFirewall(NetworkCase):
             b.wait_val("#service-name", expected)
 
         def check_error(text):
-            b.wait_visible(f".pf-c-form__helper-text.pf-m-error:contains({text})")
+            b.wait_visible(f".pf-c-form__helper-text .pf-m-error:contains({text})")
 
         def save(identifier, tcp, udp, desc="", submit_text="Add ports"):
             b.click(f"button:contains({submit_text})")

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -180,7 +180,7 @@ class TestAccounts(MachineCase):
         b.set_input_text('#accounts-create-password-pw1', good_password)
         b.set_input_text('#accounts-create-password-pw2', good_password)
         b.click('#accounts-create-dialog button.apply')
-        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "The full name must not contain colons.")
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text .pf-m-error", "The full name must not contain colons.")
         b.click('#accounts-create-dialog button.cancel')
         b.wait_visible("#accounts")
 
@@ -219,7 +219,7 @@ class TestAccounts(MachineCase):
         # wrong password confirmation
         b.set_input_text('#accounts-create-password-pw2', good_password + 'b')
         b.click('#accounts-create-dialog button.apply')
-        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text.pf-m-error", "The passwords do not match")
+        b.wait_in_text("#accounts-create-dialog .pf-c-form__helper-text .pf-m-error", "The passwords do not match")
         b.wait_not_present('#accounts-create-dialog button.pf-m-warning')
 
         # too long password
@@ -568,7 +568,7 @@ class TestAccounts(MachineCase):
         b.set_input_text("#account-set-password-pw1", good_password + 'a')
         b.set_input_text("#account-set-password-pw2", good_password + 'b')
         b.click('#account-set-password-dialog button.apply')
-        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text.pf-m-error", "The passwords do not match")
+        b.wait_in_text("#account-set-password-dialog .pf-c-form__helper-text .pf-m-error", "The passwords do not match")
         b.wait_not_present('#account-set-password-dialog button.pf-m-warning')
 
         # too long password
@@ -986,7 +986,7 @@ class TestAccounts(MachineCase):
         # Try an invalid date
         b.set_input_text("#account-expiration-input input", "blah")
         b.click("#account-expiration .pf-c-modal-box__footer button:contains(Change)")
-        b.wait_text("#account-expiration .pf-c-form__helper-text.pf-m-error", "Invalid expiration date")
+        b.wait_text("#account-expiration .pf-c-form__helper-text .pf-m-error", "Invalid expiration date")
 
         # Now a valid date 30 days in the future
         when = datetime.datetime.now() + datetime.timedelta(days=30)
@@ -1015,7 +1015,7 @@ class TestAccounts(MachineCase):
         # Try an invalid number
         b.set_input_text("#password-expiration-input", "-3")
         b.click("#password-expiration .pf-c-modal-box__footer button:contains(Change)")
-        b.wait_text("#password-expiration .pf-c-form__helper-text.pf-m-error", "Invalid number of days")
+        b.wait_text("#password-expiration .pf-c-form__helper-text .pf-m-error", "Invalid number of days")
 
         # Expire password every 30 days
         b.set_input_text("#password-expiration-input", "30")


### PR DESCRIPTION
FormGroup in PF5 abandonded the validated and helperText* properties. To make porting easier start using these as PF5 requires.