### PR TITLE
firewall: remove the default top padding from the toolbar in 'add services' dialog

### DIFF
--- a/pkg/networkmanager/firewall.jsx
+++ b/pkg/networkmanager/firewall.jsx
@@ -263,7 +263,7 @@ class SearchInput extends React.Component {
 
     render() {
         return (
-            <Toolbar>
+            <Toolbar className="filter-services-toolbar">
                 <ToolbarContent>
                     <ToolbarItem variant="label">
                         {_("Filter services")}

--- a/pkg/networkmanager/networking.scss
+++ b/pkg/networkmanager/networking.scss
@@ -294,4 +294,9 @@ th {
   color: var(--pf-global--danger-color--200);
 }
 
+// Remove the default top padding from the toolbar
+.filter-services-toolbar {
+  padding-top: 0;
+}
+
 /* End Firewall specific CSS */


### PR DESCRIPTION
This was cought by @garrett in https://github.com/cockpit-project/cockpit/pull/18672#issuecomment-1516592383 but it's unrelated to that PR.