### PR TITLE
flatpak: add envvar for enabling cockpit-beiboot

### DIFF
--- a/containers/flatpak/beiboot-extra-packages
+++ b/containers/flatpak/beiboot-extra-packages
@@ -1,0 +1,8 @@
+https://github.com/cockpit-project/cockpit-machines/releases/download/292/cockpit-machines-292.tar.xz
+07482207c15f1884caa905e050a75f142473aae9b9f64c287b3f96ed5b430e5d
+
+https://github.com/cockpit-project/cockpit-ostree/releases/download/193/cockpit-ostree-193.tar.xz
+ecc82698ac5e9a9486b7db361d26441c3a9897deecc40a9a802ad8e8702f52db
+
+https://github.com/cockpit-project/cockpit-podman/releases/download/70/cockpit-podman-70.tar.xz
+10441bd2bc212b52a32d57d295fa6a932df32e5609c28da082d3d77025093b22

--- a/containers/flatpak/cockpit-client.yml.in
+++ b/containers/flatpak/cockpit-client.yml.in
@@ -16,6 +16,7 @@ modules:
     buildsystem: autotools
     config-opts:
       - --enable-cockpit-client
+      - --@PYBRIDGE_ENABLE@-pybridge
       - --disable-polkit
       - --disable-ssh
       - --disable-pcp

--- a/containers/flatpak/prepare
+++ b/containers/flatpak/prepare
@@ -61,7 +61,23 @@ sed \
     -e "s|@ARCHIVE_TYPE@|${ARCHIVE_TYPE}|" \
     -e "s|@ARCHIVE_LOCATION@|${ARCHIVE_LOCATION}|" \
     -e "s|@ARCHIVE_SHA256@|${ARCHIVE_SHA256}|" \
+    -e "s|@PYBRIDGE_ENABLE@|${PYBRIDGE_ENABLE:-disable}|" \
     "${0%/*}/cockpit-client.yml.in" > "${FLATPAK_ID}.yml.tmp"
+
+if [ "${PYBRIDGE_ENABLE:-}" = 'enable' ]; then
+    printf "
+  - name: cockpit-podman
+    buildsystem: simple
+    build-commands:
+      - make install PREFIX=/app
+
+    sources:
+      - type: archive
+        url: %s
+        sha256: %s
+" $(cat "${0%/*}/beiboot-extra-packages") >> "${FLATPAK_ID}.yml.tmp"
+fi
+
 mv "${FLATPAK_ID}.yml.tmp" "${FLATPAK_ID}.yml"
 touch "${FLATPAK_ID}.releases.xml"
 echo "${FLATPAK_ID}.yml"


### PR DESCRIPTION
It's now possible to do

```
PYBRIDGE_ENABLE=enable containers/flatpak/install --user
```

to get a version of Cockpit Client including cockpit-beiboot.