### PR TITLE
Add "macro 'an-trap' not defined" warning to lintian overrides

### DIFF
--- a/tools/debian/cockpit-ws.lintian-overrides
+++ b/tools/debian/cockpit-ws.lintian-overrides
@@ -2,3 +2,4 @@
 cockpit-ws: shared-library-lacks-prerequisites *security/pam_cockpit_cert.so*
 cockpit-ws: font-outside-font-dir *usr/share/cockpit/static/fonts/*
 cockpit-ws: font-in-non-font-package *usr/share/cockpit/static/fonts/*
+cockpit-ws: groff-message *macro *an-trap*usr/share/man/man8/cockpit-ws.8.gz*


### PR DESCRIPTION
As of groff 1.23.0 "an-trap" macro was renamed to "an-input-trap". This change is already present in debian-testing.
However, xsltproc which we use to generate manpages still uses the old macro, since it runs on Fedora 38 docbook.