### PR TITLE
testlib: Adjust expected pybridge traceback for Fedora 38

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1820,7 +1820,7 @@ class MachineCase(unittest.TestCase):
 
         # https://github.com/cockpit-project/cockpit/issues/18355
         self.allowed_messages += [
-            "exception ignored in:.*DBusChannel.setup_path_watch.*",
+            "[eE]xception ignored in:.*DBusChannel.setup_path_watch.*",
             "Traceback .*most recent call last.*",
             "File .*",
             "async with self.watch_processing_lock:",


### PR DESCRIPTION
The expected stack trace added in commit 3d789f473fd was done for RHEL 8 with Python 3.6. Newer Python on Fedora 38 capitalizes the exception message, so allow both cases.

---

See https://cockpit-logs.us-east-1.linodeobjects.com/pull-18837-20230523-144846-e3e409ee-fedora-38-pybridge/log.html#111