### PR TITLE
systemd: Fix journalctl follow invocation race

### DIFF
--- a/pkg/lib/journal.js
+++ b/pkg/lib/journal.js
@@ -200,6 +200,7 @@ journal.journalctl = function journalctl(/* ... */) {
     };
     promise.stop = function stop() {
         streamers = [];
+        promise.stopped = true;
         proc.close("cancelled");
     };
     return promise;

--- a/pkg/systemd/logsJournal.jsx
+++ b/pkg/systemd/logsJournal.jsx
@@ -137,7 +137,7 @@ export class JournalBox extends React.Component {
                 .done(() => {
                     this.setState({ streamFinished: true });
 
-                    if (!last) {
+                    if (!last && !promise.stopped) {
                         const journalctlOptions = {
                             boot,
                             count: 0,

--- a/test/verify/check-system-journal
+++ b/test/verify/check-system-journal
@@ -75,7 +75,6 @@ class TestJournal(testlib.MachineCase):
 
     def testBasic(self):
         b = self.browser
-        b.wait_timeout(120)
 
         m = self.machine
 
@@ -189,8 +188,9 @@ ExecStart=/bin/sh -c 'sleep 5; for s in $(seq 10); do echo SLOW; sleep 0.1; done
             else:
                 stop_message = "Succeeded."
 
-            wait_log_lines([["systemd", "slow10.service: " + stop_message, ""], ["sh", "SLOW", "10"],
-                            ["systemd", "Started.*Slowly log 10 identical lines.", ""]])
+            with b.wait_timeout(30):
+                wait_log_lines([["systemd", "slow10.service: " + stop_message, ""], ["sh", "SLOW", "10"],
+                                ["systemd", "Started.*Slowly log 10 identical lines.", ""]])
 
         def wait_log_present(message):
             b.wait_visible(f"#journal-box .cockpit-logline .cockpit-log-message:contains('{message}')")


### PR DESCRIPTION
When the filter gets changed while the initial non-following journalctl
runs, that runs updateQuery with new options. That will first stop all
previous journalctls. However, that will still call the `.done()`
handler for that initial journalctl query, and happily go on with
starting the subsequent journalctl in following mode. This results in
two journalctls running at the same time, leading to duplicated entries.

To fix that, add a `stopped` flag to the returned journalctl object, and
don't start the following journalctl if it's set.

Fixes #18976

-----

This fixes the [TestJournal.testRebootAndTime() flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19009-20230628-103340-4195a080-fedora-38-other/log.html#126-2). See #18976 for the gory details. This now locally survived two parallel runs of

    for i in `seq 10`; do TEST_ALLOW_JOURNAL_MESSAGES='.*avc.*' test/verify/check-system-journal TestJournal.testRebootAndTime || break; done
 
on a fedora-38 pybridge image.