### PR TITLE
Backport test and some safe code fixes to rhel-9.3

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -23,86 +23,15 @@ srpm_build_deps:
 # use the nicely formatted release NEWS from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
 jobs:
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - centos-stream-9-x86_64
+      - centos-stream-9-aarch64
+
   - job: tests
     identifier: self
     trigger: pull_request
     targets:
-      - fedora-38
-      - fedora-39
-      - fedora-latest-aarch64
-      - fedora-development
-      - centos-stream-8-x86_64
       - centos-stream-9-x86_64
       - centos-stream-9-aarch64
-
-  # current Fedora runs reverse dependency testing against https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/
-  - job: tests
-    identifier: revdeps
-    trigger: pull_request
-    targets:
-      - fedora-latest-stable
-    tf_extra_params:
-      environments:
-        - artifacts:
-          - type: repository-file
-            id: https://copr.fedorainfracloud.org/coprs/g/cockpit/main-builds/repo/fedora-$releasever/group_cockpit-main-builds-fedora-$releasever.repo
-          tmt:
-            context:
-              revdeps: "yes"
-
-  # run build/unit tests on some interesting architectures
-  - job: copr_build
-    trigger: pull_request
-    targets:
-      # 32 bit
-      - fedora-development-i386
-      # big-endian
-      - fedora-development-s390x
-
-  # for cross-project testing
-  - job: copr_build
-    trigger: commit
-    branch: "^main$"
-    owner: "@cockpit"
-    project: "main-builds"
-    preserve_project: True
-
-  - job: copr_build
-    trigger: release
-    owner: "@cockpit"
-    project: "cockpit-preview"
-    preserve_project: True
-    actions:
-      # same as the global one, but specifying actions: does not inherit
-      post-upstream-clone:
-        # build patched spec
-        - tools/node-modules make_package_lock_json
-        - cp tools/cockpit.spec .
-        # packit will compute and set the version by itself
-        - tools/fix-spec ./cockpit.spec 0
-      # HACK: tarball for releases (copr_build, koji, etc.), copying spec's Source0; this
-      # really should be the default, see https://github.com/packit/packit-service/issues/1505
-      create-archive:
-        - sh -exc "curl -L -O https://github.com/cockpit-project/cockpit/releases/download/${PACKIT_PROJECT_VERSION}/${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
-        - sh -exc "ls ${PACKIT_PROJECT_NAME_VERSION}.tar.xz"
-
-  - job: propose_downstream
-    trigger: release
-    dist_git_branches:
-      - fedora-development
-      - fedora-38
-      - fedora-39
-
-  - job: koji_build
-    trigger: commit
-    dist_git_branches:
-      - fedora-development
-      - fedora-38
-      - fedora-39
-
-  - job: bodhi_update
-    trigger: commit
-    dist_git_branches:
-      # rawhide updates are created automatically
-      - fedora-38
-      - fedora-39

--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -51,7 +51,7 @@ const UnlockDialog = ({ proxy, host }) => {
     const [methods, setMethods] = useState(null);
     const [method, setMethod] = useState(false);
     const [busy, setBusy] = useState(false);
-    const [cancel, setCancel] = useState(null);
+    const [cancel, setCancel] = useState(() => D.close);
     const [prompt, setPrompt] = useState(null);
     const [message, setMessage] = useState(null);
     const [error, setError] = useState(null);
@@ -178,7 +178,7 @@ const UnlockDialog = ({ proxy, host }) => {
                 <Button variant='primary' onClick={apply} isDisabled={busy} isLoading={busy}>
                     {_("Authenticate")}
                 </Button>
-                <Button variant='link' className='btn-cancel' onClick={cancel} isDisabled={!cancel}>
+                <Button variant='link' className='btn-cancel' onClick={cancel}>
                     {_("Cancel")}
                 </Button>
             </>);
@@ -215,8 +215,7 @@ const UnlockDialog = ({ proxy, host }) => {
                 <Button variant='primary' onClick={() => start(method)} isDisabled={busy} isLoading={busy}>
                     {_("Authenticate")}
                 </Button>
-                <Button variant='link' className='btn-cancel' onClick={busy ? cancel : D.close}
-                        isDisabled={busy && !cancel}>
+                <Button variant='link' className='btn-cancel' onClick={cancel}>
                     {_("Cancel")}
                 </Button>
             </>);
@@ -229,7 +228,7 @@ const UnlockDialog = ({ proxy, host }) => {
         <Modal isOpen
                position="top"
                variant="medium"
-               onClose={D.close}
+               onClose={cancel}
                title={title}
                titleIconVariant={title_icon}
                footer={footer}>

--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -32,10 +32,11 @@ import {
     DropdownSeparator
 } from '@patternfly/react-core/dist/esm/deprecated/components/Dropdown/index.js';
 import { ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 
 import { ListingTable } from "cockpit-components-table.jsx";
 import { ListingPanel } from 'cockpit-components-listing-panel.jsx';
-import { StorageButton, StorageLink, StorageBarMenu, StorageMenuItem, StorageUsageBar } from "./storage-controls.jsx";
+import { StorageButton, StorageBarMenu, StorageMenuItem, StorageUsageBar } from "./storage-controls.jsx";
 import * as PK from "packagekit.js";
 import {
     format_dialog, parse_options, extract_option, unparse_options
@@ -567,7 +568,7 @@ function append_row(client, rows, level, key, name, desc, tabs, job_object, opti
                 </span>)
         },
         { title: desc.type },
-        { title: desc.link ? <StorageLink onClick={() => cockpit.location.go(desc.link)}>{desc.used_for}</StorageLink> : desc.used_for },
+        { title: desc.link ? <Button isInline variant="link" onClick={() => cockpit.location.go(desc.link)}>{desc.used_for}</Button> : desc.used_for },
         {
             title: desc.size.length
                 ? <StorageUsageBar stats={desc.size} critical={desc.critical_size || 0.95} block={name} />

--- a/pkg/storaged/stratis-details.jsx
+++ b/pkg/storaged/stratis-details.jsx
@@ -26,6 +26,7 @@ import { DescriptionList, DescriptionListDescription, DescriptionListGroup, Desc
 import { Flex, FlexItem } from "@patternfly/react-core/dist/esm/layouts/Flex/index.js";
 import { List, ListItem } from "@patternfly/react-core/dist/esm/components/List/index.js";
 import { PlusIcon, ExclamationTriangleIcon } from "@patternfly/react-icons";
+import { Button } from "@patternfly/react-core/dist/esm/components/Button/index.js";
 
 import { FilesystemTab, mounting_dialog, is_mounted, is_valid_mount_point, get_fstab_config } from "./fsys-tab.jsx";
 import { ListingTable } from "cockpit-components-table.jsx";
@@ -663,7 +664,7 @@ export const StratisPoolDetails = ({ client, pool }) => {
                            variant="warning"
                            title={_("This pool is in a degraded state.")}>
             <div className="storage_alert_action_buttons">
-                <StorageLink onClick={goToStratisLogs}>{_("View logs")}</StorageLink>
+                <Button variant="link" isInline onClick={goToStratisLogs}>{_("View logs")}</Button>
             </div>
         </Alert>);
     }

--- a/pkg/systemd/overview-cards/realmd.jsx
+++ b/pkg/systemd/overview-cards/realmd.jsx
@@ -96,6 +96,15 @@ export class RealmdClient {
     }
 
     initProxy() {
+        // Ignore intermediate states of superuser.allowed to
+        // avoid initializing the proxy twice during page
+        // load. This is less wasteful and helps the tests avoid
+        // race conditions. We are guaranteed to see a real "true"
+        // or "false" value eventually.
+        //
+        if (superuser.allowed === null)
+            return;
+
         if (this.dbus_realmd) {
             this.dbus_realmd.removeEventListener("close", this.onClose);
             this.dbus_realmd.close();

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -55,6 +55,7 @@ class PackageCase(MachineCase):
 
         # HACK: packagekit often hangs on shutdown; https://bugzilla.redhat.com/show_bug.cgi?id=1717185
         self.write_file("/etc/systemd/system/packagekit.service.d/timeout.conf", "[Service]\nTimeoutStopSec=5\n")
+        self.addCleanup(self.machine.execute, "systemctl stop packagekit; systemctl reset-failed packagekit || true")
 
         # disable all existing repositories to avoid hitting the network
         if self.backend == "apt":

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1732,7 +1732,7 @@ class MachineCase(unittest.TestCase):
                                     ".*couldn't create polkit session subject: No session for pid.*",
                                     "We are no longer a registered authentication agent.",
                                     ".*: failed to retrieve resource: terminated",
-                                    ".*: external channel failed: terminated",
+                                    ".*: external channel failed: (terminated|protocol-error)",
                                     'audit:.*denied.*comm="systemd-user-se".*nologin.*',
                                     ".*No session for cookie",
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1651,6 +1651,7 @@ class MachineCase(unittest.TestCase):
         # SELinux messages to ignore
         "(audit: )?type=1403 audit.*",
         "(audit: )?type=1404 audit.*",
+        "(audit: )?type=1405 audit.*",
 
         # apparmor loading
         "(audit: )?type=1400.*apparmor=\"STATUS\".*",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1794,6 +1794,7 @@ class MachineCase(unittest.TestCase):
             "Traceback .*most recent call last.*",
             "File .*",
             "async with self.watch_processing_lock:",
+            "self.send_message.*",
             "self.release.*",
             "self._wake_up_first.*",
             "fut.set_result.*",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -2070,11 +2070,10 @@ class MachineCase(unittest.TestCase):
 
         if self.file_exists(path):
             backup = os.path.join(self.vm_tmpdir, path.replace('/', '_'))
-            self.machine.execute("mkdir -p %(vm_tmpdir)s; cp -a %(path)s %(backup)s" % {
-                "vm_tmpdir": self.vm_tmpdir, "path": path, "backup": backup})
-            self.addCleanup(self.machine.execute, "mv %(backup)s %(path)s" % {"path": path, "backup": backup})
+            self.machine.execute(f"mkdir -p {self.vm_tmpdir}; cp -a {path} {backup}")
+            self.addCleanup(self.machine.execute, f"mv {backup} {path}")
         else:
-            self.addCleanup(self.machine.execute, "rm -rf %s" % path)
+            self.addCleanup(self.machine.execute, f"rm -f {path}")
 
     def write_file(self, path: str, content: str, append: bool = False, owner: Optional[str] = None, perm: Optional[str] = None,
                    post_restore_action: Optional[str] = None):

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -52,6 +52,18 @@ ReportStderr = true
 Command = {self.libexecdir}/cockpit-beiboot
 """)
 
+    def check_login(self, expected_user):
+        b = self.browser
+        b.wait_visible('#content')
+        b.wait_in_text("#host-toggle", expected_user)
+        b.enter_page("/system")
+        if self.is_devel_build():
+            b.wait_visible("#system_information_hostname_text")
+            # devel disables preloads
+        else:
+            b.wait_visible("#page_status_notification_updates")
+        b.switch_to_top()
+
     def logout(self, check_last_host=None):
         b = self.browser
 
@@ -96,11 +108,9 @@ Command = {self.libexecdir}/cockpit-beiboot
         b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
         b.set_val("#conversation-input", "foobar")
         b.click("#login-button")
-
-        b.wait_visible('#content')
+        self.check_login("admin@target")
         b.wait_in_text("#host-apps", "Services")
         b.wait_in_text("#host-apps", "Terminal")
-        b.wait_in_text("#host-toggle", "admin@target")
         b.become_superuser()
         b.drop_superuser()
         self.logout(check_last_host="10.111.113.2")
@@ -113,9 +123,7 @@ Command = {self.libexecdir}/cockpit-beiboot
         b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
         b.set_val("#conversation-input", "foobar")
         b.click("#login-button")
-
-        b.wait_visible('#content')
-        b.wait_in_text("#host-toggle", "admin@target")
+        self.check_login("admin@target")
         b.become_superuser()
 
         # cockpit-pcp is installed on client, but not on target; recognize that
@@ -154,8 +162,7 @@ Command = {self.libexecdir}/cockpit-beiboot
         b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
         b.set_val("#conversation-input", "foobar")
         b.click("#login-button")
-        b.wait_visible('#content')
-        b.wait_in_text("#host-toggle", "admin@target")
+        self.check_login("admin@target")
         self.logout()
 
         # different user name + password
@@ -165,8 +172,7 @@ Command = {self.libexecdir}/cockpit-beiboot
         b.wait_text("#conversation-prompt", "user@10.111.113.2's password: ")
         b.set_val("#conversation-input", "barfoo")
         b.click("#login-button")
-        b.wait_visible('#content')
-        b.wait_in_text("#host-toggle", "user@target")
+        self.check_login("user@target")
 
         # not a sudoer
         b.open_superuser_dialog()
@@ -194,8 +200,7 @@ Command = {self.libexecdir}/cockpit-beiboot
         pubkey = self.m_client.execute("cat ~admin/.ssh/id_rsa.pub")
         self.m_target.write("/home/user/.ssh/authorized_keys", pubkey, owner="user:user", perm="600")
         b.click("#recent-hosts-list .host-line:contains('user@10.111.113.2') button.host-name")
-        b.wait_visible('#content')
-        b.wait_in_text("#host-toggle", "user@target")
+        self.check_login("user@target")
         self.logout()
 
         # encrypted SSH key login
@@ -208,8 +213,7 @@ Command = {self.libexecdir}/cockpit-beiboot
         b.wait_text("#conversation-prompt", "Enter passphrase for key '/home/admin/.ssh/id_rsa': ")
         b.set_val("#conversation-input", "foobarfoo")
         b.click("#login-button")
-        b.wait_visible('#content')
-        b.wait_in_text("#host-toggle", "user@target")
+        self.check_login("user@target")
         self.logout()
 
 

--- a/test/verify/check-connection
+++ b/test/verify/check-connection
@@ -217,6 +217,7 @@ class TestConnection(testlib.MachineCase):
                 self.assertEqual(count, https_instances, out)
 
         # at the beginning, no cockpit related units are running
+        m.execute("systemctl reset-failed")
         m.stop_cockpit()
         expect_actives(ws_socket=False, instance_sockets=False, http_instances=[])
 
@@ -301,6 +302,7 @@ class TestConnection(testlib.MachineCase):
         orig = m.execute("cat /proc/sys/kernel/core_pattern").strip()
         m.execute("echo core > /proc/sys/kernel/core_pattern")
         self.addCleanup(m.execute, f"echo '{orig}' > /proc/sys/kernel/core_pattern")
+        self.addCleanup(m.execute, "systemctl reset-failed")
         m.start_cockpit(tls=True)
 
         # some netcat versions need an explicit shutdown option, others default to shutting down and don't have -N

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1404,21 +1404,22 @@ class TestMultiCPU(testlib.MachineCase):
         # Test current usage of cores
         b.wait_text("#current-cpu-usage-description", "2 CPUs")
         b.wait(lambda: progressValue(self, "#current-cpu-usage") < 20)
-        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=60% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
-        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=30% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=50% --unit cpu-hog dd if=/dev/urandom of=/dev/null")
+        m.execute("systemd-run --collect --slice cockpittest -p CPUQuota=20% --unit cpu-piglet dd if=/dev/urandom of=/dev/null")
         # View all CPUs
         b.click("#current-metrics-card-cpu button")
-        b.wait(lambda: int(b.text(".pf-v5-c-popover .cpu-all dd:nth-of-type(1)")[:-1]) > 50)
-        b.wait(lambda: int(b.text(".pf-v5-c-popover .cpu-all dd:nth-of-type(2)")[:-1]) > 20)
+        b.wait(lambda: int(b.text(".pf-v5-c-popover .cpu-all dd:nth-of-type(1)")[:-1]) > 40)
+        b.wait(lambda: int(b.text(".pf-v5-c-popover .cpu-all dd:nth-of-type(2)")[:-1]) > 15)
         b.click(".pf-v5-c-popover button")
         b.wait_not_present(".pf-v5-c-popover")
 
         # the top CPU core runs cpu-hog
-        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") >= 58)
-        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") <= 70)
+        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") >= 38)
+        # the hoglet gets scheduled between core 1 and 2
+        b.wait(lambda: progressValue(self, "#current-top-cpu-usage") <= 80)
         # looks like "average: 45% max: 60%"
-        b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) >= 58)
-        b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) <= 70)
+        b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) >= 38)
+        b.wait(lambda: int(b.text("#current-cpu-usage .pf-v5-c-progress__status").split()[-1].rstrip('%')) <= 80)
 
 
 @testlib.skipOstree("no PCP support")

--- a/test/verify/check-networkmanager-other
+++ b/test/verify/check-networkmanager-other
@@ -49,6 +49,7 @@ class TestNetworkingOther(netlib.NetworkCase):
         b.set_input_text('#network-ip-settings-address-0', "1.2.3.4")
         b.set_input_text('#network-ip-settings-netmask-0', "24")
         b.click("#network-ip-settings-dialog button:contains('Save')")
+        self.addCleanup(m.execute, "nmcli con del tun0")
         b.wait_not_present("#network-ip-settings-dialog")
         self.wait_for_iface_setting('Status', '1.2.3.4/24')
 

--- a/test/verify/check-shell-multi-os
+++ b/test/verify/check-shell-multi-os
@@ -157,6 +157,7 @@ class TestMultiOS(testlib.MachineCase):
 
         # Messages from previous versions of cockpit
         self.allow_journal_messages(".*pam_authenticate failed: Authentication failure")
+        self.allow_restart_journal_messages()
 
 
 @testlib.skipDistroPackage()

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -61,7 +61,8 @@ class TestStorageResize(storagelib.StorageCase):
             self.dialog_set_val("passphrase", "vainu-reku-toma-rolle-kaja")
             self.dialog_set_val("passphrase2", "vainu-reku-toma-rolle-kaja")
         self.dialog_apply()
-        self.dialog_wait_close()
+        with b.wait_timeout(60):
+            self.dialog_wait_close()
         self.content_tab_wait_in_info(fsys_row, fsys_tab, "Name", "FSYS")
         self.content_tab_wait_in_info(fsys_row, fsys_tab, "Mount point", "/run/foo")
 

--- a/test/verify/check-storage-resize
+++ b/test/verify/check-storage-resize
@@ -139,7 +139,7 @@ class TestStorageResize(storagelib.StorageCase):
         # and unmount the fs explicitly.  But then we also need to
         # check it explicitly.
         #
-        self.machine.execute(f"(! findmnt -S '{fs_dev}' || umount '{fs_dev}') && fsadm -y check '{fs_dev}' && fsadm -y resize '{fs_dev}' '{size}'")
+        self.machine.execute(f"(! findmnt -S '{fs_dev}' || umount '{fs_dev}'); fsadm -y check '{fs_dev}'; fsadm -y resize '{fs_dev}' '{size}'; udevadm trigger")
 
     def testGrowShrinkHelp(self):
         m = self.machine

--- a/test/verify/check-superuser
+++ b/test/verify/check-superuser
@@ -81,6 +81,17 @@ class TestSuperuser(testlib.MachineCase):
         b.leave_page()
         b.check_superuser_indicator("Administrative access")
 
+        # Test that closing instead of cancelling the dialog keeps the "switch
+        # to administrative button"
+        b.open_superuser_dialog()
+        b.click(".pf-v5-c-modal-box:contains('Switch to limited access') button:contains('Limit access')")
+        b.wait_not_present(".pf-v5-c-modal-box:contains('Switch to limited access')")
+        b.check_superuser_indicator("Limited access")
+
+        b.open_superuser_dialog()
+        b.click(".pf-v5-c-modal-box__close button")
+        b.check_superuser_indicator("Limited access")
+
     def testSudoIOLogging(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -257,7 +257,8 @@ class TestSystemInfo(packagelib.PackageCase):
         b.wait_not_present("#systime-manual-row .dialog-error")
         b.assert_pixels("#system_information_change_systime", "systime-manual-time")
         b.click("#system_information_change_systime .apply")
-        b.wait_not_present("#system_information_change_systime")
+        with b.wait_timeout(60):
+            b.wait_not_present("#system_information_change_systime")
 
         b.wait_text("#system_information_systime_button", "Jan 24, 2037, 8:03 AM")
 
@@ -270,7 +271,8 @@ class TestSystemInfo(packagelib.PackageCase):
         b.wait_visible("#system_information_change_systime")
         self.set_change_time_dialog_mode("Automatically using NTP")
         b.click("#system_information_change_systime .apply")
-        b.wait_not_present("#system_information_change_systime")
+        with b.wait_timeout(60):
+            b.wait_not_present("#system_information_change_systime")
 
         testlib.wait(ntp_enabled)
 

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -821,7 +821,8 @@ ipa-advise enable-admins-sudo | sh -ex
         # and there is no ccache; so, emulate what cockpit-ssh could eventually do and check that *if* the
         # session had the ticket forwarded, it *could* do sudo. See https://issues.redhat.com/browse/COCKPIT-643
         b.open("/@x0.cockpit.lan/system/terminal")
-        b.enter_page("/system/terminal", host="x0.cockpit.lan")
+        with b.wait_timeout(60):
+            b.enter_page("/system/terminal", host="x0.cockpit.lan")
         b.wait_in_text(".terminal .xterm-accessibility-tree", "alice")
         b.key_press(f"{ccache_env} sudo whoami\r")
         b.wait_in_text(".terminal .xterm-accessibility-tree", "root")

--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -336,6 +336,7 @@ WantedBy=default.target
         b.wait_not_present('#test.service > svg.service-thumbtack-icon-color')
 
         self.goto_service("test.service")
+        self.check_service_details(["Disabled"], ["Start", "Disallow running (mask)", "Pin unit"], enabled=False)
         b.wait_not_present('#service-details-unit > article > div > svg.service-thumbtack-icon')
         self.do_action("Pin unit")
         b.is_present('#service-details-unit > article > div > svg.service-thumbtack-icon')

--- a/tools/cockpit.spec
+++ b/tools/cockpit.spec
@@ -103,7 +103,7 @@ BuildRequires: pam-devel
 
 BuildRequires: autoconf automake
 BuildRequires: make
-BuildRequires: /usr/bin/python3
+BuildRequires: python3-devel
 %if 0%{?rhel} && 0%{?rhel} <= 8
 # RHEL 8's gettext does not yet have metainfo.its
 BuildRequires: gettext >= 0.19.7


### PR DESCRIPTION
We have a bunch of Python bridge regressions that we need to fix for RHEL 9.3.z. To get this started, I created a [rhel-9.3](https://github.com/cockpit-project/cockpit/tree/rhel-9.3) stable branch straight from the 300.1 tag, and cherry-picked an initial set of integration test fixes.

This also contains the BuildRequires fix (see https://issues.redhat.com/browse/RHEL-2215), and two safe bug fixes on the Storage and Metrics pages.

After this lands, I'll send some more intrusive changes, and two of the issues aren't even fixed yet (I also still need to file Jira tickets).