### PR TITLE
python: Generalize subprocess cleanup, and use TERM instead of HUP

### DIFF
--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -16,10 +16,8 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import ctypes
 import logging
 import os
-import signal
 import subprocess
 
 from typing import Dict
@@ -29,16 +27,6 @@ from ..channel import ProtocolChannel, ChannelError
 from ..transports import SubprocessTransport, SubprocessProtocol
 
 logger = logging.getLogger(__name__)
-
-libc6 = ctypes.cdll.LoadLibrary('libc.so.6')
-
-
-def prctl(*args):
-    if libc6.prctl(*args) != 0:
-        raise OSError('prctl() failed')
-
-
-SET_PDEATHSIG = 1
 
 
 class SocketStreamChannel(ProtocolChannel):
@@ -153,8 +141,7 @@ class SubprocessStreamChannel(ProtocolChannel, SubprocessProtocol):
             env.update(dict(e.split('=', 1) for e in environ))
 
         try:
-            transport = SubprocessTransport(loop, self, args, pty, window, env=env, cwd=cwd, stderr=stderr,
-                                            preexec_fn=lambda: prctl(SET_PDEATHSIG, signal.SIGHUP))
+            transport = SubprocessTransport(loop, self, args, pty, window, env=env, cwd=cwd, stderr=stderr)
             logger.debug('Spawned process args=%s pid=%i', args, transport.get_pid())
             return transport
         except FileNotFoundError as error:


### PR DESCRIPTION
Trying to terminate our children with SIGHUP was slightly odd anyway (as the canonical signal is TERM). We did that because the C bridge does.

However, this does not work with the Python bridge on Debian/Ubuntu: its PAM stack does not reset the signal mask, and the Python bridge does not configure the signals or do any cleanups on SIGTERM either. As cockpit-session ignores SIGHUP, we ended up with ignoring SIGHUP in the user and priv bridges and all processes spawned by it.    

While that unintended inheritance of SIGHUP should be fixed, let's also try to avoid it and send SIGTERM to the bridge children on exit.

Also, this really applies to all processes that the bridge spawns: We don't want to leak any process, not just the "spawn" channel ones in particular. Thus lift the PDEATHSIG up to SubprocessTransport.

---

Broken out from 318757 to fix `TestReauthorize.testBasic` (which is tailor-made to cover exactly this case). See https://github.com/cockpit-project/cockpit/pull/18757#issuecomment-1538015838 for the debugging notes and background.