### PR TITLE
package.json: Update chrome-remote-interface to 0.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "axe-core": "^2.6.1",
     "babel-eslint": "^10.0.1",
     "babel-loader": "^8.0.4",
-    "chrome-remote-interface": "^0.31.2",
+    "chrome-remote-interface": "^0.32.1",
     "clean-css": "~3.4.20",
     "copy-webpack-plugin": "^4.5.2",
     "css-loader": "^0.28.10",


### PR DESCRIPTION
This fixes tests with current Chromium versions.

---

Should fix [this total failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4652-20230414-230818-565f8442-centos-7-cockpit-project-cockpit-rhel-7.9/log.html) after the recent cockpit/tasks refresh.