### PR TITLE
test: apply eslint to .js files as well

### DIFF
--- a/test/static-code
+++ b/test/static-code
@@ -20,11 +20,11 @@ set -eu
 # note: `set -e` is not active during the tests.
 
 find_scripts() {
-    # Helper to find all Python files in the tree
+    # Helper to find all scripts in the tree
     (
-        # Any non-binary file which contains a python3 shebang
+        # Any non-binary file which contains a given shebang
         git grep --cached -lIz '^#!.*'"$1"
-        # Any file ending in '.py'
+        # Any file ending in the provided regex
         git ls-files -z "$2"
     ) | sort -z | uniq -z
 }
@@ -69,7 +69,7 @@ test_js_translatable_strings() {
 if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
     test_eslint() {
         test -x node_modules/.bin/eslint -a -x /usr/bin/node || skip 'no eslint'
-        find_scripts 'node' '*.js?' | xargs -0 node_modules/.bin/eslint
+        find_scripts 'node' '*.js' '*.js?' | xargs -0 node_modules/.bin/eslint
     }
 fi
 

--- a/tools/webpack-make.js
+++ b/tools/webpack-make.js
@@ -1,3 +1,3 @@
-#!/bin/sh
-echo "This got renamed to ./build.js. Please see HACKING.md"
-exit 1
+#!/bin/env node
+console.error("This got renamed to ./build.js. Please see HACKING.md");
+process.exit(1);


### PR DESCRIPTION
We want to lint all our JavaScript code, this would trip over tools/webpack-make.js as it's a shell script. Ignorning it still gives an eslint warning so this has to be converted to a proper JavaScript file.