### PR TITLE
test: Make pybridge initial superuser behavior official

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -867,17 +867,15 @@ class Browser:
 
         self.open_superuser_dialog()
 
-        pf_prefix = "" if self.machine.system_before(293) else "-v5"
-
         if passwordless:
-            self.wait_in_text(f".pf{pf_prefix}-c-modal-box:contains('Administrative access')", "You now have administrative access.")
-            self.click(f".pf{pf_prefix}-c-modal-box button:contains('Close')")
-            self.wait_not_present(f".pf{pf_prefix}-c-modal-box:contains('You now have administrative access.')")
+            self.wait_in_text("div[role=dialog]:contains('Administrative access')", "You now have administrative access.")
+            self.click("div[role=dialog] button:contains('Close')")
+            self.wait_not_present("div[role=dialog]:contains('You now have administrative access.')")
         else:
-            self.wait_in_text(f".pf{pf_prefix}-c-modal-box:contains('Switch to administrative access')", f"Password for {user or 'admin'}:")
-            self.set_input_text(f".pf{pf_prefix}-c-modal-box:contains('Switch to administrative access') input", password or "foobar")
-            self.click(f".pf{pf_prefix}-c-modal-box button:contains('Authenticate')")
-            self.wait_not_present(f".pf{pf_prefix}-c-modal-box:contains('Switch to administrative access')")
+            self.wait_in_text("div[role=dialog]:contains('Switch to administrative access')", f"Password for {user or 'admin'}:")
+            self.set_input_text("div[role=dialog]:contains('Switch to administrative access') input", password or "foobar")
+            self.click("div[role=dialog] button:contains('Authenticate')")
+            self.wait_not_present("div[role=dialog]:contains('Switch to administrative access')")
 
         self.check_superuser_indicator("Administrative access")
         self.switch_to_frame(cur_frame)
@@ -886,11 +884,9 @@ class Browser:
         cur_frame = self.cdp.cur_frame
         self.switch_to_top()
 
-        pf_prefix = "" if self.machine.system_before(293) else "-v5"
-
         self.open_superuser_dialog()
-        self.click(f".pf{pf_prefix}-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
-        self.wait_not_present(f".pf{pf_prefix}-c-modal-box:contains('Switch to limited access')")
+        self.click("div[role=dialog]:contains('Switch to limited access') button:contains('Limit access')")
+        self.wait_not_present("div[role=dialog]:contains('Switch to limited access')")
         self.check_superuser_indicator("Limited access")
 
         self.switch_to_frame(cur_frame)

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -411,7 +411,6 @@ class TestSuperuserOldWebserver(testlib.MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @testlib.todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machine
@@ -438,13 +437,33 @@ class TestSuperuserOldWebserver(testlib.MachineCase):
         b.click('#login-button')
         b.wait_visible('#content')
 
-        # We should have gotten the password from the old cockpit-ws and it should work
-        b.check_superuser_indicator("Administrative access")
-        b.go("/playground/test")
-        b.enter_page("/playground/test")
-        b.click(".super-channel button")
-        b.wait_in_text(".super-channel span", 'result: ')
-        self.assertIn('result: uid=0', b.text(".super-channel span"))
+        if not self.is_pybridge():
+            # The C bridge will recognize that it is being started by
+            # a old webserver (or old bridge) and will start "any"
+            # privileged bridge during startup.
+            b.check_superuser_indicator("Administrative access")
+            b.go("/playground/test")
+            b.enter_page("/playground/test")
+            b.click(".super-channel button")
+            b.wait_in_text(".super-channel span", 'result: ')
+            self.assertIn('result: uid=0', b.text(".super-channel span"))
+
+        else:
+            # The Python bridge will not start any privileged bridge
+            # if not explicitly told, and a old webserver (or old
+            # bridge) does not tell it anything.
+            b.check_superuser_indicator("Limited access")
+            b.go("/playground/test")
+            b.enter_page("/playground/test")
+            b.click(".super-channel button")
+            b.wait_in_text(".super-channel span", 'access-denied')
+
+            b.become_superuser()
+            b.go("/playground/test")
+            b.enter_page("/playground/test")
+            b.click(".super-channel button")
+            b.wait_in_text(".super-channel span", 'result: ')
+            self.assertIn('result: uid=0', b.text(".super-channel span"))
 
     def testNotAuth(self):
         b = self.browser
@@ -565,7 +584,6 @@ class TestSuperuserOldDashboard(testlib.MachineCase):
         "machine2": {"address": "10.111.113.2/20", "memory_mb": 512},
     }
 
-    @testlib.todoPybridge(reason="https://github.com/cockpit-project/cockpit/issues/18712")
     def test(self):
         b = self.browser
         m = self.machines["machine1"]
@@ -597,29 +615,50 @@ class TestSuperuserOldDashboard(testlib.MachineCase):
 
         # There should be a superuser button in the Overview of machine2
 
-        b.enter_page("/system", host="10.111.113.2")
-        b.click(".ct-overview-header-actions button:contains('Administrative access')")
-        b.click(".pf-v5-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
-        b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to limited access')")
-        b.wait_visible(".ct-overview-header-actions button:contains('Limited access')")
-        b.go("/@10.111.113.2/playground/test")
-        b.enter_page("/playground/test", host="10.111.113.2")
-        b.click(".super-channel button")
-        b.wait_in_text(".super-channel span", 'access-denied')
+        def get_admin():
+            b.go("/@10.111.113.2")
+            b.enter_page("/system", host="10.111.113.2")
+            b.click(".ct-overview-header-actions button:contains('Limited access')")
+            b.wait_in_text(".pf-v5-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
+            b.set_input_text(".pf-v5-c-modal-box:contains('Switch to administrative access') input", "foobar")
+            b.click(".pf-v5-c-modal-box button:contains('Authenticate')")
+            b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to administrative access')")
+            b.wait_visible(".ct-overview-header-actions button:contains('Administrative access')")
+            b.go("/@10.111.113.2/playground/test")
+            b.enter_page("/playground/test", host="10.111.113.2")
+            b.click(".super-channel button")
+            b.wait_in_text(".super-channel span", 'result: ')
+            self.assertIn('result: uid=0', b.text(".super-channel span"))
 
-        b.go("/@10.111.113.2")
-        b.enter_page("/system", host="10.111.113.2")
-        b.click(".ct-overview-header-actions button:contains('Limited access')")
-        b.wait_in_text(".pf-v5-c-modal-box:contains('Switch to administrative access')", "Password for admin:")
-        b.set_input_text(".pf-v5-c-modal-box:contains('Switch to administrative access') input", "foobar")
-        b.click(".pf-v5-c-modal-box button:contains('Authenticate')")
-        b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to administrative access')")
-        b.wait_visible(".ct-overview-header-actions button:contains('Administrative access')")
-        b.go("/@10.111.113.2/playground/test")
-        b.enter_page("/playground/test", host="10.111.113.2")
-        b.click(".super-channel button")
-        b.wait_in_text(".super-channel span", 'result: ')
-        self.assertIn('result: uid=0', b.text(".super-channel span"))
+        def drop_admin():
+            b.go("/@10.111.113.2")
+            b.enter_page("/system", host="10.111.113.2")
+            b.click(".ct-overview-header-actions button:contains('Administrative access')")
+            b.click(".pf-v5-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
+            b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to limited access')")
+            b.wait_visible(".ct-overview-header-actions button:contains('Limited access')")
+            b.go("/@10.111.113.2/playground/test")
+            b.enter_page("/playground/test", host="10.111.113.2")
+            b.click(".super-channel button")
+            b.wait_in_text(".super-channel span", 'access-denied')
+
+        if not self.is_pybridge():
+            # The C bridge will recognize that it is being started by
+            # a old bridge (or old webserver) and will start "any"
+            # privileged bridge during startup.  So we have admin at
+            # this point.
+            #
+            drop_admin()
+            get_admin()
+
+        else:
+            # The Python bridge will not start any privileged bridge
+            # if not explicitly told, and a old bridge (or old
+            # webserver) does not tell it anything.  So we don't have
+            # admin at this point.
+            #
+            get_admin()
+            drop_admin()
 
 
 @testlib.skipDistroPackage()


### PR DESCRIPTION
The pybridge will only start a privileged bridge during startup when explicitly instructed in the "init" message.  This is now the officially correct behavior, although it differs from what the C bridge did.

Replaces #18984 