### PR TITLE
test: Drop fedora-37

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -157,7 +157,6 @@ You can set these environment variables to configure the test suite:
                   "centos-8-stream"
                   "debian-stable"
                   "debian-testing"
-                  "fedora-37"
                   "fedora-38"
                   "fedora-39"
                   "fedora-coreos"

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -20,8 +20,7 @@
 import testlib
 
 
-@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "fedora-37",
-                   "rhel-8*", "centos-8*")
+@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "rhel-8*", "centos-8*")
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -77,7 +77,7 @@ class TestKdump(KdumpHelpers):
         def assertActive(active):
             b.wait_visible(".pf-v5-c-switch__input" + (active and ":checked" or ":not(:checked)"))
 
-        if m.image in ["fedora-37", "fedora-38", "fedora-testing"]:
+        if m.image in ["fedora-38", "fedora-testing"]:
             # crashkernel command line not set
             b.wait_visible(".pf-v5-c-switch__input:disabled")
             # right now we have no memory reserved


### PR DESCRIPTION
Commit 47bc4c58 dropped F37 from releasing, and
https://github.com/cockpit-project/bots/pull/5171 dropped it from CI.