### PR TITLE
python: isort everything via ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ disable = [
 ]
 
 [tool.ruff]
+select = [
+    "E",       # pycodestyle
+    "F",       # pyflakes
+    "I",       # isort
+]
 exclude = [
     ".git/",
     "modules/",

--- a/src/build_backend.py
+++ b/src/build_backend.py
@@ -6,7 +6,6 @@ import shutil
 import subprocess
 import tarfile
 import zipfile
-
 from typing import Dict, Iterable, Optional
 
 from cockpit import __version__

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -20,19 +20,17 @@ import asyncio
 import ctypes
 import json
 import logging
-import pwd
 import os
+import pwd
 import shlex
 import signal
 import socket
 import subprocess
-
 from typing import Dict, Iterable, List, Tuple, Type
 
 from cockpit._vendor.systemd_ctypes import bus, run_async
 
 from . import polyfills
-
 from .channel import ChannelRoutingRule
 from .channels import CHANNEL_TYPES
 from .config import Config, Environment

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -17,11 +17,9 @@
 
 import asyncio
 import logging
-
 from typing import ClassVar, Dict, Generator, List, Optional, Sequence, Set, Tuple, Type
 
 from .router import Endpoint, Router, RoutingRule
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/channels/__init__.py
+++ b/src/cockpit/channels/__init__.py
@@ -20,9 +20,8 @@ from .filesystem import FsListChannel, FsReadChannel, FsReplaceChannel, FsWatchC
 from .http import HttpChannel
 from .metrics import InternalMetricsChannel
 from .packages import PackagesChannel
-from .stream import SubprocessStreamChannel, SocketStreamChannel
+from .stream import SocketStreamChannel, SubprocessStreamChannel
 from .trivial import EchoChannel, NullChannel
-
 
 CHANNEL_TYPES = [
     DBusChannel,

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -18,12 +18,10 @@
 import logging
 import os
 import random
-
 from typing import Dict
 
 from .._vendor.systemd_ctypes import PathWatch
 from .._vendor.systemd_ctypes.inotify import Event as InotifyEvent
-
 from ..channel import Channel, ChannelError, GeneratorChannel
 
 logger = logging.getLogger(__name__)

--- a/src/cockpit/channels/http.py
+++ b/src/cockpit/channels/http.py
@@ -18,8 +18,8 @@
 import asyncio
 import http.client
 import logging
-import ssl
 import socket
+import ssl
 import threading
 
 from ..channel import Channel

--- a/src/cockpit/channels/metrics.py
+++ b/src/cockpit/channels/metrics.py
@@ -17,14 +17,14 @@
 
 import asyncio
 import json
+import logging
 import sys
 import time
-import logging
-from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 from collections import defaultdict
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 from ..channel import AsyncChannel, ChannelError
-from ..samples import SAMPLERS, Sampler, Samples, SampleDescription
+from ..samples import SAMPLERS, SampleDescription, Sampler, Samples
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/channels/stream.py
+++ b/src/cockpit/channels/stream.py
@@ -19,12 +19,10 @@ import asyncio
 import logging
 import os
 import subprocess
-
 from typing import Dict
 
-
-from ..channel import ProtocolChannel, ChannelError
-from ..transports import SubprocessTransport, SubprocessProtocol
+from ..channel import ChannelError, ProtocolChannel
+from ..transports import SubprocessProtocol, SubprocessTransport
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/config.py
+++ b/src/cockpit/config.py
@@ -18,7 +18,6 @@
 import configparser
 import logging
 import os
-
 from pathlib import Path
 
 from ._vendor.systemd_ctypes import bus

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -22,12 +22,10 @@ import json
 import logging
 import os
 import pwd
-
 from typing import Dict, Optional
 
-from ._vendor.systemd_ctypes import bus, pathwatch, inotify, Variant
-
 from . import config
+from ._vendor.systemd_ctypes import Variant, bus, inotify, pathwatch
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/misc/bootloader.py
+++ b/src/cockpit/misc/bootloader.py
@@ -1,8 +1,8 @@
 # COCKPIT BOOTLOADER
 
-from hashlib import sha256
 import os
 import sys
+from hashlib import sha256
 
 
 class Bootloader:

--- a/src/cockpit/misc/print.py
+++ b/src/cockpit/misc/print.py
@@ -24,7 +24,6 @@ import readline  # noqa side-effecting import
 import shlex
 import sys
 import time
-
 from typing import BinaryIO, Iterable, Optional
 
 

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -25,13 +25,11 @@ import mimetypes
 import os
 import re
 import shutil
-
 from pathlib import Path
 from typing import ClassVar, Dict, List, Optional, Pattern, Tuple
 
-from ._vendor.systemd_ctypes import bus
-
 from . import config
+from ._vendor.systemd_ctypes import bus
 
 VERSION = '300'
 logger = logging.getLogger(__name__)

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -18,12 +18,11 @@
 import asyncio
 import logging
 import os
-
 from typing import Callable, Dict, List, Optional, Sequence
 
+from .protocol import CockpitProblem, CockpitProtocol, CockpitProtocolError
 from .router import Endpoint, Router, RoutingRule
-from .protocol import CockpitProtocol, CockpitProblem, CockpitProtocolError
-from .transports import SubprocessTransport, SubprocessProtocol
+from .transports import SubprocessProtocol, SubprocessTransport
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/polyfills.py
+++ b/src/cockpit/polyfills.py
@@ -24,6 +24,7 @@ def install():
     # introduced in 3.9
     if not hasattr(socket, 'recv_fds'):
         import array
+
         import _socket
 
         def recv_fds(sock, bufsize, maxfds, flags=0):

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -19,11 +19,9 @@ import asyncio
 import json
 import logging
 import uuid
-
 from typing import ClassVar, Dict, Optional
 
 from ._vendor import systemd_ctypes
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/remote.py
+++ b/src/cockpit/remote.py
@@ -20,12 +20,11 @@ import getpass
 import logging
 import re
 import socket
-
-from typing import Dict, Optional, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from ._vendor import ferny
-from .router import RoutingRule, Router
 from .peer import Peer, PeerError
+from .router import Router, RoutingRule
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/router.py
+++ b/src/cockpit/router.py
@@ -17,10 +17,9 @@
 
 import collections
 import logging
-
 from typing import Dict, List, Optional
 
-from .protocol import CockpitProtocolServer, CockpitProtocolError
+from .protocol import CockpitProtocolError, CockpitProtocolServer
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/samples.py
+++ b/src/cockpit/samples.py
@@ -17,10 +17,9 @@
 
 import os
 import re
-from ._vendor.systemd_ctypes import Handle
-
 from typing import Any, DefaultDict, Iterable, List, NamedTuple, Optional, Tuple
 
+from ._vendor.systemd_ctypes import Handle
 
 USER_HZ = os.sysconf(os.sysconf_names['SC_CLK_TCK'])
 MS_PER_JIFFY = 1000 / (USER_HZ if (USER_HZ > 0) else 100)

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -16,16 +16,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import asyncio
-import logging
 import getpass
+import logging
 import os
-
 from typing import Dict, List, Optional, Sequence, Union
 
-from ._vendor.systemd_ctypes import bus
 from ._vendor import ferny
+from ._vendor.systemd_ctypes import bus
+from .peer import ConfiguredPeer, Peer, PeerError
 from .router import Router, RoutingError, RoutingRule
-from .peer import Peer, PeerError, ConfiguredPeer
 
 logger = logging.getLogger(__name__)
 

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -29,9 +29,7 @@ import signal
 import struct
 import subprocess
 import termios
-
 from typing import Any, ClassVar, Deque, Dict, List, Optional, Sequence, Tuple
-
 
 libc6 = ctypes.cdll.LoadLibrary('libc.so.6')
 

--- a/test/pytest/mockpeer.py
+++ b/test/pytest/mockpeer.py
@@ -2,8 +2,8 @@ import asyncio
 import os
 import sys
 
-from cockpit.transports import StdioTransport
 from cockpit.protocol import CockpitProtocolServer
+from cockpit.transports import StdioTransport
 
 
 class MockPeer(CockpitProtocolServer):

--- a/test/pytest/mocktransport.py
+++ b/test/pytest/mocktransport.py
@@ -2,7 +2,6 @@ import asyncio
 import json
 import os
 import subprocess
-
 from typing import Any, Dict, Iterable, Optional, Tuple
 
 from cockpit.router import Router

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -2,20 +2,18 @@ import argparse
 import asyncio
 import json
 import os
-import pytest
-import unittest
-import unittest.mock
 import sys
 import tempfile
-
+import unittest
+import unittest.mock
 from pathlib import Path
 from typing import Dict
 
-from cockpit._vendor.systemd_ctypes import bus, EventLoopPolicy
+import pytest
+from cockpit._vendor.systemd_ctypes import EventLoopPolicy, bus
 from cockpit.bridge import Bridge
 from cockpit.channels import CHANNEL_TYPES
-
-from mocktransport import MockTransport, MOCK_HOSTNAME, settle_down
+from mocktransport import MOCK_HOSTNAME, MockTransport, settle_down
 
 asyncio.set_event_loop_policy(EventLoopPolicy())
 

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -17,10 +17,9 @@
 
 import json
 
-import pytest
-
 import cockpit.config
-from cockpit.packages import parse_accept_language, Packages
+import pytest
+from cockpit.packages import Packages, parse_accept_language
 
 
 @pytest.mark.parametrize("test_input,expected", [

--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -2,13 +2,11 @@ import asyncio
 import os
 import sys
 
+import mockpeer
 import pytest
-
+from cockpit.peer import ConfiguredPeer, PeerRoutingRule
 from cockpit.protocol import CockpitProtocolError
 from cockpit.router import Router
-from cockpit.peer import ConfiguredPeer, PeerRoutingRule
-
-import mockpeer
 from mocktransport import MockTransport, assert_no_subprocesses, settle_down
 
 PEER_CONFIG = {

--- a/test/pytest/test_samples.py
+++ b/test/pytest/test_samples.py
@@ -20,9 +20,8 @@ import multiprocessing
 import numbers
 import os
 
-import pytest
-
 import cockpit.samples
+import pytest
 
 
 @pytest.fixture

--- a/test/pytest/test_transport.py
+++ b/test/pytest/test_transport.py
@@ -23,7 +23,6 @@ import signal
 import subprocess
 import unittest
 import unittest.mock
-
 from typing import Any, List, Optional, Tuple
 
 import cockpit.transports


### PR DESCRIPTION
This commit is based on doing two things:

  - selecting "i" rules for ruff in our `pyproject.toml`

  - running `ruff check --fix .`