### PR TITLE
test: Relax boot timer check in TestServices.testTimerSession

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -590,11 +590,13 @@ WantedBy=default.target
         b.wait_visible(self.svc_sel('test-onboot.timer'))
         b.wait_text(self.svc_sel('test-onboot.timer') + ' .service-unit-triggers', '')
         self.run_systemctl(user, "start test-onboot.timer")
-        # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow (after 20:40)
-        today_stamp = int(m.execute("date +%s").strip())
-        time_zone = b.eval_js("Intl.DateTimeFormat().resolvedOptions().timeZone")  # get browser's time zone
-        today_plus_200min = m.execute(f"TZ='{time_zone}' date --date=@{today_stamp + 200 * 60} '+%b %-d, %Y'").strip()
-        b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger', today_plus_200min)
+        # Check the next run. Since it triggers 200mins after the boot, it might be today or tomorrow
+        # this is too racy to predict accurately
+        today = m.execute("date '+%b %-d, %Y'").strip()
+        tomorrow = m.execute("date --date tomorrow '+%b %-d, %Y'").strip()
+        sel_next = self.svc_sel('test-onboot.timer') + ' .service-unit-next-trigger'
+        b.wait_in_text(sel_next, ", ")
+        self.assertRegex(b.text(sel_next), f"{today}|{tomorrow}")
         b.wait_in_text(self.svc_sel('test-onboot.timer') + ' .service-unit-last-trigger', "unknown")  # last trigger
         self.run_systemctl(user, "stop test-onboot.timer")
 


### PR DESCRIPTION
Stop pretending that we can accurately predict the next `OnBoot` timer in TestServices.testTimerSession. It is very much *not* "now + 200 minutes", but "200 minutes after the current VM booted" (which may be long-running in Testing Farm or our CI machinery). As this is a neverending race condition in evenings, and we don't test the accuracy of systemd here, relax the check to just ensure that it happens today or tomorrow.

---

Fixes flakes like [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19518-20231023-202301-3eac2136-fedora-38-other/log.html#144-2) or [this](https://artifacts.dev.testing-farm.io/29ff6859-a09d-458e-9dc2-3d5c1075b8f6/)