### PR TITLE
python bridge: don't warn about missing ssh-agent

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -232,6 +232,9 @@ def start_ssh_agent() -> None:
         else:
             proc.terminate()
 
+    except FileNotFoundError:
+        logger.debug("Couldn't start ssh-agent (FileNotFoundError)")
+
     except OSError as exc:
         logger.warning("Could not start ssh-agent: %s", exc)
 


### PR DESCRIPTION
If we get FileNotFoundError when trying to start the agent then don't consider it an error worth warning about, and write a debugging message instead.

ssh-agent is not present in the Anaconda environment and this warning is causing tests to fail with unexpected journal messages.