### PR TITLE
storage: StorageBarMenu dropdown should not always be plain

### DIFF
--- a/pkg/storaged/storage-controls.jsx
+++ b/pkg/storaged/storage-controls.jsx
@@ -254,7 +254,7 @@ export const StorageBarMenu = ({ label, isKebab, onlyNarrow, menuItems }) => {
                   onSelect={() => setIsOpen(!isOpen)}
                   toggle={toggle}
                   isOpen={isOpen}
-                  isPlain
+                  isPlain={isKebab}
                   position="right"
                   dropdownItems={menuItems} />
     );

--- a/pkg/storaged/storage.scss
+++ b/pkg/storaged/storage.scss
@@ -75,6 +75,10 @@
   vertical-align: top;
 }
 
+#storage .storage-sidebar .pf-v5-c-dropdown__toggle {
+  padding-inline: var(--pf-v5-global--spacer--md);
+}
+
 .dialog-select-row-table {
   inline-size: 100%;
 }


### PR DESCRIPTION
So this partially contributes to #19241

How it looks without plain:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/613190a6-6757-442f-b28e-fd61e86c4d25)

![image](https://github.com/cockpit-project/cockpit/assets/1463740/2198eba7-bab3-4339-8fb5-cb1e3efabaf1)

How it looked before:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/e3eb2357-efea-4769-9631-a6bc2df5b984)

![image](https://github.com/cockpit-project/cockpit/assets/1463740/af68b974-d046-42c0-a9e9-e5ccca15f7d1)

----

I am not entirely sure why plain was working like that in light mode? but the dark mode was correct (no background/border).

Also the side effect of this change is now that it is using the proper width / slimmer profile as shown by patternfly docs.