### PR TITLE
tests: increase timeout on testCPUSecurityMitigationsEnable

### DIFF
--- a/test/verify/check-system-info
+++ b/test/verify/check-system-info
@@ -511,6 +511,7 @@ machine         : 8561
         spoof_threads(2, expect_link_present=True, expect_smt_state=self.expect_smt_default, cmdline=None)
 
     @testlib.skipImage("TODO: add Arch Linux grub entry support", "arch")
+    @testlib.timeout(1200)
     def testCPUSecurityMitigationsEnable(self):
         b = self.browser
         m = self.machine


### PR DESCRIPTION
This test barely makes it within the default 10 minutes timeout. From what I see most of the time is spent by waiting for multiple reboots of the machine.
Locally this took almost 7 minutes to run so for CI we can bump this timeout to 20 minutes.