### PR TITLE
test: Better cleanup for TestNetworkingOther

### DIFF
--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -49,6 +49,7 @@ class TestNetworkingOther(netlib.NetworkCase):
         b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
         b.set_input_text('#network-ip-settings-netmask-0', "24")
         b.click("#network-ip-settings-dialog button:contains('Save')")
+        self.addCleanup(m.execute, "nmcli con del tun0")
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('Status', '1.2.3.4/24')
 


### PR DESCRIPTION
Normally, deleting a device with "ip link del" will also cause the NetworkManager connections settings to disappear. But in the right circumstances, NetworkManager seems to bring the device back to live instead of dropping its settings. This would break the test on the next run in the same VM.

Avoid this by deleting the tun0 settings explicitly during test cleanup.