### PR TITLE
WIP: Move running SSH agent from bridge to cockpit-ssh

### DIFF
--- a/src/bridge/bridge.c
+++ b/src/bridge/bridge.c
@@ -235,13 +235,6 @@ start_dbus_daemon (void)
   return start_helper_process (cmd, "^(.*)$", "DBUS_SESSION_BUS_ADDRESS");
 }
 
-static GSubprocess *
-start_ssh_agent (void)
-{
-  const char * const cmd[] = { "ssh-agent", "-s", "-D", NULL };
-  return start_helper_process (cmd, "SSH_AUTH_SOCK=([^;]*);", "SSH_AUTH_SOCK");
-}
-
 static gboolean
 on_signal_done (gpointer data)
 {
@@ -330,7 +323,6 @@ run_bridge (const gchar *interactive,
   const gchar *directory;
   struct passwd *pwd;
   g_autoptr (GSubprocess) dbus_daemon_process = NULL;
-  g_autoptr (GSubprocess) ssh_agent_process = NULL;
   guint sig_term;
   guint sig_int;
   uid_t uid;
@@ -372,7 +364,6 @@ run_bridge (const gchar *interactive,
   if (!interactive && !privileged_peer)
     {
       dbus_daemon_process = start_dbus_daemon ();
-      ssh_agent_process = start_ssh_agent ();
     }
 
   sig_term = g_unix_signal_add (SIGTERM, on_signal_done, &terminated);
@@ -437,8 +428,6 @@ run_bridge (const gchar *interactive,
 
   if (dbus_daemon_process)
     g_subprocess_send_signal (dbus_daemon_process, SIGTERM);
-  if (ssh_agent_process)
-    g_subprocess_send_signal (ssh_agent_process, SIGTERM);
 
   g_source_remove (sig_term);
   g_source_remove (sig_int);

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -17,15 +17,12 @@
 
 import argparse
 import asyncio
-import ctypes
 import json
 import logging
 import pwd
 import os
 import shlex
-import signal
 import socket
-import subprocess
 
 from typing import Dict, Iterable, List, Tuple, Type
 
@@ -189,34 +186,6 @@ def setup_logging(debug: bool):
             logging.getLogger(module).setLevel(logging.DEBUG)
 
 
-def start_ssh_agent() -> None:
-    prctl = ctypes.CDLL(None).prctl
-    PR_SET_PDEATHSIG = 1
-
-    # NB: We prefer SIGTERM to SIGKILL here since the agent needs to have a
-    # chance to clean up its listener socket.
-    try:
-        proc = subprocess.Popen(['ssh-agent',
-                                 '-D',  # no-daemon
-                                 '-s',  # shell-style output
-                                 ], stdout=subprocess.PIPE, universal_newlines=True,
-                                preexec_fn=lambda: prctl(PR_SET_PDEATHSIG, signal.SIGTERM))
-        assert proc.stdout is not None
-
-        # Wait for the agent to write at least one line and look for the
-        # listener socket.  If we fail to find it, kill the agent — something
-        # went wrong.
-        for token in shlex.shlex(proc.stdout.readline(), punctuation_chars=True):
-            if token.startswith('SSH_AUTH_SOCK='):
-                os.environ['SSH_AUTH_SOCK'] = token.replace('SSH_AUTH_SOCK=', '', 1)
-                break
-        else:
-            proc.terminate()
-
-    except OSError as exc:
-        logger.warning("Could not start ssh-agent: %s", exc)
-
-
 def main() -> None:
     polyfills.install()
 
@@ -246,10 +215,6 @@ def main() -> None:
     elif args.bridges:
         print(json.dumps(Packages().get_bridge_configs(), indent=2))
         return
-
-    # The privileged bridge doesn't need ssh-agent, but the main one does
-    if 'SSH_AUTH_SOCK' not in os.environ and not args.privileged:
-        start_ssh_agent()
 
     # asyncio.run() shim for Python 3.6 support
     run_async(run(args), debug=args.debug)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -49,6 +49,16 @@ class TestConnection(MachineCase):
         m.execute("rpm-ostree install --cache-only /var/tmp/cockpit-ws-*.rpm", timeout=180)
         m.reboot()
 
+    def assertNoAdminProcessLeaks(self):
+        '''Check that machine did not leak any bridges or ssh-agent admin processes'''
+        m = self.machine
+        try:
+            # there may still be user-wide ones like dbus-broker
+            m.execute("while pgrep -au admin '(cockpit|ssh-agent)'; do sleep 0.1; done", timeout=10)
+        except RuntimeError:
+            # show the leaked processes in the assertion
+            self.fail(m.execute("pgrep -au admin '(cockpit|ssh-agent)'"))
+
     @skipBrowser("Firefox cannot work with cookies", "firefox")
     def testBasic(self):
         m = self.machine
@@ -143,6 +153,8 @@ class TestConnection(MachineCase):
         self.assertEqual(cookie["value"], "deleted")
         self.assertTrue(cookie["httpOnly"])
         self.assertFalse(cookie["secure"])
+
+        self.assertNoAdminProcessLeaks()
 
         if not m.ostree_image:  # cannot write to /usr on OSTree, and cockpit-session is in a container
             # damage cockpit-session permissions, expect generic error message
@@ -868,8 +880,7 @@ export XDG_CONFIG_DIRS=/usr/local
                 for a in asserts:
                     self.assertIn(a, out)
 
-                # should clean up processes
-                self.assertEqual(m.execute("! pgrep -a cockpit-ws; ! pgrep -a cockpit-bridge"), "")
+                self.assertNoAdminProcessLeaks()
 
         # cockpit-desktop can start a privileged bridge through polkit
         # we don't have an agent, so just allow the privilege without interactive authentication
@@ -896,6 +907,8 @@ until pgrep -f '^(/usr/[^ ]+/[^ /]*python[^ /]* )?/usr/bin/cockpit-bridge'; do s
         m.execute("chmod 755 /tmp/browser.sh")
         m.execute(f"su - -c 'BROWSER=/tmp/browser.sh {self.libexecdir}/cockpit-desktop system' admin", timeout=10)
         self.assertIn('id="overview"', m.execute("cat /tmp/out.html"))
+
+        self.assertNoAdminProcessLeaks()
 
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
         self.allow_journal_messages("Refusing to render service to dead parents.")


### PR DESCRIPTION
This isn't necessary for local sessions ran through cockpit-session/PAM, as our pam_ssh_add module already starts an agent. That's usually the one that ends up being used, and the shell did not start an agent if `$SSH_AUTH_SOCK` was already set.

Having an agent only matters for the "bastion host" case, i.e. when directly logging into a remote host from the login page. With that, running the agent from inside cockpit-bridge is conceptually upside-down: `ssh-agent` is optimized for wrapping the session, not running inside of it, and will clean up itself automatically once the bridge ends. With the previous approach, the agent often ended up being leaked, see [1] and [2].

[1] https://github.com/cockpit-project/cockpit/pull/18803
[2] https://github.com/cockpit-project/cockpit/pull/18757#issuecomment-1543749060