### PR TITLE
pybridge: Catch OSError in http channel

### DIFF
--- a/src/cockpit/channels/http.py
+++ b/src/cockpit/channels/http.py
@@ -114,7 +114,7 @@ class HttpChannel(Channel):
                 command='response', status=response.status, reason=response.reason,
                 headers=self.parse_headers(response.headers)))
             self.read_send_response(response)
-        except http.client.HTTPException as error:
+        except (http.client.HTTPException, OSError) as error:
             msg = str(error)
             logger.debug('HTTP reading response failed: %s', msg)
             self.loop.call_soon_threadsafe(lambda: self.close(problem='terminated', message=msg))


### PR DESCRIPTION
When a socket goes down underneath a HTTP channel, depending on the
timing this could result in either a `ConnectionRefusedError` (which
http.client intercepts and wraps), or a `ConnectionResetError` (which
isn't wrapped). For the channel these should both end in the same
"terminated" error code, instead of crashing the task.

Reduce assumptions and make this robust by catching all `OSError`s.

---

This leads to [pybridge crashes in c-podman](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1322-20230703-042644-64a79ae1-fedora-38-pybridge/log.html#21), see https://github.com/cockpit-project/cockpit-podman/pull/1322