### PR TITLE
pkg: remove redundant pf-theme-dark class from the html pages

### DIFF
--- a/pkg/apps/index.html
+++ b/pkg/apps/index.html
@@ -18,7 +18,7 @@ You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html id="applications-page" class="pf-theme-dark">
+<html id="applications-page">
   <head>
     <title translate="yes">Applications</title>
     <meta charset="utf-8">

--- a/pkg/kdump/index.html
+++ b/pkg/kdump/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html id="kdump-page" lang="en" class="pf-theme-dark">
+<html id="kdump-page" lang="en">
 <head>
     <meta charset="utf-8">
     <title translate="yes">Kernel dump</title>

--- a/pkg/lib/qunit-template.html
+++ b/pkg/lib/qunit-template.html
@@ -17,7 +17,7 @@
   You should have received a copy of the GNU Lesser General Public License
   along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title><%= title %></title>

--- a/pkg/networkmanager/firewall.html
+++ b/pkg/networkmanager/firewall.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html class="pf-theme-dark">
+<html>
   <head>
     <title translate>Firewall</title>
     <meta charset="utf-8">

--- a/pkg/networkmanager/index.html
+++ b/pkg/networkmanager/index.html
@@ -18,7 +18,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html id="networkmanager-page" class="pf-theme-dark">
+<html id="networkmanager-page">
 <head>
   <title translate="yes">Networking</title>
   <meta charset="utf-8">

--- a/pkg/packagekit/index.html
+++ b/pkg/packagekit/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html id="packagekit-page" class="pf-theme-dark">
+<html id="packagekit-page">
 
 <head>
   <title translate>Software updates</title>

--- a/pkg/playground/index.html
+++ b/pkg/playground/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="playground-page" class="pf-theme-dark">
+<html id="playground-page">
 <head>
     <meta charset="utf-8">
     <title>Cockpit Development Playground</title>

--- a/pkg/playground/journal.html
+++ b/pkg/playground/journal.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Journal Box</title>

--- a/pkg/playground/metrics.html
+++ b/pkg/playground/metrics.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Monitoring</title>

--- a/pkg/playground/notifications-receiver.html
+++ b/pkg/playground/notifications-receiver.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Notifications Receiver</title>

--- a/pkg/playground/pkgs.html
+++ b/pkg/playground/pkgs.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Packages</title>

--- a/pkg/playground/plot.html
+++ b/pkg/playground/plot.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Plots</title>

--- a/pkg/playground/preloaded.html
+++ b/pkg/playground/preloaded.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Preloaded Page</title>

--- a/pkg/playground/react-patterns.html
+++ b/pkg/playground/react-patterns.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit React Patterns Usage</title>

--- a/pkg/playground/service.html
+++ b/pkg/playground/service.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Generic Service Monitor</title>

--- a/pkg/playground/speed.html
+++ b/pkg/playground/speed.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit Speed Tests</title>

--- a/pkg/playground/test.html
+++ b/pkg/playground/test.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <meta charset="utf-8">
     <title>Cockpit playground</title>

--- a/pkg/shell/shell.html
+++ b/pkg/shell/shell.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 <head>
     <title>Things have moved</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">

--- a/pkg/sosreport/index.html
+++ b/pkg/sosreport/index.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html class="pf-theme-dark">
+<html>
   <head>
     <title translate="yes">Diagnostic reports</title>
     <meta charset="utf-8">

--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="pf-theme-dark">
+<html>
 
 <head>
   <title>Loading...</title>

--- a/pkg/storaged/index.html
+++ b/pkg/storaged/index.html
@@ -18,7 +18,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html class="pf-theme-dark">
+<html>
 <head>
     <title translate="yes">Storage</title>
     <meta charset="utf-8">

--- a/pkg/systemd/hwinfo.html
+++ b/pkg/systemd/hwinfo.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="system-hwinfo-page" class="pf-theme-dark">
+<html id="system-hwinfo-page">
 <head>
     <title translate="yes">Hardware information</title>
     <meta charset="utf-8">

--- a/pkg/systemd/index.html
+++ b/pkg/systemd/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="system-overview-page" class="pf-theme-dark">
+<html id="system-overview-page">
 <head>
   <meta charset="utf-8">
   <title>Overview</title>

--- a/pkg/systemd/logs.html
+++ b/pkg/systemd/logs.html
@@ -17,7 +17,7 @@ Lesser General Public License for more details.
 You should have received a copy of the GNU Lesser General Public License
 along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
-<html id="system-logs-page" class="pf-theme-dark">
+<html id="system-logs-page">
 
 <head>
   <title translate>Journal</title>

--- a/pkg/systemd/services.html
+++ b/pkg/systemd/services.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="system-services-page" class="pf-theme-dark">
+<html id="system-services-page">
 <head>
     <title translate="yes">Services</title>
     <meta charset="utf-8">

--- a/pkg/systemd/terminal.html
+++ b/pkg/systemd/terminal.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="system-terminal-page" class="pf-theme-dark">
+<html id="system-terminal-page">
 <head>
     <title translate="yes">Terminal</title>
     <meta charset="utf-8">

--- a/pkg/users/index.html
+++ b/pkg/users/index.html
@@ -18,7 +18,7 @@
  * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 -->
 
-<html id="users-page" class="pf-theme-dark">
+<html id="users-page">
 <head>
     <title translate="yes">Local accounts</title>
     <meta charset="utf-8">

--- a/src/ws/test-handlers.c
+++ b/src/ws/test-handlers.c
@@ -538,7 +538,7 @@ static const DefaultFixture fixture_shell_path_login = {
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
       "Set-Cookie: cockpit=deleted; PATH=/; SameSite=strict; HttpOnly\r*"
-      "<html class=\"pf-theme-dark\">*"
+      "<html>*"
       "<base href=\"/path/\">*"
       "login-button*"
 };
@@ -619,7 +619,7 @@ static const DefaultFixture fixture_shell_login = {
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
       "Set-Cookie: cockpit=deleted*"
-      "<html class=\"pf-theme-dark\">*"
+      "<html>*"
       "<base href=\"/\">*"
       "login-button*"
 };
@@ -680,7 +680,7 @@ static const DefaultFixture fixture_resource_login = {
   .auth = NULL,
   .expect = "HTTP/1.1 200*"
     "Set-Cookie: cockpit=deleted*"
-    "<html class=\"pf-theme-dark\">*"
+    "<html>*"
     "login-button*"
 };
 
@@ -709,7 +709,7 @@ static const DefaultFixture fixture_host_login = {
   .config = SRCDIR "/src/ws/mock-config/cockpit/cockpit.conf",
   .expect = "HTTP/1.1 200*"
       "Set-Cookie: machine-cockpit+host=deleted*"
-      "<html class=\"pf-theme-dark\">*"
+      "<html>*"
       "<base href=\"/\">*"
       "login-button*"
 };


### PR DESCRIPTION
This is autoinserted if needed.