### PR TITLE
Initial support for running integration tests via pytest

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1264,6 +1264,7 @@ class MachineCase(unittest.TestCase):
     def kill_global_machine(cls):
         if cls.global_machine:
             cls.global_machine.kill()
+            cls.global_machine = None
 
     def label(self):
         return self.__class__.__name__ + '-' + self._testMethodName
@@ -1403,6 +1404,7 @@ class MachineCase(unittest.TestCase):
                 raise unittest.SkipTest("Cannot provision machines if test is marked as nondestructive")
             self.machine = self.machines['machine1'] = MachineCase.get_global_machine()
         else:
+            MachineCase.kill_global_machine()
             first_machine = True
             # First create all machines, wait for them later
             for key in sorted(provision.keys()):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -1030,7 +1030,7 @@ password=foobar
         change_profile(profile, new_profile)
 
         profile = m.execute(cmd + " --show").strip()
-        self.assertEquals(profile, new_profile)
+        self.assertEqual(profile, new_profile)
         b.wait_text("#crypto-policy-button", shown_profile_text(profile))
         new_profile = "FIPS"
         change_profile(profile, new_profile)

--- a/test/verify/conftest.py
+++ b/test/verify/conftest.py
@@ -1,15 +1,28 @@
 import importlib.machinery
 import importlib.util
+import os
+import sys
 from pathlib import Path
 from typing import List, Optional
 
 import pytest
-import testlib
+
+TOPDIR = os.path.realpath(__file__ + '../../../..')
+COMMON_PATH = [
+    f'{TOPDIR}/bots',
+    f'{TOPDIR}/bots/machine',
+    f'{TOPDIR}/test/common',
+]
 
 
 @pytest.hookimpl
 def pytest_collect_file(file_path: Path, parent: pytest.Collector) -> Optional[pytest.Collector]:
-    """Support for loading our check-* scripts as if they were modules"""
+    """Support for loading our check-* scripts as if they were modules
+
+    Also adds our testlib paths to sys.path.  Doesn't check out the bots
+    because it's not possible to run tests without first running
+    test/image-prepare, and that will check out the bots automatically.
+    """
     if file_path.name.startswith('check-'):
         # Pretend that test/verify/check-name is called like test.verify.check_name
         modname = 'test.verify.' + file_path.name.replace('-', '_')
@@ -17,7 +30,13 @@ def pytest_collect_file(file_path: Path, parent: pytest.Collector) -> Optional[p
         spec = importlib.util.spec_from_loader(loader.name, loader)
         assert spec is not None
         module = importlib.util.module_from_spec(spec)
-        loader.exec_module(module)
+
+        old_path = sys.path
+        try:
+            sys.path = [*COMMON_PATH, *sys.path]
+            loader.exec_module(module)
+        finally:
+            sys.path = old_path
 
         # Return the tree node with our module pre-loaded inside of it
         collector = pytest.Module.from_parent(parent, path=file_path)
@@ -33,9 +52,10 @@ def pytest_collection_modifyitems(session: pytest.Session, items: List[pytest.It
     assert isinstance(items, list)
 
     def is_nondestructive(item: pytest.Item) -> bool:
+        attr = '_testlib__nondestructive'
         assert isinstance(item, pytest.Function)
         assert isinstance(item.parent, pytest.Class | pytest.Module)
-        return testlib.get_decorator(item.obj, item.parent.obj, "nondestructive", False)
+        return getattr(item.obj, attr, getattr(item.parent.obj, attr, False))
 
     # put the destructive tests last under the assumption that they're slower
     items.sort(key=is_nondestructive, reverse=True)


### PR DESCRIPTION
With this in place, it's now possible to run the integration test suite via pytest with something like the following:

      $ test/common/pixel-tests pull
      $ test/image-prepare
      $ test/common/pywrap -m pytest test/verify -n4
    
Note: the -n option is for specifying the level of parallelism and requires the python3-pytest-xdist plugin to be installed.

~Note also: there's currently no support for sharing machines for non-destructive tests, but I have some ideas there...~


 - [x] Rebase after PR #18954 
 - [ ] Rebase, or at least re-check after PR #18957 