### PR TITLE
test: Increase timeout for stratis pool unlocking

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -368,7 +368,8 @@ class TestStorageStratis(storagelib.StorageCase):
         self.dialog_wait_open()
         self.dialog_set_val('passphrase', "wrong-passphrase")
         self.dialog_apply()
-        b.wait_visible("#dialog .pf-v5-c-alert.pf-m-danger")
+        with b.wait_timeout(60):
+            b.wait_visible("#dialog .pf-v5-c-alert.pf-m-danger")
         self.dialog_set_val('passphrase', passphrase)
         self.dialog_apply()
         self.dialog_wait_close()


### PR DESCRIPTION
Trying to unlock with a wrong passphrase sometimes takes longer than the default 15s.

---

I've seen [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19223-20230823-021435-5329e45c-rhel-9-3-storage/log.html#53-2) twice in a row this morning.