### PR TITLE
cockpit.js: Add debugging marking for translated strings

### DIFF
--- a/pkg/lib/cockpit.js
+++ b/pkg/lib/cockpit.js
@@ -3709,6 +3709,7 @@ function factory() {
 
     cockpit.language = "en";
     cockpit.language_direction = "ltr";
+    const test_l10n = window.localStorage.test_l10n;
 
     cockpit.locale = function locale(po) {
         let lang = cockpit.language;
@@ -3796,8 +3797,12 @@ function factory() {
         if (po_data) {
             const translated = po_data[key];
             if (translated?.[1])
-                return translated[1];
+                string = translated[1];
         }
+
+        if (test_l10n === 'true')
+            return "»" + string + "«";
+
         return string;
     };
 


### PR DESCRIPTION
I am still trying to understand how this would help, opening PR to demonstrate how we can do this.

Looks like this:
![Screenshot from 2023-08-30 09-12-56](https://github.com/cockpit-project/cockpit/assets/12330670/ff64cba2-bb17-4306-a6c0-851dac7c8a08)
