### PR TITLE
test: show a known naughty as a failure

### DIFF
--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -119,7 +119,7 @@ class Test:
             return None, 0
 
         if not opts.thorough:
-            cmd = ["test-failure-policy"]
+            cmd = ["test-failure-policy", "--all"]
             if not opts.track_naughties:
                 cmd.append("--offline")
             cmd.append(testvm.DEFAULT_IMAGE)
@@ -131,6 +131,11 @@ class Test:
                     self.returncode = proc.returncode
                     self._print_test(skip_reason="# SKIP {0}".format(reason.decode("utf-8")))
                     return None, 0
+
+                if proc.returncode == 78:
+                    self.returncode = proc.returncode
+                    self._print_test(skip_reason="# NOTE {0}".format(reason.decode("utf-8")))
+                    return None, 1
 
                 if proc.returncode == 1:
                     retry_reason = reason.decode("utf-8")


### PR DESCRIPTION
When a naughty appears in a different distribution mark it as failure with a reason that it is known somewhere else.

* [x] Depends on https://github.com/cockpit-project/bots/pull/5081