### PR TITLE
networking: Don't let the user manage loopback devices

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -1338,7 +1338,8 @@ export function syn_click(model, fun) {
 }
 
 export function is_managed(dev) {
-    return dev.State != 10;
+    // Never let the user manage loopback devices, nothing good can come from that.
+    return dev.State != 10 && dev.DeviceType != "loopback" && dev.Interface != "lo";
 }
 
 function render_interface_link(iface) {
@@ -1670,7 +1671,7 @@ export function is_interface_connection(iface, connection) {
 }
 
 export function is_interesting_interface(iface) {
-    return !iface.Device || (is_managed(iface.Device) && iface.Device.DeviceType != "loopback");
+    return !iface.Device || is_managed(iface.Device);
 }
 
 export function member_connection_for_interface(group, iface) {

--- a/pkg/networkmanager/network-interface.jsx
+++ b/pkg/networkmanager/network-interface.jsx
@@ -271,17 +271,7 @@ export const NetworkInterfacePage = ({
     }
 
     function renderConnectionSettingsRows(con, settings) {
-        if (!isManaged) {
-            return ([
-                <DescriptionListGroup key="not-managed-device">
-                    <DescriptionListDescription>
-                        {_("This device cannot be managed here.")}
-                    </DescriptionListDescription>
-                </DescriptionListGroup>
-            ]);
-        }
-
-        if (!settings)
+        if (!isManaged || !settings)
             return [];
 
         let group_settings = null;
@@ -738,7 +728,6 @@ export const NetworkInterfacePage = ({
                                 <span id="network-interface-hw">{renderDesc()}</span>
                                 <span id="network-interface-mac">{renderMac()}</span>
                             </CardTitle>
-
                         </CardHeader>
                         <CardBody>
                             <DescriptionList id="network-interface-settings" className="network-interface-settings pf-m-horizontal-on-sm">
@@ -747,6 +736,12 @@ export const NetworkInterfacePage = ({
                                 {settingsRows}
                             </DescriptionList>
                         </CardBody>
+                        { !isManaged
+                            ? <CardBody>
+                                {_("This device cannot be managed here.")}
+                            </CardBody>
+                            : null
+                        }
                     </Card>
                     {renderConnectionMembers(iface.MainConnection)}
                 </Gallery>

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1268,19 +1268,14 @@ BEGIN {{
         b.click("[aria-label='Network usage'] [data-interface='lo'] button")
         b.enter_page("/network")
         b.wait_visible("#network-interface-name:contains('lo')")
-        if m.image in ["ubuntu-2204", "centos-8-stream"] or "rhel-8" in m.image:
-            b.wait_not_present(".pf-v5-c-switch")
-            b.wait_in_text("#network-interface-settings", "This device cannot be managed here.")
-        else:
-            # loopback can currently be managed, toggle on/off is present
-            b.wait_visible(".pf-v5-c-switch")
+        b.wait_in_text(".network-interface-details", "This device cannot be managed here.")
 
         b.go("/metrics")
         b.enter_page("/metrics")
         b.click("[aria-label='Network usage'] [data-interface='cockpittest1'] button")
         b.enter_page("/network")
         b.wait_visible("#network-interface-name:contains('cockpittest1')")
-        b.wait_in_text("#network-interface-settings", "This device cannot be managed here.")
+        b.wait_in_text(".network-interface-details", "This device cannot be managed here.")
 
 
 @testlib.skipImage("TODO: Arch Linux packagekit support", "arch")


### PR DESCRIPTION
The user can't normally even navigate to such a device, but it is
possible to construct a URL for them, of course. Specifically, the
Metrics page now links to "lo".