### PR TITLE
Remove unused css id #machine_id

### DIFF
--- a/pkg/systemd/overview.scss
+++ b/pkg/systemd/overview.scss
@@ -221,13 +221,6 @@
   }
 }
 
-#machine_id {
-  font-family: var(--pf-v5-global--FontFamily--redhatfont--monospace);
-  // Some browsers don't support anywhere yet, so we provide break-word as a fallback
-  overflow-wrap: break-word;
-  overflow-wrap: anywhere;
-}
-
 .pf-v5-c-table tr > * {
   vertical-align: top;
 }


### PR DESCRIPTION
PF dropped pf-v5-global--FontFamily--redhat--monospace since https://github.com/patternfly/patternfly/commit/4ec21e34fc3