### PR TITLE
test: Drop unnecessary leave/enter page

### DIFF
--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -544,9 +544,7 @@ class TestSuperuserDashboard(MachineCase):
         b.wait_in_text(".super-channel span", 'result: ')
         self.assertIn('result: uid=0', b.text(".super-channel span"))
 
-        b.leave_page()
         b.drop_superuser()
-        b.enter_page("/playground/test", host="10.111.113.2")
         b.click(".super-channel button")
         b.wait_in_text(".super-channel span", 'access-denied')
 


### PR DESCRIPTION
Missed chance for more cleanup in commit 66f02c4dec. The helpers already switch the frame and restore it afterwards.