### PR TITLE
fmf: Add missing cockpit-pcp test dep for /optional plan

### DIFF
--- a/test/browser/main.fmf
+++ b/test/browser/main.fmf
@@ -52,6 +52,8 @@
     - cockpit
     - cockpit-storaged
     - cockpit-packagekit
+    # for at least swap metrics on storage page
+    - cockpit-pcp
     # build/test infra dependencies
     - git
     - make


### PR DESCRIPTION
`TestStorageswap.test` checks swap usage, which we get from the "direct" metrics source, i.e. from PCP. This doesn't fail for cockpit's own PRs as these TF runs install all built cockpit RPMs. But it's missing for cross-project test runs.

Fixes #19683