### PR TITLE
test: Increase timeout for insights-client --register

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -891,7 +891,7 @@ password=foobar
         b.wait_text(".system-health-insights a", "Not connected to Insights")
 
         # Enable insights, results should appear automatically
-        m.execute("insights-client --register")
+        m.execute("insights-client --register", timeout=180)
         self.addCleanup(m.execute, "insights-client --unregister")
         with b.wait_timeout(60):
             b.wait_in_text(".system-health-insights a", "3 hits, including important")


### PR DESCRIPTION
One minute is often too tight, causing timeouts.

----

See [failed test](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19011-20230626-181027-a9a8fe4a-rhel-9-3-other/log.html#109)