### PR TITLE
fmf: Replace deprecated dnf --noautoremove option

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -34,7 +34,7 @@ fi
 # HACK: setroubleshoot-server crashes/times out randomly (breaking TestServices),
 # and is hard to disable as it does not use systemd
 if rpm -q setroubleshoot-server; then
-    dnf remove -y --noautoremove setroubleshoot-server
+    dnf remove -y --setopt=clean_requirements_on_remove=False setroubleshoot-server
 fi
 
 if grep -q 'ID=.*fedora' /etc/os-release && [ "$PLAN" = "basic" ]; then


### PR DESCRIPTION
This option got dropped in dnf 5, and thus this started to fail on Rawhide. Replace it with the corresponding option.

See https://bugzilla.redhat.com/show_bug.cgi?id=2216622

---

Should fix [this rawhide TF failure](https://artifacts.dev.testing-farm.io/958c5148-f22a-4a23-aa91-5e37a8f26188/). Let's see what else is wrong.