### PR TITLE
test: Factorize and fix timeout for contacting domain

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -151,8 +151,9 @@ class CommonTests:
         b.logout()
 
         # wait until IPA user works
-        m.execute('while ! su - -c "echo %s | sudo -S true" %s@cockpit.lan; do sleep 5; sss_cache -E || true; systemctl try-restart sssd; done' % (
-                  self.admin_password, self.admin_user), timeout=300)
+        m.execute(f'while ! su - -c "echo {self.admin_password} | sudo -S true" {self.admin_user}@cockpit.lan; do '
+                  '    sleep 5; sss_cache -E || true; systemctl reset-failed sssd; systemctl try-restart sssd; done',
+                  timeout=300)
 
         # change existing local "admin" home dir to domain "admin" user
         m.execute(f"chown -R {self.admin_user}@cockpit.lan /home/admin")
@@ -370,7 +371,7 @@ class CommonTests:
         with b.wait_timeout(300):
             b.wait_not_present("#realms-join-dialog")
         b.logout()
-        m.execute('while ! id alice; do sleep 5; systemctl restart sssd; done', timeout=300)
+        m.execute('while ! id alice; do sleep 5; systemctl reset-failed sssd; systemctl restart sssd; done', timeout=300)
 
         # alice's certificate was written by testClientCertAuthentication()
         alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -207,7 +207,7 @@ class CommonTests:
         # b.assert_pixels("#realms-leave-dialog", "realm-leave", [".pf-v5-c-expandable-section__toggle-icon"])
         b.click("#realms-op-leave")
 
-        with b.wait_timeout(30):
+        with b.wait_timeout(60):
             b.wait_not_present("#realms-leave-dialog")
         wait_number_domains(0)
         # re-enables hostname changing

--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -84,6 +84,15 @@ ExecStart=/bin/true
 
 @testlib.skipDistroPackage()
 class CommonTests:
+
+    def wait_discover(self):
+        with self.browser.wait_timeout(60):
+            self.browser.wait_attr("#realms-op-address", "data-discover", "done")
+
+    def wait_address_helper(self, expected=None):
+        with self.browser.wait_timeout(60):
+            self.browser.wait_text("#realms-op-address-helper", expected or "Contacted domain")
+
     @testlib.timeout(900)
     def testQualifiedUsers(self):
         m = self.machine
@@ -114,7 +123,7 @@ class CommonTests:
         b.click(self.domain_sel)
         b.wait_popup("realms-join-dialog")
         wait_domain_detected()
-        b.wait_text("#realms-op-address-helper", "Contacted domain")
+        self.wait_address_helper()
         # admin gets auto-detected
         b.wait_val(self.op_admin, self.admin_user)
         b.set_input_text(self.op_admin_password, self.admin_password)
@@ -253,8 +262,7 @@ class CommonTests:
         # wait for auto-detection
         wait_domain_detected()
         b.set_input_text(self.op_address, "NOPE")
-        with b.wait_timeout(30):
-            b.wait_text("#realms-op-address-helper", "Domain could not be contacted")
+        self.wait_address_helper("Domain could not be contacted")
         b.wait_visible(f"#realms-join-dialog button{self.primary_btn_class}:disabled")
         b.click("#realms-join-dialog button.pf-m-link")
         b.wait_not_present("#realms-join-dialog")
@@ -262,10 +270,9 @@ class CommonTests:
         # Join a domain with the server as address (input differs from domain name)
         b.click(self.domain_sel)
         b.wait_popup("realms-join-dialog")
-        b.wait_attr("#realms-op-address", "data-discover", "done")
+        self.wait_discover()
         b.set_input_text(self.op_address, "f0.cockpit.lan")
-        with b.wait_timeout(60):
-            b.wait_text("#realms-op-address-helper", "Contacted domain")
+        self.wait_address_helper()
         # admin gets auto-detected
         b.wait_val(self.op_admin, self.admin_user)
         b.set_input_text(self.op_admin_password, self.admin_password)
@@ -353,9 +360,10 @@ class CommonTests:
         self.login_and_go("/system")
         b.click("#system_information_domain_button")
         b.wait_popup("realms-join-dialog")
-        b.wait_attr("#realms-op-address", "data-discover", "done")
+        self.wait_discover()
+
         b.set_input_text("#realms-op-address", "cockpit.lan")
-        b.wait_text("#realms-op-address-helper", "Contacted domain")
+        self.wait_address_helper()
         b.set_input_text("#realms-op-admin", self.admin_user)
         b.set_input_text("#realms-op-admin-password", self.admin_password)
         b.click(f"#realms-join-dialog button{self.primary_btn_class}")
@@ -673,9 +681,9 @@ class TestIPA(TestRealms, CommonTests):
         # Join cockpit.lan
         b.click(self.domain_sel)
         b.wait_popup("realms-join-dialog")
-        b.wait_attr("#realms-op-address", "data-discover", "done")
+        self.wait_discover()
         b.set_input_text(self.op_address, "cockpit.lan")
-        b.wait_in_text("#realms-op-address-helper", "Domain is not supported")
+        self.wait_address_helper("Domain is not supported")
         # no admin name auto-detection for unsupported domains
         b.wait_val(self.op_admin, "")
         b.set_input_text(self.op_admin, self.admin_user)
@@ -1210,7 +1218,8 @@ class TestPackageInstall(packagelib.PackageCase):
         b.wait_visible("#realms-join-dialog")
 
         # no auto-detected domain/admin
-        b.wait_attr("#realms-op-address", "data-discover", "done")
+        with b.wait_timeout(60):
+            b.wait_attr("#realms-op-address", "data-discover", "done")
         self.assertEqual(b.val("#realms-op-address"), "")
         self.assertEqual(b.val("#realms-op-admin"), "")
 


### PR DESCRIPTION
In most cases this is fast, but quite often Samba takes annoyingly long to answer. Make the timeout consistent and enforce this with helper functions.

----

Since yesterday's services image update, this test and related ones now [flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19611-20231115-213214-175ae070-fedora-39-firefox-networking/log.html#34) [annoyingly often](https://ci-weather-cockpit.apps.ocp.cloud.ci.centos.org/tests.html?days=3&repo=cockpit-project%2Fcockpit&test=test%2Fverify%2Fcheck-system-realms+TestAD.testClientCertAuthentication) :+1: 

![image](https://github.com/cockpit-project/cockpit/assets/200109/82e2e429-6ef1-40a9-adea-dfe4a908eee4)
