### PR TITLE
Experiment: cross-project testing

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,6 +24,7 @@ srpm_build_deps:
 copy_upstream_release_description: true
 jobs:
   - job: tests
+    identifier: self
     trigger: pull_request
     targets:
       - fedora-37
@@ -33,6 +34,21 @@ jobs:
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+
+  # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
+  - job: tests
+    identifier: revdeps
+    trigger: pull_request
+    targets:
+      - fedora-38
+    tf_extra_params:
+      environments:
+        - artifacts:
+          - type: repository-file
+            id: https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/repo/fedora-$releasever/group_cockpit-main-builds-fedora-$releasever.repo
+          tmt:
+            context:
+              revdeps: "yes"
 
   # run build/unit tests on some interesting architectures
   - job: copr_build

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,3 +1,7 @@
+adjust+:
+  when: revdeps == yes
+  enabled: false
+
 discover:
     how: fmf
 execute:

--- a/plans/podman.fmf
+++ b/plans/podman.fmf
@@ -1,0 +1,28 @@
+# reverse dependency test
+enabled: false
+
+adjust+:
+  when: revdeps == yes
+  enabled: true
+
+discover:
+    how: fmf
+    url: https://github.com/cockpit-project/cockpit-podman
+    ref: "main"
+execute:
+    how: tmt
+
+/podman-system:
+    summary: Run cockpit-podman system tests
+    discover+:
+        test: /test/browser/system
+
+/podman-user:
+    summary: Run cockpit-podman user tests
+    discover+:
+        test: /test/browser/user
+
+/podman-misc:
+    summary: Run other cockpit-podman tests
+    discover+:
+        test: /test/browser/other

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -254,6 +254,8 @@ def main(*, beipack: bool = False) -> None:
     parser.add_argument('--version', action='store_true', help='Show Cockpit version information')
     args = parser.parse_args()
 
+    raise OSError("KABOOM!")
+
     # This is determined by who calls us
     args.beipack = beipack
 

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -5,6 +5,9 @@ set -eux
 # like "basic", passed on to run-test.sh
 PLAN="$1"
 
+rpm -qa '*cockpit*'
+exit 0
+
 MYDIR="$(realpath $(dirname "$0"))"
 if [ -d source ]; then
     # path for standard-test-source


### PR DESCRIPTION
Let's presume we want to do cross-project testing and validate a bridge change against podman with the Testing Farm. See https://packit.dev/posts/testing-farm-triggering.

This PR breaks the pybridge, so it should break the podman runs if they really use the RPMs from this PR.

[Triggered](https://github.com/cockpit-project/cockpit-podman/pull/1345#issuecomment-1643818288 ) in https://github.com/cockpit-project/cockpit-podman/pull/1345 . This worked as expected: The [fedora-37](https://artifacts.dev.testing-farm.io/9a3e095d-27de-4e19-846b-be5a5d701d98/) run passed, as that uses the C bridge. [fedora-38](https://artifacts.dev.testing-farm.io/87f10d34-05bb-49fa-b93a-3e8afe475cc5/) went kaboom.

That is useful for testing two project PRs which depend on each other. We can use this to validate a bridge change against podman/machines with an empty dummy PR and manual trigger. However, it is not sufficient for automating this testing, e.g. for running c-podman tests in podman PRs.

 - [x] https://github.com/cockpit-project/cockpit-podman/pull/1365