### PR TITLE
test: don't run testMultipleBridgeConfig in networking scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -12,7 +12,7 @@ PREPARE_OPTS=""
 RUN_OPTS=""
 ALL_TESTS="$(test/common/run-tests --test-dir test/verify -l)"
 
-RE_NETWORKING='Networking|Bonding|Bridge|Firewall|Team|IPA|AD'
+RE_NETWORKING='Networking|Bonding|TestBridge|Firewall|Team|IPA|AD'
 RE_STORAGE='Storage'
 RE_EXPENSIVE='HostSwitching|MultiMachine|Updates|Superuser|Kdump|Pages'
 


### PR DESCRIPTION
Bridge matches more then just networking tests but also testMultipleBridgeConfig of superuser which is also run in the expensive scenario.

I've only triggered the fedora-38 tests as this is mostly logic. This now excludes the following tests from networking:

```
TestClient.testBeibootNoBridge
TestClient.testBeibootWithBridge
TestSuperuser.testBrokenBridgeConfig
TestSuperuser.testMultipleBridgeConfig
TestSuperuser.testRemoveBridgeConfig
TestSuperuser.testSingleLabelBridgeConfig
```