### PR TITLE
systemd, tls: Robustify cockpit-certificate-helper ipa cleanup

### DIFF
--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -187,6 +187,12 @@ export class RealmdClient {
         if (cockpit.transport.host !== "localhost")
             return Promise.resolve();
 
+        const server_sw = find_detail(realm, "server-software");
+        if (server_sw !== "ipa") {
+            console.log("cleaning up ws credentials not supported for server software", server_sw);
+            return Promise.resolve();
+        }
+
         const kerberos = this.dbus_realmd.proxy(KERBEROS, realm.path);
         return kerberos.wait()
                 .then(() => {

--- a/src/tls/cockpit-certificate-helper.in
+++ b/src/tls/cockpit-certificate-helper.in
@@ -114,9 +114,11 @@ cmd_ipa_cleanup() {
     fi
 
     # clean up certificate; support both "copy" and "direct" modes from cmd_ipa_request()
-    rm "${COCKPIT_WS_CERTS_D}/10-ipa.cert" "${COCKPIT_WS_CERTS_D}/10-ipa.key"
-    ipa-getcert stop-tracking -f "${COCKPIT_WS_CERTS_D}/10-ipa.cert" -k "${COCKPIT_WS_CERTS_D}/10-ipa.key" || \
-        ipa-getcert stop-tracking -f /run/cockpit/certificate-helper/10-ipa.cert -k /run/cockpit/certificate-helper/10-ipa.key
+    if [ -e "${COCKPIT_WS_CERTS_D}/10-ipa.key" ]; then
+        rm "${COCKPIT_WS_CERTS_D}/10-ipa.cert" "${COCKPIT_WS_CERTS_D}/10-ipa.key"
+        ipa-getcert stop-tracking -f "${COCKPIT_WS_CERTS_D}/10-ipa.cert" -k "${COCKPIT_WS_CERTS_D}/10-ipa.key" || \
+            ipa-getcert stop-tracking -f /run/cockpit/certificate-helper/10-ipa.cert -k /run/cockpit/certificate-helper/10-ipa.key
+    fi
 }
 
 cmd_ipa() {


### PR DESCRIPTION
Don't try to clean up IPA credentials on non-IPA domains. It's a bit of a mystery how that ever worked, as `cockpit-certificate-helper ipa cleanup` was failing reliably due to the nonexisting key file. Use the same check as when joining the domain.

For belt-and-suspenders, and also to avoid failing when the admin manually removed the certificate after joining, also robustify the helper to only remove and untrack the certificate if it actually exists.

---

Fixes [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19011-20230628-083244-bfadd600-rhel-9-3-networking/log.html). This is straight out of the "WTH??" category, how was this not a plain failure all the time? :thinking: 