### PR TITLE
storage: Grow Stratis blockdevs

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -1051,6 +1051,7 @@ function stratis3_start() {
                 client.features.stratis_crypto_binding = true;
                 client.features.stratis_encrypted_caches = true;
                 client.features.stratis_managed_fsys_sizes = true;
+                client.features.stratis_grow_blockdevs = true;
                 client.stratis_pools = client.stratis_manager.client.proxies("org.storage.stratis3.pool." +
                                                                              stratis3_interface_revision,
                                                                              "/org/storage/stratis3",

--- a/pkg/storaged/lvol-tabs.jsx
+++ b/pkg/storaged/lvol-tabs.jsx
@@ -400,11 +400,11 @@ export class BlockVolTab extends React.Component {
         }
 
         function shrink() {
-            lvol_shrink(client, lvol, info, unused_space);
+            return lvol_shrink(client, lvol, info, unused_space);
         }
 
         function grow() {
-            lvol_grow(client, lvol, info, unused_space);
+            return lvol_grow(client, lvol, info, unused_space);
         }
 
         return (

--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -90,6 +90,7 @@ function checked(callback, setSpinning) {
                     setSpinning(false);
             });
             promise.catch(function (error) {
+                console.warn(error.toString());
                 dialog_open({
                     Title: _("Error"),
                     Body: error.toString()

--- a/pkg/storaged/warnings.jsx
+++ b/pkg/storaged/warnings.jsx
@@ -72,6 +72,7 @@ export function find_warnings(client) {
         const fsys = client.blocks_fsys[content_path];
         const content_block = client.blocks[content_path];
         const vdo = content_block ? client.legacy_vdo_overlay.find_by_backing_block(content_block) : null;
+        const stratis_bdev = client.blocks_stratis_blockdev[content_path];
 
         if (fsys && fsys.Size && (lvol.Size - fsys.Size - crypto_overhead) > vgroup.ExtentSize && fsys.Resize) {
             enter_warning(path, {
@@ -86,6 +87,14 @@ export function find_warnings(client) {
                 warning: "unused-space",
                 volume_size: lvol.Size - crypto_overhead,
                 content_size: vdo.physical_size
+            });
+        }
+
+        if (stratis_bdev && (lvol.Size - Number(stratis_bdev.TotalPhysicalSize) - crypto_overhead) > vgroup.ExtentSize) {
+            enter_warning(path, {
+                warning: "unused-space",
+                volume_size: lvol.Size - crypto_overhead,
+                content_size: Number(stratis_bdev.TotalPhysicalSize)
             });
         }
     }

--- a/pkg/storaged/warnings.jsx
+++ b/pkg/storaged/warnings.jsx
@@ -19,6 +19,7 @@
 
 import { get_parent } from "./utils.js";
 import { check_mismounted_fsys } from "./fsys-tab.jsx";
+import { check_stratis_warnings } from "./stratis-details.jsx";
 
 export function find_warnings(client) {
     const path_warnings = { };
@@ -103,6 +104,8 @@ export function find_warnings(client) {
         check_unused_space(path);
         check_mismounted_fsys(client, path, enter_warning);
     }
+
+    check_stratis_warnings(client, enter_warning);
 
     return path_warnings;
 }

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -617,6 +617,70 @@ class TestStorageStratis(storagelib.StorageCase):
         # And the pool should be full again
         b.wait_visible("button:contains(Create new filesystem):disabled")
 
+    @testlib.skipImage("Stratis too old", "rhel-8-*", "centos-8-*")
+    def testPoolResize(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        dev = "/dev/sda"
+        m.add_disk("4G", serial="DISK1")
+        b.wait_in_text("#drives", dev)
+
+        # Create a logical volume that we will later grow
+        m.execute(f"vgcreate vgroup0 {dev}; lvcreate vgroup0 -n lvol0 -L 1500000256b")
+        b.wait_in_text("#devices", "vgroup0")
+
+        # Create a pool
+        self.dialog_with_retry(trigger=lambda: self.devices_dropdown("Create Stratis pool"),
+                               expect=lambda: self.dialog_is_present('disks', "lvol0"),
+                               values={"disks": {"lvol0": True}})
+        b.wait_in_text("#devices", "pool0")
+        b.wait_in_text("#devices", "1.50 GB Stratis pool")
+
+        # Grow the logical volume in Cockpit, the pool should grow automatically
+        b.click('.sidepanel-row:contains("vgroup0")')
+        b.wait_visible('#storage-detail')
+        self.content_tab_action(1, 1, "Grow")
+        self.dialog({"size": 1600})
+        b.go("#/")
+        b.wait_in_text("#devices", "1.60 GB Stratis pool")
+
+        # Grow the logical volume from outside of Cockpit, the pool should complain
+        m.execute("lvresize vgroup0/lvol0 -L +100000256b")
+        b.wait_visible('.sidepanel-row:contains(pool0) .ct-icon-exclamation-triangle')
+        b.click('.sidepanel-row:contains("pool0")')
+        b.wait_visible('#storage-detail')
+        b.wait_visible('.pf-v5-c-alert:contains("This pool does not use all the space")')
+        b.click('button:contains("Grow the pool")')
+        b.wait_not_present('.pf-v5-c-alert')
+        b.wait_in_text("#detail-header", "1.7 GB")
+
+        b.go("#/")
+
+        # Grow the logical volume from outside of Cockpit, the logical volume should also complain
+        m.execute("lvresize vgroup0/lvol0 -L +100000256b")
+        b.wait_visible('.sidepanel-row:contains(vgroup0) .ct-icon-exclamation-triangle')
+        b.click('.sidepanel-row:contains("vgroup0")')
+        b.wait_visible('#storage-detail')
+        vol_tab = self.content_tab_expand(1, 1)
+        # First shrink the volume to test whether Cockpit can figure out the right size for that
+        b.wait_in_text("#detail-content td[data-label=Size]", "1.80 GB")
+        b.wait_visible(vol_tab + " button:contains(Shrink volume)")
+        self.content_tab_action(1, 1, "Shrink volume")
+        b.wait_in_text("#detail-content td[data-label=Size]", "1.70 GB")
+        b.wait_not_present(vol_tab + " button:contains(Shrink volume)")
+        # Then enlarge the volume from the outside again and grow the blockdev
+        m.execute("lvresize vgroup0/lvol0 -L +100000256b")
+        b.wait_in_text("#detail-content td[data-label=Size]", "1.80 GB")
+        b.wait_visible(vol_tab + " button:contains(Grow content)")
+        self.content_tab_action(1, 1, "Grow content")
+        vol_tab = self.content_tab_expand(1, 1)
+        b.wait_not_present(vol_tab + " button:contains(Grow content)")
+        b.go("#/")
+        b.wait_in_text("#devices", "1.80 GB Stratis pool")
+
 
 @testlib.skipImage("No Stratis", "debian-*", "ubuntu-*", "arch")
 class TestStoragePackagesStratis(packagelib.PackageCase, storagelib.StorageCase):


### PR DESCRIPTION
Demo: https://youtu.be/IvwnqFjhMXw

--------------

### Storage: Support for growing block devices of a Stratis pool

Cockpit can now grow logical volumes that are used as block devices in a Stratis pool. Also, if a Stratis block device grows for any reason, Cockpit will notify you about this and can extend the pool to use all of it.