### PR TITLE
test: add coverage for asset tag

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -532,6 +532,7 @@ class TestSystemInfo(packagelib.PackageCase):
         self.login_and_go("/system")
         # asset tag should be hidden
         b.wait_not_present('#system_information_asset_tag_text')
+
         # Hardware should be hidden
         b.wait_not_present('#system_information_hardware_text')
         b.click(hardware_page_link)
@@ -565,12 +566,17 @@ class TestSystemInfo(packagelib.PackageCase):
         # Clean up after lazy OEMs, falls back to board vendor/name
         m.write("/sys/class/dmi/id/sys_vendor", "To Be Filled By O.E.M.")
         m.write("/sys/class/dmi/id/product_name", "To Be Filled By O.E.M.")
+        m.write("/sys/class/dmi/id/product_serial", "PL1234")
         m.write("/sys/class/dmi/id/board_vendor", "brdven")
         m.write("/sys/class/dmi/id/board_name", "brdnam")
         b.reload()
         b.go("/system")
         b.enter_page('/system')
         b.wait_in_text('#system_information_hardware_text', "brdven brdnam")
+        if m.execute("uname -m").strip() == "x86_64":
+            b.wait_in_text('#system_information_asset_tag_text', "PL1234")
+        else:
+            b.wait_not_present('#system_information_asset_tag_text')
         b.click(hardware_page_link)
         b.enter_page("/system/hwinfo")
         b.wait_in_text('#hwinfo-system-info-list .hwinfo-system-info-list-item:nth-of-type(1) .pf-v5-c-description-list__group:nth-of-type(2) dd', "brdnam")


### PR DESCRIPTION
The asset tag should be available on x86_64 if product_serial is set.

Need to figure out if this does what it tells in ARM.

Should cover https://cockpit-logs.us-east-1.linodeobjects.com/pull-19111-20230720-115822-2f073721-fedora-38-devel/Coverage/pkg/systemd/overview-cards/systemInformationCard.jsx.gcov.html
