### PR TITLE
Add support for beiboot-via-sudo

### DIFF
--- a/src/build_backend.py
+++ b/src/build_backend.py
@@ -75,10 +75,10 @@ def build_wheel(wheel_directory: str,
     }
 
     with zipfile.ZipFile(f'{wheel_directory}/{wheel_filename}', 'w') as wheel:
-        def beipack_self(main: str) -> bytes:
+        def beipack_self(main: str, args: str = '') -> bytes:
             from cockpit._vendor.bei import beipack
             contents = {name: wheel.read(name) for name in wheel.namelist()}
-            pack = beipack.pack(contents, main).encode('utf-8')
+            pack = beipack.pack(contents, main, args=args).encode('utf-8')
             return lzma.compress(pack, preset=lzma.PRESET_EXTREME)
 
         def write_distinfo(filename: str, lines: Iterable[str]) -> None:
@@ -94,7 +94,7 @@ def build_wheel(wheel_directory: str,
         for filename in find_sources(srcpkg=False):
             wheel.write(filename, arcname=os.path.relpath(filename, start='src'))
 
-        wheel.writestr('cockpit/data/cockpit-bridge.beipack.xz', beipack_self('cockpit.bridge:main'))
+        wheel.writestr('cockpit/data/cockpit-bridge.beipack.xz', beipack_self('cockpit.bridge:main', 'beipack=True'))
 
         for filename, lines in distinfo.items():
             write_distinfo(filename, lines)

--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -269,6 +269,7 @@ class SshBridge(Router):
         pass  # wait for the peer to do it first
 
     def do_init(self, message):
+        assert 'superuser' not in message  # see 'capabilities' below
         self.ssh_peer.write_control(**message)
 
 
@@ -280,6 +281,9 @@ async def run(args) -> None:
 
     try:
         message = await bridge.ssh_peer.start()
+        # https://github.com/cockpit-project/cockpit/issues/18927
+        if 'capabilities' in message:
+            message['capabilities']['explicit-superuser'] = False
         bridge.write_control(**dict(message, packages={p: None for p in bridge.packages.packages}))
         bridge.ssh_peer.thaw_endpoint()
     except ferny.InteractionError as exc:

--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -186,8 +186,11 @@ class AuthorizeResponder(ferny.InteractionResponder):
 
 
 class SshPeer(Peer):
-    def __init__(self, router: Router, destination: str):
+    always: bool
+
+    def __init__(self, router: Router, destination: str, args: argparse.Namespace):
         self.destination = destination
+        self.always = args.always
         super().__init__(router)
 
     async def do_connect_transport(self) -> asyncio.Transport:
@@ -220,8 +223,14 @@ class SshPeer(Peer):
         logger.debug("Launching command: cmd=%s env=%s", cmd, env)
         transport = await self.spawn(cmd, env, stderr=agent, start_new_session=True)
 
+        if not self.always:
+            exec_cockpit_bridge_steps = [('try_exec', (['cockpit-bridge'],))]
+        else:
+            exec_cockpit_bridge_steps = []
+
         # Send the first-stage bootloader
         stage1 = bootloader.make_bootloader([
+            *exec_cockpit_bridge_steps,
             ('report_exists', [list(get_interesting_files())]),
             *beiboot_helper.steps,
         ], gadgets=BEIBOOT_GADGETS)
@@ -234,11 +243,11 @@ class SshPeer(Peer):
 
 
 class SshBridge(Router):
-    packages: Packages
+    packages: Optional[Packages] = None
     ssh_peer: SshPeer
 
     def __init__(self, args: argparse.Namespace):
-        self.ssh_peer = SshPeer(self, args.destination)
+        self.ssh_peer = SshPeer(self, args.destination, args)
 
         super().__init__([
             DefaultRoutingRule(self, self.ssh_peer),
@@ -263,7 +272,12 @@ async def run(args) -> None:
         # https://github.com/cockpit-project/cockpit/issues/18927
         if 'capabilities' in message:
             message['capabilities']['explicit-superuser'] = False
-        bridge.write_control(**dict(message, packages={p: None for p in bridge.packages.packages}))
+
+        # only patch the packages line if we are in beiboot mode
+        if bridge.packages:
+            message['packages'] = {p: None for p in bridge.packages.packages}
+
+        bridge.write_control(**message)
         bridge.ssh_peer.thaw_endpoint()
     except ferny.InteractionError as exc:
         sys.exit(str(exc))
@@ -283,6 +297,7 @@ def main() -> None:
     polyfills.install()
 
     parser = argparse.ArgumentParser(description='cockpit-bridge is run automatically inside of a Cockpit session.')
+    parser.add_argument('--always', action='store_true', help="Never try to run cockpit-bridge from the system")
     parser.add_argument('--debug', action='store_true')
     parser.add_argument('destination', help="Name of the remote host to connect to, or 'localhost'")
     args = parser.parse_args()

--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -23,7 +23,6 @@ import base64
 import importlib.resources
 import json
 import logging
-import lzma
 import os
 import shlex
 import sys
@@ -32,11 +31,11 @@ from typing import Iterable, Optional, Sequence
 
 from cockpit import polyfills
 from cockpit._vendor import ferny
-from cockpit._vendor.bei import beipack, bootloader
+from cockpit._vendor.bei import bootloader
+from cockpit.beipack import BridgeBeibootHelper
 from cockpit.bridge import setup_logging
 from cockpit.channel import ChannelRoutingRule
 from cockpit.channels import PackagesChannel
-from cockpit.data import read_cockpit_data_file
 from cockpit.packages import Package, Packages
 from cockpit.peer import Peer
 from cockpit.protocol import CockpitProblem
@@ -71,21 +70,6 @@ def ensure_ferny_askpass() -> Path:
         dest_path.chmod(0o700)
 
     return dest_path
-
-
-def get_bridge_beipack_xz() -> tuple[str, bytes]:
-    try:
-        bridge_beipack_xz = read_cockpit_data_file('cockpit-bridge.beipack.xz')
-        logger.debug('Got pre-built cockpit-bridge.beipack.xz')
-    except FileNotFoundError:
-        logger.debug('Pre-built cockpit-bridge.beipack.xz; building our own.')
-        # beipack ourselves
-        cockpit_contents = beipack.collect_module('cockpit', recursive=True)
-        bridge_beipack = beipack.pack(cockpit_contents, entrypoint='cockpit.bridge:main')
-        bridge_beipack_xz = lzma.compress(bridge_beipack.encode())
-        logger.debug('  ... done!')
-
-    return 'cockpit/data/cockpit-bridge.beipack.xz', bridge_beipack_xz
 
 
 def get_xdg_data_dirs():
@@ -150,11 +134,11 @@ class DefaultRoutingRule(RoutingRule):
 
 
 class AuthorizeResponder(ferny.InteractionResponder):
+    commands = ('ferny.askpass', 'cockpit.report-exists')
     router: Router
 
-    def __init__(self, router: Router, payload: bytes):
+    def __init__(self, router: Router):
         self.router = router
-        self.payload = payload
 
     async def do_askpass(self, messages: str, prompt: str, hint: str) -> Optional[str]:
         if hint == 'none':
@@ -189,14 +173,7 @@ class AuthorizeResponder(ferny.InteractionResponder):
     async def do_custom_command(self, command: str, args: tuple, fds: list[int], stderr: str) -> None:
         logger.debug('Got ferny command %s %s %s', command, args, stderr)
 
-        if command == 'beiboot.provide':
-            size, = args
-            assert size == len(self.payload)
-            assert isinstance(self.router, SshBridge)
-            assert self.router.ssh_peer.transport is not None
-            self.router.ssh_peer.transport.write(self.payload)
-
-        elif command == 'cockpit.report-exists':
+        if command == 'cockpit.report-exists':
             file_status, = args
             # Constructed to throw KeyError if an unexpected file is requested
             # HACK:  ...please don't look at this code...
@@ -214,8 +191,10 @@ class SshPeer(Peer):
         super().__init__(router)
 
     async def do_connect_transport(self) -> asyncio.Transport:
-        beipack_filename, bridge_beipack_xz = get_bridge_beipack_xz()
-        agent = ferny.InteractionAgent(AuthorizeResponder(self.router, bridge_beipack_xz))
+        beiboot_helper = BridgeBeibootHelper(self)
+
+        agent = ferny.InteractionAgent(AuthorizeResponder(self.router))
+        agent.add_handler(beiboot_helper)
 
         # We want to run a python interpreter somewhere...
         cmd: Sequence[str] = ('python3', '-ic', '# cockpit-bridge')
@@ -244,7 +223,7 @@ class SshPeer(Peer):
         # Send the first-stage bootloader
         stage1 = bootloader.make_bootloader([
             ('report_exists', [list(get_interesting_files())]),
-            ('boot_xz', [beipack_filename, len(bridge_beipack_xz)])
+            *beiboot_helper.steps,
         ], gadgets=BEIBOOT_GADGETS)
         transport.write(stage1.encode())
 

--- a/src/cockpit/beipack.py
+++ b/src/cockpit/beipack.py
@@ -36,7 +36,7 @@ def get_bridge_beipack_xz() -> Tuple[str, bytes]:
         logger.debug('Pre-built cockpit-bridge.beipack.xz; building our own.')
         # beipack ourselves
         cockpit_contents = beipack.collect_module('cockpit', recursive=True)
-        bridge_beipack = beipack.pack(cockpit_contents, entrypoint='cockpit.bridge:main')
+        bridge_beipack = beipack.pack(cockpit_contents, entrypoint='cockpit.bridge:main', args='beipack=True')
         bridge_beipack_xz = lzma.compress(bridge_beipack.encode())
         logger.debug('  ... done!')
 

--- a/src/cockpit/beipack.py
+++ b/src/cockpit/beipack.py
@@ -1,0 +1,76 @@
+# This file is part of Cockpit.
+#
+# Copyright (C) 2023 Red Hat, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import lzma
+from typing import List, Sequence, Tuple
+
+from cockpit._vendor import ferny
+from cockpit._vendor.bei import beipack
+
+from .data import read_cockpit_data_file
+from .peer import Peer, PeerError
+
+logger = logging.getLogger(__name__)
+
+
+def get_bridge_beipack_xz() -> Tuple[str, bytes]:
+    try:
+        bridge_beipack_xz = read_cockpit_data_file('cockpit-bridge.beipack.xz')
+        logger.debug('Got pre-built cockpit-bridge.beipack.xz')
+    except FileNotFoundError:
+        logger.debug('Pre-built cockpit-bridge.beipack.xz; building our own.')
+        # beipack ourselves
+        cockpit_contents = beipack.collect_module('cockpit', recursive=True)
+        bridge_beipack = beipack.pack(cockpit_contents, entrypoint='cockpit.bridge:main')
+        bridge_beipack_xz = lzma.compress(bridge_beipack.encode())
+        logger.debug('  ... done!')
+
+    return 'cockpit/data/cockpit-bridge.beipack.xz', bridge_beipack_xz
+
+
+class BridgeBeibootHelper(ferny.InteractionHandler):
+    # ferny.InteractionHandler ClassVar
+    commands = ['beiboot.provide', 'beiboot.exc']
+
+    peer: Peer
+    payload: bytes
+    steps: Sequence[Tuple[str, Sequence[object]]]
+
+    def __init__(self, peer: Peer, args: Sequence[str] = ()) -> None:
+        filename, payload = get_bridge_beipack_xz()
+
+        self.peer = peer
+        self.payload = payload
+        self.steps = (('boot_xz', (filename, len(payload), tuple(args))),)
+
+    async def run_command(self, command: str, args: Tuple, fds: List[int], stderr: str) -> None:
+        logger.debug('Got ferny request %s %s %s %s', command, args, fds, stderr)
+        if command == 'beiboot.provide':
+            try:
+                size, = args
+                assert size == len(self.payload)
+            except (AssertionError, ValueError) as exc:
+                raise PeerError('internal-error', message=f'ferny interaction error {exc!s}') from exc
+
+            assert self.peer.transport is not None
+            logger.debug('Writing %d bytes of payload', len(self.payload))
+            self.peer.transport.write(self.payload)
+        elif command == 'beiboot.exc':
+            raise PeerError('internal-error', message=f'Remote exception: {args[0]}')
+        else:
+            raise PeerError('internal-error', message=f'Unexpected ferny interaction command {command}')

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -79,6 +79,14 @@ class Bridge(Router, PackagesListener):
         self.peers_rule = PeersRoutingRule(self)
 
         if args.beipack:
+            # Some special stuff for beipack
+            self.superuser_rule.set_configs([
+                {
+                    "privileged": True,
+                    "spawn": ["sudo", "-k", "-A", "python3", "-ic", "# cockpit-bridge", "--privileged"],
+                    "environ": ["SUDO_ASKPASS=ferny-askpass"],
+                }
+            ])
             self.packages = None
         else:
             self.packages = Packages(self)

--- a/src/cockpit/misc/print.py
+++ b/src/cockpit/misc/print.py
@@ -54,13 +54,14 @@ class Printer:
         """Send init.  This is normally done automatically, but you can override it."""
         self.control('init', host=host, version=version, **kwargs)
 
-    def open(self, payload: str, channel: Optional[str] = None, **kwargs: object) -> None:
+    def open(self, payload: str, channel: Optional[str] = None, **kwargs: object) -> str:
         """Opens a channel for the named payload.  A channel name is generated if not provided."""
         if channel is None:
             self.last_channel += 1
             channel = f'ch{self.last_channel}'
 
         self.control('open', channel=channel, payload=payload, **kwargs)
+        return channel
 
     def done(self, channel: Optional[str] = None, **kwargs: object) -> None:
         """Sends a done command on the named channel, or the last opened channel."""
@@ -95,6 +96,14 @@ class Printer:
     def spawn(self, *args: str, channel: Optional[str] = None, **kwargs: object) -> None:
         """Open a stream channel with a spawned command"""
         self.open('stream', spawn=args, channel=channel, **kwargs)
+
+    def dbus_open(self, *args: str, channel: Optional[str] = None, bus: str = 'internal', **kwargs: object) -> str:
+        return self.open('dbus-json3', channel=channel, bus=bus)
+
+    def dbus_call(self, *args: str, channel: Optional[str] = None, bus: str = 'internal', **kwargs: object) -> None:
+        if channel is None:
+            channel = self.dbus_open(bus=bus)
+        self.json(channel, call=[*args], id=1)
 
     def help(self) -> None:
         """Show help"""

--- a/test/pytest/test_beiboot.py
+++ b/test/pytest/test_beiboot.py
@@ -1,0 +1,30 @@
+import sys
+
+import pytest
+
+from cockpit._vendor import ferny
+from cockpit._vendor.bei import bootloader
+from cockpit.beipack import BridgeBeibootHelper
+from cockpit.peer import Peer
+from cockpit.router import Router
+
+from .mocktransport import settle_down
+
+
+class BeibootPeer(Peer):
+    async def do_connect_transport(self) -> None:
+        helper = BridgeBeibootHelper(self)
+        agent = ferny.InteractionAgent(helper)
+        transport = await self.spawn([sys.executable, '-iq'], env=[], stderr=agent)
+        transport.write(bootloader.make_bootloader(helper.steps, gadgets=ferny.BEIBOOT_GADGETS).encode())
+        await agent.communicate()
+
+
+@pytest.mark.asyncio
+async def test_bridge_beiboot():
+    # Try to beiboot a copy of the bridge and read its init message
+    peer = BeibootPeer(Router([]))
+    init_msg = await peer.start()
+    assert init_msg['version'] == 1
+    peer.close()
+    await settle_down()

--- a/test/pytest/test_beiboot.py
+++ b/test/pytest/test_beiboot.py
@@ -26,5 +26,6 @@ async def test_bridge_beiboot():
     peer = BeibootPeer(Router([]))
     init_msg = await peer.start()
     assert init_msg['version'] == 1
+    assert 'packages' not in init_msg
     peer.close()
     await settle_down()

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -37,7 +37,7 @@ class TestBridge(unittest.IsolatedAsyncioTestCase):
         await self.transport.stop()
 
     async def start(self, *, send_init: bool = True) -> None:
-        self.bridge = Bridge(argparse.Namespace(privileged=False))
+        self.bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
         self.transport = MockTransport(self.bridge)
 
         if send_init:
@@ -418,7 +418,7 @@ class TestBridge(unittest.IsolatedAsyncioTestCase):
 @pytest.mark.asyncio
 @pytest.mark.parametrize('channeltype', CHANNEL_TYPES)
 async def test_channel(channeltype, tmp_path):
-    bridge = Bridge(argparse.Namespace(privileged=False))
+    bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
     transport = MockTransport(bridge)
     await transport.assert_msg('', command='init')
     transport.send_init()

--- a/tools/vulture-suppressions/cockpit.py
+++ b/tools/vulture-suppressions/cockpit.py
@@ -9,5 +9,6 @@ User.id
 User.shell
 
 # getattr()
+Printer.dbus_call
 Printer.help
 Printer.wait

--- a/tools/vulture-suppressions/ferny.py
+++ b/tools/vulture-suppressions/ferny.py
@@ -1,0 +1,4 @@
+from cockpit._vendor.ferny import InteractionHandler
+
+InteractionHandler.commands
+InteractionHandler.run_command


### PR DESCRIPTION
This is the last missing piece from Cockpit Client beibooting — we can now run a root bridge, recursively beibooted.