### PR TITLE
apps: Warn if appstream data package is missing

### DIFF
--- a/pkg/lib/packagekit.js
+++ b/pkg/lib/packagekit.js
@@ -343,6 +343,8 @@ export function watchRedHatSubscription(callback) {
  * - missing_names:     Packages that were requested, are currently not installed,
  *                      and can be installed.
  *
+ * - missing_ids:       The full PackageKit IDs corresponding to missing_names
+ *
  * - unavailable_names: Packages that were requested, are currently not installed,
  *                      but can't be found in any repository.
  *
@@ -359,6 +361,7 @@ export function watchRedHatSubscription(callback) {
 
 export function check_missing_packages(names, progress_cb) {
     const data = {
+        missing_ids: [],
         missing_names: [],
         unavailable_names: [],
     };
@@ -371,8 +374,6 @@ export function check_missing_packages(names, progress_cb) {
     }
 
     function resolve() {
-        data.missing_ids = [];
-
         const installed_names = { };
 
         return cancellableTransaction("Resolve",

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -101,20 +101,24 @@ class TestApps(packagelib.PackageCase):
 
         self.login_and_go("/apps", urlroot=urlroot)
         b.wait_in_text(".pf-v5-c-empty-state", "No applications installed or available")
+        b.wait_in_text(".pf-v5-c-empty-state", "Application information is missing")
 
         # still no metadata, but already installed application
         self.createAppStreamPackage("already", "1.0", "1", install=True)
         b.wait_not_present(".pf-v5-c-empty-state")
         b.wait_visible(".app-list .pf-v5-c-data-list__item-row:contains('already') button:contains('Remove')")
+        b.wait_in_text(".pf-v5-c-alert", "Application information is missing")
 
         self.createAppStreamPackage("app-1", "1.0", "1")
         self.createAppStreamRepoPackage()
 
-        # Refresh package info to install metadata
-        b.click("#refresh")
+        # Install package metadata
+        b.click(".pf-v5-c-alert button")
 
         with b.wait_timeout(30):
+            b.wait_not_present(".pf-v5-c-alert")
             b.click(".app-list #app-1")
+
         b.wait_visible('a[href="https://app-1.com"]')
         b.wait_visible(f'#app-page img[src^="{urlroot}/cockpit/channel/"]')
         b.click(".pf-v5-c-breadcrumb a:contains('Applications')")
@@ -172,6 +176,12 @@ class TestApps(packagelib.PackageCase):
         time.sleep(1)
         b.wait_not_present("#refresh-progress")
         b.wait_visible(".pf-v5-c-empty-state")
+        # wait until check for installed metadata package finished
+        b.wait_attr("#list-page", "data-packages-checked", "true")
+        # no appstream metadata available, don't advertise it
+        b.wait_in_text(".pf-v5-c-empty-state", "No applications installed or available")
+        self.assertNotIn("Install application information", b.text(".pf-v5-c-empty-state"))
+        b.wait_not_present(".pf-v5-c-empty-state button")
 
         # unknown OS: nothing gets installed
         m.write("/etc/os-release", 'ID="unmapped"\nID_LIKE="mysterious"\nVERSION_ID="1"\n')


### PR DESCRIPTION
Fixes #18454

 - [x] Goes on top of #19324
 - [x] Goes on top of #19416

Empty state:

![image](https://github.com/cockpit-project/cockpit/assets/200109/161d3c01-9d23-464b-bb02-e31b207de53c)

Alert with already installed applications:

![image](https://github.com/cockpit-project/cockpit/assets/200109/03407884-e809-475e-b1bb-6e2535503bab)
