### PR TITLE
logs: remove redundant CSS - toolbar paddings are fine

### DIFF
--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -30,13 +30,6 @@
   #journal-identifier-menu .pf-c-select__menu-item {
     white-space: normal;
   }
-
-  // This might be a PF bug; but it seems the top calculation no longer needs
-  // to take the toolbar content's row-gap into consideration. Changing it
-  // locally, as I'm not certain if it's PF or the way we're using it.
-  .pf-c-toolbar__expandable-content.pf-m-expanded {
-    inset-block: 0 auto;
-  }
 }
 
 #log-details {
@@ -124,13 +117,6 @@
   --pf-c-toolbar--BackgroundColor: var(--pf-c-page__main-section--BackgroundColor);
 
   // Make toolbar stretch to all the available space and wrap up to two lines
-  --pf-c-toolbar--PaddingTop: 0;
-  --pf-c-toolbar--PaddingBottom: 0;
-
-  .pf-c-toolbar__group {
-    padding-block: 0.5rem;
-  }
-
   .pf-c-toolbar__group:nth-child(3) {
     flex-grow: 1;
   }


### PR DESCRIPTION
This just got messed up from multiple layers of custom CSS.

This partially reverts https://github.com/cockpit-project/cockpit/pull/18780