### PR TITLE
test: don't install weak dependencies for updatest-testing scenario

### DIFF
--- a/test/run
+++ b/test/run
@@ -41,7 +41,7 @@ case "${TEST_SCENARIO:=}" in
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&
    *updates-testing*)
-        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing >&2' "$TEST_OS"
+        bots/image-customize --fresh -v --run-command 'dnf -y update --enablerepo=updates-testing --setopt=install_weak_deps=False >&2' "$TEST_OS"
         RUN_OPTS="$RUN_OPTS "
         PREPARE_OPTS="$PREPARE_OPTS --overlay"
         ;;&


### PR DESCRIPTION
In Fedora-39 the dnf weak dependencies behaviour changed to install them by default which leads to podman's tests having
packagekit/networkmanager and storaged installed. This is unwanted so explicitly disable it.