### PR TITLE
containers/ws: Move to Fedora 38

### DIFF
--- a/containers/ws/Dockerfile
+++ b/containers/ws/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora:37 AS builder
+FROM registry.fedoraproject.org/fedora:38 AS builder
 LABEL maintainer="cockpit-devel@lists.fedorahosted.org"
 LABEL VERSION=main
 


### PR DESCRIPTION
37 will soon be EOL.

---

This can't be covered by our CI, as that runs offline. I locally built the container image:

    make -f containers/Makefile.am srcdir=$(pwd) ws-container

then copied it to a FCOS VM:

    podman save quay.io/cockpit/ws:latest | ssh c podman load -

started it in FCOS:

    podman container runlabel INSTALL cockpit/ws
    podman container runlabel RUN cockpit/ws

and get a working cockpit.