### PR TITLE
test: include an Fedora updates-testing scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -27,6 +27,11 @@ case "${TEST_SCENARIO:=}" in
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&
+   *updates-testing*)
+        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing,updates-testing-modular >&2' "$TEST_OS"
+        RUN_OPTS="$RUN_OPTS "
+        PREPARE_OPTS="$PREPARE_OPTS --overlay"
+        ;;&
 
     # split tests into roughly equal scenarios for more parallelism
     *networking*)


### PR DESCRIPTION
This scenario installs updates-testing updates before running the tests to offer a "nightly" scenario and to replace the fedora-testing image which is tested every X days.

Added `no-test` as it doesn't feel like it's required to test all images, just one run should be fine.