### PR TITLE
test: Increase timeout for dialog closing in TestStorageLegacyVDO.testVdo

### DIFF
--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -246,7 +246,8 @@ class TestStorageLegacyVDO(StorageCase):
         self.dialog_wait_open()
         b.wait_in_text("#dialog", "unmount, stop")
         self.dialog_apply()
-        self.dialog_wait_close()
+        with b.wait_timeout(60):
+            self.dialog_wait_close()
         b.wait_not_present('#detail-content table')
 
         # Delete


### PR DESCRIPTION
Stopping a VDO just takes a while, and the dialog sometimes timed out.

----

Seen e.g. [here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18280-20230418-102746-de488724-centos-8-stream-pybridge/log.html#206-2)