### PR TITLE
test: Update "Faster iteration" documentation

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -93,14 +93,14 @@ disable them, run it with `-e`/`--no-eslint` and/or `-s`/`--no-stylelint`.
 Reload cockpit in your browser after page is built. Press `Ctrl`-`C` to
 stop watch mode once you are done with changing the code.
 
-You often need to test code changes in a VM. There is an `-r`/`--rsync`
-option for copying the built page into the given SSH target's
-/usr/share/cockpit/ directory. If you use Cockpit's own test VMs and set up the
+You often need to test code changes in a VM. You can set the `$RSYNC` env
+variable to copy the built page into the given SSH target's
+/usr/local/share/cockpit/ directory. If you use Cockpit's own test VMs and set up the
 SSH `c` alias as described in [test/README.md](./test/README.md), you can use
 one of these commands:
 
-    ./build.js -w -r c kdump
-    ./build.js -w -r c
+    RSYNC=c ./build.js -w kdump
+    RSYNC=c ./build.js -w
 
 To make Cockpit use system packages again, instead of your checkout directory,
 remove the symlink with the following command and log back into Cockpit:

--- a/build.js
+++ b/build.js
@@ -153,7 +153,9 @@ async function build() {
             }
         },
 
-        ...args.rsync ? [cockpitRsyncEsbuildPlugin({ source: "dist/" + (args.onlydir || '') })] : [],
+        ...(args.rsync || process.env.RSYNC)
+            ? [cockpitRsyncEsbuildPlugin({ source: "dist/" + (args.onlydir || '') })]
+            : [],
     ];
 
     if (useWasm) {

--- a/test/README.md
+++ b/test/README.md
@@ -141,8 +141,11 @@ you can log in to test machines without authentication:
         StrictHostKeyChecking no
         UserKnownHostsFile /dev/null
         CheckHostIp no
-        IdentityFile ~/src/cockpit/bots/machine/identity
+        IdentityFile CHECKOUT_DIR/bots/machine/identity
         IdentitiesOnly yes
+
+You need to replace `CHECKOUT_DIR` with the actual directory where you cloned
+`cockpit.git`, or `bots.git` if you have a separate clone for that.
 
 Many cockpit developers take it a step further, and add an alias to
 allow typing `ssh c`:


### PR DESCRIPTION
For a long time we've had a better way than `image-customize` for
iterating destructive tests. Split the section for
destructive/nondestructive, and use watch+rsync mode for the former.

Stop explicitly documenting running against an arbitrary running machine. This
is still way too dangerous. People can and will figure it out with the
`--machine`/`--browser` arguments, but at least stop recommending this footgun.

----

Rendered preview: https://github.com/martinpitt/cockpit/blob/doc-test-iterate/test/README.md#fast-developtest-iteration