### PR TITLE
python: update ferny, implement cockpit.send-stderr

### DIFF
--- a/test/pytest/pseudo.py
+++ b/test/pytest/pseudo.py
@@ -7,7 +7,7 @@ pw = os.environ.get('PSEUDO_PASSWORD')
 if pw:
     reader, writer = os.pipe()
     # '-' is the (ignored) argv[0], and 'can haz pw' is the message in argv[1]
-    interaction_client.interact(2, writer, ['-', 'can haz pw?'], {})
+    interaction_client.askpass(2, writer, ['-', 'can haz pw?'], {})
     os.close(writer)
 
     response = os.read(reader, 1024).decode('utf-8').strip()


### PR DESCRIPTION
ferny stopped implementing our send-stderr command, which was only used for us, so we have to implement it ourselves now, from our InteractionResponder in superuser.py.

On the plus side, we can now use interaction_client.py to send custom commands.  According to the ferny documentation, we should prefer this over sending messages for ourselves.

Note: in comparison to the old send-stderr handling inside of ferny, our new `cockpit.send-stderr` command no longer implies that the ferny interaction is complete — we need to send `ferny.end` separately.  This isn't actually required for the interaction to exit (since we'll send our "init" message very soon anyway) but is required in some situations to prevent ferny from interpreting our dropping the stderr socket as an unexpected exit.