### PR TITLE
test: Retry after UDisks2 timeout in TestStorageUsed.testUsed

### DIFF
--- a/test/verify/check-storage-used
+++ b/test/verify/check-storage-used
@@ -89,7 +89,21 @@ ExecStart=/usr/bin/sleep infinity
         b.wait_visible("#dialog tbody:first-of-type button:contains(Currently in use)")
         b.assert_pixels('#dialog', "format-disk")
         self.dialog_apply()
-        self.dialog_wait_close()
+        try:
+            self.dialog_wait_close()
+        except testlib.Error:
+            if "Timed out waiting for object" in b.text("#dialog"):
+                # Sometimes /dev/sda1 is still held open by something
+                # immediately after locking it. This prevents the
+                # kernel from reading the new partition table. Let's
+                # just try again.
+                print("WARNING: Retrying partition table creation")
+                self.dialog_cancel()
+                self.dialog_wait_close()
+                b.click('button:contains(Create partition table)')
+                self.confirm()
+            else:
+                raise
 
         m.execute("! systemctl --quiet is-active keep-mnt-busy")
 


### PR DESCRIPTION
It is not clear what exactly keeps /dev/sda1 busy when the kernel tries to read the new partition table. It can't be the artificial processes and services started by the test itself since unmounting and locking have already succeeded at that point.

This bug happens only in quite specific conditions, and can't be expected to ever get fixed. So let's do what every user would do as well: Retry the dialog.