### PR TITLE
networking: don't pass null to input elements

### DIFF
--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -128,7 +128,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
         return false;
     };
     const addressIpv4Helper = (address) => {
-        const config = { address, netmask: null, gateway: null };
+        const config = { address, netmask: '', gateway: '' };
         const split = address.split('.');
 
         if (split.length !== 4)
@@ -141,7 +141,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
             return { ...config, netmask: "255.255.0.0" };
         } else if (split[0] <= 192 && split[0] <= 223) {
             return { ...config, netmask: "255.255.255.0" };
-        } else return { ...config, gateway: null };
+        } else return { ...config, gateway: '' };
     };
 
     return (


### PR DESCRIPTION
changing the `value` attribute of React input elements to null changes it from controlled to uncontrolled, which leads to React logging errors in the browser console.

This fixes errors of the form:

Warning: A component is changing a controlled input to be uncontrolled. This is likely caused by the value changing from a defined to undefined, which should not happen...

Fixes these:

![image](https://github.com/cockpit-project/cockpit/assets/108616679/301d01c4-bd2e-4029-a9cc-c693bac4b179)
