### PR TITLE
storage: fix alignment of 'Block devices' form element in 'Create stratis pool' dialog

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -691,7 +691,7 @@ export const SelectSpaces = (tag, title, options) => {
         title,
         options,
         initial_value: [],
-
+        hasNoPaddingTop: options.spaces.length == 0,
         render: (val, change) => {
             if (options.spaces.length === 0)
                 return <span className="text-danger">{options.empty_warning}</span>;


### PR DESCRIPTION
Before:
![Screen Shot 2023-04-17 at 08 32 52](https://user-images.githubusercontent.com/14921356/232403603-f5d185d0-f48d-4492-abe5-2c2fe79b8e11.png)

Now:
![Screen Shot 2023-04-17 at 08 36 51](https://user-images.githubusercontent.com/14921356/232403781-ac987d6f-dc19-45a6-ac6f-0bad6b188cb2.png)
