### PR TITLE
tools/cockpit.spec: add BuildRequires on procps-ng

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -137,6 +137,9 @@ BuildRequires: gdb
 # For documentation
 BuildRequires: xmlto
 
+# For pytest unit tests
+BuildRequires: procps-ng
+
 BuildRequires:  selinux-policy
 BuildRequires:  selinux-policy-devel
 


### PR DESCRIPTION
This is required to run the pytest tests inside of mock.  We don't actually do that yet, but we need to regenerate our images before we can proceed, so let's land this first to solve the catch-22.