### PR TITLE
tools: Enable Python bridge on Fedora ≥ 39

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -53,7 +53,11 @@ Version:        0
 Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 
-# Experimental Python support
+# Use Python bridge on non-stable versions
+%if 0%{?fedora} >= 39
+%define cockpit_enable_python 1
+%endif
+
 %if !%{defined cockpit_enable_python}
 %define cockpit_enable_python 0
 %endif

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -294,8 +294,7 @@ rm -f %{buildroot}/%{_libdir}/security/pam_*
 rm -f %{buildroot}/usr/bin/cockpit-bridge
 rm -f %{buildroot}%{_libexecdir}/cockpit-ssh
 rm -f %{buildroot}%{_datadir}/metainfo/cockpit.appdata.xml
-rm -rf %{buildroot}%{python3_sitelib}/cockpit/
-rm -rf %{buildroot}%{python3_sitelib}/cockpit-%{version}.dist-info/
+rm -rf %{buildroot}%{python3_sitelib}/cockpit*
 %endif
 
 # when not building optional packages, remove their files
@@ -377,8 +376,7 @@ system on behalf of the web based user interface.
 %{_bindir}/cockpit-bridge
 %{_libexecdir}/cockpit-askpass
 %if %{cockpit_enable_python}
-%{python3_sitelib}/%{name}/
-%{python3_sitelib}/%{name}-%{version}.dist-info/
+%{python3_sitelib}/%{name}*
 %endif
 
 %package doc


### PR DESCRIPTION
Let's start cautiosly with Rawhide. Once this got some field experience, we can lower this to 38 and replace the /pybridge scenario.

---

We don't run rawihde tests on our CI, but we have the TMT tests.

https://issues.redhat.com/browse/COCKPIT-940