### PR TITLE
test: Don't use CSS to replace DOM elements with arbitrary text

### DIFF
--- a/pkg/storaged/part-tab.jsx
+++ b/pkg/storaged/part-tab.jsx
@@ -43,9 +43,7 @@ export class PartitionTab extends React.Component {
 
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("UUID")}</DescriptionListTerm>
-                    <DescriptionListDescription className="mock-partition-uuid">
-                        {block_part.UUID}
-                    </DescriptionListDescription>
+                    <DescriptionListDescription>{block_part.UUID}</DescriptionListDescription>
                 </DescriptionListGroup>
 
                 <DescriptionListGroup>

--- a/test/common/test-functions.js
+++ b/test/common/test-functions.js
@@ -315,3 +315,13 @@ function ph_element_clip(sel) {
 function ph_count_animations(sel) {
     return ph_find(sel).getAnimations({ subtree: true }).length;
 }
+
+function ph_set_texts(new_texts) {
+    for (const sel in new_texts) {
+        const elts = ph_select(sel);
+        if (elts.length == 0)
+            throw new Error(sel + " not found");
+        for (const elt of ph_select(sel))
+            elt.textContent = new_texts[sel];
+    }
+}

--- a/test/verify/check-storage-basic
+++ b/test/verify/check-storage-basic
@@ -62,7 +62,7 @@ class TestStorageBasic(StorageCase):
 
         self.content_tab_expand(1, 1)
         b.assert_pixels("#detail-content", "partition",
-                        mock={"dd.mock-partition-uuid > div": "a12978a1-5d6e-f24f-93de-11789977acde"})
+                        mock={"dt:contains(UUID) + dd": "a12978a1-5d6e-f24f-93de-11789977acde"})
         self.content_tab_expand(1, 2)
         b.assert_pixels("#detail-content", "filesystem")
 

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -77,6 +77,8 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_in_text("#dialog", "Test Service")
         b.wait_in_text("#dialog", "/usr/bin/sleep infinity")
         b.wait_in_text("#dialog", "The listed processes and services will be forcefully stopped.")
+        b.assert_pixels("#dialog", "busy-unmount", mock={"td[data-label='PID']": "1234",
+                                                         "td[data-label='Runtime']": "a little while"})
         self.confirm()
         self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
 

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -278,6 +278,8 @@ class TestStorageNfs(StorageCase):
         b.wait_in_text("#dialog", "sleep infinity")
         b.wait_in_text("#dialog", "The listed processes will be forcefully stopped.")
         b.wait_in_text("#dialog", "Stop and unmount")
+        b.assert_pixels("#dialog", "unmount", mock={"td[data-label='PID']": "1234",
+                                                    "td[data-label='Runtime']": "a little while"})
         self.dialog_apply()
         self.dialog_wait_close()
 

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -68,6 +68,9 @@ ExecStart=/usr/bin/sleep infinity
         b.click("#dialog button:contains(Currently in use)")
         b.wait_in_text(".pf-v5-c-popover", str(sleep_pid))
         b.wait_in_text(".pf-v5-c-popover", "keep-mnt-busy")
+        b.assert_pixels(".pf-v5-c-popover", "popover",
+                        mock={".pf-v5-c-popover__body p:nth-of-type(2) li": "process (user: root, pid: 1234)"},
+                        scroll_into_view="#dialog button:contains(Currently in use)")
         b.click(".pf-v5-c-popover button")
         b.assert_pixels('#dialog', "format")
         self.dialog_cancel()


### PR DESCRIPTION
The tricky CSS tricks turned out to be a bit too tricky in the case where the production CSS already uses ::after or ::before pseudo elements.  Our ListingTable component uses those alot for handling the mobile layout, for example.

Let's use to most straightforward way: setting the text of an element via injected JavaScript.

This might fail when React decided to render inbetween the call to set_mock and capturing of the actual screenshot.  But the tests keep the pages quiet during pixel testing anyway, so hopefully this will not happen in practice.

Another way this might fail is that React gets confused the next time it renders after the call to set_mock because the DOM has changed too much.  This can hopefully be prevented by only replacing the text of elements, and not their children.

- [x] update pixel tests