### PR TITLE
Revert "testlib: change approach for --sit and log captures"

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -25,6 +25,7 @@ import functools
 import glob
 import gzip
 import io
+import itertools
 import json
 import os
 import re
@@ -1232,6 +1233,61 @@ class Browser:
                 assert not self.is_visible("#navbar-oops"), "Cockpit shows an Oops"
 
 
+class _DebugOutcome(unittest.case._Outcome):  # type: ignore[name-defined]
+    """Run debug actions after test methods
+
+    This will do screenshots, HTML dumps, and sitting before cleanup handlers run.
+    """
+
+    def testPartExecutor(self, test_case, isTest=False):
+        def failureHandler(exc_info, python_311=False):
+            if python_311:
+                # exc_info is now a string
+                print(exc_info, file=sys.stderr)
+            else:
+                # strip off the two topmost frames for testPartExecutor and TestCase.run(); uninteresting and breaks naughties
+                traceback.print_exception(exc_info[0], exc_info[1], exc_info[2].tb_next.tb_next)
+            try:
+                test_case.snapshot("FAIL")
+                test_case.copy_js_log("FAIL")
+                test_case.copy_journal("FAIL")
+                test_case.copy_cores("FAIL")
+            except (OSError, RuntimeError):
+                # failures in these debug artifacts should not skip cleanup actions
+                sys.stderr.write("Failed to generate debug artifact:\n")
+                traceback.print_exc(file=sys.stderr)
+
+            if opts.sit:
+                sit(test_case.machines)
+
+        superResult = super().testPartExecutor(test_case, isTest)
+        ran_debug = hasattr(test_case, "_ran_debug")
+
+        if ran_debug or not isinstance(test_case, MachineCase):
+            return superResult
+
+        # Python < 3.11 (Outcome class does not have a errors attribute anymore
+        # https://github.com/python/cpython/commit/664448d81f41c5fa971d8523a71b0f19e76cc136#diff-c6fe1ffe930def48a6adf1fa99b974737bac586fdacccacd1474e7b2f11370ebL79
+        if hasattr(self, 'errors'):
+            if self.errors and not isTest:
+                (err_case, exc_info) = self.errors[-1]
+                if exc_info:
+                    assert err_case == test_case
+                    setattr(test_case, "_ran_debug", True)
+                    failureHandler(exc_info, False)
+        elif self.result.errors or self.result.failures:
+            errors = [err for err in itertools.chain(self.result.errors, self.result.failures) if err[0] == test_case]
+            if errors:
+                (err_case, exc_info) = errors[-1]
+                setattr(test_case, "_ran_debug", True)
+                failureHandler(exc_info, True)
+
+        return superResult
+
+
+unittest.case._Outcome = _DebugOutcome  # type: ignore[attr-defined]
+
+
 class MachineCase(unittest.TestCase):
     image = testvm.DEFAULT_IMAGE
     libexecdir = None
@@ -1561,31 +1617,13 @@ class MachineCase(unittest.TestCase):
         self.addCleanup(terminate_sessions)
 
     def tearDown(self):
-        success = self.checkSuccess()
-
-        if not success:
-            try:
-                self.snapshot("FAIL")
-                self.copy_js_log("FAIL")
-                self.copy_journal("FAIL")
-                self.copy_cores("FAIL")
-            except (OSError, RuntimeError):
-                # failures in these debug artifacts should not skip cleanup actions
-                sys.stderr.write("Failed to generate debug artifact:\n")
-                traceback.print_exc(file=sys.stderr)
-
-            if opts.sit:
-                sit(self.machines)
-
         if self.browser:
             self.browser.write_coverage_data()
-
         if self.machine.ssh_reachable:
             self.check_journal_messages()
-            if success:
+            if self.checkSuccess():
                 self.check_browser_errors()
                 self.check_pixel_tests()
-
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def login_and_go(self, path: Optional[str] = None, user: Optional[str] = None, host: Optional[str] = None,


### PR DESCRIPTION
This causes several regressions: It breaks at least timeout handling, and thus naughty matching. It also does not print tracebacks any more in `--sit` mode.

This reverts commit 163555f90dc2872be715da073ae468c9b77867cf.

---

This should fix failures like [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18954-20230616-093408-e87916ce-centos-8-stream/log.html#230-2) which got introduced by prematurely landing #18954.