### PR TITLE
workflows: Move reposchutz back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/reposchutz.yml
+++ b/.github/workflows/reposchutz.yml
@@ -6,7 +6,8 @@ on:
 jobs:
   check:
     name: Protection checks
-    runs-on: ubuntu-latest
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Moving to 22.04 in commit eb2b320c956 brought back the tar errors. To avoid these, commit 4ae9fc5068ba3 pinned this workflow to Ubuntu 20.04. So go back to that, and add a comment to remind us.

----

This caused the broken reposchutz runs like in #18719 or in #18672