### PR TITLE
test: wait for journal to rotate in testLogs

### DIFF
--- a/test/verify/check-system-services
+++ b/test/verify/check-system-services
@@ -162,10 +162,11 @@ trap "echo STOP" 0
 
 if [ $(id -u) -eq 0 ]; then
     journalctl --sync
-else
-    # increase the chance for journal to catch up
-    sleep 5
 fi
+
+# increase the chance for journal to catch up
+sleep 5
+
 echo START
 while true; do
   sleep 5


### PR DESCRIPTION
In our CI the testLogs sometimes does not get a `START` and then fails. From the failed log it looks like this is due to journal being rotated. The user test case already sleeps to let journalctl settle so now we unify this approach.

Nov 08 13:13:09 ubuntu systemd[1]: Started test.service - Test Service.
Nov 08 13:13:09 ubuntu test-service[2427]: START
Nov 08 13:13:09 ubuntu systemd-journald[271]: Received client request to rotate journal.

Nov 08 13:19:51 ubuntu systemd-journald[271]: Received client request to rotate journal.
Nov 08 13:19:52 ubuntu test-service[2480]: START
Nov 08 13:19:57 ubuntu test-service[2480]: WORKING