### PR TITLE
networking: fix page crash when wg properties go missing

### DIFF
--- a/pkg/networkmanager/interfaces.js
+++ b/pkg/networkmanager/interfaces.js
@@ -591,7 +591,7 @@ export function NetworkManagerModel() {
                 peers: get("wireguard", "peers", []).map(peer => ({
                     publicKey: peer['public-key'].v,
                     endpoint: peer.endpoint?.v, // enpoint of a peer is optional
-                    allowedIps: peer['allowed-ips'].v
+                    allowedIps: peer['allowed-ips']?.v
                 })),
             };
         }

--- a/pkg/networkmanager/wireguard.jsx
+++ b/pkg/networkmanager/wireguard.jsx
@@ -73,7 +73,7 @@ export function WireGuardDialog({ settings, connection, dev }) {
     const [listenPort, setListenPort] = useState(settings.wireguard.listen_port);
     const [addresses, setAddresses] = useState(addressesToString(settings.ipv4.addresses));
     const [dialogError, setDialogError] = useState("");
-    const [peers, setPeers] = useState(settings.wireguard.peers.map(peer => ({ ...peer, allowedIps: peer.allowedIps.join(",") })));
+    const [peers, setPeers] = useState(settings.wireguard.peers.map(peer => ({ ...peer, allowedIps: peer.allowedIps?.join(",") ?? '' })));
 
     // Additional check for `wg` after install_dialog for non-packagekit and el8 environments
     useEffect(() => {

--- a/test/verify/check-networkmanager-wireguard
+++ b/test/verify/check-networkmanager-wireguard
@@ -123,6 +123,24 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         b.wait_not_present("#network-wireguard-settings-dialog")
         b.wait_in_text(f"#networking-interfaces th:contains('{iface_name}') + td", f"1.2.3.4/32, {m1_ip4}/24")
 
+        # if some wg properties are not valid, for example, if it was changed by some external tool, don't crash
+        m1.execute("sed -i 's/.*allowed-ips.*//' /etc/NetworkManager/system-connections/con-wg0.nmconnection")
+        m1.execute("systemctl restart NetworkManager")
+        b.reload()
+        b.enter_page("/network")
+        b.wait_visible("#networking")
+        b.click(f"#networking-interfaces button:contains('{iface_name}')")
+        b.wait_visible("#network-interface")
+        b.click("#networking-edit-wg")
+        b.click("#network-wireguard-settings-save")
+        b.wait_visible(".pf-v5-c-alert:contains('has invalid allowed-ips')")
+        b.set_input_text("#network-wireguard-settings-allowedips-peer-0", m2_ip4)
+        b.click("#network-wireguard-settings-save")
+        b.wait_not_present("#network-wireguard-settings-dialog")
+
+        m1.execute("until wg show wg0 | grep -q 'allowed ips.*10.0.0.2/32'; do sleep 1; done")
+        m1.execute("until ip route | grep -q '10.0.0.0/24 dev wg0 proto kernel scope link src 10.0.0.1 metric 50'; do sleep 1; done")
+
         # endpoint and port is not necessary for a peer if that peer estalishes the connectio first (i.e. the client)
         m2.execute(f"wg set wg0 peer {m1_pubkey} allowed-ips {m1_ip4}/32")
 
@@ -140,7 +158,6 @@ class TestWireGuard(packagelib.PackageCase, netlib.NetworkCase):
         m2.execute(f"ip addr add {m2_ip6}/64 dev wg0")
         m2.execute(f"wg set wg0 peer {m1_pubkey} allowed-ips {m1_ip4}/32,{m1_ip6}")
 
-        b.click(f"#networking-interfaces button:contains('{iface_name}')")
         b.click("#networking-edit-wg")
         b.wait_visible("#network-wireguard-settings-dialog")
         b.set_input_text("#network-wireguard-settings-allowedips-peer-0", f"{m2_ip4}/32,{m2_ip6}")


### PR DESCRIPTION
Though the original issue #19384 used wg-quick to configure wireguard, I was unable to reproduce the issue with it, unless I created a brand new connection which seems unnecessary as the tests already had a profile configured. Using `sed` to edit wg keyfile and reproduce should be equivalent.

Other wireguard properties `endpoint` and `listen-port` are either optional or have a default value, so the /network page shouldn't break if they're not set. Missing or invalid `public-key` is equivalent to no peer, so it shouldn't break /network page as well.

fixes #19384