### PR TITLE
test: Ignore PCP name lookup failure after disk removal

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -121,6 +121,8 @@ class StorageHelpers:
         the cleanup after a forceful removal.
         """
         self.machine.execute(f'echo 1 > /sys/block/{os.path.basename(device)}/device/delete')
+        # the removal trips up PCP and our usage graphs
+        self.allow_browser_errors("direct: instance name lookup failed.*")
 
     def devices_dropdown(self, title):
         self.browser.click("#devices .pf-v5-c-dropdown button.pf-v5-c-dropdown__toggle")


### PR DESCRIPTION
Making a (virtual) disk suddenly disappear into thin air sometimes trips up the Storage page's usage graphs, and PCP complains about

    direct: instance name lookup failed: disk.dev.write_bytes.3: Unknown or illegal instance identifier

This is expected, ignore these errors.

Fixes #19568