### PR TITLE
po: Also include pkg/lib translations

### DIFF
--- a/pkg/lib/cockpit-po-plugin.js
+++ b/pkg/lib/cockpit-po-plugin.js
@@ -70,7 +70,7 @@ function buildFile(po_file, subdir, webpack_module, webpack_compilation) {
             for (const [msgid, translation] of Object.entries(context)) {
                 /* Only include msgids which appear in this source directory */
                 const references = translation.comments.reference.split(/\s/);
-                if (!references.some(str => str.startsWith(`pkg/${subdir}`) || str.startsWith(config.src_directory)))
+                if (!references.some(str => str.startsWith(`pkg/${subdir}`) || str.startsWith(config.src_directory) || str.startsWith(`pkg/lib`)))
                     continue;
 
                 if (translation.comments.flag?.match(/\bfuzzy\b/))

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1818,6 +1818,20 @@ class MachineCase(unittest.TestCase):
         # happens fairly reliably with TestKeys.testAuthorizedKeys, TestConnection.testTls and TestHistoryMetrics.testEvents
         self.allowed_messages.append('cockpit.router-ERROR: trying to drop non-existent channel .* from .*')
 
+        # https://github.com/cockpit-project/cockpit/issues/18355
+        self.allowed_messages += [
+            "exception ignored in:.*DBusChannel.setup_path_watch.*",
+            "Traceback .*most recent call last.*",
+            "File .*",
+            "async with self.watch_processing_lock:",
+            "self.release.*",
+            "self._wake_up_first.*",
+            "fut.set_result.*",
+            "self._check_closed.*",
+            "raise RuntimeError.*",
+            "RuntimeError: Event loop is closed",
+        ]
+
         messages = machine.journal_messages(matches, 6, cursor=cursor)
 
         if "TEST_AUDIT_NO_SELINUX" not in os.environ:

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -838,6 +838,9 @@ OnCalendar=daily
             b.click(f"#nav-system .nav-item a[href='{href}']")
             b.wait_visible(f"iframe.container-frame[name='cockpit1:localhost{href}'][data-loaded]")
 
+        # logging out too fast, some D-Bus services get disconnected
+        self.allow_restart_journal_messages()
+
 
 if __name__ == '__main__':
     test_main()

--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -192,7 +192,10 @@ OnCalendar=daily
         # Check that the system page is translated
         b.go("/system")
         b.enter_page("/system")
-        b.wait_in_text(".ct-overview-header", "Neustart")
+        b.click(".ct-overview-header button:contains('Neustart')")
+
+        # Restart dialog is loaded from pkg/lib and it also needs to be translated
+        b.wait_in_text("#shutdown-dialog", "Nachricht an angemeldete Benutzer")
 
         # Systemd timer localization
         b.go("/system/services")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -619,7 +619,9 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             self.run_systemctl(user, "start mem-hog.service")
             # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")
-            b.wait_visible("#memory")
+            # initial memory detection takes very long especially on RHEL 8
+            with b.wait_timeout(60):
+                b.wait_visible("#memory")
             initial_memory = float(b.text("#memory").split(" ")[0])
             self.assertGreater(initial_memory, 0.5)
             m.execute(f"touch /tmp/continue{params}")


### PR DESCRIPTION
Package specific translation files (e.g ./usr/share/cockpit/storaged/po.zh_CN.js.gz) do not include translations for imported components from pkg/lib.

Some reproducers for example are (switch to chinese for example as this is almost 100% translated):
- Try to add-hoc install anything (cockpit-pcp, realmd...)
- Try to reboot machine
- Try to change system time
- Try to change password for user

@martinpitt or @allisonkarlitskaya I think you were making changes to translations lately. This already landed in 8.8/9.2 so this is at least a couple of months old. I consider this PR a hack and I believe there is better solution. Do you have better idea what can be broken?