### PR TITLE
doc: don't escape " when not required

### DIFF
--- a/doc/guide/Makefile-guide.am
+++ b/doc/guide/Makefile-guide.am
@@ -97,7 +97,7 @@ clean-guide:
 
 CHECK_LOCAL_TARGETS += check-guide
 check-guide:
-	if grep -n -r 'name=\"id' doc/guide/html >&2; then \
+	if grep -n -r 'name="id' doc/guide/html >&2; then \
 		echo "Unexpected generated id in the documentation" >&2; \
 		exit 1; \
 	fi


### PR DESCRIPTION
This silences a grep warning about a stray \ before ".

Silences:

```
[jelle@t14s][~/projects/cockpit/main]%make check-guide
if grep -n -r 'name=\"id' doc/guide/html >&2; then \
        echo "Unexpected generated id in the documentation" >&2; \
        exit 1; \
fi
grep: warning: stray \ before "
```