### PR TITLE
lib: Don't show icon unless 'icon' prop is passed

### DIFF
--- a/pkg/lib/cockpit-components-form-helper.jsx
+++ b/pkg/lib/cockpit-components-form-helper.jsx
@@ -34,7 +34,7 @@ export const FormHelper = ({ helperText, helperTextInvalid, variant, icon, field
                 <HelperTextItem
                     id={fieldId ? (fieldId + "-helper") : undefined}
                     variant={formHelperVariant}
-                    hasIcon={formHelperVariant !== "default" || icon} icon={icon}>
+                    icon={icon}>
                     {formHelperVariant === "error" ? helperTextInvalid : helperText}
                 </HelperTextItem>
             </HelperText>


### PR DESCRIPTION
As per patternfly guidelines [1], validation text (which is main use of FormHelper) should not have an icon

[1] https://www.patternfly.org/components/forms/form/design-guidelines/#errors-and-validation