### PR TITLE
selinux: Remove copied checkmark when switching SELinux modifications tab

### DIFF
--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -41,6 +41,7 @@ class ModificationsExportDialog extends React.Component {
     constructor(props) {
         super(props);
 
+        this.timeoutId = null;
         this.state = {
             active_tab: "shell",
             copied: false
@@ -51,7 +52,11 @@ class ModificationsExportDialog extends React.Component {
     }
 
     handleSelect(event, active_tab) {
-        this.setState({ active_tab });
+        this.setState({ active_tab, copied: false });
+        if (this.timeoutId !== null) {
+            clearTimeout(this.timeoutId);
+            this.timeoutId = null;
+        }
     }
 
     copyToClipboard() {
@@ -59,7 +64,7 @@ class ModificationsExportDialog extends React.Component {
             navigator.clipboard.writeText(this.props[this.state.active_tab].trim())
                     .then(() => {
                         this.setState({ copied: true });
-                        setTimeout(() => {
+                        this.timeoutId = setTimeout(() => {
                             this.setState({ copied: false });
                         }, 3000);
                     })


### PR DESCRIPTION
Resolves #19057 .  Added support of clearTimeOut function to re-render the copy icon in case of switching tabs in selinux automation script.