### PR TITLE
storage: Partition resizing

### DIFF
--- a/pkg/storaged/content-views.jsx
+++ b/pkg/storaged/content-views.jsx
@@ -226,7 +226,7 @@ function create_tabs(client, target, options) {
     }
 
     if (options.is_partition) {
-        add_tab(_("Partition"), PartitionTab);
+        add_tab(_("Partition"), PartitionTab, false, ["unused-space"]);
     }
 
     let is_unrecognized = false;

--- a/pkg/storaged/part-tab.jsx
+++ b/pkg/storaged/part-tab.jsx
@@ -18,29 +18,54 @@
  */
 
 import React from "react";
+import { Alert } from "@patternfly/react-core/dist/esm/components/Alert/index.js";
 import { DescriptionList, DescriptionListDescription, DescriptionListGroup, DescriptionListTerm } from "@patternfly/react-core/dist/esm/components/DescriptionList/index.js";
+import { StorageButton } from "./storage-controls.jsx";
+import { get_resize_info, free_space_after_part, grow_dialog, shrink_dialog } from "./resize.jsx";
 
 import cockpit from "cockpit";
 import * as utils from "./utils.js";
 
 const _ = cockpit.gettext;
 
-export class PartitionTab extends React.Component {
-    render() {
-        const block_part = this.props.client.blocks_part[this.props.block.path];
+export const PartitionTab = ({ client, block, warnings }) => {
+    const block_part = client.blocks_part[block.path];
+    const unused_space_warning = warnings.find(w => w.warning == "unused-space");
+    const unused_space = !!unused_space_warning;
 
-        return (
+    let { info, shrink_excuse, grow_excuse } = get_resize_info(client, block, unused_space);
+
+    if (!unused_space && !grow_excuse && free_space_after_part(client, block_part) == 0) {
+        grow_excuse = _("No free space after this partition");
+    }
+
+    function shrink() {
+        return shrink_dialog(client, block_part, info, unused_space);
+    }
+
+    function grow() {
+        return grow_dialog(client, block_part, info, unused_space);
+    }
+
+    return (
+        <div>
             <DescriptionList className="pf-m-horizontal-on-sm">
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Name")}</DescriptionListTerm>
                     <DescriptionListDescription>{block_part.Name || "-"}</DescriptionListDescription>
                 </DescriptionListGroup>
-
+                { !unused_space &&
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("Size")}</DescriptionListTerm>
-                    <DescriptionListDescription>{utils.fmt_size(block_part.Size)}</DescriptionListDescription>
+                    <DescriptionListDescription>
+                        {utils.fmt_size(block_part.Size)}
+                        <div className="tab-row-actions">
+                            <StorageButton excuse={shrink_excuse} onClick={shrink}>{_("Shrink")}</StorageButton>
+                            <StorageButton excuse={grow_excuse} onClick={grow}>{_("Grow")}</StorageButton>
+                        </div>
+                    </DescriptionListDescription>
                 </DescriptionListGroup>
-
+                }
                 <DescriptionListGroup>
                     <DescriptionListTerm>{_("UUID")}</DescriptionListTerm>
                     <DescriptionListDescription>{block_part.UUID}</DescriptionListDescription>
@@ -51,6 +76,22 @@ export class PartitionTab extends React.Component {
                     <DescriptionListDescription>{block_part.Type}</DescriptionListDescription>
                 </DescriptionListGroup>
             </DescriptionList>
-        );
-    }
-}
+            { unused_space &&
+            <>
+                <br />
+                <Alert variant="warning"
+                         isInline
+                         title={_("This partition is not completely used by its content.")}>
+                    {cockpit.format(_("Partition size is $0. Content size is $1."),
+                                    utils.fmt_size(unused_space_warning.volume_size),
+                                    utils.fmt_size(unused_space_warning.content_size))}
+                    <div className='storage_alert_action_buttons'>
+                        <StorageButton excuse={shrink_excuse} onClick={shrink}>{_("Shrink partition")}</StorageButton>
+                        <StorageButton excuse={grow_excuse} onClick={grow}>{_("Grow content")}</StorageButton>
+                    </div>
+                </Alert>
+            </>
+            }
+        </div>
+    );
+};

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -102,6 +102,77 @@ class TestStoragePartitions(storagelib.StorageCase):
         # 25.1M while newer versions give us 26M or 25M.
         testlib.wait(lambda: m.execute(f"lsblk -no SIZE {disk}1").strip() in ["25M", "25.1M", "26M"])
 
+    def testResize(self):
+        m = self.machine
+        b = self.browser
+
+        # Different versions of UDisks2 round partition sizes
+        # differently during creation, urks.  We nudge the input sizes
+        # a bit in the right places to end up with the same partition
+        # sizes on all platforms.
+
+        if self.storaged_version >= [2, 10]:
+            nudge = 1
+        else:
+            nudge = 0
+
+        self.login_and_go("/storage")
+
+        disk = self.add_ram_disk(100)
+        b.click(f'#drives .sidepanel-row:contains("{disk}")')
+        b.wait_visible('#storage-detail')
+
+        b.click('button:contains(Create partition table)')
+        self.dialog({"type": "gpt"})
+        self.content_row_wait_in_col(1, 0, "Free space")
+
+        # Make two partitions that cover the whole disk.
+
+        self.content_row_action(1, "Create partition")
+        self.dialog({"type": "ext4",
+                     "mount_point": "/foo1",
+                     "size": 80 + nudge},
+                    secondary=True)
+        self.content_row_action(2, "Create partition", isExpandable=False)
+        self.dialog({"type": "ext4",
+                     "mount_point": "/foo2",
+                     "size": 23},
+                    secondary=True)
+
+        self.content_tab_wait_in_info(1, 1, "Size", "80.7 MB")
+        self.content_tab_wait_in_info(2, 1, "Size", "22.0 MB")
+
+        # Both partitions can't be grown
+        self.wait_content_tab_action_disabled(1, 1, "Grow")
+        self.wait_content_tab_action_disabled(2, 1, "Grow")
+
+        # Shrink the first
+        self.content_tab_action(1, 1, "Shrink")
+        self.dialog({"size": 50})
+        self.content_tab_wait_in_info(1, 1, "Size", "50.3 MB")
+
+        # Grow it back externally, Cockpit should complain.  Shrink it
+        # again with Cockpit.
+        m.execute(f"parted -s {disk} resizepart 1 81.7MB")
+        self.content_tab_action(1, 1, "Shrink partition")
+        self.content_tab_wait_in_info(1, 1, "Size", "50.3 MB")
+
+        # Grow it back externally again. Grow the filesystem with
+        # Cockpit.
+        m.execute(f"parted -s {disk} resizepart 1 81.7MB")
+        self.content_tab_action(1, 1, "Grow content")
+        self.content_tab_wait_in_info(1, 1, "Size", "80.7 MB")
+        self.wait_content_tab_action_disabled(1, 1, "Grow")
+
+        # Delete second partition and grow the first to take all the
+        # space.
+        self.content_dropdown_action(2, "Delete")
+        self.confirm()
+        self.content_tab_action(1, 1, "Grow")
+        self.dialog({"size": 103})
+        self.wait_content_tab_action_disabled(1, 1, "Grow")
+        self.content_tab_wait_in_info(1, 1, "Size", "103 MB")
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
Demo: https://www.youtube.com/watch?v=rZ2ZExzkIto

## Storage: Partitions can be resized

Cockpit can now also resize partitions, including their content such as filesystems or LUKS containers.

![image](https://github.com/cockpit-project/cockpit/assets/3228183/77eb0ee3-ed22-4690-be66-a48407346fbb)
