### PR TITLE
test: Properly clean up after stratis test failures

### DIFF
--- a/test/verify/check-storage-stratis
+++ b/test/verify/check-storage-stratis
@@ -65,6 +65,8 @@ class TestStorageStratis(storagelib.StorageCase):
         self.addCleanup(exe,
                         "stratis report | jq -r '.pools[] | .name' |"
                         f"xargs -n1 --no-run-if-empty stratis pool stop {self.stop_type_opt}")
+        self.addCleanup(exe,
+                        "mount | grep mapper/stratis | awk '{print $1}' | xargs --no-run-if-empty umount")
 
     def testBasic(self):
         m = self.machine


### PR DESCRIPTION
If TestStorageStratis.testBasic failed at a point when stratis filesystems were mounted, the `pool stop` and `pool destroy` commands would both fail, with "low-level ioctl error due to nix error" [sic] and "filesystems remaining on pool" respectively. This also prevented the loop devices from being cleaned up.

This broke the subsequent tests very hard, so that retries and testCLI would all fail.

---

Cleans up [this mess](https://artifacts.dev.testing-farm.io/692e36ad-9682-43de-a9f8-ef745752cec7/). I have some trouble with reproducing the initial failure, but the effect can be simulated easily:
```diff
--- test/verify/check-storage-stratis
+++ test/verify/check-storage-stratis
@@ -267,6 +267,7 @@ class TestStorageStratis(storagelib.StorageCase):
                          self.inode("/dev/stratis/pool0-renamed/fsys3"))
 
         # Destroy the pool
+        self.assertTrue(False)
         self.wait_mounted(1, 1)
         self.wait_mounted(2, 1)
         b.click('#detail-header button:contains(Delete)')
```