### PR TITLE
Test VM snapshotting for moar speed

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,42 +23,6 @@ srpm_build_deps:
 # use the nicely formatted release NEWS from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 jobs:
-  - job: tests
-    identifier: self
-    trigger: pull_request
-    targets:
-      - fedora-38
-      - fedora-39
-      - fedora-latest-aarch64
-      - fedora-development
-      - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
-      - centos-stream-9-aarch64
-
-  # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
-  - job: tests
-    identifier: revdeps
-    trigger: pull_request
-    targets:
-      - fedora-latest-stable
-    tf_extra_params:
-      environments:
-        - artifacts:
-          - type: repository-file
-            id: https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/repo/fedora-$releasever/group_cockpit-main-builds-fedora-$releasever.repo
-          tmt:
-            context:
-              revdeps: "yes"
-
-  # run build/unit tests on some interesting architectures
-  - job: copr_build
-    trigger: pull_request
-    targets:
-      # 32 bit
-      - fedora-development-i386
-      # big-endian
-      - fedora-development-s390x
-
   # for cross-project testing
   - job: copr_build
     trigger: commit

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -227,12 +227,12 @@ class GlobalMachine:
         self.web_address = f"{self.machine.web_address}:{self.machine.web_port}"
         self.running_test = None
 
+        # snapshot the clean boot, so that we can easily reset the VM when it gets corrupted
+        self.machine.wait_boot()
+        self.machine.snapshot()
+
     def reset(self):
-        # It is important to re-use self.networking here, so that the
-        # machine keeps its browser and control port.
-        self.machine.kill()
-        self.machine = self.machine_class(verbose=True, networking=self.networking, image=self.image)
-        self.machine.start()
+        self.machine.restore()
 
     def kill(self):
         assert self.running_test is None, "can't kill global machine with running test"

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -50,7 +50,8 @@ class Test:
         self.returncode = None
 
     def assign_machine(self, machine_id, ssh_address, web_address):
-        assert self.nondestructive, "assigning a machine only works for nondestructive test"
+        assert self.nondestructive or not self.provision, \
+            "assigning a machine only works for nondestructive or non-provisioning test"
         self.machine_id = machine_id
         self.command.insert(-2, "--machine")
         self.command.insert(-2, ssh_address)
@@ -227,7 +228,7 @@ class GlobalMachine:
         self.web_address = f"{self.machine.web_address}:{self.machine.web_port}"
         self.running_test = None
 
-        # snapshot the clean boot, so that we can easily reset the VM when it gets corrupted
+    def snapshot(self):
         self.machine.wait_boot()
         self.machine.snapshot()
 
@@ -368,8 +369,10 @@ def detect_tests(test_files, image, opts):
     # robust, reproducible, and provides an even distribution of both directions
     nondestructive_tests.sort(key=lambda t: t.command[-1], reverse=bool(binascii.crc32(image.encode()) & 1))
 
-    # sort destructive tests by class/test name, mostly for niceness and --list
-    destructive_tests.sort(key=lambda t: t.command[-1])
+    # sort destructive tests:
+    # - put the "default provisioning" before "custom provisioning" to maximize VM reuse,
+    # - then by class/test name, for niceness and --list
+    destructive_tests.sort(key=lambda t: ('1' if t.provision else '0') + t.command[-1])
 
     return (nondestructive_tests, destructive_tests, machine_class)
 
@@ -392,6 +395,7 @@ def run(opts, image):
     changed_tests = get_affected_tests(opts.test_dir, opts.base, test_files)
     nondestructive_tests, destructive_tests, machine_class = detect_tests(test_files, image, opts)
     nondestructive_tests_len = len(nondestructive_tests)
+    nonprovision_tests_len = len([t for t in destructive_tests if not t.provision])
     destructive_tests_len = len(destructive_tests)
 
     if opts.machine:
@@ -407,12 +411,16 @@ def run(opts, image):
         # Create appropriate number of nondestructive machines; prioritize the nondestructive tests, to get
         # them out of the way as fast as possible, then let the destructive ones start as soon as
         # a given nondestructive runner is done.
-        num_global = min(nondestructive_tests_len, opts.jobs)
+        num_global = min(max(nondestructive_tests_len, nonprovision_tests_len), opts.jobs)
 
         for _ in range(num_global):
             global_machines.append(GlobalMachine(restrict=not opts.enable_network, cpus=opts.nondestructive_cpus,
                                                  memory_mb=opts.nondestructive_memory_mb,
                                                  machine_class=machine_class or testvm.VirtMachine))
+
+        # snapshot the clean boots, so that we can easily reset the VM when it gets corrupted
+        for m in global_machines:
+            m.snapshot()
 
     # test scheduling loop
     while True:
@@ -463,13 +471,21 @@ def run(opts, image):
                 if machine.is_available():
                     if nondestructive_tests:
                         test = nondestructive_tests.pop(0)
-                        logging.debug("Global machine %s is free, assigning next test %s", idx, test)
+                        logging.debug("Global machine %s is free, assigning next nondestructive test %s", idx, test)
+                        machine.running_test = test
+                        test.assign_machine(idx, machine.ssh_address, machine.web_address)
+                        test.start()
+                        running_tests.append(test)
+                    elif destructive_tests and not destructive_tests[0].provision:
+                        test = destructive_tests.pop(0)
+                        logging.debug("Global machine %s is free, assigning next non-provision test %s", idx, test)
+                        machine.reset()
                         machine.running_test = test
                         test.assign_machine(idx, machine.ssh_address, machine.web_address)
                         test.start()
                         running_tests.append(test)
                     else:
-                        logging.debug("Global machine %s is free, and no more non destructive tests; killing", idx)
+                        logging.debug("Global machine %s is free, and no more non destructive or non-provision tests; killing", idx)
                         machine.kill()
 
                     made_progress = True
@@ -480,6 +496,9 @@ def run(opts, image):
         # fill the remaining available job slots with destructive tests; run tests with a cost higher than #jobs by themselves
         while destructive_tests and (running_cost() + destructive_tests[0].cost <= opts.jobs or len(running_tests) == 0):
             test = destructive_tests.pop(0)
+            if not test.provision:
+                # provision a default VM and run the test in it
+                pass
             logging.debug("%d running tests with total cost %d, starting next destructive test %s",
                           len(running_tests), running_cost(), test)
             test.start()

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -451,7 +451,7 @@ def run(opts, image):
                         global_machines[test_machine].reset()
 
                 # run again if needed
-                if test_result == 0 and retry_reason:
+                if False and test_result == 0 and retry_reason:
                     if test.nondestructive:
                         nondestructive_tests.insert(0, test)
                     else:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -34,7 +34,7 @@ def flush_stdout():
 
 
 class Test:
-    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, todo, cost=1):
+    def __init__(self, test_id, command, timeout, nondestructive, retry_when_affected, todo, provision):
         self.process = None
         self.retries = 0
         self.test_id = test_id
@@ -44,7 +44,9 @@ class Test:
         self.machine_id = None
         self.retry_when_affected = retry_when_affected
         self.todo = todo
-        self.cost = cost
+        self.provision = provision
+        # each additionally provisioned VM costs destructive test capacity
+        self.cost = len(provision) if provision else 1
         self.returncode = None
 
     def assign_machine(self, machine_id, ssh_address, web_address):
@@ -352,12 +354,8 @@ def detect_tests(test_files, image, opts):
                 nd = testlib.get_decorator(test_method, test, "nondestructive")
                 rwa = not testlib.get_decorator(test_method, test, "no_retry_when_changed")
                 todo = testlib.get_decorator(test_method, test, "todo")
-                if getattr(test.__class__, "provision", None):
-                    # each additionally provisioned VM costs destructive test capacity
-                    cost = len(test.__class__.provision)
-                else:
-                    cost = 1
-                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, todo, cost=cost)
+                provision = getattr(test.__class__, "provision", None)
+                test = Test(test_id, build_command(filename, test_str, opts), test_timeout, nd, rwa, todo, provision)
                 if nd:
                     nondestructive_tests.append(test)
                 else:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -581,5 +581,5 @@ def main():
 
 
 if __name__ == '__main__':
-    # logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=logging.DEBUG)
     sys.exit(main())

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -158,7 +158,7 @@ class Test:
         self.output += b"\n"
         self._print_test()
         self.machine_id = None
-        return None, 1
+        return retry_reason, 1
 
     # internal methods
 
@@ -445,7 +445,7 @@ def run(opts, image):
                         global_machines[test_machine].reset()
 
                 # run again if needed
-                if retry_reason:
+                if test_result == 0 and retry_reason:
                     if test.nondestructive:
                         nondestructive_tests.insert(0, test)
                     else:

--- a/test/common/run-tests
+++ b/test/common/run-tests
@@ -370,14 +370,16 @@ def detect_tests(test_files, image, opts):
     # robust, reproducible, and provides an even distribution of both directions
     nondestructive_tests.sort(key=lambda t: t.command[-1], reverse=bool(binascii.crc32(image.encode()) & 1))
 
+    # sort destructive tests by class/test name, mostly for niceness and --list
+    destructive_tests.sort(key=lambda t: t.command[-1])
+
     return (nondestructive_tests, destructive_tests, machine_class)
 
 
-def list_tests(opts):
+def list_tests(opts, image):
     test_files = glob.glob(os.path.join(opts.test_dir, opts.test_glob))
-    nondestructive_tests, destructive_tests, _ = detect_tests(test_files, "dummy", opts)
-    names = {t.command[-1] for t in nondestructive_tests + destructive_tests}
-    for n in sorted(names):
+    nondestructive_tests, destructive_tests, _ = detect_tests(test_files, image, opts)
+    for n in [t.command[-1] for t in [*nondestructive_tests, *destructive_tests]]:
         print(n)
 
 
@@ -574,7 +576,7 @@ def main():
     sys.path.append(os.path.realpath(opts.test_dir))
 
     if opts.list:
-        list_tests(opts)
+        list_tests(opts, image)
         return 0
 
     return run(opts, image)

--- a/test/verify/check-testlib
+++ b/test/verify/check-testlib
@@ -40,7 +40,8 @@ class TestRunTestListing(unittest.TestCase):
                          "TestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo")
         # Filter on class
         p = subprocess.run([run_tests, "--test-dir", EXAMPLE_DIR, "-l", "TestNondestructiveExample"], capture_output=True, check=True)
-        self.assertIn(b"TestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo", p.stdout.strip())
+        self.assertIn(b"TestNondestructiveExample.testOne\n", p.stdout)
+        self.assertIn(b"TestNondestructiveExample.testTwo\n", p.stdout)
         # Filter a specific test
         self.assertIn("TestNondestructiveExample.testOne",
                       subprocess.check_output([run_tests, "--test-dir", EXAMPLE_DIR, "-l", "TestNondestructiveExample.testOne"]).strip().decode())
@@ -53,11 +54,21 @@ class TestRunTestListing(unittest.TestCase):
 
         ndtests = subprocess.run([run_tests, "--test-dir", EXAMPLE_DIR, "-n", "-l"], check=True, capture_output=True)
         self.assertIn(b"TestExample.testNondestructive\n", ndtests.stdout)
-        self.assertIn(b"TestNondestructiveExample.testOne\nTestNondestructiveExample.testTwo", ndtests.stdout)
+        self.assertIn(b"TestNondestructiveExample.testOne\n", ndtests.stdout)
+        self.assertIn(b"TestNondestructiveExample.testTwo\n", ndtests.stdout)
 
         # nondestructive tests are sorted alphabetically
-        verify_ndtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"], check=True, capture_output=True)
+        env = os.environ.copy()
+        # ... ascending for even crc32(image):
+        env["TEST_OS"] = "dummy-1"
+        verify_ndtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"],
+                                        check=True, capture_output=True, env=env)
         self.assertRegex(verify_ndtests.stdout, re.compile(b".*TestAccounts.*TestFirewall.*TestLogin.*TestServices.*TestTerminal.*", re.S))
+        # ... descending for odd crc32(image)
+        env["TEST_OS"] = "dummy"
+        verify_ndtests = subprocess.run([run_tests, "--test-dir", VERIFY_DIR, "-n", "-l"],
+                                        check=True, capture_output=True, env=env)
+        self.assertRegex(verify_ndtests.stdout, re.compile(b".*TestTerminal.*TestServices.*TestLogin.*TestFirewall.*TestAccounts.", re.S))
 
     def testNonDestructive(self):
         self.assertEqual(subprocess.check_output([run_tests, "--test-dir", EXAMPLE_DIR, "--nondestructive", "-l", "TestExample"]).strip().decode(),


### PR DESCRIPTION
 - [ ] Needs https://github.com/cockpit-project/bots/pull/5199

https://issues.redhat.com/browse/COCKPIT-1011

I tested the restoring after a broken GlobalMachine with
```diff
--- test/example/check-example
+++ test/example/check-example
@@ -59,6 +59,7 @@ class TestExample(testlib.MachineCase):
 class TestNondestructiveExample(testlib.MachineCase):
 
     def testOne(self):
+        self.machine.execute("set +e; systemctl stop sshd; systemctl stop sshd.socket; pkill -e ssh")
         self.assertEqual(self.machine.execute("whoami").strip(), "root")
 
     def testTwo(self):

```

and the scheduling/restoration locally with:
```
cp test/example/check-example test/verify/

test/common/run-tests -j2 -v --test-dir test/verify TestExample.testBasic TestBondingVirt.testMain TestExample.testFail TestNondestructiveExample.testOne TestNondestructiveExample.testTwo TestConnection.testBridgeCLI TestConnection.testWsPackage TestConnection.testReverseProxy
```

## Speed comparison

fedora-38/other references on main:
 - [0 retries, 18min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19246-20230828-061310-5d786ab8-fedora-38-other/log): 1030s on 1-ci-srv-06, 57 destructive tests, 133 nondestructive tests: 0: 499s, 1: 450s, 2: 486s, 3: 452s, 4: 446s, 5: 443s, 6: 460s, 7: 454s
 - [0 retries, 18min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5189-20230901-062708-eb57a6a8-fedora-38-other-cockpit-project-cockpit/log): 1021s on 4-ci-srv-01, 45 destructive tests, 130 nondestructive tests: 0: 444s, 1: 497s, 2: 481s, 3: 448s, 4: 460s, 5: 442s, 6: 452s, 7: 441s
 - [3 retries, 22min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19268-20230901-120500-ff5bc0ad-fedora-38-other/log): 1287s on 4-ci-srv-02, 45 destructive tests, 130 nondestructive tests: 0: 638s, 1: 705s, 2: 751s, 3: 632s, 4: 648s, 5: 688s, 6: 647s, 7: 657s

fedora/38 other on this PR:
 - [14 retries, 22min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19271-20230903-074732-de7665d3-fedora-38-other-bots-5199/log.html): 1270s on 4-cockpit-11, 45 destructive tests, 130 nondestructive tests: 0: 1000s, 1: 970s, 2: 948s, 3: 916s, 4: 978s, 5: 1013s, 6: 938s, 7: 904s
 - [6 retries, 20min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19271-20230903-155402-074ab057-fedora-38-other-bots-5199/log.html)

fedora-38/devel references on main:
 - [0 retries, 44min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19246-20230828-054020-5d786ab8-fedora-38-devel/log.html): 2631s on 4-cockpit-8, 146 destructive tests, 216 nondestructive tests: 0: 696s, 1: 699s, 2: 691s, 3: 689s, 4: 687s, 5: 687s, 6: 693s, 7: 697s
 - [2 retries, 44min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5189-20230901-060037-eb57a6a8-fedora-38-devel-cockpit-project-cockpit/log.html): 2593s on 3-ci-srv-03, 126 destructive tests, 222 nondestructive tests: 0: 744s, 1: 751s, 2: 749s, 3: 750s, 4: 740s, 5: 740s, 6: 740s, 7: 750s
 - [7 retries, 45min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19268-20230901-120500-ff5bc0ad-fedora-38-devel/log.html): 2684s on 3-cockpit-11, 126 destructive tests, 222 nondestructive tests: 0: 842s, 1: 830s, 2: 838s, 3: 834s, 4: 829s, 5: 833s, 6: 823s, 7: 829s

fedora-38/devel on this PR:
 - [14 retries, 46min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19271-20230903-080510-de7665d3-fedora-38-devel-bots-5199/log.html)
 - [12 retries, 44min](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19271-20230903-155359-074ab057-fedora-38-devel-bots-5199/log.html#197)