### PR TITLE
fmf: Hack around Testing Farm's tag-repository priority

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -48,6 +48,14 @@ if grep -q 'ID=.*rhel' /etc/os-release; then
     dnf install -y kpatch kpatch-dnf
 fi
 
+# HACK: TF prioritizes Fedora tag repo over all others, in particular our daily COPR for revdep tests
+# This is bad -- let the highest version win instead!
+# https://gitlab.com/testing-farm/infrastructure/-/blob/testing-farm/ranch/public/citool-config/guest-setup/pre-artifact-installation/templates/tag.repo.j2?ref_type=heads
+for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do
+    sed -i '/priority/d' "$f"
+done
+dnf update -y 'cockpit*'
+
 # RHEL 8 does not build cockpit-tests; when dropping RHEL 8 support, move to test/browser/main.fmf
 if [ "$PLAN" = basic ] && ! grep -q el8 /etc/os-release; then
     dnf install -y cockpit-tests

--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -18,7 +18,7 @@ chmod a+w "$LOGS"
 # show some system info
 nproc
 free -h
-rpm -q cockpit-system
+rpm -qa | grep cockpit
 
 # install firefox (available everywhere in Fedora and RHEL)
 # we don't need the H.264 codec, and it is sometimes not available (rhbz#2005760)


### PR DESCRIPTION
TF runs add the Fedora tag repository with `priority=9`. This breaks
upstream reverse dependency tests, as that repository will then win over
our "main builds" COPR and thus run tests against mismatching
cockpit-* rpms.

Counter the hack by dropping the tag repo priority and
upgrading all cockpit packages.

-----

This is similar to https://github.com/cockpit-project/cockpit-podman/commit/5ab52df9dd43461eae90aa7103fee7513809cf1e . This should hopefully improve/fix https://github.com/fedora-selinux/selinux-policy/pull/1870 or at least make it easier to investigate.