### PR TITLE
python: try a different approach with Peer.start()

### DIFF
--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -135,6 +135,8 @@ class SuperuserRoutingRule(RoutingRule, ferny.InteractionResponder, bus.Object, 
 
         try:
             await self.peer.start()
+        except asyncio.CancelledError:
+            raise bus.BusError('cockpit.Superuser.Error.Cancelled', 'Operation aborted')
         except (OSError, PeerError) as exc:
             raise bus.BusError('cockpit.Superuser.Error', str(exc))
 

--- a/test/pytest/mocktransport.py
+++ b/test/pytest/mocktransport.py
@@ -194,7 +194,7 @@ class MockTransport(asyncio.Transport):
         assert 'id' in reply, reply
         assert reply['id'] == tag, reply
         assert 'error' in reply, reply
-        assert reply['error'] == [code, [message]]
+        assert reply['error'] == [code, [message]], reply['error']
 
     async def check_bus_call(
         self,


### PR DESCRIPTION
We need to cancel the .do_connect_transport() function in various situations:

  - we called .close() ourselves

  - we got an error or EOF on Peer stdout

  - we got our "init" message on Peer stdout and are therefore connected

This non-linearity undermines our somewhat naive approach to thinking that the connection process could be done using pure async/await.

Let's repurpose our init_future future: it's now created on the Peer on initialization and, for as long as it's around, the peer is considered to be uninitialized.  It represents (approximately) the future result of the .start() function.

It can have its value filled it from exactly two places:

 - when .do_close() is called [which can happen in response to many things]

 - when we get the "init" message from the other side

.start() basically now just involves awaiting the future.

Instead of awaiting .do_transport_connect() in .start() we run it in its own task. If it throws, we use that to close the peer (which will report the error via init_future, as mentioned above).  If it is successful, we do nothing (until we either get some other error, or the init message).

This new approach satisfies all existing tests and we add a bunch of new ones as well, including two cases which test the core feature enabled here: we can now receive an init message or call .close() while .do_connect_transport() is running and expect the correct result.

This commit also contains a small cleanup to the "background startup" functionality: now that the only thing that .start() waits on is the init_future, it is sufficient to signal that from .do_close() — we don't need to cancel the background startup task.  As such, we can drop the instance variable and run the task done function as a local.