### PR TITLE
Logs: align filters

### DIFF
--- a/pkg/systemd/logs.jsx
+++ b/pkg/systemd/logs.jsx
@@ -187,7 +187,7 @@ export const LogsPage = () => {
             <PageSection id="journal" padding={{ default: 'noPadding' }}>
                 <Toolbar>
                     <ToolbarContent>
-                        <ToolbarToggleGroup className="pf-u-flex-wrap pf-u-flex-grow-1" toggleIcon={<><span className="pf-c-button__icon pf-m-start"><FilterIcon /></span>{_("Toggle filters")}</>} breakpoint="lg">
+                        <ToolbarToggleGroup className="pf-u-flex-wrap pf-u-flex-grow-1 pf-u-align-items-flex-start" toggleIcon={<><span className="pf-c-button__icon pf-m-start"><FilterIcon /></span>{_("Toggle filters")}</>} breakpoint="lg">
                             <ToolbarGroup>
                                 <ToolbarItem>
                                     <Select toggleId="logs-predefined-filters"

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -30,6 +30,13 @@
   #journal-identifier-menu .pf-c-select__menu-item {
     white-space: normal;
   }
+
+  // This might be a PF bug; but it seems the top calculation no longer needs
+  // to take the toolbar content's row-gap into consideration. Changing it
+  // locally, as I'm not certain if it's PF or the way we're using it.
+  .pf-c-toolbar__expandable-content.pf-m-expanded {
+    inset-block: 0 auto;
+  }
 }
 
 #log-details {


### PR DESCRIPTION
Filterbar is misaligned in desktop mode:

![image](https://github.com/cockpit-project/cockpit/assets/10246/211448d9-94ef-462b-bf77-31bd2d24daf9)

And its popover is offset in mobile:

![Screen Shot 2023-05-10 at 14 45 52](https://github.com/cockpit-project/cockpit/assets/10246/c6001cea-6ee1-4ed2-ad1e-e8fc3ef26cf9)

This PR fixes both problems with two different commits.