### PR TITLE
ws: Drop empty cockpit.service.d directory

### DIFF
--- a/src/ws/Makefile-ws.am
+++ b/src/ws/Makefile-ws.am
@@ -167,10 +167,8 @@ mock_pam_conv_mod_so_CFLAGS = -fPIC $(AM_CFLAGS)
 mock_pam_conv_mod_so_LDFLAGS = -shared
 mock_pam_conv_mod_so_LDADD = $(PAM_LIBS)
 
-testserviceddir = $(systemdunitdir)/cockpit.service.d
-
 install-tests::
-	mkdir -p $(DESTDIR)$(pamdir) $(DESTDIR)$(testserviceddir) $(DESTDIR)/etc/cockpit
+	mkdir -p $(DESTDIR)$(pamdir) $(DESTDIR)/etc/cockpit
 	$(INSTALL_PROGRAM) mock-pam-conv-mod.so $(DESTDIR)$(pamdir)/
 
 install-exec-hook::


### PR DESCRIPTION
This was causing cockpit-tests to ship an empty directory. The tests don't even use that, but write the file into /etc. This gets in the way of Debian's remaining usrmerge migration, so just get rid of it.

https://bugs.debian.org/1043322