### PR TITLE
common: handle non-blocking fd in cockpit_socket_receive_fd()

### DIFF
--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -81,6 +81,24 @@ class TestSuperuser(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
+    def testSudoIOLogging(self):
+        b = self.browser
+        m = self.machine
+
+        self.write_file("/etc/sudoers.d/log", "Defaults log_output\n")
+
+        # with explicitly becoming superuser
+        self.login_and_go(superuser=False)
+        b.check_superuser_indicator("Limited access")
+        b.become_superuser()
+        self.assertIn("00\n", m.execute("ls /var/log/sudo-io"))
+        b.logout()
+
+        # with immediate superuser at login
+        b.login_and_go()
+        b.check_superuser_indicator("Administrative access")
+        b.logout()
+
     def testNoPasswd(self):
         b = self.browser
 


### PR DESCRIPTION
In some setups it happens that the spawned root bridge's stdin is non-blocking. Trying to call recvmsg() on it then often fails with `EAGAIN`, causing the superuser dialog to fail with "Problem becoming administrator: Cockpit-bridge: recvmsg(stdin) failed: Resource temporarily unavailable".

By default all stdio fds should be blocking. But when enabling sudo's `log_output` option, sudo splices the original stdio pipes to the log, and the stdin seen by cockpit-bridge ends up as non-blocking.

Avoid this by polling stdin until data is available. (There is no opposite to the `MSG_DONTWAIT` flag).

Fixes #17412
https://bugzilla.redhat.com/show_bug.cgi?id=2211760
