### PR TITLE
shell: Disallow remote frames from opening channels to other hosts

### DIFF
--- a/doc/protocol.md
+++ b/doc/protocol.md
@@ -105,7 +105,7 @@ The following fields are defined:
  * "binary": If present set to "raw"
  * "channel": A uniquely chosen channel id
  * "payload": A payload type, see below
- * "host": The destination host for the channel, defaults to "localhost"
+ * "host": The destination host for the channel; see "Host values" below
  * "user": Optional alternate user for authenticating with host
  * "superuser": Optional. Use "require" to run as root, or "try" to attempt to run as root.
  * "group": An optional channel group
@@ -200,6 +200,11 @@ will be expanded to
         "host": "my.host"
     }
 
+**Security restriction**: Only the Shell (top-level page) and frames from the
+same machine as the Shell are allowed to open channels to remote hosts. Pages
+(frames) loaded from remote machines are not allowed to do that. This ensures
+that pages from malicious remote hosts cannot run arbitrary commands on other
+hosts.
 
 Command: close
 --------------

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import re
 import time
 
@@ -441,6 +442,24 @@ class TestMultiMachine(testlib.MachineCase):
         # Add a machine
         self.login_and_go(None)
         self.add_machine("10.111.113.2")
+
+        # channels in frames cannot speak to other authenticated hosts
+        # firefox CDP cannot eval cockpit channels
+        if os.environ.get("TEST_BROWSER") != "firefox":
+            # remote frame can *not* use host channel option
+            b.go(m2_path)
+            b.enter_page("/playground/test", "10.111.113.2")
+            ex = b.eval_js('cockpit.spawn(["hostname"], { host: "10.111.113.1" })'
+                           '.then(() => Promise.reject("remote frame could speak to other host"))'
+                           '.catch(ex => ex)')
+            self.assertEqual(ex["problem"], "protocol-error")
+            self.assertEqual(ex["message"], "remote frames cannot open channels to other remote hosts")
+
+            # frame from initial machine (same host as shell) *can* use host channel option
+            b.go("/playground/test")
+            b.enter_page("/playground/test")
+            res = b.eval_js('cockpit.spawn(["hostname"], { host: "10.111.113.2" })')
+            self.assertEqual(res, "machine2\n")
 
         # Go to the path, remove the image
         b.go(m2_path)


### PR DESCRIPTION
This avoids pages from malicious remote hosts from running arbitrary
commands on other hosts. None of the known Cockpit projects use this
feature, and commit bd5be5dd55 already dropped the documentation.

Note that this is a necessary, but not sufficient measure to isolate
frames from each other. See COCKPIT-870 for all the other steps.
However, this is a sensible API restriction to discourage future
projects from doing questionable things.

https://issues.redhat.com/browse/COCKPIT-950
https://issues.redhat.com/browse/RHEL-4035
https://bugzilla.redhat.com/show_bug.cgi?id=2161090

 - [x] Let RHCERT project confirm that this restriction does not break them