### PR TITLE
doc: Drop wrong cockpit.user.onchanged()

### DIFF
--- a/doc/guide/cockpit-session.xml
+++ b/doc/guide/cockpit-session.xml
@@ -55,14 +55,6 @@ promise.then(user => { ... });
     <para>Returns a promise that completes once the user information is available.</para>
   </refsection>
 
-  <refsection id="cockpit-info-changed">
-    <title>cockpit.user.onchanged</title>
-<programlisting>
-cockpit.user.addEventListener("changed", function() { ... })
-</programlisting>
-    <para>This event is fired when the user info changes or first becomes available.</para>
-  </refsection>
-
   <refsection id="cockpit-permission">
     <title>Permission lookup</title>
 


### PR DESCRIPTION
`cockpit.user` is a simple function that will return a Promise. It's not an event object, and trying to add an event listener to it fails:

    Uncaught TypeError: cockpit.user.addEventListener is not a function

There's also no reason to do this: The user of the current session *never* changes. The only thing to wait for is for the value to become available, which is what the promise does.

Thanks to Ivan Devat for finding and reporting this.