### PR TITLE
apps, systemd/services: Use single source of truth for page location

### DIFF
--- a/pkg/apps/apps.jsx
+++ b/pkg/apps/apps.jsx
@@ -58,7 +58,7 @@ const App = () => {
                                 appProgress={progress}
                                 appProgressTitle={progressTitle} />;
     } else if (path.length == 1) {
-        const id = cockpit.location.path[0];
+        const id = path[0];
         return <Application metainfo_db={metainfo_db}
                             action={action}
                             progress={progress[id]}


### PR DESCRIPTION
The current iframe path/options for ServicesPageBody is currently coming
from two different sources: `cockpit.location` and properties passed
from the parent ServicesPage element, which tracks it as React state. As
the latter is "laggy" and sometimes disagrees with cockpit.location,
this led to inconsistent states: the page sometimes "forgot" its current
location when an asynchronous state update overwrote a recently happened
cockpit.location update.

Avoid this race by consistently using cockpit.location for everything.
Keep usePageLocation() only for triggering renders when the options
change, but ignore its state.

Fixes #18465

---

This also fixes the same inconsistency on the apps page, but the other way round: As we don't have to deal with multiple nested components there, and sub-elements (like Service filters) changing the location, it's much simpler to just always use the React state.

This fixes the current top flake:

![image](https://user-images.githubusercontent.com/200109/233820599-0101d5cc-c500-4886-802e-539644bc4420.png)
