### PR TITLE
workflows: Move npm-update back to Ubuntu 20.04

### DIFF
--- a/.github/workflows/npm-update-pf.yml
+++ b/.github/workflows/npm-update-pf.yml
@@ -10,7 +10,8 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-latest
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3

--- a/.github/workflows/npm-update.yml
+++ b/.github/workflows/npm-update.yml
@@ -10,7 +10,8 @@ jobs:
     permissions:
       pull-requests: write
       contents: write
-    runs-on: ubuntu-latest
+    # 22.04's podman has issues with piping and causes tar errors
+    runs-on: ubuntu-20.04
     steps:
       - name: Clone repository
         uses: actions/checkout@v3


### PR DESCRIPTION
Similarly to reposchutz (commit 269bf89276c6), the npm-update* workflows pipeline large tar archives, which is broken in Ubuntu 22.04's version.

---

See https://github.com/cockpit-project/cockpit/actions/runs/4848031943/jobs/8638798355