### PR TITLE
bridge: Improve handling of control messages

### DIFF
--- a/src/cockpit/beiboot.py
+++ b/src/cockpit/beiboot.py
@@ -281,7 +281,7 @@ class SshBridge(Router):
         if isinstance(message.get('superuser'), dict):
             self.write_control(command='superuser-init-done')
         message['superuser'] = False
-        self.ssh_peer.write_control(**message)
+        self.ssh_peer.write_control(message)
 
 
 async def run(args) -> None:
@@ -306,12 +306,12 @@ async def run(args) -> None:
         if bridge.packages:
             message['packages'] = {p: None for p in bridge.packages.packages}
 
-        bridge.write_control(**message)
+        bridge.write_control(message)
         bridge.ssh_peer.thaw_endpoint()
     except ferny.InteractionError as exc:
         sys.exit(str(exc))
     except CockpitProblem as exc:
-        bridge.write_control(command='init', problem=exc.problem, **exc.kwargs)
+        bridge.write_control(exc.attrs, command='init')
         return
 
     logger.debug('Startup done.  Looping until connection closes.')

--- a/src/cockpit/bridge.py
+++ b/src/cockpit/bridge.py
@@ -138,13 +138,15 @@ class Bridge(Router, PackagesListener):
     def do_send_init(self) -> None:
         init_args = {
             'capabilities': {'explicit-superuser': True},
+            'command': 'init',
             'os-release': self.get_os_release(),
+            'version': 1,
         }
 
         if self.packages is not None:
             init_args['packages'] = {p: None for p in self.packages.packages}
 
-        self.write_control(command='init', version=1, **init_args)
+        self.write_control(init_args)
 
     # PackagesListener interface
     def packages_loaded(self) -> None:

--- a/src/cockpit/channels/dbus.py
+++ b/src/cockpit/channels/dbus.py
@@ -261,7 +261,7 @@ class DBusChannel(Channel):
                     if self.owner:
                         self.ready(unique_name=self.owner)
                     else:
-                        self.close(problem="not-found")
+                        self.close({'problem': 'not-found'})
             self.create_task(get_ready())
         else:
             self.ready()

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -61,7 +61,7 @@ class FsListChannel(Channel):
         else:
             mode = 'special'
 
-        self.send_message(event=event, path=entry.name, type=mode)
+        self.send_json(event=event, path=entry.name, type=mode)
 
     def do_open(self, options):
         path = options.get('path')
@@ -239,20 +239,20 @@ class FsWatchChannel(Channel):
             # file inside watched directory changed
             path = os.path.join(self._path, name.decode())
             tag = tag_from_path(path)
-            self.send_message(event=event, path=path, tag=tag, type=type_)
+            self.send_json(event=event, path=path, tag=tag, type=type_)
         else:
             # the watched path itself changed; filter out duplicate events
             tag = tag_from_path(self._path)
             if tag == self._tag:
                 return
             self._tag = tag
-            self.send_message(event=event, path=self._path, tag=self._tag, type=type_)
+            self.send_json(event=event, path=self._path, tag=self._tag, type=type_)
 
     def do_identity_changed(self, fd, err):
         logger.debug("do_identity_changed(%s): fd %s, err %s", self._path, str(fd), err)
         self._tag = tag_from_fd(fd) if fd else '-'
         if self._active:
-            self.send_message(event='created' if fd else 'deleted', path=self._path, tag=self._tag)
+            self.send_json(event='created' if fd else 'deleted', path=self._path, tag=self._tag)
 
     def do_open(self, options):
         self._path = options['path']

--- a/src/cockpit/channels/filesystem.py
+++ b/src/cockpit/channels/filesystem.py
@@ -198,7 +198,7 @@ class FsReplaceChannel(Channel):
             self._tempfile = None
 
         self.done()
-        self.close(tag=tag_from_path(self._path))
+        self.close({'tag': tag_from_path(self._path)})
 
     def do_close(self):
         if self._tempfile is not None:

--- a/src/cockpit/channels/metrics.py
+++ b/src/cockpit/channels/metrics.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 from ..channel import AsyncChannel, ChannelError
+from ..jsonutil import JsonList
 from ..samples import SAMPLERS, SampleDescription, Sampler, Samples
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ class InternalMetricsChannel(AsyncChannel):
         self.samplers = {cls() for cls in sampler_classes}
 
     def send_meta(self, samples: Samples, timestamp: float):
-        metrics = []
+        metrics: JsonList = []
         for metricinfo in self.metrics:
             if metricinfo.desc.instanced:
                 metrics.append({
@@ -105,13 +106,7 @@ class InternalMetricsChannel(AsyncChannel):
                     'semantics': metricinfo.desc.semantics
                 })
 
-        meta = {
-            'timestamp': timestamp * 1000,
-            'interval': self.interval,
-            'source': 'internal',
-            'metrics': metrics
-        }
-        self.send_message(**meta)
+        self.send_json(source='internal', interval=self.interval, timestamp=timestamp * 1000, metrics=metrics)
         self.need_meta = False
 
     def sample(self):

--- a/src/cockpit/channels/packages.py
+++ b/src/cockpit/channels/packages.py
@@ -35,7 +35,7 @@ class PackagesChannel(AsyncChannel):
 
     def http_error(self, status: int, message: str) -> None:
         template = read_cockpit_data_file('fail.html')
-        self.send_message(status=status, reason='ERROR', headers={'Content-Type': 'text/html; charset=utf-8'})
+        self.send_json(status=status, reason='ERROR', headers={'Content-Type': 'text/html; charset=utf-8'})
         self.send_data(template.replace(b'@@message@@', message.encode('utf-8')))
         self.done()
         self.close()
@@ -58,7 +58,7 @@ class PackagesChannel(AsyncChannel):
             # Note: we can't cache documents right now.  See
             # https://github.com/cockpit-project/cockpit/issues/19071
             # for future plans.
-            out_headers = {
+            out_headers: JsonObject = {
                 'Cache-Control': 'no-cache, no-store',
                 'Content-Type': document.content_type,
             }
@@ -97,5 +97,5 @@ class PackagesChannel(AsyncChannel):
             self.http_error(500, f'Internal error: {exc!s}')
 
         else:
-            self.send_message(status=200, reason='OK', headers=out_headers)
+            self.send_json(status=200, reason='OK', headers=out_headers)
             await self.sendfile(document.data)

--- a/src/cockpit/jsonutil.py
+++ b/src/cockpit/jsonutil.py
@@ -104,3 +104,28 @@ def get_objv(obj: JsonObject, key: str, constructor: Callable[[JsonObject], T]) 
     def as_objv(value: JsonDocument) -> Sequence[T]:
         return tuple(constructor(typechecked(item, dict)) for item in typechecked(value, list))
     return _get(obj, as_objv, key, ())
+
+
+def create_object(message: 'JsonObject | None', kwargs: JsonObject) -> JsonObject:
+    """Constructs a JSON object based on message and kwargs.
+
+    If only message is given, it is returned, unmodified.  If message is None,
+    it is equivalent to an empty dictionary.  A copy is always made.
+
+    If kwargs are present, then any underscore ('_') present in a key name is
+    rewritten to a dash ('-').  This is intended to bridge between the required
+    Python syntax when providing kwargs and idiomatic JSON (which uses '-' for
+    attributes).  These values override values in message.
+
+    The idea is that `message` should be used for passing data along, and
+    kwargs used for data originating at a given call site, possibly including
+    modifications to an original message.
+    """
+    result = dict(message or {})
+
+    for key, value in kwargs.items():
+        # rewrite '_' (necessary in Python syntax kwargs list) to '-' (idiomatic JSON)
+        json_key = key.replace('_', '-')
+        result[json_key] = value
+
+    return result

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -19,11 +19,9 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import ClassVar, Dict, Optional
+from typing import Dict, Optional
 
-from cockpit._vendor import systemd_ctypes
-
-from .jsonutil import JsonError, JsonObject, get_str, typechecked
+from .jsonutil import JsonDocument, JsonError, JsonObject, create_object, get_str, typechecked
 
 logger = logging.getLogger(__name__)
 
@@ -40,10 +38,11 @@ class CockpitProblem(Exception):
     It is usually thrown in response to some violation of expected protocol
     when parsing messages, connecting to a peer, or opening a channel.
     """
-    def __init__(self, problem: str, **kwargs):
-        super().__init__(kwargs.get('message') or problem)
+    def __init__(self, problem: str, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+        self.attrs = create_object(_msg, kwargs)
+        self.attrs['problem'] = problem
         self.problem = problem
-        self.kwargs = kwargs
+        super().__init__(get_str(self.attrs, 'message', problem))
 
 
 class CockpitProtocolError(CockpitProblem):
@@ -57,7 +56,6 @@ class CockpitProtocol(asyncio.Protocol):
     We need to use this because Python's SelectorEventLoop doesn't supported
     buffered protocols.
     """
-    json_encoder: ClassVar[json.JSONEncoder] = systemd_ctypes.JSONEncoder(indent=2)
     transport: Optional[asyncio.Transport] = None
     buffer = b''
     _closed: bool = False
@@ -191,21 +189,11 @@ class CockpitProtocol(asyncio.Protocol):
         else:
             logger.debug('cannot write to closed transport')
 
-    def write_message(self, _channel, **kwargs):
-        """Format kwargs as a JSON blob and send as a message
-           Any kwargs with '_' in their names will be converted to '-'
-        """
-        for name in list(kwargs):
-            if '_' in name:
-                kwargs[name.replace('_', '-')] = kwargs[name]
-                del kwargs[name]
-
-        logger.debug('sending message %s %s', _channel, kwargs)
-        pretty = CockpitProtocol.json_encoder.encode(kwargs) + '\n'
-        self.write_channel_data(_channel, pretty.encode('utf-8'))
-
-    def write_control(self, **kwargs):
-        self.write_message('', **kwargs)
+    def write_control(self, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
+        """Write a control message.  See jsonutil.create_object() for details."""
+        logger.debug('sending control message %r %r', _msg, kwargs)
+        pretty = json.dumps(create_object(_msg, kwargs), indent=2) + '\n'
+        self.write_channel_data('', pretty.encode())
 
     def data_received(self, data):
         try:
@@ -269,14 +257,16 @@ class CockpitProtocolServer(CockpitProtocol):
         self.do_send_init()
 
     # authorize request/response API
-    async def request_authorization(self, challenge: str, timeout: Optional[int] = None, **kwargs: object) -> str:
+    async def request_authorization(
+        self, challenge: str, timeout: 'int | None' = None, **kwargs: JsonDocument
+    ) -> str:
         if self.authorizations is None:
             self.authorizations = {}
         cookie = str(uuid.uuid4())
         future = asyncio.get_running_loop().create_future()
         try:
             self.authorizations[cookie] = future
-            self.write_control(command='authorize', challenge=challenge, cookie=cookie, **kwargs)
+            self.write_control(None, command='authorize', challenge=challenge, cookie=cookie, **kwargs)
             return await asyncio.wait_for(future, timeout)
         finally:
             self.authorizations.pop(cookie)

--- a/src/cockpit/protocol.py
+++ b/src/cockpit/protocol.py
@@ -38,10 +38,11 @@ class CockpitProblem(Exception):
     It is usually thrown in response to some violation of expected protocol
     when parsing messages, connecting to a peer, or opening a channel.
     """
+    attrs: JsonObject
+
     def __init__(self, problem: str, _msg: 'JsonObject | None' = None, **kwargs: JsonDocument) -> None:
         self.attrs = create_object(_msg, kwargs)
         self.attrs['problem'] = problem
-        self.problem = problem
         super().__init__(get_str(self.attrs, 'message', problem))
 
 

--- a/src/cockpit/remote.py
+++ b/src/cockpit/remote.py
@@ -110,7 +110,7 @@ class SshPeer(Peer):
                 # containing the key that would need to be accepted.  That will
                 # cause the front-end to present a dialog.
                 _reason, host, algorithm, key, fingerprint = responder.hostkeys_seen[0]
-                error_args = {'host_key': f'{host} {algorithm} {key}', 'host_fingerprint': fingerprint}
+                error_args: JsonObject = {'host-key': f'{host} {algorithm} {key}', 'host-fingerprint': fingerprint}
             else:
                 error_args = {}
 
@@ -124,12 +124,12 @@ class SshPeer(Peer):
 
             logger.debug('SshPeer got a %s %s; private %s, seen hostkeys %r; raising %s with extra args %r',
                          type(exc), exc, self.private, responder.hostkeys_seen, error, error_args)
-            raise PeerError(error, error=error, auth_method_results={}, **error_args) from exc
+            raise PeerError(error, error_args, error=error, auth_method_results={}) from exc
 
         except ferny.SshAuthenticationError as exc:
             logger.debug('authentication to host %s failed: %s', host, exc)
 
-            results = {method: 'not-provided' for method in exc.methods}
+            results: JsonObject = {method: 'not-provided' for method in exc.methods}
             if 'password' in results and self.password is not None:
                 if responder.password_attempts == 0:
                     results['password'] = 'not-tried'

--- a/src/cockpit/superuser.py
+++ b/src/cockpit/superuser.py
@@ -222,7 +222,7 @@ class SuperuserRoutingRule(RoutingRule, CockpitResponder, bus.Object, interface=
         self._init_task = asyncio.create_task(self.go(name, responder))
         self._init_task.add_done_callback(self._init_done)
 
-    def _init_done(self, task):
+    def _init_done(self, task: 'asyncio.Task[None]') -> None:
         logger.debug('superuser init done! %s', task.exception())
         self.router.write_control(command='superuser-init-done')
         del self._init_task

--- a/test/pytest/test_peer.py
+++ b/test/pytest/test_peer.py
@@ -210,5 +210,5 @@ async def test_spawn_broken_pipe(bridge):
     peer = BrokenPipePeer(specific_error=True)
     with pytest.raises(ChannelError) as raises:
         await peer.start()
-    assert raises.value.kwargs == {'message': 'kaputt', 'problem': 'not-supported'}
+    assert raises.value.attrs == {'message': 'kaputt', 'problem': 'not-supported'}
     peer.close()


### PR DESCRIPTION
Remove the general purpose mechanism for sending JSON-formatted messages from the protocol level, leaving only the mechanism for sending control messages.  Non-control JSON-formatted messages (such as those used for D-Bus replies) are now handled at the channel level and treated as normal data, subject to flow control.  This removes one of the main interaction points between endpoints and the router.

Add a pair of functions to jsonutil which define the exact way in which we intend to handle keyword args when building control messages.  We make a clear distinction between data which is meant to be handled "verbatim" and data which is meant to be subject to processing rules
(our '_' to '-' replacements, etc).

Start using the new jsonutil functions for all control message handling. That means that all control-message-creating paths now offer the opportunity to pass a verbatim dictionary as well as a set of kwargs. Propagate this change upwards, throughout. For forwarding messages from peers this is substantially cleaner because it means we don't rewrite their messages.  The improved typing results in some extra mypy errors which requires some hinting at call sites.

One note: ideally, we'd use `/` in the argument list of all of these functions to ensure that the "verbatim object" field that we add everywhere can only be passed positionally.  This is unfortunately only in Python 3.8.  To work around that issue, we add a `_msg` field everywhere with its name chosen never to clash with an actual kwarg we might use (such as `message`).  Unfortunately, `mypy` isn't yet convinced that this is a purely positional argument, and in places that we write `**kwargs` it has no way to know that one of the kwargs won't in fact be `_msg`, so it complains that the types don't match.  In the cases where that happens, we can manually specify `None` to avoid that problem.