### PR TITLE
packit: Build COPR for main commits

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -59,6 +59,14 @@ jobs:
       # big-endian
       - fedora-development-s390x
 
+  # for cross-project testing
+  - job: copr_build
+    trigger: commit
+    branch: "^main$"
+    owner: "@cockpit"
+    project: "main-builds"
+    preserve_project: True
+
   - job: copr_build
     trigger: release
     owner: "@cockpit"


### PR DESCRIPTION
Build every commit into main into
https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/

We will use that for cross-project testing (e.g. running cockpit's tests in systemd-policy or udisks upstream PRs). Users can also install that to test bug fixes and new features after they landed, but before they got released.

----

Pretty much the same as https://github.com/cockpit-project/cockpit-podman/pull/1365 . It uses the same COPR -- it doesn't hurt if the packages get mixed there.