### PR TITLE
shell: Drop leftover property

### DIFF
--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -821,7 +821,7 @@ class ChangeAuth extends React.Component {
                                 type="password" value={this.state.login_setup_new_key_password} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} />
                         <FormHelper helperTextInvalid={this.state.login_setup_new_key_password_error} />
                     </FormGroup>
-                    <FormGroup label={_("Confirm new key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password2_error}>
+                    <FormGroup label={_("Confirm new key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"}>
                         <TextInput id="login-setup-new-key-password2" onChange={(_event, value) => this.setState({ login_setup_new_key_password2: value })}
                                 type="password" value={this.state.login_setup_new_key_password2} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} />
 

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1705,7 +1705,6 @@ class MachineCase(unittest.TestCase):
         # HACK: Fix these ASAP, these are major bugs
         "Warning: validateDOMNesting.*cannot appear as a",
         "Warning: React does not recognize the.*prop on a DOM element",
-        "Warning: .*prop on .* should not be null",
         # HACK: These should be fixed, but debugging these is not trivial, and the impact is very low
         "Warning: .* setState.*on an unmounted component",
         "Warning: Can't perform a React state update on an unmounted component",

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1704,7 +1704,6 @@ class MachineCase(unittest.TestCase):
     default_allowed_console_errors = [
         # HACK: Fix these ASAP, these are major bugs
         "Warning: validateDOMNesting.*cannot appear as a",
-        "Warning: React does not recognize the.*prop on a DOM element",
         # HACK: These should be fixed, but debugging these is not trivial, and the impact is very low
         "Warning: .* setState.*on an unmounted component",
         "Warning: Can't perform a React state update on an unmounted component",


### PR DESCRIPTION
Commit 5648586f0a4 ported the hosts dialog to `<FormHelper>`, but forgot
to drop one `helperTextInvalid` from a form group. This caused a "React
does not recognize the helperTextInvalid prop" console error.

 - [ ] Builds on top of #19507 