### PR TITLE
Adjust tests for services image refresh

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1504,15 +1504,6 @@ class TestGrafanaClient(testlib.MachineCase):
             bg.click("button:contains('Log in')")
             bg.wait_in_text("body", "Add your first data source")
 
-            # HACK Unsigned plugin needs to be enabled manually
-            # See https://github.com/performancecopilot/grafana-pcp/issues/94
-            bg.open("/plugins/performancecopilot-pcp-app")
-            with bg.wait_timeout(30):
-                bg.wait_visible(".gf-form-button-row button")
-                if bg.text(".gf-form-button-row button") == "Enable":
-                    bg.click(".gf-form-button-row button")
-                    bg.wait_text(".gf-form-button-row button", "Disable")
-
             # Add the PCP redis data source for our client machine
             # Cog (Configuration) menu → Data Sources → Add
             # Select PCP redis, HTTP URL http://10.111.112.1:44322
@@ -1523,6 +1514,17 @@ class TestGrafanaClient(testlib.MachineCase):
             bg.set_input_text("input[placeholder='http://localhost:44322']", redis_url)
             bg.click("button:contains('Save &')")  # Save & [tT]est
             bg.wait_in_text("body", "Data source is working")
+
+            # HACK: There is no way to disable the plugin update check; it happens in the background
+            # and kills a random CDP wait with this RuntimeError; `check_for_plugin_updates = false`
+            # is supposed to avoid that, but it doesn't work; so wait for that error to happen and
+            # ignore it
+            try:
+                with bg.wait_timeout(60):
+                    bg.wait_js_cond("false")
+            except RuntimeError as e:
+                if "Failed to fetch plugins from catalog" not in str(e):
+                    raise
 
             # Grafana auto-discovers "host" variable for incoming metrics; it takes a while to receive the first
             # measurement; that event is not observable directly in Grafana, and the dashboard does not auto-update to
@@ -1541,7 +1543,7 @@ class TestGrafanaClient(testlib.MachineCase):
             # .. and the dashboard name becomes clickable
             bg.click("a:contains('PCP Redis: Host Overview')")
 
-            bg.wait_in_text(".submenu-controls", "grafana-client")
+            bg.wait_in_text("#var-host", "grafana-client")
 
             # expect a "Load average" panel with a sensible number
             max_load = bg.text("div:contains('Load average') .graph-legend-series:contains('1 minute') .max")

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -26,7 +26,7 @@ import testlib
 
 WAIT_SCRIPT = """
 for x in $(seq 1 200); do
-    if curl --insecure -s https://%(addr)s:8443/candlepin; then
+    if curl --fail --insecure --silent --show-error https://%(addr)s:8443/candlepin/status; then
         break
     else
         sleep 1

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -115,7 +115,8 @@ class CommonTests:
                 b.set_input_text(self.op_address, "cockpit.lan")
             else:
                 # on current OSes, domain and suggested admin get auto-detected
-                b.wait_val(self.op_address, "cockpit.lan")
+                with b.wait_timeout(60):
+                    b.wait_val(self.op_address, "cockpit.lan")
 
         # Join cockpit.lan
         b.click(self.domain_sel)
@@ -271,7 +272,8 @@ class CommonTests:
         b.wait_popup("realms-join-dialog")
         b.wait_attr("#realms-op-address", "data-discover", "done")
         b.set_input_text(self.op_address, "f0.cockpit.lan")
-        b.wait_text("#realms-op-address-helper", "Contacted domain")
+        with b.wait_timeout(60):
+            b.wait_text("#realms-op-address-helper", "Contacted domain")
         # admin gets auto-detected
         b.wait_val(self.op_admin, self.admin_user)
         b.set_input_text(self.op_admin_password, self.admin_password)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -149,12 +149,12 @@ class CommonTests:
         m.execute("! su -c klist " + self.admin_user)
         b.logout()
 
-        # change existing local "admin" home dir to domain "admin" user
-        m.execute(f"chown -R {self.admin_user}@cockpit.lan /home/admin")
-
         # wait until IPA user works
         m.execute('while ! su - -c "echo %s | sudo -S true" %s@cockpit.lan; do sleep 5; sss_cache -E || true; systemctl try-restart sssd; done' % (
                   self.admin_password, self.admin_user), timeout=300)
+
+        # change existing local "admin" home dir to domain "admin" user
+        m.execute(f"chown -R {self.admin_user}@cockpit.lan /home/admin")
 
         # log in as domain admin and check that we can do privileged operations
         b.login_and_go('/system/services#/systemd-tmpfiles-clean.timer', user=f'{self.admin_user}@cockpit.lan', password=self.admin_password)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -106,22 +106,14 @@ class CommonTests:
 
         wait_number_domains(0)
 
-        def set_address():
-            # old realmd/IPA don't support realmd auto-detection yet
-            if m.image == "rhel-8-7":
-                b.wait_attr("#realms-op-address", "data-discover", "done")
-                b.wait_val(self.op_address, "")
-                b.wait_not_present("#realms-op-address-helper")
-                b.set_input_text(self.op_address, "cockpit.lan")
-            else:
-                # on current OSes, domain and suggested admin get auto-detected
-                with b.wait_timeout(60):
-                    b.wait_val(self.op_address, "cockpit.lan")
+        def wait_domain_detected():
+            with b.wait_timeout(60):
+                b.wait_val(self.op_address, "cockpit.lan")
 
         # Join cockpit.lan
         b.click(self.domain_sel)
         b.wait_popup("realms-join-dialog")
-        set_address()
+        wait_domain_detected()
         b.wait_text("#realms-op-address-helper", "Contacted domain")
         # admin gets auto-detected
         b.wait_val(self.op_admin, self.admin_user)
@@ -223,7 +215,7 @@ class CommonTests:
             # Send a wrong password
             b.click(self.domain_sel)
             b.wait_popup("realms-join-dialog")
-            set_address()
+            wait_domain_detected()
             b.wait_val(self.op_admin, self.admin_user)
             b.set_input_text(self.op_admin_password, "foo")
             b.click(f"#realms-join-dialog button{self.primary_btn_class}")
@@ -259,7 +251,7 @@ class CommonTests:
         b.click(self.domain_sel)
         b.wait_popup("realms-join-dialog")
         # wait for auto-detection
-        set_address()
+        wait_domain_detected()
         b.set_input_text(self.op_address, "NOPE")
         with b.wait_timeout(30):
             b.wait_text("#realms-op-address-helper", "Domain could not be contacted")

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -900,15 +900,19 @@ class TestAD(TestRealms, CommonTests):
             alice_cert = f.read().strip()
         # mangle into form palatable for LDAP
         alice_cert = ''.join([line for line in alice_cert.splitlines() if not line.startswith("----")])
-        # set up an AD user and import their TLS certificate; avoid using the common "userCertificate;binary",
-        # as that does not work with Samba
-        services_machine.execute(r"""podman exec -i samba sh -exc '
-samba-tool user add alice %(alice_pass)s
-printf "version: 1\ndn: cn=alice,cn=users,dc=cockpit,dc=lan\nchangetype: modify\nadd: userCertificate\nuserCertificate: %(alice_cert)s\n" | \
-        ldapmodify -v -U Administrator -w '%(admin_pass)s'
+        # set up an AD user and import their TLS certificate
+        services_machine.write("/tmp/alice_edit", f'''#!/bin/sh -eu
+sed -i "/^$/d" "$1"
+echo "userCertificate: {alice_cert}" >> "$1"
+''', perm="755")
+        services_machine.execute(f"""
+podman cp /tmp/alice_edit samba:/tmp/
+podman exec -i samba sh -exc '
+samba-tool user add alice {self.alice_password}
+samba-tool user edit --editor=/tmp/alice_edit alice
 # for debugging:
-ldapsearch -v -U Administrator -w '%(admin_pass)s' -b 'cn=alice,cn=users,dc=cockpit,dc=lan'
-' """ % {"alice_pass": self.alice_password, "admin_pass": self.admin_password, "alice_cert": alice_cert})
+samba-tool user show alice
+' """, stdout=None)
 
         # set up sssd for certificate mapping to AD
         # see sssd.conf(5) "CERTIFICATE MAPPING SECTION" and sss-certmap(5)

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -884,7 +884,7 @@ class TestAD(TestRealms, CommonTests):
         # create another AD user
         self.machines['services'].execute(f"podman exec -i samba samba-tool user add alice {self.alice_password}")
         # ensure it works
-        m.execute('id alice')
+        m.execute('while ! id alice; do sleep 5; done', timeout=300)
         b.login_and_go('/system', user='alice', password=self.alice_password)
         b.wait_visible("#overview")
         b.logout()


### PR DESCRIPTION
This needs to go in lockstep with https://github.com/cockpit-project/bots/pull/4885 . There's lots of red here for the changes which don't work on main (sorry, some are incompatible), I triggered them on `@bots#4885`.