### PR TITLE
lib: use Patternfly's breakpoit for sm

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -531,7 +531,7 @@ select.pf-v5-c-form-control {
 // intended mainly for PF PageSection elements (pf-v5-c-page__main-section).
 // It's similar to adding padding={{ default: 'noPadding', sm: 'padding' }},
 // except this only affects the sides, not the top and bottom.
-@media screen and (max-width: $pf-v5-global--breakpoint--sm) {
+@media screen and (max-width: var(--pf-global--breakpoint--sm)) {
   .pf-v5-c-page__main > section.pf-v5-c-page__main-section:not(.pf-m-padding) {
     padding-inline: 0;
   }


### PR DESCRIPTION
Apart from pf-v5-global--breakpoint--sm not existing, we do not override smaller breakpoints of PF as the menu isn't on the left as explained in e8baf3da131105352a9.

Fixes in podman:

```
✘ [ERROR] Undefined variable.
    ╷
534 │ @media screen and (max-width: $pf-v5-global--breakpoint--sm) {
    │                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ╵
  pkg/lib/patternfly/patternfly-5-overrides.scss 534:31  @use
  page.scss 3:1                                          @use
  src/podman.scss 2:1                                    root stylesheet [plugin sass-plugin]

```