### PR TITLE
client: disable DBusActivatable=true in desktop file

### DIFF
--- a/src/client/org.cockpit_project.CockpitClient.desktop
+++ b/src/client/org.cockpit_project.CockpitClient.desktop
@@ -3,6 +3,5 @@ Type=Application
 Name=Cockpit Client
 Comment=Connect via ssh to servers running Cockpit
 Icon=cockpit-client
-DBusActivatable=true
 Exec=cockpit-client
 Categories=Network;RemoteAccess


### PR DESCRIPTION
This doesn't seem to be particularly well supported in all flatpak environments, particularly under KDE.

Fixes https://github.com/flathub/org.cockpit_project.CockpitClient/issues/29