### PR TITLE
test: Adjust special cases for debian-stable moving to Debian 12 "bookworm"

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -109,6 +109,8 @@ class NetworkCase(MachineCase, NetworkHelpers):
         m.execute("systemctl reload-or-restart NetworkManager")
 
         # our assertions and pixel tests assume that virbr0 is absent
+        m.execute('[ -z "$(systemctl --legend=false list-unit-files libvirtd.service)" ] || '
+                  'systemctl try-restart libvirtd.service')
         if 'default' in m.execute("virsh net-list --name || true"):
             m.execute("virsh net-autostart --disable default; virsh net-destroy default")
 

--- a/test/image-prepare
+++ b/test/image-prepare
@@ -102,7 +102,7 @@ def build_install_package(dist_tar, image):
         args.append("--run-command")
         suppress = {'initial-upload-closes-no-bugs', 'newer-standards-version'}
         # older lintian not yet complain about pkg/static/login.html and src/common/fail.html
-        if image in ["debian-stable", "ubuntu-2204"]:
+        if image in ["ubuntu-2204"]:
             suppress.add("mismatched-override")
         # Ubuntu 22.04 raises elf-error on *-dbgsym: "In program headers: Unable to find program interpreter name"
         if image == "ubuntu-2204":

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -578,7 +578,7 @@ class TestConnection(testlib.MachineCase):
 
         def checkMotdContent(string, expected=True):
             # Needs https://github.com/linux-pam/linux-pam/pull/292 (or PAM 1.5.0)
-            old_pam = (m.image in ['centos-8-stream', 'debian-stable', 'ubuntu-2204', 'rhel-8-7', 'rhel-8-8', 'rhel-8-9'])
+            old_pam = (m.image in ['centos-8-stream', 'ubuntu-2204', 'rhel-8-7', 'rhel-8-8', 'rhel-8-9'])
 
             # check issue (should be exactly the same as motd)
             assertInOrNot(string, m.execute("cat /etc/issue.d/cockpit.issue"), expected)

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -122,10 +122,6 @@ class TestHistoryMetrics(testlib.MachineCase):
         super().setUp()
         # start with a clean slate and avoid running into restart limits
         self.machine.execute("systemctl stop pmlogger pmproxy; systemctl reset-failed pmlogger pmproxy 2>/dev/null || true")
-        if self.machine.image == 'debian-stable':
-            # HACK: work around pcp breaking permissions: https://bugzilla.redhat.com/show_bug.cgi?id=2013937
-            # This is failing in too many ways to meaningfully cover with naughty
-            self.machine.execute("chown -R pcp:pcp /var/log/pcp/pmlogger/")
 
     def waitStream(self, current_max):
         # should only have at most <current_max> valid minutes, the rest should be empty
@@ -456,7 +452,7 @@ class TestHistoryMetrics(testlib.MachineCase):
         # Journal was recorded on Fedora 33 and when trying to use it with older systemd it fails with:
         # `Journal file /var/log/journal/*/journal.journal uses an unsupported feature, ignoring file.`
 
-        if self.machine.image in ["centos-8-stream", "rhel-8-7", "rhel-8-8", "rhel-8-9", "debian-stable"]:
+        if self.machine.image in ["centos-8-stream", "rhel-8-7", "rhel-8-8", "rhel-8-9"]:
             return
 
         m.upload(["verify/files/metrics-archives/journal.journal.gz"], "/tmp")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -801,7 +801,7 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # we don't want to completely pinpoint the OS list to avoid lockstep image refreshes+cockpit PRs
         # and spontaneous packit test failures as sssd 2.6.1 goes into more distros; but make sure we hit
         # this code path on some known-good ones
-        if m.image.startswith("fedora") or m.image in ["debian-testing"]:
+        if m.image.startswith("fedora") or m.image.startswith("debian"):
             self.assertTrue(has_validate_api)
 
         if has_validate_api:

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -64,7 +64,7 @@ class TestSuperuser(testlib.MachineCase):
         # Get the privileges back, this time in the mobile layout
         b.set_layout("mobile")
         b.open_superuser_dialog()
-        if "ubuntu" not in m.image and m.image != "debian-testing":
+        if "ubuntu" not in m.image and "debian" not in m.image:
             b.wait_in_text(".pf-v5-c-modal-box:contains('Switch to administrative access')",
                            "We trust you have received the usual lecture")
         b.wait_in_text(".pf-v5-c-modal-box:contains('Switch to administrative access')", "Password for admin:")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -667,7 +667,7 @@ machine         : 8561
 
         b.reload()
         b.enter_page('/system/hwinfo')
-        distros_without_systemd_memory_dmi = ['rhel-8-7', 'rhel-8-8', 'rhel-8-9', 'centos-8-stream', 'debian-stable']
+        distros_without_systemd_memory_dmi = ['rhel-8-7', 'rhel-8-8', 'rhel-8-9', 'centos-8-stream']
 
         # Test more specific memory data with a fake dmidecode
         b.wait_in_text('#memory-listing tr:nth-of-type(1) td[data-label=ID]', "BANK 0: ChannelA-DIMM0")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -85,6 +85,7 @@ ExecStart=/bin/true
 @testlib.skipDistroPackage()
 class CommonTests:
     @testlib.timeout(900)
+    @testlib.skipImage("fails to leave the domain", "debian-*")
     def testQualifiedUsers(self):
         m = self.machine
         b = self.browser
@@ -493,7 +494,6 @@ class TestRealms(testlib.MachineCase):
         self.allow_journal_messages("couldn't get all properties of org.freedesktop.realmd.Service.*org.freedesktop.DBus.Error.NoReply: Remote peer disconnected")
 
 
-@testlib.skipImage("freeipa not currently available", "debian-*")
 @testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestIPA(TestRealms, CommonTests):
@@ -990,7 +990,6 @@ sed -i '/^sudoers:/ s/files sss/sss files/' /etc/nsswitch.conf
 
 @testlib.skipOstree("No realmd available")
 @testlib.skipImage("No realmd available", "arch")
-@testlib.skipImage("freeipa not currently available", "debian-*")
 @testlib.skipDistroPackage()
 @testlib.no_retry_when_changed
 class TestKerberos(testlib.MachineCase):


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/4886 moves our "debian-stable" image from Debian 11 to 12. Adjust the test special cases.

Also enable the FreeIPA tests on Debian, as the packages are again available in both stable and testing. TestIPA.testQualifiedUsers still fails, so keep skipping that one for now -- let's unblock the lockstep bots+cockpit PR and investigate that as a follow-up.

---

This needs to land in lockstep with https://github.com/cockpit-project/bots/pull/4886

#18978 ran the libvirt change for all other OSes.