### PR TITLE
test: Restart libvirtd between tests

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -109,6 +109,8 @@ class NetworkCase(MachineCase, NetworkHelpers):
         m.execute("systemctl reload-or-restart NetworkManager")
 
         # our assertions and pixel tests assume that virbr0 is absent
+        m.execute('[ -z "$(systemctl --legend=false list-unit-files libvirtd.service)" ] || '
+                  'systemctl try-restart libvirtd.service')
         if 'default' in m.execute("virsh net-list --name || true"):
             m.execute("virsh net-autostart --disable default; virsh net-destroy default")
 


### PR DESCRIPTION
libvirtd sometimes gets locked up in between saving and restoring config files and restarting NM. Restart it as well between networking tests.

---

Fixes [this disaster](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18975-20230620-111014-b5985eec-debian-testing-bots-4886/log.html). Testing separately so that it validates independently from the image refresh/test adjustments.