### PR TITLE
ws: Update AppStream screenshot, drop translation tag

### DIFF
--- a/src/ws/cockpit.appdata.xml.in
+++ b/src/ws/cockpit.appdata.xml.in
@@ -30,15 +30,14 @@
   <categories>
     <category>System</category>
   </categories>
-  <translation type="gettext">cockpit</translation>
   <icon type="local" width="128" height="128">/usr/share/pixmaps/cockpit.png</icon>
   <launchable type="url">https://localhost:9090</launchable>
   <screenshots>
     <screenshot type="default">
-        <image>https://cockpit-project.org/images/site/screenshot-storage.png</image>
+        <image>https://cockpit-project.org/images/screenshot/overview-f33.webp</image>
     </screenshot>
     <screenshot>
-        <image>https://cockpit-project.org/images/site/screenshot-network.png</image>
+        <image>https://cockpit-project.org/images/screenshot/network-overview.webp</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://cockpit-project.org/</url>


### PR DESCRIPTION
The previous screenshots don't exist any more, update to current ones (Overview and networking).

Drop the `<translation>` tag. We don't build/ship *.mo files, and don't plan to.

----

See https://appstream.debian.org/sid/main/issues/cockpit.html . This leaves the "icon" type, but I don't know what to do about that.