### PR TITLE
test: Remove obsolete skipMobile decorator

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -70,7 +70,6 @@ __all__ = (
     'onlyImage',
     'skipImage',
     'skipDistroPackage',
-    'skipMobile',
     'skipOstree',
     'skipBrowser',
     'todo',
@@ -2215,16 +2214,6 @@ def skipOstree(reason: str):
     """
     if testvm.DEFAULT_IMAGE in OSTREE_IMAGES:
         return unittest.skip("{0}: {1}".format(testvm.DEFAULT_IMAGE, reason))
-    return lambda testEntity: testEntity
-
-
-def skipMobile():
-    """Decorator for skipping a test on mobile
-
-    Skip test on when TEST_MOBILE is set.
-    """
-    if bool(os.environ.get("TEST_MOBILE", "")):
-        return unittest.skip("mobile: This test breaks on small screen sizes")
     return lambda testEntity: testEntity
 
 

--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1442,7 +1442,6 @@ class TestMultiCPU(testlib.MachineCase):
 
 @testlib.skipOstree("no PCP support")
 @testlib.skipDistroPackage()
-@testlib.skipMobile()
 class TestGrafanaClient(testlib.MachineCase):
 
     provision = {

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -59,7 +59,6 @@ class TestStoragePartitions(storagelib.StorageCase):
         self.confirm()
         self.content_row_wait_in_col(1, 0, "Free space")
 
-    @testlib.skipMobile()
     def testSizeSlider(self):
         m = self.machine
         b = self.browser


### PR DESCRIPTION
There is no "mobile" scenario anymore, we test the mobile layout via changing the layout during regular testing.