### PR TITLE
pkg: correctly call onChange handler

### DIFF
--- a/pkg/lib/cockpit-components-shutdown.jsx
+++ b/pkg/lib/cockpit-components-shutdown.jsx
@@ -196,7 +196,7 @@ export class ShutdownModal extends React.Component {
                 <>
                     <Form isHorizontal onSubmit={this.onSubmit}>
                         <FormGroup fieldId="message" label={_("Message to logged in users")}>
-                            <TextArea id="message" resizeOrientation="vertical" value={this.state.message} onChange={v => this.setState({ message: v })} />
+                            <TextArea id="message" resizeOrientation="vertical" value={this.state.message} onChange={(_, v) => this.setState({ message: v })} />
                         </FormGroup>
                         <FormGroup fieldId="delay" label={_("Delay")}>
                             <Flex className="shutdown-delay-group" alignItems={{ default: 'alignItemsCenter' }}>

--- a/test/verify/check-system-shutdown-restart
+++ b/test/verify/check-system-shutdown-restart
@@ -47,6 +47,7 @@ class TestShutdownRestart(testlib.MachineCase):
         b.click("#reboot-button")
         b.wait_popup("shutdown-dialog")
         b.wait_in_text(f"#shutdown-dialog button{self.danger_btn_class}", 'Reboot')
+        b.set_input_text("#message", "Rebooting for maintenance")
         b.click("#delay")
         b.click("button:contains('No delay')")
         b.wait_text("#delay .pf-v5-c-select__toggle-text", "No delay")


### PR DESCRIPTION
PatternFly 5 changed it's onChange callback function to now always return an event as first argument.

Additionally add a basic test to test if we can set a reboot message, as testing if the message appears is hard and prone to race conditions.

---

Fixes #18966

I wonder if we have more of these issues, I'll try  to find them.