### PR TITLE
tools: Explicitly set admin group on arch

### DIFF
--- a/tools/arch/PKGBUILD
+++ b/tools/arch/PKGBUILD
@@ -40,6 +40,7 @@ build() {
     --localstatedir=/var \
     --disable-dependency-tracking \
     --disable-silent-rules \
+    --with-admin-group=wheel \
     --with-cockpit-user=cockpit-ws \
     --with-cockpit-ws-instance-user=cockpit-wsinstance
 


### PR DESCRIPTION
Apparently the `wheel` group is not present any more in latest Arch's build environment, so the auto-detection now falls back to "root".

---

This fixes the image refresh in https://github.com/cockpit-project/bots/pull/5233 .

@jelly: I noticed that our upstream and the [downstream](https://gitlab.archlinux.org/archlinux/packaging/packages/cockpit/-/tree/main?ref_type=heads) packaging have diverted quite a bit. Most importantly, the [PAM file](https://gitlab.archlinux.org/archlinux/packaging/packages/cockpit/-/blob/main/cockpit.pam?ref_type=heads) is missing
```
# List of users to deny access to Cockpit, by default root is included.
auth       required     pam_listfile.so item=user sense=deny file=/etc/cockpit/disallowed-users onerr=succeed
```
But also PKGBUILD has quite a lot of differences. E.g. Arch split off cockpit-packagekit and cockpit-storaged, which we should do as well. There's also this `gendesk` call which we should adopt. Would you mind going through and do a two-way sync?