### PR TITLE
pf: Fix RTL for masthead, menus, and expandables

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -313,6 +313,17 @@ select.pf-c-form-control {
   margin-inline: 0 var(--pf-c-button__icon--m-start--MarginRight);
 }
 
+// RTL fix: Masthead actions should be on the far side
+.pf-c-masthead__content {
+  margin-inline: auto var(--pf-c-masthead__content--MarginLeft);
+}
+
+// RTL fix: Menu direction should take direction into consideration
+.pf-c-dropdown .pf-c-menu.pf-m-align-right,
+.pf-c-dropdown__menu.pf-m-align-right {
+  inset-inline: auto 0;
+}
+
 // RTL fix: Modal close button
 .pf-c-modal {
   &-box__header {
@@ -428,6 +439,11 @@ select.pf-c-form-control {
 
   // Flip submit button icons (they're often arrows or direction related)
   .pf-c-button > .pf-svg {
+    transform: scaleX(-1);
+  }
+
+  // Flip expandable buttons
+  .pf-c-expandable-section__toggle-icon {
     transform: scaleX(-1);
   }
 


### PR DESCRIPTION
This looks like a lot, but it's really just this commit: df3bc8cc1327feda35ef5c93550868b24dd9bb4a. The rest should go away after the RTL branch (#18777) lands and this is rebased.

If there are any conflicts when rebasing, do a hard reset on this branch and git cherry-pick that commit.

It's really rather small and should land in the same release.