### PR TITLE
More console.error() cleanup

### DIFF
--- a/pkg/lib/serverTime.js
+++ b/pkg/lib/serverTime.js
@@ -193,7 +193,7 @@ export function ServerTime() {
                             .catch(e => {
                                 ntp_waiting_resolve();
                                 ntp_waiting_resolve = null;
-                                console.error(e.message);
+                                console.error("Failed to call SetNTP:", e.message); // not-covered: OS error
                             });
                 });
         return promise;

--- a/pkg/networkmanager/dialogs-common.jsx
+++ b/pkg/networkmanager/dialogs-common.jsx
@@ -248,9 +248,9 @@ export const NetworkAction = ({ buttonText, iface, connectionSettings, type }) =
             dlg = <IpSettingsDialog topic="ipv6" {...properties} />;
 
         if (dlg)
-            resolveDeps(type).then(() => {
-                Dialogs.show(dlg);
-            }).catch(console.error); // not-covered: OS error
+            resolveDeps(type)
+                    .then(() => Dialogs.show(dlg))
+                    .catch(err => console.error("NetworkAction Dialog failed:", err)); // not-covered: OS error
     }
 
     return (

--- a/pkg/networkmanager/wireguard.jsx
+++ b/pkg/networkmanager/wireguard.jsx
@@ -117,7 +117,7 @@ export function WireGuardDialog({ settings, connection, dev }) {
                 const key = await cockpit.spawn(["wg", "pubkey"], { err: 'message' }).input(privateKey.trim());
                 setPublicKey(key.trim());
             } catch (e) {
-                console.error(e.message);
+                console.error("Failed to call wg pubkey:", e.message);
                 setPublicKey('');
             }
         }

--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -150,7 +150,7 @@ export class KpatchSettings extends React.Component {
                                 })
                             );
                 })
-                .catch(console.error);
+                .catch(err => console.error("Could not determine kpatch packages:", err)); // not-covered: OS error
 
         return Promise.allSettled([kpatch_promise, uname_promise]);
     }

--- a/pkg/shell/hosts_dialog.jsx
+++ b/pkg/shell/hosts_dialog.jsx
@@ -821,7 +821,7 @@ class ChangeAuth extends React.Component {
                                 type="password" value={this.state.login_setup_new_key_password} validated={this.state.login_setup_new_key_password_error ? "error" : "default"} />
                         <FormHelper helperTextInvalid={this.state.login_setup_new_key_password_error} />
                     </FormGroup>
-                    <FormGroup label={_("Confirm new key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} helperTextInvalid={this.state.login_setup_new_key_password2_error}>
+                    <FormGroup label={_("Confirm new key password")} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"}>
                         <TextInput id="login-setup-new-key-password2" onChange={(_event, value) => this.setState({ login_setup_new_key_password2: value })}
                                 type="password" value={this.state.login_setup_new_key_password2} validated={this.state.login_setup_new_key_password2_error ? "error" : "default"} />
 

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -177,7 +177,8 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
     });
 
     task.catch(error => {
-        console.error(JSON.stringify(error)); // easier investigation of failures, errors in pty mode may be hard to see
+        // easier investigation of failures, errors in pty mode may be hard to see
+        console.error("Failed to call sos report:", JSON.stringify(error));
         setError(error.toString() || _("sos report failed"));
         setErrorDetail(output);
     });

--- a/pkg/sosreport/sosreport.jsx
+++ b/pkg/sosreport/sosreport.jsx
@@ -178,7 +178,8 @@ function sosCreate(args, setProgress, setError, setErrorDetail) {
 
     task.catch(error => {
         // easier investigation of failures, errors in pty mode may be hard to see
-        console.error("Failed to call sos report:", JSON.stringify(error));
+        if (error.problem !== 'cancelled')
+            console.error("Failed to call sos report:", JSON.stringify(error));
         setError(error.toString() || _("sos report failed"));
         setErrorDetail(output);
     });

--- a/pkg/users/account-logs-panel.jsx
+++ b/pkg/users/account-logs-panel.jsx
@@ -65,9 +65,7 @@ export function AccountLogs({ name }) {
                     logins = logins.slice(0, 15);
                     setLogins(logins);
                 })
-                .catch((ex) => {
-                    console.error(ex);
-                });
+                .catch(ex => console.error("Failed to call last:", ex)); // not-covered: OS error
     }, [name]);
 
     return (

--- a/pkg/users/users.js
+++ b/pkg/users/users.js
@@ -151,7 +151,7 @@ function get_locked(name, shadow) {
 }
 
 async function getLogins(shadow) {
-    let lastlog = [];
+    let lastlog = "";
     try {
         lastlog = await cockpit.spawn(["lastlog"], { environ: ["LC_ALL=C"] });
     } catch (err) {

--- a/test/common/chromium-cdp-driver.js
+++ b/test/common/chromium-cdp-driver.js
@@ -68,11 +68,24 @@ function clearExceptions() {
     return Promise.resolve();
 }
 
+function stringifyConsoleArg(arg) {
+    if (arg.type === 'string')
+        return arg.value;
+    if (arg.type === 'object') {
+        const obj = {};
+        arg.preview.properties.forEach(prop => {
+            obj[prop.name] = prop.value.toString();
+        });
+        return JSON.stringify(obj);
+    }
+    return JSON.stringify(arg);
+}
+
 function setupLogging(client) {
     client.Runtime.enable();
 
     client.Runtime.consoleAPICalled(info => {
-        const msg = info.args.map(v => (v.value || "").toString()).join(" ");
+        const msg = info.args.map(stringifyConsoleArg).join(" ");
         messages.push([info.type, msg]);
         process.stderr.write("> " + info.type + ": " + msg + "\n");
 

--- a/test/common/firefox-cdp-driver.js
+++ b/test/common/firefox-cdp-driver.js
@@ -89,11 +89,19 @@ function clearExceptions() {
     return Promise.resolve();
 }
 
+function stringifyConsoleArg(arg) {
+    if (arg.type === 'string')
+        return arg.value;
+    if (arg.type === 'object')
+        return JSON.stringify(arg.value);
+    return JSON.stringify(arg);
+}
+
 function setupLogging(client) {
     client.Runtime.enable();
 
     client.Runtime.consoleAPICalled(info => {
-        const msg = info.args.map(v => (v.value || "").toString()).join(" ");
+        const msg = info.args.map(stringifyConsoleArg).join(" ");
         messages.push([info.type, msg]);
         process.stderr.write("> " + info.type + ": " + msg + "\n");
 

--- a/test/common/packagelib.py
+++ b/test/common/packagelib.py
@@ -121,6 +121,9 @@ Server = file://{empty_repo_dir}
 
         self.updateInfo = {}
 
+        # HACK: kpatch check sometimes complains that we don't set up repomd.xml
+        self.allow_browser_errors("Could not determine kpatch packages:.*repodata updates was not complete.*repomd.xml")
+
     #
     # Helper functions for creating packages/repository
     #

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1704,7 +1704,6 @@ class MachineCase(unittest.TestCase):
     default_allowed_console_errors = [
         # HACK: Fix these ASAP, these are major bugs
         "Warning: validateDOMNesting.*cannot appear as a",
-        "Warning: React does not recognize the.*prop on a DOM element",
         # HACK: These should be fixed, but debugging these is not trivial, and the impact is very low
         "Warning: .* setState.*on an unmounted component",
         "Warning: Can't perform a React state update on an unmounted component",

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -174,9 +174,6 @@ only-plugins=release,date,host,cgroups,networking
         m.execute("while pgrep -a -x sos; do sleep 1; done", timeout=10)
         self.assertEqual(m.execute("ls /var/tmp/sosreport* 2>/dev/null || true"), "")
 
-        # HACK: Fix this in the code, this is useless
-        self.allow_browser_errors('error: Failed to call sos report: {"problem":"cancelled","exit_status":null')
-
     def testAppStream(self):
         b = self.browser
         m = self.machine

--- a/test/verify/check-sosreport
+++ b/test/verify/check-sosreport
@@ -121,8 +121,7 @@ exit 1""", perm="755")
         b.wait_not_present("#sos-dialog")
 
         self.allow_journal_messages('.*comm="sosreport".*')
-        # HACK: Fix this in the code, this is useless
-        self.allow_browser_errors('error: {"problem":null,"exit_status":1,"exit_signal":null')
+        self.allow_browser_errors('error: Failed to call sos report: {"problem":null,"exit_status":1,"exit_signal":null')
 
     def testWithUrlRoot(self):
         self.testBasic(urlroot="/webcon")
@@ -176,7 +175,7 @@ only-plugins=release,date,host,cgroups,networking
         self.assertEqual(m.execute("ls /var/tmp/sosreport* 2>/dev/null || true"), "")
 
         # HACK: Fix this in the code, this is useless
-        self.allow_browser_errors('error: {"problem":"cancelled","exit_status":null')
+        self.allow_browser_errors('error: Failed to call sos report: {"problem":"cancelled","exit_status":null')
 
     def testAppStream(self):
         b = self.browser


### PR DESCRIPTION
This gets rid of two more error ignores, and also addresses failures like [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19507-20231019-203931-1115978c-centos-8-stream-pybridge-other/log.html) and [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19507-20231019-203931-1115978c-rhel-8-9-distropkg-expensive/log.html) to not just show an useless empty "> error: ".

