### PR TITLE
test: fix more test_spawn_broken_pipe races

### DIFF
--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -187,8 +187,10 @@ async def test_spawn_broken_pipe(bridge):
             self.specific_error = specific_error
 
         async def do_connect_transport(self) -> None:
-            transport = await self.spawn(['sh', '-c', 'exit 9'], ())
+            transport = await self.spawn(['sh', '-c', 'read a; exit 9'], ())
             assert isinstance(transport, SubprocessTransport)
+            # Make the process exit by writing a newline (causing `read` to finish)
+            transport.write(b'\n')
             # The process will exit soon — try writing to it until a write fails.
             while not transport.is_closing():
                 transport.write(b'x')


### PR DESCRIPTION
On old Python versions, we can get the process-exited callback from the child watcher at the time of registration, without a return to the mainloop.  That means that for very fast-exiting processes, we might never get a chance to write to them to observe a EPIPE error.

Add a synchronization point so that we can prevent the process from exiting until after we've finished spawning it (and registering the watch).

Closes #19586