### PR TITLE
Debian: Fix reproducible build, some lintian updates

### DIFF
--- a/tools/debian/cockpit-doc.lintian-overrides
+++ b/tools/debian/cockpit-doc.lintian-overrides
@@ -1,0 +1,2 @@
+cockpit-doc: font-in-non-font-package *usr/share/doc/cockpit/guide/*
+cockpit-doc: font-outside-font-dir *usr/share/doc/cockpit/guide/*

--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -1,3 +1,4 @@
 # this is just an empty stub to avoid breaking existing PAM files
 cockpit-ws: shared-library-lacks-prerequisites *security/pam_cockpit_cert.so*
+cockpit-ws: font-outside-font-dir *usr/share/cockpit/static/fonts/*
 cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*

--- a/tools/debian/control
+++ b/tools/debian/control
@@ -109,8 +109,9 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${source:Version}),
          packagekit,
          python3,
-Description: Cockpit user interface for packages
- The Cockpit component for installing packages, via PackageKit.
+Description: Cockpit user interface for apps and package updates
+ The Cockpit components installing OS updates and Cockpit add-ons,
+ via PackageKit.
 
 Package: cockpit-storaged
 Architecture: all

--- a/tools/debian/copyright.template
+++ b/tools/debian/copyright.template
@@ -106,35 +106,6 @@ License: GPL-2+
  On Debian systems, the complete text of the GNU General
  Public License can be found in "/usr/share/common-licenses/GPL-2".
 
-License: BSD-3-clause
- Redistribution and use in source and binary forms, with or without
- modification, are permitted provided that the following conditions
- are met:
- .
-     * Redistributions of source code must retain the above
-       copyright notice, this list of conditions and the
-       following disclaimer.
-     * Redistributions in binary form must reproduce the
-       above copyright notice, this list of conditions and
-       the following disclaimer in the documentation and/or
-       other materials provided with the distribution.
-     * The names of contributors to this software may not be
-       used to endorse or promote products derived from this
-       software without specific prior written permission.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
- OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
- THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
- DAMAGE.
-
 License: BSD-4-clause
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -58,6 +58,8 @@ override_dh_install:
 
 	dh_install -Xusr/src/debug
 ifeq ($(C_BRIDGE),)
+	# we don't need this, it contains full build paths and breaks reproducibility
+	rm -r debian/tmp/usr/lib/python*/*-packages/*.dist-info
 	dh_install -p cockpit-bridge debian/tmp/usr/lib/python*
 endif
 


### PR DESCRIPTION
Shipping the pybridge broke reproducibility, see https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/cockpit.html