### PR TITLE
tools: Enable the Python bridge on stable Debian/Ubuntu

### DIFF
--- a/tools/debian/cockpit-bridge.install
+++ b/tools/debian/cockpit-bridge.install
@@ -1,7 +1,9 @@
 etc/cockpit/machines.d
 usr/bin/cockpit-bridge
 usr/lib/cockpit/cockpit-askpass
+usr/lib/cockpit/cockpit-beiboot
 usr/lib/cockpit/cockpit-ssh
+usr/lib/python*
 usr/share/cockpit/base1/
 usr/share/cockpit/ssh/
 usr/share/man/man1/cockpit-bridge.1

--- a/tools/debian/rules
+++ b/tools/debian/rules
@@ -2,12 +2,6 @@
 
 DEB_HOST_MULTIARCH ?= $(shell dpkg-architecture -qDEB_HOST_MULTIARCH)
 
-# Keep the older C bridge on stable releases
-OLD_BRIDGE = $(filter $(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),11 12 22.04)
-ifneq ($(OLD_BRIDGE),)
-CONFIG_OPTIONS += --enable-old-bridge
-endif
-
 # riscv is an emulated architecture for now, and too slow to run expensive unit tests
 # hppa's threading is absurdly slow (#981127)
 SLOW_ARCHES = $(filter $(shell dpkg-architecture -qDEB_BUILD_ARCH),riscv64 hppa)
@@ -53,25 +47,21 @@ override_dh_install:
 	rm debian/tmp/usr/share/metainfo/org.cockpit-project.cockpit-selinux.metainfo.xml
 
 	dh_install -Xusr/src/debug
-ifeq ($(OLD_BRIDGE),)
 	# we don't need this, it contains full build paths and breaks reproducibility
 	rm -r debian/tmp/usr/lib/python*/*-packages/*.dist-info
-	dh_install -p cockpit-bridge debian/tmp/usr/lib/python*
-	dh_install -p cockpit-bridge debian/tmp/usr/lib/cockpit/cockpit-beiboot
-endif
 
 	make install-tests DESTDIR=debian/cockpit-tests
 
 execute_after_dh_install-indep:
 	# avoid dh_missing failure
-ifeq ($(OLD_BRIDGE),)
 	rm -r debian/tmp/usr/lib/python* debian/tmp/usr/lib/cockpit/cockpit-beiboot
-endif
 
 # run pytests *after* installation, so that we can make sure that we installed the right files
 execute_after_dh_install-arch:
 ifeq (, $(findstring nocheck, $(DEB_BUILD_OPTIONS)))
-ifeq ($(OLD_BRIDGE),)
+ifeq ($(shell . /etc/os-release; echo $${VERSION_ID:-unstable}),22.04)
+	PYTHONPATH=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages) python3 -m pytest -vv -k 'not linter and not test_descriptions'
+else
 	pytest -vv -k 'not linter and not test_descriptions' -opythonpath=$$(ls -d debian/cockpit-bridge/usr/lib/python3*/dist-packages)
 endif
 endif


### PR DESCRIPTION
By now we have enough faith in it that we can drop the special case. This only leaves the C bridge for RHEL/CentOS 8, which will be branched off and thus disappear in about half a year.

Invoking pytests on Ubuntu 22.04 requires a special case for the old pytest version unfortunately, but this will go away in ~ 9 months.