### PR TITLE
test: Adjust TestFirewall.testNetworkingPage for firewalld 2.0.1

### DIFF
--- a/test/verify/check-networkmanager-firewall
+++ b/test/verify/check-networkmanager-firewall
@@ -69,7 +69,7 @@ class TestFirewall(netlib.NetworkCase):
         m = self.machine
 
         def get_num_zones():
-            return len(m.execute("firewall-cmd --get-active-zones | grep '^[a-zA-Z]'").split())
+            return int(m.execute("firewall-cmd --get-active-zones | grep --count '^[a-zA-Z]'").strip())
 
         active_zones = get_num_zones()
 


### PR DESCRIPTION
Commit 90abd41cd3 only fixed testFirewallPage(). But the counting fix also needs to be applied to testNetworkingPage().

----

This will fix the image refreshes of arch, fedora-39, and 1/3 of debian-testing.