### PR TITLE
test: Fix shebang in TestUpdates.testKpatch

### DIFF
--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -186,8 +186,7 @@ class TestUpdates(NoSubManCase):
         # To make sure it has the same structure as we expect it to be first check the real command
         self.assertEqual(m.execute("kpatch list"), "Loaded patch modules:\n\nInstalled patch modules:\n")
 
-        kpatch = """
-#!/bin/bash
+        kpatch = """#!/bin/bash
 echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled patch modules:\nkpatch_3_10_0_1062_1_1 (3.10.0-1062.el7.x86_64)"
 """
 


### PR DESCRIPTION
The initial empty line in the mocked /usr/local/bin/kpatch causes execve() to fail with `ENOEXEC` "Exec format error". The shell and the C bridge paper over this by falling back to interpreting the file as a shell script, but Python's subprocess gives up at this point.

----

Fixes [TestUpdates.testKpatch](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19011-20230626-181028-a9a8fe4a-rhel-9-3-expensive/log.html#11-2) with the Python bridge. That runs only on RHEL, so we didn't see it yet. Spotted in #19011