### PR TITLE
#18424 Issue: Added functions reboot and wait_reboot

### DIFF
--- a/test/common/.cph/.storagelib.py_3d56c8dcccb8f10f465f9742d65d11c1.prob
+++ b/test/common/.cph/.storagelib.py_3d56c8dcccb8f10f465f9742d65d11c1.prob
@@ -1,1 +1,0 @@
-{"name":"Local: storagelib","url":"c:\\Users\\gupta\\OneDrive\\Documents\\GitHub\\cockpit\\test\\common\\storagelib.py","tests":[{"id":1681747240936,"input":"","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"c:\\Users\\gupta\\OneDrive\\Documents\\GitHub\\cockpit\\test\\common\\storagelib.py","group":"local","local":true}

--- a/test/common/.cph/.storagelib.py_3d56c8dcccb8f10f465f9742d65d11c1.prob
+++ b/test/common/.cph/.storagelib.py_3d56c8dcccb8f10f465f9742d65d11c1.prob
@@ -1,0 +1,1 @@
+{"name":"Local: storagelib","url":"c:\\Users\\gupta\\OneDrive\\Documents\\GitHub\\cockpit\\test\\common\\storagelib.py","tests":[{"id":1681747240936,"input":"","output":""}],"interactive":false,"memoryLimit":1024,"timeLimit":3000,"srcPath":"c:\\Users\\gupta\\OneDrive\\Documents\\GitHub\\cockpit\\test\\common\\storagelib.py","group":"local","local":true}

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -622,7 +622,7 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
 """, timeout=300)
         luks_uuid = m.execute(f"blkid -p {dev}2 -s UUID -o value").strip()
         m.spawn("dd if=/dev/zero of=/dev/vda bs=1M count=100; reboot", "reboot", check=False)
-        m.wait_reboot(timeout_sec = 300)
+        m.wait_reboot(300)
         self.assertEqual(m.execute("findmnt -n -o SOURCE /").strip(), f"/dev/mapper/luks-{luks_uuid}")
 
 

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -622,7 +622,7 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
 """, timeout=300)
         luks_uuid = m.execute(f"blkid -p {dev}2 -s UUID -o value").strip()
         m.spawn("dd if=/dev/zero of=/dev/vda bs=1M count=100; reboot", "reboot", check=False)
-        m.wait_reboot(300)
+        m.wait_reboot(timeout_sec = 300)
         self.assertEqual(m.execute("findmnt -n -o SOURCE /").strip(), f"/dev/mapper/luks-{luks_uuid}")
 
 

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -622,7 +622,7 @@ grubby --update-kernel=ALL --args="root=UUID=$uuid rootflags=defaults rd.luks.uu
 """, timeout=300)
         luks_uuid = m.execute(f"blkid -p {dev}2 -s UUID -o value").strip()
         m.spawn("dd if=/dev/zero of=/dev/vda bs=1M count=100; reboot", "reboot", check=False)
-        m.wait_reboot(300)
+        self.wait_reboot(300)
         self.assertEqual(m.execute("findmnt -n -o SOURCE /").strip(), f"/dev/mapper/luks-{luks_uuid}")
 
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2131,11 +2131,11 @@ class MachineCase(unittest.TestCase):
             m.execute(f"hostnamectl set-hostname {name}")
             if disable_preload:
                 self.disable_preload("packagekit", "playground", "systemd", machine=m)
-    def reboot(self, timeout_sec):
+    def reboot(self, timeout_sec = None):
         self.machine.allow_restart_journal_messages()
         self.machine.reboot(timeout_sec = timeout_sec)
         
-    def wait_reboot(self, timeout_sec): 
+    def wait_reboot(self, timeout_sec = None): 
         self.machine.allow_restart_journal_messages()
         self.machine.wait_reboot(timeout_sec = timeout_sec)
     

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2140,8 +2140,6 @@ class MachineCase(unittest.TestCase):
         self.machine.wait_reboot(timeout_sec = timeout_sec)
     
 
-
-
 ###########################
 # Global helper functions
 #

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2131,21 +2131,14 @@ class MachineCase(unittest.TestCase):
             m.execute(f"hostnamectl set-hostname {name}")
             if disable_preload:
                 self.disable_preload("packagekit", "playground", "systemd", machine=m)
-    def reboot(self,timeout_sec):
+    def reboot(self, timeout_sec):
         self.machine.allow_restart_journal_messages()
-        self.machine.reboot(timeout = timeout_sec)
-    
-    def reboot(self):
-        self.machine.allow_restart_journal_messages()
-        self.machine.reboot()
-    
+        self.machine.reboot(timeout_sec = timeout_sec)
+        
     def wait_reboot(self, timeout_sec): 
         self.machine.allow_restart_journal_messages()
         self.machine.wait_reboot(timeout_sec = timeout_sec)
-
-    def wait_reboot(self): 
-        self.machine.allow_restart_journal_messages()
-        self.machine.wait_reboot()    
+    
 
 
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2131,6 +2131,22 @@ class MachineCase(unittest.TestCase):
             m.execute(f"hostnamectl set-hostname {name}")
             if disable_preload:
                 self.disable_preload("packagekit", "playground", "systemd", machine=m)
+    def reboot(self,timeout_sec):
+        self.machine.allow_restart_journal_messages()
+        self.machine.reboot(timeout = timeout_sec)
+    
+    def reboot(self):
+        self.machine.allow_restart_journal_messages()
+        self.machine.reboot()
+    
+    def wait_reboot(self, timeout_sec): 
+        self.machine.allow_restart_journal_messages()
+        self.machine.wait_reboot(timeout_sec = timeout_sec)
+
+    def wait_reboot(self): 
+        self.machine.allow_restart_journal_messages()
+        self.machine.wait_reboot()    
+
 
 
 ###########################

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2131,12 +2131,13 @@ class MachineCase(unittest.TestCase):
             m.execute(f"hostnamectl set-hostname {name}")
             if disable_preload:
                 self.disable_preload("packagekit", "playground", "systemd", machine=m)
+                
     def reboot(self, timeout_sec = None):
-        self.machine.allow_restart_journal_messages()
+        self.allow_restart_journal_messages()
         self.machine.reboot(timeout_sec = timeout_sec)
         
     def wait_reboot(self, timeout_sec = None): 
-        self.machine.allow_restart_journal_messages()
+        self.allow_restart_journal_messages()
         self.machine.wait_reboot(timeout_sec = timeout_sec)
     
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -49,7 +49,7 @@ class TestConnection(MachineCase):
         m.execute("rm /etc/systemd/system/cockpit.service")
         # overlay cockpit-ws rpm
         m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm", timeout=180)
-        self.machine.reboot()
+        self.reboot()
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testBasic(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -49,7 +49,7 @@ class TestConnection(MachineCase):
         m.execute("rm /etc/systemd/system/cockpit.service")
         # overlay cockpit-ws rpm
         m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm", timeout=180)
-        m.reboot()
+        m.reboot(600)
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testBasic(self):

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -49,7 +49,7 @@ class TestConnection(MachineCase):
         m.execute("rm /etc/systemd/system/cockpit.service")
         # overlay cockpit-ws rpm
         m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm", timeout=180)
-        m.reboot(600)
+        self.machine.reboot()
 
     @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testBasic(self):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -27,7 +27,7 @@ class KdumpHelpers(MachineCase):
         # all current Fedora/CentOS/RHEL images use BootLoaderSpec
         self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
         self.machine.execute("mkdir -p /var/crash")
-        self.machine.reboot()
+        self.reboot()
         self.allow_restart_journal_messages()
         self.machine.start_cockpit()
         self.browser.switch_to_top()

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -28,7 +28,6 @@ class KdumpHelpers(MachineCase):
         self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
         self.machine.execute("mkdir -p /var/crash")
         self.reboot()
-        self.allow_restart_journal_messages()
         self.machine.start_cockpit()
         self.browser.switch_to_top()
         self.browser.relogin("/kdump")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -523,7 +523,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot()
+                        m.wait_reboot(timeout_sec = 600)
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -550,7 +550,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot()
+                        m.wait_reboot(timeout_sec = 600)
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -852,7 +852,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.wait_in_text(".curtains-ct h1", "Disconnected")
 
             # ensure that rebooting actually worked
-            m.wait_reboot()
+            m.wait_reboot(timeout_sec = 600)
             m.start_cockpit()
             b.reload()
             b.login_and_go("/updates")
@@ -1008,7 +1008,7 @@ ExecStart=/usr/local/bin/{packageName}
         # reboots automatically
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         self.allow_restart_journal_messages()
 
     @nondestructive

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1009,7 +1009,6 @@ ExecStart=/usr/local/bin/{packageName}
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
         self.wait_reboot()
-        self.allow_restart_journal_messages()
 
     @nondestructive
     def testUpdateError(self):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -523,7 +523,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        self.machine.wait_reboot()
+                        self.wait_reboot()
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -550,7 +550,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        self.machine.wait_reboot()
+                        self.wait_reboot()
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -852,7 +852,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.wait_in_text(".curtains-ct h1", "Disconnected")
 
             # ensure that rebooting actually worked
-            self.machine.wait_reboot()
+            self.wait_reboot()
             m.start_cockpit()
             b.reload()
             b.login_and_go("/updates")
@@ -1008,7 +1008,7 @@ ExecStart=/usr/local/bin/{packageName}
         # reboots automatically
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        self.machine.wait_reboot()
+        self.wait_reboot()
         self.allow_restart_journal_messages()
 
     @nondestructive

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -523,7 +523,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot(timeout_sec = 600)
+                        self.machine.wait_reboot()
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -550,7 +550,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot(timeout_sec = 600)
+                        self.machine.wait_reboot()
                         m.start_cockpit()
                         b.reload()
                         b.login_and_go("/updates")
@@ -852,7 +852,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.wait_in_text(".curtains-ct h1", "Disconnected")
 
             # ensure that rebooting actually worked
-            m.wait_reboot(timeout_sec = 600)
+            self.machine.wait_reboot()
             m.start_cockpit()
             b.reload()
             b.login_and_go("/updates")
@@ -1008,7 +1008,7 @@ ExecStart=/usr/local/bin/{packageName}
         # reboots automatically
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         self.allow_restart_journal_messages()
 
     @nondestructive

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -682,7 +682,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
         m.execute("grubby --update-kernel=ALL --args='ip=10.111.112.1::10.111.112.1:255.255.255.0::eth1:off'")
 
         try:
-            m.reboot(timeout_sec = 300)
+            self.reboot(timeout_sec = 300)
         except Exception:
             console_screenshot(m, "failed-reboot.ppm")
             raise

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -455,7 +455,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -593,7 +593,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
 
         # Reboot
         #
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -455,7 +455,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -593,7 +593,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
 
         # Reboot
         #
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -455,7 +455,7 @@ class TestStorageLuks(StorageCase):
         self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -593,7 +593,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
 
         # Reboot
         #
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -682,7 +682,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
         m.execute("grubby --update-kernel=ALL --args='ip=10.111.112.1::10.111.112.1:255.255.255.0::eth1:off'")
 
         try:
-            m.reboot(timeout_sec=300)
+            m.reboot(timeout_sec = 300)
         except Exception:
             console_screenshot(m, "failed-reboot.ppm")
             raise

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -253,7 +253,7 @@ class TestStorageStratis(StorageCase):
         b.wait_in_text('#detail-sidebar', dev_2)
         b.wait_in_text(f'#detail-sidebar .sidepanel-row:contains({dev_2})', "data")
 
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -276,7 +276,7 @@ class TestStorageStratis(StorageCase):
 
         # Reboot (this requires the passphrase)
         self.setup_systemd_password_agent("foodeeboodeebar")
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -376,7 +376,7 @@ class TestStorageStratis(StorageCase):
                      'mount_point': '/run/fsys1'})
         b.wait_in_text("#detail-content", "fsys1")
 
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -253,7 +253,7 @@ class TestStorageStratis(StorageCase):
         b.wait_in_text('#detail-sidebar', dev_2)
         b.wait_in_text(f'#detail-sidebar .sidepanel-row:contains({dev_2})', "data")
 
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -276,7 +276,7 @@ class TestStorageStratis(StorageCase):
 
         # Reboot (this requires the passphrase)
         self.setup_systemd_password_agent("foodeeboodeebar")
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -376,7 +376,7 @@ class TestStorageStratis(StorageCase):
                      'mount_point': '/run/fsys1'})
         b.wait_in_text("#detail-content", "fsys1")
 
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -253,7 +253,7 @@ class TestStorageStratis(StorageCase):
         b.wait_in_text('#detail-sidebar', dev_2)
         b.wait_in_text(f'#detail-sidebar .sidepanel-row:contains({dev_2})', "data")
 
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -276,7 +276,7 @@ class TestStorageStratis(StorageCase):
 
         # Reboot (this requires the passphrase)
         self.setup_systemd_password_agent("foodeeboodeebar")
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -376,7 +376,7 @@ class TestStorageStratis(StorageCase):
                      'mount_point': '/run/fsys1'})
         b.wait_in_text("#detail-content", "fsys1")
 
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -800,7 +800,7 @@ fi
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
         m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
-        m.reboot(600)
+        m.reboot(timeout_sec = 600)
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')
         b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -985,7 +985,6 @@ password=foobar
     def testCryptoPolicies(self):
         m = self.machine
         b = self.browser
-        self.allow_restart_journal_messages()
 
         def shown_profile_text(profile):
             return profile if profile == "FIPS" else profile[0] + profile[1:].lower()

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -746,7 +746,7 @@ machine         : 8561
                        (self.expect_smt_default and ':not(:checked)' or ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
 
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         if self.expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -791,7 +791,7 @@ fi
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
                        (self.expect_smt_default and ':checked' or ':not(:checked)'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         if self.expect_smt_default:
             self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -800,7 +800,7 @@ fi
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
         m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')
         b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
@@ -808,7 +808,7 @@ fi
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         self.assertIn('mitigations=auto', m.execute('cat /proc/cmdline'))
 
@@ -1068,7 +1068,7 @@ password=foobar
         b.click(".system-health-crypto-policies button.pf-c-button.pf-m-link")
         b.wait_in_text(".pf-c-menu__item.pf-m-selected .pf-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "Default")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -746,7 +746,7 @@ machine         : 8561
                        (self.expect_smt_default and ':not(:checked)' or ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
 
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         if self.expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -791,7 +791,7 @@ fi
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
                        (self.expect_smt_default and ':checked' or ':not(:checked)'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         if self.expect_smt_default:
             self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -800,7 +800,7 @@ fi
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
         m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
-        m.reboot()
+        m.reboot(600)
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')
         b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
@@ -808,7 +808,7 @@ fi
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         self.assertIn('mitigations=auto', m.execute('cat /proc/cmdline'))
 
@@ -997,7 +997,7 @@ password=foobar
             b.click(f".pf-c-menu__item-main .pf-c-menu__item-text:contains('{profile_button_name}')")
             b.click("#crypto-policy-save-reboot")
             # Initramfs re-generation takes a while
-            m.wait_reboot(timeout_sec=600)
+            m.wait_reboot(timeout_sec = 600)
             m.start_cockpit()
             self.login_and_go("/system")
             b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
@@ -1050,7 +1050,7 @@ password=foobar
         b.wait_in_text(".pf-c-menu__item.pf-m-selected .pf-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
         # Initramfs re-generation takes a while
-        m.wait_reboot(timeout_sec=600)
+        m.wait_reboot(timeout_sec = 600)
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "FIPS")
@@ -1068,7 +1068,7 @@ password=foobar
         b.click(".system-health-crypto-policies button.pf-c-button.pf-m-link")
         b.wait_in_text(".pf-c-menu__item.pf-m-selected .pf-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "Default")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -746,7 +746,7 @@ machine         : 8561
                        (self.expect_smt_default and ':not(:checked)' or ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
 
-        self.machine.wait_reboot()
+        self.wait_reboot()
         if self.expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -791,7 +791,7 @@ fi
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
                        (self.expect_smt_default and ':checked' or ':not(:checked)'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        self.machine.wait_reboot()
+        self.wait_reboot()
         if self.expect_smt_default:
             self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -800,7 +800,7 @@ fi
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/systemd/kernelopt.sh"], "/tmp/")
         m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
-        self.machine.reboot()
+        self.reboot()
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')
         b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
@@ -808,7 +808,7 @@ fi
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        self.machine.wait_reboot()
+        self.wait_reboot()
         self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         self.assertIn('mitigations=auto', m.execute('cat /proc/cmdline'))
 
@@ -1068,7 +1068,7 @@ password=foobar
         b.click(".system-health-crypto-policies button.pf-c-button.pf-m-link")
         b.wait_in_text(".pf-c-menu__item.pf-m-selected .pf-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
-        self.machine.wait_reboot()
+        self.wait_reboot()
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "Default")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -997,7 +997,7 @@ password=foobar
             b.click(f".pf-c-menu__item-main .pf-c-menu__item-text:contains('{profile_button_name}')")
             b.click("#crypto-policy-save-reboot")
             # Initramfs re-generation takes a while
-            m.wait_reboot(timeout_sec = 600)
+            self.wait_reboot(timeout_sec = 600)
             m.start_cockpit()
             self.login_and_go("/system")
             b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
@@ -1050,7 +1050,7 @@ password=foobar
         b.wait_in_text(".pf-c-menu__item.pf-m-selected .pf-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
         # Initramfs re-generation takes a while
-        m.wait_reboot(timeout_sec = 600)
+        self.wait_reboot(timeout_sec = 600)
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "FIPS")

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -394,7 +394,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         m.execute("systemctl stop systemd-journald.service")
 
         # Now reboot things
-        m.reboot(600)
+        m.reboot(timeout_sec = 600)
         m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -394,7 +394,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         m.execute("systemctl stop systemd-journald.service")
 
         # Now reboot things
-        m.reboot()
+        m.reboot(600)
         m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -394,7 +394,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         m.execute("systemctl stop systemd-journald.service")
 
         # Now reboot things
-        self.machine.reboot()
+        self.reboot()
         m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -394,7 +394,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         m.execute("systemctl stop systemd-journald.service")
 
         # Now reboot things
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -338,7 +338,7 @@ class CommonTests:
         b.click("#shutdown-dialog button:contains(Reboot)")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        self.machine.wait_reboot()
+        self.wait_reboot()
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -339,7 +339,7 @@ class CommonTests:
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
         self.wait_reboot()
-
+        
         self.allow_journal_messages(".*No authentication agent found.*")
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -338,7 +338,7 @@ class CommonTests:
         b.click("#shutdown-dialog button:contains(Reboot)")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -341,7 +341,6 @@ class CommonTests:
         self.wait_reboot()
 
         self.allow_journal_messages(".*No authentication agent found.*")
-        self.allow_restart_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -338,7 +338,7 @@ class CommonTests:
         b.click("#shutdown-dialog button:contains(Reboot)")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
 
         self.allow_journal_messages(".*No authentication agent found.*")
         self.allow_restart_journal_messages()

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1297,7 +1297,7 @@ class TestTimers(MachineCase):
         wait(lambda: "false" in m.execute(
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
-        m.reboot()
+        m.reboot(timeout_sec =600)
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")
@@ -1545,7 +1545,7 @@ class TestTimers(MachineCase):
         b.click("#timer-save-button")
         b.wait_not_present("#timer-dialog")
         b.wait_visible(self.svc_sel('boot_timer.timer'))
-        m.reboot()
+        m.reboot(timeout_sec = 600)
         m.start_cockpit()
         with testvm.Timeout(seconds=15, machine=m, error_message="Timeout while waiting for boot timer to run"):
             m.execute("while [ ! -f /tmp/hello ] ; do sleep 0.5; done")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1297,7 +1297,7 @@ class TestTimers(MachineCase):
         wait(lambda: "false" in m.execute(
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
-        self.machine.reboot()
+        self.reboot()
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")
@@ -1545,7 +1545,7 @@ class TestTimers(MachineCase):
         b.click("#timer-save-button")
         b.wait_not_present("#timer-dialog")
         b.wait_visible(self.svc_sel('boot_timer.timer'))
-        self.machine.reboot()
+        self.reboot()
         m.start_cockpit()
         with testvm.Timeout(seconds=15, machine=m, error_message="Timeout while waiting for boot timer to run"):
             m.execute("while [ ! -f /tmp/hello ] ; do sleep 0.5; done")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1297,7 +1297,7 @@ class TestTimers(MachineCase):
         wait(lambda: "false" in m.execute(
             "busctl get-property org.freedesktop.timedate1 /org/freedesktop/timedate1 org.freedesktop.timedate1 NTP"))
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
-        m.reboot(timeout_sec =600)
+        self.machine.reboot()
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")
@@ -1545,7 +1545,7 @@ class TestTimers(MachineCase):
         b.click("#timer-save-button")
         b.wait_not_present("#timer-dialog")
         b.wait_visible(self.svc_sel('boot_timer.timer'))
-        m.reboot(timeout_sec = 600)
+        self.machine.reboot()
         m.start_cockpit()
         with testvm.Timeout(seconds=15, machine=m, error_message="Timeout while waiting for boot timer to run"):
             m.execute("while [ ! -f /tmp/hello ] ; do sleep 0.5; done")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -56,7 +56,7 @@ class TestShutdownRestart(MachineCase):
 
         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
         m.start_cockpit()
         b.click("#machine-reconnect")
         b.wait_visible("#login")
@@ -101,7 +101,7 @@ class TestShutdownRestart(MachineCase):
         b2.wait_visible(".curtains-ct .ct-spinner")
         b2.wait_in_text(".curtains-ct h1", "rebooting")
 
-        m.wait_reboot()
+        m.wait_reboot(timeout_sec = 600)
 
         with b2.wait_timeout(30):
             b2.wait_visible("#machine-troubleshoot")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -56,7 +56,7 @@ class TestShutdownRestart(MachineCase):
 
         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
         m.start_cockpit()
         b.click("#machine-reconnect")
         b.wait_visible("#login")
@@ -101,7 +101,7 @@ class TestShutdownRestart(MachineCase):
         b2.wait_visible(".curtains-ct .ct-spinner")
         b2.wait_in_text(".curtains-ct h1", "rebooting")
 
-        m.wait_reboot(timeout_sec = 600)
+        self.machine.wait_reboot()
 
         with b2.wait_timeout(30):
             b2.wait_visible("#machine-troubleshoot")

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -61,7 +61,6 @@ class TestShutdownRestart(MachineCase):
         b.click("#machine-reconnect")
         b.wait_visible("#login")
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages("Shutdown scheduled for .*")
         self.check_journal_messages()
 

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -56,7 +56,7 @@ class TestShutdownRestart(MachineCase):
 
         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
-        self.machine.wait_reboot()
+        self.wait_reboot()
         m.start_cockpit()
         b.click("#machine-reconnect")
         b.wait_visible("#login")
@@ -101,7 +101,7 @@ class TestShutdownRestart(MachineCase):
         b2.wait_visible(".curtains-ct .ct-spinner")
         b2.wait_in_text(".curtains-ct h1", "rebooting")
 
-        self.machine.wait_reboot()
+        self.wait_reboot()
 
         with b2.wait_timeout(30):
             b2.wait_visible("#machine-troubleshoot")


### PR DESCRIPTION
I have made some updates to the `MachineCase` class in the `testlib.py` file. Specifically, I have added two new functions: `reboot` and `wait_reboot`. These functions now support a `timeout_sec` parameter, and I have implemented function overloading to achieve this.

Additionally, I have included a call to `self.machine.allow_restart_journal_messages()` within both of these functions. This will automatically trigger whenever either of the two functions is called.