### PR TITLE
test: Add another another expected restart message

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1732,7 +1732,7 @@ class MachineCase(unittest.TestCase):
                                     ".*couldn't create polkit session subject: No session for pid.*",
                                     "We are no longer a registered authentication agent.",
                                     ".*: failed to retrieve resource: terminated",
-                                    ".*: external channel failed: terminated",
+                                    ".*: external channel failed: (terminated|protocol-error)",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
                                     ".*No session for cookie",
 

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -157,6 +157,7 @@ class TestMultiOS(testlib.MachineCase):
 
         # Messages from previous versions of cockpit
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
+        self.allow_restart_journal_messages()
 
 
 @testlib.skipDistroPackage()


### PR DESCRIPTION
fcb73df1cb56 added this message back in 2019 but the specific error code that we receive from the Python bridge is now different, as we can see in new failures:

```
  /base1/fonts/patternfly.woff: external channel failed: protocol-error
```

Instead of trying to figure out how to make the Python bridge return exactly the same error code in this situation, let's just expand the pattern.