### PR TITLE
test: Retry `git fetch` in git-utils.sh

### DIFF
--- a/test/common/git-utils.sh
+++ b/test/common/git-utils.sh
@@ -84,8 +84,15 @@ fetch_to_cache() {
     #  - we should always do the fetch because it might have changed. but
     #  - we might be able to skip updating in case we already have it
     if [ -z "${OFFLINE-}" ]; then
-        message FETCH "${SUBDIR}  ${1+[ref: $*]}"
-        git_cache fetch --prune ${quiet} origin "$@"
+        for retry in $(seq 3); do
+            message FETCH "${SUBDIR}  ${1+[ref: $*]}"
+            if git_cache fetch --prune ${quiet} origin "$@"; then
+                return
+            fi
+            sleep $((retry * retry * 5))
+        done
+        echo "repeated git fetch failure, giving up" >&2
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This prevents test failures on transient issues like

> fatal: unable to access 'https://github.com/cockpit-project/bots/':
> Failed to connect to github.com port 443 after 129563 ms:
> Couldn't connect to server

---

[example failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5529-20231109-225250-c6b08028-ubuntu-stable-networking-cockpit-project-cockpit/log.html)

Tested failure case with `GITHUB_BASE=foo/bar test/common/make-bots`.