### PR TITLE
storage: Support stopped Stratis pools

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -121,7 +121,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     const block_swap = content_block && client.blocks_swap[content_block.path];
 
     const block_stratis_blockdev = block && client.blocks_stratis_blockdev[block.path];
-    const block_stratis_locked_pool = block && client.blocks_stratis_locked_pool[block.path];
+    const block_stratis_stopped_pool = block && client.blocks_stratis_stopped_pool[block.path];
 
     const lvol = (endsWith(target.iface, ".LogicalVolume")
         ? target
@@ -130,7 +130,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     const is_filesystem = (content_block && content_block.IdUsage == 'filesystem');
     const is_stratis = ((content_block && content_block.IdUsage == "raid" && content_block.IdType == "stratis") ||
                         (block_stratis_blockdev && client.stratis_pools[block_stratis_blockdev.Pool]) ||
-                        block_stratis_locked_pool);
+                        block_stratis_stopped_pool);
 
     // Adjust for encryption leaking out of Stratis
     if (is_crypto && is_stratis)
@@ -439,7 +439,7 @@ function create_tabs(client, target, is_partition, is_extended) {
 function block_description(client, block) {
     let type, used_for, link, size, critical_size;
     const block_stratis_blockdev = client.blocks_stratis_blockdev[block.path];
-    const block_stratis_locked_pool = client.blocks_stratis_locked_pool[block.path];
+    const block_stratis_stopped_pool = client.blocks_stratis_stopped_pool[block.path];
     const vdo = client.legacy_vdo_overlay.find_by_backing_block(block);
     const cleartext = client.blocks_cleartext[block.path];
     if (cleartext)
@@ -455,9 +455,9 @@ function block_description(client, block) {
         if (config) {
             type = C_("storage-id-desc", "Filesystem (encrypted)");
             used_for = mount_point;
-        } else if (block_stratis_locked_pool) {
+        } else if (block_stratis_stopped_pool) {
             type = _("Stratis member");
-            used_for = block_stratis_locked_pool;
+            used_for = block_stratis_stopped_pool;
             link = ["pool", used_for];
             omit_encrypted_label = true;
         } else

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -32,7 +32,7 @@ import { VGroupDetails } from "./vgroup-details.jsx";
 import { MDRaidDetails } from "./mdraid-details.jsx";
 import { VDODetails } from "./vdo-details.jsx";
 import { NFSDetails } from "./nfs-details.jsx";
-import { StratisPoolDetails, StratisLockedPoolDetails } from "./stratis-details.jsx";
+import { StratisPoolDetails, StratisStoppedPoolDetails } from "./stratis-details.jsx";
 import { JobsPanel } from "./jobs-panel.jsx";
 
 const _ = cockpit.gettext;
@@ -123,12 +123,12 @@ export class Details extends React.Component {
         } else if (this.props.type == "pool") {
             const pool = (client.stratis_poolnames_pool[this.props.name] ||
                           client.stratis_pooluuids_pool[this.props.name]);
-            const locked_props = client.stratis_manager.LockedPools[this.props.name];
+            const stopped_props = client.stratis_manager.StoppedPools[this.props.name];
 
             if (pool)
                 body = <StratisPoolDetails client={client} pool={pool} />;
-            else if (locked_props)
-                body = <StratisLockedPoolDetails client={client} uuid={this.props.name} />;
+            else if (stopped_props)
+                body = <StratisStoppedPoolDetails client={client} uuid={this.props.name} />;
         }
 
         if (!body)

--- a/pkg/storaged/pvol-tabs.jsx
+++ b/pkg/storaged/pvol-tabs.jsx
@@ -97,9 +97,9 @@ export class VDOBackingTab extends React.Component {
 export const StratisBlockdevTab = ({ client, block }) => {
     const stratis_blockdev = client.blocks_stratis_blockdev[block.path];
     const pool = stratis_blockdev && client.stratis_pools[stratis_blockdev.Pool];
-    const stratis_locked_pool_uuid = client.blocks_stratis_locked_pool[block.path];
+    const stratis_stopped_pool_uuid = client.blocks_stratis_stopped_pool[block.path];
 
-    const name = pool ? pool.Name : stratis_locked_pool_uuid;
+    const name = pool ? pool.Name : stratis_stopped_pool_uuid;
 
     return (
         <DescriptionList className="pf-m-horizontal-on-sm">

--- a/pkg/storaged/stratis-panel.jsx
+++ b/pkg/storaged/stratis-panel.jsx
@@ -25,9 +25,9 @@ import {
     decode_filename, fmt_size,
     get_available_spaces, prepare_available_spaces,
 } from "./utils.js";
-import { validate_pool_name, unlock_pool } from "./stratis-details.jsx";
+import { validate_pool_name, start_pool } from "./stratis-details.jsx";
 import { StorageButton } from "./storage-controls.jsx";
-import { UnlockIcon } from "@patternfly/react-icons";
+import { PlayIcon } from "@patternfly/react-icons";
 
 const _ = cockpit.gettext;
 
@@ -61,8 +61,8 @@ function stratis_pool_row(client, path) {
     };
 }
 
-function stratis_locked_pool_row(client, uuid) {
-    const action = <StorageButton onClick={() => unlock_pool(client, uuid, true)}><UnlockIcon /></StorageButton>;
+function stratis_stopped_pool_row(client, uuid) {
+    const action = <StorageButton ariaLabel={_("Start pool")} onClick={() => start_pool(client, uuid, true)}><PlayIcon /></StorageButton>;
 
     return {
         client,
@@ -70,7 +70,7 @@ function stratis_locked_pool_row(client, uuid) {
         name: uuid,
         key: uuid,
         truncate_name: false,
-        detail: _("Locked encrypted Stratis pool"),
+        detail: _("Stopped Stratis pool"),
         go: () => cockpit.location.go(["pool", uuid])
     };
 }
@@ -80,17 +80,17 @@ export function stratis_rows(client) {
         return client.stratis_pools[path_a].Name.localeCompare(client.stratis_pools[path_b].Name);
     }
 
-    function cmp_locked_pool(uuid_a, uuid_b) {
+    function cmp_stopped_pool(uuid_a, uuid_b) {
         return uuid_a.localeCompare(uuid_b);
     }
 
     const pools = Object.keys(client.stratis_pools).sort(cmp_pool)
             .map(p => stratis_pool_row(client, p));
 
-    const locked_pools = Object.keys(client.stratis_manager.LockedPools).sort(cmp_locked_pool)
-            .map(uuid => stratis_locked_pool_row(client, uuid));
+    const stopped_pools = Object.keys(client.stratis_manager.StoppedPools).sort(cmp_stopped_pool)
+            .map(uuid => stratis_stopped_pool_row(client, uuid));
 
-    return pools.concat(locked_pools);
+    return pools.concat(stopped_pools);
 }
 
 function store_new_passphrase(client, desc_prefix, passphrase) {

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -78,6 +78,17 @@ class TestStorageStratis(StorageCase):
         self.dialog_cancel()
         self.dialog_wait_close()
 
+        if not m.image.startswith("rhel-8-9") and m.image != "centos-8-stream":
+            # Stop the pool (only works with Stratis 3)
+            pool_uuid = m.execute("stratis --unhyphenated-uuids pool list --name pool0 | grep ^UUID | cut -d' ' -f2").strip()
+            m.execute("stratis pool stop pool0")
+            b.wait_in_text(f'.sidepanel-row:contains("{pool_uuid}")', "Stopped Stratis pool")
+
+            # Start it
+            b.click(f'.sidepanel-row:contains("{pool_uuid}") button')
+            b.wait_in_text("#devices", "pool0")
+            b.wait_in_text("#devices", "8 GB Stratis pool")
+
         b.click('.sidepanel-row:contains("pool0")')
         b.wait_visible('#storage-detail')
 
@@ -259,14 +270,14 @@ class TestStorageStratis(StorageCase):
         b.enter_page("/storage")
         b.wait_visible("#storage-detail")
 
-        b.wait_in_text('#detail-header', "Locked encrypted Stratis pool")
+        b.wait_in_text('#detail-header', "Stopped Stratis pool")
         b.wait_in_text('#detail-sidebar', dev_1)
         b.wait_in_text('#detail-sidebar', dev_2)
 
         # Unlock the pool
-        b.click('#detail-header button:contains(Unlock)')
+        b.click('#detail-header button:contains(Start)')
         self.dialog({'passphrase': "foodeeboodeebar"})
-        b.wait_not_in_text('#detail-header', "Locked")
+        b.wait_not_in_text('#detail-header', "Stopped")
         b.wait_in_text('#detail-header', "Encrypted Stratis pool pool0")
 
         # Mount the filesystem


### PR DESCRIPTION
Stopped pools are a generalization of locked encrypted pools introduced in newer versions of Stratis.  Now every kind of pool can be inactive, not just encrypted ones.