### PR TITLE
packit: Add Fedora 39, drop Fedora 37

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -27,8 +27,8 @@ jobs:
     identifier: self
     trigger: pull_request
     targets:
-      - fedora-37
       - fedora-38
+      - fedora-39
       - fedora-latest-aarch64
       - fedora-development
       - centos-stream-8-x86_64
@@ -90,19 +90,19 @@ jobs:
     trigger: release
     dist_git_branches:
       - fedora-development
-      - fedora-37
       - fedora-38
+      - fedora-39
 
   - job: koji_build
     trigger: commit
     dist_git_branches:
       - fedora-development
-      - fedora-37
       - fedora-38
+      - fedora-39
 
   - job: bodhi_update
     trigger: commit
     dist_git_branches:
       # rawhide updates are created automatically
-      - fedora-37
       - fedora-38
+      - fedora-39


### PR DESCRIPTION
Too late for today's releases, we'll have to do the F39 commit/build/bodhi manually, but for the next time..