### PR TITLE
tools: Fix "only arch all" Debian build

### DIFF
--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -69,7 +69,7 @@ endif
 execute_after_dh_install-indep:
 	# avoid dh_missing failure
 ifeq ($(C_BRIDGE),)
-	rm -r debian/tmp/usr/lib/python*
+	rm -r debian/tmp/usr/lib/python* debian/tmp/usr/lib/cockpit/cockpit-beiboot
 endif
 
 # run pytests *after* installation, so that we can make sure that we installed the right files


### PR DESCRIPTION
Similarly to commit 584cdfb6a0, remove the installed cockpit-beiboot from the temporary install tree for arch-indep builds. That file was added in commit fb673e0a7.

---

This made [all builds of release 300 fail](https://buildd.debian.org/status/package.php?p=cockpit) yesterday, like [this](https://buildd.debian.org/status/fetch.php?pkg=cockpit&arch=amd64&ver=300-1&stamp=1694026722&file=log):
```
dh_missing: warning: usr/lib/cockpit/cockpit-beiboot exists in debian/tmp but is not installed to anywhere 
dh_missing: error: missing files, aborting
```

Our CI does not do it that way, so won't detect this.