### PR TITLE
users: port shell selection to FormSelect

### DIFF
--- a/pkg/users/account-create-dialog.js
+++ b/pkg/users/account-create-dialog.js
@@ -23,7 +23,7 @@ import React from 'react';
 import { Bullseye } from "@patternfly/react-core/dist/esm/layouts/Bullseye/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
-import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select/index.js";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { Popover } from "@patternfly/react-core/dist/esm/components/Popover/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
@@ -48,7 +48,7 @@ function AccountCreateBody({ state, errors, change, shells }) {
     const {
         real_name, user_name,
         locked, change_passw_force,
-        shell, isShellSelectExpanded,
+        shell,
     } = state;
 
     // We want to let user know that password and confirmation password do not match without them having to constantly click on "Create" to validate the form.
@@ -92,16 +92,13 @@ function AccountCreateBody({ state, errors, change, shells }) {
 
             <FormGroup label={_("Shell")}
                        fieldId="accounts-create-user-shell">
-                <Select variant={SelectVariant.single}
-                        toggleId="accounts-create-user-shell"
-                        onToggle={statusIsExpanded => change("isShellSelectExpanded", statusIsExpanded)}
-                        onSelect={(event, selection) => { change("shell", selection); change("isShellSelectExpanded", false) }}
-                        selections={shell}
-                        isOpen={isShellSelectExpanded}
-                        aria-labelledby="vm-state-select"
-                        menuAppendTo="parent">
-                    { shells.map(shell_path => <SelectOption value={shell_path} key={shell_path} label={shell_path}>{shell_path}</SelectOption>) }
-                </Select>
+                <FormSelect
+                        data-selected={shell}
+                        id="accounts-create-user-shell"
+                        onChange={selection => { change("shell", selection) }}
+                        value={shell}>
+                    { shells.map(shell_path => <FormSelectOption key={shell_path} value={shell_path} label={shell_path} />) }
+                </FormSelect>
             </FormGroup>
 
             <FormGroup label={_("User ID")}
@@ -281,7 +278,6 @@ export function account_create_dialog(accounts, min_uid, max_uid, shells) {
         max_uid,
         home_dir: null,
         home_dir_dirty: false,
-        isShellSelectExpanded: false,
     };
     let errors = { };
 

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -69,7 +69,7 @@ def createUser(
     run_assert_pixels=False,
 ):
     if default_shell is None:
-        default_shell = getUserAddDetails(machine)["SHELL"]
+        default_shell = getUserAddDetails(machine)["SHELL"] or "/bin/bash"
     browser.wait_visible('#accounts-create')
     browser.click('#accounts-create')
     browser.wait_visible('#accounts-create-dialog')
@@ -102,10 +102,9 @@ def createUser(
         browser.wait_visible(f"#accounts-create-user-home-dir[value='{expected_home_dir}']")
 
     if custom_shell:
-        browser.click("#accounts-create-user-shell")
-        browser.click(f"li button[label='{custom_shell}']")
+        browser.select_from_dropdown("#accounts-create-user-shell", custom_shell)
     else:
-        browser.wait_in_text('#accounts-create-user-shell', default_shell)
+        browser.wait_visible(f"#accounts-create-user-shell[data-selected='{default_shell}']")
 
     browser.click('#accounts-create-dialog button.apply')
 


### PR DESCRIPTION
The used Select component implementation is deprecated in PF5.

Port this to FormSelect as it's better fit in general (simple Selects in dialogs should use FormSelect) and make it ready for PF5.