### PR TITLE
workflows: Run pytest-cov scenario in unit-tests-refresh, fix for ruff 0.0.274

### DIFF
--- a/.github/workflows/unit-tests-refresh.yml
+++ b/.github/workflows/unit-tests-refresh.yml
@@ -24,6 +24,10 @@ jobs:
         timeout-minutes: 10
         run: containers/unit-tests/build
 
+      - name: Run pytest-cov test
+        timeout-minutes: 15
+        run: containers/unit-tests/start --verbose --env=CC=gcc --image-tag=latest --make pytest-cov
+
       - name: Run amd64 gcc check-memory test
         timeout-minutes: 20
         run: containers/unit-tests/start --verbose --env=CC=gcc --image-tag=latest --make check-memory

--- a/containers/unit-tests/setup.sh
+++ b/containers/unit-tests/setup.sh
@@ -63,8 +63,10 @@ DEBIAN_FRONTEND=noninteractive eatmydata apt-get install -y --no-install-recomme
 
 adduser --gecos "Builder" builder
 
-# See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1030835
-pip install --break-system-packages ruff
+if [ "$(uname -m)" = "x86_64" ] ; then
+    # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1030835
+    pip install --break-system-packages ruff
+fi
 
 # minimize image
 # useful command: dpkg-query --show -f '${package} ${installed-size}\n' | sort -k2n

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ ignore = [
     "B011",  # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "PT011", # `pytest.raises(OSError)` is too broad
+    "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
 ]
 line-length = 118
 src = []


### PR DESCRIPTION
This spontaneously broke our CI the last time around, as ruff got upgraded and started to complain.

----

I know the latest run throws some complaints. I fixed many of them yesterday already, but we need to start ignoring this:

> RUF012 Mutable class attributes should be annotated with `typing.ClassVar`

I'll do a [first refresh run](https://github.com/cockpit-project/cockpit/actions/runs/5348110692)  and expect this to fail. **Update**: [and it did in the right way](https://github.com/cockpit-project/cockpit/actions/runs/5348110692/jobs/9697535698#step:4:450)