### PR TITLE
shell: Fix crash on uninitialized superuser proxy Bridges

### DIFF
--- a/pkg/shell/superuser.jsx
+++ b/pkg/shell/superuser.jsx
@@ -303,7 +303,7 @@ const SuperuserDialogs = ({ superuser_proxy, host, create_trigger }) => {
         return;
 
     const show = (superuser_proxy.Current != "root" && superuser_proxy.Current != "init" &&
-                  superuser_proxy.Bridges.length > 0);
+                  (superuser_proxy.Bridges?.length ?? 0) > 0);
     const unlocked = superuser_proxy.Current != "none";
 
     function unlock() {


### PR DESCRIPTION
During superuser initialization it can happen that `superuser_proxy.Bridges` does not exist yet. This made the shell crash with

    TypeError: Cannot read properties of undefined (reading 'length')

---

Spotted in https://github.com/cockpit-project/cockpit-ostree/pull/437 , see that for details. There may be an underlying bug/race condition in the bridge here, but it doesn't hurt to make the shell code robust against that. I tested cockpit-ostree against that fix 10 times (it previously crashed after two or three), and it seems stable now.