### PR TITLE
pybridge: Fix handling of changed SSH host keys

### DIFF
--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -604,7 +604,7 @@ class TestMultiMachine(MachineCase):
 
         self.allow_hostkey_messages()
 
-    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18713")
+    @todoPybridge(reason="wrong error: peer-disconnected instead of no-cockpit")
     def testTroubleshooting(self):
         b = self.browser
         m1 = self.machine


### PR DESCRIPTION
Update ferny to c161ab97558. This gets us the finer-grained HostKeyError
subclasses from https://github.com/allisonkarlitskaya/ferny/pull/15 and
the better `handle_known_hosts` behaviour from
https://github.com/allisonkarlitskaya/ferny/pull/16.

Fix SshPeer to at raise `invalid-hostkey` instead of `unknown-host` for
the "changed key" case. Factorize the building of the PeerError.

TestMultiMachine.testTroubleshooting gets a little further now. It still
fails later on because of an unrelated error (UI expects `no-cockpit`,
but gets `peer-disconnected`), so keep the todo, but adjust its reason.

Fixes #18713

-----

 - [x] https://github.co[m/allisonkarlitskaya/ferny/pull/15
 - [x] https://github.co[m/allisonkarlitskaya/ferny/pull/16