### PR TITLE
lib: Workaround FormSelect background-color

### DIFF
--- a/pkg/lib/patternfly/patternfly-5-overrides.scss
+++ b/pkg/lib/patternfly/patternfly-5-overrides.scss
@@ -68,6 +68,13 @@ select.pf-v5-c-form-control {
   }
 }
 
+// Workaround the transparent background for HTML select options
+// https://github.com/patternfly/patternfly/issues/5695
+.pf-v5-c-form-control option {
+  background-color: var(--pf-v5-c-form-control--BackgroundColor);
+  color: var(--pf-v5-c-form-control--Color);
+}
+
 // The default gap between the rows in horizontal lists is too large
 .pf-v5-c-description-list.pf-m-horizontal-on-sm,
 .pf-v5-c-description-list.pf-m-horizontal {


### PR DESCRIPTION
Not sure if the right approach, but closes #19241

I am able to replicate this both in chromium and firefox based browsers, and it is not limited on networking only.

Gonna show just a few screenshots from dark mode:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/815f15e7-b13c-4c28-8b75-88f117243250)

Firefox Before:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/134afdbf-3973-461e-871c-580b5f424d80)

Firefox After:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/79ffa3c0-5840-4431-831f-cc56de1bf2ab)


-----

Chrome Before:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/f009ded2-2e7f-4abe-8451-7c2ff18859f7)

Chrome After:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/2d00b83e-69f5-4208-a8cb-5944b46dd96a)


Light mode also works as expected:

Chrome After:
![image](https://github.com/cockpit-project/cockpit/assets/1463740/55f6afef-3e54-4b23-966c-bd9a92ca2c10)

Firefox After:
![image](https://github.com/cockpit-project/cockpit/assets/1463740/98cff63a-6345-4935-9f84-cc6b66d18b78)


