### PR TITLE
test: Fix --sit with existing machines

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2530,7 +2530,7 @@ def sit(machines=None):
     the browser.
     """
 
-    for (_, machine) in (machines or []).items():
+    for (_, machine) in (machines or {}).items():
         sys.stderr.write(machine.diagnose())
     print("Press RET to continue...")
     sys.stdin.readline()


### PR DESCRIPTION
Commit 8ffca5d5ee botched the fix for the case that `machines` was not provided. It's expected to be a dict, so actually fall back to a dict, not a list (as it was before commit 582a91fc5d199f). Fixes

```
  File "test/verify/check-system-realms", line 96, in testQualifiedUsers
    testlib.sit()
  File "main/test/common/testlib.py", line 2533, in sit
    for (_, machine) in (machines or []).items():
                        ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'list' object has no attribute 'items'
```

---

I am really embarrassed and ashamed now.. :see_no_evil: 