### PR TITLE
debug testtimers on firefox

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -320,6 +320,7 @@ class TestSystemInfo(packagelib.PackageCase):
         b.click('#systime-ntp-servers div:nth-child(1) button')
         b.set_input_text("#systime-ntp-servers div:nth-child(2) input", "1.pool.ntp.org")
         b.click("#system_information_change_systime .apply")
+        print('test retry')
         with b.wait_timeout(120):  # Changing time on Arch can be slow
             b.wait_not_present("#system_information_change_systime")
 


### PR DESCRIPTION
Debug https://cockpit-logs.us-east-1.linodeobjects.com/pull-19124-20230724-143150-9563a83b-fedora-38-firefox-other/log.html#189-2

Not reproducible locally.. and already has a 120 second timeout.