### PR TITLE
test: Link @todoPybridge to issues

### DIFF
--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -594,7 +594,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
 
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18713")
     def testTroubleshooting(self):
         b = self.browser
         m1 = self.machine
@@ -729,7 +729,7 @@ class TestMultiMachine(MachineCase):
                                     '.*: server offered unsupported authentication methods: .*')
 
     @skipImage("TODO: Broken on Arch Linux", "arch")
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18714")
     def testSshKeySetup(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -232,7 +232,7 @@ class TestMultiMachineKeyAuth(MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18714")
     def testLockedIdentity(self):
         b = self.browser
         m1 = self.machine

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -267,7 +267,7 @@ session include system-auth
         b.click(".pf-c-modal-box button:contains('Close')")
         b.check_superuser_indicator("Limited access")
 
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18711")
     def testMultipleBridgeConfig(self):
         b = self.browser
 
@@ -391,7 +391,7 @@ class TestSuperuserOldWebserver(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machine
@@ -543,7 +543,7 @@ class TestSuperuserOldDashboard(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machines["machine1"]
@@ -607,7 +607,7 @@ class TestSuperuserDashboardOldMachine(MachineCase):
         "machine2": {"address": "10.111.113.2/20", "image": "centos-7"},
     }
 
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -695,7 +695,7 @@ class TestIPA(TestRealms, CommonTests):
                                     "sudo: unable to resolve host x0.cockpit.lan: Name or service not known")
 
     @timeout(900)
-    @todoPybridge()
+    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18676")
     def testClientCertAuthentication(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
These issues allow us to better track the discussion, debugging, and triaging which ones are blockers for releasing the Python bridge.

----

See https://github.com/cockpit-project/cockpit/labels/pybridge , this is now a complete list of things which we still need to work on. The https://github.com/cockpit-project/cockpit/labels/pybridge-blocker subset are the ones which we need to address until we let this lose to distros.