### PR TITLE
storaged: Fix crash on fstab lines without mntopts

### DIFF
--- a/pkg/storaged/client.js
+++ b/pkg/storaged/client.js
@@ -633,7 +633,7 @@ client.mount_at = (block, target) => {
     const entry = block.Configuration.find(c => c[0] == "fstab" && utils.decode_filename(c[1].dir.v) == target);
     if (entry)
         return cockpit.script('set -e; mkdir -p "$2"; mount "$1" "$2" -o "$3"',
-                              [utils.decode_filename(block.Device), target, utils.decode_filename(entry[1].opts.v)],
+                              [utils.decode_filename(block.Device), target, utils.get_block_mntopts(entry[1])],
                               { superuser: true, err: "message" });
     else
         return Promise.reject(cockpit.format("Internal error: No fstab entry for $0 and $1",

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -39,7 +39,7 @@ import {
     dialog_open,
     SelectOneRadio, TextInput, PassInput, Skip
 } from "./dialog.jsx";
-import { decode_filename, encode_filename, block_name, for_each_async, get_children } from "./utils.js";
+import { decode_filename, encode_filename, get_block_mntopts, block_name, for_each_async, get_children } from "./utils.js";
 import { fmt_to_fragments } from "utils.jsx";
 import { StorageButton } from "./storage-controls.jsx";
 import { parse_options, unparse_options } from "./format-dialog.jsx";
@@ -356,7 +356,7 @@ function ensure_fstab_option(steps, progress, client, block, option) {
     const fsys_config = cleartext
         ? cleartext.Configuration.find(c => c[0] == "fstab")
         : crypto?.ChildConfiguration.find(c => c[0] == "fstab");
-    const fsys_options = fsys_config && parse_options(decode_filename(fsys_config[1].opts.v));
+    const fsys_options = fsys_config && parse_options(get_block_mntopts(fsys_config[1]));
 
     if (!fsys_options || fsys_options.indexOf(option) >= 0)
         return Promise.resolve();

--- a/pkg/storaged/fsys-tab.jsx
+++ b/pkg/storaged/fsys-tab.jsx
@@ -61,15 +61,14 @@ export function get_fstab_config(block, also_child_config) {
         config = client.blocks_crypto[block.path]?.ChildConfiguration.find(c => c[0] == "fstab");
 
     if (config && utils.decode_filename(config[1].type.v) != "swap") {
+        const mnt_opts = utils.get_block_mntopts(config[1]).split(",");
         let dir = utils.decode_filename(config[1].dir.v);
-        let opts = (utils.decode_filename(config[1].opts.v)
-                .split(",")
+        let opts = mnt_opts
                 .filter(function (s) { return s.indexOf("x-parent") !== 0 })
-                .join(","));
-        const parents = (utils.decode_filename(config[1].opts.v)
-                .split(",")
+                .join(",");
+        const parents = mnt_opts
                 .filter(function (s) { return s.indexOf("x-parent") === 0 })
-                .join(","));
+                .join(",");
         if (dir[0] != "/")
             dir = "/" + dir;
         if (opts == "defaults")

--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -77,6 +77,11 @@ export function encode_filename(decoded) {
             .concat([0]));
 }
 
+export function get_block_mntopts(config) {
+    // treat an absent field as "default", like util-linux
+    return (config.opts ? decode_filename(config.opts.v) : "defaults");
+}
+
 export function fmt_size(bytes) {
     return cockpit.format_bytes(bytes);
 }

--- a/test/verify/check-storage-mounting
+++ b/test/verify/check-storage-mounting
@@ -203,7 +203,7 @@ ExecStart=/usr/bin/sleep infinity
         m.execute("sed -i -e 's/noauto/noauto,x-systemd.automount/' /etc/fstab")
         b.wait_not_present(fsys_tab + " button:contains(Mount also automatically on boot)")
 
-    def testFirstMount(self):
+    def testFstabOptions(self):
         m = self.machine
         b = self.browser
 
@@ -222,6 +222,11 @@ ExecStart=/usr/bin/sleep infinity
                      "mount_options.extra": "x-foo"})
         m.execute("grep /run/data /etc/fstab")
         m.execute("grep 'x-foo' /etc/fstab")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "/run/data (ignore failure, x-foo)")
+
+        # absent mntopts and fsck columns implies "defaults"
+        m.execute(r"sed -i '/run\/data/ s/auto.*$/auto/' /etc/fstab")
+        self.content_tab_wait_in_info(1, 1, "Mount point", "/run/data (stop boot on failure)")
 
     def testNeverAuto(self):
         m = self.machine


### PR DESCRIPTION
util-linux accepts them and treats them like having mount options "defaults". Do the same instead of crashing on an undefined `.opts.v`.

As this is done three times in the code, introduce an utility function for it.

Rename testFirstMount() (which had a confusing name) to testFstabOptions(), and add reproducer there. Also strengthen the initial test to actually validate that the `x-foo` and `nofail` options appear in the UI.

Fixes #18406