### PR TITLE
test: Set correct SELinux context for PCP

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -499,7 +499,7 @@ class TestHistoryMetrics(MachineCase):
 
         m.execute("""mount -t tmpfs tmpfs /var/log/pcp/pmlogger
                      chown -R pcp:pcp /var/log/pcp/pmlogger
-                     restorecon /var/log/pcp/pmlogger || true""")
+                     if selinuxenabled; then restorecon /var/log/pcp/pmlogger; fi""")
         self.addCleanup(m.execute, "systemctl stop pmlogger; until umount /var/log/pcp/pmlogger; do sleep 1; done")
 
         self.login_and_go("/metrics")
@@ -534,6 +534,7 @@ class TestHistoryMetrics(MachineCase):
 
         m.write("/run/systemd/system/pmlogger.service.d/break.conf", "[Service]\nExecStart=\nExecStart=/bin/false")
         m.execute(r"""mount -t tmpfs tmpfs /var/log/pcp/pmlogger
+                      if selinuxenabled; then restorecon /var/log/pcp/pmlogger; fi
                       systemctl daemon-reload
                       systemctl start pmlogger || true""")
         self.addCleanup(m.execute,


### PR DESCRIPTION
TestHistoryMetrics.testNoDataFailed did not do that, which leads to unexpected SELinux denials with latest PCP.

testNoDataEnable already did it, but in a brittle way, clean this up as well.

---

This broke https://github.com/cockpit-project/bots/pull/4779, see [failed test](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4779-20230517-230633-afb83d1f-fedora-testing-daily-cockpit-project-cockpit/log.html#64). Triggering this image run here as well.