### PR TITLE
services: improve alignment of last (status) column

### DIFF
--- a/pkg/systemd/services-list.jsx
+++ b/pkg/systemd/services-list.jsx
@@ -49,6 +49,7 @@ export const ServicesList = ({ units, isTimer, filtersRef }) => {
     return (
         <ListingTable aria-label={_("Systemd units")}
                       columns={columns}
+                      gridBreakPoint={isTimer ? "grid-xl" : "grid-lg"}
                       showHeader={false}
                       id="services-list"
                       rows={ units.map(unit => getServicesRow({ key: unit[0], isTimer, shortId: unit[0], ...unit[1] })) }
@@ -109,18 +110,20 @@ const getServicesRow = ({ Id, shortId, AutomaticStartup, UnitFileState, LoadStat
         },
         {
             title: (
-                <Flex id={cockpit.format("$0-service-unit-state", Id)} className='service-unit-status-flex-container'>
-                    <FlexItem flex={{ default: 'flex_2' }} className={"service-unit-status" + (HasFailed ? " service-unit-status-failed" : "")}>
+                <Flex
+                    id={cockpit.format("$0-service-unit-state", Id)}
+                    flexWrap={{ default: 'wrap', md: 'nowrap' }}
+                    justifyContent={{ default: 'justifyContentFlexStart', [isTimer ? 'xl' : 'lg']: 'justifyContentFlexEnd' }}
+                    className='service-unit-status-flex-container'>
+                    <FlexItem className={"service-unit-status" + (HasFailed ? " service-unit-status-failed" : "")}>
                         {HasFailed && <ExclamationCircleIcon className='ct-exclamation-circle' />}
                         {CombinedState}
                     </FlexItem>
-                    <FlexItem flex={{ default: 'flex_1' }}>
-                        {tooltipMessage ? <Tooltip id="switch-unit-state" content={tooltipMessage} position={TooltipPosition.left}>{unitFileState}</Tooltip> : unitFileState}
-                    </FlexItem>
+                    {tooltipMessage ? <Tooltip id="switch-unit-state" content={tooltipMessage} position={TooltipPosition.left}>{unitFileState}</Tooltip> : unitFileState}
                 </Flex>
             ),
             props: {
-                className: 'pf-c-table__action service-unit-second-column'
+                className: 'service-unit-second-column'
             }
         },
     ];

--- a/pkg/systemd/services.scss
+++ b/pkg/systemd/services.scss
@@ -24,15 +24,9 @@
 
 .service-unit-status {
   white-space: nowrap;
-  text-align: right;
 
   &-failed {
     color: red;
-    white-space: break-spaces;
-  }
-
-  &-flex-container {
-    --pf-l-flex--FlexWrap: nowrap;
   }
 }
 
@@ -71,6 +65,7 @@
 }
 
 .service-unit-first-column {
+  min-width: 20rem;
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(5rem, 25rem));
   grid-gap: var(--pf-global--spacer--sm);
@@ -84,20 +79,20 @@
   color: var(--pf-global--icon--Color--light);
 }
 
-.pf-c-table .pf-c-table__action.service-unit-second-column {
-  --pf-c-table--cell--Width: 20%;
+.service-unit-triggers {
+  min-width: 20ch;
+}
 
-  &-flex-container {
-    row-gap: var(--pf-global--spacer--sm);
-  }
+.pf-c-table .service-unit-second-column {
+  --pf-c-table--cell--Width: 20%;
 }
 
 // Don't show labels from mobile mode
-.pf-m-grid-md.pf-c-table [data-label]::before {
+.pf-c-table [data-label]::before {
   display: none;
 }
 
-.pf-m-grid-md.pf-c-table [data-label] {
+.pf-c-table [data-label] {
   display: revert;
 }
 


### PR DESCRIPTION
When we are in timer view let the breakpoint be earlier as timers have also the previous/next trigger column.

Fixes #18011
Fixes #15928