### PR TITLE
test: Allow more time for configuring chrony

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -387,7 +387,8 @@ class TestSystemInfo(PackageCase):
         b.click('#systime-ntp-servers div:nth-child(1) button')
         b.set_input_text("#systime-ntp-servers div:nth-child(2) input", "1.pool.ntp.org")
         b.click("#system_information_change_systime .apply")
-        b.wait_not_present("#system_information_change_systime")
+        with b.wait_timeout(60):
+            b.wait_not_present("#system_information_change_systime")
 
         m.execute(f"grep 0.pool.ntp.org {enabled_conf}")
         m.execute(f"grep 1.pool.ntp.org {enabled_conf}")
@@ -407,7 +408,8 @@ class TestSystemInfo(PackageCase):
         self.set_change_time_dialog_mode("Automatically using NTP")
         b.wait_not_present("#systime-ntp-servers")
         b.click("#system_information_change_systime .apply")
-        b.wait_not_present("#system_information_change_systime")
+        with b.wait_timeout(60):
+            b.wait_not_present("#system_information_change_systime")
 
         m.execute(f"! test -f {enabled_conf}")
         m.execute(f"grep 2.pool.ntp.org {disabled_conf}")


### PR DESCRIPTION
On a local undisturbed system, it takes about 12s to reconfigure chrony. It often times out on our CI machines.

----

See [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-4775-20230517-070749-d90299da-fedora-38-pybridge-cockpit-project-cockpit/log.html#273-2)