### PR TITLE
storage: Allow adding cache to encrypted pools

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -963,7 +963,7 @@ client.stratis_start = () => {
 // not allowed.  If we need to bump it, it should be bumped here for all
 // of them at the same time.
 //
-const stratis3_interface_revision = "r2";
+const stratis3_interface_revision = "r5";
 
 function stratis3_start() {
     const stratis = cockpit.dbus("org.storage.stratis3", { superuser: "try" });
@@ -985,11 +985,11 @@ function stratis3_start() {
                 };
 
                 client.stratis_start_pool = (uuid, unlock_method) => {
-                    return client.stratis_manager.StartPool(uuid, [!!unlock_method, unlock_method || ""]);
+                    return client.stratis_manager.StartPool(uuid, "uuid", [!!unlock_method, unlock_method || ""]);
                 };
 
                 client.stratis_create_pool = (name, devs, key_desc, clevis_info) => {
-                    return client.stratis_manager.CreatePool(name, [false, 0],
+                    return client.stratis_manager.CreatePool(name,
                                                              devs,
                                                              key_desc ? [true, key_desc] : [false, ""],
                                                              clevis_info ? [true, clevis_info] : [false, ["", ""]]);
@@ -1005,6 +1005,7 @@ function stratis3_start() {
 
                 client.features.stratis = true;
                 client.features.stratis_crypto_binding = true;
+                client.features.stratis_encrypted_caches = true;
                 client.stratis_pools = client.stratis_manager.client.proxies("org.storage.stratis3.pool." +
                                                                              stratis3_interface_revision,
                                                                              "/org/storage/stratis3",

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -85,7 +85,11 @@ const StratisPoolSidebar = ({ client, pool }) => {
                               {
                                   choices: [
                                       { value: "data", title: _("Data") },
-                                      { value: "cache", title: _("Cache"), disabled: pool.Encrypted }
+                                      {
+                                          value: "cache",
+                                          title: _("Cache"),
+                                          disabled: pool.Encrypted && !client.features.stratis_encrypted_caches
+                                      }
                                   ]
                               }),
                     PassInput("passphrase", _("Passphrase"),

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -273,7 +273,7 @@ class StorageHelpers:
             self.browser.set_val(sel + " .size-unit select", "1000000")
             self.browser.set_input_text(sel + " .size-text input", str(val))
         elif ftype == "select":
-            self.browser._wait_present(sel + f" select option[value={val}]:not([disabled])")
+            self.browser._wait_present(sel + f" select option[value='{val}']:not([disabled])")
             self.browser.set_val(sel + " select", val)
         elif ftype == "select-radio":
             self.browser.click(sel + f" input[data-data='{val}']")

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -273,6 +273,7 @@ class StorageHelpers:
             self.browser.set_val(sel + " .size-unit select", "1000000")
             self.browser.set_input_text(sel + " .size-text input", str(val))
         elif ftype == "select":
+            self.browser._wait_present(sel + f" select option[value={val}]:not([disabled])")
             self.browser.set_val(sel + " select", val)
         elif ftype == "select-radio":
             self.browser.click(sel + f" input[data-data='{val}']")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -277,6 +277,10 @@ class TestStorageStratis(storagelib.StorageCase):
         m.add_disk("4G", serial="DISK2")
         b.wait_in_text("#drives", dev_2)
 
+        dev_3 = "/dev/sdc"
+        m.add_disk("4G", serial="DISK3")
+        b.wait_in_text("#drives", dev_3)
+
         passphrase = "foodeeboodeebar"
 
         # Create an encrypted pool with a filesystem, but don't mount
@@ -337,6 +341,18 @@ class TestStorageStratis(storagelib.StorageCase):
                          'new_passphrase2': passphrase})
             m.execute("stratis key unset pool0")
 
+        # Add a cache blockdev (if supported)
+        if not self.stratis_v2:
+            b.click('#detail-sidebar .pf-v5-c-card__actions button')
+            self.dialog_wait_open()
+            self.dialog_set_val('tier', "cache")
+            self.dialog_set_val('disks', {dev_3: True})
+            self.dialog_set_val('passphrase', passphrase)
+            self.dialog_apply()
+            self.dialog_wait_close()
+            b.wait_in_text('#detail-sidebar', dev_3)
+            b.wait_in_text(f'#detail-sidebar .sidepanel-row:contains({dev_3})', "cache")
+
         m.reboot()
         m.start_cockpit()
         b.relogin()
@@ -344,8 +360,8 @@ class TestStorageStratis(storagelib.StorageCase):
         b.wait_visible("#storage-detail")
 
         b.wait_in_text('#detail-header', "Stopped Stratis pool")
-        b.wait_in_text('#detail-sidebar', dev_1)
-        b.wait_in_text('#detail-sidebar', dev_2)
+        b.wait_in_text('#detail-sidebar', "DISK1")
+        b.wait_in_text('#detail-sidebar', "DISK2")
 
         # Unlock the pool
         b.click('#detail-header button:contains(Start)')


### PR DESCRIPTION
This requires moving to "r5" of the D-Bus API.

------------------

## Storage: Cockpit can now add caches to encrypted Stratis pools

Encrypted caches are a new feature in Stratis 3.5, and now you can use it also from Cockpit.