### PR TITLE
shell: fix minor CSS alignment of shell search menu independant to themes

### DIFF
--- a/pkg/shell/nav.scss
+++ b/pkg/shell/nav.scss
@@ -389,13 +389,14 @@ $desktop: $phone + 1px;
 
 .pf-theme-dark {
   .pf-c-select__toggle {
-    //mobile
-    height: 100%;
-
     > * {
       color: var(--pf-global--Color--light-100);
     }
   }
+}
+
+.pf-c-select__toggle {
+  height: 100%;
 }
 
 .nav-action {


### PR DESCRIPTION
Closes #18649 

> This CSS `height: 100%` was applied only in Dark theme
> 
> https://github.com/cockpit-project/cockpit/blob/c33285c2cad23636c5a8a86d63609f9bf7462b0e/pkg/shell/nav.scss#L360-L363

This resulted in light theme having the search menu element to be slightly off-centered

> [Screencast.from.2023-04-17.12-11-18.webm](https://user-images.githubusercontent.com/67428/232460972-633aa26b-d2e9-4d64-96dd-52eb02a672ae.webm)

This change allows that specific CSS to be applied regardless of themes, fixing the alignment of the shell search menu effectively in light theme