### PR TITLE
apps: Fix reading AppStream metadata config

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -103,15 +103,13 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
         const os_list = [os_release.ID || "", ...(os_release.ID_LIKE || "").split(/\s+/)];
 
         if (cockpit.manifests.apps && cockpit.manifests.apps.config) {
-            let val = cockpit.manifests.apps.config[name];
+            const val = cockpit.manifests.apps.config[name];
             if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
-                os_list.find(c => {
-                    if (val[c]) {
-                        val = val[c];
-                        return true;
-                    }
-                    return false;
-                });
+                for (const os of os_list) {
+                    if (val[os])
+                        return val[os];
+                }
+                return def;
             }
             return val !== undefined ? val : def;
         } else {

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -147,7 +147,8 @@ class TestApps(packagelib.PackageCase):
         # use a fake distro map
         self.write_file("/etc/cockpit/apps.override.json",
                         '{ "config": { "appstream_data_packages":'
-                        '    {"testy": ["appstream-data-test"], "otheros": ["nosuchpackage"]}'
+                        '    {"testy": ["appstream-data-test"], "otheros": ["nosuchpackage"]},'
+                        '              "appstream_config_packages": []'
                         '  }}')
 
         self.createAppStreamPackage("app-1", "1.0", "1")

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -32,19 +32,19 @@ class TestApps(packagelib.PackageCase):
         self.appstream_collection = set()
         self.machine.upload(["verify/files/test.png"], "/var/tmp/")
 
-    def createAppStreamPackage(self, name, version, revision):
+    def createAppStreamPackage(self, name, version, revision, install=False):
         self.createPackage(name, version, revision, content={
             f"/usr/share/metainfo/org.cockpit-project.{name}.metainfo.xml": f"""
 <component type="addon">
   <extends>org.cockpit_project.cockpit</extends>
   <id>org.cockpit-project.{name}</id>
-  <icon type="local">/usr/share/pixmaps/test.png</icon>
+  <icon type="local">/usr/share/pixmaps/{name}.png</icon>
   <name>{name}</name>
-  <summary>An application for testing</summary>
+  <summary>{name} application for testing</summary>
   <launchable type="cockpit-manifest">{name}</launchable>
 </component>
 """,
-            "/usr/share/pixmaps/test.png": {"path": "/var/tmp/test.png"}})
+            f"/usr/share/pixmaps/{name}.png": {"path": "/var/tmp/test.png"}}, install=install)
         self.appstream_collection.add(name)
 
     def createAppStreamRepoPackage(self):
@@ -100,12 +100,17 @@ class TestApps(packagelib.PackageCase):
             m.write("/etc/cockpit/cockpit.conf", f"[WebService]\nUrlRoot={urlroot}")
 
         self.login_and_go("/apps", urlroot=urlroot)
-        b.wait_visible(".pf-v5-c-empty-state")
+        b.wait_in_text(".pf-v5-c-empty-state", "No applications installed or available")
+
+        # still no metadata, but already installed application
+        self.createAppStreamPackage("already", "1.0", "1", install=True)
+        b.wait_not_present(".pf-v5-c-empty-state")
+        b.wait_visible(".app-list .pf-v5-c-data-list__item-row:contains('already') button:contains('Remove')")
 
         self.createAppStreamPackage("app-1", "1.0", "1")
         self.createAppStreamRepoPackage()
 
-        # Refresh package info
+        # Refresh package info to install metadata
         b.click("#refresh")
 
         with b.wait_timeout(30):


### PR DESCRIPTION
Commit 7bbf9168ac33 introduced a major bug: If the OS in os-release was
not found in the iteration, get_config() would return the whole map
instead of the default value. That crashed the page with
`TypeError: names.forEach is not a function`.

This is awkward to do correctly with .find(), especially due to
modifying `val` as a side effect; iterate over `os_list` the good old
`for` way instead.

This was hidden by the test's manifest override leaving
`appstream_config_packages` intact, so it was always taken from the real
underlying OS. Override it as well.

---

Broken out from PR #19281, as this is a release-blocker, and the former needs some more work.