### PR TITLE
lib: Fix DynamicListForm's 'Maximum update depth exceeded' flake

### DIFF
--- a/pkg/lib/DynamicListForm.jsx
+++ b/pkg/lib/DynamicListForm.jsx
@@ -41,12 +41,12 @@ export class DynamicListForm extends React.Component {
     }
 
     removeItem(idx) {
-        this.setState(state => {
-            const validationFailedDelta = this.props.validationFailed ? [...this.props.validationFailed] : [];
-            // We also need to remove any error messages which the item (row) may have contained
-            validationFailedDelta.splice(idx, 1);
-            this.props.onValidationChange?.(validationFailedDelta);
+        const validationFailedDelta = this.props.validationFailed ? [...this.props.validationFailed] : [];
+        // We also need to remove any error messages which the item (row) may have contained
+        validationFailedDelta.splice(idx, 1);
+        this.props.onValidationChange?.(validationFailedDelta);
 
+        this.setState(state => {
             const items = state.list.concat();
             items.splice(idx, 1);
 


### PR DESCRIPTION
Fixes a flake, which is present at https://github.com/cockpit-project/cockpit-podman/pull/1354 . It happens in about 10-20% of test runs:

```
Traceback (most recent call last):
  File "/work/bots/make-checkout-workdir/test/check-application", line 1645, in testRunImageSystem
    self._testRunImage(True)
  File "/work/bots/make-checkout-workdir/test/check-application", line 1797, in _testRunImage
    b.click('#run-image-dialog-volume-1-btn-close')
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 385, in click
    self.mouse(selector + ":not([disabled]):not([aria-disabled=true])", "click", 0, 0, 0)
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 378, in mouse
    self.call_js_func('ph_mouse', selector, event, x, y, btn, ctrlKey, shiftKey, altKey, metaKey)
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 331, in call_js_func
    return self.eval_js("%s(%s)" % (func, ','.join(map(jsquote, args))))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bots/make-checkout-workdir/test/common/testlib.py", line 309, in eval_js
    result = self.cdp.invoke("Runtime.evaluate", expression=code, trace=code,
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 204, in invoke
    res = self.command(cmd)
          ^^^^^^^^^^^^^^^^^
  File "/work/bots/make-checkout-workdir/test/common/cdp.py", line 231, in command
    raise RuntimeError(res["error"])
RuntimeError: Error: Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185 for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
```

The minified react error is:

`Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`