### PR TITLE
test: Drop python3 -P option

### DIFF
--- a/test/common/pywrap
+++ b/test/common/pywrap
@@ -26,5 +26,5 @@ export PYTHONPATH
 
 # Run the script
 # -B     : don't write .pyc files on import; also PYTHONDONTWRITEBYTECODE=x
-# -P     : don't prepend a potentially unsafe path to sys.path
-exec python3 -B -P "$@"
+# -P     : don't prepend a potentially unsafe path to sys.path -- but not available in RHEL 8/9 yet, use once we can
+exec python3 -B "$@"


### PR DESCRIPTION
This option is not yet available in RHEL 8 and 9 (Python 3.9), which broke the FMF tests.

Commit 0d58ab9dbfd introduced that, but I landed that prematurely.

--- 

See e.g. https://artifacts.dev.testing-farm.io/a5b4ffaf-d3e8-420d-b323-2bb246e28185/ for how this fails. Sorry about that!