### PR TITLE
cockpit.superuser: prevent 'any' from being set

### DIFF
--- a/src/cockpit/packages.py
+++ b/src/cockpit/packages.py
@@ -106,17 +106,19 @@ class PackagesListener:
         """Called when the packages have been reloaded"""
 
 
-class BridgeConfig:
+class BridgeConfig(JsonObject):
     def __init__(self, value: JsonObject):
-        self.label = get_str(value, 'label', None)
+        super().__init__(value)
 
-        self.privileged = get_bool(value, 'privileged', default=False)
-        self.match: JsonObject = get_dict(value, 'match', {})
+        self.label = get_str(self, 'label', None)
+
+        self.privileged = get_bool(self, 'privileged', default=False)
+        self.match: JsonObject = get_dict(self, 'match', {})
         if not self.privileged and not self.match:
             raise JsonError(value, 'must have match rules or be privileged')
 
-        self.environ = get_strv(value, 'environ', ())
-        self.spawn = get_strv(value, 'spawn')
+        self.environ = get_strv(self, 'environ', ())
+        self.spawn = get_strv(self, 'spawn')
         if not self.spawn:
             raise JsonError(value, 'spawn vector must be non-empty')
 

--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -219,10 +219,12 @@ class Peer(CockpitProtocol, SubprocessProtocol, Endpoint):
 
 
 class ConfiguredPeer(Peer):
+    config: BridgeConfig
     args: Sequence[str]
     env: Sequence[str]
 
     def __init__(self, router: Router, config: BridgeConfig):
+        self.config = config
         self.args = config.spawn
         self.env = config.environ
         super().__init__(router)

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -56,6 +56,14 @@ class TestSuperuser(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Limited access")
 
+        # A reload should not lose privileges
+        b.become_superuser()
+        b.reload()
+        b.check_superuser_indicator("Administrative access")
+
+        # Drop privileges
+        b.drop_superuser()
+
         # We want to be lectured again
         self.restore_file("/var/db/sudo/lectured/admin")
         self.restore_file("/var/lib/sudo/lectured/admin")


### PR DESCRIPTION
ae5ce0a331f0 introduced a bug in the code that handled the case where the `any` superuser bridge was requested: previously, the code would set `self.current` to the name of the selected peer, but after the change, it would get set to `any` instead.  Fix that up by using the name of the peer as the value for `self.current`.

This allows us to simplify the condition for checking if the running bridge ought to be shut down when reloading packages.  The current logic reads that we should shutdown the current bridge "if there's any bridge which has our name" (which is very likely, in case nothing changed).  We need to change that to `not any`, but we can also write it a bit differently to make it even clearer what's going on.

Thanks to Jelle for the testcase.