### PR TITLE
Fix large file uploads through cockpit.spawn()

### DIFF
--- a/pkg/playground/speed.html
+++ b/pkg/playground/speed.html
@@ -108,6 +108,20 @@
                     </tbody>
                 </table>
             </section>
+            <section class="pf-v5-c-page__main-section pf-m-light">
+                <h1>spawn input test</h1>
+                <table>
+                    <tbody>
+                        <tr>
+                            <td><label class="control-label" for="spawn-input-result">result</label></td>
+                            <td><label class="form-control" id="spawn-input-result"></label></td>
+                        </tr>
+                        <tr>
+                            <td><button class="pf-v5-c-button pf-m-secondary pf-m-primary" id="spawn-input">spawn command</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
         </main>
     </div>
 </body>

--- a/pkg/playground/speed.js
+++ b/pkg/playground/speed.js
@@ -226,6 +226,31 @@ function spawn() {
     });
 }
 
+function spawn_input() {
+    stop();
+
+    const el_result = document.getElementById("spawn-input-result");
+    el_result.textContent = "Running...";
+
+    start = Date.now();
+    total = 0;
+    channel = cockpit.spawn(["dd", "of=/tmp/spawninput"], { err: "message" });
+    const chunk = 'a'.repeat(65536);
+    for (let i = 0; i < 1000; i++) {
+        channel.input(chunk, true);
+        total += chunk.length;
+    }
+    channel.input(); // send EOF
+    channel
+            .then(() => {
+                el_result.textContent = "success";
+            })
+            .catch(ex => {
+                el_result.textContent = `failed with exit code ${ex.exit_status}: ${ex.message}`;
+            })
+            .finally(stop);
+}
+
 function stop() {
     update();
 
@@ -249,6 +274,7 @@ cockpit.transport.wait(function() {
     document.getElementById("read-sideband").addEventListener("click", read);
     document.getElementById("download-external").addEventListener("click", download);
     document.getElementById("spawn").addEventListener("click", spawn);
+    document.getElementById("spawn-input").addEventListener("click", spawn_input);
     document.getElementById("stop").addEventListener("click", stop);
     window.setInterval(update, 500);
     document.body.removeAttribute("hidden");

--- a/src/cockpit/channel.py
+++ b/src/cockpit/channel.py
@@ -302,7 +302,7 @@ class ProtocolChannel(Channel, asyncio.Protocol):
     _transport: Optional[asyncio.Transport]
     _loop: Optional[asyncio.AbstractEventLoop]
     _send_pongs: bool = True
-    _last_ping: Optional[JsonObject]
+    _last_ping: Optional[JsonObject] = None
     _create_transport_task = None
 
     # read-side EOF handling

--- a/src/cockpit/transports.py
+++ b/src/cockpit/transports.py
@@ -196,7 +196,7 @@ class _Transport(asyncio.Transport):
             n_bytes -= len(block)
             logger.debug('  removed complete block.  %d remains.', n_bytes)
 
-        else:
+        if not self._queue:
             logger.debug('%s queue drained.')
             self._remove_write_queue()
             if self._eof:

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -804,12 +804,6 @@ class TestConnection(testlib.MachineCase):
         b = self.browser
 
         self.login_and_go("/playground/speed", user="root", enable_root_login=True)
-
-        # Check the speed playground page
-        b.switch_to_top()
-        b.go("/playground/speed")
-        b.enter_page("/playground/speed")
-
         b.wait_text_not("#pid", "")
         pid = b.text("#pid")
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -799,7 +799,7 @@ class TestConnection(testlib.MachineCase):
 
     @testlib.skipOstree("ssh root login not allowed")
     @testlib.nondestructive
-    def testFlowControl(self):
+    def testFlowControlDownload(self):
         m = self.machine
         b = self.browser
 
@@ -817,6 +817,23 @@ class TestConnection(testlib.MachineCase):
 
         # This fails when flow control is not present
         self.assertLess(rss, 250000)
+
+    @testlib.nondestructive
+    @testlib.skipImage("Broken with C bridge", "centos-8-stream", "rhel-8*")
+    def testFlowControlUpload(self):
+        m = self.machine
+        b = self.browser
+
+        self.login_and_go("/playground/speed")
+        self.addCleanup(m.execute, "rm -f /tmp/spawninput")
+        b.click("#spawn-input")
+
+        b.wait_text_not("#speed", "")
+        with b.wait_timeout(60):
+            b.wait_text("#spawn-input-result", "success")
+
+        self.assertEqual(int(m.execute("stat -c %s /tmp/spawninput")), 65536000)
+        self.assertEqual(m.execute("tail -c10 /tmp/spawninput").strip(), "a" * 10)
 
     @testlib.skipOstree("OSTree doesn't have cockpit-ws")
     @testlib.nondestructive


### PR DESCRIPTION
This fixes a bridge crash

    'SubprocessStreamChannel' object has no attribute '_last_ping'

when resume_writing() is called before the initial ping arrived.

Fixes #19323

----

That fixes the crash, but it's only half of the story. The new test case still fails with a too short file size:

```
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/file-upload/test/verify/check-connection", line 831, in testFlowControlUpload
    self.assertEqual(m.execute("stat -c %s /tmp/spawninput").strip(), 65536000)
AssertionError: '52494336' != 65536000
```

Then again, with the C bridge (rhel-8-9) it's even worse: it fails sometimes with
```
  File "/var/home/martin/upstream/cockpit/file-upload/test/verify/check-connection", line 827, in testFlowControlUpload
    b.wait_text_not("#speed", "")
```
as it finishes way too fast, and sometimes with
```
Traceback (most recent call last):
  File "/var/home/martin/upstream/cockpit/file-upload/test/verify/check-connection", line 831, in testFlowControlUpload
    self.assertEqual(m.execute("stat -c %s /tmp/spawninput").strip(), 65536000)
AssertionError: '65536' != 65536000
```
again because it finishes way too fast, and only writes the first block.

Let's make this work properly, so that navigator etc. works, and we generally have a way to support large file uploads in Cockpit.