### PR TITLE
Disable unsupported IPv4/IPv6 methods for wireguard

### DIFF
--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -47,11 +47,20 @@ const ip_method_choices = [
 ];
 
 const supported_ipv4_methods = ['auto', 'link-local', 'manual', 'shared', 'disabled'];
+// NM only supports a subset of IPv4 and IPv6 methods for wireguard
+// See: https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/blob/1.42.8/src/libnm-core-impl/nm-setting-wireguard.c#L1723
+const wg_supported_ipv4_methods = ['manual', 'disabled'];
+const wg_supported_ipv6_methods = ['link-local', 'manual', 'ignored', 'disabled'];
 
-export function get_ip_method_choices(topic) {
+export function get_ip_method_choices(topic, device_type) {
     if (topic === 'ipv4') {
+        if (device_type === 'wireguard')
+            return ip_method_choices.filter(item => wg_supported_ipv4_methods.includes(item.choice));
         return ip_method_choices.filter(item => supported_ipv4_methods.includes(item.choice));
     }
+
+    if (device_type === 'wireguard')
+        return ip_method_choices.filter(item => wg_supported_ipv6_methods.includes(item.choice));
 
     // IPv6 supports all the choices
     return ip_method_choices;
@@ -165,7 +174,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                             aria-label={_("Select method")}
                                             onChange={(_, val) => setMethod(val)}
                                             value={method}>
-                                    {get_ip_method_choices(topic).map(choice => <FormSelectOption value={choice.choice} label={choice.title} key={choice.choice} />)}
+                                    {get_ip_method_choices(topic, dev.DeviceType).map(choice => <FormSelectOption value={choice.choice} label={choice.title} key={choice.choice} />)}
                                 </FormSelect>
                                 <Tooltip content={_("Add address")}>
                                     <Button variant="secondary"

--- a/pkg/networkmanager/ip-settings.jsx
+++ b/pkg/networkmanager/ip-settings.jsx
@@ -36,25 +36,26 @@ import { useDialogs } from "dialogs.jsx";
 
 const _ = cockpit.gettext;
 
-export const ipv4_method_choices =
-    [
-        { choice: 'auto', title: _("Automatic (DHCP)") },
-        { choice: 'link-local', title: _("Link local") },
-        { choice: 'manual', title: _("Manual") },
-        { choice: 'shared', title: _("Shared") },
-        { choice: 'disabled', title: _("Disabled") }
-    ];
+const ip_method_choices = [
+    { choice: 'auto', title: _("Automatic") },
+    { choice: 'dhcp', title: _("Automatic (DHCP only)") },
+    { choice: 'link-local', title: _("Link local") },
+    { choice: 'manual', title: _("Manual") },
+    { choice: 'ignore', title: _("Ignore") },
+    { choice: 'shared', title: _("Shared") },
+    { choice: 'disabled', title: _("Disabled") }
+];
 
-export const ipv6_method_choices =
-    [
-        { choice: 'auto', title: _("Automatic") },
-        { choice: 'dhcp', title: _("Automatic (DHCP only)") },
-        { choice: 'link-local', title: _("Link local") },
-        { choice: 'manual', title: _("Manual") },
-        { choice: 'ignore', title: _("Ignore") },
-        { choice: 'shared', title: _("Shared") },
-        { choice: 'disabled', title: _("Disabled") }
-    ];
+const supported_ipv4_methods = ['auto', 'link-local', 'manual', 'shared', 'disabled'];
+
+export function get_ip_method_choices(topic) {
+    if (topic === 'ipv4') {
+        return ip_method_choices.filter(item => supported_ipv4_methods.includes(item.choice));
+    }
+
+    // IPv6 supports all the choices
+    return ip_method_choices;
+}
 
 export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
     const Dialogs = useDialogs();
@@ -164,7 +165,7 @@ export const IpSettingsDialog = ({ topic, connection, dev, settings }) => {
                                             aria-label={_("Select method")}
                                             onChange={(_, val) => setMethod(val)}
                                             value={method}>
-                                    {(topic == "ipv4" ? ipv4_method_choices : ipv6_method_choices).map(choice => <FormSelectOption value={choice.choice} label={choice.title} key={choice.choice} />)}
+                                    {get_ip_method_choices(topic).map(choice => <FormSelectOption value={choice.choice} label={choice.title} key={choice.choice} />)}
                                 </FormSelect>
                                 <Tooltip content={_("Add address")}>
                                     <Button variant="secondary"

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -53,9 +53,8 @@ import {
 import {
     bond_mode_choices,
 } from './bond.jsx';
-import {
-    ipv4_method_choices, ipv6_method_choices,
-} from './ip-settings.jsx';
+
+import { get_ip_method_choices } from './ip-settings.jsx';
 
 const _ = cockpit.gettext;
 
@@ -283,8 +282,7 @@ export const NetworkInterfacePage = ({
             const parts = [];
 
             if (params.method != "manual")
-                parts.push(choice_title((topic == "ipv4") ? ipv4_method_choices : ipv6_method_choices,
-                                        params.method, _("Unknown configuration")));
+                parts.push(choice_title(get_ip_method_choices(topic), params.method, _("Unknown configuration")));
 
             const addr_is_extra = (params.method != "manual");
             const addrs = [];

--- a/test/verify/check-networkmanager-basic
+++ b/test/verify/check-networkmanager-basic
@@ -139,7 +139,7 @@ class TestNetworkingBasic(netlib.NetworkCase):
         m.execute(f"nmcli connection modify '{con_id}' ipv4.method auto")
         m.execute(f"nmcli connection modify '{con_id}' ipv4.gateway ''")
         m.execute(f"nmcli connection modify '{con_id}' ipv4.addresses ''")
-        self.wait_for_iface_setting('IPv4', "Automatic (DHCP)")
+        self.wait_for_iface_setting('IPv4', "Automatic")
         m.execute(f"nmcli connection up '{con_id}'")
         self.wait_for_iface_setting('Status', '10.111.')
 

--- a/test/verify/check-networkmanager-settings
+++ b/test/verify/check-networkmanager-settings
@@ -127,6 +127,31 @@ class TestNetworkingSettings(netlib.NetworkCase):
         b.click("#network-ip-settings-dns-search-add")
         b.assert_pixels("#network-ip-settings-dialog", "network-ip-settings-dialog")
 
+        # Check that IPv4/IPv6 settings dialogs only show the supported IP methods for wireguard
+        # Skip images without the wireguard-tools package
+        if m.image not in ["rhel4edge", "centos-8-stream"] and not m.image.startswith("rhel-8"):
+            b.go("/network")
+            b.click("#networking-add-wg")
+            b.set_input_text("#network-wireguard-settings-addresses-input", "1.2.3.4/24")
+            wg_iface = b.val("#network-wireguard-settings-interface-name-input")
+            b.click("#network-wireguard-settings-save")
+            self.select_iface(wg_iface)
+            self.configure_iface_setting("IPv4")
+            b._wait_present("#network-ip-settings-select-method option[value='manual']")
+            b._wait_present("#network-ip-settings-select-method option[value='disabled']")
+            unsupported_ip4_methods = ['auto', 'dhcp', 'link-local', 'ignore', 'shared']
+            for method in unsupported_ip4_methods:
+                b.wait_not_present(f"#network-ip-settings-select-method option[value='{method}']")
+            b.click("#network-ip-settings-cancel")
+            b.wait_not_present("#network-ip-settings-dialog")
+            self.configure_iface_setting("IPv6")
+            supported_ip6_methods = ['link-local', 'manual', 'disabled']
+            for method in supported_ip6_methods:
+                b._wait_present(f"#network-ip-settings-select-method option[value='{method}']")
+            unsupported_ip6_methods = ['auto', 'dhcp', 'ignore', 'shared']
+            for method in unsupported_ip6_methods:
+                b.wait_not_present(f"#network-ip-settings-select-method option[value='{method}']")
+
     def testOtherSettings(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
Follow-up from #19024