### PR TITLE
Address failures/flakes of the day

### DIFF
--- a/pkg/packagekit/updates.jsx
+++ b/pkg/packagekit/updates.jsx
@@ -1081,6 +1081,8 @@ class OsUpdates extends React.Component {
                         !exception.message?.includes("UnsupportedDistribution") &&
                         // or polkit does not allow it
                         exception.problem !== "access-denied" &&
+                        // or unprivileged session
+                        exception.problem !== "authentication-failed" &&
                         // or the session goes away while checking
                         exception.problem !== "terminated")
                         console.error(`Tracer failed: "${JSON.stringify(exception)}", data: "${JSON.stringify(data)}"`);

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1714,6 +1714,9 @@ class MachineCase(unittest.TestCase):
         # FIXME: PatternFly complains about these, but https://www.a11y-collective.com/blog/the-first-rule-for-using-aria/
         # and https://www.accessibility-developer-guide.com/knowledge/aria/bad-practices/
         "aria-label",
+
+        # PackageKit crashes a lot; let that not be the sole reason for failing a test
+        "error: Could not determine kpatch packages:.*PackageKit crashed",
     ]
 
     env_allow = os.environ.get("TEST_ALLOW_BROWSER_ERRORS")

--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -890,7 +890,10 @@ class TestStorageStratisNBDE(packagelib.PackageCase, storagelib.StorageCase):
         tang_m.execute("systemctl stop tangd.socket")
         b.click('#detail-header button:contains(Start)')
         self.dialog_wait_open()
-        b.wait_in_text("#dialog", "Error communicating")
+        # stratis' error message for unreachable tang server is very poor:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=2246920 Version < 3.6.0 said
+        # "Error communicating with server 10.111.112.5", check this again after fixing
+        b.wait_in_text("#dialog", "Error")
         self.dialog_cancel()
         self.dialog_wait_close()
 


### PR DESCRIPTION
First commit: Fixes #19519

Second commit: Fixes [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5491-20231102-225811-c7f9961e-fedora-39-firefox-expensive-cockpit-project-cockpit/log.html#62) / [this](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19560-20231102-215908-c4080709-fedora-39-firefox-expensive/log.html#62) unexpected message

Third commit: Replace https://github.com/cockpit-project/bots/issues/5469 . See https://bugzilla.redhat.com/show_bug.cgi?id=2246920 for details. The more important part of the test comes afterwards, and it covers a much more serious regression in stratis 3.6.0 which was fixed in 3.6.1. That will work in updates-testing. Not sure if 3.6.0 is on any image right now, tests will tell -- if so, I'll have to add another temporary naughty.