### PR TITLE
tools/git-hook-post-commit: checkout extra files

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -3,6 +3,8 @@
 
 set -eu
 
+# requires: pyproject.toml
+
 # we consider any function named test_* to be a test case
 # each test is considered to succeed if it exits with no output
 # exit with status 77 is a skip, with the message in the output

--- a/tools/git-hook-post-commit
+++ b/tools/git-hook-post-commit
@@ -15,8 +15,9 @@ tmpdir="tmp/pre-push/${commit}"
 rm -rf "tmp/pre-push/${commit}"
 
 # unpack all of the changed files, plus the test/static-code from that commit
-files="$(git diff-tree --no-commit-id --no-renames --diff-filter=d --name-only -r "${commit}" --) test/static-code"
-git archive --prefix="${tmpdir}/" "${commit}" -- ${files} | tar x
+changed_files="$(git diff-tree --no-commit-id --no-renames --diff-filter=d --name-only -r "${commit}" --)"
+required_files="$(git cat-file -p "${commit}":test/static-code | sed -n 's/^# requires: //p') test/static-code"
+git archive --prefix="${tmpdir}/" "${commit}" -- ${changed_files} ${required_files} | tar x
 
 # check that node_modules always gets updated with package.json
 if [ -e "${tmpdir}/package.json" -a ! -e "${tmpdir}/node_modules" ]; then


### PR DESCRIPTION
Scan test/static-code for a list of extra files that need to be checked out to effectively check a given commit.

This is better than putting the list in the post-commit hook itself, because the commit hook is static: it exists in a given place on the filesystem which is usually symlinked to from the git config.  The list of files required to check each commit, on the other hand, can change with the commit in question.

Our first candidate file for the new treatment: pyproject.toml.  This is required because it contains our ruff configuration.