### PR TITLE
Updated Default Test OS: Fedora 38

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -21,7 +21,7 @@ You first need to build cockpit, and install it into a VM:
 
     test/image-prepare
 
-This uses the default OS image, which is currently Fedora 37. See `$TEST_OS`
+This uses the default OS image, which is currently Fedora 38. See `$TEST_OS`
 below how to select a different one.
 
 In most cases you want to run an individual test in a suite, for example:
@@ -107,7 +107,7 @@ You can set these environment variables to configure the test suite:
                   "rhel4edge",
                   "ubuntu-2204"
                   "ubuntu-stable"
-               "fedora-37" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)
+               "fedora-38" is the default (TEST_OS_DEFAULT in bots/lib/constants.py)
 
     TEST_JOBS  How many tests to run in parallel.  The default is 1.
 


### PR DESCRIPTION
Hey, I found that you changed to default test os to Fedora 38. So I thought of updating it in the "Integration Tests of Cockpit" documentation