### PR TITLE
tools: Adjust Debian libblockdev-mdraid dependency for udisks 2.10

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -118,7 +118,7 @@ Architecture: all
 Multi-Arch: foreign
 Depends: ${misc:Depends},
          udisks2 (>= 2.9),
-         libblockdev-mdraid2,
+         udisks2 (>= 2.10) | libblockdev-mdraid2,
          cockpit-bridge (>= ${source:Version}),
          python3,
          python3-dbus


### PR DESCRIPTION
The most recent udisks2 version moved to libblockdev 3.0, which bumped its soname to libblockdev-mdraid3. udisks2 2.10 has a hard dependency to libblockdev-mdraid3, so we don't need to depend on the latter directly any more. But keep an alternative dependency for older releases.

Fixes https://bugs.debian.org/1040803