### PR TITLE
storage: Tell people that big mdraids really should have a bitmap

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -66,17 +66,22 @@ class StorageHelpers:
 
         The disk gets removed automatically when the test ends. This is safe for @nondestructive tests.
 
-        Unlike add_ram_disk(), this can be called multiple times, and is less size constrained.
-        However, loopback devices look quite special to the OS, so they are not a very good
-        simulation of a "real" disk.
+        Unlike add_ram_disk(), this can be called multiple times, and
+        is less size constrained.  The backing file starts out sparse,
+        so this can be used to create massive block devices, as long
+        as you are careful to not actually use much of it.
+
+        However, loopback devices look quite special to the OS, so
+        they are not a very good simulation of a "real" disk.
 
         Return the device name.
+
         """
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1969408
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
         dev = self.machine.execute("F=$(mktemp /var/tmp/loop.XXXX); "
-                                   "dd if=/dev/zero of=$F bs=1000000 count=%s; "
+                                   "truncate --size=%sMB $F; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # If this device had partions in its last incarnation on this
         # machine, they might come back for unknown reasons, in a

--- a/test/verify/check-storage-mdraid
+++ b/test/verify/check-storage-mdraid
@@ -343,6 +343,44 @@ class TestStorageMdRaid(storagelib.StorageCase):
         # The last disk can not be removed
         b.wait_visible('#detail-sidebar .sidepanel-row:contains(DISK2) button:disabled')
 
+    def testBitmap(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Make two huge block devices, so that we can make a array
+        # that is beyond the threshold where Cockpit and mdadm start
+        # to worry about bitmaps.  The backing files are sparse, so
+        # this is okay as long nobody actually writes a lot to these
+        # devices.
+
+        dev1 = self.add_loopback_disk(110000)
+        dev2 = self.add_loopback_disk(110000)
+
+        # We need to use "--assume-clean" so that mdraid doesn't try
+        # to write 110GB to one of the devices during synchronization.
+
+        m.execute(f"mdadm --create md0 --level=1 --assume-clean --run --raid-devices=2 {dev1} {dev2}")
+        m.execute("udevadm trigger")
+
+        b.wait_in_text("#devices", "md0")
+        b.click('#devices .sidepanel-row:contains("md")')
+        b.wait_visible('#storage-detail')
+
+        self.wait_states({dev1: "In sync",
+                          dev2: "In sync"})
+
+        b.wait_not_present('.pf-v5-c-alert:contains("This RAID array has no write-intent bitmap")')
+
+        # Remove the bitmap, Cockpit should complain and let us put it back.
+
+        m.execute("mdadm --grow --bitmap=none /dev/md/md0; udevadm trigger /dev/md/md0")
+
+        b.wait_visible('.pf-v5-c-alert:contains("This RAID array has no write-intent bitmap")')
+        b.click('button:contains("Add a bitmap")')
+        b.wait_not_present('.pf-v5-c-alert:contains("This RAID array has no write-intent bitmap")')
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
mdadm uses a bitmap for arrays that are larger than 100GiB, and not having a bitmap is a warning.