### PR TITLE
test: Invert "no crashkernel= by default" expectation in kdump test; fix testCPUSecurityMitigationsEnable on fedora-39

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -159,6 +159,7 @@ You can set these environment variables to configure the test suite:
                   "debian-testing"
                   "fedora-37"
                   "fedora-38"
+                  "fedora-39"
                   "fedora-coreos"
                   "fedora-testing"
                   "rhel-8-9"

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -77,11 +77,7 @@ class TestKdump(KdumpHelpers):
         def assertActive(active):
             b.wait_visible(".pf-v5-c-switch__input" + (active and ":checked" or ":not(:checked)"))
 
-        if m.image.startswith("rhel-") or m.image in ["centos-8-stream"]:
-            # some OSes have kdump enabled by default (crashkernel=auto)
-            b.wait_in_text("#app", "Service is running")
-            assertActive(active=True)
-        else:
+        if m.image in ["fedora-37", "fedora-38", "fedora-testing"]:
             # crashkernel command line not set
             b.wait_visible(".pf-v5-c-switch__input:disabled")
             # right now we have no memory reserved
@@ -104,6 +100,10 @@ class TestKdump(KdumpHelpers):
             b.mouse("button:contains(Test configuration)", "mouseenter")
             b.wait_in_text(".pf-v5-c-tooltip", "kdump service")
             b.mouse("button:contains(Test configuration)", "mouseleave")
+        else:
+            # most OSes have a default crashkernel=
+            b.wait_in_text("#app", "Service is running")
+            assertActive(active=True)
 
         # there shouldn't be any crash reports in the target directory
         self.assertEqual(m.execute("find /var/crash -maxdepth 1 -mindepth 1 -type d"), "")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -778,7 +778,7 @@ machine         : 8561
         # - BLS, options go directly into entries, or entries use $kernelopt (defined in grubenv)
         if not m.ostree_image:
             m.execute(r"""
-touch /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
+echo dummy > /boot/vmlinuz-42.0.0; mkdir -p /lib/modules/42.0.0/
 if type update-grub >/dev/null 2>&1; then
     update-grub  # Debian/Ubuntu
     grep -q 'linux.*/vmlinuz-42.0.0.*nosmt' /boot/grub*/grub.cfg


### PR DESCRIPTION
Fedora 39 now has a default crashkernel= kernel option, so that
kdump.service can start by default. Now only old Fedoras are left, so
invert the condition to become simpler and eventually empty.


---

This blocks https://github.com/cockpit-project/bots/pull/5171 . I locally validated that TestKdump.testBasic works against fedora-39 with this fix, but as there are lots of other failures, I don't want to trigger a fedora-39 run here. I'll do that in the bots PR.