### PR TITLE
test: don't use non-standard :first selector

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -114,7 +114,7 @@ class TestFirewall(NetworkCase):
         b.click("#networking-firewall-link")
         b.enter_page("/network/firewall")
 
-        b.click(".pf-v5-c-breadcrumb li:first")
+        b.click(".pf-v5-c-breadcrumb li:first-of-type")
 
         b.enter_page("/network")
 

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -520,7 +520,7 @@ class TestSystemInfo(PackageCase):
         b.wait_not_in_text(pci_selector + ' tbody tr:last-of-type td[data-label=Model]', "Unclassified")
 
         # go back to system page
-        b.click('.pf-v5-c-breadcrumb li:first')
+        b.click('.pf-v5-c-breadcrumb li:first-of-type')
 
         b.enter_page("/system")
 

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -480,7 +480,7 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
             b.wait_text(".pf-v5-c-card__title", msg)
             wait_field("FOO", "bar")
             wait_field("BIN", bin_msg)
-            b.click('.pf-v5-c-breadcrumb li:first')
+            b.click('.pf-v5-c-breadcrumb li:first-of-type')
             b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{msg}')")
 
         m.execute(fr"printf 'MESSAGE={bin_data_short['MSG']}\nPRIORITY=3\nFOO=bar\nBIN={bin_data_short['BIN']}\n' | logger --journald")


### PR DESCRIPTION
To stop using sizzle we need to stop using some of it's custom css pseudo selectors, `:first` is one of them and can in most cases be easily replaced.