### PR TITLE
python: Close process stdin when closing SubprocessTransport

### DIFF
--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -412,14 +412,18 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
         self.send_signal(signal.SIGKILL)
 
     def _close(self) -> None:
+        if self._pty_fd is not None:
+            os.close(self._pty_fd)
+            self._pty_fd = None
+
         if self._process is not None:
+            if self._process.stdin is not None:
+                self._process.stdin.close()
+                self._process.stdin = None
             try:
                 self.terminate()  # best effort...
             except PermissionError:
                 logger.debug("can't kill %i due to EPERM", self._process.pid)
-        if self._pty_fd is not None:
-            os.close(self._pty_fd)
-            self._pty_fd = None
 
 
 class StdioTransport(_Transport):

--- a/test/verify/check-reauthorize
+++ b/test/verify/check-reauthorize
@@ -18,13 +18,12 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, todoPybridgeRHEL8, test_main
+from testlib import MachineCase, nondestructive, skipDistroPackage, skipOstree, test_main
 
 
 @skipDistroPackage()
 @nondestructive
 class TestReauthorize(MachineCase):
-    @todoPybridgeRHEL8(reason="regression from https://github.com/cockpit-project/cockpit/pull/18398")
     def testBasic(self):
         self.allow_journal_messages('.*dropping message while waiting for child to exit.*')
         b = self.browser

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -237,7 +237,6 @@ session include system-auth
         b.wait_not_present(".pf-c-modal-box:contains('Problem becoming administrator')")
         b.check_superuser_indicator("Limited access")
 
-    @todoPybridgeRHEL8(reason="regression from https://github.com/cockpit-project/cockpit/pull/18398")
     def testRemoveBridgeConfig(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
When closing a running subprocess, EOF its stdin first, before    
terminating it. Commit ead84ab7ba1a dropped the equivalent code for a    
socket in the _close() function. Put it back. This fixes the last two    
regressions on CentOS/RHEL 8 from moving to ferny.    
    
This this also the first half of properly terminating the    
sudo+cockpit-askpass process pair when the authentication dialog gets    
cancelled (issue #18676): SIGTERMing sudo does not have any effect while    
it asks for a password, but its askpass child inherits its stdin and    
thus can see EOF on it when the channel closes. This is what happens    
with the C bridge+askpass.    

----

https://issues.redhat.com/browse/COCKPIT-971

~The second half of the fix will happen in ferny. With both of these fixes, issue #18676 is fixed. I'll send this as a ferny PR ASAP, but I have some trouble with running the tests, and also want to see if this can be unit-tested. For now, let's regression-test this cockpit-side fix separately.~

**Update**: That approach was nack'ed by Lis, but this PR is still valid IMHO (and fixes two regressions) -- it's generally good practice to close stdin before terminating a process.