### PR TITLE
fmf: Force nodejs 18 on Rawhide

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -31,6 +31,12 @@ if grep -q platform:el8 /etc/os-release; then
     dnf module switch-to -y nodejs:16
 fi
 
+# HACK: nodejs 20 is very segfaulty: https://bugzilla.redhat.com/show_bug.cgi?id=2190075
+if grep -q VERSION_ID=39 /etc/os-release; then
+    dnf install -y nodejs18
+    ln -sfn node-18 /usr/bin/node
+fi
+
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd
 if rpm -q setroubleshoot-server; then


### PR DESCRIPTION
nodejs 20 crashes left and right, see
https://bugzilla.redhat.com/show_bug.cgi?id=2190075

Install the previous nodejs 18 for now, and update the /usr/bin/node symlink to point to 18.

----

This should fix [this rawhide crash](https://artifacts.dev.testing-farm.io/33885ddc-aae0-4f24-9d59-3b6af98e9830/) which we've been seeing since last week.