### PR TITLE
test: Use dynamic pybridge detection instead of $TEST_SCENARIO

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -23,6 +23,7 @@ import argparse
 import base64
 import errno
 import fnmatch
+import functools
 import os
 import shutil
 import socket
@@ -1394,6 +1395,10 @@ class MachineCase(unittest.TestCase):
     def is_devel_build(self) -> bool:
         return os.environ.get('NODE_ENV') == 'development'
 
+    def is_pybridge(self) -> bool:
+        # some tests start e.g. centos-7 as first machine, bridge may not exist there
+        return any('python' in m.execute('head -c 30 /usr/bin/cockpit-bridge || true') for m in self.machines.values())
+
     def disable_preload(self, *packages, machine=None):
         if machine is None:
             machine = self.machine
@@ -2257,15 +2262,33 @@ def todo(reason=''):
 
 
 def todoPybridge(reason=None):
-    if os.getenv('TEST_SCENARIO') == 'pybridge':
-        return todo(reason or 'still fails with python bridge')
-    return lambda testEntity: testEntity
+    if not reason:
+        reason = 'still fails with python bridge'
+
+    def wrap(test_method):
+        @functools.wraps(test_method)
+        def wrapped_test(self):
+            is_pybridge = self.is_pybridge()
+            try:
+                test_method(self)
+                if is_pybridge:
+                    return unittest.fail(reason)
+                return None
+            # only accept our testlib Errors, plus RuntimeError for TestSuperuserDashboardOldMachine
+            except (Error, RuntimeError):
+                if is_pybridge:
+                    traceback.print_exc()
+                    return self.skipTest(reason)
+                raise
+
+        return wrapped_test
+
+    return wrap
 
 
 def todoPybridgeRHEL8(reason=None):
-    if os.getenv('TEST_SCENARIO') == 'pybridge' and (
-            testvm.DEFAULT_IMAGE.startswith('rhel-8') or testvm.DEFAULT_IMAGE.startswith('centos-8')):
-        return todo(reason or 'known fail on el8 with python bridge')
+    if testvm.DEFAULT_IMAGE.startswith('rhel-8') or testvm.DEFAULT_IMAGE.startswith('centos-8'):
+        return todoPybridge(reason or 'known fail on el8 with python bridge')
     return lambda testEntity: testEntity
 
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1095,7 +1095,7 @@ ExecStart=/usr/local/bin/{packageName}
                            systemctl daemon-reload'''.format(system_service))
 
         m.start_cockpit()
-        if os.environ.get("TEST_SCENARIO") != "pybridge":
+        if not self.is_pybridge():
             # TODO: conditions not implemented on C bridge; once we drop it, drop this special case and
             # enable the manifest documentation for conditions in doc/guide/packages.xml
             self.assertIn("\nupdates", m.execute("cockpit-bridge --packages"))

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -17,7 +17,6 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
-import os
 import time
 
 import parent  # noqa: F401
@@ -256,7 +255,7 @@ session include system-auth
         b.enter_page("/playground/pkgs")
         b.click("#reload")
         b.leave_page()
-        if os.environ.get("TEST_SCENARIO") == "pybridge":
+        if self.is_pybridge():
             b.check_superuser_indicator("")
         else:
             # C bridge gets that wrong: Its .Bridges property remains at [sudo, pkexec], showing a broken indicator


### PR DESCRIPTION
We will soon enable the Python bridge in the real packages for some distributions. Then the normal test runs will use the Python bridge, instead of having a separate `/pybridge` scenario. To unblock this, change our `@todoPybridge{,RHEL8}` decorators and the two remaining special cases to detect the Python bridge at runtime, instead of statically from the test scenario.

---

Broken out from PR #18757 