### PR TITLE
package.json: eslint-plugin-standard no longer requires eslint-config…

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-standard": "^5.0.0",
     "gettext-parser": "^2.0.0",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",


### PR DESCRIPTION
```
npm WARN deprecated eslint-plugin-standard@5.0.0: standard 16.0.0 and eslint-config-standard 16.0.0 no longer require the eslint-plugin-standard package. You can remove it
from your dependencies with 'npm rm eslint-plugin-standard'. More info here: https://github.com/standard/standard/issues/1316
```

https://github.com/standard/standard/issues/1316

This is an issue in all Cockpit projects now.