### PR TITLE
Remove duplicate / from submodule url

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "modules/systemd_ctypes"]
 	path = modules/systemd_ctypes
-	url = https://github.com//allisonkarlitskaya/systemd_ctypes.git
+	url = https://github.com/allisonkarlitskaya/systemd_ctypes.git
 [submodule "node_modules"]
 	path = node_modules
 	url = https://github.com/cockpit-project/node-cache.git


### PR DESCRIPTION
Otherwise modules initialization fails with:

Cloning into '/home/kkoukiou/repos/cockpit/modules/systemd_ctypes'... fatal: remote error: /allisonkarlitskaya/systemd_ctypes is not a valid repository name