### PR TITLE
Add some aria-labels

### DIFF
--- a/pkg/lib/cockpit-components-modifications.jsx
+++ b/pkg/lib/cockpit-components-modifications.jsx
@@ -86,7 +86,7 @@ const ModificationsExportDialog = ({ show, onClose, shell, ansible }) => {
                title={_("Automation script") }>
             <Tabs activeKey={active_tab} onSelect={handleSelect}>
                 <Tab eventKey="ansible" title={_("Ansible")}>
-                    <TextArea resizeOrientation='vertical' readOnlyVariant="default" defaultValue={ansible.trim()} />
+                    <TextArea aria-label={_("Ansible")} resizeOrientation='vertical' readOnlyVariant="default" defaultValue={ansible.trim()} />
                     <div className="ansible-docs-link">
                         <OutlinedQuestionCircleIcon />
                         { _("Create new task file with this content.") }
@@ -98,7 +98,7 @@ const ModificationsExportDialog = ({ show, onClose, shell, ansible }) => {
                     </div>
                 </Tab>
                 <Tab eventKey="shell" title={_("Shell script")}>
-                    <TextArea resizeOrientation='vertical' readOnlyVariant="default" defaultValue={shell.trim()} />
+                    <TextArea aria-label={_("Shell script")} resizeOrientation='vertical' readOnlyVariant="default" defaultValue={shell.trim()} />
                 </Tab>
             </Tabs>
         </Modal>

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -557,7 +557,7 @@ export const TextInput = (tag, title, options) => {
         render: (val, change, validated) =>
             <TextInputPF4 data-field={tag} data-field-type="text-input"
                           validated={validated}
-                          aria-label={title}
+                          aria-label={title || tag}
                           value={val}
                           isDisabled={options.disabled}
                           onChange={(_event, value) => change(value)} />

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -893,7 +893,8 @@ const TextInputCheckedComponent = ({ tag, val, title, update_function }) => {
                       id={tag}
                       label={title}
                       onChange={(_event, checked) => update_function(checked ? "" : false)} />
-            {val !== false && <TextInputPF4 id={tag + "-input"} value={val} onChange={(_event, value) => update_function(value)} />}
+            {val !== false && <TextInputPF4 id={tag + "-input"} value={val} onChange={(_event, value) => update_function(value)}
+                                            aria-label={title} />}
         </div>
     );
 };
@@ -977,7 +978,7 @@ class SizeSliderElement extends React.Component {
                     <Slider showBoundaries={false} value={(slider_val / max) * 100} onChange={change_slider} />
                 </GridItem>
                 <GridItem span={6} sm={2}>
-                    <TextInputPF4 className="size-text" value={text_val} onChange={(_event, value) => change_text(value)} />
+                    <TextInputPF4 className="size-text" aria-label={tag} value={text_val} onChange={(_event, value) => change_text(value)} />
                 </GridItem>
                 <GridItem span={6} sm={2}>
                     <FormSelect className="size-unit" value={unit} aria-label={tag} onChange={change_unit}>

--- a/pkg/systemd/hwinfo.jsx
+++ b/pkg/systemd/hwinfo.jsx
@@ -213,6 +213,7 @@ const CPUSecurityMitigationsDialog = () => {
                     <DataListAction>
                         <div id="nosmt-switch">
                             <Switch isDisabled={rebooting}
+                                    aria-label={_("Enable or disable nosmt")}
                                     onChange={(_event, value) => setNoSMT(value)}
                                     isChecked={nosmt} />
                         </div>


### PR DESCRIPTION
Taken from @jelly 's PR #19053 after rebasing, and vetting whether an aria-label actually makes sense. E.g. [this commit](https://github.com/cockpit-project/cockpit/pull/19053/commits/b903372b567bb3930bb04342395e8c0ee855df26) seems redundant to me, as it already has an `aria-labelledby`, and I'm not sure about [this one](https://github.com/cockpit-project/cockpit/pull/19053/commits/e11a00a21456b42df6f036fab02dbb05da264476). But these four seem good fixes.