### PR TITLE
lib: Avoid `which` in python.js

### DIFF
--- a/pkg/lib/python.js
+++ b/pkg/lib/python.js
@@ -19,8 +19,7 @@
 
 import cockpit from "cockpit";
 
-// FIXME: eventually convert all images to python 3
-const pyinvoke = ["sh", "-ec", "exec $(which /usr/libexec/platform-python 2>/dev/null || which python3 2>/dev/null || which python) -c \"$@\"", "--"];
+const pyinvoke = ["sh", "-ec", "exec $(command -v /usr/libexec/platform-python || command -v python3) -c \"$@\"", "--"];
 
 export function spawn (script_pieces, args, options) {
     const script = (typeof script_pieces == "string")


### PR DESCRIPTION
This isn't installed everywhere any more. Use `command -v`.

Also drop the long-obsolete check for `python`, all our images have Python 3 now.

-----

This helps to fix [this aarch64 failure](https://artifacts.dev.testing-farm.io/05127b37-6124-4c25-a26e-02cfddf31b27/), see https://github.com/cockpit-project/starter-kit/pull/660 . That PR now pulls in this PR, and it passed everywhere.