### PR TITLE
static: allow 'auto' theme to be applied as default theme for login page

### DIFF
--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -14,7 +14,7 @@ import "./login.css";
     }
 
     /* Dark mode */
-    const theme = localStorage.getItem('shell:style');
+    const theme = localStorage.getItem('shell:style') || 'auto';
     if ((window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches && theme === "auto") || theme === "dark") {
         document.documentElement.classList.add('pf-theme-dark');
     } else {


### PR DESCRIPTION
Closes #18637

Currently the login page defaults to 'light theme' when the `shell:style` is missing in the local store of browser.
This change hopefully (_testing needed opening as draft_) allows the login page to have 'auto theme' by default.

Below snippets from existing code-base already have this code pattern in place.


https://github.com/cockpit-project/cockpit/blob/137357fb85daaebcfef651ee70c148eb0805bef8/pkg/lib/cockpit-dark-theme.js#L37
https://github.com/cockpit-project/cockpit/blob/137357fb85daaebcfef651ee70c148eb0805bef8/pkg/shell/base_index.js#L212
https://github.com/cockpit-project/cockpit/blob/137357fb85daaebcfef651ee70c148eb0805bef8/pkg/shell/topnav.jsx#L61