### PR TITLE
metrics: Fix CPU temperature sensor for AMD

### DIFF
--- a/src/bridge/cockpitcpusamples.c
+++ b/src/bridge/cockpitcpusamples.c
@@ -186,9 +186,6 @@ detect_cpu_sensors (GList **devices,
           // only sample CPU Temperature in atk0110
           if (!g_str_equal (label_content, "CPU Temperature") && g_str_equal (hwmon_name, "atk0110"))
               continue;
-          // ignore Tctl on AMD devices
-          if (g_str_equal (label_content, "Tctl"))
-              continue;
         }
 
       *devices = g_list_append (*devices, g_steal_pointer (&sensor_path));

--- a/src/cockpit/samples.py
+++ b/src/cockpit/samples.py
@@ -157,8 +157,7 @@ class CPUTemperatureSampler(Sampler):
             # accept all labels on Intel
             predicate = None
         elif name in ['k8temp', 'k10temp']:
-            # ignore Tctl on AMD devices
-            predicate = (lambda label: label != 'Tctl')
+            predicate = None
         else:
             # Not a CPU sensor
             return

--- a/test/pytest/test_samples.py
+++ b/test/pytest/test_samples.py
@@ -141,7 +141,8 @@ def test_cpu_temperature(hwmon_mock):
         assert 20 < temperature < 50
 
     expected = ['hwmon4/temp4_input', 'hwmon4/temp3_input', 'hwmon4/temp2_input',
-                'hwmon4/temp1_input', 'hwmon3/temp3_input', 'hwmon2/temp1_input']
+                'hwmon4/temp1_input', 'hwmon3/temp3_input', 'hwmon3/temp1_input',
+                'hwmon2/temp1_input']
     sensors = [os.path.relpath(p, start=hwmon_mock) for p in samples['cpu.temperature']]
     assert sorted(sensors) == sorted(expected)
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -897,7 +897,6 @@ class TestCurrentMetrics(testlib.MachineCase):
         # AMD
         m.execute("rm -rf /tmp/sensor-sys-class/hwmon/hwmon1/*")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/name", "k10temp")
-        # Tctl (temp1_input) will be ignored
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_label", "Tctl")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_input", "40000")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp1_max", "100000")
@@ -911,7 +910,7 @@ class TestCurrentMetrics(testlib.MachineCase):
         b.logout()
         self.login_and_go("/metrics")
 
-        b.wait_in_text("#current-metrics-card-cpu", "35 °C")
+        b.wait_in_text("#current-metrics-card-cpu", "40 °C")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp3_input", "55000")
         b.wait_in_text("#current-metrics-card-cpu", "55 °C")
         m.write("/tmp/sensor-sys-class/hwmon/hwmon1/temp2_input", "90000")


### PR DESCRIPTION
Fixes: #19055

After discussion in #19055 and on matrix we've decided to not ignore Tctl sensor as sometimes it is the only available sensor some CPUs expose in hwmon.