### PR TITLE
test: Disable preload to stabilize TestPages.testBasic

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -67,6 +67,12 @@ class TestPages(MachineCase):
     def testBasic(self):
         m = self.machine
         b = self.browser
+
+        # HACK: somehow the "services" preload causes a race condition and injects some spurious `window.hashchange /`
+        # event when switching between pages, losing the "on details page" state
+        # see debugging history in https://github.com/cockpit-project/cockpit/pull/18766
+        self.disable_preload("systemd")
+
         self.restore_dir("/etc/systemd/system", post_restore_action="systemctl daemon-reload")
         self.addCleanup(m.execute, "systemctl stop test.timer test.service")
         m.write("/etc/systemd/system/test.service",


### PR DESCRIPTION
When switching between the Services detail page, Networking page, and    
the shell to inspect the doc entries, the page often gets a spurious URL    
change (`window.hashchanged` event). This is real, it's visible in the    
browser's URL bar. This is not coming from any `cockpit.location.*` call    
from inside the services page, and has resisted debugging for too many    
hours [1].    
    
This is a very special combination of page preloading, frame changing,    
and careful timing (changing either one makes this bug go away), and the    
fallout is minor: the services page loses its "on the details page"    
state and goes back to the service list, which wouldn't be dramatic (if    
it is even possible to get this effect manually).    
    
So cut off the wasted time here, and work around this by disabling the    
services page preload for this test. It is not covered there anyway (but    
in check-system-services), and does not change the intention of this    
test.    
    
[1] https://github.com/cockpit-project/cockpit/pull/18766#issuecomment-1538898901    

-----

I realize that this is kind of lame, but I'm losing motivation/patience -- the "bang for the buck" ratio has become way too low for my taste by now.

-------

Original PR:

I'm interested in learning some more information about [test_branding on ubuntu-stable](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4733-20230506-035134-7619f6e9-ubuntu-stable-cockpit-project-cockpit/log.html#28-2) and [TestPages.testBasic on rhel-8-9](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18749-20230505-201054-e574cbf9-rhel-8-9/log.html#99-2). The latter is our current top flake on the weather report, with a 60% [sic!] failure rate on rhel-8-9. 

![image](https://github.com/cockpit-project/cockpit/assets/200109/a2c66b3d-e875-4998-a8fc-de14ecb73aef)
