### PR TITLE
sosreport: Add fallback error message, fix testInsightsClient failure on rhel4edge

### DIFF
--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -177,7 +177,8 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
     });
 
     task.catch(error => {
-        setError(error.toString());
+        console.error(JSON.stringify(error)); // easier investigation of failures, errors in pty mode may be hard to see
+        setError(error.toString() || _("sos report failed"));
         setErrorDetail(output);
     });
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2049,7 +2049,7 @@ class MachineCase(unittest.TestCase):
             if path.startswith("/home"):
                 cmd = f"umount -lf {path}"
             else:
-                cmd = f"umount {path} || {{ fuser -uvk {path}/* || true; sleep 1; umount {path}; }}"
+                cmd = f"umount {path} || {{ fuser -uvk {path} {path}/* >&2 || true; sleep 1; umount {path}; }}"
             self.addCleanup(self.machine.execute, cmd)
 
     def restore_file(self, path: str, post_restore_action: Optional[str] = None):

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -107,6 +107,19 @@ only-plugins=release,date,host,cgroups,networking
         b.click("#sos-remove-dialog button:contains(Delete)")
         testlib.wait(lambda: m.execute(f"! test -f /var/tmp/{base_report_gpg} && echo yes"))
 
+        # error reporting
+        self.write_file("/usr/sbin/sos", """#!/bin/sh
+echo "EssOhEss is kaputt" >&2
+exit 1""", perm="755")
+        b.click("button:contains('Run report')")
+        b.wait_visible("#sos-dialog")
+        b.click("#sos-dialog button:contains(Run report)")
+        b.wait_in_text("#sos-dialog .pf-v5-c-alert",
+                       "sos report failed" if self.is_pybridge() else "sos exited with code 1")
+        b.wait_in_text("#sos-dialog .pf-v5-c-alert", "EssOhEss is kaputt")
+        b.click("#sos-dialog button:contains(Cancel)")
+        b.wait_not_present("#sos-dialog")
+
         self.allow_journal_messages('.*comm="sosreport".*')
 
     def testWithUrlRoot(self):

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -905,6 +905,7 @@ password=foobar
         b.become_superuser()
         b.wait_in_text(".system-health-insights a", "3 hits, including important")
         self.assertIn("123-nice-id", b.attr(".system-health-insights a", "href"))
+        b.logout()
 
     def testOverview(self):
         m = self.machine


### PR DESCRIPTION
If `sos report` fails, we can get an empty message in `error`. That will lead to not showing the error in the dialog at all (as it's falsy), even if errorDetail was set. Fix that by adding a generic fallback title.

Also log the full error for easier debugging. 

----

I noticed this while investigating the [current sos rawhide failure](https://bugzilla.redhat.com/show_bug.cgi?id=2223526). This looks really unfriendly -- you click "Report", the dialog flickers and nothing happens. Now it shows the error properly:

![sos](https://github.com/cockpit-project/cockpit/assets/200109/bca20581-b786-4286-9458-078d5a03f45f)