### PR TITLE
metrics: Fix y-flipped history polygons for saturation, and RTL orientation

### DIFF
--- a/pkg/metrics/metrics.scss
+++ b/pkg/metrics/metrics.scss
@@ -550,17 +550,24 @@ $graphs: cpu, memory, disks, network;
       }
     }
 
+    /* we always need to flip the polygons in Y direction, as the SVG
+     * coordinate system's Y goes downwards, and the computed SVGs are relative
+     * to (0,0), with a non-constant max-Y.
+     * Flip them in X direction for RTL. */
+
     .polygon.polygon-use {
-      transform: scale(-1);
-    }
-
-    .polygon-use {
       grid-area: utilization;
+      // horizontally the use graphs go to the left on LTR, to the right on RTL
+      transform: scale(-1);
+      [dir="rtl"] & { transform: scaleY(-1); }
     }
 
-    .polygon-sat {
-      opacity: 0.7;
+    .polygon.polygon-sat {
       grid-area: saturation;
+      opacity: 0.7;
+      // horizontally the load graphs go to the right on LTR, to the left on RTL
+      transform: scaleY(-1);
+      [dir="rtl"] & { transform: scale(-1); }
     }
 
     .compressed.polygon-sat {


### PR DESCRIPTION
SVG polygon's coordinates have Y go downward, but in our graph we expect the time coordinate to go upward. So we always have to scaleY(-1). Changing the numbers to be aligned to 100% instead of 0% is more computational effort -- all transform()s are a single matrix multiplication, which happens anyway.

Flip them on the X direction depending on RTL and whether it's use or saturation.

This fixes the saturation graphs being the wrong way around in LTR, and flips the horizontal orientation in RTL: i.e. in RTL, usage goes to the right and saturation to the left.

----

[pixel review](https://github.com/cockpit-project/pixel-test-reference/compare/d47238b76131c2b14c00e28b67404a0d1865d662..48a69f3dc27dd7f853f2f3dd4a76c761ad899126) -- RTL is still a mess, but that's fully fixed in PR #18777
