### PR TITLE
Fix TestStorageHidden.testHiddenLuks OOM, fix crash if block device lacks Encrypted interface

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1617,32 +1617,8 @@ export function is_interesting_interface(iface) {
     return !iface.Device || is_managed(iface.Device);
 }
 
-export function array_find(array, predicate) {
-    if (array === null || array === undefined) {
-        throw new TypeError('Array.prototype.find called on null or undefined');
-    }
-    if (typeof predicate !== 'function') {
-        throw new TypeError('predicate must be a function');
-    }
-    const list = Object(array);
-    const length = list.length >>> 0;
-    const thisArg = arguments[1];
-
-    for (let i = 0; i < length; i++) {
-        if (i in list) {
-            const value = list[i];
-            if (predicate.call(thisArg, value, i, list)) {
-                return value;
-            }
-        }
-    }
-    return undefined;
-}
-
 export function member_connection_for_interface(group, iface) {
-    return group && array_find(group.Members, function (s) {
-        return is_interface_connection(iface, s);
-    });
+    return group?.Members.find(s => is_interface_connection(iface, s));
 }
 
 export function member_interface_choices(model, group) {

--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -630,8 +630,7 @@ client.stop_mount_users = (users) => {
  */
 
 client.mount_at = (block, target) => {
-    const entry = utils.array_find(block.Configuration,
-                                   c => c[0] == "fstab" && utils.decode_filename(c[1].dir.v) == target);
+    const entry = block.Configuration.find(c => c[0] == "fstab" && utils.decode_filename(c[1].dir.v) == target);
     if (entry)
         return cockpit.script('set -e; mkdir -p "$2"; mount "$1" "$2" -o "$3"',
                               [utils.decode_filename(block.Device), target, utils.decode_filename(entry[1].opts.v)],

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -242,7 +242,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     }
 
     if (is_crypto) {
-        const config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
+        const config = client.blocks_crypto[block.path]?.ChildConfiguration.find(c => c[0] == "fstab");
         if (config && !content_block)
             add_tab(_("Filesystem"), FilesystemTab, false, ["mismounted-fsys"]);
         add_tab(_("Encryption"), CryptoTab);
@@ -293,7 +293,7 @@ function create_tabs(client, target, is_partition, is_extended) {
             if (!block_fsys)
                 add_menu_action(_("Lock"), lock);
         } else {
-            const config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
+            const config = client.blocks_crypto[block.path]?.ChildConfiguration.find(c => c[0] == "fstab");
             if (config && !content_block)
                 add_action(_("Mount"), () => mounting_dialog(client, block, "mount"));
             else

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -242,7 +242,7 @@ function create_tabs(client, target, is_partition, is_extended) {
     }
 
     if (is_crypto) {
-        const config = utils.array_find(client.blocks_crypto[block.path].ChildConfiguration, c => c[0] == "fstab");
+        const config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
         if (config && !content_block)
             add_tab(_("Filesystem"), FilesystemTab, false, ["mismounted-fsys"]);
         add_tab(_("Encryption"), CryptoTab);
@@ -293,8 +293,7 @@ function create_tabs(client, target, is_partition, is_extended) {
             if (!block_fsys)
                 add_menu_action(_("Lock"), lock);
         } else {
-            const config = utils.array_find(client.blocks_crypto[block.path].ChildConfiguration,
-                                            c => c[0] == "fstab");
+            const config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
             if (config && !content_block)
                 add_action(_("Mount"), () => mounting_dialog(client, block, "mount"));
             else

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -39,7 +39,7 @@ import {
     dialog_open,
     SelectOneRadio, TextInput, PassInput, Skip
 } from "./dialog.jsx";
-import { array_find, decode_filename, encode_filename, block_name, for_each_async } from "./utils.js";
+import { decode_filename, encode_filename, block_name, for_each_async } from "./utils.js";
 import { fmt_to_fragments } from "utils.jsx";
 import { StorageButton } from "./storage-controls.jsx";
 import { parse_options, unparse_options } from "./format-dialog.jsx";
@@ -208,7 +208,7 @@ export function existing_passphrase_fields(explanation) {
 }
 
 function get_stored_passphrase(block, just_type) {
-    const pub_config = array_find(block.Configuration, function (c) { return c[0] == "crypttab" });
+    const pub_config = block.Configuration.find(c => c[0] == "crypttab");
     if (pub_config && pub_config[1]["passphrase-path"] && decode_filename(pub_config[1]["passphrase-path"].v) != "") {
         if (just_type)
             return Promise.resolve("stored");
@@ -338,9 +338,9 @@ function ensure_root_nbde_support(steps, progress) {
 function ensure_fstab_option(steps, progress, client, block, option) {
     const cleartext = client.blocks_cleartext[block.path];
     const crypto = client.blocks_crypto[block.path];
-    const fsys_config = (cleartext
-        ? array_find(cleartext.Configuration, function (c) { return c[0] == "fstab" })
-        : array_find(crypto.ChildConfiguration, function (c) { return c[0] == "fstab" }));
+    const fsys_config = cleartext
+        ? cleartext.Configuration.find(c => c[0] == "fstab")
+        : crypto.ChildConfiguration.find(c => c[0] == "fstab");
     const fsys_options = fsys_config && parse_options(decode_filename(fsys_config[1].opts.v));
 
     if (!fsys_options || fsys_options.indexOf(option) >= 0)
@@ -362,7 +362,7 @@ function ensure_fstab_option(steps, progress, client, block, option) {
 }
 
 function ensure_crypto_option(steps, progress, client, block, option) {
-    const crypto_config = array_find(block.Configuration, function (c) { return c[0] == "crypttab" });
+    const crypto_config = block.Configuration.find(c => c[0] == "crypttab");
     const crypto_options = crypto_config && parse_options(decode_filename(crypto_config[1].options.v));
     if (!crypto_options || crypto_options.indexOf(option) >= 0)
         return Promise.resolve();
@@ -398,9 +398,9 @@ function ensure_non_root_nbde_support(steps, progress, client, block) {
 function ensure_nbde_support(steps, progress, client, block) {
     const cleartext = client.blocks_cleartext[block.path];
     const crypto = client.blocks_crypto[block.path];
-    const fsys_config = (cleartext
-        ? array_find(cleartext.Configuration, function (c) { return c[0] == "fstab" })
-        : array_find(crypto.ChildConfiguration, function (c) { return c[0] == "fstab" }));
+    const fsys_config = cleartext
+        ? cleartext.Configuration.find(c => c[0] == "fstab")
+        : crypto.ChildConfiguration.find(c => c[0] == "fstab");
     const dir = decode_filename(fsys_config[1].dir.v);
 
     if (dir == "/") {

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -340,7 +340,7 @@ function ensure_fstab_option(steps, progress, client, block, option) {
     const crypto = client.blocks_crypto[block.path];
     const fsys_config = cleartext
         ? cleartext.Configuration.find(c => c[0] == "fstab")
-        : crypto.ChildConfiguration.find(c => c[0] == "fstab");
+        : crypto?.ChildConfiguration.find(c => c[0] == "fstab");
     const fsys_options = fsys_config && parse_options(decode_filename(fsys_config[1].opts.v));
 
     if (!fsys_options || fsys_options.indexOf(option) >= 0)

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -21,7 +21,7 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import cockpit from "cockpit";
 import { dialog_open, TextInput, PassInput } from "./dialog.jsx";
-import { array_find, encode_filename, decode_filename, block_name } from "./utils.js";
+import { encode_filename, decode_filename, block_name } from "./utils.js";
 import { parse_options, unparse_options, extract_option } from "./format-dialog.jsx";
 import { is_mounted } from "./fsys-tab.jsx";
 
@@ -63,7 +63,7 @@ export function edit_config(block, modify) {
 
     return block.GetSecretConfiguration({}).then(
         function (items) {
-            old_config = array_find(items, function (c) { return c[0] == "crypttab" });
+            old_config = items.find(c => c[0] == "crypttab");
             new_config = ["crypttab", old_config ? Object.assign({ }, old_config[1]) : { }];
 
             // UDisks insists on always having a "passphrase-contents" field when
@@ -168,7 +168,7 @@ export class CryptoTab extends React.Component {
         }
 
         let old_options, passphrase_path;
-        const old_config = array_find(block.Configuration, function (c) { return c[0] == "crypttab" });
+        const old_config = block.Configuration.find(c => c[0] == "crypttab");
         if (old_config) {
             old_options = (decode_filename(old_config[1].options.v)
                     .split(",")
@@ -184,8 +184,7 @@ export class CryptoTab extends React.Component {
         const extra_options = unparse_options(split_options);
 
         function edit_options() {
-            const fsys_config = array_find(client.blocks_crypto[block.path].ChildConfiguration,
-                                           c => c[0] == "fstab");
+            const fsys_config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
             const content_block = client.blocks_cleartext[block.path];
             const is_fsys = fsys_config || (content_block && content_block.IdUsage == "filesystem");
 

--- a/pkg/storaged/crypto-tab.jsx
+++ b/pkg/storaged/crypto-tab.jsx
@@ -184,7 +184,7 @@ export class CryptoTab extends React.Component {
         const extra_options = unparse_options(split_options);
 
         function edit_options() {
-            const fsys_config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
+            const fsys_config = client.blocks_crypto[block.path]?.ChildConfiguration.find(c => c[0] == "fstab");
             const content_block = client.blocks_cleartext[block.path];
             const is_fsys = fsys_config || (content_block && content_block.IdUsage == "filesystem");
 

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -239,7 +239,7 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
         return;
     }
 
-    const crypto_config = utils.array_find(block.Configuration, function (c) { return c[0] == "crypttab" });
+    const crypto_config = block.Configuration.find(c => c[0] == "crypttab");
     let crypto_options;
     if (crypto_config) {
         crypto_options = (utils.decode_filename(crypto_config[1].options.v)

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -58,7 +58,7 @@ export function get_fstab_config(block, also_child_config) {
     let config = block.Configuration.find(c => c[0] == "fstab");
 
     if (!config && also_child_config && client.blocks_crypto[block.path])
-        config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
+        config = client.blocks_crypto[block.path]?.ChildConfiguration.find(c => c[0] == "fstab");
 
     if (config && utils.decode_filename(config[1].type.v) != "swap") {
         let dir = utils.decode_filename(config[1].dir.v);

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -44,7 +44,7 @@ const _ = cockpit.gettext;
 export function is_mounted(client, block) {
     const block_fsys = client.blocks_fsys[block.path];
     const mounted_at = block_fsys ? block_fsys.MountPoints : [];
-    const config = utils.array_find(block.Configuration, function (c) { return c[0] == "fstab" });
+    const config = block.Configuration.find(c => c[0] == "fstab");
     if (config && config[1].dir.v) {
         let dir = utils.decode_filename(config[1].dir.v);
         if (dir[0] != "/")
@@ -55,10 +55,10 @@ export function is_mounted(client, block) {
 }
 
 export function get_fstab_config(block, also_child_config) {
-    let config = utils.array_find(block.Configuration, c => c[0] == "fstab");
+    let config = block.Configuration.find(c => c[0] == "fstab");
 
     if (!config && also_child_config && client.blocks_crypto[block.path])
-        config = utils.array_find(client.blocks_crypto[block.path].ChildConfiguration, c => c[0] == "fstab");
+        config = client.blocks_crypto[block.path].ChildConfiguration.find(c => c[0] == "fstab");
 
     if (config && utils.decode_filename(config[1].type.v) != "swap") {
         let dir = utils.decode_filename(config[1].dir.v);
@@ -115,7 +115,7 @@ export function get_cryptobacking_noauto(client, block) {
     if (!crypto_backing)
         return false;
 
-    const crypto_config = utils.array_find(crypto_backing.Configuration, function (c) { return c[0] == "crypttab" });
+    const crypto_config = crypto_backing.Configuration.find(c => c[0] == "crypttab");
     if (!crypto_config)
         return false;
 

--- a/pkg/storaged/mdraid-details.jsx
+++ b/pkg/storaged/mdraid-details.jsx
@@ -98,9 +98,7 @@ class MDRaidSidebar extends React.Component {
             running = mdraid.ActiveDevices && mdraid.ActiveDevices.length > 0;
 
         function render_member(block) {
-            const active_state = utils.array_find(mdraid.ActiveDevices, function(as) {
-                return as[0] == block.path;
-            });
+            const active_state = mdraid.ActiveDevices.find(as => as[0] == block.path);
 
             function state_text(state) {
                 return {

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -61,13 +61,6 @@ export function mock_hostnamed(value) {
     }
 }
 
-export function array_find(array, pred) {
-    for (let i = 0; i < array.length; i++)
-        if (pred(array[i]))
-            return array[i];
-    return undefined;
-}
-
 export function flatten(array_of_arrays) {
     if (array_of_arrays.length > 0)
         return Array.prototype.concat.apply([], array_of_arrays);
@@ -659,9 +652,7 @@ export function get_active_usage(client, path, top_action, child_action) {
                 });
             });
         } else if (mdraid) {
-            const active_state = array_find(mdraid.ActiveDevices, function (as) {
-                return as[0] == block.path;
-            });
+            const active_state = mdraid.ActiveDevices.find(as => as[0] == block.path);
             usage.push({
                 level,
                 usage: 'mdraid-member',

--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -25,9 +25,14 @@ import unittest
 import testvm
 
 
-class TestStorageHidden(StorageCase):
+class TestStorageHiddenLuks(StorageCase):
 
-    def testHiddenLuks(self):
+    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    provision = {
+        "0": {"memory_mb": 1536}
+    }
+
+    def test(self):
         m = self.machine
         b = self.browser
 
@@ -85,6 +90,9 @@ class TestStorageHidden(StorageCase):
         b.wait_visible("#storage")
         self.assertEqual(m.execute(f"grep {mount_point_1} /etc/fstab || true"), "")
         self.assertEqual(m.execute(f"grep {'my-crypto-tag'} /etc/crypttab || true"), "")
+
+
+class TestStorageHidden(StorageCase):
 
     def testHiddenRaid(self):
         m = self.machine


### PR DESCRIPTION
This sometimes runs into out of memory errors with the default VM size. Split it out into its own test class and increase memory like we do in check-storage-{luks,resize}.

----

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-18662-20230421-050018-6ed1ae43-rhel-8-9/log.html#341 and https://cockpit-logs.us-east-1.linodeobjects.com/pull-18662-20230421-054212-ae04049b-debian-testing/log.html#341

After fixing OOM, the [undefined ChildConfiguration still happens](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18686-20230421-194249-fd65ffa3-centos-8-stream/log.html#348-2)