### PR TITLE
pkg/lib/get-timesync-backend.py: Add '/lib' to root directories list

### DIFF
--- a/pkg/lib/get-timesync-backend.py
+++ b/pkg/lib/get-timesync-backend.py
@@ -4,7 +4,7 @@ import subprocess
 # get-timesync-backend - determine which NTP backend unit timedatectl
 #                        will likely enable.
 
-roots = ["/etc", "/run", "/usr/local", "/usr/lib"]
+roots = ["/etc", "/run", "/usr/local", "/usr/lib", "/lib"]
 
 
 def gather_files(name, suffix):


### PR DESCRIPTION
Extend list of root directories to parse with new entry: '/lib'. On most systems this is just a symlink to '/usr/bin' and everything works as expected, but it may not be the case for custom distributions, i.e. ones created using Yocto.

Extending the list fixes problems with Time Management tab on such systems.