### PR TITLE
nondestructive tests: apps, loopback, testPrivateKeys; fix testPrivateKeys flake; fix test-connection regressions

### DIFF
--- a/pkg/shell/credentials.jsx
+++ b/pkg/shell/credentials.jsx
@@ -177,7 +177,7 @@ const AddNewKey = ({ load, unlockKey, onClose }) => {
             </GridItem>
             <GridItem span={1}>
                 <Button id="ssh-file-add"
-                        isDisabled={addNewKeyLoading}
+                        isDisabled={addNewKeyLoading || !newKeyPath}
                         isLoading={addNewKeyLoading}
                         onClick={addCustomKey}
                         variant="secondary">

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -531,23 +531,10 @@ class Browser:
             self.wait_val(selector, val)
 
     def set_file_autocomplete_val(self, group_identifier: str, location: str):
-        file_item_selector_template = "{0} li button:contains({1})"
-
-        path = ''
-        index = 0
-        for path_part in filter(None, location.split('/')):
-            self.click("{0} > div .pf-c-select__toggle-button".format(group_identifier))
-            self._wait_present(group_identifier + " .pf-c-select__menu")
-            path += '/' + path_part
-            file_item_selector = file_item_selector_template.format(group_identifier, path)
-            self.click(file_item_selector)
-            if index != len(list(filter(None, location.split('/')))) - 1 or location[-1] == '/':
-                self.wait_val("{0} > div input[type=text]".format(group_identifier), path + '/')
-            else:
-                self.wait_val("{0} > div input[type=text]".format(group_identifier), path)
-            index += 1
-
-        self.wait_val("{0} > div input[type=text]".format(group_identifier), location)
+        self.set_input_text(f"{group_identifier} .pf-c-select__toggle-typeahead", location)
+        # click away the selection list, to force a state update
+        self.click(f"{group_identifier} .pf-c-select__toggle-typeahead")
+        self.wait_not_present(f"{group_identifier} .pf-c-select__menu")
 
     def wait_timeout(self, timeout: int):
         browser = self

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1551,7 +1551,7 @@ class MachineCase(unittest.TestCase):
             self.addCleanup(m.execute, "rm -rf /run/faillock")
 
         # cockpit configuration
-        self.addCleanup(m.execute, "rm -f /etc/cockpit/cockpit.conf /etc/cockpit/machines.d/* /etc/cockpit/*.override.json")
+        self.restore_dir("/etc/cockpit")
 
         if not m.ostree_image:
             # for storage tests

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -19,12 +19,13 @@
 
 import parent  # noqa: F401
 from packagelib import PackageCase
-from testlib import skipImage, skipOstree, skipPackage, test_main
+from testlib import skipImage, skipOstree, skipPackage, test_main, nondestructive
 
 
 @skipImage("TODO: bug in refreshing removed/installed state on Arch Linux", "arch")
 @skipOstree("Not supported")
 @skipPackage("cockpit-apps")
+@nondestructive
 class TestApps(PackageCase):
 
     def setUp(self):
@@ -84,20 +85,22 @@ class TestApps(PackageCase):
 
         self.allow_journal_messages("can't remove watch: Invalid argument")
 
+        self.restore_dir("/usr/share/metainfo", reboot_safe=True)
+        self.restore_dir("/usr/share/app-info", reboot_safe=True)
+        self.restore_dir("/var/cache/app-info", reboot_safe=True)
+
         # Make sure none of the appstream directories exist.  They
         # will be created later and we need to cope with that.
-
         m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
 
         # instead of the actual distro packages, use our own fake repo data package
-        m.write("/etc/cockpit/apps.override.json",
-                '{ "config": { "appstream_data_packages": [ "appstream-data-test" ] } }')
+        self.write_file("/etc/cockpit/apps.override.json",
+                        '{ "config": { "appstream_data_packages": [ "appstream-data-test" ] } }')
 
         if urlroot != "":
             m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
-        m.start_cockpit()
-        b.login_and_go("/apps", urlroot=urlroot)
+        self.login_and_go("/apps", urlroot=urlroot)
         b.wait_visible(".pf-c-empty-state")
 
         self.createAppStreamPackage("app-1", "1.0", "1")
@@ -137,10 +140,10 @@ class TestApps(PackageCase):
                                     "Error .* data: Connection reset by peer")
 
         # Reset everything
-        m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
+        m.execute("for d in /usr/share/metainfo /usr/share/app-info /var/cache/app-info; do mkdir -p $d; mount -t tmpfs tmpfs $d; done")
+        self.addCleanup(m.execute, "for d in /usr/share/metainfo /usr/share/app-info /var/cache/app-info; do umount $d; done")
 
-        m.start_cockpit()
-        b.login_and_go("/apps")
+        self.login_and_go("/apps")
         b.wait_visible(".pf-c-empty-state")
 
         m.write("/usr/share/app-info/xmls/test.xml", """
@@ -195,10 +198,10 @@ class TestApps(PackageCase):
         m = self.machine
 
         # Reset everything
-        m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
+        m.execute("for d in /usr/share/metainfo /usr/share/app-info /var/cache/app-info; do mkdir -p $d; mount -t tmpfs tmpfs $d; done")
+        self.addCleanup(m.execute, "for d in /usr/share/metainfo /usr/share/app-info /var/cache/app-info; do umount $d; done")
 
-        m.start_cockpit()
-        b.login_and_go("/apps")
+        self.login_and_go("/apps")
         b.wait_visible(".pf-c-empty-state")
 
         self.allow_journal_messages(".*/usr/share/app-info/xmls/test.xml.*",

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -34,37 +34,37 @@ class TestApps(PackageCase):
 
     def createAppStreamPackage(self, name, version, revision):
         self.createPackage(name, version, revision, content={
-            f"/usr/share/metainfo/org.cockpit-project.{name}.metainfo.xml": """
+            f"/usr/share/metainfo/org.cockpit-project.{name}.metainfo.xml": f"""
 <component type="addon">
   <extends>org.cockpit_project.cockpit</extends>
-  <id>org.cockpit-project.{0}</id>
+  <id>org.cockpit-project.{name}</id>
   <icon type="local">/usr/share/pixmaps/test.png</icon>
-  <name>{0}</name>
+  <name>{name}</name>
   <summary>An application for testing</summary>
-  <launchable type="cockpit-manifest">{0}</launchable>
+  <launchable type="cockpit-manifest">{name}</launchable>
 </component>
-""".format(name),
+""",
             "/usr/share/pixmaps/test.png": {"path": "/var/tmp/test.png"}})
         self.appstream_collection.add(name)
 
     def createAppStreamRepoPackage(self):
         body = ""
         for p in self.appstream_collection:
-            body += """
+            body += f"""
   <component type="addon">
   <extends>org.cockpit_project.cockpit</extends>
-    <id>org.cockpit-project.{0}</id>
+    <id>org.cockpit-project.{p}</id>
     <icon type="cached">test.png</icon>
-    <name>{0}</name>
+    <name>{p}</name>
     <summary>An application for testing</summary>
-    <launchable type="cockpit-manifest">{0}</launchable>
+    <launchable type="cockpit-manifest">{p}</launchable>
     <description>
         <p>DESCRIPTION:none</p>
     </description>
-    <url type="homepage">https://{0}.com</url>
-    <pkgname>{0}</pkgname>
+    <url type="homepage">https://{p}.com</url>
+    <pkgname>{p}</pkgname>
   </component>
-""".format(p)
+"""
         self.machine.execute("mkdir -p /usr/share/app-info/xmls")
         self.createPackage("appstream-data-test", "1.0", "1", content={
             "/usr/share/app-info/xmls/test.xml": f"""

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -705,7 +705,8 @@ class TestConnection(MachineCase):
         m.execute(f"{self.libexecdir}/cockpit-certificate-ensure")
         self.assertTrue(m.execute("ls /etc/cockpit/ws-certs.d/*"))
 
-        m.execute(f"{self.ws_executable} --port 9000 --address 127.0.0.1 0<&- &>/dev/null &")
+        pid = m.spawn(f"{self.ws_executable} --port 9000 --address 127.0.0.1", "cockpit-ws.log")
+        self.addCleanup(m.execute, f"kill {pid}")
 
         # The port may not be available immediately, so wait for it
         wait(lambda: 'A Custom Title' in m.curl('-k', 'https://localhost:9000/'))

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -699,7 +699,6 @@ class TestConnection(MachineCase):
         self.assertIn('id="login"', m.curl('-k', 'https://localhost:9090/', headers=large_headers))
         m.stop_cockpit()
 
-        self.restore_dir("/etc/cockpit")
         m.execute("rm -f /etc/cockpit/ws-certs.d/* /etc/cockpit/cockpit.conf")
         m.write("/etc/cockpit/cockpit.conf", "[WebService]\nLoginTitle = A Custom Title\n")
 

--- a/test/verify/check-loopback
+++ b/test/verify/check-loopback
@@ -17,12 +17,15 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
+
 import parent  # noqa: F401
-from testlib import MachineCase, skipDistroPackage, skipOstree, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main
 
 
 @skipOstree("OSTree always uses loopback")
 @skipDistroPackage()
+@nondestructive
 class TestLoopback(MachineCase):
 
     def testBasic(self):
@@ -30,14 +33,21 @@ class TestLoopback(MachineCase):
         m = self.machine
 
         # Start Cockpit with option to access SSH
-        m.spawn(f"{self.libexecdir}/cockpit-ws --local-ssh --no-tls", "cockpit-ws")
+        m.stop_cockpit()
+        pid = m.spawn(f"{self.libexecdir}/cockpit-ws --local-ssh --no-tls", "cockpit-ws")
+        self.addCleanup(m.execute, "kill %i" % pid)
         m.wait_for_cockpit_running()
 
         b.login_and_go("/system", user="admin")
         b.logout()
         b.wait_visible("#login")
 
-        m.execute("while B=$(command -v cockpit-bridge); do rm $B; done")
+        self.restore_file("/usr/bin/cockpit-bridge")
+        m.execute("rm /usr/bin/cockpit-bridge")
+        if os.environ.get("TEST_SCENARIO") == "pybridge":
+            self.restore_file("/usr/local/bin/cockpit-bridge")
+            m.execute("rm /usr/local/bin/cockpit-bridge")
+
         b.set_val('#login-user-input', "admin")
         b.set_val('#login-password-input', "foobar")
         b.click('#login-button')
@@ -45,8 +55,9 @@ class TestLoopback(MachineCase):
         self.assertIn("no-cockpit", b.text('#login-fatal'))
 
         m.disconnect()
+        self.restore_dir("/etc/ssh", post_restore_action="systemctl try-restart sshd.service")
         m.execute("sed -i 's/.*PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config $(ls /etc/ssh/sshd_config.d/* 2>/dev/null || true)")
-        m.execute("( ! systemctl is-active sshd.socket || systemctl stop sshd.socket) && systemctl restart sshd.service")
+        m.execute("systemctl try-restart sshd.service")
         m.wait_execute()
 
         b.reload()

--- a/test/verify/check-packages
+++ b/test/verify/check-packages
@@ -89,7 +89,6 @@ class TestPackages(MachineCase):
         check_nav_entry("Test", False)
 
         # Hide the terminal with a system override
-        self.restore_dir("/etc/cockpit")
         m.write("/etc/cockpit/systemd.override.json", """{
     "tools": {
         "terminal": null

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -26,9 +26,8 @@ KEY = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIEAkRTvQCSEZNPXpA5bP82ilQn3TMeQ6z2NO3
 
 
 @skipDistroPackage()
+@nondestructive
 class TestKeys(MachineCase):
-
-    @nondestructive
     def testAuthorizedKeys(self):
         m = self.machine
         b = self.browser
@@ -192,6 +191,8 @@ auth       optional     pam_ssh_add.so
 session    optional     pam_ssh_add.so
 """, append=True)
 
+        self.restore_dir("/home/admin")
+
         # Put all the keys in place
         m.execute("mkdir -p /home/admin/.ssh")
         m.upload([
@@ -293,6 +294,7 @@ session    optional     pam_ssh_add.so
         # Add bad keys
         # generate a new key
         m.execute("ssh-keygen -t rsa -N '' -f /tmp/new.rsa")
+        self.addCleanup(m.execute, "rm -f /tmp/new.rsa*")
         m.execute("chown admin:admin /tmp/new.rsa")
         new_pk = m.execute("cat /tmp/new.rsa.pub").strip().split()[0]
         m.execute("rm /tmp/new.rsa.pub")
@@ -382,6 +384,7 @@ session    optional     pam_ssh_add.so
 
         # Test adding key with passphrase
         m.execute("ssh-keygen -t rsa -N 'foobar' -f /tmp/new_with_passphrase.rsa")
+        self.addCleanup(m.execute, "rm -f /tmp/new_with_passphrase.rsa*")
         m.execute("chown admin:admin /tmp/new_with_passphrase.rsa")
         m.execute("rm /tmp/new_with_passphrase.rsa.pub")
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -297,7 +297,7 @@ session    optional     pam_ssh_add.so
         b.wait_visible("#credential-keys")
         b.wait_not_present("#ssh-file-add")
         b.click("#ssh-file-add-custom")
-        b.set_input_text("#credentials-modal .pf-c-select__toggle-typeahead", "/bad")
+        b.set_file_autocomplete_val("#ssh-file-add-key", "/bad")
         b.click("#ssh-file-add")
         b.wait_text("#credentials-modal .pf-m-error > .pf-c-helper-text__item-text", "Not a valid private key")
 

--- a/test/verify/check-shell-keys
+++ b/test/verify/check-shell-keys
@@ -204,13 +204,6 @@ session    optional     pam_ssh_add.so
         m.execute("chmod 600 /home/admin/.ssh/*")
         m.execute("chown -R admin:admin /home/admin/.ssh")
 
-        # Determine OpenSSH version
-        ver = m.execute("ssh -V 2>&1 |  grep -Eo 'OpenSSH_[[:digit:]]+.[[:digit:]]+'")
-        if ver:
-            openssh_version = [int(x) for x in ver.split("_")[1].split(".")]
-        else:
-            openssh_version = [0]
-
         self.login_and_go()
 
         id_rsa = "2048 SHA256:SRvBhCmkCEVnJ6ascVH0AoVEbS3nPbowZkNevJnXtgw"
@@ -324,12 +317,9 @@ session    optional     pam_ssh_add.so
         # keys are marked as "agent_only", thereby limiting functionality
         keys = list_keys()
         keys_length = 3 if auto_load else 2
-        if openssh_version >= [7, 8]:
-            # Keys are like: 256 SHA256:x6S6fxMuEyqhpwNRAIK7ms6bZDY6xK9wzdDr2kCaWVY id_ed25519 (ED25519)
-            # We need the id_ed25519 part, (name or comment)
-            new_key = keys.splitlines()[keys_length - 1].split(' ')[2]
-        else:
-            new_key = "new.rsa"
+        # Keys are like: 256 SHA256:x6S6fxMuEyqhpwNRAIK7ms6bZDY6xK9wzdDr2kCaWVY id_ed25519 (ED25519)
+        # We need the id_ed25519 part, (name or comment)
+        new_key = keys.splitlines()[keys_length - 1].split(' ')[2]
         toggleKeyState(new_key)
 
         toggleExpandedStateKey(new_key)
@@ -342,45 +332,8 @@ session    optional     pam_ssh_add.so
 
         # OpenSSH 7.8 and up has a new default key format where
         # keys are marked as "agent_only", thereby limiting functionality
-        if openssh_version >= [7, 8]:
-            # "agent_only" keys cannot be turned off, or have their passwords changed
-            waitKeyLoaded(new_key, True)
-        else:
-            # Change password of key
-            selectTab('new.rsa', 'Password')
-            b.set_input_text("#" + new_key + "-old-password", "")
-            b.set_input_text("#" + new_key + "-old-new", "foobar")
-            b.set_input_text("#" + new_key + "-old-two", "foobar")
-            b.click("#" + new_key + "-change-password")
-
-            waitTabActive(new_key, 'Details')
-
-            # Turn key off, it goes away
-            toggleKeyState(new_key)
-            waitKeyPresent(new_key, False)
-
-            # Key now has password that needs to be entered to add
-            b.wait_not_visible("tr.load-custom-key")
-            b.click("#credential-keys a")
-            b.wait_visible("tr.load-custom-key")
-            b.wait_visible("#ssh-file-add")
-            b.set_val("#ssh-file-container input[type=text]", "/bad")
-            b.click("#ssh-file-add")
-
-            b.set_val("#ssh-file-container input[type=text]", "/tmp/new.rsa")
-            b.click("#ssh-file-add")
-            b.wait_not_visible("tr.load-custom-key")
-            b.wait_visible("tbody.ssh-add-key-body[data-name='/tmp/new.rsa']")
-
-            b.set_input_text(f"{new_key}-password", "badbad")
-            b.click(f"{new_key}-unlock")
-
-            b.wait_in_text("#credential-dialog .pf-c-alert", "Password not accepted")
-            b.set_input_text(f"#{new_key}-password", "foobar")
-            b.click("#{new_key}-unlock")
-
-            waitKeyLoaded(new_key, True)
-            waitKeyPresent(new_key, False)
+        # "agent_only" keys cannot be turned off, or have their passwords changed
+        waitKeyLoaded(new_key, True)
 
         # Test adding key with passphrase
         m.execute("ssh-keygen -t rsa -N 'foobar' -f /tmp/new_with_passphrase.rsa")

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -34,7 +34,6 @@ class TestWsBastionContainer(MachineCase):
         # stop ws container from previous runs
         self.machine.stop_cockpit()
         # undo cockpit/ws install steps
-        self.restore_file("/etc/systemd/system/cockpit.service")
         self.machine.execute("rm /etc/systemd/system/cockpit.service")
         self.addCleanup(self.machine.execute, "podman rm -f --all")
 

--- a/test/vm.install
+++ b/test/vm.install
@@ -46,6 +46,10 @@ if [ "${PLATFORM_ID#platform:el}" != "$PLATFORM_ID" ]; then
     echo 'Defaults secure_path = /sbin:/usr/sbin:/usr/local/bin:/bin:/usr/bin' > /etc/sudoers.d/usr-local
 fi
 
+# start cockpit once to ensure it works, and generate the certificate (to avoid re-doing that for each test)
+systemctl start cockpit
+systemctl stop cockpit
+
 # clean out the journal
 journalctl --flush
 journalctl --sync || killall systemd-journald


### PR DESCRIPTION
This should help with reducing the overall test time. ATM chromium tests take between 42 and 50 minutes on an e2e machine.

----

I locally converted pretty much everything except networking and storage test. This is the first batch. For my own reference, these can be potentially converted still (but in a separate PR, this is becoming too big):

```
TestNetworkingCheckpoints.testCheckpoint    
TestNetworkingCheckpoints.testCheckpointSlowRollback    
TestNetworkingCheckpoints.testNoRollback    
TestStorageISCSI.testISCSI    
TestStorageLuks.testKeepKeys    
TestStorageLuks.testLuks    
TestStorageLuks.testLuks1Slots    
TestStorageLuks.testNoFsys    
TestStorageLuks.testReboot    
TestStorageMdRaid.testNotRemovingDisks    
TestStorageMdRaid.testRaid    
TestStorageMounting.testAtBoot    
TestStorageMounting.testBadOption    
TestStorageMounting.testDuplicateMountPoints    
TestStorageMounting.testEncryptedMountingHelp    
TestStorageMounting.testFirstMount    
TestStorageMounting.testMounting    
TestStorageMounting.testMountingHelp    
TestStorageMounting.testNeverAuto    
TestStorageMsDOS.testDosParts    
TestStorageMultipath.testBasic    
TestStorageNBDE.testBasic    
TestStorageNBDE.testRootReboot    
TestStoragePackagesStratis.testStratisOndemandInstallation    
TestStorageRaid1.testRaidLevelOne    
TestStorageResize.testGrowShrinkEncryptedHelp    
TestStorageResize.testGrowShrinkHelp    
TestStorageResize.testResizeExt4    
TestStorageResize.testResizeLuks    
TestStorageResize.testResizeNtfs    
TestStorageResize.testResizeXfs    
TestStorageScaling.testScaling    
TestStorageStratis.testBasic    
TestStorageStratis.testCli    
TestStorageUnused.testUnused    
```