### PR TITLE
fmf: Fix installation of cockpit-tests

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -48,6 +48,12 @@ if grep -q 'ID=.*rhel' /etc/os-release; then
     dnf install -y kpatch kpatch-dnf
 fi
 
+# RHEL 8 does not build cockpit-tests; when dropping RHEL 8 support, move to test/browser/main.fmf
+if [ "$PLAN" = basic ] && ! grep -q el8 /etc/os-release; then
+    dnf install -y cockpit-tests
+fi
+
+
 # On CentOS Stream 8 the cockpit package is upgraded so the file isn't touched.
 if [ ! -f /etc/cockpit/disallowed-users ]; then
     echo 'root' > /etc/cockpit/disallowed-users

--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -6,7 +6,8 @@
     - cockpit-kdump
     - cockpit-networkmanager
     - cockpit-sosreport
-    - cockpit-tests
+    # FIXME: add this after dropping RHEL8 support
+    # - cockpit-tests
     # build/test infra dependencies
     - git
     - make
@@ -51,7 +52,6 @@
     - cockpit
     - cockpit-storaged
     - cockpit-packagekit
-    - cockpit-tests
     # build/test infra dependencies
     - git
     - make


### PR DESCRIPTION
Previous TF versions ignored the unavailable cockpit-tests test dependency, but now it (rightfully) fails on that. Install the package dynamically for non-RHEL 8 for now, until we drop support for RHEL 8 from our main branch.
    
Drop cockpit-tests for the storage plan, we don't need it there.

----

Sort out https://gitlab.com/redhat/centos-stream/rpms/cockpit/-/merge_requests/64 , tests were running successfully there against this branch.