### PR TITLE
python bridge: rewrite packages.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Makefile.in
 # toplevel (/...)
 /*.list
 /.coverage
+/.tox
 /Coverage
 /aclocal.m4
 /autom4te.cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,12 @@ max-line-length = 118
 disable = [
   "C0114",  # Missing module docstring
   "C0115",  # Missing class docstring
+  "C0116",  # Missing function or method docstring
   "R0902",  # Too many instance attributes
   "R0903",  # Too few public methods
   "R0913",  # Too many arguments
   "R1705",  # Unnecessary "else" after "return"
+  "W0120",  # Else clause on loop without a break statement
   "W1113",  # Keyword argument before variable positional arguments  (PEP-570 is Python 3.8)
 ]
 
@@ -58,6 +60,7 @@ ignore = [
     "E731",  # Do not assign a `lambda` expression, use a `def`
     "PT011", # `pytest.raises(OSError)` is too broad
     "RUF012", # Mutable class attributes should be annotated with `typing.ClassVar`
+    "TCH001", # Move application import into a type-checking block
 ]
 line-length = 118
 src = []

--- a/src/build_backend.py
+++ b/src/build_backend.py
@@ -11,7 +11,8 @@ from typing import Dict, Iterable, Optional
 
 from cockpit import __version__
 
-PACKAGE = f'cockpit-{__version__}'
+VERSION = __version__ or '0'
+PACKAGE = f'cockpit-{VERSION}'
 TAG = 'py3-none-any'
 
 
@@ -65,7 +66,7 @@ def build_wheel(wheel_directory: str,
         'METADATA': [
             'Metadata-Version: 2.1',
             'Name: cockpit',
-            f'Version: {__version__}',
+            f'Version: {VERSION}',
         ],
         'entry_points.txt': [
             '[console_scripts]',

--- a/src/client/cockpit-beiboot
+++ b/src/client/cockpit-beiboot
@@ -21,7 +21,6 @@ import argparse
 import asyncio
 import base64
 import importlib.resources
-import json
 import logging
 import os
 import shlex
@@ -36,7 +35,7 @@ from cockpit.beipack import BridgeBeibootHelper
 from cockpit.bridge import setup_logging
 from cockpit.channel import ChannelRoutingRule
 from cockpit.channels import PackagesChannel
-from cockpit.packages import Package, Packages
+from cockpit.packages import Packages, PackagesLoader
 from cockpit.peer import Peer
 from cockpit.protocol import CockpitProblem
 from cockpit.router import Router, RoutingRule
@@ -73,41 +72,37 @@ def ensure_ferny_askpass() -> Path:
     return dest_path
 
 
-def get_xdg_data_dirs():
-    try:
-        yield os.environ['XDG_DATA_HOME']
-    except KeyError:
-        yield os.path.expanduser('~/.local/share')
-
-    try:
-        yield from os.environ['XDG_DATA_DIRS'].split(':')
-    except KeyError:
-        yield from ('/usr/local/share', '/usr/share')
-
-
 def get_interesting_files() -> Iterable[str]:
-    for datadir in get_xdg_data_dirs():
-        logger.debug("Scanning for manifest files under %s", datadir)
-        for file in Path(datadir).glob('cockpit/*/manifest.json'):
-            logger.debug("Considering file %s", file)
-            try:
-                manifest = json.loads(file.read_text())
-            except json.JSONDecodeError as exc:
-                logger.error("%s: %s", file, exc)
-                continue
-            if not isinstance(manifest, dict):
-                logger.error("%s: json document isn't an object", file)
-                continue
+    for candidate in PackagesLoader.load_candidates():
+        try:
+            conditions = candidate.manifest['conditions']
+        except KeyError:
+            continue
 
-            try:
-                conditions = manifest['conditions']
-            except KeyError:
-                continue
+        assert isinstance(conditions, list)
+        for condition in conditions:
+            assert isinstance(condition, dict)
+            for key, value in condition.items():
+                if key in ['path-exists', 'path-not-exists']:
+                    yield value
 
-            for condition in conditions:
-                for key, value in condition.items():
-                    if key in ['path-exists', 'path-not-exists']:
-                        yield value
+
+class ProxyPackagesLoader(PackagesLoader):
+    file_status: Dict[str, bool]
+
+    def check_condition(self, condition: str, value: object) -> bool:
+        assert isinstance(value, str)
+        assert value in self.file_status
+
+        if condition == 'path-exists':
+            return self.file_status[value]
+        elif condition == 'path-not-exists':
+            return not self.file_status[value]
+        else:
+            raise KeyError
+
+    def __init__(self, file_status: Dict[str, bool]):
+        self.file_status = file_status
 
 
 BEIBOOT_GADGETS = {
@@ -176,13 +171,7 @@ class AuthorizeResponder(ferny.InteractionResponder):
 
         if command == 'cockpit.report-exists':
             file_status, = args
-            # Constructed to throw KeyError if an unexpected file is requested
-            # HACK:  ...please don't look at this code...
-            Package.CONDITIONS = {
-                'path-exists': lambda filename: file_status[filename],
-                'path-not-exists': lambda filename: not file_status[filename],
-            }
-            self.router.packages = Packages()  # type: ignore[attr-defined]
+            self.router.packages = Packages(loader=ProxyPackagesLoader(file_status))
             self.router.routing_rules.insert(0, ChannelRoutingRule(self.router, [PackagesChannel]))
 
 

--- a/src/cockpit/_version.py
+++ b/src/cockpit/_version.py
@@ -1,2 +1,5 @@
 # This file is only in git.  It gets replaced by `make dist`.
-__version__ = '0'
+
+from typing import Optional
+
+__version__: Optional[str] = None

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -121,17 +121,15 @@ class Bridge(Router, PackagesListener):
             self.superuser_rule.init(superuser)
 
     def do_send_init(self) -> None:
-        if self.packages is not None:
-            packages_info = {
-                'checksum': self.packages.checksum,
-                'packages': {p: None for p in self.packages.packages}
-            }
-        else:
-            packages_info = {}
+        init_args = {
+            'capabilities': {'explicit-superuser': True},
+            'os-release': self.get_os_release(),
+        }
 
-        self.write_control(command='init', version=1, **packages_info,
-                           os_release=self.get_os_release(),
-                           capabilities={'explicit-superuser': True})
+        if self.packages is not None:
+            init_args['packages'] = {p: None for p in self.packages.packages}
+
+        self.write_control(command='init', version=1, **init_args)
 
     # PackagesListener interface
     def packages_loaded(self):

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -324,7 +324,6 @@ class Package:
             data, (content_type, encoding) = self.files[path]
 
         headers = {
-            "Access-Control-Allow-Origin": channel.origin,
             "Content-Encoding": encoding,
         }
         if content_type is not None and content_type.startswith('text/html'):

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -15,10 +15,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
 import collections
+import contextlib
+import functools
 import gzip
-import hashlib
 import json
 import logging
 import mimetypes
@@ -26,122 +26,39 @@ import os
 import re
 import shutil
 from pathlib import Path
-from typing import Callable, ClassVar, Dict, List, Optional, Pattern, Tuple
+from typing import Callable, ClassVar, Dict, Iterable, List, NamedTuple, Optional, Pattern, Tuple, TypeVar, Union
 
 from cockpit._vendor.systemd_ctypes import bus
 
 from . import config
+from ._version import __version__
 
-VERSION = '300'
 logger = logging.getLogger(__name__)
 
+JsonList = List['JsonDocument']
+JsonObject = Dict[str, 'JsonDocument']
+JsonLiteral = Union[str, float, bool, None]
+JsonDocument = Union[JsonObject, JsonList, JsonLiteral]
 
-# An entity to serve is a set of bytes plus a content-type/content-encoding pair
-Entity = Tuple[bytes, Tuple[Optional[str], Optional[str]]]
-Entities = Dict[str, Entity]
-
-
-# Sorting is important because the checksums are dependent on the order we
-# visit these.  This is not the same as sorting on the full pathname, since
-# each directory component is considered separately.  We could split the path
-# and sort on that, but it ends up not being particularly elegant.
-# Changing the approach here will change the checksum.
-# We're allowed to change it as we wish, but let's try to match behaviour with
-# cockpitpackages.c for the time being, since the unit tests depend on it.
-def directory_items(path):
-    return sorted(path.iterdir(), key=lambda item: item.name)
+# HACK: Type narrowing over Union types is not supported in the general case,
+# but this works for the case we care about: knowing that when we pass in an
+# JsonObject, we'll get an JsonObject back.
+J = TypeVar('J', JsonObject, JsonDocument)
 
 
-# HACK: We eventually want to get rid of all ${libexecdir} in manifests:
-# - rewrite cockpit-{ssh,pcp} in Python and import them as module instead of exec'ing
-# - rewrite cockpit-askpass in Python and write it into a temporary file
-# - bundle helper shell scripts
-# Until then, we need this libexecdir detection hack.
-LIBEXECDIR = None
+def sortify_version(version: str) -> str:
+    """Convert a version string to a form that can be compared"""
+    # 0-pad each numeric component.  Only supports numeric versions like 1.2.3.
+    return '.'.join(part.zfill(8) for part in version.split('.'))
 
 
-def get_libexecdir() -> str:
-    """Detect libexecdir on current machine
-
-    This only works for systems which have cockpit-ws installed.
-    """
-    global LIBEXECDIR
-    if LIBEXECDIR is None:
-        for candidate in ['/usr/local/libexec', '/usr/libexec', '/usr/local/lib/cockpit', '/usr/lib/cockpit']:
-            if os.path.exists(os.path.join(candidate, 'cockpit-askpass')):
-                LIBEXECDIR = candidate
-                break
-        else:
-            logger.warning('Could not detect libexecdir')
-            # give readable error messages
-            LIBEXECDIR = '/nonexistent/libexec'
-
-    return LIBEXECDIR
-
-
-def patch_libexecdir(obj):
-    if isinstance(obj, str):
-        if '${libexecdir}/cockpit-askpass' in obj:
-            # extra-special case: we handle this internally
-            abs_askpass = shutil.which('cockpit-askpass')
-            if abs_askpass is not None:
-                return obj.replace('${libexecdir}/cockpit-askpass', abs_askpass)
-        return obj.replace('${libexecdir}', get_libexecdir())
-    elif isinstance(obj, dict):
-        return {key: patch_libexecdir(value) for key, value in obj.items()}
-    elif isinstance(obj, list):
-        return [patch_libexecdir(item) for item in obj]
-    else:
-        return obj
-
-
-def parse_accept_language(headers: Dict[str, object]) -> List[str]:
-    """Parse the Accept-Language header, if it exists.
-
-    Returns an ordered list of languages.
-
-    https://tools.ietf.org/html/rfc7231#section-5.3.5
-    """
-
-    accept_language = headers.get('Accept-Language')
-    if not isinstance(accept_language, str):
-        return []
-
-    accept_languages = accept_language.split(',')
-    locales = []
-    for language in accept_languages:
-        language = language.strip()
-        locale, _, weightstr = language.partition(';q=')
-        weight = float(weightstr or 1)
-
-        # Skip possible empty locales
-        if not locale:
-            continue
-
-        # Locales are case-insensitive and we store our list in lowercase
-        locales.append((locale.lower(), weight))
-
-    return [locale for locale, _ in sorted(locales, key=lambda k: k[1], reverse=True)]
-
-
-def find_translation(translations: Entities, locales: List[str]) -> Entity:
-    # First check the locales that the user sent
-    for locale in locales:
-        translation = translations.get(locale)
-        if translation is not None:
-            return translation
-
-    # Next, check the language-only versions of variant-specified locales
-    for locale in locales:
-        language, _, region = locale.partition('-')
-        if not region:
-            continue
-        translation = translations.get(language)
-        if translation:
-            return translation
-
-    # If nothing else worked, we always have English
-    return translations['en']
+# A document is a binary blob with a Content-Type, optional Content-Encoding,
+# and optional Content-Security-Policy
+class Document(NamedTuple):
+    data: bytes
+    content_type: str
+    content_encoding: Optional[str] = None
+    content_security_policy: Optional[str] = None
 
 
 class PackagesListener:
@@ -149,163 +66,89 @@ class PackagesListener:
         """Called when the packages have been reloaded"""
 
 
-class Package:
-    CONDITIONS: ClassVar[Dict[str, Callable[[str], bool]]] = {
-        'path-exists': os.path.exists,
-        'path-not-exists': lambda p: not os.path.exists(p),
-    }
+class Candidate:
+    # immutable after __init__
+    path: Path
+    manifest: JsonObject
 
-    # For po.js files, the interesting part is the locale name
+    def __init__(self, path: Path, manifest: JsonObject):
+        self.path = path
+        self.manifest = manifest
+
+    def get_name(self) -> str:
+        name = self.manifest.get('name')
+        return name if isinstance(name, str) else self.path.name
+
+    def get_priority(self) -> int:
+        priority = self.manifest.get('priority')
+        return priority if isinstance(priority, int) else 1
+
+
+class Package:
     PO_JS_RE: ClassVar[Pattern] = re.compile(r'po\.([^.]+)\.js(\.gz)?')
 
-    # A built in base set of "English" translations
-    PO_EN_JS: ClassVar[Entity] = (b'', mimetypes.guess_type('po.js'))
-    BASE_TRANSLATIONS: ClassVar[Entities] = {'en': PO_EN_JS, 'en-us': PO_EN_JS}
+    # immutable after __init__
+    name: str
+    manifest: JsonObject
+    bridges: List[JsonDocument]
 
-    files: Entities
-    translations: Entities
+    # computed later
+    translations: Optional[Dict[str, str]] = None
+    files: Optional[Dict[str, str]] = None
 
-    def __init__(self, path):
-        self.path = path
+    def __init__(self, candidate: Candidate):
+        self.name = candidate.get_name()
+        self.priority = candidate.get_priority()
+        self.path = candidate.path
+        self.manifest = candidate.manifest
+        bridges = self.manifest.get('bridges', [])
+        if isinstance(bridges, list):
+            self.bridges = bridges
+        else:
+            self.bridges = []
 
-        with (self.path / 'manifest.json').open(encoding='utf-8') as manifest_file:
-            self.manifest = json.load(manifest_file)
+    def ensure_scanned(self) -> None:
+        """Ensure that the package has been scanned.
 
-        self.try_override(self.path / 'override.json')
-        self.try_override(config.lookup_config(f'{path.name}.override.json'))
-        self.try_override(config.DOT_CONFIG_COCKPIT / f'{path.name}.override.json')
+        This allows us to defer scanning the files of the package until we know
+        that we'll actually use it.
+        """
 
-        # HACK: drop this after getting rid of ${libexecdir}, see above
-        self.manifest = patch_libexecdir(self.manifest)
-
-        self.name = self.manifest.get('name', path.name)
-        self.priority = self.manifest.get('priority', 1)
-        self.bridges = self.manifest.get('bridges', [])
+        if self.files is not None:
+            return
 
         self.files = {}
-        self.translations = dict(Package.BASE_TRANSLATIONS)
+        self.translations = {}
 
-        self.version = Package.sortify_version(VERSION)
-
-    def try_override(self, path: Path) -> None:
-        try:
-            with path.open(encoding='utf-8') as override_file:
-                override = json.load(override_file)
-            self.manifest = self.merge_patch(self.manifest, override)
-        except FileNotFoundError:
-            # This is the expected usual case
-            pass
-        except json.JSONDecodeError as exc:
-            # User input error: report a warning
-            logger.warning('%s: %s', path, exc)
-
-    # https://www.rfc-editor.org/rfc/rfc7386
-    @staticmethod
-    def merge_patch(target: object, patch: object) -> object:
-        # Loosely based on example code from the RFC
-        if not isinstance(patch, dict):
-            return patch
-
-        # Always take a copy ('result') — we never modify the input ('target')
-        result = dict(target if isinstance(target, dict) else {})
-        for name, value in patch.items():
-            if value is not None:
-                result[name] = Package.merge_patch(result.get(name), value)
-            else:
-                result.pop(name)
-        return result
-
-    @staticmethod
-    def sortify_version(version: str) -> str:
-        """Convert a version string to a form that can be compared"""
-        # 0-pad each numeric component.  Only supports numeric versions like 1.2.3.
-        return '.'.join(part.zfill(8) for part in version.split('.'))
-
-    def add_file(self, item: Path, checksums: List['hashlib._Hash']) -> None:
-        rel = str(item.relative_to(self.path))
-        guessed_type = mimetypes.guess_type(rel)
-
-        with item.open('rb') as file:
-            data = file.read()
-
-        # Keep the file in memory to serve it later: if this is a 'po.*.js'
-        # file then add it to the list of translations, by locale name.
-        # Otherwise, add it to the normal files list (after stripping '.gz').
-        po_match = Package.PO_JS_RE.fullmatch(rel)
-        if po_match:
-            locale = po_match.group(1)
-            # Accept-Language is case-insensitive and uses '-' to separate variants
-            lower_locale = locale.lower().replace('_', '-')
-            self.translations[lower_locale] = data, guessed_type
-        else:
-            basename = rel[:-3] if rel.endswith('.gz') else rel
-            self.files[basename] = data, guessed_type
-
-        # Perform checksum calculation
-        sha = hashlib.sha256(data).hexdigest()
-        for context in checksums:
-            context.update(f'{rel}\0{sha}\0'.encode('ascii'))
-
-    def walk(self, checksums, path):
-        for item in directory_items(path):
-            if item.is_dir():
-                self.walk(checksums, item)
-            elif item.is_file():
-                self.add_file(item, checksums)
-
-    def check(self, at_least_prio):
-        if 'requires' in self.manifest:
-            requires = self.manifest['requires']
-            if any(package != 'cockpit' for package in requires):
-                return False
-
-            if 'cockpit' in requires and self.version < Package.sortify_version(requires['cockpit']):
-                return False
-
-        if at_least_prio is not None:
-            if 'priority' not in self.manifest:
-                return False
-
-            if self.manifest['priority'] <= at_least_prio:
-                return False
-
-        for condition in self.manifest.get('conditions', []):
-            try:
-                (predicate, value), = condition.items()
-            except (AttributeError, ValueError):
-                # ignore manifests with broken syntax
-                logger.warning('invalid condition in %s: %s', self.path, condition)
-                return False
-
-            try:
-                test_fn = Package.CONDITIONS[predicate]
-            except KeyError:
-                # do *not* ignore manifests with unknown predicates, for forward compatibility
-                logger.warning('ignoring unknown predicate in %s: %s', self.path, predicate)
+        for file in self.path.rglob('*'):
+            name = str(file.relative_to(self.path))
+            if name in ['.', '..', 'manifest.json']:
                 continue
 
-            if not test_fn(value):
-                logger.info('Hiding package %s as its %s condition is not met', self.path, condition)
-                return False
+            po_match = Package.PO_JS_RE.fullmatch(name)
+            if po_match:
+                locale = po_match.group(1)
+                # Accept-Language is case-insensitive and uses '-' to separate variants
+                lower_locale = locale.lower().replace('_', '-')
+                self.translations[lower_locale] = name
+            else:
+                basename = name[:-3] if name.endswith('.gz') else name
+                self.files[basename] = name
 
-        return True
-
-    def get_content_security_policy(self, origin):
-        assert origin.startswith('http')
-        origin_ws = origin.replace('http', 'ws', 1)
-
-        # fix me: unit tests depend on the specific order
-        policy = collections.OrderedDict({
-            "default-src": f"'self' {origin}",
-            "connect-src": f"'self' {origin} {origin_ws}",
-            "form-action": f"'self' {origin}",
-            "base-uri": f"'self' {origin}",
+    def get_content_security_policy(self) -> str:
+        policy = {
+            "default-src": "'self'",
+            "connect-src": "'self'",
+            "form-action": "'self'",
+            "base-uri": "'self'",
             "object-src": "'none'",
-            "font-src": f"'self' {origin} data:",
-            "img-src": f"'self' {origin} data:",
-        })
+            "font-src": "'self' data:",
+            "img-src": "'self' data:",
+        }
 
         manifest_policy = self.manifest.get('content-security-policy', '')
+        if not isinstance(manifest_policy, str):
+            manifest_policy = ''
         for item in manifest_policy.split(';'):
             item = item.strip()
             if item:
@@ -314,42 +157,254 @@ class Package:
 
         return ' '.join(f'{k} {v};' for k, v in policy.items()) + ' block-all-mixed-content'
 
-    def serve_file(self, path, channel):
-        if path == 'po.js':
-            # We do locale-dependent lookup only for /po.js.  This always succeeds.
-            locales = parse_accept_language(channel.headers)
-            data, (content_type, encoding) = find_translation(self.translations, locales)
+    def load_file(self, filename: str) -> Document:
+        path = self.path / filename
+        logger.debug('  loading data from %s', path)
+        data = path.read_bytes()
+
+        content_type, content_encoding = mimetypes.guess_type(filename)
+        content_security_policy = None
+
+        if content_type is None:
+            content_type = 'text/plain'
+        elif content_type.startswith('text/html'):
+            content_security_policy = self.get_content_security_policy()
+
+        return Document(data, content_type, content_encoding, content_security_policy)
+
+    def load_translation(self, locales: List[str]) -> Document:
+        self.ensure_scanned()
+        assert self.translations is not None
+
+        # First check the locales that the user sent
+        for locale in locales:
+            with contextlib.suppress(KeyError):
+                return self.load_file(self.translations[locale])
+
+        # Next, check the language-only versions of variant-specified locales
+        for locale in locales:
+            language, _, region = locale.partition('-')
+            if region:
+                with contextlib.suppress(KeyError):
+                    return self.load_file(self.translations[language])
+
+        # We prefer to return an empty document than 404 in order to avoid
+        # errors in the console when a translation can't be found
+        return Document(b'', 'text/javascript')
+
+    def load_path(self, path: str) -> Document:
+        self.ensure_scanned()
+        assert self.files is not None
+
+        # We can throw either KeyError from the lookup on self.files[] (which
+        # will become a 404) or an OSError from .load_file() (which will become
+        # a 500).
+        return self.load_file(self.files[path])
+
+
+class PackagesLoader:
+    # Skip version check when running out of the git checkout (__version__ is None)
+    COCKPIT_VERSION = __version__ and sortify_version(__version__)
+
+    CONDITIONS: ClassVar[Dict[str, Callable[[str], bool]]] = {
+        'path-exists': os.path.exists,
+        'path-not-exists': lambda p: not os.path.exists(p),
+    }
+
+    @staticmethod
+    @functools.lru_cache()
+    def get_libexecdir() -> str:
+        """Detect libexecdir on current machine
+
+        This only works for systems which have cockpit-ws installed.
+        """
+        for candidate in ['/usr/local/libexec', '/usr/libexec', '/usr/local/lib/cockpit', '/usr/lib/cockpit']:
+            if os.path.exists(os.path.join(candidate, 'cockpit-askpass')):
+                return candidate
         else:
-            # Otherwise, just look up the file based on its path.  May raise KeyError.
-            data, (content_type, encoding) = self.files[path]
+            logger.warning('Could not detect libexecdir')
+            # give readable error messages
+            return '/nonexistent/libexec'
 
-        headers = {
-            "Content-Encoding": encoding,
-        }
-        if content_type is not None and content_type.startswith('text/html'):
-            headers['Content-Security-Policy'] = self.get_content_security_policy(channel.origin)
+    @classmethod
+    def patch_libexecdir(cls, obj: J) -> J:
+        if isinstance(obj, str):
+            if '${libexecdir}/cockpit-askpass' in obj:
+                # extra-special case: we handle this internally
+                abs_askpass = shutil.which('cockpit-askpass')
+                if abs_askpass is not None:
+                    return obj.replace('${libexecdir}/cockpit-askpass', abs_askpass)
+            return obj.replace('${libexecdir}', cls.get_libexecdir())
+        elif isinstance(obj, dict):
+            return {key: cls.patch_libexecdir(value) for key, value in obj.items()}
+        elif isinstance(obj, list):
+            return [cls.patch_libexecdir(item) for item in obj]
+        else:
+            return obj
 
-        channel.http_ok(content_type, headers)
-        channel.send_data(data)
+    @classmethod
+    def get_xdg_data_dirs(cls) -> Iterable[str]:
+        try:
+            yield os.environ['XDG_DATA_HOME']
+        except KeyError:
+            yield os.path.expanduser('~/.local/share')
 
+        try:
+            yield from os.environ['XDG_DATA_DIRS'].split(':')
+        except KeyError:
+            yield from ('/usr/local/share', '/usr/share')
 
-# TODO: This doesn't yet implement the slighty complicated checksum
-# scheme of the C bridge (see cockpitpackages.c) to support caching
-# and reloading.
+    # https://www.rfc-editor.org/rfc/rfc7386
+    @classmethod
+    def merge_patch(cls, target: JsonDocument, patch: J) -> J:
+        # Loosely based on example code from the RFC
+        if not isinstance(patch, dict):
+            return patch
+
+        # Always take a copy ('result') — we never modify the input ('target')
+        result = dict(target if isinstance(target, dict) else {})
+        for name, value in patch.items():
+            if value is not None:
+                result[name] = cls.merge_patch(result.get(name), value)
+            else:
+                result.pop(name)
+        return result
+
+    @classmethod
+    def patch_manifest(cls, manifest: JsonObject, parent: Path) -> JsonObject:
+        override_files = [
+            parent / 'override.json',
+            config.lookup_config(f'{parent.name}.override.json'),
+            config.DOT_CONFIG_COCKPIT / f'{parent.name}.override.json',
+        ]
+
+        for override_file in override_files:
+            try:
+                override: JsonDocument = json.loads(override_file.read_bytes())
+            except FileNotFoundError:
+                continue
+            except json.JSONDecodeError as exc:
+                # User input error: report a warning
+                logger.warning('%s: %s', override_file, exc)
+
+            if not isinstance(override, dict):
+                logger.warning('%s: override file is not a dictionary', override_file)
+                continue
+
+            manifest = cls.merge_patch(manifest, override)
+
+        return cls.patch_libexecdir(manifest)
+
+    @classmethod
+    def load_candidates(cls) -> Iterable[Candidate]:
+        for datadir in cls.get_xdg_data_dirs():
+            logger.debug("Scanning for manifest files under %s", datadir)
+            for file in Path(datadir).glob('cockpit/*/manifest.json'):
+                logger.debug("Considering file %s", file)
+                try:
+                    manifest = json.loads(file.read_text())
+                except json.JSONDecodeError as exc:
+                    logger.error("%s: %s", file, exc)
+                    continue
+                if not isinstance(manifest, dict):
+                    logger.error("%s: json document isn't an object", file)
+                    continue
+
+                parent = file.parent
+                yield Candidate(parent, cls.patch_manifest(manifest, parent))
+
+    @classmethod
+    def check_requires(cls, candidate: Candidate) -> bool:
+        try:
+            requires = candidate.manifest['requires']
+            if not isinstance(requires, dict):
+                logger.warning('%s: requires key in manifest is not a dictionary', candidate.path)
+                return False
+        except KeyError:
+            return True  # no requires?  no problem!
+
+        if any(package != 'cockpit' for package in requires):
+            return False
+
+        try:
+            cockpit_requires = requires['cockpit']
+            if not isinstance(cockpit_requires, str):
+                logger.warning('%s: requires key in manifest is not a dictionary', candidate.path)
+                return False
+            # Skip version check when running out of the git checkout
+            return not cls.COCKPIT_VERSION or cls.COCKPIT_VERSION >= sortify_version(cockpit_requires)
+        except KeyError:
+            return True  # no requires?  no problem!
+
+    def check_condition(self, condition: str, value: object) -> bool:
+        check_fn = self.CONDITIONS[condition]
+
+        # All known predicates currently only work on strings
+        if not isinstance(value, str):
+            return False
+
+        return check_fn(value)
+
+    def check_conditions(self, candidate: Candidate) -> bool:
+        conditions = candidate.manifest.get('conditions', [])
+        if not isinstance(conditions, list):
+            logger.warning('  %s: conditions key in manifest is not a list', candidate.path)
+            return False
+
+        for condition in conditions:
+            try:
+                (predicate, value), = condition.items()  # type: ignore[union-attr] # can throw AttributeError
+            except (AttributeError, ValueError):
+                # ignore manifests with broken syntax
+                logger.warning('  %s: invalid condition in manifest: %s', candidate.path, condition)
+                return False
+
+            try:
+                okay = self.check_condition(predicate, value)
+            except KeyError:
+                # do *not* ignore manifests with unknown predicates, for forward compatibility
+                logger.warning('  %s: ignoring unknown predicate in manifest: %s', candidate.path, predicate)
+                continue
+
+            if not okay:
+                logger.debug('  hiding package %s as its %s condition is not met', candidate.path, condition)
+                return False
+
+        return True
+
+    def load_packages(self) -> Iterable[Tuple[str, Package]]:
+        logger.debug('Scanning for available package manifests:')
+        # Sort all available packages into buckets by to their claimed name
+        names: Dict[str, List[Candidate]] = collections.defaultdict(list)
+        for candidate in self.load_candidates():
+            logger.debug('  %s/manifest.json', candidate.path)
+            names[candidate.get_name()].append(candidate)
+        logger.debug('done.')
+
+        logger.debug('Selecting packages to serve:')
+        for name, candidates in names.items():
+            # For each package name, iterate the candidates in descending
+            # priority order and select the first one which passes all checks
+            for candidate in sorted(candidates, key=Candidate.get_priority, reverse=True):
+                if self.check_requires(candidate) and self.check_conditions(candidate):
+                    logger.debug('  creating package %s -> %s', name, candidate.path)
+                    yield name, Package(candidate)
+                    break
+
+                logger.debug('  ignoring %s: unmet conditions', candidate.path)
+        logger.debug('done.')
+
 
 class Packages(bus.Object, interface='cockpit.Packages'):
-    manifests = bus.Interface.Property('s', value="{}")
-
+    loader: PackagesLoader
     listener: Optional[PackagesListener]
     packages: Dict[str, Package]
-    checksum: str = ''
+    saw_first_reload_hint: bool
 
-    def __init__(self, listener: Optional[PackagesListener] = None):
-        super().__init__()
-
+    def __init__(self, listener: Optional[PackagesListener] = None, loader: Optional[PackagesLoader] = None):
         self.listener = listener
-        self.packages = {}
-        self.load_packages()
+        self.loader = loader or PackagesLoader()
+        self.load()
 
         # Reloading the Shell in the browser should reload the
         # packages.  This is implemented by having the Shell call
@@ -359,73 +414,87 @@ class Packages(bus.Object, interface='cockpit.Packages'):
         #
         self.saw_first_reload_hint = False
 
+    def load(self) -> None:
+        self.packages = dict(self.loader.load_packages())
+        self.manifests = json.dumps({name: package.manifest for name, package in self.packages.items()})
+        logger.debug('Packages loaded: %s', list(self.packages))
+
     def show(self):
         for name in sorted(self.packages):
             package = self.packages[name]
             menuitems = ''
             print(f'{name:20} {menuitems:40} {package.path}')
-        if self.checksum:
-            print(f'checksum = {self.checksum}')
 
-    def try_packages_dir(self, path, checksums):
-        try:
-            items = directory_items(path)
-        except FileNotFoundError:
-            return
+    def get_bridge_configs(self):
+        bridges = []
+        for package in sorted(self.packages.values(), key=lambda package: -package.priority):
+            bridges.extend(package.bridges)
+        return bridges
 
-        for item in items:
-            if item.is_dir():
-                try:
-                    package = Package(item)
-                except (FileNotFoundError, json.JSONDecodeError):
-                    # ignore packages with broken/empty manifests
-                    continue
+    # D-Bus Interface
+    manifests = bus.Interface.Property('s', value="{}")
 
-                if package.name in self.packages:
-                    at_least_prio = self.packages[package.name].priority
-                else:
-                    at_least_prio = None
+    @bus.Interface.Method()
+    def reload(self):
+        self.load()
+        if self.listener is not None:
+            self.listener.packages_loaded()
 
-                if package.check(at_least_prio):
-                    self.packages[package.name] = package
-                    package.walk(checksums, package.path)
+    @bus.Interface.Method()
+    def reload_hint(self):
+        if self.saw_first_reload_hint:
+            self.reload()
+        self.saw_first_reload_hint = True
 
-    def load_packages(self):
-        checksums = []
+    # Support for serving files via the packages channel
+    @staticmethod
+    def parse_accept_language(headers: Dict[str, str]) -> List[str]:
+        """Parse the Accept-Language header, if it exists.
 
-        xdg_data_home = os.environ.get('XDG_DATA_HOME') or os.path.expanduser('~/.local/share')
-        self.try_packages_dir(Path(xdg_data_home) / 'cockpit', checksums)
+        Returns an ordered list of languages.
 
-        # we only checksum the system content if there's no user content
-        if not self.packages:
-            checksums.append(hashlib.sha256())
+        https://tools.ietf.org/html/rfc7231#section-5.3.5
+        """
 
-        xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', '/usr/local/share:/usr/share')
-        for xdg_dir in xdg_data_dirs.split(':'):
-            self.try_packages_dir(Path(xdg_dir) / 'cockpit', checksums)
+        accept_language = headers.get('Accept-Language')
+        if not isinstance(accept_language, str):
+            return []
 
-        if checksums:
-            self.checksum = checksums[0].hexdigest()
-        else:
-            self.checksum = None
+        accept_languages = accept_language.split(',')
+        locales = []
+        for language in accept_languages:
+            language = language.strip()
+            locale, _, weightstr = language.partition(';q=')
+            weight = float(weightstr or 1)
 
-        self.manifests = json.dumps({name: package.manifest for name, package in self.packages.items()})
+            # Skip possible empty locales
+            if not locale:
+                continue
 
-    def serve_manifests_js(self, channel):
-        channel.http_ok('text/javascript')
+            # Locales are case-insensitive and we store our list in lowercase
+            locales.append((locale.lower(), weight))
+
+        return [locale for locale, _ in sorted(locales, key=lambda k: k[1], reverse=True)]
+
+    def load_manifests_js(self, headers: Dict[str, str]) -> Document:
+        logger.debug('Serving /manifests.js')
+
+        chunks: List[bytes] = []
 
         # Send the translations required for the manifest files, from each package
-        locales = parse_accept_language(channel.headers)
+        locales = self.parse_accept_language(headers)
         for name, package in self.packages.items():
             if name in ['static', 'base1']:
                 continue
             # find_translation will always find at least 'en'
-            data, (content_type, encoding) = find_translation(package.translations, locales)
-            if encoding == 'gzip':
-                data = gzip.decompress(data)
-            channel.send_data(data)
+            translation = package.load_translation(locales)
+            if translation.content_encoding == 'gzip':
+                data = gzip.decompress(translation.data)
+            else:
+                data = translation.data
+            chunks.append(data)
 
-        channel.send_data(("""
+        chunks.append(b"""
             (function (root, data) {
                 if (typeof define === 'function' && define.amd) {
                     define(data);
@@ -436,60 +505,28 @@ class Packages(bus.Object, interface='cockpit.Packages'):
                 } else {
                     root.manifests = data;
                 }
-            }(this, """ + self.manifests + """))""").encode('ascii'))
+            }(this, """ + self.manifests.encode() + b"""))""")
 
-    def serve_manifests_json(self, channel):
-        channel.http_ok('application/json')
-        channel.send_data(self.manifests.encode('ascii'))
+        return Document(b'\n'.join(chunks), 'text/javascript')
 
-    def serve_package_file(self, path, channel):
-        package, _, package_path = path[1:].partition('/')
-        try:
-            self.packages[package].serve_file(package_path, channel)
-        except KeyError:
-            channel.http_error(404, "Not Found")
+    def load_manifests_json(self) -> Document:
+        logger.debug('Serving /manifests.json')
+        return Document(self.manifests.encode(), 'application/json')
 
-    def serve_checksum(self, channel):
-        channel.http_ok('text/plain')
-        channel.send_data(self.checksum.encode('ascii'))
-
-    def serve_file(self, path, channel):
-        assert path[0] == '/'
-
-        # HACK: If the response is language specific, don't cache the file. Caching "po.js" breaks
-        # changing the language in Chromium, as that does not respect `Vary: Cookie` properly.
-        # See https://github.com/cockpit-project/cockpit/issues/8160
-        # We also can't cache /manifests.js because it changes if packages are installed/removed.
-        locale_specific = path.endswith('po.js') or path in ['/manifests.js', '/manifests.json']
-        if self.checksum is not None and not locale_specific:
-            channel.push_header('X-Cockpit-Pkg-Checksum', self.checksum)
-        else:
-            channel.push_header('Cache-Control', 'no-cache, no-store')
+    def load_path(self, path: str, headers: Dict[str, str]) -> Document:
+        logger.debug('packages: serving %s', path)
 
         if path == '/manifests.js':
-            self.serve_manifests_js(channel)
+            return self.load_manifests_js(headers)
         elif path == '/manifests.json':
-            self.serve_manifests_json(channel)
-        elif path == '/checksum':
-            self.serve_checksum(channel)
+            return self.load_manifests_json()
         else:
-            self.serve_package_file(path, channel)
+            assert path.startswith('/')
+            package_name, _, package_path = path[1:].partition('/')
 
-    def get_bridge_configs(self):
-        bridges = []
-        for package in sorted(self.packages.values(), key=lambda package: -package.priority):
-            bridges.extend(package.bridges)
-        return bridges
-
-    @bus.Interface.Method()
-    def reload(self):
-        self.packages = {}
-        self.load_packages()
-        if self.listener is not None:
-            self.listener.packages_loaded()
-
-    @bus.Interface.Method()
-    def reload_hint(self):
-        if self.saw_first_reload_hint:
-            self.reload()
-        self.saw_first_reload_hint = True
+            package = self.packages[package_name]
+            if package_path == 'po.js':
+                locales = self.parse_accept_language(headers)
+                return package.load_translation(locales)
+            else:
+                return package.load_path(package_path)

--- a/test/pytest/test_packages.py
+++ b/test/pytest/test_packages.py
@@ -19,7 +19,7 @@ import json
 
 import pytest
 
-from cockpit.packages import Packages, parse_accept_language
+from cockpit.packages import Packages
 
 
 @pytest.mark.parametrize(("test_input", "expected"), [
@@ -28,7 +28,7 @@ from cockpit.packages import Packages, parse_accept_language
     ('fr-CH, fr;q=0.9, en;q=0.8, de;q=0.7, *;q=0.5', ['fr-ch', 'fr', 'en', 'de', '*'])
 ])
 def test_parse_accept_language(test_input, expected):
-    assert parse_accept_language({'Accept-Language': test_input}) == expected
+    assert Packages.parse_accept_language({'Accept-Language': test_input}) == expected
 
 
 @pytest.fixture

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -439,7 +439,21 @@ class TestConnection(testlib.MachineCase):
         headers = m.execute("curl -k --head -b cockpit.jar -s https://127.0.0.1:9090/")
         self.assertIn(
             "default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 wss://127.0.0.1:9090", headers)
-        self.assertIn("Access-Control-Allow-Origin: https://127.0.0.1:9090", headers)
+        if self.is_pybridge():
+            # We want to make sure we're *not* sending any CORS headers.
+            CORS_HEADERS = [
+                # https://en.wikipedia.org/wiki/Cross-origin_resource_sharing#Response_headers
+                'Access-Control-Allow-Credentials',
+                'Access-Control-Expose-Headers',
+                'Access-Control-Max-Age',
+                'Access-Control-Allow-Methods',
+                'Access-Control-Allow-Headers',
+            ]
+            for cors_header in CORS_HEADERS:
+                self.assertNotIn(cors_header, headers)
+        else:
+            self.assertIn("Access-Control-Allow-Origin: https://127.0.0.1:9090", headers)
+
         # CORP and Frame-Options are also set for dynamic paths
         self.assertIn("Cross-Origin-Resource-Policy: same-origin", headers)
         self.assertIn("X-Frame-Options: sameorigin", headers)

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -437,8 +437,18 @@ class TestConnection(testlib.MachineCase):
         m.execute("curl -k -c cockpit.jar -s --head --header 'Authorization: Basic {}' https://127.0.0.1:9090/cockpit/login".format(
             base64.b64encode(b"admin:foobar").decode(), ))
         headers = m.execute("curl -k --head -b cockpit.jar -s https://127.0.0.1:9090/")
-        self.assertIn(
-            "default-src 'self' https://127.0.0.1:9090; connect-src 'self' https://127.0.0.1:9090 wss://127.0.0.1:9090", headers)
+
+        # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src
+        #
+        #    Note: connect-src 'self' does not resolve to websocket
+        #    schemes in all browsers, more info in this issue.
+        #
+        # https://github.com/w3c/webappsec-csp/issues/7
+        #
+        # Make sure we send the explicit `wss://` item until we're absolutely
+        # sure about the browser support situation for `connect-src 'self';`.
+        self.assertIn("wss://127.0.0.1:9090", headers)
+
         if self.is_pybridge():
             # We want to make sure we're *not* sending any CORS headers.
             CORS_HEADERS = [

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1219,7 +1219,10 @@ BEGIN {{
             # without cockpit-storaged, mounts are not links
             self.restore_file("/usr/share/cockpit/storaged/manifest.json")
             m.write("/usr/share/cockpit/storaged/manifest.json", "")
-            self.allow_journal_messages("storaged: couldn't read manifest.json: JSON data was empty")
+            if self.is_pybridge():
+                self.allow_journal_messages(".*/storaged/manifest.json: Expecting value: line 1 column 1.*")
+            else:
+                self.allow_journal_messages("storaged: couldn't read manifest.json: JSON data was empty")
             login(self)
         b.wait_visible(progress_sel)
         self.assertFalse(b.is_present("#current-disks-usage button"))

--- a/tools/vulture-suppressions/cockpit.py
+++ b/tools/vulture-suppressions/cockpit.py
@@ -11,4 +11,5 @@ User.shell
 # getattr()
 Printer.dbus_call
 Printer.help
+Printer.packages_reload
 Printer.wait


### PR DESCRIPTION
Rework the packages loading code.  The main changes:

 - we don't attempt to do checksums anymore.  This was taking a large amount of time when loading the bridge and we never implemented it properly anyway (since we weren't sending the `.checksum` fields in the manifests)

 - drop all of the extra code we had for walking the paths in a particular order.  We just do (r)globs now.

 - move all of the code for deciding which packages to load to a separate class.  We now load all of the manifests and evaluate them (requirements, conditionals, priorities) and only the packages that we actually intend to serve are then scanned.  The new structure also makes it easier for cockpit-beiboot to do its thing.