### PR TITLE
test: Reset insights-client after TestSystemInfo.testInsightsStatus

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -853,6 +853,10 @@ fi
         # apparently.  So let's prevent that.
         m.execute("systemctl disable --now insights-client")
 
+        self.restore_dir("/etc/insights-client")
+        self.restore_dir("/etc/yum")
+        self.restore_dir("/var/lib/insights")
+
         # Pretend that the Subscriptions page can do Insights stuff
         self.write_file("/etc/cockpit/subscription-manager.override.json", '{ "features": { "insights": true } }')
 


### PR DESCRIPTION
Otherwise it keeps running in later tests, and throws lots of errors into the journal which pop up as unexpected messages.

---

[example 1](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18603-20230420-094857-fcef2f24-rhel-8-9/log.html), [example 2](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18662-20230420-105608-6c24060f-rhel-8-9/log.html#122)