### PR TITLE
Fixing space b/w Purpose dropdown and helptext

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -906,6 +906,7 @@ export class VGroup extends React.Component {
                     Message(cockpit.format(_("The $0 package will be installed to create VDO devices."), vdo_package),
                             {
                                 visible: vals => vals.purpose === 'vdo' && need_vdo_install,
+                                style: { marginTop: '1px' }
                             }),
 
                     /* Not Implemented


### PR DESCRIPTION
Decreases the space between the purpose dropdown and helper message in the vdo-support dialog. Part of #18531.