### PR TITLE
Stop storing mtime of css

### DIFF
--- a/pkg/lib/esbuild-compress-plugin.js
+++ b/pkg/lib/esbuild-compress-plugin.js
@@ -40,7 +40,7 @@ export const cockpitCompressPlugin = ({ subdir = '', exclude = null } = {}) => (
                 if (exclude && exclude.test(dirent))
                     continue;
                 if (dirent.endsWith('.js') || dirent.endsWith('.css')) {
-                    gzipPromises.push(exec('gzip', ['-9', dirent]));
+                    gzipPromises.push(exec('gzip', ['-n9', dirent]));
                 }
             }
             await Promise.all(gzipPromises);


### PR DESCRIPTION
Stop storing mtime of css in `.gz` files
to make package builds reproducible.
Without this patch, `/usr/share/cockpit/machines/index.css.gz` would vary between build.

This patch was done while working on reproducible builds for openSUSE.