### PR TITLE
storage: Create stratis filesystem snapshot without requiring mount_point

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -380,7 +380,7 @@ export const dialog_open = (def) => {
 
     function run_action(progress_callback, variant) {
         const func = () => {
-            return validate()
+            return validate(variant)
                     .then(() => {
                         const visible_values = { variant };
                         fields.forEach(f => {
@@ -453,10 +453,10 @@ export const dialog_open = (def) => {
         };
     };
 
-    const validate = () => {
+    const validate = (variant) => {
         return Promise.all(fields.map(f => {
             if (is_visible(f, values) && f.options && f.options.validate)
-                return f.options.validate(values[f.tag], values);
+                return f.options.validate(values[f.tag], values, variant);
             else
                 return null;
         })).then(results => {

--- a/pkg/storaged/format-dialog.jsx
+++ b/pkg/storaged/format-dialog.jsx
@@ -296,7 +296,10 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                       {
                           visible: is_filesystem,
                           value: old_dir || "",
-                          validate: val => is_valid_mount_point(client, block, val)
+                          validate: (val, values, variant) => {
+                              if (variant !== "nomount")
+                                  return is_valid_mount_point(client, block, val);
+                          }
                       }),
             SelectOne("type", _("Type"),
                       { choices: filesystem_options }),
@@ -484,17 +487,19 @@ function format_dialog_internal(client, path, start, size, enable_dos_extended, 
                         mount_options.push(vals.mount_options.extra);
 
                     mount_point = vals.mount_point;
-                    if (mount_point[0] != "/")
-                        mount_point = "/" + mount_point;
+                    if (mount_point != "") {
+                        if (mount_point[0] != "/")
+                            mount_point = "/" + mount_point;
 
-                    config_items.push(["fstab", {
-                        dir: { t: 'ay', v: utils.encode_filename(mount_point) },
-                        type: { t: 'ay', v: utils.encode_filename("auto") },
-                        opts: { t: 'ay', v: utils.encode_filename(mount_options.join(",") || "defaults") },
-                        freq: { t: 'i', v: 0 },
-                        passno: { t: 'i', v: 0 },
-                        "track-parents": { t: 'b', v: true }
-                    }]);
+                        config_items.push(["fstab", {
+                            dir: { t: 'ay', v: utils.encode_filename(mount_point) },
+                            type: { t: 'ay', v: utils.encode_filename("auto") },
+                            opts: { t: 'ay', v: utils.encode_filename(mount_options.join(",") || "defaults") },
+                            freq: { t: 'i', v: 0 },
+                            passno: { t: 'i', v: 0 },
+                            "track-parents": { t: 'b', v: true }
+                        }]);
+                    }
                 }
 
                 if (config_items.length > 0)

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -306,6 +306,8 @@ export const StratisPoolDetails = ({ client, pool }) => {
         mount_options = mount_options.concat(forced_options);
 
         let mount_point = vals.mount_point;
+        if (mount_point == "")
+            return Promise.resolve();
         if (mount_point[0] != "/")
             mount_point = "/" + mount_point;
 
@@ -366,7 +368,10 @@ export const StratisPoolDetails = ({ client, pool }) => {
                           }),
                 TextInput("mount_point", _("Mount point"),
                           {
-                              validate: val => is_valid_mount_point(client, null, val)
+                              validate: (val, values, variant) => {
+                                  if (variant !== "nomount")
+                                      return is_valid_mount_point(client, null, val);
+                              }
                           }),
                 CheckBoxes("mount_options", _("Mount options"),
                            {
@@ -520,7 +525,10 @@ export const StratisPoolDetails = ({ client, pool }) => {
                               }),
                     TextInput("mount_point", _("Mount point"),
                               {
-                                  validate: val => is_valid_mount_point(client, null, val)
+                                  validate: (val, values, variant) => {
+                                      if (variant !== "nomount")
+                                          return is_valid_mount_point(client, null, val);
+                                  }
                               }),
                     CheckBoxes("mount_options", _("Mount options"),
                                {

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -88,6 +88,12 @@ class TestStorageFormat(StorageCase):
         else:
             check_type("ntfs", 128)
 
+        # Format without mount point
+        self.content_dropdown_action(1, "Format")
+        self.dialog_wait_open()
+        self.dialog_apply_secondary()
+        self.dialog_wait_close()
+
         # Verify button text is 'Format' when no filesystem is selected
         self.content_dropdown_action(1, "Format")
         self.dialog_wait_open()

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -161,6 +161,34 @@ class TestStorageStratis(StorageCase):
         self.confirm()
         b.wait_not_in_text("#detail-content", "fsys2-copy")
 
+        # Make an unmounted copy of the filesystem
+        self.content_dropdown_action(1, "Snapshot")
+        self.dialog_wait_open()
+        self.dialog_set_val('name', 'fsys2-copy')
+        self.dialog_set_val('at_boot', 'never')
+        self.dialog_apply_secondary()
+        self.dialog_wait_close()
+        b.wait_in_text("#detail-content", "fsys2-copy")
+
+        # Delete the copy
+        self.content_dropdown_action(2, "Delete")
+        self.confirm()
+        b.wait_not_in_text("#detail-content", "fsys2-copy")
+
+        # Create an unmounted filesystem
+        b.click("button:contains(Create new filesystem)")
+        self.dialog_wait_open()
+        self.dialog_set_val('name', 'fsys-unmounted')
+        self.dialog_apply_secondary()
+        self.dialog_wait_close()
+
+        b.wait_in_text("#detail-content", "fsys-unmounted")
+
+        # Delete the unmounted filesystem
+        self.content_dropdown_action(2, "Delete")
+        self.confirm()
+        b.wait_not_in_text("#detail-content", "fsys2-copy")
+
         # Add a data blockdev
         b.click('#detail-sidebar .pf-c-card__actions button')
         self.dialog_wait_open()


### PR DESCRIPTION
Fixes #18718.

I passed the `variant` from the footer buttons to the `validate` function for the mount point, so it checks the type before validating.
Let me know if this feels like a long workaround or if there is a better approach!