### PR TITLE
SystemInformationCard cleanups

### DIFF
--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -50,7 +50,7 @@ export class SystemInformationCard extends React.Component {
     }
 
     componentWillUnmount() {
-        clearInterval(this.uptimeTimer);
+        clearInterval(this.uptimeTimer); // not-covered: callers currently never unmount this
     }
 
     getMachineId() {
@@ -58,7 +58,7 @@ export class SystemInformationCard extends React.Component {
 
         machine_id.read()
                 .then(machineID => this.setState({ machineID }))
-                .catch(ex => console.error("Error reading machine id", ex.toString()))
+                .catch(ex => console.error("Error reading machine id", ex.toString())) // not-covered: OS error
                 .finally(machine_id.close);
     }
 
@@ -80,7 +80,7 @@ export class SystemInformationCard extends React.Component {
                 })
                 .catch(ex => {
                     // try DeviceTree
-                    machine_info.devicetree_info()
+                    machine_info.devicetree_info() // not-covered: coverage only runs on x86_64
                             .then(fields => this.setState({ assetTag: fields.serial, model: fields.model }))
                             .catch(dmiex => {
                                 console.debug("couldn't read dmi info: " + ex.toString());
@@ -97,7 +97,7 @@ export class SystemInformationCard extends React.Component {
                     const bootTime = new Date().valueOf() - uptime * 1000;
                     this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
                 })
-                .catch(ex => console.error("Error reading system uptime", ex.toString()));
+                .catch(ex => console.error("Error reading system uptime", ex.toString())); // not-covered: OS error
     }
 
     render() {

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -28,13 +28,16 @@ import "./systemInformationCard.scss";
 
 const _ = cockpit.gettext;
 
-export class SystemInfomationCard extends React.Component {
+export class SystemInformationCard extends React.Component {
     constructor(props) {
         super(props);
 
-        this.state = {};
-        this.getDMIInfo = this.getDMIInfo.bind(this);
-        this.getMachineId = this.getMachineId.bind(this);
+        this.state = {
+            machineID: null,
+            model: null,
+            assetTag: null,
+            systemUptime: null,
+        };
         this.getSystemUptime = this.getSystemUptime.bind(this);
     }
 
@@ -60,7 +63,7 @@ export class SystemInfomationCard extends React.Component {
                 })
                 .fail(function(ex) {
                     // FIXME show proper Alerts
-                    console.error("Error reading machine id", ex);
+                    console.error("Error reading machine id", ex.toString());
                 })
                 .always(function() {
                     machine_id.close();
@@ -79,20 +82,20 @@ export class SystemInfomationCard extends React.Component {
                         name = fields.board_name;
                     }
                     if (!vendor || !name)
-                        self.setState({ hardwareText: undefined });
+                        self.setState({ model: null });
                     else
-                        self.setState({ hardwareText: vendor + " " + name });
+                        self.setState({ model: vendor + " " + name });
 
-                    self.setState({ assetTagText: fields.product_serial || fields.chassis_serial || undefined });
+                    self.setState({ assetTag: fields.product_serial || fields.chassis_serial });
                 })
                 .catch(ex => {
                     // try DeviceTree
                     machine_info.devicetree_info()
-                            .then(fields => self.setState({ assetTagText: fields.serial, hardwareText: fields.model || undefined }))
+                            .then(fields => self.setState({ assetTag: fields.serial, model: fields.model }))
                             .catch(dmiex => {
-                                console.debug("couldn't read dmi info: " + ex);
+                                console.debug("couldn't read dmi info: " + ex.toString());
                                 console.debug("couldn't read DeviceTree info: " + dmiex.toString());
-                                self.setState({ assetTagText: undefined, hardwareText: undefined });
+                                self.setState({ assetTag: null, model: null });
                             });
                 });
     }
@@ -104,7 +107,7 @@ export class SystemInfomationCard extends React.Component {
                     const bootTime = new Date().valueOf() - uptime * 1000;
                     this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
                 })
-                .fail(ex => console.error("Error reading system uptime", ex));
+                .fail(ex => console.error("Error reading system uptime", ex.toString()));
     }
 
     render() {
@@ -114,16 +117,16 @@ export class SystemInfomationCard extends React.Component {
                 <CardBody>
                     <table className="pf-v5-c-table pf-m-grid-md pf-m-compact">
                         <tbody>
-                            {this.state.hardwareText && <tr>
+                            {this.state.model && <tr>
                                 <th scope="row">{_("Model")}</th>
                                 <td>
-                                    <div id="system_information_hardware_text">{this.state.hardwareText}</div>
+                                    <div id="system_information_hardware_text">{this.state.model}</div>
                                 </td>
                             </tr>}
-                            {this.state.assetTagText && <tr>
+                            {this.state.assetTag && <tr>
                                 <th scope="row">{_("Asset tag")}</th>
                                 <td>
-                                    <div id="system_information_asset_tag_text">{this.state.assetTagText}</div>
+                                    <div id="system_information_asset_tag_text">{this.state.assetTag}</div>
                                 </td>
                             </tr>}
                             <tr>

--- a/pkg/systemd/overview-cards/systemInformationCard.jsx
+++ b/pkg/systemd/overview-cards/systemInformationCard.jsx
@@ -55,24 +55,14 @@ export class SystemInformationCard extends React.Component {
 
     getMachineId() {
         const machine_id = cockpit.file("/etc/machine-id");
-        const self = this;
 
         machine_id.read()
-                .done(function(content) {
-                    self.setState({ machineID: content });
-                })
-                .fail(function(ex) {
-                    // FIXME show proper Alerts
-                    console.error("Error reading machine id", ex.toString());
-                })
-                .always(function() {
-                    machine_id.close();
-                });
+                .then(machineID => this.setState({ machineID }))
+                .catch(ex => console.error("Error reading machine id", ex.toString()))
+                .finally(machine_id.close);
     }
 
     getDMIInfo() {
-        const self = this;
-
         machine_info.dmi_info()
                 .then(fields => {
                     let vendor = fields.sys_vendor;
@@ -82,20 +72,20 @@ export class SystemInformationCard extends React.Component {
                         name = fields.board_name;
                     }
                     if (!vendor || !name)
-                        self.setState({ model: null });
+                        this.setState({ model: null });
                     else
-                        self.setState({ model: vendor + " " + name });
+                        this.setState({ model: vendor + " " + name });
 
-                    self.setState({ assetTag: fields.product_serial || fields.chassis_serial });
+                    this.setState({ assetTag: fields.product_serial || fields.chassis_serial });
                 })
                 .catch(ex => {
                     // try DeviceTree
                     machine_info.devicetree_info()
-                            .then(fields => self.setState({ assetTag: fields.serial, model: fields.model }))
+                            .then(fields => this.setState({ assetTag: fields.serial, model: fields.model }))
                             .catch(dmiex => {
                                 console.debug("couldn't read dmi info: " + ex.toString());
                                 console.debug("couldn't read DeviceTree info: " + dmiex.toString());
-                                self.setState({ assetTag: null, model: null });
+                                this.setState({ assetTag: null, model: null });
                             });
                 });
     }
@@ -107,7 +97,7 @@ export class SystemInformationCard extends React.Component {
                     const bootTime = new Date().valueOf() - uptime * 1000;
                     this.setState({ systemUptime: timeformat.distanceToNow(bootTime) });
                 })
-                .fail(ex => console.error("Error reading system uptime", ex.toString()));
+                .catch(ex => console.error("Error reading system uptime", ex.toString()));
     }
 
     render() {

--- a/pkg/systemd/overview.jsx
+++ b/pkg/systemd/overview.jsx
@@ -30,7 +30,7 @@ import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle, DropdownToggl
 
 import { superuser } from "superuser";
 
-import { SystemInfomationCard } from './overview-cards/systemInformationCard.jsx';
+import { SystemInformationCard } from './overview-cards/systemInformationCard.jsx';
 import { ConfigurationCard } from './overview-cards/configurationCard.jsx';
 import { HealthCard } from './overview-cards/healthCard.jsx';
 import { MotdCard } from './overview-cards/motdCard.jsx';
@@ -169,7 +169,7 @@ class OverviewPage extends React.Component {
                         <MotdCard />
                         <HealthCard />
                         <UsageCard />
-                        <SystemInfomationCard />
+                        <SystemInformationCard />
                         <ConfigurationCard hostname={this.hostname_text()} />
                     </Gallery>
                 </PageSection>


### PR DESCRIPTION
Triggered by PR #19118, trying to clean up the last bits of https://cockpit-logs.us-east-1.linodeobjects.com/pull-19118-20230720-180012-952e0fa8-fedora-38-devel/Coverage/pkg/systemd/overview-cards/systemInformationCard.jsx.gcov.html