### PR TITLE
test: Disable busy swap on scsi_debug

### DIFF
--- a/test/common/testlib.py
+++ b/test/common/testlib.py
@@ -1548,6 +1548,7 @@ class MachineCase(unittest.TestCase):
                         "    done; "
                         "    while fuser --mount /dev/$dev --kill; do sleep 0.1; done; "
                         "    umount /dev/$dev || true; "
+                        "    swapon --show=NAME --noheadings | grep $dev | xargs -r swapoff; "
                         "done; until rmmod scsi_debug; do sleep 0.2; done", stdout=None)
 
         def terminate_sessions():


### PR DESCRIPTION
When e.g. TestStorageswap.test fails in the middle, the active swap partition on the scsi_debug driver will prevent the module removal, and break all subsequent tests.

Helps with #19683

-----

Reproduced and tested with
```diff
--- test/verify/check-storage-swap
+++ test/verify/check-storage-swap
@@ -39,6 +39,7 @@ class TestStorageswap(storagelib.StorageCase):
         b.wait_text(self.card_desc("Swap", "Used"), "-")
 
         b.click(self.card_button("Swap", "Start"))
+        self.assertTrue(False)
         b.wait_text(self.card_desc("Swap", "Used"), "0")
 
         self.assertEqual(m.execute(f"lsblk -n -o MOUNTPOINT {disk}").strip(), "[SWAP]")

```