### PR TITLE
flatpak: Update description

### DIFF
--- a/src/client/org.cockpit_project.CockpitClient.metainfo.xml
+++ b/src/client/org.cockpit_project.CockpitClient.metainfo.xml
@@ -13,7 +13,7 @@
       Cockpit Client provides a graphical interface to your servers, containers, and virtual machines.  Connections are made over SSH, using the SSH configuration of the local user (including aliases, known hosts, key files, hardware tokens, etc).
     </p>
     <p>
-      The server needs to have Cockpit installed, but the Cockpit webserver doesn't need to be enabled, and no extra ports need to be opened.
+      The server needs to have Python installed, but the Cockpit webserver doesn't need to be enabled, and no extra ports need to be opened.
     </p>
   </description>
 


### PR DESCRIPTION
The server does not need cockpit installed any more since the beiboot functionality.

----

Thanks @briansmith0 for pointing out!