### PR TITLE
client: save cookies in XDG_DATA_HOME

### DIFF
--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -223,9 +223,9 @@ class CockpitClient(Gtk.Application):
         context.set_sandbox_enabled(enabled=True)
         context.set_cache_model(WebKit2.CacheModel.DOCUMENT_VIEWER)
 
-        cookiesPath = os.path.join(data_manager.get_local_storage_directory(), "cookies.txt")
+        cookiesFile = os.path.join(GLib.get_user_state_dir(), "cockpit-client", "cookies.txt")
         cookies = context.get_cookie_manager()
-        cookies.set_persistent_storage(cookiesPath, WebKit2.CookiePersistentStorage.TEXT)
+        cookies.set_persistent_storage(cookiesFile, WebKit2.CookiePersistentStorage.TEXT)
 
         self.uri = self.ws.start()
 


### PR DESCRIPTION
WebKit2.WebsiteDataManager.get_local_storage_directory is deprecated and as this is the location of the browsers LocalStorage it doesn't seem logical to save cookies there.

---

I'm wondering if we should change this to `XDG_STATE_HOME` or `CACHE`? Either way, I never have any cookies after using cockpit client.

```
File: /home/jelle/.local/share/cockpit-client/cookies.txt   <EMPTY>
```

If I change the window location, cookies do get saved :) So hmm my Cockpit does not seem to save cookies.

BTW: webkit tells you to use `dm.get_base_data_directory` but this seems to always be None so we might as well use GLib.

