### PR TITLE
bridge, session: Drop changing umask

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -368,9 +368,6 @@ run_bridge (const gchar *interactive,
         g_warning ("couldn't change to runtime dir: %s: %s", directory, g_strerror (errno));
     }
 
-  /* Reset the umask, typically this is done in .bashrc for a login shell */
-  umask (022);
-
   /* Start daemons if necessary */
   if (!interactive && !privileged_peer)
     {

--- a/src/session/session.c
+++ b/src/session/session.c
@@ -914,9 +914,6 @@ main (int argc,
 
   program_name = basename (argv[0]);
 
-  /* Cleanup the umask */
-  umask (077);
-
   rhost = getenv ("COCKPIT_REMOTE_PEER") ?: "";
 
   save_environment ();


### PR DESCRIPTION
cockpit-session set a tight 077 umask for extra paranoia. However, on    
OSes without pam_umask configured by default (like Debian), this causes    
all session processes to run with that umask as well. This then caused    
e.g. `cockpit.file('/etc/motd').replace()` to write motd with 0600    
permissions, making it inaccessible. (cf. issue #18033)    
    
The C bridge counteracted this by harcoding `umask(022)`, but that    
really does not belong there: The bridge also gets run through SSH or    
directly from ws. The Python bridge does no such thing, and we rather    
don't want to add that.    
    
There is no real benefit for cockpit-session to change the umask. It    
does not create any files by itself, and security related files created    
by GSSAPI or PAM modules should already do their own explicit permission    
setting instead of relying on a tight umask. For example, krb5's    
open_file() ensures 0600 permissions when writing ccache files. (The    
only case where a new file is plausibly written during login).    

----

This fixes [most of the mess here](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18757-20230508-070615-e88af50c-debian-testing-bots-4733/log.html#98-2), see https://github.com/cockpit-project/cockpit/pull/18757#issuecomment-1538015838 for the debugging details.