### PR TITLE
fmf: Fix prioritization of our main-builds COPR

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -48,13 +48,13 @@ if grep -q 'ID=.*rhel' /etc/os-release; then
     dnf install -y kpatch kpatch-dnf
 fi
 
-# HACK: TF prioritizes Fedora tag repo over all others, in particular our daily COPR for revdep tests
-# This is bad -- let the highest version win instead!
-# https://gitlab.com/testing-farm/infrastructure/-/blob/testing-farm/ranch/public/citool-config/guest-setup/pre-artifact-installation/templates/tag.repo.j2?ref_type=heads
-for f in $(grep -l -r 'testing-farm-tag-repository' /etc/yum.repos.d); do
-    sed -i '/priority/d' "$f"
-done
-dnf update -y 'cockpit*'
+# if we run during cross-project testing against our main-builds COPR, then let that win
+# even if Fedora has a newer revision
+main_builds_repo="$(ls /etc/yum.repos.d/*cockpit:main-builds* 2>/dev/null || true)"
+if [ -n "$main_builds_repo" ]; then
+    echo 'priority=0' >> "$main_builds_repo"
+    dnf distro-sync -y 'cockpit*'
+fi
 
 # RHEL 8 does not build cockpit-tests; when dropping RHEL 8 support, move to test/browser/main.fmf
 if [ "$PLAN" = basic ] && ! grep -q el8 /etc/os-release; then


### PR DESCRIPTION
Commit fb4faa31c5 was not sufficient: The problem wasn't the tag repository, but that current Fedora rawhide has a 303-2 rebuild of cockpit which is formally newer than our 303-1.<git stamp> revisions from our main-builds COPR.

If the env has a main-builds COPR (for reverse dependency tests), we always want to install the latest version from that. So give it the highest priority (uninutitively, lower priority wins), and use `distro-sync` to up- or downgrade the packages as necessary.

----

This can be seen in https://github.com/fedora-selinux/selinux-policy/pull/1913 . Yesterday's fix helped for F39, but [rawhide](https://artifacts.dev.testing-farm.io/5035c7e8-507d-40fe-8a79-648bb2c1473d) still installed the wrong version (303-2). I tested this on a reserved TF machine and also in a container, using the same [copr install step](https://artifacts.dev.testing-farm.io/5035c7e8-507d-40fe-8a79-648bb2c1473d/guest-setup-12fcc3da-24f0-4a5a-8444-20247d3ff03b/artifact-installation-12fcc3da-24f0-4a5a-8444-20247d3ff03b/0-Download-repository-file.txt) as TF.