### PR TITLE
static: flatten nested .pf-theme-dark in login.css

### DIFF
--- a/pkg/static/login.css
+++ b/pkg/static/login.css
@@ -925,97 +925,95 @@ input[type="password"] + .login-password-toggle .password-hide {
 }
 
 /* Dark */
-.pf-theme-dark {
-  .login-pf .container,
-  .login-pf .details {
-    z-index: 2;
-  }
+.pf-theme-dark .login-pf .container,
+.pf-theme-dark .login-pf .details {
+  z-index: 2;
+}
 
-  .login-pf .container {
-    background: #26292d;
-    color: #f0f0f0;
-  }
+.pf-theme-dark .login-pf .container {
+  background: #26292d;
+  color: #f0f0f0;
+}
 
-  .login-pf .details {
-    background: #151515;
-    color: #f0f0f0;
-  }
+.pf-theme-dark .login-pf .details {
+  background: #151515;
+  color: #f0f0f0;
+}
 
-  .pf-c-button.pf-m-control,
-  .form-control[type="password"],
-  .form-control[type="text"] {
-    background: #393f44;
-    border-color: #393f44;
-    border-bottom-color: #6c6f72;
-    color: #f0f0f0;
-  }
+.pf-theme-dark .pf-c-button.pf-m-control,
+.pf-theme-dark .form-control[type="password"],
+.pf-theme-dark .form-control[type="text"] {
+  background: #393f44;
+  border-color: #393f44;
+  border-bottom-color: #6c6f72;
+  color: #f0f0f0;
+}
 
-  a:active,
-  a:focus,
-  a:hover,
-  a,
-  summary {
-    color: #8ac0f6;
-  }
+.pf-theme-dark a:active,
+.pf-theme-dark a:focus,
+.pf-theme-dark a:hover,
+.pf-theme-dark a,
+.pf-theme-dark summary {
+  color: #8ac0f6;
+}
 
-  .input-clear,
-  .inline .container .help-block {
-    color: #f0f0f0;
-  }
+.pf-theme-dark .input-clear,
+.pf-theme-dark .inline .container .help-block {
+  color: #f0f0f0;
+}
 
-  .host-line {
-    border-color: #34373b;
-  }
+.pf-theme-dark .host-line {
+  border-color: #34373b;
+}
 
-  /* The × icon's focus ring */
-  .host-remove:focus {
-    outline-color: #f1f1f1;
-  }
+/* The × icon's focus ring */
+.pf-theme-dark .host-remove:focus {
+  outline-color: #f1f1f1;
+}
 
-  /* The × icon */
-  .host-remove::before {
-    background-color: #f1f1f1;
-  }
+/* The × icon */
+.pf-theme-dark .host-remove::before {
+  background-color: #f1f1f1;
+}
 
-  .unsupported-browser ul {
-    color: #999;
-  }
+.pf-theme-dark .unsupported-browser ul {
+  color: #999;
+}
 
-  .pf-c-alert.pf-m-inline.pf-m-danger {
-    background: #1e2125;
-    border-color: #fe5142;
-  }
+.pf-theme-dark .pf-c-alert.pf-m-inline.pf-m-danger {
+  background: #1e2125;
+  border-color: #fe5142;
+}
 
-  .pf-c-alert.pf-m-danger > svg,
-  .pf-c-alert.pf-m-danger .pf-c-alert__title {
-    color: #fe5142;
-  }
+.pf-theme-dark .pf-c-alert.pf-m-danger > svg,
+.pf-theme-dark .pf-c-alert.pf-m-danger .pf-c-alert__title {
+  color: #fe5142;
+}
 
-  .pf-c-button[disabled] {
-    background-color: #444548;
-    border-color: #444548;
-    color: #c6c7c8;
-  }
+.pf-theme-dark .pf-c-button[disabled] {
+  background-color: #444548;
+  border-color: #444548;
+  color: #c6c7c8;
+}
 
-  /* Screen the background and logo darker */
-  .login-pf::after {
-    /* Pass through mouse events */
-    pointer-events: none;
-    background: #000;
-    opacity: 0.66;
-    display: block;
-    content: "";
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 1;
-  }
+/* Screen the background and logo darker */
+.pf-theme-dark .login-pf::after {
+  /* Pass through mouse events */
+  pointer-events: none;
+  background: #000;
+  opacity: 0.66;
+  display: block;
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1;
+}
 
-  .pf-c-helper-text.pf-m-warning {
-    color: #f0ab00;
-  }
+.pf-theme-dark .pf-c-helper-text.pf-m-warning {
+  color: #f0ab00;
 }
 
 /* Animation */


### PR DESCRIPTION
Fixes #18652 

>It seems like the nested CSS is not flattened after moving the front end build tool from webpack to esbuild https://github.com/cockpit-project/cockpit/commit/fe89f2eff580970bac4a142dceeb4f8e6d16a19e
>
>This was the comparison between the dist/login.css between that commit https://github.com/cockpit-project/cockpit/commit/fe89f2eff580970bac4a142dceeb4f8e6d16a19e and its previous commit https://github.com/cockpit-project/cockpit/commit/a06d1e8ae6df57a1403b9467582b4079e688a171
![image](https://user-images.githubusercontent.com/39620234/233201408-ebaa3545-08f5-4f02-b8c2-c1ca1279f0c6.png)

This **_hacky_** change flattens the `.pf-theme-dark` in the source login.css, for the bundler produce the flattened CSS which FireFox can read and apply the dark theme correctly for the login.

