### PR TITLE
kdump: always set kdump.conf defaults

### DIFF
--- a/pkg/kdump/config-client.js
+++ b/pkg/kdump/config-client.js
@@ -24,6 +24,8 @@ const knownKeys = [
     "raw", "nfs", "ssh", "sshkey", "path", "core_collector", "kdump_post", "kdump_pre", "extra_bins", "extra_modules",
     "default", "force_rebuild", "override_resettable", "dracut_args", "fence_kdump_args", "fence_kdump_nodes"
 ];
+// man kdump.conf suggests this as default configuration
+const defaultCoreCollector = "makedumpfile -l --message-level 7 -d 31";
 
 /* Parse an ini-style config file
  * and monitor it for changes
@@ -264,6 +266,11 @@ export class ConfigFile {
                                 .split(" ")
                                 .filter(e => e != "-F")
                                 .join(" ");
+            } else {
+                settings._internal.core_collector = { value: defaultCoreCollector };
+                if (target.type === "ssh") {
+                    settings._internal.core_collector.value += " -F";
+                }
             }
         }
         // compression
@@ -273,7 +280,7 @@ export class ConfigFile {
                 if ("core_collector" in settings._internal)
                     settings._internal.core_collector.value = settings._internal.core_collector.value + " -c";
                 else
-                    settings._internal.core_collector = { value: "makedumpfile -c" };
+                    settings._internal.core_collector = { value: defaultCoreCollector };
             } else {
                 // disable compression
                 if ("core_collector" in this.settings._internal) {

--- a/pkg/kdump/test-config-client.js
+++ b/pkg/kdump/test-config-client.js
@@ -40,6 +40,7 @@ const changedConfig = [
     "",
     "#key value #comment",
     "hooray value",
+    "core_collector makedumpfile -l --message-level 7 -d 31",
     ""
 ].join("\n");
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -195,6 +195,22 @@ class TestKdump(KdumpHelpers):
         self.login_and_go("/kdump")
         b.wait_visible("#app")
 
+        # Check defaults
+        current = m.execute("grep '^core_collector' /etc/kdump.conf").strip()
+        m.execute("sed -i /^core_collector/d /etc/kdump.conf")
+        # Drop the custom path so we can make sure our changes are synced to JavaScript
+        m.execute("sed -i 's#^path /var/crash#path /var/tmp#' /etc/kdump.conf")
+        last_modified = m.execute("stat /etc/kdump.conf")
+        b.wait_text("#kdump-change-target", "locally in /var/tmp")
+        b.click("#kdump-change-target")
+        b.wait_visible("#kdump-settings-dialog")
+        b.set_input_text("#kdump-settings-local-directory", "/var/crash")
+        b.click("button:contains('Save')")
+        b.wait_not_present("#kdump-settings-dialog")
+        new = m.execute("grep '^core_collector' /etc/kdump.conf").strip()
+        self.assertEqual(current, new)
+        self.assertNotEqual(last_modified, m.execute("stat /etc/kdump.conf"))
+
         # Check remote ssh location
         b.click("#kdump-change-target")
         b.wait_visible("#kdump-settings-dialog")


### PR DESCRIPTION
When an administrator clears core_collector setting and we save a new configuration the core_collector value is set to `makedumpfile` without arguments. This is an invalid setting for kdump and not what the kdump.conf man page recommends as default setting.

The downside of hardcoding the default recommendation is that it may change over time, so this change includes a test to validate that when absent we re-set the default value.