### PR TITLE
workflows: Drop COCKPITUOUS_TOKEN from trigger-anaconda.yml, update Anaconda trigger for -webui split

### DIFF
--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -16,8 +16,9 @@ on:
 jobs:
   trigger:
     runs-on: ubuntu-22.04
-    # the default workflow token cannot read our org membership, for deciding who is allowed to trigger tests
-    environment: gh-cockpituous
+    permissions:
+      contents: read
+      statuses: write
     container: registry.fedoraproject.org/fedora:rawhide
     # this polls for a COPR build, which can take long
     timeout-minutes: 120
@@ -55,5 +56,5 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
-          echo '${{ secrets.COCKPITUOUS_TOKEN }}' > ~/.config/cockpit-dev/github-token
+          echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
           bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/cockpit-pr-${{ github.event.number }}@rhinstaller/anaconda

--- a/.github/workflows/trigger-anaconda.yml
+++ b/.github/workflows/trigger-anaconda.yml
@@ -57,4 +57,4 @@ jobs:
           git clone --depth=1 https://github.com/cockpit-project/bots
           mkdir -p ~/.config/cockpit-dev
           echo '${{ secrets.GITHUB_TOKEN }}' > ~/.config/cockpit-dev/github-token
-          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/cockpit-pr-${{ github.event.number }}@rhinstaller/anaconda
+          bots/tests-trigger --repo ${{ github.repository }} ${{ github.event.number }} fedora-rawhide-boot/cockpit-pr-${{ github.event.number }}@rhinstaller/anaconda-webui

--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1730,8 +1730,8 @@ class MachineCase(unittest.TestCase):
     ]
 
     if testvm.DEFAULT_IMAGE.startswith('rhel-8') or testvm.DEFAULT_IMAGE.startswith('centos-8'):
-        # old occasional bug in tracer, does not happen in newer versions any more
-        default_allowed_console_errors.append('Tracer failed:.*bus.*_pid.*IndexError')
+        # old occasional bugs in tracer, don't happen in newer versions any more
+        default_allowed_console_errors.append('Tracer failed:.*Traceback')
 
     env_allow = os.environ.get("TEST_ALLOW_BROWSER_ERRORS")
     if env_allow:


### PR DESCRIPTION
https://github.com/cockpit-project/bots/pull/5569 changed the allowlist from a GitHub team to a hardcoded Python list, so we don't need the cockpituous token privilege with its `read:org` any more.

---

I also piggy-backed a fix for [this flake](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19625-20231119-093440-3a5a8a8f-rhel-8-10-distropkg-other/log.html#58)

 - [x] Test this on a PR #19631 which triggers anaconda: [workflow success](https://github.com/cockpit-project/cockpit/actions/runs/6928553768/job/18844570667?pr=19631); [triggered test](https://cockpit-logs.us-east-1.linodeobjects.com/pull-19631-20231120-102117-e2579352-fedora-rawhide-boot-cockpit-pr-19631-rhinstaller-anaconda-webui/log.html)