### PR TITLE
shell: handle closing dialog the same as cancel

### DIFF
--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -51,7 +51,7 @@ const UnlockDialog = ({ proxy, host }) => {
     const [methods, setMethods] = useState(null);
     const [method, setMethod] = useState(false);
     const [busy, setBusy] = useState(false);
-    const [cancel, setCancel] = useState(null);
+    const [cancel, setCancel] = useState(() => D.close);
     const [prompt, setPrompt] = useState(null);
     const [message, setMessage] = useState(null);
     const [error, setError] = useState(null);
@@ -178,7 +178,7 @@ const UnlockDialog = ({ proxy, host }) => {
                 <Button variant='primary' onClick={apply} isDisabled={busy} isLoading={busy}>
                     {_("Authenticate")}
                 </Button>
-                <Button variant='link' className='btn-cancel' onClick={cancel} isDisabled={!cancel}>
+                <Button variant='link' className='btn-cancel' onClick={cancel}>
                     {_("Cancel")}
                 </Button>
             </>);
@@ -215,8 +215,7 @@ const UnlockDialog = ({ proxy, host }) => {
                 <Button variant='primary' onClick={() => start(method)} isDisabled={busy} isLoading={busy}>
                     {_("Authenticate")}
                 </Button>
-                <Button variant='link' className='btn-cancel' onClick={busy ? cancel : D.close}
-                        isDisabled={busy && !cancel}>
+                <Button variant='link' className='btn-cancel' onClick={cancel}>
                     {_("Cancel")}
                 </Button>
             </>);
@@ -229,7 +228,7 @@ const UnlockDialog = ({ proxy, host }) => {
         <Modal isOpen
                position="top"
                variant="medium"
-               onClose={D.close}
+               onClose={cancel}
                title={title}
                titleIconVariant={title_icon}
                footer={footer}>

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -81,6 +81,17 @@ class TestSuperuser(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
+        # Test that closing instead of cancelling the dialog keeps the "switch
+        # to administrative button"
+        b.open_superuser_dialog()
+        b.click(".pf-v5-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
+        b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to limited access')")
+        b.check_superuser_indicator("Limited access")
+
+        b.open_superuser_dialog()
+        b.click(".pf-v5-c-modal-box__close button")
+        b.check_superuser_indicator("Limited access")
+
     def testSudoIOLogging(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
When closing the dialog via the cross icon also cancel the superuser proxy. Otherwise the switch to administrative access button will stay hidden.

Closes #19288