### PR TITLE
test: Add VM's XML and VM's log into link-patterns

### DIFF
--- a/test/common/link-patterns.json
+++ b/test/common/link-patterns.json
@@ -25,5 +25,15 @@
         "label": "coverage",
         "pattern": "Code coverage report in ([A-Za-z0-9.-]+)$",
         "url": "$1/"
+    },
+    {
+        "label": "vm xml",
+        "pattern": "Wrote ([A-Za-z0-9.-]+) XML to ([A-Za-z0-9.-]+.xml)$",
+        "url": "$2"
+    },
+    {
+        "label": "vm log",
+        "pattern": "Wrote ([A-Za-z0-9.-]+) log to ([A-Za-z0-9.-]+.log)$",
+        "url": "$2"
     }
 ]

--- a/test/common/link-patterns.json
+++ b/test/common/link-patterns.json
@@ -1,29 +1,29 @@
 [
     {
         "label": "screenshot",
-        "pattern": "Wrote screenshot to ([A-Za-z0-9\\-\\.]+\\.png)$",
+        "pattern": "Wrote screenshot to ([A-Za-z0-9.-]+.png)$",
         "url": "$1",
         "icon": "bi bi-camera-fill"
     },
     {
         "label": "new pixels",
-        "pattern": "New pixel test reference ([A-Za-z0-9\\-\\.]+\\.png)$",
+        "pattern": "New pixel test reference ([A-Za-z0-9.-]+.png)$",
         "url": "$1"
     },
     {
         "label": "journal",
-        "pattern": "Journal extracted to ([A-Za-z0-9\\-\\.]+\\.log(?:\\.[gx]z)?)$",
+        "pattern": "Journal extracted to ([A-Za-z0-9.-]+.log(?:.[gx]z)?)$",
         "url": "$1",
         "icon": "bi bi-card-text"
     },
     {
         "label": "changed pixels",
-        "pattern": "Differences in pixel test ([A-Za-z0-9\\-\\.]+)$",
+        "pattern": "Differences in pixel test ([A-Za-z0-9.-]+)$",
         "url": "pixeldiff.html#$1"
     },
     {
         "label": "coverage",
-        "pattern": "Code coverage report in ([A-Za-z0-9\\-\\.]+)$",
+        "pattern": "Code coverage report in ([A-Za-z0-9.-]+)$",
         "url": "$1/"
     }
 ]


### PR DESCRIPTION
Capturing VM's xml and logs was implemented in [1], now it's time to also include the in our link-patterns.

[1] https://github.com/cockpit-project/cockpit-machines/pull/1158