### PR TITLE
test: re-use admin ssh key setup across machines

### DIFF
--- a/test/verify/check-shell-host-switching
+++ b/test/verify/check-shell-host-switching
@@ -82,23 +82,6 @@ class HostSwitcherHelpers:
         b.click("a[href='/@localhost']")
         b.click("#hosts-sel button")
 
-    def get_pubkey(self, machine, account):
-        return machine.execute(f"cat /home/{account}/.ssh/id_rsa.pub")
-
-    def authorize_pubkey(self, machine, account, pubkey):
-        machine.execute(f"a={account} d=/home/$a/.ssh; mkdir -p $d; chown $a:$a $d; chmod 700 $d")
-        machine.write(f"/home/{account}/.ssh/authorized_keys", pubkey)
-        machine.execute(f"a={account}; chown $a:$a /home/$a/.ssh/authorized_keys")
-
-    def setup_ssh_auth(self):
-        self.machine.execute("d=/home/admin/.ssh; mkdir -p $d; chown admin:admin $d; chmod 700 $d")
-        self.machine.execute("test -f /home/admin/.ssh/id_rsa || ssh-keygen -f /home/admin/.ssh/id_rsa -t rsa -N ''")
-        self.machine.execute("chown admin:admin /home/admin/.ssh/id_rsa*")
-        pubkey = self.get_pubkey(self.machine, "admin")
-
-        for m in self.machines:
-            self.authorize_pubkey(self.machines[m], "admin", pubkey)
-
 
 @testlib.skipDistroPackage()
 @testlib.todoPybridgeRHEL8()

--- a/test/verify/check-shell-multi-machine
+++ b/test/verify/check-shell-multi-machine
@@ -146,17 +146,6 @@ class TestMultiMachineAdd(testlib.MachineCase):
         "machine3": {"address": "10.111.113.3/20", "memory_mb": 660},
     }
 
-    def setup_ssh_auth(self):
-        self.machine.execute("d=/home/admin/.ssh; mkdir -p $d; chown admin:admin $d; chmod 700 $d")
-        self.machine.execute("test -f /home/admin/.ssh/id_rsa || ssh-keygen -f /home/admin/.ssh/id_rsa -t rsa -N ''")
-        self.machine.execute("chown admin:admin /home/admin/.ssh/id_rsa*")
-        pubkey = self.machine.execute("cat /home/admin/.ssh/id_rsa.pub")
-
-        for m in self.machines:
-            self.machines[m].execute("d=/home/admin/.ssh; mkdir -p $d; chown admin:admin $d; chmod 700 $d")
-            self.machines[m].write("/home/admin/.ssh/authorized_keys", pubkey)
-            self.machines[m].execute("chown admin:admin /home/admin/.ssh/authorized_keys")
-
     def setUp(self):
         super().setUp()
         self.machine2 = self.machines['machine2']


### PR DESCRIPTION
This was copy'd twice in Cockpit tests and will also come in useful in the cockpit-machines multi machine tests.