### PR TITLE
apps: Fix application progress bar

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -145,9 +145,13 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
                 <Flex alignItems={{ default: 'alignItemsCenter' }}>
                     <h2 className="pf-v5-u-font-size-3xl">{_("Applications")}</h2>
                     <FlexItem align={{ default: 'alignRight' }}>
-                        <Flex>
-                            {refresh_progress}
-                            {refresh_button}
+                        <Flex alignItems={{ default: 'alignItemsCenter' }} spacer={{ default: 'spacerXs' }}>
+                            <FlexItem>
+                                {refresh_progress}
+                            </FlexItem>
+                            <FlexItem>
+                                {refresh_button}
+                            </FlexItem>
                         </Flex>
                     </FlexItem>
                 </Flex>

--- a/pkg/apps/application.scss
+++ b/pkg/apps/application.scss
@@ -23,7 +23,7 @@
 }
 
 .progress-bar {
-  display: inline-block;
+  min-inline-size: 12rem;
   inline-size: 20%;
   overflow: hidden;
 }


### PR DESCRIPTION
The refresh progress bar does not really reserve any space, I took a brief look at the PF4 version on my RPI so I am not sure if the expectation is just a plain progress bar, so let me know if it doesnt make any sense.

Looks like this:
![image](https://github.com/cockpit-project/cockpit/assets/1463740/59559fca-3f8d-4d86-9f74-291322aafb42)

![image](https://github.com/cockpit-project/cockpit/assets/1463740/f358b304-a5b2-457b-88db-11f541c91a96)

Tried to avoid changing the other usage significantly.

Closes #19062