### PR TITLE
test: ignore mobile layout network interfaces

### DIFF
--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -74,6 +74,8 @@ class TestNetworkingBasic(netlib.NetworkCase):
                             "span + #networking-edit-ipv6",
                             "span + #networking-edit-ipv4",
                         ],
+                        # IPv6 addresses vary wildly, and their different rendered widths change the column widths
+                        skip_layouts=['mobile']
                         )
 
         con_id = testlib.wait(lambda: self.iface_con_id(iface))


### PR DESCRIPTION
Same as the pixel test above, every image refresh the ipv6 address changes and the new image has a different width.

For example: https://github.com/cockpit-project/bots/pull/5126