### PR TITLE
storage: Cleanup for table clickable rows

### DIFF
--- a/pkg/lib/table.css
+++ b/pkg/lib/table.css
@@ -106,19 +106,9 @@
   }
 }
 
-/*
- * Fix up table row hovering.
- *
- * When you hover over table rows it's because they're clickable.
- */
-.table-hover > tbody > tr > td,
-.table-hover > tbody > tr > th {
-  cursor: pointer;
-}
-
-.table-hover > tbody > tr:hover > td,
-.table-hover > tbody > tr:hover > th {
-  /* PF3 uses a light blue; we have to force the override for hover colors */
+.pf-v5-c-table__tr.pf-m-clickable:hover > td,
+.pf-v5-c-table__tr.pf-m-clickable:hover > th {
+  /* PF5 has no hover background color; we have to force the override for hover colors */
   background-color: var(--ct-color-list-hover-bg) !important;
   color: var(--ct-color-list-hover-text) !important;
 }

--- a/pkg/storaged/crypto-panel.jsx
+++ b/pkg/storaged/crypto-panel.jsx
@@ -70,15 +70,12 @@ export class LockedCryptoPanel extends React.Component {
             go_to_block(row.props.client, row.props.path);
         }
 
-        // table-hover class is needed till PF4 Table has proper support for clickable rows
-        // https://github.com/patternfly/patternfly-react/issues/3267
         return (
             <OptionalPanel id="locked-cryptos"
                 title={_("Locked devices")}>
                 <ListingTable
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Locked devices")}
-                    className={locked_cryptos.length ? 'table-hover' : ''}
                     onRowClick={onRowClick}
                     columns={[
                         { title: _("Name"), sortable: true },

--- a/pkg/storaged/fsys-panel.jsx
+++ b/pkg/storaged/fsys-panel.jsx
@@ -169,8 +169,6 @@ export class FilesystemsPanel extends React.Component {
                 go_to_block(row.props.client, row.props.path);
         }
 
-        // table-hover class is needed till PF4 Table has proper support for clickable rows
-        // https://github.com/patternfly/patternfly-react/issues/3267
         return (
             <OptionalPanel id="mounts" className="storage-mounts"
                 title={_("Filesystems")}>
@@ -178,7 +176,6 @@ export class FilesystemsPanel extends React.Component {
                     gridBreakPoint="grid-xl"
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("Filesystems")}
-                    className={mounts.length ? 'table-hover' : ''}
                     onRowClick={onRowClick}
                     columns={[
                         { title: _("Source"), sortable: true },

--- a/pkg/storaged/nfs-panel.jsx
+++ b/pkg/storaged/nfs-panel.jsx
@@ -82,8 +82,6 @@ export class NFSPanel extends React.Component {
             cockpit.location.go(["nfs", row.props.entry.fields[0], row.props.entry.fields[1]]);
         }
 
-        // table-hover class is needed till PF4 Table has proper support for clickable rows
-        // https://github.com/patternfly/patternfly-react/issues/3267
         return (
             <OptionalPanel className="storage-mounts" id="nfs-mounts"
                        client={client}
@@ -96,7 +94,6 @@ export class NFSPanel extends React.Component {
                     sortBy={{ index: 0, direction: SortByDirection.asc }}
                     aria-label={_("NFS mounts")}
                     onRowClick={onRowClick}
-                    className={mounts.length ? 'table-hover' : ''}
                     emptyCaption={_("No NFS mounts set up")}
                     columns={[
                         { title: _("Server"), sortable: true },


### PR DESCRIPTION
So in PF5 the row is already getting the proper clickable and added hover styles, the only override that seems to be cockpit specific is the hover color/background-color.

I wonder if the remaining change in `table.css` change should be inside `patternfly-5-overrides.scss` instead?