### PR TITLE
filesystem: send 'ready' on fsread1 and fslist1

### DIFF
--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -80,6 +80,8 @@ class FsListChannel(Channel):
             else:
                 problem = 'internal-error'
             raise ChannelError(problem, message=str(error)) from error
+
+        self.ready()
         for entry in scan_dir:
             self.send_entry("present", entry)
 
@@ -107,6 +109,8 @@ class FsReadChannel(GeneratorChannel):
                 buf = os.stat(filep.fileno())
                 if max_read_size is not None and buf.st_size > max_read_size:
                     raise ChannelError('too-large')
+
+                self.ready()
 
                 while True:
                     data = filep.read1(Channel.BLOCK_SIZE)


### PR DESCRIPTION
It's not really conceptually clear that we should send 'ready' on channels that don't expect to receive data, so we haven't done it until now.

Unfortunately, `Channel.ready()` is also the place we thaw the receive side of the channel, so those channels were never being thawed.  The only place this matters for is flow control: pong messages will be received and queued, but never delivered, causing the channel to stall out after the window is filled for the first time.

Let's send 'ready' everywhere.  That fixes the flow control issue.  It's what the C bridge does as well.

Adjust our generic channel test case to make sure we always get the 'ready' message.  Also move our uses of the low-level `.send_open()` for the `fsread1` and `fslist1` channels to use `.check_open()` (which waits for the ready message).

Since we now see 'ready' in cases where the bridge isn't expecting data, remove a couple of assertions stipulating that the channel was definitely open to receive that data — it's possible we're getting a ready message from a channel that already sent all of its data and closed.

Fixes #19192