### PR TITLE
storage: Make some functions global in preparation for UI redesign

### DIFF
--- a/pkg/storaged/iscsi-panel.jsx
+++ b/pkg/storaged/iscsi-panel.jsx
@@ -30,6 +30,203 @@ import { dialog_open, TextInput, PassInput, SelectRow } from "./dialog.jsx";
 
 const _ = cockpit.gettext;
 
+function iscsi_discover(client) {
+    dialog_open({
+        Title: _("Add iSCSI portal"),
+        Fields: [
+            TextInput("address", _("Server address"),
+                      { validate: val => val === "" ? _("Server address cannot be empty.") : null, }),
+            TextInput("username", _("Username"), { }),
+            PassInput("password", _("Password"), { })
+        ],
+        Action: {
+            Title: _("Next"),
+            action: (vals, progress_callback) => new Promise((resolve, reject) => {
+                const options = { };
+                if (vals.username || vals.password) {
+                    options.username = { t: 's', v: vals.username };
+                    options.password = { t: 's', v: vals.password };
+                }
+
+                let cancelled = false;
+                client.manager_iscsi.call('DiscoverSendTargets',
+                                          [vals.address,
+                                              0,
+                                              options
+                                          ])
+                        .then(function (results) {
+                            if (!cancelled) {
+                                resolve();
+                                iscsi_add(client, vals, results[0]);
+                            }
+                        })
+                        .catch(function (error) {
+                            if (cancelled)
+                                return;
+
+                            // HACK - https://github.com/storaged-project/udisks/issues/26
+                            if (error.message.indexOf("initiator failed authorization") != -1)
+                                error = {
+                                    username: true, // make it red without text below
+                                    password: _("Invalid username or password")
+                                };
+                            else if (error.message.indexOf("cannot resolve host name") != -1)
+                                error = {
+                                    address: _("Unknown host name")
+                                };
+                            else if (error.message.indexOf("connection login retries") != -1)
+                                error = {
+                                    address: _("Unable to reach server")
+                                };
+
+                            reject(error);
+                        });
+
+                progress_callback(null, function () {
+                    cancelled = true;
+                    reject();
+                });
+            }),
+        }
+    });
+}
+
+function iscsi_login(client, target, cred_vals) {
+    const options = {
+        'node.startup': { t: 's', v: "automatic" }
+    };
+    if (cred_vals.username || cred_vals.password) {
+        options.username = { t: 's', v: cred_vals.username };
+        options.password = { t: 's', v: cred_vals.password };
+    }
+    return client.manager_iscsi.call('Login',
+                                     [target[0],
+                                         target[1],
+                                         target[2],
+                                         target[3],
+                                         target[4],
+                                         options
+                                     ]);
+}
+
+function iscsi_add(client, discover_vals, nodes) {
+    dialog_open({
+        Title: cockpit.format(_("Available targets on $0"),
+                              discover_vals.address),
+        Fields: [
+            SelectRow("target", [_("Name"), _("Address"), _("Port")],
+                      {
+                          choices: nodes.map(n => ({
+                              columns: [n[0], n[2], n[3]],
+                              value: n
+                          }))
+                      })
+        ],
+        Action: {
+            Title: _("Add"),
+            action: function (vals) {
+                return iscsi_login(client, vals.target, discover_vals)
+                        .catch(err => {
+                            if (err.message.indexOf("authorization") != -1)
+                                iscsi_add_with_creds(client, discover_vals, vals);
+                            else
+                                return Promise.reject(err);
+                        });
+            }
+        }
+    });
+}
+
+function iscsi_add_with_creds(client, discover_vals, login_vals) {
+    dialog_open({
+        Title: _("Authentication required"),
+        Fields: [
+            TextInput("username", _("Username"),
+                      { value: discover_vals.username }),
+            PassInput("password", _("Password"),
+                      { value: discover_vals.password })
+        ],
+        Action: {
+            Title: _("Add"),
+            action: function (vals) {
+                return iscsi_login(client, login_vals.target, vals)
+                        .catch(err => {
+                        // HACK - https://github.com/storaged-project/udisks/issues/26
+                            if (err.message.indexOf("authorization") != -1)
+                                err = {
+                                    username: true, // makes it red without text below
+                                    password: _("Invalid username or password")
+                                };
+                            return Promise.reject(err);
+                        });
+            }
+        }
+    });
+}
+
+function iscsi_change_name(client) {
+    return client.manager_iscsi.call('GetInitiatorName')
+            .then(function (results) {
+                const name = results[0];
+                dialog_open({
+                    Title: _("Change iSCSI initiator name"),
+                    Fields: [
+                        TextInput("name", _("Name"), { value: name })
+                    ],
+                    Action: {
+                        Title: _("Change"),
+                        action: function (vals) {
+                            return client.manager_iscsi.call('SetInitiatorName',
+                                                             [vals.name,
+                                                                 { }
+                                                             ]);
+                        }
+                    }
+                });
+            });
+}
+
+export function iscsi_rows(client, options) {
+    function cmp_session(path_a, path_b) {
+        const a = client.iscsi_sessions[path_a];
+        const b = client.iscsi_sessions[path_b];
+        const a_name = a.data.target_name || "";
+        const b_name = b.data.target_name || "";
+
+        return a_name.localeCompare(b_name);
+    }
+
+    function make_session(path) {
+        const session = client.iscsi_sessions[path];
+
+        function iscsi_remove() {
+            if (options.disarm)
+                options.disarm();
+            return session.Logout({ 'node.startup': { t: 's', v: "manual" } });
+        }
+
+        let actions = null;
+        if (options.armed)
+            actions = (
+                <StorageButton kind="danger" onClick={iscsi_remove}>
+                    <TrashIcon className="ct-TrashIcon" />
+                </StorageButton>
+            );
+
+        return {
+            client,
+            actions,
+            kind: "array",
+            name: session.data.target_name || "",
+            key: path,
+            detail: session.data.persistent_address + ":" + session.data.persistent_port
+        };
+    }
+
+    return Object.keys(client.iscsi_sessions).sort(cmp_session)
+            .map(make_session);
+}
+
 export class IscsiPanel extends React.Component {
     constructor() {
         super();
@@ -37,208 +234,15 @@ export class IscsiPanel extends React.Component {
     }
 
     render() {
-        const self = this;
         const client = this.props.client;
-
-        function iscsi_discover() {
-            dialog_open({
-                Title: _("Add iSCSI portal"),
-                Fields: [
-                    TextInput("address", _("Server address"),
-                              { validate: val => val === "" ? _("Server address cannot be empty.") : null, }),
-                    TextInput("username", _("Username"), { }),
-                    PassInput("password", _("Password"), { })
-                ],
-                Action: {
-                    Title: _("Next"),
-                    action: (vals, progress_callback) => new Promise((resolve, reject) => {
-                        const options = { };
-                        if (vals.username || vals.password) {
-                            options.username = { t: 's', v: vals.username };
-                            options.password = { t: 's', v: vals.password };
-                        }
-
-                        let cancelled = false;
-                        client.manager_iscsi.call('DiscoverSendTargets',
-                                                  [vals.address,
-                                                      0,
-                                                      options
-                                                  ])
-                                .then(function (results) {
-                                    if (!cancelled) {
-                                        resolve();
-                                        iscsi_add(vals, results[0]);
-                                    }
-                                })
-                                .catch(function (error) {
-                                    if (cancelled)
-                                        return;
-
-                                    // HACK - https://github.com/storaged-project/udisks/issues/26
-                                    if (error.message.indexOf("initiator failed authorization") != -1)
-                                        error = {
-                                            username: true, // make it red without text below
-                                            password: _("Invalid username or password")
-                                        };
-                                    else if (error.message.indexOf("cannot resolve host name") != -1)
-                                        error = {
-                                            address: _("Unknown host name")
-                                        };
-                                    else if (error.message.indexOf("connection login retries") != -1)
-                                        error = {
-                                            address: _("Unable to reach server")
-                                        };
-
-                                    reject(error);
-                                });
-
-                        progress_callback(null, function () {
-                            cancelled = true;
-                            reject();
-                        });
-                    }),
-                }
-            });
-        }
-
-        function iscsi_login(target, cred_vals) {
-            const options = {
-                'node.startup': { t: 's', v: "automatic" }
-            };
-            if (cred_vals.username || cred_vals.password) {
-                options.username = { t: 's', v: cred_vals.username };
-                options.password = { t: 's', v: cred_vals.password };
-            }
-            return client.manager_iscsi.call('Login',
-                                             [target[0],
-                                                 target[1],
-                                                 target[2],
-                                                 target[3],
-                                                 target[4],
-                                                 options
-                                             ]);
-        }
-
-        function iscsi_add(discover_vals, nodes) {
-            dialog_open({
-                Title: cockpit.format(_("Available targets on $0"),
-                                      discover_vals.address),
-                Fields: [
-                    SelectRow("target", [_("Name"), _("Address"), _("Port")],
-                              {
-                                  choices: nodes.map(n => ({
-                                      columns: [n[0], n[2], n[3]],
-                                      value: n
-                                  }))
-                              })
-                ],
-                Action: {
-                    Title: _("Add"),
-                    action: function (vals) {
-                        return iscsi_login(vals.target, discover_vals)
-                                .catch(err => {
-                                    if (err.message.indexOf("authorization") != -1)
-                                        iscsi_add_with_creds(discover_vals, vals);
-                                    else
-                                        return Promise.reject(err);
-                                });
-                    }
-                }
-            });
-        }
-
-        function iscsi_add_with_creds(discover_vals, login_vals) {
-            dialog_open({
-                Title: _("Authentication required"),
-                Fields: [
-                    TextInput("username", _("Username"),
-                              { value: discover_vals.username }),
-                    PassInput("password", _("Password"),
-                              { value: discover_vals.password })
-                ],
-                Action: {
-                    Title: _("Add"),
-                    action: function (vals) {
-                        return iscsi_login(login_vals.target, vals)
-                                .catch(err => {
-                                    // HACK - https://github.com/storaged-project/udisks/issues/26
-                                    if (err.message.indexOf("authorization") != -1)
-                                        err = {
-                                            username: true, // makes it red without text below
-                                            password: _("Invalid username or password")
-                                        };
-                                    return Promise.reject(err);
-                                });
-                    }
-                }
-            });
-        }
-
-        function iscsi_change_name() {
-            client.manager_iscsi.call('GetInitiatorName')
-                    .then(function (results) {
-                        const name = results[0];
-                        dialog_open({
-                            Title: _("Change iSCSI initiator name"),
-                            Fields: [
-                                TextInput("name", _("Name"), { value: name })
-                            ],
-                            Action: {
-                                Title: _("Change"),
-                                action: function (vals) {
-                                    return client.manager_iscsi.call('SetInitiatorName',
-                                                                     [vals.name,
-                                                                         { }
-                                                                     ]);
-                                }
-                            }
-                        });
-                    });
-        }
-
-        function cmp_session(path_a, path_b) {
-            const a = client.iscsi_sessions[path_a];
-            const b = client.iscsi_sessions[path_b];
-            const a_name = a.data.target_name || "";
-            const b_name = b.data.target_name || "";
-
-            return a_name.localeCompare(b_name);
-        }
-
-        function make_session(path) {
-            const session = client.iscsi_sessions[path];
-
-            function iscsi_remove() {
-                self.setState({ armed: false });
-                return session.Logout({ 'node.startup': { t: 's', v: "manual" } });
-            }
-
-            let actions = null;
-            if (self.state.armed)
-                actions = (
-                    <StorageButton kind="danger" onClick={iscsi_remove}>
-                        <TrashIcon className="ct-TrashIcon" />
-                    </StorageButton>
-                );
-
-            return {
-                client,
-                actions,
-                kind: "array",
-                name: session.data.target_name || "",
-                key: path,
-                detail: session.data.persistent_address + ":" + session.data.persistent_port
-            };
-        }
+        const sessions = iscsi_rows(client,
+                                    { armed: this.state.armed, disarm: () => this.setState({ armed: false }) });
 
         const toggle_armed = (event) => {
             if (!event || event.button !== 0)
                 return;
             this.setState(prevState => ({ armed: !prevState.armed }));
         };
-
-        const sessions = Object.keys(client.iscsi_sessions).sort(cmp_session)
-                .map(make_session);
 
         const actions = (
             <>
@@ -248,11 +252,14 @@ export class IscsiPanel extends React.Component {
                     : null
                 }
                 { "\n" }
-                <StorageButton ariaLabel={_("Edit")} onClick={iscsi_change_name} id="edit-iscsi">
+                <StorageButton ariaLabel={_("Edit")} onClick={() => iscsi_change_name(client)} id="edit-iscsi">
                     <EditIcon />
                 </StorageButton>
                 { "\n" }
-                <StorageButton ariaLabel={_("Add")} kind="primary" onClick={iscsi_discover} id="add-iscsi-portal">
+                <StorageButton ariaLabel={_("Add")}
+                               kind="primary"
+                               onClick={() => iscsi_discover(client)}
+                               id="add-iscsi-portal">
                     <PlusIcon />
                 </StorageButton>
             </>

--- a/pkg/storaged/mdraids-panel.jsx
+++ b/pkg/storaged/mdraids-panel.jsx
@@ -43,7 +43,7 @@ function mdraid_row(client, path) {
     };
 }
 
-export function mdraid_rows(client) {
+export function mdraid_rows(client, options) {
     function cmp_mdraid(path_a, path_b) {
         return mdraid_name(client.mdraids[path_a]).localeCompare(mdraid_name(client.mdraids[path_b]));
     }

--- a/pkg/storaged/others-panel.jsx
+++ b/pkg/storaged/others-panel.jsx
@@ -25,30 +25,37 @@ import { block_name, fmt_size, make_block_path_cmp, get_other_devices } from "./
 
 const _ = cockpit.gettext;
 
+export function other_rows(client, options) {
+    function make_other(path) {
+        const block = client.blocks[path];
+        const name = block_name(block);
+        const dev = name.replace(/^\/dev\//, "");
+
+        return {
+            client,
+            kind: false,
+            testkey: dev,
+            devname: name,
+            name,
+            detail: cockpit.format(_("$0 block device"), fmt_size(block.Size)),
+            type: _("Block device"),
+            size: block.Size,
+            go: () => cockpit.location.go([dev]),
+            job_path: path,
+            key: path,
+            block
+        };
+    }
+
+    return get_other_devices(client)
+            .sort(make_block_path_cmp(client))
+            .map(make_other);
+}
+
 export class OthersPanel extends React.Component {
     render() {
         const client = this.props.client;
-
-        function make_other(path) {
-            const block = client.blocks[path];
-            const name = block_name(block);
-            const dev = name.replace(/^\/dev\//, "");
-
-            return {
-                client,
-                kind: false,
-                testkey: dev,
-                devname: block_name(block),
-                detail: cockpit.format(_("$0 block device"), fmt_size(block.Size)),
-                go: () => cockpit.location.go([dev]),
-                job_path: path,
-                key: path
-            };
-        }
-
-        const others = get_other_devices(client)
-                .sort(make_block_path_cmp(client))
-                .map(make_other);
+        const others = other_rows(client, {});
 
         if (others.length > 0)
             return (

--- a/pkg/storaged/stratis-panel.jsx
+++ b/pkg/storaged/stratis-panel.jsx
@@ -78,7 +78,7 @@ function stratis_stopped_pool_row(client, uuid) {
     };
 }
 
-export function stratis_rows(client) {
+export function stratis_rows(client, options) {
     function cmp_pool(path_a, path_b) {
         return client.stratis_pools[path_a].Name.localeCompare(client.stratis_pools[path_b].Name);
     }

--- a/pkg/storaged/vdos-panel.jsx
+++ b/pkg/storaged/vdos-panel.jsx
@@ -39,7 +39,7 @@ function vdo_row(client, vdo) {
     };
 }
 
-export function vdo_rows(client) {
+export function vdo_rows(client, options) {
     function cmp_vdo(a, b) {
         return a.name.localeCompare(b.Name);
     }

--- a/pkg/storaged/vgroups-panel.jsx
+++ b/pkg/storaged/vgroups-panel.jsx
@@ -42,7 +42,7 @@ function vgroup_row(client, path) {
     };
 }
 
-export function vgroup_rows(client) {
+export function vgroup_rows(client, options) {
     function cmp_vgroup(path_a, path_b) {
         return client.vgroups[path_a].Name.localeCompare(client.vgroups[path_b].Name);
     }


### PR DESCRIPTION
 - Expose the content row producers, and generalize "is_partition" etc to "options" for the content row producers, so that we can add more overview specific tuning options later.

 - Expose side panel row and action providers, and add "options" for later tuning.

 - Expose top-level content actions, such as "Create logical volume"

This allows us to use those functions from new UI elements, and it is best to make them global as early as possible so that future changes to the actual code in those functions doesn't lead to constant merge conflicts while the new UI is slowly brewing.