### PR TITLE
pybridge: Fix crash when connecting to nonexisting D-Bus address

### DIFF
--- a/pkg/base1/test-dbus.js
+++ b/pkg/base1/test-dbus.js
@@ -526,4 +526,23 @@ Empty=
                    "unknown key raises an error");
 });
 
+QUnit.test("nonexisting address", async assert => {
+    const dbus = cockpit.dbus("org.freedesktop.DBus", { address: "unix:path=/nonexisting", bus: "none" });
+
+    try {
+        await dbus.call("/org/freedesktop/DBus", "org.freedesktop.DBus", "Hello", []);
+        assert.ok(false, "should not be reached");
+    } catch (ex) {
+        if (await QUnit.mock_info("pybridge")) {
+            assert.equal(ex.problem, "protocol-error", "got right close code");
+            assert.equal(ex.message, "failed to connect to none bus: [Errno 2] sd_bus_start: No such file or directory",
+                         "error message");
+        } else {
+            // C bridge has a weird error code
+            assert.equal(ex.problem, "internal-error", "got right close code");
+            assert.equal(ex.message, "Could not connect: No such file or directory", "error message");
+        }
+    }
+});
+
 QUnit.start();

--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -221,16 +221,16 @@ class DBusChannel(Channel):
         bus = options.get('bus')
         address = options.get('address')
 
-        if address is not None:
-            if bus is not None and bus != 'none':
-                raise ChannelError('protocol-error', message='only one of "bus" and "address" can be specified')
-            logger.debug('get bus with address %s for %s', address, self.name)
-            self.bus = Bus.new(address=address, bus_client=self.name is not None)
-        elif bus == 'internal':
-            logger.debug('get internal bus for %s', self.name)
-            self.bus = self.router.internal_bus.client
-        else:
-            try:
+        try:
+            if address is not None:
+                if bus is not None and bus != 'none':
+                    raise ChannelError('protocol-error', message='only one of "bus" and "address" can be specified')
+                logger.debug('get bus with address %s for %s', address, self.name)
+                self.bus = Bus.new(address=address, bus_client=self.name is not None)
+            elif bus == 'internal':
+                logger.debug('get internal bus for %s', self.name)
+                self.bus = self.router.internal_bus.client
+            else:
                 if bus == 'session':
                     logger.debug('get session bus for %s', self.name)
                     self.bus = Bus.default_user()
@@ -239,8 +239,8 @@ class DBusChannel(Channel):
                     self.bus = Bus.default_system()
                 else:
                     raise ChannelError('protocol-error', message=f'invalid bus "{bus}"')
-            except OSError as exc:
-                raise ChannelError('protocol-error', message=f'failed to connect to {bus} bus: {exc}') from exc
+        except OSError as exc:
+            raise ChannelError('protocol-error', message=f'failed to connect to {bus} bus: {exc}') from exc
 
         try:
             self.bus.attach_event(None, 0)


### PR DESCRIPTION
Enlarge the scope of OSError interception to also comprise the "custom address" case.

----

Spotted in https://github.com/rhinstaller/anaconda/pull/4978