### PR TITLE
WIP debug TestConnection.testBasic on arch

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,26 +23,6 @@ srpm_build_deps:
 # use the nicely formatted release NEWS from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 jobs:
-  - job: tests
-    trigger: pull_request
-    targets:
-      - fedora-37
-      - fedora-38
-      - fedora-latest-aarch64
-      - fedora-development
-      - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-
-  # run build/unit tests on some interesting architectures
-  - job: copr_build
-    trigger: pull_request
-    targets:
-      # 32 bit
-      - fedora-development-i386
-      # big-endian
-      - fedora-development-s390x
-
   - job: copr_build
     trigger: release
     owner: "@cockpit"

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -190,6 +190,21 @@ class TestConnection(testlib.MachineCase):
         self.allow_core_dumps = True
         self.allow_journal_messages(".*org.freedesktop.hostname1.*DBus.Error.NoReply.*")
 
+    def testBasic2(self):
+        self.testBasic()
+
+    def testBasic3(self):
+        self.testBasic()
+
+    def testBasic4(self):
+        self.testBasic()
+
+    def testBasic5(self):
+        self.testBasic()
+
+    def testBasic6(self):
+        self.testBasic()
+
     @testlib.skipOstree("OSTree doesn't use systemd units")
     @testlib.nondestructive
     def testUnitLifecycle(self):


### PR DESCRIPTION
[This TestConnection failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18860-20230602-154417-e9d37fb8-arch/log.html#330) on arch is stubborn. It keeps happening on "3x affected" runs, but refuses to reproduce locally.

The first attempt of simply [bumping the timeout](https://github.com/cockpit-project/cockpit/pull/18877/commits/6bffdbaa62dc2de858948ba1de8538253225e06d#diff-0a021f2b189c0bc16d23651fc96f367571fd719cdda25c443086f0b6caf270c0R65) [did not work](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18877-20230604-175632-6bffdbaa-arch/log.html#330).