### PR TITLE
tools: BuildRequires: python3-devel

### DIFF
--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -100,7 +100,7 @@ BuildRequires: pam-devel
 
 BuildRequires: autoconf automake
 BuildRequires: make
-BuildRequires: /usr/bin/python3
+BuildRequires: python3-devel
 %if 0%{?rhel} && 0%{?rhel} <= 8
 # RHEL 8's gettext does not yet have metainfo.its
 BuildRequires: gettext >= 0.19.7


### PR DESCRIPTION
Fedora packaging policy demands python3-devel [1]. RHEL 8 has multiple
Python versions available, and depending on the python3 binary can
possibly select the non-default one from a module (such as Python
3.11). Ensure that we build against 3.6 by requiring python3-devel
  instead.

https://issues.redhat.com/browse/RHEL-2215
https://issues.redhat.com/browse/RHEL-2218

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_buildrequire_python3_devel
