### PR TITLE
Allow building on systems using musl C library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,13 @@ AC_ARG_ENABLE(old_bridge, AS_HELP_STRING([--enable-old-bridge], [Install old C c
 AM_CONDITIONAL(WITH_OLD_BRIDGE, test "$enable_old_bridge" = "yes")
 AC_MSG_RESULT(${enable_old_bridge:=no})
 
+AC_SEARCH_LIBS([argp_parse], [argp])
+case "$ac_cv_search_argp_parse" in
+    no) AC_MSG_FAILURE([failed to find argp_parse]) ;;
+    -l*) argp_LIBS="$ac_cv_search_argp_parse" ;;
+    *) argp_LIBS= ;;
+esac
+AC_SUBST([argp_LIBS])
 
 AC_SEARCH_LIBS([fts_close], [fts])
 case "$ac_cv_search_fts_close" in

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,14 @@ AM_CONDITIONAL(WITH_OLD_BRIDGE, test "$enable_old_bridge" = "yes")
 AC_MSG_RESULT(${enable_old_bridge:=no})
 
 
+AC_SEARCH_LIBS([fts_close], [fts])
+case "$ac_cv_search_fts_close" in
+    no) AC_MSG_FAILURE([failed to find fts_close]) ;;
+    -l*) fts_LIBS="$ac_cv_search_fts_close" ;;
+    *) fts_LIBS= ;;
+esac
+AC_SUBST([fts_LIBS])
+
 # pkg-config
 GLIB_API_VERSION="GLIB_VERSION_2_56"
 PKG_CHECK_MODULES(glib, [gio-2.0 >= 2.56 gio-unix-2.0])

--- a/src/bridge/Makefile.am
+++ b/src/bridge/Makefile.am
@@ -12,6 +12,7 @@ libcockpit_metrics_a_CPPFLAGS = \
 libcockpit_metrics_a_LIBS = \
 	libcockpit-metrics.a \
 	$(libcockpit_common_a_LIBS) \
+	$(fts_LIBS) \
 	-lm \
 	$(NULL)
 

--- a/src/common/cockpitunixsignal.c
+++ b/src/common/cockpitunixsignal.c
@@ -73,7 +73,9 @@ struct signv {
   { "STKFLT",   SIGSTKFLT },    /* 16 (arm,i386,m68k,ppc) */
 #endif
   { "CHLD",     SIGCHLD },      /* 17 (arm,i386,m68k,ppc), 20 (alpha,sparc*), 18 (mips) */
-  { "CLD",      SIGCLD },       /* same as SIGCHLD (mips) */
+#ifdef SIGCLD
+  { "CLD",      SIGCLD },       /* same as SIGCHLD (mips, musl libc) */
+#endif
   { "CONT",     SIGCONT },      /* 18 (arm,i386,m68k,ppc), 19 (alpha,sparc*), 25 (mips) */
   { "STOP",     SIGSTOP },      /* 19 (arm,i386,m68k,ppc), 17 (alpha,sparc*), 23 (mips) */
   { "TSTP",     SIGTSTP },      /* 20 (arm,i386,m68k,ppc), 18 (alpha,sparc*), 24 (mips) */

--- a/src/session/session-utils.c
+++ b/src/session/session-utils.c
@@ -26,6 +26,7 @@
 #include "common/cockpithacks.h"
 
 #include <fcntl.h>
+#include <paths.h>
 #include <stdarg.h>
 #include <stdlib.h>
 #include <sys/param.h>

--- a/src/session/session-utils.h
+++ b/src/session/session-utils.h
@@ -33,7 +33,7 @@
 #include <grp.h>
 #include <errno.h>
 #include <unistd.h>
-#include <sys/signal.h>
+#include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/src/tls/Makefile-tls.am
+++ b/src/tls/Makefile-tls.am
@@ -31,7 +31,7 @@ libcockpit_tls_a_SOURCES = \
 # cockpit-tls
 
 libexec_PROGRAMS += cockpit-tls
-cockpit_tls_LDADD = $(libcockpit_tls_a_LIBS)
+cockpit_tls_LDADD = $(libcockpit_tls_a_LIBS) $(argp_LIBS)
 cockpit_tls_SOURCES = src/tls/main.c
 
 # -----------------------------------------------------------------------------

--- a/src/tls/cockpit-certificate-ensure.c
+++ b/src/tls/cockpit-certificate-ensure.c
@@ -28,9 +28,9 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/wait.h>
 #include <sys/fcntl.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include <common/cockpitwebcertificate.h>

--- a/src/tls/cockpit-certificate-ensure.c
+++ b/src/tls/cockpit-certificate-ensure.c
@@ -24,11 +24,11 @@
 #include <assert.h>
 #include <err.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <spawn.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/fcntl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>

--- a/src/tls/connection.c
+++ b/src/tls/connection.c
@@ -28,13 +28,13 @@
 #include <fcntl.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/epoll.h>
 #include <sys/param.h>
-#include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/timerfd.h>

--- a/src/tls/socket-io.c
+++ b/src/tls/socket-io.c
@@ -26,10 +26,10 @@
 #include <err.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
-#include <sys/poll.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 


### PR DESCRIPTION
Fix a couple of things to allow building on musl based systems:
- musl doesn't define `SIGCLD` but only `SIGCHLD` => ifdef it as done for other signals
- `src/session/session-utils.c` uses `_PATH_LASTLOG` but doesn't include `<paths.h>` where it's defined (on musl and glibc)
- musl doesn't provide `fts_{open,read,close}` itself and needs to link against an external fts library 
- musl doesn't provide `argp_{parse,error}` itself and needs to link against an external argp library
- the last 4 patches just fix warnings about including `<xyz.h>` instead of `<sys/xyz.h>` so the build on musl systems is warning-free