### PR TITLE
lib: Fix a dropdown being hidden by a card

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -591,3 +591,8 @@ select.pf-v5-c-form-control {
 .pf-v5-u-font-weight-light {
   font-weight: 300;
 }
+
+// Workaround for https://github.com/patternfly/patternfly/issues/5865
+.pf-v5-c-card.pf-m-selectable, .pf-v5-c-card.pf-m-clickable {
+  isolation: auto;
+}


### PR DESCRIPTION
Workaround for https://github.com/patternfly/patternfly/issues/5865

Closes https://github.com/cockpit-project/cockpit-machines/issues/1188

### The issue:
PF's Dropdown is being hidden by a PF's Card
![Screenshot from 2023-08-28 10-45-33](https://github.com/cockpit-project/cockpit/assets/42733240/f76f5672-8701-45b4-af47-dd944ec0d9fe)
