### PR TITLE
test: allow journal message to a known pybridge error

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1794,6 +1794,7 @@ class MachineCase(unittest.TestCase):
             "Traceback .*most recent call last.*",
             "File .*",
             "async with self.watch_processing_lock:",
+            "self.send_message.*",
             "self.release.*",
             "self._wake_up_first.*",
             "fut.set_result.*",


### PR DESCRIPTION
See #18355
New stacktrace:
```
Exception ignored in: <coroutine object DBusChannel.setup_path_watch.<locals>.handler at 0x7f7d488612c0>
Traceback (most recent call last):
   File "/usr/lib/python3.9/site-packages/cockpit/channels/dbus.py", line 435, in handler
     self.send_message(notify=notify)
   File "/usr/lib64/python3.9/asyncio/locks.py", line 20, in __aexit__
     self.release()
   File "/usr/lib64/python3.9/asyncio/locks.py", line 144, in release
     self._wake_up_first()
   File "/usr/lib64/python3.9/asyncio/locks.py", line 161, in _wake_up_first
     fut.set_result(True)
   File "/usr/lib64/python3.9/asyncio/base_events.py", line 751, in call_soon
     self._check_closed()
   File "/usr/lib64/python3.9/asyncio/base_events.py", line 515, in _check_closed
     raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
asyncio-ERROR: Task was destroyed but it is pending!
```