### PR TITLE
kdump: Show message in 'Test configuration' to verify the crash

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -267,7 +267,7 @@ export class KdumpPage extends React.Component {
         const dialogProps = {
             title: _("Test kdump settings"),
             body: (
-                <span>{_("This will test kdump settings by crashing the kernel and thereby the system. Depending on the settings, the system may not automatically reboot and the process may take a while.")}</span>
+                <span>{_("Test kdump settings by crashing the kernel. This may take a while and the system might not automatically reboot. Do not purposefully crash the system while any important task is running.")}</span>
             )
         };
         // also test modifying properties in subsequent render calls

--- a/pkg/kdump/kdump.scss
+++ b/pkg/kdump/kdump.scss
@@ -19,6 +19,9 @@
 
 @use "page";
 
+@import "global-variables";
+@import "@patternfly/patternfly/utilities/Text/text.scss";
+
 #kdump-settings-location {
   inline-size: 100%;
 }

--- a/pkg/lib/cockpit-components-dialog.jsx
+++ b/pkg/lib/cockpit-components-dialog.jsx
@@ -209,6 +209,7 @@ DialogFooter.propTypes = {
  *  - id optional, id that is assigned to the top level dialog node, but not the backdrop
  *  - variant: See PF4 Modal component's 'variant' property
  *  - titleIconVariant: See PF4 Modal component's 'titleIconVariant' property
+ *  - showClose optional, specifies if 'X' button for closing the dialog is present
  */
 class Dialog extends React.Component {
     componentDidMount() {
@@ -241,7 +242,7 @@ class Dialog extends React.Component {
             <Modal position="top" variant={this.props.variant || "medium"}
                    titleIconVariant={this.props.titleIconVariant}
                    onEscapePress={() => undefined}
-                   showClose={false}
+                   showClose={!!this.props.showClose}
                    id={this.props.id}
                    isOpen
                    help={help}
@@ -264,6 +265,7 @@ Dialog.propTypes = {
     footer: PropTypes.element, // is effectively required, see above
     id: PropTypes.string,
     error: PropTypes.object,
+    showClose: PropTypes.bool,
 };
 
 /* Create and show a dialog

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -32,20 +32,24 @@ class KdumpHelpers(testlib.MachineCase):
         self.browser.switch_to_top()
         self.browser.relogin("/kdump")
 
-    def crashKernel(self):
+    def crashKernel(self, message, cancel=False):
         b = self.browser
         b.click(f"button{self.default_btn_class}")
-        # we should get a warning dialog, confirm
-        b.click(f"button{self.danger_btn_class}")
-        # wait until we've actually triggered a crash
-        b.wait_visible(".apply.pf-m-in-progress")
+        self.browser.wait_in_text(".pf-v5-c-modal-box__body", message)
+        if cancel:
+            b.click(".pf-v5-c-modal-box button:contains('Cancel')")
+        else:
+            # we should get a warning dialog, confirm
+            b.click(f"button{self.danger_btn_class}")
+            # wait until we've actually triggered a crash
+            b.wait_visible(".apply.pf-m-in-progress")
 
-        # wait for disconnect and then try connecting again
-        b.switch_to_top()
-        with b.wait_timeout(60):
-            b.wait_in_text("div.curtains-ct h1", "Disconnected")
-        self.machine.disconnect()
-        self.machine.wait_boot(timeout_sec=300)
+            # wait for disconnect and then try connecting again
+            b.switch_to_top()
+            with b.wait_timeout(60):
+                b.wait_in_text("div.curtains-ct h1", "Disconnected")
+            self.machine.disconnect()
+            self.machine.wait_boot(timeout_sec=300)
 
 
 @testlib.skipOstree("kexec-tools not installed")
@@ -141,6 +145,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text(pathInput, "/var/crash")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_not_present(pathInput)
+        self.crashKernel("copied through SSH to root@localhost:/var/crash as vmcore", cancel=True)
 
         # we should have the amount of memory reserved that we indicated
         b.wait_in_text("#app", "256 MiB")
@@ -174,7 +179,7 @@ class TestKdump(KdumpHelpers):
         assertActive(active=True)
 
         # crash the kernel and make sure it wrote a report into the right directory
-        self.crashKernel()
+        self.crashKernel("stored in /var/crash2 as vmcore")
         m.execute(f"until test -e {customPath}/127.0.0.1*/vmcore; do sleep 1; done", timeout=180)
         self.assertIn("Kdump compressed dump", m.execute(f"file {customPath}/127.0.0.1*/vmcore"))
 
@@ -425,7 +430,7 @@ class TestKdumpNFS(KdumpHelpers):
         self.assertIn("\nnfs 10.111.113.2:/srv/kdump\n", conf)
         self.assertNotIn("\npath", conf)
 
-        self.crashKernel()
+        self.crashKernel("copied through NFS to 10.111.113.2:/srv/kdump/var/crash")
 
         # dump is done during boot, so should exist now
         self.assertIn("Kdump compressed dump",
@@ -454,7 +459,7 @@ class TestKdumpNFS(KdumpHelpers):
 
         b.wait_visible(".pf-v5-c-switch__input:checked")
 
-        self.crashKernel()
+        self.crashKernel("copied through NFS to 10.111.113.2:/srv/kdump/dumps")
         self.assertIn("Kdump compressed dump",
                       self.machines["nfs"].execute("file /srv/kdump/dumps/10.111.113.1*/vmcore"))
 


### PR DESCRIPTION
This adds message showing a location where user can verify whetever crash was successful:
- Local filesystem: "To verify whether the crash was successful check /var/crash location for kernel crash dump(vmcore)."
- SSH: "To verify whether the crash was successful check /var/crash location at skobyda@myserver.com for kernel crash dump(vmcore)"
- -NFS: "To verify whether the crash was successful check /var/crash location at myserver.com:/export/cores for kernel crash dump(vmcore)."

Closes https://issues.redhat.com/browse/RHELPLAN-125375
Closes https://bugzilla.redhat.com/show_bug.cgi?id=2097440

![Screenshot from 2023-08-17 14-30-10](https://github.com/cockpit-project/cockpit/assets/42733240/ea1e6cf3-2b58-4599-9149-cfc30eacd844)
![Screenshot from 2023-08-17 14-29-59](https://github.com/cockpit-project/cockpit/assets/42733240/7af64ea3-81bd-4ef6-9910-6873d8afc66f)
![Screenshot from 2023-08-17 14-29-47](https://github.com/cockpit-project/cockpit/assets/42733240/3cdcd28d-c520-4081-b002-f45e7c31db94)

