### PR TITLE
lib: provide an optional error callback for validation

### DIFF
--- a/pkg/lib/cockpit-components-file-autocomplete.jsx
+++ b/pkg/lib/cockpit-components-file-autocomplete.jsx
@@ -142,7 +142,7 @@ export class FileAutoComplete extends React.Component {
         }
 
         if (error || !this.state.value)
-            this.props.onChange('');
+            this.props.onChange('', error);
 
         if (!error)
             this.setState({ displayFiles: listItems, directory });
@@ -162,7 +162,7 @@ export class FileAutoComplete extends React.Component {
             value: null,
             isOpen: false
         });
-        this.props.onChange('');
+        this.props.onChange('', null);
     }
 
     render() {
@@ -184,7 +184,7 @@ export class FileAutoComplete extends React.Component {
                 onSelect={(_, value) => {
                     this.setState({ value, isOpen: false });
                     this.debouncedChange(value);
-                    this.props.onChange(value || '');
+                    this.props.onChange(value || '', null);
                 }}
                 onToggle={this.onToggle}
                 onClear={this.clearSelection}


### PR DESCRIPTION
In podman we want to validate if the hostPath is correct, as this component returns an empty string on error and also as default state meaning we can't determine easily from an application.

This should not break our API. 