### PR TITLE
tools: Fix building Debian source package after binary build

### DIFF
--- a/tools/debian/clean
+++ b/tools/debian/clean
@@ -1,0 +1,2 @@
+tmp/
+.pytest_cache/

--- a/tools/debian/source/options
+++ b/tools/debian/source/options
@@ -1,0 +1,2 @@
+# FIXME: Running the unit tests changes the identifier in that file
+extend-diff-ignore = "src/ssh/mock_rsa_key.pub$"


### PR DESCRIPTION
Building the binary and running the tests creates tmp/wheel and .pytest_cache/, which are considered as unrepresentable source changes. Let dh_clean remove them before building a source package.

Moreover, running the unit tests changes the "dev@cockpit-project.org" in src/ssh/mock_rsa_key.pub to the local user@hostname. Our tests don't explicitly do that, this smells like some libssh bug/weirdness. Until this is investigated, just ignore the changes in that file for building a source package.

https://bugs.debian.org/1044095