### PR TITLE
beiboot: feature parity with cockpit-ssh

### DIFF
--- a/containers/flatpak/test/test-browser-login-ssh.js
+++ b/containers/flatpak/test/test-browser-login-ssh.js
@@ -12,9 +12,9 @@ async function test() {
         document.getElementById("server-field").value = "%HOST%";
         ph_mouse("#login-button", "click");
 
-        // unknown host key
-        await assert_conversation("authenticity of host");
-        document.getElementById("conversation-input").value = "yes";
+        // accept unknown host key
+        await ph_wait_present("#hostkey-message-1");
+        await ph_wait_in_text("#hostkey-message-1", "%HOST%");
         ph_mouse("#login-button", "click");
 
         await ph_wait_present("#conversation-prompt");

--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -99,14 +99,15 @@ Cockpit also supports logging directly into remote machines. The remote machine 
 connect to is provided by using a application name that begins with `cockpit+=`.
 The default command used for this is cockpit-ssh.
 
-The section `SSH-Login` defines the options for all ssh commands. The section
+The section `Ssh-Login` defines the options for all ssh commands. The section
 has the same options as the other authentication sections with the following additions.
 
- * `host` The default host to log into. Defaults to 127.0.0.1.
+ * `host` The default host to log into. Defaults to 127.0.0.1. That host's key
+   will not be checked/validated.
  * `connectToUnknownHosts`. By default cockpit will refuse to connect to any machines that
- are not already present in ssh's global `known_hosts` file (usually
- `/etc/ssh/ssh_known_hosts`). Set this to `true` is to allow those connections
- to proceed.
+   are not already present in ssh's global `known_hosts` file (usually
+   `/etc/ssh/ssh_known_hosts`). Set this to `true` is to allow those connections
+   to proceed.
 
 This uses the [cockpit-ssh](https://github.com/cockpit-project/cockpit/tree/main/src/ssh)
 bridge. After the user authentication with the `"*"` challenge, if the remote
@@ -159,7 +160,7 @@ Actions
 Setting an action can modify the behavior for an auth scheme. Currently two actions
 are supported.
 
- * **remote-login-ssh** Use the `SSH-Login` section instead.
+ * **remote-login-ssh** Use the `Ssh-Login` section instead.
  * **none** Disable this auth scheme.
 
 To configure an action add the `action` option. For example to disable basic authentication,

--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -185,8 +185,11 @@ def python_interpreter(comment: str) -> tuple[Sequence[str], Sequence[str]]:
 
 def via_ssh(cmd: Sequence[str], dest: str, ssh_askpass: Path, *ssh_opts: str) -> tuple[Sequence[str], Sequence[str]]:
     host, _, port = dest.rpartition(':')
-    # catch cases like `host:123` but not cases like `[2001:abcd::1]
-    if port.isdigit():
+    # catch cases like `host:123` but not cases like `[2001:abcd::1]` or `::1`
+    if port.isdigit() and not host.endswith(':'):
+        # strip off [] IPv6 brackets
+        if host.startswith('[') and host.endswith(']'):
+            host = host[1:-1]
         destination = ['-p', port, host]
     else:
         destination = [dest]

--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -238,7 +238,8 @@ class SshPeer(Peer):
     async def connect_from_bastion_host(self) -> None:
         basic_password = None
         known_hosts = None
-        args = []
+        # right now we open a new ssh connection for each auth attempt
+        args = ['-o', 'NumberOfPasswordPrompts=1']
 
         # do we have user/password (Basic auth) from the login page?
         auth = await self.router.request_authorization_object("*")

--- a/test/browser/run-test.sh
+++ b/test/browser/run-test.sh
@@ -91,6 +91,7 @@ if [ "$PLAN" = "main" ]; then
               TestLogin.testFailingWebsocketSafari
               TestLogin.testFailingWebsocketSafariNoCA
               TestLogin.testLogging
+              TestLogin.testLoginSshBeiboot
               TestLogin.testRaw
               TestLogin.testServer
               TestLogin.testUnsupportedBrowser

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -118,8 +118,9 @@ exec "$@"
         b.wait_not_visible("#recent-hosts-list")
         b.set_val("#server-field", "10.111.113.2")
         b.click("#login-button")
-        b.wait_in_text("#conversation-group", "authenticity of host '10.111.113.2")
-        b.set_val("#conversation-input", "yes")
+        # accept unknown host key
+        b.wait_in_text("#hostkey-message-1", "10.111.113.2")
+        b.wait_in_text("#hostkey-fingerprint", "SHA256:")
         b.click("#login-button")
         b.wait_text("#conversation-prompt", "admin@10.111.113.2's password: ")
         b.set_val("#conversation-input", "foobar")

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -58,6 +58,17 @@ LoginTo = true
 [Ssh-Login]
 Command = /usr/bin/env python3 -m cockpit.beiboot
 """)
+        # use the connect_from_flatpak() code path of beiboot.py
+        self.m_client.write("/.flatpak-info", "test mock")
+        self.m_client.write("/usr/local/bin/flatpak-spawn", """#!/bin/sh -eux
+if [ "$1" = "--host" ]; then shift; continue; fi
+while [ "${1#--env=}" != "$1" ]; do
+    export "${1#--env=}"
+    shift
+    continue
+done
+exec "$@"
+""", perm="0755")
 
     def check_login(self, expected_user):
         b = self.browser

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -971,17 +971,17 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
 """, append=True)
         m.start_cockpit()
 
-        def try_login(user, password, server=None):
+        def try_login(user, password, server=None, expect_hostkey=False):
             b.open("/")
             b.set_val('#login-user-input', user)
             b.set_val('#login-password-input', password)
             b.click("#show-other-login-options")
             b.set_val("#server-field", server or my_ip)
             b.click("#login-button")
-            # ack unknown host key; FIXME: this should be a proper authorize message, not a prompt
-            b.wait_in_text("#conversation-prompt", "authenticity of host")
-            b.set_val("#conversation-input", "yes")
-            b.click("#login-button")
+            if expect_hostkey:
+                b.wait_in_text("#hostkey-message-1", server or my_ip)
+                b.wait_in_text("#hostkey-fingerprint", "SHA256:")
+                b.click("#login-button")
 
         def check_no_processes():
             m.execute(f"while pgrep -af '[s]sh .* {my_ip}' >&2; do sleep 1; done")
@@ -996,13 +996,25 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
             b.logout()
             check_no_processes()
 
-        # successful login through SSH
-        try_login("admin", "foobar")
-        check_session()
+        def check_store_hostkey(expected: str) -> None:
+            db_hostkey = b.eval_js(f'JSON.parse(window.localStorage.getItem("known_hosts"))["{my_ip}"]')
+            if m.image.startswith('debian') or m.image.startswith('ubuntu'):
+                # these OSes encrypt host keys, so don't compare them
+                db_hostkey = ' '.join(db_hostkey.split()[1:])
+                expected = ' '.join(expected.split()[1:])
+            self.assertEqual(db_hostkey, expected)
 
-        # wrong password
+        # successful login through SSH
+        try_login("admin", "foobar", expect_hostkey=True)
+        check_session()
+        # wrote full host key into session storage
+        # some OpenSSH versions add a comment here, filter that out
+        real_hostkey = m.execute(f"ssh-keyscan -t ssh-ed25519 {my_ip} | grep -v ^#")
+        check_store_hostkey(real_hostkey)
+
+        # host key is now known, but wrong password
         try_login("admin", "wrong")
-        b.wait_in_text("#login-error-message", "Authentication failed")
+        b.wait_text("#login-error-message", "Wrong user name or password")
         check_no_processes()
         # goes back to normal login form
         b.wait_visible('#login-user-input')
@@ -1013,7 +1025,7 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
         check_session()
 
         # IPv6
-        try_login("admin", "foobar", server="::1")
+        try_login("admin", "foobar", server="::1", expect_hostkey=True)
         check_session(server="::1")
         try_login("admin", "foobar", server="[::1]:22")
         check_session(server="::1")
@@ -1030,6 +1042,35 @@ Command = /usr/bin/env python3 -m cockpit.beiboot
             # HACK: PermitEmptyPasswords somehow breaks regular password auth
             m.execute("rm /etc/ssh/sshd_config.d/01-empty-password.conf")
             m.execute(self.restart_sshd)
+
+        # non-matching host key
+        bad_key = "172.27.0.15 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINKEIUL5s7ebg5Y6JdYNq4+mAaaaaaP1VRBDUiVdHT3R"
+        b.eval_js(f"""window.localStorage.setItem('known_hosts', '{{"{my_ip}": "{bad_key}"}}')""")
+
+        # first try with wrong credentials
+        try_login("admin", "wrong")
+        b.wait_text("#hostkey-title", f"{my_ip} key changed")
+        b.wait_in_text("#hostkey-fingerprint", "SHA256:")
+        b.click("#login-button.pf-m-danger")
+        b.wait_text("#login-error-message", "Authentication failed")
+        check_no_processes()
+        # new host key is accepted and updated in db
+        # confirmation replaces (not amends) known key
+        check_store_hostkey(real_hostkey)
+
+        # now with correct credentials, does not ask for host key any more
+        try_login("admin", "foobar")
+        check_session()
+        check_store_hostkey(real_hostkey)
+
+        # good credentials with bad key
+        b.eval_js(f"""window.localStorage.setItem('known_hosts', '{{"{my_ip}": "{bad_key}"}}')""")
+        try_login("admin", "foobar")
+        b.wait_text("#hostkey-title", f"{my_ip} key changed")
+        b.wait_in_text("#hostkey-fingerprint", "SHA256:")
+        b.click("#login-button.pf-m-danger")
+        check_session()
+        check_store_hostkey(real_hostkey)
 
 
 if __name__ == '__main__':

--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -954,6 +954,83 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
         # by IPv6 address and port
         check_server("[::1]:22", expect_fp_ack=True)
 
+    # check cockpit-beiboot as replacement of cockpit-ssh on the login page
+    # once that becomes the default, TestMultiMachine* and the other TestLogin* cover this
+    @testlib.skipImage("needs pybridge", "rhel-8*", "centos-8*")
+    # enable this once our cockpit/ws container can beiboot
+    @testlib.skipOstree("client setup does not work with ws container")
+    def testLoginSshBeiboot(self):
+        m = self.machine
+        b = self.browser
+
+        # this matches our bots test VMs
+        my_ip = "172.27.0.15"
+        m.write("/etc/cockpit/cockpit.conf", """
+[Ssh-Login]
+Command = /usr/bin/env python3 -m cockpit.beiboot
+""", append=True)
+        m.start_cockpit()
+
+        def try_login(user, password, server=None):
+            b.open("/")
+            b.set_val('#login-user-input', user)
+            b.set_val('#login-password-input', password)
+            b.click("#show-other-login-options")
+            b.set_val("#server-field", server or my_ip)
+            b.click("#login-button")
+            # ack unknown host key; FIXME: this should be a proper authorize message, not a prompt
+            b.wait_in_text("#conversation-prompt", "authenticity of host")
+            b.set_val("#conversation-input", "yes")
+            b.click("#login-button")
+
+        def check_no_processes():
+            m.execute(f"while pgrep -af '[s]sh .* {my_ip}' >&2; do sleep 1; done")
+            m.execute("while pgrep -af '[c]ockpit.beiboot' >&2; do sleep 1; done")
+
+        def check_session(server=None):
+            b.wait_visible('#content')
+            b.enter_page('/system')
+            b.wait_visible('.system-information')
+            m.execute(f"pgrep -af '[s]sh .* -l admin .*{server or my_ip}'")
+            m.execute(f"pgrep -af '[c]ockpit.beiboot.*{server or my_ip}'")
+            b.logout()
+            check_no_processes()
+
+        # successful login through SSH
+        try_login("admin", "foobar")
+        check_session()
+
+        # wrong password
+        try_login("admin", "wrong")
+        b.wait_in_text("#login-error-message", "Authentication failed")
+        check_no_processes()
+        # goes back to normal login form
+        b.wait_visible('#login-user-input')
+
+        # colliding usernames; user names in "Connect to:" are *not* supported,
+        # but pin down the behaviour
+        try_login("admin", "foobar", server=f"other@{my_ip}")
+        check_session()
+
+        # IPv6
+        try_login("admin", "foobar", server="::1")
+        check_session(server="::1")
+        try_login("admin", "foobar", server="[::1]:22")
+        check_session(server="::1")
+
+        # empty password
+        self.write_file("/etc/ssh/sshd_config.d/01-empty-password.conf", "PermitEmptyPasswords yes",
+                        post_restore_action=self.restart_sshd)
+        m.execute(self.restart_sshd)
+        m.execute("passwd -d admin")
+        try_login("admin", "")
+        check_session()
+        m.execute("echo 'admin:foobar' | chpasswd")
+        if m.image == 'arch':
+            # HACK: PermitEmptyPasswords somehow breaks regular password auth
+            m.execute("rm /etc/ssh/sshd_config.d/01-empty-password.conf")
+            m.execute(self.restart_sshd)
+
 
 if __name__ == '__main__':
     testlib.test_main()


### PR DESCRIPTION
In order to use cockpit-beiboot as cockpit-ssh replacement from the "normal" (not Client mode) login page, it needs to consider the given username and password. It also needs to properly handle "unknown host key" prompts.

This paves the way for completely replacing cockpit-ssh with cockpit.beiboot. See https://issues.redhat.com/browse/COCKPIT-954 and #19441.

 - [x] Builds on top of PR #19413
 - [x] Preferably fix PR #19414
 - [x] Builds on top of PR #19859
 - [x] Builds on top of PR #20967