### PR TITLE
fmf: Fix COPR yum repo globbing

### DIFF
--- a/test/browser/browser.sh
+++ b/test/browser/browser.sh
@@ -50,7 +50,7 @@ fi
 
 # if we run during cross-project testing against our main-builds COPR, then let that win
 # even if Fedora has a newer revision
-main_builds_repo="$(ls /etc/yum.repos.d/*cockpit:main-builds* 2>/dev/null || true)"
+main_builds_repo="$(ls /etc/yum.repos.d/*cockpit*main-builds* 2>/dev/null || true)"
 if [ -n "$main_builds_repo" ]; then
     echo 'priority=0' >> "$main_builds_repo"
     dnf distro-sync -y 'cockpit*'


### PR DESCRIPTION
Commit 7ab102a5512e inexplicably slipped in a `:` which is not actually part of the downloaded file name. This breaks the globbing.

----

See most recent failure in https://github.com/fedora-selinux/selinux-policy/pull/1913 . I can't say anything else than "sorry!" and "no idea".. I did test the commands in a container, not sure where it went wrong.

/me draws a penalty card ♣️