### PR TITLE
test: hide scrollbar in pixel testing

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -191,3 +191,8 @@ html:not(.index-page) body {
   margin-top: var(--offset);
   margin-bottom: var(--offset);
 }
+
+// To be used only from testlib.py for pixel-tests
+main.pixel-test {
+  overflow-y: clip;
+}

--- a/pkg/systemd/service.jsx
+++ b/pkg/systemd/service.jsx
@@ -19,7 +19,7 @@
 
 import React, { useRef, useState } from "react";
 import { Breadcrumb, BreadcrumbItem } from "@patternfly/react-core/dist/esm/components/Breadcrumb/index.js";
-import { Page, PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
+import { PageBreadcrumb, PageSection } from "@patternfly/react-core/dist/esm/components/Page/index.js";
 import { Gallery, GalleryItem } from "@patternfly/react-core/dist/esm/layouts/Gallery/index.js";
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
@@ -146,32 +146,30 @@ export const Service = ({ dbusClient, owner, unitId, unitIsValid, addTimerProper
 
     return (
         <WithDialogs>
-            <Page id="service-details">
-                <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
-                    <Breadcrumb>
-                        <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
-                        <BreadcrumbItem isActive>
-                            {cur_unit_id}
-                        </BreadcrumbItem>
-                    </Breadcrumb>
-                </PageBreadcrumb>
-                <PageSection>
-                    <Gallery hasGutter>
-                        <GalleryItem id="service-details-unit">
-                            <ServiceDetails unit={unitProps}
-                                            owner={owner}
-                                            permitted={superuser.allowed}
-                                            loadingUnits={reloading}
-                                            isValid={unitIsValid}
-                                            pinnedUnits={pinnedUnits} />
-                        </GalleryItem>
-                        {(load_state === "loaded" || load_state === "masked") &&
-                        <GalleryItem id="service-details-logs">
-                            <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", [service_type]: cur_unit_id }} />
-                        </GalleryItem>}
-                    </Gallery>
-                </PageSection>
-            </Page>
+            <PageBreadcrumb stickyOnBreakpoint={{ default: "top" }}>
+                <Breadcrumb>
+                    <BreadcrumbItem to={"#" + cockpit.location.href.replace(/\/[^?]*/, '')}>{_("Services")}</BreadcrumbItem>
+                    <BreadcrumbItem isActive>
+                        {cur_unit_id}
+                    </BreadcrumbItem>
+                </Breadcrumb>
+            </PageBreadcrumb>
+            <PageSection id="service-details">
+                <Gallery hasGutter>
+                    <GalleryItem id="service-details-unit">
+                        <ServiceDetails unit={unitProps}
+                                        owner={owner}
+                                        permitted={superuser.allowed}
+                                        loadingUnits={reloading}
+                                        isValid={unitIsValid}
+                                        pinnedUnits={pinnedUnits} />
+                    </GalleryItem>
+                    {(load_state === "loaded" || load_state === "masked") &&
+                    <GalleryItem id="service-details-logs">
+                        <LogsPanel title={_("Service logs")} match={match} emptyMessage={_("No log entries")} max={10} goto_url={url} search_options={{ prio: "debug", [service_type]: cur_unit_id }} />
+                    </GalleryItem>}
+                </Gallery>
+            </PageSection>
         </WithDialogs>
     );
 };

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1159,6 +1159,14 @@ class Browser:
         if not (Image and self.pixels_label):
             return
 
+        # If the page overflows make sure to not show a scrollbar
+        # Don't apply this hack for login and terminal and shell as they don't use PF Page
+        if not self.is_present("#shell-page") and not self.is_present("#login-details") and not self.is_present("#system-terminal-page"):
+            self.switch_to_frame(self.cdp.cur_frame)
+            classes = self.attr("main", "class")
+            if "pf-c-page__main" in classes:
+                self.set_attr("main.pf-c-page__main", "class", f"{classes} pixel-test")
+
         if self.current_layout:
             previous_layout = self.current_layout["name"]
             for layout in self.layouts:


### PR DESCRIPTION
Sometimes we take screenshots of a whole page as part of the pixel tests and in medium screen sizes the page content often exceeds the viewport causing a scrollbar to appear. The scrollbar's height changes according to the non-displayed contents which is introducing some factor for flakiness.

For this reason let's always hide the scrollbar when pixel testing.