### PR TITLE
fmf: Plumb through $TEST_* variables for unexpected messages

### DIFF
--- a/plans/all.fmf
+++ b/plans/all.fmf
@@ -7,6 +7,10 @@ discover:
 execute:
     how: tmt
 
+# Let's handle them upstream only, don't break Fedora/RHEL reverse dependency gating
+environment:
+    TEST_AUDIT_NO_SELINUX: 1
+
 /basic:
     summary: Run tests for basic packages
     discover+:

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -6,12 +6,7 @@ set -eux
 PLAN="$1"
 
 MYDIR="$(realpath $(dirname "$0"))"
-if [ -d source ]; then
-    # path for standard-test-source
-    SOURCE="$(pwd)/source"
-else
-    SOURCE="$(realpath $MYDIR/../..)"
-fi
+SOURCE="$(realpath $MYDIR/../..)"
 # https://tmt.readthedocs.io/en/stable/overview.html#variables
 LOGS="${TMT_TEST_DATA:-$(pwd)/logs}"
 mkdir -p "$LOGS"

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -39,11 +39,6 @@ if [ "${TEST_OS#centos-}" != "$TEST_OS" ]; then
     TEST_OS="${TEST_OS}-stream"
 fi
 
-if [ "$ID" = "fedora" ]; then
-    # Testing Farm machines are really slow at some times of the day
-    export TEST_TIMEOUT_FACTOR=3
-fi
-
 TEST_ALLOW_JOURNAL_MESSAGES=""
 
 # HACK: CI hits this selinux denial. Unrelated to our tests.

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -62,6 +62,11 @@ export TEST_ALLOW_JOURNAL_MESSAGES
 TESTS=""
 EXCLUDES=""
 RC=0
+
+# make it easy to check in logs
+echo "TEST_ALLOW_JOURNAL_MESSAGES: ${TEST_ALLOW_JOURNAL_MESSAGES:-}"
+echo "TEST_AUDIT_NO_SELINUX: ${TEST_AUDIT_NO_SELINUX:-}"
+
 if [ "$PLAN" = "optional" ]; then
     TESTS="$TESTS
            TestAutoUpdates


### PR DESCRIPTION
This will allow us to control the value from test plans, in particular
for disabling at least some unexpected message checks for reverse
dependency testing. We don't want to disable unexpected messages
in general for fmf, as we are looking for exactly these in e.g.
selinux-policy reverse dependency tests.

Move from `su` to `runtest`, as with the former it's impossible to plumb
through variables with non-trivial characters, as they cannot be quoted.

Taken from https://github.com/cockpit-project/cockpit-podman/commit/c38692fa4ce66