### PR TITLE
Metrics: Link to network interface

### DIFF
--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -223,23 +223,16 @@ function decompress_samples(samples, state) {
     });
 }
 
-function make_rows(rows, rowWrapper, _columns) {
-    return rows.map((columns, rowIndex) => {
-        const props = rowWrapper ? rowWrapper(columns) : {};
-
-        return (
-            <Tr key={"row-" + rowIndex} {...props}>
-                {columns.map((column, columnIndex) => {
-                    const dataLabel = _columns && _columns[columnIndex];
-                    return (
-                        <Td data-label={dataLabel} key={"column-" + columnIndex}>
-                            {column}
-                        </Td>
-                    );
-                })}
-            </Tr>
-        );
-    });
+function make_rows(rows, rowProps, columnLabels) {
+    return rows.map((columns, rowIndex) =>
+        <Tr key={"row-" + rowIndex} {...rowProps?.(columns)}>
+            {columns.map((column, columnIndex) =>
+                <Td data-label={columnLabels?.[columnIndex]} key={"column-" + columnIndex}>
+                    {column}
+                </Td>
+            )}
+        </Tr>
+    );
 }
 
 class CurrentMetrics extends React.Component {
@@ -787,7 +780,7 @@ class CurrentMetrics extends React.Component {
             : [];
 
         let allDisks = null;
-        const rowWrapperDisks = row => ({ 'device-name': row[0] });
+        const rowPropsDisks = row => ({ 'device-name': row[0] });
         const diskColumns = [_("Device"), _("Read"), _("Write")];
         if (disksUsage.length > 1) {
             const disksTableContent = (
@@ -800,7 +793,7 @@ class CurrentMetrics extends React.Component {
                         <Tr>{diskColumns.map(col => <Th key={col}>{col}</Th>)}</Tr>
                     </Thead>
                     <Tbody className="pf-v5-m-tabular-nums disks-nowrap">
-                        {make_rows(disksUsage, rowWrapperDisks, diskColumns)}
+                        {make_rows(disksUsage, rowPropsDisks, diskColumns)}
                     </Tbody>
                 </Table>
             );
@@ -812,8 +805,8 @@ class CurrentMetrics extends React.Component {
             );
         }
 
-        const rowWrapperIface = row => ({ 'data-interface': row[0] });
-        const rowWrapperDiskIO = row => ({ 'cgroup-name': row[0] });
+        const rowPropsIface = row => ({ 'data-interface': row[0] });
+        const rowPropsDiskIO = row => ({ 'cgroup-name': row[0] });
         const topServicesCPUColumns = [_("Service"), "%"];
         const topServicesMemoryColumns = [_("Service"), _("Used")];
         const ifaceColumns = [_("Interface"), _("In"), _("Out")];
@@ -974,7 +967,7 @@ class CurrentMetrics extends React.Component {
                                     </Tr>
                                 </Thead>
                                 <Tbody className="pf-v5-m-tabular-nums">
-                                    {make_rows(this.state.topServicesDiskIO, rowWrapperDiskIO, [_("Service"), _("Read"), _("Write")])}
+                                    {make_rows(this.state.topServicesDiskIO, rowPropsDiskIO, [_("Service"), _("Read"), _("Write")])}
                                 </Tbody>
                             </Table> }
                     </CardBody>
@@ -995,7 +988,7 @@ class CurrentMetrics extends React.Component {
                                 <Tr>{ifaceColumns.map(col => <Th key={col}>{col}</Th>)}</Tr>
                             </Thead>
                             <Tbody className="network-nowrap-shrink">
-                                {make_rows(netIO, rowWrapperIface, ifaceColumns)}
+                                {make_rows(netIO, rowPropsIface, ifaceColumns)}
                             </Tbody>
                         </Table>
                     </CardBody>

--- a/pkg/metrics/metrics.jsx
+++ b/pkg/metrics/metrics.jsx
@@ -707,7 +707,7 @@ class CurrentMetrics extends React.Component {
         const num_cpu_str = cockpit.format(cockpit.ngettext("$0 CPU", "$0 CPUs", numCpu), numCpu);
 
         const netIO = this.netInterfacesNames.map((iface, i) => [
-            iface,
+            <Button variant="link" isInline onClick={() => cockpit.jump(`/network#/${iface}`) } key={iface}>{iface}</Button>,
             this.state.netInterfacesRx[i] >= 1 ? cockpit.format_bytes_per_sec(this.state.netInterfacesRx[i]) : "0",
             this.state.netInterfacesTx[i] >= 1 ? cockpit.format_bytes_per_sec(this.state.netInterfacesTx[i]) : "0",
         ]);
@@ -805,7 +805,8 @@ class CurrentMetrics extends React.Component {
             );
         }
 
-        const rowPropsIface = row => ({ 'data-interface': row[0] });
+        // first element is the jump button, key is interface name
+        const rowPropsIface = row => ({ 'data-interface': row[0].key });
         const rowPropsDiskIO = row => ({ 'cgroup-name': row[0] });
         const topServicesCPUColumns = [_("Service"), "%"];
         const topServicesMemoryColumns = [_("Service"), _("Used")];

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1243,6 +1243,10 @@ BEGIN {{
         b.wait_in_text("[aria-label='Network usage'] [data-interface='cockpittest1']", "cockpittest1")
         b.wait_in_text("[aria-label='Network usage'] [data-interface='lo']", "lo")
 
+        # can jump to network interface details
+        b.wait_visible("[aria-label='Network usage'] [data-interface='cockpittest1'] button")
+        b.wait_visible("[aria-label='Network usage'] [data-interface='lo'] button")
+
         def rateMatches(label, regexp):
             text = b.text(f"[aria-label='Network usage'] [data-interface='lo'] td[data-label='{label}']")
             return re.match(regexp, text) is not None
@@ -1260,6 +1264,23 @@ BEGIN {{
         # nothing happens on cockpittest1
         b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='In']", "0")
         b.wait_text("[aria-label='Network usage'] [data-interface='cockpittest1'] td[data-label='Out']", "0")
+
+        b.click("[aria-label='Network usage'] [data-interface='lo'] button")
+        b.enter_page("/network")
+        b.wait_visible("#network-interface-name:contains('lo')")
+        if m.image in ["ubuntu-2204", "centos-8-stream"] or "rhel-8" in m.image:
+            b.wait_not_present(".pf-v5-c-switch")
+            b.wait_in_text("#network-interface-settings", "This device cannot be managed here.")
+        else:
+            # loopback can currently be managed, toggle on/off is present
+            b.wait_visible(".pf-v5-c-switch")
+
+        b.go("/metrics")
+        b.enter_page("/metrics")
+        b.click("[aria-label='Network usage'] [data-interface='cockpittest1'] button")
+        b.enter_page("/network")
+        b.wait_visible("#network-interface-name:contains('cockpittest1')")
+        b.wait_in_text("#network-interface-settings", "This device cannot be managed here.")
 
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")


### PR DESCRIPTION
I just want to get a first pass on this, I am trying to abide by the NetworkManager, albeit I am not sure how expensive the full blown NetworkManagerModel is.

Also please disregard `rowWrapperIface` for now, I didn't bother to really fix, just stitched it together so it would still pass tests.

So I have a few questions that need addressing and I am willing to do the fixes afterward:

1) Is asking the networkmanager really necessary?

Even though some interfaces are unmanaged, I tried by hand and cockpit can indeed show some information related to them such as:

![image](https://github.com/cockpit-project/cockpit/assets/1463740/95d0ee6f-1910-40e0-bfaf-9b443a2a9bee)

The only exception would be loopback, I guess?

![image](https://github.com/cockpit-project/cockpit/assets/1463740/7b75baf0-88e5-4f91-8c17-85b63e1f600d)

Bit afraid to figure out what that disable toggle would attempt to do in this case.

2) Loopback should not get a link, right?

I believe the right choice here would be to move the check from https://github.com/cockpit-project/cockpit/blob/main/pkg/networkmanager/network-main.jsx#L64 to interfaces.js and reuse across both

3) Testing eth0 is bad right?

I have checked other examples and there is some other testcases using `.add_veth()` but that implies using another base class, just wanna make sure there is no downside to inhering from the netlib testcase.

## Metrics: Link to network interface details

The interface names in the current network I/O card are now clickable links which lead to the detail view of the "Networking" page.

![Screen Shot 2023-09-19 at 06 20 11](https://github.com/cockpit-project/cockpit/assets/200109/c455fced-2ea3-4ef5-8221-5b04f99cb9ae)

_Thanks to [leomoty](https://github.com/leomoty/) for this feature!_