### PR TITLE
fmf: Declare our own dependencies

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -1,6 +1,12 @@
 /basic:
   summary: Run browser integration tests for basic Cockpit packages
   require:
+    # ourself
+    - cockpit
+    - cockpit-kdump
+    - cockpit-networkmanager
+    - cockpit-sosreport
+    - cockpit-tests
     # build/test infra dependencies
     - git
     - make
@@ -22,6 +28,9 @@
 /network:
   summary: Run browser integration tests for cockpit-networkmanager
   require:
+    # ourself
+    - cockpit
+    - cockpit-networkmanager
     # build/test infra dependencies
     - git
     - make
@@ -38,6 +47,11 @@
 /optional:
   summary: Run browser integration tests for optional Cockpit packages
   require:
+    # ourself
+    - cockpit
+    - cockpit-storaged
+    - cockpit-packagekit
+    - cockpit-tests
     # build/test infra dependencies
     - git
     - make


### PR DESCRIPTION
tmt implicitly installs the packages for the primary (packit generated) COPR, but not the ones for all the other test plans. This led to cockpit-system and friends not being installed when running cockpit as reverse depedency gating test in PRs of other projects.

Do what we already do in c-podman etc. and declare our own dependencies properly. They were dropped in commit 9877d5163352, but the reason is obsolete: TF will now go out of its way to upgrade/downgrade packages to the versions in the COPR, and even validate their versions.

----

This broke running our tests in [udisks](https://artifacts.dev.testing-farm.io/cfb8d90b-c0d6-4df5-8c57-7ebefb0ce0e4/) and [selinux-policy](https://artifacts.dev.testing-farm.io/c7acd1f2-3616-4c8b-b2a5-58e009506030/). I validated that this works in https://github.com/martinpitt/selinux-policy/pull/2, the [test passes now](https://artifacts.dev.testing-farm.io/82b91597-4ba8-4bc4-b784-814bd51c1cd6/).