### PR TITLE
RTL bdi-css

### DIFF
--- a/pkg/lib/page.scss
+++ b/pkg/lib/page.scss
@@ -191,6 +191,14 @@ html:not(.index-page) body {
   margin-block: var(--offset);
 }
 
+// RTL: Pass through computer-generated text as-is
+// Important: Only apply this to elements that are or can be inline.
+// In many cases, it may be better to wrap output text with a <bdi> element
+.ct-rtl-passthrough {
+  display: inline;
+  unicode-bidi: plaintext;
+}
+
 // To be used only from testlib.py for pixel-tests
 main.pixel-test {
   overflow-y: clip;

--- a/pkg/systemd/logs.scss
+++ b/pkg/systemd/logs.scss
@@ -72,6 +72,11 @@
     padding-block-start: var(--pf-global--spacer--md);
   }
 
+  // RTL: Pass through computer-generated text as-is
+  .pf-c-description-list__text {
+    @extend .ct-rtl-passthrough;
+  }
+
   .table-hide-labels {
     [data-label] {
       display: revert;


### PR DESCRIPTION
Here's my attempt at making something that's like `<bdi>`, but in CSS. This is an attempt to fix paths so they're `/etc/foo` instead of `etc/foo/` and other similar issues.

It depends on the big RTL PR, so it duplicates the commits. When that lands and this is rebased, then it will be just one commit, c8681b518cd6acf24af5a59f2d72d58f8ed04cbf.

Due to the new build system, we can extend classes across files too, so we don't even have to add a class in the JSX; it can be included in SCSS via `@extend` now.

So elements that are formatted by the OS, such as paths, IPv6 addresses, and probably some other things, should be formatted one of the following ways:

1. Wrapped by a `<bdi>` element.
2. Include the class, currently called `ct-rtl-passthrough`.
3. Use `ct-rtl-passthrough` via an `@extend` in SCSS, as shown here on the logs details page.

In most cases, especially one-off places, we probably want to use `<bdi>`. But it's good to have options, as we might not be able to use `<bdi>` everywhere it's needed

---

I have this as a WIP commit and a draft pull request because we need to:
- figure out if this name is what we want (or something else)
- apply the fix to more places throughout Cockpit

Please feel free to pick up this PR and work on it (and unmark as draft and rework the commit).