### PR TITLE
pybridge: Fix cockpit_Machines directory lookup

### DIFF
--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -124,7 +124,7 @@ class cockpit_Machines(bus.Object):
         self.notify()
 
     def __init__(self):
-        self.path = config.lookup_config('/machines.d')
+        self.path = config.lookup_config('machines.d')
         self.loop = asyncio.get_running_loop()
 
         # ignore the first callback


### PR DESCRIPTION
lookup_config() must be called with a relative path, as otherwise joining some "/etc/.." prefix to the given value always results in the value itself, due to how path joining works. That led to trying to write the config into the nonexisting /machines.d/ directory, breaking a lot of TestMultiMachine tests on CoreOS with the Python bridge.

---

Broken out from #19009 and tested there on coreos.