### PR TITLE
Robustify/fix TestFirewall.testNetworkingPage, add firewall debug messages

### DIFF
--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -75,6 +75,9 @@ firewall.debouncedGetServices = debounce(300, () => {
 
 function initFirewalldDbus() {
     debug("initializing D-Bus connection");
+    if (firewalld_dbus)
+        firewalld_dbus.close();
+
     firewalld_dbus = cockpit.dbus('org.fedoraproject.FirewallD1', { superuser: "try" });
 
     firewalld_dbus.addEventListener('owner', (event, owner) => {

--- a/pkg/networkmanager/firewall-client.js
+++ b/pkg/networkmanager/firewall-client.js
@@ -204,20 +204,24 @@ function initFirewalldDbus() {
 
 firewalld_service.addEventListener('changed', () => {
     const installed = !!firewalld_service.exists;
+    const is_running = firewalld_service.state === 'running';
+
+    // we get lots of these events, for internal property changes; filter interesting changes
+    if (is_running === firewalld_service.prev_running && firewall.installed === installed)
+        return;
+    firewall.installed = installed;
+    firewalld_service.prev_running = is_running;
+
     debug("systemd service changed: exists", firewalld_service.exists, "state", firewalld_service.state,
           "firewall.enabled:", JSON.stringify(firewall.enabled));
 
     /* HACK: cockpit.dbus() remains dead for non-activatable names, so reinitialize it if the service gets enabled and started
      * See https://github.com/cockpit-project/cockpit/pull/9125 */
-    if (!firewall.enabled && firewalld_service.state == 'running') {
+    if (!firewall.enabled && is_running) {
         debug("reinitializing D-Bus connection after unit got started");
         initFirewalldDbus();
     }
 
-    if (firewall.installed == installed)
-        return;
-
-    firewall.installed = installed;
     firewall.dispatchEvent('changed');
 });
 

--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -66,7 +66,11 @@ class TestFirewall(netlib.NetworkCase):
     def testNetworkingPage(self):
         b = self.browser
         m = self.machine
-        active_zones = len(m.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split())
+
+        def get_num_zones():
+            return len(m.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split())
+
+        active_zones = get_num_zones()
 
         # Zones should be visible as unprivileged user
         self.login_and_go("/network", superuser=False)
@@ -98,7 +102,12 @@ class TestFirewall(netlib.NetworkCase):
             raise
 
         self.wait_onoff("#networking-firewall-summary", val=True)
-        b.wait_in_text("#networking-firewall-summary", f"{active_zones} active zone")
+        try:
+            testlib.wait(lambda: get_num_zones() == active_zones)
+            b.wait_in_text("#networking-firewall-summary", f"{active_zones} active zone")
+        except testlib.Error:
+            m.execute("firewall-cmd --get-active-zones >&2")
+            raise
 
         try:
             m.execute("systemctl stop firewalld")


### PR DESCRIPTION
Trying to understand [this failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19334-20230915-080244-14eb9df1-fedora-38-networking/log.html#20), I can't get it locally.