### PR TITLE
use test -f over grep for finding cockpit files

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -502,7 +502,7 @@ fi
 test -f %{_bindir}/firewall-cmd && firewall-cmd --reload --quiet || true
 
 # check for deprecated PAM config
-if grep --color=auto pam_cockpit_cert %{_sysconfdir}/pam.d/cockpit; then
+if test -f %{_sysconfdir}/pam.d/cockpit &&  grep -q pam_cockpit_cert %{_sysconfdir}/pam.d/cockpit; then
     echo '**** WARNING:'
     echo '**** WARNING: pam_cockpit_cert is a no-op and will be removed in a'
     echo '**** WARNING: future release; remove it from your /etc/pam.d/cockpit.'


### PR DESCRIPTION
when using grep in the post run on a new install of cockpit the output contains `grep: /etc/pam.d/cockpit: No such file or directory` which is confusing and can mislead people into thinking cockpit has failed to install, by using test if `/etc/pam.d/cockpit` doesn't exist it will be silent.