### PR TITLE
python: don't process kill messages on closing channels

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -143,6 +143,10 @@ class Channel(Endpoint):
             self.close(**exc.kwargs)
 
     def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+        # Already closing?  Ignore.
+        if self._close_args is not None:
+            return
+
         if host is not None:
             return
         if group is not None and self.group != group:


### PR DESCRIPTION
We guard for the channel being in the closing state on incoming data and control messages for the channel, but we forgot to add this same check for .do_kill(), even thought the docs for .close() are pretty clear that no .do_*() methods should get called after .close().

Add the same check as in the other places.

This fixes a backtrace recently seen in an unrelated PR:

```
  ...
    File "/usr/local/lib/python3.11/site-packages/cockpit/channel.py", line 150, in do_kill
      self.do_close()
    File "/usr/local/lib/python3.11/site-packages/cockpit/channels/dbus.py", line 505, in do_close
      for slot in self.matches:
  TypeError: 'NoneType' object is not iterable
```