### PR TITLE
tools: Drop cockpit-pcp on ix86 on recent Fedora/RHEL

### DIFF
--- a/pkg/Makefile.am
+++ b/pkg/Makefile.am
@@ -16,8 +16,10 @@ EXTRA_DIST += \
 	$(pixmaps_DATA) \
 	$(NULL)
 
+if ENABLE_PCP
 pcpmanifestdir = $(datadir)/cockpit/pcp
 dist_pcpmanifest_DATA = pkg/pcp/manifest.json
+endif
 
 # one built file in dist/ which we use as dependency
 DIST_STAMP = $(srcdir)/dist/static/manifest.json


### PR DESCRIPTION
The most recent PCP Fedora rawhide update [1] stopped building pcp on ix86 for Fedora ≥ 40 and RHEL ≥ 10. Follow suit and disable building the PCP bridge and the cockpit-package there.

[1] https://bodhi.fedoraproject.org/updates/FEDORA-2023-cf7eccd442
[2] https://src.fedoraproject.org/rpms/pcp/c/fc70568e935f8f4c88937cbe8fc17db9995ae7d5?branch=rawhide

---
Failed build example: https://dashboard.packit.dev/results/copr-builds/1163610