### PR TITLE
cockpit: add to_json() method to BridgeConfig

### DIFF
--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -280,7 +280,7 @@ def main(*, beipack: bool = False) -> None:
         print(f'Version: {__version__}\nProtocol: 1')
         return
     elif args.bridges:
-        print(json.dumps(Packages().get_bridge_configs(), indent=2))
+        print(json.dumps([config.__dict__ for config in Packages().get_bridge_configs()], indent=2))
         return
 
     # The privileged bridge doesn't need ssh-agent, but the main one does

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -18,6 +18,7 @@
 # along with Cockpit; If not, see <http://www.gnu.org/licenses/>.
 
 import base64
+import json
 import os
 import subprocess
 import time
@@ -1191,6 +1192,16 @@ UnixPath=/run/cockpit/session
         packages = m.execute("cockpit-bridge --packages")
         self.assertRegex(packages, r"(^|\n)base1\s+.*/usr/share/cockpit/base1")
         self.assertRegex(packages, r"(^|\n)system\s+.*/usr/share/cockpit/systemd")
+
+        if self.is_pybridge():
+            bridges = json.loads(m.execute("cockpit-bridge --bridges").strip())
+            bridge_names = [b['name'] for b in bridges]
+            self.assertGreater(len(bridges), 0)
+            self.assertIn('sudo', bridge_names)
+
+            # OStree has no PCP bridge
+            if not m.ostree_image:
+                self.assertIn(f'{self.libexecdir}/cockpit-pcp', bridge_names)
 
 
 @testlib.skipDistroPackage()


### PR DESCRIPTION
A Bridgeconfig does not serialise to JSON by default.

Closes: #19319

Alternatively we pass `json.dumps(cls=Config())`