### PR TITLE
cockpit-beiboot: ignore unexpected "authorize"

### DIFF
--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -27,7 +27,7 @@ import os
 import shlex
 import sys
 from pathlib import Path
-from typing import Iterable, Optional, Sequence
+from typing import Dict, Iterable, Optional, Sequence
 
 from cockpit import polyfills
 from cockpit._vendor import ferny
@@ -240,6 +240,14 @@ class SshPeer(Peer):
         await agent.communicate()
 
         return transport
+
+    def transport_control_received(self, command: str, message: Dict[str, object]) -> None:
+        if command == 'authorize':
+            # We've disabled this for explicit-superuser bridges, but older
+            # bridges don't support that and will ask us anyway.
+            return
+
+        super().transport_control_received(command, message)
 
 
 class SshBridge(Router):


### PR DESCRIPTION
If we get "authorize" control messages from the Peer (in spite of our attempt do disable them) then just ignore them.  This happens with old peers (such as in CentOS 7) that have the "legacy" superuser code in the bridge.

Fixes #18944