### PR TITLE
cockpit-beiboot: immediately close on EOF

### DIFF
--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -267,6 +267,10 @@ class SshBridge(Router):
         message['superuser'] = False
         self.ssh_peer.write_control(**message)
 
+    def eof_received(self) -> bool:
+        # We don't care about a clean exit.  Let's just shutdown.
+        return False
+
 
 async def run(args) -> None:
     logger.debug("Hi. How are you today?")


### PR DESCRIPTION
We've observed that this processes leaks after Cockpit Client has exited.  Hopefully this helps.

@martinpitt was hitting leaked processes yesterday.  Let's see if (a) that's still a problem, and (b) if this helps.