### PR TITLE
static: use a unique id for the bypass browser check

### DIFF
--- a/pkg/static/login.html
+++ b/pkg/static/login.html
@@ -58,7 +58,7 @@
           <svg height="16" width="16" viewBox="0 0 16 16" id="option-caret" class="caret caret-right" aria-hidden="true">
             <polygon fill="#ffffff" points="4,0 4,14 12,7"></polygon>
           </svg>
-          <span id="show-other-login-options-text" translate="yes">
+          <span id="bypass-browser-check" translate="yes">
             Bypass browser check
           </span>
         </summary>

--- a/pkg/static/login.js
+++ b/pkg/static/login.js
@@ -378,6 +378,8 @@ import "./login.scss";
             id("banner-message").textContent = environment.banner.trimEnd();
         }
 
+        id("bypass-browser-check").addEventListener("click", toggle_options);
+        id("bypass-browser-check").addEventListener("keypress", toggle_options);
         id("show-other-login-options").addEventListener("click", toggle_options);
         id("show-other-login-options").addEventListener("keypress", toggle_options);
         id("server-clear").addEventListener("click", function () {

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -560,7 +560,7 @@ account    required     pam_succeed_if.so user ingroup %s""" % m.get_admin_group
         """)
         b.open("/system")
         b.wait_visible("#unsupported-browser")
-        b.wait_in_text("#show-other-login-options-text", "Bypass browser check")
+        b.wait_in_text("#bypass-browser-check", "Bypass browser check")
         b.click(".pf-v5-c-expandable-section")
 
         b.set_val('#login-user-input', "admin")


### PR DESCRIPTION
Currently we have two two identical id's which is not allowed.

QuerySelectorAll Does not like it :) https://cockpit-logs.us-east-1.linodeobjects.com/pull-18896-20230724-085434-ad7df50c-fedora-coreos/log.html#172-2