### PR TITLE
Fix all shellcheck errors

### DIFF
--- a/pkg/systemd/kernelopt.sh
+++ b/pkg/systemd/kernelopt.sh
@@ -41,7 +41,7 @@ grub() {
     elif cur=$(rpm-ostree kargs 2>&1); then
         if [ "$1" = set ]; then
             # replace if already present; can happen in the middle (must be separated by space) or at the beginning of line
-            if [ "${cur% $key *}" != "$cur" ] || [ "${cur% $key=*}" != "$cur" ] || [ "${cur#$key[ =]}" != "$cur" ]; then
+            if [ "${cur% $key *}" != "$cur" ] || [ "${cur% $key=*}" != "$cur" ] || [ "${cur#${key}[ =]}" != "$cur" ]; then
                 rpm-ostree kargs --replace="$2"
             else
                 rpm-ostree kargs --append="$2"

--- a/src/ws/mock-kdc
+++ b/src/ws/mock-kdc
@@ -21,7 +21,6 @@
 set -euf
 
 cd $(dirname $0)
-srcdir=$(pwd)
 
 warning()
 {

--- a/src/ws/mock-kdc
+++ b/src/ws/mock-kdc
@@ -24,12 +24,12 @@ cd $(dirname $0)
 
 warning()
 {
-	echo "mock-kdc: $@" >&2
+	echo "mock-kdc: $*" >&2
 }
 
 check_require()
 {
-	for n in $@; do
+	for n in "$@"; do
 		if ! which $n 2> /dev/null; then
 			warning "$n not present"
 			exit 18

--- a/src/ws/mock-pipes/exit127
+++ b/src/ws/mock-pipes/exit127
@@ -1,3 +1,3 @@
-#/bin/sh
+#!/bin/sh
 # exception like in cockpit-session
 exit 127

--- a/test/static-code
+++ b/test/static-code
@@ -146,7 +146,7 @@ main() {
     tests=($(compgen -A function 'test_'))
     [ -n "${tap}" ] && printf "1..%d\n" "${#tests[@]}"
 
-    for test_function in ${tests[@]}; do
+    for test_function in "${tests[@]}"; do
         path="/static-code/$(echo ${test_function} | tr '_' '-')"
         counter=$((counter + 1))
         fail=''


### PR DESCRIPTION
We have plenty more shellcheck issues, but after fixing the missing shebang I thought it would be good to at least fix all shellcheck error's reported by `shellcheck -S error`. And shown by https://github.com/cockpit-project/cockpit/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3Ashellcheck++