### PR TITLE
test: Allow "vdo create" to take more time; clean up test skips

### DIFF
--- a/test/verify/check-storage-hidden
+++ b/test/verify/check-storage-hidden
@@ -19,10 +19,7 @@
 
 import parent  # noqa: F401
 from storagelib import StorageCase, json
-from testlib import nondestructive, test_main
-
-import unittest
-import testvm
+from testlib import nondestructive, test_main, onlyImage
 
 
 class TestStorageHiddenLuks(StorageCase):
@@ -134,7 +131,7 @@ class TestStorageHidden(StorageCase):
         b.wait_visible("#storage")
         self.assertEqual(m.execute(f"grep {mount_point_2} /etc/fstab || true"), "")
 
-    @unittest.skipUnless("ubuntu" in testvm.DEFAULT_IMAGE, "Only test snaps on Ubuntu")
+    @onlyImage("Only test snaps on Ubuntu", "ubuntu*")
     @nondestructive
     def testHiddenSnap(self):
         m = self.machine

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -22,7 +22,6 @@ import unittest
 
 from storagelib import StorageCase
 from testlib import skipImage, test_main
-from testvm import DEFAULT_IMAGE
 
 
 class TestStorageResize(StorageCase):
@@ -120,7 +119,7 @@ class TestStorageResize(StorageCase):
                          can_shrink=False,
                          can_grow=True, grow_needs_unmount=False)
 
-    @unittest.skipIf(DEFAULT_IMAGE.startswith("rhel-") or DEFAULT_IMAGE.startswith("centos"), "NTFS not supported on RHEL")
+    @skipImage("NTFS not supported on RHEL", "rhel-*", "centos-*")
     def testResizeNtfs(self):
         self.checkResize("ntfs", False,
                          can_shrink=True, shrink_needs_unmount=True,

--- a/test/verify/check-storage-swap
+++ b/test/verify/check-storage-swap
@@ -17,15 +17,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
 import parent  # noqa: F401
 from storagelib import StorageCase
-from testlib import test_main, nondestructive
-from testvm import DEFAULT_IMAGE
+from testlib import test_main, nondestructive, onlyImage
 
 
 @nondestructive
-@unittest.skipIf(not DEFAULT_IMAGE.startswith("fedora"), "No zram by default")
+@onlyImage("No zram by default", "fedora-*")
 class TestStorageswap(StorageCase):
 
     def testZram(self):

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -193,7 +193,7 @@ class TestStorageLegacyVDO(StorageCase):
         b.wait_in_text("#drives", "DISK1")
         m.execute("vgcreate vdo_vgroup /dev/sda; lvcreate -n lvol -L 5G vdo_vgroup")
         # Create VDO; this is not supported any more, thus no UI for it
-        m.execute("vdo create --device /dev/vdo_vgroup/lvol --name vdo0 --vdoLogicalSize 5G")
+        m.execute("vdo create --device /dev/vdo_vgroup/lvol --name vdo0 --vdoLogicalSize 5G", timeout=300)
 
         b.wait_in_text("#devices", "vdo0")
         b.click("#devices .sidepanel-row:contains(vdo0)")

--- a/test/verify/check-storage-vdo
+++ b/test/verify/check-storage-vdo
@@ -19,12 +19,10 @@
 
 import parent  # noqa: F401
 import re
-import unittest
 
 from packagelib import PackageCase
 from storagelib import StorageCase, StorageHelpers
-from testlib import test_main
-import testvm
+from testlib import test_main, onlyImage
 
 
 SIZE_10G = "10000000000"
@@ -176,8 +174,7 @@ class TestStorageVDO(StorageCase):
         b.wait_in_text("#detail-content", "No logical volumes")
 
 
-@unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel-8") or testvm.DEFAULT_IMAGE.startswith("centos-8"),
-                     "legacy VDO API only supported on RHEL 8")
+@onlyImage("legacy VDO API only supported on RHEL 8", "rhel-8*", "centos-8*")
 class TestStorageLegacyVDO(StorageCase):
 
     def testVdo(self):
@@ -400,8 +397,7 @@ config: !Configuration
         b.wait_in_text("#devices", "vdo1")
 
 
-@unittest.skipUnless(testvm.DEFAULT_IMAGE.startswith("rhel-") or testvm.DEFAULT_IMAGE.startswith("centos"),
-                     "VDO API only supported on RHEL")
+@onlyImage("VDO API only supported on RHEL", "rhel-*", "centos-*")
 class TestStoragePackagesVDO(PackageCase, StorageHelpers):
 
     provision = {"0": {"memory_mb": 1500}}

--- a/test/verify/check-ws-bastion
+++ b/test/verify/check-ws-bastion
@@ -17,16 +17,13 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import unittest
-
 import parent  # noqa: F401
-from testlib import MachineCase, nondestructive, test_main
-from testvm import DEFAULT_IMAGE
+from testlib import MachineCase, nondestructive, test_main, onlyImage
 
 HOST = "host.containers.internal"
 
 
-@unittest.skipUnless(DEFAULT_IMAGE in ["fedora-coreos", "rhel4edge"], "no cockpit/ws container on this image")
+@onlyImage("no cockpit/ws container on this image", "fedora-coreos", "rhel4edge")
 @nondestructive
 class TestWsBastionContainer(MachineCase):
     def setUp(self):
@@ -226,7 +223,7 @@ class TestWsBastionContainer(MachineCase):
         b.wait_visible('#content')
 
 
-@unittest.skipUnless(DEFAULT_IMAGE in ["fedora-coreos", "rhel4edge"], "no cockpit/ws container on this image")
+@onlyImage("no cockpit/ws container on this image", "fedora-coreos", "rhel4edge")
 @nondestructive
 class TestWsPrivileged(MachineCase):
     def testService(self):


### PR DESCRIPTION
One minute often is not enough on our CI machines, the test timed out in most cases.

[example one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18758-20230508-053357-16dac345-centos-8-stream-pybridge/log.html#230-1), [example two](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18758-20230507-065718-5b53fa4a-centos-8-stream-pybridge/log.html#230).

While I was at it, I also noticed some unnecessarily complicated test skip conditions, I added a second commit to clean these up.