### PR TITLE
test: Fix firewall-cmd output parsing for firewalld 2.0.1

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -36,7 +36,7 @@ def wait_unit_state(machine, unit, state):
 
 
 def get_active_rules(machine):
-    active_zones = machine.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split()
+    active_zones = machine.execute("firewall-cmd --get-active-zones | grep -o '^[[:alnum:]]*'").split()
     active_rules = []
     for zone in active_zones:
         active_rules += machine.execute(f"firewall-cmd --zone '{zone}' --list-services").split()


### PR DESCRIPTION
The output format of `--get-active-zones` zone names changed from `public` to `public (default)`. Adjust the name parsing to only consider the first word.

---

This fixes the [TestFirewall.testFirewallPage failure](https://artifacts.dev.testing-farm.io/c6d2ace9-688b-4f16-ad4b-e510162b3452/) that we started to see on Rawhide, and will soon see on the other releases.