### PR TITLE
apps: Consider ID_LIKE for mapping AppStream data packages

### DIFF
--- a/pkg/apps/manifest.json
+++ b/pkg/apps/manifest.json
@@ -14,10 +14,10 @@
 
     "config": {
         "appstream_config_packages": {
-            "debian": ["appstream"], "ubuntu": ["appstream"]
+            "debian": ["appstream"]
         },
         "appstream_data_packages": {
-            "fedora": ["appstream-data"], "rhel": ["appstream-data"]
+            "fedora": ["appstream-data"]
         }
     }
 }

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -55,6 +55,7 @@ class PackageCase(MachineCase):
 
         # HACK: packagekit often hangs on shutdown; https://bugzilla.redhat.com/show_bug.cgi?id=1717185
         self.write_file("/etc/systemd/system/packagekit.service.d/timeout.conf", "[Service]\nTimeoutStopSec=5\n")
+        self.addCleanup(self.machine.execute, "systemctl stop packagekit; systemctl reset-failed packagekit || true")
 
         # disable all existing repositories to avoid hitting the network
         if self.backend == "apt":

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2070,11 +2070,10 @@ class MachineCase(unittest.TestCase):
 
         if self.file_exists(path):
             backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))
-            self.machine.execute("mkdir -p %(vm_tmpdir)s; cp -a %(path)s %(backup)s" % {
-                "vm_tmpdir": self.vm_tmpdir, "path": path, "backup": backup})
-            self.addCleanup(self.machine.execute, "mv %(backup)s %(path)s" % {"path": path, "backup": backup})
+            self.machine.execute(f"mkdir -p {self.vm_tmpdir}; cp -a {path} {backup}")
+            self.addCleanup(self.machine.execute, f"mv {backup} {path}")
         else:
-            self.addCleanup(self.machine.execute, "rm -rf %s" % path)
+            self.addCleanup(self.machine.execute, f"rm -f {path}")
 
     def write_file(self, path: str, content: str, append: bool = False, owner: Optional[str] = None, perm: Optional[str] = None,
                    post_restore_action: Optional[str] = None):

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -16,6 +16,7 @@
 #
 # You should have received a copy of the GNU Lesser General Public License
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
+import time
 
 import packagelib
 import testlib
@@ -128,6 +129,50 @@ class TestApps(packagelib.PackageCase):
 
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
+
+    def testOsMap(self):
+        b = self.browser
+        m = self.machine
+
+        self.allow_journal_messages("can't remove watch: Invalid argument")
+
+        self.restore_dir("/usr/share/metainfo", reboot_safe=True)
+        self.restore_dir("/usr/share/app-info", reboot_safe=True)
+        self.restore_dir("/var/cache/app-info", reboot_safe=True)
+
+        # Make sure none of the appstream directories exist.  They
+        # will be created later and we need to cope with that.
+        m.execute("rm -rf /usr/share/metainfo /usr/share/app-info /var/cache/app-info")
+
+        # use a fake distro map
+        self.write_file("/etc/cockpit/apps.override.json",
+                        '{ "config": { "appstream_data_packages":'
+                        '    {"testy": ["appstream-data-test"], "otheros": ["nosuchpackage"]}'
+                        '  }}')
+
+        self.createAppStreamPackage("app-1", "1.0", "1")
+        self.createAppStreamRepoPackage()
+
+        self.login_and_go("/apps")
+        b.wait_visible(".pf-v5-c-empty-state")
+
+        # os-release is a symlink target, don't clobber that
+        self.restore_file("/etc/os-release")
+        m.execute("rm /etc/os-release")
+
+        # unknown OS: nothing gets installed
+        m.write("/etc/os-release", 'ID="unmapped"\nID_LIKE="mysterious"\nVERSION_ID="1"\n')
+        b.click("#refresh")
+        # the progress bar is too fast to reliably catch it
+        time.sleep(1)
+        b.wait_not_present("#refresh-progress")
+        b.wait_visible(".pf-v5-c-empty-state")
+
+        # known OS: appstream-data-tst gets installed from the map
+        m.write("/etc/os-release", 'ID="derivative"\nID_LIKE="spicy testy"\nVERSION_ID="1"\n')
+        b.click("#refresh")
+        with b.wait_timeout(30):
+            b.wait_visible(".app-list #app-1")
 
     def testL10N(self):
         b = self.browser


### PR DESCRIPTION
With only looking at aos-release's `ID` field, we are missing out a lot of derivatives, such as CentOS Stream, Rocky, or Debian-likes. Consider ID_LIKE as well to fix that.

E.g. on Ubuntu, `ID_LIKE` is "debian", on CentOS it's "rhel fedora", on Rocky Linux it's "rhel centos fedora".

Use that to clean up the manifest map, as Ubuntu and RHEL are now redundant.

---

Spotted in https://github.com/cockpit-project/cockpit/pull/19281#discussion_r1315723556