### PR TITLE
tools: Switch Debian devel series to Python bridge

### DIFF
--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -1,2 +1,3 @@
 # this is just an empty stub to avoid breaking existing PAM files
 cockpit-ws: shared-library-lacks-prerequisites *security/pam_cockpit_cert.so*
+cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -3,6 +3,7 @@ Section: admin
 Priority: optional
 Maintainer: Cockpit <cockpit@cockpit-project.org>
 Build-Depends: debhelper-compat (= 13),
+               dh-python,
                gettext (>= 0.19.7),
                gettext (>= 0.21) | appstream,
                libssh-dev (>= 0.8.5),
@@ -23,8 +24,14 @@ Build-Depends: debhelper-compat (= 13),
                xmlto,
                docbook-xsl,
                glib-networking,
-               openssh-client <!nocheck>,
                python3,
+               python3-pip,
+               python3-setuptools,
+               python3-wheel,
+               openssh-client <!nocheck>,
+               procps <!nocheck>,
+               python3-pytest-asyncio <!nocheck>,
+               python3-pytest-timeout <!nocheck>,
 Standards-Version: 4.6.2
 Homepage: https://cockpit-project.org/
 Vcs-Git: https://salsa.debian.org/utopia-team/cockpit.git
@@ -56,7 +63,9 @@ Package: cockpit-bridge
 Architecture: any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
+         ${python3:Depends},
          glib-networking
+Recommends: openssh-client
 Provides: cockpit-ssh
 Breaks: cockpit-ws (<< 181.x),
 Replaces: cockpit-dashboard (<< 170.x), cockpit-ws (<< 181.x)

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -2,6 +2,13 @@
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
+# Keep the older C bridge on stable releases
+# also keep it on Ubuntu until testCockpitDesktop gets fixed
+C_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 22.04 22.10 23.04)
+ifeq ($(C_BRIDGE),)
+CONFIG_OPTIONS += --enable-pybridge
+endif
+
 # riscv is an emulated architecture for now, and too slow to run expensive unit tests
 # hppa's threading is absurdly slow (#981127)
 SLOW_ARCHES = $(filter $(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64 hppa)
@@ -10,7 +17,7 @@ ifneq ($(SLOW_ARCHES),)
 endif
 
 %:
-	dh $@ --buildsystem=autoconf
+	dh $@ --buildsystem=autoconf --with=python3
 
 override_dh_auto_configure:
 	dh_auto_configure -- \
@@ -18,6 +25,15 @@ override_dh_auto_configure:
 		--with-cockpit-ws-instance-user=cockpit-wsinstance \
 		--with-pamdir=/lib/$(DEB_HOST_MULTIARCH)/security \
 		--libexecdir=/usr/lib/cockpit $(CONFIG_OPTIONS)
+
+# HACK: Debian's pip breaks --prefix: https://bugs.debian.org/1035546
+# redirect /usr/local to /usr, as merging the trees after install is brittle
+execute_before_dh_auto_install:
+	mkdir -p debian/tmp/usr; ln -s . debian/tmp/usr/local
+
+# undo the pip hack
+execute_after_dh_auto_install:
+	rm debian/tmp/usr/local
 
 # avoid trying to start cockpit-motd.service and cockpit-wsinstance-*.socket etc.
 override_dh_installsystemd:
@@ -42,4 +58,15 @@ override_dh_install:
 	rm debian/tmp/usr/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 
 	dh_install -Xusr/src/debug
+ifeq ($(C_BRIDGE),)
+	dh_install -p cockpit-bridge debian/tmp/usr/lib/python*
+endif
+
 	make install-tests DESTDIR=debian/cockpit-tests
+
+	# run pytests *after* installation, so that we can make sure that we installed the right files
+ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
+ifeq ($(C_BRIDGE),)
+	pytest -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
+endif
+endif


### PR DESCRIPTION
Run the bridge unit pytests during package build, but with a twist:
Normally they run as part of `dh_auto_test` after building, but before
installation. But we want to make sure that we installed all files
correctly, so instead run them after install against the
debian/cockpit-bridge/ binary package tree.

Add a hack around broken pip, it always appends an extra `/local` to the
given --prefix, no matter what gets specified. See
https://bugs.debian.org/1035546

Keep the older C bridge on stable releases, in particular Debian 11 and
Ubuntu 22.04 LTS. But also still keep Ubuntu stable on the C bridge,
until testCockpitDesktop gets fixed.

Add a recommendation for openssh-client, as the bridge now uses the
ssh(1) program to connect to remote hosts.

-----

 - [x] Add new build dependencies to Debian/Ubuntu images: https://github.com/cockpit-project/bots/pull/4733
 - [x] First smoke-test that this works in principle, to validate above bots refresh: [debian-stable](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230506-074027-ecbac709-debian-stable-bots-4733/log.html), [debian-testing](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230506-072818-ecbac709-debian-testing-bots-4733/log.html), [ubuntu-2204](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230506-072811-ecbac709-ubuntu-2204-bots-4733/log.html), [ubuntu-stable](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230506-072814-ecbac709-ubuntu-stable-bots-4733/log.html)
 - [x] PR #18758
 - [x] Update tests to detect pybridge dynamically instead of through `$TEST_SCENARIO`: PR #18768 
 - [x] Fix umask in Python bridge: PR #18761
 - [x] Re-evaluate [TestReauthorize.testBasic failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230508-091050-f2ac52fa-debian-testing-bots-4733/log.html#98-2) after fixing #18676 (didn't fix it); [debugging notes](https://github.com/cockpit-project/cockpit/pull/18757#issuecomment-1538015838), PR #18791
 - [x] Validate/fix leaked ssh-agent: PR #18803 
 - [x] Restrict actual switch to ubuntu-stable and debian-testing
 - [ ] ~[testCockpitDesktop failure on ubuntu-stable](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230605-111939-81a559f1-ubuntu-stable/log.html#16-2) -- [original fix](https://github.com/cockpit-project/cockpit/commit/b09aa3e5cf118334e6e41048faf772d1c5434108) (not working any more)~ -- postponed
 - [x] Fix all https://github.com/cockpit-project/cockpit/labels/pybridge-blocker
 - [ ] After this lands, send bots PR to clean up the redundant extra build-deps list