### PR TITLE
workflows: Fix weblate-sync-po for moved make-bots

### DIFF
--- a/.github/workflows/weblate-sync-po.yml
+++ b/.github/workflows/weblate-sync-po.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run po-refresh bot
         run: |
           cd src
-          tools/make-bots
+          test/common/make-bots
           git config --global user.name "GitHub Workflow"
           git config --global user.email "cockpituous@cockpit-project.org"
           mkdir -p ~/.config/cockpit-dev


### PR DESCRIPTION
This was forgotten in commit 89db1c68a9.

---

See [recent failure](https://github.com/cockpit-project/cockpit/actions/runs/5124751088/jobs/9217014445)