### PR TITLE
lib: Drop unknown noVerticalAlign property from HelpIcon

### DIFF
--- a/pkg/lib/cockpit-components-password.jsx
+++ b/pkg/lib/cockpit-components-password.jsx
@@ -99,7 +99,7 @@ export const PasswordFormFields = ({
                            <Popover bodyContent={password_label_info}>
                                <button onClick={e => e.preventDefault()}
                                        className="pf-v5-c-form__group-label-help">
-                                   <HelpIcon noVerticalAlign />
+                                   <HelpIcon />
                                </button>
                            </Popover>
                        }


### PR DESCRIPTION
This isn't documented anywhere on https://www.patternfly.org/components/icon/, no other instance uses it, and React complains about it:

> React does not recognize the `noVerticalAlig` prop on a DOM element.
We don't cover that bit in Cockpit's tests, but cockpit-machines does.