### PR TITLE
network: distinguish create and edit dialogs

### DIFF
--- a/pkg/networkmanager/bond.jsx
+++ b/pkg/networkmanager/bond.jsx
@@ -132,7 +132,7 @@ export const BondDialog = ({ connection, dev, settings }) => {
         <NetworkModal dialogError={dialogError}
                       idPrefix={idPrefix}
                       onSubmit={onSubmit}
-                      title={_("Bond settings")}
+                      title={!connection ? _("Add bond") : _("Edit bond settings")}
                       help={
                           <Popover
                               headerContent={_("Network bond")}
@@ -158,6 +158,7 @@ export const BondDialog = ({ connection, dev, settings }) => {
                               </Button>
                           </Popover>
                       }
+                      isCreateDialog={!connection}
         >
             <>
                 <Name idPrefix={idPrefix} iface={iface} setIface={setIface} />

--- a/pkg/networkmanager/bridge.jsx
+++ b/pkg/networkmanager/bridge.jsx
@@ -93,7 +93,8 @@ export const BridgeDialog = ({ connection, dev, settings }) => {
         <NetworkModal dialogError={dialogError}
                       idPrefix="network-bridge-settings"
                       onSubmit={onSubmit}
-                      title={_("Bridge settings")}
+                      title={!connection ? _("Add bridge") : _("Edit bridge settings")}
+                      isCreateDialog={!connection}
         >
             <>
                 <Name idPrefix={idPrefix} iface={iface} setIface={setIface} />

--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -141,7 +141,7 @@ export const Name = ({ idPrefix, iface, setIface }) => {
     );
 };
 
-export const NetworkModal = ({ dialogError, help, idPrefix, title, onSubmit, children, isFormHorizontal }) => {
+export const NetworkModal = ({ dialogError, help, idPrefix, title, onSubmit, children, isFormHorizontal, isCreateDialog }) => {
     const Dialogs = useDialogs();
 
     return (
@@ -153,7 +153,7 @@ export const NetworkModal = ({ dialogError, help, idPrefix, title, onSubmit, chi
             footer={
                 <>
                     <Button variant='primary' id={idPrefix + "-save"} onClick={onSubmit}>
-                        {_("Save")}
+                        {isCreateDialog ? _("Add") : _("Save")}
                     </Button>
                     <Button variant='link' id={idPrefix + "-cancel"} onClick={Dialogs.close}>
                         {_("Cancel")}

--- a/pkg/networkmanager/team.jsx
+++ b/pkg/networkmanager/team.jsx
@@ -151,7 +151,8 @@ export const TeamDialog = ({ connection, dev, settings }) => {
         <NetworkModal dialogError={dialogError}
                       idPrefix={idPrefix}
                       onSubmit={onSubmit}
-                      title={_("Team settings")}
+                      title={!connection ? _("Add team") : _("Edit team settings")}
+                      isCreateDialog={!connection}
         >
             <>
                 <Name idPrefix={idPrefix} iface={iface} setIface={setIface} />

--- a/pkg/networkmanager/vlan.jsx
+++ b/pkg/networkmanager/vlan.jsx
@@ -88,7 +88,8 @@ export const VlanDialog = ({ connection, dev, settings }) => {
         <NetworkModal dialogError={dialogError}
                       idPrefix={idPrefix}
                       onSubmit={onSubmit}
-                      title={_("VLAN settings")}
+                      title={!connection ? _("Add VLAN") : _("Edit VLAN settings")}
+                      isCreateDialog={!connection}
         >
             <>
                 <FormGroup fieldId={idPrefix + "-parent-select"} label={_("Parent")}>

--- a/test/verify/check-networkmanager-bond
+++ b/test/verify/check-networkmanager-bond
@@ -61,7 +61,7 @@ class TestBonding(netlib.NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbond']")
 
@@ -144,7 +144,7 @@ class TestBonding(netlib.NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         b.click("#networking-interfaces tr[data-interface='tbond'] button")
@@ -170,7 +170,7 @@ class TestBonding(netlib.NetworkCase):
         b.select_from_dropdown("#network-bond-settings-link-monitoring-select", "arp")
         b.set_input_text("#network-bond-settings-monitoring-targets-input", "1.1.1.1")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Rename while it is active
@@ -213,7 +213,7 @@ class TestBonding(netlib.NetworkCase):
         b.set_checked(f"input[data-iface='{iface}']", val=True)
         b.click("#network-bond-settings-mac-input")
         b.click("li button:contains('(cockpit1)')")
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the interface and the right IP address
@@ -280,7 +280,7 @@ class TestBondingVirt(netlib.NetworkCase):
         b.wait_visible("#network-bond-settings-dialog")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface}']", val=True)
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address
@@ -319,7 +319,7 @@ class TestBondingVirt(netlib.NetworkCase):
         b.wait_visible("#network-bond-settings-dialog")
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface}']", val=True)
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         # Check that it has the main connection and the right IP address

--- a/test/verify/check-networkmanager-bridge
+++ b/test/verify/check-networkmanager-bridge
@@ -53,7 +53,7 @@ class TestBridge(netlib.NetworkCase):
         b.set_input_text("#network-bridge-settings-interface-name-input", "tbridge")
         b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
-        b.click("#network-bridge-settings-dialog button:contains('Save')")
+        b.click("#network-bridge-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bridge-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tbridge']")
 
@@ -96,7 +96,7 @@ class TestBridge(netlib.NetworkCase):
         b.wait_visible("#network-bridge-settings-dialog")
         b.set_input_text("#network-bridge-settings-interface-name-input", "tbridge")
         b.set_checked(f"input[data-iface='{iface}']", val=True)
-        b.click("#network-bridge-settings-dialog button:contains('Save')")
+        b.click("#network-bridge-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bridge-settings-dialog")
 
         # Check that it has the interface and the right IP address

--- a/test/verify/check-networkmanager-mac
+++ b/test/verify/check-networkmanager-mac
@@ -76,7 +76,7 @@ class TestNetworkingMAC(netlib.NetworkCase):
         b.set_input_text("#network-bond-settings-interface-name-input", "tbond")
         b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
-        b.click("#network-bond-settings-dialog button:contains('Save')")
+        b.click("#network-bond-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-bond-settings-dialog")
 
         self.select_iface('tbond')

--- a/test/verify/check-networkmanager-team
+++ b/test/verify/check-networkmanager-team
@@ -56,7 +56,7 @@ class TestTeam(netlib.NetworkCase):
         b.set_input_text("#network-team-settings-interface-name-input", "tteam")
         b.set_checked(f"input[data-iface='{iface1}']", val=True)
         b.set_checked(f"input[data-iface='{iface2}']", val=True)
-        b.click("#network-team-settings-dialog button:contains('Save')")
+        b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
 
         b.wait_attr("#networking", "data-test-wait", "false")
@@ -109,7 +109,7 @@ class TestTeam(netlib.NetworkCase):
         b.wait_visible("#network-team-settings-dialog")
         b.set_input_text("#network-team-settings-interface-name-input", "tteam")
         b.set_checked(f"input[data-iface='{iface}']", val=True)
-        b.click("#network-team-settings-dialog button:contains('Save')")
+        b.click("#network-team-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-team-settings-dialog")
 
         b.wait_attr("#networking", "data-test-wait", "false")

--- a/test/verify/check-networkmanager-vlan
+++ b/test/verify/check-networkmanager-vlan
@@ -49,7 +49,7 @@ class TestNetworkingVLAN(netlib.NetworkCase):
         b.select_from_dropdown("#network-vlan-settings-parent-select", iface)
         b.set_input_text("#network-vlan-settings-interface-name-input", "tvlan")
         b.set_input_text("#network-vlan-settings-vlan-id-input", "123")
-        b.click("#network-vlan-settings-dialog button:contains('Save')")
+        b.click("#network-vlan-settings-dialog button:contains('Add')")
         b.wait_not_present("#network-vlan-settings-dialog")
         b.wait_visible("#networking-interfaces tr[data-interface='tvlan']")
 


### PR DESCRIPTION
Based on @garrett's suggestions [here](https://github.com/cockpit-project/cockpit/pull/19024#issuecomment-1621328633).

> Is this a create dialog? Then it should say "Create VPN", not "Save". In edit mode, it should say "Save", however.

> The title "WireGuard settings" should either be "Create WireGuard VPN" or "Edit WireGuard VPN", based on the mode of the modal.

And [here](https://github.com/cockpit-project/cockpit/pull/19024#issuecomment-1667738465).

> Can you add more than one WireGuard VPN? (It doesn't look like it. It's "WireGuard settings" here with a "Save" button. It's not settings though? Shouldn't it be "Add WireGuard VPN"? With an "Add" button?

This needed to be a separate PR as the code/issue is shared between the other interface Dialogs.

~For the time being, create dialogs have a "Add" button and edit dialogs have a "Save" button.~

Create Dialog:

![image](https://github.com/cockpit-project/cockpit/assets/108616679/a94f79d4-abcd-4a7e-98ce-b738a40339a7)

Edit Dialog:

![image](https://github.com/cockpit-project/cockpit/assets/108616679/6ff17a79-b696-4a10-884d-3ca5cfb3e5b2)

~I haven't changed the titles yet; changing "Bond settings" to "Create bond settings" seems redundant and should be obvious from the context, but happy to get any feedback on that.~