### PR TITLE
test: Run mypy on Python scripts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,9 @@ build-backend = 'build_backend'
 mypy_path = 'src:test/common'
 exclude = '_vendor'
 [[tool.mypy.overrides]]
-module = ["cockpit._vendor.*"]
+module = ["cockpit._vendor.*", "dbus", "gi.*", "task", "vdo.*"]
 follow_imports = 'silent'
+ignore_missing_imports = true
 
 [tool.pylint]
 max-line-length = 118

--- a/src/client/cockpit-client
+++ b/src/client/cockpit-client
@@ -55,7 +55,7 @@ def prctl(*args):
         raise Exception('prctl() failed')
 
 
-prctl.SET_PDEATHSIG = 1
+SET_PDEATHSIG = 1
 
 
 @Gtk.Template(filename=f'{libexecdir}/cockpit-client.ui')
@@ -304,7 +304,7 @@ class InternalCockpitWs:
 
     def preexec_fn(self):
         os.environ['XDG_CONFIG_DIRS'] = self.config_dir.name
-        prctl(prctl.SET_PDEATHSIG, signal.SIGKILL)
+        prctl(SET_PDEATHSIG, signal.SIGKILL)
 
     def stop(self):
         self.ws.kill()

--- a/test/static-code
+++ b/test/static-code
@@ -24,7 +24,7 @@ find_scripts() {
     (
         # Any non-binary file which contains a given shebang
         git grep --cached -lIz '^#!.*'"$1"
-        # Any file ending in the provided regex
+        # Any file matching the provided glob
         git ls-files -z "$2"
     ) | sort -z | uniq -z
 }
@@ -50,6 +50,9 @@ if [ "${WITH_PARTIAL_TREE:-0}" = 0 ]; then
             test -e "src/cockpit/_vendor/${pkg}/__init__.py" || skip "no ${pkg}"
         done
         mypy --no-error-summary src/cockpit test/pytest
+        # test scripts individually, to avoid clashing on `__main__`
+        # also skip integration tests, they are too big and not annotated
+        find_scripts 'python3' "*.none" | grep -zv 'test/' | xargs -r -0 -n1 mypy --no-error-summary
     }
 
     test_vulture() {

--- a/tools/build-debian-copyright
+++ b/tools/build-debian-copyright
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import time
+from typing import Dict, Set
 
 BASE_DIR = os.path.realpath(f'{__file__}/../..')
 TEMPLATE_FILE = f'{BASE_DIR}/tools/debian/copyright.template'
@@ -76,8 +77,8 @@ license_ids = template_licenses(template)
 
 # scan dist/ bundles for third-party copyrights and licenses
 
-dist_copyrights = {}  # Files: dirglob → set(copyrights)
-dist_licenses = {}  # Files: dirglob → set(licenses)
+dist_copyrights: Dict[str, Set[str]] = {}  # Files: dirglob → set(copyrights)
+dist_licenses: Dict[str, Set[str]] = {}  # Files: dirglob → set(licenses)
 
 for directory, _subdirs, files in os.walk(f'{BASE_DIR}/dist'):
     for file in files:
@@ -129,11 +130,11 @@ for pattern in set.union(set(license_patterns), set(copyright_patterns)):
         sys.exit(f'build-debian-copyright: Unused pattern: {pattern}')
 
 paragraphs = []
-for files in sorted(dist_copyrights):
+for dirglob in sorted(dist_copyrights):
     paragraphs.append("Files: {0}\nCopyright: {1}\nLicense: {2}".format(
-        files,
-        '\n '.join(sorted(dist_copyrights[files])),
-        ' and '.join(sorted(dist_licenses[files]))))
+        dirglob,
+        '\n '.join(sorted(dist_copyrights[dirglob])),
+        ' and '.join(sorted(dist_licenses[dirglob]))))
 
 # force UTF-8 output, even when running in C locale
 for line in template.splitlines():


### PR DESCRIPTION
This covers e.g. src/client/cockpit-client or tools/urls-check, and also some helpers in pkg, which are not executable files, but have a shebang.
    
https://issues.redhat.com/browse/COCKPIT-1038