### PR TITLE
Add isActive property in dialogs object

### DIFF
--- a/pkg/lib/dialogs.jsx
+++ b/pkg/lib/dialogs.jsx
@@ -108,7 +108,7 @@ export const WithDialogs = ({ children }) => {
     const Dialogs = {
         show: setDialog,
         close: () => setDialog(null),
-        isActive: dialog !== null
+        isActive: () => dialog !== null
     };
 
     return (

--- a/pkg/lib/dialogs.jsx
+++ b/pkg/lib/dialogs.jsx
@@ -107,7 +107,8 @@ export const WithDialogs = ({ children }) => {
 
     const Dialogs = {
         show: setDialog,
-        close: () => setDialog(null)
+        close: () => setDialog(null),
+        isActive: dialog !== null
     };
 
     return (


### PR DESCRIPTION
Returns true if a dialog is currently active. This change fixes keyboard input in navigator ([PR)](https://github.com/KKoukiou/cockpit-navigator/pull/88)