### PR TITLE
tools: drop perl-json/perl-locale-po from depends as well

### DIFF
--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -48,7 +48,7 @@ build() {
 }
 
 package_cockpit() {
-  depends=(krb5 libssh accountsservice perl-json perl-locale-po json-glib glib-networking python)
+  depends=(krb5 libssh json-glib glib-networking python)
   backup=('etc/pam.d/cockpit')
   optdepends=("cockpit-pcp: reading performance metrics"
               "cockpit-podman: user interface for managing podman containers"


### PR DESCRIPTION
In 344705aeec1530d9d09b we dropped the makedepends, but there where runtime dependencies as well which we forgot to drop.

---

It really is Monday.. :) Let's trigger this with the image-refresh to validate it's kosher.