### PR TITLE
test: Ignore all PF SVG icon pixels

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1005,6 +1005,11 @@ class Browser:
         if ignore is None:
             ignore = []
 
+        # Let's ignore PF SVG icons, they seem to be not entirely
+        # pixel perfect
+
+        ignore = ignore + [".pf-v5-svg"]
+
         if not (Image and self.pixels_label):
             return
 


### PR DESCRIPTION
They seem to be rendered less pixel perfectly than the rest.

Fixes #19001