### PR TITLE
lib: pf-overrides: override background of page header for dark theme also  if it's in a group

### DIFF
--- a/pkg/lib/patternfly/patternfly-4-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-4-overrides.scss
@@ -236,6 +236,7 @@ select.pf-c-form-control {
   // Adapt breadcrumb bar to be similar color as PF website
   // (We use header bars in slightly different ways from PF)
   // https://github.com/patternfly/patternfly/issues/5301
+  .pf-c-page__main-group section,
   .pf-c-page__main-breadcrumb {
     --pf-c-page__main-breadcrumb--BackgroundColor: var(--pf-global--BackgroundColor--dark-100);
     background-color: var(--pf-global--BackgroundColor--dark-100);


### PR DESCRIPTION
This page layout exists in cockpit-machines.