### PR TITLE
HACKING: Warn against cloning a fork

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -8,6 +8,13 @@ Start by getting the code:
 The remainder of the commands assume you're in the top level of the
 Cockpit git repository checkout.
 
+**Do not clone a fork!** This will not work for various reasons (missing tags,
+determining version, integration with bots commands). Please keep `origin` as
+the read-only actual upstream project, and add your fork as a separate writable
+remote, for example with
+
+    git remote add my git@github.com:yourgithubid/cockpit.git
+
 ## Setting up development container
 
 The cockpit team maintains a [cockpit/tasks container](https://quay.io/repository/cockpit/tasks)


### PR DESCRIPTION
New contributors keep trying this and fail, this has become a FAQ. Explicitly point out that the given clone command is not an accident, but deliberate, and show how to work with a fork.

---

Rendered view: https://github.com/martinpitt/cockpit/blob/hacking-forks/HACKING.md