### PR TITLE
test: Don't unmount restored directories lazily

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2070,9 +2070,15 @@ class MachineCase(unittest.TestCase):
             self.addCleanup(self.machine.execute, post_restore_action)
 
         if reboot_safe:
-            self.addCleanup(self.machine.execute, "rm -rf {0}; mv {1} {0}".format(path, backup))
+            self.addCleanup(self.machine.execute, f"rm -rf {path}; mv {backup} {path}")
         else:
-            self.addCleanup(self.machine.execute, "umount -lf " + path)
+            # HACK: a lot of tests call this on /home/...; that restoration happens before killing all user
+            # processes in nonDestructiveSetup(), so we have to do it lazily
+            if path.startswith("/home"):
+                cmd = f"umount -lf {path}"
+            else:
+                cmd = f"umount {path} || {{ fuser -uvk {path}/* || true; sleep 1; umount {path}; }}"
+            self.addCleanup(self.machine.execute, cmd)
 
     def restore_file(self, path: str, post_restore_action: Optional[str] = None):
         """Backup/restore a file for a nondestructive test

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -164,7 +164,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
         # And now we remove cockpit-ssh which affects the default
         if not m.ostree_image:
-            self.restore_dir(self.libexecdir)
+            self.restore_file(f"{self.libexecdir}/cockpit-ssh")
             m.execute(f"rm {self.libexecdir}/cockpit-ssh")
             m.restart_cockpit()
             b.open("/system")


### PR DESCRIPTION
If there is a busy file, this leads to the cleanup silently succeeding, and the subsequent test then failing with "directory already exists" or similar errors from trying to recursively mount/restore.

This was introduced into the initial restore_dir() implementation in commit 1dcb1a60365f5 (later generalized in commit 48fff9a683702a without particular justification).

With this change, the cleanup of the affected test now fails directly, which is easier to debug.

The main exception is restoring /home/admin -- many tests do that without stopping all admin processes first. This happens in nonDestructiveSetup(), but that runs after restoring the home dir. This is tricky to fix, so for now add an exception to continue unmounting that lazily.

---

I don't have a recent log at hand, but I remember seeing logs with tons of failures which all matched this pattern. It *could* also explain the cases where we had lots of tests on a serial machine fail with login page timeouts.

Let's see how well that holds up. I do expect that there are some tests which keep the file system busy, but we need to land this change first to actually find them.