### PR TITLE
test: drop pixel testing of popover for services using storage

### DIFF
--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -68,8 +68,6 @@ ExecStart=/usr/bin/sleep infinity
         b.click("#dialog button:contains(Currently in use)")
         b.wait_in_text(".pf-c-popover", str(sleep_pid))
         b.wait_in_text(".pf-c-popover", "keep-mnt-busy")
-        b.assert_pixels(".pf-c-popover", "popover", ignore=["li"],
-                        scroll_into_view="#dialog button:contains(Currently in use)")
         b.click(".pf-c-popover button")
         b.assert_pixels('#dialog', "format")
         self.dialog_cancel()


### PR DESCRIPTION
The width of the popover is automatically fitting it's content. The content of this popover can change as it contains service names and their PIDs causing the width to change and this pixel test to fail.

Since this is quite a trivial UI, let's drop it to make our CI green again.