### PR TITLE
lib: selinux: add screen reader text for badges

### DIFF
--- a/pkg/lib/cockpit-components-logs-panel.jsx
+++ b/pkg/lib/cockpit-components-logs-panel.jsx
@@ -95,7 +95,7 @@ export class JournalOutput {
                     count > 1
                         ? <div className="cockpit-log-service-container" role="cell">
                             <div className="cockpit-log-service-reduced">{ident}</div>
-                            <Badge isRead key={count}>{count}</Badge>
+                            <Badge screenReaderText={_("Occurrences")} isRead key={count}>{count}</Badge>
                         </div>
                         : <div className="cockpit-log-service" role="cell">{ident}</div>
                 }


### PR DESCRIPTION
For badges with only a number add a screenReaderText which indicates the content/status of the badge.

https://www.patternfly.org/v4/components/badge/#badge

