### PR TITLE
Fix TestConnection.testCockpitDesktop for pybridge

### DIFF
--- a/test/image-prepare
+++ b/test/image-prepare
@@ -201,7 +201,7 @@ def install_python_bridge():
     import build
     builder = build.ProjectBuilder(BASE_DIR)
     wheel = builder.build('wheel', f'{BASE_DIR}/tmp/wheel')
-    return ['--install', wheel]
+    return ['--install', wheel, '--run-command', 'sed -i "s_/usr/bin_/usr/local/bin_" /usr/share/polkit-1/actions/org.cockpit-project.cockpit-bridge.policy']
 
 
 def main():

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -23,7 +23,7 @@ import os
 import subprocess
 
 import parent  # noqa: F401
-from testlib import (MachineCase, TEST_DIR, nondestructive, todoPybridge, test_main, wait,
+from testlib import (MachineCase, TEST_DIR, nondestructive, test_main, wait,
                      skipBrowser, skipDistroPackage, skipImage, skipOstree)
 
 
@@ -823,7 +823,6 @@ export XDG_CONFIG_DIRS=/usr/local
 
     @skipOstree("OSTree doesn't have cockpit-ws")
     @skipImage("Kernel does not allow user namespaces", "debian-*")
-    @todoPybridge()
     @nondestructive
     def testCockpitDesktop(self):
         m = self.machine

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -862,7 +862,8 @@ export XDG_CONFIG_DIRS=/usr/local
 
         for (pages, asserts) in cases:
             for page in pages:
-                m.execute(f'''su - -c 'BROWSER="curl --silent --compressed -o /tmp/out.html" {self.libexecdir}/cockpit-desktop {page}' admin''')
+                m.execute(f'''su - -c 'BROWSER="curl --silent --compressed -o /tmp/out.html" {self.libexecdir}/cockpit-desktop {page}' admin''',
+                          timeout=10)
 
                 out = m.execute("cat /tmp/out.html")
                 for a in asserts:
@@ -894,7 +895,7 @@ curl --silent --compressed -o /tmp/out.html "$@"
 until pgrep -f '[c]ockpit-bridge.*--privileged'; do sleep 1; done
 """)
         m.execute("chmod 755 /tmp/browser.sh")
-        m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin")
+        m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin", timeout=10)
         self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -23,7 +23,7 @@ import os
 import subprocess
 
 import parent  # noqa: F401
-from testlib import (MachineCase, TEST_DIR, nondestructive, todoPybridgeRHEL8, test_main, wait,
+from testlib import (MachineCase, TEST_DIR, nondestructive, todoPybridge, test_main, wait,
                      skipBrowser, skipDistroPackage, skipImage, skipOstree)
 
 
@@ -823,7 +823,7 @@ export XDG_CONFIG_DIRS=/usr/local
 
     @skipOstree("OSTree doesn't have cockpit-ws")
     @skipImage("Kernel does not allow user namespaces", "debian-*")
-    @todoPybridgeRHEL8(reason="regression from https://github.com/cockpit-project/cockpit/pull/18398")
+    @todoPybridge()
     @nondestructive
     def testCockpitDesktop(self):
         m = self.machine
@@ -889,10 +889,15 @@ ResultAny=yes
 ResultInactive=yes
 ResultActive=yes""")
 
-        self.write_file(r"/tmp/browser.sh", """#!/bin/sh -e
+        if os.environ.get("TEST_SCENARIO") == "pybridge":
+            pgrep = "^/usr/bin/python.*cockpit-bridge.*--privileged"
+        else:
+            pgrep = "^/usr/bin/cockpit-bridge.*--privileged"
+
+        self.write_file("/tmp/browser.sh", f"""#!/bin/sh -e
 curl --silent --compressed -o /tmp/out.html "$@"
 # wait until privileged bridge starts
-until pgrep -f '[c]ockpit-bridge.*--privileged'; do sleep 1; done
+until pgrep -f '{pgrep}'; do sleep 1; done
 """)
         m.execute("chmod 755 /tmp/browser.sh")
         m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin", timeout=10)


### PR DESCRIPTION
Previously, that test [sometimes failed on f37](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18603-20230420-093114-fcef2f24-fedora-37-pybridge/log.html#16), and [sometimes succeeded on c8s](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18662-20230421-054212-ae04049b-centos-8-stream-pybridge/log.html), as commit 2c9b18246f2 introduced a race condition. Fix the race, and fix the test properly.