### PR TITLE
pybridge: Fix ssh-agent launching

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -210,7 +210,7 @@ def start_ssh_agent() -> None:
     # Launch the agent so that it goes down with us on EOF; PDEATHSIG would be more robust,
     # but it gets cleared on setgid ssh-agent, which some distros still do
     try:
-        proc = subprocess.Popen(['ssh-agent', 'sh', '-ec', 'echo $SSH_AUTH_SOCK; read a'],
+        proc = subprocess.Popen(['ssh-agent', 'sh', '-ec', 'echo SSH_AUTH_SOCK=$SSH_AUTH_SOCK; read a'],
                                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
         assert proc.stdout is not None
 
@@ -223,6 +223,7 @@ def start_ssh_agent() -> None:
                 break
         else:
             proc.terminate()
+            proc.wait()
 
     except FileNotFoundError:
         logger.debug("Couldn't start ssh-agent (FileNotFoundError)")


### PR DESCRIPTION
Commit b7895b8e8e broke the agent spawned by the bridge. This is only exercised on our CoreOS images, for which we don't yet run pybridge tests; the other integration tests just make sure that it gets cleaned up after logout, which was still the case.

The parsing code relies on the format `SSH_AUTH_SOCK=/path`, which the shell command did not previously provide; fix that. We could also simplify the parsing instead to just read the sole path from stdout, but the `NAME=` format provides an additional assertion that we are not just reading some unrelated gibberish from the command.

On failure, clean up the terminated process to avoid the zombie sticking around.

----


See https://github.com/cockpit-project/cockpit/pull/19009#issuecomment-1608807887 -- this fixes some failures in [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19009-20230625-094858-4674125e-fedora-coreos-other/log.html) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19009-20230625-091951-4674125e-fedora-coreos-expensive/log.html) scenario. I'll trigger an extra fedora-coreos/pybridge-other scenario here (because we can! :wink: ) --  that will still fail check-system-info until PR #19025 lands, but at least check-shell-keys should succeed.

