### PR TITLE
test: Drop updates-testing-modular repo

### DIFF
--- a/test/run
+++ b/test/run
@@ -41,7 +41,7 @@ case "${TEST_SCENARIO:=}" in
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&
    *updates-testing*)
-        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing,updates-testing-modular >&2' "$TEST_OS"
+        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing >&2' "$TEST_OS"
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&


### PR DESCRIPTION
It does not exist any more in Fedora 39.

Fixes #19539