### PR TITLE
test: print message to stderr when no coverage is generated

### DIFF
--- a/test/common/lcov.py
+++ b/test/common/lcov.py
@@ -484,3 +484,5 @@ def create_coverage_report():
                 api.post(f"pulls/{pull}/reviews",
                          {"commit_id": rev, "event": "COMMENT",
                           "comments": comments})
+    else:
+        sys.stderr.write("Error: no code coverage files generated\n")


### PR DESCRIPTION
This code only runs when coverage is enabled and gives a good indication no coverage was generated.