### PR TITLE
storage: When fixing NBDE, also recognize indirect root filesystems

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -303,6 +303,21 @@ function ensure_package_installed(steps, progress, package_name) {
                                 return install_missing_packages(data, status_callback(progress));
                         }
                     });
+            })
+            .catch(error => {
+            // Something wrong with PackageKit, maybe it is not even
+            // installed.  Let's show the error during fixing.
+                progress(null, null);
+                steps.push({
+                    title: cockpit.format(_("The $0 package must be installed."), package_name),
+                    func: progress => {
+                        if (error.problem == "not-found") {
+                            return Promise.reject(cockpit.format(_("Error installing $0: PackageKit is not installed"), package_name));
+                        } else {
+                            return Promise.reject(cockpit.format(_("Unexpected PackageKit error during installation of $0: $1"), package_name, error.toString())); // not-covered: OS error
+                        }
+                    }
+                });
             });
 }
 

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -39,7 +39,7 @@ import {
     dialog_open,
     SelectOneRadio, TextInput, PassInput, Skip
 } from "./dialog.jsx";
-import { decode_filename, encode_filename, block_name, for_each_async } from "./utils.js";
+import { decode_filename, encode_filename, block_name, for_each_async, get_children } from "./utils.js";
 import { fmt_to_fragments } from "utils.jsx";
 import { StorageButton } from "./storage-controls.jsx";
 import { parse_options, unparse_options } from "./format-dialog.jsx";
@@ -395,15 +395,26 @@ function ensure_non_root_nbde_support(steps, progress, client, block) {
             .then(() => ensure_crypto_option(steps, progress, client, block, "_netdev"));
 }
 
-function ensure_nbde_support(steps, progress, client, block) {
-    const cleartext = client.blocks_cleartext[block.path];
-    const crypto = client.blocks_crypto[block.path];
-    const fsys_config = cleartext
-        ? cleartext.Configuration.find(c => c[0] == "fstab")
-        : crypto.ChildConfiguration.find(c => c[0] == "fstab");
-    const dir = decode_filename(fsys_config[1].dir.v);
+function contains_rootfs(client, path) {
+    const block = client.blocks[path];
+    const crypto = client.blocks_crypto[path];
+    let fsys_config = null;
 
-    if (dir == "/") {
+    if (block)
+        fsys_config = block.Configuration.find(c => c[0] == "fstab");
+    if (!fsys_config && crypto)
+        fsys_config = crypto.ChildConfiguration.find(c => c[0] == "fstab");
+
+    if (fsys_config) {
+        const dir = decode_filename(fsys_config[1].dir.v);
+        return dir == "/";
+    }
+
+    return get_children(client, path).some(p => contains_rootfs(client, p));
+}
+
+function ensure_nbde_support(steps, progress, client, block) {
+    if (contains_rootfs(client, block.path)) {
         if (client.get_config("nbde_root_help", false)) {
             steps.is_root = true;
             return ensure_root_nbde_support(steps, progress);

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -569,7 +569,20 @@ export function is_netdev(client, path) {
     return false;
 }
 
-function get_children(client, path) {
+/* GET_CHILDREN gets the direct children of the storage object at
+   PATH, like the partitions of a partitioned block device, or the
+   volume group of a physical volume.  By calling GET_CHILDREN
+   recursively, you can traverse the whole storage hierachy from
+   hardware drives at the bottom to filesystems at the top.
+
+   GET_CHILDREN_FOR_TEARDOWN is similar but doesn't consider things
+   like volume groups to be children of their physical volumes.  This
+   is appropriate for teardown processing, where tearing down a
+   physical volume does not imply tearing down the whole volume groups
+   with everything that it contains.
+*/
+
+function get_children_for_teardown(client, path) {
     const children = [];
 
     if (client.blocks_cleartext[path]) {
@@ -617,6 +630,30 @@ function get_children(client, path) {
     return children;
 }
 
+export function get_children(client, path) {
+    const children = get_children_for_teardown(client, path);
+
+    if (client.blocks[path]) {
+        const mdraid = client.blocks[path].MDRaidMember;
+        if (mdraid != "/")
+            children.push(mdraid);
+    }
+
+    if (client.blocks_pvol[path]) {
+        const vgroup = client.blocks_pvol[path].VolumeGroup;
+        if (vgroup != "/")
+            children.push(vgroup);
+    }
+
+    if (client.blocks_stratis_blockdev[path]) {
+        const pool = client.blocks_stratis_blockdev[path].Pool;
+        if (pool != "/")
+            children.push(pool);
+    }
+
+    return children;
+}
+
 export function get_active_usage(client, path, top_action, child_action) {
     function get_usage(path, level) {
         const block = client.blocks[path];
@@ -628,7 +665,7 @@ export function get_active_usage(client, path, top_action, child_action) {
         const stratis_blockdev = block && client.blocks_stratis_blockdev[path];
         const stratis_pool = stratis_blockdev && client.stratis_pools[stratis_blockdev.Pool];
 
-        const usage = flatten(get_children(client, path).map(p => get_usage(p, level + 1)));
+        const usage = flatten(get_children_for_teardown(client, path).map(p => get_usage(p, level + 1)));
 
         function get_actions(teardown_action) {
             const actions = [];

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -527,6 +527,7 @@ class TestStorageNBDE(StorageCase, PackageCase):
         with b.wait_timeout(60):
             if need_fixing:
                 b.wait_in_text("#dialog", "Add Network Bound Disk Encryption")
+                b.wait_in_text("#dialog", "The clevis-systemd package must be installed")
                 self.dialog_apply()
             b.wait_in_text("#dialog", "No key available with this passphrase.")
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
@@ -570,7 +571,13 @@ class TestStorageNBDE(StorageCase, PackageCase):
         self.dialog({"at_boot": "nofail"})
         self.content_tab_wait_in_info(1, 2, "Options", "nofail")
 
-        # Add a second key, this should not show the fixing dialog.
+        if need_fixing:
+            # Break things again, including PackageKit
+            m.execute("if type dnf; then dnf remove -y clevis-systemd; else apt-get purge -y clevis-systemd; fi")
+            m.execute("systemctl mask --now packagekit")
+
+        # Add a second key, this should try to fix things again, but
+        # we have to help with the package install
         #
         b.click(panel + "[aria-label=Add]")
         self.dialog_wait_open()
@@ -581,8 +588,36 @@ class TestStorageNBDE(StorageCase, PackageCase):
         b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches")
         b.wait_in_text("#dialog", tang_m.execute("tang-show-keys").strip())
         self.dialog_apply()
-        self.dialog_wait_close()
-        self.dialog_wait_close()
+        with b.wait_timeout(60):
+            if need_fixing:
+                b.wait_in_text("#dialog", "Add Network Bound Disk Encryption")
+                b.wait_in_text("#dialog", "The clevis-systemd package must be installed")
+                self.dialog_apply()
+                b.wait_in_text("#dialog", "PackageKit is not installed")
+                self.dialog_cancel()
+                self.dialog_wait_close()
+
+                # Manually install the missing package, Cockpit should
+                # be happy with that even when PackageKit is not
+                # available.  Also disable the unit, for variety.
+                # Cockpit will enable it without needing explicit
+                # confirmation.
+                #
+                m.execute("if type dnf; then dnf install -y clevis-systemd; else apt-get install -y clevis-systemd; fi")
+                m.execute("systemctl disable --now clevis-luks-askpass.path")
+
+                b.click(panel + "[aria-label=Add]")
+                self.dialog_wait_open()
+                self.dialog_wait_apply_enabled()
+                self.dialog_set_val("type", "tang")
+                self.dialog_set_val("tang_url", "http://10.111.112.5")
+                self.dialog_apply()
+                b.wait_in_text("#dialog", "Make sure the key hash from the Tang server matches")
+                b.wait_in_text("#dialog", tang_m.execute("tang-show-keys").strip())
+                self.dialog_apply()
+
+            self.dialog_wait_close()
+
         b.wait_visible(panel + "ul li:nth-child(3)")
         b.wait_in_text(panel + "ul li:nth-child(3)", "http://10.111.112.5")
 

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -632,26 +632,17 @@ class TestStorageNBDE(StorageCase, PackageCase):
 
         self.login_and_go("/storage")
 
-        # Add a clevis key to the root filesystem and then reboot.
+        # Add a clevis key and then reboot.
         #
         # We also remove the original passphrase in order to be sure
         # that it was in fact clevis that has unlocked the rootfs, and
         # not the magic provided by "encrypt_root"
 
-        b.wait_visible("#mounts")
-        for i in range(1, 100):
-            if b.text(f"#mounts tbody tr:nth-child({i}) td[data-label=Mount]") == "/":
-                b.click(f"#mounts tbody tr:nth-child({i})")
-                break
+        b.click('#devices .sidepanel-row:contains("/dev/root/")')
+        b.wait_visible("#storage-detail")
+        b.click('.sidepanel-row:contains("Encrypted partition")')
 
-        b.wait_visible("#detail-content")
-        for i in range(1, 100):
-            col = self.content_row_tbody(i) + ' tr:first-child td[data-label="Used for"]'
-            if b.text(col) == "/":
-                root_row = i
-                break
-
-        tab = self.content_tab_expand(root_row, 3)
+        tab = self.content_tab_expand(2, 2)
         panel = tab + " .pf-c-card:contains(Keys) "
         b.wait_visible(panel)
         b.wait_in_text(panel + "ul li:nth-child(1)", "Passphrase")
@@ -668,6 +659,8 @@ class TestStorageNBDE(StorageCase, PackageCase):
             b.wait_in_text("#dialog", tang_m.execute("tang-show-keys").strip())
             self.dialog_apply()
             b.wait_in_text("#dialog", "Add Network Bound Disk Encryption")
+            b.wait_in_text("#dialog", "The clevis-dracut package must be installed")
+            b.wait_in_text("#dialog", "The initrd must be regenerated")
             self.dialog_apply()
             self.dialog_wait_close()
 


### PR DESCRIPTION
For example, when adding a Clevis key to a block device that is a physical volume of the volume group that contains the root filesystem.

Fixes #18687