### PR TITLE
shell: Apply host dialogs on form submission

### DIFF
--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -69,6 +69,14 @@ function is_method_supported(methods, method) {
     return result ? result !== "no-server-support" : false;
 }
 
+function prevent_default(callback) {
+    return event => {
+        callback();
+        event.preventDefault();
+        return false;
+    };
+}
+
 class NotSupported extends React.Component {
     render() {
         return (
@@ -247,7 +255,7 @@ class AddMachine extends React.Component {
         const title = this.state.old_machine ? _("Edit host") : _("Add new host");
         const submitText = this.state.old_machine ? _("Set") : _("Add");
 
-        const body = <Form isHorizontal>
+        const body = <Form isHorizontal onSubmit={prevent_default(callback)}>
             <FormGroup label={_("Host")}>
                 <TextInput id="add-machine-address" onChange={(_event, address) => this.setState({ address })}
                         validated={this.state.addressError ? "error" : "default"} onBlur={this.onAddressChange}
@@ -357,7 +365,7 @@ class MachinePort extends React.Component {
                 <span>{cockpit.format(_("Unable to contact $0."), this.props.full_address)}</span>
                 <span>{_("Is sshd running on a different port?")}</span>
             </p>
-            <Form isHorizontal>
+            <Form isHorizontal onSubmit={prevent_default(callback)}>
                 <FormGroup label={_("Port")}>
                     <TextInput id="edit-machine-port" onChange={(_event, value) => this.setState({ port: value })} />
                 </FormGroup>
@@ -823,7 +831,7 @@ class ChangeAuth extends React.Component {
             {statement}
             <br />
             {(offer_login_password || offer_key_password) &&
-                <Form isHorizontal>
+                <Form isHorizontal onSubmit={prevent_default(callback)}>
                     {both &&
                         <FormGroup label={_("Authentication")} isInline hasNoPaddingTop>
                             <Radio isChecked={this.state.auth === "password"}

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -669,7 +669,9 @@ class TestMultiMachine(testlib.MachineCase):
         b.click('#hosts_setup_server_dialog button:contains(Accept key and connect)')
         b.wait_in_text('#hosts_setup_server_dialog', "Unable to log in")
         b.set_input_text('#login-custom-password', "foobar")
-        b.click('#hosts_setup_server_dialog button:contains(Log in)')
+        # Submit the dialog with Enter instead of clicking the Login button, for variety
+        b.focus("#login-custom-password")
+        b.key_press("\r")
         b.wait_not_present('#hosts_setup_server_dialog')
 
         # Reconnect


### PR DESCRIPTION
Without handling this explicitly, a form submit event will reload the page.  This is very confusing when hitting enter in the login dialog for a remote host.

Fixes #18653