### PR TITLE
test: Apply TestServices extended timeout to all unit status checks

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -64,7 +64,8 @@ class TestServices(testlib.MachineCase):
         self.browser.click(f".service-top-panel .pf-v5-c-dropdown__menu a:contains('{action}')")
 
     def check_service_details(self, statuses, actions, enabled, onoff=True, kebab=True):
-        self.browser.wait_collected_text("#statuses .status", "".join(statuses))
+        with self.browser.wait_timeout(60):
+            self.browser.wait_collected_text("#statuses .status", "".join(statuses))
         if onoff:
             self.wait_onoff(val=enabled)
         else:
@@ -79,17 +80,15 @@ class TestServices(testlib.MachineCase):
             self.browser.wait_not_present(".service-top-panel .pf-v5-c-dropdown")
 
     def check_service_on(self, expect_reload=True):
-        with self.browser.wait_timeout(60):
-            self.check_service_details(
-                ["Running", "Automatically starts"],
-                ["Reload" if expect_reload else "", "Restart", "Stop", "Disallow running (mask)", "Pin unit"],
-                enabled=True)
+        self.check_service_details(
+            ["Running", "Automatically starts"],
+            ["Reload" if expect_reload else "", "Restart", "Stop", "Disallow running (mask)", "Pin unit"],
+            enabled=True)
 
     def check_service_off(self):
-        with self.browser.wait_timeout(30):
-            self.check_service_details(["Disabled"],
-                                       ["Start", "Disallow running (mask)", "Pin unit"],
-                                       enabled=False)
+        self.check_service_details(["Disabled"],
+                                   ["Start", "Disallow running (mask)", "Pin unit"],
+                                   enabled=False)
 
     def svc_sel(self, service):
         return f'tr[data-goto-unit="{service}"]'


### PR DESCRIPTION
This sometimes also times out for other status checks. Do what I should        
have done in the beginning, and apply the extended timeout to        
check_service_details() itself, not just to the common case wrapper.        
        
    WARNING: Waiting for ph_collected_text_is("#statuses .status","Failed to startAutomatically starts")        
    took 13.0 seconds, which is 86% of the timeout.        

----

Should help for [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18968-20230621-203459-0814b3d3-ubuntu-stable/log.html#335-2). I [stress-test](https://github.com/cockpit-project/cockpit/pull/18988/commits/93ab8a369eba368b70357272fabc2c69289909ea) this in the first round.