### PR TITLE
lib: Update RedHatMono weight properties

### DIFF
--- a/pkg/lib/patternfly/_fonts.scss
+++ b/pkg/lib/patternfly/_fonts.scss
@@ -32,7 +32,7 @@
 @include printRedHatFont(400, "Regular");
 @include printRedHatFont(700, "Bold", $familyName: "RedHatMono");
 @include printRedHatFont(700, "BoldItalic", $style: "italic", $familyName: "RedHatMono");
-@include printRedHatFont(300, "Italic", $style: "italic", $familyName: "RedHatMono");
-@include printRedHatFont(400, "Medium", $familyName: "RedHatMono");
-@include printRedHatFont(400, "MediumItalic", $style: "italic", $familyName: "RedHatMono");
-@include printRedHatFont(300, "Regular", $familyName: "RedHatMono");
+@include printRedHatFont(400, "Italic", $style: "italic", $familyName: "RedHatMono");
+@include printRedHatFont(500, "Medium", $familyName: "RedHatMono");
+@include printRedHatFont(500, "MediumItalic", $style: "italic", $familyName: "RedHatMono");
+@include printRedHatFont(400, "Regular", $familyName: "RedHatMono");


### PR DESCRIPTION
This fixes a discussed issue[1] where Patternfly's default monospace font gets incorrectly calculated as Red Hat Mono Light, which as 2 degrees thinner/lighter than medium.
Updating our overrides weight values to the ones used by Red Hat Mono[2] pagckage should fix the issue,

[1] https://github.com/cockpit-project/cockpit-machines/pull/1178#issuecomment-1686225290
[2] https://fontsource.org/fonts/red-hat-mono