### PR TITLE
Fix DOM nesting on the Storage page dialogs, enable DOM nesting errors

### DIFF
--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -622,15 +622,13 @@ export const TangKeyVerification = ({ url, adv }) => {
             <Text component={TextVariants.p}>{_("Check the key hash with the Tang server.")}</Text>
 
             <Text component={TextVariants.h3}>{_("How to check")}</Text>
-            <Text component={TextVariants.p}>
-                {_("In a terminal, run: ")}
-                <ClipboardCopy hoverTip={_("Copy to clipboard")}
-                               clickTip={_("Successfully copied to clipboard!")}
-                               variant="inline-compact"
-                               isCode>
-                    {cmd}
-                </ClipboardCopy>
-            </Text>
+            <span>{_("In a terminal, run: ")}</span>
+            <ClipboardCopy hoverTip={_("Copy to clipboard")}
+                            clickTip={_("Successfully copied to clipboard!")}
+                            variant="inline-compact"
+                            isCode>
+                {cmd}
+            </ClipboardCopy>
             <Text component={TextVariants.p}>
                 {_("Check that the SHA-256 or SHA-1 hash from the command matches this dialog.")}
             </Text>

--- a/pkg/storaged/crypto-keyslots.jsx
+++ b/pkg/storaged/crypto-keyslots.jsx
@@ -23,7 +23,7 @@ import React from "react";
 import { Card, CardBody, CardHeader, CardTitle } from '@patternfly/react-core/dist/esm/components/Card/index.js';
 import { Checkbox } from "@patternfly/react-core/dist/esm/components/Checkbox/index.js";
 import { ClipboardCopy } from "@patternfly/react-core/dist/esm/components/ClipboardCopy/index.js";
-import { Form, FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
+import { FormGroup } from "@patternfly/react-core/dist/esm/components/Form/index.js";
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from "@patternfly/react-core/dist/esm/components/DataList/index.js";
 import { Text, TextContent, TextList, TextListItem, TextVariants } from "@patternfly/react-core/dist/esm/components/Text/index.js";
 import { TextInput as TextInputPF } from "@patternfly/react-core/dist/esm/components/TextInput/index.js";
@@ -692,21 +692,19 @@ const RemovePassphraseField = (tag, key, dev) => {
             return (
                 <Stack hasGutter>
                     <p>{ fmt_to_fragments(_("Passphrase removal may prevent unlocking $0."), <b>{dev}</b>) }</p>
-                    <Form>
-                        <Checkbox id="force-remove-passphrase"
-                                  isChecked={val !== false}
-                                  label={_("Confirm removal with an alternate passphrase")}
-                                  onChange={(_event, checked) => change(checked ? "" : false)}
-                                  body={val === false
-                                      ? <p className="slot-warning">
-                                          {_("Removing a passphrase without confirmation of another passphrase may prevent unlocking or key management, if other passphrases are forgotten or lost.")}
-                                      </p>
-                                      : <FormGroup label={_("Passphrase from any other key slot")} fieldId="remove-passphrase">
-                                          <TextInputPF id="remove-passphrase" type="password" value={val} onChange={(_event, value) => change(value)} />
-                                      </FormGroup>
-                                  }
-                        />
-                    </Form>
+                    <Checkbox id="force-remove-passphrase"
+                                isChecked={val !== false}
+                                label={_("Confirm removal with an alternate passphrase")}
+                                onChange={(_event, checked) => change(checked ? "" : false)}
+                                body={val === false
+                                    ? <p className="slot-warning">
+                                        {_("Removing a passphrase without confirmation of another passphrase may prevent unlocking or key management, if other passphrases are forgotten or lost.")}
+                                    </p>
+                                    : <FormGroup label={_("Passphrase from any other key slot")} fieldId="remove-passphrase">
+                                        <TextInputPF id="remove-passphrase" type="password" value={val} onChange={(_event, value) => change(value)} />
+                                    </FormGroup>
+                                }
+                    />
                 </Stack>
             );
         }

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1257,7 +1257,8 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
     return (
         <div className="modal-footer-teardown">
             { process_rows.length > 0
-                ? <p>{fmt_to_fragments(_("The mount point $0 is in use by these processes:"), <b>{mount_point}</b>)}
+                ? <>
+                    <p>{fmt_to_fragments(_("The mount point $0 is in use by these processes:"), <b>{mount_point}</b>)}</p>
                     <ListingTable variant='compact'
                                   columns={
                                       [
@@ -1268,7 +1269,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                                       ]
                                   }
                                       rows={process_rows} />
-                </p>
+                </>
                 : null
             }
             { process_rows.length > 0 && service_rows.length > 0
@@ -1276,7 +1277,8 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                 : null
             }
             { service_rows.length > 0
-                ? <p>{fmt_to_fragments(_("The mount point $0 is in use by these services:"), <b>{mount_point}</b>)}
+                ? <>
+                    <p>{fmt_to_fragments(_("The mount point $0 is in use by these services:"), <b>{mount_point}</b>)}</p>
                     <ListingTable variant='compact'
                                   columns={
                                       [
@@ -1287,7 +1289,7 @@ export const StopProcessesMessage = ({ mount_point, users }) => {
                                       ]
                                   }
                                   rows={service_rows} />
-                </p>
+                </>
                 : null
             }
         </div>);

--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -1107,13 +1107,13 @@ const UsersPopover = ({ users }) => {
             bodyContent={
                 <>
                     { services.length > 0
-                        ? <p>
-                            <b>{_("Services using the location")}</b>
+                        ? <>
+                            <p><b>{_("Services using the location")}</b></p>
                             <List>
                                 { services.slice(0, max).map((u, i) => <ListItem key={i}>{u.unit.replace(/\.service$/, "")}</ListItem>) }
                                 { services.length > max ? <ListItem key={max}>...</ListItem> : null }
                             </List>
-                        </p>
+                        </>
                         : null
                     }
                     { services.length > 0 && processes.length > 0
@@ -1121,13 +1121,13 @@ const UsersPopover = ({ users }) => {
                         : null
                     }
                     { processes.length > 0
-                        ? <p>
-                            <b>{_("Processes using the location")}</b>
+                        ? <>
+                            <p><b>{_("Processes using the location")}</b></p>
                             <List>
                                 { processes.slice(0, max).map((u, i) => <ListItem key={i}>{u.comm} (user: {u.user}, pid: {u.pid})</ListItem>) }
                                 { processes.length > max ? <ListItem key={max}>...</ListItem> : null }
                             </List>
-                        </p>
+                        </>
                         : null
                     }
                 </>}>

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1701,8 +1701,6 @@ class MachineCase(unittest.TestCase):
 
     # List of allowed console.error() messages during tests; these match substrings
     default_allowed_console_errors = [
-        # HACK: Fix these ASAP, these are major bugs
-        "Warning: validateDOMNesting.*cannot appear as a",
         # HACK: These should be fixed, but debugging these is not trivial, and the impact is very low
         "Warning: .* setState.*on an unmounted component",
         "Warning: Can't perform a React state update on an unmounted component",

--- a/test/verify/check-storage-luks
+++ b/test/verify/check-storage-luks
@@ -193,6 +193,9 @@ class TestStorageLuks(storagelib.StorageCase):
         b.logout()
         testlib.wait(lambda: m.execute("(loginctl list-users | grep admin) || true") == "")
 
+        # FIXME: race condition after unmounting; hard to investigate, re-check after storage redesign
+        self.allow_browser_errors("validateDOMNesting.*cannot appear as a child.*<tr> ul")
+
     def testNoFsys(self):
         m = self.machine
         b = self.browser

--- a/test/verify/check-storage-lvm2
+++ b/test/verify/check-storage-lvm2
@@ -251,6 +251,9 @@ class TestStorageLvm2(storagelib.StorageCase):
         b.wait_not_in_text("#devices", "vgroup1")
         self.assertEqual(m.execute(f"grep {mount_point_thin} /etc/fstab || true"), "")
 
+        # FIXME: Grow/Shrink buttons are in a dd > div > dd without dl wrapper
+        self.allow_browser_errors("validateDOMNesting.*cannot appear as a descendant.*<dd> dd")
+
     def testUnpartitionedSpace(self):
         m = self.machine
         b = self.browser
@@ -333,6 +336,9 @@ class TestStorageLvm2(storagelib.StorageCase):
 
         self.content_row_wait_in_col(1, 1, "lvol0")
         b.wait_not_in_text("#storage-detail", "snap0")
+
+        # FIXME: Grow/Shrink buttons are in a dd > div > dd without dl wrapper
+        self.allow_browser_errors("validateDOMNesting.*cannot appear as a descendant.*<dd> dd")
 
 
 if __name__ == '__main__':

--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -68,7 +68,7 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_in_text(".pf-v5-c-popover", str(sleep_pid))
         b.wait_in_text(".pf-v5-c-popover", "keep-mnt-busy")
         b.assert_pixels(".pf-v5-c-popover", "popover",
-                        mock={".pf-v5-c-popover__body p:nth-of-type(2) li": "process (user: root, pid: 1234)"},
+                        mock={".pf-v5-c-popover__body ul:nth-of-type(2) li": "process (user: root, pid: 1234)"},
                         scroll_into_view="#dialog button:contains(Currently in use)")
         b.click(".pf-v5-c-popover button")
         b.assert_pixels('#dialog', "format", wait_after_layout_change=True)


### PR DESCRIPTION
We have the following cases  in main:

[storage](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19509-20231023-195002-28ebf951-fedora-38-devel-storage/log.html#18):
 - [ ] TestStorageLuks.testLuks: race condition, hard to investigate; not in dialog, wait for storage rewrite, ignore
 - [ ] TestStorageLvm2.test{Lvm,Snapshots}: Grow button is in "dd > div > dd" without a new list wrapper; affected by page reorg, postpone and ignore for now
 - [x] TestStorageMounting.testMounting, TestStorageNfs.testNfsBusy: in "used by pid/service" dialog, let's fix
 - [x] TestStorageLuksDestructive.testLuks1Slots: in dialog, let's fix
 - [x] TestStorageNBDE.test{Basic,RootReboot}: In dialog, let's fix
 - [x] [TestStorage.testUsed](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19509-20231024-102432-6e7b9faf-fedora-38-devel-storage/log.html#59) - in dialog, let's fix

expensive/networking already got fixed in #19520:
 - [x] expensive: [kdump error dialog](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19509-20231019-151349-2a0e10f1-fedora-38-devel-expensive/log.html)
 - [x] networking: [firewall table](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19509-20231019-151351-2a0e10f1-fedora-38-devel-networking/log.html#17)

/other is okay.

Builds on top of:
 - [x] PR #19511 (conflicty otherwise)
 - [x] PR #19520 (broken out, intrusive)