### PR TITLE
bridge: Prefer label as superuser rule ID

### DIFF
--- a/src/bridge/cockpitrouter.c
+++ b/src/bridge/cockpitrouter.c
@@ -1198,21 +1198,22 @@ static gchar *
 rule_superuser_id (RouterRule *rule)
 {
   gboolean privileged;
-  const gchar **spawn = NULL;
-  gchar *id;
 
   if (rule->config
       && cockpit_json_get_bool (rule->config, "privileged", FALSE, &privileged)
-      && privileged
-      && cockpit_json_get_strv (rule->config, "spawn", NULL, &spawn)
-      && spawn)
-    {
-      id = g_path_get_basename (spawn[0]);
-      g_free (spawn);
-      return id;
+      && privileged) {
+      /* if bridge has a label, prefer that */
+      const gchar *label;
+      if (cockpit_json_get_string (rule->config, "label", NULL, &label) && label)
+        return g_strdup (label);
+
+      /* else, use program name */
+      g_autofree const gchar **spawn = NULL;
+      if (cockpit_json_get_strv (rule->config, "spawn", NULL, &spawn) && spawn)
+        return g_path_get_basename (spawn[0]);
     }
-  else
-    return NULL;
+
+  return NULL;
 }
 
 /* D-Bus interface */

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -328,9 +328,9 @@ session include system-auth
         b.leave_page()
         b.check_superuser_indicator("Limited access")
 
-        # Get admin rights with "pkexec" method
+        # Get admin rights with Polkit method
         b.open_superuser_dialog()
-        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "pkexec")
+        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "Polkit")
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access') select", "Polkit")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Please authenticate")
@@ -347,7 +347,7 @@ session include system-auth
 
         # Run the regular sudo method, which should work as always
         b.open_superuser_dialog()
-        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "sudo")
+        b.set_val(".pf-c-modal-box:contains('Switch to administrative access') select", "Sudo")
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access') select", "Sudo")
         b.click(".pf-c-modal-box button:contains('Authenticate')")
         b.wait_in_text(".pf-c-modal-box:contains('Switch to administrative access')", "Password for admin:")


### PR DESCRIPTION
If a superuser rule has a label, use that as ID instead of argv[0]. That's what the Python bridge already does, and it's more robust: Labels are meant to be unique, while it's conceivable to have more than one rule for a given program name: they could run in different modes, or there could be alternatives in different paths.

----

I noticed that as part of issue #18711. That will make the test fail "better" under the Python bridge, it should now say "No authentication agent found".

[corresponding python bridge code](https://github.com/cockpit-project/cockpit/blob/68980cd34568a52bc0e2000d79ff0dd823762a87/src/cockpit/superuser.py#L153)

With this PR, `TestSuperuser.testMultipleBridgeConfig` fails more reasonably with the pybridge:

![image](https://github.com/cockpit-project/cockpit/assets/200109/edee6cf5-69f6-4ba2-9e88-eb6185503550)