### PR TITLE
tools: Keep C bridge on Debian stable (12) for now

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -3,8 +3,7 @@
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
 # Keep the older C bridge on stable releases
-# also keep it on Ubuntu until testCockpitDesktop gets fixed
-C_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 22.04)
+C_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 12 22.04)
 ifeq ($(C_BRIDGE),)
 CONFIG_OPTIONS += --enable-pybridge
 endif


### PR DESCRIPTION
We intended to keep the C bridge on Debian stable (for backports) for the time being. But Debian stable recently moved from 11 (bullseye) to 12 (bookworm), so adjust the version filter.

Also drop the obsolete Ubuntu comment, as that was fixed in commit b7895b8e8e0508, and the pybridge got enabled in commit 2dce6929c1.