### PR TITLE
pybridge: Avoid BrokenPipeError crash of SubprocessTransport.write()

### DIFF
--- a/src/cockpit/peer.py
+++ b/src/cockpit/peer.py
@@ -99,9 +99,11 @@ class Peer(CockpitProtocol, SubprocessProtocol, Endpoint):
             #   - other transport exception
             init_message = await self.init_future
 
-        except PeerExited:
-            # This is a fairly generic error.  If the connection process is
-            # still running, perhaps we'd get a better error message from it.
+        except (PeerExited, BrokenPipeError):
+            # These are fairly generic errors. PeerExited means that we observed the process exiting.
+            # BrokenPipeError means that we got EPIPE when attempting to write() to it. In both cases,
+            # the process is gone, but it's not clear why. If the connection process is still running,
+            # perhaps we'd get a better error message from it.
             await connect_task
             # Otherwise, re-raise
             raise

--- a/test/verify/check-client
+++ b/test/verify/check-client
@@ -20,7 +20,7 @@
 import testlib
 
 
-@testlib.skipImage("needs pybridge", "debian-stable", "ubuntu-2204", "rhel-8*", "centos-8*")
+@testlib.skipImage("needs pybridge", "rhel-8*", "centos-8*")
 # enable this once our cockpit/ws container can beiboot
 @testlib.skipOstree("client setup does not work with ws container")
 class TestClient(testlib.MachineCase):


### PR DESCRIPTION
A SubprocessTransport may die soon after starting without draining its
stdin. This can e.g. happen with "connection refused" and similar
networking errors when running `ssh`.

Trying to write to the process is then likely to trigger a
`BrokenPipeError`. This messes up proper error handling, as the error
usually gets read from the process'es err and exit code.

At this point "exited" signal didn't arrive yet, so ignore the
BrokenPipeError abort in the Peer, and defer error reporting to the
process exit handler.



---

Beiboot is broken [in an interesting way on ubuntu-2204](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19401-20230928-054506-d7f3fa3e-ubuntu-2204-other/log.html#161). It also happens on [fedora-39](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19401-20230928-085641-f3ee0e70-fedora-39-other/log.html#160) and [rhel-9-4](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19401-20230928-085641-f3ee0e70-rhel-9-4-other/log.html#161-2), but much less often -- the automatic retries usually "take care" of it. On ubuntu-2204 this reproduces almost perfectly locally (for some weird reason of timing/py version/etc.), it actually works only very rarely. That makes it ideal to investigate it on, and test fixes on.

What happens: beiboot.py's `SshPeer.do_connect_transport` starts the `ssh` transport and immediately starts sending data to it (the stage 1 boot loader). That data does not currently get queued. This always has to wait for ssh doing its (possibly interactive) authentication, but the thing is, we can't really predict -- it may be noninteractive SSH key authentication with none of `AuthorizeResponder`'s handlers ever getting invoked. I.e. it's not clear what to wait on actually.

So in some cases it overflows the kernel fd buffer and thus triggers the `BrokenPipeError`.  