### PR TITLE
test: Adjust hack in TestGrafanaClient for non-crashing page

### DIFF
--- a/test/verify/check-metrics
+++ b/test/verify/check-metrics
@@ -1525,6 +1525,10 @@ class TestGrafanaClient(testlib.MachineCase):
             except RuntimeError as e:
                 if "Failed to fetch plugins from catalog" not in str(e):
                     raise
+            except testlib.Error as e:
+                if not e.msg.startswith("timeout"):
+                    raise
+                # no plugin check error? great!
 
             # Grafana auto-discovers "host" variable for incoming metrics; it takes a while to receive the first
             # measurement; that event is not observable directly in Grafana, and the dashboard does not auto-update to


### PR DESCRIPTION
Later Grafana versions [1] fixed the page crash on "Failed to fetch plugins from catalog", and just log it to the console now. That will make the "wait for false" loop timeout and eventually fail. If that happens, then all is actually well.

[1] https://github.com/cockpit-project/bots/pull/5601

----

I tested this with the new services image from above PR, and it works well. I do this to avoid a lockstep update and lots of failing tests. After the new services image has landed, I'll try to drop the hack.