### PR TITLE
test: Wait for tooltips after scrolling stuff into view

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -994,7 +994,8 @@ class Browser:
                                         mock: Optional[Dict[str, str]] = None,
                                         sit_after_mock: bool = False,
                                         scroll_into_view: Optional[str] = None,
-                                        wait_animations: bool = True):
+                                        wait_animations: bool = True,
+                                        wait_delay: float = 0.5):
         """Compare the given element with its reference in the current layout"""
 
         if ignore is None:
@@ -1033,6 +1034,7 @@ class Browser:
         # wait half a second to and side-step all that complexity.
 
         if wait_animations:
+            time.sleep(wait_delay)
             self.wait_js_cond('ph_count_animations(%s) == 0' % jsquote(selector))
 
         rect = self.call_js_func('ph_element_clip', selector)
@@ -1178,13 +1180,13 @@ class Browser:
             for layout in self.layouts:
                 if layout["name"] not in skip_layouts:
                     self.set_layout(layout["name"])
-                    time.sleep(wait_delay)
                     if "rtl" in self.current_layout["name"]:
                         self._set_direction("rtl")
                     self.assert_pixels_in_current_layout(selector, key, ignore=ignore,
                                                          mock=mock, sit_after_mock=sit_after_mock,
                                                          scroll_into_view=scroll_into_view,
-                                                         wait_animations=wait_animations)
+                                                         wait_animations=wait_animations,
+                                                         wait_delay=wait_delay)
 
                     if "rtl" in self.current_layout["name"]:
                         self._set_direction("ltr")

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -277,7 +277,18 @@ class TestHistoryMetrics(testlib.MachineCase):
         b.wait_in_text("#metrics-hour-1597662000000:not(.metrics-hour-compressed) .metrics-events-hour-header-expanded .spikes_count", "3 spikes")
         b.wait_in_text("#metrics-hour-1597662000000:not(.metrics-hour-compressed) .metrics-events-hour-header-expanded .spikes_info", "1 Memory, 1 Disk I/O, 1 Network I/O")
 
-        b.assert_pixels(".metrics", "metrics-history-expanded-hour", ignore=[".spikes_count"])
+        # There is something really funny going on with the navigation
+        # bar in the mobile layout; it sometimes appears in a random
+        # position in the screenshot. We fix that by adding an extra
+        # delay after switching to "mobile".
+
+        b.assert_pixels(".metrics", "metrics-history-expanded-hour", ignore=[".spikes_count"],
+                        skip_layouts=["mobile"])
+        b.set_layout("mobile")
+        time.sleep(1.0)
+        b.assert_pixels_in_current_layout(".metrics", "metrics-history-expanded-hour",
+                                          ignore=[".spikes_count"])
+        b.set_layout("desktop")
 
         b.click("#metrics-hour-1597662000000 button.metrics-events-expander")
         b.wait_in_text("#metrics-hour-1597662000000.metrics-hour-compressed", "1:00")

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -460,7 +460,9 @@ class TestSystemInfo(packagelib.PackageCase):
         # strips empty lines, but not leading spaces
         b.wait_text('#motd', "  Hello\n  World")
 
-        b.assert_pixels("#motd-box", "motd")
+        # For some reason, switching to RTL takes a long time
+        # here. Let's increase the delay.
+        b.assert_pixels("#motd-box", "motd", wait_delay=2.0)
 
         b.click('#motd-box button:not(#motd-box-edit)')
         b.wait_not_present('#motd-box')


### PR DESCRIPTION
Scrolling might trigger a tooltip (or popup) and thus we should wait for their animation to be over after scrolling.

This fixes the TestStorageUsed-testUsed-popover-medium flake in #19268 for me.