### PR TITLE
cryptoPolicy: Move strings closer to their usage

### DIFF
--- a/pkg/systemd/overview-cards/cryptoPolicies.jsx
+++ b/pkg/systemd/overview-cards/cryptoPolicies.jsx
@@ -34,27 +34,6 @@ import "./cryptoPolicies.scss";
 
 const _ = cockpit.gettext;
 
-// Found in /usr/share/crypto-policies/policies/
-const cryptopolicies = {
-    DEFAULT: _("Recommended, secure settings for current threat models."),
-    "DEFAULT:SHA1": _("DEFAULT with SHA-1 signature verification allowed."),
-    LEGACY: _("Higher interoperability at the cost of an increased attack surface."),
-    "LEGACY:AD-SUPPORT": _("LEGACY with Active Directory interoperability."),
-    FIPS: (<Flex alignItems={{ default: 'alignItemsCenter' }}>
-        {_("Only use approved and allowed algorithms when booting in FIPS mode.")}
-        <Button component='a'
-                rel="noopener noreferrer" target="_blank"
-                variant='link'
-                isInline
-                icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
-                href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening">
-            {_("Learn more")}
-        </Button>
-    </Flex>),
-    "FIPS:OSPP": _("FIPS with further Common Criteria restrictions."),
-    FUTURE: _("Protects from anticipated near-term future attacks at the expense of interoperability."),
-};
-
 const displayProfileText = profile => profile === "FIPS" ? profile : profile.charAt(0) + profile.slice(1, profile.length).toLowerCase();
 const isInconsistentPolicy = (policy, fipsEnabled) => policy === "FIPS" !== fipsEnabled;
 
@@ -122,6 +101,27 @@ const CryptoPolicyDialog = ({
     const [error, setError] = useState();
     const [inProgress, setInProgress] = useState(false);
     const [selected, setSelected] = useState(currentCryptoPolicy);
+
+    // Found in /usr/share/crypto-policies/policies/
+    const cryptopolicies = {
+        DEFAULT: _("Recommended, secure settings for current threat models."),
+        "DEFAULT:SHA1": _("DEFAULT with SHA-1 signature verification allowed."),
+        LEGACY: _("Higher interoperability at the cost of an increased attack surface."),
+        "LEGACY:AD-SUPPORT": _("LEGACY with Active Directory interoperability."),
+        FIPS: (<Flex alignItems={{ default: 'alignItemsCenter' }}>
+            {_("Only use approved and allowed algorithms when booting in FIPS mode.")}
+            <Button component='a'
+                    rel="noopener noreferrer" target="_blank"
+                    variant='link'
+                    isInline
+                    icon={<ExternalLinkSquareAltIcon />} iconPosition="right"
+                    href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening">
+                {_("Learn more")}
+            </Button>
+        </Flex>),
+        "FIPS:OSPP": _("FIPS with further Common Criteria restrictions."),
+        FUTURE: _("Protects from anticipated near-term future attacks at the expense of interoperability."),
+    };
 
     const policies = Object.keys(cryptopolicies)
             .filter(pol => pol.endsWith(':SHA1') ? shaSubPolicyAvailable : true)

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -306,20 +306,6 @@ const LeaveDialog = ({ realmd_client }) => {
         </Modal>);
 };
 
-const DOMAIN_VALID_HELPER_TEXT = {
-    default: _("Validating address"),
-    success: _("Contacted domain"),
-    error: _("Domain could not be contacted"),
-    unsupported: _("Domain is not supported"),
-};
-
-const DOMAIN_VALID_HELPER_ICON = {
-    default: <InProgressIcon />,
-    success: <CheckIcon />,
-    error: <ExclamationCircleIcon />,
-    unsupported: <ExclamationCircleIcon />,
-};
-
 let domainValidateTimeout;
 
 const JoinDialog = ({ realmd_client }) => {
@@ -388,6 +374,20 @@ const JoinDialog = ({ realmd_client }) => {
     useEffect(() => checkAddress(""), []); // eslint-disable-line react-hooks/exhaustive-deps
 
     const join_disabled = pending || addressValid !== "success" || !admin || !kerberosMembership;
+
+    const DOMAIN_VALID_HELPER_TEXT = {
+        default: _("Validating address"),
+        success: _("Contacted domain"),
+        error: _("Domain could not be contacted"),
+        unsupported: _("Domain is not supported"),
+    };
+
+    const DOMAIN_VALID_HELPER_ICON = {
+        default: <InProgressIcon />,
+        success: <CheckIcon />,
+        error: <ExclamationCircleIcon />,
+        unsupported: <ExclamationCircleIcon />,
+    };
 
     const domainHelperText = DOMAIN_VALID_HELPER_TEXT[addressValid];
     const domainHelperIcon = DOMAIN_VALID_HELPER_ICON[addressValid];


### PR DESCRIPTION
These declared strings are used only on one place so move them closer. The reason behind this is that if they are defined as static variables they are immediately loaded and `_()` is valuated before `cockpit.lang` is set and thus are not translated. If these strings are declared inside of a function they are evaluated only upon usage when `cockpit.lang` is set.