### PR TITLE
test: Switch check-client from "only" to a "skip" list

### DIFF
--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -21,7 +21,10 @@ import testlib
 
 
 # Run this on more OSes as we roll out the pybridge
-@testlib.onlyImage("needs pybridge", "debian-testing", "ubuntu-stable")
+@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "fedora-37", "fedora-38",
+                   "rhel-8*", "centos-8*", "rhel-9*", "centos-9*")
+# enable this once our cockpit/ws container can beiboot
+@testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):
 
     provision = {


### PR DESCRIPTION
This is more robust and explicit. This also enables the test on arch, which runs the Python bridge now.