### PR TITLE
tools: Enable Python bridge on Fedora 38

### DIFF
--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -21,8 +21,8 @@ import testlib
 
 
 # Run this on more OSes as we roll out the pybridge
-@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "fedora-37", "fedora-38",
-                   "fedora-testing", "rhel-8*", "centos-8*", "rhel-9*", "centos-9*")
+@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "fedora-37",
+                   "rhel-8*", "centos-8*", "rhel-9*", "centos-9*")
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -53,8 +53,7 @@ Version:        0
 Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 
-# Use Python bridge on non-stable versions
-%if 0%{?fedora} >= 39
+%if 0%{?fedora} >= 38
 %define cockpit_enable_python 1
 %endif
 


### PR DESCRIPTION
After this, we can remove the fedora-38/pybridge scenario.

 - [x] PR #19025
 - [x] PR #19029
 - [x] PR #19034
 - [x] PR #19038
 - [x] more properly fix package loading (@allisonkarlitskaya is working on it) #19065  ? Alternatively I added a commit to avoid the  [OOM failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19009-20230713-053600-3a36307a-fedora-38-devel/log.html)