### PR TITLE
testlib: introduce two new CDP helper methods

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -237,6 +237,12 @@ class Browser:
         self.switch_to_top()
         self.cdp.invoke("Page.navigate", url=href)
 
+    def close(self):
+        self.cdp.invoke("Page.close")
+
+    def handle_alert(self, accept=True):
+        self.cdp.invoke("Page.handleJavaScriptDialog", accept=accept)
+
     def set_user_agent(self, ua: str):
         """Set the user agent of the browser
 

--- a/test/verify/check-system-terminal
+++ b/test/verify/check-system-terminal
@@ -120,6 +120,10 @@ PROMPT_COMMAND='printf "\033]0;%s@%s:%s\007" "${USER}" "${HOSTNAME%%.*}" "${PWD/
         wait_line(n, prompt)
         b.wait_not_in_text(".terminal .xterm-accessibility-tree", "disconnected")
 
+        # Check that closing the terminal tab is guarded by a confirmation dialog
+        b.close()
+        b.handle_alert(accept=False)
+
         def select_line(sel, width):
             # Select line by dragging mouse
             # Height on a line is around 14px, so start approx. in the middle of line


### PR DESCRIPTION
One for closing the browser page and one for responding to alert windows.

This will help to test pages like Terminal or Anaconda WebUI which have special handling for window.unload.