### PR TITLE
test: Fix sit regression with --machine

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2564,9 +2564,7 @@ def sit(machines=None):
     the browser.
     """
 
-    assert machines is None, "No machines found to sit in"
-
-    for (_, machine) in machines.items():
+    for (_, machine) in (machines or []).items():
         sys.stderr.write(machine.diagnose())
     print("Press RET to continue...")
     sys.stdin.readline()


### PR DESCRIPTION
Commit 582a91fc5d199f introduced the assertion that sit() is always called with at least one machine. But that isn't true when running a test with `--machine`, which breaks debugging.