### PR TITLE
storage: Put the minimum of a slider at the far left

### DIFF
--- a/pkg/storaged/dialog.jsx
+++ b/pkg/storaged/dialog.jsx
@@ -943,7 +943,7 @@ class SizeSliderElement extends React.Component {
         const { unit } = this.state;
 
         const change_slider = (_event, f) => {
-            onChange(Math.max(min, size_slider_round(f * max / 100, round)));
+            onChange(Math.max(min, size_slider_round(f, round)));
         };
 
         const change_text = (value) => {
@@ -972,7 +972,8 @@ class SizeSliderElement extends React.Component {
         return (
             <Grid hasGutter className="size-slider">
                 <GridItem span={12} sm={8}>
-                    <Slider showBoundaries={false} value={(slider_val / max) * 100} onChange={change_slider} />
+                    <Slider showBoundaries={false} min={min} max={max} step={(max - min) / 500}
+                            value={slider_val} onChange={change_slider} />
                 </GridItem>
                 <GridItem span={6} sm={2}>
                     <TextInputPF4 className="size-text" value={text_val} onChange={(_event, value) => change_text(value)} />

--- a/test/verify/check-storage-partitions
+++ b/test/verify/check-storage-partitions
@@ -85,22 +85,27 @@ class TestStoragePartitions(storagelib.StorageCase):
         about_half_way = width / 2 + 1
 
         b.mouse(slider, "click", about_half_way, 0)
-        self.dialog_wait_val("size", 27.3)
+        self.dialog_wait_val("size", 27.4)
         b.focus(slider + " + .pf-v5-c-slider__thumb")
         b.key_press(chr(37), use_ord=True)  # arrow left
-        self.dialog_wait_val("size", 26.7)
+        b.key_press(chr(37), use_ord=True)
+        b.key_press(chr(37), use_ord=True)
+        self.dialog_wait_val("size", 27.1)
 
         # Check that changing units affects the text input
         unit = "1000000000"
         b.select_from_dropdown(".size-unit > select", unit)
-        self.dialog_wait_val("size", "0.0267", unit)
+        self.dialog_wait_val("size", "0.0271", unit)
 
         self.dialog_apply()
         self.dialog_wait_close()
 
-        # With old Udisks2 versions, the partition will end up being
-        # 25.1M while newer versions give us 26M or 25M.
-        testlib.wait(lambda: m.execute(f"lsblk -no SIZE {disk}1").strip() in ["25M", "25.1M", "26M"])
+        # 27.1 MB is about 25.84 MiB. Some versions of
+        # UDisks2/libblockdev/libparted/... round this up to 26 MiB
+        # when creating the partition, some (newer ones) round it down
+        # to 25 MiB.
+        #
+        testlib.wait(lambda: m.execute(f"lsblk -no SIZE {disk}1").strip() in ["26M", "25M"])
 
     def testResize(self):
         m = self.machine


### PR DESCRIPTION
Instead of always putting zero at the far left.

The previous code was written for a older version of the slider that could be restricted, and would not allow the user to slide below the minimum. Patternfly sliders can not be restricted in this way and will allow the user to slide the knob into every position. Thus, we need to make the far left the minimum to avoid confusion.