### PR TITLE
pybridge: Fix clobbering remote user set in SSH config

### DIFF
--- a/test/verify/check-shell-multi-machine-key
+++ b/test/verify/check-shell-multi-machine-key
@@ -26,7 +26,6 @@ from testlib import (
     skipDistroPackage,
     skipImage,
     test_main,
-    todoPybridge,
     todoPybridgeRHEL8,
     wait,
 )
@@ -240,7 +239,7 @@ class TestMultiMachineKeyAuth(MachineCase):
 
     # Possible workaround - ssh as `admin` and just do `m.execute()`
     @skipBrowser("Firefox cannot do `cockpit.spawn`", "firefox")
-    @todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18714")
+    @todoPybridgeRHEL8()
     def testLockedIdentity(self):
         b = self.browser
         m1 = self.machine


### PR DESCRIPTION
When opening a remote host channel without `user`, stop assuming the current local user name, as that overwrites any `User` field in the SSH configuration.

Instead, we need to do the opposite: for an unknown host, the UI will not set a `user` field in the channel options, but for an actual login attempt with a password it will. We need to treat them as the same channel in the `self.remotes` map. The C bridge deals with this in cockpit_router_normalize_host_params() by disregarding the `user` field if it is equal to the current user name.

This is a rather silly hack for backwards compatibility, but while we have two bridges, let's rather stay bug-for-bug compatible and clean this up in the UI only after we drop the C bridge.

There is one extra tweak: `rpartition()` returns an empty string, but we can't pass that on literally. So turn those into `None`.

Fixes #18714