### PR TITLE
test: Kill processes that keep scsi_debug mounts busy

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1538,10 +1538,12 @@ class MachineCase(unittest.TestCase):
                         "for dev in $(ls /sys/bus/pseudo/drivers/scsi_debug/adapter*/host*/target*/*:*/block); do "
                         "    for s in /sys/block/*/slaves/${dev}*; do [ -e $s ] || break; "
                         "        d=/dev/$(dirname $(dirname ${s#/sys/block/})); "
+                        "        while fuser --mount $d --kill; do sleep 0.1; done; "
                         "        umount $d || true; dmsetup remove --force $d || true; "
                         "    done; "
-                        "    umount /dev/$dev 2>/dev/null || true; "
-                        "done; until rmmod scsi_debug; do sleep 0.2; done")
+                        "    while fuser --mount /dev/$dev --kill; do sleep 0.1; done; "
+                        "    umount /dev/$dev || true; "
+                        "done; until rmmod scsi_debug; do sleep 0.2; done", stdout=None)
 
         def terminate_sessions():
             # on OSTree we don't get "web console" sessions with the cockpit/ws container; just SSH; but also, some tests start

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1731,7 +1731,7 @@ class MachineCase(unittest.TestCase):
 
     if testvm.DEFAULT_IMAGE.startswith('rhel-8') or testvm.DEFAULT_IMAGE.startswith('centos-8'):
         # old occasional bug in tracer, does not happen in newer versions any more
-        default_allowed_console_errors.append('Tracer failed:.*bus.get_unit_property_from_pid.*IndexError')
+        default_allowed_console_errors.append('Tracer failed:.*bus.*_pid.*IndexError')
 
     env_allow = os.environ.get("TEST_ALLOW_BROWSER_ERRORS")
     if env_allow:

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1694,9 +1694,9 @@ class MachineCase(unittest.TestCase):
         "For security reasons, the password you type will not be visible",
 
         # starting out with empty PCP logs and pmlogger not running causes these metrics channel messages
-        "pcp-archive: no such metric: .*: Unknown metric name",
-        "pcp-archive: instance name lookup failed:.*",
-        "pcp-archive: couldn't create pcp archive context for.*",
+        "(direct|pcp-archive): no such metric: .*: Unknown metric name",
+        "(direct|pcp-archive): instance name lookup failed:.*",
+        "(direct|pcp-archive): couldn't create pcp archive context for.*",
 
         # timedatex.service shuts down after timeout, runs into race condition with property watching
         ".*org.freedesktop.timedate1: couldn't get all properties.*Error:org.freedesktop.DBus.Error.NoReply.*",


### PR DESCRIPTION
Tests like TestStorageUsed.testTeardownRetry run processes that keep a
scsi_debug block device mount busy. If they fail on some assertion in
the middle, the generic storage cleanup (umount, rmmod scsi_debug)
fails, and the following tests get broken. Add an `fuser` kill loop to
prevent that.

Also show all stdout output from these commands. We don't need it
returned in the code, it's more useful for developers in the test
output.

----

Fixes [this failure](https://artifacts.dev.testing-farm.io/42f44dfe-807e-4534-a817-dc5bb843e245/) from https://github.com/storaged-project/udisks/pull/1212 . I validated this with adding an `assert False` in the middle of `TestStorageUsed.testTeardownRetry` and ensuring that the test can be run multiple times.