### PR TITLE
users: allow administrators to change the user shell

### DIFF
--- a/pkg/users/account-details.js
+++ b/pkg/users/account-details.js
@@ -41,6 +41,7 @@ import { ExclamationCircleIcon, HelpIcon, UndoIcon } from '@patternfly/react-ico
 import { show_unexpected_error } from "./dialog-utils.js";
 import { delete_account_dialog } from "./delete-account-dialog.js";
 import { account_expiration_dialog, password_expiration_dialog } from "./expiration-dialogs.js";
+import { account_shell_dialog } from "./shell-dialog.js";
 import { set_password_dialog, reset_password_dialog } from "./password-dialogs.js";
 import { AccountLogs } from "./account-logs-panel.jsx";
 import { AuthorizedKeys } from "./authorized-keys-panel.js";
@@ -102,7 +103,7 @@ function get_expire(name) {
             .then(parse_expire);
 }
 
-export function AccountDetails({ accounts, groups, shadow, current_user, user }) {
+export function AccountDetails({ accounts, groups, shadow, current_user, user, shells }) {
     const [expiration, setExpiration] = useState(null);
     useEffect(() => {
         get_expire(user).then(setExpiration);
@@ -334,7 +335,16 @@ export function AccountDetails({ accounts, groups, shadow, current_user, user })
                                     <output id="account-home-dir">{account.home}</output>
                                 </FormGroup> }
                                 { account.shell && <FormGroup fieldId="account-shell" hasNoPaddingTop label={_("Shell")}>
-                                    <output id="account-shell">{account.shell}</output>
+                                    <Flex flex={{ default: 'inlineFlex' }}>
+                                        <output id="account-shell">{account.shell}</output>
+                                        <Button onClick={() => account_shell_dialog(account, shells)}
+                                                isDisabled={!superuser.allowed}
+                                                variant="link"
+                                                isInline
+                                                id="change-shell-button">
+                                            {_("change")}
+                                        </Button>
+                                    </Flex>
                                 </FormGroup> }
                             </Form>
                         </CardBody>

--- a/pkg/users/shell-dialog.js
+++ b/pkg/users/shell-dialog.js
@@ -1,0 +1,102 @@
+/*
+ * This file is part of Cockpit.
+ *
+ * Copyright (C) 2023 Red Hat, Inc.
+ *
+ * Cockpit is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * Cockpit is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import cockpit from 'cockpit';
+import React from 'react';
+import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/components/FormSelect/index.js";
+
+import { has_errors } from "./dialog-utils.js";
+import { show_modal_dialog, apply_modal_dialog } from "cockpit-components-dialog.jsx";
+
+const _ = cockpit.gettext;
+
+function ShellDialogBody({ state, errors, change, shells }) {
+    const { shell } = state;
+    return (
+        <Form className="shell-modal" onSubmit={apply_modal_dialog}>
+            <FormGroup fieldId="edit-user-shell">
+                <FormSelect
+                        data-selected={shell}
+                        id="edit-user-shell"
+                        onChange={(_, selection) => { change("shell", selection) }}
+                        value={shell}>
+                    { shells.map(shell_path => <FormSelectOption key={shell_path} value={shell_path} label={shell_path} />) }
+                </FormSelect>
+            </FormGroup>
+        </Form>
+    );
+}
+
+export function account_shell_dialog(account, shells) {
+    let dlg = null;
+
+    const state = {
+        shell: account.shell,
+    };
+
+    let errors = { };
+
+    function change(field, value) {
+        state[field] = value;
+        update();
+    }
+
+    function validate() {
+        errors = { };
+
+        return !has_errors(errors);
+    }
+
+    function update() {
+        const props = {
+            id: "shell-dialog",
+            title: _("Change shell"),
+            body: <ShellDialogBody state={state} errors={errors} change={change} shells={shells} />,
+            variant: "small"
+        };
+
+        const footer = {
+            actions: [
+                {
+                    caption: _("Change"),
+                    style: "primary",
+                    clicked: () => {
+                        if (validate()) {
+                            return cockpit.spawn(["usermod", "--shell", state.shell, account.name],
+                                                 { superuser: true, err: "message" });
+                        } else {
+                            update();
+                            return Promise.reject();
+                        }
+                    }
+                }
+            ]
+        };
+
+        if (!dlg)
+            dlg = show_modal_dialog(props, footer);
+        else {
+            dlg.setProps(props);
+            dlg.setFooterProps(footer);
+        }
+    }
+
+    update();
+}

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -141,7 +141,7 @@ function AccountsPage() {
     } else if (path.length === 1) {
         return (
             <AccountDetails accounts={accountsInfo} groups={groupsExtraInfo} shadow={shadow || []}
-                            current_user={current_user_info?.name} user={path[0]} />
+                            current_user={current_user_info?.name} user={path[0]} shells={shells} />
         );
     } else return null;
 }

--- a/test/verify/check-users
+++ b/test/verify/check-users
@@ -1254,6 +1254,27 @@ class TestAccounts(testlib.MachineCase):
         # Rename and delete actions are available only for user created groups
         b.wait_not_present(f"#groups-list tbody tr:contains({m.get_admin_group()}) .pf-v5-c-dropdown button")
 
+    def testChangeShell(self):
+        b = self.browser
+        m = self.machine
+
+        self.login_and_go("/users")
+
+        # Add a user externally
+        m.execute("useradd anton")
+        m.execute("echo anton:foobar | chpasswd")
+        with b.wait_timeout(30):
+            b.wait_in_text('#accounts-list', "anton")
+
+        b.go("#/anton")
+        b.wait_text("#account-shell", getUserAddDetails(m)["SHELL"])
+        b.click("#change-shell-button")
+        b.wait_visible("#shell-dialog")
+        new_shell = "/bin/sh"
+        b.select_from_dropdown("#edit-user-shell", new_shell)
+        b.click('#shell-dialog button.apply')
+        b.wait_text("#account-shell", new_shell)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
On Fedora a normal user can change it's own shell only through `lchsh` while other distributions do package `chsh` a setuid binary. As a compromise allow changing of the shell only for the Administrator and use `usermod` for changing the users shell which should be available on all supported systems by default.

---

# Allow administrators to change the user shell

Administrators can now change a users shell via the user account page.

![image](https://github.com/cockpit-project/cockpit/assets/67428/2c4895e4-e71c-4068-926b-5335d434b75d.png)

![image](https://github.com/cockpit-project/cockpit/assets/67428/379a3ff1-20c6-46db-a966-88e4d3bfa108.png)

 
