### PR TITLE
verify/check-client: skip fedora-testing also

### DIFF
--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -22,7 +22,7 @@ import testlib
 
 # Run this on more OSes as we roll out the pybridge
 @testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "fedora-37", "fedora-38",
-                   "rhel-8*", "centos-8*", "rhel-9*", "centos-9*")
+                   "fedora-testing", "rhel-8*", "centos-8*", "rhel-9*", "centos-9*")
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):


### PR DESCRIPTION
fedora-testing is Fedora 38 and doesn't get the Python bridge installed, which means we can't do the beiboot test with it yet.  Add `fedora-testing` to the skip list.