### PR TITLE
pybridge: Implement cockpit-bridge --version; some small cleanups

### DIFF
--- a/doc/man/cockpit-bridge.xml
+++ b/doc/man/cockpit-bridge.xml
@@ -82,6 +82,12 @@
             available to the user running this command.</para>
         </listitem>
       </varlistentry>
+      <varlistentry>
+        <term><option>--version</option></term>
+        <listitem>
+          <para>Show Cockpit version information.</para>
+        </listitem>
+      </varlistentry>
     </variablelist>
   </refsect1>
 

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -25,7 +25,7 @@ import pwd
 import shlex
 import socket
 import subprocess
-from typing import Iterable, List, Optional, Tuple, Type
+from typing import Iterable, List, Optional, Sequence, Tuple, Type
 
 from cockpit._vendor.ferny import interaction_client
 from cockpit._vendor.systemd_ctypes import bus, run_async
@@ -62,12 +62,12 @@ class InternalBus:
 class Bridge(Router, PackagesListener):
     internal_bus: InternalBus
     packages: Optional[Packages]
-    bridge_rules: List[JsonObject]
+    bridge_configs: Sequence[BridgeConfig]
     args: argparse.Namespace
 
     def __init__(self, args: argparse.Namespace):
         self.internal_bus = InternalBus(EXPORTS)
-        self.bridge_rules = []
+        self.bridge_configs = []
         self.args = args
 
         self.superuser_rule = SuperuserRoutingRule(self, privileged=args.privileged)
@@ -149,7 +149,7 @@ class Bridge(Router, PackagesListener):
     def packages_loaded(self) -> None:
         assert self.packages
         bridge_configs = self.packages.get_bridge_configs()
-        if self.bridge_rules != bridge_configs:
+        if self.bridge_configs != bridge_configs:
             self.superuser_rule.set_configs(bridge_configs)
             self.peers_rule.set_configs(bridge_configs)
             self.bridge_configs = bridge_configs

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -31,6 +31,7 @@ from cockpit._vendor.ferny import interaction_client
 from cockpit._vendor.systemd_ctypes import bus, run_async
 
 from . import polyfills
+from ._version import __version__
 from .channel import ChannelRoutingRule
 from .channels import CHANNEL_TYPES
 from .config import Config, Environment
@@ -274,6 +275,9 @@ def main(*, beipack: bool = False) -> None:
     # Special modes
     if args.packages:
         Packages().show()
+        return
+    elif args.version:
+        print(f'Version: {__version__}\nProtocol: 1')
         return
     elif args.bridges:
         print(json.dumps(Packages().get_bridge_configs(), indent=2))

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -146,7 +146,8 @@ class Bridge(Router, PackagesListener):
         self.write_control(command='init', version=1, **init_args)
 
     # PackagesListener interface
-    def packages_loaded(self):
+    def packages_loaded(self) -> None:
+        assert self.packages
         bridge_configs = self.packages.get_bridge_configs()
         if self.bridge_rules != bridge_configs:
             self.superuser_rule.set_configs(bridge_configs)

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -254,7 +254,6 @@ def main(*, beipack: bool = False) -> None:
     parser.add_argument('--privileged', action='store_true', help='Privileged copy of the bridge')
     parser.add_argument('--packages', action='store_true', help='Show Cockpit package information')
     parser.add_argument('--bridges', action='store_true', help='Show Cockpit bridges information')
-    parser.add_argument('--rules', action='store_true', help='Show Cockpit bridge rules')
     parser.add_argument('--debug', action='store_true', help='Enable debug output (very verbose)')
     parser.add_argument('--version', action='store_true', help='Show Cockpit version information')
     args = parser.parse_args()

--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -88,7 +88,7 @@ class Document(NamedTuple):
 
 
 class PackagesListener:
-    def packages_loaded(self):
+    def packages_loaded(self) -> None:
         """Called when the packages have been reloaded"""
 
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -1173,6 +1173,22 @@ UnixPath=/run/cockpit/session
         b.wait_visible("#nav-system li:contains(Hackices)")
         self.assertFalse(b.is_present("#nav-system li:contains(Services)"))
 
+    def testBridgeCLI(self):
+        m = self.machine
+
+        out = m.execute("cockpit-bridge --help")
+        # this needs to work with both the C and Python bridges
+        self.assertRegex(out, r"[uU]sage:")
+        self.assertIn("--packages", out)
+
+        version = m.execute("cockpit-bridge --version")
+        self.assertIn("Protocol: 1", version)
+        self.assertRegex(version, r"Version: \d{3,}")
+
+        packages = m.execute("cockpit-bridge --packages")
+        self.assertRegex(packages, r"(^|\n)base1\s+.*/usr/share/cockpit/base1")
+        self.assertRegex(packages, r"(^|\n)system\s+.*/usr/share/cockpit/systemd")
+
 
 @testlib.skipDistroPackage()
 class TestReverseProxy(testlib.MachineCase):


### PR DESCRIPTION
It was defined in argparse, but entirely ignored, so that it started the
protocol. Also add it to the manpage.

This also unbreaks the regular cockpit/ws container builds, as they use
--version to define the tag.

Add an integration test which exercises all non-protocol options.

Fixes #19233

----

See https://quay.io/repository/cockpit/ws?tab=tags , this stopped updating since we moved Fedora 38 to the pybridge.