### PR TITLE
Kdump page improvements

### DIFF
--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -601,16 +601,6 @@ ${enableCrashKernel}
                         <CardBody>
                             <DescriptionList className="pf-m-horizontal-on-sm">
                                 <DescriptionListGroup>
-                                    <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
-                                    <DescriptionListDescription>
-                                        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-                                            {serviceWaiting}
-                                            {kdumpServiceDetails}
-                                        </Flex>
-                                    </DescriptionListDescription>
-                                </DescriptionListGroup>
-
-                                <DescriptionListGroup>
                                     <DescriptionListTerm>{_("Reserved memory")}</DescriptionListTerm>
                                     <DescriptionListDescription>
                                         {reservedMemory}
@@ -621,6 +611,16 @@ ${enableCrashKernel}
                                     <DescriptionListTerm>{_("Crash dump location")}</DescriptionListTerm>
                                     <DescriptionListDescription>
                                         {settingsLink}
+                                    </DescriptionListDescription>
+                                </DescriptionListGroup>
+
+                                <DescriptionListGroup>
+                                    <DescriptionListTerm>{_("Status")}</DescriptionListTerm>
+                                    <DescriptionListDescription>
+                                        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
+                                            {serviceWaiting}
+                                            {kdumpServiceDetails}
+                                        </Flex>
                                     </DescriptionListDescription>
                                 </DescriptionListGroup>
 

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -23,7 +23,7 @@ import cockpit from "cockpit";
 import React, { useEffect, useState } from "react";
 import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
-import { Card, CardBody } from "@patternfly/react-core/dist/esm/components/Card/index.js";
+import { Card, CardBody, CardTitle } from "@patternfly/react-core/dist/esm/components/Card/index.js";
 import { HelperText, HelperTextItem } from "@patternfly/react-core/dist/esm/components/HelperText/index.js";
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { Form, FormGroup, FormSection } from "@patternfly/react-core/dist/esm/components/Form/index.js";
@@ -576,6 +576,7 @@ ${enableCrashKernel}
                     {kdumpSwitch}
                 </Tooltip>);
         }
+
         return (
             <Page>
                 <PageSection variant={PageSectionVariants.light}>
@@ -592,6 +593,11 @@ ${enableCrashKernel}
                 </PageSection>
                 <PageSection>
                     <Card>
+                        <CardTitle>
+                            <Title headingLevel="h4" size="xl">
+                                {_("Kdump settings")}
+                            </Title>
+                        </CardTitle>
                         <CardBody>
                             <DescriptionList className="pf-m-horizontal-on-sm">
                                 <DescriptionListGroup>

--- a/pkg/kdump/kdump-view.jsx
+++ b/pkg/kdump/kdump-view.jsx
@@ -545,7 +545,7 @@ ${enableCrashKernel}
         let testButton;
         if (serviceRunning) {
             testButton = (
-                <PrivilegedButton variant="secondary"
+                <PrivilegedButton variant="secondary" isDanger
                                   excuse={ _("The user $0 is not permitted to test crash the kernel") }
                                   onClick={this.handleTestSettingsClick}>
                     { _("Test configuration") }
@@ -555,13 +555,12 @@ ${enableCrashKernel}
             const tooltip = _("Test is only available while the kdump service is running.");
             testButton = (
                 <Tooltip id="tip-test" content={tooltip}>
-                    <Button variant="secondary" isAriaDisabled>
+                    <Button variant="secondary" isDanger isAriaDisabled>
                         {_("Test configuration")}
                     </Button>
                 </Tooltip>
             );
         }
-        const tooltip_info = _("This will test the kdump configuration by crashing the kernel.");
 
         let automationButton = null;
         if (this.props.kdumpStatus && this.props.kdumpStatus.config !== null && this.state.os_release !== null && targetCanChange) {
@@ -638,12 +637,7 @@ ${enableCrashKernel}
                                 <DescriptionListGroup>
                                     <DescriptionListTerm />
                                     <DescriptionListDescription>
-                                        <Flex spaceItems={{ default: 'spaceItemsSm' }} alignItems={{ default: 'alignItemsCenter' }}>
-                                            {testButton}
-                                            <Tooltip id="tip-test-info" content={tooltip_info}>
-                                                <OutlinedQuestionCircleIcon className="popover-ct-kdump" />
-                                            </Tooltip>
-                                        </Flex>
+                                        {testButton}
                                     </DescriptionListDescription>
                                 </DescriptionListGroup>
                             </DescriptionList>

--- a/pkg/kdump/kdump.js
+++ b/pkg/kdump/kdump.js
@@ -59,10 +59,12 @@ const initStore = function(rootElement) {
         const promise = desiredState ? dataStore.kdumpClient.ensureOn() : dataStore.kdumpClient.ensureOff();
         dataStore.stateChanging = true;
         dataStore.render();
-        promise.finally(function() {
-            dataStore.stateChanging = false;
-            dataStore.render();
-        });
+        promise
+                .catch(error => console.warn("Failed to change kdump state:", error))
+                .finally(() => {
+                    dataStore.stateChanging = false;
+                    dataStore.render();
+                });
     }
     const render = function() {
         root.render(<WithDialogs>{React.createElement(KdumpPage, {

--- a/pkg/kdump/kdump.scss
+++ b/pkg/kdump/kdump.scss
@@ -21,6 +21,7 @@
 
 @import "global-variables";
 @import "@patternfly/patternfly/utilities/Text/text.scss";
+@import "@patternfly/patternfly/utilities/Spacing/spacing.scss";
 
 #kdump-settings-location {
   inline-size: 100%;

--- a/pkg/lib/cockpit-components-privileged.jsx
+++ b/pkg/lib/cockpit-components-privileged.jsx
@@ -50,7 +50,7 @@ export function Privileged({ excuse, allowed, placement, tooltipId, children }) 
 /**
  * Convenience element for a Privilege wrapped Button
  */
-export const PrivilegedButton = ({ tooltipId, placement, excuse, buttonId, onClick, ariaLabel, variant, children }) => {
+export const PrivilegedButton = ({ tooltipId, placement, excuse, buttonId, onClick, ariaLabel, variant, isDanger, children }) => {
     const [user, setUser] = useState(null);
     useEvent(superuser, "changed");
     useEffect(() => cockpit.user().then(user => setUser(user)));
@@ -58,7 +58,7 @@ export const PrivilegedButton = ({ tooltipId, placement, excuse, buttonId, onCli
     return (
         <Privileged allowed={ superuser.allowed } tooltipId={ tooltipId } placement={ placement }
                     excuse={ cockpit.format(excuse, user?.name ?? '') }>
-            <Button id={ buttonId } variant={ variant } onClick={ onClick }
+            <Button id={ buttonId } variant={ variant } isDanger={ isDanger } onClick={ onClick }
                     isInline isDisabled={ !superuser.allowed } aria-label={ ariaLabel }>
                 { children }
             </Button>

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -54,7 +54,7 @@ class KdumpHelpers(testlib.MachineCase):
             browser.click(".pf-v5-c-modal-box button:contains('Cancel')")
         else:
             # we should get a warning dialog, confirm
-            browser.click(f"button{self.danger_btn_class}")
+            browser.click(f".pf-v5-c-modal-box button{self.danger_btn_class}")
             # wait until we've actually triggered a crash
             browser.wait_visible(".apply.pf-m-in-progress")
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -139,7 +139,7 @@ class TestKdump(KdumpHelpers):
         self.enableLocalSsh()
 
         # minimal nfs validation
-        b.wait_text("#kdump-change-target", "locally in /var/crash")
+        b.wait_text("#kdump-target-info", "Local, /var/crash")
 
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")
@@ -181,7 +181,7 @@ class TestKdump(KdumpHelpers):
         # service should start up properly and the button should be on
         self.assertActive(active=True)
         b.wait_in_text("#app", "Service is running")
-        b.wait_text("#kdump-change-target", "Remote over SSH")
+        b.wait_text("#kdump-target-info", "Remote over SSH, root@localhost:/var/crash")
 
         # try to change the path to a directory that doesn't exist
         customPath = "/var/crash2"
@@ -200,7 +200,7 @@ class TestKdump(KdumpHelpers):
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         with b.wait_timeout(120):
             b.wait_not_present(pathInput)
-        b.wait_text("#kdump-change-target", f"locally in {customPath}")
+        b.wait_text("#kdump-target-info", f"Local, {customPath}")
 
         # service has to restart after changing the config, wait for it to be running
         # otherwise the button to test will be disabled
@@ -244,7 +244,7 @@ class TestKdump(KdumpHelpers):
         # Drop the custom path so we can make sure our changes are synced to JavaScript
         m.execute("sed -i 's#^path /var/crash#path /var/tmp#' /etc/kdump.conf")
         last_modified = m.execute("stat /etc/kdump.conf")
-        b.wait_text("#kdump-change-target", "locally in /var/tmp")
+        b.wait_text("#kdump-target-info", "Local, /var/tmp")
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")
         b.set_input_text("#kdump-settings-local-directory", "/var/crash")
@@ -346,11 +346,11 @@ class TestKdump(KdumpHelpers):
 
         # Remove malformed KDUMP_SAVEDIR to check default if nothing specified
         m.execute("sed -i '/KDUMP_SAVEDIR=.*/d' /etc/sysconfig/kdump")
-        b.wait_text("#kdump-change-target", "locally in /var/crash")
+        b.wait_text("#kdump-target-info", "Local, /var/crash")
 
         # Check fixing of (some) malformed lines and local target without file://
         m.execute("echo KDUMP_SAVEDIR=/tmp >> /etc/sysconfig/kdump")
-        b.wait_text("#kdump-change-target", "locally in /tmp")
+        b.wait_text("#kdump-target-info", "Local, /tmp")
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")
         b.click("button:contains('Save')")
@@ -370,7 +370,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text("#kdump-settings-ssh-directory", "/var/tmp/crash")
         b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-change-target", "Remote over SSH")
+        b.wait_text("#kdump-target-info", "Remote over SSH, admin@localhost:/var/tmp/crash")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=ssh://admin@localhost/var/tmp/crash', conf)
         self.assertIn('KDUMP_SSH_IDENTITY="/home/admin/.ssh/id_rsa"', conf)
@@ -383,7 +383,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text("#kdump-settings-nfs-export", "/srv")
         b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-change-target", "Remote over NFS")
+        b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/var/crash")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=nfs://someserver/srv', conf)
         self.assertNotIn("ssh://", conf)
@@ -394,7 +394,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text("#kdump-settings-nfs-directory", "dumps")
         b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-change-target", "Remote over NFS")
+        b.wait_text("#kdump-target-info", "Remote over NFS, someserver:/srv/dumps/var/crash")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=nfs://someserver/srv/dumps', conf)
 
@@ -405,7 +405,7 @@ class TestKdump(KdumpHelpers):
         b.set_input_text("#kdump-settings-local-directory", "/var/tmp")
         b.click("button:contains('Save')")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-change-target", "locally in /var/tmp")
+        b.wait_text("#kdump-target-info", "Local, /var/tmp")
         conf = m.execute("cat /etc/sysconfig/kdump")
         self.assertIn('KDUMP_SAVEDIR=file:///var/tmp', conf)
         self.assertNotIn("nfs://", conf)
@@ -611,7 +611,7 @@ class TestKdumpAnsible(KdumpHelpers):
         pathInput = "#kdump-settings-local-directory"
         b.set_input_text(pathInput, customPath)
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
-        b.wait_text("#kdump-change-target", f"locally in {customPath}")
+        b.wait_text("#kdump-target-info", f"Local, {customPath}")
 
         # HACK: workaround ansible role not creating /var/crash2 https://github.com/linux-system-roles/kdump/issues/8
         kdump_machine.execute(f"mkdir -p {customPath}")
@@ -649,7 +649,7 @@ class TestKdumpAnsible(KdumpHelpers):
         b.set_val("#kdump-settings-location", "local")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_not_present("#kdump-settings-dialog")
-        b.wait_text("#kdump-change-target", "locally in /var/crash")
+        b.wait_text("#kdump-target-info", "Local, /var/crash")
 
         b.click("#kdump-change-target")
         b.set_val("#kdump-settings-location", "ssh")
@@ -661,7 +661,7 @@ class TestKdumpAnsible(KdumpHelpers):
         b.set_input_text(pathInput, "/var/crash")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_not_present(pathInput)
-        b.wait_text("#kdump-change-target", "Remote over SSH")
+        b.wait_text("#kdump-target-info", "Remote over SSH, admin@localhost:/var/crash")
 
         self.enableLocalSsh()
         # running the role starts kdump.service which verifies if /var/crash is readable for the admin
@@ -675,7 +675,7 @@ class TestKdumpAnsible(KdumpHelpers):
         self.assertIn("\npath /var/crash\n", conf)
 
         kdump_browser.login_and_go("/kdump")
-        kdump_browser.wait_text("#kdump-change-target", "Remote over SSH")
+        kdump_browser.wait_text("#kdump-target-info", "Remote over SSH, admin@localhost:/var/crash")
         self.crashKernel("copied through SSH to admin@localhost:/var/crash as vmcore", cancel=True,
                          browser=kdump_browser, machine=kdump_machine)
 
@@ -685,7 +685,7 @@ class TestKdumpAnsible(KdumpHelpers):
         b.set_input_text(pathInput, "/var/crash2")
         b.click(f"#kdump-settings-dialog button{self.primary_btn_class}")
         b.wait_not_present(sshInput)
-        b.wait_text("#kdump-change-target", "Remote over SSH")
+        b.wait_text("#kdump-target-info", "Remote over SSH, localhost:/var/crash2")
 
         self.run_ansible_playbook(browser=b, machine=kdump_machine)
         conf = kdump_machine.execute("cat /etc/kdump.conf")

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -214,6 +214,32 @@ class TestKdump(KdumpHelpers):
         b.wait_not_present(".automation-script-modal")
         m.execute("diff /etc/kdump.conf /etc/kdump.conf.orig", stdout=None)
 
+        # service errors
+
+        m.execute("systemctl disable --now kdump.service")
+        self.assertActive(active=False)
+        b.wait_not_present(".pf-v5-c-alert__title")
+
+        # service is absent (not installed)
+        m.execute("mv /usr/lib/systemd/system/kdump.service /usr/lib/systemd/system/kdump.service.disabled")
+        m.execute("systemctl daemon-reload")
+        b.wait_in_text(".pf-v5-c-alert__title", "Kdump service is not installed")
+
+        # put it back, but cause error on startup
+        m.execute("mv /usr/lib/systemd/system/kdump.service.disabled /usr/lib/systemd/system/kdump.service")
+        m.write("/etc/systemd/system/kdump.service.d/break.conf",
+                "[Service]\nExecStart=\nExecStart=/bin/false\n")
+        m.execute("systemctl daemon-reload")
+        b.wait_not_present(".pf-v5-c-alert__title")
+        b.click(".pf-v5-c-switch__input")
+        b.wait_in_text(".pf-v5-c-alert__title", "Service has an error")
+        self.assertActive(active=False)
+        # "more details" leads to services page
+        b.click(".pf-v5-c-alert__title button")
+        b.switch_to_top()
+        b.wait_js_cond('window.location.pathname === "/system/services"')
+        b.wait_js_cond('window.location.hash === "#/kdump.service"')
+
     @testlib.nondestructive
     def testConfiguration(self):
         b = self.browser

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -101,21 +101,9 @@ class TestKdump(KdumpHelpers):
 
         if m.image.startswith("fedora"):
             # crashkernel command line not set, needs to be explicitly enabled in Fedora
-            b.wait_visible(".pf-v5-c-switch__input:disabled")
-            # right now we have no memory reserved
-            b.mouse("span + div > .popover-ct-kdump", "mouseenter")
-            b.wait_in_text(".pf-v5-c-tooltip", "No memory reserved.")
-            b.mouse("span + div >.popover-ct-kdump", "mouseleave")
-            # newer kdump.service have `ConditionKernelCommandLine=crashkernel` which fails gracefully
-            unit = m.execute("systemctl cat kdump.service")
-            if 'ConditionKernelCommandLine=crashkernel' in unit:
-                # service should indicate that the unit is stopped
-                b.wait_in_text("#app", "Service is stopped")
-            else:
-                # service should indicate an error
-                b.wait_in_text("#app", "Service has an error")
-            # ... and the button should be off
-            self.assertActive(active=False)
+            b.wait_in_text(".pf-v5-c-alert__title", "Kernel did not boot with the crashkernel setting")
+            # no service on/off button
+            b.wait_not_present(".pf-v5-c-switch__input")
 
             # disabled "Test configuration" button should have a tooltip
             b.wait_visible("button:contains(Test configuration)[aria-disabled=true]")
@@ -129,8 +117,10 @@ class TestKdump(KdumpHelpers):
         else:
             # enabled by default in RHEL
             m.execute("until systemctl is-active kdump; do sleep 1; done")
-            b.wait_in_text("#app", "Service is running")
             self.assertActive(active=True)
+
+        # no alert about configuration
+        b.wait_not_present(".pf-v5-c-alert__title")
 
         # there shouldn't be any crash reports in the target directory
         self.assertEqual(m.execute("find /var/crash -maxdepth 1 -mindepth 1 -type d"), "")
@@ -180,7 +170,6 @@ class TestKdump(KdumpHelpers):
         b.wait_in_text("#app", "192 MiB")
         # service should start up properly and the button should be on
         self.assertActive(active=True)
-        b.wait_in_text("#app", "Service is running")
         b.wait_text("#kdump-target-info", "Remote over SSH, root@localhost:/var/crash")
 
         # try to change the path to a directory that doesn't exist
@@ -204,7 +193,6 @@ class TestKdump(KdumpHelpers):
 
         # service has to restart after changing the config, wait for it to be running
         # otherwise the button to test will be disabled
-        b.wait_in_text("#app", "Service is running")
         self.assertActive(active=True)
 
         # crash the kernel and make sure it wrote a report into the right directory
@@ -461,7 +449,7 @@ class TestKdumpNFS(KdumpHelpers):
         self.enableKdump()
         self.login_and_go("/kdump")
         with b.wait_timeout(120):  # needs to rebuild initrd
-            b.wait_in_text("#app", "Service is running")
+            b.wait_visible(".pf-v5-c-switch__input:checked")
 
         # Wait a few seconds so that the newly written kdump.conf is
         # guaranteed to look older to kdump.service than the just
@@ -569,7 +557,7 @@ class TestKdumpNFSAnsible(KdumpHelpers):
         # Verify that kdump runs and crashkernel is configured
         kdump_machine.execute("until systemctl is-active kdump; do sleep 1; done")
         kdump_browser.login_and_go("/kdump")
-        kdump_browser.wait_in_text("#app", "Service is running")
+        kdump_browser.wait_visible(".pf-v5-c-switch__input:checked")
         kdump_browser.wait_in_text("#app", "192 MiB")
         self.assertActive(active=True, browser=kdump_browser)
 
@@ -627,7 +615,6 @@ class TestKdumpAnsible(KdumpHelpers):
         kdump_browser.login_and_go("/kdump")
 
         # Verify that kdump runs and crashkernel is configured
-        kdump_browser.wait_in_text("#app", "Service is running")
         kdump_browser.wait_in_text("#app", "192 MiB")
         self.assertActive(active=True, browser=kdump_browser)
 


### PR DESCRIPTION
- Remove service status, use Alert instead for situations when service is failed / not installed / kernelcrash parameter is not set
- 'Test configuration' should use danger variant button
- Show target location on the card
- Reorganize content of kdump card 
- Add title to kdump card 

### New design:
![image](https://github.com/cockpit-project/cockpit/assets/200109/668a1976-4622-4af9-8fa3-9f1df11dcf8c)

With SSH:
![image](https://github.com/cockpit-project/cockpit/assets/200109/1e1f58a0-09dc-450a-b38b-8ee1297d2c05)

With NFS:
![image](https://github.com/cockpit-project/cockpit/assets/200109/aed7f8e5-3487-4edf-8a50-a2cb2168b115)


### kernelcrash parameter is not set
![image](https://github.com/cockpit-project/cockpit/assets/200109/0288c132-45c3-4b91-a9ff-c2eafcbd444b)

### Service is not installed:
![image](https://github.com/cockpit-project/cockpit/assets/200109/924403d2-1fc5-4ba9-a034-b91ca2e63a43)

### Service is failed
![image](https://github.com/cockpit-project/cockpit/assets/200109/6f1005a6-97b0-4398-8929-84d1eb96cc86)

Designs are available here https://github.com/cockpit-project/cockpit/discussions/19203#discussion-5527715