### PR TITLE
test: Add pixel test for firewall "Add zone" dialog

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -472,13 +472,16 @@ class TestFirewall(netlib.NetworkCase):
             b.wait_visible(f".zone-section[data-id='{zone}'] tr[data-row-id='{service}']")
             self.assertIn(service, m.execute(f"firewall-cmd --zone={zone} --list-services"))
 
-        def addZone(zone, interfaces=None, sources=None, error=None):
+        def addZone(zone, interfaces=None, sources=None, error=None, do_pixel=False):
             if interfaces is None:
                 interfaces = []
             b.click("#add-zone-button")
             b.wait_visible("#add-zone-dialog")
             b.wait_visible(f"#add-zone-dialog footer button.{self.btn_primary}:disabled")
             b.click(f"#add-zone-dialog .add-zone-zones-firewalld input[value='{zone}']")
+
+            if do_pixel:
+                b.assert_pixels("#add-zone-dialog", "firewall-add-zone-dialog")
 
             for i in interfaces:
                 b.click(f"#add-zone-dialog input[value='{i}']")
@@ -512,7 +515,7 @@ class TestFirewall(netlib.NetworkCase):
         b.wait_in_text("#zones-listing .zone-section[data-id='public']", self.default_zone)
 
         # add predefined work zone
-        addZone("work", sources="192.168.1.0/24")
+        addZone("work", sources="192.168.1.0/24", do_pixel=True)
 
         addServiceToZone("pop3", "work")
         b.wait_visible(".zone-section[data-id='work'] tr[data-row-id='pop3']")


### PR DESCRIPTION
This is moderately complex, and newer PatternFly breaks the horizontal arrangement of the radio button blocks.

---

See https://github.com/cockpit-project/cockpit/pull/19138#issuecomment-1659789528 and the next comment -- I want to land this *before* resuming #19138, as this regression wasn't previously spotted by pixel tests. The RTL dialog shows a spacing error -- let's sort this out with all the checkbox/radio button fixes in #19138, and just capture the status quo for now.

I ran it 4 times locally, seems stable.

[new pixels view](https://github.com/cockpit-project/pixel-test-reference/compare/968cdc99848df96cd8806932c745c2dd220846bd..ccf0d43bb2e80cf9eb1ac3729e9304bcefd6a317)