### PR TITLE
test: Explicitly trigger udev after resizing ext4

### DIFF
--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -139,7 +139,7 @@ class TestStorageResize(storagelib.StorageCase):
         # and unmount the fs explicitly.  But then we also need to
         # check it explicitly.
         #
-        self.machine.execute(f"(! findmnt -S '{fs_dev}' || umount '{fs_dev}') && fsadm -y check '{fs_dev}' && fsadm -y resize '{fs_dev}' '{size}'")
+        self.machine.execute(f"(! findmnt -S '{fs_dev}' || umount '{fs_dev}'); fsadm -y check '{fs_dev}'; fsadm -y resize '{fs_dev}' '{size}'; udevadm trigger")
 
     def testGrowShrinkHelp(self):
         m = self.machine


### PR DESCRIPTION
UDisks2 now reads filesystem sizes from udev, which seems to sometimes need an extra trigger.