### PR TITLE
test: Make Browser.{focus,blur}() synchronous

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -454,16 +454,18 @@ class Browser:
 
         :param selector: the selector
         """
-        self.wait_visible(selector + ':not([disabled]):not([aria-disabled=true])')
+        self.wait_visible(f'{selector}:not([disabled]):not([aria-disabled=true])')
         self.call_js_func('ph_focus', selector)
+        self.wait_js_cond(f'document.activeElement == document.querySelector("{selector}")')
 
     def blur(self, selector: str):
         """Remove keyboard focus from selected element.
 
         :param selector: the selector
         """
-        self.wait_visible(selector + ':not([disabled]):not([aria-disabled=true])')
+        self.wait_visible(f'{selector}:not([disabled]):not([aria-disabled=true])')
         self.call_js_func('ph_blur', selector)
+        self.wait_js_cond(f'document.activeElement != document.querySelector("{selector}")')
 
     # TODO: Unify them so we can have only one
     def key_press(self, keys: str, modifiers: int = 0, use_ord: bool = False):


### PR DESCRIPTION
Calling .focus() and .blur() is asynchronous. When followed by key presses (which is the common use case for foucssing), this sometimes leads to typing the key presses somewhere else than the intended focussed element. To fix that, wait until the active element actually switched to the desired one.

----

Should help with [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230706-080945-2272c7a4-rhel4edge/log.html#36), which produces [this lovely mess](https://cockpit-logs.us-east-1.linodeobjects.com/pull-1324-20230706-080945-2272c7a4-rhel4edge/TestApplication-testPods4-rhel4edge-127.0.0.2-2201-FAIL.png). I'll test that in https://github.com/cockpit-project/cockpit-podman/pull/1324