### PR TITLE
tools: Suggest mdadm for cockpit-storaged

### DIFF
--- a/tools/debian/control
+++ b/tools/debian/control
@@ -122,7 +122,8 @@ Depends: ${misc:Depends},
          cockpit-bridge (>= ${source:Version}),
          python3,
          python3-dbus
-Suggests: udisks2-lvm2
+Suggests: udisks2-lvm2,
+          mdadm,
 Description: Cockpit user interface for storage
  The Cockpit components for interacting with storage.
  .


### PR DESCRIPTION
The latest libblockdev-mdraid package does not depend on `mdraid` any more. That is okay, as it comes with some initrd and boot baggage, so we don't want to force it upon every cockpit user either. Trying to create an md array without mdadm installed gives a clear error message:

    Error creating RAID array: The 'mdadm' utility is not available

So just add a Suggests for it.

Thanks to Michael Biebl for pointing this out!