### PR TITLE
test: Support Debian/Ubuntu images with chronyd and no systemd-timesyncd

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -288,8 +288,15 @@ class TestSystemInfo(PackageCase):
         b = self.browser
 
         if m.image.startswith("debian") or m.image.startswith("ubuntu") or m.image == "arch":
-            # timesyncd is default
-            pass
+            if m.execute("type chronyc || true").strip() != "":
+                # chronyd is default, install timesyncd
+                self.addPackageSet("timesyncd")
+                self.enableRepo()
+                m.execute("apt-get update; apt-get install -y systemd-timesyncd")
+                m.execute("systemctl restart systemd-timedated; timedatectl set-ntp off; timedatectl set-ntp on")
+            else:
+                # timesyncd is default
+                pass
         else:
             # chronyd is default, give priority to timesyncd
             self.write_file("/etc/systemd/ntp-units.d/10-test.list", "systemd-timesyncd.service")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -72,16 +72,18 @@ def hotp_token(secret, counter, digits=6, hash_alg=hashlib.sha1):
     return numbers[-digits:].rjust(digits, '0')
 
 
-def setup_fake_chrony(machine):
-    # Our Debian/Ubuntu VM images have systemd-timesyncd installed, which conflicts with chrony.
-    # Set up a mock chrony.service to make ipa-client-install happy
-    machine.write("/run/systemd/system/chrony.service", """
+def maybe_setup_fake_chrony(machine):
+    # Some of our VM images have systemd-timesyncd installed, which
+    # conflicts with chrony.  Set up a mock chrony.service to make
+    # ipa-client-install happy.
+    if machine.execute("type chronyc || echo not-found").strip() == "not-found":
+        machine.write("/run/systemd/system/chrony.service", """
 [Service]
 Type=oneshot
 ExecStart=/bin/true
 """)
-    machine.execute("ln -s /bin/true /usr/bin/chronyc")
-    machine.execute("systemctl unmask chrony")
+        machine.execute("ln -s /bin/true /usr/bin/chronyc")
+        machine.execute("systemctl unmask chrony")
 
 
 @skipDistroPackage()
@@ -510,8 +512,7 @@ class TestIPA(TestRealms, CommonTests):
         # https://bugzilla.redhat.com/show_bug.cgi?id=1071356#c11
         wait(lambda: self.machine.execute("nslookup -type=SRV _ldap._tcp.cockpit.lan"))
 
-        if "ubuntu" in self.machine.image or "debian" in self.machine.image:
-            setup_fake_chrony(self.machine)
+        maybe_setup_fake_chrony(self.machine)
 
         # wait until FreeIPA started up
         self.machines['services'].execute("""podman exec -i freeipa sh -ec '
@@ -1005,8 +1006,7 @@ class TestKerberos(MachineCase):
 
     def setUp(self):
         super().setUp()
-        if "ubuntu" in self.machine.image or "debian" in self.machine.image:
-            setup_fake_chrony(self.machine)
+        maybe_setup_fake_chrony(self.machine)
 
     def configure_kerberos(self, keytab):
         self.machines["services"].execute("/root/run-freeipa")


### PR DESCRIPTION
The freeipa-client package has started to conflict with systemd-timesyncd, and our Debian/Ubuntu images will therefore over time switch to running chronyd by default.  Let's prepare the tests for that by adapting themselves dynamically.

(Once they have all switched, we might go back to static determination of whether to expect chronyd, if we prefer that.)

TestIPA will inspect the image to determine whether to fake chronyd.

TestTime.testTimeServersTimesyncd will explicitly install systemd-timesyncd if necessary.