### PR TITLE
test: Add MachineCase reboot wrappers

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2435,6 +2435,20 @@ class MachineCase(unittest.TestCase):
         if not self.machine.ws_container and self.file_exists(disallowed_conf):
             self.sed_file('/root/d', disallowed_conf)
 
+    def reboot(self, timeout_sec: int | None = None) -> None:
+        self.allow_restart_journal_messages()
+        if timeout_sec is None:
+            self.machine.reboot()
+        else:
+            self.machine.reboot(timeout_sec=timeout_sec)
+
+    def wait_reboot(self, timeout_sec: int | None = None) -> None:
+        self.allow_restart_journal_messages()
+        if timeout_sec is None:
+            self.machine.wait_reboot()
+        else:
+            self.machine.wait_reboot(timeout_sec=timeout_sec)
+
     def setup_provisioned_hosts(self, disable_preload: bool = False) -> None:
         """Setup provisioned hosts for testing
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1474,7 +1474,6 @@ server {
         self.checkCockpitOnProxy(urlroot="/myroot", login=False)
         kill_ws()
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages("couldn't register polkit authentication agent.*")
         self.allow_journal_messages("couldn't change to runtime dir.*Permission denied")
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -505,7 +505,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot()
+                        self.testObj.wait_reboot()
                         self.testObj.login_and_go("/updates")
                     else:
                         b.wait_in_text("#status", "1 service needs to be restarted")
@@ -530,7 +530,7 @@ ExecStart=/usr/local/bin/{self.packageName}
                         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
                         # ensure that rebooting actually worked
-                        m.wait_reboot()
+                        self.testObj.wait_reboot()
                         self.testObj.login_and_go("/updates")
                     else:
                         # update required a service restart
@@ -808,7 +808,7 @@ ExecStart=/usr/local/bin/{packageName}
             b.wait_in_text(".curtains-ct h1", "Disconnected")
 
             # ensure that rebooting actually worked
-            m.wait_reboot()
+            self.wait_reboot()
             self.login_and_go("/updates")
         else:
             b.click("#ignore")
@@ -958,8 +958,7 @@ ExecStart=/usr/local/bin/{packageName}
         # reboots automatically
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot()
-        self.allow_restart_journal_messages()
+        self.wait_reboot()
 
     @testlib.nondestructive
     def testUpdateError(self):

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -522,7 +522,7 @@ class TestStorageLuksDestructive(storagelib.StorageCase):
         self.wait_mounted("ext4 filesystem")
 
         self.setup_systemd_password_agent("vainu-reku-toma-rolle-kaja")
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -706,7 +706,7 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
 
         # Reboot
         #
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -784,7 +784,7 @@ class TestStorageNBDE(storagelib.StorageCase, packagelib.PackageCase):
         m.execute(f"grubby --update-kernel=ALL --args='ip=10.111.112.1::10.111.112.1:255.255.255.0::{iface}:off'")
 
         try:
-            m.reboot(timeout_sec=300)
+            self.reboot(timeout_sec=300)
         except Exception:
             console_screenshot(m, "failed-reboot.ppm")
             raise

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -641,7 +641,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         self.dialog_wait_close()
         b.wait_in_text(self.card_row("Encrypted Stratis pool", name=dev_3), "cache")
 
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -670,7 +670,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
 
         # Reboot (this requires the passphrase)
         self.setup_systemd_password_agent(passphrase)
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -712,7 +712,7 @@ class TestStorageStratisReboot(storagelib.StorageCase):
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 3), "/run/fsys1")
 
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")
@@ -1027,7 +1027,7 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
                      'mount_point': '/run/fsys1'})
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 1), "fsys1")
         b.wait_text(self.card_row_col("Stratis filesystems", 1, 3), "/run/fsys1")
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         b.relogin()
         b.enter_page("/storage")

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -43,7 +43,6 @@ class TestSuperuser(testlib.MachineCase):
         b.assert_pixels("#topnav", "topnav-unprivileged")
 
         # Check they are still gone after logout
-        self.allow_restart_journal_messages()
         b.relogin()
         b.leave_page()
         b.check_superuser_indicator("Limited access")
@@ -457,7 +456,6 @@ class TestSuperuserDashboard(testlib.MachineCase):
 
         # Logging out and logging back in should give us immediate
         # superuser on m2 (once we have logged in there).
-        self.allow_restart_journal_messages()
         b.relogin()
         b.wait_visible('#hosts_connect_server_dialog')
         b.click('#hosts_connect_server_dialog button.pf-m-warning')

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -541,7 +541,7 @@ machine         : 8561
                        (':not(:checked)' if self.expect_smt_default else ':checked'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
 
-        m.wait_reboot()
+        self.wait_reboot()
         if self.expect_smt_default:
             self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -586,7 +586,7 @@ fi
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input' +
                        (':checked' if self.expect_smt_default else ':not(:checked)'))
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot()
+        self.wait_reboot()
         if self.expect_smt_default:
             self.assertIn('nosmt', m.execute('cat /proc/cmdline'))
         else:
@@ -595,7 +595,7 @@ fi
         # updates mitigations=nosmt when that is present
         m.upload(["../pkg/lib/kernelopt.sh"], "/tmp/")
         m.execute("/tmp/kernelopt.sh remove nosmt; /tmp/kernelopt.sh set mitigations=auto,nosmt")
-        m.reboot()
+        self.reboot()
         self.login_and_go('/system/hwinfo')
         b.click('#hwinfo button:contains(Mitigations)')
         b.wait_visible('#cpu-mitigations-dialog .nosmt-heading:contains(nosmt)')
@@ -603,7 +603,7 @@ fi
         b.click('#cpu-mitigations-dialog #nosmt-switch input')
         b.wait_visible('#cpu-mitigations-dialog #nosmt-switch input:not(:checked)')
         b.click('#cpu-mitigations-dialog Button:contains(Save and reboot)')
-        m.wait_reboot()
+        self.wait_reboot()
         self.assertNotIn('nosmt', m.execute('cat /proc/cmdline'))
         self.assertIn('mitigations=auto', m.execute('cat /proc/cmdline'))
 
@@ -781,7 +781,6 @@ password=foobar
     def testCryptoPolicies(self):
         m = self.machine
         b = self.browser
-        self.allow_restart_journal_messages()
 
         def shown_profile_text(profile):
             return "Default" if profile == "DEFAULT" else profile
@@ -793,7 +792,7 @@ password=foobar
             b.click(f"#crypto-policy-dialog .pf-v5-c-menu__list-item[data-value='{profile_button_name}'] button")
             b.click("#crypto-policy-save-reboot")
             # Initramfs re-generation takes a while
-            m.wait_reboot(timeout_sec=600)
+            self.wait_reboot(timeout_sec=600)
             m.start_cockpit()
             self.login_and_go("/system")
             b.wait_text("#crypto-policy-button", shown_profile_text(new_profile))
@@ -853,7 +852,6 @@ password=foobar
     def testInconsistentCryptoPolicy(self):
         m = self.machine
         b = self.browser
-        self.allow_restart_journal_messages()
         cmd = "update-crypto-policies"
 
         # Admin sets FIPS crypto policy in terminal, but FIPS mode is disabled
@@ -869,7 +867,7 @@ password=foobar
             b.click("#crypto-policy-dialog .pf-v5-c-menu__list-item[data-value='DEFAULT'] button")
         b.click("#crypto-policy-save-reboot")
         # Initramfs re-generation takes a while
-        m.wait_reboot(timeout_sec=600)
+        self.wait_reboot(timeout_sec=600)
         m.start_cockpit()
         self.login_and_go("/system")
         if self.supportsFIPS:
@@ -892,7 +890,7 @@ password=foobar
         b.click(".system-health-crypto-policies button.pf-v5-c-button.pf-m-link")
         b.wait_in_text(".pf-v5-c-menu__item.pf-m-selected .pf-v5-c-label.pf-m-orange", "inconsistent")
         b.click("#crypto-policy-save-reboot")
-        m.wait_reboot()
+        self.wait_reboot()
         m.start_cockpit()
         self.login_and_go("/system")
         b.wait_text("#crypto-policy-button", "Default")

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -440,7 +440,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
         m.execute("systemctl stop systemd-journald.service")
 
         # Now reboot things
-        m.reboot()
+        self.reboot()
         m.execute("timedatectl set-time '2037-01-01 00:05:00'")
         m.execute("logger -p user.err --tag check-journal AFTER BOOT")
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -334,10 +334,9 @@ class CommonTests:
         b.click("#shutdown-dialog button:contains(Reboot)")
         b.switch_to_top()
         b.wait_in_text(".curtains-ct h1", "Disconnected")
-        m.wait_reboot()
+        self.wait_reboot()
 
         self.allow_journal_messages(".*No authentication agent found.*")
-        self.allow_restart_journal_messages()
         # sometimes polling for info and joining a domain creates this noise
         self.allow_journal_messages('.*org.freedesktop.DBus.Error.Spawn.ChildExited.*')
 

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -1412,7 +1412,7 @@ class TestTimers(testlib.MachineCase):
         m.execute("timedatectl set-time '2036-01-01 12:00:00'")
         # this sometimes confuses PAM session tracking
         self.allow_journal_messages("cockpit-session: admin: couldn't close session: System error: Unknown error -7")
-        m.reboot()
+        self.reboot()
 
         m.execute("timedatectl set-time '2036-01-01 15:30:00'")
         self.login_and_go("/system/services")
@@ -1656,13 +1656,11 @@ class TestTimers(testlib.MachineCase):
         b.click("#timer-save-button")
         b.wait_not_present("#timer-dialog")
         b.wait_visible(self.svc_sel('boot_timer.timer'))
-        m.reboot()
+        self.reboot()
         m.start_cockpit()
         with testvm.Timeout(seconds=15, machine=m, error_message="Timeout while waiting for boot timer to run"):
             m.execute("while [ ! -f /tmp/hello ] ; do sleep 0.5; done")
         self.assertIn("hello", m.execute("cat /tmp/hello"))
-
-        self.allow_restart_journal_messages()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -57,12 +57,11 @@ class TestShutdownRestart(testlib.MachineCase):
 
         b.wait_in_text(".curtains-ct h1", "Disconnected")
 
-        m.wait_reboot()
+        self.wait_reboot()
         m.start_cockpit()
         b.click("#machine-reconnect")
         b.wait_visible("#login")
 
-        self.allow_restart_journal_messages()
         self.allow_journal_messages("Shutdown scheduled for .*")
         self.check_journal_messages()
 
@@ -88,7 +87,7 @@ class TestShutdownRestart(testlib.MachineCase):
         b2.wait_visible(".curtains-ct .pf-v5-c-spinner")
         b2.wait_in_text(".curtains-ct h1", "rebooting")
 
-        m.wait_reboot()
+        self.wait_reboot()
 
         with b2.wait_timeout(30):
             b2.wait_visible("#machine-troubleshoot")

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -234,7 +234,6 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         # Relogin on different page, as reloging on terminal prompts asking if you want to leave the site
         b.go("/system")
         b.relogin("/system")
-        self.allow_restart_journal_messages()
         b.go("/system/terminal")
         b.enter_page("/system/terminal")
         b.wait_visible('.terminal')


### PR DESCRIPTION
This avoids having to explicitly call `allow_restart_messages()`.
    
Fixes #18424
