### PR TITLE
networkmanager: Use TrashIcon instead of MinusIcon for field groups, and text-based add buttons instead of PlusIcon

### DIFF
--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -26,6 +26,7 @@ import { FormSelect, FormSelectOption } from "@patternfly/react-core/dist/esm/co
 import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
+import { Tooltip } from "@patternfly/react-core/dist/esm/components/Tooltip/index.js";
 
 import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
 
@@ -165,12 +166,15 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                             value={method}>
                                     {(topic == "ipv4" ? ipv4_method_choices : ipv6_method_choices).map(choice => <FormSelectOption value={choice.choice} label={choice.title} key={choice.choice} />)}
                                 </FormSelect>
-                                <Button variant="secondary"
+                                <Tooltip content={_("Add address")}>
+                                    <Button variant="secondary"
                                         isDisabled={!canHaveExtra}
                                         onClick={() => setAddresses([...addresses, { address: "", netmask: "", gateway: "" }])}
                                         id={idPrefix + "-address-add"}
-                                        aria-label={_("Add item")}
-                                        icon={<PlusIcon />} />
+                                        aria-label={_("Add address")}>
+                                        <PlusIcon />
+                                    </Button>
+                                </Tooltip>
                             </Flex>
                         }
                     />
@@ -228,12 +232,15 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     isDisabled={!canAuto}
                                     onChange={(_event, value) => setIgnoreAutoDns(!value)}
                                     label={_("Automatic")} />
-                                <Button variant="secondary"
+                                <Tooltip content={_("Add DNS server")}>
+                                    <Button variant="secondary"
                                         isDisabled={!canHaveExtra}
                                         onClick={() => setDns([...dns, ""])}
                                         id={idPrefix + "-dns-add"}
-                                        aria-label={_("Add item")}
-                                        icon={<PlusIcon />} />
+                                        aria-label={_("Add DNS server")}>
+                                        <PlusIcon />
+                                    </Button>
+                                </Tooltip>
                             </Flex>
                         }
                     />
@@ -273,12 +280,15 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     isDisabled={!canAuto}
                                     onChange={(_event, value) => setIgnoreAutoDns(!value)}
                                     label={_("Automatic")} />
-                                <Button variant="secondary"
+                                <Tooltip content={_("Add search domain")}>
+                                    <Button variant="secondary"
                                         isDisabled={!canHaveExtra}
                                         onClick={() => setDnsSearch([...dnsSearch, ""])}
                                         id={idPrefix + "-dns-search-add"}
-                                        aria-label={_("Add item")}
-                                        icon={<PlusIcon />} />
+                                        aria-label={_("Add search domain")}>
+                                        <PlusIcon />
+                                    </Button>
+                                </Tooltip>
                             </Flex>
                         }
                     />
@@ -318,12 +328,15 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     isDisabled={!canAuto}
                                     onChange={(_event, value) => setIgnoreAutoRoutes(!value)}
                                     label={_("Automatic")} />
-                                <Button variant="secondary"
+                                <Tooltip content={_("Add route")}>
+                                    <Button variant="secondary"
                                         isDisabled={isOff}
                                         onClick={() => setRoutes([...routes, { address: "", netmask: "", gateway: "", metric: "" }])}
                                         id={idPrefix + "-route-add"}
-                                        aria-label={_("Add item")}
-                                        icon={<PlusIcon />} />
+                                        aria-label={_("Add route")}>
+                                        <PlusIcon />
+                                    </Button>
+                                </Tooltip>
                             </Flex>
                         }
                     />

--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -27,7 +27,7 @@ import { Grid } from "@patternfly/react-core/dist/esm/layouts/Grid/index.js";
 import { Switch } from "@patternfly/react-core/dist/esm/components/Switch/index.js";
 import { TextInput } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
 
-import { MinusIcon, PlusIcon } from '@patternfly/react-icons';
+import { PlusIcon, TrashIcon } from '@patternfly/react-icons';
 
 import { NetworkModal, dialogSave } from './dialogs-common.jsx';
 import { ModelContext } from './model-context.jsx';
@@ -206,11 +206,11 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     ))} />
                             </FormGroup>
                             <FormGroup className="pf-m-1-col-on-sm remove-button-group">
-                                <Button variant='secondary'
+                                <Button variant='plain'
                                         isDisabled={method == 'manual' && i == 0}
                                         onClick={() => setAddresses(addresses.filter((_, index) => index !== i))}
                                         aria-label={_("Remove item")}
-                                        icon={<MinusIcon />} />
+                                        icon={<TrashIcon />} />
                             </FormGroup>
                         </Grid>
                     );
@@ -251,11 +251,11 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     ))} />
                             </FormGroup>
                             <FormGroup className="pf-m-1-col-on-sm remove-button-group">
-                                <Button variant='secondary'
+                                <Button variant='plain'
                                         size="sm"
                                         onClick={() => setDns(dns.filter((_, index) => index !== i))}
                                         aria-label={_("Remove item")}
-                                        icon={<MinusIcon />} />
+                                        icon={<TrashIcon />} />
                             </FormGroup>
                         </Grid>
                     );
@@ -296,11 +296,11 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     ))} />
                             </FormGroup>
                             <FormGroup className="pf-m-1-col-on-sm remove-button-group">
-                                <Button variant='secondary'
+                                <Button variant='plain'
                                         size="sm"
                                         onClick={() => setDnsSearch(dnsSearch.filter((_, index) => index !== i))}
                                         aria-label={_("Remove item")}
-                                        icon={<MinusIcon />} />
+                                        icon={<TrashIcon />} />
                             </FormGroup>
                         </Grid>
                     );
@@ -365,11 +365,11 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                     ))} />
                             </FormGroup>
                             <FormGroup className="pf-m-1-col-on-sm remove-button-group">
-                                <Button variant='secondary'
+                                <Button variant='plain'
                                         size="sm"
                                         onClick={() => setRoutes(routes.filter((_, index) => index !== i))}
                                         aria-label={_("Remove item")}
-                                        icon={<MinusIcon />} />
+                                        icon={<TrashIcon />} />
                             </FormGroup>
                         </Grid>
                     );

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -119,6 +119,14 @@ class TestNetworkingSettings(netlib.NetworkCase):
 
         assert_connection_setting(con_id, "ipv6.method", "disabled")
 
+        # Open the dialog, expand all the fields and assert pixels
+        self.configure_iface_setting("IPv4")
+        b.click("#network-ip-settings-address-add")
+        b.click("#network-ip-settings-route-add")
+        b.click("#network-ip-settings-dns-add")
+        b.click("#network-ip-settings-dns-search-add")
+        b.assert_pixels("#network-ip-settings-dialog", "network-ip-settings-dialog")
+
     def testOtherSettings(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Fixes https://github.com/cockpit-project/cockpit/issues/19211

![Screenshot from 2023-08-21 17-29-08](https://github.com/cockpit-project/cockpit/assets/42733240/0bc84c71-e8ed-4c74-9f9b-d8881607a381)
