### PR TITLE
pybridge: Don't scan packages in the --privileged bridge

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -86,6 +86,8 @@ class Bridge(Router, PackagesListener):
                 }
             ])
             self.packages = None
+        elif args.privileged:
+            self.packages = None
         else:
             self.packages = Packages(self)
             self.internal_bus.export('/packages', self.packages)

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -164,7 +164,7 @@ async def verify_root_bridge_running(bridge, transport):
 
     # verify that the bridge thinks that it's the root bridge
     await transport.assert_bus_props('/superuser', 'cockpit.Superuser',
-                                     {'Bridges': bridge.superuser_bridges, 'Current': 'root'}, bus=root_dbus)
+                                     {'Bridges': [], 'Current': 'root'}, bus=root_dbus)
 
     # close up
     await transport.check_close(channel=root_dbus)


### PR DESCRIPTION
The UI never retrieves package data from the privileged instance, so this is just a waste of time, and moreover, RAM: Currently, the bridge keeps all package files in memory. We need to fix that, but at least stop from having them twice.