### PR TITLE
test: Adjust testClientCertAuthentication to changed loginctl 255 output format

### DIFF
--- a/test/verify/check-static-login
+++ b/test/verify/check-static-login
@@ -841,7 +841,10 @@ matchrule = <SUBJECT>^DC=LAN,DC=COCKPIT,CN=alice$
                     if "State: active" in out:  # skip closing sessions
                         self.assertIn(session_leader, out)
                         self.assertIn('cockpit-bridge', out)
-                        self.assertIn('cockpit; type web', out)
+                        # systemd < 255: "Service: cockpit; type web; class user"
+                        # systemd ≥ 255: "Service: cockpit\n   Type: web\n Class: user"
+                        self.assertRegex(out, r"Service:\s+cockpit")
+                        self.assertRegex(out, "[tT]ype.*web")
                         break
                 else:
                     self.fail("no active session for active user")


### PR DESCRIPTION
The type and class are separate fields with systemd ≥ 255, not part of `Service:` any more. Adjust the check to get along with both formats.

---

Fixes the [rawhide failure](https://artifacts.dev.testing-farm.io/c51b7e96-c58d-4006-8efb-48660ddc6b74/) that started to happen yesterday.