### PR TITLE
python: Init 'any' superuser when started by old cockpit

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -114,7 +114,7 @@ class Bridge(Router, PackagesListener):
             return dict(token.split('=', 1) for token in lexer)
 
     def do_init(self, message: Dict[str, object]) -> None:
-        superuser = message.get('superuser')
+        superuser = message.get('superuser', {})
         if isinstance(superuser, dict):
             self.superuser_rule.init(superuser)
 

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -220,11 +220,12 @@ class SuperuserRoutingRule(RoutingRule, CockpitResponder, bus.Object, interface=
 
     # Connect-on-startup functionality
     def init(self, params: Dict[str, Union[bool, str, Sequence[str]]]) -> None:
-        name = params.get('id', 'any')
-        assert isinstance(name, str)
-        responder = AuthorizeResponder(self.router)
-        self._init_task = asyncio.create_task(self.go(name, responder))
-        self._init_task.add_done_callback(self._init_done)
+        if self.current != "root":
+            name = params.get('id', 'any')
+            assert isinstance(name, str)
+            responder = AuthorizeResponder(self.router)
+            self._init_task = asyncio.create_task(self.go(name, responder))
+            self._init_task.add_done_callback(self._init_done)
 
     def _init_done(self, task):
         logger.debug('superuser init done! %s', task.exception())

--- a/test/pytest/mocktransport.py
+++ b/test/pytest/mocktransport.py
@@ -67,8 +67,8 @@ class MockTransport(asyncio.Transport):
         msg = str(len(msg)).encode('ascii') + b'\n' + msg
         self.protocol.data_received(msg)
 
-    def send_init(self, version=1, host=MOCK_HOSTNAME, **kwargs):
-        self.send_json('', command='init', version=version, host=host, **kwargs)
+    def send_init(self, version=1, host=MOCK_HOSTNAME, superuser=False, **kwargs):  # noqa: FBT002
+        self.send_json('', command='init', version=version, host=host, superuser=superuser, **kwargs)
 
     def get_id(self, prefix: str) -> str:
         self.next_id += 1

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -411,7 +411,6 @@ class TestSuperuserOldWebserver(testlib.MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @testlib.todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machine
@@ -565,7 +564,6 @@ class TestSuperuserOldDashboard(testlib.MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @testlib.todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machines["machine1"]


### PR DESCRIPTION
Old cockpit peers would not include any "superuser" parameter in the "init" message, and would expect the bridge to greedily start any of their configured rules.  Let's implement this behavior also in the Python bridge.