### PR TITLE
package.json: remove unused eslint-flowtype-plugin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-config-standard-react": "^13.0.0",
-    "eslint-plugin-flowtype": "^8.0.3",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jsx-a11y": "^6.7.1",
     "eslint-plugin-node": "^11.1.0",


### PR DESCRIPTION
Nothing uses it in .eslintrc so this can be safely removed.