### PR TITLE
apps: Fix crash with nonexisting /etc/os-release

### DIFF
--- a/pkg/apps/application-list.jsx
+++ b/pkg/apps/application-list.jsx
@@ -100,7 +100,7 @@ export const ApplicationList = ({ metainfo_db, appProgress, appProgressTitle, ac
 
     function get_config(name, os_release, def) {
         // ID is a single value, ID_LIKE is a list
-        const os_list = [os_release.ID || "", ...(os_release.ID_LIKE || "").split(/\s+/)];
+        const os_list = [os_release?.ID || "", ...(os_release?.ID_LIKE || "").split(/\s+/)];
 
         if (cockpit.manifests.apps && cockpit.manifests.apps.config) {
             const val = cockpit.manifests.apps.config[name];

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -174,11 +174,11 @@ class TestApps(packagelib.PackageCase):
         b.wait_not_present("#refresh-progress")
         b.wait_visible(".pf-v5-c-empty-state")
 
-        # known OS: appstream-data-tst gets installed from the map
+        # known OS: appstream-data-test gets installed from the map
         m.write("/etc/os-release", 'ID="derivative"\nID_LIKE="spicy testy"\nVERSION_ID="1"\n')
         b.click("#refresh")
-        with b.wait_timeout(30):
-            b.wait_visible(".app-list #app-1")
+        m.execute("until test -e /usr/share/app-info/xmls/test.xml; do sleep 1; done")
+        b.wait_visible(".app-list #app-1")
 
     def testL10N(self):
         b = self.browser

--- a/test/verify/check-apps
+++ b/test/verify/check-apps
@@ -166,6 +166,13 @@ class TestApps(packagelib.PackageCase):
         self.restore_file("/etc/os-release")
         m.execute("rm /etc/os-release")
 
+        # get along with absent os-release
+        b.click("#refresh")
+        # the progress bar is too fast to reliably catch it
+        time.sleep(1)
+        b.wait_not_present("#refresh-progress")
+        b.wait_visible(".pf-v5-c-empty-state")
+
         # unknown OS: nothing gets installed
         m.write("/etc/os-release", 'ID="unmapped"\nID_LIKE="mysterious"\nVERSION_ID="1"\n')
         b.click("#refresh")


### PR DESCRIPTION
Broken out from PR #19281, as this is an embarassing crash/regression.