### PR TITLE
fmf: Run cockpit-podman tests on current Fedora

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -24,6 +24,7 @@ srpm_build_deps:
 copy_upstream_release_description: true
 jobs:
   - job: tests
+    identifier: self
     trigger: pull_request
     targets:
       - fedora-37
@@ -33,6 +34,21 @@ jobs:
       - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
+
+  # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
+  - job: tests
+    identifier: revdeps
+    trigger: pull_request
+    targets:
+      - fedora-latest-stable
+    tf_extra_params:
+      environments:
+        - artifacts:
+          - type: repository-file
+            id: https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/repo/fedora-$releasever/group_cockpit-main-builds-fedora-$releasever.repo
+          tmt:
+            context:
+              revdeps: "yes"
 
   # run build/unit tests on some interesting architectures
   - job: copr_build

--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -1,3 +1,7 @@
+adjust+:
+  when: revdeps == yes
+  enabled: false
+
 discover:
     how: fmf
 execute:

--- a/plans/podman.fmf
+++ b/plans/podman.fmf
@@ -1,0 +1,29 @@
+# reverse dependency test
+enabled: false
+
+adjust+:
+  when: revdeps == yes
+  enabled: true
+
+discover:
+    how: fmf
+    url: https://github.com/cockpit-project/cockpit-podman
+    ref: "main"
+execute:
+    how: tmt
+
+# This has to duplicate cockpit-podman's plan structure; see https://github.com/teemtee/tmt/issues/1770
+/podman-system:
+    summary: Run cockpit-podman system tests
+    discover+:
+        test: /test/browser/system
+
+/podman-user:
+    summary: Run cockpit-podman user tests
+    discover+:
+        test: /test/browser/user
+
+/podman-misc:
+    summary: Run other cockpit-podman tests
+    discover+:
+        test: /test/browser/other


### PR DESCRIPTION
This ensures that changes to the Python bridge don't break podman.

----

 - [x] https://github.com/cockpit-project/cockpit-podman/pull/1365

This introduces reverse dependency testing on the upstream level. Details and experiments are in https://github.com/cockpit-project/cockpit/pull/19117 -- especially with a commit that [breaks the bridge](https://github.com/cockpit-project/cockpit/commit/fb163e5cf2bf4430828fff04a0e168aec4d96032), and the [revdeps run](https://artifacts.dev.testing-farm.io/6925a99f-9f98-4e01-ba12-87c7b8960fc3/) installs c-ws from the PR packit COPR and c-podman from the main-builds COPR, and the podman tests fail as expected on the "KABOOM".

This particular test could be optimized, and only run on changes to src/ (bridge or ws), as these are the only things that actually affect cockpit-podman. There is a mechanism to do that with packit, which I tested that https://github.com/martinpitt/cockpit/pull/16. But this doesn't work with the default GITHUB_TOKEN, and thus would require faffing around with more secrets. I shelved that for now. While cockpit → cockpit-podman testing is marginally useful, I really want this to be a model PR for triggering podman → cockpit-podman, or selinux-policy → cockpit. For these, we don't need conditional runs.

Once this lands, I'll do a blog post about all of this (see [current draft](https://martinpitt.github.io/cockpit-project.github.io/blog/tmt-cross-project-testing.html)), and propose it to podman, selinux, and udisks. The latter could even replace our "daily" scenario on fedora-testing, or at least improve it ("shift left") -- stop regressions *before* they land upstream, instead of after the fact.