### PR TITLE
services: adjust service details header to use less custom CSS

### DIFF
--- a/pkg/lib/ct-card.scss
+++ b/pkg/lib/ct-card.scss
@@ -32,7 +32,8 @@
   font-weight: normal;
 }
 
-.ct-card.pf-c-card .pf-c-card__title > h2 {
+.ct-card.pf-c-card .pf-c-card__title > h2,
+.ct-card.pf-c-card h2.pf-c-card__title {
   font-size: var(--pf-global--FontSize--2xl);
 }
 

--- a/pkg/systemd/service-details.jsx
+++ b/pkg/systemd/service-details.jsx
@@ -26,7 +26,6 @@ import { Flex } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { ExpandableSection } from "@patternfly/react-core/dist/esm/components/ExpandableSection/index.js";
 import { Tooltip, TooltipPosition } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 import { Card, CardHeader, CardBody, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
-import { Text, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List/index.js";
 import { Modal } from "@patternfly/react-core/dist/esm/components/Modal/index.js";
 import { Spinner } from "@patternfly/react-core/dist/esm/components/Spinner/index.js";
@@ -607,7 +606,7 @@ export class ServiceDetails extends React.Component {
             });
 
         return (
-            <Card>
+            <Card className="ct-card">
                 { this.state.showDeleteDialog &&
                 <DeleteModal
                     name={this.props.unit.Description}
@@ -623,24 +622,20 @@ export class ServiceDetails extends React.Component {
                 />
                 }
                 <CardHeader>
-                    <Flex className="service-top-panel" spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-                        <CardTitle>
-                            <Text component={TextVariants.h2} className="service-name">{this.props.unit.Description}</Text>
-                            {this.state.isPinned &&
-                                <Tooltip content={_("Pinned unit")}>
-                                    <ThumbtackIcon className='service-thumbtack-icon' />
-                                </Tooltip>}
-                        </CardTitle>
+                    <Flex className="service-top-panel" spaceItems={{ default: 'spaceItemsMd' }} alignItems={{ default: 'alignItemsCenter' }}>
+                        <CardTitle component="h2" className="service-name">{this.props.unit.Description}</CardTitle>
+                        {this.state.isPinned &&
+                        <Tooltip content={_("Pinned unit")}>
+                            <ThumbtackIcon className='service-thumbtack-icon' />
+                        </Tooltip>}
                         { showAction &&
                             <>
                                 { !masked && !isStatic &&
                                     <Tooltip id="switch-unit-state" content={tooltipMessage} position={TooltipPosition.right}>
-                                        <span>
-                                            <Switch isChecked={enabled}
-                                                    aria-label={tooltipMessage}
-                                                    isDisabled={this.state.waitsAction || this.state.waitsFileAction}
-                                                    onChange={this.onOnOffSwitch} />
-                                        </span>
+                                        <Switch isChecked={enabled}
+                                                aria-label={tooltipMessage}
+                                                isDisabled={this.state.waitsAction || this.state.waitsFileAction}
+                                                onChange={this.onOnOffSwitch} />
                                     </Tooltip>
                                 }
                                 <ServiceActions { ...{ active, failed, enabled, masked } } canReload={this.props.unit.CanReload}

--- a/pkg/systemd/service-details.scss
+++ b/pkg/systemd/service-details.scss
@@ -33,29 +33,13 @@
   margin-right: 0.5em;
 }
 
-.service-top-panel {
-  padding-bottom: 1.25rem;
-  display: flex;
-  align-items: baseline;
+/* Rely on flex for spacing only */
+#service-actions button {
+  padding-left: 0;
 }
 
-.service-top-panel > .service-name {
-  margin: 0 0.75rem 0 0;
-}
-
-.service-top-panel .pf-c-switch {
-  vertical-align: text-bottom;
-  margin: 0 0 0 0.75rem;
-}
-
-.service-top-panel > .service-thumbtack-icon {
+.service-thumbtack-icon {
   color: var(--pf-global--icon--Color--light);
-  margin: 0 0.5rem 0 0;
-}
-
-/* Make the kebab wrapper flex to parents for proper alignment */
-.service-top-panel .pf-c-dropdown {
-  display: flex;
 }
 
 .action-button {


### PR DESCRIPTION
Use ct-card for making this card same to all other cards in cockpit.

Rely on Flex for spacing the card header elements.