### PR TITLE
test: Drop locale change check from TestPages.testBasic

### DIFF
--- a/test/verify/check-pages
+++ b/test/verify/check-pages
@@ -252,7 +252,7 @@ OnCalendar=daily
         b.wait_text("#password-group > label", "Passwort")
 
         # Test all languages
-        # Test that pages do not oops and that locale is valid
+        # Test that pages do not oops
 
         if not m.image.startswith("rhel-"):
             return
@@ -270,6 +270,8 @@ OnCalendar=daily
         self.assertIn('en-us', languages)
         b.click("#display-language-modal footer button.pf-m-link")  # Close the menu
 
+        is_pybridge = self.is_pybridge()
+
         for language in languages:
             # Remove failed units which will show up in the first terminal line
             m.execute("systemctl reset-failed")
@@ -282,21 +284,22 @@ OnCalendar=daily
             b.click("#display-language-modal footer button.pf-m-primary")
             b.wait_language(language)
 
-            # Test some pages, end up in terminal
+            # Test some pages
             for page in pages:
                 b.go(page)
                 b.enter_page(page)
                 b.wait_language(language)
 
-            locale = language.split("-")
-            if len(locale) == 1:
-                locale.append("")
-            locale = f"{locale[0]}_{locale[1].upper()}.UTF-8"
+            if not is_pybridge:
+                locale = language.split("-")
+                if len(locale) == 1:
+                    locale.append("")
+                locale = f"{locale[0]}_{locale[1].upper()}.UTF-8"
 
-            b.wait_visible(".terminal .xterm-accessibility-tree")
-            b.wait_in_text(line_sel(1), "admin")
-            b.key_press("echo $LANG\r")
-            b.wait_in_text(line_sel(2), locale)
+                b.wait_visible(".terminal .xterm-accessibility-tree")
+                b.wait_in_text(line_sel(1), "admin")
+                b.key_press("echo $LANG\r")
+                b.wait_in_text(line_sel(2), locale)
 
             b.switch_to_top()
 


### PR DESCRIPTION
The Python bridge does not dynamically change its locale from `Accept-Languages:`, but just defaults to the standard environment of the logged in machine.

We decided to not reimplement this in the pybridge, as that is weird, error prone, and a corner case: No other Linux command line software does that, it won't change the locale of existing running programs which got spawned before changing the language (as that's impossible), the code was making assumptions about locale names and availability, and we take very little human readable text directly from command-line programs, most of it gets interpreted, formatted, and translated in the UI.

----

Spotted in PR #19011 with [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19011-20230626-181028-a9a8fe4a-rhel-9-3-expensive/log.html#23-2).