### PR TITLE
test: Ignore "invalid non-UTF8 @data passed" message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1691,6 +1691,9 @@ class MachineCase(unittest.TestCase):
 
         # timedatex.service shuts down after timeout, runs into race condition with property watching
         ".*org.freedesktop.timedate1: couldn't get all properties.*Error:org.freedesktop.DBus.Error.NoReply.*",
+
+        # https://github.com/cockpit-project/cockpit/issues/19235
+        "invalid non-UTF8 @data passed as text to web_socket_connection_send.*",
     ]
 
     default_allowed_messages += os.environ.get("TEST_ALLOW_JOURNAL_MESSAGES", "").split(",")


### PR DESCRIPTION
The cause of this is unclear, but this keeps breaking random tests and thus causes unnecessary pain/retries. Until we investigate this bug, let's shut it up.

See issue #19235