### PR TITLE
tools: sync arch makedepends

### DIFF
--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -12,8 +12,8 @@ arch=('x86_64')
 url='https://cockpit-project.org/'
 license=(LGPL)
 install=cockpit.install
-makedepends=(krb5 libssh accountsservice perl-json perl-locale-po json-glib glib-networking
-             git intltool gtk-doc gobject-introspection networkmanager libgsystem xmlto npm pcp
+makedepends=(krb5 libssh accountsservice json-glib glib-networking
+             git intltool gtk-doc gobject-introspection networkmanager xmlto npm pcp
              python-build python-installer python-wheel)
 source=("cockpit-${pkgver}.tar.xz"
         "cockpit.pam"


### PR DESCRIPTION
This is a partial sync of the PKGBUILD, as they split the cockpit package into cockpit-{storaged/packagekit} which might require some more work.

This would be nice to land to unblock https://github.com/cockpit-project/bots/pull/4930 or I revert the dropping of the deps there but they are kinda useless so let's make the build chroot smaller :)