### PR TITLE
test: Increase encrypted root partition size

### DIFF
--- a/test/common/storagelib.py
+++ b/test/common/storagelib.py
@@ -499,7 +499,7 @@ MakeDirectory=yes
         # Before the reboot, we destroy the original disk to make
         # really sure that it wont be used anymore.
 
-        info = m.add_disk("4G", serial="NEWROOT", boot_disk=True)
+        info = m.add_disk("6G", serial="NEWROOT", boot_disk=True)
         dev = "/dev/" + info["dev"]
         wait(lambda: m.execute(f"test -b {dev} && echo present").strip() == "present")
         m.execute(f"""


### PR DESCRIPTION
The test was already regularly scratching the ceiling with its hair, but with the recent RHEL package updates [1] it's finally bumping its head.

Raise the ceiling higher.

[1] https://github.com/cockpit-project/bots/pull/5627

---

See [failure log](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5627-20231202-084403-de479f47-rhel-8-10-distropkg-storage-cockpit-project-cockpit/log.html#17-2), [second failure](https://cockpit-logs.us-east-1.linodeobjects.com/pull-5627-20231202-084400-de479f47-rhel-8-10-storage-cockpit-project-cockpit/log.html). `/` is at 99% usage at this time, so it can't even get the few KB to install the rpms.

I triggered an additional rhel-8-10 storage run against the refresh PR.