### PR TITLE
various cleanups for typing stuff

### DIFF
--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -144,7 +144,7 @@ class Channel(Endpoint):
         except ChannelError as exc:
             self.close(exc.attrs)
 
-    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', _message: JsonObject) -> None:
         # Already closing?  Ignore.
         if self._close_args is not None:
             return

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -225,9 +225,9 @@ class Peer(CockpitProtocol, SubprocessProtocol, Endpoint):
         assert self.init_future is None
         self.write_channel_data(channel, data)
 
-    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', message: JsonObject) -> None:
         assert self.init_future is None
-        self.write_control(command='kill', host=host, group=group)
+        self.write_control(message)
 
     def do_close(self) -> None:
         self.close()

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -203,7 +203,7 @@ class CockpitProtocolServer(CockpitProtocol):
     def do_init(self, message: JsonObject) -> None:
         pass
 
-    def do_kill(self, host: 'str | None', group: 'str | None') -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', message: JsonObject) -> None:
         raise NotImplementedError
 
     def transport_control_received(self, command, message):
@@ -222,7 +222,7 @@ class CockpitProtocolServer(CockpitProtocol):
                 raise CockpitProtocolError('missing host field', 'protocol-error') from exc
             self.do_init(message)
         elif command == 'kill':
-            self.do_kill(message.get('host'), message.get('group'))
+            self.do_kill(message.get('host'), message.get('group'), message)
         elif command == 'authorize':
             self.do_authorize(message)
         else:

--- a/src/cockpit/remote.py
+++ b/src/cockpit/remote.py
@@ -147,11 +147,11 @@ class SshPeer(Peer):
         args = self.session.wrap_subprocess_args(['cockpit-bridge'])
         await self.spawn(args, [])
 
-    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', message: JsonObject) -> None:
         if host == self.host:
             self.close()
         elif host is None:
-            super().do_kill(None, group)
+            super().do_kill(host, group, message)
 
     def do_authorize(self, message: JsonObject) -> None:
         if get_str(message, 'challenge').startswith('plain1:'):

--- a/src/cockpit/router.py
+++ b/src/cockpit/router.py
@@ -86,7 +86,7 @@ class Endpoint:
     def do_channel_data(self, channel: str, data: bytes) -> None:
         raise NotImplementedError
 
-    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', message: JsonObject) -> None:
         raise NotImplementedError
 
     # interface for sending messages
@@ -185,11 +185,11 @@ class Router(CockpitProtocolServer):
                 logger.debug('  close transport')
                 self.transport.close()
 
-    def do_kill(self, host: Optional[str], group: Optional[str]) -> None:
+    def do_kill(self, host: 'str | None', group: 'str | None', message: JsonObject) -> None:
         endpoints = set(self.endpoints)
         logger.debug('do_kill(%s, %s).  Considering %d endpoints.', host, group, len(endpoints))
         for endpoint in endpoints:
-            endpoint.do_kill(host, group)
+            endpoint.do_kill(host, group, message)
 
     def channel_control_received(self, channel: str, command: str, message: JsonObject) -> None:
         # If this is an open message then we need to apply the routing rules to

--- a/test/static-code
+++ b/test/static-code
@@ -49,6 +49,7 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
         src/cockpit/_version.py
         src/cockpit/jsonutil.py
         src/cockpit/protocol.py
+        src/cockpit/transports.py
     '
     test_mypy() {
         command -v mypy >/dev/null || skip 'no mypy'

--- a/test/static-code
+++ b/test/static-code
@@ -48,6 +48,7 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
         src/cockpit/__init__.py
         src/cockpit/_version.py
         src/cockpit/jsonutil.py
+        src/cockpit/protocol.py
     '
     test_mypy() {
         command -v mypy >/dev/null || skip 'no mypy'

--- a/test/static-code
+++ b/test/static-code
@@ -44,6 +44,11 @@ test_ruff() {
 }
 
 if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
+    mypy_strict_files='
+        src/cockpit/__init__.py
+        src/cockpit/_version.py
+        src/cockpit/jsonutil.py
+    '
     test_mypy() {
         command -v mypy >/dev/null || skip 'no mypy'
         for pkg in systemd_ctypes ferny bei; do
@@ -53,6 +58,7 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
         # test scripts individually, to avoid clashing on `__main__`
         # also skip integration tests, they are too big and not annotated
         find_scripts 'python3' "*.none" | grep -zv 'test/' | xargs -r -0 -n1 mypy --no-error-summary
+        mypy --no-error-summary --strict $mypy_strict_files
     }
 
     test_vulture() {


### PR DESCRIPTION
This enables `mypy --strict` on a handful of files.  This was all fairly straight-forward.

In general, we need to proceed from the bottom of the dependency tree upwards.  That means that the next targets are:

 - config
   - packages
 - router
   - channel
     - all the channels 
   - peer
   - bridge

We're stuck on config because systemd_ctypes dbus stuff isn't `--strict` friendly.  We're stuck on router because the 'freeze' mechanism is pretty evil from a types perspective and I kind of want to get rid of it anyway.

Let's get these "easy" ones in now.