### PR TITLE
Mark TestStorageHidden.testHiddenSnap as nondestructive; make TestWsBastionContainer really nondestructive

### DIFF
--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -19,7 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase, json
-from testlib import test_main
+from testlib import nondestructive, test_main
 
 import unittest
 import testvm
@@ -127,6 +127,7 @@ class TestStorageHidden(StorageCase):
         self.assertEqual(m.execute(f"grep {mount_point_2} /etc/fstab || true"), "")
 
     @unittest.skipUnless("ubuntu" in testvm.DEFAULT_IMAGE, "Only test snaps on Ubuntu")
+    @nondestructive
     def testHiddenSnap(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -34,7 +34,7 @@ class TestWsBastionContainer(MachineCase):
         # stop ws container from previous runs
         self.machine.stop_cockpit()
         # undo cockpit/ws install steps
-        self.machine.execute("rm /etc/systemd/system/cockpit.service")
+        self.restore_file("/etc/systemd/system/cockpit.service")
         self.addCleanup(self.machine.execute, "podman rm -f --all")
 
     def approve_key(self, b, hostname):


### PR DESCRIPTION
Also fixes [this test failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4680-20230420-232001-7e1dc975-rhel4edge-cockpit-project-cockpit/log.html#348-2). Completely unrelated, but let's avoid an useless CI run just for changing a commit message.