### PR TITLE
test: Fix pytest race in test_spawn_broken_pipe()

### DIFF
--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -189,8 +189,10 @@ async def test_spawn_broken_pipe(bridge):
         async def do_connect_transport(self) -> None:
             transport = await self.spawn(['sh', '-c', 'exit 9'], ())
             assert isinstance(transport, SubprocessTransport)
-            time.sleep(0.1)  # sync! increase chance for process to end already
-            transport.write(b'abcdefg\n')
+            # The process will exit soon — try writing to it until a write fails.
+            while not transport.is_closing():
+                transport.write(b'x')
+                time.sleep(0.1)
             while transport.get_returncode() is None:
                 await asyncio.sleep(0.1)
             if self.specific_error:


### PR DESCRIPTION
The static `time.sleep(0.1)` was racy: On slow architectures like Debian mips [1] it repeatedly fails, and it even sometimes fails on GitHub actions.

Keep writing until the transport closes, so that we are guaranteed to eventually run into a BrokenPipeError.

Fixes #19469

[1] https://buildd.debian.org/status/logs.php?pkg=cockpit&ver=302-1&arch=mips64el

------

Failures on GitHub: [example 1](https://github.com/cockpit-project/cockpit/actions/runs/6495367925/job/17640184094?pr=19281), [example 2](https://github.com/cockpit-project/cockpit/actions/runs/6479245087/job/17592403347?pr=19459#step:5:223)