### PR TITLE
test: Increase TestSELinux VM memory

### DIFF
--- a/test/verify/check-selinux
+++ b/test/verify/check-selinux
@@ -59,7 +59,7 @@ mv -f ~/.ssh/authorized_keys.test-avc ~/.ssh/authorized_keys
 @testlib.skipDistroPackage()
 class TestSelinux(testlib.MachineCase):
     provision = {
-        "0": {"memory_mb": 768},
+        "0": {},
         "ansible_machine": {"image": TEST_OS_DEFAULT, "memory_mb": 512}
     }
 


### PR DESCRIPTION
`semanage` needs a lot of memory, and with 768 MiB the VM often runs into low ram and kswapd rampage especially on RHEL 8. Increase to default RAM size to fix that.

The original reason for reducing the memory was the static "packing" of parallelized tests by run-tests, but since it introduced the concept of "cost" that isn't necessary any more.

---

This fixes [this common failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5160-20230828-082610-2aeb7781-centos-8-stream-pybridge-other-cockpit-project-cockpit/log.html#73-2)