### PR TITLE
RHEL/Fedora now defaults to setting crashkernel

### DIFF
--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -25,7 +25,6 @@ class KdumpHelpers(testlib.MachineCase):
     def setUp(self):
         super().setUp()
         self.allow_restart_journal_messages()
-        self.machine.execute("mkdir -p /var/crash")
 
     def enableKdump(self):
         # all current Fedora/CentOS/RHEL images use BootLoaderSpec
@@ -424,8 +423,10 @@ class TestKdumpNFS(KdumpHelpers):
         self.machines["nfs"].write("/etc/exports", "/srv/kdump 10.111.113.0/24(rw,no_root_squash)\n")
         self.machines["nfs"].execute("mkdir -p /srv/kdump/var/crash; firewall-cmd --add-service nfs; systemctl restart nfs-server")
 
-        # ensure there is no local /var/crash, should not break kdump
-        m.execute("rmdir /var/crash")
+        # there shouldn't be any crash reports in the target directory
+        self.assertEqual(m.execute("find /var/crash -maxdepth 1 -mindepth 1 -type d"), "")
+
+        # set up client machine
         self.login_and_go("/kdump")
         self.enableKdump()
 

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -22,15 +22,20 @@ from lib.constants import TEST_OS_DEFAULT
 
 
 class KdumpHelpers(testlib.MachineCase):
+    def setUp(self):
+        super().setUp()
+        self.allow_restart_journal_messages()
+        self.machine.execute("mkdir -p /var/crash")
+
     def enableKdump(self):
         # all current Fedora/CentOS/RHEL images use BootLoaderSpec
-        self.machine.execute("grubby --args=crashkernel=256M --update-kernel=ALL")
-        self.machine.execute("mkdir -p /var/crash")
-        self.machine.reboot()
-        self.allow_restart_journal_messages()
-        self.machine.start_cockpit()
-        self.browser.switch_to_top()
-        self.browser.relogin("/kdump")
+        if self.machine.image == "fedora-38":
+            self.machine.execute("grubby --args=crashkernel=192M --update-kernel=ALL")
+            self.machine.reboot()
+
+            self.machine.start_cockpit()
+            self.browser.switch_to_top()
+            self.browser.relogin("/kdump")
 
     def crashKernel(self, message, cancel=False):
         b = self.browser
@@ -68,7 +73,10 @@ class TestKdump(KdumpHelpers):
         m = self.machine
 
         b.wait_timeout(120)
-        m.execute("systemctl enable kdump; systemctl start kdump || true")
+        if m.image.startswith("fedora"):
+            m.execute("systemctl enable --now kdump")
+        else:
+            m.execute("until systemctl is-active kdump; do sleep 1; done")
 
         self.login_and_go("/kdump")
 
@@ -147,8 +155,8 @@ class TestKdump(KdumpHelpers):
         b.wait_not_present(pathInput)
         self.crashKernel("copied through SSH to root@localhost:/var/crash as vmcore", cancel=True)
 
-        # we should have the amount of memory reserved that we indicated
-        b.wait_in_text("#app", "256 MiB")
+        # we should have the amount of memory reserved that crashkernel=auto defaults to for our VM RAM size
+        b.wait_in_text("#app", "192 MiB")
         # service should start up properly and the button should be on
         b.wait_in_text("#app", "Service is running")
         assertActive(active=True)
@@ -416,8 +424,6 @@ class TestKdumpNFS(KdumpHelpers):
         self.machines["nfs"].write("/etc/exports", "/srv/kdump 10.111.113.0/24(rw,no_root_squash)\n")
         self.machines["nfs"].execute("mkdir -p /srv/kdump/var/crash; firewall-cmd --add-service nfs; systemctl restart nfs-server")
 
-        # set up client machine
-        m.execute("systemctl disable kdump")
         # ensure there is no local /var/crash, should not break kdump
         m.execute("rmdir /var/crash")
         self.login_and_go("/kdump")
@@ -435,10 +441,11 @@ class TestKdumpNFS(KdumpHelpers):
             b.wait_not_present("#kdump-settings-dialog")
 
         # enable service, regenerates initrd and tests NFS settings
-        b.wait_visible(".pf-v5-c-switch__input:not(:checked)")
-        b.click(".pf-v5-c-switch__input")
-        with b.wait_timeout(300):
-            b.wait_visible(".pf-v5-c-switch__input:checked")
+        if m.image.startswith("fedora"):
+            b.wait_visible(".pf-v5-c-switch__input:not(:checked)")
+            b.click(".pf-v5-c-switch__input")
+            with b.wait_timeout(300):
+                b.wait_visible(".pf-v5-c-switch__input:checked")
         b.wait_in_text("#app", "Service is running")
 
         # explicit nfs option, unset path

--- a/test/verify/check-kdump
+++ b/test/verify/check-kdump
@@ -85,7 +85,7 @@ class TestKdump(KdumpHelpers):
         def assertActive(active):
             b.wait_visible(".pf-v5-c-switch__input" + (active and ":checked" or ":not(:checked)"))
 
-        if m.image in ["fedora-38", "fedora-testing"]:
+        if m.image in ["fedora-38"]:
             # crashkernel command line not set
             b.wait_visible(".pf-v5-c-switch__input:disabled")
             # right now we have no memory reserved


### PR DESCRIPTION
This does not save us a lot of time, as even on RHEL we need to re-generate the initrd however we do skip one reboot which can be flaky.

But what is a nice side effect is that we now test the Distro default crashkernel setting.