### PR TITLE
test: Don't encrypt/move the EFI partition in encrypt_root

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -607,6 +607,8 @@ mkfs.ext4 /dev/root/root
 mkdir /new-root
 mount /dev/root/root /new-root
 mkfs.ext4 {dev}1
+# don't move the EFI partition
+if mountpoint /boot/efi; then umount /boot/efi; fi
 mkdir /new-root/boot
 mount {dev}1 /new-root/boot
 tar --selinux --one-file-system -cf - --exclude /boot --exclude='/var/tmp/*' --exclude='/var/cache/*' \


### PR DESCRIPTION
Doing that messes up the kernel's mount state, and eventually mounts the new /boot *on top of* the old /boot and /boot/efi. This results in /boot/efi not being umountable any more, and hanging forever during shutdown on waiting for boot-efi.mount to finish stopping.

---

This blocks https://github.com/cockpit-project/bots/pull/5171