### PR TITLE
Makefile.am: cockpit_enable_python was dropped

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,7 +37,7 @@ distdir: $(DISTFILES)
 	sed -i "s/[@]VERSION@/$(VERSION)/" "$(distdir)/src/client/org.cockpit_project.CockpitClient.metainfo.xml"
 	$(srcdir)/tools/fix-spec $(distdir)/tools/cockpit.spec $(VERSION)
 	test -z '$(HACK_SPEC_FOR_PYTHON)' || \
-		sed -i 's/\(define cockpit_enable_python\) 0/\1 1/' $(distdir)/tools/cockpit.spec
+		sed -i 's/\(define enable_old_bridge\) 1/\1 0/' $(distdir)/tools/cockpit.spec
 	sed -i "/^pkgver=/ s/0/$(VERSION)/" "$(distdir)/tools/arch/PKGBUILD"
 	sed -i "1 s/0/$(VERSION)/" "$(distdir)/tools/debian/changelog"
 	cp -r "$(srcdir)/dist" "$(distdir)"

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -54,7 +54,7 @@ Release:        1%{?dist}
 Source0:        https://github.com/cockpit-project/cockpit/releases/download/%{version}/cockpit-%{version}.tar.xz
 
 # Don't change the bridge in the RHEL 8; the old SSH breaks some features, see @todoPybridgeRHEL8
-%if 0%{?rhel} == 8
+%if 0%{?rhel} == 8 && !%{defined enable_old_bridge}
 %define enable_old_bridge 1
 %endif
 


### PR DESCRIPTION
The Python bridge is now default enabled in 14c07d70878621640c2d2f and this also removed cockpit_enable_python in favour of explicitly enabling the old bridge. As RHEL 8 ships the old bridge by default we need to toggle this for the pybridge scenario.

This needs a change in bots and then an image refresh most likely to get the pybridge scenario back on track for RHEL-8

https://github.com/cockpit-project/bots/pull/5256

With this spec change we get in bots
```
[jelle@toolbox rhel-8-revive-pybridge]$ cat tools/cockpit.spec  | rpmspec -D "rhel 8" -D 'version 0' -D 'enable_old_bridge 0' --buildrequires --query /dev/stdin | sed 's/.*/"&"/' | tr '\n' ' '
warning: Macro expanded in comment on line 28: %{version}.

warning: line 439: Possible unexpanded macro in: Requires: (selinux-policy >= %{_selinux_policy_version} if selinux-policy-targeted)
"autoconf" "automake" "docbook-style-xsl" "gcc" "gdb" "gettext >= 0.19.7" "glib-networking" "glib2-devel >= 2.50.0" "gnutls-devel >= 3.4.3" "krb5-devel >= 1.11" "krb5-server" "libappstream-glib-devel" "libssh-devel >= 0.8.5" "libxslt-devel" "make" "openssh-clients" "openssl-devel" "pam-devel" "pcp-libs-devel" "pkgconfig(gio-unix-2.0)" "pkgconfig(json-glib-1.0)" "pkgconfig(polkit-agent-1) >= 0.105" "python3-devel" "python3-pip" "sed" "selinux-policy" "selinux-policy-devel" "systemd-devel >= 235" "xmlto" "zlib-devel"
```

Normal build should not get `python3-pip`.
```
[jelle@toolbox rhel-8-revive-pybridge]$ cat tools/cockpit.spec  | rpmspec -D "rhel 8" -D 'version 0' --buildrequires --query /dev/stdin | sed 's/.*/"&"/' | tr '\n' ' '
warning: Macro expanded in comment on line 28: %{version}.

warning: line 439: Possible unexpanded macro in: Requires: (selinux-policy >= %{_selinux_policy_version} if selinux-policy-targeted)
"autoconf" "automake" "docbook-style-xsl" "gcc" "gdb" "gettext >= 0.19.7" "glib-networking" "glib2-devel >= 2.50.0" "gnutls-devel >= 3.4.3" "krb5-devel >= 1.11" "krb5-server" "libappstream-glib-devel" "libssh-devel >= 0.8.5" "libxslt-devel" "make" "openssh-clients" "openssl-devel" "pam-devel" "pcp-libs-devel" "pkgconfig(gio-unix-2.0)" "pkgconfig(json-glib-1.0)" "pkgconfig(polkit-agent-1) >= 0.105" "python3-devel" "sed" "selinux-policy" "selinux-policy-devel" "systemd-devel >= 235" "xmlto" "zlib-devel" 
```