### PR TITLE
storaged: add max btrfs label size

### DIFF
--- a/pkg/storaged/utils.js
+++ b/pkg/storaged/utils.js
@@ -227,6 +227,7 @@ export function validate_fsys_label(label, type) {
         ext4: 16,
         vfat: 11,
         ntfs: 128,
+        btrfs: 256,
     };
 
     const limit = fs_label_max[type.replace("luks+", "")];


### PR DESCRIPTION
According to the btrfs-filesystem man page the maximum allowable length shall be less than 256 chars.

https://man.archlinux.org/man/core/btrfs-progs/btrfs-filesystem.8.en#label