### PR TITLE
Adjust Breadcrumb usage on all affected pages to match PF5 guidelines

### DIFF
--- a/pkg/apps/application.jsx
+++ b/pkg/apps/application.jsx
@@ -23,7 +23,7 @@ import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
 import { Card, CardActions, CardBody, CardHeader, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
@@ -141,16 +141,14 @@ export const Application = ({ metainfo_db, id, progress, progress_title, action 
     }
 
     return (
-        <Page groupProps={{ sticky: 'top' }}
-              id="app-page"
-              className="application-details"
-              isBreadcrumbGrouped
-              breadcrumb={
-                  <Breadcrumb>
-                      <BreadcrumbItem to="#/">{_("Applications")}</BreadcrumbItem>
-                      <BreadcrumbItem isActive>{comp ? comp.name : id}</BreadcrumbItem>
-                  </Breadcrumb>
-              }>
+        <Page id="app-page"
+              className="application-details">
+            <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                <Breadcrumb>
+                    <BreadcrumbItem to="#/">{_("Applications")}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>{comp ? comp.name : id}</BreadcrumbItem>
+                </Breadcrumb>
+            </PageBreadcrumb>
             <PageSection>
                 {render_comp()}
             </PageSection>

--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -236,8 +236,7 @@ select.pf-c-form-control {
   // Adapt breadcrumb bar to be similar color as PF website
   // (We use header bars in slightly different ways from PF)
   // https://github.com/patternfly/patternfly/issues/5301
-  .pf-c-page__main-breadcrumb,
-  .pf-c-page__main-breadcrumb + .pf-c-page__main-section {
+  .pf-c-page__main-breadcrumb {
     --pf-c-page__main-breadcrumb--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
     background-color: var(--pf-global--BackgroundColor--dark-100);
   }

--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -36,7 +36,7 @@ import { Stack } from "@patternfly/react-core/dist/esm/layouts/Stack/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 import { Title } from "@patternfly/react-core/dist/esm/components/Title/index.js";
 import { Toolbar, ToolbarContent, ToolbarItem } from "@patternfly/react-core/dist/esm/components/Toolbar/index.js";
-import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -1042,26 +1042,25 @@ export class Firewall extends React.Component {
         const enabled = this.state.firewall.enabled;
 
         return (
-            <Page groupProps={{ sticky: 'top' }}
-                  isBreadcrumbGrouped
-                  breadcrumb={
-                      <Breadcrumb>
-                          <BreadcrumbItem onClick={go_up} className="pf-c-breadcrumb__link">{_("Networking")}</BreadcrumbItem>
-                          <BreadcrumbItem isActive>{_("Firewall")}</BreadcrumbItem>
-                      </Breadcrumb>}
-                  additionalGroupedContent={
-                      <PageSection id="firewall-heading" variant={PageSectionVariants.light} className="firewall-heading">
-                          <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
-                              <Flex alignItems={{ default: 'alignItemsCenter' }} id="firewall-heading-title-group">
-                                  <Title headingLevel="h2" size="3xl">
-                                      {_("Firewall")}
-                                  </Title>
-                                  <FirewallSwitch firewall={firewall} />
-                                  <p>{_("Incoming requests are blocked by default. Outgoing requests are not blocked.")}</p>
-                              </Flex>
-                              { enabled && !firewall.readonly && <span className="btn-group">{addZoneAction}</span> }
-                          </Flex>
-                      </PageSection>}>
+            <Page>
+                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                    <Breadcrumb>
+                        <BreadcrumbItem onClick={go_up} className="pf-c-breadcrumb__link">{_("Networking")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{_("Firewall")}</BreadcrumbItem>
+                    </Breadcrumb>
+                </PageBreadcrumb>
+                <PageSection id="firewall-heading" variant={PageSectionVariants.light} className="firewall-heading">
+                    <Flex alignItems={{ default: 'alignItemsCenter' }} justifyContent={{ default: 'justifyContentSpaceBetween' }}>
+                        <Flex alignItems={{ default: 'alignItemsCenter' }} id="firewall-heading-title-group">
+                            <Title headingLevel="h2" size="3xl">
+                                {_("Firewall")}
+                            </Title>
+                            <FirewallSwitch firewall={firewall} />
+                            <p>{_("Incoming requests are blocked by default. Outgoing requests are not blocked.")}</p>
+                        </Flex>
+                        { enabled && !firewall.readonly && <span className="btn-group">{addZoneAction}</span> }
+                    </Flex>
+                </PageSection>
                 <PageSection id="zones-listing">
                     { enabled && <Stack hasGutter>
                         {

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -24,7 +24,7 @@ import { Card, CardActions, CardBody, CardHeader, CardTitle } from "@patternfly/
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
-import { Page, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection, PageSectionVariants } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 
 import { ModelContext } from './model-context.jsx';
@@ -689,19 +689,18 @@ export const NetworkInterfacePage = ({
             .map((component, idx) => <React.Fragment key={idx}>{component}</React.Fragment>);
 
     return (
-        <Page groupProps={{ sticky: 'top' }}
-              isBreadcrumbGrouped
-              id="network-interface"
-              data-test-wait={operationInProgress}
-              breadcrumb={
-                  <Breadcrumb>
-                      <BreadcrumbItem to='#/'>
-                          {_("Networking")}
-                      </BreadcrumbItem>
-                      <BreadcrumbItem isActive>
-                          {dev_name}
-                      </BreadcrumbItem>
-                  </Breadcrumb>}>
+        <Page id="network-interface"
+              data-test-wait={operationInProgress}>
+            <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                <Breadcrumb>
+                    <BreadcrumbItem to='#/'>
+                        {_("Networking")}
+                    </BreadcrumbItem>
+                    <BreadcrumbItem isActive>
+                        {dev_name}
+                    </BreadcrumbItem>
+                </Breadcrumb>
+            </PageBreadcrumb>
             <PageSection variant={PageSectionVariants.light}>
                 <NetworkPlots plot_state={plot_state} />
             </PageSection>

--- a/pkg/storaged/details.jsx
+++ b/pkg/storaged/details.jsx
@@ -20,7 +20,7 @@
 import cockpit from "cockpit";
 import React from "react";
 
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Grid, GridItem } from "@patternfly/react-core/dist/esm/layouts/Grid/index.js";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
@@ -135,14 +135,13 @@ export class Details extends React.Component {
             body = <GridItem span={12}>{_("Not found")}</GridItem>;
 
         return (
-            <Page groupProps={{ sticky: 'top' }}
-                  isBreadcrumbGrouped
-                  id="storage-detail"
-                  breadcrumb={
-                      <Breadcrumb>
-                          <BreadcrumbItem to="#/">{_("Storage")}</BreadcrumbItem>
-                          <BreadcrumbItem isActive>{name}</BreadcrumbItem>
-                      </Breadcrumb>}>
+            <Page id="storage-detail">
+                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                    <Breadcrumb>
+                        <BreadcrumbItem to="#/">{_("Storage")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{name}</BreadcrumbItem>
+                    </Breadcrumb>
+                </PageBreadcrumb>
                 <PageSection>
                     <Grid hasGutter>
                         {body}

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -35,7 +35,7 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 import { EmptyState } from "@patternfly/react-core/dist/esm/components/EmptyState/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
@@ -317,13 +317,13 @@ class HardwareInfo extends React.Component {
         }
 
         return (
-            <Page groupProps={{ sticky: 'top' }}
-                  isBreadcrumbGrouped
-                  breadcrumb={
-                      <Breadcrumb>
-                          <BreadcrumbItem onClick={ () => cockpit.jump("/system", cockpit.transport.host)} className="pf-c-breadcrumb__link">{ _("Overview") }</BreadcrumbItem>
-                          <BreadcrumbItem isActive>{ _("Hardware information") }</BreadcrumbItem>
-                      </Breadcrumb>}>
+            <Page>
+                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                    <Breadcrumb>
+                        <BreadcrumbItem onClick={ () => cockpit.jump("/system", cockpit.transport.host)} className="pf-c-breadcrumb__link">{ _("Overview") }</BreadcrumbItem>
+                        <BreadcrumbItem isActive>{ _("Hardware information") }</BreadcrumbItem>
+                    </Breadcrumb>
+                </PageBreadcrumb>
                 <PageSection>
                     <Gallery hasGutter>
                         <Card>

--- a/pkg/systemd/logDetails.jsx
+++ b/pkg/systemd/logDetails.jsx
@@ -29,7 +29,7 @@ import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/comp
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Card, CardActions, CardBody, CardHeader, CardHeaderMain, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery, GalleryItem } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 
 const _ = cockpit.gettext;
@@ -191,16 +191,15 @@ export class LogEntry extends React.Component {
         }
 
         return (
-            <Page groupProps={{ sticky: 'top' }}
-                  isBreadcrumbGrouped
-                  id="log-details"
-                  breadcrumb={
-                      <Breadcrumb>
-                          <BreadcrumbItem onClick={this.goHome} className="pf-c-breadcrumb__link">{_("Logs")}</BreadcrumbItem>
-                          <BreadcrumbItem isActive>
-                              {breadcrumb}
-                          </BreadcrumbItem>
-                      </Breadcrumb>}>
+            <Page id="log-details">
+                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                    <Breadcrumb>
+                        <BreadcrumbItem onClick={this.goHome} className="pf-c-breadcrumb__link">{_("Logs")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>
+                            {breadcrumb}
+                        </BreadcrumbItem>
+                    </Breadcrumb>
+                </PageBreadcrumb>
                 <PageSection>
                     <Gallery hasGutter>
                         {content}

--- a/pkg/systemd/service.jsx
+++ b/pkg/systemd/service.jsx
@@ -19,7 +19,7 @@
 
 import React, { useRef, useState } from "react";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery, GalleryItem } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -146,16 +146,15 @@ export const Service = ({ dbusClient, owner, unitId, unitIsValid, addTimerProper
 
     return (
         <WithDialogs>
-            <Page groupProps={{ sticky: 'top' }}
-                    isBreadcrumbGrouped
-                    id="service-details"
-                    breadcrumb={
-                        <Breadcrumb>
-                            <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
-                            <BreadcrumbItem isActive>
-                                {cur_unit_id}
-                            </BreadcrumbItem>
-                        </Breadcrumb>}>
+            <Page id="service-details">
+                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                    <Breadcrumb>
+                        <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
+                        <BreadcrumbItem isActive>
+                            {cur_unit_id}
+                        </BreadcrumbItem>
+                    </Breadcrumb>
+                </PageBreadcrumb>
                 <PageSection>
                     <Gallery hasGutter>
                         <GalleryItem id="service-details-unit">

--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -30,7 +30,7 @@ import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Label } from "@patternfly/react-core/dist/esm/components/Label/index.js";
 import { LabelGroup } from "@patternfly/react-core/dist/esm/components/LabelGroup/index.js";
-import { Page, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { Select, SelectOption, SelectVariant } from "@patternfly/react-core/dist/esm/components/Select/index.js";
 import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
@@ -229,14 +229,13 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
         last_login = timeformat.dateTime(new Date(account.lastLogin));
 
     return (
-        <Page groupProps={{ sticky: 'top' }}
-              isBreadcrumbGrouped
-              id="account"
-              breadcrumb={
-                  <Breadcrumb>
-                      <BreadcrumbItem to="#/">{_("Accounts")}</BreadcrumbItem>
-                      <BreadcrumbItem isActive>{title_name}</BreadcrumbItem>
-                  </Breadcrumb>}>
+        <Page id="account">
+            <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                <Breadcrumb>
+                    <BreadcrumbItem to="#/">{_("Accounts")}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>{title_name}</BreadcrumbItem>
+                </Breadcrumb>
+            </PageBreadcrumb>
             <PageSection>
                 <Gallery hasGutter>
                     <Card className="account-details" id="account-details">

--- a/pkg/users/users.scss
+++ b/pkg/users/users.scss
@@ -15,10 +15,6 @@
   margin-bottom: var(--pf-global--spacer--lg);
 }
 
-#account {
-  --pf-c-page__main-breadcrumb--PaddingBottom: var(--pf-c-page__main-breadcrumb--PaddingTop);
-}
-
 #account .pf-l-gallery {
   --pf-l-gallery--GridTemplateColumns: 1fr;
 }


### PR DESCRIPTION
This is still PF4 compatible.

The only noticeable change is on firewall, as now only the breadcrumbs will remain sticky and the rest of the page headers will hide on scroll. This is the desired behavior as suggested here [0]

[0] https://github.com/cockpit-project/cockpit/pull/18476#pullrequestreview-1343830115