### PR TITLE
networkmanager: Recreate the D-Bus watch when the service restarts

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -404,6 +404,12 @@ export function NetworkManagerModel() {
         subscription = client.subscribe({ }, signal_emitted);
         client.addEventListener("notify", onNotifyEventHandler);
         watch = client.watch({ path_namespace: "/org/freedesktop" });
+        client.addEventListener("owner", (event, owner) => {
+            if (owner) {
+                watch.remove();
+                watch = client.watch({ path_namespace: "/org/freedesktop" });
+            }
+        });
     });
 
     self.close = function close() {


### PR DESCRIPTION
The watch doesn't survive a restart of the D-Bus service, let's recreate it when a new owner appears.

This didn't seem to matter much in the past since NetworkManager used to have a very incremental startup and would send out PropertiesChanged notifications for a lot of things.  It is sending less now, apparently.