### PR TITLE
systemd: Consistently use CardTitle's component attribute

### DIFF
--- a/pkg/systemd/abrtLog.jsx
+++ b/pkg/systemd/abrtLog.jsx
@@ -288,7 +288,7 @@ export class AbrtLogDetails extends React.Component {
                     <Card>
                         <CardHeader actions={{ actions: <><Button variant="danger" onClick={this.onDelete}>{_("Delete")}</Button></> }}>
 
-                            <CardTitle><h2>{_("Extended information")}</h2></CardTitle>
+                            <CardTitle component="h2">{_("Extended information")}</CardTitle>
                         </CardHeader>
                         <CardBody>
                             <Tabs activeKey={this.state.active_tab} onSelect={this.handleSelect}>

--- a/pkg/systemd/reporting.jsx
+++ b/pkg/systemd/reporting.jsx
@@ -472,7 +472,7 @@ export class ReportingTable extends React.Component {
     render() {
         return (
             <Card>
-                <CardTitle><h2>{_("Crash reporting")}</h2></CardTitle>
+                <CardTitle component="h2">{_("Crash reporting")}</CardTitle>
                 <CardBody>
                     <FAFWorkflowRow problem={this.props.problem} />
                     {


### PR DESCRIPTION
These two places were the lsat ones still using the old method.

----

@KKoukiou : FTR, I also looked at the [new PF5 select](https://patternfly-react-v5.surge.sh/components/menus/select/). but admittedly I quickly lost motivation -- that new replacement feels horribly complicated compared to the old one..