### PR TITLE
pybridge: Ignore OSErrors in MountSampler

### DIFF
--- a/src/cockpit/samples.py
+++ b/src/cockpit/samples.py
@@ -387,12 +387,14 @@ class MountSampler(Sampler):
                     continue
 
                 path = line.split()[1]
-                res = os.statvfs(path)
-                if res:
-                    frsize = res.f_frsize
-                    total = frsize * res.f_blocks
-                    samples['mount.total'][path] = total
-                    samples['mount.used'][path] = total - frsize * res.f_bfree
+                try:
+                    res = os.statvfs(path)
+                except OSError:
+                    continue
+                frsize = res.f_frsize
+                total = frsize * res.f_blocks
+                samples['mount.total'][path] = total
+                samples['mount.used'][path] = total - frsize * res.f_bfree
 
 
 class BlockSampler(Sampler):


### PR DESCRIPTION
This often crashes with

    PermissionError: [Errno 13] Permission denied: '/var/lib/containers/storage/overlay'

There is not much that we can do about it, so ignore it. The code already tried to do that, but in Python a failure is an exception, not a falsy return value.

---

I've seen [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19009-20230625-083043-dbb55d02-debian-testing-storage/log.html#22) quite often recently, since we enable the pybridge on more OSes.