### PR TITLE
storage: Account for overhead in Stratis pools

### DIFF
--- a/pkg/storaged/fsys-panel.jsx
+++ b/pkg/storaged/fsys-panel.jsx
@@ -124,6 +124,9 @@ export class FilesystemsPanel extends React.Component {
                     total += Number(fs.Used[1]);
             });
 
+            const overhead = pool.TotalPhysicalUsed[0] ? (Number(pool.TotalPhysicalUsed[1]) - total) : 0;
+            const pool_total = Number(pool.TotalPhysicalSize) - overhead;
+
             return filesystems.map((fs, i) => {
                 const block = client.slashdevs_block[fs.Devnode];
                 let mount = "-";
@@ -139,8 +142,7 @@ export class FilesystemsPanel extends React.Component {
                         { title: "Stratis" },
                         { title: mount },
                         {
-                            title: <StorageUsageBar stats={[Number(fs.Used[0] && Number(fs.Used[1])),
-                                Number(pool.TotalPhysicalSize)]}
+                            title: <StorageUsageBar stats={[Number(fs.Used[0] && Number(fs.Used[1])), pool_total]}
                                                     critical={1} total={total} offset={offsets[i]} />,
                             props: { className: "pf-v5-u-text-align-right" }
                         }

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -468,6 +468,8 @@ export const StratisPoolDetails = ({ client, pool }) => {
     const sidebar = <StratisPoolSidebar client={client} pool={pool} />;
 
     function render_fsys(fsys, offset, total) {
+        const overhead = pool.TotalPhysicalUsed[0] ? (Number(pool.TotalPhysicalUsed[1]) - total) : 0;
+        const pool_total = Number(pool.TotalPhysicalSize) - overhead;
         const block = client.slashdevs_block[fsys.Devnode];
 
         if (!block) {
@@ -664,8 +666,7 @@ export const StratisPoolDetails = ({ client, pool }) => {
                 title: mount_point
             },
             {
-                title: <StorageUsageBar stats={[Number(fsys.Used[0] && Number(fsys.Used[1])),
-                    Number(pool.TotalPhysicalSize)]}
+                title: <StorageUsageBar stats={[Number(fsys.Used[0] && Number(fsys.Used[1])), pool_total]}
                                         critical={1} total={total} offset={offset} />,
                 props: { className: "pf-v5-u-text-align-right" }
             },


### PR DESCRIPTION
The filesystems of a pool can not grow to fill the whole pool so let's reduce their usage bar to their maximum (combined) size.

https://issues.redhat.com/browse/COCKPIT-999