### PR TITLE
test: Add hack to retry a failed AD joining

### DIFF
--- a/test/verify/check-system-realms
+++ b/test/verify/check-system-realms
@@ -371,7 +371,19 @@ class CommonTests:
         with b.wait_timeout(300):
             b.wait_not_present("#realms-join-dialog")
         b.logout()
-        m.execute('while ! id alice; do sleep 5; done', timeout=300)
+        try:
+            m.execute('while ! id alice; do sleep 5; done', timeout=300)
+        except RuntimeError as e:
+            # HACK: https://github.com/samba-in-kubernetes/samba-container/issues/160
+            # if this fails to set up, try again ; we can just join with the CLI, cockpit doesn't
+            # do anything extra for AD
+            print("AD setup failed, retrying:", e)
+            if self.__class__ == TestAD:
+                m.execute("realm leave")
+                m.execute(f"echo {self.admin_password}| realm join -vU {self.admin_user} cockpit.lan")
+                m.execute('while ! id alice; do sleep 5; done', timeout=300)
+            else:
+                raise
 
         # alice's certificate was written by testClientCertAuthentication()
         alice_cert_key = ['--cert', "/var/tmp/alice.pem", '--key', "/var/tmp/alice.key"]


### PR DESCRIPTION
There is a race condition with the current Samba AD container on the services image: Sometimes joining the domain doesn't pick up the global directory server, and queries fail with "SSSD is offline" / "Unspecified GSS failure".

This is too hard for us to track down ourselves, it needs help from [1]. In the meantime, leave and re-join the domain to give it another chance of succeeding. This avoids the extra I/O/CPU noise that goes along with the cockpit session (such as checking for package updates), and has a higher chance of succeeding.

Note that joining AD via cockpit is still covered by test{Un,}QualifiedUser.

[1] https://github.com/samba-in-kubernetes/samba-container/issues/160

----

I hate this, but I've already sunk 3½ days into debugging this, and am none the wiser. This is beyond me.

This is one of our worst flakes right now:

![image](https://github.com/cockpit-project/cockpit/assets/200109/b37e7c79-c2ef-491c-b6db-a88fbdd6398f)
