### PR TITLE
python: use os.login_tty() on pty stream channels

### DIFF
--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -343,6 +343,8 @@ class SubprocessTransport(_Transport, asyncio.SubprocessTransport):
         # go down as a team -- we don't want any leaked processes when the bridge terminates
         def preexec_fn():
             prctl(SET_PDEATHSIG, signal.SIGTERM)
+            if pty:
+                fcntl.ioctl(0, termios.TIOCSCTTY, 0)
 
         if pty:
             self._pty_fd, session_fd = os.openpty()


### PR DESCRIPTION
When creating a pty-enabled stream channel we call setsid() but depend on the shell to take control of the terminal.  fish doesn't do that, leading to an error message, rendering the Terminal page unusable if the user has fish as their default shell.

Let's call `os.login_tty()` explicitly.

Fixes #19075