### PR TITLE
test: Replace .format() with f-strings

### DIFF
--- a/test/common/netlib.py
+++ b/test/common/netlib.py
@@ -40,13 +40,13 @@ class NetworkHelpers:
             udevadm trigger --subsystem-match=net
             udevadm settle
             """ % {"name": name})
-        self.addCleanup(self.machine.execute, "rm /run/udev/rules.d/99-nm-veth-{0}-test.rules; ip link del dev {0}".format(name))
+        self.addCleanup(self.machine.execute, f"rm /run/udev/rules.d/99-nm-veth-{name}-test.rules; ip link del dev {name}")
         if dhcp_cidr:
             # up the remote end, give it an IP, and start DHCP server
             self.machine.execute(f"ip a add {dhcp_cidr} dev v_{name}; ip link set v_{name} up")
             server = self.machine.spawn("dnsmasq --keep-in-foreground --log-queries --log-facility=- "
-                                        "--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{0} --no-resolv "
-                                        "--bind-interfaces --except-interface=lo --interface=v_{0} --dhcp-range={1},{2},4h".format(name, dhcp_range[0], dhcp_range[1]),
+                                        f"--conf-file=/dev/null --dhcp-leasefile=/tmp/leases.{name} --no-resolv "
+                                        f"--bind-interfaces --except-interface=lo --interface=v_{name} --dhcp-range={dhcp_range[0]},{dhcp_range[1]},4h",
                                         f"dhcp-{name}.log")
             self.addCleanup(self.machine.execute, "kill %i" % server)
             self.machine.execute("if firewall-cmd --state >/dev/null 2>&1; then firewall-cmd --add-service=dhcp; fi")

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -158,8 +158,7 @@ Server = file://{empty_repo_dir}
             arch = self.primary_arch
         deb = f"{self.repo_dir}/{name}_{version}_{arch}.deb"
         if postinst:
-            postinstcode = "printf '#!/bin/sh\n{0}' > /tmp/b/DEBIAN/postinst; chmod 755 /tmp/b/DEBIAN/postinst".format(
-                postinst)
+            postinstcode = f"printf '#!/bin/sh\n{postinst}' > /tmp/b/DEBIAN/postinst; chmod 755 /tmp/b/DEBIAN/postinst"
         else:
             postinstcode = ''
         if content is not None:
@@ -358,17 +357,14 @@ post_upgrade() {{
         for ((pkg, ver, rel), info) in self.updateInfo.items():
             refs = ""
             for b in info.get("bugs", []):
-                refs += '      <reference href="https://bugs.example.com?bug={0}" id="{0}" title="Bug#{0} Description" type="bugzilla"/>\n'.format(
-                    b)
+                refs += f'      <reference href="https://bugs.example.com?bug={b}" id="{b}" title="Bug#{b} Description" type="bugzilla"/>\n'
             for c in info.get("cves", []):
-                refs += '      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={0}" id="{0}" title="{0}" type="cve"/>\n'.format(
-                    c)
+                refs += f'      <reference href="https://cve.mitre.org/cgi-bin/cvename.cgi?name={c}" id="{c}" title="{c}" type="cve"/>\n'
             if info.get("securitySeverity"):
                 refs += '      <reference href="https://access.redhat.com/security/updates/classification/#{0}" id="" title="" type="other"/>\n'.format(info[
                                                                                                                                                         "securitySeverity"])
             for e in info.get("errata", []):
-                refs += '      <reference href="https://access.redhat.com/errata/{0}" id="{0}" title="{0}" type="self"/>\n'.format(
-                    e)
+                refs += f'      <reference href="https://access.redhat.com/errata/{e}" id="{e}" title="{e}" type="self"/>\n'
 
             xml += """  <update from="test@example.com" status="stable" type="{severity}" version="2.0">
     <id>UPDATE-{pkg}-{ver}-{rel}</id>
@@ -398,12 +394,12 @@ post_upgrade() {{
     def enableRepo(self):
         if self.backend == "apt":
             self.createAptChangelogs()
-            self.machine.execute("""echo 'deb [trusted=yes] file://{0} /' > /etc/apt/sources.list.d/test.list
-                                    cd {0}; apt-ftparchive packages . > Packages
+            self.machine.execute(f"""echo 'deb [trusted=yes] file://{self.repo_dir} /' > /etc/apt/sources.list.d/test.list
+                                    cd {self.repo_dir}; apt-ftparchive packages . > Packages
                                     xz -c Packages > Packages.xz
                                     O=$(apt-ftparchive -o APT::FTPArchive::Release::Origin=cockpittest release .); echo "$O" > Release
                                     echo 'Changelogs: http://localhost:12345/changelogs/@CHANGEPATH@' >> Release
-                                    """.format(self.repo_dir))
+                                    """)
             pid = self.machine.spawn(f"cd {self.repo_dir}; exec python3 -m http.server 12345", "changelog")
             # pid will not be present for rebooting tests
             self.addCleanup(self.machine.execute, "kill %i || true" % pid)

--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -89,7 +89,7 @@ class StorageHelpers:
         # them.
         self.machine.execute("partprobe '%s'" % dev)
         # right after unmounting the device is often still busy, so retry a few times
-        self.addCleanup(self.machine.execute, "umount {0} || true; rm $(losetup -n -O BACK-FILE -l {0}); until losetup -d {0}; do sleep 1; done".format(dev), timeout=10)
+        self.addCleanup(self.machine.execute, f"umount {dev} || true; rm $(losetup -n -O BACK-FILE -l {dev}); until losetup -d {dev}; do sleep 1; done", timeout=10)
         return dev
 
     def force_remove_disk(self, device):

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1082,13 +1082,13 @@ ExecStart=/usr/local/bin/{packageName}
 
         m.execute("systemctl stop packagekit")
         system_service = m.execute("systemctl show -p FragmentPath packagekit.service | cut -f2 -d=").strip()
-        m.execute("""mv {0} {0}.disabled
+        m.execute(f"""mv {system_service} {system_service}.disabled
                      mv /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service.disabled
-                     systemctl daemon-reload""".format(system_service))
+                     systemctl daemon-reload""")
         self.addCleanup(m.execute,
-                        """mv {0}.disabled {0}
+                        f"""mv {system_service}.disabled {system_service}
                            mv /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service.disabled /usr/share/dbus-1/system-services/org.freedesktop.PackageKit.service
-                           systemctl daemon-reload""".format(system_service))
+                           systemctl daemon-reload""")
 
         m.start_cockpit()
         if not self.is_pybridge():


### PR DESCRIPTION
ruff 0.1 rightfully starts to complain about these. Done with `ruff check --fix`.

---

This "spontaneously" broke main, the tox test now [fails on this](https://github.com/martinpitt/cockpit/actions/runs/6543807297/job/17769038320?pr=19#step:5:18).