### PR TITLE
test: Bump wait_for_iface() timeout

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -159,7 +159,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
             text = "Inactive"
 
         try:
-            with self.browser.wait_timeout(20):
+            with self.browser.wait_timeout(30):
                 self.browser.wait_in_text(sel, text)
         except Error as e:
             print(f"Interface {iface} didn't show up.")


### PR DESCRIPTION
On slow CI machines, the networking page sometimes is still loading after 20 seconds.

---

See [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-18982-20230621-213019-389e6c00-ubuntu-stable/log.html#92-2), in particular the screenshot.