### PR TITLE
all: do not flip the direction of all icons

### DIFF
--- a/pkg/lib/cockpit-components-plot.jsx
+++ b/pkg/lib/cockpit-components-plot.jsx
@@ -278,11 +278,11 @@ export const ZoomControls = ({ plot_state }) => {
             { "\n" }
             <Button variant="secondary" onClick={() => zoom_state.scroll_left()}
                     isDisabled={!zoom_state.enable_scroll_left}>
-                <AngleLeftIcon />
+                <AngleLeftIcon className="shows-direction" />
             </Button>
             <Button variant="secondary" onClick={() => zoom_state.scroll_right()}
                     isDisabled={!zoom_state.enable_scroll_right}>
-                <AngleRightIcon />
+                <AngleRightIcon className="shows-direction" />
             </Button>
         </div>
     );

--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -438,7 +438,7 @@ select.pf-c-form-control {
   }
 
   // Flip submit button icons (they're often arrows or direction related)
-  .pf-c-button > .pf-svg {
+  .pf-c-button > .shows-direction.pf-svg {
     transform: scaleX(-1);
   }
 

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -1322,7 +1322,7 @@ const HourDescription = ({ minute_events, isHourExpanded, onToggleHourExpanded, 
     return (
         <span className={"metrics-events" + (isHourExpanded ? " metrics-events-hour-header-expanded" : "")}>
             {spikes > 0 &&
-                <Button variant="plain" className="metrics-events-expander" onClick={() => onToggleHourExpanded(!isHourExpanded)} icon={isHourExpanded ? <AngleDownIcon /> : <AngleRightIcon />} />}
+                <Button variant="plain" className="metrics-events-expander" onClick={() => onToggleHourExpanded(!isHourExpanded)} icon={isHourExpanded ? <AngleDownIcon /> : <AngleRightIcon className="shows-direction" />} />}
             <time>{ timeformat.time(startTime) }</time>
             <Flex flexWrap={{ default: 'nowrap' }} spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsBaseline' }} className="spikes_count">
                 {spikes >= 10 && <ResourcesFullIcon color="var(--resource-icon-color-full)" />}


### PR DESCRIPTION
This override was mostly introduced because of the plots in storage and network page. Flipping the arrows there is correct, but general icons should not be flipped.