### PR TITLE
make Bridge init non-async

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -423,8 +423,6 @@ class AsyncChannel(Channel):
     On the sending side, write() will block if the channel backs up.
     """
 
-    loop = None
-
     # Receive-side flow control: intermix pings and data in the queue and reply
     # to pings as we dequeue them.  This is a buffer: since we need to handle
     # do_data() without blocking, we have no choice.

--- a/src/cockpit/channels/packages.py
+++ b/src/cockpit/channels/packages.py
@@ -20,8 +20,8 @@ import logging
 import threading
 from typing import Dict, Optional
 
-from .. import data
 from ..channel import Channel
+from ..data import read_cockpit_data_file
 from ..packages import Packages
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ class PackagesChannel(Channel):
     options: Optional[Dict[str, object]] = None
 
     def http_error(self, status: int, message: str) -> None:
-        template = data.read_cockpit_data_file('fail.html')
+        template = read_cockpit_data_file('fail.html')
         self.send_message(status=status, reason='ERROR', headers={'Content-Type': 'text/html; charset=utf-8'})
         self.send_data(template.replace(b'@@message@@', message.encode('utf-8')))
         self.done()

--- a/src/cockpit/internal_endpoints.py
+++ b/src/cockpit/internal_endpoints.py
@@ -114,7 +114,7 @@ class cockpit_Machines(bus.Object):
 
         # avoid a flurry of update notifications
         if self.pending_notify is None:
-            self.pending_notify = self.loop.call_later(1.0, _notify_now)
+            self.pending_notify = asyncio.get_running_loop().call_later(1.0, _notify_now)
 
     # inotify events
     def do_inotify_event(self, mask: inotify.Event, cookie: int, name: Optional[str]) -> None:
@@ -125,7 +125,6 @@ class cockpit_Machines(bus.Object):
 
     def __init__(self):
         self.path = config.lookup_config('machines.d')
-        self.loop = asyncio.get_running_loop()
 
         # ignore the first callback
         self.pending_notify = ...

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -452,12 +452,7 @@ async def test_fslist1_notexist(transport):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize('channeltype', CHANNEL_TYPES)
-async def test_channel(channeltype, tmp_path):
-    bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
-    transport = MockTransport(bridge)
-    await transport.assert_msg('', command='init')
-    transport.send_init()
-
+async def test_channel(bridge, transport, channeltype, tmp_path):
     payload = channeltype.payload
     args = dict(channeltype.restrictions)
 

--- a/test/pytest/test_bridge.py
+++ b/test/pytest/test_bridge.py
@@ -27,15 +27,10 @@ class test_iface(bus.Object):
 
 
 @pytest.fixture
-def bridge(event_loop) -> Bridge:
-    async def get_bridge() -> Bridge:
-        bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
-        asyncio.set_event_loop(None)
-        # We use this for assertions
-        bridge.superuser_bridges = list(bridge.superuser_rule.bridges)  # type: ignore[attr-defined]
-        return bridge
-
-    return event_loop.run_until_complete(get_bridge())
+def bridge() -> Bridge:
+    bridge = Bridge(argparse.Namespace(privileged=False, beipack=False))
+    bridge.superuser_bridges = list(bridge.superuser_rule.bridges)  # type: ignore[attr-defined]
+    return bridge
 
 
 def add_pseudo(bridge: Bridge) -> None:


### PR DESCRIPTION
Make a minor change to allow `Bridge()` to be instantiated without an active event loop, allowing some nice cleanups in the unit tests.