### PR TITLE
test: add avc type=1405

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1646,6 +1646,7 @@ class MachineCase(unittest.TestCase):
         # SELinux messages to ignore
         "(audit: )?type=1403 audit.*",
         "(audit: )?type=1404 audit.*",
+        "(audit: )?type=1405 audit.*",
 
         # apparmor loading
         "(audit: )?type=1400.*apparmor=\"STATUS\".*",


### PR DESCRIPTION
Audit type=1405 is a "changes to booleans" event thus not a violation.

https://github.com/torvalds/linux/blob/master/include/uapi/linux/audit.h#L131C41-L131C60