### PR TITLE
pybridge: Fix ssh-agent cleanup for setgid, enable on on current Ubuntu releases

### DIFF
--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -61,9 +61,8 @@ Command = {ssh_command}
         self.machine.execute('''
             while [ -n "$(pgrep -au admin | grep -Ev 'cockpit-ws|ssh.*cockpit-bridge' >&2)" ]; do sleep 1; done
         ''', timeout=10)
-        # FIXME: ssh-agent leaks both with and without remote bridge; fixed in PR#18917
-        self.machines["target"].execute("while pgrep -af '([c]ockpit|[s]sh-agentFIXME)' >&2; do sleep 1; done",
-                                        timeout=10)
+        self.machines["target"].execute("while pgrep -af '([c]ockpit|[s]sh-agent)' >&2; do sleep 1; done",
+                                        timeout=30)
 
     # deprecated: c-client-ssh will disappear once c-beiboot goes from beta to release
     def testClientSSH(self):

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -21,7 +21,7 @@ import testlib
 
 
 # Run this on more OSes as we roll out the pybridge
-@testlib.onlyImage("needs pybridge", "debian-testing")
+@testlib.onlyImage("needs pybridge", "debian-testing", "ubuntu-stable")
 class TestClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -52,7 +52,7 @@ class TestConnection(testlib.MachineCase):
         m = self.machine
         try:
             # there may still be user-wide ones like dbus-broker
-            m.execute("while pgrep -au admin '(cockpit|ssh-agent)'; do sleep 0.1; done", timeout=10)
+            m.execute("while pgrep -au admin '(cockpit|ssh-agent)'; do sleep 0.1; done", timeout=30)
         except RuntimeError:
             # show the leaked processes in the assertion
             self.fail(m.execute("pgrep -au admin '(cockpit|ssh-agent)'"))

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -4,7 +4,7 @@ DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 # Keep the older C bridge on stable releases
 # also keep it on Ubuntu until testCockpitDesktop gets fixed
-C_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 22.04 22.10 23.04)
+C_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 22.04)
 ifeq ($(C_BRIDGE),)
 CONFIG_OPTIONS += --enable-pybridge
 endif

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -74,6 +74,6 @@ endif
 execute_after_dh_install-arch:
 ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
 ifeq ($(C_BRIDGE),)
-	pytest -vv -k 'not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
+	pytest -vv -k 'not linter and not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
 endif
 endif


### PR DESCRIPTION
This picks up the remaining issue on #18757.

 - [x] Builds on top of #18757

https://issues.redhat.com/browse/COCKPIT-938