### PR TITLE
test: unbreak the post-commit hook

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -6,7 +6,6 @@ set -eu
 # requires: pyproject.toml
 # requires: containers/flatpak/test/ruff.toml
 # requires: pkg/ruff.toml
-# requires: src/client/ruff.toml
 # requires: test/common/ruff.toml
 # requires: test/verify/ruff.toml
 # requires: tools/vulture-suppressions/ruff.toml


### PR DESCRIPTION
a122ebdb9628f9a5cebc821 removed the ruff.toml file but did not update `test/static-code`.