### PR TITLE
storage: Only show "Format" button for empty filesystem in format modal

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -490,6 +490,15 @@ export const dialog_open = (def) => {
             update();
         },
 
+        get_value: (tag) => {
+            return values[tag];
+        },
+
+        update_actions: (new_actions) => {
+            Object.assign(def.Action, new_actions);
+            update_footer(null, null);
+        },
+
         set_nested_values: (key, new_vals) => {
             const updated = values[key];
             Object.assign(updated, new_vals);

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -280,6 +280,9 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
     else
         at_boot = "local";
 
+    const action_title = create_partition ? _("Create and mount") : _("Format and mount");
+    const action_variant = { tag: "nomount", Title: create_partition ? _("Create only") : _("Format only") };
+
     const dlg = dialog_open({
         Title: title,
         Teardown: TeardownMessage(usage),
@@ -399,11 +402,18 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
         update: function (dlg, vals, trigger) {
             if (trigger == "at_boot")
                 dlg.set_options("at_boot", { explanation: mount_explanation[vals.at_boot] });
+            else if (trigger == "type") {
+                if (dlg.get_value("type") == "empty") {
+                    dlg.update_actions({ Variants: null, Title: _("Format") });
+                } else {
+                    dlg.update_actions({ Variants: [action_variant], Title: action_title });
+                }
+            }
         },
         Action: {
-            Title: create_partition ? _("Create and mount") : _("Format and mount"),
+            Title: action_title,
             Danger: (create_partition ? null : _("Formatting erases all data on a storage device.")),
-            Variants: [{ tag: "nomount", Title: create_partition ? _("Create only") : _("Format only") }],
+            Variants: [action_variant],
             wrapper: job_progress_wrapper(client, block.path, client.blocks_cleartext[block.path]?.path),
             action: function (vals) {
                 const mount_now = vals.variant != "nomount";

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -88,6 +88,12 @@ class TestStorageFormat(StorageCase):
         else:
             check_type("ntfs", 128)
 
+        # Verify button text is 'Format' when no filesystem is selected
+        self.content_dropdown_action(1, "Format")
+        self.dialog_wait_open()
+        self.dialog_set_val("type", "empty")
+        b.wait_text("#dialog .apply", "Format")
+
     def testFormatCancel(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
Fixes #18623.

![image](https://user-images.githubusercontent.com/90795679/232054656-98a50491-e84e-4292-bf8a-10156675e2e4.png)

I couldn't access the chosen filesystem type when inside `dialog_open()`, so I added a function in `dialog` to return a value based on an input tag. The footer is updated based on the filesystem type.

I also changed the condition for `mount_now` so it doesn't attempt to mount an empty filesystem.

This workaround feels a bit hacky, it might be better to implement the logic of updating the footer inside `dialog` directly. Let me know what you think!