### PR TITLE
test: Split and fix TestServices.testBasic, fix with current ruff 0.0.274

### DIFF
--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -205,8 +205,8 @@ class DBusChannel(Channel):
                                                      "/org/freedesktop/DBus",
                                                      "org.freedesktop.DBus",
                                                      "StartServiceByName", "su", self.name, 0)
-                except BusError as error:
-                    logger.debug("Failed to start service '%s': %s", self.name, error.message)
+                except BusError as start_error:
+                    logger.debug("Failed to start service '%s': %s", self.name, start_error.message)
                     self.send_message(owner=None)
             else:
                 logger.debug("Failed to get owner of service '%s': %s", self.name, error.message)

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -995,7 +995,7 @@ class Browser:
                 self._set_window_size(shell_size[0] + delta[0], shell_size[1] + delta[1])
 
     def assert_pixels_in_current_layout(self, selector: str, key: str,
-                                        ignore: List[str] = None,
+                                        ignore: Optional[List[str]] = None,
                                         mock: Optional[Dict[str, str]] = None,
                                         sit_after_mock: bool = False,
                                         scroll_into_view: Optional[str] = None,

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -78,6 +78,17 @@ class TestServices(testlib.MachineCase):
         else:
             self.browser.wait_not_present(".service-top-panel .pf-v5-c-dropdown")
 
+    def check_service_on(self, expect_reload=True):
+        self.check_service_details(
+            ["Running", "Automatically starts"],
+            ["Reload" if expect_reload else "", "Restart", "Stop", "Disallow running (mask)", "Pin unit"],
+            enabled=True)
+
+    def check_service_off(self):
+        self.check_service_details(["Disabled"],
+                                   ["Start", "Disallow running (mask)", "Pin unit"],
+                                   enabled=False)
+
     def svc_sel(self, service):
         return f'tr[data-goto-unit="{service}"]'
 
@@ -386,22 +397,24 @@ WantedBy=default.target
         self.wait_service_present("test.service")
         m.execute("udevadm trigger; udevadm settle")
         self.goto_service("test.service")
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_on()
 
         # Stop and disable and back again
         self.toggle_onoff()
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
         self.toggle_onoff()
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_on()
         self.toggle_onoff()  # later on we need some disabled test
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
 
         # Check service that fails to start
         b.go(f'/system/services#/{suffix}')
         self.goto_service("test-fail.service")
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
         self.toggle_onoff()
-        self.check_service_details(["Failed to start", "Automatically starts"], ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_details(["Failed to start", "Automatically starts"],
+                                   ["Start", "Clear 'Failed to start'", "Disallow running (mask)", "Pin unit"],
+                                   enabled=True)
         if not user:
             b.assert_pixels("#service-details-unit", "details-test-fail",
                             # in medium layout we sometimes get a scrollbar depending on how many test-fail logs exist
@@ -415,7 +428,9 @@ WantedBy=default.target
 
         # Check static service
         self.goto_service("systemd-exit.service")
-        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=True, onoff=False)
+        self.check_service_details(["Static", "Not running"],
+                                   ["Start", "Disallow running (mask)", "Pin unit"],
+                                   enabled=True, onoff=False)
 
         # Mask and unmask
         self.do_action("Disallow running (mask)")
@@ -426,7 +441,9 @@ WantedBy=default.target
         b.wait_not_present("#service-details-show-relationships")
 
         self.do_action("Allow running (unmask)")
-        self.check_service_details(["Static", "Not running"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=True, onoff=False)
+        self.check_service_details(["Static", "Not running"],
+                                   ["Start", "Disallow running (mask)", "Pin unit"],
+                                   enabled=True, onoff=False)
 
         # Pin unit
         b.go(f'/system/services#/{suffix}')
@@ -459,6 +476,7 @@ WantedBy=default.target
         self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Unpin unit"], enabled=False)
         self.do_action("Unpin unit")
         b.wait_not_present('#service-details-unit > article > div > svg.service-thumbtack-icon')
+        self.check_service_off()
         b.go(f'/system/services#/{suffix}')
         b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
 
@@ -670,10 +688,10 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
 
         # Check test.service and then start it
         self.goto_service("test.service")
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
         b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
         self.toggle_onoff()
-        self.check_service_details(["Running", "Automatically starts"], ["Reload", "Restart", "Stop", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_on()
         b.wait_in_text('.cockpit-log-panel .pf-v5-c-card__body', "START")
         b.wait_in_text('.cockpit-log-panel .pf-v5-c-card__body', "WORKING")
         b.click(".cockpit-log-panel .pf-v5-c-card__header button")
@@ -761,7 +779,9 @@ WantedBy=multi-user.target
 
         self.wait_service_in_panel("condtest.service", "Enabled")
         self.goto_service("condtest.service")
-        self.check_service_details(["Not running", "Automatically starts"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_details(["Not running", "Automatically starts"],
+                                   ["Start", "Disallow running (mask)", "Pin unit"],
+                                   enabled=True)
         self.do_action("Start")
         b.wait_text("#condition", "Condition ConditionDirectoryNotEmpty=/var/tmp/empty was not met")
 
@@ -769,7 +789,7 @@ WantedBy=multi-user.target
         m.execute("touch /var/tmp/empty/non-empty")
         self.addCleanup(m.execute, "rm /var/tmp/empty/non-empty")
         self.do_action("Start")
-        self.check_service_details(["Running", "Automatically starts"], ["Restart", "Stop", "Disallow running (mask)", "Pin unit"], enabled=True)
+        self.check_service_on(expect_reload=False)
         b.wait_not_present("#condition")
 
     def testRelationships(self):
@@ -917,7 +937,7 @@ WantedBy=default.target
         self.goto_service("test-fail.service")
         b.wait_js_cond('window.location.hash === "#/test-fail.service"')
 
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
 
         self.wait_onoff(val=False)
         self.toggle_onoff()
@@ -928,8 +948,7 @@ WantedBy=default.target
         # Disabling should reset the "Failed to start" status
         self.wait_onoff(val=True)
         self.toggle_onoff()
-
-        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
+        self.check_service_off()
 
         self.wait_onoff(val=False)
         self.toggle_onoff()

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -256,34 +256,6 @@ WantedBy=default.target
         b.click(".pf-v5-c-breadcrumb a:contains('Services')")
         b.wait_visible("#services-list")
 
-        # Selects Targets tab
-        self.pick_tab(2)
-        b.wait_not_in_text("#services-list", "test")
-        self.wait_service_state("basic.target", "active")
-
-        if not user:
-            # Make sure that symlinked services also appear in the list
-            self.wait_service_state("reboot.target", "inactive")
-            self.wait_service_present("ctrl-alt-del.target")
-            self.goto_service("ctrl-alt-del.target")
-            b.wait_in_text(".service-name", "Reboot")
-            b.click("#services-page .pf-v5-c-breadcrumb__link")
-
-        # Selects Sockets tab
-        self.pick_tab(3)
-        b.wait_not_in_text("#services-list", "test")
-        b.wait_not_in_text("#services-list", ".target")
-        self.wait_service_state("dbus.socket", "active (running)")
-
-        if not user:
-            # Selects Paths tab - the test VM does not have any user path units
-            self.pick_tab(5)
-            b.wait_not_in_text("#services-list", "test")
-            b.wait_not_in_text("#services-list", ".target")
-            b.wait_not_in_text("#services-list", ".socket")
-            b.wait_not_in_text("#services-list", ".timer")
-            b.wait_visible(self.svc_sel("systemd-ask-password-console.path"))
-
         suffix = "?owner=user" if user else ''
 
         # Check empty state error for nonexistent unit with valid name
@@ -301,9 +273,7 @@ WantedBy=default.target
         b.wait_in_text(".pf-v5-c-empty-state", "Loading unit failed")
         b.wait_in_text(".pf-v5-c-empty-state", "Unit name nonexistent is not valid")
 
-        # Selects Services tab
         b.go(f"#/{suffix}")
-        self.pick_tab(1)
 
         # Survives a burst of events
         self.wait_service_present("test.service")
@@ -343,6 +313,9 @@ WantedBy=default.target
         self.check_service_details(["Static", "Not running"],
                                    ["Start", "Disallow running (mask)", "Pin unit"],
                                    enabled=True, onoff=False)
+        # Check that journalbox shows empty state
+        b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
+        b.wait_not_present("button:contains('View all logs')")
 
         # Mask and unmask
         self.do_action("Disallow running (mask)")
@@ -391,22 +364,6 @@ WantedBy=default.target
         self.check_service_off()
         b.go(f'/system/services#/{suffix}')
         b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
-
-        # Check that `Listen` and `Triggers` properties are shown for socket units
-        self.pick_tab(3)
-        self.goto_service("dbus.socket")
-        if not user:
-            self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen"))
-        else:
-            self.assertIn("/run/user/", b.text("#listen"))
-        self.assertIn(b.text("#Triggers"), ["dbus.service", "dbus-broker.service"])
-        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
-
-        # Check that journalbox shows empty state
-        self.pick_tab(1)
-        self.goto_service("systemd-exit.service")
-        b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
-        b.wait_not_present("button:contains('View all logs')")
 
     def testFilter(self):
         b = self.browser
@@ -705,6 +662,57 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             b.wait_not_present("#memory")
         # Check that listen is not shown for .service units
         b.wait_not_present("#listen")
+
+    def testOtherTypes(self):
+        self._testOtherTypes(user=False)
+
+    def testOtherTypesSession(self):
+        self._testOtherTypes(user=True)
+
+    def _testOtherTypes(self, user):
+        b = self.browser
+
+        self.login_and_go(f'/system/services#/{"?owner=user" if user else ""}')
+
+        path = "/etc/systemd/user" if user else "/etc/systemd/system"
+        self.make_test_service(path)
+
+        # Targets tab
+        self.pick_tab(2)
+        b.wait_not_in_text("#services-list", "test")
+        self.wait_service_state("basic.target", "active")
+
+        if not user:
+            # Make sure that symlinked services also appear in the list
+            self.wait_service_state("reboot.target", "inactive")
+            self.wait_service_present("ctrl-alt-del.target")
+            self.goto_service("ctrl-alt-del.target")
+            b.wait_in_text(".service-name", "Reboot")
+            b.click("#services-page .pf-v5-c-breadcrumb__link")
+
+        # Sockets tab
+        self.pick_tab(3)
+        b.wait_not_in_text("#services-list", "test")
+        b.wait_not_in_text("#services-list", ".target")
+        self.wait_service_state("dbus.socket", "active (running)")
+
+        # Check that `Listen` and `Triggers` properties are shown for socket units
+        self.goto_service("dbus.socket")
+        if not user:
+            self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen"))
+        else:
+            self.assertIn("/run/user/", b.text("#listen"))
+        self.assertIn(b.text("#Triggers"), ["dbus.service", "dbus-broker.service"])
+        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
+
+        # Paths tab - the test VM does not have any user path units
+        if not user:
+            self.pick_tab(5)
+            b.wait_not_in_text("#services-list", "test")
+            b.wait_not_in_text("#services-list", ".target")
+            b.wait_not_in_text("#services-list", ".socket")
+            b.wait_not_in_text("#services-list", ".timer")
+            b.wait_visible(self.svc_sel("systemd-ask-password-console.path"))
 
     def testLogs(self):
         self._testLogs(user=False)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -494,6 +494,38 @@ WantedBy=default.target
         b.go(f'/system/services#/{suffix}')
         b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
 
+        # Check that `Listen` and `Triggers` properties are shown for socket units
+        self.pick_tab(3)
+        self.goto_service("dbus.socket")
+        if not user:
+            self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen"))
+        else:
+            self.assertIn("/run/user/", b.text("#listen"))
+        self.assertIn(b.text("#Triggers"), ["dbus.service", "dbus-broker.service"])
+        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
+
+        # Check that journalbox shows empty state
+        self.goto_service("systemd-exit.service")
+        b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
+        b.wait_not_present("button:contains('View all logs')")
+
+    def testFilter(self):
+        b = self.browser
+
+        self.write_file("/run/systemd/system/test-fail.service",
+                        """
+[Unit]
+Description=Failing Test Service
+
+[Service]
+ExecStart=/usr/bin/false
+
+[Install]
+WantedBy=default.target
+""")
+        self.make_test_service("/etc/systemd/system")
+        self.machine.execute("systemctl enable --now test-fail.service")
+
         def init_filter_state():
             if not b.is_visible("#services-text-filter"):
                 b.click(".pf-v5-c-toolbar__toggle button")
@@ -508,20 +540,9 @@ WantedBy=default.target
             self.wait_service_present("test.service")
             self.wait_service_present("test-fail.service")
 
-        b.go(f'/system/services#/{suffix}')
-
-        # Check that `Listen` and `Triggers` properties are shown for socket units
-        self.pick_tab(3)
-        self.goto_service("dbus.socket")
-        if not user:
-            self.assertIn("/run/dbus/system_bus_socket (Stream)", b.text("#listen"))
-        else:
-            self.assertIn("/run/user/", b.text("#listen"))
-        self.assertIn(b.text("#Triggers"), ["dbus.service", "dbus-broker.service"])
-        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
-
-        # Select services tab
-        self.pick_tab(1)
+        self.login_and_go('/system/services')
+        self.wait_service_present("test-fail.service")
+        self.wait_service_state("test-fail.service", "failed")
 
         # Filter by id
         init_filter_state()
@@ -534,8 +555,7 @@ WantedBy=default.target
         b.set_input_text("#services-text-filter input", "Test Service")
         # test.service is not loaded, thus description search does not find it
         self.wait_service_present("test-fail.service")
-        if not user:
-            b.assert_pixels("#services-page", "text-filter-test", skip_layouts=["mobile"])
+        b.assert_pixels("#services-page", "text-filter-test", skip_layouts=["mobile"])
         b.set_layout("mobile")
         # Waiting a bit for the layout to stabilize.  The scrolling of
         # the header happens asynchronously with an animation.
@@ -545,8 +565,7 @@ WantedBy=default.target
         while b.call_js_func("ph_attr", nav_scroll_btn, "disabled") is None:
             b.click(nav_scroll_btn)
             time.sleep(0.5)
-        if not user:
-            b.assert_pixels_in_current_layout("#services-page", "text-filter-test")
+        b.assert_pixels_in_current_layout("#services-page", "text-filter-test")
         b.set_layout("desktop")
 
         # Filter by description capitalization not matching the unit description
@@ -556,11 +575,9 @@ WantedBy=default.target
         self.wait_service_present("test-fail.service")
 
         # Filter by Id capitalization not matching the unit Id
-        # NetworkManager exists only as a system service, skip user test
-        if not user:
-            init_filter_state()
-            b.set_input_text("#services-text-filter input", "networkmanager")
-            self.wait_service_present("NetworkManager.service")
+        init_filter_state()
+        b.set_input_text("#services-text-filter input", "networkmanager")
+        self.wait_service_present("NetworkManager.service")
 
         # Select only static services
         init_filter_state()
@@ -589,12 +606,13 @@ WantedBy=default.target
         self.wait_service_present("test-fail.service")
 
         # Select Alias and Masked services
-        # No indirect user services exist, skip user test
-        if not user:
-            init_filter_state()
-            self.select_file_state(["Indirect", "Masked"])
-            self.wait_service_not_present("test.service")
-            self.wait_service_present("getty@tty1.service")
+        self.machine.execute("systemctl mask test-fail.service")
+        self.wait_service_in_panel("test-fail.service", "Masked")
+        init_filter_state()
+        self.select_file_state(["Indirect", "Masked"])
+        self.wait_service_not_present("test.service")
+        self.wait_service_present("test-fail.service")
+        self.wait_service_present("getty@tty1.service")
 
         # Check filtering and selecting together - empty state
         init_filter_state()
@@ -620,11 +638,6 @@ WantedBy=default.target
         self.wait_service_not_present("test.service")
         b.click(".pf-v5-c-chip-group:contains('Active state') .pf-v5-c-chip-group__close > button")
         b.wait_not_present(".pf-v5-c-chip-group")
-
-        # Check that journalbox shows empty state
-        self.goto_service("systemd-exit.service")
-        b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
-        b.wait_not_present("button:contains('View all logs')")
 
     def testServiceMetrics(self):
         self._testServiceMetrics(user=False)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -208,54 +208,6 @@ ExecStart=/usr/bin/false
 [Install]
 WantedBy=default.target
 """)
-        self.write_file(f"{path}/test.timer",
-                        """
-[Unit]
-Description=Test Timer
-
-[Timer]
-OnCalendar=*:1/2
-""")
-        self.write_file(f"{path}/test-onboot.timer",
-                        """
-[Unit]
-Description=Test OnBoot Timer
-
-[Timer]
-OnBootSec=200min
-Unit=test.service
-""")
-        self.write_file("/usr/local/lib/systemd/system/cockpit-system.timer",
-                        """
-[Unit]
-Description=Not deleteable Timer
-
-[Timer]
-OnCalendar=*:1/2
-""")
-        self.write_file(f"{path}/deleteme.service",
-                        """
-[Unit]
-Description=Delete Me Service
-
-[Service]
-ExecStart=/usr/bin/true
-
-[Install]
-WantedBy=default.target
-""")
-        self.write_file(f"{path}/deleteme.timer",
-                        """
-[Unit]
-Description=Delete Me Timer
-
-[Timer]
-OnCalendar=*:1/2
-
-# just for user mode
-[Install]
-WantedBy=default.target
-""")
         self.write_file(f"{path}/special@:-characters.service",
                         """
 [Unit]
@@ -269,10 +221,6 @@ WantedBy=default.target
 """)
 
         self.make_test_service(path)
-        # ensure we have one running timer; in user mode we do not have
-        # a running logind session at this point yet, so enable instead
-        self.run_systemctl(user=False, cmd=("enable --global --runtime" if user else "start") + " deleteme.timer")
-        self.addCleanup(self.run_systemctl, user, "stop deleteme.timer || true")
 
         url = "/system/services#/?owner=user" if user else "/system/services"
         self.login_and_go(url, user="admin")
@@ -327,57 +275,7 @@ WantedBy=default.target
         b.wait_not_in_text("#services-list", ".target")
         self.wait_service_state("dbus.socket", "active (running)")
 
-        # Selects Timer tab
-        self.pick_tab(4)
-        b.wait_not_in_text("#services-list", "test-fail")
-        b.wait_not_in_text("#services-list", ".target")
-        b.wait_not_in_text("#services-list", ".socket")
-        b.wait_visible(self.svc_sel('test.timer'))
-        b.wait_text(self.svc_sel('test.timer') + ' .service-unit-triggers', '')
-        today = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format()")
-        # timer from initial page/units load
-        b.wait_in_text(self.svc_sel('deleteme.timer') + ' .service-unit-next-trigger', today)
-        # timer gets updated on PropertiesChanged event
-        self.run_systemctl(user, "start test.timer")
-        b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-next-trigger', today)  # next run
-        b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
-
-        # Timer details should also show information about next and last trigger
-        self.goto_service("test.timer")
-        b.wait_in_text('.service-unit-next-trigger', today)  # next run
-        b.wait_in_text('.service-unit-last-trigger', "unknown")  # last trigger
-        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
-
-        self.run_systemctl(user, "stop test.timer")
-
-        b.wait_visible(self.svc_sel('test-onboot.timer'))
-        b.wait_text(self.svc_sel('test-onboot.timer') + ' .service-unit-triggers', '')
-        self.run_systemctl(user, "start test-onboot.timer")
-        # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
-        today_stamp = int(m.execute("date +%s").strip())
-        time_zone = b.eval_js("Intl.DateTimeFormat().resolvedOptions().timeZone")  # get browser's time zone
-        today_plus_200min = m.execute(f"TZ='{time_zone}' date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
-        b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
-        b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
-        self.run_systemctl(user, "stop test-onboot.timer")
-
         if not user:
-            self.goto_service("deleteme.timer")
-            self.do_action("Delete")
-            b.click("#delete-timer-modal-btn")
-            b.wait_not_present(".pf-v5-c-modal-box")
-            self.wait_page_load()
-            self.assertNotIn("deleteme", m.execute("systemctl list-timers"))
-            m.execute(f"! test -f {path}/deleteme.service")
-            m.execute(f"! test -f {path}/deleteme.timer")
-
-            # system timers are not allowed to be deleted
-            self.goto_service("cockpit-system.timer")
-            b.click(".service-top-panel .pf-v5-c-dropdown button")
-            b.wait_in_text(".service-top-panel .pf-v5-c-dropdown__menu", "Disallow running")
-            b.wait_not_in_text(".service-top-panel .pf-v5-c-dropdown__menu", "Delete")
-            b.click(".pf-v5-c-breadcrumb a:contains('Services')")
-
             # Selects Paths tab - the test VM does not have any user path units
             self.pick_tab(5)
             b.wait_not_in_text("#services-list", "test")
@@ -505,6 +403,7 @@ WantedBy=default.target
         b.click(".pf-v5-c-breadcrumb a:contains('Services')")
 
         # Check that journalbox shows empty state
+        self.pick_tab(1)
         self.goto_service("systemd-exit.service")
         b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
         b.wait_not_present("button:contains('View all logs')")
@@ -638,6 +537,124 @@ WantedBy=default.target
         self.wait_service_not_present("test.service")
         b.click(".pf-v5-c-chip-group:contains('Active state') .pf-v5-c-chip-group__close > button")
         b.wait_not_present(".pf-v5-c-chip-group")
+
+    def testTimer(self):
+        self._testTimer(user=False)
+
+    def testTimerSession(self):
+        self._testTimer(user=True)
+
+    def _testTimer(self, user):
+        m = self.machine
+        b = self.browser
+
+        path = "/etc/systemd/user" if user else "/etc/systemd/system"
+        self.write_file(f"{path}/test.timer",
+                        """
+[Unit]
+Description=Test Timer
+
+[Timer]
+OnCalendar=*:1/2
+""")
+        self.write_file(f"{path}/test-onboot.timer",
+                        """
+[Unit]
+Description=Test OnBoot Timer
+
+[Timer]
+OnBootSec=200min
+Unit=test.service
+""")
+        self.write_file("/usr/local/lib/systemd/system/cockpit-system.timer",
+                        """
+[Unit]
+Description=Not deleteable Timer
+
+[Timer]
+OnCalendar=*:1/2
+""")
+        self.write_file(f"{path}/deleteme.service",
+                        """
+[Unit]
+Description=Delete Me Service
+
+[Service]
+ExecStart=/usr/bin/true
+
+[Install]
+WantedBy=default.target
+""")
+        self.write_file(f"{path}/deleteme.timer",
+                        """
+[Unit]
+Description=Delete Me Timer
+
+[Timer]
+OnCalendar=*:1/2
+
+# just for user mode
+[Install]
+WantedBy=default.target
+""")
+        self.make_test_service(path)
+
+        # ensure we have one running timer; in user mode we do not have
+        # a running logind session at this point yet, so enable instead
+        self.run_systemctl(user=False, cmd=("enable --global --runtime" if user else "start") + " deleteme.timer")
+        self.addCleanup(self.run_systemctl, user, "stop deleteme.timer || true")
+
+        # Select Timer tab
+        self.login_and_go(f'/system/services#/{"?owner=user" if user else ""}')
+        self.pick_tab(4)
+        b.wait_not_in_text("#services-list", "test-fail")
+        b.wait_not_in_text("#services-list", ".target")
+        b.wait_not_in_text("#services-list", ".socket")
+        b.wait_visible(self.svc_sel('test.timer'))
+        b.wait_text(self.svc_sel('test.timer') + ' .service-unit-triggers', '')
+        today = b.eval_js("Intl.DateTimeFormat('en', { dateStyle: 'medium' }).format()")
+        # timer from initial page/units load
+        b.wait_in_text(self.svc_sel('deleteme.timer') + ' .service-unit-next-trigger', today)
+        # timer gets updated on PropertiesChanged event
+        self.run_systemctl(user, "start test.timer")
+        b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-next-trigger', today)  # next run
+        b.wait_in_text(self.svc_sel('test.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
+
+        # Timer details should also show information about next and last trigger
+        self.goto_service("test.timer")
+        b.wait_in_text('.service-unit-next-trigger', today)  # next run
+        b.wait_in_text('.service-unit-last-trigger', "unknown")  # last trigger
+        b.click(".pf-v5-c-breadcrumb a:contains('Services')")
+
+        self.run_systemctl(user, "stop test.timer")
+
+        b.wait_visible(self.svc_sel('test-onboot.timer'))
+        b.wait_text(self.svc_sel('test-onboot.timer') + ' .service-unit-triggers', '')
+        self.run_systemctl(user, "start test-onboot.timer")
+        # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
+        today_stamp = int(m.execute("date +%s").strip())
+        time_zone = b.eval_js("Intl.DateTimeFormat().resolvedOptions().timeZone")  # get browser's time zone
+        today_plus_200min = m.execute(f"TZ='{time_zone}' date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
+        b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
+        b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
+        self.run_systemctl(user, "stop test-onboot.timer")
+
+        if not user:
+            self.goto_service("deleteme.timer")
+            self.do_action("Delete")
+            b.click("#delete-timer-modal-btn")
+            b.wait_not_present(".pf-v5-c-modal-box")
+            self.wait_page_load()
+            self.assertNotIn("deleteme", m.execute("systemctl list-timers"))
+            m.execute(f"! test -f {path}/deleteme.service")
+            m.execute(f"! test -f {path}/deleteme.timer")
+
+            # system timers are not allowed to be deleted
+            self.goto_service("cockpit-system.timer")
+            b.click(".service-top-panel .pf-v5-c-dropdown button")
+            b.wait_in_text(".service-top-panel .pf-v5-c-dropdown__menu", "Disallow running")
+            b.wait_not_in_text(".service-top-panel .pf-v5-c-dropdown__menu", "Delete")
+            b.click(".pf-v5-c-breadcrumb a:contains('Services')")
 
     def testServiceMetrics(self):
         self._testServiceMetrics(user=False)

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -79,15 +79,17 @@ class TestServices(testlib.MachineCase):
             self.browser.wait_not_present(".service-top-panel .pf-v5-c-dropdown")
 
     def check_service_on(self, expect_reload=True):
-        self.check_service_details(
-            ["Running", "Automatically starts"],
-            ["Reload" if expect_reload else "", "Restart", "Stop", "Disallow running (mask)", "Pin unit"],
-            enabled=True)
+        with self.browser.wait_timeout(60):
+            self.check_service_details(
+                ["Running", "Automatically starts"],
+                ["Reload" if expect_reload else "", "Restart", "Stop", "Disallow running (mask)", "Pin unit"],
+                enabled=True)
 
     def check_service_off(self):
-        self.check_service_details(["Disabled"],
-                                   ["Start", "Disallow running (mask)", "Pin unit"],
-                                   enabled=False)
+        with self.browser.wait_timeout(30):
+            self.check_service_details(["Disabled"],
+                                       ["Start", "Disallow running (mask)", "Pin unit"],
+                                       enabled=False)
 
     def svc_sel(self, service):
         return f'tr[data-goto-unit="{service}"]'

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -386,14 +386,28 @@ WantedBy=default.target
             b.wait_not_in_text("#services-list", ".timer")
             b.wait_visible(self.svc_sel("systemd-ask-password-console.path"))
 
+        suffix = "?owner=user" if user else ''
+
+        # Check empty state error for nonexistent unit with valid name
+        b.go(f'/system/services#/nonexistent.service{suffix}')
+        b.wait_in_text(".pf-v5-c-empty-state", "Unit nonexistent.service not found")
+        b.click("a:contains('View all services')")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname == "/system/services"')
+        if user:
+            b.wait_js_cond(f"window.location.hash === '#/{suffix}'")
+
+        # Check empty state error for invalid unit name
+        b.go(f'/system/services#/nonexistent{suffix}')
+        b.enter_page("/system/services")
+        b.wait_in_text(".pf-v5-c-empty-state", "Loading unit failed")
+        b.wait_in_text(".pf-v5-c-empty-state", "Unit name nonexistent is not valid")
+
         # Selects Services tab
+        b.go(f"#/{suffix}")
         self.pick_tab(1)
 
         # Survives a burst of events
-        suffix = ''
-        if user:
-            suffix = "?owner=user"
-        b.go(f"#/{suffix}")
         self.wait_service_present("test.service")
         m.execute("udevadm trigger; udevadm settle")
         self.goto_service("test.service")
@@ -612,9 +626,20 @@ WantedBy=default.target
         b.wait_text('.cockpit-log-panel .pf-v5-c-card__body', "No log entries")
         b.wait_not_present("button:contains('View all logs')")
 
-        b.go(f'/system/services#/{suffix}')
+    def testServiceMetrics(self):
+        self._testServiceMetrics(user=False)
+
+    def testServiceMetricsSession(self):
+        self._testServiceMetrics(user=True)
+
+    def _testServiceMetrics(self, user):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go(f'/system/services#/{"?owner=user" if user else ""}')
 
         params = "-user" if user else ""
+        path = "/etc/systemd/user" if user else "/etc/systemd/system"
 
         self.write_file(f"/tmp/mem-hog{params}.awk", f'BEGIN {{ system("while [ ! -f /tmp/continue{params} ]; do sleep 1; done"); y = sprintf("%50000000s",""); system("sleep infinity") }}')
         self.write_file(f"{path}/mem-hog.service",
@@ -634,7 +659,7 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
         # In some distros systemctl is showing memory current as [Not Set] for user units
         if not user or m.image not in ["rhel-8-7", "rhel-8-8", "rhel-8-9", "centos-8-stream"]:
             self.run_systemctl(user, "start mem-hog.service")
-            # If the test fails before we stop the mem-hog the next test run will not get the correct memory usage here
+            # If the test fails before we stop mem-hog, the next test run will not get the correct memory usage here
             self.addCleanup(self.run_systemctl, user, "stop mem-hog.service || true")
             # initial memory detection takes very long especially on RHEL 8
             with b.wait_timeout(60):
@@ -650,21 +675,6 @@ ExecStart=/bin/awk -f /tmp/mem-hog{params}.awk
             b.wait_not_present("#memory")
         # Check that listen is not shown for .service units
         b.wait_not_present("#listen")
-
-        # Check empty state error for nonexisent unit with valid name
-        b.go(f'/system/services#/nonexistent.service{suffix}')
-        b.wait_in_text(".pf-v5-c-empty-state", "Unit nonexistent.service not found")
-        b.click("a:contains('View all services')")
-        b.switch_to_top()
-        b.wait_js_cond('window.location.pathname == "/system/services"')
-        if user:
-            b.wait_js_cond(f"window.location.hash === '#/{suffix}'")
-
-        # Check empty state error for invalid unit name
-        b.go(f'/system/services#/nonexistent{suffix}')
-        b.enter_page("/system/services")
-        b.wait_in_text(".pf-v5-c-empty-state", "Loading unit failed")
-        b.wait_in_text(".pf-v5-c-empty-state", "Unit name nonexistent is not valid")
 
     def testLogs(self):
         self._testLogs(user=False)


### PR DESCRIPTION
We've had [this one](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18656-20230419-120249-8715af15-fedora-37-pybridge/log.html#274) for ages, but it becomes more pressing now that the pybridge is in production.