### PR TITLE
package.json: Update to gettext-parser 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "gettext-parser": "^2.0.0",
+    "gettext-parser": "^7.0.1",
     "htmlparser": "^1.7.7",
     "jed": "^1.1.1",
     "qunit": "^2.19.0",


### PR DESCRIPTION
This changes API a bit.

Also enable PO file validation. This gets tripped up by weblate's `#~` disabled items, which sometimes start with a `|`. Filter them out first.

---

I diffed the generated `dist/*/po*.js` between current main and this, they are identical. I also tested this with starter-kit, see https://github.com/cockpit-project/starter-kit/pull/705