### PR TITLE
lib: Fix race condition in "double dialog" error check

### DIFF
--- a/pkg/lib/dialogs.jsx
+++ b/pkg/lib/dialogs.jsx
@@ -97,24 +97,29 @@
  * Same as "Dialogs.show(null)".
  */
 
-import React, { useState, useContext } from "react";
+import React, { useContext, useRef, useState } from "react";
 
 export const DialogsContext = React.createContext();
 export const useDialogs = () => useContext(DialogsContext);
 
 export const WithDialogs = ({ children }) => {
+    const is_open = useRef(false); // synchronous
     const [dialog, setDialog] = useState(null);
 
     const Dialogs = {
         show: component => {
-            if (component && dialog !== null)
+            if (component && is_open.current)
                 console.error("Dialogs.show() called for",
                               JSON.stringify(component),
                               "while a dialog is already open:",
                               JSON.stringify(dialog));
+            is_open.current = !!component;
             setDialog(component);
         },
-        close: () => setDialog(null),
+        close: () => {
+            is_open.current = false;
+            setDialog(null);
+        },
         isActive: () => dialog !== null
     };
 


### PR DESCRIPTION
useState() setters are async. c-podman and navigator call `Dialogs.close(); Dialogs.show(...)` in direct succession. In that case, Dialogs.show() does not yet see the updated `null` value for `dialog` and logs the error, which fails the test.

To avoid that, use a ref for "is the dialog open", which is synchronous.

----

Spotted in https://github.com/cockpit-project/cockpit-navigator/pull/156 and https://github.com/cockpit-project/cockpit-podman/pull/1484 .