### PR TITLE
Fix new auto enabled ruff rules

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -592,7 +592,7 @@ class Browser:
                 return
             except RuntimeError as e:
                 data = e.args[0]
-                if count < 20 and type(data) == dict and "response" in data and data["response"].get("message") in ["Execution context was destroyed.", "Cannot find context with specified id"]:
+                if count < 20 and isinstance(data, dict) and "response" in data and data["response"].get("message") in ["Execution context was destroyed.", "Cannot find context with specified id"]:
                     time.sleep(1)
                 else:
                     raise e

--- a/test/verify/ruff.toml
+++ b/test/verify/ruff.toml
@@ -1,4 +1,5 @@
 extend = "../common/ruff.toml"
 ignore = [
     "B023",     # Function definition does not bind loop variable
+    "PT",       # pytest rules do not apply as our integration tests use a custom unittest runner
 ]


### PR DESCRIPTION
As this effects `testlib` let's run one full test run, but not all distro's that seems a bit excessive.