### PR TITLE
packagekit: Use dnf-automatic reboot option if available

### DIFF
--- a/pkg/packagekit/kpatch.jsx
+++ b/pkg/packagekit/kpatch.jsx
@@ -323,7 +323,7 @@ export class KpatchSettings extends React.Component {
 }
 
 KpatchSettings.propTypes = {
-    privileged: PropTypes.bool.isRequired,
+    privileged: PropTypes.bool,
 };
 
 export class KpatchStatus extends React.Component {

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1412,7 +1412,7 @@ class TestUpdatesSubscriptions(packagelib.PackageCase):
         b.wait_in_text("#status", "System is up to date")
 
 
-@testlib.skipOstree
+@testlib.skipOstree("Image uses OSTree")
 @testlib.nondestructive
 class TestAutoUpdates(NoSubManCase):
 

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1421,6 +1421,7 @@ class TestAutoUpdates(NoSubManCase):
         # not implemented for yum and apt yet, only dnf
         self.supported_backend = self.backend in ["dnf"]
         if self.backend == 'dnf':
+            self.restore_file("/etc/dnf/automatic.conf")
             self.addCleanup(self.machine.execute, "systemctl disable --now dnf-automatic-install.timer 2>/dev/null; rm -rf /etc/systemd/system/dnf-automatic-*")
 
     def closeSettings(self, browser):
@@ -1461,7 +1462,15 @@ class TestAutoUpdates(NoSubManCase):
             # automatic reboots should be enabled whenever timer is enabled
             out = m.execute("systemctl cat dnf-automatic-install.service")
             if hour:
-                self.assertRegex(out, "ExecStartPost=/.*shutdown")
+                if m.image.startswith("rhel-8") or m.image == "centos-8-stream":
+                    # for RHEL 8, dnf-automatic does not support reboot; we have a unit drop-in hack
+                    self.assertRegex(out, "ExecStartPost=/.*shutdown")
+                    # validate our assumption
+                    self.assertNotIn("reboot", m.execute("cat /etc/dnf/automatic.conf"))
+                else:
+                    # newer dnf supports that natively
+                    self.assertNotIn("ExecStartPost", out)
+                    self.assertIn("reboot = when-needed", m.execute("cat /etc/dnf/automatic.conf"))
             else:
                 self.assertNotIn("ExecStartPost", out)
 
@@ -1605,8 +1614,9 @@ class TestAutoUpdates(NoSubManCase):
         b = self.browser
         m = self.machine
 
-        self.createPackage("vanilla", "1.0", "1", install=True)
-        self.createPackage("vanilla", "1.0", "2")
+        # use a package which dnf recognizes as "needs reboot"
+        self.createPackage("kernel-rt", "1.0", "1", install=True)
+        self.createPackage("kernel-rt", "1.0", "2")
         self.enableRepo()
 
         m.start_cockpit()
@@ -1631,24 +1641,24 @@ class TestAutoUpdates(NoSubManCase):
             self.sed_file("/random_sleep/ s/=.*$/= 3/", "/etc/dnf/automatic.conf")
             # then manually start the upgrade job like the timer would
             m.execute("systemctl start dnf-automatic-install.service")
-            # new vanilla package got installed, and triggered reboot; cancel that
-            m.execute("test -f /stamp-vanilla-1.0-2")
+            # new kernel-rt package got installed, and triggered reboot; cancel that
+            m.execute("test -f /stamp-kernel-rt-1.0-2")
             m.execute("until test -f /run/nologin; do sleep 1; done")
             m.execute("shutdown -c; test ! -f /run/nologin")
-            # service should show vanilla upgrade and scheduling shutdown
+            # service should show kernel-rt upgrade and scheduling shutdown
             out = m.execute(
-                "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
-            self.assertIn("vanilla", out)
+                "if systemctl status --lines=50 dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
+            self.assertIn("kernel-rt", out)
             # systemd 245.7 correctly says "reboot", older version say "shutdown"
             self.assertRegex(out, "(Shutdown|Reboot) scheduled")
 
             # run it again, now there are no available updates → no reboot
             m.execute("systemctl start dnf-automatic-install.service")
-            m.execute("test -f /stamp-vanilla-1.0-2; test ! -f /run/nologin")
+            m.execute("test -f /stamp-kernel-rt-1.0-2; test ! -f /run/nologin")
             # service should not do much
             out = m.execute(
                 "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
-            self.assertNotIn("vanilla", out)
+            self.assertNotIn("kernel-rt", out)
             self.assertNotIn("Shutdown", out)
         else:
             raise NotImplementedError(self.backend)

--- a/test/verify/check-packagekit
+++ b/test/verify/check-packagekit
@@ -1627,7 +1627,29 @@ class TestAutoUpdates(NoSubManCase):
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
 
         if self.backend == 'dnf':
-            self.checkUpgradeRebootDnf()
+            # dial down the random sleep to avoid the test having to wait 5 mins
+            self.sed_file("/random_sleep/ s/=.*$/= 3/", "/etc/dnf/automatic.conf")
+            # then manually start the upgrade job like the timer would
+            m.execute("systemctl start dnf-automatic-install.service")
+            # new vanilla package got installed, and triggered reboot; cancel that
+            m.execute("test -f /stamp-vanilla-1.0-2")
+            m.execute("until test -f /run/nologin; do sleep 1; done")
+            m.execute("shutdown -c; test ! -f /run/nologin")
+            # service should show vanilla upgrade and scheduling shutdown
+            out = m.execute(
+                "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
+            self.assertIn("vanilla", out)
+            # systemd 245.7 correctly says "reboot", older version say "shutdown"
+            self.assertRegex(out, "(Shutdown|Reboot) scheduled")
+
+            # run it again, now there are no available updates → no reboot
+            m.execute("systemctl start dnf-automatic-install.service")
+            m.execute("test -f /stamp-vanilla-1.0-2; test ! -f /run/nologin")
+            # service should not do much
+            out = m.execute(
+                "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
+            self.assertNotIn("vanilla", out)
+            self.assertNotIn("Shutdown", out)
         else:
             raise NotImplementedError(self.backend)
 
@@ -1660,35 +1682,6 @@ class TestAutoUpdates(NoSubManCase):
         b.drop_superuser()
         b.wait_in_text("#autoupdates-settings", "Updates will be applied every day at 06:00")
         b.wait_visible("#autoupdates-settings button:disabled")
-
-    def checkUpgradeRebootDnf(self):
-        """part of testWithAvailableUpdates() for dnf backend"""
-
-        m = self.machine
-
-        # dial down the random sleep to avoid the test having to wait 5 mins
-        self.sed_file("/random_sleep/ s/=.*$/= 3/", "/etc/dnf/automatic.conf")
-        # then manually start the upgrade job like the timer would
-        m.execute("systemctl start dnf-automatic-install.service")
-        # new vanilla package got installed, and triggered reboot; cancel that
-        m.execute("test -f /stamp-vanilla-1.0-2")
-        m.execute("until test -f /run/nologin; do sleep 1; done")
-        m.execute("shutdown -c; test ! -f /run/nologin")
-        # service should show vanilla upgrade and scheduling shutdown
-        out = m.execute(
-            "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
-        self.assertIn("vanilla", out)
-        # systemd 245.7 correctly says "reboot", older version say "shutdown"
-        self.assertRegex(out, "(Shutdown|Reboot) scheduled")
-
-        # run it again, now there are no available updates → no reboot
-        m.execute("systemctl start dnf-automatic-install.service")
-        m.execute("test -f /stamp-vanilla-1.0-2; test ! -f /run/nologin")
-        # service should not do much
-        out = m.execute(
-            "if systemctl status dnf-automatic-install.service; then echo 'expected service to be stopped'; exit 1; fi")
-        self.assertNotIn("vanilla", out)
-        self.assertNotIn("Shutdown", out)
 
 
 @testlib.skipImage("Image uses OSTree", "fedora-coreos", "rhel4edge")


### PR DESCRIPTION
dnf 4.15 introduced a `reboot` option for automatic updates at last
[1][2]. This is available in all current Fedoras and RHEL 9.3+, but not
yet in RHEL 8. On systems which support it (i.e. which have a `reboot=`
option in automatic.conf), set that to "when-needed" instead of the
unit drop-in hack. Remove the latter to clean up on upgrades; that will
only have an effect if the admin disables and re-enables automatic
updates, but that's better than nothing.

Fixes https://issues.redhat.com/browse/RHEL-16392

[1] https://github.com/rpm-software-management/dnf/blob/master/doc/automatic.rst#commands-section
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1491190

----

I tested this interactively on a real F39 machine with lots of pending updates (including a kernel), waited for the timer to trigger, and eventually:
```
shutdown[13040]: Reboot scheduled for Thu 2023-11-23 09:49:54 UTC, use 'shutdown -c' to cancel.
Nov 23 09:44:54 fedora-39-127-0-0-2-2201 dnf-automatic[1677]: Updates completed at Thu 23 Nov 2023 09:44:54 AM UTC
[...]
Broadcast message from root@fedora-39-127-0-0-2-2201 (Thu 2023-11-23 09:45:54 UTC):

Rebooting after applying package updates
The system will reboot at Thu 2023-11-23 09:49:54 UTC!
```

So this works nicely!