### PR TITLE
shell: Move "Web Console" doc link into manifest

### DIFF
--- a/pkg/lib/manifest2po.js
+++ b/pkg/lib/manifest2po.js
@@ -64,6 +64,8 @@ function process_manifest(manifest) {
         process_menu(manifest.tools);
     if (manifest.bridges)
         process_bridges(manifest.bridges);
+    if (manifest.docs)
+        process_docs(manifest.docs);
 }
 
 function process_keywords(keywords) {

--- a/pkg/shell/manifest.json
+++ b/pkg/shell/manifest.json
@@ -25,6 +25,12 @@
         "uk-ua": "Українська",
         "zh-cn": "中文（中国）"
     },
+    "docs": [
+        {
+            "label": "Web Console",
+            "url": "https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/index"
+        }
+    ],
     "bridges": [
         {
             "privileged": true,

--- a/pkg/shell/topnav.jsx
+++ b/pkg/shell/topnav.jsx
@@ -148,9 +148,12 @@ export class TopNav extends React.Component {
                 {cockpit.format(_("$0 documentation"), this.state.osRelease.NAME)}
             </DropdownItem>);
 
-        docItems.push(<DropdownItem key="cockpit-doc" href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_systems_using_the_rhel_8_web_console/index" target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>
-            {_("Web Console")}
-        </DropdownItem>);
+        // global documentation for cockpit as a whole
+        (cockpit.manifests.shell?.docs ?? []).forEach(doc => {
+            docItems.push(<DropdownItem key={doc.label} href={doc.url} target="blank" rel="noopener noreferrer" icon={<ExternalLinkAltIcon />}>
+                {doc.label}
+            </DropdownItem>);
+        });
 
         if (docs.length > 0)
             docItems.push(<DropdownSeparator key="separator" />);


### PR DESCRIPTION
Stop hardcoding the "Web Console" top-level doc link. It does not work well for some use cases which ship only a limited set of pages, like an Appliance.

Move it to the manifest instead, similar to menu entry `docs` links, but at the top level.

Fixes #18958

----

This allows users/admins to use manifest overrides to customize or remove it, see discussion in the issue.

I diffed po/cockpit.pot before/afterwards, and aside from time stamp and line number noise, there's the expected:
```diff
@@ -8018,7 +8018,7 @@
 msgid "Warning and above"
 msgstr ""
 
-#: pkg/shell/shell-modals.jsx:63 pkg/shell/topnav.jsx:152
+#: pkg/shell/shell-modals.jsx:63 pkg/shell/manifest.json:0
 msgid "Web Console"
 msgstr ""
```