### PR TITLE
test: Make some storage tests nondestructive

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -50,11 +50,12 @@
     - dnf-automatic
     - firewalld
     - lvm2
-    - udisks2-lvm2
     - nfs-utils
     - python3-tracer
     - rpm-build
     - subscription-manager
     - targetcli
+    - udisks2-lvm2
+    - udisks2-iscsi
   test: ./browser.sh optional
   duration: 1h

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -93,6 +93,7 @@ if [ "$PLAN" = "optional" ]; then
               TestStoragePackagesNFS.testNfsMissingPackages
               TestStoragePartitions.testSizeSlider
               TestStorageIgnored.testIgnored
+              TestStorageUnused.testUnused
 
               TestUpdates.testUnprivileged
               TestUpdates.testPackageKitCrash

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -77,6 +77,9 @@ if [ "$PLAN" = "optional" ]; then
     # Testing Farm machines often have pending restarts/reboot
     EXCLUDES="$EXCLUDES TestUpdates.testBasic TestUpdates.testFailServiceRestart TestUpdates.testKpatch"
 
+    # FIXME: creation dialog hangs forever
+    EXCLUDES="$EXCLUDES TestStorageISCSI.testISCSI"
+
     # These don't test more external APIs
     EXCLUDES="$EXCLUDES
               TestAutoUpdates.testBasic

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -82,6 +82,11 @@ if [ "$PLAN" = "optional" ]; then
               TestAutoUpdates.testBasic
               TestAutoUpdates.testPrivilegeChange
 
+              TestStorageFormat.testAtBoot
+              TestStorageFormat.testFormatCancel
+              TestStorageFormat.testFormatTooSmall
+              TestStorageFormat.testFormatTypes
+
               TestStoragePackagesNFS.testNfsMissingPackages
               TestStoragePartitions.testSizeSlider
               TestStorageIgnored.testIgnored

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -90,6 +90,13 @@ if [ "$PLAN" = "optional" ]; then
               TestStorageFormat.testFormatTooSmall
               TestStorageFormat.testFormatTypes
 
+              TestStorageMounting.testAtBoot
+              TestStorageMounting.testBadOption
+              TestStorageMounting.testFirstMount
+              TestStorageMounting.testMounting
+              TestStorageMounting.testMountingHelp
+              TestStorageMounting.testNeverAuto
+
               TestStoragePackagesNFS.testNfsMissingPackages
               TestStoragePartitions.testSizeSlider
               TestStorageIgnored.testIgnored

--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -31,7 +31,7 @@ class NetworkHelpers:
         """
         if dhcp_range is None:
             dhcp_range = ['10.111.112.2', '10.111.127.254']
-        self.machine.execute(r"""set -e
+        self.machine.execute(r"""
             mkdir -p /run/udev/rules.d/
             echo 'ENV{ID_NET_DRIVER}=="veth", ENV{INTERFACE}=="%(name)s", ENV{NM_UNMANAGED}="0"' > /run/udev/rules.d/99-nm-veth-%(name)s-test.rules
             udevadm control --reload
@@ -191,7 +191,7 @@ class NetworkCase(MachineCase, NetworkHelpers):
         m.execute("systemctl restart NetworkManager")
 
     def slow_down_dhclient(self, delay):
-        self.machine.execute("""set -e
+        self.machine.execute("""
         mkdir -p {0}
         cp -a /usr/sbin/dhclient {0}/dhclient.real
         printf '#!/bin/sh\\nsleep {1}\\nexec {0}/dhclient.real "$@"' > {0}/dhclient

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -397,7 +397,7 @@ post_upgrade() {{
     def enableRepo(self):
         if self.backend == "apt":
             self.createAptChangelogs()
-            self.machine.execute("""set -e; echo 'deb [trusted=yes] file://{0} /' > /etc/apt/sources.list.d/test.list
+            self.machine.execute("""echo 'deb [trusted=yes] file://{0} /' > /etc/apt/sources.list.d/test.list
                                     cd {0}; apt-ftparchive packages . > Packages
                                     xz -c Packages > Packages.xz
                                     O=$(apt-ftparchive -o APT::FTPArchive::Release::Origin=cockpittest release .); echo "$O" > Release
@@ -408,8 +408,7 @@ post_upgrade() {{
             self.addCleanup(self.machine.execute, "kill %i || true" % pid)
             self.machine.wait_for_cockpit_running(port=12345)  # wait for changelog HTTP server to start up
         elif self.backend == "alpm":
-            self.machine.execute(f"""set -e;
-                                     cd {self.repo_dir}
+            self.machine.execute(f"""cd {self.repo_dir}
                                      repo-add {self.repo_dir}/testrepo.db.tar.gz *.pkg.tar.zst
                     """)
 
@@ -422,7 +421,7 @@ Server = file://{self.repo_dir}
                 self.machine.write("/etc/pacman.conf", config, append=True)
 
         else:
-            self.machine.execute("""set -e; printf '[updates]\nname=cockpittest\nbaseurl=file://{0}\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
+            self.machine.execute("""printf '[updates]\nname=cockpittest\nbaseurl=file://{0}\nenabled=1\ngpgcheck=0\n' > /etc/yum.repos.d/cockpittest.repo
                                     echo '{1}' > /tmp/updateinfo.xml
                                     createrepo_c {0}
                                     modifyrepo_c /tmp/updateinfo.xml {0}/repodata

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -55,7 +55,7 @@ class StorageHelpers:
         # sanity test: should not yet be loaded
         self.machine.execute("test ! -e /sys/module/scsi_debug")
         self.machine.execute(f"modprobe scsi_debug dev_size_mb={size}")
-        dev = self.machine.execute('set -e; while true; do O=$(ls /sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block 2>/dev/null || true); '
+        dev = self.machine.execute('while true; do O=$(ls /sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block 2>/dev/null || true); '
                                    '[ -n "$O" ] && break || sleep 0.1; done; echo "/dev/$O"').strip()
         # don't use addCleanup() here, this is often busy and needs to be cleaned up late; done in MachineCase.nonDestructiveSetup()
 
@@ -75,7 +75,7 @@ class StorageHelpers:
         # HACK: https://bugzilla.redhat.com/show_bug.cgi?id=1969408
         # It would be nicer to remove $F immediately after the call to
         # losetup, but that will break some versions of lvm2.
-        dev = self.machine.execute("set -e; F=$(mktemp /var/tmp/loop.XXXX); "
+        dev = self.machine.execute("F=$(mktemp /var/tmp/loop.XXXX); "
                                    "dd if=/dev/zero of=$F bs=1000000 count=%s; "
                                    "losetup --show %s $F" % (size, name if name else "--find")).strip()
         # If this device had partions in its last incarnation on this

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -882,7 +882,7 @@ export XDG_CONFIG_DIRS=/usr/local
                  ]
 
         # prepare fake ssh target; to verify that we really use that, fake dashboard manifest
-        m.execute("""set -e; useradd test1
+        m.execute("""useradd test1
                   [ -f ~admin/.ssh/id_rsa ] || su -c "ssh-keygen -t rsa -N '' -f ~/.ssh/id_rsa" admin
                   mkdir -p ~test1/.ssh ~test1/.local/share/cockpit/dashboard
                   echo '{ "version": "42", "dashboard": { "index": { "label": "HACK" } } }' > ~test1/.local/share/cockpit/dashboard/manifest.json

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1173,17 +1173,16 @@ BEGIN {{
         # Disk usage
 
         # add 50 MB loopback disk; mount it once rw and once ro
-        m.execute("""set -e
-                  F=$(mktemp /var/tmp/loop.XXXX)
-                  dd if=/dev/zero of=$F bs=1M count=50
-                  mkfs -t ext3 $F
-                  mkdir -p /var/cockpittest /var/cockpit-ro-test
-                  mount -o loop $F /var/cockpittest
-                  RODEV=$(losetup -f --show $F)
-                  mount -r $RODEV /var/cockpit-ro-test
-                  losetup -d $RODEV
-                  rm $F
-                  """)
+        m.execute("""
+            F=$(mktemp /var/tmp/loop.XXXX)
+            dd if=/dev/zero of=$F bs=1M count=50
+            mkfs -t ext3 $F
+            mkdir -p /var/cockpittest /var/cockpit-ro-test
+            mount -o loop $F /var/cockpittest
+            RODEV=$(losetup -f --show $F)
+            mount -r $RODEV /var/cockpit-ro-test
+            losetup -d $RODEV
+            rm $F""")
         self.addCleanup(m.execute, "umount /var/cockpittest /var/cockpit-ro-test")
 
         self.assertLess(progressValue(self, ".pf-v5-c-progress[data-disk-usage-target='/var/cockpittest']"), 5)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -25,7 +25,6 @@ import packagelib
 import testlib
 
 WAIT_SCRIPT = """
-set -ex
 for x in $(seq 1 200); do
     if curl --insecure -s https://%(addr)s:8443/candlepin; then
         break
@@ -358,7 +357,7 @@ echo -e "Loaded patch modules:\nkpatch_3_10_0_1062_1_1 [enabled]\n\nInstalled pa
         self.assertEqual(b.text("#available-updates button#install-all"), "Install all updates")
 
         # stall the download of chocolate by replacing the package with a pipe, so that we can test cancelling
-        chocolate = m.execute(f"""set -eux;
+        chocolate = m.execute(f"""set -ux;
             p=$(ls {self.vm_tmpdir}/repo/chocolate*2.0*2*)
             f={self.vm_tmpdir}/fifo
             mkfifo $f
@@ -1674,7 +1673,7 @@ class TestAutoUpdates(NoSubManCase):
         # new vanilla package got installed, and triggered reboot; cancel that
         m.execute("test -f /stamp-vanilla-1.0-2")
         m.execute("until test -f /run/nologin; do sleep 1; done")
-        m.execute("set -e; shutdown -c; test ! -f /run/nologin")
+        m.execute("shutdown -c; test ! -f /run/nologin")
         # service should show vanilla upgrade and scheduling shutdown
         out = m.execute(
             "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
@@ -1684,7 +1683,7 @@ class TestAutoUpdates(NoSubManCase):
 
         # run it again, now there are no available updates → no reboot
         m.execute("systemctl start dnf-automatic-install.service")
-        m.execute("set -e; test -f /stamp-vanilla-1.0-2; test ! -f /run/nologin")
+        m.execute("test -f /stamp-vanilla-1.0-2; test ! -f /run/nologin")
         # service should not do much
         out = m.execute(
             "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -184,10 +184,10 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
 
             # login with user shell that prints some stdout/err noise
             # having stdout output in ~/.bashrc confuses docker, so don't run on OSTree
-            m.execute("set -e; cd ~admin; cp -a .bashrc .bashrc.bak; [ ! -e .profile ] || cp -a .profile .profile.bak; "
+            m.execute("cd ~admin; cp -a .bashrc .bashrc.bak; [ ! -e .profile ] || cp -a .profile .profile.bak; "
                       "echo 'echo noise-rc-out; echo noise-rc-err >&2' >> .bashrc; "
                       "echo 'echo noise-profile-out; echo noise-profile-err >&2' >> .profile")
-            self.addCleanup(m.execute, "set -e; cd ~admin; mv .bashrc.bak .bashrc; "
+            self.addCleanup(m.execute, "cd ~admin; mv .bashrc.bak .bashrc; "
                                        "if [ -e .profile.bak ]; then mv .profile.bak .profile; else rm .profile; fi")
             b.login_and_go()
 

--- a/test/verify/check-storage-format
+++ b/test/verify/check-storage-format
@@ -21,19 +21,18 @@ import storagelib
 import testlib
 
 
+@testlib.nondestructive
 class TestStorageFormat(storagelib.StorageCase):
 
     def testFormatTooSmall(self):
-        m = self.machine
         b = self.browser
 
         self.login_and_go("/storage")
 
         # Try to format a disk that is too small for XFS.
 
-        m.add_disk("5M", serial="DISK1")
-        b.wait_in_text("#drives", "DISK1")
-        b.click('#drives .sidepanel-row:contains("DISK1")')
+        disk = self.add_ram_disk(size=5)
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         self.content_row_action(1, "Format")
@@ -51,9 +50,8 @@ class TestStorageFormat(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        m.add_disk("320M", serial="DISK1")  # xfs minimum size is ~300MB.
-        b.wait_in_text("#drives", "DISK1")
-        b.click('#drives .sidepanel-row:contains("DISK1")')
+        disk = self.add_ram_disk(size=320)  # xfs minimum size is ~300MB
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         def check_type(fstype, label_limit, head_action=False):
@@ -141,10 +139,8 @@ class TestStorageFormat(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        info = m.add_disk("50M", serial="DISK1")
-        dev = "/dev/" + info['dev']
-        b.wait_in_text("#drives", "DISK1")
-        b.click('#drives .sidepanel-row:contains("DISK1")')
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         def format_partition(expected_at_boot, at_boot, keep, row_action=False):
@@ -172,32 +168,32 @@ class TestStorageFormat(storagelib.StorageCase):
         format_partition("local", "nofail", keep=True)
         self.content_tab_wait_in_info(1, 1, "Mount point", "ignore failure")
         self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "nofail")
+        self.assert_in_configuration(disk, "crypttab", "options", "nofail")
 
         format_partition("nofail", "netdev", keep=True)
         self.content_tab_wait_in_info(1, 1, "Mount point", "after network")
         self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "_netdev")
+        self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
 
         format_partition("netdev", "never", keep=True)
         self.content_tab_wait_in_info(1, 1, "Mount point", "never mount")
         self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_configuration(disk, "crypttab", "options", "noauto")
 
         format_partition("never", "nofail", keep=False)
         self.content_tab_wait_in_info(1, 1, "Mount point", "ignore failure")
         self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "nofail")
+        self.assert_in_configuration(disk, "crypttab", "options", "nofail")
 
         format_partition("nofail", "netdev", keep=False)
         self.content_tab_wait_in_info(1, 1, "Mount point", "after network")
         self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "_netdev")
+        self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
 
         format_partition("netdev", "never", keep=False)
         self.content_tab_wait_in_info(1, 1, "Mount point", "never mount")
         self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
+        self.assert_in_configuration(disk, "crypttab", "options", "noauto")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -28,7 +28,6 @@ class TestStorageISCSI(storagelib.StorageCase):
     def testISCSI(self):
         m = self.machine
         b = self.browser
-        b.wait_timeout(120)
 
         self.restore_dir("/etc/iscsi")
         self.restore_dir("/var/lib/iscsi")
@@ -141,7 +140,8 @@ class TestStorageISCSI(storagelib.StorageCase):
 
         b.click('#iscsi-sessions .toggle-armed')
         b.click('#iscsi-sessions .sidepanel-row:contains(127.0.0.1) button.pf-m-danger')
-        b.wait_not_present('#iscsi-sessions .sidepanel-row:contains(127.0.0.1)')
+        with b.wait_timeout(120):
+            b.wait_not_present('#iscsi-sessions .sidepanel-row:contains(127.0.0.1)')
 
         b.click('#iscsi-sessions .toggle-armed')
         b.click('#iscsi-sessions .sidepanel-row:contains(172.27.0.15) button.pf-m-danger')

--- a/test/verify/check-storage-iscsi
+++ b/test/verify/check-storage-iscsi
@@ -22,12 +22,16 @@ import testlib
 
 
 @testlib.skipImage("UDisks doesn't have support for iSCSI", "debian-*", "ubuntu-*", "arch")
+@testlib.nondestructive
 class TestStorageISCSI(storagelib.StorageCase):
 
     def testISCSI(self):
         m = self.machine
         b = self.browser
         b.wait_timeout(120)
+
+        self.restore_dir("/etc/iscsi")
+        self.restore_dir("/var/lib/iscsi")
 
         # ensure that we generate a /etc/iscsi/initiatorname.iscsi
         m.execute("systemctl start iscsid; systemctl stop iscsid")
@@ -55,6 +59,10 @@ class TestStorageISCSI(storagelib.StorageCase):
                   targetcli /iscsi/%(tgt)s/tpg1/acls create %(ini)s
                   targetcli /iscsi/%(tgt)s/tpg1/acls/%(ini)s set auth userid=admin password=barfoo
                   """ % {"tgt": target_iqn, "ini": initiator_iqn})
+        self.addCleanup(m.execute, f"""
+            targetcli /iscsi delete {target_iqn}
+            iscsiadm -m node -o delete || true
+            targetcli /backstores/ramdisk delete test""")
         # m.execute("targetcli ls")
 
         self.login_and_go("/storage")

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -21,6 +21,7 @@ import storagelib
 import testlib
 
 
+@testlib.nondestructive
 class TestStorageMounting(storagelib.StorageCase):
 
     def testMounting(self):
@@ -33,9 +34,8 @@ class TestStorageMounting(storagelib.StorageCase):
         self.login_and_go("/storage")
 
         # Add a disk
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('#drives .sidepanel-row:contains("MYDISK")')
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         # Format it
@@ -130,7 +130,7 @@ ExecStart=/usr/bin/sleep infinity
         def wait_info_field_value(name, value):
             return b.wait_text(f'#detail-header dt:contains("{name}") + dd', value)
 
-        wait_info_field_value("Serial number", "MYDISK")
+        wait_info_field_value("Serial number", "8000")  # scsi_debug serial
 
     def testMountingHelp(self):
         m = self.machine
@@ -139,9 +139,8 @@ ExecStart=/usr/bin/sleep infinity
         self.login_and_go("/storage")
 
         # Add a disk
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('#drives .sidepanel-row:contains("MYDISK")')
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         # Format it
@@ -187,14 +186,14 @@ ExecStart=/usr/bin/sleep infinity
         # Move mount point externally, move back with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute("mkdir -p /run/bar; mount /dev/sda /run/bar")
+        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
         b.click(fsys_tab + " button:contains(Mount on /run/foo now)")
         b.wait_not_present(fsys_tab + " button:contains(Mount on /run/foo now)")
 
         # Move mount point externally, adjust fstab with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute("mkdir -p /run/bar; mount /dev/sda /run/bar")
+        m.execute(f"mkdir -p /run/bar; mount {disk} /run/bar")
         b.click(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Mount automatically on /run/bar on boot)")
 
@@ -204,6 +203,207 @@ ExecStart=/usr/bin/sleep infinity
         m.execute("sed -i -e 's/noauto/noauto,x-systemd.automount/' /etc/fstab")
         b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
 
+    def testFirstMount(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
+        b.wait_visible('#storage-detail')
+
+        m.execute(f"mkfs.ext4 {disk}")
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
+
+        m.execute("! grep /run/data /etc/fstab")
+        self.content_row_action(1, "Mount")
+        self.dialog({"mount_point": "/run/data",
+                     "mount_options.extra": "x-foo"})
+        m.execute("grep /run/data /etc/fstab")
+        m.execute("grep 'x-foo' /etc/fstab")
+
+    def testNeverAuto(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        # Add a disk and format it with luks and a filesystem, but with "Never unlock at boot"
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
+        b.wait_visible("#storage-detail")
+
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "crypto": self.default_crypto_type,
+                     "passphrase": "vainu-reku-toma-rolle-kaja",
+                     "passphrase2": "vainu-reku-toma-rolle-kaja",
+                     "at_boot": "never",
+                     "mount_point": "/run/foo"})
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "never mount at boot")
+
+        # The filesystem should be mounted but have the "noauto"
+        # option in both fstab and crypttab
+        self.wait_mounted(1, 1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Unmounting should keep the noauto option, as always
+        self.content_dropdown_action(1, "Unmount")
+        self.confirm()
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Mounting should also keep the "noauto", but it should not show up in the extra options
+        self.content_row_action(1, "Mount")
+        self.dialog_check({"mount_options.extra": False})
+        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.wait_mounted(1, 1)
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # As should updating the mount information
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog_check({"mount_options.extra": False})
+        self.dialog_apply()
+        self.dialog_wait_close()
+        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
+        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
+
+        # Removing "noauto" from fstab but not from crypttab externally should show a warning
+        m.execute("sed -i -e 's/noauto//' /etc/fstab")
+        fsys_tab = self.content_tab_expand(1, 1)
+        b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
+        b.click(fsys_tab + " button:contains(Do not mount automatically)")
+        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
+
+    def testBadOption(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
+        b.wait_visible("#storage-detail")
+
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "mount_point": "/run/foo"},
+                    secondary=True)
+        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+
+        self.content_row_action(1, "Mount")
+        self.dialog_wait_open()
+        self.dialog_set_val("mount_options.extra", "hurr")
+        self.dialog_apply()
+        self.dialog_wait_alert("bad option")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        # No changes should have been done to fstab, and the
+        # filesystem should not be mounted.
+        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.wait_not_mounted(1, 1)
+
+        # Mount
+        self.content_row_action(1, "Mount")
+        self.dialog({})
+
+        # Apply the dialog without changes and verify that the
+        # filesystem is still mounted afterwards.  Cockpit used to
+        # have a bug where this would accidentally unmount the
+        # filesystem.
+
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog({})
+        self.wait_mounted(1, 1)
+
+        # Try to set a bad option while the filesystem is mounted.
+        self.content_tab_info_action(1, 1, "Mount point")
+        self.dialog_wait_open()
+        self.dialog_set_val("mount_options.extra", "hurr")
+        self.dialog_apply()
+        self.dialog_wait_alert("bad option")
+        self.dialog_cancel()
+        self.dialog_wait_close()
+
+        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
+        self.wait_mounted(1, 1)
+
+    def testAtBoot(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/storage")
+
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
+        b.wait_visible("#storage-detail")
+
+        self.content_row_action(1, "Format")
+        self.dialog({"type": "ext4",
+                     "mount_point": "/foo",
+                     "at_boot": "local",
+                     "crypto": "luks1",
+                     "passphrase": "foobarfoo",
+                     "passphrase2": "foobarfoo"},
+                    secondary=True)
+        self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assert_in_configuration(disk, "crypttab", "options", "noauto")
+
+        def mount(expected_at_boot, at_boot):
+            self.content_row_action(1, "Mount")
+            self.dialog_wait_open()
+            self.dialog_wait_val("at_boot", expected_at_boot)
+            self.dialog_set_val("at_boot", at_boot)
+            self.dialog_set_val("passphrase", "foobarfoo")
+            self.dialog_apply()
+            self.dialog_wait_close()
+
+        def unmount():
+            self.content_dropdown_action(1, "Unmount")
+            self.dialog_wait_open()
+            self.dialog_apply()
+            self.dialog_wait_close()
+            self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
+
+        mount("local", "nofail")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "ignore failure")
+        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assert_in_configuration(disk, "crypttab", "options", "nofail")
+        unmount()
+
+        mount("nofail", "netdev")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "after network")
+        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assert_in_configuration(disk, "crypttab", "options", "_netdev")
+        unmount()
+
+        mount("netdev", "never")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "never mount")
+        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
+        self.assert_in_configuration(disk, "crypttab", "options", "noauto")
+        unmount()
+
+
+class TestStorageMountingLUKS(storagelib.StorageCase):
+
+    # LUKS uses memory hard PBKDF, 1 GiB is not enough; see https://bugzilla.redhat.com/show_bug.cgi?id=1881829
+    provision = {
+        "0": {"memory_mb": 1536}
+    }
+
     def testEncryptedMountingHelp(self):
         m = self.machine
         b = self.browser
@@ -211,11 +411,8 @@ ExecStart=/usr/bin/sleep infinity
         self.login_and_go("/storage")
 
         # Add a disk
-        m.add_disk("50M", serial="MYDISK")
-        dev = "/dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_MYDISK"
-
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('#drives .sidepanel-row:contains("MYDISK")')
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible('#storage-detail')
 
         # Format it with encryption
@@ -239,7 +436,7 @@ ExecStart=/usr/bin/sleep infinity
         # Unmount and lock externally, unlock and remount with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute(f"udisksctl lock -b {dev}")
+        m.execute(f"udisksctl lock -b {disk}")
         # wait until the UI updated to the locking
         self.content_tab_wait_in_info(1, 2, "Cleartext device", "-")
         fsys_tab = self.content_tab_expand(1, 1)
@@ -251,7 +448,7 @@ ExecStart=/usr/bin/sleep infinity
         # Unmount and lock externally, adjust fstab with Cockpit
 
         m.execute("umount /run/foo")
-        m.execute(f"udisksctl lock -b {dev}")
+        m.execute(f"udisksctl lock -b {disk}")
         # wait until the UI updated to the locking
         self.content_tab_wait_in_info(1, 2, "Cleartext device", "-")
         fsys_tab = self.content_tab_expand(1, 1)
@@ -260,14 +457,14 @@ ExecStart=/usr/bin/sleep infinity
 
         # Unlock and mount externally, unmount and lock with Cockpit
 
-        m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {dev}")
+        m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {disk}")
         m.execute("mount /run/foo")
         b.click(fsys_tab + " button:contains(Unmount now)")
         b.wait_not_present(fsys_tab + " button:contains(Unmount now)")
 
         # Unlock and mount externally, adjust fstab with Cockpit
 
-        m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {dev}")
+        m.execute(f"echo -n vainu-reku-toma-rolle-kaja | udisksctl unlock --key-file /dev/stdin -b {disk}")
         m.execute("mount /run/foo")
         b.click(fsys_tab + " button:contains(Mount also automatically on boot)")
         b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
@@ -326,204 +523,6 @@ ExecStart=/usr/bin/sleep infinity
                      "mount_point": "/run/data"})
         self.content_row_wait_in_col(1, 2, "ext4 filesystem")
         self.content_tab_wait_in_info(1, 2, "Mount point", "/run/data")
-
-    def testFirstMount(self):
-        m = self.machine
-        b = self.browser
-
-        self.login_and_go("/storage")
-
-        m.add_disk("50M", serial="MYDISK")
-        b.click("#drives .sidepanel-row:contains(MYDISK)")
-        b.wait_visible("#storage-detail")
-
-        m.execute("mkfs.ext4 /dev/sda")
-        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-
-        m.execute("! grep /run/data /etc/fstab")
-        self.content_row_action(1, "Mount")
-        self.dialog({"mount_point": "/run/data",
-                     "mount_options.extra": "x-foo"})
-        m.execute("grep /run/data /etc/fstab")
-        m.execute("grep 'x-foo' /etc/fstab")
-
-    def testNeverAuto(self):
-        m = self.machine
-        b = self.browser
-
-        self.login_and_go("/storage")
-
-        # Add a disk and format it with luks and a filesystem, but with "Never unlock at boot"
-
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('.sidepanel-row:contains("MYDISK")')
-        b.wait_visible("#storage-detail")
-
-        self.content_row_action(1, "Format")
-        self.dialog({"type": "ext4",
-                     "crypto": self.default_crypto_type,
-                     "passphrase": "vainu-reku-toma-rolle-kaja",
-                     "passphrase2": "vainu-reku-toma-rolle-kaja",
-                     "at_boot": "never",
-                     "mount_point": "/run/foo"})
-        self.content_row_wait_in_col(1, 2, "ext4 filesystem (encrypted)")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "never mount at boot")
-
-        # The filesystem should be mounted but have the "noauto"
-        # option in both fstab and crypttab
-        self.wait_mounted(1, 1)
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
-        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
-
-        # Unmounting should keep the noauto option, as always
-        self.content_dropdown_action(1, "Unmount")
-        self.confirm()
-        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
-        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
-
-        # Mounting should also keep the "noauto", but it should not show up in the extra options
-        self.content_row_action(1, "Mount")
-        self.dialog_check({"mount_options.extra": False})
-        self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
-        self.dialog_apply()
-        self.dialog_wait_close()
-        self.wait_mounted(1, 1)
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
-        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
-
-        # As should updating the mount information
-        self.content_tab_info_action(1, 1, "Mount point")
-        self.dialog_check({"mount_options.extra": False})
-        self.dialog_apply()
-        self.dialog_wait_close()
-        self.assertIn("noauto", m.execute("grep /run/foo /etc/fstab || true"))
-        self.assertNotEqual(m.execute("grep noauto /etc/crypttab"), "")
-
-        # Removing "noauto" from fstab but not from crypttab externally should show a warning
-        m.execute("sed -i -e 's/noauto//' /etc/fstab")
-        fsys_tab = self.content_tab_expand(1, 1)
-        b.wait_in_text(fsys_tab, "The filesystem is configured to be automatically mounted on boot but its encryption container will not be unlocked at that time.")
-        b.click(fsys_tab + " button:contains(Do not mount automatically)")
-        b.wait_not_present(fsys_tab + " button:contains(Do not mount automatically)")
-
-    def testBadOption(self):
-        m = self.machine
-        b = self.browser
-
-        self.login_and_go("/storage")
-
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('.sidepanel-row:contains("MYDISK")')
-        b.wait_visible("#storage-detail")
-
-        self.content_row_action(1, "Format")
-        self.dialog({"type": "ext4",
-                     "mount_point": "/run/foo"},
-                    secondary=True)
-        self.content_row_wait_in_col(1, 2, "ext4 filesystem")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
-
-        self.content_row_action(1, "Mount")
-        self.dialog_wait_open()
-        self.dialog_set_val("mount_options.extra", "hurr")
-        self.dialog_apply()
-        self.dialog_wait_alert("bad option")
-        self.dialog_cancel()
-        self.dialog_wait_close()
-
-        # No changes should have been done to fstab, and the
-        # filesystem should not be mounted.
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
-        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
-        self.wait_not_mounted(1, 1)
-
-        # Mount
-        self.content_row_action(1, "Mount")
-        self.dialog({})
-
-        # Apply the dialog without changes and verify that the
-        # filesystem is still mounted afterwards.  Cockpit used to
-        # have a bug where this would accidentally unmount the
-        # filesystem.
-
-        self.content_tab_info_action(1, 1, "Mount point")
-        self.dialog({})
-        self.wait_mounted(1, 1)
-
-        # Try to set a bad option while the filesystem is mounted.
-        self.content_tab_info_action(1, 1, "Mount point")
-        self.dialog_wait_open()
-        self.dialog_set_val("mount_options.extra", "hurr")
-        self.dialog_apply()
-        self.dialog_wait_alert("bad option")
-        self.dialog_cancel()
-        self.dialog_wait_close()
-
-        self.assertNotIn("hurr", m.execute("findmnt --fstab -n -o OPTIONS /run/foo"))
-        self.wait_mounted(1, 1)
-
-    def testAtBoot(self):
-        m = self.machine
-        b = self.browser
-
-        self.login_and_go("/storage")
-
-        info = m.add_disk("50M", serial="MYDISK")
-        dev = "/dev/" + info['dev']
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('.sidepanel-row:contains("MYDISK")')
-        b.wait_visible("#storage-detail")
-
-        self.content_row_action(1, "Format")
-        self.dialog({"type": "ext4",
-                     "mount_point": "/foo",
-                     "at_boot": "local",
-                     "crypto": "luks1",
-                     "passphrase": "foobarfoo",
-                     "passphrase2": "foobarfoo"},
-                    secondary=True)
-        self.content_row_wait_in_col(1, 2, "Filesystem (encrypted)")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
-        self.assertIn("noauto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
-
-        def mount(expected_at_boot, at_boot):
-            self.content_row_action(1, "Mount")
-            self.dialog_wait_open()
-            self.dialog_wait_val("at_boot", expected_at_boot)
-            self.dialog_set_val("at_boot", at_boot)
-            self.dialog_set_val("passphrase", "foobarfoo")
-            self.dialog_apply()
-            self.dialog_wait_close()
-
-        def unmount():
-            self.content_dropdown_action(1, "Unmount")
-            self.dialog_wait_open()
-            self.dialog_apply()
-            self.dialog_wait_close()
-            self.content_tab_wait_in_info(1, 1, "Mount point", "The filesystem is not mounted")
-
-        mount("local", "nofail")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "ignore failure")
-        self.assertIn("nofail", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "nofail")
-        unmount()
-
-        mount("nofail", "netdev")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "after network")
-        self.assertIn("_netdev", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "_netdev")
-        unmount()
-
-        mount("netdev", "never")
-        self.content_tab_wait_in_info(1, 1, "Mount point", "never mount")
-        self.assertIn("x-cockpit-never-auto", m.execute("findmnt --fstab -n -o OPTIONS /foo"))
-        self.assert_in_configuration(dev, "crypttab", "options", "noauto")
-        unmount()
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-msdos
+++ b/test/verify/check-storage-msdos
@@ -21,18 +21,17 @@ import storagelib
 import testlib
 
 
+@testlib.nondestructive
 class TestStorageMsDOS(storagelib.StorageCase):
 
     def testDosParts(self):
-        m = self.machine
         b = self.browser
 
         self.login_and_go("/storage")
 
         # Add a disk
-        m.add_disk("50M", serial="MYDISK")
-        b.wait_in_text("#drives", "MYDISK")
-        b.click('.sidepanel-row:contains("MYDISK")')
+        disk = self.add_ram_disk()
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
         b.wait_visible("#storage-detail")
 
         # Format it with a DOS partition table

--- a/test/verify/check-storage-nfs
+++ b/test/verify/check-storage-nfs
@@ -100,7 +100,7 @@ class TestStorageNfs(storagelib.StorageCase):
         self.dialog_set_val("dir", "/mounts/barbar")
         self.dialog_apply()
         self.dialog_wait_close()
-        self.addCleanup(m.execute, "set -e; umount /mounts/barbar; rmdir /mounts/barbar")
+        self.addCleanup(m.execute, "umount /mounts/barbar; rmdir /mounts/barbar")
 
         b.wait_text('#detail-header dt:contains("Mount point") + dd', "/mounts/barbar")
         m.execute("! test -e /mounts/bar")

--- a/test/verify/check-storage-raid1
+++ b/test/verify/check-storage-raid1
@@ -21,6 +21,7 @@ import storagelib
 import testlib
 
 
+@testlib.nondestructive
 class TestStorageRaid1(storagelib.StorageCase):
 
     def testRaidLevelOne(self):
@@ -29,18 +30,19 @@ class TestStorageRaid1(storagelib.StorageCase):
 
         self.login_and_go("/storage")
 
-        # Add four two and make a RAID out of them
-        m.add_disk("50M", serial="DISK1")
-        m.add_disk("50M", serial="DISK2")
-        b.wait_in_text("#drives", "DISK1")
-        b.wait_in_text("#drives", "DISK2")
+        # Create two disks and make a RAID out of them
+        disk1 = self.add_loopback_disk()
+        disk2 = self.add_loopback_disk()
+        b.wait_in_text("#others", disk1)
+        b.wait_in_text("#others", disk2)
 
+        self.addCleanup(m.execute, "mdadm --manage --stop /dev/md/SOMERAID")
         self.devices_dropdown('Create RAID device')
         self.dialog_wait_open()
         # No swap block devices should show up
         b.wait_not_in_text("#dialog .pf-v5-c-data-list", "zram")
         self.dialog_set_val("level", "raid1")
-        self.dialog_set_val("disks", {"DISK1": True, "DISK2": True})
+        self.dialog_set_val("disks", {disk1: True, disk2: True})
         self.dialog_set_val("name", "SOMERAID")
         # The dialog should make sure that the Chunk size is ignored (has to be 0 for RAID 1)
         self.dialog_apply()

--- a/test/verify/check-storage-unused
+++ b/test/verify/check-storage-unused
@@ -21,6 +21,7 @@ import storagelib
 import testlib
 
 
+@testlib.nondestructive
 class TestStorageUnused(storagelib.StorageCase):
 
     def testUnused(self):
@@ -39,17 +40,17 @@ class TestStorageUnused(storagelib.StorageCase):
         # So we partition a disk with two logical partitions, one of which
         # has a filesystem on it.
 
-        m.add_disk("50M", serial="DISK1")
-        m.add_disk("50M", serial="DISK2")
-        b.wait_in_text("#drives", "DISK1")
-        b.wait_in_text("#drives", "DISK2")
+        disk1 = self.add_ram_disk()
+        disk2 = self.add_loopback_disk()
+        b.wait_in_text("#drives", disk1)
+        b.wait_in_text("#others", disk2)
         script = """mktable msdos \
 mkpart extended 1 50 \
 mkpart logical ext2 2 24 \
 mkpart logical ext2 24 48"""
-        m.execute("parted -s /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1 " + script)
+        m.execute(f"parted -s {disk1} {script}")
         m.execute("udevadm settle")
-        m.execute("mke2fs -q -L TEST /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_DISK1-part5")
+        m.execute(f"mke2fs -q -L TEST {disk1}5")
 
         b.inject_js("""
           ph_texts = function (sel) {
@@ -61,7 +62,7 @@ mkpart logical ext2 24 48"""
             print("blocks", blocks)
             # On Ubuntu we see /dev/ram devices as well
             # On Fedora also /dev/zram0 - see https://github.com/cockpit-project/cockpit/issues/14516
-            allowed = ["/dev/sda", "/dev/sdb", "/dev/vda", "/dev/ram", "/dev/zram"]
+            allowed = ["/dev/sda", "/dev/loop", "/dev/vda", "/dev/ram", "/dev/zram"]
             for block in blocks:
                 for allow in allowed:
                     if allow in block:
@@ -70,7 +71,7 @@ mkpart logical ext2 24 48"""
                     return False
 
             # Require these two to be present
-            return "/dev/sda6" in blocks and "/dev/sdb" in blocks
+            return f"{disk1}6" in blocks and disk2 in blocks
 
         self.dialog_with_retry(trigger=lambda: self.devices_dropdown('Create RAID device'),
                                expect=check_free_block_devices,

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -763,7 +763,7 @@ machine         : 8561
         # - Debian: no BLS, options go into /etc/default/grub and grub.cfg
         # - BLS, options go directly into entries, or entries use $kernelopt (defined in grubenv)
         if not m.ostree_image:
-            m.execute(r"""set -e
+            m.execute(r"""
 touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
@@ -777,7 +777,7 @@ else
 fi
 """)
             # clean up so that next reboot works
-            m.execute(r"""set -e
+            m.execute(r"""
 rm /boot/vmlinuz-42.0.0
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -853,7 +853,7 @@ class TestAD(TestRealms, CommonTests):
         # DNS is not sufficient yet, needs to start LDAP server as well
         m.execute("until nc -z f0.cockpit.lan 389; do sleep 1; done")
         # also wait for Kerberos
-        m.execute(f"set -e; until echo {self.admin_password} | kinit {self.admin_user}@COCKPIT.LAN; do sleep 1; done; kdestroy")
+        m.execute(f"until echo {self.admin_password} | kinit {self.admin_user}@COCKPIT.LAN; do sleep 1; done; kdestroy")
 
         # allow sudo access to domain admins; FIXME: Is there a server-side setting for this,
         # similar to "ipa-advise enable-admins-sudo"?


### PR DESCRIPTION
This makes them nicer to develop/debug, faster to run, and we can run some in FMF.

Some spot-checks of the /storage scenario:
 -  [main/f38](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19100-20230717-043759-accf9f88-fedora-38-storage/log): [642s on rhos-01-18, 46 parallel tests, 16 serial tests: 0: 71s, 1: 70s, 2: 75s, 3: 100s, 4: 71s, 5: 72s, 6: 81s, 7: 108s]
 - [main/f38](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19085-20230710-072336-bd849f48-fedora-38-storage/log): [684s on 4-ci-srv-06, 46 parallel tests, 16 serial tests: 0: 78s, 1: 91s, 2: 88s, 3: 124s, 4: 78s, 5: 78s, 6: 90s, 7: 121s]
- [here/f38](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19102-20230717-084620-ce2cce7a-fedora-38-storage/log): [560s on rhos-01-8, 29 parallel tests, 33 serial tests: 0: 136s, 1: 178s, 2: 135s, 3: 134s, 4: 138s, 5: 146s, 6: 153s, 7: 169s]