### PR TITLE
Fetch path from url when loading terminal

### DIFF
--- a/pkg/systemd/terminal.jsx
+++ b/pkg/systemd/terminal.jsx
@@ -33,7 +33,7 @@ const _ = cockpit.gettext;
                 environ: [
                     "TERM=xterm-256color",
                 ],
-                directory: user.home || "/",
+                directory: cockpit.location.options.path || user.home || "/",
                 pty: true
             });
         }


### PR DESCRIPTION
This change will be used in Navigator to implement an "Open in terminal" button
https://github.com/KKoukiou/cockpit-navigator/pull/68