### PR TITLE
pybridge: correct superuser bridge removal

### DIFF
--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -195,7 +195,7 @@ class SuperuserRoutingRule(RoutingRule, CockpitResponder, bus.Object, interface=
             if self.current == 'any':
                 removed = len(self.superuser_configs) == 0
             else:
-                removed = any(c.name == self.peer.name for c in self.superuser_configs)
+                removed = not any(c.name == self.peer.name for c in self.superuser_configs)
 
             if removed:
                 logger.debug(

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -56,6 +56,14 @@ class TestSuperuser(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Limited access")
 
+        # A reload should not lose privileges
+        b.become_superuser()
+        b.reload()
+        b.check_superuser_indicator("Administrative access")
+
+        # Drop privileges
+        b.drop_superuser()
+
         # We want to be lectured again
         self.restore_file("/var/db/sudo/lectured/admin")
         self.restore_file("/var/lib/sudo/lectured/admin")


### PR DESCRIPTION
The JSON deconstruction static typing commit ae5ce0a331f0e5f07450f0d6 changed the original condition removal condition for when a peer is no longer in the superuser configs. We want to mark the peer to be removed when it is no longer in the superuser_configs instead of when it is.

This lead to a regression where a browser refresh would no longer retain administrative privileges as the superuser peer was stopped.

Fixes #19327